### PR TITLE
Reuse Radiant floating panel primitives

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -57,6 +57,7 @@ use crate::gui::paint::{
     DrawImage, FillCircle, FillLinearGradient, FillRect, PaintFrame as NativeViewFrame, Primitive,
     TextAlign, TextRun,
 };
+use crate::gui::panel::FloatingPanelDrag;
 use crate::gui::range::NormalizedPixelSnap;
 use crate::gui::{
     input::KeyCode,
@@ -192,7 +193,7 @@ pub(crate) struct NativeShellState {
     browser_pill_editor_visual: Option<TextFieldVisualState>,
     folder_create_editor_visual: Option<TextFieldVisualState>,
     options_panel_origin: Option<Point>,
-    options_panel_drag: Option<OptionsPanelDrag>,
+    options_panel_drag: Option<FloatingPanelDrag>,
     hovered_folder_pane: Option<crate::app_core::native_shell::runtime_contract::FolderPaneIdModel>,
     hovered_folder_row_index: Option<usize>,
     hovered_source_add_button: bool,

--- a/src/app_core/native_shell/composition/state/options_panel.rs
+++ b/src/app_core/native_shell/composition/state/options_panel.rs
@@ -1,6 +1,7 @@
 //! Top-right options button and options-panel helpers for the native shell.
 
 use super::*;
+use crate::gui::panel::FloatingPanelDrag;
 
 #[path = "options_panel/actions.rs"]
 mod actions;
@@ -26,12 +27,6 @@ pub(super) struct OptionsPanelLayout {
     pub(super) detail_rect: Option<Rect>,
     pub(super) title: String,
     pub(super) buttons: Vec<OptionsPanelButton>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(super) struct OptionsPanelDrag {
-    pub(super) grab_offset_x: f32,
-    pub(super) grab_offset_y: f32,
 }
 
 pub(super) fn status_right_text_rect(
@@ -193,10 +188,7 @@ impl NativeShellState {
             return false;
         }
         self.options_panel_origin = Some(panel.panel_rect.min);
-        self.options_panel_drag = Some(OptionsPanelDrag {
-            grab_offset_x: point.x - panel.panel_rect.min.x,
-            grab_offset_y: point.y - panel.panel_rect.min.y,
-        });
+        self.options_panel_drag = Some(FloatingPanelDrag::new(panel.panel_rect, point));
         true
     }
 
@@ -209,7 +201,7 @@ impl NativeShellState {
         let Some(drag) = self.options_panel_drag else {
             return false;
         };
-        let requested = Point::new(point.x - drag.grab_offset_x, point.y - drag.grab_offset_y);
+        let requested = drag.origin_for_pointer(point);
         self.options_panel_origin = Some(requested);
         let style = style_for_layout(layout);
         if let Some(panel) =

--- a/src/app_core/native_shell/composition/state/options_panel/geometry.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/geometry.rs
@@ -5,6 +5,7 @@ use super::actions::{
     picker_action, picker_options,
 };
 use super::*;
+use crate::gui::{panel::floating_panel_rect, types::Vector2};
 
 pub(super) fn status_right_text_rect(
     segment: Rect,
@@ -57,13 +58,18 @@ pub(super) fn options_panel_layout(
     let default_min_y = layout.top_bar.max.y + inset;
     let max_y = (default_min_y + panel_height).min(layout.status_bar.min.y - inset);
     let default_min_y = (max_y - panel_height).max(layout.top_bar.max.y + inset);
-    let (min_x, min_y) = clamped_panel_origin(
+    let panel_bounds = Rect::from_min_max(
+        Point::new(layout.root.rect.min.x, layout.top_bar.max.y),
+        Point::new(layout.root.rect.max.x, layout.status_bar.min.y),
+    );
+    let clamped_panel = floating_panel_rect(
+        panel_bounds,
         origin.unwrap_or(Point::new(default_min_x, default_min_y)),
-        panel_width,
-        panel_height,
-        layout,
+        Vector2::new(panel_width, panel_height),
         inset,
     );
+    let min_x = clamped_panel.min.x;
+    let min_y = clamped_panel.min.y;
     let panel_rect = Rect::from_min_max(
         Point::new(min_x, min_y),
         Point::new(
@@ -143,20 +149,6 @@ pub(super) fn options_panel_action_at_point(
         .into_iter()
         .find(|button| button.rect.contains(point))
         .map(|button| button.action)
-}
-
-fn clamped_panel_origin(
-    origin: Point,
-    panel_width: f32,
-    panel_height: f32,
-    layout: &ShellLayout,
-    inset: f32,
-) -> (f32, f32) {
-    let min_x = layout.root.rect.min.x + inset;
-    let max_x = (layout.root.rect.max.x - panel_width - inset).max(min_x);
-    let min_y = layout.top_bar.max.y + inset;
-    let max_y = (layout.status_bar.min.y - panel_height - inset).max(min_y);
-    (origin.x.clamp(min_x, max_x), origin.y.clamp(min_y, max_y))
 }
 
 fn build_options_panel_buttons(model: &AppModel) -> Vec<(String, UiAction, bool)> {


### PR DESCRIPTION
## Summary
- update the Radiant submodule to the floating panel primitives PR
- replace Wavecrate's audio options panel drag-offset and clamp math with Radiant helpers
- keep Wavecrate-owned audio panel layout and hit testing behavior unchanged

## Validation
- cargo test floating_panel --lib
- cargo test -p wavecrate options_panel_ --lib
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent