### PR TITLE
Keep waveform playhead smooth during hover and rapid restarts

### DIFF
--- a/src/audio/player/progress.rs
+++ b/src/audio/player/progress.rs
@@ -63,6 +63,12 @@ impl AudioPlayer {
         self.stream.active_source_count() > 0 && self.started_at.is_some()
     }
 
+    /// Wall-clock elapsed time since the current playback span was started.
+    pub fn playback_elapsed(&self) -> Option<Duration> {
+        self.started_at
+            .map(|started_at| self.elapsed_since(started_at))
+    }
+
     /// True when the current sink is configured to loop.
     pub fn is_looping(&self) -> bool {
         self.looping
@@ -148,6 +154,26 @@ mod tests {
         let progress = player.progress().expect("progress");
         let expected = 12_000.0 / 48_000.0;
         assert!((progress - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn playback_elapsed_tracks_started_playback_state() {
+        let Ok(outcome) = open_output_stream(&AudioOutputConfig::default()) else {
+            return;
+        };
+        let stream = outcome.stream;
+        let elapsed = duration_for_frames(1_200, 48_000);
+        let player = AudioPlayer::test_with_state(
+            stream,
+            Some(1.0),
+            Some(Instant::now()),
+            Some((0.0, 1.0)),
+            false,
+            None,
+            Some(elapsed),
+        );
+
+        assert_eq!(player.playback_elapsed(), Some(elapsed));
     }
 
     #[test]

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -43,6 +43,7 @@ const MIN_FOLDER_WIDTH: f32 = 180.0;
 const MAX_FOLDER_WIDTH: f32 = 420.0;
 const WAVEFORM_VIEW_HEIGHT: f32 = 172.0;
 const WAVEFORM_PANEL_HEIGHT: f32 = 226.0;
+const PLAYBACK_START_ACTIVE_SOURCE_GRACE: Duration = Duration::from_millis(120);
 
 #[derive(Clone, Debug, PartialEq)]
 enum GuiMessage {
@@ -906,7 +907,11 @@ impl GuiAppState {
             );
             return;
         }
-        if player.is_playing() {
+        if player.is_playing()
+            || player
+                .playback_elapsed()
+                .is_some_and(|elapsed| elapsed <= PLAYBACK_START_ACTIVE_SOURCE_GRACE)
+        {
             if let Some(progress) = player.progress() {
                 self.waveform.set_playhead_ratio(progress);
             }


### PR DESCRIPTION
## Summary
- update Radiant to the merged runtime fix that keeps animation-frame cadence independent from hover redraw cadence
- keep due frame messages flowing while GPU hover redraws are pending so the waveform playhead remains smooth under mouse movement
- add a short playback startup grace so rapid waveform click restarts do not clear the playhead before the audio stream reports the new source active

## Validation
- cargo test --manifest-path vendor/radiant/Cargo.toml hover_redraws_do_not_reset_timed_animation_deadline --no-default-features
- cargo test --manifest-path vendor/radiant/Cargo.toml --no-default-features
- cargo test -p wavecrate playback_elapsed_tracks_started_playback_state --lib
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent