### PR TITLE
Use LayoutOutput clamped rects in adapters

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/bands.rs
@@ -120,20 +120,14 @@ pub(crate) fn compute_top_bar_band_sections(
         }],
     );
     let cluster_output = layout_tree(&clusters_tree, title_row);
-    let title_cluster = clamp_rect_to_bounds(
-        rect_for(
-            &cluster_output.rects,
-            TOP_TITLE_CLUSTER_ID,
-            Rect::from_min_max(title_inner.min, title_inner.min),
-        ),
+    let title_cluster = cluster_output.rect_for_clamped(
+        TOP_TITLE_CLUSTER_ID,
+        Rect::from_min_max(title_inner.min, title_inner.min),
         title_row,
     );
-    let action_cluster = clamp_rect_to_bounds(
-        rect_for(
-            &cluster_output.rects,
-            TOP_ACTION_CLUSTER_ID,
-            Rect::from_min_max(title_inner.max, title_inner.max),
-        ),
+    let action_cluster = cluster_output.rect_for_clamped(
+        TOP_ACTION_CLUSTER_ID,
+        Rect::from_min_max(title_inner.max, title_inner.max),
         title_row,
     );
     TopBarBandSections {
@@ -169,26 +163,11 @@ pub(crate) fn compute_browser_band_sections_with_layout_engine(
         LayoutDebugOptions::default(),
     );
     BrowserBandSections {
-        browser_tabs: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_TABS_ID, empty),
-            browser_panel,
-        ),
-        browser_toolbar: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_TOOLBAR_ID, empty),
-            browser_panel,
-        ),
-        browser_table_header: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_HEADER_ID, empty),
-            browser_panel,
-        ),
-        browser_rows: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_ROWS_ID, empty),
-            browser_panel,
-        ),
-        browser_footer: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_FOOTER_ID, empty),
-            browser_panel,
-        ),
+        browser_tabs: output.rect_for_clamped(BROWSER_TABS_ID, empty, browser_panel),
+        browser_toolbar: output.rect_for_clamped(BROWSER_TOOLBAR_ID, empty, browser_panel),
+        browser_table_header: output.rect_for_clamped(BROWSER_HEADER_ID, empty, browser_panel),
+        browser_rows: output.rect_for_clamped(BROWSER_ROWS_ID, empty, browser_panel),
+        browser_footer: output.rect_for_clamped(BROWSER_FOOTER_ID, empty, browser_panel),
     }
 }
 
@@ -285,16 +264,8 @@ fn fixed_width_slot(width: f32) -> SlotParams {
     }
 }
 
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
-}
-
 fn empty_rect(bounds: Rect) -> Rect {
     bounds.empty_at_min()
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
 }
 
 fn inset_horizontal(rect: Rect, inset: f32) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
@@ -49,14 +49,8 @@ pub(crate) fn compute_browser_tabs_rects(
     );
     let output = layout_tree(&tree, tabs_rect);
     BrowserTabsRects {
-        items: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_TABS_ITEMS_ID, empty),
-            tabs_rect,
-        ),
-        map: clamp_rect_to_bounds(
-            rect_for(&output.rects, BROWSER_TABS_MAP_ID, empty),
-            tabs_rect,
-        ),
+        items: output.rect_for_clamped(BROWSER_TABS_ITEMS_ID, empty, tabs_rect),
+        map: output.rect_for_clamped(BROWSER_TABS_MAP_ID, empty, tabs_rect),
     }
 }
 
@@ -72,14 +66,6 @@ fn fill_tab_slot(node_id: u64, min_width: f32) -> SlotChild {
         },
         child: LayoutNode::widget(node_id, Vector2::new(1.0, 1.0)),
     }
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -70,9 +70,8 @@ pub(crate) fn compute_browser_table_columns(
         ],
     );
     let output = layout_tree(&tree, rect);
-    let index = clamp_rect_to_bounds(rect_for(&output.rects, BROWSER_COL_INDEX_ID, empty), rect);
-    let raw_sample =
-        clamp_rect_to_bounds(rect_for(&output.rects, BROWSER_COL_SAMPLE_ID, empty), rect);
+    let index = output.rect_for_clamped(BROWSER_COL_INDEX_ID, empty, rect);
+    let raw_sample = output.rect_for_clamped(BROWSER_COL_SAMPLE_ID, empty, rect);
     let sample_min_x = raw_sample.min.x.max(index.max.x);
     let sample = Rect::from_min_max(
         Point::new(sample_min_x, raw_sample.min.y),
@@ -177,14 +176,6 @@ fn snap_browser_row_text_baseline(line: Rect) -> Rect {
         Point::new(line.min.x, min_y),
         Point::new(line.max.x, baseline),
     )
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/map_canvas.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_canvas.rs
@@ -37,10 +37,7 @@ pub(crate) fn compute_browser_map_canvas_rect(browser_rows: Rect, sizing: Sizing
         }],
     );
     let output = layout_tree(&tree, browser_rows);
-    clamp_rect_to_bounds(
-        rect_for(&output.rects, MAP_CANVAS_FILL_ID, empty),
-        browser_rows,
-    )
+    output.rect_for_clamped(MAP_CANVAS_FILL_ID, empty, browser_rows)
 }
 
 /// Compute a point center within the map canvas from normalized milli coords.
@@ -51,14 +48,6 @@ pub(crate) fn compute_browser_map_point_center(canvas: Rect, x_milli: u16, y_mil
         canvas.min.x + (canvas.width().max(0.0) * x_ratio),
         canvas.min.y + (canvas.height().max(0.0) * y_ratio),
     )
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -73,14 +73,8 @@ pub(crate) fn compute_browser_map_header_text_layout(
         }],
     );
     let output = layout_tree(&tree, header_rect);
-    let left_bounds = clamp_rect_to_bounds(
-        rect_for(&output.rects, MAP_HEADER_LEFT_ID, empty),
-        header_rect,
-    );
-    let right_bounds = clamp_rect_to_bounds(
-        rect_for(&output.rects, MAP_HEADER_RIGHT_ID, empty),
-        header_rect,
-    );
+    let left_bounds = output.rect_for_clamped(MAP_HEADER_LEFT_ID, empty, header_rect);
+    let right_bounds = output.rect_for_clamped(MAP_HEADER_RIGHT_ID, empty, header_rect);
     BrowserMapHeaderTextLayout {
         left_label: compute_map_header_text_line(left_bounds, sizing, sizing.font_meta),
         right_label: compute_map_header_text_line(right_bounds, sizing, sizing.font_meta),
@@ -118,14 +112,6 @@ fn compute_map_header_text_line(rect: Rect, sizing: SizingTokens, font_size: f32
         },
         0.0,
     )
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
@@ -39,17 +39,10 @@ pub(crate) fn compute_sidebar_band_sections_with_layout_engine(
     let section_tree = build_sidebar_bands_tree(sidebar, sizing);
     let output =
         engine.layout_with_state(&section_tree, sidebar, state, LayoutDebugOptions::default());
-    let sidebar_rows = rect_for(&output.rects, SIDEBAR_ROWS_ID, empty);
     SidebarBandSections {
-        sidebar_header: clamp_rect_to_bounds(
-            rect_for(&output.rects, SIDEBAR_HEADER_ID, empty),
-            sidebar,
-        ),
-        sidebar_rows: clamp_rect_to_bounds(sidebar_rows, sidebar),
-        sidebar_footer: clamp_rect_to_bounds(
-            rect_for(&output.rects, SIDEBAR_FOOTER_ID, empty),
-            sidebar,
-        ),
+        sidebar_header: output.rect_for_clamped(SIDEBAR_HEADER_ID, empty, sidebar),
+        sidebar_rows: output.rect_for_clamped(SIDEBAR_ROWS_ID, empty, sidebar),
+        sidebar_footer: output.rect_for_clamped(SIDEBAR_FOOTER_ID, empty, sidebar),
     }
 }
 
@@ -100,14 +93,6 @@ fn fixed_height_child(node_id: u64, height: f32, bottom_margin: f32) -> SlotChil
     }
 }
 
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
-}
-
 fn empty_rect(bounds: Rect) -> Rect {
     bounds.empty_at_min()
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
 }

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
@@ -93,8 +93,8 @@ fn compute_two_rows(bounds: Rect, inset_y: f32, row_gap: f32, spec: TwoRowSpec) 
     let tree = two_row_tree(inset_y, row_gap, spec);
     let output = layout_tree(&tree, bounds);
     [
-        clamp_rect_to_bounds(rect_for(&output.rects, spec.first_id, empty), bounds),
-        clamp_rect_to_bounds(rect_for(&output.rects, spec.second_id, empty), bounds),
+        output.rect_for_clamped(spec.first_id, empty, bounds),
+        output.rect_for_clamped(spec.second_id, empty, bounds),
     ]
 }
 
@@ -157,14 +157,6 @@ fn sidebar_text_bounds(rect: Rect, sizing: SizingTokens) -> Rect {
         Point::new(min_x, rect.min.y),
         Point::new(max_x, rect.max.y.max(rect.min.y)),
     )
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
@@ -34,14 +34,8 @@ pub(crate) fn compute_waveform_header_text_layout(
     }
     let tree = waveform_header_tree(sizing);
     let output = layout_tree(&tree, header_rect);
-    let title_row = clamp_rect_to_bounds(
-        rect_for(&output.rects, WAVEFORM_HEADER_TITLE_ID, empty),
-        header_rect,
-    );
-    let metadata_row = clamp_rect_to_bounds(
-        rect_for(&output.rects, WAVEFORM_HEADER_META_ID, empty),
-        header_rect,
-    );
+    let title_row = output.rect_for_clamped(WAVEFORM_HEADER_TITLE_ID, empty, header_rect);
+    let metadata_row = output.rect_for_clamped(WAVEFORM_HEADER_META_ID, empty, header_rect);
     WaveformHeaderTextLayout {
         title_row,
         metadata_row,
@@ -108,14 +102,6 @@ fn fixed_height_row(node_id: u64, height: f32) -> SlotChild {
         },
         child: LayoutNode::widget(node_id, Vector2::new(1.0, height.max(1.0))),
     }
-}
-
-fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-fn rect_for(rects: &std::collections::BTreeMap<u64, Rect>, id: u64, fallback: Rect) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 fn empty_rect(bounds: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- migrate older layout adapter modules to LayoutOutput::rect_for_clamped
- remove duplicate local rect lookup/clamp helpers from band, browser, map, sidebar, and waveform header adapters
- keep geometry behavior unchanged while relying on the Radiant layout API surface

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent