### PR TITLE
Use LayoutOutput clamped rect helper

### DIFF
--- a/src/app_core/native_shell/composition/browser_chrome_surface.rs
+++ b/src/app_core/native_shell/composition/browser_chrome_surface.rs
@@ -140,8 +140,8 @@ pub(crate) fn resolve_browser_tabs_surface_layout(
     let output = surface.layout(tabs_rect);
     let empty = Rect::from_min_max(tabs_rect.min, tabs_rect.min);
     BrowserTabsSurfaceLayout {
-        items: clamp_rect_to_bounds(rect_for(&output.rects, TABS_ITEMS_ID, empty), tabs_rect),
-        map: clamp_rect_to_bounds(rect_for(&output.rects, TABS_MAP_ID, empty), tabs_rect),
+        items: output.rect_for_clamped(TABS_ITEMS_ID, empty, tabs_rect),
+        map: output.rect_for_clamped(TABS_MAP_ID, empty, tabs_rect),
     }
 }
 
@@ -157,60 +157,27 @@ pub(crate) fn resolve_browser_toolbar_surface_layout(
     let empty = Rect::from_min_max(toolbar_rect.min, toolbar_rect.min);
     BrowserToolbarSurfaceLayout {
         rating_filter_chips: std::array::from_fn(|index| {
-            clamp_rect_to_bounds(
-                rect_for(&output.rects, TOOLBAR_RATING_BASE_ID + index as u64, empty),
-                toolbar_rect,
-            )
+            output.rect_for_clamped(TOOLBAR_RATING_BASE_ID + index as u64, empty, toolbar_rect)
         }),
         playback_age_filter_chips: std::array::from_fn(|index| {
-            clamp_rect_to_bounds(
-                rect_for(
-                    &output.rects,
-                    TOOLBAR_PLAYBACK_BASE_ID + index as u64,
-                    empty,
-                ),
-                toolbar_rect,
-            )
+            output.rect_for_clamped(TOOLBAR_PLAYBACK_BASE_ID + index as u64, empty, toolbar_rect)
         }),
-        marked_filter_chip: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOOLBAR_MARKED_ID, empty),
-            toolbar_rect,
-        ),
-        derived_label_filter_chip: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOOLBAR_DERIVED_LABEL_ID, empty),
+        marked_filter_chip: output.rect_for_clamped(TOOLBAR_MARKED_ID, empty, toolbar_rect),
+        derived_label_filter_chip: output.rect_for_clamped(
+            TOOLBAR_DERIVED_LABEL_ID,
+            empty,
             toolbar_rect,
         ),
         action_slots: [
-            clamp_rect_to_bounds(
-                rect_for(&output.rects, TOOLBAR_RANDOM_ID, empty),
-                toolbar_rect,
-            ),
-            clamp_rect_to_bounds(
-                rect_for(&output.rects, TOOLBAR_CLEANUP_ID, empty),
-                toolbar_rect,
-            ),
-            clamp_rect_to_bounds(
-                rect_for(&output.rects, TOOLBAR_TAGS_ID, empty),
-                toolbar_rect,
-            ),
+            output.rect_for_clamped(TOOLBAR_RANDOM_ID, empty, toolbar_rect),
+            output.rect_for_clamped(TOOLBAR_CLEANUP_ID, empty, toolbar_rect),
+            output.rect_for_clamped(TOOLBAR_TAGS_ID, empty, toolbar_rect),
         ],
-        search_field: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOOLBAR_SEARCH_ID, empty),
-            toolbar_rect,
-        ),
-        activity_chip: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOOLBAR_ACTIVITY_ID, empty),
-            toolbar_rect,
-        ),
-        sort_chip: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOOLBAR_SORT_ID, empty),
-            toolbar_rect,
-        ),
+        search_field: output.rect_for_clamped(TOOLBAR_SEARCH_ID, empty, toolbar_rect),
+        activity_chip: output.rect_for_clamped(TOOLBAR_ACTIVITY_ID, empty, toolbar_rect),
+        sort_chip: output.rect_for_clamped(TOOLBAR_SORT_ID, empty, toolbar_rect),
         triage_chips: std::array::from_fn(|index| {
-            clamp_rect_to_bounds(
-                rect_for(&output.rects, TOOLBAR_TRIAGE_BASE_ID + index as u64, empty),
-                toolbar_rect,
-            )
+            output.rect_for_clamped(TOOLBAR_TRIAGE_BASE_ID + index as u64, empty, toolbar_rect)
         }),
     }
 }
@@ -256,12 +223,4 @@ fn build_browser_toolbar_surface(
     .padding_x(widths.horizontal_padding.max(0.0))
     .fill()
     .into_surface()
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
 }

--- a/src/app_core/native_shell/composition/sidebar_surface.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface.rs
@@ -13,7 +13,7 @@ mod tests;
 
 use super::style::SizingTokens;
 use crate::{app::AppModel, gui::types::Rect, runtime::UiSurface};
-use helpers::{clamp_rect_to_bounds, footer_action_button_width, header_button_side, rect_for};
+use helpers::{footer_action_button_width, header_button_side};
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
 
@@ -157,18 +157,12 @@ pub(crate) fn resolve_sidebar_header_surface_layout(
     let surface = build_sidebar_header_surface(content, sizing);
     let output = surface.layout(header_rect);
     let empty = Rect::from_min_max(header_rect.min, header_rect.min);
-    let add_button = rect_for(&output.rects, HEADER_ADD_BUTTON_ID, empty);
+    let add_button = output.rect_for_clamped(HEADER_ADD_BUTTON_ID, empty, header_rect);
     SidebarHeaderSurfaceLayout {
-        title_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, HEADER_TITLE_ID, empty),
-            header_rect,
-        ),
-        query_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, HEADER_QUERY_ID, empty),
-            header_rect,
-        ),
+        title_text_rect: output.rect_for_clamped(HEADER_TITLE_ID, empty, header_rect),
+        query_text_rect: output.rect_for_clamped(HEADER_QUERY_ID, empty, header_rect),
         add_button_rect: (add_button.width() > 0.0 && add_button.height() > 0.0)
-            .then_some(clamp_rect_to_bounds(add_button, header_rect)),
+            .then_some(add_button),
     }
 }
 
@@ -186,10 +180,8 @@ pub(crate) fn resolve_sidebar_footer_surface_layout(
         .iter()
         .enumerate()
         .filter_map(|(index, spec)| {
-            let rect = clamp_rect_to_bounds(
-                rect_for(&output.rects, FOOTER_ACTION_BASE_ID + index as u64, empty),
-                footer_rect,
-            );
+            let rect =
+                output.rect_for_clamped(FOOTER_ACTION_BASE_ID + index as u64, empty, footer_rect);
             (rect.width() > 0.0 && rect.height() > 0.0).then(|| SidebarFooterActionLayout {
                 spec: spec.clone(),
                 rect,
@@ -197,14 +189,8 @@ pub(crate) fn resolve_sidebar_footer_surface_layout(
         })
         .collect();
     SidebarFooterSurfaceLayout {
-        primary_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, FOOTER_PRIMARY_ID, empty),
-            footer_rect,
-        ),
-        secondary_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, FOOTER_SECONDARY_ID, empty),
-            footer_rect,
-        ),
+        primary_text_rect: output.rect_for_clamped(FOOTER_PRIMARY_ID, empty, footer_rect),
+        secondary_text_rect: output.rect_for_clamped(FOOTER_SECONDARY_ID, empty, footer_rect),
         action_buttons,
     }
 }

--- a/src/app_core/native_shell/composition/status_surface.rs
+++ b/src/app_core/native_shell/composition/status_surface.rs
@@ -140,42 +140,15 @@ pub(crate) fn resolve_status_surface_layout(
     let output = surface.layout(status_bar);
     let empty = Rect::from_min_max(status_bar.min, status_bar.min);
     StatusSurfaceLayout {
-        left_segment: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_LEFT_SEGMENT_ID, empty),
-            status_bar,
-        ),
-        center_segment: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_CENTER_SEGMENT_ID, empty),
-            status_bar,
-        ),
-        right_segment: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_RIGHT_SEGMENT_ID, empty),
-            status_bar,
-        ),
-        progress_segment: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_PROGRESS_SEGMENT_ID, empty),
-            status_bar,
-        ),
-        left_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_LEFT_TEXT_ID, empty),
-            status_bar,
-        ),
-        center_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_CENTER_TEXT_ID, empty),
-            status_bar,
-        ),
-        right_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_RIGHT_TEXT_ID, empty),
-            status_bar,
-        ),
-        progress_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_PROGRESS_TEXT_ID, empty),
-            status_bar,
-        ),
-        progress_track_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, STATUS_PROGRESS_TRACK_ID, empty),
-            status_bar,
-        ),
+        left_segment: output.rect_for_clamped(STATUS_LEFT_SEGMENT_ID, empty, status_bar),
+        center_segment: output.rect_for_clamped(STATUS_CENTER_SEGMENT_ID, empty, status_bar),
+        right_segment: output.rect_for_clamped(STATUS_RIGHT_SEGMENT_ID, empty, status_bar),
+        progress_segment: output.rect_for_clamped(STATUS_PROGRESS_SEGMENT_ID, empty, status_bar),
+        left_text_rect: output.rect_for_clamped(STATUS_LEFT_TEXT_ID, empty, status_bar),
+        center_text_rect: output.rect_for_clamped(STATUS_CENTER_TEXT_ID, empty, status_bar),
+        right_text_rect: output.rect_for_clamped(STATUS_RIGHT_TEXT_ID, empty, status_bar),
+        progress_text_rect: output.rect_for_clamped(STATUS_PROGRESS_TEXT_ID, empty, status_bar),
+        progress_track_rect: output.rect_for_clamped(STATUS_PROGRESS_TRACK_ID, empty, status_bar),
     }
 }
 
@@ -231,14 +204,6 @@ fn progress_slot_width(viewport_width: f32, sizing: SizingTokens) -> f32 {
     let inner_width = (viewport_width - (sizing.panel_inset.max(0.0) * 2.0)).max(0.0);
     (inner_width * STATUS_PROGRESS_RATIO)
         .clamp(STATUS_PROGRESS_MIN_WIDTH, STATUS_PROGRESS_MAX_WIDTH)
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -150,28 +150,16 @@ pub(crate) fn resolve_top_bar_surface_layout(
     let surface = build_top_bar_surface(content, sizing, top_bar.width());
     let output = surface.layout(top_bar);
     let empty = Rect::from_min_max(top_bar.min, top_bar.min);
-    let title_cluster = clamp_rect_to_bounds(
-        rect_for(&output.rects, TOP_TITLE_CLUSTER_ID, empty),
-        top_bar,
-    );
-    let action_cluster = clamp_rect_to_bounds(
-        rect_for(&output.rects, TOP_ACTION_CLUSTER_ID, empty),
-        top_bar,
-    );
-    let options_button_rect = rect_for(&output.rects, TOP_OPTIONS_BUTTON_ID, empty);
+    let title_cluster = output.rect_for_clamped(TOP_TITLE_CLUSTER_ID, empty, top_bar);
+    let action_cluster = output.rect_for_clamped(TOP_ACTION_CLUSTER_ID, empty, top_bar);
+    let options_button_rect = output.rect_for_clamped(TOP_OPTIONS_BUTTON_ID, empty, top_bar);
     let update_buttons = content
         .update_actions
         .iter()
         .enumerate()
         .filter_map(|(index, spec)| {
-            let rect = clamp_rect_to_bounds(
-                rect_for(
-                    &output.rects,
-                    TOP_UPDATE_BUTTON_BASE_ID + index as u64,
-                    empty,
-                ),
-                top_bar,
-            );
+            let rect =
+                output.rect_for_clamped(TOP_UPDATE_BUTTON_BASE_ID + index as u64, empty, top_bar);
             (rect.width() > 0.0 && rect.height() > 0.0).then(|| TopBarUpdateButtonLayout {
                 spec: spec.clone(),
                 rect,
@@ -181,25 +169,13 @@ pub(crate) fn resolve_top_bar_surface_layout(
     TopBarSurfaceLayout {
         title_cluster,
         action_cluster,
-        title_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOP_TITLE_TEXT_ID, empty),
-            top_bar,
-        ),
-        volume_meter_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOP_VOLUME_METER_ID, empty),
-            top_bar,
-        ),
-        volume_value_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOP_VOLUME_VALUE_ID, empty),
-            top_bar,
-        ),
-        volume_label_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, TOP_VOLUME_LABEL_ID, empty),
-            top_bar,
-        ),
+        title_text_rect: output.rect_for_clamped(TOP_TITLE_TEXT_ID, empty, top_bar),
+        volume_meter_rect: output.rect_for_clamped(TOP_VOLUME_METER_ID, empty, top_bar),
+        volume_value_rect: output.rect_for_clamped(TOP_VOLUME_VALUE_ID, empty, top_bar),
+        volume_label_rect: output.rect_for_clamped(TOP_VOLUME_LABEL_ID, empty, top_bar),
         options_button_rect: (options_button_rect.width() > 0.0
             && options_button_rect.height() > 0.0)
-            .then_some(clamp_rect_to_bounds(options_button_rect, top_bar)),
+            .then_some(options_button_rect),
         update_buttons,
     }
 }
@@ -400,14 +376,6 @@ fn visible_update_widths(
         })
         .collect();
     visible_suffix_widths(&widths, available_width, sizing.action_button_gap.max(1.0))
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/waveform_header_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_header_surface.rs
@@ -84,12 +84,10 @@ pub(crate) fn resolve_waveform_header_surface_layout(
     let output = surface.layout(header_rect);
     let empty = Rect::from_min_max(header_rect.min, header_rect.min);
     WaveformHeaderSurfaceLayout {
-        title_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, WAVEFORM_HEADER_TITLE_ID, empty),
-            header_rect,
-        ),
-        metadata_text_rect: clamp_rect_to_bounds(
-            rect_for(&output.rects, WAVEFORM_HEADER_METADATA_ID, empty),
+        title_text_rect: output.rect_for_clamped(WAVEFORM_HEADER_TITLE_ID, empty, header_rect),
+        metadata_text_rect: output.rect_for_clamped(
+            WAVEFORM_HEADER_METADATA_ID,
+            empty,
             header_rect,
         ),
     }
@@ -131,14 +129,6 @@ fn build_waveform_header_surface(
 
 fn format_milli_value(value: u16) -> String {
     format!("{:.3}", f32::from(value.min(1000)) / 1000.0)
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
+++ b/src/app_core/native_shell/composition/waveform_toolbar_surface.rs
@@ -78,8 +78,7 @@ pub(crate) fn resolve_waveform_toolbar_surface_layout(
     let output = surface.layout(header_rect);
     for item_index in visible_start..content.items.len() {
         let id = waveform_toolbar_widget_id(item_index);
-        item_rects[item_index] =
-            clamp_rect_to_bounds(rect_for(&output.rects, id, empty), header_rect);
+        item_rects[item_index] = output.rect_for_clamped(id, empty, header_rect);
     }
     WaveformToolbarSurfaceLayout { item_rects }
 }
@@ -200,14 +199,6 @@ fn waveform_toolbar_layout_label(item: &WaveformToolbarSurfaceItem) -> String {
 
 fn waveform_toolbar_widget_id(index: usize) -> NodeId {
     WAVEFORM_TOOLBAR_BASE_ID + index as u64 + 1
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- replace local rect fallback/clamp helpers in generic surface adapters with LayoutOutput::rect_for_clamped
- remove duplicate helper functions from top/status/sidebar/browser/waveform surface modules
- preserve existing geometry behavior while relying on the Radiant layout API already exposed through Wavecrate

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent