### PR TITLE
Fix default GUI folder and waveform interactions

### DIFF
--- a/src/app/controller/ui/hotkeys/actions/folders.rs
+++ b/src/app/controller/ui/hotkeys/actions/folders.rs
@@ -43,7 +43,7 @@ pub(super) const EXPAND_FOCUSED_FOLDER: HotkeyAction = HotkeyAction {
 pub(super) const DELETE_FOLDER: HotkeyAction = HotkeyAction {
     id: "delete-folder",
     label: "Delete folder",
-    gesture: HotkeyGesture::new(Key::D),
+    gesture: HotkeyGesture::new(Key::Delete),
     scope: SOURCE_FOLDERS,
     action: NativeUiAction::DeleteFocusedFolder,
 };

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -15,7 +15,7 @@ use rfd::{FileDialog, MessageButtons, MessageDialog, MessageDialogResult, Messag
 use std::{
     ffi::OsString,
     panic::{self, AssertUnwindSafe},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process,
     sync::{
         Arc,
@@ -57,6 +57,7 @@ enum GuiMessage {
     StopPlayback,
     FocusRenameInput(u64),
     DeleteSelectedFolder,
+    ExtractPlaymarkedRange,
     NavigateBrowser(i32),
     CollapseSelectedFolder,
     ExpandSelectedFolder,
@@ -104,7 +105,7 @@ impl GuiAppState {
             folder_resize: None,
             folder_browser: FolderBrowserState::load_default(),
             waveform: WaveformState::load_default()?,
-            sample_status: String::from("Default sample loaded from assets"),
+            sample_status: String::from("Select a sample to load"),
             worker_sender,
             worker_receiver: Some(worker_receiver),
             next_task_id: 1,
@@ -307,6 +308,7 @@ impl GuiAppState {
                 );
             }
             GuiMessage::DeleteSelectedFolder => self.delete_selected_folder(),
+            GuiMessage::ExtractPlaymarkedRange => self.extract_playmarked_range(),
             GuiMessage::NavigateBrowser(delta) => {
                 let started_at = Instant::now();
                 if let Some(path) = self.folder_browser.navigate_vertical(delta) {
@@ -513,6 +515,37 @@ impl GuiAppState {
         }
     }
 
+    fn extract_playmarked_range(&mut self) {
+        let started_at = Instant::now();
+        match self.waveform.extract_play_selection_to_sibling() {
+            Ok(path) => {
+                let label = sample_path_label(&path);
+                self.waveform.flash_play_selection();
+                self.folder_browser.refresh_file_path(&path);
+                self.sample_status = format!("Extracted {label}");
+                emit_gui_action(
+                    "waveform.extract_playmarked_range",
+                    Some("waveform"),
+                    Some(&label),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Err(error) => {
+                self.sample_status = error.clone();
+                emit_gui_action(
+                    "waveform.extract_playmarked_range",
+                    Some("waveform"),
+                    None,
+                    "error",
+                    started_at,
+                    Some(&error),
+                );
+            }
+        }
+    }
+
     fn launch_folder_scan(
         &mut self,
         request: FolderScanRequest,
@@ -629,8 +662,8 @@ impl GuiAppState {
         self.folder_browser.select_file(path.clone());
         let task_id = self.next_sample_task_id();
         self.pending_sample_task_id = Some(task_id);
-        self.sample_status = format!("Loading {}", sample_path_label(&path));
-        let label = sample_path_label(&path);
+        self.sample_status = format!("Loading {}", sample_path_label(path.as_str()));
+        let label = sample_path_label(path.as_str());
         emit_gui_action(
             "browser.select_sample",
             Some("browser"),
@@ -655,7 +688,7 @@ impl GuiAppState {
 
     fn finish_sample_load(&mut self, load: SampleLoadResult) {
         let started_at = Instant::now();
-        let label = sample_path_label(&load.path);
+        let label = sample_path_label(load.path.as_str());
         if self.pending_sample_task_id != Some(load.task_id) {
             emit_gui_action(
                 "browser.sample_load.finish",
@@ -818,6 +851,9 @@ impl GuiAppState {
         if self.audio_player.is_none() {
             self.audio_player = Some(AudioPlayer::new()?);
         }
+        if !self.waveform.has_loaded_sample() {
+            return Err(String::from("Select a sample to load"));
+        }
         let start_ratio = start_ratio.clamp(0.0, 1.0);
         let end_ratio = end_ratio.clamp(start_ratio, 1.0);
         let duration = self.waveform.frames() as f32 / self.waveform.sample_rate().max(1) as f32;
@@ -926,7 +962,11 @@ pub(crate) fn run() -> Result<(), String> {
         radiant::app(state)
             .options(options)
             .view(view)
-            .animation(|state| state.waveform.is_playing() || state.folder_progress.is_some())
+            .animation(|state| {
+                state.waveform.is_playing()
+                    || state.waveform.play_selection_flash_active()
+                    || state.folder_progress.is_some()
+            })
             .on_frame(|| GuiMessage::Frame)
             .subscriptions(GuiAppState::worker_subscription)
             .shortcuts(|state, _, press, _| {
@@ -938,6 +978,8 @@ pub(crate) fn run() -> Result<(), String> {
                     ))
                 } else if press == ui::KeyPress::new(ui::KeyCode::Delete) {
                     ui::ShortcutResolution::action(GuiMessage::DeleteSelectedFolder)
+                } else if press == ui::KeyPress::new(ui::KeyCode::E) {
+                    ui::ShortcutResolution::action(GuiMessage::ExtractPlaymarkedRange)
                 } else if press == ui::KeyPress::new(ui::KeyCode::Space) {
                     ui::ShortcutResolution::action(GuiMessage::PlaySelectedSample)
                 } else if press == ui::KeyPress::new(ui::KeyCode::ArrowUp) {
@@ -1008,11 +1050,11 @@ where
         .any(|arg| arg == DEBUG_LAYOUT_ARG || arg == DEBUG_LAYOUT_SHORT_ARG)
 }
 
-fn sample_path_label(path: &str) -> String {
-    PathBuf::from(path)
-        .file_name()
+fn sample_path_label(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    path.file_name()
         .map(|name| name.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.to_string())
+        .unwrap_or_else(|| path.display().to_string())
 }
 
 fn log_default_gui_startup(args: &[OsString]) {
@@ -1455,6 +1497,9 @@ fn waveform_panel(state: &GuiAppState) -> ui::View<GuiMessage> {
 }
 
 fn waveform_title(waveform: &WaveformState) -> String {
+    if !waveform.has_loaded_sample() {
+        return String::from("No sample loaded");
+    }
     format!(
         "{} | {} Hz | {} channel{} -> mono | {} frames",
         waveform.file_name(),
@@ -1613,7 +1658,6 @@ fn sample_file_cell(
         .key(format!("sample-{}-{column_id}", file.id))
         .fill_width()
         .height(20.0)
-        .input_only()
         .width(width)
 }
 
@@ -1762,6 +1806,16 @@ mod tests {
     };
     use std::{ffi::OsString, sync::mpsc};
 
+    fn selected_asset_file_path(browser: &super::FolderBrowserState, name: &str) -> String {
+        browser
+            .selected_audio_files()
+            .iter()
+            .find(|file| file.name == name)
+            .unwrap_or_else(|| panic!("expected bundled asset {name} to be visible"))
+            .id
+            .clone()
+    }
+
     #[test]
     fn canonical_debug_layout_arg_enables_default_gui_overlay() {
         assert!(debug_layout_requested([
@@ -1825,17 +1879,10 @@ mod tests {
     }
 
     #[test]
-    fn default_waveform_sample_is_bundled_asset() {
-        let path = super::waveform::default_sample_path();
-        assert!(path.ends_with("assets/portal_SS_kick_003.wav"));
-        assert!(path.is_file());
-    }
-
-    #[test]
-    fn default_waveform_sample_loads_for_default_gui() {
+    fn default_gui_starts_without_loading_a_sample() {
         let waveform = super::WaveformState::load_default().expect("default sample loads");
-        assert!(waveform.frames() > 0);
-        assert!(waveform.sample_rate() > 0);
+        assert!(!waveform.has_loaded_sample());
+        assert_eq!(waveform.file_name(), "No sample loaded");
     }
 
     #[test]
@@ -1855,7 +1902,7 @@ mod tests {
             progress_tick: 0.0,
             audio_player: None,
         };
-        let sample_path = state.folder_browser.selected_audio_files()[0].id.clone();
+        let sample_path = selected_asset_file_path(&state.folder_browser, "portal_SS_kick_003.wav");
 
         let mut context = ui::UpdateContext::default();
         state.apply_message(
@@ -1888,6 +1935,9 @@ mod tests {
         };
         let mut state = GuiAppState::load_default().expect("default state loads");
         state.audio_player = Some(player);
+        let sample_path = selected_asset_file_path(&state.folder_browser, "portal_SS_kick_003.wav");
+        state.waveform =
+            super::WaveformState::load_path(sample_path.into()).expect("test sample loads");
         state
             .waveform
             .apply_interaction(WaveformInteraction::BeginSelection {
@@ -1984,13 +2034,11 @@ mod tests {
                 .iter()
                 .any(|file| file.name == "portal_SS_kick_003.wav")
         );
-        assert_eq!(
+        assert!(
             browser
                 .selected_audio_files()
                 .iter()
-                .map(|file| file.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["portal_SS_kick_003.wav"]
+                .any(|file| file.name == "portal_SS_kick_003.wav")
         );
     }
 }

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -11,7 +11,7 @@ use radiant::widgets::{
     DragHandleMessage, FocusBehavior, PaintBounds, PointerButton, ScrollbarMessage,
     TextInputWidget, Widget, WidgetCommon, WidgetInput, WidgetOutput, WidgetSizing,
 };
-use rfd::FileDialog;
+use rfd::{FileDialog, MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
 use std::{
     ffi::OsString,
     panic::{self, AssertUnwindSafe},
@@ -56,6 +56,7 @@ enum GuiMessage {
     PlaySelectedSample,
     StopPlayback,
     FocusRenameInput(u64),
+    DeleteSelectedFolder,
     NavigateBrowser(i32),
     CollapseSelectedFolder,
     ExpandSelectedFolder,
@@ -305,6 +306,7 @@ impl GuiAppState {
                     None,
                 );
             }
+            GuiMessage::DeleteSelectedFolder => self.delete_selected_folder(),
             GuiMessage::NavigateBrowser(delta) => {
                 let started_at = Instant::now();
                 if let Some(path) = self.folder_browser.navigate_vertical(delta) {
@@ -453,6 +455,61 @@ impl GuiAppState {
                 started_at,
                 Some("source_not_found"),
             );
+        }
+    }
+
+    fn delete_selected_folder(&mut self) {
+        let started_at = Instant::now();
+        let target = match self.folder_browser.selected_delete_target() {
+            Ok(target) => target,
+            Err(error) => {
+                self.sample_status = error.clone();
+                emit_gui_action(
+                    "folder_browser.delete_selected",
+                    Some("folder_browser"),
+                    None,
+                    "short_circuit",
+                    started_at,
+                    Some(&error),
+                );
+                return;
+            }
+        };
+        if !confirm_folder_delete(&target) {
+            self.sample_status = format!("Delete cancelled for {}", target.name);
+            emit_gui_action(
+                "folder_browser.delete_selected",
+                Some("folder_browser"),
+                Some(&target.name),
+                "cancelled",
+                started_at,
+                None,
+            );
+            return;
+        }
+        match self.folder_browser.delete_selected_folder() {
+            Ok(status) => {
+                self.sample_status = status;
+                emit_gui_action(
+                    "folder_browser.delete_selected",
+                    Some("folder_browser"),
+                    Some(&target.name),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Err(error) => {
+                self.sample_status = error.clone();
+                emit_gui_action(
+                    "folder_browser.delete_selected",
+                    Some("folder_browser"),
+                    Some(&target.name),
+                    "error",
+                    started_at,
+                    Some(&error),
+                );
+            }
         }
     }
 
@@ -879,6 +936,8 @@ pub(crate) fn run() -> Result<(), String> {
                     ui::ShortcutResolution::action(GuiMessage::FolderBrowser(
                         FolderBrowserMessage::BeginRenameSelected,
                     ))
+                } else if press == ui::KeyPress::new(ui::KeyCode::Delete) {
+                    ui::ShortcutResolution::action(GuiMessage::DeleteSelectedFolder)
                 } else if press == ui::KeyPress::new(ui::KeyCode::Space) {
                     ui::ShortcutResolution::action(GuiMessage::PlaySelectedSample)
                 } else if press == ui::KeyPress::new(ui::KeyCode::ArrowUp) {
@@ -1668,6 +1727,25 @@ fn worker_progress_bar(state: &GuiAppState) -> ui::View<GuiMessage> {
     })
     .width(track_width)
     .height(10.0)
+}
+
+fn confirm_folder_delete(target: &folder_browser::FolderDeleteTargetView) -> bool {
+    if cfg!(test) {
+        return true;
+    }
+    let message = format!(
+        "Delete {} and all files inside it?\n\nThis cannot be undone from the default GUI.",
+        target.path.display()
+    );
+    matches!(
+        MessageDialog::new()
+            .set_title("Delete folder")
+            .set_description(message)
+            .set_level(MessageLevel::Warning)
+            .set_buttons(MessageButtons::YesNo)
+            .show(),
+        MessageDialogResult::Yes
+    )
 }
 
 #[cfg(test)]

--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -629,6 +629,29 @@ impl FolderBrowserState {
         }
     }
 
+    pub(super) fn refresh_file_path(&mut self, path: &Path) -> bool {
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+        let parent_id = path_id(parent);
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return false;
+        };
+        let Some(root_folder) = &mut source.root_folder else {
+            return false;
+        };
+        let Some(parent_folder) = root_folder.find_mut(&parent_id) else {
+            return false;
+        };
+        upsert_file(&mut parent_folder.files, file_entry(&path.to_path_buf()));
+        self.folders = vec![root_folder.clone()];
+        true
+    }
+
     fn visible_folders(&self) -> Vec<VisibleFolder> {
         let mut folders = Vec::new();
         for folder in &self.folders {

--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -201,6 +201,36 @@ impl FolderBrowserState {
         Ok(Some(input_id))
     }
 
+    pub(super) fn selected_delete_target(&self) -> Result<FolderDeleteTargetView, String> {
+        if self.rename_active() {
+            return Err(String::from("Finish rename before deleting a folder"));
+        }
+        if self.selected_file.is_some() {
+            return Err(String::from("Select a folder to delete"));
+        }
+        let Some(folder) = self.selected_folder() else {
+            return Err(String::from("Select a folder to delete"));
+        };
+        if self.selected_folder_is_source_root() {
+            return Err(String::from("Root folder cannot be deleted"));
+        }
+        Ok(FolderDeleteTargetView {
+            path: PathBuf::from(&folder.id),
+            name: folder.name.clone(),
+        })
+    }
+
+    pub(super) fn delete_selected_folder(&mut self) -> Result<String, String> {
+        let target = self.selected_delete_target()?;
+        if !target.path.is_dir() {
+            return Err(format!("Folder delete failed: {} is missing", target.name));
+        }
+        fs::remove_dir_all(&target.path)
+            .map_err(|error| format!("Folder delete failed: {error}"))?;
+        self.remove_deleted_folder(&target.path);
+        Ok(format!("Deleted folder {}", target.name))
+    }
+
     pub(super) fn apply_rename_input(&mut self, message: TextInputMessage) -> Option<String> {
         match message {
             TextInputMessage::Changed { value } => {
@@ -560,6 +590,38 @@ impl FolderBrowserState {
         self.selected_file = Some(new_id);
     }
 
+    fn remove_deleted_folder(&mut self, target: &Path) {
+        let target_id = path_id(target);
+        let parent_id = target
+            .parent()
+            .map(path_id)
+            .unwrap_or_else(|| self.selected_folder.clone());
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return;
+        };
+        if let Some(root_folder) = &mut source.root_folder {
+            root_folder.remove_child_by_id(&target_id);
+            self.folders = vec![root_folder.clone()];
+        }
+        self.selected_file = None;
+        self.selected_folder = if self.find_folder(&parent_id).is_some() {
+            parent_id
+        } else {
+            self.folders
+                .first()
+                .map(|folder| folder.id.clone())
+                .unwrap_or_default()
+        };
+        self.expanded_folders.retain(|id| {
+            let path = Path::new(id);
+            id != &target_id && !path.starts_with(target)
+        });
+    }
+
     pub(super) fn select_file(&mut self, id: String) {
         if self.selected_files().iter().any(|file| file.id == id) {
             self.cancel_rename();
@@ -687,6 +749,16 @@ impl FolderEntry {
             .iter_mut()
             .any(|child| child.rewrite_file_path(old_path, new_path))
     }
+
+    fn remove_child_by_id(&mut self, target_id: &str) -> bool {
+        if let Some(index) = self.children.iter().position(|child| child.id == target_id) {
+            self.children.remove(index);
+            return true;
+        }
+        self.children
+            .iter_mut()
+            .any(|child| child.remove_child_by_id(target_id))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -711,6 +783,12 @@ pub(super) struct FileRenameView {
     pub(super) input_id: u64,
     pub(super) selection_start: usize,
     pub(super) selection_end: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct FolderDeleteTargetView {
+    pub(super) path: PathBuf,
+    pub(super) name: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1722,6 +1800,47 @@ mod tests {
         assert_eq!(
             browser.begin_rename_selected(),
             Err(String::from("Select a subfolder to rename"))
+        );
+        assert!(root.is_dir());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn folder_delete_removes_selected_subtree_and_selects_parent() {
+        let root = temp_source_root("radiant-gui-folder-delete");
+        let drums = root.join("drums");
+        let kicks = drums.join("kicks");
+        fs::create_dir_all(&kicks).expect("create nested folder");
+        fs::write(kicks.join("kick.wav"), [0_u8; 8]).expect("write wav");
+        let mut browser = FolderBrowserState::from_root(root.clone());
+        browser.activate_folder(path_id(&drums));
+        browser.expand_selected_folder();
+        browser.activate_folder(path_id(&kicks));
+
+        let target = browser
+            .selected_delete_target()
+            .expect("subfolder can be deleted");
+        assert_eq!(target.name, "kicks");
+        let status = browser
+            .delete_selected_folder()
+            .expect("delete should remove subtree");
+
+        assert_eq!(status, "Deleted folder kicks");
+        assert!(!kicks.exists());
+        assert_eq!(browser.selected_folder, path_id(&drums));
+        assert!(browser.find_folder(&path_id(&kicks)).is_none());
+        assert!(!browser.expanded_folders.contains(&path_id(&kicks)));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn root_folder_delete_is_rejected_from_tree() {
+        let root = temp_source_root("radiant-gui-root-delete");
+        let browser = FolderBrowserState::from_root(root.clone());
+
+        assert_eq!(
+            browser.selected_delete_target(),
+            Err(String::from("Root folder cannot be deleted"))
         );
         assert!(root.is_dir());
         let _ = fs::remove_dir_all(root);

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -33,6 +33,7 @@ const BAND_COUNT: usize = 4;
 const SELECTION_DRAG_EPSILON: f32 = 0.001;
 const EDIT_FADE_HANDLE_TAB_SIZE: f32 = 10.0;
 const EDIT_FADE_HANDLE_WIDTH: f32 = 3.0;
+const SELECTION_FLASH_FRAMES: u8 = 12;
 #[cfg(test)]
 const SYNTHETIC_SAMPLE_RATE: u32 = 48_000;
 #[cfg(test)]
@@ -49,18 +50,23 @@ pub(super) struct WaveformState {
     edit_mark_ratio: Option<f32>,
     play_selection: Option<wavecrate::selection::SelectionRange>,
     edit_selection: Option<wavecrate::selection::SelectionRange>,
+    play_selection_flash_frames: u8,
     active_drag: Option<WaveformDrag>,
     pending_playback_start: Option<f32>,
 }
 
 impl WaveformState {
     pub(super) fn load_default() -> Result<Self, String> {
-        Self::load_path(default_sample_path())
+        Ok(Self::empty())
     }
 
     pub(super) fn load_path(path: PathBuf) -> Result<Self, String> {
         let file = Arc::new(load_waveform_file(path)?);
         Ok(Self::from_file(file))
+    }
+
+    pub(super) fn empty() -> Self {
+        Self::from_file(Arc::new(empty_waveform_file()))
     }
 
     #[cfg(test)]
@@ -80,6 +86,7 @@ impl WaveformState {
             edit_mark_ratio: None,
             play_selection: None,
             edit_selection: None,
+            play_selection_flash_frames: 0,
             active_drag: None,
             pending_playback_start: None,
         }
@@ -119,6 +126,32 @@ impl WaveformState {
 
     pub(super) fn edit_selection(&self) -> Option<wavecrate::selection::SelectionRange> {
         self.edit_selection
+    }
+
+    pub(super) fn play_selection_flash_frames(&self) -> u8 {
+        self.play_selection_flash_frames
+    }
+
+    pub(super) fn play_selection_flash_active(&self) -> bool {
+        self.play_selection_flash_frames > 0
+    }
+
+    pub(super) fn flash_play_selection(&mut self) {
+        self.play_selection_flash_frames = SELECTION_FLASH_FRAMES;
+    }
+
+    pub(super) fn extract_play_selection_to_sibling(&self) -> Result<PathBuf, String> {
+        let selection = self
+            .play_selection
+            .filter(|selection| selection.width() > 0.0)
+            .ok_or_else(|| String::from("Mark a play range before extracting"))?;
+        if !self.has_loaded_sample() {
+            return Err(String::from("Load a sample before extracting"));
+        }
+        if !is_wav_path(&self.file.path) {
+            return Err(String::from("Extraction currently supports WAV files"));
+        }
+        extract_wav_range_to_sibling(&self.file.path, &self.file.audio_bytes, selection)
     }
 
     fn active_drag_kind(&self) -> Option<WaveformActiveDragKind> {
@@ -161,6 +194,9 @@ impl WaveformState {
     }
 
     pub(super) fn file_name(&self) -> String {
+        if self.file.path.as_os_str().is_empty() {
+            return String::from("No sample loaded");
+        }
         self.file
             .path
             .file_name()
@@ -170,6 +206,10 @@ impl WaveformState {
 
     pub(super) fn path(&self) -> PathBuf {
         self.file.path.clone()
+    }
+
+    pub(super) fn has_loaded_sample(&self) -> bool {
+        !self.file.audio_bytes.is_empty() && !self.file.path.as_os_str().is_empty()
     }
 
     pub(super) fn audio_bytes(&self) -> Arc<[u8]> {
@@ -212,6 +252,7 @@ impl WaveformState {
                     WaveformSelectionKind::Play => {
                         self.play_mark_ratio = Some(ratio);
                         self.play_selection = None;
+                        self.play_selection_flash_frames = 0;
                     }
                     WaveformSelectionKind::Edit => {
                         self.edit_mark_ratio = Some(ratio);
@@ -263,7 +304,8 @@ impl WaveformState {
                 self.finish_active_drag(visible_ratio);
             }
             WaveformInteraction::Frame => {
-                // Playback progress is driven by the audio engine; frames only keep repainting.
+                self.play_selection_flash_frames =
+                    self.play_selection_flash_frames.saturating_sub(1);
             }
         }
     }
@@ -1066,10 +1108,6 @@ pub(super) struct WaveformViewport {
     end: usize,
 }
 
-pub(super) fn default_sample_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/portal_SS_kick_003.wav")
-}
-
 pub(super) fn waveform_viewport_view(state: &WaveformState) -> ui::View<super::GuiMessage> {
     ui::stack([
         ui::custom_widget(
@@ -1088,6 +1126,7 @@ pub(super) fn waveform_viewport_view(state: &WaveformState) -> ui::View<super::G
                 state.edit_mark_ratio(),
                 state.play_selection(),
                 state.edit_selection(),
+                state.play_selection_flash_frames(),
                 state.active_drag_kind(),
             ),
             |output| {
@@ -1156,6 +1195,10 @@ fn synthetic_waveform_file() -> WaveformFile {
         1,
         samples,
     )
+}
+
+fn empty_waveform_file() -> WaveformFile {
+    waveform_file_from_mono_samples(PathBuf::new(), Arc::from([]), 0, 1, vec![0.0])
 }
 
 fn waveform_file_from_mono_samples(
@@ -1237,6 +1280,109 @@ fn is_wav_path(path: &std::path::Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("wav"))
+}
+
+fn extract_wav_range_to_sibling(
+    source_path: &std::path::Path,
+    bytes: &[u8],
+    selection: wavecrate::selection::SelectionRange,
+) -> Result<PathBuf, String> {
+    let cursor = Cursor::new(bytes);
+    let reader =
+        hound::WavReader::new(cursor).map_err(|err| format!("failed to open WAV: {err}"))?;
+    let spec = reader.spec();
+    let channels = usize::from(spec.channels).max(1);
+    let total_frames = reader.duration() as usize / channels;
+    if total_frames == 0 {
+        return Err(String::from("WAV contains no complete frames"));
+    }
+    let start_frame = (selection.start().clamp(0.0, 1.0) * total_frames as f32).floor() as usize;
+    let end_frame = (selection.end().clamp(0.0, 1.0) * total_frames as f32).ceil() as usize;
+    let start_frame = start_frame.min(total_frames.saturating_sub(1));
+    let end_frame = end_frame.clamp(start_frame + 1, total_frames);
+    let output_path = next_extraction_path(source_path)?;
+    write_wav_frame_range(reader, spec, channels, start_frame, end_frame, &output_path)?;
+    Ok(output_path)
+}
+
+fn next_extraction_path(source_path: &std::path::Path) -> Result<PathBuf, String> {
+    let parent = source_path
+        .parent()
+        .ok_or_else(|| String::from("Source sample has no parent folder"))?;
+    let stem = source_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| String::from("Source sample has no file name"))?;
+    for index in 0..10_000 {
+        let suffix = if index == 0 {
+            String::from("_extraction")
+        } else {
+            format!("_extraction_{index}")
+        };
+        let candidate = parent.join(format!("{stem}{suffix}.wav"));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(String::from(
+        "Could not find an available extraction file name",
+    ))
+}
+
+fn write_wav_frame_range<R: std::io::Read>(
+    mut reader: hound::WavReader<R>,
+    spec: hound::WavSpec,
+    channels: usize,
+    start_frame: usize,
+    end_frame: usize,
+    output_path: &std::path::Path,
+) -> Result<(), String> {
+    let start_sample = start_frame.saturating_mul(channels);
+    let sample_count = end_frame
+        .saturating_sub(start_frame)
+        .saturating_mul(channels);
+    let mut writer = hound::WavWriter::create(output_path, spec)
+        .map_err(|err| format!("failed to create extraction: {err}"))?;
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            for sample in reader
+                .samples::<f32>()
+                .skip(start_sample)
+                .take(sample_count)
+            {
+                writer
+                    .write_sample(sample.map_err(|err| format!("failed to read sample: {err}"))?)
+                    .map_err(|err| format!("failed to write extraction: {err}"))?;
+            }
+        }
+        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => {
+            for sample in reader
+                .samples::<i16>()
+                .skip(start_sample)
+                .take(sample_count)
+            {
+                writer
+                    .write_sample(sample.map_err(|err| format!("failed to read sample: {err}"))?)
+                    .map_err(|err| format!("failed to write extraction: {err}"))?;
+            }
+        }
+        hound::SampleFormat::Int => {
+            for sample in reader
+                .samples::<i32>()
+                .skip(start_sample)
+                .take(sample_count)
+            {
+                writer
+                    .write_sample(sample.map_err(|err| format!("failed to read sample: {err}"))?)
+                    .map_err(|err| format!("failed to write extraction: {err}"))?;
+            }
+        }
+    }
+    writer
+        .finalize()
+        .map_err(|err| format!("failed to finalize extraction: {err}"))?;
+    Ok(())
 }
 
 fn load_wav_waveform_file(path: PathBuf, bytes: Arc<[u8]>) -> Result<WaveformFile, String> {
@@ -1491,6 +1637,7 @@ struct WaveformWidget {
     edit_mark_ratio: Option<f32>,
     play_selection: Option<wavecrate::selection::SelectionRange>,
     edit_selection: Option<wavecrate::selection::SelectionRange>,
+    play_selection_flash_frames: u8,
     edit_preview: TimelineEditPreview,
     active_drag_kind: Option<WaveformActiveDragKind>,
 }
@@ -1505,6 +1652,7 @@ impl WaveformWidget {
         edit_mark_ratio: Option<f32>,
         play_selection: Option<wavecrate::selection::SelectionRange>,
         edit_selection: Option<wavecrate::selection::SelectionRange>,
+        play_selection_flash_frames: u8,
         active_drag_kind: Option<WaveformActiveDragKind>,
     ) -> Self {
         let mut common = WidgetCommon::new(
@@ -1524,6 +1672,7 @@ impl WaveformWidget {
             edit_mark_ratio,
             play_selection,
             edit_selection,
+            play_selection_flash_frames,
             edit_preview: edit_preview_for_selection(edit_selection),
             active_drag_kind,
         }
@@ -1696,6 +1845,7 @@ impl WaveformWidget {
         bounds: Rect,
     ) {
         if let Some((start, end)) = self.visible_range_for_selection(self.play_selection) {
+            let flash_active = self.play_selection_flash_frames > 0;
             self.push_visible_range_fill(
                 primitives,
                 bounds,
@@ -1705,7 +1855,7 @@ impl WaveformWidget {
                     r: 255,
                     g: 142,
                     b: 92,
-                    a: 48,
+                    a: if flash_active { 118 } else { 48 },
                 },
             );
             self.append_selection_resize_handles(
@@ -1717,7 +1867,7 @@ impl WaveformWidget {
                     r: 255,
                     g: 142,
                     b: 92,
-                    a: 220,
+                    a: if flash_active { 255 } else { 220 },
                 },
             );
         }
@@ -2260,7 +2410,7 @@ mod tests {
         theme::ThemeTokens,
         widgets::{PointerButton, Widget, WidgetInput},
     };
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
 
     #[test]
     fn waveform_summary_preserves_raw_transient_detail() {
@@ -2301,6 +2451,41 @@ mod tests {
             .map(|bucket| bucket.min.abs().max(bucket.max.abs()))
             .fold(0.0_f32, f32::max);
         assert!(frame_peak > 0.89);
+    }
+
+    #[test]
+    fn playmark_extraction_writes_sibling_wav_range() {
+        let root = std::env::temp_dir().join(format!(
+            "wavecrate-playmark-extract-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create temp root");
+        let source = root.join("source.wav");
+        write_test_wav_i16(&source, &[0, 100, 200, 300, 400, 500]);
+        let mut state = WaveformState::load_path(source).expect("load source");
+        state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.25, 0.75));
+
+        let output = state
+            .extract_play_selection_to_sibling()
+            .expect("extract range");
+
+        assert_eq!(output.file_name().unwrap(), "source_extraction.wav");
+        assert_eq!(read_test_wav_i16(&output), vec![100, 200, 300, 400]);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn empty_waveform_rejects_playmark_extraction() {
+        let mut state = WaveformState::empty();
+        state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.1, 0.2));
+
+        assert_eq!(
+            state.extract_play_selection_to_sibling(),
+            Err(String::from("Load a sample before extracting"))
+        );
     }
 
     #[test]
@@ -2377,6 +2562,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let mut primitives = Vec::new();
@@ -2435,6 +2621,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
@@ -2480,6 +2667,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(10.0, 20.0), Vector2::new(200.0, 80.0));
@@ -2519,6 +2707,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(10.0, 20.0), Vector2::new(200.0, 80.0));
@@ -2600,6 +2789,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
@@ -2765,6 +2955,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
@@ -3005,6 +3196,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
@@ -3189,6 +3381,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(200.0, 80.0));
@@ -3256,6 +3449,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let (start, end) = widget
@@ -3283,6 +3477,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let mut primitives = Vec::new();
@@ -3329,6 +3524,7 @@ mod tests {
             state.edit_mark_ratio(),
             state.play_selection(),
             state.edit_selection(),
+            state.play_selection_flash_frames(),
             state.active_drag_kind(),
         );
         let mut primitives = Vec::new();
@@ -3433,5 +3629,27 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    fn write_test_wav_i16(path: &std::path::Path, samples: &[i16]) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 48_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        for sample in samples {
+            writer.write_sample(*sample).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    fn read_test_wav_i16(path: &std::path::Path) -> Vec<i16> {
+        let mut reader = hound::WavReader::open(path).expect("open wav");
+        reader
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read samples")
     }
 }


### PR DESCRIPTION
## Summary
- wire Delete key folder deletion and keep folder rename/delete actions logged
- add playmark extraction with E, sibling WAV output, and selection flash feedback
- start default GUI without auto-loading the bundled kick sample
- render sample-list rows visibly instead of input-only gray hit targets

## Validation
- cargo test -p wavecrate gui_app --features radiant-gui
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent