### PR TITLE
Use global handoff staging directory

### DIFF
--- a/crates/wavecrate-library/src/app_dirs.rs
+++ b/crates/wavecrate-library/src/app_dirs.rs
@@ -315,6 +315,16 @@ pub fn logs_dir() -> Result<PathBuf, AppDirError> {
     Ok(path)
 }
 
+/// Return the global handoff staging directory inside the `.wavecrate` root.
+pub fn handoff_staging_dir() -> Result<PathBuf, AppDirError> {
+    let path = app_root_dir()?.join("handoff_staging");
+    std::fs::create_dir_all(&path).map_err(|source| AppDirError::CreateDir {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
 /// Return the base directory used for `.wavecrate` when no override is set.
 pub fn config_base_dir_path() -> Option<PathBuf> {
     config_base_dir()

--- a/src/app/controller/ui/clipboard.rs
+++ b/src/app/controller/ui/clipboard.rs
@@ -62,7 +62,7 @@ impl AppController {
                 .ok_or_else(|| "Load a sample before copying a selection".to_string())?;
             (audio.source_id.clone(), audio.relative_path.clone())
         };
-        let clip_root = crate::app_dirs::app_root_dir()
+        let clip_root = crate::app_dirs::handoff_staging_dir()
             .map_err(|err| err.to_string())?
             .join("clipboard_clips");
         std::fs::create_dir_all(&clip_root)

--- a/src/app_dirs_tests.rs
+++ b/src/app_dirs_tests.rs
@@ -78,6 +78,24 @@ fn dependency_sandbox_logs_dir_stays_under_sandbox_profile_root() {
 }
 
 #[test]
+fn dependency_handoff_staging_dir_stays_under_app_root() {
+    if explicit_persistence_env_present() {
+        return;
+    }
+    let base = tempdir().expect("create base dir");
+    let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+    let _profile_guard = PersistenceProfileGuard::live();
+
+    let staging_dir = app_dirs::handoff_staging_dir().expect("resolve handoff staging dir");
+
+    assert_eq!(
+        staging_dir,
+        base.path().join(".wavecrate").join("handoff_staging")
+    );
+    assert!(staging_dir.is_dir());
+}
+
+#[test]
 fn dependency_explicit_app_root_override_wins_over_test_default() {
     if explicit_persistence_env_present() {
         return;


### PR DESCRIPTION
## Summary
- add a named app-dir helper for the global .wavecrate/handoff_staging directory
- route waveform-selection clipboard clip staging through that helper
- cover the handoff staging directory shape with an app-dir regression test

## Validation
- cargo test -p wavecrate dependency_handoff_staging_dir_stays_under_app_root
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent