### PR TITLE
Assert Sempal chrome widgets through generic nodes

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface_tests.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface_tests.rs
@@ -1,14 +1,14 @@
 use super::*;
-use crate::{
-    app_core::native_shell::composition::style::StyleTokens,
-    gui::types::Point,
-    widgets::{ButtonWidget, TextInputWidget, ToggleWidget, Widget},
-};
+use crate::{app_core::native_shell::composition::style::StyleTokens, gui::types::Point};
 
-fn is_widget<T: Widget + 'static>(surface: &UiSurface<()>, id: u64) -> bool {
-    surface
-        .find_widget(id)
-        .is_some_and(|widget| widget.widget().as_any().downcast_ref::<T>().is_some())
+fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+    assert_eq!(
+        surface
+            .find_widget(id)
+            .expect("widget node should exist")
+            .id(),
+        id
+    );
 }
 
 fn assert_inside(outer: Rect, inner: Rect) {
@@ -19,15 +19,15 @@ fn assert_inside(outer: Rect, inner: Rect) {
 }
 
 #[test]
-fn browser_tabs_surface_uses_public_button_widgets() {
+fn browser_tabs_surface_projects_widget_nodes() {
     let style = StyleTokens::for_viewport_width(1280.0);
     let surface = build_browser_tabs_surface(
         &browser_tabs_surface_content(&AppModel::default()),
         style.sizing,
         800.0,
     );
-    assert!(is_widget::<ButtonWidget>(&surface, TABS_ITEMS_ID));
-    assert!(is_widget::<ButtonWidget>(&surface, TABS_MAP_ID));
+    assert_widget_node(&surface, TABS_ITEMS_ID);
+    assert_widget_node(&surface, TABS_MAP_ID);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn browser_tabs_surface_layout_stays_inside_tabs_band() {
 }
 
 #[test]
-fn browser_toolbar_surface_uses_public_toggle_button_and_text_input_widgets() {
+fn browser_toolbar_surface_projects_widget_nodes() {
     let style = StyleTokens::for_viewport_width(1280.0);
     let content = browser_toolbar_surface_content(&AppModel::default());
     let surface = build_browser_toolbar_surface(
@@ -56,9 +56,9 @@ fn browser_toolbar_surface_uses_public_toggle_button_and_text_input_widgets() {
             style.sizing,
         ),
     );
-    assert!(is_widget::<ToggleWidget>(&surface, TOOLBAR_RATING_BASE_ID));
-    assert!(is_widget::<ButtonWidget>(&surface, TOOLBAR_RANDOM_ID));
-    assert!(is_widget::<TextInputWidget>(&surface, TOOLBAR_SEARCH_ID));
+    assert_widget_node(&surface, TOOLBAR_RATING_BASE_ID);
+    assert_widget_node(&surface, TOOLBAR_RANDOM_ID);
+    assert_widget_node(&surface, TOOLBAR_SEARCH_ID);
 }
 
 #[test]

--- a/src/app_core/native_shell/composition/sidebar_surface_tests.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_tests.rs
@@ -1,12 +1,15 @@
 use super::*;
 use crate::app_core::native_shell::composition::style::StyleTokens;
 use crate::gui::types::Point;
-use crate::widgets::{ButtonWidget, TextWidget, Widget};
 
-fn is_widget<T: Widget + 'static>(surface: &UiSurface<()>, id: u64) -> bool {
-    surface
-        .find_widget(id)
-        .is_some_and(|widget| widget.widget().as_any().downcast_ref::<T>().is_some())
+fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+    assert_eq!(
+        surface
+            .find_widget(id)
+            .expect("widget node should exist")
+            .id(),
+        id
+    );
 }
 
 fn assert_inside(outer: Rect, inner: Rect) {
@@ -17,7 +20,7 @@ fn assert_inside(outer: Rect, inner: Rect) {
 }
 
 #[test]
-fn sidebar_surfaces_use_public_text_and_button_widgets() {
+fn sidebar_surfaces_project_widget_nodes() {
     let style = StyleTokens::for_viewport_width(1280.0);
     let header =
         build_sidebar_header_surface(&SidebarHeaderSurfaceContent::default(), style.sizing);
@@ -29,9 +32,9 @@ fn sidebar_surfaces_use_public_text_and_button_widgets() {
         style.sizing,
         208.0,
     );
-    assert!(is_widget::<TextWidget>(&header, HEADER_TITLE_ID));
-    assert!(is_widget::<ButtonWidget>(&header, HEADER_ADD_BUTTON_ID));
-    assert!(is_widget::<ButtonWidget>(&footer, FOOTER_ACTION_BASE_ID));
+    assert_widget_node(&header, HEADER_TITLE_ID);
+    assert_widget_node(&header, HEADER_ADD_BUTTON_ID);
+    assert_widget_node(&footer, FOOTER_ACTION_BASE_ID);
 }
 
 #[test]

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -382,7 +382,16 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 mod tests {
     use super::*;
     use crate::app_core::native_shell::composition::style::StyleTokens;
-    use crate::widgets::{CanvasWidget, TextWidget};
+
+    fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+        assert_eq!(
+            surface
+                .find_widget(id)
+                .expect("widget node should exist")
+                .id(),
+            id
+        );
+    }
 
     fn assert_inside(outer: Rect, inner: Rect) {
         assert!(inner.min.x >= outer.min.x);
@@ -392,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn status_surface_uses_public_text_and_canvas_widgets() {
+    fn status_surface_projects_widget_nodes() {
         let style = StyleTokens::for_viewport_width(1280.0);
         let surface = build_status_surface(
             &StatusSurfaceContent {
@@ -404,25 +413,8 @@ mod tests {
             style.sizing,
             1280.0,
         );
-        let left = surface
-            .find_widget(STATUS_LEFT_TEXT_ID)
-            .expect("left text widget");
-        let track = surface
-            .find_widget(STATUS_PROGRESS_TRACK_ID)
-            .expect("progress track widget");
-        assert!(
-            left.widget()
-                .as_any()
-                .downcast_ref::<TextWidget>()
-                .is_some()
-        );
-        assert!(
-            track
-                .widget()
-                .as_any()
-                .downcast_ref::<CanvasWidget>()
-                .is_some()
-        );
+        assert_widget_node(&surface, STATUS_LEFT_TEXT_ID);
+        assert_widget_node(&surface, STATUS_PROGRESS_TRACK_ID);
     }
 
     #[test]

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -544,10 +544,17 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        app_core::native_shell::composition::style::StyleTokens,
-        widgets::{ButtonWidget, CanvasWidget, TextWidget},
-    };
+    use crate::app_core::native_shell::composition::style::StyleTokens;
+
+    fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+        assert_eq!(
+            surface
+                .find_widget(id)
+                .expect("widget node should exist")
+                .id(),
+            id
+        );
+    }
 
     fn assert_inside(outer: Rect, inner: Rect) {
         assert!(inner.min.x >= outer.min.x);
@@ -586,36 +593,12 @@ mod tests {
     }
 
     #[test]
-    fn top_bar_surface_uses_public_text_button_and_canvas_widgets() {
+    fn top_bar_surface_projects_widget_nodes() {
         let style = StyleTokens::for_viewport_width(1280.0);
         let surface = build_top_bar_surface(&content(), style.sizing, 1280.0);
-        assert!(
-            surface
-                .find_widget(TOP_TITLE_TEXT_ID)
-                .expect("title")
-                .widget()
-                .as_any()
-                .downcast_ref::<TextWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(TOP_VOLUME_METER_ID)
-                .expect("meter")
-                .widget()
-                .as_any()
-                .downcast_ref::<CanvasWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(TOP_OPTIONS_BUTTON_ID)
-                .expect("options")
-                .widget()
-                .as_any()
-                .downcast_ref::<ButtonWidget>()
-                .is_some()
-        );
+        assert_widget_node(&surface, TOP_TITLE_TEXT_ID);
+        assert_widget_node(&surface, TOP_VOLUME_METER_ID);
+        assert_widget_node(&surface, TOP_OPTIONS_BUTTON_ID);
     }
 
     #[test]

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -193,11 +193,17 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        app::AppModel,
-        app_core::native_shell::composition::style::StyleTokens,
-        widgets::{CanvasWidget, TextWidget},
-    };
+    use crate::{app::AppModel, app_core::native_shell::composition::style::StyleTokens};
+
+    fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+        assert_eq!(
+            surface
+                .find_widget(id)
+                .expect("widget node should exist")
+                .id(),
+            id
+        );
+    }
 
     fn assert_inside(outer: Rect, inner: Rect) {
         assert!(inner.min.x >= outer.min.x);
@@ -211,36 +217,12 @@ mod tests {
     }
 
     #[test]
-    fn waveform_header_surface_uses_public_text_and_canvas_widgets() {
+    fn waveform_header_surface_projects_widget_nodes() {
         let style = StyleTokens::for_viewport_width(1280.0);
         let surface = build_waveform_header_surface(&content(), style.sizing);
-        assert!(
-            surface
-                .find_widget(WAVEFORM_HEADER_TITLE_ID)
-                .expect("title")
-                .widget()
-                .as_any()
-                .downcast_ref::<TextWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(WAVEFORM_HEADER_METADATA_ID)
-                .expect("metadata")
-                .widget()
-                .as_any()
-                .downcast_ref::<TextWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(WAVEFORM_HEADER_FILL_ID)
-                .expect("fill")
-                .widget()
-                .as_any()
-                .downcast_ref::<CanvasWidget>()
-                .is_some()
-        );
+        assert_widget_node(&surface, WAVEFORM_HEADER_TITLE_ID);
+        assert_widget_node(&surface, WAVEFORM_HEADER_METADATA_ID);
+        assert_widget_node(&surface, WAVEFORM_HEADER_FILL_ID);
     }
 
     #[test]

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -254,10 +254,17 @@ fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        app_core::native_shell::composition::style::StyleTokens,
-        widgets::{ButtonWidget, TextInputWidget, ToggleWidget},
-    };
+    use crate::app_core::native_shell::composition::style::StyleTokens;
+
+    fn assert_widget_node(surface: &UiSurface<()>, id: u64) {
+        assert_eq!(
+            surface
+                .find_widget(id)
+                .expect("widget node should exist")
+                .id(),
+            id
+        );
+    }
 
     fn sample_content() -> WaveformToolbarSurfaceContent {
         WaveformToolbarSurfaceContent {
@@ -316,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    fn waveform_toolbar_surface_uses_public_toggle_button_and_text_input_widgets() {
+    fn waveform_toolbar_surface_projects_widget_nodes() {
         let header_rect = Rect::from_min_max(Point::new(220.0, 32.0), Point::new(1260.0, 64.0));
         let content = sample_content();
         let surface = build_waveform_toolbar_surface(
@@ -328,33 +335,9 @@ mod tests {
                 &content,
             ),
         );
-        assert!(
-            surface
-                .find_widget(waveform_toolbar_widget_id(0))
-                .expect("channel toggle")
-                .widget()
-                .as_any()
-                .downcast_ref::<ToggleWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(waveform_toolbar_widget_id(2))
-                .expect("bpm value input")
-                .widget()
-                .as_any()
-                .downcast_ref::<TextInputWidget>()
-                .is_some()
-        );
-        assert!(
-            surface
-                .find_widget(waveform_toolbar_widget_id(4))
-                .expect("compare button")
-                .widget()
-                .as_any()
-                .downcast_ref::<ButtonWidget>()
-                .is_some()
-        );
+        assert_widget_node(&surface, waveform_toolbar_widget_id(0));
+        assert_widget_node(&surface, waveform_toolbar_widget_id(2));
+        assert_widget_node(&surface, waveform_toolbar_widget_id(4));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove remaining concrete Radiant primitive downcasts from Sempal chrome composition tests
- assert projected widgets through the generic UiSurface::find_widget / SurfaceWidget::id API instead
- keep concrete widget construction isolated to the composition/widget_nodes boundary

## Validation
- cargo fmt
- cargo test -p sempal browser_chrome_surface --lib
- cargo test -p sempal sidebar_surface --lib
- cargo test -p sempal status_surface --lib
- cargo test -p sempal waveform_header_surface --lib
- cargo test -p sempal top_bar_surface --lib
- cargo test -p sempal waveform_toolbar_surface --lib
- rg scan: concrete primitive constructors only remain in composition/widget_nodes.rs
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke

Refs OPT-393