### PR TITLE
Fix delete confirmation and folder rename F2

### DIFF
--- a/src/app/controller/library/source_folders/actions/rename_move_delete/mod.rs
+++ b/src/app/controller/library/source_folders/actions/rename_move_delete/mod.rs
@@ -5,6 +5,7 @@ use super::ops;
 use super::*;
 use crate::app::controller::jobs::{FileOpResult, FolderDeleteResult, FolderRenameResult};
 use crate::app::controller::undo::{UndoEntry, UndoExecution};
+use crate::app::state::FolderActionPrompt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, atomic::AtomicBool};
 
@@ -15,12 +16,50 @@ mod rename_execution;
 use self::rename_execution::run_folder_rename_job;
 
 impl AppController {
+    /// Open a confirmation prompt for deleting the currently focused folder.
+    pub(crate) fn request_delete_focused_folder(&mut self) -> bool {
+        let Some(target) = self.focused_folder_path() else {
+            self.set_status("Focus a folder to delete it", StatusTone::Info);
+            return false;
+        };
+        self.ui.sources.folders.pending_action = Some(FolderActionPrompt::Delete { target });
+        true
+    }
+
+    /// Confirm the active folder delete prompt.
+    pub(crate) fn apply_pending_folder_delete(&mut self) -> bool {
+        let Some(FolderActionPrompt::Delete { target }) =
+            self.ui.sources.folders.pending_action.clone()
+        else {
+            return false;
+        };
+        self.ui.sources.folders.pending_action = None;
+        self.delete_folder_at_path(&target);
+        true
+    }
+
+    /// Cancel the active folder delete prompt.
+    pub(crate) fn cancel_pending_folder_delete(&mut self) -> bool {
+        if matches!(
+            self.ui.sources.folders.pending_action,
+            Some(FolderActionPrompt::Delete { .. })
+        ) {
+            self.ui.sources.folders.pending_action = None;
+            return true;
+        }
+        false
+    }
+
     /// Delete the currently focused folder after validating recovery and root-folder constraints.
     pub(crate) fn delete_focused_folder(&mut self) {
         let Some(target) = self.focused_folder_path() else {
             self.set_status("Focus a folder to delete it", StatusTone::Info);
             return;
         };
+        self.delete_folder_at_path(&target);
+    }
+
+    fn delete_folder_at_path(&mut self, target: &Path) {
         let Some(source) = self.current_source() else {
             self.set_status("Select a source first", StatusTone::Info);
             return;

--- a/src/app/controller/library/source_folders/delete_recovery/retained_restore.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/retained_restore.rs
@@ -63,6 +63,7 @@ impl AppController {
             return false;
         };
         let started = match action {
+            FolderActionPrompt::Delete { .. } => return false,
             FolderActionPrompt::RestoreRetainedDeletes { .. } => {
                 self.begin_retained_delete_resolution(RetainedDeleteResolutionMode::Restore)
             }

--- a/src/app/controller/library/wavs/browser_actions/row_actions.rs
+++ b/src/app/controller/library/wavs/browser_actions/row_actions.rs
@@ -104,6 +104,7 @@ impl AppController {
                 target_folder,
                 &name,
             ),
+            Some(SampleBrowserActionPrompt::Delete { .. }) => {}
             None => {}
         }
     }
@@ -149,13 +150,64 @@ impl AppController {
                 }
                 false
             }
+            Some(SampleBrowserActionPrompt::Delete { .. }) => false,
             None => false,
         }
     }
 
     /// Report whether a browser prompt is currently active.
     pub(crate) fn has_pending_browser_rename(&self) -> bool {
-        self.ui.browser.pending_action.is_some()
+        matches!(
+            self.ui.browser.pending_action,
+            Some(
+                SampleBrowserActionPrompt::Rename { .. }
+                    | SampleBrowserActionPrompt::MoveToFolderConflict { .. }
+            )
+        )
+    }
+
+    /// Open a confirmation prompt for deleting the focused browser row or active multi-selection.
+    pub(crate) fn request_delete_active_browser_selection(&mut self) -> bool {
+        let primary_row = self.focused_browser_row();
+        let target_paths = primary_row
+            .map(|row| self.browser_action_paths_from_primary(row))
+            .unwrap_or_else(|| self.browser_selected_paths_snapshot());
+        if target_paths.is_empty() {
+            return false;
+        }
+        self.ui.browser.pending_action = Some(SampleBrowserActionPrompt::Delete {
+            targets: target_paths,
+        });
+        true
+    }
+
+    /// Confirm the active browser delete prompt.
+    pub(crate) fn apply_pending_browser_delete(&mut self) -> bool {
+        let Some(SampleBrowserActionPrompt::Delete { targets }) =
+            self.ui.browser.pending_action.clone()
+        else {
+            return false;
+        };
+        self.ui.browser.pending_action = None;
+        self.set_browser_selected_paths(targets.clone());
+        if let Err(err) = self.delete_browser_sample_paths(&targets, None)
+            && self.ui.status.text != err
+        {
+            self.set_status(err, StatusTone::Error);
+        }
+        true
+    }
+
+    /// Cancel the active browser delete prompt.
+    pub(crate) fn cancel_pending_browser_delete(&mut self) -> bool {
+        if matches!(
+            self.ui.browser.pending_action,
+            Some(SampleBrowserActionPrompt::Delete { .. })
+        ) {
+            self.ui.browser.pending_action = None;
+            return true;
+        }
+        false
     }
 
     /// Delete the focused browser row or active multi-selection, if any.
@@ -177,7 +229,9 @@ impl AppController {
 
     /// Delete current browser selection from UI actions, ignoring no-op outcomes.
     pub fn delete_active_browser_selection_action(&mut self) {
-        let _ = self.delete_active_browser_selection();
+        if !self.request_delete_active_browser_selection() {
+            self.set_status("Focus a sample to delete it", StatusTone::Info);
+        }
     }
 
     /// Run deterministic auto rename across the current browser selection snapshot.

--- a/src/app/controller/playback/transport/playback.rs
+++ b/src/app/controller/playback/transport/playback.rs
@@ -91,6 +91,9 @@ pub(crate) fn stop_playback_if_active(controller: &mut AppController) -> bool {
 }
 
 pub(crate) fn handle_escape(controller: &mut AppController) {
+    if controller.cancel_active_prompt() {
+        return;
+    }
     if controller.clear_browser_duplicate_cleanup() {
         controller.set_status("Duplicate cleanup canceled", StatusTone::Info);
         return;

--- a/src/app/controller/tests/browser_actions/row_actions/delete_similarity.rs
+++ b/src/app/controller/tests/browser_actions/row_actions/delete_similarity.rs
@@ -212,7 +212,7 @@ fn confirming_duplicate_cleanup_moves_only_unkept_duplicates_to_trash() {
 }
 
 #[test]
-fn delete_hotkey_applies_to_all_selected_rows() {
+fn delete_hotkey_prompts_then_applies_to_all_selected_rows() {
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", Rating::NEUTRAL),
         sample_entry("two.wav", Rating::NEUTRAL),
@@ -231,10 +231,42 @@ fn delete_hotkey_applies_to_all_selected_rows() {
 
     controller.handle_hotkey(action, FocusContext::SampleBrowser);
 
+    assert!(matches!(
+        controller.ui.browser.pending_action,
+        Some(crate::app::state::SampleBrowserActionPrompt::Delete { .. })
+    ));
+    assert_eq!(controller.wav_entries_len(), 3);
+    assert!(source.root.join("one.wav").exists());
+
+    controller.confirm_active_prompt_action();
+
     assert_eq!(controller.wav_entries_len(), 0);
     assert!(!source.root.join("one.wav").exists());
     assert!(!source.root.join("two.wav").exists());
     assert!(!source.root.join("three.wav").exists());
+}
+
+#[test]
+fn canceling_delete_hotkey_keeps_selected_rows() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
+        sample_entry("one.wav", Rating::NEUTRAL),
+        sample_entry("two.wav", Rating::NEUTRAL),
+    ]);
+    write_test_wav(&source.root.join("one.wav"), &[0.0, 0.1]);
+    write_test_wav(&source.root.join("two.wav"), &[0.0, 0.1]);
+    controller.focus_browser_row_only(0);
+    controller.toggle_browser_row_selection(1);
+    let action = hotkeys::iter_actions()
+        .find(|action| action.id == "delete-browser")
+        .expect("delete-browser hotkey");
+
+    controller.handle_hotkey(action, FocusContext::SampleBrowser);
+    controller.cancel_active_prompt_action();
+
+    assert!(controller.ui.browser.pending_action.is_none());
+    assert_eq!(controller.wav_entries_len(), 2);
+    assert!(source.root.join("one.wav").exists());
+    assert!(source.root.join("two.wav").exists());
 }
 
 #[test]
@@ -252,6 +284,7 @@ fn delete_hotkey_keeps_focus_when_file_delete_fails() {
         .expect("delete-browser hotkey");
 
     controller.handle_hotkey(action, FocusContext::SampleBrowser);
+    controller.confirm_active_prompt_action();
 
     assert_eq!(
         controller.focused_browser_path().as_deref(),
@@ -287,6 +320,13 @@ fn delete_hotkey_waits_for_loading_sample() {
         .expect("delete-browser hotkey");
 
     controller.handle_hotkey(action, FocusContext::SampleBrowser);
+
+    assert!(source.root.join("one.wav").exists());
+    assert!(matches!(
+        controller.ui.browser.pending_action,
+        Some(crate::app::state::SampleBrowserActionPrompt::Delete { .. })
+    ));
+    controller.confirm_active_prompt_action();
 
     assert!(source.root.join("one.wav").exists());
     assert_eq!(

--- a/src/app/controller/tests/folders_core/rename_delete_recovery/delete.rs
+++ b/src/app/controller/tests/folders_core/rename_delete_recovery/delete.rs
@@ -45,6 +45,49 @@ fn deleting_folder_removes_wavs() -> Result<(), String> {
 }
 
 #[test]
+fn folder_delete_prompt_can_be_canceled_or_confirmed() -> Result<(), String> {
+    let (mut controller, source) = dummy_controller();
+    controller.library.sources.push(source.clone());
+    controller.selection_state.ctx.selected_source = Some(source.id.clone());
+    let target = source.root.join("gone");
+    std::fs::create_dir_all(&target).unwrap();
+    write_test_wav(&target.join("sample.wav"), &[0.0, 0.2]);
+    controller.set_wav_entries_for_tests(vec![sample_entry(
+        "gone/sample.wav",
+        crate::sample_sources::Rating::NEUTRAL,
+    )]);
+    controller.rebuild_wav_lookup();
+    controller.rebuild_browser_lists();
+    controller.refresh_folder_browser_for_tests();
+    if let Some(index) = controller
+        .ui
+        .sources
+        .folders
+        .rows
+        .iter()
+        .position(|row| row.path == PathBuf::from("gone"))
+    {
+        controller.focus_folder_row(index);
+    }
+
+    assert!(controller.request_delete_focused_folder());
+    assert!(matches!(
+        controller.ui.sources.folders.pending_action,
+        Some(crate::app::state::FolderActionPrompt::Delete { .. })
+    ));
+    controller.cancel_active_prompt_action();
+    assert!(target.exists());
+    assert_eq!(controller.wav_entries_len(), 1);
+
+    assert!(controller.request_delete_focused_folder());
+    controller.confirm_active_prompt_action();
+
+    assert!(!target.exists());
+    assert_eq!(controller.wav_entries_len(), 0);
+    Ok(())
+}
+
+#[test]
 fn deleting_folder_supports_undo_and_redo() -> Result<(), String> {
     let (mut controller, source) = dummy_controller();
     controller.library.sources.push(source.clone());

--- a/src/app/controller/ui/hotkeys/actions.rs
+++ b/src/app/controller/ui/hotkeys/actions.rs
@@ -58,6 +58,7 @@ pub(crate) const HOTKEY_ACTIONS: &[HotkeyAction] = &[
     folders::EXPAND_FOCUSED_FOLDER,
     folders::DELETE_FOLDER,
     folders::RENAME_FOLDER,
+    folders::RENAME_FOLDER_LEGACY,
     folders::CREATE_FOLDER,
     folders::FOCUS_SEARCH,
     sources::MOVE_SOURCE_FOCUS_UP,

--- a/src/app/controller/ui/hotkeys/actions/folders.rs
+++ b/src/app/controller/ui/hotkeys/actions/folders.rs
@@ -50,6 +50,13 @@ pub(super) const DELETE_FOLDER: HotkeyAction = HotkeyAction {
 pub(super) const RENAME_FOLDER: HotkeyAction = HotkeyAction {
     id: "rename-folder",
     label: "Rename folder",
+    gesture: HotkeyGesture::new(Key::F2),
+    scope: SOURCE_FOLDERS,
+    action: NativeUiAction::StartFolderRename,
+};
+pub(super) const RENAME_FOLDER_LEGACY: HotkeyAction = HotkeyAction {
+    id: "rename-folder-r",
+    label: "Rename folder",
     gesture: HotkeyGesture::new(Key::R),
     scope: SOURCE_FOLDERS,
     action: NativeUiAction::StartFolderRename,

--- a/src/app/controller/ui/hotkeys_controller/browser.rs
+++ b/src/app/controller/ui/hotkeys_controller/browser.rs
@@ -67,7 +67,7 @@ impl HotkeysController<'_> {
     }
 
     fn delete_focused_browser_sample(&mut self) {
-        if !self.delete_active_browser_selection() {
+        if !self.request_delete_active_browser_selection() {
             self.set_status("Focus a sample to delete it", StatusTone::Info);
         }
     }

--- a/src/app/controller/ui/prompt_flow.rs
+++ b/src/app/controller/ui/prompt_flow.rs
@@ -23,12 +23,18 @@ impl AppController {
         if self.apply_pending_destructive_prompt() {
             return true;
         }
+        if self.apply_pending_browser_delete() {
+            return true;
+        }
         if self.has_pending_browser_rename() {
             self.apply_pending_browser_rename();
             return true;
         }
         if self.has_pending_options_panel_prompt() {
             self.apply_pending_options_panel_prompt();
+            return true;
+        }
+        if self.apply_pending_folder_delete() {
             return true;
         }
         if self.apply_pending_folder_delete_recovery_prompt() {
@@ -42,12 +48,18 @@ impl AppController {
             self.clear_destructive_prompt();
             return true;
         }
+        if self.cancel_pending_browser_delete() {
+            return true;
+        }
         if self.has_pending_browser_rename() {
             self.cancel_browser_rename();
             return true;
         }
         if self.has_pending_options_panel_prompt() {
             self.cancel_options_panel_prompt();
+            return true;
+        }
+        if self.cancel_pending_folder_delete() {
             return true;
         }
         if matches!(

--- a/src/app/state/browser.rs
+++ b/src/app/state/browser.rs
@@ -78,6 +78,11 @@ impl Default for SampleBrowserState {
 /// Pending inline action for the sample browser.
 #[derive(Clone, Debug)]
 pub enum SampleBrowserActionPrompt {
+    /// Confirm deleting the selected browser entries.
+    Delete {
+        /// Paths selected for deletion when the prompt was opened.
+        targets: Vec<PathBuf>,
+    },
     /// Rename the selected entry.
     Rename {
         /// Path to rename.

--- a/src/app/state/sources.rs
+++ b/src/app/state/sources.rs
@@ -280,6 +280,11 @@ pub struct FolderRowView {
 /// Pending inline action for the folder browser.
 #[derive(Clone, Debug)]
 pub enum FolderActionPrompt {
+    /// Confirm deleting one folder.
+    Delete {
+        /// Folder path selected for deletion when the prompt was opened.
+        target: PathBuf,
+    },
     /// Confirm restoring all retained folder deletes currently tracked in Recovery.
     RestoreRetainedDeletes {
         /// Number of retained folder deletes that will be restored.

--- a/src/app_core/controller/browser_actions/folders.rs
+++ b/src/app_core/controller/browser_actions/folders.rs
@@ -51,7 +51,9 @@ pub(super) fn apply_folder_native_ui_action(
         }
         NativeUiAction::FocusFolderCreateInput => controller.focus_inline_folder_edit_input(),
         NativeUiAction::StartFolderRename => controller.start_folder_rename(),
-        NativeUiAction::DeleteFocusedFolder => controller.delete_focused_folder(),
+        NativeUiAction::DeleteFocusedFolder => {
+            controller.request_delete_focused_folder();
+        }
         NativeUiAction::RestoreRetainedFolderDeletes => {
             controller.start_restore_retained_folder_deletes()
         }

--- a/src/app_core/native_shell/confirm_prompt_projection.rs
+++ b/src/app_core/native_shell/confirm_prompt_projection.rs
@@ -11,6 +11,20 @@ pub(crate) fn project_confirm_prompt_model(ui: &UiState) -> ConfirmPromptModel {
     if let Some(prompt) = ui.options_panel.pending_prompt.clone() {
         return project_options_panel_prompt(prompt);
     }
+    if let Some(FolderActionPrompt::Delete { target }) = ui.sources.folders.pending_action.clone() {
+        return ConfirmPromptModel {
+            visible: true,
+            kind: Some(ConfirmPromptKind::DestructiveEdit),
+            title: String::from("Delete folder"),
+            message: String::from("Delete this folder and its samples?"),
+            confirm_label: String::from("Delete"),
+            cancel_label: String::from("Cancel"),
+            target_label: Some(folder_delete_target_label(&target)),
+            input_value: None,
+            input_placeholder: None,
+            input_error: None,
+        };
+    }
     if let Some(FolderActionPrompt::RestoreRetainedDeletes { entry_count }) =
         ui.sources.folders.pending_action.clone()
     {
@@ -81,6 +95,29 @@ fn project_options_panel_prompt(prompt: OptionsPanelPrompt) -> ConfirmPromptMode
 
 fn project_browser_prompt(prompt: SampleBrowserActionPrompt) -> ConfirmPromptModel {
     match prompt {
+        SampleBrowserActionPrompt::Delete { targets } => {
+            let target_count = targets.len();
+            ConfirmPromptModel {
+                visible: true,
+                kind: Some(ConfirmPromptKind::DestructiveEdit),
+                title: if target_count == 1 {
+                    String::from("Delete sample")
+                } else {
+                    String::from("Delete samples")
+                },
+                message: if target_count == 1 {
+                    String::from("Delete this selected sample?")
+                } else {
+                    format!("Delete {target_count} selected samples?")
+                },
+                confirm_label: String::from("Delete"),
+                cancel_label: String::from("Cancel"),
+                target_label: browser_delete_target_label(&targets),
+                input_value: None,
+                input_placeholder: None,
+                input_error: None,
+            }
+        }
         SampleBrowserActionPrompt::Rename {
             target,
             name,
@@ -124,5 +161,21 @@ fn folder_drop_target_label(target_folder: &std::path::Path) -> String {
         String::from("Source root")
     } else {
         format!("Folder: {}", target_folder.display())
+    }
+}
+
+fn browser_delete_target_label(targets: &[std::path::PathBuf]) -> Option<String> {
+    match targets {
+        [] => None,
+        [target] => Some(target.display().to_string()),
+        _ => Some(format!("{} samples", targets.len())),
+    }
+}
+
+fn folder_delete_target_label(target: &std::path::Path) -> String {
+    if target.as_os_str().is_empty() {
+        String::from("Source root")
+    } else {
+        target.display().to_string()
     }
 }

--- a/src/app_core/native_shell/tests/overlays.rs
+++ b/src/app_core/native_shell/tests/overlays.rs
@@ -101,6 +101,45 @@ fn confirm_prompt_projects_folder_drop_conflict_prompt() {
     );
 }
 
+/// Browser delete prompts should project through the shared destructive prompt overlay.
+#[test]
+fn confirm_prompt_projects_browser_delete_prompt() {
+    let mut ui = UiState::default();
+    ui.browser.pending_action = Some(SampleBrowserActionPrompt::Delete {
+        targets: vec![
+            std::path::PathBuf::from("kick.wav"),
+            std::path::PathBuf::from("snare.wav"),
+        ],
+    });
+
+    let projected = project_confirm_prompt_model(&ui);
+
+    assert!(projected.visible);
+    assert_eq!(projected.kind, Some(ConfirmPromptKind::DestructiveEdit));
+    assert_eq!(projected.title, "Delete samples");
+    assert_eq!(projected.confirm_label, "Delete");
+    assert_eq!(projected.target_label.as_deref(), Some("2 samples"));
+    assert_eq!(projected.input_value, None);
+}
+
+/// Folder delete prompts should project through the shared destructive prompt overlay.
+#[test]
+fn confirm_prompt_projects_folder_delete_prompt() {
+    let mut ui = UiState::default();
+    ui.sources.folders.pending_action = Some(FolderActionPrompt::Delete {
+        target: std::path::PathBuf::from("Drums"),
+    });
+
+    let projected = project_confirm_prompt_model(&ui);
+
+    assert!(projected.visible);
+    assert_eq!(projected.kind, Some(ConfirmPromptKind::DestructiveEdit));
+    assert_eq!(projected.title, "Delete folder");
+    assert_eq!(projected.confirm_label, "Delete");
+    assert_eq!(projected.target_label.as_deref(), Some("Drums"));
+    assert_eq!(projected.input_value, None);
+}
+
 /// Options-panel identifier editing should project through the shared prompt overlay.
 #[test]
 fn confirm_prompt_projects_default_identifier_prompt() {

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -214,6 +214,19 @@ impl<B> WavecrateRuntimeBridge<B> {
     pub(super) fn retained_model_for_tests(&self) -> &runtime_contract::AppModel {
         self.model.as_ref()
     }
+
+    #[cfg(test)]
+    pub(super) fn text_target_value_after_action_for_tests(
+        &mut self,
+        action: &UiAction,
+    ) -> Option<String>
+    where
+        B: NativeAppBridge,
+    {
+        self.update_text_target_after_action(action);
+        (self.text_input_target != RetainedTextInputTarget::None)
+            .then(|| self.text_edit.value.clone())
+    }
 }
 
 impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
@@ -388,7 +401,7 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
                 }
                 self.edit_retained_text(|edit| edit.backspace())
             }
-            WidgetKey::Delete => self.edit_retained_text(|edit| edit.delete()),
+            WidgetKey::Delete => self.handle_retained_delete_key(),
             WidgetKey::ArrowLeft => self.edit_retained_text(|edit| {
                 edit.move_caret(edit.caret.saturating_sub(1), false);
                 false
@@ -456,6 +469,19 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
         if character.is_control() {
             return false;
         }
+        if self.model.confirm_prompt.visible && self.model.confirm_prompt.input_value.is_none() {
+            match character {
+                'y' | 'Y' => {
+                    self.emit_action(UiAction::ConfirmPrompt);
+                    return true;
+                }
+                'n' | 'N' => {
+                    self.emit_action(UiAction::CancelPrompt);
+                    return true;
+                }
+                _ => {}
+            }
+        }
         self.sync_text_edit_from_model();
         if self.text_input_target == RetainedTextInputTarget::BrowserPillEditor && character == ','
         {
@@ -479,6 +505,31 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
             edit.insert_char(character);
             true
         })
+    }
+
+    fn handle_retained_delete_key(&mut self) -> bool {
+        if self.model.confirm_prompt.visible {
+            if self.text_input_target == RetainedTextInputTarget::Prompt
+                && self.model.confirm_prompt.input_value.is_some()
+            {
+                return self.edit_retained_text(|edit| edit.delete());
+            }
+            return true;
+        }
+        if self.text_input_target != RetainedTextInputTarget::None {
+            return self.edit_retained_text(|edit| edit.delete());
+        }
+        match self.model.focus_context {
+            runtime_contract::FocusContextModel::ContentList => {
+                self.emit_action(UiAction::DeleteBrowserSelection);
+                true
+            }
+            runtime_contract::FocusContextModel::NavigationTree => {
+                self.emit_action(UiAction::DeleteFocusedFolder);
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Rewrite the active retained text target and emit the matching host action.
@@ -536,21 +587,24 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
             RetainedTextInputTarget::BrowserPillEditor => {
                 Some(self.model.browser.pill_editor.input_value.clone())
             }
-            RetainedTextInputTarget::FolderCreate => self
-                .model
-                .sources
-                .tree_rows
-                .iter()
-                .find(|row| {
-                    matches!(
-                        row.kind,
-                        runtime_contract::FolderRowKind::CreateDraft
-                            | runtime_contract::FolderRowKind::RenameDraft
-                    )
-                })
-                .map(|row| row.label.clone()),
+            RetainedTextInputTarget::FolderCreate => self.folder_inline_editor_value(),
             RetainedTextInputTarget::Prompt => self.model.confirm_prompt.input_value.clone(),
         }
+    }
+
+    fn folder_inline_editor_value(&self) -> Option<String> {
+        self.model
+            .sources
+            .tree_rows
+            .iter()
+            .find(|row| {
+                matches!(
+                    row.kind,
+                    runtime_contract::FolderRowKind::CreateDraft
+                        | runtime_contract::FolderRowKind::RenameDraft
+                )
+            })
+            .and_then(|row| row.input_value.clone())
     }
 
     /// Keep the local retained text target synchronized with host focus actions.
@@ -565,9 +619,12 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
             UiAction::FocusBrowserTagSidebarInput | UiAction::SetBrowserTagSidebarInput { .. } => {
                 RetainedTextInputTarget::BrowserPillEditor
             }
-            UiAction::FocusFolderCreateInput | UiAction::SetFolderCreateInput { .. } => {
-                RetainedTextInputTarget::FolderCreate
-            }
+            UiAction::StartNewFolder
+            | UiAction::StartNewFolderAtFolderRow { .. }
+            | UiAction::StartNewFolderAtRoot
+            | UiAction::StartFolderRename
+            | UiAction::FocusFolderCreateInput
+            | UiAction::SetFolderCreateInput { .. } => RetainedTextInputTarget::FolderCreate,
             UiAction::SetPromptInput { .. } => RetainedTextInputTarget::Prompt,
             UiAction::BlurBrowserSearch
             | UiAction::CommitBrowserTagSidebarInput
@@ -578,6 +635,11 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
             | UiAction::HandleEscape => RetainedTextInputTarget::None,
             _ => self.text_input_target,
         };
+        if self.text_input_target == RetainedTextInputTarget::FolderCreate
+            && self.folder_inline_editor_value().is_none()
+        {
+            self.text_input_target = RetainedTextInputTarget::None;
+        }
         self.sync_text_edit_from_model();
     }
 

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -134,13 +134,15 @@ mod tests {
         bridge.update(WavecrateRuntimeMessage::RetainedInput(
             WidgetInput::FocusChanged(true),
         ));
-        bridge.update(WavecrateRuntimeMessage::Action(UiAction::FocusBrowserSearch));
+        bridge.update(WavecrateRuntimeMessage::Action(
+            UiAction::FocusBrowserSearch,
+        ));
         bridge.inner.reduced.clear();
         assert!(
             bridge
-                .update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::Character(
-                    'k'
-                )))
+                .update(WavecrateRuntimeMessage::RetainedInput(
+                    WidgetInput::Character('k')
+                ))
                 .requests_repaint()
         );
         assert_eq!(
@@ -278,18 +280,18 @@ mod tests {
             "focused tag text entry should clear pending chords without consuming printable text"
         );
 
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::Character(
-            'k',
-        )));
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::Character(
-            'i',
-        )));
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::Character(
-            ',',
-        )));
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::Character(
-            'h',
-        )));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character('k'),
+        ));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character('i'),
+        ));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character(','),
+        ));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character('h'),
+        ));
 
         assert_eq!(
             bridge.inner.reduced,
@@ -321,17 +323,19 @@ mod tests {
             exit_status: None,
         });
 
-        bridge.update(WavecrateRuntimeMessage::Action(UiAction::FocusBrowserSearch));
+        bridge.update(WavecrateRuntimeMessage::Action(
+            UiAction::FocusBrowserSearch,
+        ));
         bridge.inner.reduced.clear();
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
-            TextEditCommand::InsertText(String::from("kick")),
-        )));
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
-            TextEditCommand::SelectAll,
-        )));
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::TextEdit(
-            TextEditCommand::InsertText(String::from("snare")),
-        )));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::TextEdit(TextEditCommand::InsertText(String::from("kick"))),
+        ));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::TextEdit(TextEditCommand::SelectAll),
+        ));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::TextEdit(TextEditCommand::InsertText(String::from("snare"))),
+        ));
 
         assert_eq!(
             bridge.inner.reduced.last(),
@@ -339,6 +343,131 @@ mod tests {
                 query: String::from("snare"),
             })
         );
+    }
+
+    #[test]
+    fn delete_key_routes_to_focused_browser_or_folder_when_no_text_target_is_active() {
+        let mut model = runtime_contract::AppModel {
+            focus_context: runtime_contract::FocusContextModel::ContentList,
+            ..runtime_contract::AppModel::default()
+        };
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.set_retained_model_for_tests(model.clone());
+
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::TextEdit(TextEditCommand::Delete),
+        ));
+        assert_eq!(
+            bridge.inner.reduced.last(),
+            Some(&UiAction::DeleteBrowserSelection)
+        );
+
+        model.focus_context = runtime_contract::FocusContextModel::NavigationTree;
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.set_retained_model_for_tests(model);
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::TextEdit(TextEditCommand::Delete),
+        ));
+
+        assert_eq!(
+            bridge.inner.reduced.last(),
+            Some(&UiAction::DeleteFocusedFolder)
+        );
+    }
+
+    #[test]
+    fn folder_tree_f2_resolves_to_folder_rename_action() {
+        let mut model = runtime_contract::AppModel {
+            focus_context: runtime_contract::FocusContextModel::NavigationTree,
+            ..runtime_contract::AppModel::default()
+        };
+        model.sources.focused_tree_row = Some(1);
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.set_retained_model_for_tests(model);
+
+        let shortcut = bridge.resolve_key_press(
+            None,
+            RadiantKeyPress {
+                key: RadiantKeyCode::F2,
+                command: false,
+                shift: false,
+                alt: false,
+            },
+            RadiantFocusSurface::None,
+        );
+
+        assert!(shortcut.handled);
+        assert_eq!(
+            shortcut.action,
+            Some(WavecrateRuntimeMessage::Action(UiAction::StartFolderRename))
+        );
+    }
+
+    #[test]
+    fn starting_folder_rename_syncs_retained_text_from_inline_input_value() {
+        let mut model = runtime_contract::AppModel::default();
+        model.sources.tree_rows.push(
+            runtime_contract::FolderRowModel::rename_draft(1, "drums", "Folder name", None, true)
+                .with_select_all_on_focus(true),
+        );
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        bridge.set_retained_model_for_tests(model);
+
+        assert_eq!(
+            bridge.text_target_value_after_action_for_tests(&UiAction::StartFolderRename),
+            Some(String::from("drums"))
+        );
+    }
+
+    #[test]
+    fn visible_prompt_accepts_yes_and_cancels_no_without_text_input() {
+        let mut model = runtime_contract::AppModel::default();
+        model.confirm_prompt.visible = true;
+        model.confirm_prompt.input_value = None;
+        let mut yes_bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        yes_bridge.set_retained_model_for_tests(model.clone());
+
+        yes_bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character('Y'),
+        ));
+        assert_eq!(yes_bridge.inner.reduced, vec![UiAction::ConfirmPrompt]);
+
+        let mut no_bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+        no_bridge.set_retained_model_for_tests(model);
+        no_bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::Character('n'),
+        ));
+        assert_eq!(no_bridge.inner.reduced, vec![UiAction::CancelPrompt]);
     }
 
     #[test]
@@ -374,9 +503,9 @@ mod tests {
             },
             RadiantFocusSurface::None,
         );
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::KeyPress(
-            WidgetKey::Backspace,
-        )));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::KeyPress(WidgetKey::Backspace),
+        ));
 
         assert_eq!(
             bridge.inner.reduced.last(),
@@ -392,9 +521,9 @@ mod tests {
             "Backspace with selected draft text should edit text before removing an accepted chip"
         );
 
-        bridge.update(WavecrateRuntimeMessage::RetainedInput(WidgetInput::KeyPress(
-            WidgetKey::Backspace,
-        )));
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::KeyPress(WidgetKey::Backspace),
+        ));
         assert!(bridge.inner.reduced.iter().any(|action| matches!(
             action,
             UiAction::ToggleBrowserSidebarNormalTag { label } if label == "Kick"


### PR DESCRIPTION
## Summary
- route Delete from focused browser/folder surfaces into confirmation prompts
- add Enter/Y/Escape/N prompt flows for destructive delete confirmations
- bind F2 to folder rename in the native shell and sync inline rename text from the draft input value

## Validation
- cargo test -p wavecrate folder_rename --lib
- cargo test -p wavecrate delete --lib
- cargo test -p wavecrate native_shell_runtime::tests --lib
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent