### PR TITLE
chore(changelog): v0.358.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
-## [unreleased]
-
-### 🐛 Bug Fixes
-
-- *(ui)* Clarify update available message
+## [0.358.0] - 2025-12-14
 
 ### ⚙️ Miscellaneous Tasks
 


### PR DESCRIPTION
Update CHANGELOG.md after tagging v0.358.0.

Note: the tag remains on the release commit; this PR only updates documentation.