### PR TITLE
Update Radiant widget output API

### DIFF
--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -94,7 +94,7 @@ mod tests {
         let message = surface
             .dispatch_widget_output(
                 1,
-                WidgetOutput::Canvas(CanvasMessage::Input {
+                WidgetOutput::typed(CanvasMessage::Input {
                     input: WidgetInput::PointerPress {
                         position: radiant::gui::types::Point::new(4.0, 5.0),
                         button: radiant::widgets::PointerButton::Primary,


### PR DESCRIPTION
## Summary
- advance vendor/radiant to the merged open widget output routing API
- update Sempal retained-shell test coverage to use WidgetOutput::typed for canvas messages

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke