### PR TITLE
Coalesce pending audio-load jobs so browser navigation remains instant

### DIFF
--- a/src/egui_app/controller/playback/audio_loader.rs
+++ b/src/egui_app/controller/playback/audio_loader.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Component, Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{Receiver, Sender},
+        mpsc::{Receiver, Sender, TryRecvError},
         Arc,
     },
     thread,
@@ -65,7 +65,11 @@ impl AudioLoaderHandle {
 /// Spawn the audio loader worker and return its job channel plus shutdown handle.
 pub(crate) fn spawn_audio_loader(
     renderer: WaveformRenderer,
-) -> (Sender<AudioLoadJob>, Receiver<AudioLoadResult>, AudioLoaderHandle) {
+) -> (
+    Sender<AudioLoadJob>,
+    Receiver<AudioLoadResult>,
+    AudioLoaderHandle,
+) {
     let (tx, rx) = std::sync::mpsc::channel::<AudioLoadJob>();
     let (result_tx, result_rx) = std::sync::mpsc::channel::<AudioLoadResult>();
     let shutdown = Arc::new(AtomicBool::new(false));
@@ -74,6 +78,7 @@ pub(crate) fn spawn_audio_loader(
         while !shutdown_worker.load(Ordering::Relaxed) {
             match rx.recv_timeout(AUDIO_LOADER_POLL_INTERVAL) {
                 Ok(job) => {
+                    let job = coalesce_latest_job(job, &rx);
                     let outcome = load_audio(&renderer, &job);
                     let _ = result_tx.send(AudioLoadResult {
                         request_id: job.request_id,
@@ -95,6 +100,17 @@ pub(crate) fn spawn_audio_loader(
             join_handle: Some(handle),
         },
     )
+}
+
+fn coalesce_latest_job(mut job: AudioLoadJob, rx: &Receiver<AudioLoadJob>) -> AudioLoadJob {
+    loop {
+        match rx.try_recv() {
+            Ok(next) => {
+                job = next;
+            }
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => return job,
+        }
+    }
 }
 
 fn load_audio(
@@ -212,7 +228,8 @@ fn ensure_safe_relative_path(path: &Path) -> Result<(), AudioLoadError> {
 
 #[cfg(test)]
 mod tests {
-    use super::ensure_safe_relative_path;
+    use super::{coalesce_latest_job, ensure_safe_relative_path, AudioLoadJob};
+    use crate::source::SourceId;
     use std::path::Path;
 
     #[test]
@@ -224,5 +241,28 @@ mod tests {
     #[test]
     fn ensure_safe_relative_path_accepts_normal_relative_paths() {
         ensure_safe_relative_path(Path::new("folder/./file.wav")).unwrap();
+    }
+
+    fn job(id: u64, relative_path: &str) -> AudioLoadJob {
+        AudioLoadJob {
+            request_id: id,
+            source_id: SourceId::from_string("source"),
+            root: Path::new("/tmp").to_path_buf(),
+            relative_path: Path::new(relative_path).to_path_buf(),
+            stretch_ratio: None,
+        }
+    }
+
+    #[test]
+    fn coalesce_latest_job_keeps_most_recent_request() {
+        let (tx, rx) = std::sync::mpsc::channel::<AudioLoadJob>();
+        let first = job(1, "first.wav");
+        tx.send(job(2, "second.wav")).unwrap();
+        tx.send(job(3, "third.wav")).unwrap();
+
+        let coalesced = coalesce_latest_job(first, &rx);
+
+        assert_eq!(coalesced.request_id, 3);
+        assert_eq!(coalesced.relative_path, Path::new("third.wav"));
     }
 }


### PR DESCRIPTION
### Motivation

- Selecting samples in the browser can stall when background decoding works through every queued load; navigation should stay instant and not be blocked by stale decodes.

### Description

- Drain any queued `AudioLoadJob`s in the audio loader worker and keep only the most recent job before decoding by adding `coalesce_latest_job` and using `rx.try_recv()` to pick the latest pending request. 
- Import `TryRecvError` and update `spawn_audio_loader` to call `coalesce_latest_job(job, &rx)` so background decoding always targets the newest selection.
- Add a focused unit test `coalesce_latest_job_keeps_most_recent_request` to verify the coalescing behavior and small test scaffolding for `AudioLoadJob` construction.

### Testing

- Ran `rustfmt src/egui_app/controller/playback/audio_loader.rs` successfully on the modified file.
- Attempted `cargo test` (targeting the crate tests) but the run failed to complete due to the environment missing the system ALSA development package (`alsa.pc`), causing `alsa-sys` build to fail; the new unit test is present and exercised where the build environment allows.
- Ran `cargo fmt --all`, which failed in this workspace due to unrelated pre-existing trailing-whitespace in `src/egui_app/ui/waveform_view/controls.rs` rather than issues introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aacdd340848329a604a4479aa4e4b5)