### PR TITLE
Fix playhead edge case and make bottom selection strip drag-only

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -109,7 +109,7 @@ impl AudioPlayer {
             }
         }
         self.loop_offset = None;
-        self.start_with_span(clamped_start, bounded_end, duration, looped)
+        self.start_with_span(bounded_start, bounded_end, duration, looped)
     }
 
     /// Loop the full track while starting playback at the given normalized position.

--- a/src/audio/tests.rs
+++ b/src/audio/tests.rs
@@ -260,6 +260,22 @@ fn progress_wraps_full_loop_from_offset() {
 }
 
 #[test]
+fn play_range_at_track_end_expands_backwards() {
+    let Ok(mut player) = AudioPlayer::new() else {
+        return;
+    };
+    let duration = 0.5;
+    player.set_audio(silent_wav_bytes(duration, 44_100, 1), duration);
+
+    assert!(player.play_range(1.0, 1.0, false).is_ok());
+    let (start, end) = player.play_span.expect("play span set");
+
+    assert!(start < duration);
+    assert!((end - duration).abs() < 0.0005);
+    assert!((start - (duration - 0.01)).abs() < 0.002);
+}
+
+#[test]
 fn set_audio_prefers_provided_duration() {
     let Ok(mut player) = AudioPlayer::new() else {
         return;


### PR DESCRIPTION
- Fixes AudioPlayer::play_range to start from bounded_start, preventing playhead/progress stopping early near end-of-track.
- Makes the bottom selection strip always act as a drag handle by excluding it from resize hit-rects; adds a unit test for non-overlap.
- Tests: cargo test play_range_at_track_end_expands_backwards, cargo test edge_handles_do_not_overlap_drag_handle.