### PR TITLE
Keep fade silence handles pinned on collapse

### DIFF
--- a/src/app/controller/playback/waveform_action_tests.rs
+++ b/src/app/controller/playback/waveform_action_tests.rs
@@ -308,6 +308,34 @@ fn set_waveform_edit_fade_out_mute_end_milli_preserves_crossfade_handles() {
     assert!((fade_out_outer_end - 0.7).abs() < 0.001);
 }
 
+/// Collapsing the fade-out length with the bottom handle should not collapse its silence handle.
+#[test]
+fn set_waveform_edit_fade_out_mute_end_milli_preserves_crossfade_when_fade_collapses() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_out(0.25, 0.7)
+        .with_fade_out_mute(1.0);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_out_mute_end_milli(500);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_out = updated.fade_out().expect("fade-out silence handle should remain");
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    let fade_out_outer_end = updated.end() + (updated.width() * fade_out.mute);
+    assert!((updated.start() - 0.2).abs() < 0.001);
+    assert!((updated.end() - 0.5).abs() < 0.001);
+    assert!((fade_out_start - 0.5).abs() < 0.001);
+    assert!((fade_out_outer_end - 1.0).abs() < 0.001);
+    assert!(fade_out.length.abs() < 0.001);
+    assert!((fade_out.curve - 0.7).abs() < 0.001);
+}
+
 /// Edit fade-in bottom-handle updates should keep the opposite fade-out boundary fixed.
 #[test]
 fn set_waveform_edit_fade_in_mute_start_milli_preserves_fade_out_boundary() {
@@ -366,6 +394,29 @@ fn set_waveform_edit_fade_in_mute_start_milli_preserves_crossfade_handles() {
     assert!((fade_in_outer_start - 0.1).abs() < 0.001);
     assert!((fade_out_start - 0.5).abs() < 0.001);
     assert!((fade_out_outer_end - 0.7).abs() < 0.001);
+}
+
+/// Resizing the opposite edge should keep a sample-edge fade-in silence handle pinned.
+#[test]
+fn set_waveform_edit_fade_out_mute_end_milli_keeps_left_crossfade_pinned_to_sample_edge() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_in_mute(0.5)
+        .with_fade_out(0.25, 0.7);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_out_mute_end_milli(700);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_in = updated.fade_in().expect("fade-in should remain");
+    let fade_in_outer_start = updated.start() - (updated.width() * fade_in.mute);
+    assert!(fade_in_outer_start.abs() < 0.000_001);
 }
 
 /// Collapsed fade-out drags should recover the original fade while the same drag stays active.

--- a/src/app/controller/playback/waveform_actions/edit_fades.rs
+++ b/src/app/controller/playback/waveform_actions/edit_fades.rs
@@ -78,7 +78,7 @@ pub(super) fn update_edit_fade_in_mute_start_from_micros(
         ((fade_in_end - new_start) / new_width).clamp(0.0, 1.0)
     };
     let old_outer_start = range.start() - (width * fade_in.mute);
-    let new_mute = if new_width <= f32::EPSILON {
+    let new_mute = if fade_in.mute <= 0.0 || new_width <= f32::EPSILON {
         0.0
     } else {
         ((new_start - old_outer_start) / new_width).max(0.0)
@@ -170,7 +170,7 @@ pub(super) fn update_edit_fade_out_mute_end_from_micros(
         ((new_end - fade_out_start) / new_width).clamp(0.0, 1.0)
     };
     let old_outer_end = range.end() + (width * fade_out.mute);
-    let new_mute = if new_width <= f32::EPSILON {
+    let new_mute = if fade_out.mute <= 0.0 || new_width <= f32::EPSILON {
         0.0
     } else {
         ((old_outer_end - new_end) / new_width).max(0.0)
@@ -218,16 +218,10 @@ fn rebuild_edit_range(
 ) -> SelectionRange {
     let mut next = SelectionRange::new(start, end).with_gain(range.gain());
     if let Some(fade) = fade_in {
-        next = next.with_fade_in(fade.length, fade.curve);
-        if fade.mute > 0.0 {
-            next = next.with_fade_in_mute(fade.mute);
-        }
+        next = next.with_fade_in_and_mute(fade.length, fade.curve, fade.mute);
     }
     if let Some(fade) = fade_out {
-        next = next.with_fade_out(fade.length, fade.curve);
-        if fade.mute > 0.0 {
-            next = next.with_fade_out_mute(fade.mute);
-        }
+        next = next.with_fade_out_and_mute(fade.length, fade.curve, fade.mute);
     }
     next
 }

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -879,25 +879,23 @@ fn resize_fade_in_start(
         } else {
             (fade_out_abs / resized.width()).clamp(0.0, 1.0)
         };
-        let mute = if resized.width() <= f32::EPSILON {
+        let mute = if fade_out.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
             (old_width * fade_out.mute / resized.width()).max(0.0)
         };
-        resized = resized
-            .with_fade_out(length, fade_out.curve)
-            .with_fade_out_mute(mute);
+        resized = resized.with_fade_out_and_mute(length, fade_out.curve, mute);
     }
     let length = fade_in_length_for_end(resized, fade_end);
     let mut resized = resized.with_fade_in(length, curve);
     if let Some(fade_in) = selection.fade_in() {
         let old_outer_start = selection.start() - old_width * fade_in.mute;
-        let mute = if resized.width() <= f32::EPSILON {
+        let mute = if fade_in.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
             ((resized.start() - old_outer_start) / resized.width()).max(0.0)
         };
-        resized = resized.with_fade_in_mute(mute);
+        resized = resized.with_fade_in_and_mute(length, curve, mute);
     }
     resized
 }
@@ -918,25 +916,23 @@ fn resize_fade_out_end(
         } else {
             (fade_in_abs / resized.width()).clamp(0.0, 1.0)
         };
-        let mute = if resized.width() <= f32::EPSILON {
+        let mute = if fade_in.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
             (old_width * fade_in.mute / resized.width()).max(0.0)
         };
-        resized = resized
-            .with_fade_in(length, fade_in.curve)
-            .with_fade_in_mute(mute);
+        resized = resized.with_fade_in_and_mute(length, fade_in.curve, mute);
     }
     let length = fade_out_length_for_start(resized, fade_start);
     let mut resized = resized.with_fade_out(length, curve);
     if let Some(fade_out) = selection.fade_out() {
         let old_outer_end = selection.end() + old_width * fade_out.mute;
-        let mute = if resized.width() <= f32::EPSILON {
+        let mute = if fade_out.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
             ((old_outer_end - resized.end()) / resized.width()).max(0.0)
         };
-        resized = resized.with_fade_out_mute(mute);
+        resized = resized.with_fade_out_and_mute(length, curve, mute);
     }
     resized
 }
@@ -2796,6 +2792,59 @@ mod tests {
         assert!((fade_out_outer_end - 0.7).abs() < 0.001);
         assert!((fade_in.curve - 0.2).abs() < 0.001);
         assert!((fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_out_bottom_handle_preserves_crossfade_when_fade_collapses() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_out(0.25, 0.7)
+                .with_fade_out_mute(1.0),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.5 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_out = selection
+            .fade_out()
+            .expect("fade-out silence handle should remain");
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        let fade_out_outer_end = selection.end() + selection.width() * fade_out.mute;
+
+        assert!((selection.start() - 0.2).abs() < 0.001);
+        assert!((selection.end() - 0.5).abs() < 0.001);
+        assert!((fade_out_start - 0.5).abs() < 0.001);
+        assert!((fade_out_outer_end - 1.0).abs() < 0.001);
+        assert!(fade_out.length.abs() < 0.001);
+        assert!((fade_out.curve - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn edit_fade_out_bottom_handle_keeps_left_crossfade_pinned_to_sample_edge() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_in_mute(0.5)
+                .with_fade_out(0.25, 0.7),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.7 });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_in = selection.fade_in().expect("fade-in should remain");
+        let fade_in_outer_start = selection.start() - selection.width() * fade_in.mute;
+
+        assert!(fade_in_outer_start.abs() < 0.000_001);
     }
 
     #[test]

--- a/src/selection/range.rs
+++ b/src/selection/range.rs
@@ -280,6 +280,22 @@ impl SelectionRange {
         self
     }
 
+    /// Set fade-in parameters and muted length together.
+    pub fn with_fade_in_and_mute(mut self, length: f32, curve: f32, mute: f32) -> Self {
+        let clamped_length = clamp_fade_length(length, self.fade_out_length());
+        let clamped_mute = clamp_mute_length(mute, self.max_fade_in_mute_length());
+        if clamped_length > 0.0 || clamped_mute > 0.0 {
+            self.fade_in = Some(FadeParams::with_curve_and_mute(
+                clamped_length,
+                curve,
+                clamped_mute,
+            ));
+        } else {
+            self.fade_in = None;
+        }
+        self
+    }
+
     /// Set fade-out parameters.
     ///
     /// Keeps a zero-length fade when a mute region is configured so mute handles persist.
@@ -287,6 +303,22 @@ impl SelectionRange {
         let clamped_length = clamp_fade_length(length, self.fade_in_length());
         let current_mute = self.fade_out.map(|f| f.mute).unwrap_or(0.0);
         let clamped_mute = clamp_mute_length(current_mute, self.max_fade_out_mute_length());
+        if clamped_length > 0.0 || clamped_mute > 0.0 {
+            self.fade_out = Some(FadeParams::with_curve_and_mute(
+                clamped_length,
+                curve,
+                clamped_mute,
+            ));
+        } else {
+            self.fade_out = None;
+        }
+        self
+    }
+
+    /// Set fade-out parameters and muted length together.
+    pub fn with_fade_out_and_mute(mut self, length: f32, curve: f32, mute: f32) -> Self {
+        let clamped_length = clamp_fade_length(length, self.fade_in_length());
+        let clamped_mute = clamp_mute_length(mute, self.max_fade_out_mute_length());
         if clamped_length > 0.0 || clamped_mute > 0.0 {
             self.fade_out = Some(FadeParams::with_curve_and_mute(
                 clamped_length,


### PR DESCRIPTION
Fixes two edit-fade stability issues:\n\n- Existing silence/crossfade handles now remain pinned when a bottom fade handle collapses into its upper fade handle.\n- A silence handle pinned to the sample edge stays exactly pinned while the opposite bottom handle is adjusted, avoiding the faint one-pixel waveform reveal.\n\nImplementation notes:\n- Adds atomic fade length+mute setters so zero-length fades can still retain an existing silence handle.\n- Preserves mute handles only when they existed before, so ordinary zero-length fades still collapse normally.\n- Covers both controller actions and retained waveform widget state.\n\nValidation:\n- cargo test -p wavecrate crossfade --lib\n- cargo test -p wavecrate gui_app::waveform::tests\n- cargo test -p wavecrate edit_fade --lib\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent