### PR TITLE
Update Sempal for Radiant open widget API

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -20,7 +20,7 @@ use crate::{
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{ButtonWidget, WidgetSizing, WidgetSpec},
+    widgets::{ButtonWidget, WidgetSizing},
 };
 use helpers::{
     BrowserToolbarSurfaceWidths, browser_sort_label, browser_toolbar_surface_widths,
@@ -287,11 +287,11 @@ fn build_browser_toolbar_surface(
 
 fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Button(ButtonWidget::new(
+        ButtonWidget::new(
             id,
             label,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }

--- a/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
@@ -3,7 +3,7 @@ use crate::{
     gui::types::{Rect, Vector2},
     layout::{CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
     runtime::{SurfaceChild, SurfaceNode, WidgetMessageMapper},
-    widgets::{CanvasWidget, TextInputWidget, TextWidget, ToggleWidget, WidgetSizing, WidgetSpec},
+    widgets::{CanvasWidget, TextInputWidget, TextWidget, ToggleWidget, WidgetSizing},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -156,10 +156,10 @@ pub(super) fn build_toolbar_children(
     children.push(SurfaceChild::new(
         SlotParams::fill(),
         SurfaceNode::widget(
-            WidgetSpec::Canvas(CanvasWidget::new(
+            CanvasWidget::new(
                 TOOLBAR_TRIAGE_BASE_ID + BROWSER_TRIAGE_CHIP_COUNT as u64,
                 WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-            )),
+            ),
             WidgetMessageMapper::none(),
         ),
     ));
@@ -264,11 +264,11 @@ fn playback_chip_label(index: usize) -> &'static str {
 
 fn toggle_widget(id: u64, label: &str, side: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Toggle(ToggleWidget::new(
+        ToggleWidget::new(
             id,
             label,
             WidgetSizing::fixed(Vector2::new(side.max(1.0), side.max(1.0))),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }
@@ -286,17 +286,17 @@ fn text_input_widget(
         WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
     );
     widget.props.placeholder = (!placeholder.is_empty()).then(|| placeholder.to_string());
-    SurfaceNode::widget(WidgetSpec::TextInput(widget), WidgetMessageMapper::none())
+    SurfaceNode::widget(widget, WidgetMessageMapper::none())
 }
 
 fn text_widget(id: u64, text: &str, width: f32, height: f32, font_size: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Text(TextWidget::new(
+        TextWidget::new(
             id,
             text,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }
@@ -321,10 +321,7 @@ fn spacer_child(id: u64, width: f32) -> SurfaceChild<()> {
     SurfaceChild::new(
         fixed_slot(width.max(0.0), 1.0),
         SurfaceNode::widget(
-            WidgetSpec::Canvas(CanvasWidget::new(
-                id,
-                WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0)),
-            )),
+            CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0))),
             WidgetMessageMapper::none(),
         ),
     )

--- a/src/app_core/native_shell/composition/browser_chrome_surface_tests.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_tests.rs
@@ -1,7 +1,15 @@
 use super::*;
 use crate::{
-    app_core::native_shell::composition::style::StyleTokens, gui::types::Point, widgets::WidgetKind,
+    app_core::native_shell::composition::style::StyleTokens,
+    gui::types::Point,
+    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, Widget},
 };
+
+fn is_widget<T: Widget + 'static>(surface: &UiSurface<()>, id: u64) -> bool {
+    surface
+        .find_widget(id)
+        .is_some_and(|widget| widget.widget().as_any().downcast_ref::<T>().is_some())
+}
 
 fn assert_inside(outer: Rect, inner: Rect) {
     assert!(inner.min.x >= outer.min.x);
@@ -18,22 +26,8 @@ fn browser_tabs_surface_uses_public_button_widgets() {
         style.sizing,
         800.0,
     );
-    assert_eq!(
-        surface
-            .find_widget(TABS_ITEMS_ID)
-            .expect("primary tab")
-            .widget()
-            .kind(),
-        WidgetKind::Button
-    );
-    assert_eq!(
-        surface
-            .find_widget(TABS_MAP_ID)
-            .expect("map tab")
-            .widget()
-            .kind(),
-        WidgetKind::Button
-    );
+    assert!(is_widget::<ButtonWidget>(&surface, TABS_ITEMS_ID));
+    assert!(is_widget::<ButtonWidget>(&surface, TABS_MAP_ID));
 }
 
 #[test]
@@ -62,30 +56,9 @@ fn browser_toolbar_surface_uses_public_toggle_button_and_text_input_widgets() {
             style.sizing,
         ),
     );
-    assert_eq!(
-        surface
-            .find_widget(TOOLBAR_RATING_BASE_ID)
-            .expect("compatibility-only rating chip widget")
-            .widget()
-            .kind(),
-        WidgetKind::Toggle
-    );
-    assert_eq!(
-        surface
-            .find_widget(TOOLBAR_RANDOM_ID)
-            .expect("random button")
-            .widget()
-            .kind(),
-        WidgetKind::Button
-    );
-    assert_eq!(
-        surface
-            .find_widget(TOOLBAR_SEARCH_ID)
-            .expect("search field")
-            .widget()
-            .kind(),
-        WidgetKind::TextInput
-    );
+    assert!(is_widget::<ToggleWidget>(&surface, TOOLBAR_RATING_BASE_ID));
+    assert!(is_widget::<ButtonWidget>(&surface, TOOLBAR_RANDOM_ID));
+    assert!(is_widget::<TextInputWidget>(&surface, TOOLBAR_SEARCH_ID));
 }
 
 #[test]

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -5,7 +5,7 @@ use crate::{
     gui::types::{Point, Rect, Vector2},
     layout::{Constraints, CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
     runtime::{SurfaceNode, WidgetMessageMapper},
-    widgets::{ButtonWidget, TextWidget, WidgetSizing, WidgetSpec},
+    widgets::{ButtonWidget, TextWidget, WidgetSizing},
 };
 
 /// Return the canonical square sidebar-header add-button edge length.
@@ -35,12 +35,12 @@ pub(super) fn footer_action_button_width(
 /// Build one fixed-height text widget node for a generic sidebar surface.
 pub(super) fn text_widget(id: u64, text: &str, width: f32, height: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Text(TextWidget::new(
+        TextWidget::new(
             id,
             text,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
                 .with_baseline((height * 0.75).max(0.0)),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }
@@ -48,11 +48,11 @@ pub(super) fn text_widget(id: u64, text: &str, width: f32, height: f32) -> Surfa
 /// Build one fixed-size button widget node for a generic sidebar surface.
 pub(super) fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Button(ButtonWidget::new(
+        ButtonWidget::new(
             id,
             label,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }

--- a/src/app_core/native_shell/composition/sidebar_surface_tests.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_tests.rs
@@ -1,7 +1,13 @@
 use super::*;
 use crate::app_core::native_shell::composition::style::StyleTokens;
 use crate::gui::types::Point;
-use crate::widgets::WidgetKind;
+use crate::widgets::{ButtonWidget, TextWidget, Widget};
+
+fn is_widget<T: Widget + 'static>(surface: &UiSurface<()>, id: u64) -> bool {
+    surface
+        .find_widget(id)
+        .is_some_and(|widget| widget.widget().as_any().downcast_ref::<T>().is_some())
+}
 
 fn assert_inside(outer: Rect, inner: Rect) {
     assert!(inner.min.x >= outer.min.x);
@@ -23,30 +29,9 @@ fn sidebar_surfaces_use_public_text_and_button_widgets() {
         style.sizing,
         208.0,
     );
-    assert_eq!(
-        header
-            .find_widget(HEADER_TITLE_ID)
-            .expect("title")
-            .widget()
-            .kind(),
-        WidgetKind::Text
-    );
-    assert_eq!(
-        header
-            .find_widget(HEADER_ADD_BUTTON_ID)
-            .expect("add")
-            .widget()
-            .kind(),
-        WidgetKind::Button
-    );
-    assert_eq!(
-        footer
-            .find_widget(FOOTER_ACTION_BASE_ID)
-            .expect("footer action")
-            .widget()
-            .kind(),
-        WidgetKind::Button
-    );
+    assert!(is_widget::<TextWidget>(&header, HEADER_TITLE_ID));
+    assert!(is_widget::<ButtonWidget>(&header, HEADER_ADD_BUTTON_ID));
+    assert!(is_widget::<ButtonWidget>(&footer, FOOTER_ACTION_BASE_ID));
 }
 
 #[test]

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -13,7 +13,7 @@ use crate::{
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{CanvasWidget, TextWidget, WidgetSizing, WidgetSpec},
+    widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const STATUS_ROOT_ID: u64 = 960;
@@ -246,12 +246,12 @@ fn segment_surface(
                 vec![SurfaceChild::new(
                     text_slot(sizing.font_status),
                     SurfaceNode::widget(
-                        WidgetSpec::Text(TextWidget::new(
+                        TextWidget::new(
                             text_id,
                             label,
                             WidgetSizing::fixed(Vector2::new(1.0, sizing.font_status.max(1.0)))
                                 .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                        )),
+                        ),
                         WidgetMessageMapper::none(),
                     ),
                 )],
@@ -307,7 +307,7 @@ fn progress_surface(
                             vec![SurfaceChild::new(
                                 text_slot(sizing.font_status),
                                 SurfaceNode::widget(
-                                    WidgetSpec::Text(TextWidget::new(
+                                    TextWidget::new(
                                         STATUS_PROGRESS_TEXT_ID,
                                         &content.progress_counter,
                                         WidgetSizing::fixed(Vector2::new(
@@ -315,7 +315,7 @@ fn progress_surface(
                                             sizing.font_status.max(1.0),
                                         ))
                                         .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                                    )),
+                                    ),
                                     WidgetMessageMapper::none(),
                                 ),
                             )],
@@ -324,13 +324,13 @@ fn progress_surface(
                     SurfaceChild::new(
                         fixed_slot(track_height),
                         SurfaceNode::widget(
-                            WidgetSpec::Canvas(CanvasWidget::new(
+                            CanvasWidget::new(
                                 STATUS_PROGRESS_TRACK_ID,
                                 WidgetSizing::fixed(Vector2::new(
                                     progress_width.max(1.0),
                                     track_height.max(1.0),
                                 )),
-                            )),
+                            ),
                             WidgetMessageMapper::none(),
                         ),
                     ),
@@ -348,10 +348,7 @@ fn progress_slot_width(viewport_width: f32, sizing: SizingTokens) -> f32 {
 
 fn spacer_surface(id: u64) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Canvas(CanvasWidget::new(
-            id,
-            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-        )),
+        CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(1.0, 1.0))),
         WidgetMessageMapper::none(),
     )
 }
@@ -408,6 +405,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 mod tests {
     use super::*;
     use crate::app_core::native_shell::composition::style::StyleTokens;
+    use crate::widgets::{CanvasWidget, TextWidget};
 
     fn assert_inside(outer: Rect, inner: Rect) {
         assert!(inner.min.x >= outer.min.x);
@@ -435,8 +433,19 @@ mod tests {
         let track = surface
             .find_widget(STATUS_PROGRESS_TRACK_ID)
             .expect("progress track widget");
-        assert_eq!(left.widget().kind(), crate::widgets::WidgetKind::Text);
-        assert_eq!(track.widget().kind(), crate::widgets::WidgetKind::Canvas);
+        assert!(
+            left.widget()
+                .as_any()
+                .downcast_ref::<TextWidget>()
+                .is_some()
+        );
+        assert!(
+            track
+                .widget()
+                .as_any()
+                .downcast_ref::<CanvasWidget>()
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -14,7 +14,7 @@ use crate::{
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{ButtonWidget, CanvasWidget, TextWidget, WidgetSizing, WidgetSpec},
+    widgets::{ButtonWidget, CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const TOP_ROOT_ID: u64 = 1040;
@@ -339,13 +339,13 @@ fn build_title_cluster(
                     SurfaceChild::new(
                         fixed_slot_with_cross(meter_width, meter_height),
                         SurfaceNode::widget(
-                            WidgetSpec::Canvas(CanvasWidget::new(
+                            CanvasWidget::new(
                                 TOP_VOLUME_METER_ID,
                                 WidgetSizing::fixed(Vector2::new(
                                     meter_width.max(1.0),
                                     meter_height.max(1.0),
                                 )),
-                            )),
+                            ),
                             WidgetMessageMapper::none(),
                         ),
                     ),
@@ -399,11 +399,11 @@ fn build_action_cluster(
         children.push(SurfaceChild::new(
             fixed_slot(*width),
             SurfaceNode::widget(
-                WidgetSpec::Button(ButtonWidget::new(
+                ButtonWidget::new(
                     TOP_UPDATE_BUTTON_BASE_ID + (hidden_count + index) as u64,
                     spec.label,
                     WidgetSizing::fixed(Vector2::new(width.max(1.0), button_height.max(1.0))),
-                )),
+                ),
                 WidgetMessageMapper::none(),
             ),
         ));
@@ -411,11 +411,11 @@ fn build_action_cluster(
     children.push(SurfaceChild::new(
         fixed_slot(options_width),
         SurfaceNode::widget(
-            WidgetSpec::Button(ButtonWidget::new(
+            ButtonWidget::new(
                 TOP_OPTIONS_BUTTON_ID,
                 &content.options_label,
                 WidgetSizing::fixed(Vector2::new(options_width.max(1.0), button_height.max(1.0))),
-            )),
+            ),
             WidgetMessageMapper::none(),
         ),
     ));
@@ -508,22 +508,19 @@ fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<
 
 fn text_widget(id: u64, text: &str, width: f32, font_size: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Text(TextWidget::new(
+        TextWidget::new(
             id,
             text,
             WidgetSizing::fixed(Vector2::new(width.max(1.0), font_size.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }
 
 fn spacer_widget(id: u64) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Canvas(CanvasWidget::new(
-            id,
-            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-        )),
+        CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(1.0, 1.0))),
         WidgetMessageMapper::none(),
     )
 }
@@ -569,7 +566,10 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{app_core::native_shell::composition::style::StyleTokens, widgets::WidgetKind};
+    use crate::{
+        app_core::native_shell::composition::style::StyleTokens,
+        widgets::{ButtonWidget, CanvasWidget, TextWidget},
+    };
 
     fn assert_inside(outer: Rect, inner: Rect) {
         assert!(inner.min.x >= outer.min.x);
@@ -611,29 +611,32 @@ mod tests {
     fn top_bar_surface_uses_public_text_button_and_canvas_widgets() {
         let style = StyleTokens::for_viewport_width(1280.0);
         let surface = build_top_bar_surface(&content(), style.sizing, 1280.0);
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(TOP_TITLE_TEXT_ID)
                 .expect("title")
                 .widget()
-                .kind(),
-            WidgetKind::Text
+                .as_any()
+                .downcast_ref::<TextWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(TOP_VOLUME_METER_ID)
                 .expect("meter")
                 .widget()
-                .kind(),
-            WidgetKind::Canvas
+                .as_any()
+                .downcast_ref::<CanvasWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(TOP_OPTIONS_BUTTON_ID)
                 .expect("options")
                 .widget()
-                .kind(),
-            WidgetKind::Button
+                .as_any()
+                .downcast_ref::<ButtonWidget>()
+                .is_some()
         );
     }
 

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -14,7 +14,7 @@ use crate::{
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{CanvasWidget, TextWidget, WidgetSizing, WidgetSpec},
+    widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const WAVEFORM_HEADER_ROOT_ID: u64 = 1120;
@@ -148,10 +148,10 @@ fn build_waveform_header_surface(
                     SurfaceChild::new(
                         SlotParams::fill(),
                         SurfaceNode::widget(
-                            WidgetSpec::Canvas(CanvasWidget::new(
+                            CanvasWidget::new(
                                 WAVEFORM_HEADER_FILL_ID,
                                 WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-                            )),
+                            ),
                             WidgetMessageMapper::none(),
                         ),
                     ),
@@ -163,12 +163,12 @@ fn build_waveform_header_surface(
 
 fn text_widget(id: u64, text: &str, font_size: f32) -> SurfaceNode<()> {
     SurfaceNode::widget(
-        WidgetSpec::Text(TextWidget::new(
+        TextWidget::new(
             id,
             text,
             WidgetSizing::fixed(Vector2::new(1.0, font_size.max(1.0)))
                 .with_baseline((font_size * 0.75).max(0.0)),
-        )),
+        ),
         WidgetMessageMapper::none(),
     )
 }
@@ -206,7 +206,9 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 mod tests {
     use super::*;
     use crate::{
-        app::AppModel, app_core::native_shell::composition::style::StyleTokens, widgets::WidgetKind,
+        app::AppModel,
+        app_core::native_shell::composition::style::StyleTokens,
+        widgets::{CanvasWidget, TextWidget},
     };
 
     fn assert_inside(outer: Rect, inner: Rect) {
@@ -224,29 +226,32 @@ mod tests {
     fn waveform_header_surface_uses_public_text_and_canvas_widgets() {
         let style = StyleTokens::for_viewport_width(1280.0);
         let surface = build_waveform_header_surface(&content(), style.sizing);
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(WAVEFORM_HEADER_TITLE_ID)
                 .expect("title")
                 .widget()
-                .kind(),
-            WidgetKind::Text
+                .as_any()
+                .downcast_ref::<TextWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(WAVEFORM_HEADER_METADATA_ID)
                 .expect("metadata")
                 .widget()
-                .kind(),
-            WidgetKind::Text
+                .as_any()
+                .downcast_ref::<TextWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(WAVEFORM_HEADER_FILL_ID)
                 .expect("fill")
                 .widget()
-                .kind(),
-            WidgetKind::Canvas
+                .as_any()
+                .downcast_ref::<CanvasWidget>()
+                .is_some()
         );
     }
 

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -14,7 +14,7 @@ use crate::{
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, WidgetSizing, WidgetSpec},
+    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, Widget, WidgetSizing},
 };
 
 const WAVEFORM_TOOLBAR_BASE_ID: u64 = 1320;
@@ -167,19 +167,19 @@ fn widget_for_item(
 ) -> SurfaceNode<()> {
     let id = waveform_toolbar_widget_id(item_index);
     let size = WidgetSizing::fixed(Vector2::new(rect.width().max(1.0), rect.height().max(1.0)));
-    let widget = match item.kind {
+    let widget: Box<dyn Widget> = match item.kind {
         WaveformToolbarSurfaceItemKind::Button => {
             let mut widget = ButtonWidget::new(id, &item.label, size);
             widget.common.state.disabled = !item.enabled;
             widget.common.state.active = item.active;
-            WidgetSpec::Button(widget)
+            Box::new(widget)
         }
         WaveformToolbarSurfaceItemKind::Toggle => {
             let mut widget = ToggleWidget::new(id, &item.label, size);
             widget.common.state.disabled = !item.enabled;
             widget.common.state.active = item.active;
             widget.state.checked = item.active;
-            WidgetSpec::Toggle(widget)
+            Box::new(widget)
         }
         WaveformToolbarSurfaceItemKind::TextInput => {
             let mut widget = TextInputWidget::new(id, item.value.clone().unwrap_or_default(), size);
@@ -187,10 +187,10 @@ fn widget_for_item(
             widget.common.state.active = item.active;
             widget.common.state.read_only = true;
             widget.props.placeholder = Some(item.label.clone());
-            WidgetSpec::TextInput(widget)
+            Box::new(widget)
         }
     };
-    SurfaceNode::widget(widget, WidgetMessageMapper::none())
+    SurfaceNode::custom_widget_box(widget, WidgetMessageMapper::none())
 }
 
 fn legacy_toolbar_rects(
@@ -250,7 +250,10 @@ fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{app_core::native_shell::composition::style::StyleTokens, widgets::WidgetKind};
+    use crate::{
+        app_core::native_shell::composition::style::StyleTokens,
+        widgets::{ButtonWidget, TextInputWidget, ToggleWidget},
+    };
 
     fn sample_content() -> WaveformToolbarSurfaceContent {
         WaveformToolbarSurfaceContent {
@@ -321,29 +324,32 @@ mod tests {
                 &content,
             ),
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(waveform_toolbar_widget_id(0))
                 .expect("channel toggle")
                 .widget()
-                .kind(),
-            WidgetKind::Toggle
+                .as_any()
+                .downcast_ref::<ToggleWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(waveform_toolbar_widget_id(2))
                 .expect("bpm value input")
                 .widget()
-                .kind(),
-            WidgetKind::TextInput
+                .as_any()
+                .downcast_ref::<TextInputWidget>()
+                .is_some()
         );
-        assert_eq!(
+        assert!(
             surface
                 .find_widget(waveform_toolbar_widget_id(4))
                 .expect("compare button")
                 .widget()
-                .kind(),
-            WidgetKind::Button
+                .as_any()
+                .downcast_ref::<ButtonWidget>()
+                .is_some()
         );
     }
 


### PR DESCRIPTION
## Summary
- update the Radiant vendor pointer to the merged open widget API change (radiant#5)
- replace Sempal WidgetSpec construction with direct concrete widget construction
- update composition tests to verify runtime widgets through the open Widget trait object API

## Validation
- cargo test -p sempal --lib native_shell_runtime -- --nocapture
- cargo check -p sempal --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke (passed on main before switching to this PR branch; on PR branch the script stops at the expected branch-policy guard)