### PR TITLE
chore(gui): reuse Radiant visible suffix helper

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
@@ -127,24 +127,6 @@ pub(super) fn rect_for(
     rects.get(&id).copied().unwrap_or(fallback)
 }
 
-pub(super) fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<f32> {
-    if available_width <= 0.0 || widths.is_empty() {
-        return Vec::new();
-    }
-    let mut used = 0.0;
-    let mut reversed = Vec::new();
-    for (index, width) in widths.iter().rev().enumerate() {
-        let candidate = used + width + if index > 0 { gap } else { 0.0 };
-        if candidate >= available_width {
-            break;
-        }
-        reversed.push(*width);
-        used = candidate;
-    }
-    reversed.reverse();
-    reversed
-}
-
 fn fixed_width_child(node_id: u64, width: f32, left_margin: f32) -> SlotChild {
     SlotChild {
         slot: SlotParams {

--- a/src/app_core/native_shell/composition/layout_adapter/controls/update_buttons.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/update_buttons.rs
@@ -1,5 +1,6 @@
 use super::super::super::style::SizingTokens;
-use super::shared::{layout_right_aligned_fixed_widths, visible_suffix_widths};
+use super::shared::layout_right_aligned_fixed_widths;
+use crate::gui::layout_core::visible_suffix_widths;
 use crate::gui::types::{Point, Rect};
 
 const UPDATE_BUTTON_ROW_ID: u64 = 700;

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -8,6 +8,7 @@
 use super::style::SizingTokens;
 use crate::{
     app::{AppModel, UiAction, UpdateStatusModel},
+    gui::layout_core::visible_suffix_widths,
     gui::types::{Point, Rect},
     layout::layout_tree,
     runtime::UiSurface,
@@ -400,24 +401,6 @@ fn visible_update_widths(
         })
         .collect();
     visible_suffix_widths(&widths, available_width, sizing.action_button_gap.max(1.0))
-}
-
-fn visible_suffix_widths(widths: &[f32], available_width: f32, gap: f32) -> Vec<f32> {
-    if available_width <= 0.0 || widths.is_empty() {
-        return Vec::new();
-    }
-    let mut used = 0.0;
-    let mut reversed = Vec::new();
-    for (index, width) in widths.iter().rev().enumerate() {
-        let candidate = used + width + if index > 0 { gap } else { 0.0 };
-        if candidate >= available_width {
-            break;
-        }
-        reversed.push(*width);
-        used = candidate;
-    }
-    reversed.reverse();
-    reversed
 }
 
 fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- remove duplicate Wavecrate visible-suffix width helpers
- route top-bar and update-action clusters through Radiant layout_core
- align exact-fit behavior with Radiant's tested row-helper contract

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition::layout_adapter::controls:: -- --nocapture
- cargo test -p wavecrate --lib top_bar_surface -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent