### PR TITLE
Centralize Sempal chrome widget node builders

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -11,16 +11,15 @@ mod helpers;
 #[path = "browser_chrome_surface_tests.rs"]
 mod tests;
 
-use super::style::SizingTokens;
+use super::{style::SizingTokens, widget_nodes::button_node};
 use crate::{
     app::AppModel,
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Point, Rect},
     layout::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface},
-    widgets::{ButtonWidget, WidgetSizing},
 };
 use helpers::{
     BrowserToolbarSurfaceWidths, browser_sort_label, browser_toolbar_surface_widths,
@@ -286,11 +285,7 @@ fn build_browser_toolbar_surface(
 }
 
 fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(ButtonWidget::new(
-        id,
-        label,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-    ))
+    button_node(id, label, width, height)
 }
 
 fn fill_slot(min_width: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_helpers.rs
@@ -1,9 +1,11 @@
 use super::*;
+use crate::app_core::native_shell::composition::widget_nodes::{
+    canvas_node, text_input_node, text_node, toggle_square_node,
+};
 use crate::{
-    gui::types::{Rect, Vector2},
+    gui::types::Rect,
     layout::{CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
     runtime::{SurfaceChild, SurfaceNode},
-    widgets::{CanvasWidget, TextInputWidget, TextWidget, ToggleWidget, WidgetSizing},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -155,10 +157,11 @@ pub(super) fn build_toolbar_children(
     }
     children.push(SurfaceChild::new(
         SlotParams::fill(),
-        SurfaceNode::static_widget(CanvasWidget::new(
+        canvas_node(
             TOOLBAR_TRIAGE_BASE_ID + BROWSER_TRIAGE_CHIP_COUNT as u64,
-            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-        )),
+            1.0,
+            1.0,
+        ),
     ));
     children
 }
@@ -260,11 +263,7 @@ fn playback_chip_label(index: usize) -> &'static str {
 }
 
 fn toggle_widget(id: u64, label: &str, side: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(ToggleWidget::new(
-        id,
-        label,
-        WidgetSizing::fixed(Vector2::new(side.max(1.0), side.max(1.0))),
-    ))
+    toggle_square_node(id, label, side)
 }
 
 fn text_input_widget(
@@ -274,22 +273,11 @@ fn text_input_widget(
     width: f32,
     height: f32,
 ) -> SurfaceNode<()> {
-    let mut widget = TextInputWidget::new(
-        id,
-        value,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-    );
-    widget.props.placeholder = (!placeholder.is_empty()).then(|| placeholder.to_string());
-    SurfaceNode::static_widget(widget)
+    text_input_node(id, value, Some(placeholder), width, height)
 }
 
 fn text_widget(id: u64, text: &str, width: f32, height: f32, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(TextWidget::new(
-        id,
-        text,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
-            .with_baseline((font_size * 0.75).max(0.0)),
-    ))
+    text_node(id, text, width, height, font_size)
 }
 
 fn fixed_slot(width: f32, height: f32) -> SlotParams {
@@ -309,11 +297,5 @@ fn fixed_slot(width: f32, height: f32) -> SlotParams {
 }
 
 fn spacer_child(id: u64, width: f32) -> SurfaceChild<()> {
-    SurfaceChild::new(
-        fixed_slot(width.max(0.0), 1.0),
-        SurfaceNode::static_widget(CanvasWidget::new(
-            id,
-            WidgetSizing::fixed(Vector2::new(width.max(1.0), 1.0)),
-        )),
-    )
+    SurfaceChild::new(fixed_slot(width.max(0.0), 1.0), canvas_node(id, width, 1.0))
 }

--- a/src/app_core/native_shell/composition/mod.rs
+++ b/src/app_core/native_shell/composition/mod.rs
@@ -20,6 +20,7 @@ mod tests;
 mod top_bar_surface;
 mod waveform_header_surface;
 mod waveform_toolbar_surface;
+mod widget_nodes;
 
 pub(crate) use layout::ShellLayout;
 pub(crate) use layout::ShellNodeKind;

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -1,11 +1,13 @@
 //! Shared widget, slot, and clamp helpers for sidebar chrome surfaces.
 
-use crate::app_core::native_shell::composition::style::SizingTokens;
+use crate::app_core::native_shell::composition::{
+    style::SizingTokens,
+    widget_nodes::{button_node, text_node},
+};
 use crate::{
     gui::types::{Point, Rect, Vector2},
     layout::{Constraints, CrossAlign, Insets, SizeModeCross, SizeModeMain, SlotParams},
     runtime::SurfaceNode,
-    widgets::{ButtonWidget, TextWidget, WidgetSizing},
 };
 
 /// Return the canonical square sidebar-header add-button edge length.
@@ -34,21 +36,12 @@ pub(super) fn footer_action_button_width(
 
 /// Build one fixed-height text widget node for a generic sidebar surface.
 pub(super) fn text_widget(id: u64, text: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(TextWidget::new(
-        id,
-        text,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
-            .with_baseline((height * 0.75).max(0.0)),
-    ))
+    text_node(id, text, width, height, height)
 }
 
 /// Build one fixed-size button widget node for a generic sidebar surface.
 pub(super) fn button_widget(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(ButtonWidget::new(
-        id,
-        label,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0))),
-    ))
+    button_node(id, label, width, height)
 }
 
 /// Return a fixed-width slot that stretches vertically inside its parent row.

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -5,15 +5,17 @@
 //! building blocks before the whole native window runtime migrates away from
 //! the legacy `AppModel` path.
 
-use super::style::SizingTokens;
+use super::{
+    style::SizingTokens,
+    widget_nodes::{canvas_node, text_node},
+};
 use crate::{
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Point, Rect},
     layout::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface},
-    widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const STATUS_ROOT_ID: u64 = 960;
@@ -245,12 +247,7 @@ fn segment_surface(
                 },
                 vec![SurfaceChild::new(
                     text_slot(sizing.font_status),
-                    SurfaceNode::static_widget(TextWidget::new(
-                        text_id,
-                        label,
-                        WidgetSizing::fixed(Vector2::new(1.0, sizing.font_status.max(1.0)))
-                            .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                    )),
+                    text_node(text_id, label, 1.0, sizing.font_status, sizing.font_status),
                 )],
             ),
         )],
@@ -303,27 +300,19 @@ fn progress_surface(
                             },
                             vec![SurfaceChild::new(
                                 text_slot(sizing.font_status),
-                                SurfaceNode::static_widget(TextWidget::new(
+                                text_node(
                                     STATUS_PROGRESS_TEXT_ID,
                                     &content.progress_counter,
-                                    WidgetSizing::fixed(Vector2::new(
-                                        progress_width.max(1.0),
-                                        sizing.font_status.max(1.0),
-                                    ))
-                                    .with_baseline((sizing.font_status * 0.75).max(0.0)),
-                                )),
+                                    progress_width,
+                                    sizing.font_status,
+                                    sizing.font_status,
+                                ),
                             )],
                         ),
                     ),
                     SurfaceChild::new(
                         fixed_slot(track_height),
-                        SurfaceNode::static_widget(CanvasWidget::new(
-                            STATUS_PROGRESS_TRACK_ID,
-                            WidgetSizing::fixed(Vector2::new(
-                                progress_width.max(1.0),
-                                track_height.max(1.0),
-                            )),
-                        )),
+                        canvas_node(STATUS_PROGRESS_TRACK_ID, progress_width, track_height),
                     ),
                 ],
             ),
@@ -338,10 +327,7 @@ fn progress_slot_width(viewport_width: f32, sizing: SizingTokens) -> f32 {
 }
 
 fn spacer_surface(id: u64) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(CanvasWidget::new(
-        id,
-        WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-    ))
+    canvas_node(id, 1.0, 1.0)
 }
 
 fn percent_slot(ratio: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -5,16 +5,18 @@
 //! options, and update-action composition, while the compatibility shell still
 //! paints those resolved rects with the existing native theme.
 
-use super::style::SizingTokens;
+use super::{
+    style::SizingTokens,
+    widget_nodes::{button_node, canvas_node, text_node},
+};
 use crate::{
     app::{AppModel, UiAction, UpdateStatusModel},
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Point, Rect},
     layout::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface},
-    widgets::{ButtonWidget, CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const TOP_ROOT_ID: u64 = 1040;
@@ -338,13 +340,7 @@ fn build_title_cluster(
                 vec![
                     SurfaceChild::new(
                         fixed_slot_with_cross(meter_width, meter_height),
-                        SurfaceNode::static_widget(CanvasWidget::new(
-                            TOP_VOLUME_METER_ID,
-                            WidgetSizing::fixed(Vector2::new(
-                                meter_width.max(1.0),
-                                meter_height.max(1.0),
-                            )),
-                        )),
+                        canvas_node(TOP_VOLUME_METER_ID, meter_width, meter_height),
                     ),
                     SurfaceChild::new(
                         fixed_slot(value_width),
@@ -395,20 +391,22 @@ fn build_action_cluster(
         let spec = &content.update_actions[hidden_count + index];
         children.push(SurfaceChild::new(
             fixed_slot(*width),
-            SurfaceNode::static_widget(ButtonWidget::new(
+            button_node(
                 TOP_UPDATE_BUTTON_BASE_ID + (hidden_count + index) as u64,
                 spec.label,
-                WidgetSizing::fixed(Vector2::new(width.max(1.0), button_height.max(1.0))),
-            )),
+                *width,
+                button_height,
+            ),
         ));
     }
     children.push(SurfaceChild::new(
         fixed_slot(options_width),
-        SurfaceNode::static_widget(ButtonWidget::new(
+        button_node(
             TOP_OPTIONS_BUTTON_ID,
             &content.options_label,
-            WidgetSizing::fixed(Vector2::new(options_width.max(1.0), button_height.max(1.0))),
-        )),
+            options_width,
+            button_height,
+        ),
     ));
     SurfaceNode::container(
         TOP_ACTION_CLUSTER_ID,
@@ -498,19 +496,11 @@ fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<
 }
 
 fn text_widget(id: u64, text: &str, width: f32, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(TextWidget::new(
-        id,
-        text,
-        WidgetSizing::fixed(Vector2::new(width.max(1.0), font_size.max(1.0)))
-            .with_baseline((font_size * 0.75).max(0.0)),
-    ))
+    text_node(id, text, width, font_size, font_size)
 }
 
 fn spacer_widget(id: u64) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(CanvasWidget::new(
-        id,
-        WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-    ))
+    canvas_node(id, 1.0, 1.0)
 }
 
 fn fixed_slot(width: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -5,16 +5,18 @@
 //! pattern used by the top bar, status bar, and sidebar chrome bands while the
 //! waveform plot, overlays, and edit geometry remain on the compatibility path.
 
-use super::style::SizingTokens;
+use super::{
+    style::SizingTokens,
+    widget_nodes::{canvas_node, text_node},
+};
 use crate::{
     app::NativeMotionModel,
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Point, Rect},
     layout::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, MainAlign, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface},
-    widgets::{CanvasWidget, TextWidget, WidgetSizing},
 };
 
 const WAVEFORM_HEADER_ROOT_ID: u64 = 1120;
@@ -147,10 +149,7 @@ fn build_waveform_header_surface(
                     ),
                     SurfaceChild::new(
                         SlotParams::fill(),
-                        SurfaceNode::static_widget(CanvasWidget::new(
-                            WAVEFORM_HEADER_FILL_ID,
-                            WidgetSizing::fixed(Vector2::new(1.0, 1.0)),
-                        )),
+                        canvas_node(WAVEFORM_HEADER_FILL_ID, 1.0, 1.0),
                     ),
                 ],
             ),
@@ -159,12 +158,7 @@ fn build_waveform_header_surface(
 }
 
 fn text_widget(id: u64, text: &str, font_size: f32) -> SurfaceNode<()> {
-    SurfaceNode::static_widget(TextWidget::new(
-        id,
-        text,
-        WidgetSizing::fixed(Vector2::new(1.0, font_size.max(1.0)))
-            .with_baseline((font_size * 0.75).max(0.0)),
-    ))
+    text_node(id, text, 1.0, font_size, font_size)
 }
 
 fn text_slot(font_size: f32) -> SlotParams {

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -5,16 +5,18 @@
 //! pattern used by the earlier chrome migrations while waveform plot rendering,
 //! overlays, and edit geometry stay on the compatibility renderer.
 
-use super::style::SizingTokens;
+use super::{
+    style::SizingTokens,
+    widget_nodes::{button_node_with, text_input_node_with, toggle_node_with},
+};
 use crate::{
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Point, Rect},
     layout::NodeId,
     layout::{
         Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, OverflowPolicy,
         SizeModeCross, SizeModeMain, SlotParams, layout_tree,
     },
     runtime::{SurfaceChild, SurfaceNode, UiSurface},
-    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, WidgetSizing},
 };
 
 const WAVEFORM_TOOLBAR_BASE_ID: u64 = 1320;
@@ -166,29 +168,32 @@ fn widget_for_item(
     rect: Rect,
 ) -> SurfaceNode<()> {
     let id = waveform_toolbar_widget_id(item_index);
-    let size = WidgetSizing::fixed(Vector2::new(rect.width().max(1.0), rect.height().max(1.0)));
     match item.kind {
         WaveformToolbarSurfaceItemKind::Button => {
-            let mut widget = ButtonWidget::new(id, &item.label, size);
-            widget.common.state.disabled = !item.enabled;
-            widget.common.state.active = item.active;
-            SurfaceNode::static_widget(widget)
+            button_node_with(id, &item.label, rect.width(), rect.height(), |widget| {
+                widget.common.state.disabled = !item.enabled;
+                widget.common.state.active = item.active;
+            })
         }
         WaveformToolbarSurfaceItemKind::Toggle => {
-            let mut widget = ToggleWidget::new(id, &item.label, size);
-            widget.common.state.disabled = !item.enabled;
-            widget.common.state.active = item.active;
-            widget.state.checked = item.active;
-            SurfaceNode::static_widget(widget)
+            toggle_node_with(id, &item.label, rect.width(), rect.height(), |widget| {
+                widget.common.state.disabled = !item.enabled;
+                widget.common.state.active = item.active;
+                widget.state.checked = item.active;
+            })
         }
-        WaveformToolbarSurfaceItemKind::TextInput => {
-            let mut widget = TextInputWidget::new(id, item.value.clone().unwrap_or_default(), size);
-            widget.common.state.disabled = !item.enabled;
-            widget.common.state.active = item.active;
-            widget.common.state.read_only = true;
-            widget.props.placeholder = Some(item.label.clone());
-            SurfaceNode::static_widget(widget)
-        }
+        WaveformToolbarSurfaceItemKind::TextInput => text_input_node_with(
+            id,
+            item.value.as_deref().unwrap_or_default(),
+            rect.width(),
+            rect.height(),
+            |widget| {
+                widget.common.state.disabled = !item.enabled;
+                widget.common.state.active = item.active;
+                widget.common.state.read_only = true;
+                widget.props.placeholder = Some(item.label.clone());
+            },
+        ),
     }
 }
 

--- a/src/app_core/native_shell/composition/widget_nodes.rs
+++ b/src/app_core/native_shell/composition/widget_nodes.rs
@@ -1,0 +1,91 @@
+use crate::{
+    gui::types::Vector2,
+    runtime::SurfaceNode,
+    widgets::{
+        ButtonWidget, CanvasWidget, TextInputWidget, TextWidget, ToggleWidget, WidgetSizing,
+    },
+};
+
+pub(super) fn button_node(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
+    button_node_with(id, label, width, height, |_| {})
+}
+
+pub(super) fn button_node_with(
+    id: u64,
+    label: &str,
+    width: f32,
+    height: f32,
+    configure: impl FnOnce(&mut ButtonWidget),
+) -> SurfaceNode<()> {
+    let mut widget = ButtonWidget::new(id, label, fixed_size(width, height));
+    configure(&mut widget);
+    SurfaceNode::static_widget(widget)
+}
+
+pub(super) fn toggle_node(id: u64, label: &str, width: f32, height: f32) -> SurfaceNode<()> {
+    toggle_node_with(id, label, width, height, |_| {})
+}
+
+pub(super) fn toggle_square_node(id: u64, label: &str, side: f32) -> SurfaceNode<()> {
+    toggle_node(id, label, side, side)
+}
+
+pub(super) fn toggle_node_with(
+    id: u64,
+    label: &str,
+    width: f32,
+    height: f32,
+    configure: impl FnOnce(&mut ToggleWidget),
+) -> SurfaceNode<()> {
+    let mut widget = ToggleWidget::new(id, label, fixed_size(width, height));
+    configure(&mut widget);
+    SurfaceNode::static_widget(widget)
+}
+
+pub(super) fn text_input_node(
+    id: u64,
+    value: &str,
+    placeholder: Option<&str>,
+    width: f32,
+    height: f32,
+) -> SurfaceNode<()> {
+    text_input_node_with(id, value, width, height, |widget| {
+        widget.props.placeholder = placeholder
+            .filter(|placeholder| !placeholder.is_empty())
+            .map(str::to_string);
+    })
+}
+
+pub(super) fn text_input_node_with(
+    id: u64,
+    value: &str,
+    width: f32,
+    height: f32,
+    configure: impl FnOnce(&mut TextInputWidget),
+) -> SurfaceNode<()> {
+    let mut widget = TextInputWidget::new(id, value, fixed_size(width, height));
+    configure(&mut widget);
+    SurfaceNode::static_widget(widget)
+}
+
+pub(super) fn text_node(
+    id: u64,
+    text: &str,
+    width: f32,
+    height: f32,
+    font_size: f32,
+) -> SurfaceNode<()> {
+    SurfaceNode::static_widget(TextWidget::new(
+        id,
+        text,
+        fixed_size(width, height).with_baseline((font_size * 0.75).max(0.0)),
+    ))
+}
+
+pub(super) fn canvas_node(id: u64, width: f32, height: f32) -> SurfaceNode<()> {
+    SurfaceNode::static_widget(CanvasWidget::new(id, fixed_size(width, height)))
+}
+
+fn fixed_size(width: f32, height: f32) -> WidgetSizing {
+    WidgetSizing::fixed(Vector2::new(width.max(1.0), height.max(1.0)))
+}


### PR DESCRIPTION
## Summary
- add a composition-local widget node builder module for static text/button/toggle/input/canvas leaves
- update Sempal chrome surfaces to use the local node API instead of importing and wiring Radiant primitive structs directly
- keep primitive type downcasts only in tests and keep runtime behavior unchanged

## Validation
- cargo fmt
- cargo test -p sempal browser_chrome_surface --lib
- cargo test -p sempal sidebar_surface --lib
- cargo test -p sempal waveform_toolbar_surface --lib
- cargo test -p sempal waveform_header_surface --lib
- cargo test -p sempal top_bar_surface --lib
- cargo test -p sempal status_surface --lib
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke

Refs OPT-393