### PR TITLE
Restore retained GUI dynamic updates

### DIFF
--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -14,6 +14,8 @@ pub(super) struct SempalRuntimeBridge<B> {
     static_segments_initialized: bool,
     frame: PaintFrame,
     layout_viewport: Option<Vector2>,
+    pending_motion_model: Option<runtime_contract::NativeMotionModel>,
+    motion_only_surface_refresh: bool,
     text_input_target: RetainedTextInputTarget,
     text_edit: RetainedTextEditState,
 }
@@ -179,6 +181,8 @@ impl<B> SempalRuntimeBridge<B> {
             static_segments_initialized: false,
             frame: PaintFrame::default(),
             layout_viewport: None,
+            pending_motion_model: None,
+            motion_only_surface_refresh: false,
             text_input_target: RetainedTextInputTarget::None,
             text_edit: RetainedTextEditState::default(),
         }
@@ -545,6 +549,16 @@ fn replace_char_range(text: &mut String, start: usize, end: usize, replacement: 
 impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBridge<B> {
     /// Project Sempal state into the retained canvas surface visible to Radiant.
     fn project_surface(&mut self) -> Arc<UiSurface<SempalRuntimeMessage>> {
+        if self.motion_only_surface_refresh {
+            self.motion_only_surface_refresh = false;
+            let revisions = self.inner.take_segment_revisions();
+            return Self::generic_shell_surface(RetainedSurfaceDescriptor {
+                key: 1,
+                revision: retained_surface_revision(revisions),
+                dirty_mask: 0,
+                volatile: true,
+            });
+        }
         let model = self.inner.pull_model_arc();
         self.model = Arc::new(model.as_ref().into());
         let dirty = self.inner.take_dirty_segments();
@@ -553,6 +567,7 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
             key: 1,
             revision: retained_surface_revision(revisions),
             dirty_mask: u64::from(dirty.bits()),
+            volatile: true,
         })
     }
 
@@ -608,7 +623,21 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         self.inner.install_repaint_signal(signal);
     }
 
-    fn needs_animation(&self) -> bool {
+    fn needs_animation(&mut self) -> bool {
+        if let Some(motion_model) = self.inner.pull_motion_model() {
+            let motion_model: runtime_contract::NativeMotionModel = motion_model.into();
+            self.shell_state.sync_from_motion_model(&motion_model);
+            if self.shell_state.needs_animation() {
+                self.motion_only_surface_refresh = true;
+                self.pending_motion_model = Some(motion_model);
+            } else {
+                self.motion_only_surface_refresh = false;
+                self.pending_motion_model = None;
+            }
+        } else {
+            self.motion_only_surface_refresh = false;
+            self.pending_motion_model = None;
+        }
         self.shell_state.needs_animation()
     }
 
@@ -633,7 +662,10 @@ impl<B: NativeAppBridge> RuntimeBridge<SempalRuntimeMessage> for SempalRuntimeBr
         self.shell_state.sync_from_model(&self.model);
         let mut model = self.model.as_ref().clone();
         self.apply_local_text_projection(&mut model);
-        let motion_model = runtime_contract::NativeMotionModel::from_app_model(&model);
+        let motion_model = self
+            .pending_motion_model
+            .take()
+            .unwrap_or_else(|| runtime_contract::NativeMotionModel::from_app_model(&model));
         self.shell_state.sync_from_motion_model(&motion_model);
         let dirty_bits = descriptor.dirty_mask.min(u64::from(u16::MAX)) as u16;
         for segment in StaticFrameSegment::ALL {

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -71,6 +71,10 @@ mod tests {
             retained.dirty_mask,
             u64::from(crate::app_core::actions::NativeDirtySegments::all().bits())
         );
+        assert!(
+            retained.volatile,
+            "Sempal retained shell overlays must opt out of Radiant full-frame cache hits"
+        );
         let frame = bridge
             .render_retained_surface(
                 retained,
@@ -357,6 +361,55 @@ mod tests {
     }
 
     #[test]
+    fn retained_shell_animation_refresh_uses_motion_only_projection() {
+        let mut app_model = runtime_contract::AppModel::default();
+        app_model.transport_running = true;
+        app_model.waveform.playhead_milli = Some(100);
+        app_model.waveform.playhead_micros = Some(100_000);
+        let native_model: NativeAppModel = app_model.clone().into();
+
+        let mut motion_model = runtime_contract::NativeMotionModel::from_app_model(&app_model);
+        motion_model.waveform_playhead_milli = Some(450);
+        motion_model.waveform_playhead_micros = Some(450_000);
+
+        let mut bridge = SempalRuntimeBridge::new(MotionOnlyRecordingBridge {
+            model: Arc::new(native_model),
+            motion_model: Some(motion_model.into()),
+            model_pull_count: 0,
+            motion_pull_count: 0,
+        });
+        let retained = retained_motion_descriptor(&mut bridge);
+
+        assert_eq!(bridge.inner.model_pull_count, 1);
+        assert!(
+            bridge.needs_animation(),
+            "playback motion should keep the generic runtime on animation frames"
+        );
+        assert_eq!(bridge.inner.motion_pull_count, 1);
+        let _ = bridge.project_surface();
+        assert_eq!(
+            bridge.inner.model_pull_count, 1,
+            "animation refreshes should not force a full app-model pull"
+        );
+
+        let viewport = radiant::gui::types::Vector2::new(1280.0, 720.0);
+        let rect = radiant::gui::types::Rect::from_min_size(
+            radiant::gui::types::Point::new(0.0, 0.0),
+            viewport,
+        );
+        let frame = bridge
+            .render_retained_surface(retained, rect, viewport)
+            .expect("motion-only retained shell frame");
+        let layout = ShellLayout::build(viewport);
+        let style = StyleTokens::for_viewport_width(viewport.x);
+
+        assert!(
+            frame_contains_playhead_marker(&frame, &layout, &style),
+            "motion-only refresh should still render the playhead overlay"
+        );
+    }
+
+    #[test]
     fn retained_shell_render_rebuilds_only_dirty_static_segments() {
         let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
             model: Arc::new(NativeAppModel::default()),
@@ -389,6 +442,7 @@ mod tests {
                     key: 1,
                     revision: initial.revision + 1,
                     dirty_mask: u64::from(DirtySegments::STATUS_BAR),
+                    volatile: true,
                 },
                 rect,
                 viewport,
@@ -471,6 +525,29 @@ mod tests {
         }
     }
 
+    struct MotionOnlyRecordingBridge {
+        model: Arc<NativeAppModel>,
+        motion_model: Option<NativeMotionModel>,
+        model_pull_count: usize,
+        motion_pull_count: usize,
+    }
+
+    impl NativeAppBridge for MotionOnlyRecordingBridge {
+        fn project_model(&mut self) -> Arc<NativeAppModel> {
+            self.model_pull_count += 1;
+            Arc::clone(&self.model)
+        }
+
+        fn pull_model_arc(&mut self) -> Arc<NativeAppModel> {
+            self.project_model()
+        }
+
+        fn pull_motion_model(&mut self) -> Option<NativeMotionModel> {
+            self.motion_pull_count += 1;
+            self.motion_model.clone()
+        }
+    }
+
     struct TestRepaintSignal;
 
     impl RepaintSignal for TestRepaintSignal {
@@ -480,6 +557,28 @@ mod tests {
     /// Return the retained shell descriptor projected by the bridge surface.
     fn retained_shell_descriptor(
         bridge: &mut SempalRuntimeBridge<RecordingBridge>,
+    ) -> RetainedSurfaceDescriptor {
+        let surface = bridge.project_surface();
+        let layout = radiant::layout::layout_tree(
+            &surface.layout_node(),
+            radiant::gui::types::Rect::from_min_size(
+                radiant::gui::types::Point::new(0.0, 0.0),
+                radiant::gui::types::Vector2::new(1280.0, 720.0),
+            ),
+        );
+        let plan = surface.paint_plan(&layout, &ThemeTokens::default());
+        plan.primitives
+            .iter()
+            .find_map(|primitive| match primitive {
+                PaintPrimitive::CustomSurface(surface) => surface.retained,
+                _ => None,
+            })
+            .expect("generic bridge should project retained shell metadata")
+    }
+
+    /// Return the retained shell descriptor projected by a motion-only bridge.
+    fn retained_motion_descriptor(
+        bridge: &mut SempalRuntimeBridge<MotionOnlyRecordingBridge>,
     ) -> RetainedSurfaceDescriptor {
         let surface = bridge.project_surface();
         let layout = radiant::layout::layout_tree(


### PR DESCRIPTION
## Summary

Fixes OPT-376 and child issues OPT-377, OPT-378, OPT-379, OPT-380, and OPT-381.

- Add a generic Radiant retained-surface `volatile` contract and reject retained cache hits when the current descriptor is dirty or volatile.
- Mark Sempal's retained shell as volatile so hover, waveform, and playhead overlays cannot be hidden behind a stale cached full frame.
- Route animation refreshes through the existing motion-only model pull so playback/playhead frames avoid full app-model pulls while idle remains repaint-driven.
- Add regression coverage for dirty-current cache misses, volatile retained surfaces, Sempal volatile descriptor projection, hover/playhead overlays, motion-only animation refresh, and waveform image arrival.

## Validation

- `cargo test --manifest-path vendor\radiant\Cargo.toml retained_custom_surface_cache --lib`
- `cargo test -p sempal --lib retained_shell`
- `cargo test -p sempal --lib sempal_generic_runtime_bridge_routes_messages_repaint_exit_and_snapshots`
- `cargo test -p sempal --lib bridge_reprojects_after_async_waveform_image_arrival`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`

## Notes

Nested Radiant commit pushed to `PORTALSURFER/radiant@ebd1b8e05c807c52dcb119e2f20636731b54e21a`.