### PR TITLE
Reuse Radiant virtual list scrollbar interactions

### DIFF
--- a/src/app_core/native_shell/composition/state/browser_rows/sidebar.rs
+++ b/src/app_core/native_shell/composition/state/browser_rows/sidebar.rs
@@ -3,8 +3,8 @@
 use super::*;
 use crate::app_core::native_shell::runtime_contract::{FolderPaneIdModel, FolderPaneModel};
 use crate::gui::list::{
-    VirtualListScrollbarRequest, VirtualListStackMetrics, VirtualListWindowRequest,
-    resolve_virtual_list_scrollbar, resolve_virtual_list_window,
+    VirtualListScrollbar, VirtualListScrollbarRequest, VirtualListStackMetrics,
+    VirtualListWindowRequest, resolve_virtual_list_scrollbar, resolve_virtual_list_window,
     virtual_list_scrollbar_view_start_for_pointer, virtual_list_viewport_len_for_extent,
 };
 
@@ -323,7 +323,7 @@ pub(in crate::app_core::native_shell::composition::state) fn folder_scrollbar_vi
     thumb_pointer_offset_y: f32,
 ) -> Option<usize> {
     virtual_list_scrollbar_view_start_for_pointer(
-        crate::gui::list::VirtualListScrollbar {
+        VirtualListScrollbar {
             track: scrollbar.track,
             thumb: scrollbar.thumb,
         },

--- a/src/app_core/native_shell/composition/state/browser_rows/windowing/scrollbars.rs
+++ b/src/app_core/native_shell/composition/state/browser_rows/windowing/scrollbars.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::gui::list::{
-    VirtualListScrollbarRequest, VirtualListStackMetrics, resolve_virtual_list_scrollbar,
-    virtual_list_scrollbar_view_start_for_pointer, virtual_list_viewport_len_for_extent,
+    VirtualListScrollbar, VirtualListScrollbarRequest, VirtualListStackMetrics,
+    resolve_virtual_list_scrollbar, virtual_list_scrollbar_view_start_for_pointer,
+    virtual_list_viewport_len_for_extent,
 };
 
 pub(in crate::app_core::native_shell::composition::state) fn browser_rows_capacity(
@@ -94,7 +95,7 @@ pub(in crate::app_core::native_shell::composition::state) fn browser_scrollbar_v
     thumb_pointer_offset_y: f32,
 ) -> Option<usize> {
     virtual_list_scrollbar_view_start_for_pointer(
-        crate::gui::list::VirtualListScrollbar {
+        VirtualListScrollbar {
             track: scrollbar.track,
             thumb: scrollbar.thumb,
         },

--- a/src/app_core/native_shell/composition/state/hit_testing/browser.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser.rs
@@ -1,6 +1,10 @@
 use super::*;
 #[cfg(test)]
 use crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip;
+use crate::gui::list::{
+    VirtualListScrollbar, virtual_list_scrollbar_thumb_offset_at_point,
+    virtual_list_scrollbar_view_start_at_point,
+};
 
 impl NativeShellState {
     /// Return a browser column-chip rect for one column index in tests.
@@ -144,19 +148,14 @@ impl NativeShellState {
     ) -> Option<f32> {
         let geometry = self.cached_browser_interaction_geometry(layout, model);
         let scrollbar = geometry.scrollbar?;
-        let hit_rect = Rect::from_min_max(
-            Point::new(
-                scrollbar.track.min.x - BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
-                scrollbar.thumb.min.y - BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
-            ),
-            Point::new(
-                scrollbar.track.max.x + BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
-                scrollbar.thumb.max.y + BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
-            ),
-        );
-        hit_rect
-            .contains(point)
-            .then_some((point.y - scrollbar.thumb.min.y).clamp(0.0, scrollbar.thumb.height()))
+        virtual_list_scrollbar_thumb_offset_at_point(
+            VirtualListScrollbar {
+                track: scrollbar.track,
+                thumb: scrollbar.thumb,
+            },
+            point,
+            BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
+        )
     }
 
     /// Resolve the browser viewport start row for an active scrollbar-thumb drag.
@@ -191,15 +190,14 @@ impl NativeShellState {
     ) -> Option<usize> {
         let geometry = self.cached_browser_interaction_geometry(layout, model);
         let scrollbar = geometry.scrollbar?;
-        if !scrollbar.track.contains(point) || scrollbar.thumb.contains(point) {
-            return None;
-        }
-        browser_scrollbar_view_start_for_pointer(
-            scrollbar,
+        virtual_list_scrollbar_view_start_at_point(
+            VirtualListScrollbar {
+                track: scrollbar.track,
+                thumb: scrollbar.thumb,
+            },
             geometry.scrollbar_viewport_len,
             model.browser.visible_count,
-            point.y,
-            scrollbar.thumb.height() * 0.5,
+            point,
         )
     }
 

--- a/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/scrollbar.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/scrollbar.rs
@@ -1,5 +1,9 @@
 use super::*;
 use crate::app_core::native_shell::runtime_contract::FolderPaneIdModel;
+use crate::gui::list::{
+    VirtualListScrollbar, virtual_list_scrollbar_thumb_offset_at_point,
+    virtual_list_scrollbar_view_start_at_point,
+};
 
 impl NativeShellState {
     pub(crate) fn folder_viewport_len(
@@ -86,20 +90,15 @@ fn folder_scrollbar_thumb_hit(
     point: Point,
 ) -> Option<(FolderPaneIdModel, f32)> {
     let (scrollbar, _) = shell_state.cached_folder_scrollbar(layout, model, pane)?;
-    let hit_rect = Rect::from_min_max(
-        Point::new(
-            scrollbar.track.min.x - FOLDER_SCROLLBAR_THUMB_HIT_SLOP,
-            scrollbar.thumb.min.y - FOLDER_SCROLLBAR_THUMB_HIT_SLOP,
-        ),
-        Point::new(
-            scrollbar.track.max.x + FOLDER_SCROLLBAR_THUMB_HIT_SLOP,
-            scrollbar.thumb.max.y + FOLDER_SCROLLBAR_THUMB_HIT_SLOP,
-        ),
-    );
-    hit_rect.contains(point).then_some((
-        pane,
-        (point.y - scrollbar.thumb.min.y).clamp(0.0, scrollbar.thumb.height()),
-    ))
+    virtual_list_scrollbar_thumb_offset_at_point(
+        VirtualListScrollbar {
+            track: scrollbar.track,
+            thumb: scrollbar.thumb,
+        },
+        point,
+        FOLDER_SCROLLBAR_THUMB_HIT_SLOP,
+    )
+    .map(|offset| (pane, offset))
 }
 
 fn folder_scrollbar_track_jump(
@@ -110,15 +109,14 @@ fn folder_scrollbar_track_jump(
     point: Point,
 ) -> Option<(FolderPaneIdModel, usize)> {
     let (scrollbar, viewport_len) = shell_state.cached_folder_scrollbar(layout, model, pane)?;
-    if !scrollbar.track.contains(point) || scrollbar.thumb.contains(point) {
-        return None;
-    }
-    folder_scrollbar_view_start_for_pointer(
-        scrollbar,
+    virtual_list_scrollbar_view_start_at_point(
+        VirtualListScrollbar {
+            track: scrollbar.track,
+            thumb: scrollbar.thumb,
+        },
         viewport_len,
         model.sources.folder_pane(pane).tree_rows.len(),
-        point.y,
-        scrollbar.thumb.height() * 0.5,
+        point,
     )
     .map(|view_start| (pane, view_start))
 }


### PR DESCRIPTION
## Summary
- replace Wavecrate browser/folder scrollbar thumb-hit math with Radiant's generic helper
- replace browser/folder scrollbar track-click math with Radiant's generic helper
- update the Radiant submodule pointer

## Validation
- cargo test -p wavecrate opt_272_tests
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent