### PR TITLE
Use static widget nodes in Sempal chrome surfaces

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -19,7 +19,7 @@ use crate::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
-    runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
+    runtime::{SurfaceChild, SurfaceNode, UiSurface},
     widgets::{ButtonWidget, WidgetSizing},
 };
 use helpers::{
@@ -286,14 +286,11 @@ fn build_browser_toolbar_surface(
 }
 
 fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        ButtonWidget::new(
-            id,
-            label,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(ButtonWidget::new(
+        id,
+        label,
+        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
+    ))
 }
 
 fn fill_slot(min_width: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     gui::types::{Rect, Vector2},
     layout::{CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
-    runtime::{SurfaceChild, SurfaceNode, WidgetMessageMapper},
+    runtime::{SurfaceChild, SurfaceNode},
     widgets::{CanvasWidget, TextInputWidget, TextWidget, ToggleWidget, WidgetSizing},
 };
 
@@ -155,13 +155,10 @@ pub(super) fn build_toolbar_children(
     }
     children.push(SurfaceChild::new(
         SlotParams::fill(),
-        SurfaceNode::widget(
-            CanvasWidget::new(
-                TOOLBAR_TRIAGE_BASE_ID + BROWSER_TRIAGE_CHIP_COUNT as u64,
-                WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-            ),
-            WidgetMessageMapper::none(),
-        ),
+        SurfaceNode::static_widget(CanvasWidget::new(
+            TOOLBAR_TRIAGE_BASE_ID + BROWSER_TRIAGE_CHIP_COUNT as u64,
+            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
+        )),
     ));
     children
 }
@@ -263,14 +260,11 @@ fn playback_chip_label(index: usize) -> &'static str {
 }
 
 fn toggle_widget(id: u64, label: &str, side: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        ToggleWidget::new(
-            id,
-            label,
-            WidgetSizing::fixed(Vector2::new(side.max(1.0), side.max(1.0))),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(ToggleWidget::new(
+        id,
+        label,
+        WidgetSizing::fixed(Vector2::new(side.max(1.0), side.max(1.0))),
+    ))
 }
 
 fn text_input_widget(
@@ -286,19 +280,16 @@ fn text_input_widget(
         WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
     );
     widget.props.placeholder = (!placeholder.is_empty()).then(|| placeholder.to_string());
-    SurfaceNode::widget(widget, WidgetMessageMapper::none())
+    SurfaceNode::static_widget(widget)
 }
 
 fn text_widget(id: u64, text: &str, width: f32, height: f32, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        TextWidget::new(
-            id,
-            text,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
-                .with_baseline((font_size * 0.75).max(0.0)),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(TextWidget::new(
+        id,
+        text,
+        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
+            .with_baseline((font_size * 0.75).max(0.0)),
+    ))
 }
 
 fn fixed_slot(width: f32, height: f32) -> SlotParams {
@@ -320,9 +311,9 @@ fn fixed_slot(width: f32, height: f32) -> SlotParams {
 fn spacer_child(id: u64, width: f32) -> SurfaceChild<()> {
     SurfaceChild::new(
         fixed_slot(width.max(0.0), 1.0),
-        SurfaceNode::widget(
-            CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0))),
-            WidgetMessageMapper::none(),
-        ),
+        SurfaceNode::static_widget(CanvasWidget::new(
+            id,
+            WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0)),
+        )),
     )
 }

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -4,7 +4,7 @@ use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::{
     gui::types::{Point, Rect, Vector2},
     layout::{Constraints, CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
-    runtime::{SurfaceNode, WidgetMessageMapper},
+    runtime::SurfaceNode,
     widgets::{ButtonWidget, TextWidget, WidgetSizing},
 };
 
@@ -34,27 +34,21 @@ pub(super) fn footer_action_button_width(
 
 /// Build one fixed-height text widget node for a generic sidebar surface.
 pub(super) fn text_widget(id: u64, text: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        TextWidget::new(
-            id,
-            text,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
-                .with_baseline((height * 0.75).max(0.0)),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(TextWidget::new(
+        id,
+        text,
+        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
+            .with_baseline((height * 0.75).max(0.0)),
+    ))
 }
 
 /// Build one fixed-size button widget node for a generic sidebar surface.
 pub(super) fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        ButtonWidget::new(
-            id,
-            label,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(ButtonWidget::new(
+        id,
+        label,
+        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
+    ))
 }
 
 /// Return a fixed-width slot that stretches vertically inside its parent row.

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -12,7 +12,7 @@ use crate::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
-    runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
+    runtime::{SurfaceChild, SurfaceNode, UiSurface},
     widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
@@ -245,15 +245,12 @@ fn segment_surface(
                 },
                 vec![SurfaceChild::new(
                     text_slot(sizing.font_status),
-                    SurfaceNode::widget(
-                        TextWidget::new(
-                            text_id,
-                            label,
-                            WidgetSizing::fixed(Vector2::new(1.0, sizing.font_status.max(1.0)))
-                                .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                        ),
-                        WidgetMessageMapper::none(),
-                    ),
+                    SurfaceNode::static_widget(TextWidget::new(
+                        text_id,
+                        label,
+                        WidgetSizing::fixed(Vector2::new(1.0, sizing.font_status.max(1.0)))
+                            .with_baseline((sizing.font_status * 0.75).max(0.0)),
+                    )),
                 )],
             ),
         )],
@@ -306,33 +303,27 @@ fn progress_surface(
                             },
                             vec![SurfaceChild::new(
                                 text_slot(sizing.font_status),
-                                SurfaceNode::widget(
-                                    TextWidget::new(
-                                        STATUS_PROGRESS_TEXT_ID,
-                                        &content.progress_counter,
-                                        WidgetSizing::fixed(Vector2::new(
-                                            progress_width.max(1.0),
-                                            sizing.font_status.max(1.0),
-                                        ))
-                                        .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                                    ),
-                                    WidgetMessageMapper::none(),
-                                ),
+                                SurfaceNode::static_widget(TextWidget::new(
+                                    STATUS_PROGRESS_TEXT_ID,
+                                    &content.progress_counter,
+                                    WidgetSizing::fixed(Vector2::new(
+                                        progress_width.max(1.0),
+                                        sizing.font_status.max(1.0),
+                                    ))
+                                    .with_baseline((sizing.font_status * 0.75).max(0.0)),
+                                )),
                             )],
                         ),
                     ),
                     SurfaceChild::new(
                         fixed_slot(track_height),
-                        SurfaceNode::widget(
-                            CanvasWidget::new(
-                                STATUS_PROGRESS_TRACK_ID,
-                                WidgetSizing::fixed(Vector2::new(
-                                    progress_width.max(1.0),
-                                    track_height.max(1.0),
-                                )),
-                            ),
-                            WidgetMessageMapper::none(),
-                        ),
+                        SurfaceNode::static_widget(CanvasWidget::new(
+                            STATUS_PROGRESS_TRACK_ID,
+                            WidgetSizing::fixed(Vector2::new(
+                                progress_width.max(1.0),
+                                track_height.max(1.0),
+                            )),
+                        )),
                     ),
                 ],
             ),
@@ -347,10 +338,10 @@ fn progress_slot_width(viewport_width: f32, sizing: SizingTokens) -> f32 {
 }
 
 fn spacer_surface(id: u64) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(1.0, 1.0))),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(CanvasWidget::new(
+        id,
+        WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
+    ))
 }
 
 fn percent_slot(ratio: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -13,7 +13,7 @@ use crate::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
-    runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
+    runtime::{SurfaceChild, SurfaceNode, UiSurface},
     widgets::{ButtonWidget, CanvasWidget, TextWidget, WidgetSizing},
 };
 
@@ -338,16 +338,13 @@ fn build_title_cluster(
                 vec![
                     SurfaceChild::new(
                         fixed_slot_with_cross(meter_width, meter_height),
-                        SurfaceNode::widget(
-                            CanvasWidget::new(
-                                TOP_VOLUME_METER_ID,
-                                WidgetSizing::fixed(Vector2::new(
-                                    meter_width.max(1.0),
-                                    meter_height.max(1.0),
-                                )),
-                            ),
-                            WidgetMessageMapper::none(),
-                        ),
+                        SurfaceNode::static_widget(CanvasWidget::new(
+                            TOP_VOLUME_METER_ID,
+                            WidgetSizing::fixed(Vector2::new(
+                                meter_width.max(1.0),
+                                meter_height.max(1.0),
+                            )),
+                        )),
                     ),
                     SurfaceChild::new(
                         fixed_slot(value_width),
@@ -398,26 +395,20 @@ fn build_action_cluster(
         let spec = &content.update_actions[hidden_count + index];
         children.push(SurfaceChild::new(
             fixed_slot(*width),
-            SurfaceNode::widget(
-                ButtonWidget::new(
-                    TOP_UPDATE_BUTTON_BASE_ID + (hidden_count + index) as u64,
-                    spec.label,
-                    WidgetSizing::fixed(Vector2::new(width.max(1.0), button_height.max(1.0))),
-                ),
-                WidgetMessageMapper::none(),
-            ),
+            SurfaceNode::static_widget(ButtonWidget::new(
+                TOP_UPDATE_BUTTON_BASE_ID + (hidden_count + index) as u64,
+                spec.label,
+                WidgetSizing::fixed(Vector2::new(width.max(1.0), button_height.max(1.0))),
+            )),
         ));
     }
     children.push(SurfaceChild::new(
         fixed_slot(options_width),
-        SurfaceNode::widget(
-            ButtonWidget::new(
-                TOP_OPTIONS_BUTTON_ID,
-                &content.options_label,
-                WidgetSizing::fixed(Vector2::new(options_width.max(1.0), button_height.max(1.0))),
-            ),
-            WidgetMessageMapper::none(),
-        ),
+        SurfaceNode::static_widget(ButtonWidget::new(
+            TOP_OPTIONS_BUTTON_ID,
+            &content.options_label,
+            WidgetSizing::fixed(Vector2::new(options_width.max(1.0), button_height.max(1.0))),
+        )),
     ));
     SurfaceNode::container(
         TOP_ACTION_CLUSTER_ID,
@@ -507,22 +498,19 @@ fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<
 }
 
 fn text_widget(id: u64, text: &str, width: f32, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        TextWidget::new(
-            id,
-            text,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), font_size.max(1.0)))
-                .with_baseline((font_size * 0.75).max(0.0)),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(TextWidget::new(
+        id,
+        text,
+        WidgetSizing::fixed(Vector2::new(width.max(1.0), font_size.max(1.0)))
+            .with_baseline((font_size * 0.75).max(0.0)),
+    ))
 }
 
 fn spacer_widget(id: u64) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        CanvasWidget::new(id, WidgetSizing::fixed(Vector2::new(1.0, 1.0))),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(CanvasWidget::new(
+        id,
+        WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
+    ))
 }
 
 fn fixed_slot(width: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -13,7 +13,7 @@ use crate::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
-    runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
+    runtime::{SurfaceChild, SurfaceNode, UiSurface},
     widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
@@ -147,13 +147,10 @@ fn build_waveform_header_surface(
                     ),
                     SurfaceChild::new(
                         SlotParams::fill(),
-                        SurfaceNode::widget(
-                            CanvasWidget::new(
-                                WAVEFORM_HEADER_FILL_ID,
-                                WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-                            ),
-                            WidgetMessageMapper::none(),
-                        ),
+                        SurfaceNode::static_widget(CanvasWidget::new(
+                            WAVEFORM_HEADER_FILL_ID,
+                            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
+                        )),
                     ),
                 ],
             ),
@@ -162,15 +159,12 @@ fn build_waveform_header_surface(
 }
 
 fn text_widget(id: u64, text: &str, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::widget(
-        TextWidget::new(
-            id,
-            text,
-            WidgetSizing::fixed(Vector2::new(1.0, font_size.max(1.0)))
-                .with_baseline((font_size * 0.75).max(0.0)),
-        ),
-        WidgetMessageMapper::none(),
-    )
+    SurfaceNode::static_widget(TextWidget::new(
+        id,
+        text,
+        WidgetSizing::fixed(Vector2::new(1.0, font_size.max(1.0)))
+            .with_baseline((font_size * 0.75).max(0.0)),
+    ))
 }
 
 fn text_slot(font_size: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -13,8 +13,8 @@ use crate::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
-    runtime::{SurfaceChild, SurfaceNode, UiSurface, WidgetMessageMapper},
-    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, Widget, WidgetSizing},
+    runtime::{SurfaceChild, SurfaceNode, UiSurface},
+    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, WidgetSizing},
 };
 
 const WAVEFORM_TOOLBAR_BASE_ID: u64 = 1320;
@@ -167,19 +167,19 @@ fn widget_for_item(
 ) -> SurfaceNode<()> {
     let id = waveform_toolbar_widget_id(item_index);
     let size = WidgetSizing::fixed(Vector2::new(rect.width().max(1.0), rect.height().max(1.0)));
-    let widget: Box<dyn Widget> = match item.kind {
+    match item.kind {
         WaveformToolbarSurfaceItemKind::Button => {
             let mut widget = ButtonWidget::new(id, &item.label, size);
             widget.common.state.disabled = !item.enabled;
             widget.common.state.active = item.active;
-            Box::new(widget)
+            SurfaceNode::static_widget(widget)
         }
         WaveformToolbarSurfaceItemKind::Toggle => {
             let mut widget = ToggleWidget::new(id, &item.label, size);
             widget.common.state.disabled = !item.enabled;
             widget.common.state.active = item.active;
             widget.state.checked = item.active;
-            Box::new(widget)
+            SurfaceNode::static_widget(widget)
         }
         WaveformToolbarSurfaceItemKind::TextInput => {
             let mut widget = TextInputWidget::new(id, item.value.clone().unwrap_or_default(), size);
@@ -187,10 +187,9 @@ fn widget_for_item(
             widget.common.state.active = item.active;
             widget.common.state.read_only = true;
             widget.props.placeholder = Some(item.label.clone());
-            Box::new(widget)
+            SurfaceNode::static_widget(widget)
         }
-    };
-    SurfaceNode::custom_widget_box(widget, WidgetMessageMapper::none())
+    }
 }
 
 fn legacy_toolbar_rects(


### PR DESCRIPTION
## Summary
- convert Sempal chrome composition surfaces to build static widget nodes directly for non-emitting text/button/toggle/input/canvas leaves
- remove leftover none-mapper and boxed custom-widget paths from parent Sempal surface construction
- keep the retained canvas input bridge unchanged as the app/runtime boundary

## Validation
- cargo fmt
- cargo test -p sempal browser_chrome_surface --lib
- cargo test -p sempal sidebar_surface --lib
- cargo test -p sempal waveform_header_surface --lib
- cargo test -p sempal waveform_toolbar_surface --lib
- cargo test -p sempal top_bar_surface --lib
- cargo test -p sempal status_surface --lib
- cargo test -p sempal status_bar_progress --lib
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke

Refs OPT-393