### PR TITLE
[codex] Explain nested source conflicts

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1055,6 +1055,8 @@ Adding a source should:
 - report scan progress without blocking browsing or auditioning
 - preserve existing metadata when a source is reopened
 
+When a source-add request is rejected because it is nested with an existing source, Wavecrate should explain the conflict and offer a deliberate source swap where safe. For example, if the user tries to add a parent folder that contains an existing child source, Wavecrate may offer to remove the child source reference and add the parent source instead. If the user tries to add a child folder inside an existing parent source, Wavecrate may offer to replace the parent source with the child source. A swap should be an explicit source-reference operation, should not delete audio files or source database files, and should follow the undo, relink, and source-scan rules for source changes.
+
 Removing a source from Wavecrate should remove it from the indexed source list but should not delete audio files from disk. Source removal can happen immediately without confirmation because it is an undoable source-reference change and does not delete files. The UI should still make clear that removing a source only removes Wavecrate's active index reference.
 
 If the root folder for a configured source is moved, renamed, deleted, disconnected, or otherwise unavailable outside Wavecrate, Wavecrate should mark the source as broken or missing in the source list and folder tree. The UI should not silently drop the source, delete its metadata, or pretend the source is empty.

--- a/src/app/controller/library/sources/lifecycle.rs
+++ b/src/app/controller/library/sources/lifecycle.rs
@@ -48,13 +48,12 @@ impl AppController {
             );
             return Ok(());
         }
-        if self
+        if let Some(error) = self
             .library
             .sources
             .iter()
-            .any(|s| source_roots_are_nested(&s.root, &normalized))
+            .find_map(|s| nested_source_conflict_error(&s.root, &normalized))
         {
-            let error = String::from("Source folders cannot be nested");
             record_source_lifecycle_event(
                 "sources.add",
                 Some(&source),
@@ -238,14 +237,14 @@ impl AppController {
             );
             return Err(error);
         }
-        if self
+        if let Some(error) = self
             .library
             .sources
             .iter()
             .enumerate()
-            .any(|(i, source)| i != index && source_roots_are_nested(&source.root, &normalized))
+            .filter(|(i, _)| *i != index)
+            .find_map(|(_, source)| nested_source_conflict_error(&source.root, &normalized))
         {
-            let error = String::from("Source folders cannot be nested");
             record_source_lifecycle_event(
                 "sources.remap",
                 Some(existing.id.as_str()),
@@ -387,14 +386,31 @@ fn source_roots_match(existing: &PathBuf, candidate: &PathBuf) -> bool {
     existing == candidate
 }
 
-fn source_roots_are_nested(existing: &PathBuf, candidate: &PathBuf) -> bool {
+fn nested_source_conflict_error(existing: &PathBuf, candidate: &PathBuf) -> Option<String> {
     let Ok(existing) = fs::canonicalize(existing) else {
-        return false;
+        return None;
     };
     let Ok(candidate) = fs::canonicalize(candidate) else {
-        return false;
+        return None;
     };
-    existing.starts_with(&candidate) || candidate.starts_with(&existing)
+    if existing == candidate {
+        return None;
+    }
+    if candidate.starts_with(&existing) {
+        Some(format!(
+            "Source folders cannot be nested: {} is inside existing source {}. Remove or remap the existing source before adding this folder.",
+            candidate.display(),
+            existing.display()
+        ))
+    } else if existing.starts_with(&candidate) {
+        Some(format!(
+            "Source folders cannot be nested: {} contains existing source {}. Remove or remap the existing source before adding this folder.",
+            candidate.display(),
+            existing.display()
+        ))
+    } else {
+        None
+    }
 }
 
 fn record_source_lifecycle_event(

--- a/src/app/controller/tests/source_lifecycle.rs
+++ b/src/app/controller/tests/source_lifecycle.rs
@@ -41,7 +41,9 @@ fn adding_source_rejects_nested_source_roots() {
     let child_err = controller
         .add_source_from_path(child.clone())
         .expect_err("nested child source should be rejected");
-    assert_eq!(child_err, "Source folders cannot be nested");
+    assert!(child_err.contains("Source folders cannot be nested"));
+    assert!(child_err.contains("is inside existing source"));
+    assert!(child_err.contains("Remove or remap the existing source"));
     assert_eq!(controller.library.sources.len(), 1);
 
     let (mut controller, _) = dummy_controller();
@@ -53,7 +55,9 @@ fn adding_source_rejects_nested_source_roots() {
     let parent_err = controller
         .add_source_from_path(parent)
         .expect_err("containing parent source should be rejected");
-    assert_eq!(parent_err, "Source folders cannot be nested");
+    assert!(parent_err.contains("Source folders cannot be nested"));
+    assert!(parent_err.contains("contains existing source"));
+    assert!(parent_err.contains("Remove or remap the existing source"));
     assert_eq!(controller.library.sources.len(), 1);
 }
 


### PR DESCRIPTION
## Summary
- extend the target source-add rules with deliberate nested-source swap guidance
- make nested source add/remap rejection explain whether the requested folder is inside or contains an existing source
- update source lifecycle regression coverage for the clearer conflict messages

## Validation
- cargo test -p wavecrate --lib adding_source_rejects_nested_source_roots
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent