### PR TITLE
Add Backspace delete shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "arboard",
  "hound",
  "image",
+ "kurbo",
  "pollster",
  "raw-window-handle",
  "roxmltree 0.21.1",

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -2291,6 +2291,10 @@ fn default_gui_shortcut_resolution(
                 GuiMessage::DeleteSelectedItem,
             )
             .bind(
+                ui::KeyPress::new(ui::KeyCode::Backspace),
+                GuiMessage::DeleteSelectedItem,
+            )
+            .bind(
                 ui::KeyPress::new(ui::KeyCode::E),
                 GuiMessage::ExtractPlaymarkedRange,
             )
@@ -3505,6 +3509,21 @@ mod tests {
         assert_eq!(
             resolution.action,
             Some(super::GuiMessage::CopySelectedFiles)
+        );
+        assert!(resolution.handled);
+    }
+
+    #[test]
+    fn backspace_shortcut_routes_to_delete_selected_item() {
+        let state = GuiAppState::load_default().expect("default state loads");
+        let resolution = super::default_gui_shortcut_resolution(
+            &state,
+            ui::KeyPress::new(ui::KeyCode::Backspace),
+        );
+
+        assert_eq!(
+            resolution.action,
+            Some(super::GuiMessage::DeleteSelectedItem)
         );
         assert!(resolution.handled);
     }


### PR DESCRIPTION
## Summary
- update Wavecrate to the current Radiant main pointer that exposes Backspace key input
- bind Backspace to the same selected-item delete action as Delete in the default GUI
- add a shortcut regression test

## Validation
- cargo test -p wavecrate backspace_shortcut_routes_to_delete_selected_item
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent