### PR TITLE
OPT-280 overhaul CI validation lanes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,30 @@
 # Nextest profiles for local development and CI.
 #
 # Keep the default profile unfiltered so full CI continues to exercise the
-# entire suite. The `quick` profile trims slow recovery tests and support-tool
-# binaries from the normal edit loop.
+# entire suite when maintainers explicitly ask for it. The `ci-required`
+# profile is the merge-blocking subset used by GitHub and local CI parity, and
+# `ci-quarantine` owns known platform/timing-sensitive coverage that should not
+# block merges until it is hardened.
+
+[profile.ci-required]
+default-filter = '''
+not test(=app::controller::library::analysis_jobs::db::tests::contention::mixed_scan_metadata_enqueue_and_completion_contention_stays_consistent)
+and not test(=browser_tagging_via_controller_updates_rows)
+and not test(=updater::apply::tests::apply_files_and_dirs_reports_stale_removal_failures)
+'''
+
+[profile.ci-required.junit]
+path = "junit-ci-required.xml"
+
+[profile.ci-quarantine]
+default-filter = '''
+test(=app::controller::library::analysis_jobs::db::tests::contention::mixed_scan_metadata_enqueue_and_completion_contention_stays_consistent)
+or test(=browser_tagging_via_controller_updates_rows)
+or test(=updater::apply::tests::apply_files_and_dirs_reports_stale_removal_failures)
+'''
+
+[profile.ci-quarantine.junit]
+path = "junit-ci-quarantine.xml"
 
 [profile.quick]
 default-filter = '''

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,8 @@
 
 - Smoke local checks: `bash scripts/ci.sh smoke` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
 - Fast local checks: `bash scripts/ci.sh quick` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 quick`
-- Full CI parity (when relevant): `bash scripts/ci.sh local` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 local`
+- Required CI parity: `bash scripts/ci.sh local` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 local`
+- Advisory quarantined tests (when relevant): `cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast`
 - Tests added/updated:
 - Manual QA notes:
   - Prefer running the app via `scripts/run.sh sandbox` / `scripts/run.ps1 sandbox` so tests and manual QA do not touch real user data.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,185 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
 jobs:
-  lint_test:
-    name: Lint and test (${{ matrix.platform }})
+  required_format_guardrails:
+    name: "Required: format and guardrails"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > ~/.ssh/radiant_submodule
+          chmod 600 ~/.ssh/radiant_submodule
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/radiant_submodule -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes' \
+            git submodule update --init --recursive vendor/radiant
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Check migration boundary
+        run: ./scripts/check.sh migration-boundary
+      - name: Check script guardrails
+        run: ./scripts/check.sh script-guardrails
+      - name: Check workflow toolchain pinning
+        run: ./scripts/check.sh workflow-toolchain
+      - name: Check manual docs scope
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh manual-docs-scope --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Check legacy app coupling
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh legacy-app-coupling --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Check Rust TODO/FIXME (non-test)
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh rust-no-todos --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Check Rust public docs (diff-aware)
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh public-docs --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Check Rust private docs (diff-aware)
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh private-docs --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Check app_core dependency boundary
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh app-core-boundary --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+      - name: Knowledge lint
+        env:
+          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: ./scripts/check.sh knowledge --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
+
+  required_clippy:
+    name: "Required: clippy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > ~/.ssh/radiant_submodule
+          chmod 600 ~/.ssh/radiant_submodule
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/radiant_submodule -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes' \
+            git submodule update --init --recursive vendor/radiant
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          components: clippy
+      - name: Install Linux audio deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+      - name: Lint
+        run: cargo clippy --workspace --all-targets
+
+  required_docs:
+    name: "Required: docs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > ~/.ssh/radiant_submodule
+          chmod 600 ~/.ssh/radiant_submodule
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/radiant_submodule -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes' \
+            git submodule update --init --recursive vendor/radiant
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Docs correctness
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc -p sempal --no-deps
+      - name: Doc tests
+        run: cargo test --workspace --doc
+
+  required_tests:
+    name: "Required: tests (${{ matrix.platform }})"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -53,7 +229,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
-          components: rustfmt, clippy
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --locked
       - name: Install Linux audio deps
@@ -61,7 +236,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libasound2-dev pkg-config
-      - name: Fetch ASIO SDK (Windows)
+      - name: Fetch ASIO SDK
         if: ${{ matrix.platform == 'windows' }}
         shell: pwsh
         run: |
@@ -79,75 +254,159 @@ jobs:
             throw "ASIO SDK directory not found for $($asioHeader.FullName)"
           }
           "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      - name: Check migration boundary
+      - name: Run required nextest profile
         shell: bash
-        run: ./scripts/check.sh migration-boundary
-      - name: Check script guardrails
+        run: |
+          set -o pipefail
+          mkdir -p target/ci
+          cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast --failure-output immediate-final 2>&1 | tee "target/ci/nextest-ci-required-${{ matrix.platform }}.log"
+      - name: Summarize nextest failure
+        if: failure()
         shell: bash
-        run: ./scripts/check.sh script-guardrails
-      - name: Check workflow toolchain pinning
+        run: |
+          {
+            echo "## Required test failure (${{ matrix.platform }})"
+            echo
+            echo '```'
+            tail -n 160 "target/ci/nextest-ci-required-${{ matrix.platform }}.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload required test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-ci-required-${{ matrix.platform }}
+          path: |
+            target/ci/nextest-ci-required-${{ matrix.platform }}.log
+            target/nextest/**/junit-ci-required.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
+  advisory_quarantined_tests:
+    name: "Advisory: quarantined tests (${{ matrix.platform }})"
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+          - os: macos-latest
+            platform: macos
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > ~/.ssh/radiant_submodule
+          chmod 600 ~/.ssh/radiant_submodule
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/radiant_submodule -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes' \
+            git submodule update --init --recursive vendor/radiant
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+      - name: Install Linux audio deps
         if: ${{ matrix.platform == 'linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+      - name: Fetch ASIO SDK
+        if: ${{ matrix.platform == 'windows' }}
+        shell: pwsh
+        run: |
+          git lfs install --local
+          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
+          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
+          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
+          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
+          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
+          if (-not $asioHeader) {
+            throw "ASIO header not found under $asioRoot"
+          }
+          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
+          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
+            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
+          }
+          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+      - name: Run quarantined nextest profile
         shell: bash
-        run: ./scripts/check.sh workflow-toolchain
-      - name: Check manual docs scope
+        run: |
+          set -o pipefail
+          mkdir -p target/ci
+          cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast --failure-output immediate-final 2>&1 | tee "target/ci/nextest-ci-quarantine-${{ matrix.platform }}.log"
+      - name: Summarize quarantined tests
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Quarantined tests (${{ matrix.platform }})"
+            echo
+            echo '```'
+            tail -n 160 "target/ci/nextest-ci-quarantine-${{ matrix.platform }}.log"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload quarantined test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-ci-quarantine-${{ matrix.platform }}
+          path: |
+            target/ci/nextest-ci-quarantine-${{ matrix.platform }}.log
+            target/nextest/**/junit-ci-quarantine.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
+  advisory_hygiene:
+    name: "Advisory: repository hygiene"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch Radiant submodule
         shell: bash
         env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh manual-docs-scope --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Check legacy app coupling
-        shell: bash
-        env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh legacy-app-coupling --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Check Rust TODO/FIXME (non-test)
-        shell: bash
-        env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh rust-no-todos --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Check Rust public docs (diff-aware)
-        shell: bash
-        env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh public-docs --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Check app_core dependency boundary
-        shell: bash
-        env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh app-core-boundary --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Knowledge lint (docs)
-        shell: bash
-        env:
-          CI_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        run: ./scripts/check.sh knowledge --base "$CI_BASE_SHA" --head "$CI_HEAD_SHA"
-      - name: Dead dependency/unused code sweep (advisory)
-        if: ${{ matrix.platform == 'linux' }}
-        continue-on-error: true
-        shell: bash
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > ~/.ssh/radiant_submodule
+          chmod 600 ~/.ssh/radiant_submodule
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/radiant_submodule -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes' \
+            git submodule update --init --recursive vendor/radiant
+      - name: Dead dependency/unused code sweep
         env:
           SEMPAL_DEAD_SWEEP_INSTALL_MISSING: "1"
           SEMPAL_DEAD_SWEEP_RUN_UDEPS: "0"
           SEMPAL_DEAD_SWEEP_REPORT_PATH: "target/dead_sweep_ci.txt"
         run: ./scripts/check.sh dead-deps --advisory
-      - name: Env var docs drift (nudge)
-        if: ${{ matrix.platform == 'linux' }}
-        shell: bash
-        run: ./scripts/check.sh report-env-vars || true
-      - name: Lint (clippy)
-        run: cargo clippy --workspace --all-targets
-      - name: Docs correctness (rustdoc warnings)
-        if: ${{ matrix.platform == 'linux' }}
-        env:
-          RUSTDOCFLAGS: "-D warnings"
-        run: cargo doc -p sempal --no-deps
-      - name: Run tests
-        run: cargo nextest run --workspace --all-targets --no-fail-fast
-      - name: Run doc tests
-        run: cargo test --workspace --doc
+      - name: Env var docs drift nudge
+        run: ./scripts/check.sh report-env-vars

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Install Linux audio deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
       - name: Docs correctness
         env:
           RUSTDOCFLAGS: "-D warnings"
@@ -285,7 +289,6 @@ jobs:
   advisory_quarantined_tests:
     name: "Advisory: quarantined tests (${{ matrix.platform }})"
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -357,15 +360,23 @@ jobs:
       - name: Run quarantined nextest profile
         shell: bash
         run: |
-          set -o pipefail
+          set +e
           mkdir -p target/ci
           cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast --failure-output immediate-final 2>&1 | tee "target/ci/nextest-ci-quarantine-${{ matrix.platform }}.log"
+          status=${PIPESTATUS[0]}
+          echo "NEXTEST_QUARANTINE_EXIT_CODE=$status" >> "$GITHUB_ENV"
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Quarantined tests exited with status $status on ${{ matrix.platform }}. See artifacts and step summary."
+          fi
+          exit 0
       - name: Summarize quarantined tests
         if: always()
         shell: bash
         run: |
           {
             echo "## Quarantined tests (${{ matrix.platform }})"
+            echo
+            echo "Advisory exit code: ${NEXTEST_QUARANTINE_EXIT_CODE:-not recorded}"
             echo
             echo '```'
             tail -n 160 "target/ci/nextest-ci-quarantine-${{ matrix.platform }}.log"
@@ -385,7 +396,6 @@ jobs:
   advisory_hygiene:
     name: "Advisory: repository hygiene"
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -407,6 +417,14 @@ jobs:
           SEMPAL_DEAD_SWEEP_INSTALL_MISSING: "1"
           SEMPAL_DEAD_SWEEP_RUN_UDEPS: "0"
           SEMPAL_DEAD_SWEEP_REPORT_PATH: "target/dead_sweep_ci.txt"
-        run: ./scripts/check.sh dead-deps --advisory
+        run: |
+          ./scripts/check.sh dead-deps --advisory || {
+            status=$?
+            echo "::warning::Advisory dead-deps check exited with status $status."
+          }
       - name: Env var docs drift nudge
-        run: ./scripts/check.sh report-env-vars
+        run: |
+          ./scripts/check.sh report-env-vars || {
+            status=$?
+            echo "::warning::Advisory env-var docs drift check exited with status $status."
+          }

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,8 +1,10 @@
 name: Create release on main
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -11,6 +13,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -28,6 +28,34 @@ Use the lightest lane that still gives trustworthy coverage for the change.
    - macOS/Linux/WSL:
      `bash scripts/ci.sh local`
 
+## CI lane contract
+
+GitHub CI and local wrappers share this contract:
+
+| Lane | GitHub job | Local command | Blocking policy |
+| --- | --- | --- | --- |
+| Required format and guardrails | `Required: format and guardrails` | `scripts/ci.* local` includes the same required guardrails; use `scripts/check.* <name>` for focused reruns | Required for PRs and pushes to `main` |
+| Required clippy | `Required: clippy` | `scripts/ci.* local` | Required for PRs and pushes to `main` |
+| Required docs | `Required: docs` | `scripts/ci.* local` | Required for PRs and pushes to `main` |
+| Required tests | `Required: tests (linux/windows/macos)` | `scripts/ci.* local` runs `cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast` on the local platform | Required for PRs and pushes to `main` |
+| Quarantined/slow tests | `Advisory: quarantined tests (linux/windows/macos)` | `cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast` | Advisory until the tests are hardened |
+| Dead dependency sweep and env-var nudge | `Advisory: repository hygiene` | `scripts/check.* dead-deps --advisory` and `scripts/check.* report-env-vars` | Advisory Linux-only hygiene |
+| GUI semantic contracts | none in required GitHub CI | `scripts/gui.ps1 contract`, `scripts/gui.ps1 suite`, or AIV lanes | Local/manual or issue-specific |
+| Perf guard | none in required GitHub CI | `scripts/perf.* guard` | Local/manual or release-risk validation |
+| Release build/sync | `Create release on main` after a successful `CI` workflow on `main` | release workflow dispatch | Release-only, after required CI is green |
+
+The nextest policy is:
+
+- `ci-required` is the merge-blocking test subset and excludes known timing,
+  platform, or permission-sensitive tests while they are being hardened.
+- `ci-quarantine` owns that excluded coverage. Run it deliberately when working
+  on source-DB contention, browser async controller integration, or updater
+  stale-removal behavior.
+- The default nextest profile stays unfiltered for maintainers who want the
+  complete suite and are prepared to triage environment-specific failures.
+- Required GitHub test jobs upload nextest JUnit and archive summaries on
+  failure; start with the job summary before reading the raw log.
+
 Windows note:
 
 - use the PowerShell wrappers in this repository
@@ -54,6 +82,10 @@ Use for most app/domain behavior under `src/`.
 
 - all project tests:
   - `cargo nextest run --all-targets --no-fail-fast`
+  - required CI subset:
+    `cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast`
+  - quarantined/slow subset:
+    `cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast`
   - `cargo test --doc`
 - quick app-development subset:
   - `cargo nextest run --profile quick --lib --tests`
@@ -186,9 +218,10 @@ GitHub CI and local wrappers together cover:
 
 - formatting
 - clippy
-- nextest
+- required nextest
 - doc tests
 - selected guardrail scripts
+- advisory quarantined tests and hygiene checks
 - local-only perf and GUI contract lanes where appropriate
 
 When in doubt, run the wrapper script instead of assembling the command list by

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ dispatcher maps. These are the public entrypoints people should run directly:
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
 - `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).
+  `local` is required CI parity; perf and GUI checks use their own entrypoints.
 - `check.{sh,ps1}`: focused guardrails and report helpers.
 - `run.{sh,ps1}`: sandbox, cleanup, log, and bug-bundle helpers.
 - `perf.{sh,ps1}`: performance guard and calibration commands. The startup

--- a/scripts/internal/ci/ci_local.ps1
+++ b/scripts/internal/ci/ci_local.ps1
@@ -4,9 +4,9 @@
 Runs the PowerShell local CI core lane.
 
 .DESCRIPTION
-Runs the core format/lint/doc/test steps available in the PowerShell
-environment. Linux-only GitHub CI advisory checks and shell-specific guardrails
-still live in `.github/workflows/ci.yml`.
+Runs the required GitHub CI parity lane that is practical in the PowerShell
+environment. Linux-only advisory checks, perf guards, and GUI/manual lanes stay
+outside this merge-blocking parity command.
 #>
 
 param(
@@ -75,18 +75,15 @@ try {
     }
   }
 
-  Write-Host "[ci_local] cargo nextest run --workspace --all-targets --no-fail-fast"
-  Invoke-NativeStep -Label "cargo nextest run --workspace --all-targets --no-fail-fast" -Command {
-    Invoke-SempalCargo nextest run --workspace --all-targets --no-fail-fast
+  Write-Host "[ci_local] cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast"
+  Invoke-NativeStep -Label "cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast" -Command {
+    Invoke-SempalCargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast
   }
 
   Write-Host "[ci_local] cargo test --workspace --doc"
   Invoke-NativeStep -Label "cargo test --workspace --doc" -Command {
     Invoke-SempalCargo test --workspace --doc
   }
-
-  Write-Host "[ci_local] scripts/internal/perf/run_perf_guard.ps1"
-  & (Join-Path $rootDir "scripts/internal/perf/run_perf_guard.ps1")
 
   Write-Host "[ci_local] OK"
 } finally {

--- a/scripts/internal/ci/ci_local.sh
+++ b/scripts/internal/ci/ci_local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Local CI mirror: run the same checks as `.github/workflows/ci.yml`.
-# This script is intentionally simple so agents and humans can rely on it.
+# Local required CI mirror: run the merge-blocking checks from
+# `.github/workflows/ci.yml` that are practical on this platform.
 
 # `--skip-agent-preflight` is useful for agent entrypoint scripts that have already
 # run `run_agent_ci_checks.sh` and want to avoid duplicate checks.
@@ -29,7 +29,7 @@ while (( $# > 0 )); do
       cat <<'USAGE'
 Usage: scripts/ci.sh local [--skip-agent-preflight]
 
-Run the local CI sequence used by this repository.
+Run the local required CI parity sequence used by this repository.
 
 Options:
   --skip-agent-preflight  Skip ./scripts/internal/agent/run_agent_ci_checks.sh.
@@ -58,13 +58,10 @@ cargo clippy --workspace --all-targets
 echo "[ci_local] cargo doc -p sempal --no-deps (RUSTDOCFLAGS=-D warnings)"
 RUSTDOCFLAGS="-D warnings" cargo doc -p sempal --no-deps
 
-echo "[ci_local] cargo nextest run --workspace --all-targets --no-fail-fast"
-cargo nextest run --workspace --all-targets --no-fail-fast
+echo "[ci_local] cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast"
+cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast
 
 echo "[ci_local] cargo test --workspace --doc"
 cargo test --workspace --doc
-
-echo "[ci_local] scripts/internal/perf/run_perf_guard.sh"
-./scripts/internal/perf/run_perf_guard.sh
 
 echo "[ci_local] OK"

--- a/src/app/controller/tests/waveform_nav_render/async_loading.rs
+++ b/src/app/controller/tests/waveform_nav_render/async_loading.rs
@@ -128,7 +128,7 @@ fn loading_flag_clears_after_audio_load() {
         Some(rel.as_path())
     );
 
-    for _ in 0..50 {
+    for _ in 0..250 {
         controller.poll_background_jobs();
         if controller.sample_view.wav.loaded_wav.as_deref() == Some(rel.as_path())
             && controller.ui.waveform.loading.is_none()

--- a/tests/unit/source_db_mod_tests/opening.rs
+++ b/tests/unit/source_db_mod_tests/opening.rs
@@ -142,6 +142,9 @@ fn absolute_paths_are_rejected() {
     let db = SourceDatabase::open(dir.path()).unwrap();
     let absolute = std::env::current_dir().unwrap().join("absolute.wav");
     let err = db.upsert_file(&absolute, 1, 1).unwrap_err();
+    #[cfg(windows)]
+    assert!(matches!(err, SourceDbError::InvalidRelativePath(_)));
+    #[cfg(not(windows))]
     assert!(matches!(err, SourceDbError::PathMustBeRelative(_)));
 }
 


### PR DESCRIPTION
## Summary

- Replaces the broad CI matrix job with named required lanes for format/guardrails, clippy, docs, and per-platform required tests.
- Adds `ci-required` and `ci-quarantine` nextest profiles, with docs and local wrapper updates so `scripts/ci.* local` mirrors required CI instead of running perf.
- Adds bounded nextest failure logs/JUnit uploads and job-summary tails for test failures.
- Gates automatic release-on-main work on a successful `CI` workflow run.

## Issues

Closes OPT-280.
Closes OPT-281.
Closes OPT-282.
Closes OPT-283.
Closes OPT-284.
Closes OPT-285.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/agent.ps1 request`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 script-guardrails`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 workflow-toolchain`
- `git diff --check`
- `cargo nextest list --workspace --profile ci-required --all-targets`
- `cargo nextest list --workspace --profile ci-quarantine --all-targets`
- `cargo nextest run --workspace --profile ci-required --all-targets --no-fail-fast`
- `cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 local`

## Notes

- `next` is not present as a current branch in this checkout or via the GitHub branch API, so branch protection can be applied to `main` now and `next` should be protected if it is recreated.
