### PR TITLE
Reuse Radiant empty rect helper

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/bands.rs
@@ -290,7 +290,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/browser_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_chrome_text.rs
@@ -64,7 +64,7 @@ fn compute_text_line_rect(rect: Rect, sizing: SizingTokens, font_size: f32) -> R
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -188,7 +188,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/control_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/control_text.rs
@@ -41,7 +41,7 @@ fn inset_horizontal(rect: Rect, inset: f32) -> Rect {
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
@@ -14,7 +14,7 @@ pub(super) fn clamp_rect_right_edge(rect: Rect, bounds: Rect, right_edge: f32) -
     let clamped = clamp_rect_to_bounds(rect, bounds);
     let max_x = clamped.max.x.min(right_edge.max(bounds.min.x));
     if max_x < clamped.min.x {
-        return Rect::from_min_max(bounds.min, bounds.min);
+        return bounds.empty_at_min();
     }
     Rect::from_min_max(
         clamped.min,

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -129,7 +129,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
@@ -79,7 +79,7 @@ pub(super) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
 
 /// Return an empty rect pinned at the bounds origin.
 pub(super) fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 /// Inset horizontally with saturation.

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
@@ -168,7 +168,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
@@ -179,7 +179,7 @@ pub(crate) fn rect_for(
 }
 
 pub(crate) fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 fn compact_recovery_badge_label(

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_text.rs
@@ -100,7 +100,7 @@ fn folder_row_disclosure_spacing(sizing: SizingTokens) -> f32 {
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/status_bar.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/status_bar.rs
@@ -53,7 +53,7 @@ pub(crate) fn compute_status_text_line_rect(
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
@@ -119,7 +119,7 @@ fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Re
 }
 
 fn empty_rect(bounds: Rect) -> Rect {
-    Rect::from_min_max(bounds.min, bounds.min)
+    bounds.empty_at_min()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace manual empty-at-bounds-min rectangles with Radiant's Rect::empty_at_min helper
- keep layout adapter behavior unchanged while removing repeated geometry construction

## Validation
- cargo test -p wavecrate gui_test::shell_shots::startup_shot_matches_fixture --lib
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent