### PR TITLE
Route browser delete through configured trash

### DIFF
--- a/src/app/controller/library/browser_controller/actions/destructive.rs
+++ b/src/app/controller/library/browser_controller/actions/destructive.rs
@@ -1,35 +1,6 @@
 use super::*;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, atomic::AtomicBool};
-
-struct DeleteAttemptSummary {
-    deleted_paths: HashSet<PathBuf>,
-    deleted_count: usize,
-    error_count: usize,
-    last_error: Option<String>,
-}
-
-impl DeleteAttemptSummary {
-    fn new(initial_error: Option<String>) -> Self {
-        Self {
-            deleted_paths: HashSet::new(),
-            deleted_count: 0,
-            error_count: usize::from(initial_error.is_some()),
-            last_error: initial_error,
-        }
-    }
-
-    fn record_deleted_path(&mut self, path: &Path) {
-        self.deleted_paths.insert(path.to_path_buf());
-        self.deleted_count += 1;
-    }
-
-    fn record_error(&mut self, err: String) {
-        self.error_count += 1;
-        self.last_error = Some(err);
-    }
-}
+use std::path::PathBuf;
 
 impl BrowserController<'_> {
     pub(super) fn delete_browser_sample_action(&mut self, row: usize) -> Result<(), String> {
@@ -74,43 +45,27 @@ impl BrowserController<'_> {
             self.set_status("File operation already in progress", StatusTone::Warning);
             return Ok(());
         }
-        if cfg!(test) {
-            let summary = self.delete_browser_contexts(contexts, initial_error);
-            if !summary.deleted_paths.is_empty() {
-                let selected_source_id = self.selected_source_id();
-                let similar_query = self.ui.browser.search.similar_query.clone();
-                crate::app::controller::library::wavs::schedule_similarity_filter_rebuild_after_delete_with_state(
-                    self,
-                    selected_source_id,
-                    similar_query,
-                    &summary.deleted_paths,
-                );
-                crate::app::controller::library::wavs::apply_pending_similarity_filter_rebuild(
-                    self,
-                );
-                self.restore_browser_focus_after_delete(next_focus);
-            }
-            self.finish_delete_browser_samples(summary)?;
-            return Ok(());
-        }
-        if let Some(source_id) = contexts.first().map(|ctx| ctx.source.id.clone()) {
-            self.begin_pending_file_mutation(
-                &source_id,
-                contexts
-                    .iter()
-                    .map(|ctx| ctx.entry.relative_path.clone())
-                    .collect::<Vec<_>>(),
+        let focus_path = next_focus
+            .as_ref()
+            .and_then(|plan| plan.preferred_path.clone());
+        let samples = contexts
+            .into_iter()
+            .map(|ctx| (ctx.source, ctx.entry))
+            .collect::<Vec<_>>();
+        let selected_source_id = self.selected_source_id();
+        let similar_query = self.ui.browser.search.similar_query.clone();
+        let moved = self.move_samples_to_configured_trash_detailed(samples, focus_path);
+        if !moved.moved_paths.is_empty() {
+            let deleted_paths = moved.moved_paths.iter().cloned().collect::<HashSet<_>>();
+            crate::app::controller::library::wavs::schedule_similarity_filter_rebuild_after_delete_with_state(
+                self,
+                selected_source_id,
+                similar_query,
+                &deleted_paths,
             );
+            crate::app::controller::library::wavs::apply_pending_similarity_filter_rebuild(self);
         }
-        self.runtime.jobs.begin_one_shot_file_op(move |cancel| {
-            crate::app::controller::jobs::FileOpResult::SampleDelete(run_sample_delete_job(
-                contexts,
-                next_focus,
-                initial_error,
-                cancel,
-            ))
-        })?;
-        self.set_status("Deleting samples...", StatusTone::Busy);
+        self.finish_delete_browser_samples(moved, initial_error)?;
         Ok(())
     }
 
@@ -131,44 +86,48 @@ impl BrowserController<'_> {
         ))
     }
 
-    fn delete_browser_contexts(
-        &mut self,
-        contexts: Vec<super::super::helpers::TriageSampleContext>,
-        initial_error: Option<String>,
-    ) -> DeleteAttemptSummary {
-        let mut summary = DeleteAttemptSummary::new(initial_error);
-        for ctx in contexts {
-            match self.try_delete_browser_sample_ctx(&ctx) {
-                Ok(()) => summary.record_deleted_path(&ctx.entry.relative_path),
-                Err(err) => summary.record_error(err),
-            }
-        }
-        summary
-    }
-
     fn finish_delete_browser_samples(
         &mut self,
-        summary: DeleteAttemptSummary,
+        moved: crate::app::controller::library::trash::ConfiguredTrashMoveResult,
+        initial_error: Option<String>,
     ) -> Result<(), String> {
-        if summary.error_count == 0 {
+        let error_count = moved.errors.len() + usize::from(initial_error.is_some());
+        let moved_count = moved.moved_count();
+        if error_count == 0 {
+            if moved_count > 0 {
+                self.set_status(
+                    format!(
+                        "Moved {} {} to trash",
+                        moved_count,
+                        sample_label(moved_count)
+                    ),
+                    StatusTone::Info,
+                );
+            }
             return Ok(());
         }
-        let Some(last_error) = summary.last_error else {
+        let last_error = moved
+            .errors
+            .last()
+            .cloned()
+            .or(initial_error)
+            .unwrap_or_default();
+        if last_error.is_empty() {
             return Ok(());
-        };
-        let message = if summary.deleted_count == 0 {
+        }
+        let message = if moved_count == 0 {
             last_error
         } else {
             format!(
-                "Deleted {} {} with {} {}: {}",
-                summary.deleted_count,
-                sample_label(summary.deleted_count),
-                summary.error_count,
-                error_label(summary.error_count),
+                "Moved {} {} to trash with {} {}: {}",
+                moved_count,
+                sample_label(moved_count),
+                error_count,
+                error_label(error_count),
                 last_error
             )
         };
-        let tone = if summary.deleted_count == 0 {
+        let tone = if moved_count == 0 {
             StatusTone::Error
         } else {
             StatusTone::Warning
@@ -201,49 +160,6 @@ impl BrowserController<'_> {
     }
 }
 
-fn run_sample_delete_job(
-    contexts: Vec<super::super::helpers::TriageSampleContext>,
-    next_focus: Option<super::super::helpers::DeleteBrowserFocusPlan>,
-    initial_error: Option<String>,
-    cancel: Arc<AtomicBool>,
-) -> crate::app::controller::jobs::SampleDeleteResult {
-    let source_id = contexts
-        .first()
-        .map(|ctx| ctx.source.id.clone())
-        .unwrap_or_default();
-    let requested_paths = contexts
-        .iter()
-        .map(|ctx| ctx.entry.relative_path.clone())
-        .collect::<Vec<_>>();
-    let mut summary = DeleteAttemptSummary::new(initial_error);
-    for ctx in contexts {
-        if cancel.load(std::sync::atomic::Ordering::Relaxed) {
-            break;
-        }
-        match std::fs::remove_file(&ctx.absolute_path) {
-            Ok(()) => {
-                match crate::sample_sources::SourceDatabase::open(&ctx.source.root)
-                    .map_err(|err| format!("Database unavailable: {err}"))
-                    .and_then(|db| {
-                        db.remove_file(&ctx.entry.relative_path)
-                            .map_err(|err| format!("Failed to drop database row: {err}"))
-                    }) {
-                    Ok(()) => summary.record_deleted_path(&ctx.entry.relative_path),
-                    Err(err) => summary.record_error(err),
-                }
-            }
-            Err(err) => summary.record_error(format!("Failed to delete file: {err}")),
-        }
-    }
-    crate::app::controller::jobs::SampleDeleteResult {
-        source_id,
-        requested_paths,
-        deleted_paths: summary.deleted_paths.into_iter().collect(),
-        next_focus,
-        last_error: summary.last_error,
-    }
-}
-
 fn sample_label(count: usize) -> &'static str {
     if count == 1 { "sample" } else { "samples" }
 }
@@ -258,6 +174,7 @@ mod tests {
     use crate::app::controller::test_support::{prepare_with_source_and_wav_entries, sample_entry};
     use crate::app::state::{SampleBrowserSort, SimilarQuery};
     use crate::sample_sources::Rating;
+    use std::path::Path;
 
     #[test]
     fn restore_browser_focus_after_delete_uses_visible_fallback_when_preferred_path_is_hidden() {

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation.rs
@@ -42,7 +42,7 @@ pub(super) fn take_rename_looped_provenance_logs_for_tests() -> Vec<RenameLooped
 }
 
 impl BrowserController<'_> {
-    /// Delete the resolved browser sample immediately in the current thread.
+    /// Move the resolved browser sample into the configured trash folder.
     pub(crate) fn try_delete_browser_sample_ctx(
         &mut self,
         ctx: &TriageSampleContext,
@@ -54,19 +54,19 @@ impl BrowserController<'_> {
         ) {
             return Ok(());
         }
-        std::fs::remove_file(&ctx.absolute_path)
-            .map_err(|err| format!("Failed to delete file: {err}"))?;
-        let db = self
-            .database_for(&ctx.source)
-            .map_err(|err| format!("Database unavailable: {err}"))?;
-        db.remove_file(&ctx.entry.relative_path)
-            .map_err(|err| format!("Failed to drop database row: {err}"))?;
-        self.prune_cached_sample(&ctx.source, &ctx.entry.relative_path);
-        self.set_status(
-            format!("Deleted {}", ctx.entry.relative_path.display()),
-            StatusTone::Info,
+        let moved = self.move_samples_to_configured_trash_detailed(
+            vec![(ctx.source.clone(), ctx.entry.clone())],
+            None,
         );
-        Ok(())
+        if moved.moved_count() > 0 {
+            return Ok(());
+        }
+        let err = moved
+            .errors
+            .last()
+            .cloned()
+            .unwrap_or_else(|| self.ui.status.text.clone());
+        Err(err)
     }
 
     /// Rename the browser row at `row` while preserving playback resume details.

--- a/src/app/controller/library/trash.rs
+++ b/src/app/controller/library/trash.rs
@@ -2,3 +2,5 @@ mod config;
 mod deletion;
 mod moves;
 mod results;
+
+pub(crate) use moves::ConfiguredTrashMoveResult;

--- a/src/app/controller/library/trash/moves.rs
+++ b/src/app/controller/library/trash/moves.rs
@@ -14,6 +14,18 @@ use std::sync::atomic::Ordering;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, atomic::AtomicBool};
 
+#[derive(Default)]
+pub(crate) struct ConfiguredTrashMoveResult {
+    pub(crate) moved_paths: Vec<PathBuf>,
+    pub(crate) errors: Vec<String>,
+}
+
+impl ConfiguredTrashMoveResult {
+    pub(crate) fn moved_count(&self) -> usize {
+        self.moved_paths.len()
+    }
+}
+
 impl AppController {
     /// Move all samples tagged as Trash into the configured trash folder after confirmation.
     pub fn move_all_trashed_to_folder(&mut self) {
@@ -112,15 +124,28 @@ impl AppController {
         samples: Vec<(SampleSource, WavEntry)>,
         next_focus: Option<PathBuf>,
     ) -> bool {
+        self.move_samples_to_configured_trash_detailed(samples, next_focus)
+            .moved_count()
+            > 0
+    }
+
+    pub(crate) fn move_samples_to_configured_trash_detailed(
+        &mut self,
+        samples: Vec<(SampleSource, WavEntry)>,
+        next_focus: Option<PathBuf>,
+    ) -> ConfiguredTrashMoveResult {
         if samples.is_empty() {
-            return false;
+            return ConfiguredTrashMoveResult::default();
         }
+        let total = samples.len();
         let Some(trash_root) = self.prepare_trash_folder_for_auto_move() else {
-            return false;
+            return ConfiguredTrashMoveResult {
+                moved_paths: Vec::new(),
+                errors: Vec::new(),
+            };
         };
         let mut errors = Vec::new();
-        let mut moved = 0usize;
-        let total = samples.len();
+        let mut moved_paths = Vec::new();
         let mut affected_sources = std::collections::HashSet::new();
         for (source, entry) in samples {
             let db = match SourceDatabase::open(&source.root) {
@@ -139,7 +164,7 @@ impl AppController {
             }
             match trash_move::move_to_trash(&source, &entry, &trash_root) {
                 Ok(()) => {
-                    moved += 1;
+                    moved_paths.push(entry.relative_path.clone());
                     affected_sources.insert(source.id.clone());
                     if let Err(err) = db.remove_file(&entry.relative_path) {
                         errors.push(format!(
@@ -159,15 +184,19 @@ impl AppController {
                 }
             }
         }
+        let moved = moved_paths.len();
         self.apply_trash_move_finished(TrashMoveFinished {
             total,
             moved,
             cancelled: false,
-            errors,
+            errors: errors.clone(),
             affected_sources: affected_sources.into_iter().collect(),
         });
         self.refocus_path_after_trash_move(next_focus);
-        moved > 0
+        ConfiguredTrashMoveResult {
+            moved_paths,
+            errors,
+        }
     }
 
     pub(super) fn refocus_path_after_trash_move(&mut self, next_focus: Option<PathBuf>) {

--- a/src/app/controller/tests/browser_actions/cleanup_export.rs
+++ b/src/app/controller/tests/browser_actions/cleanup_export.rs
@@ -151,7 +151,11 @@ fn pruning_missing_browser_sample_keeps_remaining_rows_visible() -> Result<(), S
 
 #[test]
 fn deleting_browser_sample_moves_focus_forward() -> Result<(), String> {
+    let temp = tempdir().unwrap();
+    let trash_root = temp.path().join("trash");
     let (mut controller, source) = dummy_controller();
+    controller.settings.trash_folder = Some(trash_root.clone());
+    controller.ui.trash_folder = Some(trash_root.clone());
     controller.library.sources.push(source.clone());
     controller.selection_state.ctx.selected_source = Some(source.id.clone());
     for name in ["a.wav", "b.wav", "c.wav"] {
@@ -168,6 +172,7 @@ fn deleting_browser_sample_moves_focus_forward() -> Result<(), String> {
 
     controller.delete_browser_sample(1)?;
 
+    assert!(trash_root.join("b.wav").exists());
     assert_eq!(
         controller.sample_view.wav.selected_wav.as_deref(),
         Some(Path::new("c.wav"))
@@ -176,6 +181,7 @@ fn deleting_browser_sample_moves_focus_forward() -> Result<(), String> {
 
     controller.delete_browser_sample(1)?;
 
+    assert!(trash_root.join("c.wav").exists());
     assert_eq!(
         controller.sample_view.wav.selected_wav.as_deref(),
         Some(Path::new("a.wav"))

--- a/src/app/controller/tests/browser_actions/row_actions/delete_similarity.rs
+++ b/src/app/controller/tests/browser_actions/row_actions/delete_similarity.rs
@@ -1,12 +1,24 @@
 use super::*;
 
+fn configure_test_trash(
+    controller: &mut crate::app::controller::AppController,
+    temp: &tempfile::TempDir,
+) -> PathBuf {
+    let trash_root = temp.path().join("trash");
+    controller.settings.trash_folder = Some(trash_root.clone());
+    controller.ui.trash_folder = Some(trash_root.clone());
+    trash_root
+}
+
 #[test]
 fn delete_actions_apply_to_all_selected_rows() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", Rating::NEUTRAL),
         sample_entry("two.wav", Rating::NEUTRAL),
         sample_entry("three.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("one.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("two.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("three.wav"), &[0.0, 0.1]);
@@ -22,15 +34,20 @@ fn delete_actions_apply_to_all_selected_rows() {
     assert!(!source.root.join("one.wav").exists());
     assert!(!source.root.join("two.wav").exists());
     assert!(!source.root.join("three.wav").exists());
+    assert!(trash_root.join("one.wav").exists());
+    assert!(trash_root.join("two.wav").exists());
+    assert!(trash_root.join("three.wav").exists());
 }
 
 #[test]
 fn delete_active_browser_selection_includes_hidden_selected_paths() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", Rating::NEUTRAL),
         sample_entry("two.wav", Rating::NEUTRAL),
         sample_entry("three.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("one.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("two.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("three.wav"), &[0.0, 0.1]);
@@ -50,15 +67,39 @@ fn delete_active_browser_selection_includes_hidden_selected_paths() {
     assert!(!source.root.join("one.wav").exists());
     assert!(!source.root.join("two.wav").exists());
     assert!(source.root.join("three.wav").exists());
+    assert!(trash_root.join("one.wav").exists());
+    assert!(trash_root.join("two.wav").exists());
+}
+
+#[test]
+fn delete_browser_samples_requires_configured_trash_folder() {
+    let (mut controller, source) =
+        prepare_with_source_and_wav_entries(vec![sample_entry("one.wav", Rating::NEUTRAL)]);
+    write_test_wav(&source.root.join("one.wav"), &[0.0, 0.1]);
+
+    controller.delete_browser_samples(&[0]).unwrap();
+
+    assert_eq!(controller.wav_entries_len(), 1);
+    assert!(source.root.join("one.wav").exists());
+    assert_eq!(
+        controller.ui.status.status_tone,
+        crate::app::state::StatusTone::Warning
+    );
+    assert_eq!(
+        controller.ui.status.text,
+        "Set a trash folder first to auto-trash samples"
+    );
 }
 
 #[test]
 fn deleting_similarity_result_recomputes_filter_from_same_anchor() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("anchor.wav", Rating::NEUTRAL),
         sample_entry("close.wav", Rating::NEUTRAL),
         sample_entry("far.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("anchor.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("close.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("far.wav"), &[0.0, 0.1]);
@@ -85,15 +126,18 @@ fn deleting_similarity_result_recomputes_filter_from_same_anchor() {
         visible_browser_paths(&mut controller),
         vec![PathBuf::from("anchor.wav"), PathBuf::from("far.wav")]
     );
+    assert!(trash_root.join("close.wav").exists());
 }
 
 #[test]
 fn deleting_similarity_anchor_promotes_next_best_survivor() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("anchor.wav", Rating::NEUTRAL),
         sample_entry("close.wav", Rating::NEUTRAL),
         sample_entry("far.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("anchor.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("close.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("far.wav"), &[0.0, 0.1]);
@@ -124,6 +168,7 @@ fn deleting_similarity_anchor_promotes_next_best_survivor() {
         controller.focused_browser_path().as_deref(),
         Some(Path::new("close.wav"))
     );
+    assert!(trash_root.join("anchor.wav").exists());
 }
 
 #[test]
@@ -213,11 +258,13 @@ fn confirming_duplicate_cleanup_moves_only_unkept_duplicates_to_trash() {
 
 #[test]
 fn delete_hotkey_prompts_then_applies_to_all_selected_rows() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", Rating::NEUTRAL),
         sample_entry("two.wav", Rating::NEUTRAL),
         sample_entry("three.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("one.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("two.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("three.wav"), &[0.0, 0.1]);
@@ -244,6 +291,9 @@ fn delete_hotkey_prompts_then_applies_to_all_selected_rows() {
     assert!(!source.root.join("one.wav").exists());
     assert!(!source.root.join("two.wav").exists());
     assert!(!source.root.join("three.wav").exists());
+    assert!(trash_root.join("one.wav").exists());
+    assert!(trash_root.join("two.wav").exists());
+    assert!(trash_root.join("three.wav").exists());
 }
 
 #[test]
@@ -271,11 +321,13 @@ fn canceling_delete_hotkey_keeps_selected_rows() {
 
 #[test]
 fn delete_hotkey_keeps_focus_when_file_delete_fails() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("a.wav", Rating::NEUTRAL),
         sample_entry("b.wav", Rating::NEUTRAL),
         sample_entry("c.wav", Rating::NEUTRAL),
     ]);
+    configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("a.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("c.wav"), &[0.0, 0.1]);
     controller.focus_browser_row_only(1);
@@ -295,7 +347,13 @@ fn delete_hotkey_keeps_focus_when_file_delete_fails() {
         controller.ui.status.status_tone,
         crate::app::state::StatusTone::Error
     );
-    assert!(controller.ui.status.text.contains("Failed to delete file"));
+    assert!(
+        controller
+            .ui
+            .status
+            .text
+            .contains("File not found for trash")
+    );
 }
 
 #[test]
@@ -346,11 +404,13 @@ fn delete_hotkey_waits_for_loading_sample() {
 
 #[test]
 fn delete_browser_samples_reports_partial_failure_and_refocuses_survivor() {
+    let temp = tempdir().unwrap();
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("a.wav", Rating::NEUTRAL),
         sample_entry("b.wav", Rating::NEUTRAL),
         sample_entry("c.wav", Rating::NEUTRAL),
     ]);
+    let trash_root = configure_test_trash(&mut controller, &temp);
     write_test_wav(&source.root.join("a.wav"), &[0.0, 0.1]);
     write_test_wav(&source.root.join("c.wav"), &[0.0, 0.1]);
     controller.focus_browser_row_only(0);
@@ -362,6 +422,7 @@ fn delete_browser_samples_reports_partial_failure_and_refocuses_survivor() {
         .expect_err("partial delete should report failure");
 
     assert!(!source.root.join("a.wav").exists());
+    assert!(trash_root.join("a.wav").exists());
     assert_eq!(
         visible_browser_paths(&mut controller),
         vec![PathBuf::from("b.wav"), PathBuf::from("c.wav")]
@@ -379,7 +440,7 @@ fn delete_browser_samples_reports_partial_failure_and_refocuses_survivor() {
             .ui
             .status
             .text
-            .contains("Deleted 1 sample with 1 error")
+            .contains("Moved 1 sample to trash with 1 error")
     );
     assert_eq!(controller.ui.status.text, err);
 }

--- a/src/app/controller/ui/hotkeys_controller/waveform/tests.rs
+++ b/src/app/controller/ui/hotkeys_controller/waveform/tests.rs
@@ -9,10 +9,14 @@ use std::path::PathBuf;
 
 #[test]
 fn test_delete_loaded_sample_navigation() {
+    let temp = tempfile::tempdir().unwrap();
+    let trash_root = temp.path().join("trash");
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
         sample_entry("one.wav", Rating::NEUTRAL),
         sample_entry("two.wav", Rating::NEUTRAL),
     ]);
+    controller.settings.trash_folder = Some(trash_root.clone());
+    controller.ui.trash_folder = Some(trash_root.clone());
 
     load_waveform_selection(
         &mut controller,
@@ -38,4 +42,5 @@ fn test_delete_loaded_sample_navigation() {
         HotkeyCommand::DeleteLoadedSample,
     );
     assert!(result);
+    assert!(trash_root.join("one.wav").exists());
 }


### PR DESCRIPTION
## Summary
- route browser sample delete through the configured trash move workflow instead of permanent file removal
- expose moved-path results so browser focus and similarity filters keep updating correctly
- update delete and hotkey tests to assert source files move into the configured trash folder and no-trash configuration blocks deletion

## Validation
- cargo test -p wavecrate --lib browser_actions::row_actions::delete_similarity
- cargo test -p wavecrate --lib deleting_browser_sample_moves_focus_forward
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent