### PR TITLE
Fix retained audio engine panel

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -945,4 +945,82 @@ mod opt_272_tests {
         assert!(panel.panel_rect.max.x <= layout.root.rect.max.x);
         assert!(panel.panel_rect.max.y <= layout.status_bar.min.y);
     }
+
+    #[test]
+    fn options_panel_picker_mode_expands_inline_dropdown_actions() {
+        let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
+        let style = style_for_layout(&layout);
+        let state = NativeShellState::new();
+        let model = AppModel {
+            options_panel: crate::app_core::native_shell::runtime_contract::OptionsPanelModel {
+                visible: true,
+                ..crate::app_core::native_shell::runtime_contract::OptionsPanelModel::default()
+            },
+            paired_device: crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel {
+                active_picker: Some(
+                    crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
+                ),
+                primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
+                    label: String::from("Output Sample Rate"),
+                    value_label: String::from("48 kHz"),
+                },
+                primary_number_options: vec![
+                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                        label: String::from("Device default"),
+                        selected: false,
+                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(None),
+                    },
+                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                        label: String::from("48 kHz"),
+                        selected: true,
+                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(Some(
+                            48_000,
+                        )),
+                    },
+                ],
+                ..crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel::default()
+            },
+            ..AppModel::default()
+        };
+
+        let panel = options_panel_layout(&layout, &style, &model)
+            .expect("visible picker panel should resolve layout");
+        assert_eq!(panel.title, "Audio Engine");
+        let dropdown_row = panel
+            .buttons
+            .iter()
+            .position(|button| button.action == UiAction::OpenPrimaryNumberPicker)
+            .expect("active picker row should remain in the overview");
+        assert!(panel.buttons[dropdown_row].active);
+        assert!(
+            panel.buttons[dropdown_row]
+                .text
+                .starts_with("Output Sample Rate")
+        );
+        assert_eq!(
+            panel.buttons[dropdown_row + 1].action,
+            UiAction::SetPrimaryNumber { value: None }
+        );
+        assert_eq!(
+            panel.buttons[dropdown_row + 2].action,
+            UiAction::SetPrimaryNumber {
+                value: Some(48_000),
+            }
+        );
+        assert!(panel.buttons[dropdown_row + 2].active);
+
+        let dropdown_point = panel.buttons[dropdown_row].rect.center();
+        assert_eq!(
+            state.options_panel_action_at_point(&layout, &model, dropdown_point),
+            Some(UiAction::OpenPrimaryNumberPicker)
+        );
+
+        let sample_rate_point = panel.buttons[dropdown_row + 2].rect.center();
+        assert_eq!(
+            state.options_panel_action_at_point(&layout, &model, sample_rate_point),
+            Some(UiAction::SetPrimaryNumber {
+                value: Some(48_000),
+            })
+        );
+    }
 }

--- a/src/app_core/native_shell/composition/state/options_panel/actions.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/actions.rs
@@ -5,7 +5,9 @@ use crate::app_core::native_shell::runtime_contract::{
     PairedPickerOptionModel, PairedPickerTargetModel, PairedPickerValueModel,
 };
 
-pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAction)> {
+pub(super) fn audio_overview_button_defs(
+    model: &AppModel,
+) -> Vec<(String, UiAction, PairedPickerTargetModel)> {
     let paired_device = model.paired_device_panel();
     vec![
         (
@@ -15,6 +17,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.primary_group().value_label
             ),
             UiAction::OpenPrimaryGroupPicker,
+            PairedPickerTargetModel::PrimaryGroup,
         ),
         (
             format!(
@@ -23,6 +26,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.primary_item().value_label
             ),
             UiAction::OpenPrimaryItemPicker,
+            PairedPickerTargetModel::PrimaryItem,
         ),
         (
             format!(
@@ -31,6 +35,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.primary_number().value_label
             ),
             UiAction::OpenPrimaryNumberPicker,
+            PairedPickerTargetModel::PrimaryNumber,
         ),
         (
             format!(
@@ -39,6 +44,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.secondary_group().value_label
             ),
             UiAction::OpenSecondaryGroupPicker,
+            PairedPickerTargetModel::SecondaryGroup,
         ),
         (
             format!(
@@ -47,6 +53,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.secondary_item().value_label
             ),
             UiAction::OpenSecondaryItemPicker,
+            PairedPickerTargetModel::SecondaryItem,
         ),
         (
             format!(
@@ -55,6 +62,7 @@ pub(super) fn audio_overview_button_defs(model: &AppModel) -> Vec<(String, UiAct
                 paired_device.secondary_number().value_label
             ),
             UiAction::OpenSecondaryNumberPicker,
+            PairedPickerTargetModel::SecondaryNumber,
         ),
     ]
 }
@@ -108,11 +116,8 @@ pub(super) fn legacy_options_panel_button_defs(model: &AppModel) -> Vec<(String,
 }
 
 pub(super) fn options_panel_title(model: &AppModel) -> String {
-    model
-        .paired_device_panel()
-        .active_picker()
-        .map(audio_picker_title)
-        .unwrap_or_else(|| String::from("Audio Engine"))
+    let _ = model;
+    String::from("Audio Engine")
 }
 
 pub(super) fn picker_options(
@@ -146,8 +151,7 @@ pub(super) fn picker_action(value: &PairedPickerValueModel) -> UiAction {
     }
 }
 
-/// Return the title text for the active audio picker target.
-fn audio_picker_title(target: PairedPickerTargetModel) -> String {
+pub(super) fn audio_picker_label(target: PairedPickerTargetModel) -> String {
     match target {
         PairedPickerTargetModel::PrimaryGroup => String::from("Output Host"),
         PairedPickerTargetModel::PrimaryItem => String::from("Output Device"),

--- a/src/app_core/native_shell/composition/state/options_panel/geometry.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/geometry.rs
@@ -1,8 +1,8 @@
 //! Geometry and hit-testing helpers for the native-shell options panel.
 
 use super::actions::{
-    audio_overview_button_defs, legacy_options_panel_button_defs, options_panel_title,
-    picker_action, picker_options,
+    audio_overview_button_defs, audio_picker_label, legacy_options_panel_button_defs,
+    options_panel_title, picker_action, picker_options,
 };
 use super::*;
 use crate::gui::{panel::floating_panel_rect, types::Vector2};
@@ -152,23 +152,34 @@ pub(super) fn options_panel_action_at_point(
 }
 
 fn build_options_panel_buttons(model: &AppModel) -> Vec<(String, UiAction, bool)> {
-    if let Some(target) = model.paired_device_panel().active_picker() {
-        let mut buttons = Vec::new();
-        buttons.push((String::from("Back"), UiAction::ShowOptionsOverview, false));
-        buttons.extend(picker_options(model, target).iter().map(|item| {
-            (
-                item.label.clone(),
-                picker_action(&item.value),
-                item.selected,
-            )
-        }));
-        return buttons;
+    let active_picker = model.paired_device_panel().active_picker();
+    let mut buttons = Vec::new();
+    for (text, action, target) in audio_overview_button_defs(model) {
+        let expanded = active_picker == Some(target);
+        let label = if expanded {
+            format!("{text}  ^")
+        } else {
+            format!("{text}  v")
+        };
+        buttons.push((label, action, expanded));
+        if expanded {
+            let label = audio_picker_label(target);
+            buttons.extend(picker_options(model, target).iter().map(|item| {
+                (
+                    format!("  {}{}", if item.selected { "* " } else { "" }, item.label),
+                    picker_action(&item.value),
+                    item.selected,
+                )
+            }));
+            if picker_options(model, target).is_empty() {
+                buttons.push((
+                    format!("  No {label} options"),
+                    UiAction::ShowOptionsOverview,
+                    false,
+                ));
+            }
+        }
     }
-
-    let mut buttons = audio_overview_button_defs(model)
-        .into_iter()
-        .map(|(text, action)| (text, action, false))
-        .collect::<Vec<_>>();
     buttons.extend(
         legacy_options_panel_button_defs(model)
             .into_iter()

--- a/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
+++ b/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
@@ -469,7 +469,7 @@ fn options_panel_overview_lists_audio_rows_before_legacy_toggles() {
 }
 
 #[test]
-fn options_panel_picker_mode_uses_back_row_and_picker_actions() {
+fn options_panel_picker_mode_expands_inline_dropdown_actions() {
     let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
     let style = style_for_layout(&layout);
     let state = NativeShellState::new();
@@ -501,20 +501,43 @@ fn options_panel_picker_mode_uses_back_row_and_picker_actions() {
 
     let panel = options_panel_layout(&layout, &style, &model)
         .expect("visible picker panel should resolve layout");
-    assert_eq!(panel.title, "Output Sample Rate");
-    assert_eq!(panel.buttons[0].action, UiAction::ShowOptionsOverview);
-    assert!(panel.buttons[2].active);
-
-    let back_point = Point::new(
-        (panel.buttons[0].rect.min.x + panel.buttons[0].rect.max.x) * 0.5,
-        (panel.buttons[0].rect.min.y + panel.buttons[0].rect.max.y) * 0.5,
+    assert_eq!(panel.title, "Audio Engine");
+    let dropdown_row = panel
+        .buttons
+        .iter()
+        .position(|button| button.action == UiAction::OpenPrimaryNumberPicker)
+        .expect("active picker row should remain in the overview");
+    assert!(panel.buttons[dropdown_row].active);
+    assert!(
+        panel.buttons[dropdown_row]
+            .text
+            .starts_with("Sample Rate")
+            || panel.buttons[dropdown_row]
+                .text
+                .starts_with("Output Sample Rate")
     );
     assert_eq!(
-        state.options_panel_action_at_point(&layout, &model, back_point),
-        Some(UiAction::ShowOptionsOverview)
+        panel.buttons[dropdown_row + 1].action,
+        UiAction::SetPrimaryNumber { value: None }
+    );
+    assert_eq!(
+        panel.buttons[dropdown_row + 2].action,
+        UiAction::SetPrimaryNumber {
+            value: Some(48_000),
+        }
+    );
+    assert!(panel.buttons[dropdown_row + 2].active);
+
+    let dropdown_point = Point::new(
+        (panel.buttons[dropdown_row].rect.min.x + panel.buttons[dropdown_row].rect.max.x) * 0.5,
+        (panel.buttons[dropdown_row].rect.min.y + panel.buttons[dropdown_row].rect.max.y) * 0.5,
+    );
+    assert_eq!(
+        state.options_panel_action_at_point(&layout, &model, dropdown_point),
+        Some(UiAction::OpenPrimaryNumberPicker)
     );
 
-    let sample_rate_button = &panel.buttons[2];
+    let sample_rate_button = &panel.buttons[dropdown_row + 2];
     let sample_rate_point = Point::new(
         (sample_rate_button.rect.min.x + sample_rate_button.rect.max.x) * 0.5,
         (sample_rate_button.rect.min.y + sample_rate_button.rect.max.y) * 0.5,

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -942,6 +942,8 @@ fn append_retained_shell_overlays(
     append_paint_frame(frame, &overlay);
     shell_state.build_focus_overlay_into(layout, style, model, &mut overlay);
     append_paint_frame(frame, &overlay);
+    shell_state.build_modal_overlay_into(layout, style, model, &mut overlay);
+    append_paint_frame(frame, &overlay);
 }
 
 /// Append one overlay frame into the retained shell paint buffer.

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -598,6 +598,71 @@ mod tests {
     }
 
     #[test]
+    fn retained_shell_render_includes_clickable_options_panel_overlay() {
+        let repaint_installed = Arc::new(AtomicBool::new(false));
+        let mut model = runtime_contract::AppModel::default();
+        model.options_panel.visible = true;
+        model.paired_device.primary_group = runtime_contract::SummaryFieldModel {
+            label: String::from("Output Host"),
+            value_label: String::from("WASAPI"),
+        };
+        model.paired_device.primary_item = runtime_contract::SummaryFieldModel {
+            label: String::from("Output Device"),
+            value_label: String::from("Speakers"),
+        };
+        model.paired_device.primary_number = runtime_contract::SummaryFieldModel {
+            label: String::from("Output Sample Rate"),
+            value_label: String::from("48 kHz"),
+        };
+
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(model.into()),
+            reduced: Vec::new(),
+            repaint_installed,
+            exit_status: None,
+        });
+        let retained = retained_shell_descriptor(&mut bridge);
+        let viewport = radiant::gui::types::Vector2::new(1280.0, 720.0);
+        let rect = radiant::gui::types::Rect::from_min_size(
+            radiant::gui::types::Point::new(0.0, 0.0),
+            viewport,
+        );
+        let frame = bridge
+            .render_retained_surface(retained, rect, viewport)
+            .expect("retained shell frame with options panel");
+        assert!(
+            frame.text_runs.iter().any(|run| run.text == "Audio Engine"),
+            "retained frame should append the options panel overlay"
+        );
+        let output_host_label = frame
+            .text_runs
+            .iter()
+            .find(|run| run.text.starts_with("Output Host:"))
+            .expect("output host picker button should render");
+        let click = radiant::gui::types::Point::new(
+            output_host_label.position.x + 2.0,
+            output_host_label.position.y + 2.0,
+        );
+
+        bridge.update(WavecrateRuntimeMessage::RetainedInput(
+            WidgetInput::PointerPress {
+                position: click,
+                button: radiant::widgets::PointerButton::Primary,
+                modifiers: Default::default(),
+            },
+        ));
+
+        assert!(
+            bridge
+                .inner
+                .reduced
+                .iter()
+                .any(|action| matches!(action, UiAction::OpenAudioOutputHostPicker)),
+            "clicking a rendered options-panel button should route to the audio picker action"
+        );
+    }
+
+    #[test]
     fn retained_shell_animation_refresh_uses_motion_only_projection() {
         let mut app_model = runtime_contract::AppModel::default();
         app_model.transport_running = true;


### PR DESCRIPTION
## Summary
- append the modal/options overlay to retained shell frames so the audio engine panel renders and hit-tests together
- keep audio selector rows in the Audio Engine panel and expand the active selector inline as a dropdown
- add retained runtime and options-panel dropdown regressions

## Validation
- cargo test -p wavecrate --lib options_panel_picker_mode_expands_inline_dropdown_actions
- cargo test -p wavecrate --lib options_panel_
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent