### PR TITLE
[codex] Reject duplicate source aliases

### DIFF
--- a/src/app/controller/library/sources/lifecycle.rs
+++ b/src/app/controller/library/sources/lifecycle.rs
@@ -32,7 +32,12 @@ impl AppController {
             );
             return Err(error);
         }
-        if self.library.sources.iter().any(|s| s.root == normalized) {
+        if self
+            .library
+            .sources
+            .iter()
+            .any(|s| source_roots_match(&s.root, &normalized))
+        {
             self.set_status("Source already added", StatusTone::Info);
             record_source_lifecycle_event(
                 "sources.add",
@@ -205,7 +210,7 @@ impl AppController {
             .sources
             .iter()
             .enumerate()
-            .any(|(i, source)| i != index && source.root == normalized)
+            .any(|(i, source)| i != index && source_roots_match(&source.root, &normalized))
         {
             let error = String::from("Source already added");
             record_source_lifecycle_event(
@@ -334,6 +339,19 @@ impl AppController {
             None,
         );
     }
+}
+
+fn source_roots_match(existing: &PathBuf, candidate: &PathBuf) -> bool {
+    if existing == candidate {
+        return true;
+    }
+    let Ok(existing) = fs::canonicalize(existing) else {
+        return false;
+    };
+    let Ok(candidate) = fs::canonicalize(candidate) else {
+        return false;
+    };
+    existing == candidate
 }
 
 fn record_source_lifecycle_event(

--- a/src/app/controller/tests/source_lifecycle.rs
+++ b/src/app/controller/tests/source_lifecycle.rs
@@ -1,5 +1,27 @@
-use super::super::test_support::{prepare_with_source_and_wav_entries, sample_entry};
+use super::super::test_support::{
+    dummy_controller, prepare_with_source_and_wav_entries, sample_entry,
+};
 use crate::app::state::StatusTone;
+
+#[test]
+fn adding_source_rejects_same_resolved_root_with_different_spelling() {
+    let config_root = tempfile::tempdir().expect("create config root");
+    let _guard = crate::app_dirs::ConfigBaseGuard::set(config_root.path().to_path_buf());
+    let source_root = tempfile::tempdir().expect("create source root");
+    let (mut controller, _) = dummy_controller();
+    controller.library.sources.clear();
+
+    controller
+        .add_source_from_path(source_root.path().to_path_buf())
+        .expect("add source");
+    controller
+        .add_source_from_path(source_root.path().join("."))
+        .expect("duplicate source alias should short-circuit");
+
+    assert_eq!(controller.library.sources.len(), 1);
+    assert_eq!(controller.ui.status.text, "Source already added");
+    assert_eq!(controller.ui.status.status_tone, StatusTone::Info);
+}
 
 #[test]
 /// Verifies removing source rolls back when config save fails.


### PR DESCRIPTION
## Summary
- compare source roots by resolved filesystem location when adding or remapping sources
- keep the existing stored path behavior, but short-circuit aliases that point at an already configured source root
- add a regression for adding the same source through a differently spelled path

## Validation
- cargo test -p wavecrate --lib adding_source_rejects_same_resolved_root_with_different_spelling
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent