### PR TITLE
[codex] Block permanent trash deletion

### DIFF
--- a/src/app/controller/library/trash/deletion.rs
+++ b/src/app/controller/library/trash/deletion.rs
@@ -1,78 +1,11 @@
 use super::super::*;
-use std::fs;
-use tracing::warn;
 
 impl AppController {
-    /// Permanently delete the contents of the configured trash folder after confirmation.
+    /// Refuse permanent deletion from Wavecrate's normal cleanup workflow.
     pub fn take_out_trash(&mut self) {
-        if !self.confirm_warning(
-            "Take out trash?",
-            "Everything inside the trash folder will be permanently deleted. Continue?",
-        ) {
-            return;
-        }
-        let Ok(trash_root) = self.ensure_trash_folder_ready() else {
-            return;
-        };
-        self.set_status("Deleting trash...", StatusTone::Busy);
-        let mut files_removed = 0usize;
-        let mut errors = Vec::new();
-        let mut stack = vec![trash_root.clone()];
-        let mut dirs = Vec::new();
-        while let Some(dir) = stack.pop() {
-            match fs::read_dir(&dir) {
-                Ok(entries) => {
-                    dirs.push(dir.clone());
-                    for entry in entries {
-                        match entry {
-                            Ok(entry) => {
-                                let path = entry.path();
-                                if path.is_dir() {
-                                    stack.push(path);
-                                } else if path.is_file() {
-                                    match fs::remove_file(&path) {
-                                        Ok(_) => files_removed += 1,
-                                        Err(err) => errors.push(format!(
-                                            "Failed to delete {}: {err}",
-                                            path.display()
-                                        )),
-                                    }
-                                }
-                            }
-                            Err(err) => errors.push(format!("Failed to read entry: {err}")),
-                        }
-                    }
-                }
-                Err(err) => errors.push(format!(
-                    "Failed to read trash folder {}: {err}",
-                    dir.display()
-                )),
-            }
-        }
-        for dir in dirs.into_iter().rev() {
-            if dir == trash_root {
-                continue;
-            }
-            if let Err(err) = fs::remove_dir(&dir)
-                && dir.exists()
-            {
-                errors.push(format!("Failed to remove folder {}: {err}", dir.display()));
-            }
-        }
-        if errors.is_empty() {
-            self.set_status(
-                format!("Deleted {files_removed} file(s) from trash"),
-                StatusTone::Info,
-            );
-        } else {
-            let summary = format!(
-                "Deleted {files_removed} file(s) from trash with {} error(s)",
-                errors.len()
-            );
-            self.set_status(summary, StatusTone::Warning);
-            for err in errors {
-                warn!(error = %err, trash_root = %trash_root.display(), "Trash delete error");
-            }
-        }
+        self.set_status(
+            "Permanent trash deletion is outside Wavecrate cleanup; no files were deleted",
+            StatusTone::Warning,
+        );
     }
 }

--- a/src/app/controller/tests/trash.rs
+++ b/src/app/controller/tests/trash.rs
@@ -96,7 +96,7 @@ fn moving_trashed_samples_can_cancel_midway() -> Result<(), String> {
 }
 
 #[test]
-fn taking_out_trash_deletes_files() {
+fn taking_out_trash_leaves_files_for_manual_cleanup() {
     let temp = tempdir().unwrap();
     let trash_root = temp.path().join("trash");
     std::fs::create_dir_all(trash_root.join("nested")).unwrap();
@@ -110,10 +110,16 @@ fn taking_out_trash_deletes_files() {
     controller.take_out_trash();
 
     assert!(trash_root.is_dir());
-    assert!(!trash_root.join("junk.wav").exists());
-    assert!(!trash_root.join("nested").join("more.wav").exists());
-    let remaining: Vec<_> = std::fs::read_dir(&trash_root).unwrap().collect();
-    assert!(remaining.is_empty());
+    assert!(trash_root.join("junk.wav").exists());
+    assert!(trash_root.join("nested").join("more.wav").exists());
+    assert_eq!(
+        controller.ui.status.text,
+        "Permanent trash deletion is outside Wavecrate cleanup; no files were deleted"
+    );
+    assert_eq!(
+        controller.ui.status.status_tone,
+        crate::app::state::StatusTone::Warning
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- refuse the legacy take-out-trash command instead of permanently deleting files from the configured trash folder
- report that permanent trash deletion is outside Wavecrate cleanup
- update the trash regression to prove files remain for manual cleanup

## Validation
- cargo test -p wavecrate --lib taking_out_trash_leaves_files_for_manual_cleanup
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent