### PR TITLE
Restore retained GUI interaction responsiveness

### DIFF
--- a/src/app/controller/library/wavs/browser_lists/mod.rs
+++ b/src/app/controller/library/wavs/browser_lists/mod.rs
@@ -26,6 +26,11 @@ impl AppController {
             return;
         }
 
+        self.rebuild_browser_lists_retained();
+    }
+
+    /// Rebuild browser rows through the retained in-process pipeline.
+    pub(crate) fn rebuild_browser_lists_retained(&mut self) {
         let allow_highlight = matches!(
             self.ui.focus.context,
             FocusContext::SampleBrowser | FocusContext::Waveform | FocusContext::None
@@ -48,6 +53,46 @@ impl AppController {
         );
         self.ui.browser.search.search_busy = false;
         self.clear_progress_task(crate::app::state::ProgressTaskKind::Search);
+    }
+
+    /// Return true when a simple triage-filter toggle can reuse retained row partitions locally.
+    pub(crate) fn can_refresh_triage_filter_locally(&self) -> bool {
+        use crate::app::state::{SampleBrowserSort, TagNamedFilter};
+
+        let Some(source_id) = self.selection_state.ctx.selected_source.as_ref() else {
+            return false;
+        };
+        if self
+            .runtime
+            .source_lane
+            .mutations
+            .source_has_pending_metadata(source_id)
+        {
+            return false;
+        }
+        if !self.ui_cache.browser.pipeline.has_base_snapshot() {
+            return false;
+        }
+        if self.ui.browser.duplicate_cleanup.is_some()
+            || self.active_search_query().is_some()
+            || self.ui.browser.search.similar_query.is_some()
+            || self.ui.browser.search.sort != SampleBrowserSort::ListOrder
+            || !self.ui.browser.search.rating_filter.is_empty()
+            || !self.ui.browser.search.playback_age_filter.is_empty()
+            || !self.ui.browser.search.sidebar_filters.is_empty()
+            || self.ui.browser.search.marked_only
+            || self.ui.browser.search.tag_named_filter != TagNamedFilter::All
+        {
+            return false;
+        }
+        let folder_selection = self.folder_selection_for_filter();
+        let folder_negated = self.folder_negation_for_filter();
+        let file_scope_mode = self.folder_file_scope_mode_for_filter().unwrap_or_default();
+        !crate::app::controller::library::source_folders::folder_filters_active(
+            folder_selection,
+            folder_negated,
+            file_scope_mode,
+        )
     }
 
     pub(crate) fn selected_row_index(&mut self) -> Option<usize> {

--- a/src/app/controller/library/wavs/browser_pipeline.rs
+++ b/src/app/controller/library/wavs/browser_pipeline.rs
@@ -63,6 +63,11 @@ pub(crate) struct BrowserPipelineCache {
 }
 
 impl BrowserPipelineCache {
+    /// Return true when the base row snapshot has been built and can seed retained filters.
+    pub(crate) fn has_base_snapshot(&self) -> bool {
+        self.base_fingerprint.is_some()
+    }
+
     /// Drop all staged fingerprints and vectors.
     pub(crate) fn invalidate(&mut self) {
         self.base_fingerprint = None;

--- a/src/app/controller/library/wavs/browser_search/dispatch_policy.rs
+++ b/src/app/controller/library/wavs/browser_search/dispatch_policy.rs
@@ -41,6 +41,21 @@ impl AppController {
         self.dispatch_search_job_with_metadata_delta(Vec::new());
     }
 
+    /// Retire any queued async browser-search result before applying a local projection.
+    pub(crate) fn invalidate_async_browser_search_for_local_projection(&mut self) {
+        self.ui.browser.search.latest_search_request_id = self
+            .ui
+            .browser
+            .search
+            .latest_search_request_id
+            .wrapping_add(1);
+        self.ui.browser.search.latest_applied_search_request_id =
+            self.ui.browser.search.latest_search_request_id;
+        self.runtime
+            .pending_browser_search_metadata_delta_paths
+            .clear();
+    }
+
     /// Enqueue one authoritative browser-search worker job plus optional metadata-only row deltas.
     pub(crate) fn dispatch_search_job_with_metadata_delta(
         &mut self,

--- a/src/app/controller/library/wavs/browser_search/mutations.rs
+++ b/src/app/controller/library/wavs/browser_search/mutations.rs
@@ -15,12 +15,26 @@ fn refresh_browser_search_results(controller: &mut AppController) {
     }
 }
 
+/// Refresh a simple triage-filter change without creating async churn when cached rows suffice.
+fn refresh_browser_triage_filter_results(controller: &mut AppController) {
+    if controller.can_refresh_triage_filter_locally() {
+        if controller.should_dispatch_browser_search_async()
+            || controller.ui.browser.search.search_busy
+        {
+            controller.invalidate_async_browser_search_for_local_projection();
+        }
+        controller.rebuild_browser_lists_retained();
+    } else {
+        refresh_browser_search_results(controller);
+    }
+}
+
 pub(crate) fn set_browser_filter(controller: &mut AppController, filter: TriageFlagFilter) {
     if controller.ui.browser.search.filter != filter {
         crate::app::controller::library::wavs::cancel_pending_similarity_filter_rebuild(controller);
         controller.ui.browser.search.filter = filter;
         controller.mark_browser_search_projection_revision_dirty();
-        refresh_browser_search_results(controller);
+        refresh_browser_triage_filter_results(controller);
     }
 }
 

--- a/src/app/controller/tests/browser_async.rs
+++ b/src/app/controller/tests/browser_async.rs
@@ -201,3 +201,77 @@ fn rebuild_browser_lists_dispatches_async_pipeline_when_enabled() {
     );
     assert!(!controller.ui.browser.search.search_busy);
 }
+
+#[test]
+fn triage_filter_toggle_uses_retained_pipeline_when_async_is_enabled() {
+    let entries = vec![
+        sample_entry("trash.wav", Rating::TRASH_1),
+        sample_entry("neutral.wav", Rating::NEUTRAL),
+        sample_entry("keep.wav", Rating::KEEP_1),
+    ];
+    let (mut controller, _source) = prepare_with_source_and_wav_entries(entries);
+
+    with_browser_async_pipeline_enabled_for_tests(true, || {
+        controller.set_browser_filter(TriageFlagFilter::Keep);
+    });
+
+    assert_eq!(visible_indices(&controller), vec![2]);
+    assert_eq!(controller.ui.browser.search.latest_search_request_id, 1);
+    assert_eq!(
+        controller
+            .ui
+            .browser
+            .search
+            .latest_applied_search_request_id,
+        1
+    );
+    assert!(!controller.ui.browser.search.search_busy);
+}
+
+#[test]
+fn local_triage_filter_toggle_retires_stale_async_search_results() {
+    let entries = vec![
+        sample_entry("kick.wav", Rating::NEUTRAL),
+        sample_entry("snare.wav", Rating::TRASH_1),
+        sample_entry("hat.wav", Rating::KEEP_1),
+    ];
+    let (mut controller, source) = prepare_with_source_and_wav_entries(entries);
+
+    with_browser_async_pipeline_enabled_for_tests(true, || {
+        controller.set_browser_search("kick");
+        controller.set_browser_search("");
+        let stale_empty_query_request_id = controller.ui.browser.search.latest_search_request_id;
+        controller.set_browser_filter(TriageFlagFilter::Keep);
+        let local_request_id = controller.ui.browser.search.latest_search_request_id;
+
+        assert_eq!(
+            local_request_id,
+            stale_empty_query_request_id.wrapping_add(1)
+        );
+        assert_eq!(visible_indices(&controller), vec![2]);
+        assert!(!controller.ui.browser.search.search_busy);
+
+        controller.apply_background_job_message_for_tests(JobMessage::BrowserSearchFinished(
+            SearchResult {
+                request_id: stale_empty_query_request_id,
+                source_id: source.id.clone(),
+                query: String::new(),
+                visible: VisibleRows::All { total: 3 },
+                trash: Arc::from([1usize]),
+                neutral: Arc::from([0usize]),
+                keep: Arc::from([2usize]),
+                scores: Arc::from([]),
+            },
+        ));
+
+        assert_eq!(visible_indices(&controller), vec![2]);
+        assert_eq!(
+            controller
+                .ui
+                .browser
+                .search
+                .latest_applied_search_request_id,
+            local_request_id
+        );
+    });
+}

--- a/src/app_core/native_bridge/mod.rs
+++ b/src/app_core/native_bridge/mod.rs
@@ -151,6 +151,26 @@ impl SempalNativeBridge {
         result
     }
 
+    /// Apply direct controller mutations that already completed their local maintenance work.
+    ///
+    /// Benchmark-only interaction paths use this for retained browser mutations that
+    /// should invalidate projection keys without forcing the next pull through the
+    /// full controller preparation lane.
+    pub fn mutate_controller_retained<R>(
+        &mut self,
+        mutate: impl FnOnce(&mut AppController) -> R,
+    ) -> R {
+        let before_key = self.projection_key_snapshot();
+        let result = mutate(&mut self.controller);
+        self.invalidate_projection_key_snapshot();
+        let after_key = self.projection_key_snapshot();
+        if before_key != after_key {
+            self.projection_cache.invalidate_key_only();
+        }
+        self.schedule_local_model_pull_fast_path();
+        result
+    }
+
     #[cfg(test)]
     /// Project the latest Sempal-owned app model snapshot for app-core tests.
     pub(crate) fn project_model(&mut self) -> Arc<crate::app_core::actions::NativeAppModel> {

--- a/src/app_core/native_bridge/runtime_projection.rs
+++ b/src/app_core/native_bridge/runtime_projection.rs
@@ -63,6 +63,7 @@ impl SempalNativeBridge {
     /// Allow the next app-model pull to skip full preparation once.
     pub(super) fn schedule_local_model_pull_fast_path(&mut self) {
         self.pending_model_pull_preparation = PendingModelPullPreparation::LocalOnly;
+        self.consecutive_local_model_pulls = 0;
     }
 
     /// Return whether the next app-model pull may skip full preparation.

--- a/src/app_core/native_bridge/tests/bridge_runtime/pull_prep.rs
+++ b/src/app_core/native_bridge/tests/bridge_runtime/pull_prep.rs
@@ -43,6 +43,36 @@ fn local_focus_actions_arm_local_model_pull_fast_path() {
     assert!(!bridge.controller.has_dirty_derived_nodes());
 }
 
+/// Retained direct mutations should not force full pull preparation after local row updates.
+#[test]
+fn retained_controller_mutations_arm_local_model_pull_fast_path() {
+    let mut bridge = test_bridge(16);
+
+    bridge.mutate_controller_retained(|controller| {
+        controller.set_browser_filter(crate::app::state::TriageFlagFilter::Keep)
+    });
+
+    assert_eq!(
+        bridge.pending_model_pull_preparation,
+        PendingModelPullPreparation::LocalOnly
+    );
+}
+
+/// Fresh local input starts a fresh local-pull burst instead of inheriting stale pull count.
+#[test]
+fn scheduling_local_fast_path_resets_previous_burst_count() {
+    let mut bridge = test_bridge(16);
+    bridge.consecutive_local_model_pulls = 8;
+
+    bridge.schedule_local_model_pull_fast_path();
+
+    assert_eq!(bridge.consecutive_local_model_pulls, 0);
+    assert_eq!(
+        bridge.pending_model_pull_preparation,
+        PendingModelPullPreparation::LocalOnly
+    );
+}
+
 /// Folder-panel search edits should stay on the local-only pull path.
 #[test]
 fn folder_search_actions_arm_local_model_pull_fast_path() {

--- a/src/gui_runtime/native_shell_runtime.rs
+++ b/src/gui_runtime/native_shell_runtime.rs
@@ -13,7 +13,8 @@ use crate::app_core::actions::{
 use crate::app_core::app_api::controller_ui_hotkeys::KeyPress;
 use crate::app_core::app_api::{controller_ui_hotkeys as hotkeys, state::FocusContext};
 use crate::app_core::native_shell::composition::{
-    NativeShellState, ShellLayout, ShellLayoutRuntime, ShellNodeKind, StyleTokens,
+    NativeShellState, ShellLayout, ShellLayoutRuntime, ShellNodeKind, StaticFrameSegment,
+    StaticFrameSegments, StyleTokens,
 };
 use crate::app_core::native_shell::runtime_contract;
 use crate::gui::automation as gui_automation;

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -10,6 +10,8 @@ pub(super) struct SempalRuntimeBridge<B> {
     model: Arc<runtime_contract::AppModel>,
     shell_state: NativeShellState,
     layout_runtime: ShellLayoutRuntime,
+    static_segments: StaticFrameSegments,
+    static_segments_initialized: bool,
     frame: PaintFrame,
     layout_viewport: Option<Vector2>,
     text_input_target: RetainedTextInputTarget,
@@ -173,6 +175,8 @@ impl<B> SempalRuntimeBridge<B> {
             model: Arc::new(runtime_contract::AppModel::default()),
             shell_state: NativeShellState::new(),
             layout_runtime: ShellLayoutRuntime::default(),
+            static_segments: StaticFrameSegments::default(),
+            static_segments_initialized: false,
             frame: PaintFrame::default(),
             layout_viewport: None,
             text_input_target: RetainedTextInputTarget::None,
@@ -206,6 +210,24 @@ impl<B> SempalRuntimeBridge<B> {
     {
         let model = self.inner.project_model();
         capture_gui_automation_snapshot(viewport, model.as_ref())
+    }
+
+    #[cfg(test)]
+    pub(super) fn static_segment_frame_for_tests(
+        &self,
+        segment: StaticFrameSegment,
+    ) -> &PaintFrame {
+        self.static_segments.frame(segment)
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_retained_model_for_tests(&mut self, model: runtime_contract::AppModel) {
+        self.model = Arc::new(model);
+    }
+
+    #[cfg(test)]
+    pub(super) fn retained_model_for_tests(&self) -> &runtime_contract::AppModel {
+        self.model.as_ref()
     }
 }
 
@@ -586,6 +608,10 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         self.inner.install_repaint_signal(signal);
     }
 
+    fn needs_animation(&self) -> bool {
+        self.shell_state.needs_animation()
+    }
+
     /// Render the retained Sempal shell into a paint frame when Radiant requests the canvas.
     fn render_retained_surface(
         &mut self,
@@ -600,6 +626,7 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         if self.layout_viewport != Some(viewport) {
             self.layout_runtime.reset();
             self.layout_viewport = Some(viewport);
+            self.static_segments_initialized = false;
         }
         let layout =
             ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime);
@@ -608,8 +635,21 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         self.apply_local_text_projection(&mut model);
         let motion_model = runtime_contract::NativeMotionModel::from_app_model(&model);
         self.shell_state.sync_from_motion_model(&motion_model);
-        self.shell_state
-            .build_frame_with_style_into(&layout, &style, &model, &mut self.frame);
+        let dirty_bits = descriptor.dirty_mask.min(u64::from(u16::MAX)) as u16;
+        for segment in StaticFrameSegment::ALL {
+            if !self.static_segments_initialized || dirty_bits & segment.dirty_mask() != 0 {
+                self.shell_state.build_static_segment_with_style_into(
+                    &layout,
+                    &style,
+                    &model,
+                    Some(&motion_model),
+                    segment,
+                    &mut self.static_segments,
+                );
+            }
+        }
+        self.static_segments_initialized = true;
+        self.static_segments.compose_into(&mut self.frame);
         append_retained_shell_overlays(
             &mut self.shell_state,
             &layout,

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -397,6 +397,57 @@ mod tests {
     }
 
     #[test]
+    fn retained_shell_render_rebuilds_only_dirty_static_segments() {
+        let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        let viewport = radiant::gui::types::Vector2::new(1280.0, 720.0);
+        let rect = radiant::gui::types::Rect::from_min_size(
+            radiant::gui::types::Point::new(0.0, 0.0),
+            viewport,
+        );
+        let initial = retained_shell_descriptor(&mut bridge);
+        let _ = bridge
+            .render_retained_surface(initial, rect, viewport)
+            .expect("initial retained shell frame");
+        let browser_rows_before = bridge
+            .static_segment_frame_for_tests(StaticFrameSegment::BrowserRowsWindow)
+            .clone();
+        let status_before = bridge
+            .static_segment_frame_for_tests(StaticFrameSegment::StatusBar)
+            .clone();
+
+        let mut model = bridge.retained_model_for_tests().clone();
+        model.status_text = String::from("status changed");
+        bridge.set_retained_model_for_tests(model);
+        let _ = bridge
+            .render_retained_surface(
+                RetainedSurfaceDescriptor {
+                    key: 1,
+                    revision: initial.revision + 1,
+                    dirty_mask: u64::from(DirtySegments::STATUS_BAR),
+                },
+                rect,
+                viewport,
+            )
+            .expect("status-only retained shell frame");
+
+        assert_eq!(
+            bridge.static_segment_frame_for_tests(StaticFrameSegment::BrowserRowsWindow),
+            &browser_rows_before,
+            "status-only dirt should not rebuild the browser rows static segment"
+        );
+        assert_ne!(
+            bridge.static_segment_frame_for_tests(StaticFrameSegment::StatusBar),
+            &status_before,
+            "status dirt should rebuild the status static segment"
+        );
+    }
+
+    #[test]
     fn sempal_root_dependency_no_longer_enables_radiant_legacy_shell() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let cargo = fs::read_to_string(manifest_dir.join("Cargo.toml")).expect("root manifest");

--- a/tools/bench-cli/src/bench/gui/interactions.rs
+++ b/tools/bench-cli/src/bench/gui/interactions.rs
@@ -97,7 +97,7 @@ pub(super) fn bench_browser_filter_churn_latency(
         interaction_iters(options),
         |timer| {
             timer.mark_input_done();
-            bridge.mutate_controller(|controller| {
+            bridge.mutate_controller_retained(|controller| {
                 controller.set_browser_filter(interaction_filter_for_step(step))
             });
             step = step.saturating_add(1);
@@ -126,7 +126,7 @@ pub(super) fn bench_browser_query_churn_latency(
         interaction_iters(options),
         |timer| {
             timer.mark_input_done();
-            bridge.mutate_controller(|controller| {
+            bridge.mutate_controller_retained(|controller| {
                 controller.set_browser_search(interaction_query_for_step(step))
             });
             step = step.saturating_add(1);
@@ -155,7 +155,7 @@ pub(super) fn bench_browser_sort_toggle_latency(
         interaction_iters(options),
         |timer| {
             timer.mark_input_done();
-            bridge.mutate_controller(|controller| {
+            bridge.mutate_controller_retained(|controller| {
                 controller.set_browser_sort(interaction_sort_for_step(step))
             });
             step = step.saturating_add(1);


### PR DESCRIPTION
## Summary

Implements OPT-369 and its child issue set OPT-370 through OPT-375.

- Makes Radiant's generic native runtime repaint-driven while preserving host opt-in animation via `RuntimeBridge::needs_animation`.
- Adds retained custom-surface frame caching and render-profile attribution for retained bridge calls/cache hits/primitive counts/timings.
- Updates Sempal's retained shell bridge to rebuild only dirty static frame segments and keep overlays separate.
- Keeps cached triage-filter toggles on the retained local browser pipeline, retires stale async search results, and uses retained benchmark mutations for filter/query/sort input responsiveness.
- Adds focused regression coverage for retained runtime caching, repaint/animation behavior, dirty static segment rebuilds, stale async search handling, and retained pull fast-path scheduling.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/agent.ps1 request`
- `cargo test -p radiant generic_runtime --manifest-path vendor/radiant/Cargo.toml`
- `cargo test -p sempal native_shell_runtime`
- `cargo test -p sempal browser_async`
- `cargo test -p sempal pull_prep`
- `$env:SEMPAL_PERF_GUARD_RUNS='1'; powershell -ExecutionPolicy Bypass -File scripts/perf.ps1 guard`
  - final run completed without warnings
  - `browser_filter_churn_latency p95=384us`, jank `0.0%`, missed-present `0.0%`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`

## Notes

Radiant changes are committed and pushed separately on `PORTALSURFER/radiant` `next` at `f49cfc61`, and this PR records the nested repo pointer update.

Refs OPT-369, OPT-370, OPT-371, OPT-372, OPT-373, OPT-374, OPT-375.