### PR TITLE
v0.361.0 (#61)

### DIFF
--- a/.github/workflows/changelog-on-release.yml
+++ b/.github/workflows/changelog-on-release.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch: {}
 
+env:
+  BASE_BRANCH: ${{ github.event_name == 'release' && github.event.release.target_commitish || 'main' }}
+
 permissions:
   contents: write
   pull-requests: write
@@ -20,7 +23,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 0
 
       - name: Install git-cliff
@@ -36,7 +39,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          base: main
+          base: ${{ env.BASE_BRANCH }}
           branch: chore/changelog-${{ github.event.release.tag_name || github.run_id }}
           delete-branch: true
           commit-message: "chore(changelog): update for ${{ github.event.release.tag_name || 'release' }}"
@@ -46,9 +49,11 @@ jobs:
 
             Trigger: ${{ github.event_name }}
             Tag: ${{ github.event.release.tag_name || 'n/a' }}
+            Base: ${{ env.BASE_BRANCH }}
 
       - name: Enable auto-merge
         if: ${{ steps.cpr.outputs.pull-request-number != '' }}
+        continue-on-error: true
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "sempal"
-version = "0.359.0"
+version = "0.360.0"
 dependencies = [
  "cpal",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sempal"
-version = "0.360.0"
+version = "0.361.0"
 edition = "2024"
 default-run = "sempal"
 

--- a/src/egui_app/controller/browser_controller/delegates.rs
+++ b/src/egui_app/controller/browser_controller/delegates.rs
@@ -42,6 +42,16 @@ impl EguiController {
         self.browser().delete_browser_samples(rows)
     }
 
+    /// Remove dead-link browser rows (missing samples) from the library without deleting files.
+    pub fn remove_dead_link_browser_sample(&mut self, row: usize) -> Result<(), String> {
+        self.browser().remove_dead_link_browser_samples(&[row])
+    }
+
+    /// Remove dead-link browser rows (missing samples) from the library without deleting files.
+    pub fn remove_dead_link_browser_samples(&mut self, rows: &[usize]) -> Result<(), String> {
+        self.browser().remove_dead_link_browser_samples(rows)
+    }
+
     pub(in crate::egui_app::controller) fn resolve_browser_sample(
         &self,
         row: usize,

--- a/src/egui_app/controller/hotkeys/actions.rs
+++ b/src/egui_app/controller/hotkeys/actions.rs
@@ -272,8 +272,15 @@ pub(super) const HOTKEY_ACTIONS: &[HotkeyAction] = &[
     HotkeyAction {
         id: "reverse-selection",
         label: "Reverse selection",
-        gesture: HotkeyGesture::new(Key::R),
+        gesture: HotkeyGesture::with_shift(Key::R),
         scope: HotkeyScope::Focus(FocusContext::Waveform),
+        command: HotkeyCommand::ReverseSelection,
+    },
+    HotkeyAction {
+        id: "reverse-selection-browser",
+        label: "Reverse selection",
+        gesture: HotkeyGesture::with_shift(Key::R),
+        scope: HotkeyScope::Focus(FocusContext::SampleBrowser),
         command: HotkeyCommand::ReverseSelection,
     },
     HotkeyAction {

--- a/src/egui_app/controller/hotkeys_controller.rs
+++ b/src/egui_app/controller/hotkeys_controller.rs
@@ -173,7 +173,7 @@ impl HotkeysActions for HotkeysController<'_> {
                 }
             }
             HotkeyCommand::ReverseSelection => {
-                if matches!(focus, FocusContext::Waveform) {
+                if matches!(focus, FocusContext::Waveform | FocusContext::SampleBrowser) {
                     let _ = self.request_destructive_selection_edit(
                         DestructiveSelectionEdit::ReverseSelection,
                     );

--- a/src/egui_app/controller/playback.rs
+++ b/src/egui_app/controller/playback.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 mod browser_nav;
 mod formatting;
+mod playhead_trail;
 mod player;
 mod random_nav;
 mod tagging;
@@ -99,7 +100,7 @@ impl EguiController {
         progress: Option<f32>,
         is_looping: bool,
     ) {
-        player::update_playhead_from_progress(self, progress, is_looping);
+        player::update_playhead_from_progress(self, progress, is_looping, false);
     }
 
     pub(super) fn hide_waveform_playhead(&mut self) {

--- a/src/egui_app/controller/playback/player.rs
+++ b/src/egui_app/controller/playback/player.rs
@@ -67,6 +67,17 @@ pub(super) fn play_audio(
     controller.ui.waveform.playhead.active_span_end = Some(span_end.clamp(0.0, 1.0));
     controller.ui.waveform.playhead.visible = true;
     controller.ui.waveform.playhead.position = start;
+    super::playhead_trail::start_or_seek_trail(
+        &mut controller.ui.waveform.playhead,
+        start,
+        start_override.is_some(),
+    );
+    if start_override.is_some() {
+        controller.ui.waveform.playhead.recent_seek = Some(crate::egui_app::state::PlayheadSeek {
+            position: start,
+            started_at: Instant::now(),
+        });
+    }
     Ok(())
 }
 
@@ -107,7 +118,7 @@ pub(super) fn tick_playhead(controller: &mut EguiController) {
     let progress = player_ref.progress();
     let is_looping = player_ref.is_looping();
     drop(player_ref);
-    update_playhead_from_progress(controller, progress, is_looping);
+    update_playhead_from_progress(controller, progress, is_looping, is_playing);
     if !is_playing && controller.sample_view.waveform.decoded.is_none() {
         hide_waveform_playhead(controller);
     }
@@ -117,9 +128,18 @@ pub(super) fn update_playhead_from_progress(
     controller: &mut EguiController,
     progress: Option<f32>,
     is_looping: bool,
+    is_playing: bool,
 ) {
     if let Some(progress) = progress {
+        let playhead = &mut controller.ui.waveform.playhead;
+        let progress = smooth_progress_after_seek(&mut playhead.recent_seek, progress);
         controller.ui.waveform.playhead.position = progress;
+        super::playhead_trail::tick_playhead_trail(
+            &mut controller.ui.waveform.playhead,
+            progress,
+            is_looping,
+            is_playing,
+        );
         if playhead_completed_span(controller, progress, is_looping) {
             hide_waveform_playhead(controller);
         } else {
@@ -144,9 +164,39 @@ fn playhead_completed_span(controller: &EguiController, progress: f32, is_loopin
     progress + super::PLAYHEAD_COMPLETION_EPSILON >= target
 }
 
+fn smooth_progress_after_seek(
+    recent_seek: &mut Option<crate::egui_app::state::PlayheadSeek>,
+    progress: f32,
+) -> f32 {
+    const SEEK_SMOOTH_SECS: f32 = 0.08;
+    const SEEK_CLEAR_SECS: f32 = 0.20;
+    const EPS: f32 = 1e-6;
+
+    let progress = progress.clamp(0.0, 1.0);
+    let Some(seek) = *recent_seek else {
+        return progress;
+    };
+
+    let elapsed = seek.started_at.elapsed();
+    if elapsed.as_secs_f32() >= SEEK_CLEAR_SECS || progress + EPS < seek.position {
+        *recent_seek = None;
+        return progress;
+    }
+
+    if elapsed.as_secs_f32() >= SEEK_SMOOTH_SECS || progress <= seek.position + EPS {
+        return progress;
+    }
+
+    let t = (elapsed.as_secs_f32() / SEEK_SMOOTH_SECS).clamp(0.0, 1.0);
+    let eased = t * t * (3.0 - 2.0 * t);
+    seek.position + (progress - seek.position) * eased
+}
+
 pub(super) fn hide_waveform_playhead(controller: &mut EguiController) {
+    super::playhead_trail::stash_active_trail(&mut controller.ui.waveform.playhead);
     controller.ui.waveform.playhead.visible = false;
     controller.ui.waveform.playhead.active_span_end = None;
+    controller.ui.waveform.playhead.recent_seek = None;
 }
 
 #[cfg(test)]
@@ -161,6 +211,35 @@ pub(super) fn playhead_completed_span_for_tests(
 #[cfg(test)]
 pub(super) fn hide_waveform_playhead_for_tests(controller: &mut EguiController) {
     hide_waveform_playhead(controller);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::smooth_progress_after_seek;
+    use crate::egui_app::state::PlayheadSeek;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn smooth_playhead_progress_after_seek_starts_at_seek_position() {
+        let mut seek = Some(PlayheadSeek {
+            position: 0.25,
+            started_at: Instant::now(),
+        });
+        let progress = smooth_progress_after_seek(&mut seek, 0.40);
+        assert!(progress >= 0.25);
+        assert!(progress <= 0.40);
+    }
+
+    #[test]
+    fn smooth_playhead_progress_after_seek_clears_after_timeout() {
+        let mut seek = Some(PlayheadSeek {
+            position: 0.25,
+            started_at: Instant::now() - Duration::from_millis(500),
+        });
+        let progress = smooth_progress_after_seek(&mut seek, 0.40);
+        assert_eq!(progress, 0.40);
+        assert!(seek.is_none());
+    }
 }
 
 pub(in crate::egui_app::controller) fn apply_selection(

--- a/src/egui_app/controller/playback/playhead_trail.rs
+++ b/src/egui_app/controller/playback/playhead_trail.rs
@@ -1,0 +1,140 @@
+use crate::egui_app::state::{FadingPlayheadTrail, PlayheadState, PlayheadTrailSample};
+use std::time::{Duration, Instant};
+
+const TRAIL_DURATION: Duration = Duration::from_millis(1250);
+const TRAIL_FADE: Duration = Duration::from_millis(450);
+const MAX_TRAIL_SAMPLES: usize = 384;
+const MAX_FADING_TRAILS: usize = 2;
+const POSITION_EPS: f32 = 0.0005;
+const MIN_SAMPLE_DT: Duration = Duration::from_millis(8); // ~120Hz
+
+fn seed_trail(playhead: &mut PlayheadState, position: f32, now: Instant) {
+    let position = position.clamp(0.0, 1.0);
+    playhead.trail.clear();
+    playhead.trail.push_back(PlayheadTrailSample { position, time: now });
+    playhead.trail.push_back(PlayheadTrailSample {
+        position,
+        time: now + Duration::from_millis(1),
+    });
+}
+
+pub(super) fn start_or_seek_trail(playhead: &mut PlayheadState, position: f32, is_seek: bool) {
+    let now = Instant::now();
+    if is_seek {
+        stash_active_trail(playhead);
+    }
+    seed_trail(playhead, position, now);
+}
+
+pub(super) fn stash_active_trail(playhead: &mut PlayheadState) {
+    if playhead.trail.is_empty() {
+        return;
+    }
+    let samples = std::mem::take(&mut playhead.trail);
+    playhead.fading_trails.push(FadingPlayheadTrail {
+        started_at: Instant::now(),
+        samples,
+    });
+    while playhead.fading_trails.len() > MAX_FADING_TRAILS {
+        playhead.fading_trails.remove(0);
+    }
+}
+
+pub(super) fn tick_playhead_trail(
+    playhead: &mut PlayheadState,
+    position: f32,
+    _is_looping: bool,
+    is_playing: bool,
+) {
+    let now = Instant::now();
+    playhead
+        .fading_trails
+        .retain(|trail| now.saturating_duration_since(trail.started_at) < TRAIL_FADE);
+
+    if !is_playing {
+        if !playhead.trail.is_empty() {
+            stash_active_trail(playhead);
+        }
+        return;
+    }
+
+    let mut position = position.clamp(0.0, 1.0);
+    let discontinuity = match playhead.trail.back() {
+        Some(last) => {
+            let backwards = position + POSITION_EPS < last.position;
+            backwards
+        }
+        None => false,
+    };
+
+    if discontinuity {
+        stash_active_trail(playhead);
+        seed_trail(playhead, position, now);
+        return;
+    }
+
+    if let Some(last) = playhead.trail.back() {
+        if position < last.position {
+            position = last.position;
+        }
+    }
+
+    let should_push = match playhead.trail.back() {
+        Some(last) => {
+            (position - last.position).abs() >= POSITION_EPS
+                || now.saturating_duration_since(last.time) >= MIN_SAMPLE_DT
+        }
+        None => true,
+    };
+    if should_push {
+        playhead.trail.push_back(PlayheadTrailSample { position, time: now });
+    }
+
+    while let Some(front) = playhead.trail.front() {
+        if now.saturating_duration_since(front.time) > TRAIL_DURATION {
+            playhead.trail.pop_front();
+        } else {
+            break;
+        }
+    }
+    while playhead.trail.len() > MAX_TRAIL_SAMPLES {
+        playhead.trail.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tick_playhead_trail;
+    use crate::egui_app::state::{PlayheadState, PlayheadTrailSample};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn tick_playhead_trail_clamps_tiny_backwards_jitter() {
+        let mut playhead = PlayheadState::default();
+        playhead.trail.push_back(PlayheadTrailSample {
+            position: 0.5,
+            time: Instant::now() - Duration::from_secs(1),
+        });
+
+        tick_playhead_trail(&mut playhead, 0.4999, false, true);
+
+        assert!(playhead.trail.len() >= 1);
+        let last = playhead.trail.back().unwrap();
+        assert!((last.position - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn tick_playhead_trail_allows_large_forward_deltas_for_short_audio() {
+        let mut playhead = PlayheadState::default();
+        playhead.trail.push_back(PlayheadTrailSample {
+            position: 0.10,
+            time: Instant::now() - Duration::from_millis(50),
+        });
+
+        tick_playhead_trail(&mut playhead, 0.30, false, true);
+
+        assert!(playhead.fading_trails.is_empty());
+        assert!(playhead.trail.len() >= 2);
+        assert!((playhead.trail.back().unwrap().position - 0.30).abs() < 1e-6);
+    }
+}

--- a/src/egui_app/controller/playback/transport.rs
+++ b/src/egui_app/controller/playback/transport.rs
@@ -119,7 +119,15 @@ pub(super) fn play_from_cursor(controller: &mut EguiController) -> bool {
     if !controller.waveform_ready() {
         return false;
     }
-    if let Some(cursor) = controller.ui.waveform.cursor {
+    let cursor_from_navigation = match (
+        controller.ui.waveform.cursor_last_hover_at,
+        controller.ui.waveform.cursor_last_navigation_at,
+    ) {
+        (_, None) => false,
+        (None, Some(_)) => true,
+        (Some(hover), Some(nav)) => nav >= hover,
+    };
+    if cursor_from_navigation && let Some(cursor) = controller.ui.waveform.cursor {
         seek_to(controller, cursor);
         return true;
     }


### PR DESCRIPTION
* feat(ui): show folder indicator dot for focused/selected samples

* feat(waveform): add smooth playhead gradient trail

* fix(waveform): smooth playhead trail for short samples

* fix(waveform): prevent playhead offset right after seek

* fix(waveform): stabilize playhead trail rendering

* fix(waveform): prevent playhead trail edge-clamp jumping

* fix(waveform): avoid playhead trail holes when starting mid-sample

* refactor(waveform): rebuild playhead trail sampling and stabilize rendering

* feat(hotkeys): bind reverse selection to shift+r in browser and waveform

* fix(waveform): make playhead trail interpolation robust

* fix(waveform): prevent playhead trail holes

* fix(waveform): keep trail continuous on short samples

* feat(browser): add remove dead link context action

* fix(ui): make ctrl+shift+space replay last start

* fix(playback): ctrl+space ignores hover cursor

* tweak(waveform): reduce playhead trail opacity

* fix(ci): run git-cliff on release target branch

* chore(release): v0.361.0

---------