### PR TITLE
[codex] Sync Radiant text helper API

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/browser_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_chrome_text.rs
@@ -1,15 +1,8 @@
 //! Slotized browser chrome text-line geometry helpers.
 
 use super::super::style::SizingTokens;
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::Rect;
-
-const TABS_TEXT_ITEM_ID: u64 = 1500;
-const TABS_TEXT_MAP_ID: u64 = 1501;
-const TOOLBAR_TEXT_SEARCH_ID: u64 = 1510;
-const TOOLBAR_TEXT_ACTIVITY_ID: u64 = 1511;
-const TOOLBAR_TEXT_SORT_ID: u64 = 1512;
-const FOOTER_TEXT_SUMMARY_ID: u64 = 1520;
 
 /// Slot-resolved browser-tab label bounds.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -33,13 +26,8 @@ pub(crate) fn compute_browser_tabs_text_layout(
     sizing: SizingTokens,
 ) -> BrowserTabsTextLayout {
     BrowserTabsTextLayout {
-        items_label: compute_text_line_rect(
-            items_tab,
-            sizing,
-            sizing.font_header,
-            TABS_TEXT_ITEM_ID,
-        ),
-        map_label: compute_text_line_rect(map_tab, sizing, sizing.font_header, TABS_TEXT_MAP_ID),
+        items_label: compute_text_line_rect(items_tab, sizing, sizing.font_header),
+        map_label: compute_text_line_rect(map_tab, sizing, sizing.font_header),
     }
 }
 
@@ -51,33 +39,18 @@ pub(crate) fn compute_browser_toolbar_text_layout(
     sizing: SizingTokens,
 ) -> BrowserToolbarTextLayout {
     BrowserToolbarTextLayout {
-        search_label: compute_text_line_rect(
-            search_field,
-            sizing,
-            sizing.font_meta,
-            TOOLBAR_TEXT_SEARCH_ID,
-        ),
-        activity_label: compute_text_line_rect(
-            activity_chip,
-            sizing,
-            sizing.font_meta,
-            TOOLBAR_TEXT_ACTIVITY_ID,
-        ),
-        sort_label: compute_text_line_rect(
-            sort_chip,
-            sizing,
-            sizing.font_meta,
-            TOOLBAR_TEXT_SORT_ID,
-        ),
+        search_label: compute_text_line_rect(search_field, sizing, sizing.font_meta),
+        activity_label: compute_text_line_rect(activity_chip, sizing, sizing.font_meta),
+        sort_label: compute_text_line_rect(sort_chip, sizing, sizing.font_meta),
     }
 }
 
 /// Compute browser footer summary label bounds.
 pub(crate) fn compute_browser_footer_text_rect(footer: Rect, sizing: SizingTokens) -> Rect {
-    compute_text_line_rect(footer, sizing, sizing.font_meta, FOOTER_TEXT_SUMMARY_ID)
+    compute_text_line_rect(footer, sizing, sizing.font_meta)
 }
 
-fn compute_text_line_rect(rect: Rect, sizing: SizingTokens, font_size: f32, node_id: u64) -> Rect {
+fn compute_text_line_rect(rect: Rect, sizing: SizingTokens, font_size: f32) -> Rect {
     let empty = empty_rect(rect);
     if rect.width() <= 0.0 || rect.height() <= 0.0 || font_size <= 0.0 {
         return empty;
@@ -87,7 +60,6 @@ fn compute_text_line_rect(rect: Rect, sizing: SizingTokens, font_size: f32, node
         font_size,
         TextLineInsets::symmetric(sizing.text_inset_x.max(0.0), sizing.text_inset_y.max(0.0)),
         0.0,
-        node_id,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -2,16 +2,15 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    layout_tree, Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::{Point, Rect, Vector2};
 
 const BROWSER_COLUMNS_ROOT_ID: u64 = 1200;
 const BROWSER_COL_INDEX_ID: u64 = 1201;
 const BROWSER_COL_SAMPLE_ID: u64 = 1202;
-const BROWSER_TEXT_ROOT_ID: u64 = 1210;
 
 /// Slot-resolved browser table columns.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -161,7 +160,6 @@ fn compute_text_line_rect(rect: Rect, sizing: SizingTokens, font_size: f32) -> R
         font_size,
         TextLineInsets::symmetric(sizing.text_inset_x.max(0.0), sizing.text_inset_y.max(0.0)),
         0.0,
-        BROWSER_TEXT_ROOT_ID,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/control_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/control_text.rs
@@ -1,20 +1,12 @@
 //! Slotized text-line geometry helpers for control rows and action buttons.
 
 use super::super::style::SizingTokens;
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::{Point, Rect};
-
-const ACTION_BUTTON_TEXT_BASE_ID: u64 = 1610;
 
 /// Compute an action-button label line rect with horizontal inset.
 pub(crate) fn compute_action_button_text_rect(rect: Rect, sizing: SizingTokens) -> Rect {
-    compute_text_line_rect(
-        rect,
-        sizing,
-        sizing.font_meta,
-        sizing.text_inset_x.max(0.0),
-        ACTION_BUTTON_TEXT_BASE_ID,
-    )
+    compute_text_line_rect(rect, sizing, sizing.font_meta, sizing.text_inset_x.max(0.0))
 }
 
 fn compute_text_line_rect(
@@ -22,7 +14,6 @@ fn compute_text_line_rect(
     sizing: SizingTokens,
     font_size: f32,
     horizontal_inset: f32,
-    node_id: u64,
 ) -> Rect {
     let empty = empty_rect(rect);
     if rect.width() <= 0.0 || rect.height() <= 0.0 || font_size <= 0.0 {
@@ -37,7 +28,6 @@ fn compute_text_line_rect(
         font_size,
         TextLineInsets::horizontal(0.0),
         sizing.text_inset_y.max(0.0),
-        node_id,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -2,17 +2,16 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    layout_tree, Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::{Point, Rect, Vector2};
 
 const MAP_HEADER_ROOT_ID: u64 = 1300;
 const MAP_HEADER_ROW_ID: u64 = 1301;
 const MAP_HEADER_LEFT_ID: u64 = 1302;
 const MAP_HEADER_RIGHT_ID: u64 = 1303;
-const MAP_HEADER_TEXT_LINE_ID: u64 = 1312;
 const RIGHT_LABEL_RATIO: f32 = 0.42;
 const RIGHT_LABEL_MIN_WIDTH: f32 = 36.0;
 
@@ -118,7 +117,6 @@ fn compute_map_header_text_line(rect: Rect, sizing: SizingTokens, font_size: f32
             bottom: sizing.text_inset_y.max(0.0),
         },
         0.0,
-        MAP_HEADER_TEXT_LINE_ID,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
@@ -4,15 +4,10 @@ use crate::gui::layout_core::{
     Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
     OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
-use crate::gui::text_layout::{TextLineInsets, centered_text_line, top_text_line};
+use crate::gui::text_layout::{centered_text_line, top_text_line, TextLineInsets};
 use crate::gui::types::{Rect, Vector2};
 
-pub(super) fn centered_line_in_rect(
-    rect: Rect,
-    sizing: SizingTokens,
-    font_size: f32,
-    node_id: u64,
-) -> Rect {
+pub(super) fn centered_line_in_rect(rect: Rect, sizing: SizingTokens, font_size: f32) -> Rect {
     let empty = shared::empty_rect(rect);
     if rect.width() <= 0.0 || rect.height() <= 0.0 || font_size <= 0.0 {
         return empty;
@@ -22,7 +17,6 @@ pub(super) fn centered_line_in_rect(
         font_size,
         TextLineInsets::symmetric(sizing.text_inset_x.max(0.0), sizing.text_inset_y.max(0.0)),
         0.0,
-        node_id,
     )
 }
 
@@ -40,20 +34,15 @@ pub(super) fn fixed_height_child(node_id: u64, height: f32) -> SlotChild {
     }
 }
 
-pub(super) fn top_line_in_bounds(bounds: Rect, font_size: f32, node_id: u64) -> Rect {
+pub(super) fn top_line_in_bounds(bounds: Rect, font_size: f32) -> Rect {
     let empty = shared::empty_rect(bounds);
     if bounds.width() <= 0.0 || bounds.height() <= 0.0 || font_size <= 0.0 {
         return empty;
     }
-    top_text_line(bounds, font_size, TextLineInsets::horizontal(0.0), node_id)
+    top_text_line(bounds, font_size, TextLineInsets::horizontal(0.0))
 }
 
-pub(super) fn top_line_in_rect(
-    rect: Rect,
-    sizing: SizingTokens,
-    font_size: f32,
-    node_id: u64,
-) -> Rect {
+pub(super) fn top_line_in_rect(rect: Rect, sizing: SizingTokens, font_size: f32) -> Rect {
     let empty = shared::empty_rect(rect);
     if rect.width() <= 0.0 || rect.height() <= 0.0 || font_size <= 0.0 {
         return empty;
@@ -62,7 +51,6 @@ pub(super) fn top_line_in_rect(
         shared::clamp_rect_to_bounds(rect, rect),
         font_size,
         TextLineInsets::horizontal(sizing.text_inset_x.max(0.0)),
-        node_id,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/drag.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/drag.rs
@@ -3,14 +3,12 @@ use super::common::centered_line_in_rect;
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::types::Rect;
 
-const DRAG_TEXT_LABEL_ID: u64 = 995;
-
 /// Compute drag overlay label text-line bounds.
 pub(crate) fn compute_drag_overlay_text_layout(
     banner: Rect,
     sizing: SizingTokens,
 ) -> DragOverlayTextLayout {
     DragOverlayTextLayout {
-        label: centered_line_in_rect(banner, sizing, sizing.font_meta, DRAG_TEXT_LABEL_ID),
+        label: centered_line_in_rect(banner, sizing, sizing.font_meta),
     }
 }

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/progress.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/progress.rs
@@ -1,4 +1,4 @@
-use super::super::{ProgressOverlaySections, ProgressOverlayTextLayout, shared};
+use super::super::{shared, ProgressOverlaySections, ProgressOverlayTextLayout};
 use super::common::{centered_line_in_rect, column_tree, fixed_height_child, top_line_in_bounds};
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::types::{Point, Rect};
@@ -6,8 +6,6 @@ use crate::gui::types::{Point, Rect};
 const PROGRESS_TEXT_ROOT_ID: u64 = 990;
 const PROGRESS_TEXT_TITLE_ID: u64 = 991;
 const PROGRESS_TEXT_DETAIL_ID: u64 = 992;
-const PROGRESS_TEXT_COUNTER_ID: u64 = 993;
-const PROGRESS_TEXT_CANCEL_ID: u64 = 994;
 
 struct ProgressDialogRows {
     title: Rect,
@@ -34,15 +32,9 @@ pub(crate) fn compute_progress_overlay_text_layout(
                 None
             },
             sizing,
-            PROGRESS_TEXT_COUNTER_ID,
         ),
         cancel_label: if has_cancel_button {
-            centered_line_in_rect(
-                sections.cancel_button,
-                sizing,
-                sizing.font_meta,
-                PROGRESS_TEXT_CANCEL_ID,
-            )
+            centered_line_in_rect(sections.cancel_button, sizing, sizing.font_meta)
         } else {
             shared::empty_rect(sections.cancel_button)
         },
@@ -94,7 +86,6 @@ fn compute_progress_counter_line(
     progress_bar: Rect,
     cancel_button: Option<Rect>,
     sizing: SizingTokens,
-    node_id: u64,
 ) -> Rect {
     let top = progress_bar.max.y + sizing.text_row_gap.max(0.0);
     let bottom = cancel_button
@@ -107,5 +98,5 @@ fn compute_progress_counter_line(
         Point::new(progress_bar.min.x, top),
         Point::new(progress_bar.max.x, bottom),
     );
-    top_line_in_bounds(bounds, sizing.font_meta, node_id)
+    top_line_in_bounds(bounds, sizing.font_meta)
 }

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/prompt.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/prompt.rs
@@ -1,4 +1,4 @@
-use super::super::{PromptOverlaySections, PromptOverlayTextLayout, shared};
+use super::super::{shared, PromptOverlaySections, PromptOverlayTextLayout};
 use super::common::{centered_line_in_rect, column_tree, fixed_height_child, top_line_in_rect};
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::types::{Point, Rect};
@@ -7,10 +7,6 @@ const PROMPT_TEXT_ROOT_ID: u64 = 980;
 const PROMPT_TEXT_TITLE_ID: u64 = 981;
 const PROMPT_TEXT_MESSAGE_ID: u64 = 982;
 const PROMPT_TEXT_TARGET_ID: u64 = 983;
-const PROMPT_TEXT_INPUT_ID: u64 = 984;
-const PROMPT_TEXT_INPUT_ERROR_ID: u64 = 985;
-const PROMPT_TEXT_CONFIRM_ID: u64 = 986;
-const PROMPT_TEXT_CANCEL_ID: u64 = 987;
 
 struct PromptDialogRows {
     title: Rect,
@@ -28,31 +24,16 @@ pub(crate) fn compute_prompt_overlay_text_layout(
     let rows = compute_prompt_dialog_rows(sections.dialog, sizing, has_target_label);
     let input_text = sections
         .input
-        .map(|input| top_line_in_rect(input, sizing, sizing.font_meta, PROMPT_TEXT_INPUT_ID));
-    let input_error = compute_prompt_input_error_line(
-        sections,
-        sizing,
-        has_input_error,
-        PROMPT_TEXT_INPUT_ERROR_ID,
-    );
+        .map(|input| top_line_in_rect(input, sizing, sizing.font_meta));
+    let input_error = compute_prompt_input_error_line(sections, sizing, has_input_error);
     PromptOverlayTextLayout {
         title: rows.title,
         message: rows.message,
         target: rows.target,
         input_text,
         input_error,
-        confirm_label: centered_line_in_rect(
-            sections.confirm_button,
-            sizing,
-            sizing.font_meta,
-            PROMPT_TEXT_CONFIRM_ID,
-        ),
-        cancel_label: centered_line_in_rect(
-            sections.cancel_button,
-            sizing,
-            sizing.font_meta,
-            PROMPT_TEXT_CANCEL_ID,
-        ),
+        confirm_label: centered_line_in_rect(sections.confirm_button, sizing, sizing.font_meta),
+        cancel_label: centered_line_in_rect(sections.cancel_button, sizing, sizing.font_meta),
     }
 }
 
@@ -104,7 +85,6 @@ fn compute_prompt_input_error_line(
     sections: PromptOverlaySections,
     sizing: SizingTokens,
     has_input_error: bool,
-    node_id: u64,
 ) -> Option<Rect> {
     if !has_input_error {
         return None;
@@ -123,5 +103,5 @@ fn compute_prompt_input_error_line(
         Point::new(input.min.x, top),
         Point::new(input.max.x.max(input.min.x), bottom),
     );
-    Some(top_line_in_rect(bounds, sizing, sizing.font_meta, node_id))
+    Some(top_line_in_rect(bounds, sizing, sizing.font_meta))
 }

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_text.rs
@@ -1,11 +1,8 @@
 //! Slotized sidebar row and recovery-badge text-line geometry helpers.
 
 use super::super::style::SizingTokens;
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::{Point, Rect};
-
-const SIDEBAR_TEXT_LINE_ID: u64 = 1702;
-const SIDEBAR_BADGE_TEXT_ID: u64 = 1710;
 
 /// Shared geometry for one sidebar folder row.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22,12 +19,7 @@ pub(crate) struct SidebarFolderRowLayout {
 pub(crate) fn compute_sidebar_source_row_text_rect(row_rect: Rect, sizing: SizingTokens) -> Rect {
     let inset = sizing.text_inset_x + sizing.row_corner_inset;
     let bounds = inset_rect_horizontal(row_rect, inset, inset);
-    compute_sidebar_text_line(
-        bounds,
-        sizing.font_body,
-        sizing.text_inset_y,
-        SIDEBAR_TEXT_LINE_ID,
-    )
+    compute_sidebar_text_line(bounds, sizing.font_body, sizing.text_inset_y)
 }
 
 /// Compute the horizontal indent for one tree depth level.
@@ -57,12 +49,7 @@ pub(crate) fn compute_sidebar_folder_row_layout(
     );
     let left_inset = base_inset + depth_indent + gutter_width + gutter_spacing;
     let bounds = inset_rect_horizontal(row_rect, left_inset, base_inset);
-    let label_rect = compute_sidebar_text_line(
-        bounds,
-        sizing.font_body,
-        sizing.text_inset_y,
-        SIDEBAR_TEXT_LINE_ID + 1,
-    );
+    let label_rect = compute_sidebar_text_line(bounds, sizing.font_body, sizing.text_inset_y);
     SidebarFolderRowLayout {
         depth_indent,
         disclosure_rect,
@@ -77,15 +64,10 @@ pub(crate) fn compute_sidebar_recovery_badge_text_rect(
 ) -> Rect {
     let inset = sizing.text_inset_x.max(0.0);
     let bounds = inset_rect_horizontal(badge_rect, inset, inset);
-    compute_sidebar_text_line(
-        bounds,
-        sizing.font_meta,
-        sizing.text_inset_y,
-        SIDEBAR_BADGE_TEXT_ID,
-    )
+    compute_sidebar_text_line(bounds, sizing.font_meta, sizing.text_inset_y)
 }
 
-fn compute_sidebar_text_line(rect: Rect, font_size: f32, inset_y: f32, node_seed: u64) -> Rect {
+fn compute_sidebar_text_line(rect: Rect, font_size: f32, inset_y: f32) -> Rect {
     let empty = empty_rect(rect);
     if rect.width() <= 0.0 || rect.height() <= 0.0 || font_size <= 0.0 {
         return empty;
@@ -95,7 +77,6 @@ fn compute_sidebar_text_line(rect: Rect, font_size: f32, inset_y: f32, node_seed
         font_size,
         TextLineInsets::horizontal(0.0),
         inset_y.max(0.0),
-        SIDEBAR_TEXT_LINE_ID + node_seed,
     )
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/status_bar.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/status_bar.rs
@@ -1,11 +1,9 @@
 //! Slotized helpers for status-bar segment and text-line geometry.
 
-use super::super::status_surface::{StatusSurfaceContent, resolve_status_surface_layout};
+use super::super::status_surface::{resolve_status_surface_layout, StatusSurfaceContent};
 use super::super::style::SizingTokens;
-use crate::gui::text_layout::{TextLineInsets, centered_text_line};
+use crate::gui::text_layout::{centered_text_line, TextLineInsets};
 use crate::gui::types::Rect;
-
-const STATUS_TEXT_LINE_ID: u64 = 922;
 
 /// Slot-resolved left/center/right status-bar segment geometry.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -51,7 +49,6 @@ pub(crate) fn compute_status_text_line_rect(
             bottom: sizing.text_inset_y.max(0.0),
         },
         0.0,
-        STATUS_TEXT_LINE_ID,
     )
 }
 


### PR DESCRIPTION
## Summary
- sync vendor/radiant to the merged text-line helper API cleanup from Radiant PR #213
- update Sempal native-shell layout adapter call sites to stop passing cache-only IDs into uncached Radiant helpers
- remove now-unused text-line node-id constants from those adapter helpers

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke
- cargo test -p sempal --lib large_auto_rename_background_dispatch_registers_file_ops_before_planning_finishes
- cargo test -p sempal --lib large_tag_sidebar_background_auto_rename_streams_file_ops_progress_and_refreshes_rows
- cargo test -p sempal --lib large_background_auto_rename_reports_partial_failure_through_file_ops_progress
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent