### PR TITLE
Use LayoutOutput rect helpers in sidebar header

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
@@ -151,21 +151,15 @@ pub(crate) fn compute_sidebar_folder_header_layout(
         }],
     );
     let output = layout_tree(&text_tree, text_bounds);
-    let title_row = helpers::clamp_rect_to_bounds(
-        helpers::rect_for(
-            &output.rects,
-            FOLDER_HEADER_TITLE_ID,
-            helpers::empty_rect(text_bounds),
-        ),
+    let title_row = output.rect_for_clamped(
+        FOLDER_HEADER_TITLE_ID,
+        helpers::empty_rect(text_bounds),
         text_bounds,
     );
     let metadata_row = if show_metadata {
-        let row = helpers::clamp_rect_to_bounds(
-            helpers::rect_for(
-                &output.rects,
-                FOLDER_HEADER_META_ID,
-                helpers::empty_rect(text_bounds),
-            ),
+        let row = output.rect_for_clamped(
+            FOLDER_HEADER_META_ID,
+            helpers::empty_rect(text_bounds),
             text_bounds,
         );
         (row.height() > 0.0).then_some(row)
@@ -233,12 +227,9 @@ pub(crate) fn compute_source_section_divider_rect(
         }],
     );
     let output = layout_tree(&divider_tree, align_bounds);
-    let rect = helpers::clamp_rect_to_bounds(
-        helpers::rect_for(
-            &output.rects,
-            SOURCE_DIVIDER_ID,
-            helpers::empty_rect(align_bounds),
-        ),
+    let rect = output.rect_for_clamped(
+        SOURCE_DIVIDER_ID,
+        helpers::empty_rect(align_bounds),
         Rect::from_min_max(
             Point::new(source_rows.min.x, source_rows.min.y),
             Point::new(source_rows.max.x, folder_header.max.y),

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
@@ -63,12 +63,9 @@ pub(crate) fn compute_recovery_badge_layout(
         }],
     );
     let output = layout_tree(&badge_tree, badge_bounds);
-    let rect = clamp_rect_to_bounds(
-        rect_for(
-            &output.rects,
-            FOLDER_HEADER_BADGE_ID,
-            empty_rect(badge_bounds),
-        ),
+    let rect = output.rect_for_clamped(
+        FOLDER_HEADER_BADGE_ID,
+        empty_rect(badge_bounds),
         header_rect,
     );
     (rect.height() > 0.0).then_some(RecoveryBadgeLayout {
@@ -164,18 +161,6 @@ pub(crate) fn build_text_rows(show_metadata: bool, sizing: SizingTokens) -> Vec<
         child: LayoutNode::widget(FOLDER_HEADER_TEXT_FILL_ID, Vector2::new(1.0, 1.0)),
     });
     rows
-}
-
-pub(crate) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-pub(crate) fn rect_for(
-    rects: &std::collections::BTreeMap<u64, Rect>,
-    id: u64,
-    fallback: Rect,
-) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }
 
 pub(crate) fn empty_rect(bounds: Rect) -> Rect {

--- a/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
+++ b/src/app_core/native_shell/composition/sidebar_surface_helpers.rs
@@ -1,7 +1,6 @@
-//! Shared widget, slot, and clamp helpers for sidebar chrome surfaces.
+//! Shared sizing helpers for sidebar chrome surfaces.
 
 use crate::app_core::native_shell::composition::style::SizingTokens;
-use crate::gui::types::{Point, Rect, Vector2};
 
 /// Return the canonical square sidebar-header add-button edge length.
 pub(super) fn header_button_side(sizing: SizingTokens) -> f32 {
@@ -25,18 +24,4 @@ pub(super) fn footer_action_button_width(
         / button_count as f32)
         .min(sizing.sidebar_action_button_width)
         .max(1.0)
-}
-
-/// Clamp one resolved layout rect back inside the original surface bounds.
-pub(super) fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
-    rect.clamp_to(bounds)
-}
-
-/// Look up one resolved rect by node id or return the provided fallback.
-pub(super) fn rect_for(
-    rects: &std::collections::BTreeMap<u64, Rect>,
-    id: u64,
-    fallback: Rect,
-) -> Rect {
-    rects.get(&id).copied().unwrap_or(fallback)
 }


### PR DESCRIPTION
## Summary
- replace sidebar header layout rect map lookups with LayoutOutput helper methods
- remove duplicate sidebar header rect/clamp helpers
- remove stale sidebar surface rect helpers with no callers

## Validation
- cargo test -p wavecrate --lib app_core::native_shell::composition::layout_adapter::sidebar_header -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent