### PR TITLE
OPT-393: integrate Radiant widget API migration

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -292,7 +292,7 @@ fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<(
             label,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 

--- a/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
@@ -160,7 +160,7 @@ pub(super) fn build_toolbar_children(
                 TOOLBAR_TRIAGE_BASE_ID + BROWSER_TRIAGE_CHIP_COUNT as u64,
                 WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
             )),
-            WidgetMessageMapper::None,
+            WidgetMessageMapper::none(),
         ),
     ));
     children
@@ -269,7 +269,7 @@ fn toggle_widget(id: u64, label: &str, side: f32) -> SurfaceNode<()> {
             label,
             WidgetSizing::fixed(Vector2::new(side.max(1.0), side.max(1.0))),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 
@@ -286,7 +286,7 @@ fn text_input_widget(
         WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
     );
     widget.props.placeholder = (!placeholder.is_empty()).then(|| placeholder.to_string());
-    SurfaceNode::widget(WidgetSpec::TextInput(widget), WidgetMessageMapper::None)
+    SurfaceNode::widget(WidgetSpec::TextInput(widget), WidgetMessageMapper::none())
 }
 
 fn text_widget(id: u64, text: &str, width: f32, height: f32, font_size: f32) -> SurfaceNode<()> {
@@ -297,7 +297,7 @@ fn text_widget(id: u64, text: &str, width: f32, height: f32, font_size: f32) -> 
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 
@@ -325,7 +325,7 @@ fn spacer_child(id: u64, width: f32) -> SurfaceChild<()> {
                 id,
                 WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0)),
             )),
-            WidgetMessageMapper::None,
+            WidgetMessageMapper::none(),
         ),
     )
 }

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -41,7 +41,7 @@ pub(super) fn text_widget(id: u64, text: &str, width: f32, height: f32) -> Surfa
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
                 .with_baseline((height * 0.75).max(0.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 
@@ -53,7 +53,7 @@ pub(super) fn button_widget(id: u64, label: &str, width: f32, height: f32) -> Su
             label,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -252,7 +252,7 @@ fn segment_surface(
                             WidgetSizing::fixed(Vector2::new(1.0, sizing.font_status.max(1.0)))
                                 .with_baseline((sizing.font_status * 0.75).max(0.0)),
                         )),
-                        WidgetMessageMapper::None,
+                        WidgetMessageMapper::none(),
                     ),
                 )],
             ),
@@ -316,7 +316,7 @@ fn progress_surface(
                                         ))
                                         .with_baseline((sizing.font_status * 0.75).max(0.0)),
                                     )),
-                                    WidgetMessageMapper::None,
+                                    WidgetMessageMapper::none(),
                                 ),
                             )],
                         ),
@@ -331,7 +331,7 @@ fn progress_surface(
                                     track_height.max(1.0),
                                 )),
                             )),
-                            WidgetMessageMapper::None,
+                            WidgetMessageMapper::none(),
                         ),
                     ),
                 ],
@@ -352,7 +352,7 @@ fn spacer_surface(id: u64) -> SurfaceNode<()> {
             id,
             WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -346,7 +346,7 @@ fn build_title_cluster(
                                     meter_height.max(1.0),
                                 )),
                             )),
-                            WidgetMessageMapper::None,
+                            WidgetMessageMapper::none(),
                         ),
                     ),
                     SurfaceChild::new(
@@ -404,7 +404,7 @@ fn build_action_cluster(
                     spec.label,
                     WidgetSizing::fixed(Vector2::new(width.max(1.0), button_height.max(1.0))),
                 )),
-                WidgetMessageMapper::None,
+                WidgetMessageMapper::none(),
             ),
         ));
     }
@@ -416,7 +416,7 @@ fn build_action_cluster(
                 &content.options_label,
                 WidgetSizing::fixed(Vector2::new(options_width.max(1.0), button_height.max(1.0))),
             )),
-            WidgetMessageMapper::None,
+            WidgetMessageMapper::none(),
         ),
     ));
     SurfaceNode::container(
@@ -514,7 +514,7 @@ fn text_widget(id: u64, text: &str, width: f32, font_size: f32) -> SurfaceNode<(
             WidgetSizing::fixed(Vector2::new(width.max(1.0), font_size.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 
@@ -524,7 +524,7 @@ fn spacer_widget(id: u64) -> SurfaceNode<()> {
             id,
             WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -152,7 +152,7 @@ fn build_waveform_header_surface(
                                 WAVEFORM_HEADER_FILL_ID,
                                 WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
                             )),
-                            WidgetMessageMapper::None,
+                            WidgetMessageMapper::none(),
                         ),
                     ),
                 ],
@@ -169,7 +169,7 @@ fn text_widget(id: u64, text: &str, font_size: f32) -> SurfaceNode<()> {
             WidgetSizing::fixed(Vector2::new(1.0, font_size.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
         )),
-        WidgetMessageMapper::None,
+        WidgetMessageMapper::none(),
     )
 }
 

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -190,7 +190,7 @@ fn widget_for_item(
             WidgetSpec::TextInput(widget)
         }
     };
-    SurfaceNode::widget(widget, WidgetMessageMapper::None)
+    SurfaceNode::widget(widget, WidgetMessageMapper::none())
 }
 
 fn legacy_toolbar_rects(


### PR DESCRIPTION
## Summary
- advance `vendor/radiant` to the merged dynamic widget-object implementation
- update Sempal retained composition helpers for the new `WidgetMessageMapper::none()` constructor
- preserve retained native-shell behavior while consuming the open Radiant widget API

## Implemented issue set
- OPT-393 root coordination
- OPT-400 downstream extension audit
- OPT-394 open `Widget` trait/object contract
- OPT-395 dynamic widget object runtime path
- OPT-396 widget-owned paint projection
- OPT-397 `custom_widget(...)` app-builder support
- OPT-398 closed runtime widget/message-list collapse
- OPT-399 custom widget docs and proof example

## Validation
- Radiant PR #4: `cargo check --tests`, `cargo test --all-targets`, root focused native-shell test
- Root Sempal: `cargo test -p sempal --lib native_shell_runtime -- --nocapture`
- Root Sempal on local `main` with this diff: `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- Root Sempal on local `main` with this diff: `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`

References OPT-393, OPT-394, OPT-395, OPT-396, OPT-397, OPT-398, OPT-399, OPT-400.