### PR TITLE
Preview edit fades in waveform GPU view

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1,180 +1,1252 @@
-# Sempal Project Target: A Fast, Reliable Sample Exploration Workstation
+
+# Wavecrate Project Target: Fast Sample Extraction, Curation, and Library Usage
+
+## Working Product Name
+
+The current working product name is **Wavecrate**.
+
+Documentation should use **Wavecrate** when referring to the application and **sample file**, **audio file**, or **WAV file** when referring to files in the library.
 
 ## Vision
 
-Sempal should become a focused desktop application for browsing, auditioning,
-marking, organizing, and curating large audio sample libraries without breaking
-the user's listening flow.
+Wavecrate should become a focused desktop application for browsing, auditioning, extracting, editing, organizing, and using large audio sample libraries without breaking the user’s listening flow.
 
-Sempal is not a generic GUI library, a DAW, a plugin host, or a file-manager
-skin. It is an audition-first sample workstation: the user should be able to
-move quickly through folders and files, hear material immediately, see useful
-waveform context, mark ranges, rename or organize material, and trust that the
-library state remains recoverable.
+The application should help users turn messy audio material into a clean, structured, well-managed sample library. A user should be able to record long jams or experiments in tools such as Ableton Live, Bitwig, hardware recorders, or other audio software, save them as ordinary audio files, then use Wavecrate to find the useful parts, cut those parts into usable sample files, clean them up, name them consistently, tag them, rate them, organize them, and use them in music production.
 
-The target is a dense, responsive, predictable creative tool that can handle
-large local sample collections while keeping playback, selection, and browsing
-fast enough to feel direct.
+Wavecrate is not a generic GUI library, a DAW, a plugin host, or a file-manager skin. It is a sample-focused workstation built around immediate auditioning, precise waveform interaction, destructive sample editing with safe warnings and undo, fast metadata workflows, similarity-based discovery, safe library hygiene, and reliable file management.
+
+The target is a dense, responsive, predictable, and trustworthy tool for repeated professional use on large local sample collections.
+
+## Product Identity
+
+Wavecrate is three things working together:
+
+1. A sample manager for browsing, tagging, filtering, rating, moving, renaming, and organizing sample files.
+2. An auditioning tool for quickly moving through sounds, hearing them immediately, comparing related material, and deciding what is worth keeping.
+3. A lightweight destructive sample editor for turning long or short audio files into clean, named, reusable samples without leaving the browsing flow.
+
+The product is built around three primary workflows.
+
+### 1. Sample Extraction Loop
+
+This loop turns long audio files into usable smaller sample files.
+
+There is no special “source recording” file type. A long jam recording is just an audio file in the library. It may be longer than other sample files, but Wavecrate should treat it as a normal sample file with the same browsing, auditioning, editing, tagging, rating, and file-management capabilities.
+
+This workflow should support:
+
+1. Open or scan long audio files such as hardware jams, synth experiments, resampling sessions, modular patches, field recordings, rehearsal takes, or other recordings.
+2. Navigate quickly through large WAV or AIFF/AIF files.
+3. Audition from any position without waiting.
+4. Inspect the waveform at useful zoom levels.
+5. Use analysis aids such as BPM detection, tempo grids, transient detection, silence detection, waveform overviews, and energy/section cues where practical.
+6. Create play selections for auditioning sections.
+7. Loop selected regions for closer listening.
+8. Slide or move loop selections through the waveform to audition different parts quickly.
+9. Mark interesting sections.
+10. Adjust region boundaries accurately, including grid-aware or transient-aware adjustment where practical.
+11. Extract selected regions into new audio files that sound exactly like what was auditioned.
+12. Keep visual history marks for regions that were already extracted.
+13. Continue searching the original audio file without losing flow.
+
+Extraction is non-destructive because it creates a new sample file from a selected region. The original audio file remains in place unless the user performs an explicit destructive edit on it.
+
+### 2. Sample Library Curation Loop
+
+This loop turns many existing or newly extracted sample files into a clean, structured, well-managed library.
+
+The user should be able to work through large lists of sample files, audition them quickly, decide what they are, decide whether they are useful, clean them up, name them consistently, tag them, rate them, and place them in the right location.
+
+This workflow should support:
+
+1. Browse, search, filter, or explore sample files by folder, tag, rating, metadata, age, review state, or similarity.
+2. Select a sample file and hear it immediately.
+3. Inspect and edit the waveform.
+4. Apply micro-edits such as trimming, fades, silence removal, gain adjustment, normalization, and timing/BPM metadata correction where practical.
+5. Add or remove tags quickly.
+6. Rate or triage the sample file through the keep/trash rating system.
+7. Use generated database display names based on tags, labels, prefixes, BPM, source, and other metadata.
+8. Deliberately apply generated names to disk filenames when desired.
+9. Move, copy, collect, export, or route sample files into the right folders.
+10. Continue through the library without losing flow.
+
+The purpose of this loop is to turn a pile of audio files into a clearly named, rated, tagged, searchable, and organized library.
+
+### 3. Sample Library Usage Loop
+
+This loop uses Wavecrate as a fast sample library while making music.
+
+The user should be able to open Wavecrate during production, quickly find sounds that fit the track, audition related material, and move the chosen sample file into a DAW or other creative tool with minimal friction.
+
+This workflow should support:
+
+1. Browse, search, filter, or explore the library by folder, tag, rating, metadata, age, similarity, or 2D map position.
+2. Audition samples immediately without disrupting the creative flow.
+3. Set and lock a target audition BPM where useful.
+4. Audition BPM-tagged samples warped to the target BPM where practical.
+5. Compare groups of related sounds, including sounds near each other in the similarity map.
+6. Quickly narrow results by sound type, character tags, BPM, rating, age, source, or similarity to a reference sample.
+7. Preview enough waveform and metadata context to choose the right sound quickly.
+8. Copy, drag, export, reveal, or otherwise hand off the selected sample file to a DAW or external tool.
+9. Return to browsing and auditioning immediately.
+
+The purpose of this loop is to make Wavecrate useful as an active production companion, similar in spirit to Sononym-style sample discovery, where finding and using the right sound is fast, fluid, and musically focused.
+
+Everything in the application should support one or more of these workflows.
 
 ## Scope and Interpretation
 
-This document is a product and architecture target for Sempal, not a one-shot
-implementation task.
+This document is a durable product and architecture target for Wavecrate. It is not a one-shot implementation task.
 
-Use it when reviewing features, refactors, UI changes, background work, and the
-Sempal/Radiant boundary. Prefer incremental changes that move the product closer
-to this target while preserving working validation lanes.
+Use it when reviewing features, refactors, UI changes, audio-engine work, database work, background processing, similarity systems, editing workflows, rating and triage behavior, naming systems, logging, diagnostics, and the Wavecrate/Radiant boundary.
+
+Prefer incremental changes that move Wavecrate closer to this target while preserving working validation lanes. A change does not need to solve the whole product direction at once, but it should not make the intended direction harder.
 
 ## Core Product Goals
 
-Sempal should provide:
+Wavecrate should provide:
 
 1. Fast source and folder browsing for large sample libraries.
-2. Immediate sample auditioning from keyboard, mouse, and selection changes.
-3. Clear waveform visualization with precise playhead, cursor, and mark ranges.
-4. Reliable file and folder mutation workflows with recovery behavior.
-5. Dense, low-friction UI that supports repeated professional use.
-6. Background scanning, decoding, analysis, and metadata work that never blocks
-   the GUI thread.
-7. Predictable status and progress feedback for long-running work.
-8. Stable metadata, tagging, filtering, and organization workflows.
-9. Clean separation between Sempal product logic and Radiant GUI-library logic.
-10. Tests and diagnostics that protect real user workflows and performance.
+2. Correct handling of both short sample files and long audio files.
+3. Support for WAV and AIFF/AIF as the target audio formats.
+4. A sample extraction workflow for cutting useful regions out of long audio files into new sample files.
+5. A sample library curation workflow for editing, tagging, rating, naming, moving, and cleaning up sample files.
+6. A sample library usage workflow for finding, auditioning, and handing off sounds to a DAW or external creative tool.
+7. Immediate sample auditioning from keyboard, mouse, selection changes, region selections, and similarity workflows.
+8. A robust audio engine for playback, decoding, seeking, looping, range auditioning, edit auditioning, BPM-aware auditioning, and future extraction into a standalone audio-engine library.
+9. Clear waveform visualization with precise playhead, cursor, play selection, edit selection, range, marker, loop, fade, grid, transient, extracted-region, and edit-state feedback.
+10. Lightweight destructive sample editing for both macro extraction support and micro cleanup, including trimming, cutting, splitting, muting, fading, gain adjustment, normalization, silence removal, timing metadata correction, and range export.
+11. Audio-analysis tools that help users find useful material, such as BPM detection, tempo grids, transient detection, silence detection, waveform overviews, aging/listen-history indicators, and similarity analysis where practical.
+12. Reliable file, folder, export, copy, drag, trash, and DAW handoff workflows with clear recovery behavior where relevant.
+13. Fast tagging, rating, filtering, metadata, indexing, display naming, and persistence workflows for large libraries.
+14. A tag-category and database-display-name system that helps enforce consistent sample naming.
+15. Library triage tools based on keep/trash ratings, aging, listen history, untagged filters, and temporary color collections.
+16. Similarity analysis for discovering related sounds through browser filters and a visual 2D similarity map.
+17. Dense, low-friction UI optimized for repeated scanning, auditioning, cutting, editing, rating, naming, tagging, organizing, finding, and using sounds.
+18. Background scanning, decoding, waveform preparation, analysis, edit rendering, similarity indexing, and metadata work that never blocks the GUI thread.
+19. Predictable status and progress feedback for long-running work.
+20. Detailed logging and diagnostics for tracing failures, stalls, background jobs, and unexpected state changes.
+21. A session-local undo/redo system for destructive edits, file operations, metadata operations, rating operations, and meaningful UI interaction state.
+22. Clean separation between Wavecrate product logic, Radiant GUI-library logic, reusable audio-engine logic, and persistence/indexing logic.
+23. Tests, diagnostics, and validation workflows that protect real user behavior, performance, and recovery guarantees.
 
 ## Product Principles
 
-Sempal should optimize for:
+Wavecrate should optimize for:
 
 - audition-first workflows
 - realtime-feeling navigation and playback
+- fast extraction from long audio files
+- fast destructive sample preparation and cleanup
 - dense, structural layouts over decorative surfaces
-- reversible operations where practical
+- clear warnings for destructive actions until the user opts into advanced destructive workflow mode
+- session-local undoable operations wherever practical
 - explicit status when work is running
 - correctness under large libraries and slow disks
-- recoverability for destructive file operations
+- recoverability for destructive edits and file operations through session undo and safe trash movement
 - predictable keyboard and pointer behavior
+- similarity-driven discovery without hiding the underlying file/library structure
+- fast sample handoff to DAWs and external creative tools
+- fast tagging, rating, naming, organizing, and filtering with minimal friction
+- gentle library-hygiene workflows that encourage users to keep reviewing, rating, and cleaning their libraries
+- traceable behavior when something goes wrong
 
-Perceived stalls are product bugs. If a source scan, decode, rename, analysis
-job, or metadata update can take noticeable time, it belongs off the GUI thread
-with clear state handoff back to the UI.
+Perceived stalls are product bugs. If a source scan, decode, rename, edit render, waveform update, BPM analysis, transient analysis, similarity analysis job, database/index update, logging flush, or metadata update can take noticeable time, it belongs off the GUI thread with clear state handoff back to the UI.
 
 ## Non-Goals
 
-Sempal should not become:
+Wavecrate should not become:
 
 - a general-purpose GUI framework
 - a DAW or multitrack arrangement tool
 - a plugin host
-- a generic file manager
-- a visual effects playground
+- a VST/AU/CLAP effects host
+- a modular effects processing environment
+- a managed central sample-library system that hides the real filesystem
 - a database administration tool
 - a collection of one-off UI experiments
+- a machine-learning-based audio intelligence platform in the current target
+- a general-purpose audio converter for arbitrary file formats
 
-Sempal may need DAW-like visual primitives such as waveforms, ranges, meters, or
-transport controls, but those should serve sample exploration rather than expand
-the product into full music production.
+Supported audio formats for the current target are WAV and AIFF/AIF. MP3, FLAC, and other audio file formats are non-goals unless explicitly added later.
 
-## Radiant Boundary
+Wavecrate may contain DAW-like primitives such as waveforms, ranges, meters, fades, markers, loops, transport controls, tempo grids, transient markers, warp auditioning, and timeline overlays. These exist only to support sample exploration, extraction, preparation, and handoff.
 
-Radiant owns reusable GUI capability. Sempal owns sample-manager product logic.
+Wavecrate may support copy, drag-and-drop, export, reveal-in-explorer, or file handoff into DAWs and other creative tools. This does not make Wavecrate a DAW integration layer or plugin host.
 
-Move functionality into Radiant when it is generic enough to support other
-applications:
+Wavecrate may include simple built-in sample operations such as fades, cuts, mutes, gain changes, normalization, trimming, splitting, silence removal, BPM metadata correction, audition-time warping, and exports. These are editing and auditioning tools, not an open-ended effects system.
 
-- layout panels and split panes
-- virtualized trees, lists, and detail tables
-- text input, editable rows, keyboard focus, and shortcuts
-- GPU surface overlays and waveform/timeline rendering primitives
-- icon buttons, SVG/image resource caching, progress widgets, and status
-  surfaces
-- repaint, invalidation, subscriptions, and background-resource ergonomics
+Runtime model inference and ML-based similarity are not part of the current target.
 
-Keep functionality in Sempal when it is product or domain behavior:
+## Platform Target
 
-- source configuration and sample-library policy
-- audio-file discovery and supported media rules
-- playback and audition semantics
-- sample metadata, tags, and filters
-- rename, move, trash, restore, and recovery workflows
-- Sempal-specific status wording and command behavior
+Wavecrate should be developed Windows-first.
 
-If Sempal has to build a custom UI primitive only because Radiant lacks the
-right general API, prefer improving Radiant and then migrating Sempal back to
-the generic primitive.
+The initial primary development and testing target is:
+
+- Windows
+
+Future platform targets may include:
+
+- macOS
+- Linux
+
+Cross-platform support does not need to be implemented immediately, but the architecture should avoid unnecessary Windows-only assumptions in core product logic, audio-engine logic, persistence logic, and reusable GUI integration.
+
+Platform-specific code should be isolated behind clear boundaries. File watching, drag-and-drop, DAW handoff, audio-device handling, paths, temporary recovery folders, trash-folder behavior, shell integration, and windowing behavior should be designed so future macOS and Linux support can be added without rewriting core systems.
+
+## Audio Format and Channel Target
+
+Wavecrate should support the following audio formats:
+
+- WAV
+- AIFF/AIF
+
+MP3, FLAC, and other audio formats are out of scope for the current target.
+
+This is a deliberate simplification. Wavecrate should prioritize reliable destructive editing, extraction, metadata writing, waveform analysis, and DAW-compatible file behavior over broad format support.
+
+Wavecrate should align its practical audio-file compatibility with common DAW workflows, especially Ableton Live-style sample workflows. It should support common bit depths, sample rates, and channel layouts used in music production.
+
+The target includes:
+
+- common PCM bit depths such as 16-bit and 24-bit where supported by the format
+- higher precision PCM or floating-point formats where they are part of normal DAW sample workflows
+- common music-production sample rates such as 44.1 kHz, 48 kHz, 88.2 kHz, 96 kHz, and higher rates where practical
+- mono files
+- stereo files
+
+Wavecrate should preserve source channel layout during normal destructive edits. Editing a stereo file in the mono-style editor must not collapse it to mono. In the mono-first workflow, edits should affect both stereo channels equally.
+
+The waveform view should default to a mono-style overview because it is compact and fast for browsing. A later stereo split-view mode should show channels separately and allow channel-specific selection, editing, and extraction.
+
+Implementation should be phased:
+
+1. First, implement a complete mono-style editor that works correctly for mono and stereo files, with stereo edits applied equally to both channels.
+2. Later, add stereo split-view editing where users can independently view, select, mark, edit, and extract left/right channels where useful.
+
+## Core Domain Model
+
+Wavecrate should keep the domain model simple and file-based.
+
+### Audio File / Sample File
+
+An audio file is the core object. Long recordings, short one-shots, loops, extracted slices, and edited sounds are all just audio files in the library.
+
+There should be no functional distinction between a “source recording” and a “sample.” A long jam recording is simply a longer audio file. An extracted region is simply a new audio file. An edited file remains the same audio file unless the user duplicates or exports it.
+
+### Region
+
+A region is a marked time range inside an audio file.
+
+Regions may be used for auditioning, looping, extraction, editing, markers, or visual history. Regions should be visually clear in the waveform view and should support precise boundary adjustment.
+
+### Play Selection
+
+A play selection is a waveform range used for auditioning and looping.
+
+The play selection should be easy to create with the primary pointer interaction, such as left-click/drag. It should be easy to move or slide the play selection through the waveform so users can loop and audition different parts of a long file quickly.
+
+### Edit Selection
+
+An edit selection is a waveform range used specifically for destructive editing.
+
+The edit selection should be distinct from the play selection and may be created with a separate interaction, such as right-click/drag. This allows the user to audition one area while editing another area, or to create a more precise edit range without disturbing the audition loop.
+
+Edit commands should follow this priority:
+
+1. If an edit selection exists, edit commands apply to the edit selection.
+2. If no edit selection exists but a play selection exists, edit commands apply to the play selection.
+3. If neither selection exists, edit commands apply according to the command’s explicit behavior, such as whole-file normalization or current-cursor operations.
+
+The play selection and edit selection should not interfere with each other visually or behaviorally.
+
+### Extracted Region History
+
+When a user extracts a region from a longer audio file into a new sample file, the original audio file should show a visual history mark for the extracted range where practical.
+
+This helps users avoid repeatedly extracting the same section and makes it easier to continue scanning unexplored parts of a long file.
+
+### Wavecrate Sample ID
+
+Every indexed audio file should have a stable internal Wavecrate Sample ID.
+
+The filename is not the stable identity. Disk filenames may change, display names may change, and generated names may change. The internal Sample ID should remain the stable identifier for Wavecrate metadata, rating history, analysis cache, similarity data, aging/listen history, and other persisted state.
+
+Wavecrate should store this ID in the database and should also attempt to embed it directly into supported audio files.
+
+For WAV files, Wavecrate should use a custom RIFF chunk for the primary embedded ID. The chunk should be application-specific, versioned, and small. Unknown RIFF chunks should be preserved where practical when Wavecrate rewrites the file.
+
+For AIFF/AIF files, Wavecrate should use an application-specific metadata chunk where practical, following the same principle: small, versioned, and safe to ignore by other applications.
+
+The embedded metadata should contain at minimum:
+
+- Wavecrate Sample ID
+- metadata schema version
+- optional creation/update timestamp
+- optional checksum or file fingerprint reference where useful
+
+The database remains the authoritative fallback. If embedded metadata is missing, stripped, duplicated, or conflicting, Wavecrate should reconcile using the database record, file path, file fingerprint, audio properties, and user-visible recovery behavior.
+
+Wavecrate must validate embedded IDs by round-tripping files through common DAW workflows, especially Ableton Live and Bitwig. Validation should confirm that audio data, timing, channel layout, readability, and metadata recovery remain intact.
+
+If embedded ID writing proves unsafe for WAV or AIFF/AIF, Wavecrate should disable embedding for that format and treat the target as needing adjustment rather than risking file damage.
+
+### Disk Filename
+
+The disk filename is the actual file name on disk.
+
+Wavecrate should be able to show and manipulate real disk filenames, but the disk filename should not be treated as the only or primary product label.
+
+### Display Name / Database Name
+
+The display name is the clean name shown by Wavecrate based on metadata such as tags, tag categories, label, prefix, BPM, source, and uniqueness suffix.
+
+Wavecrate should support view modes that show either the real disk filename or the generated database/display name. Applying a generated display name to the disk filename should be a deliberate file operation, not an invisible background behavior.
+
+### Label
+
+A label is a user-editable text field that can act as the human-readable identity of a sample file inside Wavecrate.
+
+The label may default to the original filename without extension. Users can refine it later. The label can be used in generated display names.
+
+### Prefix
+
+A prefix is a structured metadata field that can identify an artist, creator, project, pack, session, or other user-selected namespace.
+
+The prefix can be used in generated display names and can help users distinguish their own sounds from other material.
+
+### Tags
+
+Tags describe sound type, structure, character, source, or other useful properties.
+
+Tags should be category-aware where practical so they can support filtering and naming in a predictable order.
+
+### Rating State
+
+Rating state is based on the keep/trash rating system. It is separate from tags.
+
+Rating state should be fast to apply, visually obvious, persistent, and useful for sorting, filtering, cleanup, and library hygiene.
+
+### Aging / Listen History
+
+Aging and listen history track when a sample file was last auditioned, whether it has never been listened to, and how often it is used or auditioned.
+
+This should help users find new files, neglected files, recently used files, and frequently used files.
+
+### Temporary Color Collections
+
+Temporary color collections are lightweight shelves inspired by Ableton-style color collections.
+
+They are not the primary file organization system and do not replace folders. They should help users temporarily collect files for a project, task, comparison pass, cleanup pass, or sound selection workflow.
+
+## File Ownership and Source of Truth
+
+Wavecrate should remain grounded in the real filesystem.
+
+The filesystem is the source of truth for file existence, folder structure, and physical file location. Wavecrate indexes existing folders and operates on real files in those folders.
+
+Wavecrate should not require a central managed library folder. Users should be able to point Wavecrate at existing folders and work with the actual files there.
+
+Wavecrate may create, move, rename, duplicate, export, collect, copy, or trash files, but those operations should physically happen on disk. If a file is moved from one folder to another in Wavecrate, the file should actually move on disk.
+
+The database is the source of truth for Wavecrate-specific metadata, including tags, ratings, display names, labels, prefixes, analysis results, similarity descriptors, waveform cache references, aging/listen history, extracted-region history, and session undo/history state where appropriate.
+
+Wavecrate should detect and handle:
+
+- missing files
+- moved files
+- renamed files
+- changed files
+- duplicate files
+- stale metadata
+- stale analysis cache
+- stale waveform cache
+- database records pointing to unavailable files
+- files without embedded Wavecrate Sample IDs
+- files with embedded IDs that conflict with database state
+
+When filesystem and database state diverge, Wavecrate should provide clear reconciliation behavior instead of silently losing user metadata or pretending missing files still exist.
+
+## Destructive Editing, Duplication, and Session Undo Policy
+
+Wavecrate is intentionally a fast destructive sample editor.
+
+When the user performs an edit such as mute, cut, delete, fade, normalize, gain change, trim, or silence removal, the edit should modify the current audio file in place unless the command is explicitly an extraction, export, duplicate, or copy operation.
+
+This is a deliberate product direction. Wavecrate should not automatically create endless duplicate versions for every edit. Users who want to preserve an original file should duplicate it before editing.
+
+Wavecrate should therefore provide a clear duplicate-file command that makes it easy to create a backup or alternate version before destructive editing.
+
+Destructive editing should have two user-facing safety modes.
+
+### Default Safety Mode
+
+In default mode, destructive edits should warn the user clearly before modifying the file in place.
+
+The warning should explain that the edit will modify the audio file on disk. The user should be able to confirm, cancel, and optionally enable advanced destructive workflow mode if they understand the behavior.
+
+### Advanced Destructive Workflow / YOLO Mode
+
+Advanced users should be able to enable a persistent destructive workflow mode, informally called YOLO mode.
+
+When this mode is enabled, Wavecrate should stop showing repetitive destructive-edit warnings and should allow fast in-place editing. Users in this mode are expected to duplicate files themselves when they want backups.
+
+YOLO mode should be explicit, persistent, and easy to identify in the UI. It should not be enabled accidentally.
+
+### Session-Local Undo and Redo
+
+Even though edits are destructive, Wavecrate should have a deeply integrated undo/redo system.
+
+Undo/redo is session-local. It only needs to work while the application is running. Undo history does not need to persist across application restarts.
+
+Undo/redo should cover as much of the application as practical, including:
+
+- destructive audio edits
+- selection changes
+- play selection changes
+- edit selection changes
+- marker changes
+- region changes
+- extraction actions
+- duplicate actions
+- rename actions
+- generated-name application actions
+- tag changes
+- rating changes
+- temporary color collection changes
+- metadata changes
+- move/copy/export/trash operations
+- folder operations where practical
+
+Undo/redo should be transaction-based. A user action should either complete as a coherent operation or fail in a recoverable way. Partial failures should be logged and reported clearly.
+
+The undo history should be deep enough to be useful while remaining bounded to avoid excessive memory or disk usage. A reasonable initial target is at least 50 meaningful user actions where practical, with the architecture allowing this limit to be adjusted later.
+
+### Temporary Recovery Files
+
+For destructive audio edits and file operations that need recovery support, Wavecrate should use temporary recovery files.
+
+Wavecrate should create a standard application temp/recovery folder appropriate for the operating system. On Windows, this should live in a conventional user/application data or temp location, not inside arbitrary sample-library folders.
+
+Temporary recovery files should support undo for the current session only. Files from previous sessions should be considered stale and eligible for cleanup.
+
+Wavecrate should not slow down shutdown by doing heavy temp cleanup on exit. Instead, a background worker should clean stale recovery files while the application is running, such as on startup or during idle/background maintenance. The cleanup worker should remove old files that do not belong to the current session and are no longer valid for undo.
+
+Recovery-file creation, cleanup, and failures should be logged.
+
+## Extraction Policy
+
+Extraction is not the same as destructive editing.
+
+When a user selects a region of an audio file and extracts it, Wavecrate should create a new sample file containing that region. The original file should remain unchanged unless the user separately performs a destructive edit on it.
+
+If audition-time processing is active, such as target-BPM warping, extraction should create what the user hears. If a user auditions a warped loop and extracts it, the created sample file should bake the auditioned warp result into the new file.
+
+Extraction should support:
+
+- extracting the current play selection
+- extracting the current edit selection where appropriate
+- drag-out extraction where practical
+- enter/confirm extraction where practical
+- naming or labeling extracted files
+- applying tags and metadata to extracted files
+- assigning a new Wavecrate Sample ID to extracted files
+- writing embedded Sample ID metadata where practical
+- recording extracted-region history on the original file
+- avoiding filename collisions through predictable numbering
+
+## Trash and Cleanup Policy
+
+Wavecrate should use a configured trash folder for cleanup.
+
+Trashing a file means moving it from its current source folder into the configured trash folder. It does not mean permanent deletion.
+
+Wavecrate should not permanently delete files automatically. Permanent deletion is outside the normal cleanup workflow.
+
+The trash folder must be configured before Wavecrate can automatically move files there. If no trash folder is configured, trash actions should be blocked, downgraded to rating-only behavior, or prompt the user to configure the trash folder.
+
+Trash workflow should support:
+
+- explicit trash actions
+- automatic trash movement when a file reaches the rejected threshold
+- undo for recent trash moves during the current session
+- clear logging of trash moves
+- clear UI indication that a file was moved out of the active library
+- predictable behavior if a destination file already exists in the trash folder
+
+No special long-term untrash system is required beyond current-session undo and the fact that files remain physically present in the trash folder. Users can move files back manually if needed.
+
+## Keep/Trash Rating System
+
+Wavecrate should use a fast keep/trash rating scale rather than a generic star-rating system.
+
+All files start unrated.
+
+The user should be able to quickly apply a keep mark or a trash mark while auditioning. These marks should be visually clear in the sample browser.
+
+The rating state should move in the direction of the latest rating action. It should not use simple cancellation back to unrated once a file has been rated.
+
+The target rating behavior is:
+
+- Unrated plus keep becomes keep level 1.
+- Keep level 1 plus keep becomes keep level 2.
+- Keep level 2 plus keep becomes keep level 3.
+- Keep level 3 plus keep becomes accepted/favorite/locked.
+- Unrated plus trash becomes trash level 1.
+- Trash level 1 plus trash becomes trash level 2.
+- Trash level 2 plus trash becomes trash level 3.
+- Trash level 3 plus trash becomes rejected and eligible for trash-folder movement.
+- Applying trash to a keep-rated file should move it to trash level 1, not back to unrated.
+- Applying keep to a trash-rated file should move it to keep level 1, not back to unrated.
+
+Accepted/favorite files should be visually distinct and locked from further rating changes. To change the rating of an accepted file, the user must manually unlock it first.
+
+Rejected files should be moved to the configured trash folder automatically when cleanup policy allows it.
+
+The UI should make partial ratings clear. A file with one, two, or three keep/trash marks should visually communicate that it is moving toward accepted or rejected state.
+
+Rating controls should be keyboard-friendly and should not interrupt auditioning.
+
+## Aging and Listen-History System
+
+Wavecrate should track listen history and use it to support library hygiene.
+
+The system should track information such as:
+
+- never auditioned
+- last auditioned recently
+- last auditioned days ago
+- last auditioned weeks ago
+- last auditioned months ago
+- audition count where useful
+
+The sample browser should visually communicate aging state. Files that have not been listened to recently may be visually faded, greyed, or otherwise marked so users can quickly identify neglected material.
+
+Aging should support sorting and filtering. Users should be able to find files that are never listened to, recently listened to, not listened to for weeks/months, or heavily auditioned.
+
+Aging state should combine with tags, ratings, similarity, folders, and text filters.
+
+## Temporary Color Collections
+
+Wavecrate should support temporary color collections similar in spirit to Ableton-style collections.
+
+The target is a small fixed set of color collections, such as 10 slots. Users should be able to name these color collections and quickly assign sample files to them.
+
+Color collections should behave like temporary shelves, not as the main organization model.
+
+Possible uses include:
+
+- collecting samples for a current track
+- collecting kick candidates
+- collecting sounds to clean up later
+- collecting samples to move into a folder
+- comparing similar sounds
+- staging files before export or DAW handoff
+
+Color collections should be fast to assign, clear in the UI, sortable/filterable, and easy to clear when no longer needed.
+
+Physical folders remain the main durable organization system. Color collections are a lightweight metadata layer for temporary workflow support.
+
+## Sample Browsing, Auditioning, and Usage Target
+
+Browsing, auditioning, and using samples should feel immediate, even on large libraries.
+
+Wavecrate should support:
+
+- fast source and folder navigation
+- incremental source scanning
+- responsive sample lists for large folders and libraries
+- keyboard-first movement through samples
+- pointer-based selection and auditioning
+- immediate playback on selection when enabled
+- quick restart, stop, seek, loop, and range playback
+- target-BPM auditioning where practical
+- copy, drag, export, reveal, or handoff of selected sample files into DAWs and external tools
+- visible selected, playing, loading, unavailable, failed, edited, unsaved, unreviewed, aged, keep-rated, trash-rated, accepted, rejected, and trashed states
+- stable behavior when the user moves quickly through many samples
+
+Fast browsing is more important than decorative UI. The user should be able to scan thousands of files, hear sounds quickly, find sounds that fit a production context, and move chosen samples into their DAW without breaking flow.
+
+## DAW and External Tool Handoff Target
+
+Wavecrate should make it easy to use found sounds in music production.
+
+The initial target is practical Windows-first file-based handoff, not deep DAW integration.
+
+Wavecrate should support workflows such as:
+
+- drag a sample file into a DAW
+- copy a sample file
+- copy a file path
+- reveal a sample file in Explorer
+- export or copy a prepared sample file to a chosen folder
+- extract a region and immediately drag/copy/export the new file
+- hand off the exact audio the user auditioned, including baked audition-time warp when extraction/export requires it
+
+Initial implementation should prioritize drag-and-drop into DAWs such as Ableton Live and Bitwig where practical, plus reveal-in-Explorer and copy-file-path.
+
+Handoff should be fast and predictable. It should not require users to understand Wavecrate internals.
+
+Future macOS/Linux handoff should be possible through platform-specific adapters without rewriting core product logic.
+
+## Sample Editing and Cleanup Target
+
+Wavecrate should support lightweight, sample-centric editing directly in the waveform view.
+
+Core editing workflows should include:
+
+- trimming start and end points
+- cutting or deleting ranges
+- splitting a sample file into regions or pieces
+- muting or silencing selected sections
+- removing or reducing unwanted silence
+- adding fade-ins and fade-outs
+- adjusting fade length and curve where practical
+- normalizing a whole sample file or selected region
+- applying simple gain changes to a sample file or range
+- correcting or setting BPM metadata where practical
+- aligning loop boundaries to grid or transients where practical
+- creating named markers or regions
+- naming selected regions or extracted slices
+- rating selected regions or extracted slices
+- exporting selected ranges or slices as new files
+- saving destructive edits with clear warning/YOLO behavior
+
+Editing should be designed around fast preparation of individual sample files and long recordings. The user should be able to clean up a tail, remove silence, isolate a hit, split a loop into useful pieces, cut a long jam into named regions, normalize a quiet file, mute an unwanted section, and export prepared versions without leaving the browsing flow.
+
+The first complete editing target is mono-style editing. Stereo files should retain their stereo data, but edits should affect both channels equally until stereo split-view editing is added later.
+
+## BPM, Grid, Warp, and Timing Target
+
+Wavecrate should support BPM-aware auditioning and extraction.
+
+The system should support:
+
+- BPM detection where practical
+- manually setting or correcting BPM metadata
+- tempo-grid display when BPM is known
+- grid-aware selection and loop adjustment
+- transient-aware loop boundary adjustment where practical
+- setting a target audition BPM
+- locking the target audition BPM
+- auditioning BPM-tagged loops warped to the target BPM where practical
+- extracting or exporting warped audio exactly as heard when the user extracts from a warped audition state
+
+Time-stretching/warping is part of the audition and extraction workflow, not a general DAW-style warping environment.
+
+The initial warp target should be practical and beat-oriented, similar in spirit to a simple beats-style warp mode. Special high-quality, multi-algorithm, formant-preserving, or advanced warping modes are non-goals for the current target.
+
+Wavecrate should not become a full arrangement, clip-warping, or multitrack timing editor. The goal is to audition loops in a production-relevant tempo context and to bake that auditioned result into a new sample file when the user extracts or exports it.
+
+## Audio Engine Target
+
+Wavecrate should include a robust audio engine for fast, predictable auditioning, destructive editing, extraction, and sample-library usage.
+
+The audio engine should support:
+
+- immediate playback of selected sample files
+- low-latency start, stop, seek, loop, and retrigger behavior
+- accurate playback of play selections, edit selections, regions, markers, slices, loops, and pending edit operations
+- target-BPM auditioning where practical
+- reliable decoding of WAV and AIFF/AIF
+- editing/write support for WAV and AIFF/AIF
+- reusable decoded audio, waveform, and peak data where practical
+- background preparation of audio data without blocking the GUI thread
+- stale-result-safe handoff when selection or edit state changes while work is running
+- clear error reporting for unsupported files, decode failures, device failures, metadata write failures, and playback failures
+- diagnostic events that make playback, decode, seek, loop, warp, render, and device bugs traceable
+
+The audio engine should be designed with future extraction in mind. Wavecrate can drive its immediate requirements, but the core engine should avoid unnecessary dependency on Wavecrate-specific UI, metadata, tag, similarity, naming, or source-management concepts.
+
+The practical target is a clean internal boundary today that allows reusable audio-engine components to become their own standalone library later without rewriting the playback, editing, and extraction stack.
+
+## Similarity and Discovery Target
+
+Wavecrate should include a similarity engine for finding related sounds by audio character, not only by filename, folder, or manually assigned tags.
+
+The similarity system should remain local, deterministic, cacheable, and optimized for fast sample exploration.
+
+The default engine should use:
+
+- analysis-normalized audio
+- stable versioned DSP feature vectors
+- L2-normalized descriptor embeddings
+- cosine approximate-nearest-neighbor search
+- lightweight reranking that balances broad timbral similarity with practical envelope and loudness cues
+
+Runtime model inference is not part of the current target.
+
+Map projection and clustering are secondary exploration aids built from the same persisted embeddings. They should preserve compatibility while using implementation names that reflect the current projection method.
+
+The similarity system should support:
+
+- background audio analysis for feature extraction
+- persistent storage of analysis results
+- stale-result-safe updates when files change or analysis jobs complete out of order
+- finding sample files similar to the selected sample file
+- sorting the browser by similarity to a selected reference file
+- visual similarity indicators in the sample browser
+- filtering the sample list by similarity to a selected reference sound
+- combining similarity filters with tags, ratings, folders, search text, metadata, aging/listen state, and file properties
+- browsing a 2D similarity map for visual discovery of related sounds
+- clear status for analysis progress, unavailable analysis, stale analysis, and failed analysis
+
+The 2D similarity map should provide an XO-like exploration surface for samples. Similar-sounding samples should appear near each other so the user can scan clusters, audition nearby files, and discover variations quickly.
+
+The sample browser should provide Sononym-like similarity workflows. The user should be able to choose a reference sample and quickly find related kicks, hats, loops, textures, impacts, vocals, or other sound types through list-based filters and sorting.
+
+Similarity should assist discovery without becoming opaque. The UI should make it clear when results come from similarity analysis, when analysis is still pending, and when ordinary file, tag, rating, aging, search, or metadata filters are also active.
+
+Similarity should support both management and production use. It should help users clean up libraries, but it should also help music producers quickly audition clusters of related sounds and choose material to drag, copy, export, or otherwise hand off to a DAW.
+
+## Tagging and Metadata Target
+
+Tagging should be fast, flexible, category-aware, and low-friction.
+
+Wavecrate should support:
+
+- adding and removing tags quickly from one or many sample files or regions
+- custom tags created directly by the user
+- custom tags added to existing tag categories
+- a dynamic tag library built from tags already used in the library
+- autocomplete suggestions based on existing tags
+- clear pill visuals for assigned tags
+- keyboard-friendly tag entry and removal
+- typo-resistant tag workflows where practical
+- tag-based filtering in the sample browser
+- combination filters across tags, ratings, age, triage states, similarity, folders, search text, and metadata
+
+The tag library should not require a fixed predefined taxonomy, but Wavecrate should provide clear built-in tag categories so naming, filtering, and visual organization remain structured.
+
+Recommended tag categories:
+
+- **Structure/type:** one-shot, loop, phrase, texture, riser, impact, fill, layer, tool, recording.
+- **Sound/source:** kick, snare, clap, hat, ride, bass, synth, stab, vocal, percussion, noise, field, modular, drum loop.
+- **Character/flavor:** distorted, clean, soft, hard, dark, bright, noisy, metallic, deep, punchy, loose, tight, raw, warm.
+- **Technical/music metadata:** BPM, key, pitch, length, mono/stereo, source session where practical.
+- **Prefix/namespace:** artist, creator, project, pack, or user-defined prefix where useful.
+
+Users should be able to add their own tags to these categories. The categories should guide the system without preventing custom vocabulary.
+
+For example, if the user starts typing `ki`, the tag input should suggest an existing `kick` tag. Selecting the suggestion should apply the existing tag instead of creating a duplicate spelling variant. If the intended tag does not exist, the user should be able to create it immediately.
+
+Tagging UI should favor compact, readable pill components. Tags should be visible enough to be useful during scanning, but not so visually heavy that they dominate the sample list or waveform/editor area.
+
+## Display Naming and Disk Rename Target
+
+Wavecrate should make it easy to create a consistently named and organized sample library while avoiding accidental breakage of external file references.
+
+Wavecrate should distinguish between:
+
+- the actual disk filename
+- the generated display/database name
+- the user-editable label
+- the stable internal Wavecrate Sample ID
+
+The generated display name should be based on structured metadata such as:
+
+- prefix/namespace
+- structure/type tag
+- sound/source tag
+- character/flavor tags
+- BPM where known
+- key or pitch where known
+- user label
+- source/session information where useful
+- uniqueness suffix
+
+A recommended initial naming order is:
+
+```text
+[prefix]_[type]_[sound]_[character-tags]_[bpm]_[label]_[number]
+````
+
+Examples:
+
+```text
+wanja_loop_kick_distorted_raw_140_metal-floor_001.wav
+wanja_oneshot_hat_bright_noisy_short_017.wav
+modular_texture_noise_dark_wide_006.wav
+```
+
+Missing metadata should simply be omitted. The naming system should not invent misleading metadata.
+
+The generated name should be available as a Wavecrate display mode in the browser. Users should be able to switch between viewing the real disk filename and the generated display/database name.
+
+Applying the generated display name to the actual disk filename should be an explicit action. This action may be triggered from a context menu, command, batch operation, or future workflow mode, but it should be understood as a real filesystem rename.
+
+Renaming should:
+
+* preserve the stable internal Wavecrate Sample ID
+* avoid collisions through predictable numbering
+* handle invalid filename characters
+* be undoable during the current session where practical
+* be logged clearly
+* warn the user where external DAW/project references may break
+
+A fully automatic disk auto-rename mode is not the default target. The safer target is automatic database/display naming plus explicit apply-to-disk rename.
+
+## Physical Organization Target
+
+Wavecrate should rely primarily on real files and folders.
+
+Users organize durable collections by creating folders and moving/copying sample files into those folders. Wavecrate should expose this clearly rather than hiding it behind a central managed library.
+
+Wavecrate should support:
+
+* creating folders
+* moving files between folders
+* copying files between folders
+* duplicating files
+* renaming files
+* applying generated display names to disk filenames
+* exporting extracted or edited files to chosen folders
+* moving rejected files to the configured trash folder
+* revealing files in Explorer
+
+The folder tree should reflect actual folders on disk. The sample browser should reflect actual files on disk plus Wavecrate-specific metadata from the database.
+
+## Database, Persistence, and Indexing Target
+
+Wavecrate should use a fast, robust persistence layer for sources, tags, ratings, age/listen history, metadata, display names, labels, prefixes, embedded Sample ID state, analysis state, similarity data, waveform cache state, extracted-region history, edit state where needed, and current-session recovery information.
+
+The database and indexing system should support:
+
+* responsive queries for large sample libraries
+* fast tag filtering, rating filtering, age filtering, text filtering, metadata filtering, and similarity lookup
+* efficient updates when tags, ratings, age state, metadata, names, analysis results, source contents, embedded IDs, or edit state change
+* clear schema ownership and migration behavior
+* transactional or recovery-safe updates for user-trust surfaces
+* consistency between persisted state and UI projection
+* diagnostic information for failed writes, stale records, migration issues, metadata embedding failures, and indexing problems
+
+Tag, rating, aging, naming, and metadata workflows should remain fast as the library grows. Filtering should feel interactive, and persistence should be treated as part of the product performance surface rather than a passive storage detail.
+
+## File Operations and Recovery Target
+
+Wavecrate should treat the filesystem, source database, edit state, tags, ratings, names, similarity index, action history, and logs as user-trust surfaces.
+
+File, folder, metadata, rename, and edit operations should:
+
+* operate on real files and folders
+* preserve metadata where possible
+* avoid silent data loss
+* make destructive operations explicit unless YOLO mode is enabled
+* use session-local undoable transactions where practical
+* use clear recovery paths for partial failure
+* keep UI projection and persisted state aligned
+* report failures in user-actionable terms
+* avoid blocking the GUI while work is planned or executed
+* make derived files, exports, overwritten files, renamed files, trashed files, duplicated files, and moved files understandable to the user
+
+Background workers should be cancellable or stale-result-safe when the user changes selection, sources, folders, filters, tags, ratings, names, edit selections, play selections, or map views before work completes.
+
+Similarity data, BPM data, transient data, aging data, waveform data, embedded Sample ID state, and display-name data should be invalidated or refreshed when the underlying file changes. Tag, rating, naming, age, and metadata updates should be persisted predictably and reflected consistently across browser, waveform/editor, filters, and map views.
+
+## Logging and Diagnostics Target
+
+Wavecrate should have detailed logging throughout the application so bugs, stalls, failed operations, and unexpected state changes can be traced.
+
+Logging should cover:
+
+* application startup and shutdown
+* source scanning and file discovery
+* database reads, writes, migrations, and indexing work
+* embedded Sample ID reads, writes, conflicts, and failures
+* audio device setup, decoding, playback, seeking, looping, warping, and render failures
+* waveform preparation and cache usage
+* BPM detection, grid generation, transient detection, silence detection, and analysis failures
+* play selection and edit selection state changes where useful
+* extraction actions and extracted-region history
+* destructive edit creation, rendering, overwrite, and failure recovery
+* session undo/redo transaction creation, success, failure, and rollback
+* temp recovery file creation, usage, cleanup, and failure
+* tag creation, autocomplete, filtering, display naming, disk rename application, and metadata persistence
+* rating, aging/listen history, review-state, and trash-workflow changes
+* similarity analysis, indexing, sorting, filtering, and 2D map generation
+* temporary color collection changes
+* background job lifecycle, cancellation, stale completions, and handoff back to the UI
+* file operations such as rename, duplicate, move, copy, trash, restore via undo, collect, reveal, and export
+* DAW/external handoff actions
+* user-actionable errors and internal diagnostic details
+
+Logs should be structured enough to support debugging. Important operations should include useful context such as source IDs, Wavecrate Sample IDs, region IDs, file paths where safe, job IDs, selection versions, edit versions, action transaction IDs, cache keys, timing information, and failure reasons.
+
+Logging should help answer practical debugging questions: what happened, in what order, on which thread or worker, for which file or source, how long it took, and why it failed. Logging itself must not cause UI stalls, excessive disk writes, or unreadable noise.
 
 ## UI Target
 
-The Sempal UI should be compact, stable, and optimized for scanning:
+The Wavecrate UI should be compact, stable, and optimized for scanning, auditioning, extracting, editing, naming, tagging, rating, organizing, and using sample files.
 
-- tight margins and predictable panel geometry
-- resizable sidebars and durable split positions
-- folder tree, sample list, waveform, and status surfaces visible together
-- clear selected, playing, loading, and failed states
-- keyboard navigation for common browse and rename actions
-- pointer interactions that show exact positions and ranges
-- no marketing-style hero layout, decorative cards, or ornamental whitespace
+The UI should provide:
 
-Status bars should stay concise. Long-running operations should report what is
-happening without monopolizing the interface.
+* tight margins and predictable panel geometry
+* resizable sidebars and durable split positions
+* folder tree, sample list, waveform/editor, tags, ratings, age indicators, filters, similarity controls, naming controls, color collections, and status surfaces available without excessive navigation
+* clear selected, playing, loading, edited, unsaved, failed, analyzing, unreviewed, aged, keep-rated, trash-rated, accepted, rejected, trashed, and unavailable states
+* keyboard navigation for common browse, audition, loop, mark, cut, edit, duplicate, rename, tag, rate, collect, triage, filter, copy, and handoff actions
+* pointer interactions that show exact positions, play selections, edit selections, ranges, fades, markers, loops, grids, transients, extracted-region marks, and edit handles
+* compact tag pills and autocomplete controls
+* region, marker, loop, grid, transient, BPM, and target-BPM controls where relevant
+* fast keep/trash rating controls that do not interrupt auditioning
+* aging/listen-history visuals that make neglected or recently used files clear
+* generated-name display mode and disk-filename display mode
+* deliberate apply-display-name-to-disk controls
+* current destructive-edit safety mode indicator, especially when YOLO mode is enabled
+* mono-style waveform view by default
+* future stereo split-view mode for independent channel inspection and editing
+* copy, drag, export, reveal, and DAW handoff controls that are fast and predictable
+* similarity controls that can be used from both list and map workflows
+* concise status surfaces for long-running work
+* no marketing-style hero layout, decorative cards, or ornamental whitespace
+
+The waveform/editor should be a primary work surface, not a decorative preview. It should support precise cursor movement, play selection, edit selection, range selection, playhead display, loop display, edit handles, fades, markers, grids, transient cues, extracted-region history, and clear feedback for destructive edits.
+
+Status bars should stay concise. Long-running operations should report what is happening without monopolizing the interface.
 
 ## Performance Target
 
-Sempal should handle large sources without freezing or rebuilding unnecessary UI
-work.
+Wavecrate should handle large sources without freezing or rebuilding unnecessary UI work.
 
 Important performance rules:
 
-- source scanning must stream discoveries to the UI incrementally
-- folder and sample views should be virtualized or windowed for large datasets
-- sample decode and waveform preparation must run in background work
-- stale background completions must not overwrite newer selection state
-- playback should reuse already-loaded bytes where possible
-- repaint requests should match actual visual changes
-- GPU waveform overlays should be composited by Radiant, not faked with extra
-  application surfaces
+* source scanning must stream discoveries to the UI incrementally
+* long audio files must remain navigable without loading unnecessary full-resolution UI data at once
+* folder and sample views should be virtualized or windowed for large datasets
+* sample decode and waveform preparation must run in background work
+* BPM detection, transient detection, silence detection, similarity analysis, and 2D map generation must run in background work
+* destructive edit rendering and file overwrite work must avoid blocking the GUI thread
+* normalization scans, extraction renders, warp renders, and derived-file exports must run in background work
+* database writes, indexing, migrations, metadata embedding, and maintenance work must not block the GUI thread
+* stale background completions must not overwrite newer selection, edit, filter, tag, rating, naming, database, aging, or triage state
+* playback should reuse already-loaded bytes where possible
+* waveform previews should reuse cached analysis and peak data where practical
+* tag, rating, metadata, naming, aging, triage, and similarity filters should remain responsive on large libraries through indexing, caching, or incremental computation
+* recovery-file management should not block shutdown or normal UI interaction
+* repaint requests should match actual visual changes
+* GPU waveform overlays should be composited by Radiant, not faked with extra application surfaces
+* logging should provide useful traceability without becoming a performance bottleneck
 
-Performance-sensitive paths should have focused tests, diagnostics, examples,
-or manual validation notes when practical.
+Performance-sensitive paths should have focused tests, diagnostics, examples, benchmarks, or manual validation notes when practical.
 
-## Reliability Target
+## Architecture Boundaries
 
-Sempal should treat the filesystem and source database as user-trust surfaces.
+Wavecrate owns product behavior. Radiant owns reusable GUI capability. The audio engine should move toward reusable audio capability. The persistence layer should provide fast, reliable storage and indexing without leaking database details into every product workflow.
 
-File and folder operations should:
+### Wavecrate Owns
 
-- preserve metadata where possible
-- use clear recovery paths for partial failure
-- avoid silent data loss
-- keep UI projection and persisted state aligned
-- report failures in user-actionable terms
-- avoid blocking the GUI while work is planned or executed
+* source configuration and sample-library policy
+* audio-file discovery and supported media rules
+* audition behavior and product-level playback policy
+* sample extraction workflows and user-facing analysis behavior
+* destructive sample editing semantics
+* play selection and edit selection product rules
+* keep/trash rating behavior
+* aging/listen-history behavior
+* temporary color collection behavior
+* sample metadata, tags, ratings, age states, filters, and custom tag policy
+* similarity workflows and user-facing discovery behavior
+* display-name generation policy, disk-rename policy, and folder-routing policy
+* file operations such as rename, duplicate, move, copy, trash, reveal, collect, export, overwrite, and recovery workflows
+* DAW/external handoff policy
+* destructive warning and YOLO mode policy
+* Wavecrate-specific status wording and command behavior
 
-Background workers should be cancellable or stale-result-safe when the user
-changes selection, sources, or folders before work completes.
+### Radiant Owns
+
+* layout panels and split panes
+* virtualized trees, lists, and detail tables
+* text input, editable rows, keyboard focus, and shortcuts
+* pill/tag input primitives, autocomplete popovers, and selection chips
+* GPU surface overlays and waveform/timeline rendering primitives
+* range selection, cursor, marker, playhead, loop, grid, and timeline interaction primitives when they are domain-neutral
+* icon buttons, SVG/image resource caching, progress widgets, and status surfaces
+* repaint, invalidation, subscriptions, and background-resource ergonomics
+* generic map/canvas interaction primitives where useful for the 2D similarity map
+
+### Audio Engine Owns
+
+* reusable playback primitives
+* decoding and buffering for WAV and AIFF/AIF
+* seeking, looping, retriggering, and range playback primitives
+* audition-time warp primitives where reusable
+* audio data preparation for waveform and edit auditioning
+* render-preparation primitives needed for destructive edits, extraction, export, and baked warp output
+* mono-style edit application across mono/stereo data
+* future stereo split-channel editing primitives where useful
+* audio-analysis primitives where they are reusable beyond Wavecrate
+* audio-device and playback diagnostics
+
+### Persistence Layer Owns
+
+* durable storage
+* indexing
+* schema migrations
+* transactional or recovery-safe updates
+* query performance for tags, metadata, similarity, rating, naming, aging, color collections, and source state
+* embedded Sample ID state
+* persistence diagnostics
+
+### Undo/Recovery System Owns
+
+* session-local undo/redo history
+* action transactions
+* recovery file registration
+* recovery file cleanup coordination
+* undo/redo diagnostics
+
+If Wavecrate has to build a custom UI primitive only because Radiant lacks the right general API, prefer improving Radiant and then migrating Wavecrate back to the generic primitive.
+
+If Wavecrate has to add playback, decoding, looping, warping, destructive rendering, or reusable audio-analysis code only because the audio engine lacks a reusable primitive, prefer improving the audio-engine boundary instead of embedding one-off audio behavior directly into product code.
+
+## Code Quality and Maintainability Target
+
+Wavecrate should be simple, focused, and maintainable internally. The codebase should make the product direction easier to execute, not harder.
+
+Code should be organized around clear responsibilities:
+
+* sample discovery and source scanning
+* audio playback and decoding
+* waveform preparation and editing
+* large-audio-file analysis and extraction
+* similarity analysis and indexing
+* tags, ratings, aging, display names, metadata, and persistence
+* embedded metadata and Sample ID handling
+* file operations and recovery
+* undo/redo transactions
+* UI state and product commands
+* logging and diagnostics
+* Radiant integration
+
+Files and modules should be small, focused, and organized by responsibility. Each file should have a clear reason to exist. Each module should expose a clean surface and hide internal implementation details where practical. Module boundaries should follow real architecture boundaries, not arbitrary file splitting.
+
+Wavecrate code should follow these standards:
+
+* Keep functions small and single-purpose.
+* Keep structs focused on one responsibility.
+* Keep traits minimal, meaningful, and justified.
+* Split complex methods into named helpers.
+* Separate large impl blocks where it improves clarity.
+* Expose only intentional public API.
+* Keep internal types internal.
+* Make error handling explicit and understandable.
+* Keep control flow readable.
+* Encode or document important invariants.
+* Keep state mutation clear and predictable.
+* Make side effects easy to identify.
+* Keep hot-path code simple and efficient.
+* Prefer clear composition over broad inheritance-like trait systems.
+* Avoid premature abstraction.
+* Avoid cleverness where straightforward code is better.
+* Prefer explicit data flow.
+* Minimize global mutable state.
+* Remove dead code.
+* Remove unused experiments unless intentionally preserved and documented.
+* Make every abstraction earn its place.
+* Avoid large rewrites unless they clearly reduce complexity, unlock important architecture, improve performance, or remove real blockers.
+
+Code smells to avoid:
+
+* god files and god objects
+* long functions
+* deep nesting
+* repeated logic
+* ambiguous names
+* hidden side effects
+* unclear ownership
+* overly broad traits
+* tight coupling between unrelated modules
+* product behavior leaking into Radiant
+* Radiant implementation details leaking into Wavecrate workflows
+* audio-engine internals leaking into unrelated product code
+* persistence details leaking into every workflow
+* temporary hacks becoming architecture
+* stale legacy UI assumptions shaping the new architecture
+
+Wavecrate should be improved incrementally. Refactors should usually preserve working behavior, keep validation lanes intact, and leave the codebase in a clearer state than before. Do not turn quality work into endless renaming; renaming is useful only when it improves API clarity, architectural understanding, or developer experience.
+
+Tests should support refactoring rather than prevent it. Avoid tests that only lock in names, incidental file layout, or implementation details. Prefer tests that protect real workflows, recovery behavior, stale-result safety, persistence correctness, playback behavior, destructive editing behavior, extraction behavior, undo/redo behavior, similarity behavior, and performance-sensitive paths.
+
+## Milestone Strategy
+
+Wavecrate should move toward the target through clear phases. These phases are not rigid release promises, but they help keep implementation work practical.
+
+### Phase 1: Reliable Browser, Playback, Database, and Diagnostics
+
+Establish the core application foundation:
+
+* Windows-first folder/source scanning
+* responsive sample browser
+* immediate playback
+* WAV-first reliable decoding, playback, waveform display, and metadata writing
+* AIFF/AIF decoding, playback, waveform display, and metadata writing
+* mono-style waveform display
+* stable Wavecrate Sample IDs
+* database metadata foundation
+* embedded Sample ID writing where practical
+* basic tags
+* basic keep/trash ratings
+* aging/listen-history tracking
+* logging and diagnostics
+* Windows-first file operations
+
+### Phase 2: Mono-Style Destructive Editing, Selections, Extraction, and Undo
+
+Build the core waveform workflow:
+
+* play selection
+* edit selection
+* selection-priority rules
+* loop auditioning
+* mono-style destructive edit commands that preserve stereo files while applying edits equally to both channels
+* default warnings and YOLO mode
+* duplicate-file workflow
+* extraction from selected regions
+* extracted-region history marks
+* session-local undo/redo transaction system
+* temp recovery file system and background cleanup
+
+### Phase 3: Library Hygiene, Naming, and Organization
+
+Make the library manageable over time:
+
+* tag categories
+* generated display/database names
+* disk filename view versus generated-name view
+* apply generated name to disk
+* untagged filters
+* aging filters and sorting
+* four-keep/four-trash rating thresholds
+* accepted/favorite lock behavior
+* configured trash folder workflow
+* temporary color collections
+* folder organization workflows
+
+### Phase 4: Analysis, BPM, Warp Auditioning, and DAW Handoff
+
+Improve production usefulness:
+
+* BPM detection
+* BPM metadata editing
+* tempo-grid display
+* target BPM lock
+* practical beats-style audition-time warping
+* extraction/export of warped audio exactly as heard
+* drag/copy/export/reveal workflows
+* practical Windows-first DAW handoff
+
+### Phase 5: Similarity Search and 2D Exploration
+
+Build Sononym/XO-style discovery:
+
+* deterministic descriptor pipeline
+* versioned DSP feature vectors
+* persisted descriptor cache
+* cosine ANN search
+* browser similarity sorting
+* visual similarity indicators
+* similarity filters
+* 2D map projection
+* cluster exploration
+* map/list audition workflow
+
+### Phase 6: Stereo Split Editing, Polish, Performance, and Cross-Platform Readiness
+
+Harden and extend the product:
+
+* stereo split-view waveform display
+* independent channel selection where useful
+* independent channel editing/extraction where useful
+* large-library stress testing
+* long-file waveform performance
+* background worker reliability
+* stale-result safety
+* undo/redo robustness
+* file reconciliation workflows
+* improved diagnostics
+* macOS/Linux architecture review
+* documentation and validation passes
 
 ## Documentation and Validation
 
-Durable product and architecture contracts belong in `docs/`. Planning and
-backlog state belong in Linear.
+Durable product and architecture contracts belong in `docs/`. Planning and backlog state belongs in Linear.
 
 Meaningful changes should usually include:
 
-- focused tests for behavior that can regress
-- a smoke or agent validation pass before commit/push
-- updated docs when a durable contract changes
-- Radiant example updates when a new generic GUI API is introduced
+* focused tests for behavior that can regress
+* smoke or agent validation before commit/push
+* updated docs when a durable contract changes
+* Radiant example updates when a new generic GUI API is introduced
+* audio-engine validation when playback, decode, seek, loop, warp, render, channel handling, or device behavior changes
+* persistence and migration validation when durable storage contracts change
+* undo/redo validation when transactional behavior changes
+* embedded metadata validation when Sample ID writing changes
+* logging and diagnostic validation for important workflows and failure paths
+* manual validation notes for workflows that are hard to automate
+
+Important validation lanes should cover:
+
+* browsing responsiveness on large libraries
+* supported format import/audition behavior for WAV and AIFF/AIF files
+* mono and stereo file playback correctness
+* stereo file preservation during mono-style edits
+* long audio file navigation, auditioning, looping, marking, extraction, and export
+* immediate audition behavior during fast selection changes
+* play selection and edit selection behavior
+* waveform precision for playhead, cursor, range, loop, fade, marker, grid, transient, and extracted-history interactions
+* destructive edit warnings and YOLO mode behavior
+* session-local undo/redo for edits, file operations, metadata operations, rating operations, and selection changes
+* temporary recovery file creation and background cleanup
+* stale-result safety for decode, waveform, analysis, edit-render, database, naming, and similarity jobs
+* tag creation, autocomplete, duplicate prevention, persistence, generated names, disk rename application, and filtering
+* keep/trash rating scale, accepted lock behavior, aging/listen-history behavior, and trash-folder movement
+* embedded Sample ID creation, reading, conflict handling, and fallback behavior
+* temporary color collection behavior
+* target-BPM auditioning and baked warped extraction/export
+* similarity list sorting, filtering, and 2D map interaction
+* file mutation, duplicate, export, overwrite, rename, trash, move, copy, reveal, and partial-failure recovery
+* DAW/external handoff workflows
+* logging usefulness for tracing failures and background operations
 
 ## Completion Criteria
 
-Sempal is moving toward the target when:
+Wavecrate is moving toward the target when:
 
-- browsing remains responsive on large sample sources
-- sample selection starts playback quickly and reliably
-- waveform marks, playhead, cursor, and selections are precise and stable
-- long-running work is visible but non-blocking
-- file operations preserve trust and recovery behavior
-- Sempal code owns sample-domain decisions
-- Radiant code owns reusable GUI/runtime primitives
-- the current Radiant GUI can replace deprecated legacy UI paths without losing
-  core workflows
-
+* browsing remains responsive on large sample sources
+* short sample files and long audio files are both handled accurately and smoothly
+* WAV and AIFF/AIF files are supported according to the phased format target
+* MP3, FLAC, and other unsupported formats are clearly ignored, rejected, or reported as unsupported
+* mono and stereo files play correctly
+* mono-style editing preserves stereo files while applying edits equally to both channels
+* sample selection starts playback quickly and reliably
+* waveform marks, playhead, cursor, play selections, edit selections, loops, grids, transients, fades, edits, and markers are precise and stable
+* long audio files can be navigated, analyzed, auditioned, looped, marked, cut into useful pieces, named, rated, tagged, and exported without leaving the browsing flow
+* extracted regions create new sample files while preserving the original file unless the user performs a destructive edit
+* extracted-region history helps users see what they already used from a long file
+* destructive edits are fast, warning-protected by default, YOLO-mode capable for advanced users, and undoable during the current session where practical
+* users can duplicate files before destructive editing when they want backups
+* temp recovery files support session undo without slowing down shutdown
+* stale recovery files are cleaned up by a background worker
+* existing sample libraries can be quickly auditioned, cleaned up, tagged, rated, display-named, physically renamed when desired, moved, collected, and organized without losing flow
+* producers can quickly find, audition, compare, copy, drag, export, reveal, or otherwise hand off samples to a DAW without losing creative flow
+* target-BPM auditioning helps users hear loops in production context where practical
+* extraction/export of warped audition material creates what the user heard
+* the audio engine is robust internally and cleanly separated enough to become a standalone library later
+* tag, rating, aging, naming, metadata, database, and indexing workflows remain fast on large libraries
+* embedded Wavecrate Sample IDs are written where practical and safely fall back to database tracking where not
+* long-running work is visible but non-blocking
+* similarity analysis helps users find related sounds from both list and map workflows without runtime ML inference
+* tags are quick to add, remove, autocomplete, categorize, visualize, and filter by
+* keep/trash ratings, aging/listen-history states, accepted locks, and trash-folder movement help keep the library clean over time without unsafe permanent deletion
+* generated display names and deliberate disk-renaming behavior are predictable and safe
+* temporary color collections help users stage and compare material without replacing physical folder organization
+* file operations preserve trust and recovery behavior
+* logs make failures and slow operations traceable
+* files, modules, functions, structs, and traits stay small, focused, and maintainable
+* code smells are actively reduced instead of normalized
+* tests protect real workflows without locking in incidental implementation details
+* Wavecrate code owns sample-domain decisions
+* Radiant code owns reusable GUI/runtime primitives
+* reusable audio-engine code is not unnecessarily coupled to Wavecrate product behavior
+* the new GUI can replace legacy UI paths without losing core workflows

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -261,6 +261,8 @@ Edit commands should follow this priority:
 
 The play selection and edit selection should not interfere with each other visually or behaviorally.
 
+Previewed fade handles on an edit selection are audition and preview state until explicitly applied. Pressing Enter while an edit selection has active fades should route through the destructive-edit system and bake those fades into the current audio file. After a successful apply, the edit-marked area should flash as confirmation.
+
 ### Extracted Region History
 
 When a user extracts a region from a longer audio file into a new sample file, the original audio file should show a visual history mark for the extracted range where practical.
@@ -385,6 +387,8 @@ Destructive editing should have two user-facing safety modes.
 In default mode, destructive edits should warn the user clearly before modifying the file in place.
 
 The warning should explain that the edit will modify the audio file on disk. The user should be able to confirm, cancel, and optionally enable advanced destructive workflow mode if they understand the behavior.
+
+During active development, fresh development defaults may start in YOLO mode so fade-apply and other destructive edit flows can be tested quickly. The product target remains warning-protected default safety mode unless YOLO mode is explicitly enabled.
 
 ### Advanced Destructive Workflow / YOLO Mode
 

--- a/src/app/controller/library/selection_edits/controller_actions.rs
+++ b/src/app/controller/library/selection_edits/controller_actions.rs
@@ -362,6 +362,16 @@ impl AppController {
             DestructiveSelectionEdit::CleanExactDuplicateBeats => {
                 self.exact_duplicate_cleanup_ranges().map(|_| ())
             }
+            DestructiveSelectionEdit::CommitEditSelectionFades => {
+                self.selection_target()?;
+                let Some(selection) = self.ui.waveform.edit_selection else {
+                    return Err("Set an edit selection with a fade before applying it".to_string());
+                };
+                if !selection.has_edit_effects() {
+                    return Err("Set an edit fade before applying it".to_string());
+                }
+                Ok(())
+            }
             _ => {
                 self.selection_target()?;
                 Ok(())
@@ -384,6 +394,9 @@ impl AppController {
             DestructiveSelectionEdit::MuteSelection => self.mute_waveform_selection(),
             DestructiveSelectionEdit::NormalizeSelection => self.normalize_waveform_selection(),
             DestructiveSelectionEdit::ClickRemoval => self.repair_clicks_selection(),
+            DestructiveSelectionEdit::CommitEditSelectionFades => {
+                self.commit_edit_selection_fades().map(|_| ())
+            }
             DestructiveSelectionEdit::CleanExactDuplicateBeats => {
                 self.clean_exact_duplicate_beats()
             }

--- a/src/app/controller/library/selection_edits/prompt.rs
+++ b/src/app/controller/library/selection_edits/prompt.rs
@@ -12,6 +12,7 @@ impl DestructiveSelectionEdit {
             DestructiveSelectionEdit::MuteSelection => "Mute selection",
             DestructiveSelectionEdit::NormalizeSelection => "Normalize selection",
             DestructiveSelectionEdit::ClickRemoval => "Remove clicks in selection",
+            DestructiveSelectionEdit::CommitEditSelectionFades => "Apply edit fades",
             DestructiveSelectionEdit::CleanExactDuplicateBeats => "Clean duplicate windows",
         }
     }
@@ -44,6 +45,9 @@ impl DestructiveSelectionEdit {
             }
             DestructiveSelectionEdit::ClickRemoval => {
                 "This will overwrite the selection with an interpolated repair to remove clicks."
+            }
+            DestructiveSelectionEdit::CommitEditSelectionFades => {
+                "This will overwrite the edit selection with the currently previewed fades."
             }
             DestructiveSelectionEdit::CleanExactDuplicateBeats => {
                 "This will remove later duplicate windows and close the gaps in the source file."

--- a/src/app/controller/playback/waveform_action_tests.rs
+++ b/src/app/controller/playback/waveform_action_tests.rs
@@ -162,6 +162,42 @@ fn set_waveform_edit_fade_out_start_milli_updates_edit_fade_out_length() {
     assert!((fade_out.length - 0.25).abs() < 0.001);
 }
 
+/// Edit fade-in top-handle drags should push and restore the opposite top handle.
+#[test]
+fn set_waveform_edit_fade_in_end_milli_pushes_and_restores_fade_out() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.2)
+        .with_fade_out(0.25, 0.7);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_in_end_milli(600);
+    let pushed = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("pushed edit selection");
+    assert!(pushed.fade_out().is_none());
+    let pushed_fade_in = pushed.fade_in().expect("fade-in should remain");
+    assert!((pushed.start() + pushed.width() * pushed_fade_in.length - 0.6).abs() < 0.001);
+
+    controller.set_waveform_edit_fade_in_end_milli(300);
+    let restored = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("restored edit selection");
+    let fade_in = restored.fade_in().expect("fade-in should remain");
+    let fade_out = restored.fade_out().expect("fade-out should restore");
+    let fade_in_end = restored.start() + restored.width() * fade_in.length;
+    let fade_out_start = restored.end() - restored.width() * fade_out.length;
+    assert!((fade_in_end - 0.3).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_in.curve - 0.2).abs() < 0.001);
+    assert!((fade_out.curve - 0.7).abs() < 0.001);
+}
+
 /// Edit fade-in bottom-handle updates should resize the selection and keep fade end fixed.
 #[test]
 fn set_waveform_edit_fade_in_mute_start_milli_resizes_selection_start() {

--- a/src/app/controller/playback/waveform_action_tests.rs
+++ b/src/app/controller/playback/waveform_action_tests.rs
@@ -212,6 +212,60 @@ fn set_waveform_edit_fade_out_mute_end_milli_resizes_selection_end() {
     assert!((fade_out_start - 0.5).abs() < 0.001);
 }
 
+/// Edit fade-out bottom-handle updates should keep the opposite fade-in boundary fixed.
+#[test]
+fn set_waveform_edit_fade_out_mute_end_milli_preserves_fade_in_boundary() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_out(0.25, 0.7);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_out_mute_end_milli(800);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_in = updated.fade_in().expect("fade-in should remain");
+    let fade_out = updated.fade_out().expect("fade-out should remain");
+    let fade_in_end = updated.start() + (updated.width() * fade_in.length);
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    assert!((fade_in_end - 0.3).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_in.curve - 0.3).abs() < 0.001);
+    assert!((fade_out.curve - 0.7).abs() < 0.001);
+}
+
+/// Edit fade-in bottom-handle updates should keep the opposite fade-out boundary fixed.
+#[test]
+fn set_waveform_edit_fade_in_mute_start_milli_preserves_fade_out_boundary() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_out(0.25, 0.7);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_in_mute_start_milli(100);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_in = updated.fade_in().expect("fade-in should remain");
+    let fade_out = updated.fade_out().expect("fade-out should remain");
+    let fade_in_end = updated.start() + (updated.width() * fade_in.length);
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    assert!((fade_in_end - 0.3).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_in.curve - 0.3).abs() < 0.001);
+    assert!((fade_out.curve - 0.7).abs() < 0.001);
+}
+
 /// Collapsed fade-out drags should recover the original fade while the same drag stays active.
 #[test]
 fn set_waveform_edit_fade_out_mute_end_milli_recovers_after_temporary_collapse() {

--- a/src/app/controller/playback/waveform_actions/edit_fades.rs
+++ b/src/app/controller/playback/waveform_actions/edit_fades.rs
@@ -61,7 +61,7 @@ pub(super) fn update_edit_fade_in_mute_start_from_micros(
         new_start,
         range.end(),
         Some(next_fade_in),
-        range.fade_out(),
+        fade_out_preserved_at_width(range, new_width),
     )
 }
 
@@ -123,7 +123,7 @@ pub(super) fn update_edit_fade_out_mute_end_from_micros(
         range,
         range.start(),
         new_end,
-        range.fade_in(),
+        fade_in_preserved_at_width(range, new_width),
         Some(next_fade_out),
     )
 }
@@ -172,4 +172,36 @@ fn rebuild_edit_range(
         }
     }
     next
+}
+
+fn fade_in_preserved_at_width(
+    range: SelectionRange,
+    next_width: f32,
+) -> Option<crate::selection::FadeParams> {
+    let fade = range.fade_in()?;
+    if next_width <= f32::EPSILON {
+        return Some(crate::selection::FadeParams::with_curve(0.0, fade.curve));
+    }
+    let length = ((range.width() * fade.length) / next_width).clamp(0.0, 1.0);
+    Some(crate::selection::FadeParams::with_curve_and_mute(
+        length,
+        fade.curve,
+        ((range.width() * fade.mute) / next_width).max(0.0),
+    ))
+}
+
+fn fade_out_preserved_at_width(
+    range: SelectionRange,
+    next_width: f32,
+) -> Option<crate::selection::FadeParams> {
+    let fade = range.fade_out()?;
+    if next_width <= f32::EPSILON {
+        return Some(crate::selection::FadeParams::with_curve(0.0, fade.curve));
+    }
+    let length = ((range.width() * fade.length) / next_width).clamp(0.0, 1.0);
+    Some(crate::selection::FadeParams::with_curve_and_mute(
+        length,
+        fade.curve,
+        ((range.width() * fade.mute) / next_width).max(0.0),
+    ))
 }

--- a/src/app/controller/playback/waveform_actions/edit_fades.rs
+++ b/src/app/controller/playback/waveform_actions/edit_fades.rs
@@ -22,9 +22,31 @@ pub(super) fn update_edit_fade_in_end_from_micros(
     let start = range.start();
     let end = range.end();
     let clamped_position = normalized_from_micros(position_micros).clamp(start, end);
-    let length = ((clamped_position - start) / width).clamp(0.0, 1.0);
     let curve = range.fade_in().map(|fade| fade.curve).unwrap_or(0.5);
-    range.with_fade_in(length, curve)
+    let fade_in_abs = clamped_position - start;
+    let baseline_fade_out_abs = range.fade_out().map_or(0.0, |fade| width * fade.length);
+    let baseline_fade_out_start = end - baseline_fade_out_abs;
+    let fade_out_abs = if clamped_position > baseline_fade_out_start {
+        (end - clamped_position).max(0.0)
+    } else {
+        baseline_fade_out_abs
+    };
+    rebuild_edit_range(
+        range,
+        start,
+        end,
+        Some(crate::selection::FadeParams::with_curve(
+            fade_in_abs / width,
+            curve,
+        )),
+        range.fade_out().map(|fade| {
+            crate::selection::FadeParams::with_curve_and_mute(
+                fade_out_abs / width,
+                fade.curve,
+                fade.mute,
+            )
+        }),
+    )
 }
 
 /// Update the edit-selection start from the fade-in bottom handle position.
@@ -85,9 +107,31 @@ pub(super) fn update_edit_fade_out_start_from_micros(
     let start = range.start();
     let end = range.end();
     let clamped_position = normalized_from_micros(position_micros).clamp(start, end);
-    let length = ((end - clamped_position) / width).clamp(0.0, 1.0);
     let curve = range.fade_out().map(|fade| fade.curve).unwrap_or(0.5);
-    range.with_fade_out(length, curve)
+    let fade_out_abs = end - clamped_position;
+    let baseline_fade_in_abs = range.fade_in().map_or(0.0, |fade| width * fade.length);
+    let baseline_fade_in_end = start + baseline_fade_in_abs;
+    let fade_in_abs = if clamped_position < baseline_fade_in_end {
+        (clamped_position - start).max(0.0)
+    } else {
+        baseline_fade_in_abs
+    };
+    rebuild_edit_range(
+        range,
+        start,
+        end,
+        range.fade_in().map(|fade| {
+            crate::selection::FadeParams::with_curve_and_mute(
+                fade_in_abs / width,
+                fade.curve,
+                fade.mute,
+            )
+        }),
+        Some(crate::selection::FadeParams::with_curve(
+            fade_out_abs / width,
+            curve,
+        )),
+    )
 }
 
 /// Update the edit-selection end from the fade-out bottom handle position.

--- a/src/app/controller/tests/waveform/destructive_edits.rs
+++ b/src/app/controller/tests/waveform/destructive_edits.rs
@@ -346,6 +346,7 @@ fn destructive_edit_request_prompts_without_yolo_mode() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let outcome = controller
         .request_destructive_selection_edit(DestructiveSelectionEdit::CropSelection)
@@ -403,6 +404,7 @@ fn confirming_pending_destructive_edit_clears_prompt() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
     controller
         .request_destructive_selection_edit(DestructiveSelectionEdit::TrimSelection)
         .unwrap();
@@ -438,6 +440,7 @@ fn exact_duplicate_cleanup_request_prompts_without_selection() {
         .detect_waveform_exact_duplicate_slices_from_selection()
         .unwrap();
     controller.ui.waveform.selection = None;
+    controller.set_destructive_yolo_mode(false);
 
     let outcome = controller
         .request_destructive_selection_edit(DestructiveSelectionEdit::CleanExactDuplicateBeats)

--- a/src/app/controller/tests/waveform/hotkeys_normalize.rs
+++ b/src/app/controller/tests/waveform/hotkeys_normalize.rs
@@ -37,6 +37,7 @@ fn t_hotkey_prompts_trim_selection_in_waveform_focus() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let action = hotkeys::iter_actions()
         .find(|action| action.id == "trim-selection")
@@ -69,6 +70,7 @@ fn slash_hotkeys_prompt_fade_selection_in_waveform_focus() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let backslash = hotkeys::iter_actions()
         .find(|action| action.id == "fade-selection-left-to-right")
@@ -144,6 +146,52 @@ fn enter_hotkey_commits_edit_fades_without_exporting() {
 }
 
 #[test]
+fn enter_hotkey_prompts_before_committing_edit_fades_without_yolo_mode() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![sample_entry(
+        "apply_edit_fades_prompt_hotkey.wav",
+        crate::sample_sources::Rating::NEUTRAL,
+    )]);
+    load_waveform_selection(
+        &mut controller,
+        &source,
+        "apply_edit_fades_prompt_hotkey.wav",
+        &[0.0, 0.1, 0.2, 0.3],
+        SelectionRange::new(0.25, 0.75),
+    );
+    controller.set_destructive_yolo_mode(false);
+    let edit_selection = SelectionRange::new(0.25, 0.75).with_fade_out(0.5, 0.0);
+    controller.set_edit_selection_range(edit_selection);
+
+    let action = hotkeys::iter_actions()
+        .find(|action| action.id == "commit-waveform-edit-fades")
+        .unwrap();
+    let apply_before = controller.ui.waveform.edit_selection_apply_flash_nonce;
+
+    controller.handle_hotkey(action, FocusContext::Waveform);
+
+    assert_eq!(
+        controller.ui.waveform.edit_selection_apply_flash_nonce,
+        apply_before
+    );
+    assert_eq!(
+        controller
+            .ui
+            .waveform
+            .pending_destructive
+            .as_ref()
+            .unwrap()
+            .edit,
+        DestructiveSelectionEdit::CommitEditSelectionFades
+    );
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("edit selection after prompt");
+    assert!(updated.has_edit_effects());
+}
+
+#[test]
 fn m_hotkey_prompts_mute_selection_in_waveform_focus() {
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![sample_entry(
         "mute_hotkey.wav",
@@ -156,6 +204,7 @@ fn m_hotkey_prompts_mute_selection_in_waveform_focus() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let action = hotkeys::iter_actions()
         .find(|action| action.id == "mute-selection")
@@ -187,6 +236,7 @@ fn n_hotkey_prompts_normalize_selection_when_selection_present() {
         &[0.0, 0.2, -0.6, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let action = hotkeys::iter_actions()
         .find(|action| action.id == "normalize-waveform")
@@ -243,6 +293,7 @@ fn c_hotkey_prompts_crop_selection_in_waveform_focus() {
         &[0.0, 0.1, 0.2, 0.3],
         SelectionRange::new(0.25, 0.75),
     );
+    controller.set_destructive_yolo_mode(false);
 
     let action = hotkeys::iter_actions()
         .find(|action| action.id == "crop-selection")

--- a/src/app/controller/ui/hotkeys_controller/mod.rs
+++ b/src/app/controller/ui/hotkeys_controller/mod.rs
@@ -104,6 +104,7 @@ mod tests {
             &[0.1, -0.2, 0.3, -0.4],
             SelectionRange::new(0.0, 0.5),
         );
+        controller.set_destructive_yolo_mode(false);
         let action = action_for(|action| {
             matches!(
                 action,

--- a/src/app/state/controls.rs
+++ b/src/app/state/controls.rs
@@ -39,7 +39,7 @@ impl Default for InteractionOptionsState {
             anti_clip_fade_enabled: true,
             anti_clip_fade_ms: 2.0,
             auto_edge_fades_on_selection_exports: true,
-            destructive_yolo_mode: false,
+            destructive_yolo_mode: true,
             waveform_channel_view: WaveformChannelView::Mono,
             input_monitoring_enabled: true,
             advance_after_rating: true,
@@ -69,6 +69,8 @@ pub enum DestructiveSelectionEdit {
     NormalizeSelection,
     /// Attempt to remove clicks in the selection.
     ClickRemoval,
+    /// Apply pending edit-selection fades to the current audio file.
+    CommitEditSelectionFades,
     /// Remove later duplicate windows from the loaded file.
     CleanExactDuplicateBeats,
 }

--- a/src/app_core/controller/waveform_actions/editing.rs
+++ b/src/app_core/controller/waveform_actions/editing.rs
@@ -21,7 +21,9 @@ pub(super) fn apply_waveform_edit_action(
                 Some(crate::sample_sources::Rating::new(2)),
             ),
         NativeUiAction::CommitWaveformEditFades => {
-            let _ = controller.commit_edit_selection_fades();
+            let _ = controller.request_destructive_selection_edit(
+                DestructiveSelectionEdit::CommitEditSelectionFades,
+            );
         }
         NativeUiAction::DetectWaveformSilenceSlices => {
             controller.detect_waveform_silence_slices_action();

--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -823,4 +823,25 @@ mod opt_272_tests {
             Some(model.sources.upper_folder_pane.tree_rows.len() - rows.len())
         );
     }
+
+    #[test]
+    fn waveform_scrollbar_thumb_tracks_zoomed_view_position() {
+        let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
+        let scrollbar = waveform_scrollbar_layout(layout.waveform_scrollbar_lane, 250_000, 500_000)
+            .expect("zoomed waveform view should render a scrollbar");
+
+        assert!(scrollbar.track.min.y >= layout.waveform_scrollbar_lane.min.y);
+        assert!(scrollbar.track.max.y <= layout.waveform_scrollbar_lane.max.y);
+        assert!(scrollbar.track.min.y >= layout.waveform_plot.max.y);
+        assert!(scrollbar.thumb.min.x > scrollbar.track.min.x);
+        assert!(scrollbar.thumb.max.x < scrollbar.track.max.x);
+        assert!(scrollbar.track.height() <= 3.0);
+    }
+
+    #[test]
+    fn waveform_scrollbar_hides_when_view_is_fully_zoomed_out() {
+        let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
+
+        assert!(waveform_scrollbar_layout(layout.waveform_scrollbar_lane, 0, 1_000_000).is_none());
+    }
 }

--- a/src/app_core/native_shell/composition/state/waveform_segments/scrollbar.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/scrollbar.rs
@@ -3,9 +3,9 @@ use super::*;
 /// Horizontal inset used by the waveform scrollbar track.
 const WAVEFORM_SCROLLBAR_INSET_X: f32 = 10.0;
 /// Bottom inset used by the waveform scrollbar track.
-const WAVEFORM_SCROLLBAR_INSET_BOTTOM: f32 = 3.0;
+const WAVEFORM_SCROLLBAR_INSET_BOTTOM: f32 = 5.0;
 /// Track height used by the waveform scrollbar.
-const WAVEFORM_SCROLLBAR_TRACK_HEIGHT: f32 = 6.0;
+const WAVEFORM_SCROLLBAR_TRACK_HEIGHT: f32 = 3.0;
 /// Minimum thumb width for the waveform scrollbar.
 const WAVEFORM_SCROLLBAR_MIN_THUMB_WIDTH: f32 = 28.0;
 
@@ -37,14 +37,14 @@ pub(super) fn emit_waveform_scrollbar(
         primitives,
         Primitive::Rect(FillRect {
             rect: scrollbar.track,
-            color: blend_color(style.border, style.bg_secondary, 0.22),
+            color: blend_color(style.border, style.bg_secondary, 0.12),
         }),
     );
     emit_primitive(
         primitives,
         Primitive::Rect(FillRect {
             rect: scrollbar.thumb,
-            color: blend_color(style.text_muted, style.text_primary, 0.32),
+            color: blend_color(style.text_muted, style.text_primary, 0.18),
         }),
     );
 }
@@ -77,6 +77,9 @@ pub(crate) fn waveform_scrollbar_layout(
         .min(1_000_000)
         .max(clamped_start.saturating_add(1));
     let span = clamped_end.saturating_sub(clamped_start).max(1);
+    if span >= 999_999 {
+        return None;
+    }
     let min_thumb_width = WAVEFORM_SCROLLBAR_MIN_THUMB_WIDTH.min(track.width());
     let thumb_width = (track.width() * (span as f32 / 1_000_000.0))
         .round()

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -202,6 +202,7 @@ impl GuiAppState {
             }
             GuiMessage::Waveform(message) => {
                 self.waveform.apply_interaction(message);
+                self.sync_edit_fade_audio_state();
                 if let Some(start_ratio) = self.waveform.take_pending_playback_start() {
                     self.play_waveform_from_ratio(start_ratio);
                 }
@@ -428,9 +429,16 @@ impl GuiAppState {
             .as_mut()
             .ok_or_else(|| String::from("audio player did not initialize"))?;
         player.set_audio(self.waveform.audio_bytes(), duration);
+        player.set_edit_fade_state(self.waveform.edit_selection());
         player.play_range(f64::from(start_ratio), f64::from(end_ratio), false)?;
         self.waveform.start_playback(start_ratio);
         Ok(())
+    }
+
+    fn sync_edit_fade_audio_state(&mut self) {
+        if let Some(player) = self.audio_player.as_ref() {
+            player.set_edit_fade_state(self.waveform.edit_selection());
+        }
     }
 
     fn refresh_playback_progress(&mut self) {

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -622,6 +622,7 @@ pub(super) struct WaveformFile {
     sample_rate: u32,
     channels: usize,
     frames: usize,
+    gpu_signal_samples: Arc<[f32]>,
     gpu_signal_summary: Arc<radiant::runtime::GpuSignalSummary>,
 }
 
@@ -649,7 +650,7 @@ pub(super) fn default_sample_path() -> PathBuf {
 pub(super) fn waveform_viewport_view(state: &WaveformState) -> ui::View<super::GuiMessage> {
     ui::stack([
         ui::custom_widget(
-            WaveformSignalWidget::new(state.file(), state.viewport()),
+            WaveformSignalWidget::new(state.file(), state.viewport(), state.edit_selection()),
             |_| None,
         )
         .id(11)
@@ -755,8 +756,58 @@ fn waveform_file_from_mono_samples(
         sample_rate,
         channels,
         frames: mono_samples.len(),
+        gpu_signal_samples: Arc::from(gpu_signal_samples),
         gpu_signal_summary,
     }
+}
+
+fn apply_edit_fade_to_signal_samples(
+    samples: &mut [f32],
+    frames: usize,
+    band_count: usize,
+    selection: sempal::selection::SelectionRange,
+) {
+    if frames == 0 || band_count == 0 || !selection.has_edit_effects() {
+        return;
+    }
+    let max_frame = frames.saturating_sub(1).max(1);
+    for frame in 0..frames {
+        let position = frame as f32 / max_frame as f32;
+        let gain = selection.gain_at_position(position, 0.0);
+        if (gain - 1.0).abs() <= f32::EPSILON {
+            continue;
+        }
+        let base = frame * band_count;
+        for band in 0..band_count {
+            if let Some(sample) = samples.get_mut(base + band) {
+                *sample *= gain;
+            }
+        }
+    }
+}
+
+fn edit_selection_revision(selection: Option<sempal::selection::SelectionRange>) -> u64 {
+    let Some(selection) = selection else {
+        return 0;
+    };
+    if !selection.has_edit_effects() {
+        return 0;
+    }
+    let mut hasher = DefaultHasher::new();
+    selection.start().to_bits().hash(&mut hasher);
+    selection.end().to_bits().hash(&mut hasher);
+    selection.gain().to_bits().hash(&mut hasher);
+    if let Some(fade) = selection.fade_in() {
+        fade.length.to_bits().hash(&mut hasher);
+        fade.curve.to_bits().hash(&mut hasher);
+        fade.mute.to_bits().hash(&mut hasher);
+    }
+    if let Some(fade) = selection.fade_out() {
+        fade.length.to_bits().hash(&mut hasher);
+        fade.curve.to_bits().hash(&mut hasher);
+        fade.mute.to_bits().hash(&mut hasher);
+    }
+    hasher.finish().max(1)
 }
 
 fn is_wav_path(path: &std::path::Path) -> bool {
@@ -908,10 +959,15 @@ struct WaveformSignalWidget {
     common: WidgetCommon,
     file: Arc<WaveformFile>,
     viewport: WaveformViewport,
+    edit_selection: Option<sempal::selection::SelectionRange>,
 }
 
 impl WaveformSignalWidget {
-    fn new(file: Arc<WaveformFile>, viewport: WaveformViewport) -> Self {
+    fn new(
+        file: Arc<WaveformFile>,
+        viewport: WaveformViewport,
+        edit_selection: Option<sempal::selection::SelectionRange>,
+    ) -> Self {
         let mut common = WidgetCommon::new(
             0,
             WidgetSizing::fixed(Vector2::new(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)),
@@ -923,7 +979,30 @@ impl WaveformSignalWidget {
             common,
             file,
             viewport,
+            edit_selection,
         }
+    }
+
+    fn signal_summary(&self) -> Arc<radiant::runtime::GpuSignalSummary> {
+        let Some(selection) = self.edit_selection else {
+            return Arc::clone(&self.file.gpu_signal_summary);
+        };
+        if !selection.has_edit_effects() {
+            return Arc::clone(&self.file.gpu_signal_summary);
+        }
+        let mut samples = self.file.gpu_signal_samples.as_ref().to_vec();
+        apply_edit_fade_to_signal_samples(&mut samples, self.file.frames, BAND_COUNT, selection);
+        Arc::new(
+            radiant::runtime::GpuSignalSummary::from_interleaved_samples(
+                &samples,
+                self.file.frames,
+                BAND_COUNT,
+            ),
+        )
+    }
+
+    fn signal_revision(&self) -> u64 {
+        edit_selection_revision(self.edit_selection)
     }
 }
 
@@ -947,16 +1026,17 @@ impl Widget for WaveformSignalWidget {
         _layout: &LayoutOutput,
         _theme: &ThemeTokens,
     ) {
+        let summary = self.signal_summary();
         primitives.push(PaintPrimitive::GpuSurface(PaintGpuSurface {
             widget_id: self.common.id,
             key: self.file.path_hash(),
-            revision: 0,
+            revision: self.signal_revision(),
             rect: bounds,
             content: GpuSurfaceContent::SignalSummaryBands {
                 frames: self.file.frames,
                 band_count: BAND_COUNT,
                 frame_range: [self.viewport.start as f32, self.viewport.end as f32],
-                summary: Arc::clone(&self.file.gpu_signal_summary),
+                summary,
             },
             capabilities: GpuSurfaceCapabilities {
                 fast_pointer_move: true,
@@ -1235,6 +1315,7 @@ impl WaveformWidget {
         if let Some(fade_rect) = self.fade_out_rect(bounds, selection, selection_rect) {
             self.push_fill(primitives, fade_rect, Rgba8 { a: 52, ..accent });
         }
+        self.append_edit_fade_curve_paint(primitives, bounds, selection_rect, accent);
         for handle in [
             WaveformEditFadeHandle::FadeInEnd,
             WaveformEditFadeHandle::FadeOutStart,
@@ -1244,6 +1325,88 @@ impl WaveformWidget {
             if let Some(rect) = self.edit_fade_handle_rect(bounds, selection_rect, handle) {
                 self.push_fill(primitives, rect, Rgba8 { a: 205, ..accent });
             }
+        }
+    }
+
+    fn append_edit_fade_curve_paint(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+        selection_rect: Rect,
+        color: Rgba8,
+    ) {
+        let Some(selection) = self.edit_selection else {
+            return;
+        };
+        let width = selection.width();
+        if width <= 0.0 {
+            return;
+        }
+        if let Some(fade_in) = selection.fade_in().filter(|fade| fade.length > 0.0) {
+            let start = selection.start();
+            let end = (start + width * fade_in.length).min(selection.end());
+            self.push_edit_fade_curve_points(
+                primitives,
+                bounds,
+                selection_rect,
+                selection,
+                start,
+                end,
+                Rgba8 { a: 225, ..color },
+            );
+        }
+        if let Some(fade_out) = selection.fade_out().filter(|fade| fade.length > 0.0) {
+            let end = selection.end();
+            let start = (end - width * fade_out.length).max(selection.start());
+            self.push_edit_fade_curve_points(
+                primitives,
+                bounds,
+                selection_rect,
+                selection,
+                start,
+                end,
+                Rgba8 { a: 225, ..color },
+            );
+        }
+    }
+
+    fn push_edit_fade_curve_points(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+        selection_rect: Rect,
+        selection: sempal::selection::SelectionRange,
+        start: f32,
+        end: f32,
+        color: Rgba8,
+    ) {
+        let width = ((end - start).abs() * bounds.width()).max(1.0);
+        let steps = ((width / 4.0).round() as usize).clamp(10, 96);
+        let marker = 2.25_f32.min(selection_rect.height().max(1.0));
+        for step in 0..=steps {
+            let t = step as f32 / steps as f32;
+            let position = start + (end - start) * t;
+            let Some(visible_ratio) = self.visible_ratio_for_absolute(Some(position)) else {
+                continue;
+            };
+            let x = bounds.min.x + bounds.width() * visible_ratio.clamp(0.0, 1.0);
+            let gain = selection.gain_at_position(position, 0.0).clamp(0.0, 1.0);
+            let y = selection_rect.max.y - selection_rect.height() * gain;
+            let half = marker * 0.5;
+            self.push_fill(
+                primitives,
+                Rect::from_min_max(
+                    Point::new(
+                        (x - half).clamp(bounds.min.x, bounds.max.x),
+                        (y - half).clamp(selection_rect.min.y, selection_rect.max.y),
+                    ),
+                    Point::new(
+                        (x + half).clamp(bounds.min.x, bounds.max.x),
+                        (y + half).clamp(selection_rect.min.y, selection_rect.max.y),
+                    ),
+                ),
+                color,
+            );
         }
     }
 
@@ -1944,9 +2107,50 @@ mod tests {
     }
 
     #[test]
+    fn edit_fade_curve_paints_volume_trace_as_overlay_rects() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            sempal::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.5, 0.8)
+                .with_fade_out(0.25, 0.0),
+        );
+        let widget = WaveformWidget::new(
+            state.file(),
+            state.viewport(),
+            state.cursor_ratio(),
+            state.playhead_ratio(),
+            state.play_mark_ratio(),
+            state.edit_mark_ratio(),
+            state.play_selection(),
+            state.edit_selection(),
+            state.active_drag_kind(),
+        );
+        let mut primitives = Vec::new();
+
+        widget.append_paint(
+            &mut primitives,
+            Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0)),
+            &Default::default(),
+            &ThemeTokens::default(),
+        );
+
+        let curve_points = fill_rects(&primitives)
+            .into_iter()
+            .filter(|fill| {
+                (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 225)
+            })
+            .count();
+        assert!(
+            curve_points >= 16,
+            "expected visible fade curve trace points, got {curve_points}"
+        );
+    }
+
+    #[test]
     fn signal_widget_paints_gpu_surface_without_app_overlay_handles() {
         let state = WaveformState::synthetic_for_tests();
-        let widget = WaveformSignalWidget::new(state.file(), state.viewport());
+        let widget =
+            WaveformSignalWidget::new(state.file(), state.viewport(), state.edit_selection());
         let mut primitives = Vec::new();
 
         widget.append_paint(
@@ -1972,6 +2176,47 @@ mod tests {
             .expect("waveform gpu surface");
 
         assert!(surface.overlays.is_empty());
+    }
+
+    #[test]
+    fn signal_widget_applies_active_edit_fade_to_gpu_summary() {
+        let file = Arc::new(waveform_file_from_mono_samples(
+            "fade-preview.wav".into(),
+            Arc::from([]),
+            48_000,
+            1,
+            vec![1.0; 16],
+        ));
+        let viewport = super::WaveformViewport::full(file.frames);
+        let edit_selection =
+            Some(sempal::selection::SelectionRange::new(0.0, 1.0).with_fade_in(1.0, 0.0));
+        let widget = WaveformSignalWidget::new(file, viewport, edit_selection);
+        let mut primitives = Vec::new();
+
+        widget.append_paint(
+            &mut primitives,
+            Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0)),
+            &Default::default(),
+            &ThemeTokens::default(),
+        );
+
+        let surface = primitives
+            .iter()
+            .find_map(|primitive| match primitive {
+                PaintPrimitive::GpuSurface(surface) => Some(surface),
+                _ => None,
+            })
+            .expect("waveform gpu surface");
+
+        assert!(surface.revision > 0);
+        let GpuSurfaceContent::SignalSummaryBands { summary, .. } = &surface.content else {
+            panic!("expected signal summary bands");
+        };
+        let buckets = &summary.levels[0].buckets;
+        let first_raw = &buckets[3];
+        let last_raw = &buckets[(15 * BAND_COUNT) + 3];
+        assert!(first_raw.max.abs().max(first_raw.min.abs()) < 0.001);
+        assert!(last_raw.max.abs().max(last_raw.min.abs()) > 0.9);
     }
 
     fn fill_rects(primitives: &[PaintPrimitive]) -> Vec<&PaintFillRect> {

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -479,8 +479,10 @@ pub(super) enum WaveformSelectionEdge {
 pub(super) enum WaveformEditFadeHandle {
     FadeInEnd,
     FadeInStart,
+    FadeInOuterStart,
     FadeOutStart,
     FadeOutEnd,
+    FadeOutOuterEnd,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -585,10 +587,14 @@ struct WaveformEditFadeDrag {
 impl WaveformEditFadeDrag {
     fn new(handle: WaveformEditFadeHandle, selection: sempal::selection::SelectionRange) -> Self {
         let curve = match handle {
-            WaveformEditFadeHandle::FadeInEnd | WaveformEditFadeHandle::FadeInStart => {
+            WaveformEditFadeHandle::FadeInEnd
+            | WaveformEditFadeHandle::FadeInStart
+            | WaveformEditFadeHandle::FadeInOuterStart => {
                 selection.fade_in().map(|fade| fade.curve).unwrap_or(0.5)
             }
-            WaveformEditFadeHandle::FadeOutStart | WaveformEditFadeHandle::FadeOutEnd => {
+            WaveformEditFadeHandle::FadeOutStart
+            | WaveformEditFadeHandle::FadeOutEnd
+            | WaveformEditFadeHandle::FadeOutOuterEnd => {
                 selection.fade_out().map(|fade| fade.curve).unwrap_or(0.5)
             }
         };
@@ -601,7 +607,10 @@ impl WaveformEditFadeDrag {
                 .fade_out()
                 .map(|fade| selection.end() - selection.width() * fade.length)
                 .unwrap_or(selection.end()),
-            WaveformEditFadeHandle::FadeInEnd | WaveformEditFadeHandle::FadeOutStart => 0.0,
+            WaveformEditFadeHandle::FadeInEnd
+            | WaveformEditFadeHandle::FadeOutStart
+            | WaveformEditFadeHandle::FadeInOuterStart
+            | WaveformEditFadeHandle::FadeOutOuterEnd => 0.0,
         };
         Self {
             handle,
@@ -630,6 +639,10 @@ impl WaveformEditFadeDrag {
             WaveformEditFadeHandle::FadeOutEnd => {
                 resize_fade_out_end(selection, self.fixed_ratio, ratio, self.curve)
             }
+            WaveformEditFadeHandle::FadeInOuterStart => {
+                resize_fade_in_outer_start(selection, ratio)
+            }
+            WaveformEditFadeHandle::FadeOutOuterEnd => resize_fade_out_outer_end(selection, ratio),
         }
     }
 }
@@ -721,6 +734,44 @@ fn resize_fade_out_start_with_collision(
         }),
         Some((fade_out_abs / width, curve)),
     )
+}
+
+fn resize_fade_in_outer_start(
+    selection: sempal::selection::SelectionRange,
+    outer_start_ratio: f32,
+) -> sempal::selection::SelectionRange {
+    let Some(fade) = selection.fade_in() else {
+        return selection;
+    };
+    let width = selection.width();
+    if width <= f32::EPSILON {
+        return selection;
+    }
+    let outer_start = outer_start_ratio.clamp(0.0, selection.start());
+    let mute =
+        ((selection.start() - outer_start) / width).clamp(0.0, selection.max_fade_in_mute_length());
+    selection
+        .with_fade_in(fade.length, fade.curve)
+        .with_fade_in_mute(mute)
+}
+
+fn resize_fade_out_outer_end(
+    selection: sempal::selection::SelectionRange,
+    outer_end_ratio: f32,
+) -> sempal::selection::SelectionRange {
+    let Some(fade) = selection.fade_out() else {
+        return selection;
+    };
+    let width = selection.width();
+    if width <= f32::EPSILON {
+        return selection;
+    }
+    let outer_end = outer_end_ratio.clamp(selection.end(), 1.0);
+    let mute =
+        ((outer_end - selection.end()) / width).clamp(0.0, selection.max_fade_out_mute_length());
+    selection
+        .with_fade_out(fade.length, fade.curve)
+        .with_fade_out_mute(mute)
 }
 
 fn rebuild_edit_fades_for_same_range(
@@ -1575,12 +1626,20 @@ impl WaveformWidget {
         if let Some(fade_rect) = self.fade_out_rect(bounds, selection, selection_rect) {
             self.push_fill(primitives, fade_rect, Rgba8 { a: 52, ..accent });
         }
+        if let Some(fade_rect) = self.fade_in_outer_rect(bounds, selection, selection_rect) {
+            self.push_fill(primitives, fade_rect, Rgba8 { a: 38, ..accent });
+        }
+        if let Some(fade_rect) = self.fade_out_outer_rect(bounds, selection, selection_rect) {
+            self.push_fill(primitives, fade_rect, Rgba8 { a: 38, ..accent });
+        }
         self.append_edit_fade_curve_paint(primitives, bounds, selection_rect, accent);
         for handle in [
             WaveformEditFadeHandle::FadeInEnd,
             WaveformEditFadeHandle::FadeOutStart,
             WaveformEditFadeHandle::FadeInStart,
             WaveformEditFadeHandle::FadeOutEnd,
+            WaveformEditFadeHandle::FadeInOuterStart,
+            WaveformEditFadeHandle::FadeOutOuterEnd,
         ] {
             if let Some(rect) = self.edit_fade_handle_rect(bounds, selection_rect, handle) {
                 self.push_fill(primitives, rect, Rgba8 { a: 205, ..accent });
@@ -1663,8 +1722,8 @@ impl WaveformWidget {
             return;
         }
         if let Some(fade_in) = selection.fade_in().filter(|fade| fade.length > 0.0) {
-            let start = selection.start();
-            let end = (start + width * fade_in.length).min(selection.end());
+            let start = (selection.start() - width * fade_in.mute).max(0.0);
+            let end = (selection.start() + width * fade_in.length).min(selection.end());
             self.push_edit_fade_curve_points(
                 primitives,
                 bounds,
@@ -1676,8 +1735,8 @@ impl WaveformWidget {
             );
         }
         if let Some(fade_out) = selection.fade_out().filter(|fade| fade.length > 0.0) {
-            let end = selection.end();
-            let start = (end - width * fade_out.length).max(selection.start());
+            let end = (selection.end() + width * fade_out.mute).min(1.0);
+            let start = (selection.end() - width * fade_out.length).max(selection.start());
             self.push_edit_fade_curve_points(
                 primitives,
                 bounds,
@@ -1738,6 +1797,8 @@ impl WaveformWidget {
             WaveformEditFadeHandle::FadeOutStart,
             WaveformEditFadeHandle::FadeInStart,
             WaveformEditFadeHandle::FadeOutEnd,
+            WaveformEditFadeHandle::FadeInOuterStart,
+            WaveformEditFadeHandle::FadeOutOuterEnd,
         ]
         .into_iter()
         .find(|handle| {
@@ -1792,6 +1853,46 @@ impl WaveformWidget {
         ))
     }
 
+    fn fade_in_outer_rect(
+        &self,
+        bounds: Rect,
+        selection: NormalizedRange,
+        selection_rect: Rect,
+    ) -> Option<Rect> {
+        let start = self.edit_preview.leading_inner_start_micros?;
+        if start >= selection.start_micros {
+            return None;
+        }
+        let x = self.x_for_micros(bounds, start)?;
+        Some(Rect::from_min_max(
+            Point::new(
+                x.clamp(bounds.min.x, selection_rect.min.x),
+                selection_rect.min.y,
+            ),
+            Point::new(selection_rect.min.x, selection_rect.max.y),
+        ))
+    }
+
+    fn fade_out_outer_rect(
+        &self,
+        bounds: Rect,
+        selection: NormalizedRange,
+        selection_rect: Rect,
+    ) -> Option<Rect> {
+        let end = self.edit_preview.trailing_inner_end_micros?;
+        if end <= selection.end_micros {
+            return None;
+        }
+        let x = self.x_for_micros(bounds, end)?;
+        Some(Rect::from_min_max(
+            Point::new(selection_rect.max.x, selection_rect.min.y),
+            Point::new(
+                x.clamp(selection_rect.max.x, bounds.max.x),
+                selection_rect.max.y,
+            ),
+        ))
+    }
+
     fn edit_fade_handle_rect(
         &self,
         bounds: Rect,
@@ -1808,16 +1909,26 @@ impl WaveformWidget {
                 .edit_preview
                 .trailing_start_micros
                 .unwrap_or(selection.end_micros),
-            WaveformEditFadeHandle::FadeInStart => self.edit_preview.leading_end_micros.and(
+            WaveformEditFadeHandle::FadeInStart => self
+                .edit_preview
+                .leading_end_micros
+                .map(|_| selection.start_micros)?,
+            WaveformEditFadeHandle::FadeOutEnd => self
+                .edit_preview
+                .trailing_start_micros
+                .map(|_| selection.end_micros)?,
+            WaveformEditFadeHandle::FadeInOuterStart => self.edit_preview.leading_end_micros.and(
                 self.edit_preview
                     .leading_inner_start_micros
                     .or(Some(selection.start_micros)),
             )?,
-            WaveformEditFadeHandle::FadeOutEnd => self.edit_preview.trailing_start_micros.and(
-                self.edit_preview
-                    .trailing_inner_end_micros
-                    .or(Some(selection.end_micros)),
-            )?,
+            WaveformEditFadeHandle::FadeOutOuterEnd => {
+                self.edit_preview.trailing_start_micros.and(
+                    self.edit_preview
+                        .trailing_inner_end_micros
+                        .or(Some(selection.end_micros)),
+                )?
+            }
         };
         let x = self.x_for_micros(bounds, micros)?;
         let size = EDIT_FADE_HANDLE_TAB_SIZE
@@ -1839,6 +1950,14 @@ impl WaveformWidget {
                     .max(selection_rect.min.y)
                     .min(selection_rect.max.y - 1.0);
                 (top, selection_rect.max.y)
+            }
+            WaveformEditFadeHandle::FadeInOuterStart | WaveformEditFadeHandle::FadeOutOuterEnd => {
+                let center_y = selection_rect.center().y;
+                let top = (center_y - half)
+                    .max(selection_rect.min.y)
+                    .min(selection_rect.max.y - 1.0);
+                let bottom = (top + size).min(selection_rect.max.y).max(top + 1.0);
+                (top, bottom)
             }
         };
         Some(Rect::from_min_max(
@@ -2363,6 +2482,93 @@ mod tests {
         assert!((fade_out_start - 0.5).abs() < 0.001);
         assert!((restored_fade_in.curve - 0.2).abs() < 0.001);
         assert!((restored_fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_outer_handles_set_crossfade_lengths_without_resizing_selection() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection =
+            Some(sempal::selection::SelectionRange::new(0.2, 0.6).with_fade_in(0.25, 0.2));
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeInOuterStart,
+            visible_ratio: 0.2,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.1 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade = selection.fade_in().expect("fade-in after outer drag");
+        assert!((selection.start() - 0.2).abs() < 0.001);
+        assert!((selection.end() - 0.6).abs() < 0.001);
+        assert!((fade.length - 0.25).abs() < 0.001);
+        assert!((fade.mute - 0.25).abs() < 0.001);
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeInOuterStart,
+            visible_ratio: 0.1,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.2 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade = selection.fade_in().expect("fade-in should remain");
+        assert!((fade.length - 0.25).abs() < 0.001);
+        assert!(fade.mute.abs() < 0.001);
+
+        state.edit_selection =
+            Some(sempal::selection::SelectionRange::new(0.2, 0.6).with_fade_out(0.25, 0.7));
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutOuterEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.7 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade = selection.fade_out().expect("fade-out after outer drag");
+        assert!((selection.start() - 0.2).abs() < 0.001);
+        assert!((selection.end() - 0.6).abs() < 0.001);
+        assert!((fade.length - 0.25).abs() < 0.001);
+        assert!((fade.mute - 0.25).abs() < 0.001);
+    }
+
+    #[test]
+    fn primary_press_on_outer_fade_handle_uses_distinct_handle() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection =
+            Some(sempal::selection::SelectionRange::new(0.2, 0.6).with_fade_in(0.25, 0.2));
+        let mut widget = WaveformWidget::new(
+            state.file(),
+            state.viewport(),
+            state.cursor_ratio(),
+            state.playhead_ratio(),
+            state.play_mark_ratio(),
+            state.edit_mark_ratio(),
+            state.play_selection(),
+            state.edit_selection(),
+            state.active_drag_kind(),
+        );
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
+
+        let output = widget
+            .handle_input(
+                bounds,
+                WidgetInput::PointerPress {
+                    position: Point::new(40.0, 40.0),
+                    button: PointerButton::Primary,
+                },
+            )
+            .expect("outer fade handle interaction");
+        let interaction = output
+            .typed_ref::<WaveformInteraction>()
+            .copied()
+            .expect("waveform interaction");
+
+        assert_eq!(
+            interaction,
+            WaveformInteraction::BeginEditFade {
+                handle: WaveformEditFadeHandle::FadeInOuterStart,
+                visible_ratio: 0.2
+            }
+        );
     }
 
     #[test]

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -579,6 +579,7 @@ struct WaveformEditFadeDrag {
     handle: WaveformEditFadeHandle,
     fixed_ratio: f32,
     curve: f32,
+    baseline: sempal::selection::SelectionRange,
 }
 
 impl WaveformEditFadeDrag {
@@ -606,6 +607,7 @@ impl WaveformEditFadeDrag {
             handle,
             fixed_ratio,
             curve,
+            baseline: selection,
         }
     }
 
@@ -617,12 +619,10 @@ impl WaveformEditFadeDrag {
         let ratio = ratio.clamp(0.0, 1.0);
         match self.handle {
             WaveformEditFadeHandle::FadeInEnd => {
-                let length = fade_in_length_for_end(selection, ratio);
-                selection.with_fade_in(length, self.curve)
+                resize_fade_in_end_with_collision(selection, self.baseline, ratio, self.curve)
             }
             WaveformEditFadeHandle::FadeOutStart => {
-                let length = fade_out_length_for_start(selection, ratio);
-                selection.with_fade_out(length, self.curve)
+                resize_fade_out_start_with_collision(selection, self.baseline, ratio, self.curve)
             }
             WaveformEditFadeHandle::FadeInStart => {
                 resize_fade_in_start(selection, self.fixed_ratio, ratio, self.curve)
@@ -651,6 +651,116 @@ fn fade_out_length_for_start(
     }
     ((selection.end() - start_ratio.clamp(selection.start(), selection.end())) / selection.width())
         .clamp(0.0, 1.0)
+}
+
+fn resize_fade_in_end_with_collision(
+    selection: sempal::selection::SelectionRange,
+    baseline: sempal::selection::SelectionRange,
+    end_ratio: f32,
+    curve: f32,
+) -> sempal::selection::SelectionRange {
+    let width = selection.width();
+    if width <= f32::EPSILON {
+        return selection;
+    }
+    let start = selection.start();
+    let end = selection.end();
+    let fade_in_end = end_ratio.clamp(start, end);
+    let fade_in_abs = fade_in_end - start;
+    let baseline_fade_out_abs = baseline.fade_out().map_or(0.0, |fade| {
+        (baseline.end() - (baseline.end() - baseline.width() * fade.length)).max(0.0)
+    });
+    let baseline_fade_out_start = end - baseline_fade_out_abs;
+    let fade_out_abs = if fade_in_end > baseline_fade_out_start {
+        (end - fade_in_end).max(0.0)
+    } else {
+        baseline_fade_out_abs
+    };
+    rebuild_edit_fades_for_same_range(
+        selection,
+        Some((fade_in_abs / width, curve)),
+        fade_out_for_same_width(selection, baseline, fade_out_abs).map(|length| {
+            (
+                length,
+                baseline.fade_out().map(|fade| fade.curve).unwrap_or(0.5),
+            )
+        }),
+    )
+}
+
+fn resize_fade_out_start_with_collision(
+    selection: sempal::selection::SelectionRange,
+    baseline: sempal::selection::SelectionRange,
+    start_ratio: f32,
+    curve: f32,
+) -> sempal::selection::SelectionRange {
+    let width = selection.width();
+    if width <= f32::EPSILON {
+        return selection;
+    }
+    let start = selection.start();
+    let end = selection.end();
+    let fade_out_start = start_ratio.clamp(start, end);
+    let fade_out_abs = end - fade_out_start;
+    let baseline_fade_in_abs = baseline.fade_in().map_or(0.0, |fade| {
+        ((baseline.start() + baseline.width() * fade.length) - baseline.start()).max(0.0)
+    });
+    let baseline_fade_in_end = start + baseline_fade_in_abs;
+    let fade_in_abs = if fade_out_start < baseline_fade_in_end {
+        (fade_out_start - start).max(0.0)
+    } else {
+        baseline_fade_in_abs
+    };
+    rebuild_edit_fades_for_same_range(
+        selection,
+        fade_in_for_same_width(selection, baseline, fade_in_abs).map(|length| {
+            (
+                length,
+                baseline.fade_in().map(|fade| fade.curve).unwrap_or(0.5),
+            )
+        }),
+        Some((fade_out_abs / width, curve)),
+    )
+}
+
+fn rebuild_edit_fades_for_same_range(
+    selection: sempal::selection::SelectionRange,
+    fade_in: Option<(f32, f32)>,
+    fade_out: Option<(f32, f32)>,
+) -> sempal::selection::SelectionRange {
+    let mut rebuilt = sempal::selection::SelectionRange::new(selection.start(), selection.end())
+        .with_gain(selection.gain());
+    if let Some((length, curve)) = fade_in {
+        rebuilt = rebuilt.with_fade_in(length.clamp(0.0, 1.0), curve);
+        if let Some(fade) = selection.fade_in().filter(|fade| fade.mute > 0.0) {
+            rebuilt = rebuilt.with_fade_in_mute(fade.mute);
+        }
+    }
+    if let Some((length, curve)) = fade_out {
+        rebuilt = rebuilt.with_fade_out(length.clamp(0.0, 1.0), curve);
+        if let Some(fade) = selection.fade_out().filter(|fade| fade.mute > 0.0) {
+            rebuilt = rebuilt.with_fade_out_mute(fade.mute);
+        }
+    }
+    rebuilt
+}
+
+fn fade_in_for_same_width(
+    selection: sempal::selection::SelectionRange,
+    baseline: sempal::selection::SelectionRange,
+    fade_in_abs: f32,
+) -> Option<f32> {
+    baseline.fade_in()?;
+    Some((fade_in_abs / selection.width().max(f32::EPSILON)).clamp(0.0, 1.0))
+}
+
+fn fade_out_for_same_width(
+    selection: sempal::selection::SelectionRange,
+    baseline: sempal::selection::SelectionRange,
+    fade_out_abs: f32,
+) -> Option<f32> {
+    baseline.fade_out()?;
+    Some((fade_out_abs / selection.width().max(f32::EPSILON)).clamp(0.0, 1.0))
 }
 
 fn resize_fade_in_start(
@@ -2222,6 +2332,37 @@ mod tests {
         assert!((selection.end() - 0.6).abs() < 0.001);
         assert!((fade.length - 0.25).abs() < 0.001);
         assert!((fade.curve - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_top_handles_push_and_restore_opposite_fade() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            sempal::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_out(0.25, 0.7),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeInEnd,
+            visible_ratio: 0.3,
+        });
+        state.apply_interaction(WaveformInteraction::UpdateSelection { visible_ratio: 0.6 });
+        let pushed = state.edit_selection().expect("pushed edit selection");
+        let pushed_fade_in = pushed.fade_in().expect("fade-in after push");
+        assert!(pushed.fade_out().is_none());
+        assert!((pushed.start() + pushed.width() * pushed_fade_in.length - 0.6).abs() < 0.001);
+
+        state.apply_interaction(WaveformInteraction::UpdateSelection { visible_ratio: 0.3 });
+        let restored = state.edit_selection().expect("restored edit selection");
+        let restored_fade_in = restored.fade_in().expect("restored fade-in");
+        let restored_fade_out = restored.fade_out().expect("restored fade-out");
+        let fade_in_end = restored.start() + restored.width() * restored_fade_in.length;
+        let fade_out_start = restored.end() - restored.width() * restored_fade_out.length;
+        assert!((fade_in_end - 0.3).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((restored_fade_in.curve - 0.2).abs() < 0.001);
+        assert!((restored_fade_out.curve - 0.7).abs() < 0.001);
     }
 
     #[test]

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -553,8 +553,14 @@ fn resize_fade_in_start(
     let new_start = start_ratio.clamp(0.0, selection.end());
     let mut resized = sempal::selection::SelectionRange::new(new_start, selection.end());
     if let Some(fade_out) = selection.fade_out() {
+        let fade_out_abs = selection.width() * fade_out.length;
+        let length = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            (fade_out_abs / resized.width()).clamp(0.0, 1.0)
+        };
         resized = resized
-            .with_fade_out(fade_out.length, fade_out.curve)
+            .with_fade_out(length, fade_out.curve)
             .with_fade_out_mute(fade_out.mute);
     }
     let length = fade_in_length_for_end(resized, fade_end);
@@ -570,8 +576,14 @@ fn resize_fade_out_end(
     let new_end = end_ratio.clamp(selection.start(), 1.0);
     let mut resized = sempal::selection::SelectionRange::new(selection.start(), new_end);
     if let Some(fade_in) = selection.fade_in() {
+        let fade_in_abs = selection.width() * fade_in.length;
+        let length = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            (fade_in_abs / resized.width()).clamp(0.0, 1.0)
+        };
         resized = resized
-            .with_fade_in(fade_in.length, fade_in.curve)
+            .with_fade_in(length, fade_in.curve)
             .with_fade_in_mute(fade_in.mute);
     }
     let length = fade_out_length_for_start(resized, fade_start);
@@ -1968,6 +1980,58 @@ mod tests {
         assert!((selection.end() - 0.6).abs() < 0.001);
         assert!((selection.start() + selection.width() * fade.length - 0.3).abs() < 0.001);
         assert!((fade.curve - 0.2).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_out_bottom_handle_keeps_opposite_fade_boundary_stable() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            sempal::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_out(0.25, 0.7),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.8 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_in = selection.fade_in().expect("fade-in should remain");
+        let fade_out = selection.fade_out().expect("fade-out should remain");
+        let fade_in_end = selection.start() + selection.width() * fade_in.length;
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        assert!((fade_in_end - 0.3).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_in.curve - 0.2).abs() < 0.001);
+        assert!((fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_in_bottom_handle_keeps_opposite_fade_boundary_stable() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            sempal::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_out(0.25, 0.7),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeInStart,
+            visible_ratio: 0.2,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.1 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_in = selection.fade_in().expect("fade-in should remain");
+        let fade_out = selection.fade_out().expect("fade-out should remain");
+        let fade_in_end = selection.start() + selection.width() * fade_in.length;
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        assert!((fade_in_end - 0.3).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_in.curve - 0.2).abs() < 0.001);
+        assert!((fade_out.curve - 0.7).abs() < 0.001);
     }
 
     #[test]

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -228,6 +228,20 @@ impl WaveformState {
                 )));
                 self.update_active_edit_fade(ratio);
             }
+            WaveformInteraction::BeginSelectionResize {
+                kind,
+                edge,
+                visible_ratio,
+            } => {
+                let Some(selection) = self.selection_for_kind(kind) else {
+                    return;
+                };
+                let ratio = self.absolute_ratio_from_visible(visible_ratio);
+                self.active_drag = Some(WaveformDrag::SelectionResize(
+                    WaveformSelectionResizeDrag::new(kind, edge, selection),
+                ));
+                self.update_active_selection_resize(ratio);
+            }
             WaveformInteraction::UpdateSelection { visible_ratio } => {
                 self.update_active_drag(visible_ratio);
             }
@@ -320,6 +334,9 @@ impl WaveformState {
             WaveformDrag::EditFade(_) => {
                 self.update_active_edit_fade(ratio);
             }
+            WaveformDrag::SelectionResize(_) => {
+                self.update_active_selection_resize(ratio);
+            }
         }
     }
 
@@ -352,6 +369,11 @@ impl WaveformState {
                 self.update_active_edit_fade(ratio);
                 self.active_drag = None;
             }
+            WaveformDrag::SelectionResize(_) => {
+                self.active_drag = Some(drag);
+                self.update_active_selection_resize(ratio);
+                self.active_drag = None;
+            }
         }
     }
 
@@ -378,6 +400,36 @@ impl WaveformState {
         };
         self.edit_selection = Some(drag.apply(selection, ratio));
     }
+
+    fn update_active_selection_resize(&mut self, ratio: f32) {
+        let Some(WaveformDrag::SelectionResize(drag)) = self.active_drag else {
+            return;
+        };
+        let Some(selection) = self.selection_for_kind(drag.kind) else {
+            return;
+        };
+        let selection = drag.apply(selection, ratio);
+        match drag.kind {
+            WaveformSelectionKind::Play => {
+                self.play_mark_ratio = Some(selection.start());
+                self.play_selection = Some(selection);
+            }
+            WaveformSelectionKind::Edit => {
+                self.edit_mark_ratio = Some(selection.start());
+                self.edit_selection = Some(selection);
+            }
+        }
+    }
+
+    fn selection_for_kind(
+        &self,
+        kind: WaveformSelectionKind,
+    ) -> Option<sempal::selection::SelectionRange> {
+        match kind {
+            WaveformSelectionKind::Play => self.play_selection,
+            WaveformSelectionKind::Edit => self.edit_selection,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -397,6 +449,11 @@ pub(super) enum WaveformInteraction {
         handle: WaveformEditFadeHandle,
         visible_ratio: f32,
     },
+    BeginSelectionResize {
+        kind: WaveformSelectionKind,
+        edge: WaveformSelectionEdge,
+        visible_ratio: f32,
+    },
     UpdateSelection {
         visible_ratio: f32,
     },
@@ -413,6 +470,12 @@ pub(super) enum WaveformSelectionKind {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WaveformSelectionEdge {
+    Start,
+    End,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum WaveformEditFadeHandle {
     FadeInEnd,
     FadeInStart,
@@ -423,12 +486,14 @@ pub(super) enum WaveformEditFadeHandle {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum WaveformActiveDragKind {
     Selection(WaveformSelectionKind),
+    SelectionResize(WaveformSelectionKind, WaveformSelectionEdge),
     EditFade(WaveformEditFadeHandle),
 }
 
 #[derive(Clone, Copy, Debug)]
 enum WaveformDrag {
     Selection(WaveformSelectionDrag),
+    SelectionResize(WaveformSelectionResizeDrag),
     EditFade(WaveformEditFadeDrag),
 }
 
@@ -436,6 +501,9 @@ impl WaveformDrag {
     fn kind(self) -> WaveformActiveDragKind {
         match self {
             WaveformDrag::Selection(drag) => WaveformActiveDragKind::Selection(drag.kind),
+            WaveformDrag::SelectionResize(drag) => {
+                WaveformActiveDragKind::SelectionResize(drag.kind, drag.edge)
+            }
             WaveformDrag::EditFade(drag) => WaveformActiveDragKind::EditFade(drag.handle),
         }
     }
@@ -462,6 +530,47 @@ impl WaveformSelectionDrag {
     fn update(&mut self, ratio: f32) {
         self.current_ratio = ratio;
         self.moved |= (self.current_ratio - self.anchor_ratio).abs() > SELECTION_DRAG_EPSILON;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WaveformSelectionResizeDrag {
+    kind: WaveformSelectionKind,
+    edge: WaveformSelectionEdge,
+    fixed_ratio: f32,
+}
+
+impl WaveformSelectionResizeDrag {
+    fn new(
+        kind: WaveformSelectionKind,
+        edge: WaveformSelectionEdge,
+        selection: sempal::selection::SelectionRange,
+    ) -> Self {
+        let fixed_ratio = match edge {
+            WaveformSelectionEdge::Start => selection.end(),
+            WaveformSelectionEdge::End => selection.start(),
+        };
+        Self {
+            kind,
+            edge,
+            fixed_ratio,
+        }
+    }
+
+    fn apply(
+        self,
+        _selection: sempal::selection::SelectionRange,
+        ratio: f32,
+    ) -> sempal::selection::SelectionRange {
+        let ratio = ratio.clamp(0.0, 1.0);
+        match self.edge {
+            WaveformSelectionEdge::Start => {
+                sempal::selection::SelectionRange::new(ratio, self.fixed_ratio)
+            }
+            WaveformSelectionEdge::End => {
+                sempal::selection::SelectionRange::new(self.fixed_ratio, ratio)
+            }
+        }
     }
 }
 
@@ -1158,6 +1267,17 @@ impl Widget for WaveformWidget {
                         visible_ratio: self.ratio_from_position(bounds, position),
                     }));
                 }
+                if let Some(edge) =
+                    self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Play)
+                {
+                    return Some(WidgetOutput::typed(
+                        WaveformInteraction::BeginSelectionResize {
+                            kind: WaveformSelectionKind::Play,
+                            edge,
+                            visible_ratio: self.ratio_from_position(bounds, position),
+                        },
+                    ));
+                }
                 Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
                     kind: WaveformSelectionKind::Play,
                     visible_ratio: self.ratio_from_position(bounds, position),
@@ -1187,7 +1307,13 @@ impl Widget for WaveformWidget {
                 ))
                 || matches!(
                     self.active_drag_kind,
-                    Some(WaveformActiveDragKind::EditFade(_))
+                    Some(
+                        WaveformActiveDragKind::EditFade(_)
+                            | WaveformActiveDragKind::SelectionResize(
+                                WaveformSelectionKind::Play,
+                                _
+                            )
+                    )
                 ) =>
             {
                 Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
@@ -1247,6 +1373,18 @@ impl WaveformWidget {
                     g: 142,
                     b: 92,
                     a: 48,
+                },
+            );
+            self.append_selection_resize_handles(
+                primitives,
+                bounds,
+                start,
+                end,
+                Rgba8 {
+                    r: 255,
+                    g: 142,
+                    b: 92,
+                    a: 220,
                 },
             );
         }
@@ -1338,6 +1476,66 @@ impl WaveformWidget {
                 self.push_fill(primitives, rect, Rgba8 { a: 205, ..accent });
             }
         }
+    }
+
+    fn append_selection_resize_handles(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+        start: f32,
+        end: f32,
+        color: Rgba8,
+    ) {
+        for edge in [WaveformSelectionEdge::Start, WaveformSelectionEdge::End] {
+            if let Some(rect) = self.selection_resize_handle_rect(bounds, start, end, edge) {
+                self.push_fill(primitives, rect, color);
+            }
+        }
+    }
+
+    fn selection_resize_handle_at(
+        &self,
+        bounds: Rect,
+        position: Point,
+        kind: WaveformSelectionKind,
+    ) -> Option<WaveformSelectionEdge> {
+        let range = match kind {
+            WaveformSelectionKind::Play => self.play_selection,
+            WaveformSelectionKind::Edit => self.edit_selection,
+        };
+        let (start, end) = self.visible_range_for_selection(range)?;
+        [WaveformSelectionEdge::Start, WaveformSelectionEdge::End]
+            .into_iter()
+            .find(|edge| {
+                self.selection_resize_handle_rect(bounds, start, end, *edge)
+                    .is_some_and(|rect| rect.contains(position))
+            })
+    }
+
+    fn selection_resize_handle_rect(
+        &self,
+        bounds: Rect,
+        start: f32,
+        end: f32,
+        edge: WaveformSelectionEdge,
+    ) -> Option<Rect> {
+        let x_ratio = match edge {
+            WaveformSelectionEdge::Start => start,
+            WaveformSelectionEdge::End => end,
+        };
+        let x = bounds.min.x + bounds.width() * x_ratio.clamp(0.0, 1.0);
+        let width = 7.0_f32.min(bounds.width().max(1.0));
+        let half_width = width * 0.5;
+        let top = bounds.min.y;
+        let bottom = (bounds.min.y + 22.0)
+            .min(bounds.max.y)
+            .max(bounds.min.y + 1.0);
+        let left = (x - half_width).clamp(bounds.min.x, bounds.max.x - width.max(1.0));
+        let right = (left + width).min(bounds.max.x).max(left + 1.0);
+        Some(Rect::from_min_max(
+            Point::new(left, top),
+            Point::new(right, bottom),
+        ))
     }
 
     fn append_edit_fade_curve_paint(
@@ -1651,9 +1849,9 @@ impl WaveformWidget {
 #[cfg(test)]
 mod tests {
     use super::{
-        BAND_COUNT, WaveformEditFadeHandle, WaveformInteraction, WaveformSelectionKind,
-        WaveformSignalWidget, WaveformState, WaveformWidget, split_frequency_bands,
-        waveform_file_from_mono_samples,
+        BAND_COUNT, WaveformEditFadeHandle, WaveformInteraction, WaveformSelectionEdge,
+        WaveformSelectionKind, WaveformSignalWidget, WaveformState, WaveformWidget,
+        split_frequency_bands, waveform_file_from_mono_samples,
     };
     use radiant::{
         gui::types::{Point, Rect, Vector2},
@@ -1914,6 +2112,70 @@ mod tests {
         assert!((selection.start() - 0.2).abs() < 0.001);
         assert!((selection.end() - 0.6).abs() < 0.001);
         assert_eq!(state.play_mark_ratio(), Some(0.2));
+    }
+
+    #[test]
+    fn playmark_range_edges_are_resizable() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.play_selection = Some(sempal::selection::SelectionRange::new(0.2, 0.6));
+        state.play_mark_ratio = Some(0.2);
+
+        state.apply_interaction(WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Play,
+            edge: WaveformSelectionEdge::End,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection {
+            visible_ratio: 0.75,
+        });
+
+        let selection = state.play_selection().expect("playmark selection");
+        assert!((selection.start() - 0.2).abs() < 0.001);
+        assert!((selection.end() - 0.75).abs() < 0.001);
+        assert_eq!(state.play_mark_ratio(), Some(selection.start()));
+        assert!(!state.is_playing());
+    }
+
+    #[test]
+    fn primary_press_on_playmark_handle_starts_resize_instead_of_new_selection() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.play_selection = Some(sempal::selection::SelectionRange::new(0.2, 0.6));
+        state.play_mark_ratio = Some(0.2);
+        let mut widget = WaveformWidget::new(
+            state.file(),
+            state.viewport(),
+            state.cursor_ratio(),
+            state.playhead_ratio(),
+            state.play_mark_ratio(),
+            state.edit_mark_ratio(),
+            state.play_selection(),
+            state.edit_selection(),
+            state.active_drag_kind(),
+        );
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
+
+        let output = widget
+            .handle_input(
+                bounds,
+                WidgetInput::PointerPress {
+                    position: Point::new(120.0, 8.0),
+                    button: PointerButton::Primary,
+                },
+            )
+            .expect("playmark resize interaction");
+        let interaction = output
+            .typed_ref::<WaveformInteraction>()
+            .copied()
+            .expect("waveform interaction");
+
+        assert_eq!(
+            interaction,
+            WaveformInteraction::BeginSelectionResize {
+                kind: WaveformSelectionKind::Play,
+                edge: WaveformSelectionEdge::End,
+                visible_ratio: 0.6
+            }
+        );
     }
 
     #[test]

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -242,6 +242,12 @@ impl WaveformState {
                 ));
                 self.update_active_selection_resize(ratio);
             }
+            WaveformInteraction::BeginPan { visible_ratio } => {
+                self.active_drag = Some(WaveformDrag::Pan(WaveformPanDrag::new(
+                    visible_ratio,
+                    self.viewport.clamp(self.file.frames.max(1)),
+                )));
+            }
             WaveformInteraction::UpdateSelection { visible_ratio } => {
                 self.update_active_drag(visible_ratio);
             }
@@ -337,6 +343,9 @@ impl WaveformState {
             WaveformDrag::SelectionResize(_) => {
                 self.update_active_selection_resize(ratio);
             }
+            WaveformDrag::Pan(drag) => {
+                self.update_active_pan(drag, visible_ratio);
+            }
         }
     }
 
@@ -373,6 +382,9 @@ impl WaveformState {
                 self.active_drag = Some(drag);
                 self.update_active_selection_resize(ratio);
                 self.active_drag = None;
+            }
+            WaveformDrag::Pan(drag) => {
+                self.update_active_pan(drag, visible_ratio);
             }
         }
     }
@@ -421,6 +433,22 @@ impl WaveformState {
         }
     }
 
+    fn update_active_pan(&mut self, drag: WaveformPanDrag, visible_ratio: f32) {
+        let total = self.file.frames.max(1);
+        let viewport = drag.viewport.clamp(total);
+        let visible = viewport.visible_frames();
+        if visible >= total {
+            return;
+        }
+        let delta = ((visible_ratio - drag.anchor_visible_ratio) * visible as f32).round() as isize;
+        let start = viewport.start.saturating_add_signed(-delta);
+        self.viewport = WaveformViewport {
+            start,
+            end: start + visible,
+        }
+        .clamp(total);
+    }
+
     fn selection_for_kind(
         &self,
         kind: WaveformSelectionKind,
@@ -452,6 +480,9 @@ pub(super) enum WaveformInteraction {
     BeginSelectionResize {
         kind: WaveformSelectionKind,
         edge: WaveformSelectionEdge,
+        visible_ratio: f32,
+    },
+    BeginPan {
         visible_ratio: f32,
     },
     UpdateSelection {
@@ -490,6 +521,7 @@ pub(super) enum WaveformActiveDragKind {
     Selection(WaveformSelectionKind),
     SelectionResize(WaveformSelectionKind, WaveformSelectionEdge),
     EditFade(WaveformEditFadeHandle),
+    Pan,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -497,6 +529,7 @@ enum WaveformDrag {
     Selection(WaveformSelectionDrag),
     SelectionResize(WaveformSelectionResizeDrag),
     EditFade(WaveformEditFadeDrag),
+    Pan(WaveformPanDrag),
 }
 
 impl WaveformDrag {
@@ -507,6 +540,22 @@ impl WaveformDrag {
                 WaveformActiveDragKind::SelectionResize(drag.kind, drag.edge)
             }
             WaveformDrag::EditFade(drag) => WaveformActiveDragKind::EditFade(drag.handle),
+            WaveformDrag::Pan(_) => WaveformActiveDragKind::Pan,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WaveformPanDrag {
+    anchor_visible_ratio: f32,
+    viewport: WaveformViewport,
+}
+
+impl WaveformPanDrag {
+    fn new(anchor_visible_ratio: f32, viewport: WaveformViewport) -> Self {
+        Self {
+            anchor_visible_ratio,
+            viewport,
         }
     }
 }
@@ -1459,6 +1508,14 @@ impl Widget for WaveformWidget {
                     visible_ratio: self.ratio_from_position(bounds, position),
                 }))
             }
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Auxiliary,
+            } if bounds.contains(position) => {
+                Some(WidgetOutput::typed(WaveformInteraction::BeginPan {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
             WidgetInput::PointerRelease {
                 position,
                 button: PointerButton::Primary,
@@ -1493,6 +1550,14 @@ impl Widget for WaveformWidget {
                     Some(WaveformActiveDragKind::EditFade(_))
                 ) =>
             {
+                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Auxiliary,
+            } if self.active_drag_kind == Some(WaveformActiveDragKind::Pan) => {
                 Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
                     visible_ratio: self.ratio_from_position(bounds, position),
                 }))
@@ -2245,6 +2310,55 @@ mod tests {
         let ratio = state.absolute_ratio_from_visible(0.5);
 
         assert!((ratio - 0.5).abs() < 0.0001);
+    }
+
+    #[test]
+    fn auxiliary_drag_pans_zoomed_waveform_viewport() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.viewport = super::WaveformViewport {
+            start: 12_000,
+            end: 36_000,
+        };
+        let mut widget = WaveformWidget::new(
+            state.file(),
+            state.viewport(),
+            state.cursor_ratio(),
+            state.playhead_ratio(),
+            state.play_mark_ratio(),
+            state.edit_mark_ratio(),
+            state.play_selection(),
+            state.edit_selection(),
+            state.active_drag_kind(),
+        );
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
+        let output = widget
+            .handle_input(
+                bounds,
+                WidgetInput::PointerPress {
+                    position: Point::new(100.0, 40.0),
+                    button: PointerButton::Auxiliary,
+                },
+            )
+            .expect("middle press should arm waveform pan");
+        let interaction = output
+            .typed_ref::<WaveformInteraction>()
+            .copied()
+            .expect("waveform pan interaction");
+
+        assert_eq!(
+            interaction,
+            WaveformInteraction::BeginPan { visible_ratio: 0.5 }
+        );
+        state.apply_interaction(interaction);
+        state.apply_interaction(WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.25,
+        });
+
+        assert!(
+            state.viewport().start > 12_000,
+            "dragging left should pan the viewport later in the sample"
+        );
+        assert_eq!(state.viewport().visible_frames(), 24_000);
     }
 
     #[test]

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -20,6 +20,7 @@ pub(super) struct SempalRuntimeBridge<B> {
     pending_surface_descriptor: Option<RetainedSurfaceDescriptor>,
     text_input_target: RetainedTextInputTarget,
     text_edit: RetainedTextEditState,
+    waveform_pan_drag: Option<WaveformPanDrag>,
 }
 
 /// Private message surface used by the generic runtime before Sempal action reduction.
@@ -57,6 +58,13 @@ struct RetainedTextEditState {
     value: String,
     caret: usize,
     selection_anchor: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WaveformPanDrag {
+    anchor_x: f32,
+    start_micros: u32,
+    end_micros: u32,
 }
 
 impl RetainedTextEditState {
@@ -159,6 +167,7 @@ impl<B> SempalRuntimeBridge<B> {
             pending_surface_descriptor: None,
             text_input_target: RetainedTextInputTarget::None,
             text_edit: RetainedTextEditState::default(),
+            waveform_pan_drag: None,
         }
     }
 
@@ -242,6 +251,11 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
         match input {
             WidgetInput::PointerMove { position } => {
                 let layout = self.build_current_layout();
+                if let Some(action) = self.waveform_pan_drag_action(&layout, position) {
+                    self.emit_action(action);
+                    self.local_overlay_surface_refresh = true;
+                    return true;
+                }
                 let _effect =
                     self.shell_state
                         .handle_cursor_move_effect(&layout, &self.model, position);
@@ -249,10 +263,15 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                 true
             }
             WidgetInput::PointerPress { position, button } => {
+                let layout = self.build_current_layout();
+                if button == PointerButton::Auxiliary {
+                    self.begin_waveform_pan_drag(&layout, position);
+                    self.local_overlay_surface_refresh = true;
+                    return true;
+                }
                 if button != PointerButton::Primary {
                     return true;
                 }
-                let layout = self.build_current_layout();
                 if let Some(action) = action_from_retained_pointer(
                     &layout,
                     &self.model,
@@ -264,6 +283,14 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
                         self.sync_text_edit_from_model();
                     }
                 }
+                true
+            }
+            WidgetInput::PointerRelease {
+                button: PointerButton::Auxiliary,
+                ..
+            } => {
+                self.waveform_pan_drag = None;
+                self.local_overlay_surface_refresh = true;
                 true
             }
             WidgetInput::PointerRelease { .. } | WidgetInput::FocusChanged(_) => {
@@ -284,6 +311,39 @@ impl<B: NativeAppBridge> SempalRuntimeBridge<B> {
             .unwrap_or_else(|| Vector2::new(1280.0, 720.0));
         let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
         ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime)
+    }
+
+    fn begin_waveform_pan_drag(&mut self, layout: &ShellLayout, position: Point) {
+        self.waveform_pan_drag = None;
+        if !layout.waveform_plot.contains(position) {
+            return;
+        }
+        let viewport = self.model.waveform.viewport();
+        if viewport.end_micros.saturating_sub(viewport.start_micros) >= 999_999 {
+            return;
+        }
+        self.waveform_pan_drag = Some(WaveformPanDrag {
+            anchor_x: position.x,
+            start_micros: viewport.start_micros,
+            end_micros: viewport.end_micros,
+        });
+    }
+
+    fn waveform_pan_drag_action(&self, layout: &ShellLayout, position: Point) -> Option<UiAction> {
+        let drag = self.waveform_pan_drag?;
+        let span = drag.end_micros.saturating_sub(drag.start_micros).max(1);
+        if span >= 999_999 || layout.waveform_plot.width() <= 1.0 {
+            return None;
+        }
+        let delta_ratio = (position.x - drag.anchor_x) / layout.waveform_plot.width().max(1.0);
+        let delta_micros = (delta_ratio * span as f32).round() as i64;
+        let max_start = 1_000_000i64.saturating_sub(i64::from(span));
+        let start = (i64::from(drag.start_micros) - delta_micros).clamp(0, max_start);
+        let center_micros = (start + i64::from(span / 2)).clamp(0, 1_000_000) as u32;
+        Some(UiAction::SetWaveformViewCenter {
+            center_micros,
+            center_nanos: None,
+        })
     }
 
     /// Handle one non-text key intent routed through the focused retained canvas.

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -199,6 +199,54 @@ mod tests {
     }
 
     #[test]
+    fn retained_auxiliary_drag_pans_zoomed_waveform_view() {
+        let repaint_installed = Arc::new(AtomicBool::new(false));
+        let mut model = NativeAppModel::default();
+        model.waveform.view_start_micros = 250_000;
+        model.waveform.view_end_micros = 500_000;
+        let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(model),
+            reduced: Vec::new(),
+            repaint_installed,
+            exit_status: None,
+        });
+        let _ = bridge.project_surface();
+        let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
+        let anchor = layout.waveform_plot.center();
+
+        assert!(
+            bridge
+                .update(SempalRuntimeMessage::RetainedInput(
+                    WidgetInput::PointerPress {
+                        position: anchor,
+                        button: PointerButton::Auxiliary,
+                    }
+                ))
+                .requests_repaint()
+        );
+        assert!(
+            bridge
+                .update(SempalRuntimeMessage::RetainedInput(
+                    WidgetInput::PointerMove {
+                        position: Point::new(
+                            anchor.x - layout.waveform_plot.width() * 0.25,
+                            anchor.y
+                        ),
+                    }
+                ))
+                .requests_repaint()
+        );
+
+        assert!(matches!(
+            bridge.inner.reduced.last(),
+            Some(UiAction::SetWaveformViewCenter {
+                center_micros,
+                center_nanos: None,
+            }) if *center_micros > 375_000
+        ));
+    }
+
+    #[test]
     fn focused_browser_pill_editor_shields_typing_from_shortcuts_and_commits_commas() {
         let mut bridge = SempalRuntimeBridge::new(RecordingBridge {
             model: Arc::new(NativeAppModel::default()),

--- a/src/sample_sources/config_types/interaction.rs
+++ b/src/sample_sources/config_types/interaction.rs
@@ -8,6 +8,10 @@ use super::super::config_defaults::{
     default_scroll_speed, default_tooltip_mode, default_true, default_wheel_zoom_factor,
 };
 
+fn default_destructive_yolo_mode() -> bool {
+    true
+}
+
 /// Tooltip detail level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TooltipMode {
@@ -63,7 +67,7 @@ pub struct InteractionOptions {
     #[serde(default = "default_true")]
     pub auto_edge_fades_on_selection_exports: bool,
     /// Allow destructive edits without confirmation.
-    #[serde(default)]
+    #[serde(default = "default_destructive_yolo_mode")]
     pub destructive_yolo_mode: bool,
     /// Default waveform channel visualization mode.
     #[serde(default)]
@@ -116,7 +120,7 @@ impl Default for InteractionOptions {
             anti_clip_fade_enabled: true,
             anti_clip_fade_ms: default_anti_clip_fade_ms(),
             auto_edge_fades_on_selection_exports: default_true(),
-            destructive_yolo_mode: false,
+            destructive_yolo_mode: true,
             waveform_channel_view: WaveformChannelView::Mono,
             bpm_snap_enabled: default_false(),
             relative_bpm_grid_enabled: default_false(),

--- a/src/selection/range.rs
+++ b/src/selection/range.rs
@@ -248,6 +248,19 @@ impl SelectionRange {
             || (self.gain - 1.0).abs() > f32::EPSILON
     }
 
+    /// Gain at one normalized position according to this selection's edit effects.
+    pub fn gain_at_position(&self, position: f32, min_fade_len: f32) -> f32 {
+        fade_gain_at_position(
+            position,
+            self.start(),
+            self.end(),
+            self.gain(),
+            self.fade_in(),
+            self.fade_out(),
+            min_fade_len,
+        )
+    }
+
     /// Set fade-in parameters.
     ///
     /// Keeps a zero-length fade when a mute region is configured so mute handles persist.


### PR DESCRIPTION
## Summary
- paint the active edit fade volume curve above the GPU waveform overlay
- apply active edit fade gain to the GPU signal summary so the waveform updates live while handles move
- expose SelectionRange gain sampling for GUI preview reuse

## Validation
- cargo test -p sempal gui_app::waveform::tests -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent