### PR TITLE
Enable sample search input focus and select-all behavior

### DIFF
--- a/src/egui_app/ui/sample_browser_filter.rs
+++ b/src/egui_app/ui/sample_browser_filter.rs
@@ -92,14 +92,26 @@ impl EguiApp {
                 "Search samples ({})...",
                 hotkeys::format_keypress(&hotkeys::KeyPress::with_command(egui::Key::F))
             );
-            let response = ui.add(
-                egui::TextEdit::singleline(&mut query)
-                    .hint_text(search_hint)
-                    .desired_width(160.0),
-            );
+            let search_edit = egui::TextEdit::singleline(&mut query)
+                .hint_text(search_hint)
+                .desired_width(160.0);
+            let search_output = search_edit.show(ui);
+            let response = search_output.response;
+            let mut select_all = response.gained_focus();
             if self.controller.ui.browser.search_focus_requested {
-                response.request_focus();
-                self.controller.ui.browser.search_focus_requested = false;
+                if response.has_focus() {
+                    select_all = true;
+                    self.controller.ui.browser.search_focus_requested = false;
+                } else {
+                    response.request_focus();
+                }
+            }
+            if select_all {
+                let mut state = search_output.state;
+                state.cursor.set_char_range(Some(egui::text::CCursorRange::select_all(
+                    &search_output.galley,
+                )));
+                state.store(ui.ctx(), response.id);
             }
             if response.changed() {
                 self.controller.set_browser_search(query);


### PR DESCRIPTION
### Motivation
- Make the sample browser search box usable: clicking or pressing `Ctrl+F` should focus the input and allow immediate typing with fuzzy filtering applied. 
- When re-focusing the input (via hotkey or click/tab) the existing query should be selected so the user can quickly replace it.

### Description
- Updated `src/egui_app/ui/sample_browser_filter.rs` to call `TextEdit::show` and use the returned widget `state` and `response` so cursor/focus can be controlled directly. 
- Implemented auto-select-all when the search box `gained_focus()` or when `search_focus_requested` is honored, by setting `state.cursor.set_char_range(Some(egui::text::CCursorRange::select_all(...)))` and storing the state. 
- Preserved existing behavior that calls `controller.set_browser_search(query)` on text changes so fuzzy filtering remains unchanged. 
- No changes to hotkey mapping were made; `Ctrl/Cmd+F` already routes to `search_focus_requested` and now results in the select-all behavior when focus is granted.

### Testing
- Ran `cargo test --package sempal hotkey_search_browser_requests_focus -- --nocapture`, which failed to build in this environment due to a missing system library (`alsa.pc`) required by `alsa-sys` (external dependency issue). 
- Ran `rustfmt src/egui_app/ui/sample_browser_filter.rs`, which succeeded; running `cargo fmt --all` failed due to unrelated trailing-whitespace issues in other files in the repo. 
- The change is localized to the search input rendering and preserves existing fuzzy search wiring; unit tests that assert `search_focus_requested` behaviour already exist and remain applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aacf8736008329a23a6dac4c4095f3)