### PR TITLE
Keep fade crossfade handles stable during edge resize

### DIFF
--- a/src/app/controller/playback/waveform_action_tests.rs
+++ b/src/app/controller/playback/waveform_action_tests.rs
@@ -275,6 +275,39 @@ fn set_waveform_edit_fade_out_mute_end_milli_preserves_fade_in_boundary() {
     assert!((fade_out.curve - 0.7).abs() < 0.001);
 }
 
+/// Edit fade-out bottom-handle updates should keep existing crossfade handles fixed.
+#[test]
+fn set_waveform_edit_fade_out_mute_end_milli_preserves_crossfade_handles() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_in_mute(0.25)
+        .with_fade_out(0.25, 0.7)
+        .with_fade_out_mute(0.25);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_out_mute_end_milli(700);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_in = updated.fade_in().expect("fade-in should remain");
+    let fade_out = updated.fade_out().expect("fade-out should remain");
+    let fade_in_end = updated.start() + (updated.width() * fade_in.length);
+    let fade_in_outer_start = updated.start() - (updated.width() * fade_in.mute);
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    let fade_out_outer_end = updated.end() + (updated.width() * fade_out.mute);
+    assert!((updated.start() - 0.2).abs() < 0.001);
+    assert!((updated.end() - 0.7).abs() < 0.001);
+    assert!((fade_in_end - 0.3).abs() < 0.001);
+    assert!((fade_in_outer_start - 0.1).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_out_outer_end - 0.7).abs() < 0.001);
+}
+
 /// Edit fade-in bottom-handle updates should keep the opposite fade-out boundary fixed.
 #[test]
 fn set_waveform_edit_fade_in_mute_start_milli_preserves_fade_out_boundary() {
@@ -300,6 +333,39 @@ fn set_waveform_edit_fade_in_mute_start_milli_preserves_fade_out_boundary() {
     assert!((fade_out_start - 0.5).abs() < 0.001);
     assert!((fade_in.curve - 0.3).abs() < 0.001);
     assert!((fade_out.curve - 0.7).abs() < 0.001);
+}
+
+/// Edit fade-in bottom-handle updates should keep existing crossfade handles fixed.
+#[test]
+fn set_waveform_edit_fade_in_mute_start_milli_preserves_crossfade_handles() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_in_mute(0.25)
+        .with_fade_out(0.25, 0.7)
+        .with_fade_out_mute(0.25);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_in_mute_start_milli(100);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_in = updated.fade_in().expect("fade-in should remain");
+    let fade_out = updated.fade_out().expect("fade-out should remain");
+    let fade_in_end = updated.start() + (updated.width() * fade_in.length);
+    let fade_in_outer_start = updated.start() - (updated.width() * fade_in.mute);
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    let fade_out_outer_end = updated.end() + (updated.width() * fade_out.mute);
+    assert!((updated.start() - 0.1).abs() < 0.001);
+    assert!((updated.end() - 0.6).abs() < 0.001);
+    assert!((fade_in_end - 0.3).abs() < 0.001);
+    assert!((fade_in_outer_start - 0.1).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_out_outer_end - 0.7).abs() < 0.001);
 }
 
 /// Collapsed fade-out drags should recover the original fade while the same drag stays active.

--- a/src/app/controller/playback/waveform_actions/edit_fades.rs
+++ b/src/app/controller/playback/waveform_actions/edit_fades.rs
@@ -77,7 +77,14 @@ pub(super) fn update_edit_fade_in_mute_start_from_micros(
     } else {
         ((fade_in_end - new_start) / new_width).clamp(0.0, 1.0)
     };
-    let next_fade_in = crate::selection::FadeParams::with_curve(new_length, fade_in.curve);
+    let old_outer_start = range.start() - (width * fade_in.mute);
+    let new_mute = if new_width <= f32::EPSILON {
+        0.0
+    } else {
+        ((new_start - old_outer_start) / new_width).max(0.0)
+    };
+    let next_fade_in =
+        crate::selection::FadeParams::with_curve_and_mute(new_length, fade_in.curve, new_mute);
     rebuild_edit_range(
         range,
         new_start,
@@ -162,7 +169,14 @@ pub(super) fn update_edit_fade_out_mute_end_from_micros(
     } else {
         ((new_end - fade_out_start) / new_width).clamp(0.0, 1.0)
     };
-    let next_fade_out = crate::selection::FadeParams::with_curve(new_length, fade_out.curve);
+    let old_outer_end = range.end() + (width * fade_out.mute);
+    let new_mute = if new_width <= f32::EPSILON {
+        0.0
+    } else {
+        ((old_outer_end - new_end) / new_width).max(0.0)
+    };
+    let next_fade_out =
+        crate::selection::FadeParams::with_curve_and_mute(new_length, fade_out.curve, new_mute);
     rebuild_edit_range(
         range,
         range.start(),

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -870,20 +870,36 @@ fn resize_fade_in_start(
     curve: f32,
 ) -> wavecrate::selection::SelectionRange {
     let new_start = start_ratio.clamp(0.0, selection.end());
+    let old_width = selection.width();
     let mut resized = wavecrate::selection::SelectionRange::new(new_start, selection.end());
     if let Some(fade_out) = selection.fade_out() {
-        let fade_out_abs = selection.width() * fade_out.length;
+        let fade_out_abs = old_width * fade_out.length;
         let length = if resized.width() <= f32::EPSILON {
             0.0
         } else {
             (fade_out_abs / resized.width()).clamp(0.0, 1.0)
         };
+        let mute = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            (old_width * fade_out.mute / resized.width()).max(0.0)
+        };
         resized = resized
             .with_fade_out(length, fade_out.curve)
-            .with_fade_out_mute(fade_out.mute);
+            .with_fade_out_mute(mute);
     }
     let length = fade_in_length_for_end(resized, fade_end);
-    resized.with_fade_in(length, curve)
+    let mut resized = resized.with_fade_in(length, curve);
+    if let Some(fade_in) = selection.fade_in() {
+        let old_outer_start = selection.start() - old_width * fade_in.mute;
+        let mute = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            ((resized.start() - old_outer_start) / resized.width()).max(0.0)
+        };
+        resized = resized.with_fade_in_mute(mute);
+    }
+    resized
 }
 
 fn resize_fade_out_end(
@@ -893,20 +909,36 @@ fn resize_fade_out_end(
     curve: f32,
 ) -> wavecrate::selection::SelectionRange {
     let new_end = end_ratio.clamp(selection.start(), 1.0);
+    let old_width = selection.width();
     let mut resized = wavecrate::selection::SelectionRange::new(selection.start(), new_end);
     if let Some(fade_in) = selection.fade_in() {
-        let fade_in_abs = selection.width() * fade_in.length;
+        let fade_in_abs = old_width * fade_in.length;
         let length = if resized.width() <= f32::EPSILON {
             0.0
         } else {
             (fade_in_abs / resized.width()).clamp(0.0, 1.0)
         };
+        let mute = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            (old_width * fade_in.mute / resized.width()).max(0.0)
+        };
         resized = resized
             .with_fade_in(length, fade_in.curve)
-            .with_fade_in_mute(fade_in.mute);
+            .with_fade_in_mute(mute);
     }
     let length = fade_out_length_for_start(resized, fade_start);
-    resized.with_fade_out(length, curve)
+    let mut resized = resized.with_fade_out(length, curve);
+    if let Some(fade_out) = selection.fade_out() {
+        let old_outer_end = selection.end() + old_width * fade_out.mute;
+        let mute = if resized.width() <= f32::EPSILON {
+            0.0
+        } else {
+            ((old_outer_end - resized.end()) / resized.width()).max(0.0)
+        };
+        resized = resized.with_fade_out_mute(mute);
+    }
+    resized
 }
 
 fn edit_preview_for_selection(
@@ -2732,6 +2764,41 @@ mod tests {
     }
 
     #[test]
+    fn edit_fade_out_bottom_handle_keeps_crossfade_handles_stable() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_in_mute(0.25)
+                .with_fade_out(0.25, 0.7)
+                .with_fade_out_mute(0.25),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.7 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_in = selection.fade_in().expect("fade-in should remain");
+        let fade_out = selection.fade_out().expect("fade-out should remain");
+        let fade_in_end = selection.start() + selection.width() * fade_in.length;
+        let fade_in_outer_start = selection.start() - selection.width() * fade_in.mute;
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        let fade_out_outer_end = selection.end() + selection.width() * fade_out.mute;
+
+        assert!((selection.start() - 0.2).abs() < 0.001);
+        assert!((selection.end() - 0.7).abs() < 0.001);
+        assert!((fade_in_end - 0.3).abs() < 0.001);
+        assert!((fade_in_outer_start - 0.1).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_out_outer_end - 0.7).abs() < 0.001);
+        assert!((fade_in.curve - 0.2).abs() < 0.001);
+        assert!((fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
     fn edit_fade_in_bottom_handle_keeps_opposite_fade_boundary_stable() {
         let mut state = WaveformState::synthetic_for_tests();
         state.edit_selection = Some(
@@ -2753,6 +2820,41 @@ mod tests {
         let fade_out_start = selection.end() - selection.width() * fade_out.length;
         assert!((fade_in_end - 0.3).abs() < 0.001);
         assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_in.curve - 0.2).abs() < 0.001);
+        assert!((fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_in_bottom_handle_keeps_crossfade_handles_stable() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_in_mute(0.25)
+                .with_fade_out(0.25, 0.7)
+                .with_fade_out_mute(0.25),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeInStart,
+            visible_ratio: 0.2,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.1 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_in = selection.fade_in().expect("fade-in should remain");
+        let fade_out = selection.fade_out().expect("fade-out should remain");
+        let fade_in_end = selection.start() + selection.width() * fade_in.length;
+        let fade_in_outer_start = selection.start() - selection.width() * fade_in.mute;
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        let fade_out_outer_end = selection.end() + selection.width() * fade_out.mute;
+
+        assert!((selection.start() - 0.1).abs() < 0.001);
+        assert!((selection.end() - 0.6).abs() < 0.001);
+        assert!((fade_in_end - 0.3).abs() < 0.001);
+        assert!((fade_in_outer_start - 0.1).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_out_outer_end - 0.7).abs() < 0.001);
         assert!((fade_in.curve - 0.2).abs() < 0.001);
         assert!((fade_out.curve - 0.7).abs() < 0.001);
     }


### PR DESCRIPTION
Fixes edit-fade edge resize behavior so dragging one bottom/edge handle preserves unrelated inner fade and crossfade handle positions in absolute waveform space.\n\nIncluded:\n- preserve same-side crossfade mute handles when resizing fade-in/fade-out selection edges\n- preserve opposite-side crossfade handles as absolute positions when the selection width changes\n- add controller and retained GUI regression tests for both left and right bottom-handle drags\n\nValidation:\n- cargo test -p wavecrate crossfade_handles --lib\n- cargo test -p wavecrate gui_app::waveform::tests\n- cargo test -p wavecrate edit_fade --lib\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent