### PR TITLE
Open options panel when top-bar Options menu is clicked

### DIFF
--- a/src/egui_app/ui/chrome/top_bar.rs
+++ b/src/egui_app/ui/chrome/top_bar.rs
@@ -1,15 +1,15 @@
 use eframe::egui::{self, RichText, SliderClamping};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use super::super::EguiApp;
 use super::super::style;
+use super::super::EguiApp;
 use super::buttons;
 
 impl EguiApp {
     pub(crate) fn render_status_controls(&mut self, ui: &mut egui::Ui) {
         let palette = style::palette();
         let mut close_menu = false;
-        ui.menu_button("Options", |ui| {
+        let options_menu = ui.menu_button("Options", |ui| {
             let palette = style::palette();
             ui.label(RichText::new("Trash folder").color(palette.text_primary));
             let trash_label = self
@@ -71,6 +71,20 @@ impl EguiApp {
                 ui.close();
             }
         });
+        if options_menu.response.clicked() {
+            self.controller.ui.audio.panel_open = true;
+            let is_asio = self
+                .controller
+                .ui
+                .audio
+                .applied
+                .as_ref()
+                .is_some_and(|applied| applied.host_id.eq_ignore_ascii_case("asio"));
+            if !is_asio {
+                self.controller.refresh_audio_options(false);
+                self.controller.refresh_audio_input_options(false);
+            }
+        }
         ui.add_space(10.0);
         const APP_VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
         match self.controller.ui.update.status {


### PR DESCRIPTION
### Motivation
- The top-bar "Options" control only showed a dropdown and did not open the full Options panel, which is surprising to users who expect the menu to launch the options window immediately.

### Description
- Capture the `menu_button` response in `src/egui_app/ui/chrome/top_bar.rs` and, when clicked, set `controller.ui.audio.panel_open = true` and reuse the existing audio refresh behavior (skipping eager refresh when ASIO is active) so the options panel is opened consistently while preserving the existing menu contents.

### Testing
- Ran `CPAL_ASIO_DIR=/mnt/e/lib/asiosdk/ASIOSDK cargo check`, which failed in this environment because the system ALSA pkg-config (`alsa.pc`) is missing; `rustfmt` on the modified file succeeded; `cargo fmt --all` failed due to unrelated trailing whitespace in `src/egui_app/ui/waveform_view/controls.rs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aacd411c608329ba11348a12893128)