### PR TITLE
[codex] Reject nested source roots

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1049,7 +1049,7 @@ Adding a source should:
 
 - validate that the path exists and is readable
 - reject exact duplicate source roots that point to the same resolved filesystem location already configured
-- warn when a new source is nested inside an existing source or contains an existing source
+- reject nested source roots when the new source is inside an existing source or contains an existing source
 - create or open source database state
 - scan supported audio files incrementally
 - report scan progress without blocking browsing or auditioning

--- a/src/app/controller/library/sources/lifecycle.rs
+++ b/src/app/controller/library/sources/lifecycle.rs
@@ -48,6 +48,22 @@ impl AppController {
             );
             return Ok(());
         }
+        if self
+            .library
+            .sources
+            .iter()
+            .any(|s| source_roots_are_nested(&s.root, &normalized))
+        {
+            let error = String::from("Source folders cannot be nested");
+            record_source_lifecycle_event(
+                "sources.add",
+                Some(&source),
+                "error",
+                started_at,
+                Some(&error),
+            );
+            return Err(error);
+        }
         let source = match crate::sample_sources::library::lookup_source_id_for_root(&normalized) {
             Ok(Some(id)) => SampleSource::new_with_id(id, normalized.clone()),
             Ok(None) => SampleSource::new(normalized.clone()),
@@ -222,6 +238,23 @@ impl AppController {
             );
             return Err(error);
         }
+        if self
+            .library
+            .sources
+            .iter()
+            .enumerate()
+            .any(|(i, source)| i != index && source_roots_are_nested(&source.root, &normalized))
+        {
+            let error = String::from("Source folders cannot be nested");
+            record_source_lifecycle_event(
+                "sources.remap",
+                Some(existing.id.as_str()),
+                "error",
+                started_at,
+                Some(&error),
+            );
+            return Err(error);
+        }
         let old_db_path = crate::sample_sources::database_path_for(&existing.root);
         let new_db_path = crate::sample_sources::database_path_for(&normalized);
         if old_db_path.exists() && !new_db_path.exists() {
@@ -352,6 +385,16 @@ fn source_roots_match(existing: &PathBuf, candidate: &PathBuf) -> bool {
         return false;
     };
     existing == candidate
+}
+
+fn source_roots_are_nested(existing: &PathBuf, candidate: &PathBuf) -> bool {
+    let Ok(existing) = fs::canonicalize(existing) else {
+        return false;
+    };
+    let Ok(candidate) = fs::canonicalize(candidate) else {
+        return false;
+    };
+    existing.starts_with(&candidate) || candidate.starts_with(&existing)
 }
 
 fn record_source_lifecycle_event(

--- a/src/app/controller/tests/source_lifecycle.rs
+++ b/src/app/controller/tests/source_lifecycle.rs
@@ -24,6 +24,40 @@ fn adding_source_rejects_same_resolved_root_with_different_spelling() {
 }
 
 #[test]
+fn adding_source_rejects_nested_source_roots() {
+    let config_root = tempfile::tempdir().expect("create config root");
+    let _guard = crate::app_dirs::ConfigBaseGuard::set(config_root.path().to_path_buf());
+    let library_root = tempfile::tempdir().expect("create library root");
+    let parent = library_root.path().join("packs");
+    let child = parent.join("drums");
+    std::fs::create_dir_all(&child).expect("create nested source roots");
+
+    let (mut controller, _) = dummy_controller();
+    controller.library.sources.clear();
+    controller
+        .add_source_from_path(parent.clone())
+        .expect("add parent source");
+
+    let child_err = controller
+        .add_source_from_path(child.clone())
+        .expect_err("nested child source should be rejected");
+    assert_eq!(child_err, "Source folders cannot be nested");
+    assert_eq!(controller.library.sources.len(), 1);
+
+    let (mut controller, _) = dummy_controller();
+    controller.library.sources.clear();
+    controller
+        .add_source_from_path(child)
+        .expect("add child source first");
+
+    let parent_err = controller
+        .add_source_from_path(parent)
+        .expect_err("containing parent source should be rejected");
+    assert_eq!(parent_err, "Source folders cannot be nested");
+    assert_eq!(controller.library.sources.len(), 1);
+}
+
+#[test]
 /// Verifies removing source rolls back when config save fails.
 fn removing_source_rolls_back_when_config_save_fails() {
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![sample_entry(


### PR DESCRIPTION
## Summary
- make the target explicit that nested source roots are rejected rather than only warned
- reject source add/remap attempts where the new root contains or is contained by an existing source root after filesystem resolution
- add a regression for child-inside-parent and parent-containing-child source additions

## Validation
- cargo test -p wavecrate --lib adding_source_rejects_nested_source_roots
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent