### PR TITLE
Improve sample browser row hover contrast

### DIFF
--- a/src/egui_app/ui/style.rs
+++ b/src/egui_app/ui/style.rs
@@ -379,7 +379,7 @@ pub fn inner_border() -> Stroke {
 
 /// Background used when hovering list rows.
 pub fn row_hover_fill() -> Color32 {
-    with_alpha(palette().accent_ice, 66)
+    with_alpha(palette().accent_ice, 96)
 }
 
 /// Background used for the primary selected list row (last selected).


### PR DESCRIPTION
### Motivation
- Make hovered sample browser rows visually clearer by giving the hover background a slightly stronger tint so the hover effect is not limited to text highlighting.

### Description
- Increase the alpha used by `row_hover_fill()` from `66` to `96` in `src/egui_app/ui/style.rs` to brighten the hover background while keeping the same accent color.

### Testing
- Ran `CPAL_ASIO_DIR=/mnt/e/lib/asiosdk/ASIOSDK cargo check`, which exercised the build; it failed in this environment due to missing system ALSA pkg-config metadata (`alsa.pc` not found), so no full compile artifacts were verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aace66c97083298888f61b26529ba6)