### PR TITLE
[codex] Align source database filename with target

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -1,4 +1,8 @@
-use std::path::{Component, Path, PathBuf};
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Component, Path, PathBuf},
+};
 
 use rusqlite::{Connection, OpenFlags, Transaction};
 use serde::{Deserialize, Serialize};
@@ -30,7 +34,9 @@ pub use pending_renames::PendingRenameEntry;
 pub use util::normalize_relative_path;
 
 /// Hidden filename used for per-source databases.
-pub const DB_FILE_NAME: &str = ".wavecrate_samples.db";
+pub const DB_FILE_NAME: &str = ".wavecrate.db";
+/// Previous hidden filename used for per-source databases.
+pub const LEGACY_DB_FILE_NAME: &str = ".wavecrate_samples.db";
 /// Metadata key for the last completed scan timestamp.
 pub const META_LAST_SCAN_COMPLETED_AT: &str = "last_scan_completed_at";
 /// Metadata key for the last similarity-prep scan timestamp.
@@ -329,9 +335,19 @@ pub enum SourceDbError {
     /// Read-only mode requires an existing database file.
     #[error("Read-only source DB mode requires an existing database file: {0}")]
     ReadOnlyDatabaseMissing(PathBuf),
+    /// Failed to move a source DB from its legacy filename to the current filename.
+    #[error("Could not migrate source database from {from} to {to}: {source}")]
+    RenameLegacyDatabase {
+        /// Legacy source DB path.
+        from: PathBuf,
+        /// Current source DB path.
+        to: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
     /// Refusing to write a source DB in a path that looks like a user library.
     #[error(
-        "Refusing to write `.wavecrate_samples.db` in user-library-like path: {path}; set WAVECRATE_ALLOW_USER_LIBRARY_DB_WRITE=1 to allow this"
+        "Refusing to write `.wavecrate.db` in user-library-like path: {path}; set WAVECRATE_ALLOW_USER_LIBRARY_DB_WRITE=1 to allow this"
     )]
     UserLibraryWriteBlocked {
         /// Suspicious source root path.
@@ -510,7 +526,7 @@ fn open_read_only_source_database(
         return Err(SourceDbError::InvalidRoot(root.to_path_buf()));
     }
 
-    let db_path = root.join(DB_FILE_NAME);
+    let db_path = read_only_db_path(root);
     if !db_path.is_file() {
         return Err(SourceDbError::ReadOnlyDatabaseMissing(db_path));
     }
@@ -634,7 +650,7 @@ fn open_source_database_with_flags(
         });
     }
 
-    let db_path = root.join(DB_FILE_NAME);
+    let db_path = prepare_writable_db_path(root)?;
     util::create_parent_if_needed(&db_path)?;
     let connect_started = std::time::Instant::now();
     let connection = match Connection::open_with_flags(&db_path, open_flags) {
@@ -755,6 +771,59 @@ fn open_source_database_with_flags(
         Ok(()),
     );
     Ok(db)
+}
+
+fn read_only_db_path(root: &Path) -> PathBuf {
+    let db_path = root.join(DB_FILE_NAME);
+    if db_path.is_file() {
+        return db_path;
+    }
+    let legacy_path = root.join(LEGACY_DB_FILE_NAME);
+    if legacy_path.is_file() {
+        legacy_path
+    } else {
+        db_path
+    }
+}
+
+fn prepare_writable_db_path(root: &Path) -> Result<PathBuf, SourceDbError> {
+    let db_path = root.join(DB_FILE_NAME);
+    if db_path.exists() {
+        return Ok(db_path);
+    }
+    let legacy_path = root.join(LEGACY_DB_FILE_NAME);
+    if legacy_path.exists() {
+        migrate_legacy_source_db(&legacy_path, &db_path)?;
+    }
+    Ok(db_path)
+}
+
+fn migrate_legacy_source_db(from: &Path, to: &Path) -> Result<(), SourceDbError> {
+    fs::rename(from, to).map_err(|source| SourceDbError::RenameLegacyDatabase {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+        source,
+    })?;
+    for suffix in ["-wal", "-shm"] {
+        let legacy_sidecar = sqlite_sidecar_path(from, suffix);
+        if legacy_sidecar.exists() {
+            let current_sidecar = sqlite_sidecar_path(to, suffix);
+            fs::rename(&legacy_sidecar, &current_sidecar).map_err(|source| {
+                SourceDbError::RenameLegacyDatabase {
+                    from: legacy_sidecar,
+                    to: current_sidecar,
+                    source,
+                }
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = OsString::from(path.as_os_str());
+    name.push(suffix);
+    PathBuf::from(name)
 }
 
 impl SourceDatabaseOpenMode {

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -120,7 +120,7 @@ source registry afterward.
   - Named non-live profiles write under `<config-base>/.wavecrate/profiles/<name>/`.
   - `scripts/run.* sandbox` sets both `WAVECRATE_CONFIG_HOME` and `WAVECRATE_CONFIG_PROFILE=sandbox` so the run does **not** touch your real user profile config/log directories.
 - Per-source-folder database side effect:
-  - If you point Wavecrate at a folder, it may create or update a `.wavecrate_samples.db` in that source folder.
+  - If you point Wavecrate at a folder, it may create or update a `.wavecrate.db` in that source folder.
   - `WAVECRATE_CONFIG_HOME` does **not** relocate these per-folder DB files.
   - `scripts/run.sh sandbox` and `scripts/run.ps1 sandbox` set
     `WAVECRATE_SOURCE_DB_READ_ONLY=1` by default, so source DB writes are blocked
@@ -130,7 +130,7 @@ source registry afterward.
 
 - `WAVECRATE_SOURCE_DB_READ_ONLY`
   - When `1`/`true`/`yes`/`on`, `SourceDatabase::open` uses read-only access by
-    default and requires `<source>/.wavecrate_samples.db` to already exist.
+    default and requires `<source>/.wavecrate.db` to already exist. Legacy `<source>/.wavecrate_samples.db` files are still readable for compatibility.
   - When unset/default, normal write-capable behavior applies.
 
 - `WAVECRATE_ALLOW_USER_LIBRARY_DB_WRITE`

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -240,7 +240,15 @@ Diagnostic bundles should avoid exposing full audio content by default. If a dia
 
 Wavecrate should split storage between source-local state and global application state.
 
-Source-specific information should live in the folder of that source. Each indexed source folder should contain a special Wavecrate source database file, such as `.wavecrate.db`, unless a later naming decision changes the exact filename. This keeps source metadata close to the real files and makes a source folder more portable between machines or Wavecrate installations.
+Source-specific information should live in the folder of that source. Each indexed source folder should contain a special Wavecrate source database file named `.wavecrate.db`. This keeps source metadata close to the real files and makes a source folder more portable between machines or Wavecrate installations while avoiding confusion with the global `.wavecrate` configuration folder.
+
+The `.wavecrate.db` file is internal source metadata and should be hidden from the normal sample browser and folder tree by default. It may appear in diagnostics, source repair flows, logs, or explicit filesystem-reveal operations when relevant.
+
+The `.wavecrate.db` file should be excluded from ordinary copy, move, trash, delete, rename, batch, drag, clipboard, export, and handoff operations that target visible sample/folder items. It should only be manipulated by explicit source maintenance, repair, migration, backup, or diagnostics workflows.
+
+If a user copies, moves, backs up, syncs, or transfers an entire source folder outside Wavecrate, the `.wavecrate.db` file should travel with that folder as source-local metadata. Wavecrate should be able to relink or reopen the moved/copied source folder and use the carried `.wavecrate.db` to preserve file metadata where file identity and paths can be reconciled safely.
+
+If a copied source folder is added while the original source is still indexed, Wavecrate should treat the copied folder as an independent source rather than rejecting it as a duplicate source. Any duplicated embedded Sample IDs or duplicate audio content inside the copied source should be handled by the normal file-level duplicate-ID conflict and exact-audio duplicate systems, not by blocking source addition.
 
 Wavecrate should not offer a read-only source mode in the current target. Adding a folder as a Wavecrate source means Wavecrate may create or update its source database, write embedded Sample ID metadata, create extracted files, rename files, move files, duplicate files, apply destructive edits, and otherwise manage ordinary files according to the user's commands and configured safety settings.
 
@@ -1040,7 +1048,7 @@ Wavecrate should let users add one or more source folders. A source folder is a 
 Adding a source should:
 
 - validate that the path exists and is readable
-- reject exact duplicate source roots
+- reject exact duplicate source roots that point to the same resolved filesystem location already configured
 - warn when a new source is nested inside an existing source or contains an existing source
 - create or open source database state
 - scan supported audio files incrementally

--- a/src/app/controller/source_watcher.rs
+++ b/src/app/controller/source_watcher.rs
@@ -1,7 +1,11 @@
 //! File system watcher for source roots that reports audio-relevant changes.
 
 use crate::app::controller::jobs::{JobMessage, JobMessageSender};
-use crate::sample_sources::{SourceId, db::DB_FILE_NAME, is_supported_audio};
+use crate::sample_sources::{
+    SourceId,
+    db::{DB_FILE_NAME, LEGACY_DB_FILE_NAME},
+    is_supported_audio,
+};
 use notify::{
     Event, EventKind, RecommendedWatcher, RecursiveMode, Result as NotifyResult, Watcher,
 };
@@ -359,7 +363,7 @@ fn path_is_ignored(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
-    name.starts_with(DB_FILE_NAME)
+    name.starts_with(DB_FILE_NAME) || name.starts_with(LEGACY_DB_FILE_NAME)
 }
 
 fn path_extensionless_is_directory(path: &Path) -> bool {
@@ -381,6 +385,10 @@ mod tests {
         assert!(!path_is_candidate(Path::new(DB_FILE_NAME)));
         assert!(!path_is_candidate(Path::new(&format!(
             "{DB_FILE_NAME}-wal"
+        ))));
+        assert!(!path_is_candidate(Path::new(LEGACY_DB_FILE_NAME)));
+        assert!(!path_is_candidate(Path::new(&format!(
+            "{LEGACY_DB_FILE_NAME}-wal"
         ))));
     }
 

--- a/tests/unit/source_db_mod_tests/opening.rs
+++ b/tests/unit/source_db_mod_tests/opening.rs
@@ -45,6 +45,72 @@ fn open_defaults_to_read_only_when_enabled() {
 }
 
 #[test]
+fn writable_open_uses_current_source_database_filename() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+
+    assert_eq!(db.db_path, dir.path().join(DB_FILE_NAME));
+    assert!(dir.path().join(DB_FILE_NAME).is_file());
+    assert!(!dir.path().join(LEGACY_DB_FILE_NAME).exists());
+}
+
+#[test]
+fn writable_open_migrates_legacy_source_database_filename() {
+    let dir = tempdir().unwrap();
+    let legacy_db = dir.path().join(LEGACY_DB_FILE_NAME);
+    {
+        let conn = Connection::open(&legacy_db).unwrap();
+        conn.execute(
+            "CREATE TABLE wav_files (
+                    path TEXT PRIMARY KEY,
+                    file_size INTEGER NOT NULL,
+                    modified_ns INTEGER NOT NULL
+                )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wav_files (path, file_size, modified_ns) VALUES ('one.wav', 10, 5)",
+            [],
+        )
+        .unwrap();
+    }
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let rows = db.list_files().unwrap();
+
+    assert_eq!(db.db_path, dir.path().join(DB_FILE_NAME));
+    assert!(dir.path().join(DB_FILE_NAME).is_file());
+    assert!(!legacy_db.exists());
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].relative_path, PathBuf::from("one.wav"));
+}
+
+#[test]
+fn read_only_open_keeps_legacy_source_database_filename() {
+    let dir = tempdir().unwrap();
+    let legacy_db = dir.path().join(LEGACY_DB_FILE_NAME);
+    {
+        let conn = Connection::open(&legacy_db).unwrap();
+        conn.execute(
+            "CREATE TABLE wav_files (
+                    path TEXT PRIMARY KEY,
+                    file_size INTEGER NOT NULL,
+                    modified_ns INTEGER NOT NULL
+                )",
+            [],
+        )
+        .unwrap();
+    }
+
+    let db = SourceDatabase::open_read_only(dir.path()).unwrap();
+
+    assert_eq!(db.db_path, legacy_db);
+    assert!(dir.path().join(LEGACY_DB_FILE_NAME).is_file());
+    assert!(!dir.path().join(DB_FILE_NAME).exists());
+}
+
+#[test]
 fn open_blocks_writes_for_user_library_roots_without_override() {
     let home = match tempdir() {
         Ok(home) => home,


### PR DESCRIPTION
## Summary
- switch the canonical source-local database filename to .wavecrate.db
- migrate writable opens from legacy .wavecrate_samples.db, including SQLite sidecar names, while keeping read-only legacy compatibility
- update watcher filtering and docs for the current and legacy source DB names

## Validation
- cargo test -p wavecrate-library source_db_mod_tests::opening
- cargo test -p wavecrate --lib source_watcher::tests::path_is_candidate_filters_db_files
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent