### PR TITLE
Sync Radiant widget input boundary updates

### DIFF
--- a/src/gui_runtime/native_shell_runtime/launch.rs
+++ b/src/gui_runtime/native_shell_runtime/launch.rs
@@ -15,6 +15,8 @@ impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
             icon: value.icon.map(Into::into),
             target_fps: value.target_fps,
             drag_and_drop: true,
+            gpu: radiant::gui_runtime::NativeGpuOptions::default(),
+            text: radiant::gui_runtime::NativeTextOptions::default(),
         }
     }
 }

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -36,6 +36,14 @@ mod tests {
         assert!(!compat.decorations);
         assert_eq!(compat.target_fps, 90);
         assert!(compat.drag_and_drop);
+        assert_eq!(
+            compat.gpu,
+            radiant::gui_runtime::NativeGpuOptions::default()
+        );
+        assert_eq!(
+            compat.text,
+            radiant::gui_runtime::NativeTextOptions::default()
+        );
         let icon = compat.icon.expect("icon should be forwarded");
         assert_eq!(icon.rgba, vec![255, 0, 0, 255]);
         assert_eq!(icon.width, 1);


### PR DESCRIPTION
## Summary
- updates `vendor/radiant` to the merged widget input-boundary refactors
- maps Sempal native launch options to Radiant's default GPU/text policies so the parent remains compatible with the current Radiant runtime options
- extends the native run option mapping test to cover those forwarded defaults

## Validation
- `cargo test -p sempal native_run_options_map_field_for_field_to_radiant_runtime_options`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`