### PR TITLE
Implement Radiant dynamic widget migration

### DIFF
--- a/src/app_core/actions/tests.rs
+++ b/src/app_core/actions/tests.rs
@@ -345,7 +345,7 @@ fn native_projection_dtos_keep_product_defaults_and_generic_primitives() {
     let preferences = model.options_panel.preference_state();
     assert_eq!(preferences.toggles.len(), 4);
     assert_eq!(model.waveform.timeline_surface().markers.len(), 0);
-    assert_eq!(model.waveform_chrome.signal_tools().markers_visible, true);
+    assert!(model.waveform_chrome.signal_tools().markers_visible);
 }
 fn collect_desktop_aiv_action_ids(
     cases: &[crate::gui_test::GuiAivCase],

--- a/src/gui_runtime/native_shell_runtime.rs
+++ b/src/gui_runtime/native_shell_runtime.rs
@@ -29,7 +29,8 @@ use radiant::gui::{
 };
 use radiant::runtime::{Command, RuntimeBridge, SurfaceNode, UiSurface};
 use radiant::widgets::{
-    CanvasMessage, PointerButton, RetainedSurfaceDescriptor, WidgetInput, WidgetKey, WidgetSizing,
+    CanvasMessage, PointerButton, RetainedSurfaceDescriptor, TextEditCommand, WidgetInput,
+    WidgetKey, WidgetSizing,
 };
 use std::{collections::BTreeMap, sync::Arc};
 

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -34,7 +34,7 @@ pub(super) enum SempalRuntimeMessage {
 }
 
 /// Retained-canvas input normalized out of Radiant widget events.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) enum RetainedCanvasInput {
     /// Pointer hover moved inside the retained Sempal canvas.
     PointerMove {
@@ -61,6 +61,8 @@ pub(super) enum RetainedCanvasInput {
     KeyPress(WidgetKey),
     /// Printable character routed to the focused retained canvas.
     Character(char),
+    /// Backend-level text editing command routed to the focused retained canvas.
+    TextEdit(TextEditCommand),
 }
 
 /// Local text-input target tracked after Sempal focus actions.
@@ -304,6 +306,7 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
             }
             RetainedCanvasInput::KeyPress(key) => self.handle_retained_key_press(key),
             RetainedCanvasInput::Character(character) => self.handle_retained_character(character),
+            RetainedCanvasInput::TextEdit(command) => self.handle_retained_text_edit(command),
         }
     }
 
@@ -358,6 +361,48 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                 false
             }),
             _ => false,
+        }
+    }
+
+    /// Handle one backend-level text edit command from Radiant's native runtime.
+    fn handle_retained_text_edit(&mut self, command: TextEditCommand) -> bool {
+        match command {
+            TextEditCommand::MoveLeft { extend_selection } => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.caret.saturating_sub(1), extend_selection);
+                false
+            }),
+            TextEditCommand::MoveRight { extend_selection } => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.caret + 1, extend_selection);
+                false
+            }),
+            TextEditCommand::MoveHome { extend_selection } => self.edit_retained_text(|edit| {
+                edit.move_caret(0, extend_selection);
+                false
+            }),
+            TextEditCommand::MoveEnd { extend_selection } => self.edit_retained_text(|edit| {
+                edit.move_caret(edit.value.chars().count(), extend_selection);
+                false
+            }),
+            TextEditCommand::SelectAll => self.edit_retained_text(|edit| {
+                edit.caret = edit.value.chars().count();
+                edit.selection_anchor = Some(0);
+                false
+            }),
+            TextEditCommand::InsertText(text) => {
+                let mut handled = false;
+                for character in text.chars() {
+                    if self.handle_retained_character(character) {
+                        handled = true;
+                    }
+                }
+                handled
+            }
+            TextEditCommand::Backspace => self.handle_retained_key_press(WidgetKey::Backspace),
+            TextEditCommand::Delete => self.handle_retained_key_press(WidgetKey::Delete),
+            TextEditCommand::CutSelection => self.edit_retained_text(|edit| {
+                edit.replace_selection("");
+                true
+            }),
         }
     }
 

--- a/src/gui_runtime/native_shell_runtime/input_routing.rs
+++ b/src/gui_runtime/native_shell_runtime/input_routing.rs
@@ -55,6 +55,7 @@ pub(super) fn retained_input_from_widget_input(input: WidgetInput) -> RetainedCa
         WidgetInput::FocusChanged(focused) => RetainedCanvasInput::FocusChanged(focused),
         WidgetInput::KeyPress(key) => RetainedCanvasInput::KeyPress(key),
         WidgetInput::Character(character) => RetainedCanvasInput::Character(character),
+        WidgetInput::TextEdit(command) => RetainedCanvasInput::TextEdit(command),
     }
 }
 

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[allow(clippy::module_inception)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -236,6 +236,35 @@ mod tests {
     }
 
     #[test]
+    fn retained_text_edit_commands_preserve_selection_and_paste_flow() {
+        let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+
+        bridge.update(SempalRuntimeMessage::Action(UiAction::FocusBrowserSearch));
+        bridge.inner.reduced.clear();
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::TextEdit(TextEditCommand::InsertText(String::from("kick"))),
+        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::TextEdit(TextEditCommand::SelectAll),
+        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(
+            RetainedCanvasInput::TextEdit(TextEditCommand::InsertText(String::from("snare"))),
+        ));
+
+        assert_eq!(
+            bridge.inner.reduced.last(),
+            Some(&UiAction::SetBrowserSearch {
+                query: String::from("snare"),
+            })
+        );
+    }
+
+    #[test]
     fn focused_browser_pill_editor_selection_deletes_draft_before_chip_backspace() {
         let mut model = NativeAppModel::default();
         model.browser.tag_sidebar.input_value = String::from("abc");


### PR DESCRIPTION
## Summary

Implements the OPT-393 dynamic widget migration set:

- OPT-400: audited downstream Sempal widget-extension requirements and recorded the findings on OPT-394.
- OPT-394: adds an object-safe Radiant `Widget` contract with cloneable boxed widgets, custom output payloads, and compatibility wrappers for existing `WidgetSpec` leaves.
- OPT-395/OPT-396: routes runtime widget input, message mapping, and paint projection through dynamic widget objects while keeping built-in widget behavior intact.
- OPT-397: adds ergonomic application-builder support for custom widget elements with generated, keyed, and explicit ids.
- OPT-398: keeps the built-in widget paint/input catalog as a compatibility path instead of the only runtime path.
- OPT-399: documents the custom-widget API and adds a compiling `custom_widget` example.

The root Sempal branch records the Radiant pointer update and adds a compatibility route for Radiant `TextEditCommand` input so retained Sempal text fields continue to handle paste, selection, and edit commands correctly.

## Validation

Radiant nested repo (`vendor/radiant`, commit `ccede8b9`):

- `cargo check --tests`
- `cargo test --test runtime_surface_public_api custom_widget -- --nocapture`
- `cargo check --examples`
- `cargo test --test runtime_surface_public_api`
- `cargo test --test widgets_public_api`
- `cargo test retained_custom_surface_cache --lib -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `cargo test --no-default-features`
- `git diff --check`

Sempal root:

- `cargo check -p sempal`
- `cargo test -p sempal --lib retained_text_edit_commands_preserve_selection_and_paste_flow -- --nocapture`
- `cargo test -p sempal --lib native_shell_runtime -- --nocapture`
- `cargo clippy -p sempal --all-targets -- -D warnings`
- `git diff --check`

`powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke` reaches the branch-policy guard and stops because this is a PR branch (`wsvasek/opt-393-dynamic-widget`) instead of `main`.

## Risks

The new dynamic widget trait is intentionally additive. Existing built-in widgets still use the compatibility catalog while custom widgets use the trait path for input, message output, and paint projection.

Refs OPT-393, OPT-400, OPT-394, OPT-395, OPT-396, OPT-397, OPT-398, OPT-399.