### PR TITLE
Keep fade silence handles stable from top handles

### DIFF
--- a/src/app/controller/playback/waveform_action_tests.rs
+++ b/src/app/controller/playback/waveform_action_tests.rs
@@ -198,6 +198,37 @@ fn set_waveform_edit_fade_in_end_milli_pushes_and_restores_fade_out() {
     assert!((fade_out.curve - 0.7).abs() < 0.001);
 }
 
+/// Moving the fade-out top handle after a bottom-handle collapse should keep its silence handle.
+#[test]
+fn set_waveform_edit_fade_out_start_milli_preserves_silence_after_bottom_handle_collapse() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_out(0.25, 0.7)
+        .with_fade_out_mute(1.0);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    controller.set_waveform_edit_fade_out_mute_end_milli(500);
+    controller.set_waveform_edit_fade_out_start_milli(450);
+
+    let updated = controller
+        .ui
+        .waveform
+        .edit_selection
+        .expect("updated edit selection");
+    let fade_out = updated
+        .fade_out()
+        .expect("fade-out silence handle should remain");
+    let fade_out_start = updated.end() - (updated.width() * fade_out.length);
+    let fade_out_outer_end = updated.end() + (updated.width() * fade_out.mute);
+    assert!((updated.end() - 0.5).abs() < 0.001);
+    assert!((fade_out_start - 0.45).abs() < 0.001);
+    assert!(
+        (fade_out_outer_end - 1.0).abs() < 0.000_001,
+        "fade_out_outer_end={fade_out_outer_end}, fade_out={fade_out:?}, updated={updated:?}"
+    );
+}
+
 /// Edit fade-in bottom-handle updates should resize the selection and keep fade end fixed.
 #[test]
 fn set_waveform_edit_fade_in_mute_start_milli_resizes_selection_start() {
@@ -325,7 +356,9 @@ fn set_waveform_edit_fade_out_mute_end_milli_preserves_crossfade_when_fade_colla
         .waveform
         .edit_selection
         .expect("updated edit selection");
-    let fade_out = updated.fade_out().expect("fade-out silence handle should remain");
+    let fade_out = updated
+        .fade_out()
+        .expect("fade-out silence handle should remain");
     let fade_out_start = updated.end() - (updated.width() * fade_out.length);
     let fade_out_outer_end = updated.end() + (updated.width() * fade_out.mute);
     assert!((updated.start() - 0.2).abs() < 0.001);
@@ -417,6 +450,33 @@ fn set_waveform_edit_fade_out_mute_end_milli_keeps_left_crossfade_pinned_to_samp
     let fade_in = updated.fade_in().expect("fade-in should remain");
     let fade_in_outer_start = updated.start() - (updated.width() * fade_in.mute);
     assert!(fade_in_outer_start.abs() < 0.000_001);
+}
+
+/// Repeated opposite-edge updates should keep a sample-edge silence handle exactly pinned.
+#[test]
+fn set_waveform_edit_fade_out_mute_end_milli_keeps_left_crossfade_pinned_across_wiggles() {
+    let (mut controller, _source) = test_support::dummy_controller();
+    let range = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.3)
+        .with_fade_in_mute(0.5)
+        .with_fade_out(0.25, 0.7);
+    controller.selection_state.edit_range.set_range(Some(range));
+    controller.ui.waveform.edit_selection = Some(range);
+
+    for position in [700, 690, 710, 705, 700] {
+        controller.set_waveform_edit_fade_out_mute_end_milli(position);
+        let updated = controller
+            .ui
+            .waveform
+            .edit_selection
+            .expect("updated edit selection");
+        let fade_in = updated.fade_in().expect("fade-in should remain");
+        let fade_in_outer_start = updated.start() - (updated.width() * fade_in.mute);
+        assert!(
+            fade_in_outer_start.abs() < 0.000_001,
+            "left silence handle drifted to {fade_in_outer_start}"
+        );
+    }
 }
 
 /// Collapsed fade-out drags should recover the original fade while the same drag stays active.

--- a/src/app/controller/playback/waveform_actions/edit_fades.rs
+++ b/src/app/controller/playback/waveform_actions/edit_fades.rs
@@ -31,14 +31,16 @@ pub(super) fn update_edit_fade_in_end_from_micros(
     } else {
         baseline_fade_out_abs
     };
+    let fade_in = range.fade_in().map(|fade| {
+        crate::selection::FadeParams::with_curve_and_mute(fade_in_abs / width, curve, fade.mute)
+    });
     rebuild_edit_range(
         range,
         start,
         end,
-        Some(crate::selection::FadeParams::with_curve(
-            fade_in_abs / width,
-            curve,
-        )),
+        Some(fade_in.unwrap_or_else(|| {
+            crate::selection::FadeParams::with_curve(fade_in_abs / width, curve)
+        })),
         range.fade_out().map(|fade| {
             crate::selection::FadeParams::with_curve_and_mute(
                 fade_out_abs / width,
@@ -81,7 +83,7 @@ pub(super) fn update_edit_fade_in_mute_start_from_micros(
     let new_mute = if fade_in.mute <= 0.0 || new_width <= f32::EPSILON {
         0.0
     } else {
-        ((new_start - old_outer_start) / new_width).max(0.0)
+        fade_in_mute_for_outer_start(new_start, new_width, old_outer_start)
     };
     let next_fade_in =
         crate::selection::FadeParams::with_curve_and_mute(new_length, fade_in.curve, new_mute);
@@ -134,10 +136,20 @@ pub(super) fn update_edit_fade_out_start_from_micros(
                 fade.mute,
             )
         }),
-        Some(crate::selection::FadeParams::with_curve(
-            fade_out_abs / width,
-            curve,
-        )),
+        Some(
+            range
+                .fade_out()
+                .map(|fade| {
+                    crate::selection::FadeParams::with_curve_and_mute(
+                        fade_out_abs / width,
+                        curve,
+                        fade.mute,
+                    )
+                })
+                .unwrap_or_else(|| {
+                    crate::selection::FadeParams::with_curve(fade_out_abs / width, curve)
+                }),
+        ),
     )
 }
 
@@ -173,7 +185,7 @@ pub(super) fn update_edit_fade_out_mute_end_from_micros(
     let new_mute = if fade_out.mute <= 0.0 || new_width <= f32::EPSILON {
         0.0
     } else {
-        ((old_outer_end - new_end) / new_width).max(0.0)
+        fade_out_mute_for_outer_end(new_end, new_width, old_outer_end)
     };
     let next_fade_out =
         crate::selection::FadeParams::with_curve_and_mute(new_length, fade_out.curve, new_mute);
@@ -235,10 +247,11 @@ fn fade_in_preserved_at_width(
         return Some(crate::selection::FadeParams::with_curve(0.0, fade.curve));
     }
     let length = ((range.width() * fade.length) / next_width).clamp(0.0, 1.0);
+    let outer_start = range.start() - range.width() * fade.mute;
     Some(crate::selection::FadeParams::with_curve_and_mute(
         length,
         fade.curve,
-        ((range.width() * fade.mute) / next_width).max(0.0),
+        fade_in_mute_for_outer_start(range.start(), next_width, outer_start),
     ))
 }
 
@@ -251,9 +264,37 @@ fn fade_out_preserved_at_width(
         return Some(crate::selection::FadeParams::with_curve(0.0, fade.curve));
     }
     let length = ((range.width() * fade.length) / next_width).clamp(0.0, 1.0);
+    let outer_end = range.end() + range.width() * fade.mute;
     Some(crate::selection::FadeParams::with_curve_and_mute(
         length,
         fade.curve,
-        ((range.width() * fade.mute) / next_width).max(0.0),
+        fade_out_mute_for_outer_end(range.end(), next_width, outer_end),
     ))
+}
+
+fn fade_in_mute_for_outer_start(start: f32, width: f32, outer_start: f32) -> f32 {
+    if width <= f32::EPSILON {
+        return 0.0;
+    }
+    let outer_start = snap_to_sample_edge(outer_start).clamp(0.0, start);
+    ((start - outer_start) / width).max(0.0)
+}
+
+fn fade_out_mute_for_outer_end(end: f32, width: f32, outer_end: f32) -> f32 {
+    if width <= f32::EPSILON {
+        return 0.0;
+    }
+    let outer_end = snap_to_sample_edge(outer_end).clamp(end, 1.0);
+    ((outer_end - end) / width).max(0.0)
+}
+
+fn snap_to_sample_edge(position: f32) -> f32 {
+    const EDGE_EPSILON: f32 = 1.0e-6;
+    if position <= EDGE_EPSILON {
+        0.0
+    } else if position >= 1.0 - EDGE_EPSILON {
+        1.0
+    } else {
+        position
+    }
 }

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -390,7 +390,8 @@ impl WaveformState {
     }
 
     fn set_selection_for_drag(&mut self, drag: WaveformSelectionDrag) {
-        let range = wavecrate::selection::SelectionRange::new(drag.anchor_ratio, drag.current_ratio);
+        let range =
+            wavecrate::selection::SelectionRange::new(drag.anchor_ratio, drag.current_ratio);
         match drag.kind {
             WaveformSelectionKind::Play => {
                 self.play_mark_ratio = Some(drag.anchor_ratio);
@@ -634,7 +635,10 @@ struct WaveformEditFadeDrag {
 }
 
 impl WaveformEditFadeDrag {
-    fn new(handle: WaveformEditFadeHandle, selection: wavecrate::selection::SelectionRange) -> Self {
+    fn new(
+        handle: WaveformEditFadeHandle,
+        selection: wavecrate::selection::SelectionRange,
+    ) -> Self {
         let curve = match handle {
             WaveformEditFadeHandle::FadeInEnd
             | WaveformEditFadeHandle::FadeInStart
@@ -831,16 +835,12 @@ fn rebuild_edit_fades_for_same_range(
     let mut rebuilt = wavecrate::selection::SelectionRange::new(selection.start(), selection.end())
         .with_gain(selection.gain());
     if let Some((length, curve)) = fade_in {
-        rebuilt = rebuilt.with_fade_in(length.clamp(0.0, 1.0), curve);
-        if let Some(fade) = selection.fade_in().filter(|fade| fade.mute > 0.0) {
-            rebuilt = rebuilt.with_fade_in_mute(fade.mute);
-        }
+        let mute = selection.fade_in().map(|fade| fade.mute).unwrap_or(0.0);
+        rebuilt = rebuilt.with_fade_in_and_mute(length.clamp(0.0, 1.0), curve, mute);
     }
     if let Some((length, curve)) = fade_out {
-        rebuilt = rebuilt.with_fade_out(length.clamp(0.0, 1.0), curve);
-        if let Some(fade) = selection.fade_out().filter(|fade| fade.mute > 0.0) {
-            rebuilt = rebuilt.with_fade_out_mute(fade.mute);
-        }
+        let mute = selection.fade_out().map(|fade| fade.mute).unwrap_or(0.0);
+        rebuilt = rebuilt.with_fade_out_and_mute(length.clamp(0.0, 1.0), curve, mute);
     }
     rebuilt
 }
@@ -879,10 +879,11 @@ fn resize_fade_in_start(
         } else {
             (fade_out_abs / resized.width()).clamp(0.0, 1.0)
         };
+        let old_outer_end = selection.end() + old_width * fade_out.mute;
         let mute = if fade_out.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
-            (old_width * fade_out.mute / resized.width()).max(0.0)
+            fade_out_mute_for_outer_end(resized, old_outer_end)
         };
         resized = resized.with_fade_out_and_mute(length, fade_out.curve, mute);
     }
@@ -893,7 +894,7 @@ fn resize_fade_in_start(
         let mute = if fade_in.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
-            ((resized.start() - old_outer_start) / resized.width()).max(0.0)
+            fade_in_mute_for_outer_start(resized, old_outer_start)
         };
         resized = resized.with_fade_in_and_mute(length, curve, mute);
     }
@@ -916,10 +917,11 @@ fn resize_fade_out_end(
         } else {
             (fade_in_abs / resized.width()).clamp(0.0, 1.0)
         };
+        let old_outer_start = selection.start() - old_width * fade_in.mute;
         let mute = if fade_in.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
-            (old_width * fade_in.mute / resized.width()).max(0.0)
+            fade_in_mute_for_outer_start(resized, old_outer_start)
         };
         resized = resized.with_fade_in_and_mute(length, fade_in.curve, mute);
     }
@@ -930,11 +932,44 @@ fn resize_fade_out_end(
         let mute = if fade_out.mute <= 0.0 || resized.width() <= f32::EPSILON {
             0.0
         } else {
-            ((old_outer_end - resized.end()) / resized.width()).max(0.0)
+            fade_out_mute_for_outer_end(resized, old_outer_end)
         };
         resized = resized.with_fade_out_and_mute(length, curve, mute);
     }
     resized
+}
+
+fn fade_in_mute_for_outer_start(
+    selection: wavecrate::selection::SelectionRange,
+    outer_start: f32,
+) -> f32 {
+    if selection.width() <= f32::EPSILON {
+        return 0.0;
+    }
+    let outer_start = snap_to_sample_edge(outer_start).clamp(0.0, selection.start());
+    ((selection.start() - outer_start) / selection.width()).max(0.0)
+}
+
+fn fade_out_mute_for_outer_end(
+    selection: wavecrate::selection::SelectionRange,
+    outer_end: f32,
+) -> f32 {
+    if selection.width() <= f32::EPSILON {
+        return 0.0;
+    }
+    let outer_end = snap_to_sample_edge(outer_end).clamp(selection.end(), 1.0);
+    ((outer_end - selection.end()) / selection.width()).max(0.0)
+}
+
+fn snap_to_sample_edge(position: f32) -> f32 {
+    const EDGE_EPSILON: f32 = 1.0e-6;
+    if position <= EDGE_EPSILON {
+        0.0
+    } else if position >= 1.0 - EDGE_EPSILON {
+        1.0
+    } else {
+        position
+    }
 }
 
 fn edit_preview_for_selection(
@@ -2825,6 +2860,40 @@ mod tests {
     }
 
     #[test]
+    fn edit_fade_out_top_handle_preserves_silence_after_bottom_handle_collapse() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_out(0.25, 0.7)
+                .with_fade_out_mute(1.0),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.5 });
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutStart,
+            visible_ratio: 0.5,
+        });
+        state.apply_interaction(WaveformInteraction::FinishSelection {
+            visible_ratio: 0.45,
+        });
+
+        let selection = state.edit_selection().expect("edit selection");
+        let fade_out = selection
+            .fade_out()
+            .expect("fade-out silence handle should remain");
+        let fade_out_start = selection.end() - selection.width() * fade_out.length;
+        let fade_out_outer_end = selection.end() + selection.width() * fade_out.mute;
+
+        assert!((selection.end() - 0.5).abs() < 0.001);
+        assert!((fade_out_start - 0.45).abs() < 0.001);
+        assert!((fade_out_outer_end - 1.0).abs() < 0.000_001);
+    }
+
+    #[test]
     fn edit_fade_out_bottom_handle_keeps_left_crossfade_pinned_to_sample_edge() {
         let mut state = WaveformState::synthetic_for_tests();
         state.edit_selection = Some(
@@ -2845,6 +2914,33 @@ mod tests {
         let fade_in_outer_start = selection.start() - selection.width() * fade_in.mute;
 
         assert!(fade_in_outer_start.abs() < 0.000_001);
+    }
+
+    #[test]
+    fn edit_fade_out_bottom_handle_keeps_left_crossfade_pinned_across_wiggles() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.edit_selection = Some(
+            wavecrate::selection::SelectionRange::new(0.2, 0.6)
+                .with_fade_in(0.25, 0.2)
+                .with_fade_in_mute(0.5)
+                .with_fade_out(0.25, 0.7),
+        );
+
+        state.apply_interaction(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::FadeOutEnd,
+            visible_ratio: 0.6,
+        });
+        for visible_ratio in [0.7, 0.69, 0.71, 0.705, 0.7] {
+            state.apply_interaction(WaveformInteraction::UpdateSelection { visible_ratio });
+            let selection = state.edit_selection().expect("edit selection");
+            let fade_in = selection.fade_in().expect("fade-in should remain");
+            let fade_in_outer_start = selection.start() - selection.width() * fade_in.mute;
+            assert!(
+                fade_in_outer_start.abs() < 0.000_001,
+                "left silence handle drifted to {fade_in_outer_start}"
+            );
+        }
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.7 });
     }
 
     #[test]


### PR DESCRIPTION
Fixes two remaining fade-handle stability cases:\n\n- moving an upper/inner fade handle after a bottom-handle collapse now keeps an existing outer silence handle pinned instead of dropping it;\n- silence handles pinned to the sample edge are snapped to the exact edge while the opposite bottom handle is adjusted, avoiding tiny precision drift that can expose a one-pixel waveform line.\n\nValidation:\n- cargo test -p wavecrate edit_fade --lib\n- cargo test -p wavecrate gui_app::waveform::tests\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke\n- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent