### PR TITLE
Implement OPT-344 sidebar tag chip editor

### DIFF
--- a/src/app/controller/library/wavs/browser_facade.rs
+++ b/src/app/controller/library/wavs/browser_facade.rs
@@ -405,7 +405,7 @@ impl AppController {
     /// Apply the current tag input draft to focused/selected browser rows.
     pub(crate) fn commit_browser_tag_sidebar_input(&mut self) -> Result<(), String> {
         let value = self.ui.browser.tag_sidebar_input.clone();
-        self.apply_browser_tag_sidebar_normal_tag(&value)?;
+        self.apply_browser_tag_sidebar_normal_tag_tokens(&value)?;
         self.ui.browser.tag_sidebar_input.clear();
         Ok(())
     }
@@ -448,12 +448,35 @@ impl AppController {
         &mut self,
         label: &str,
     ) -> Result<(), String> {
+        self.apply_browser_tag_sidebar_normal_tag_tokens(label)
+    }
+
+    /// Assign one or more comma-delimited normal tags to the focused/selected browser rows.
+    pub(crate) fn apply_browser_tag_sidebar_normal_tag_tokens(
+        &mut self,
+        input: &str,
+    ) -> Result<(), String> {
         let Some(source) = self.current_source() else {
             return Err(String::from("No source selected"));
         };
-        let resolved_label = self.resolve_browser_normal_tag_label(&source, label)?;
+        let tokens = browser_tag_sidebar_tokens(input);
+        if tokens.is_empty() {
+            return Ok(());
+        }
+        let mut resolved_labels = Vec::<String>::new();
+        for token in tokens {
+            let resolved_label = self.resolve_browser_normal_tag_label(&source, &token)?;
+            if !resolved_labels
+                .iter()
+                .any(|label| label.eq_ignore_ascii_case(&resolved_label))
+            {
+                resolved_labels.push(resolved_label);
+            }
+        }
         let target_paths = self.browser_tag_sidebar_target_paths();
-        self.set_normal_tag_for_source_batch(&source, &target_paths, &resolved_label, true)?;
+        for resolved_label in resolved_labels {
+            self.set_normal_tag_for_source_batch(&source, &target_paths, &resolved_label, true)?;
+        }
         self.auto_rename_after_tag_sidebar_change(&target_paths)?;
         Ok(())
     }
@@ -502,4 +525,12 @@ impl AppController {
         self.browser()
             .auto_rename_browser_sample_paths_action(target_paths)
     }
+}
+
+fn browser_tag_sidebar_tokens(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(|token| token.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|token| !token.is_empty())
+        .collect()
 }

--- a/src/app/controller/tests/browser_core/tagging.rs
+++ b/src/app/controller/tests/browser_core/tagging.rs
@@ -218,6 +218,55 @@ fn browser_tag_sidebar_typed_input_creates_reusable_normal_tag() {
 }
 
 #[test]
+fn browser_tag_sidebar_typed_input_commits_ordered_comma_tokens_idempotently() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("one.wav", crate::sample_sources::Rating::NEUTRAL),
+        sample_entry("two.wav", crate::sample_sources::Rating::NEUTRAL),
+    ]);
+    controller
+        .database_for(&source)
+        .unwrap()
+        .assign_tag_to_path(Path::new("one.wav"), "Deep Kick")
+        .unwrap();
+    controller.focus_browser_row_only(1);
+    controller.set_browser_tag_sidebar_input(String::from(" kick, hard, one shot, kick,,  "));
+
+    controller
+        .commit_browser_tag_sidebar_input()
+        .expect("comma-delimited tags should commit");
+
+    let tags = controller
+        .database_for(&source)
+        .unwrap()
+        .tags_for_path(Path::new("two.wav"))
+        .unwrap();
+    assert_eq!(tag_labels(tags), vec!["Deep Kick", "hard", "one shot"]);
+    assert_eq!(controller.ui.browser.tag_sidebar_input, "");
+}
+
+#[test]
+fn browser_tag_sidebar_multi_selection_commits_full_comma_token_set() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("one.wav", crate::sample_sources::Rating::NEUTRAL),
+        sample_entry("two.wav", crate::sample_sources::Rating::NEUTRAL),
+    ]);
+    controller.set_browser_selected_paths(vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")]);
+    controller.set_browser_tag_sidebar_input(String::from("kick, hard"));
+
+    controller
+        .commit_browser_tag_sidebar_input()
+        .expect("multi-selection should receive every token");
+
+    let db = controller.database_for(&source).unwrap();
+    let mut first_labels = tag_labels(db.tags_for_path(Path::new("one.wav")).unwrap());
+    first_labels.sort();
+    let mut second_labels = tag_labels(db.tags_for_path(Path::new("two.wav")).unwrap());
+    second_labels.sort();
+    assert_eq!(first_labels, vec!["hard", "kick"]);
+    assert_eq!(second_labels, vec!["hard", "kick"]);
+}
+
+#[test]
 fn browser_tag_sidebar_multi_selection_tracks_mixed_and_removes_normal_tags() {
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", crate::sample_sources::Rating::NEUTRAL),

--- a/src/app_core/controller/tests/dispatch/tag_sidebar.rs
+++ b/src/app_core/controller/tests/dispatch/tag_sidebar.rs
@@ -57,6 +57,28 @@ fn apply_native_commit_browser_tag_sidebar_input_creates_normal_tag() {
     assert_eq!(controller.ui.browser.tag_sidebar_input, "");
 }
 
+#[test]
+fn apply_native_commit_browser_tag_sidebar_input_tokenizes_comma_separated_tags() {
+    let (mut controller, source) = controller_with_source_entries(vec![wav_entry("one.wav")]);
+    controller.focus_browser_row_only(0);
+    controller.apply_native_ui_action(NativeUiAction::SetBrowserTagSidebarInput {
+        value: String::from("kick, hard, one shot"),
+    });
+
+    controller.apply_native_ui_action(NativeUiAction::CommitBrowserTagSidebarInput);
+
+    let mut labels = tag_labels(
+        controller
+            .database_for(&source)
+            .unwrap()
+            .tags_for_path(Path::new("one.wav"))
+            .unwrap(),
+    );
+    labels.sort();
+    assert_eq!(labels, vec!["hard", "kick", "one shot"]);
+    assert_eq!(controller.ui.browser.tag_sidebar_input, "");
+}
+
 fn controller_with_source_entries(
     entries: Vec<WavEntry>,
 ) -> (AppController, crate::sample_sources::SampleSource) {

--- a/src/app_core/native_shell/browser_projection/panel.rs
+++ b/src/app_core/native_shell/browser_projection/panel.rs
@@ -190,11 +190,18 @@ pub(crate) fn project_browser_tag_sidebar_model(
             bool_tag_state(&target_entries, |entry| !entry.looped),
         ),
     ];
-    let (option_pills, create_pill) = if let Some(source) = controller.current_source() {
+    let (accepted_pills, option_pills, create_pill) = if let Some(source) =
+        controller.current_source()
+    {
         let target_paths = sidebar_targets.resolve_paths(controller);
-        project_normal_tag_candidates(controller, &source, &target_paths).unwrap_or_default()
+        let accepted_pills =
+            project_accepted_normal_tags(controller, &source, &target_paths, &target_entries)
+                .unwrap_or_else(|_| project_accepted_normal_tags_from_entries(&target_entries));
+        let (option_pills, create_pill) =
+            project_normal_tag_candidates(controller, &source, &target_paths).unwrap_or_default();
+        (accepted_pills, option_pills, create_pill)
     } else {
-        (Vec::new(), None)
+        (Vec::new(), Vec::new(), None)
     };
     BrowserTagSidebarModel {
         // The tag editor is now rendered in the left library sidebar. Keep the
@@ -206,7 +213,11 @@ pub(crate) fn project_browser_tag_sidebar_model(
         primary_action_enabled: controller.ui.browser.tag_sidebar_auto_rename,
         input_value: controller.ui.browser.tag_sidebar_input.clone(),
         input_placeholder: String::from("Add tag"),
+        input_focused: false,
+        input_caret: controller.ui.browser.tag_sidebar_input.chars().count(),
+        input_selection: None,
         exclusive_pills,
+        accepted_pills,
         option_pills,
         create_pill,
     }
@@ -230,6 +241,83 @@ fn bool_tag_state(entries: &[WavEntry], predicate: impl Fn(&WavEntry) -> bool) -
         count if count == entries.len() => BrowserTagState::On,
         _ => BrowserTagState::Mixed,
     }
+}
+
+fn project_accepted_normal_tags(
+    controller: &mut AppController,
+    source: &crate::sample_sources::SampleSource,
+    paths: &[std::path::PathBuf],
+    fallback_entries: &[WavEntry],
+) -> Result<Vec<BrowserTagPillModel>, String> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let labels_by_path = {
+        let db = controller
+            .database_for(source)
+            .map_err(|err| err.to_string())?;
+        paths
+            .iter()
+            .map(|path| db.tag_labels_for_path(path).map_err(|err| err.to_string()))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    if labels_by_path.iter().all(Vec::is_empty) && !fallback_entries.is_empty() {
+        return Ok(project_accepted_normal_tags_from_entries(fallback_entries));
+    }
+    Ok(project_accepted_normal_tags_from_label_sets(
+        &labels_by_path,
+    ))
+}
+
+fn project_accepted_normal_tags_from_entries(entries: &[WavEntry]) -> Vec<BrowserTagPillModel> {
+    if entries.is_empty() {
+        return Vec::new();
+    }
+    let label_sets = entries
+        .iter()
+        .map(|entry| entry.normal_tags.clone())
+        .collect::<Vec<_>>();
+    project_accepted_normal_tags_from_label_sets(&label_sets)
+}
+
+fn project_accepted_normal_tags_from_label_sets(
+    label_sets: &[Vec<String>],
+) -> Vec<BrowserTagPillModel> {
+    if label_sets.is_empty() {
+        return Vec::new();
+    }
+    let mut counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut order = Vec::<String>::new();
+    for labels in label_sets {
+        for label in labels {
+            let normalized = display_tag_input(label);
+            if normalized.is_empty() {
+                continue;
+            }
+            let count = counts.entry(normalized.clone()).or_insert_with(|| {
+                order.push(normalized.clone());
+                0
+            });
+            *count += 1;
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|label| {
+            let count = counts.get(&label).copied().unwrap_or_default();
+            (count > 0).then(|| {
+                pill_model(
+                    &label,
+                    &label,
+                    if count == label_sets.len() {
+                        BrowserTagState::On
+                    } else {
+                        BrowserTagState::Mixed
+                    },
+                )
+            })
+        })
+        .collect()
 }
 
 fn project_normal_tag_candidates(

--- a/src/app_core/native_shell/composition/state/automation/sidebar.rs
+++ b/src/app_core/native_shell/composition/state/automation/sidebar.rs
@@ -117,6 +117,24 @@ fn tags_group(rect: Rect, model: &AppModel) -> AutomationNodeSnapshot {
     ));
     children.extend(
         sidebar
+            .accepted_pills
+            .iter()
+            .enumerate()
+            .map(|(index, pill)| AutomationNodeSnapshot {
+                id: node_id(format!("sources.tags.accepted.{index}.{}", slug(&pill.id))),
+                role: AutomationRole::Button,
+                label: Some(pill.label.clone()),
+                bounds: bounds(rect),
+                value: Some(format!("{:?}", pill.state)),
+                enabled: true,
+                selected: true,
+                available_actions: vec![String::from("toggle_browser_pill_option")],
+                metadata: metadata(&[("pill_id", pill.id.as_str()), ("chip_kind", "accepted")]),
+                children: Vec::new(),
+            }),
+    );
+    children.extend(
+        sidebar
             .option_pills
             .iter()
             .enumerate()
@@ -153,6 +171,12 @@ fn tags_group(rect: Rect, model: &AppModel) -> AutomationNodeSnapshot {
         .map(|pill| pill.label.as_str())
         .collect::<Vec<_>>()
         .join("|");
+    let accepted_pill_labels = sidebar
+        .accepted_pills
+        .iter()
+        .map(|pill| pill.label.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
     AutomationNodeSnapshot {
         id: node_id("sources.tags"),
         role: AutomationRole::Group,
@@ -164,6 +188,7 @@ fn tags_group(rect: Rect, model: &AppModel) -> AutomationNodeSnapshot {
         available_actions: vec![String::from("focus_browser_pill_editor_input")],
         metadata: metadata(&[
             ("selected_count", &sidebar.selected_count.to_string()),
+            ("accepted_tag_labels", accepted_pill_labels.as_str()),
             ("normal_tag_labels", option_pill_labels.as_str()),
         ]),
         children,

--- a/src/app_core/native_shell/composition/state/frame_build/chrome/sidebar_parts/tags.rs
+++ b/src/app_core/native_shell/composition/state/frame_build/chrome/sidebar_parts/tags.rs
@@ -28,6 +28,7 @@ pub(super) fn render_sidebar_tags(
         ctx.style.border_emphasis,
         ctx.sizing.border_width,
     );
+    render_input_selection_and_caret(ctx, primitives, input);
     emit_text(
         text_runs,
         TextRun {
@@ -140,20 +141,25 @@ pub(in crate::app_core::native_shell::composition::state) fn sidebar_tag_pill_re
     let row_height = sizing.browser_row_height.max(18.0);
     let col_width = ((rect.width() - pad * 2.0 - gap) * 0.5).max(36.0);
     let mut out = Vec::new();
-    let mut pills: Vec<_> = model
-        .browser
-        .pill_editor()
-        .option_pills
-        .iter()
-        .filter(|pill| !matches!(pill.state, BrowserPillState::Off))
-        .collect();
+    let mut pills: Vec<_> = model.browser.pill_editor().accepted_pills.iter().collect();
+    if pills.is_empty() {
+        pills.extend(
+            model
+                .browser
+                .pill_editor()
+                .option_pills
+                .iter()
+                .filter(|pill| !matches!(pill.state, BrowserPillState::Off))
+                .take(4),
+        );
+    }
     if pills.is_empty() {
         pills.extend(model.browser.pill_editor().option_pills.iter().take(4));
     }
     if let Some(create) = model.browser.pill_editor().create_pill.as_ref() {
         pills.push(create);
     }
-    for (index, pill) in pills.into_iter().take(4).enumerate() {
+    for (index, pill) in pills.into_iter().take(12).enumerate() {
         let col = index % 2;
         let row = index / 2;
         let min_x = rect.min.x + pad + (col_width + gap) * col as f32;
@@ -170,6 +176,60 @@ pub(in crate::app_core::native_shell::composition::state) fn sidebar_tag_pill_re
         }
     }
     out
+}
+
+fn render_input_selection_and_caret(
+    ctx: &StaticFrameCtx<'_>,
+    primitives: &mut impl PrimitiveSink,
+    input: Rect,
+) {
+    let editor = ctx.model.browser.pill_editor();
+    if !editor.input_focused {
+        return;
+    }
+    let text_rect = sidebar_tag_input_text_rect(input, ctx.sizing);
+    let char_width = (ctx.sizing.font_meta * 0.56).max(1.0);
+    if let Some((start, end)) = normalized_selection(editor.input_selection) {
+        let min_x =
+            text_rect.min.x.min(text_rect.max.x).max(text_rect.min.x) + char_width * start as f32;
+        let max_x = text_rect.min.x + char_width * end as f32;
+        let selection = Rect::from_min_max(
+            Point::new(min_x.min(text_rect.max.x), text_rect.min.y),
+            Point::new(max_x.min(text_rect.max.x), text_rect.max.y),
+        );
+        if selection.width() > 0.5 {
+            emit_primitive(
+                primitives,
+                Primitive::Rect(FillRect {
+                    rect: selection,
+                    color: blend_color(ctx.style.accent_mint, ctx.style.surface_overlay, 0.45),
+                }),
+            );
+        }
+    }
+    let caret_index = editor.input_caret.min(editor.input_value.chars().count());
+    let caret_x = (text_rect.min.x + char_width * caret_index as f32)
+        .min(text_rect.max.x)
+        .max(text_rect.min.x);
+    let caret = Rect::from_min_max(
+        Point::new(caret_x, text_rect.min.y),
+        Point::new(
+            (caret_x + ctx.sizing.border_width.max(1.0)).min(text_rect.max.x),
+            text_rect.max.y,
+        ),
+    );
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: caret,
+            color: ctx.style.text_primary,
+        }),
+    );
+}
+
+fn normalized_selection(selection: Option<(usize, usize)>) -> Option<(usize, usize)> {
+    let (a, b) = selection?;
+    (a != b).then_some(if a < b { (a, b) } else { (b, a) })
 }
 
 /// Render the shared panel background for sidebar subsections.

--- a/src/app_core/native_shell/composition/state/hit_testing/chrome/source_controls.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/chrome/source_controls.rs
@@ -820,13 +820,18 @@ fn sidebar_tag_pill_rects(
     let input = sidebar_tag_input_rect(rect, sizing);
     let row_height = sizing.browser_row_height.max(18.0);
     let col_width = ((rect.width() - pad * 2.0 - gap) * 0.5).max(36.0);
-    let mut pills: Vec<_> = model
-        .browser
-        .pill_editor()
-        .option_pills
-        .iter()
-        .filter(|pill| !matches!(pill.state, BrowserPillState::Off))
-        .collect();
+    let mut pills: Vec<_> = model.browser.pill_editor().accepted_pills.iter().collect();
+    if pills.is_empty() {
+        pills.extend(
+            model
+                .browser
+                .pill_editor()
+                .option_pills
+                .iter()
+                .filter(|pill| !matches!(pill.state, BrowserPillState::Off))
+                .take(4),
+        );
+    }
     if pills.is_empty() {
         pills.extend(model.browser.pill_editor().option_pills.iter().take(4));
     }
@@ -835,7 +840,7 @@ fn sidebar_tag_pill_rects(
     }
     pills
         .into_iter()
-        .take(4)
+        .take(12)
         .enumerate()
         .filter_map(|(index, pill)| {
             let col = index % 2;

--- a/src/app_core/native_shell/tests/browser.rs
+++ b/src/app_core/native_shell/tests/browser.rs
@@ -296,6 +296,60 @@ fn browser_projection_sidebar_projects_mixed_normal_tag_state() {
     );
 }
 
+#[test]
+fn browser_projection_sidebar_projects_accepted_tags_separately_from_suggestions() {
+    let mut first = browser_projection_test_entry("first.wav");
+    first.normal_tags = vec![
+        String::from("Kick"),
+        String::from("Hard"),
+        String::from("One Shot"),
+        String::from("Texture"),
+        String::from("Bright"),
+        String::from("Long Tail"),
+    ];
+    let mut second = browser_projection_test_entry("second.wav");
+    second.normal_tags = vec![String::from("Kick")];
+    let (mut controller, source) = browser_projection_controller_with_source(vec![first, second]);
+    let db = controller.database_for(&source).unwrap();
+    for label in ["Kick", "Hard", "One Shot", "Texture", "Bright", "Long Tail"] {
+        db.assign_tag_to_path(std::path::Path::new("first.wav"), label)
+            .unwrap();
+    }
+    db.assign_tag_to_path(std::path::Path::new("second.wav"), "Kick")
+        .unwrap();
+    controller.ui.browser.tag_sidebar_open = true;
+    controller.ui.browser.selection.selected_paths = vec![
+        std::path::PathBuf::from("first.wav"),
+        std::path::PathBuf::from("second.wav"),
+    ];
+    controller.mark_browser_selected_paths_changed();
+    controller.ui.browser.tag_sidebar_input = String::from("zzzz");
+
+    let projected = project_browser_panel_frame_model(&mut controller);
+
+    let accepted = projected
+        .tag_sidebar
+        .accepted_pills
+        .iter()
+        .map(|pill| (pill.label.as_str(), pill.state))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        accepted,
+        vec![
+            ("Bright", BrowserTagState::Mixed),
+            ("Hard", BrowserTagState::Mixed),
+            ("Kick", BrowserTagState::On),
+            ("Long Tail", BrowserTagState::Mixed),
+            ("One Shot", BrowserTagState::Mixed),
+            ("Texture", BrowserTagState::Mixed),
+        ]
+    );
+    assert!(
+        projected.tag_sidebar.option_pills.is_empty(),
+        "accepted chips should not depend on the current suggestion filter"
+    );
+}
+
 /// Browser projection should expose manual viewport state for native scrollbar rendering.
 #[test]
 fn browser_projection_exposes_manual_viewport_state() {

--- a/src/gui_runtime/native_shell_runtime.rs
+++ b/src/gui_runtime/native_shell_runtime.rs
@@ -22,7 +22,8 @@ use crate::gui::{
     types::{Point, Rect, Vector2},
 };
 use radiant::gui::{
-    focus::FocusSurface as RadiantFocusSurface, input::KeyPress as RadiantKeyPress,
+    focus::FocusSurface as RadiantFocusSurface,
+    input::{KeyCode as RadiantKeyCode, KeyPress as RadiantKeyPress},
     shortcuts::ShortcutResolution as RadiantShortcutResolution,
 };
 use radiant::runtime::{Command, RuntimeBridge, SurfaceNode, UiSurface};

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -13,6 +13,7 @@ pub(super) struct SempalRuntimeBridge<B> {
     frame: PaintFrame,
     layout_viewport: Option<Vector2>,
     text_input_target: RetainedTextInputTarget,
+    text_edit: RetainedTextEditState,
 }
 
 /// Private message surface used by the generic runtime before Sempal action reduction.
@@ -22,6 +23,8 @@ pub(super) enum SempalRuntimeMessage {
     Action(UiAction),
     /// Raw retained-canvas input that still needs Sempal shell hit-testing.
     RetainedInput(RetainedCanvasInput),
+    /// Local retained text-edit state changed without reducing an app action.
+    LocalTextEdit,
 }
 
 /// Retained-canvas input normalized out of Radiant widget events.
@@ -72,6 +75,97 @@ pub(super) enum RetainedTextInputTarget {
     Prompt,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct RetainedTextEditState {
+    target: RetainedTextInputTarget,
+    value: String,
+    caret: usize,
+    selection_anchor: Option<usize>,
+}
+
+impl RetainedTextEditState {
+    fn selection(&self) -> Option<(usize, usize)> {
+        let anchor = self.selection_anchor?;
+        (anchor != self.caret).then_some((anchor, self.caret))
+    }
+
+    fn has_selection(&self) -> bool {
+        self.selection().is_some()
+    }
+
+    fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+    }
+
+    fn sync(&mut self, target: RetainedTextInputTarget, value: String) {
+        if self.target != target || self.value != value {
+            self.target = target;
+            self.value = value;
+            self.caret = self.value.chars().count();
+            self.selection_anchor = None;
+        }
+    }
+
+    fn selected_bounds(&self) -> Option<(usize, usize)> {
+        self.selection()
+            .map(|(a, b)| if a < b { (a, b) } else { (b, a) })
+    }
+
+    fn replace_selection(&mut self, replacement: &str) -> bool {
+        let Some((start, end)) = self.selected_bounds() else {
+            return false;
+        };
+        replace_char_range(&mut self.value, start, end, replacement);
+        self.caret = start + replacement.chars().count();
+        self.clear_selection();
+        true
+    }
+
+    fn insert_char(&mut self, character: char) {
+        self.replace_selection("");
+        let index = byte_index_for_char(&self.value, self.caret);
+        self.value.insert(index, character);
+        self.caret += 1;
+    }
+
+    fn backspace(&mut self) -> bool {
+        if self.replace_selection("") {
+            return true;
+        }
+        if self.caret == 0 {
+            return false;
+        }
+        let end = self.caret;
+        let start = self.caret - 1;
+        replace_char_range(&mut self.value, start, end, "");
+        self.caret = start;
+        true
+    }
+
+    fn delete(&mut self) -> bool {
+        if self.replace_selection("") {
+            return true;
+        }
+        if self.caret >= self.value.chars().count() {
+            return false;
+        }
+        replace_char_range(&mut self.value, self.caret, self.caret + 1, "");
+        true
+    }
+
+    fn move_caret(&mut self, caret: usize, selecting: bool) {
+        let caret = caret.min(self.value.chars().count());
+        if selecting {
+            if self.selection_anchor.is_none() {
+                self.selection_anchor = Some(self.caret);
+            }
+        } else {
+            self.clear_selection();
+        }
+        self.caret = caret;
+    }
+}
+
 impl<B> SempalRuntimeBridge<B> {
     pub(super) fn new(inner: B) -> Self {
         Self {
@@ -82,6 +176,7 @@ impl<B> SempalRuntimeBridge<B> {
             frame: PaintFrame::default(),
             layout_viewport: None,
             text_input_target: RetainedTextInputTarget::None,
+            text_edit: RetainedTextEditState::default(),
         }
     }
 
@@ -117,10 +212,10 @@ impl<B> SempalRuntimeBridge<B> {
 impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
     /// Reduce one app action through the host and refresh the retained compatibility model.
     fn emit_action(&mut self, action: UiAction) {
-        self.update_text_target_after_action(&action);
-        self.inner.reduce_action(action);
+        self.inner.reduce_action(action.clone());
         let model = self.inner.pull_model_arc();
         self.model = Arc::new(model.as_ref().into());
+        self.update_text_target_after_action(&action);
     }
 
     /// Translate retained-canvas input into Sempal actions or local repaint-only state.
@@ -145,6 +240,9 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                     position,
                 ) {
                     self.emit_action(action.into());
+                    if self.text_input_target != RetainedTextInputTarget::None {
+                        self.sync_text_edit_from_model();
+                    }
                 }
                 true
             }
@@ -179,10 +277,33 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                 self.text_input_target = RetainedTextInputTarget::None;
                 true
             }
-            WidgetKey::Backspace => self.rewrite_retained_text(|value| {
-                value.pop();
+            WidgetKey::Backspace => {
+                self.sync_text_edit_from_model();
+                if self.text_input_target == RetainedTextInputTarget::BrowserPillEditor
+                    && self.text_edit.value.is_empty()
+                    && !self.text_edit.has_selection()
+                {
+                    return self.remove_last_browser_pill_editor_chip();
+                }
+                self.edit_retained_text(|edit| edit.backspace())
+            }
+            WidgetKey::Delete => self.edit_retained_text(|edit| edit.delete()),
+            WidgetKey::ArrowLeft => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.caret.saturating_sub(1), false);
+                false
             }),
-            WidgetKey::Delete => true,
+            WidgetKey::ArrowRight => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.caret + 1, false);
+                false
+            }),
+            WidgetKey::Home => self.edit_retained_text(|edit| {
+                edit.move_caret(0, false);
+                false
+            }),
+            WidgetKey::End => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.value.chars().count(), false);
+                false
+            }),
             _ => false,
         }
     }
@@ -192,15 +313,45 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
         if character.is_control() {
             return false;
         }
-        self.rewrite_retained_text(|value| value.push(character))
+        self.sync_text_edit_from_model();
+        if self.text_input_target == RetainedTextInputTarget::BrowserPillEditor && character == ','
+        {
+            let token = self.text_edit.value.clone();
+            if token.split_whitespace().next().is_none() {
+                self.text_edit.value.clear();
+                self.text_edit.caret = 0;
+                self.text_edit.clear_selection();
+                return true;
+            }
+            self.emit_action(UiAction::SetBrowserTagSidebarInput {
+                value: token.clone(),
+            });
+            self.emit_action(UiAction::CommitBrowserTagSidebarInput);
+            self.text_input_target = RetainedTextInputTarget::BrowserPillEditor;
+            self.text_edit
+                .sync(RetainedTextInputTarget::BrowserPillEditor, String::new());
+            return true;
+        }
+        self.edit_retained_text(|edit| {
+            edit.insert_char(character);
+            true
+        })
     }
 
     /// Rewrite the active retained text target and emit the matching host action.
-    fn rewrite_retained_text(&mut self, rewrite: impl FnOnce(&mut String)) -> bool {
-        let Some(mut value) = self.current_text_value() else {
+    fn edit_retained_text(
+        &mut self,
+        rewrite: impl FnOnce(&mut RetainedTextEditState) -> bool,
+    ) -> bool {
+        if self.text_input_target == RetainedTextInputTarget::None {
             return false;
-        };
-        rewrite(&mut value);
+        }
+        self.sync_text_edit_from_model();
+        let changed = rewrite(&mut self.text_edit);
+        if !changed {
+            return true;
+        }
+        let value = self.text_edit.value.clone();
         let action = match self.text_input_target {
             RetainedTextInputTarget::None => return false,
             RetainedTextInputTarget::BrowserSearch => UiAction::SetBrowserSearch { query: value },
@@ -212,6 +363,22 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
             RetainedTextInputTarget::Prompt => UiAction::SetPromptInput { value },
         };
         self.emit_action(action);
+        true
+    }
+
+    fn sync_text_edit_from_model(&mut self) {
+        if let Some(value) = self.current_text_value() {
+            self.text_edit.sync(self.text_input_target, value);
+        }
+    }
+
+    fn remove_last_browser_pill_editor_chip(&mut self) -> bool {
+        let Some(pill) = self.model.browser.pill_editor().accepted_pills.last() else {
+            return true;
+        };
+        self.emit_action(UiAction::ToggleBrowserSidebarNormalTag {
+            label: pill.id.clone(),
+        });
         true
     }
 
@@ -268,7 +435,89 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
             | UiAction::HandleEscape => RetainedTextInputTarget::None,
             _ => self.text_input_target,
         };
+        self.sync_text_edit_from_model();
     }
+
+    fn resolve_retained_text_key_press(&mut self, press: RadiantKeyPress) -> bool {
+        if press.alt {
+            return false;
+        }
+        if press.command {
+            match press.key {
+                RadiantKeyCode::A => {
+                    self.text_edit.caret = self.text_edit.value.chars().count();
+                    self.text_edit.selection_anchor = Some(0);
+                    return true;
+                }
+                RadiantKeyCode::X => {
+                    self.text_edit.replace_selection("");
+                    let value = self.text_edit.value.clone();
+                    self.emit_text_value(value);
+                    return true;
+                }
+                RadiantKeyCode::C | RadiantKeyCode::V => return true,
+                _ => return false,
+            }
+        }
+        let len = self.text_edit.value.chars().count();
+        match press.key {
+            RadiantKeyCode::ArrowLeft => {
+                self.text_edit
+                    .move_caret(self.text_edit.caret.saturating_sub(1), press.shift);
+                true
+            }
+            RadiantKeyCode::ArrowRight => {
+                self.text_edit
+                    .move_caret((self.text_edit.caret + 1).min(len), press.shift);
+                true
+            }
+            RadiantKeyCode::Home => {
+                self.text_edit.move_caret(0, press.shift);
+                true
+            }
+            RadiantKeyCode::End => {
+                self.text_edit.move_caret(len, press.shift);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn emit_text_value(&mut self, value: String) {
+        let action = match self.text_input_target {
+            RetainedTextInputTarget::None => return,
+            RetainedTextInputTarget::BrowserSearch => UiAction::SetBrowserSearch { query: value },
+            RetainedTextInputTarget::FolderSearch => UiAction::SetFolderSearch { query: value },
+            RetainedTextInputTarget::BrowserPillEditor => {
+                UiAction::SetBrowserTagSidebarInput { value }
+            }
+            RetainedTextInputTarget::FolderCreate => UiAction::SetFolderCreateInput { value },
+            RetainedTextInputTarget::Prompt => UiAction::SetPromptInput { value },
+        };
+        self.emit_action(action);
+    }
+
+    fn apply_local_text_projection(&self, model: &mut runtime_contract::AppModel) {
+        if self.text_input_target != RetainedTextInputTarget::BrowserPillEditor {
+            return;
+        }
+        model.browser.pill_editor.input_focused = true;
+        model.browser.pill_editor.input_caret = self.text_edit.caret;
+        model.browser.pill_editor.input_selection = self.text_edit.selection();
+    }
+}
+
+fn byte_index_for_char(text: &str, char_index: usize) -> usize {
+    text.char_indices()
+        .nth(char_index)
+        .map(|(index, _)| index)
+        .unwrap_or(text.len())
+}
+
+fn replace_char_range(text: &mut String, start: usize, end: usize, replacement: &str) {
+    let start = byte_index_for_char(text, start);
+    let end = byte_index_for_char(text, end);
+    text.replace_range(start..end, replacement);
 }
 
 impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBridge<B> {
@@ -292,6 +541,7 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
                 self.emit_action(action);
                 Command::none()
             }
+            SempalRuntimeMessage::LocalTextEdit => Command::request_repaint(),
             SempalRuntimeMessage::RetainedInput(input) => {
                 let repaint = self.handle_retained_canvas_input(input);
                 if repaint {
@@ -309,6 +559,17 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         press: RadiantKeyPress,
         focus: RadiantFocusSurface,
     ) -> RadiantShortcutResolution<SempalRuntimeMessage> {
+        if self.text_input_target != RetainedTextInputTarget::None {
+            self.sync_text_edit_from_model();
+            if self.resolve_retained_text_key_press(press) {
+                return RadiantShortcutResolution {
+                    action: Some(SempalRuntimeMessage::LocalTextEdit),
+                    handled: true,
+                    pending_chord: None,
+                };
+            }
+            return RadiantShortcutResolution::unhandled();
+        }
         let resolution = hotkeys::resolve_hotkey_press(
             pending_chord.map(keypress_from_radiant),
             keypress_from_radiant(press),
@@ -343,15 +604,17 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         let layout =
             ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime);
         self.shell_state.sync_from_model(&self.model);
-        let motion_model = runtime_contract::NativeMotionModel::from_app_model(&self.model);
+        let mut model = self.model.as_ref().clone();
+        self.apply_local_text_projection(&mut model);
+        let motion_model = runtime_contract::NativeMotionModel::from_app_model(&model);
         self.shell_state.sync_from_motion_model(&motion_model);
         self.shell_state
-            .build_frame_with_style_into(&layout, &style, &self.model, &mut self.frame);
+            .build_frame_with_style_into(&layout, &style, &model, &mut self.frame);
         append_retained_shell_overlays(
             &mut self.shell_state,
             &layout,
             &style,
-            &self.model,
+            &model,
             &motion_model,
             &mut self.frame,
         );

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -182,6 +182,7 @@ mod tests {
         let snapshot = bridge.capture_gui_automation_snapshot([1280.0, 720.0]);
         assert_eq!(snapshot.root.id.0, "shell.root");
 
+        bridge.update(SempalRuntimeMessage::Action(UiAction::HandleEscape));
         let shortcut = bridge.resolve_key_press(
             None,
             RadiantKeyPress {
@@ -202,6 +203,132 @@ mod tests {
                 alt: false,
             })
         );
+    }
+
+    #[test]
+    fn focused_browser_pill_editor_shields_typing_from_shortcuts_and_commits_commas() {
+        let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.update(SempalRuntimeMessage::Action(
+            UiAction::FocusBrowserTagSidebarInput,
+        ));
+
+        let shortcut = bridge.resolve_key_press(
+            Some(RadiantKeyPress {
+                key: RadiantKeyCode::G,
+                command: false,
+                shift: false,
+                alt: false,
+            }),
+            RadiantKeyPress {
+                key: RadiantKeyCode::G,
+                command: false,
+                shift: false,
+                alt: false,
+            },
+            RadiantFocusSurface::None,
+        );
+        assert!(
+            !shortcut.handled && shortcut.action.is_none() && shortcut.pending_chord.is_none(),
+            "focused tag text entry should clear pending chords without consuming printable text"
+        );
+
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::Character('k'),
+        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::Character('i'),
+        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::Character(','),
+        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::Character('h'),
+        ));
+
+        assert_eq!(
+            bridge.inner.reduced,
+            vec![
+                UiAction::FocusBrowserTagSidebarInput,
+                UiAction::SetBrowserTagSidebarInput {
+                    value: String::from("k"),
+                },
+                UiAction::SetBrowserTagSidebarInput {
+                    value: String::from("ki"),
+                },
+                UiAction::SetBrowserTagSidebarInput {
+                    value: String::from("ki"),
+                },
+                UiAction::CommitBrowserTagSidebarInput,
+                UiAction::SetBrowserTagSidebarInput {
+                    value: String::from("h"),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn focused_browser_pill_editor_selection_deletes_draft_before_chip_backspace() {
+        let mut model = NativeAppModel::default();
+        model.browser.tag_sidebar.input_value = String::from("abc");
+        model
+            .browser
+            .tag_sidebar
+            .accepted_pills
+            .push(BrowserTagPillModel {
+                id: String::from("Kick"),
+                label: String::from("Kick"),
+                state: crate::app_core::actions::NativeBrowserTagState::On,
+            });
+        let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(model),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.update(SempalRuntimeMessage::Action(
+            UiAction::FocusBrowserTagSidebarInput,
+        ));
+        bridge.update(SempalRuntimeMessage::LocalTextEdit);
+        let _ = bridge.resolve_key_press(
+            None,
+            RadiantKeyPress {
+                key: RadiantKeyCode::A,
+                command: true,
+                shift: false,
+                alt: false,
+            },
+            RadiantFocusSurface::None,
+        );
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::KeyPress(WidgetKey::Backspace),
+        ));
+
+        assert_eq!(
+            bridge.inner.reduced.last(),
+            Some(&UiAction::SetBrowserTagSidebarInput {
+                value: String::new(),
+            })
+        );
+        assert!(
+            !bridge.inner.reduced.iter().any(|action| matches!(
+                action,
+                UiAction::ToggleBrowserSidebarNormalTag { label } if label == "Kick"
+            )),
+            "Backspace with selected draft text should edit text before removing an accepted chip"
+        );
+
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::KeyPress(WidgetKey::Backspace),
+        ));
+        assert!(bridge.inner.reduced.iter().any(|action| matches!(
+            action,
+            UiAction::ToggleBrowserSidebarNormalTag { label } if label == "Kick"
+        )));
     }
 
     #[test]
@@ -303,6 +430,25 @@ mod tests {
         }
 
         fn reduce_action(&mut self, action: UiAction) {
+            match &action {
+                UiAction::SetBrowserSearch { query } => {
+                    Arc::make_mut(&mut self.model).browser.search_query = query.clone();
+                }
+                UiAction::SetBrowserTagSidebarInput { value } => {
+                    Arc::make_mut(&mut self.model)
+                        .browser
+                        .tag_sidebar
+                        .input_value = value.clone();
+                }
+                UiAction::CommitBrowserTagSidebarInput => {
+                    Arc::make_mut(&mut self.model)
+                        .browser
+                        .tag_sidebar
+                        .input_value
+                        .clear();
+                }
+                _ => {}
+            }
             self.reduced.push(action);
         }
 

--- a/src/gui_test/packs/browser.rs
+++ b/src/gui_test/packs/browser.rs
@@ -187,6 +187,13 @@ pub(super) fn browser_tag_sidebar_unified_tag_library_scenario() -> GuiScenario 
                 action: NativeUiAction::CommitBrowserTagSidebarInput,
             },
             GuiScenarioStep::Assert {
+                assertion: GuiAssertion::NodeMetadataEquals {
+                    node_id: String::from("sources.tags"),
+                    key: String::from("accepted_tag_labels"),
+                    value: String::from("Texture|vinyl crackle"),
+                },
+            },
+            GuiScenarioStep::Assert {
                 assertion: GuiAssertion::NodePresent {
                     node_id: String::from("sources.tags.suggestion.0"),
                 },


### PR DESCRIPTION
## Summary
- Implements OPT-344 plus child issues OPT-345, OPT-346, OPT-347, and OPT-348.
- Adds retained-shell text-entry focus shielding for the left-sidebar tag editor, including caret/selection state, command-A selection, draft deletion before chip removal, and comma delimiter commits.
- Tokenizes comma-separated tag commits in the controller, projects accepted chips separately from suggestions from persisted DB metadata, and updates rendering, hit testing, automation metadata, GUI contracts, and focused tests.
- Updates `vendor/radiant` to expose generic pill-editor accepted chip and focused input state; nested Radiant commit: caa5b6cd.

## Validation
- `cargo test -p sempal focused_browser_pill_editor --lib`
- `cargo test -p sempal browser_projection_sidebar_projects_accepted_tags_separately_from_suggestions --lib`
- `cargo test -p sempal browser_tag_sidebar_typed_input_commits_ordered_comma_tokens_idempotently --lib`
- `cargo test -p sempal browser_tag_sidebar_multi_selection_commits_full_comma_token_set --lib`
- `cargo test -p sempal apply_native_commit_browser_tag_sidebar_input_tokenizes_comma_separated_tags --lib`
- `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 contract`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`

Refs OPT-344, OPT-345, OPT-346, OPT-347, OPT-348.