### PR TITLE
Use Radiant widget input in Sempal runtime bridge

### DIFF
--- a/src/gui_runtime/native_shell_runtime.rs
+++ b/src/gui_runtime/native_shell_runtime.rs
@@ -44,12 +44,11 @@ mod model_mapping;
 pub(super) use automation::capture_gui_automation_snapshot;
 #[cfg(test)]
 pub(super) use automation::capture_native_shell_shot_snapshot;
+use bridge::SempalRuntimeBridge;
 #[cfg(test)]
 use bridge::SempalRuntimeMessage;
-use bridge::{RetainedCanvasInput, SempalRuntimeBridge};
 use input_routing::{
-    action_from_retained_pointer, keypress_from_radiant, keypress_to_radiant,
-    retained_input_from_widget_input, sempal_focus_context,
+    action_from_retained_pointer, keypress_from_radiant, keypress_to_radiant, sempal_focus_context,
 };
 pub(super) use launch::{run_native_vello_app, run_native_vello_app_with_artifacts};
 use model_mapping::local_app_model_from_native_model;

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -27,42 +27,10 @@ pub(super) struct SempalRuntimeBridge<B> {
 pub(super) enum SempalRuntimeMessage {
     /// Existing application action emitted by shortcut resolution or translated retained input.
     Action(UiAction),
-    /// Raw retained-canvas input that still needs Sempal shell hit-testing.
-    RetainedInput(RetainedCanvasInput),
+    /// Radiant retained-canvas input that still needs Sempal shell hit-testing.
+    RetainedInput(WidgetInput),
     /// Local retained text-edit state changed without reducing an app action.
     LocalTextEdit,
-}
-
-/// Retained-canvas input normalized out of Radiant widget events.
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum RetainedCanvasInput {
-    /// Pointer hover moved inside the retained Sempal canvas.
-    PointerMove {
-        /// Logical pointer position in the host surface.
-        position: Point,
-    },
-    /// Pointer press started inside the retained Sempal canvas.
-    PointerPress {
-        /// Logical pointer position in the host surface.
-        position: Point,
-        /// Pressed pointer button.
-        button: PointerButton,
-    },
-    /// Pointer press ended inside the retained Sempal canvas.
-    PointerRelease {
-        /// Logical pointer position in the host surface.
-        position: Point,
-        /// Released pointer button.
-        button: PointerButton,
-    },
-    /// Runtime focus changed for the retained canvas widget.
-    FocusChanged(bool),
-    /// Non-text key intent routed to the focused retained canvas.
-    KeyPress(WidgetKey),
-    /// Printable character routed to the focused retained canvas.
-    Character(char),
-    /// Backend-level text editing command routed to the focused retained canvas.
-    TextEdit(TextEditCommand),
 }
 
 /// Local text-input target tracked after Sempal focus actions.
@@ -203,9 +171,7 @@ impl<B> SempalRuntimeBridge<B> {
             WidgetSizing::fixed(Vector2::new(1280.0, 720.0)),
             retained,
             |message: CanvasMessage| match message {
-                CanvasMessage::Input { input } => {
-                    SempalRuntimeMessage::RetainedInput(retained_input_from_widget_input(input))
-                }
+                CanvasMessage::Input { input } => SempalRuntimeMessage::RetainedInput(input),
             },
         )))
     }
@@ -272,9 +238,9 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
     }
 
     /// Translate retained-canvas input into Sempal actions or local repaint-only state.
-    fn handle_retained_canvas_input(&mut self, input: RetainedCanvasInput) -> bool {
+    fn handle_retained_canvas_input(&mut self, input: WidgetInput) -> bool {
         match input {
-            RetainedCanvasInput::PointerMove { position } => {
+            WidgetInput::PointerMove { position } => {
                 let layout = self.build_current_layout();
                 let _effect =
                     self.shell_state
@@ -282,7 +248,7 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                 self.local_overlay_surface_refresh = true;
                 true
             }
-            RetainedCanvasInput::PointerPress { position, button } => {
+            WidgetInput::PointerPress { position, button } => {
                 if button != PointerButton::Primary {
                     return true;
                 }
@@ -300,13 +266,13 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                 }
                 true
             }
-            RetainedCanvasInput::PointerRelease { .. } | RetainedCanvasInput::FocusChanged(_) => {
+            WidgetInput::PointerRelease { .. } | WidgetInput::FocusChanged(_) => {
                 self.local_overlay_surface_refresh = true;
                 true
             }
-            RetainedCanvasInput::KeyPress(key) => self.handle_retained_key_press(key),
-            RetainedCanvasInput::Character(character) => self.handle_retained_character(character),
-            RetainedCanvasInput::TextEdit(command) => self.handle_retained_text_edit(command),
+            WidgetInput::KeyPress(key) => self.handle_retained_key_press(key),
+            WidgetInput::Character(character) => self.handle_retained_character(character),
+            WidgetInput::TextEdit(command) => self.handle_retained_text_edit(command),
         }
     }
 

--- a/src/gui_runtime/native_shell_runtime/input_routing.rs
+++ b/src/gui_runtime/native_shell_runtime/input_routing.rs
@@ -42,23 +42,6 @@ pub(super) fn keypress_to_radiant(press: KeyPress) -> RadiantKeyPress {
     }
 }
 
-/// Convert one Radiant widget input event into the Sempal retained input shape.
-pub(super) fn retained_input_from_widget_input(input: WidgetInput) -> RetainedCanvasInput {
-    match input {
-        WidgetInput::PointerMove { position } => RetainedCanvasInput::PointerMove { position },
-        WidgetInput::PointerPress { position, button } => {
-            RetainedCanvasInput::PointerPress { position, button }
-        }
-        WidgetInput::PointerRelease { position, button } => {
-            RetainedCanvasInput::PointerRelease { position, button }
-        }
-        WidgetInput::FocusChanged(focused) => RetainedCanvasInput::FocusChanged(focused),
-        WidgetInput::KeyPress(key) => RetainedCanvasInput::KeyPress(key),
-        WidgetInput::Character(character) => RetainedCanvasInput::Character(character),
-        WidgetInput::TextEdit(command) => RetainedCanvasInput::TextEdit(command),
-    }
-}
-
 /// Resolve a retained pointer press into a Sempal compatibility action.
 pub(super) fn action_from_retained_pointer(
     layout: &ShellLayout,

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -104,14 +104,14 @@ mod tests {
             .expect("generic canvas should map input into a Sempal action");
         assert!(matches!(
             message,
-            SempalRuntimeMessage::RetainedInput(RetainedCanvasInput::PointerPress { .. })
+            SempalRuntimeMessage::RetainedInput(WidgetInput::PointerPress { .. })
         ));
         assert!(bridge.update(message).requests_repaint());
         assert_ne!(bridge.inner.reduced, vec![UiAction::HandleEscape]);
         assert_eq!(bridge.inner.reduced, vec![UiAction::ToggleTransport]);
         bridge.inner.reduced.clear();
 
-        let hover_message = SempalRuntimeMessage::RetainedInput(RetainedCanvasInput::PointerMove {
+        let hover_message = SempalRuntimeMessage::RetainedInput(WidgetInput::PointerMove {
             position: radiant::gui::types::Point::new(12.0, 16.0),
         });
         assert!(
@@ -120,15 +120,15 @@ mod tests {
         );
 
         bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::FocusChanged(true),
+            WidgetInput::FocusChanged(true),
         ));
         bridge.update(SempalRuntimeMessage::Action(UiAction::FocusBrowserSearch));
         bridge.inner.reduced.clear();
         assert!(
             bridge
-                .update(SempalRuntimeMessage::RetainedInput(
-                    RetainedCanvasInput::Character('k')
-                ))
+                .update(SempalRuntimeMessage::RetainedInput(WidgetInput::Character(
+                    'k'
+                )))
                 .requests_repaint()
         );
         assert_eq!(
@@ -202,18 +202,18 @@ mod tests {
             "focused tag text entry should clear pending chords without consuming printable text"
         );
 
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::Character('k'),
-        ));
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::Character('i'),
-        ));
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::Character(','),
-        ));
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::Character('h'),
-        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::Character(
+            'k',
+        )));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::Character(
+            'i',
+        )));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::Character(
+            ',',
+        )));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::Character(
+            'h',
+        )));
 
         assert_eq!(
             bridge.inner.reduced,
@@ -247,15 +247,15 @@ mod tests {
 
         bridge.update(SempalRuntimeMessage::Action(UiAction::FocusBrowserSearch));
         bridge.inner.reduced.clear();
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::TextEdit(TextEditCommand::InsertText(String::from("kick"))),
-        ));
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::TextEdit(TextEditCommand::SelectAll),
-        ));
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::TextEdit(TextEditCommand::InsertText(String::from("snare"))),
-        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
+            TextEditCommand::InsertText(String::from("kick")),
+        )));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
+            TextEditCommand::SelectAll,
+        )));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
+            TextEditCommand::InsertText(String::from("snare")),
+        )));
 
         assert_eq!(
             bridge.inner.reduced.last(),
@@ -298,9 +298,9 @@ mod tests {
             },
             RadiantFocusSurface::None,
         );
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::KeyPress(WidgetKey::Backspace),
-        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::KeyPress(
+            WidgetKey::Backspace,
+        )));
 
         assert_eq!(
             bridge.inner.reduced.last(),
@@ -316,9 +316,9 @@ mod tests {
             "Backspace with selected draft text should edit text before removing an accepted chip"
         );
 
-        bridge.update(SempalRuntimeMessage::RetainedInput(
-            RetainedCanvasInput::KeyPress(WidgetKey::Backspace),
-        ));
+        bridge.update(SempalRuntimeMessage::RetainedInput(WidgetInput::KeyPress(
+            WidgetKey::Backspace,
+        )));
         assert!(bridge.inner.reduced.iter().any(|action| matches!(
             action,
             UiAction::ToggleBrowserSidebarNormalTag { label } if label == "Kick"
@@ -374,7 +374,7 @@ mod tests {
         assert!(
             bridge
                 .update(SempalRuntimeMessage::RetainedInput(
-                    RetainedCanvasInput::PointerMove {
+                    WidgetInput::PointerMove {
                         position: hover_point,
                     },
                 ))
@@ -453,7 +453,7 @@ mod tests {
         assert!(
             bridge
                 .update(SempalRuntimeMessage::RetainedInput(
-                    RetainedCanvasInput::PointerMove {
+                    WidgetInput::PointerMove {
                         position: radiant::gui::types::Point::new(12.0, 16.0),
                     },
                 ))
@@ -479,7 +479,7 @@ mod tests {
         assert!(
             bridge
                 .update(SempalRuntimeMessage::RetainedInput(
-                    RetainedCanvasInput::PointerPress {
+                    WidgetInput::PointerPress {
                         position: radiant::gui::types::Point::new(4.0, 5.0),
                         button: radiant::widgets::PointerButton::Primary,
                     },


### PR DESCRIPTION
## Summary
- remove Sempal's duplicate RetainedCanvasInput enum
- route retained canvas input as Radiant WidgetInput directly from CanvasMessage::Input
- keep Sempal-specific interpretation at the hit-testing/action boundary instead of adding a mirrored input shape

## Validation
- cargo fmt
- cargo test -p sempal native_shell_runtime --lib
- rg scan found no RetainedCanvasInput, etained_input_from_widget_input, WidgetSpec, WidgetKind, WidgetMessageMapper, SurfaceNode::widget, custom_widget_box, or Box<dyn Widget> in Sempal src
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke

Refs OPT-393