### PR TITLE
Update Radiant retained diagnostics

### DIFF
--- a/src/gui_runtime/native_shell_runtime/launch.rs
+++ b/src/gui_runtime/native_shell_runtime/launch.rs
@@ -17,6 +17,7 @@ impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
             debug_layout: value.debug_layout,
             drag_and_drop: true,
             gpu: radiant::gui_runtime::NativeGpuOptions::default(),
+            retained_surface_cache: radiant::runtime::RetainedSurfaceCachePolicy::default(),
             text: radiant::gui_runtime::NativeTextOptions {
                 embedded_fonts: Vec::new(),
                 font_paths: vec![crate::gui_runtime::wavecrate_ui_font_path()],


### PR DESCRIPTION
## Summary
- update vendor/radiant to include retained frame diagnostics API from Radiant PR #856
- forward Wavecrate native runtime options through the new retained-surface cache policy field

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent