### PR TITLE
Reuse Radiant rect clamp helper

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -264,10 +264,5 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }

--- a/src/app_core/native_shell/composition/layout_adapter/bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/bands.rs
@@ -294,12 +294,7 @@ fn empty_rect(bounds: Rect) -> Rect {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn inset_horizontal(rect: Rect, inset: f32) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -180,12 +180,7 @@ fn snap_browser_row_text_baseline(line: Rect) -> Rect {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -121,12 +121,7 @@ fn compute_map_header_text_line(rect: Rect, sizing: SizingTokens, font_size: f32
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
@@ -74,12 +74,7 @@ pub(super) fn rect_for(
 
 /// Clamp a rect to a containing bounds rect.
 pub(super) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 /// Return an empty rect pinned at the bounds origin.

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
@@ -160,12 +160,7 @@ fn sidebar_text_bounds(rect: Rect, sizing: SizingTokens) -> Rect {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
@@ -167,12 +167,7 @@ pub(crate) fn build_text_rows(show_metadata: bool, sizing: SizingTokens) -> Vec<
 }
 
 pub(crate) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 pub(crate) fn rect_for(

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_sections.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_sections.rs
@@ -184,12 +184,7 @@ fn resolve_pane_sections(
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn inset_vertical(rect: Rect, top: f32, bottom: f32) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
@@ -111,12 +111,7 @@ fn fixed_height_row(node_id: u64, height: f32) -> SlotChild {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -29,12 +29,7 @@ pub(super) fn footer_action_button_width(
 
 /// Clamp one resolved layout rect back inside the original surface bounds.
 pub(super) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 /// Look up one resolved rect by node id or return the provided fallback.

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -234,12 +234,7 @@ fn progress_slot_width(viewport_width: f32, sizing: SizingTokens) -> f32 {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -421,12 +421,7 @@ fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -135,12 +135,7 @@ fn format_milli_value(value: u16) -> String {
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -208,12 +208,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    let min = Point::new(rect.min.x.max(bounds.min.x), rect.min.y.max(bounds.min.y));
-    let max = Point::new(rect.max.x.min(bounds.max.x), rect.max.y.min(bounds.max.y));
-    if max.x < min.x || max.y < min.y {
-        return Rect::from_min_max(bounds.min, bounds.min);
-    }
-    Rect::from_min_max(min, max)
+    rect.clamp_to(bounds)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace repeated native-shell clamp implementations with Radiant's Rect::clamp_to
- keep local helper entry points stable while centralizing the geometry edge cases

## Validation
- cargo test -p wavecrate gui_test::shell_shots::startup_shot_matches_fixture --lib
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent