### PR TITLE
Extract default context menu module

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -278,6 +278,8 @@ The global `.wavecrate` folder should contain app-wide state such as:
 
 Caches, logs, handoff staging, and recovery files should not be scattered across arbitrary sample-library folders. They should live under the global `.wavecrate` root unless there is a specific source-local reason to store a compact reference or source-owned database record.
 
+Cache payloads should live under the global `.wavecrate` folder in the current target. Source-local `.wavecrate.db` files may store cache references, status, fingerprints, and invalidation state for files in that source, but waveform, playback-readiness, analysis, similarity, map, handoff, and other cache payloads should not be written next to the source database.
+
 If a source database is missing, corrupt, locked, or unreadable, Wavecrate should keep the user's audio files untouched, report the source database problem clearly, and offer repair/rebuild/reindex options where safe.
 
 ## Audio Format and Channel Target
@@ -865,7 +867,17 @@ The only durable relationship between an extracted file and its original source 
 
 Keyboard extraction, internal extraction-drag into the browser, explicit "extract to file", and extraction from a saved region should use durable extraction by default.
 
-Transient handoff staging exists only to satisfy operating-system clipboard or drag-and-drop APIs that require a file path before the receiving application accepts the drop or paste. Transient staged files should be ordinary WAV files in the first supported format target, and later ordinary AIFF/AIF files where that format is explicitly supported. They should live in a Wavecrate-managed handoff temp folder and should be cleaned up after they are no longer needed.
+Transient handoff staging exists only to satisfy operating-system clipboard or drag-and-drop APIs that require a file path before the receiving application accepts the drop or paste. Transient staged files should be ordinary WAV files in the first supported format target, and later ordinary AIFF/AIF files where that format is explicitly supported. They should live in a Wavecrate-managed handoff temp folder under the global `.wavecrate` root.
+
+Transient staged files should not be deleted immediately at the moment a paste/drop appears to succeed, because the receiving DAW or operating-system shell may still need to read the file path. Wavecrate should keep them for a short internally defined grace period and then clean them up automatically when they are no longer needed. The grace period does not need to be user-configurable in the current target. If the user quits Wavecrate after copying or dragging a staged handoff file, the staged file should remain available through the normal grace period so clipboard or drop consumers can still read it after the app exits. Cleanup should remove stale staged files from previous sessions on the next launch or during normal cache/staging maintenance, and cleanup failures should be logged and visible in diagnostics.
+
+Transient staged handoff files should use predictable, user-readable filenames where practical because DAWs and file managers may display the imported filename after handoff. Names should be based on the current generated/display name or selected-region naming context, sanitized through the normal filename rules, and made unique through the shared collision-numbering policy. They should not use opaque random temp names unless a readable name cannot be produced safely.
+
+Transient staged handoff files should contain the rendered audio and only the minimal required or safely useful WAV metadata. They should not inherit durable Wavecrate metadata such as tags, rating, label, Prefix, BPM, Tuning/Scale, temporary color collections, extracted-region history, or embedded Wavecrate Sample ID by default. Durable extraction owns metadata inheritance; transient handoff staging should avoid creating metadata side effects.
+
+Transient staged handoff files should not be indexed as library samples. They should live outside indexed source folders under the global `.wavecrate` handoff staging area. If a path edge case or user configuration would otherwise place staging near an indexed source, Wavecrate should still treat the staged file as temporary handoff data, not as a new source sample. Users who want an indexed file should use durable extraction, export, or copy/import workflows.
+
+Wavecrate may reuse an existing transient staged handoff file for repeated copy or drag operations when it is still valid. Reuse is allowed only when the source file identity and fingerprint, selection range, audition/render settings, write format, cache/staging version, and resulting audio payload still match. If any relevant input changes, Wavecrate should render a fresh staged file.
 
 Transient handoff staging should be allowed only when the user intent is clearly temporary, such as copying a waveform selection to the clipboard without explicitly extracting it into the library. Wavecrate should make this distinction visible enough that users understand whether a new library file was created.
 
@@ -1224,6 +1236,8 @@ Pasting into a DAW should make the DAW receive normal audio files, not Wavecrate
 Pasting into Explorer should create one or more audio files in the target directory.
 
 Clipboard handoff should preserve the exact audio the user intended to copy. For a waveform selection, that means the selected range. For browser selections, that means the selected whole files.
+
+Temporary clipboard or DAW handoff staging files should live under the global `.wavecrate` handoff staging area. Explorer drops are different when the user explicitly drops a waveform selection into an Explorer target folder: in that case Wavecrate should create the final ordinary audio file in the Explorer drop target directory rather than leaving the user with a temporary staged file.
 
 Drag-and-drop should mirror clipboard handoff behavior.
 
@@ -1802,7 +1816,7 @@ Database updates that touch both filesystem state and metadata state should be t
 
 ## Cache and Storage Lifecycle
 
-Wavecrate may create local caches for generated display names, waveform summaries, decoded audio aids, analysis outputs, similarity indexes, map projections, thumbnails or visual summaries, handoff staging, and undo/recovery.
+Wavecrate may create local caches for generated display names, waveform summaries, decoded audio aids, analysis outputs, similarity indexes, map projections, thumbnails or visual summaries, handoff staging, and undo/recovery. Cache payloads should be stored under the global `.wavecrate` root. Source-local `.wavecrate.db` files should only store cache references, cache status, fingerprints, and invalidation metadata where needed.
 
 Caches should be treated as rebuildable unless explicitly documented otherwise. Generated display-name caches should persist across restarts for speed, but they are still rebuildable projections of metadata and naming rules. User-authored metadata, ratings, tags, labels, naming-template inputs, source configuration, Sample IDs, extracted-region history, and undo state for the current session are not disposable caches.
 
@@ -2259,6 +2273,21 @@ If Wavecrate has to add playback, decoding, looping, warping, destructive render
 
 Wavecrate should be simple, focused, and maintainable internally. The codebase should make the product direction easier to execute, not harder.
 
+Clean code in Wavecrate means code that a future AI coding agent or human maintainer can read, modify, test, and validate without reconstructing hidden intent from scattered behavior. It should be obvious where a product behavior lives, which module owns a decision, which data is durable, which work is background work, which action is undoable, and which side effects touch audio files, databases, caches, the clipboard, Explorer, or external DAWs.
+
+The codebase should optimize for clarity under change:
+
+* Prefer direct, readable implementations until real repetition or complexity justifies an abstraction.
+* Prefer small cohesive modules over large mixed-purpose files.
+* Prefer explicit domain vocabulary such as source, sample, selection, extraction, rating, cache, handoff, recovery, and undo transaction over generic names such as item, data, manager, helper, or service when the domain meaning is known.
+* Prefer predictable dependency direction: product workflows may call persistence, audio, file-operation, and UI-command layers through clear interfaces, but low-level utilities should not know about high-level Wavecrate workflows.
+* Prefer data structures that make invalid states hard to represent, especially for sample identity, rating state, duplicate-ID conflicts, file availability, edit safety, cache state, background-job state, and undo transactions.
+* Prefer typed command/result models for user actions that can fail, be undone, affect files, or update multiple state surfaces.
+* Prefer one shared implementation path for equivalent user actions. For example, keyboard extraction, internal drag extraction, clipboard handoff, external drag handoff, and context-menu extraction should reuse the same extraction or handoff pipeline where they perform the same logical operation.
+* Prefer local reasoning: reading a function or module should reveal its important inputs, outputs, state changes, failure modes, and invariants without requiring a search through unrelated UI code.
+* Prefer stable seams for risky behavior: destructive edits, trashing, renames, writes, source scanning, cache cleanup, embedded-ID repair, and external handoff should have clear transaction or job boundaries.
+* Prefer behavior-preserving refactors with focused validation over sweeping rewrites that change architecture and behavior at the same time.
+
 Code should be organized around clear responsibilities:
 
 * sample discovery and source scanning
@@ -2281,25 +2310,40 @@ Wavecrate code should follow these standards:
 * Keep functions small and single-purpose.
 * Keep structs focused on one responsibility.
 * Keep traits minimal, meaningful, and justified.
+* Name functions after the domain action they perform, not after vague implementation mechanics.
+* Avoid ambiguous suffixes such as `manager`, `processor`, `handler`, or `util` unless the type has a genuinely narrow and obvious role.
 * Split complex methods into named helpers.
 * Separate large impl blocks where it improves clarity.
 * Expose only intentional public API.
 * Keep internal types internal.
 * Make error handling explicit and understandable.
+* Preserve useful error context, including source ID, sample ID, path, command, job ID, transaction ID, cache key, or setting name where relevant.
 * Keep control flow readable.
 * Encode or document important invariants.
 * Keep state mutation clear and predictable.
 * Make side effects easy to identify.
+* Keep filesystem writes, database writes, cache writes, clipboard writes, OS-shell actions, and audio-device actions visible at API boundaries.
 * Keep hot-path code simple and efficient.
 * Prefer clear composition over broad inheritance-like trait systems.
 * Avoid premature abstraction.
 * Avoid cleverness where straightforward code is better.
 * Prefer explicit data flow.
 * Minimize global mutable state.
+* Avoid long-lived mutable state that is shared across scanning, playback, editing, and UI unless the ownership and synchronization model is explicit.
 * Remove dead code.
 * Remove unused experiments unless intentionally preserved and documented.
 * Make every abstraction earn its place.
 * Avoid large rewrites unless they clearly reduce complexity, unlock important architecture, improve performance, or remove real blockers.
+
+Comments should explain intent, constraints, invariants, and non-obvious tradeoffs. They should not narrate obvious code. A useful comment explains why an operation must be transactional, why a stale-result token is needed, why a cache key includes an audio setting, why an edit cannot run on a multichannel file, or why an external handoff file needs a grace period.
+
+Duplication should be judged pragmatically. Small local duplication is acceptable when it keeps two workflows simple and independent. Duplication is harmful when it lets product rules drift, especially around extraction, naming, collision numbering, destructive-edit safety, undo/redo, embedded Sample ID handling, cache invalidation, rating transitions, trash movement, or external handoff. Shared product rules should live in shared helpers or domain services with tests.
+
+Public APIs should be designed as contracts, not incidental access points. A public function should have a clear caller, a clear reason to exist, and stable behavior. Avoid exposing internal state just to make a UI update easier. When UI code needs behavior, prefer a product command or view model that preserves domain rules rather than letting the UI mutate persistence, cache, or audio state directly.
+
+Background work should be modeled explicitly. Scans, pre-cache work, waveform loads, renders, duplicate analysis, similarity analysis, metadata writes, and cleanup jobs should have job IDs, progress state, cancellation/stale-result handling, failure reasons, and clear priority rules. The UI should observe job state instead of owning job execution details.
+
+Error paths are first-class product behavior. Code should be written so rollback, partial failure, retry, diagnostics, and user-facing status are handled deliberately rather than as afterthoughts. A failure in an edit, extraction, trash move, rename, source scan, cache rebuild, or handoff should leave the system in a state that is visible, explainable, and recoverable where practical.
 
 Code smells to avoid:
 
@@ -2318,10 +2362,17 @@ Code smells to avoid:
 * persistence details leaking into every workflow
 * temporary hacks becoming architecture
 * stale legacy UI assumptions shaping the new architecture
+* UI code duplicating domain rules
+* background jobs without cancellation or stale-result protection
+* untyped stringly-typed state for important product concepts
+* silent fallbacks that hide data loss, failed writes, failed metadata updates, stale caches, or unsupported files
+* tests that pass by asserting implementation trivia while real workflows remain unprotected
 
 Wavecrate should be improved incrementally. Refactors should usually preserve working behavior, keep validation lanes intact, and leave the codebase in a clearer state than before. Do not turn quality work into endless renaming; renaming is useful only when it improves API clarity, architectural understanding, or developer experience.
 
 Tests should support refactoring rather than prevent it. Avoid tests that only lock in names, incidental file layout, or implementation details. Prefer tests that protect real workflows, recovery behavior, stale-result safety, persistence correctness, playback behavior, destructive editing behavior, extraction behavior, undo/redo behavior, similarity behavior, and performance-sensitive paths.
+
+When an AI coding agent changes Wavecrate, it should leave behind code that is easier for the next agent to reason about. It should avoid hiding complexity in generic helpers, adding undocumented special cases, or scattering product rules across UI callbacks. If a change introduces a new concept, failure mode, cache state, command, transaction, or background job, the code should name that concept clearly and connect it to the relevant documentation and validation path.
 
 ## MVP End-to-End Acceptance Criteria
 

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -29,9 +29,11 @@ use wavecrate::external_clipboard;
 use wavecrate::gui_runtime::wavecrate_ui_font_path;
 use wavecrate::logging::{self, ActionDebugEvent, emit_action_debug_event};
 
+mod context_menu;
 mod folder_browser;
 mod status_bar;
 mod waveform;
+use context_menu::{BrowserContextMenu, BrowserContextTargetKind};
 use folder_browser::{
     FileColumn, FileEntry, FolderBrowserMessage, FolderBrowserState, FolderScanDiscoveryBatch,
     FolderScanProgress, FolderScanRequest, FolderScanResult,
@@ -120,21 +122,6 @@ enum GuiMessage {
 struct SampleLoadResult {
     path: String,
     result: Result<WaveformState, String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum BrowserContextTargetKind {
-    Source,
-    Folder,
-    Sample,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-struct BrowserContextMenu {
-    kind: BrowserContextTargetKind,
-    path: PathBuf,
-    anchor: Point,
-    title: String,
 }
 
 impl PartialEq for SampleLoadResult {
@@ -1173,12 +1160,12 @@ impl GuiAppState {
             );
             return;
         };
-        if !browser_context_target_available(&BrowserContextTargetKind::Source, &path) {
+        if !context_menu::target_available(&BrowserContextTargetKind::Source, &path) {
             self.sample_status = String::from("Source folder is missing");
             emit_gui_action(
                 "browser.context_menu.source.open",
                 Some("sources"),
-                Some(context_menu_target_label(&path).as_str()),
+                Some(context_menu::target_label(&path).as_str()),
                 "error",
                 started_at,
                 Some("source folder missing"),
@@ -1213,12 +1200,12 @@ impl GuiAppState {
             );
             return;
         };
-        if !browser_context_target_available(&BrowserContextTargetKind::Folder, &path) {
+        if !context_menu::target_available(&BrowserContextTargetKind::Folder, &path) {
             self.sample_status = String::from("Folder is missing");
             emit_gui_action(
                 "browser.context_menu.folder.open",
                 Some("folder_browser"),
-                Some(context_menu_target_label(&path).as_str()),
+                Some(context_menu::target_label(&path).as_str()),
                 "error",
                 started_at,
                 Some("folder missing"),
@@ -1253,12 +1240,12 @@ impl GuiAppState {
             );
             return;
         };
-        if !browser_context_target_available(&BrowserContextTargetKind::Sample, &path) {
+        if !context_menu::target_available(&BrowserContextTargetKind::Sample, &path) {
             self.sample_status = String::from("Sample file is missing");
             emit_gui_action(
                 "browser.context_menu.sample.open",
                 Some("browser"),
-                Some(context_menu_target_label(&path).as_str()),
+                Some(context_menu::target_label(&path).as_str()),
                 "error",
                 started_at,
                 Some("sample missing"),
@@ -1279,13 +1266,13 @@ impl GuiAppState {
         let Some(menu) = self.context_menu.take() else {
             return;
         };
-        if !browser_context_target_available(&menu.kind, &menu.path) {
-            let error = context_menu_missing_target_message(&menu.kind);
+        if !context_menu::target_available(&menu.kind, &menu.path) {
+            let error = context_menu::missing_target_message(&menu.kind);
             self.sample_status = error.to_string();
             emit_gui_action(
                 "browser.context_menu.copy_path",
-                Some(context_menu_pane(&menu.kind)),
-                Some(context_menu_target_label(&menu.path).as_str()),
+                Some(context_menu::pane(&menu.kind)),
+                Some(context_menu::target_label(&menu.path).as_str()),
                 "error",
                 started_at,
                 Some(error),
@@ -1298,8 +1285,8 @@ impl GuiAppState {
                 self.sample_status = String::from("Copied path");
                 emit_gui_action(
                     "browser.context_menu.copy_path",
-                    Some(context_menu_pane(&menu.kind)),
-                    Some(context_menu_target_label(&menu.path).as_str()),
+                    Some(context_menu::pane(&menu.kind)),
+                    Some(context_menu::target_label(&menu.path).as_str()),
                     "success",
                     started_at,
                     None,
@@ -1309,8 +1296,8 @@ impl GuiAppState {
                 self.sample_status = format!("Copy path failed: {error}");
                 emit_gui_action(
                     "browser.context_menu.copy_path",
-                    Some(context_menu_pane(&menu.kind)),
-                    Some(context_menu_target_label(&menu.path).as_str()),
+                    Some(context_menu::pane(&menu.kind)),
+                    Some(context_menu::target_label(&menu.path).as_str()),
                     "error",
                     started_at,
                     Some(&error),
@@ -1324,13 +1311,13 @@ impl GuiAppState {
         let Some(menu) = self.context_menu.take() else {
             return;
         };
-        if !browser_context_target_available(&menu.kind, &menu.path) {
-            let error = context_menu_missing_target_message(&menu.kind);
+        if !context_menu::target_available(&menu.kind, &menu.path) {
+            let error = context_menu::missing_target_message(&menu.kind);
             self.sample_status = error.to_string();
             emit_gui_action(
                 "browser.context_menu.open_explorer",
-                Some(context_menu_pane(&menu.kind)),
-                Some(context_menu_target_label(&menu.path).as_str()),
+                Some(context_menu::pane(&menu.kind)),
+                Some(context_menu::target_label(&menu.path).as_str()),
                 "error",
                 started_at,
                 Some(error),
@@ -1352,8 +1339,8 @@ impl GuiAppState {
                 };
                 emit_gui_action(
                     "browser.context_menu.open_explorer",
-                    Some(context_menu_pane(&menu.kind)),
-                    Some(context_menu_target_label(&menu.path).as_str()),
+                    Some(context_menu::pane(&menu.kind)),
+                    Some(context_menu::target_label(&menu.path).as_str()),
                     "success",
                     started_at,
                     None,
@@ -1363,8 +1350,8 @@ impl GuiAppState {
                 self.sample_status = error.clone();
                 emit_gui_action(
                     "browser.context_menu.open_explorer",
-                    Some(context_menu_pane(&menu.kind)),
-                    Some(context_menu_target_label(&menu.path).as_str()),
+                    Some(context_menu::pane(&menu.kind)),
+                    Some(context_menu::target_label(&menu.path).as_str()),
                     "error",
                     started_at,
                     Some(&error),
@@ -2277,35 +2264,6 @@ fn sample_path_label(path: impl AsRef<Path>) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-fn context_menu_target_label(path: &Path) -> String {
-    path.file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.display().to_string())
-}
-
-fn context_menu_pane(kind: &BrowserContextTargetKind) -> &'static str {
-    match kind {
-        BrowserContextTargetKind::Source => "sources",
-        BrowserContextTargetKind::Folder => "folder_browser",
-        BrowserContextTargetKind::Sample => "browser",
-    }
-}
-
-fn browser_context_target_available(kind: &BrowserContextTargetKind, path: &Path) -> bool {
-    match kind {
-        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => path.is_dir(),
-        BrowserContextTargetKind::Sample => path.is_file(),
-    }
-}
-
-fn context_menu_missing_target_message(kind: &BrowserContextTargetKind) -> &'static str {
-    match kind {
-        BrowserContextTargetKind::Source => "Source folder is missing",
-        BrowserContextTargetKind::Folder => "Folder is missing",
-        BrowserContextTargetKind::Sample => "Sample file is missing",
-    }
-}
-
 fn format_copy_path(path: &Path) -> String {
     let mut rendered = path.to_string_lossy().replace('\\', "/");
     if rendered.contains(' ') {
@@ -2652,66 +2610,13 @@ fn view(state: &mut GuiAppState) -> ui::View<GuiMessage> {
         }
     }
     if let Some(menu) = state.context_menu.as_ref() {
-        layers.push(browser_context_menu_overlay(menu));
+        layers.push(context_menu::overlay(menu));
     }
     if layers.len() > 1 {
         ui::stack(layers).fill()
     } else {
         layers.pop().expect("view should contain base content")
     }
-}
-
-fn browser_context_menu_overlay(menu: &BrowserContextMenu) -> ui::View<GuiMessage> {
-    let action_label = match menu.kind {
-        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => "Open in Explorer",
-        BrowserContextTargetKind::Sample => "Reveal in Explorer",
-    };
-    let top = menu.anchor.y.max(0.0);
-    let left = menu.anchor.x.max(0.0);
-    ui::column([
-        ui::spacer().fill_width().height(top),
-        ui::row([
-            ui::spacer().width(left).height(1.0),
-            ui::column([
-                ui::text(menu.title.clone())
-                    .height(22.0)
-                    .fill_width()
-                    .truncate(),
-                ui::button(action_label)
-                    .message(GuiMessage::OpenContextTarget)
-                    .key("browser-context-open-explorer")
-                    .fill_width()
-                    .height(28.0),
-                ui::button("Copy Path")
-                    .message(GuiMessage::CopyContextPath)
-                    .key("browser-context-copy-path")
-                    .fill_width()
-                    .height(28.0),
-            ])
-            .style(ui::WidgetStyle {
-                tone: ui::WidgetTone::Accent,
-                prominence: ui::WidgetProminence::Strong,
-            })
-            .padding(8.0)
-            .spacing(5.0)
-            .size(210.0, 104.0),
-            ui::button("")
-                .message(GuiMessage::CloseContextMenu)
-                .key("browser-context-dismiss-right")
-                .input_only()
-                .fill_width()
-                .height(104.0),
-        ])
-        .fill_width()
-        .height(104.0),
-        ui::button("")
-            .message(GuiMessage::CloseContextMenu)
-            .key("browser-context-dismiss-bottom")
-            .input_only()
-            .fill_width()
-            .fill_height(),
-    ])
-    .fill()
 }
 
 fn folder_drag_preview_overlay(preview: folder_browser::FolderDragPreview) -> ui::View<GuiMessage> {
@@ -4163,29 +4068,29 @@ mod tests {
         let sample = root.join("kick.wav");
         std::fs::write(&sample, [0_u8; 8]).expect("write sample");
 
-        assert!(super::browser_context_target_available(
+        assert!(super::context_menu::target_available(
             &super::BrowserContextTargetKind::Source,
             &root
         ));
-        assert!(super::browser_context_target_available(
+        assert!(super::context_menu::target_available(
             &super::BrowserContextTargetKind::Folder,
             &root
         ));
-        assert!(super::browser_context_target_available(
+        assert!(super::context_menu::target_available(
             &super::BrowserContextTargetKind::Sample,
             &sample
         ));
-        assert!(!super::browser_context_target_available(
+        assert!(!super::context_menu::target_available(
             &super::BrowserContextTargetKind::Sample,
             &root
         ));
-        assert!(!super::browser_context_target_available(
+        assert!(!super::context_menu::target_available(
             &super::BrowserContextTargetKind::Folder,
             &sample
         ));
 
         std::fs::remove_file(&sample).expect("remove sample");
-        assert!(!super::browser_context_target_available(
+        assert!(!super::context_menu::target_available(
             &super::BrowserContextTargetKind::Sample,
             &sample
         ));

--- a/src/gui_app/context_menu.rs
+++ b/src/gui_app/context_menu.rs
@@ -1,0 +1,101 @@
+use super::GuiMessage;
+use radiant::gui::types::Point;
+use radiant::prelude as ui;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum BrowserContextTargetKind {
+    Source,
+    Folder,
+    Sample,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct BrowserContextMenu {
+    pub(super) kind: BrowserContextTargetKind,
+    pub(super) path: PathBuf,
+    pub(super) anchor: Point,
+    pub(super) title: String,
+}
+
+pub(super) fn target_label(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+pub(super) fn pane(kind: &BrowserContextTargetKind) -> &'static str {
+    match kind {
+        BrowserContextTargetKind::Source => "sources",
+        BrowserContextTargetKind::Folder => "folder_browser",
+        BrowserContextTargetKind::Sample => "browser",
+    }
+}
+
+pub(super) fn target_available(kind: &BrowserContextTargetKind, path: &Path) -> bool {
+    match kind {
+        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => path.is_dir(),
+        BrowserContextTargetKind::Sample => path.is_file(),
+    }
+}
+
+pub(super) fn missing_target_message(kind: &BrowserContextTargetKind) -> &'static str {
+    match kind {
+        BrowserContextTargetKind::Source => "Source folder is missing",
+        BrowserContextTargetKind::Folder => "Folder is missing",
+        BrowserContextTargetKind::Sample => "Sample file is missing",
+    }
+}
+
+pub(super) fn overlay(menu: &BrowserContextMenu) -> ui::View<GuiMessage> {
+    let action_label = match menu.kind {
+        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => "Open in Explorer",
+        BrowserContextTargetKind::Sample => "Reveal in Explorer",
+    };
+    let top = menu.anchor.y.max(0.0);
+    let left = menu.anchor.x.max(0.0);
+    ui::column([
+        ui::spacer().fill_width().height(top),
+        ui::row([
+            ui::spacer().width(left).height(1.0),
+            ui::column([
+                ui::text(menu.title.clone())
+                    .height(22.0)
+                    .fill_width()
+                    .truncate(),
+                ui::button(action_label)
+                    .message(GuiMessage::OpenContextTarget)
+                    .key("browser-context-open-explorer")
+                    .fill_width()
+                    .height(28.0),
+                ui::button("Copy Path")
+                    .message(GuiMessage::CopyContextPath)
+                    .key("browser-context-copy-path")
+                    .fill_width()
+                    .height(28.0),
+            ])
+            .style(ui::WidgetStyle {
+                tone: ui::WidgetTone::Accent,
+                prominence: ui::WidgetProminence::Strong,
+            })
+            .padding(8.0)
+            .spacing(5.0)
+            .size(210.0, 104.0),
+            ui::button("")
+                .message(GuiMessage::CloseContextMenu)
+                .key("browser-context-dismiss-right")
+                .input_only()
+                .fill_width()
+                .height(104.0),
+        ])
+        .fill_width()
+        .height(104.0),
+        ui::button("")
+            .message(GuiMessage::CloseContextMenu)
+            .key("browser-context-dismiss-bottom")
+            .input_only()
+            .fill_width()
+            .fill_height(),
+    ])
+    .fill()
+}


### PR DESCRIPTION
## Summary
- move default GUI browser context-menu types, availability helpers, and overlay view into src/gui_app/context_menu.rs
- keep controller mutation logic in GuiAppState while shrinking src/gui_app.rs below 5,000 lines
- update context-menu regression tests to target the extracted helper module

## Validation
- cargo test -p wavecrate context_menu
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent