### PR TITLE
Use Radiant surface layout helper

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -15,7 +15,6 @@ use super::style::SizingTokens;
 use crate::{
     app::AppModel,
     gui::types::{Point, Rect},
-    layout::layout_tree,
     runtime::UiSurface,
 };
 use helpers::{
@@ -138,7 +137,7 @@ pub(crate) fn resolve_browser_tabs_surface_layout(
     content: &BrowserTabsSurfaceContent,
 ) -> BrowserTabsSurfaceLayout {
     let surface = build_browser_tabs_surface(content, sizing, tabs_rect.width());
-    let output = layout_tree(&surface.layout_node(), tabs_rect);
+    let output = surface.layout(tabs_rect);
     let empty = Rect::from_min_max(tabs_rect.min, tabs_rect.min);
     BrowserTabsSurfaceLayout {
         items: clamp_rect_to_bounds(rect_for(&output.rects, TABS_ITEMS_ID, empty), tabs_rect),
@@ -154,7 +153,7 @@ pub(crate) fn resolve_browser_toolbar_surface_layout(
 ) -> BrowserToolbarSurfaceLayout {
     let widths = browser_toolbar_surface_widths(toolbar_rect, sizing);
     let surface = build_browser_toolbar_surface(content, toolbar_rect.height(), widths);
-    let output = layout_tree(&surface.layout_node(), toolbar_rect);
+    let output = surface.layout(toolbar_rect);
     let empty = Rect::from_min_max(toolbar_rect.min, toolbar_rect.min);
     BrowserToolbarSurfaceLayout {
         rating_filter_chips: std::array::from_fn(|index| {

--- a/src/app_core/native_shell/composition/sidebar_surface.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface.rs
@@ -12,7 +12,7 @@ mod helpers;
 mod tests;
 
 use super::style::SizingTokens;
-use crate::{app::AppModel, gui::types::Rect, layout::layout_tree, runtime::UiSurface};
+use crate::{app::AppModel, gui::types::Rect, runtime::UiSurface};
 use helpers::{clamp_rect_to_bounds, footer_action_button_width, header_button_side, rect_for};
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
@@ -155,7 +155,7 @@ pub(crate) fn resolve_sidebar_header_surface_layout(
     content: &SidebarHeaderSurfaceContent,
 ) -> SidebarHeaderSurfaceLayout {
     let surface = build_sidebar_header_surface(content, sizing);
-    let output = layout_tree(&surface.layout_node(), header_rect);
+    let output = surface.layout(header_rect);
     let empty = Rect::from_min_max(header_rect.min, header_rect.min);
     let add_button = rect_for(&output.rects, HEADER_ADD_BUTTON_ID, empty);
     SidebarHeaderSurfaceLayout {
@@ -179,7 +179,7 @@ pub(crate) fn resolve_sidebar_footer_surface_layout(
     content: &SidebarFooterSurfaceContent,
 ) -> SidebarFooterSurfaceLayout {
     let surface = build_sidebar_footer_surface(content, sizing, footer_rect.width());
-    let output = layout_tree(&surface.layout_node(), footer_rect);
+    let output = surface.layout(footer_rect);
     let empty = Rect::from_min_max(footer_rect.min, footer_rect.min);
     let action_buttons = content
         .actions

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -8,7 +8,7 @@
 use super::style::SizingTokens;
 use crate::{
     gui::types::{Point, Rect},
-    layout::{MainAlign, layout_tree},
+    layout::MainAlign,
     runtime::UiSurface,
 };
 use radiant::prelude as ui;
@@ -137,7 +137,7 @@ pub(crate) fn resolve_status_surface_layout(
     content: &StatusSurfaceContent,
 ) -> StatusSurfaceLayout {
     let surface = build_status_surface(content, sizing, status_bar.width());
-    let output = layout_tree(&surface.layout_node(), status_bar);
+    let output = surface.layout(status_bar);
     let empty = Rect::from_min_max(status_bar.min, status_bar.min);
     StatusSurfaceLayout {
         left_segment: clamp_rect_to_bounds(

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -10,7 +10,6 @@ use crate::{
     app::{AppModel, UiAction, UpdateStatusModel},
     gui::layout_core::visible_suffix_widths,
     gui::types::{Point, Rect},
-    layout::layout_tree,
     runtime::UiSurface,
 };
 use radiant::prelude as ui;
@@ -149,7 +148,7 @@ pub(crate) fn resolve_top_bar_surface_layout(
     content: &TopBarSurfaceContent,
 ) -> TopBarSurfaceLayout {
     let surface = build_top_bar_surface(content, sizing, top_bar.width());
-    let output = layout_tree(&surface.layout_node(), top_bar);
+    let output = surface.layout(top_bar);
     let empty = Rect::from_min_max(top_bar.min, top_bar.min);
     let title_cluster = clamp_rect_to_bounds(
         rect_for(&output.rects, TOP_TITLE_CLUSTER_ID, empty),

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -9,7 +9,6 @@ use super::style::SizingTokens;
 use crate::{
     app::NativeMotionModel,
     gui::types::{Point, Rect},
-    layout::layout_tree,
     runtime::UiSurface,
 };
 use radiant::prelude as ui;
@@ -82,7 +81,7 @@ pub(crate) fn resolve_waveform_header_surface_layout(
     content: &WaveformHeaderSurfaceContent,
 ) -> WaveformHeaderSurfaceLayout {
     let surface = build_waveform_header_surface(content, sizing);
-    let output = layout_tree(&surface.layout_node(), header_rect);
+    let output = surface.layout(header_rect);
     let empty = Rect::from_min_max(header_rect.min, header_rect.min);
     WaveformHeaderSurfaceLayout {
         title_text_rect: clamp_rect_to_bounds(

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -9,7 +9,6 @@ use super::style::SizingTokens;
 use crate::{
     gui::types::{Point, Rect},
     layout::NodeId,
-    layout::layout_tree,
     runtime::UiSurface,
 };
 use radiant::prelude as ui;
@@ -76,7 +75,7 @@ pub(crate) fn resolve_waveform_toolbar_surface_layout(
         return WaveformToolbarSurfaceLayout { item_rects };
     }
     let surface = build_waveform_toolbar_surface(header_rect, content, &legacy_rects);
-    let output = layout_tree(&surface.layout_node(), header_rect);
+    let output = surface.layout(header_rect);
     for item_index in visible_start..content.items.len() {
         let id = waveform_toolbar_widget_id(item_index);
         item_rects[item_index] =


### PR DESCRIPTION
## Summary
- update Radiant submodule to include UiSurface::layout and layout_with_options
- replace Wavecrate compatibility surface manual layout_node + layout_tree calls with surface.layout(...)
- keep behavior unchanged while making the host-controlled surface API easier for app slices to consume

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent

Radiant PR: https://github.com/PORTALSURFER/radiant/pull/868