### PR TITLE
nightly

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -34,7 +34,7 @@ impl AudioPlayer {
 
     /// Create a new audio player honoring the requested output configuration.
     pub fn from_config(config: &AudioOutputConfig) -> Result<Self, String> {
-        let outcome = open_output_stream(config)?;
+        let outcome = open_output_stream(config).map_err(|err| err.to_string())?;
         Ok(Self {
             stream: outcome.stream,
             sink: None,
@@ -558,6 +558,6 @@ where
 #[cfg(test)]
 mod tests;
 pub use output::{
-    AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, ResolvedOutput, available_devices,
-    available_hosts, open_output_stream, supported_sample_rates,
+    AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, AudioOutputError, ResolvedOutput,
+    available_devices, available_hosts, open_output_stream, supported_sample_rates,
 };

--- a/src/egui_app/controller/audio_options.rs
+++ b/src/egui_app/controller/audio_options.rs
@@ -36,7 +36,7 @@ impl EguiController {
             match crate::audio::available_devices(host) {
                 Ok(list) => list,
                 Err(err) => {
-                    warning = Some(err);
+                    warning = Some(err.to_string());
                     Vec::new()
                 }
             }

--- a/src/egui_app/controller/wavs/waveform_loading.rs
+++ b/src/egui_app/controller/wavs/waveform_loading.rs
@@ -43,7 +43,7 @@ impl EguiController {
             .sample_view
             .renderer
             .decode_from_bytes(&bytes)
-            .map_err(|e| e.to_string())?;
+            .map_err(|err| err.to_string())?;
         let duration_seconds = decoded.duration_seconds;
         let sample_rate = decoded.sample_rate;
         let cache_key = CacheKey::new(&source.id, relative_path);


### PR DESCRIPTION
Channel: nightly
Build date: 2025-12-14T20:08:52.9931062Z
Git SHA: 8358d66

## Changelog

## [0.347.0] - 2025-12-14

### 🚀 Features

- *(ui)* Make left/right sidebars resizable panels
- *(ui)* Add loop toggle button to waveform view
- *(waveform)* Alt-drag selection handle slides selection
- *(waveform)* Keep source focused on shift-drag selection export
- Add -log to show console in release
- *(hotkeys)* Add M hotkey to mute selection
- *(hotkeys)* Add quote hotkey to tag neutral
- *(hotkeys)* Apply triage tags in collection focus
- *(drag-drop)* Save selection clips in focused folder
- *(drag-drop)* Allow selection drops onto folders
- *(ui)* Highlight folder drops for selection drags

### 🐛 Bug Fixes

- *(hotkeys)* Prevent Windows beep on held keys
- *(collections)* Store selection-drop clips in export dir
- *(windows)* Consume handled hotkeys to prevent system beep
- *(ui)* Color hotkey overlay headings and dedupe actions
- *(windows)* Hide console window in release builds
- Reveal file in Windows Explorer
- Let keyboard cursor override idle mouse hover
- Enable windows console and filesystem APIs
- Enable Win32_Storage for windows crate
- Enable Win32_Security for CreateFileW
- *(waveform)* Avoid stale zoom-cache after edits
- *(ui)* Focus new clip after selection drop
- *(dragdrop)* Update shift behavior during selection drag
- *(ui)* Keep browser selection visible when waveform focused
- *(windows)* Reveal sample selects correct file
- *(drag-drop)* Cancel selection drop without target
- *(windows)* Avoid losing internal drag on brief pointer leave
- *(windows)* Restore external drag-out while keeping internal drags
- *(collections)* Allow tagging clip-root members
- *(wav)* Tolerate ill-formed headers via rodio fallback
- *(wav)* Sanitize nonstandard fmt chunk sizes
- *(windows)* Restore external drag-out by detecting pointer leave correctly
- *(windows)* Trigger external drag on PointerGone event
- *(windows)* Keep in-app drag active when cursor briefly leaves window
- *(windows)* Preserve drag when leaving and reentering window
- *(windows)* Treat interact_pos as inside during in-window drags
- *(windows)* Detect drag-out using OS cursor position
- *(windows)* Handle Win32 API Result return types
- *(windows)* Clear leave latch when OS cursor re-enters window
- *(windows)* Increase external drag arm delay to avoid accidental launch
- *(windows)* Hide internal drag preview after leaving window
- *(windows)* Cancel in-app drag updates after leaving window
- *(ui)* Start drags even when window unfocused
- *(windows)* Reset in-app drag after external drag ends
- *(windows)* Allow drag-start after external drag
- *(windows)* Correct GetAsyncKeyState bitmask
- *(windows)* Use OS cursor position for drag-start recovery

### 💼 Other

- *(windows)* Enable Win32_UI_WindowsAndMessaging feature

### 🚜 Refactor

- *(tests)* Move controller tests into dedicated modules
- *(controller/wavs)* Extract browser search+label cache helpers into submodule
- *(controller)* Group async jobs and pending state
- *(controller)* Extract tagging service
- *(controller)* Centralize source cache invalidation
- *(controller)* Centralize wav list UI sync
- *(controller/wavs)* Centralize browser sync after entry mutations
- *(controller)* Rely on clear_waveform_view for loaded resets
- *(controller)* Reuse helpers when folder ops mutate entries
- *(controller)* Reuse browser sync helper for selection exports
- *(controller)* Invalidate caches when removing sources
- *(controller)* Reuse clear_waveform_view for collection sample selection
- *(controller/collections)* Extract helpers for sample selection
- *(controller)* Centralize clearing loaded waveform visuals
- *(controller)* Centralize waveform reload for active sample
- *(controller/wavs)* Extract browser actions module
- *(controller/source_folders)* Extract folder actions module
- *(controller/source_folders)* Extract selection and navigation module
- *(controller/source_folders)* Extract folder tree/search module
- *(controller/source_folders)* Split folder selection module
- *(ui/waveform_view)* Extract destructive edit prompt
- *(ui/waveform_view)* Extract selection geometry helpers
- *(ui/waveform_view)* Extract selection context menu
- *(ui/waveform_view)* Extract selection overlay interactions
- *(ui/waveform_view)* Extract hover cursor overlay
- *(ui/waveform_view)* Extract marker/loop/playhead overlays
- *(ui/waveform_view)* Extract base interactions
- *(ui/waveform_view)* Extract base rendering and texture upload
- *(ui/waveform_view)* Extract controls row
- *(controller/playback)* Extract transport and selection ops
- *(controller/playback)* Extract random navigation module
- *(controller/playback)* Extract player and playhead logic
- *(controller/playback)* Extract browser navigation helpers
- *(controller/playback)* Extract tagging and triage helpers
- *(controller/playback)* Extract formatting helpers
- *(controller/wavs)* Extract audio loading module

### 📚 Documentation

- Update usage guide
- Refresh usage guide
- Refresh usage guide for config paths, exports, and hotkeys
- Add refactor strategy for small PR module splits

### ⚙️ Miscellaneous Tasks

- Resolve compile warnings
- *(release)* V0.347.0 (#40)