### PR TITLE
Use LayoutOutput rect helpers in overlay adapters

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/overlays/drag.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/drag.rs
@@ -53,8 +53,9 @@ pub(super) fn compute_drag_overlay_rect(
         )],
     );
     let output = layout_tree(&tree, align_bounds);
-    shared::clamp_rect_to_bounds(
-        shared::rect_for(&output.rects, DRAG_OVERLAY_ID, shared::empty_rect(content)),
+    output.rect_for_clamped(
+        DRAG_OVERLAY_ID,
+        shared::empty_rect(content),
         Rect::from_min_max(
             Point::new(content.min.x, min_y),
             Point::new(content.max.x, max_y),

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
@@ -59,11 +59,7 @@ fn compute_progress_dialog_rect(content: Rect, sizing: SizingTokens, modal: bool
             ],
         );
         let output = layout_tree(&tree, content);
-        return shared::rect_for(
-            &output.rects,
-            PROGRESS_DIALOG_ID,
-            shared::empty_rect(content),
-        );
+        return output.rect_for(PROGRESS_DIALOG_ID, shared::empty_rect(content));
     }
 
     let width = (sizing.prompt_width * 0.7).min(content.width() - (sizing.overlay_padding * 2.0));
@@ -86,11 +82,7 @@ fn compute_progress_dialog_rect(content: Rect, sizing: SizingTokens, modal: bool
         )],
     );
     let output = layout_tree(&tree, bounds);
-    shared::rect_for(
-        &output.rects,
-        PROGRESS_DIALOG_ID,
-        shared::empty_rect(content),
-    )
+    output.rect_for(PROGRESS_DIALOG_ID, shared::empty_rect(content))
 }
 
 fn compute_progress_bar_rect(dialog: Rect, sizing: SizingTokens) -> Rect {
@@ -148,7 +140,7 @@ fn compute_progress_bar_rect(dialog: Rect, sizing: SizingTokens) -> Rect {
         &tree,
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
-    shared::rect_for(&output.rects, PROGRESS_BAR_ID, shared::empty_rect(dialog))
+    output.rect_for(PROGRESS_BAR_ID, shared::empty_rect(dialog))
 }
 
 fn compute_progress_cancel_button_rect(dialog: Rect, sizing: SizingTokens) -> Rect {
@@ -213,11 +205,7 @@ fn compute_progress_cancel_button_rect(dialog: Rect, sizing: SizingTokens) -> Re
         &tree,
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
-    shared::rect_for(
-        &output.rects,
-        PROGRESS_CANCEL_BUTTON_ID,
-        shared::empty_rect(dialog),
-    )
+    output.rect_for(PROGRESS_CANCEL_BUTTON_ID, shared::empty_rect(dialog))
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
@@ -70,7 +70,7 @@ fn compute_prompt_dialog_rect(content: Rect, sizing: SizingTokens) -> Rect {
         ],
     );
     let output = layout_tree(&tree, content);
-    shared::rect_for(&output.rects, PROMPT_DIALOG_ID, shared::empty_rect(content))
+    output.rect_for(PROMPT_DIALOG_ID, shared::empty_rect(content))
 }
 
 fn compute_prompt_buttons(dialog: Rect, sizing: SizingTokens) -> (Rect, Rect) {
@@ -142,16 +142,8 @@ fn compute_prompt_buttons(dialog: Rect, sizing: SizingTokens) -> (Rect, Rect) {
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
     (
-        shared::rect_for(
-            &output.rects,
-            PROMPT_CONFIRM_BUTTON_ID,
-            shared::empty_rect(dialog),
-        ),
-        shared::rect_for(
-            &output.rects,
-            PROMPT_CANCEL_BUTTON_ID,
-            shared::empty_rect(dialog),
-        ),
+        output.rect_for(PROMPT_CONFIRM_BUTTON_ID, shared::empty_rect(dialog)),
+        output.rect_for(PROMPT_CANCEL_BUTTON_ID, shared::empty_rect(dialog)),
     )
 }
 
@@ -225,11 +217,7 @@ fn compute_prompt_input_rect(
         &tree,
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
-    Some(shared::rect_for(
-        &output.rects,
-        PROMPT_INPUT_ID,
-        shared::empty_rect(dialog),
-    ))
+    Some(output.rect_for(PROMPT_INPUT_ID, shared::empty_rect(dialog)))
 }
 
 #[cfg(test)]

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
@@ -63,15 +63,6 @@ pub(super) fn fixed_width_button(node_id: u64, width: f32, left_margin: f32) -> 
     }
 }
 
-/// Resolve a rect from layout output or return a fallback.
-pub(super) fn rect_for(
-    rects: &std::collections::BTreeMap<u64, Rect>,
-    id: u64,
-    fallback: Rect,
-) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
-}
-
 /// Clamp a rect to a containing bounds rect.
 pub(super) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
     rect.clamp_to(bounds)

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/progress.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/progress.rs
@@ -72,12 +72,8 @@ fn compute_progress_dialog_rows(
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
     ProgressDialogRows {
-        title: shared::rect_for(&output.rects, PROGRESS_TEXT_TITLE_ID, empty),
-        detail: has_detail.then_some(shared::rect_for(
-            &output.rects,
-            PROGRESS_TEXT_DETAIL_ID,
-            empty,
-        )),
+        title: output.rect_for(PROGRESS_TEXT_TITLE_ID, empty),
+        detail: has_detail.then_some(output.rect_for(PROGRESS_TEXT_DETAIL_ID, empty)),
     }
 }
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/prompt.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/prompt.rs
@@ -71,13 +71,9 @@ fn compute_prompt_dialog_rows(
         shared::inset_horizontal(dialog, sizing.text_inset_x.max(0.0)),
     );
     PromptDialogRows {
-        title: shared::rect_for(&output.rects, PROMPT_TEXT_TITLE_ID, empty),
-        message: shared::rect_for(&output.rects, PROMPT_TEXT_MESSAGE_ID, empty),
-        target: has_target.then_some(shared::rect_for(
-            &output.rects,
-            PROMPT_TEXT_TARGET_ID,
-            empty,
-        )),
+        title: output.rect_for(PROMPT_TEXT_TITLE_ID, empty),
+        message: output.rect_for(PROMPT_TEXT_MESSAGE_ID, empty),
+        target: has_target.then_some(output.rect_for(PROMPT_TEXT_TARGET_ID, empty)),
     }
 }
 


### PR DESCRIPTION
## Summary
- replace overlay adapter raw layout rect map lookups with LayoutOutput helper methods
- remove the duplicate overlay rect_for helper
- use rect_for_clamped for the drag overlay bounded lookup

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition::layout_adapter::overlays -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent