### PR TITLE
[codex] Sync Radiant target audit updates

### DIFF
--- a/src/gui_runtime/native_shell_runtime/launch.rs
+++ b/src/gui_runtime/native_shell_runtime/launch.rs
@@ -14,6 +14,7 @@ impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
             decorations: value.decorations,
             icon: value.icon.map(Into::into),
             target_fps: value.target_fps,
+            drag_and_drop: true,
         }
     }
 }

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -35,6 +35,7 @@ mod tests {
         assert!(compat.maximized);
         assert!(!compat.decorations);
         assert_eq!(compat.target_fps, 90);
+        assert!(compat.drag_and_drop);
         let icon = compat.icon.expect("icon should be forwarded");
         assert_eq!(icon.rgba, vec![255, 0, 0, 255]);
         assert_eq!(icon.width, 1);


### PR DESCRIPTION
## Summary
- Advance the `vendor/radiant` pointer to the merged Radiant target-audit commits.
- Map SemPal's native shell launch options to Radiant's new platform-neutral `drag_and_drop` launch policy.
- Add adapter coverage for the forwarded drag-and-drop policy.

## Validation
- `cargo test -p sempal native_run_options_map_field_for_field_to_radiant_runtime_options`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- `cargo test --manifest-path vendor/radiant/Cargo.toml --no-default-features --test runtime_surface_public_api surface_runtime_executes_focus_exit_and_deferred_commands -- --exact`
- `cargo test -p sempal --lib app_core::native_bridge::tests::runtime_exit_detaches_active_controller_shutdown_work -- --exact`

## Notes
- Root `cargo fmt --check` still reports an unrelated existing formatting diff in `src/radiant_rebuild_app.rs`.
- `scripts/ci.ps1 agent` was rerun after the smoke fix; Radiant passed, then a SemPal shutdown timing test failed once at ~900 ms and passed when rerun directly.