### PR TITLE
Expose rebuildable cache clearing in settings

### DIFF
--- a/crates/wavecrate-library/src/app_dirs.rs
+++ b/crates/wavecrate-library/src/app_dirs.rs
@@ -325,6 +325,53 @@ pub fn handoff_staging_dir() -> Result<PathBuf, AppDirError> {
     Ok(path)
 }
 
+/// Return the root directory for rebuildable cache payloads.
+pub fn rebuildable_cache_root_dir() -> Result<PathBuf, AppDirError> {
+    let path = app_root_dir()?.join("cache");
+    std::fs::create_dir_all(&path).map_err(|source| AppDirError::CreateDir {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
+/// Return the persistent waveform cache payload directory.
+pub fn waveform_cache_dir() -> Result<PathBuf, AppDirError> {
+    let path = rebuildable_cache_root_dir()?.join("waveforms");
+    std::fs::create_dir_all(&path).map_err(|source| AppDirError::CreateDir {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
+/// Clear all rebuildable cache payloads without touching logs, handoff staging,
+/// source databases, or durable user metadata.
+pub fn clear_rebuildable_cache_payloads() -> Result<PathBuf, String> {
+    let path = app_root_dir().map_err(|err| err.to_string())?.join("cache");
+    if path.exists() {
+        if !path.is_dir() {
+            return Err(format!(
+                "Rebuildable cache path is not a directory: {}",
+                path.display()
+            ));
+        }
+        std::fs::remove_dir_all(&path).map_err(|err| {
+            format!(
+                "Failed to clear rebuildable caches at {}: {err}",
+                path.display()
+            )
+        })?;
+    }
+    std::fs::create_dir_all(&path).map_err(|err| {
+        format!(
+            "Failed to recreate rebuildable cache directory at {}: {err}",
+            path.display()
+        )
+    })?;
+    Ok(path)
+}
+
 /// Return the base directory used for `.wavecrate` when no override is set.
 pub fn config_base_dir_path() -> Option<PathBuf> {
     config_base_dir()

--- a/src/app/controller/playback/persistent_waveform_cache.rs
+++ b/src/app/controller/playback/persistent_waveform_cache.rs
@@ -20,7 +20,6 @@ const CACHE_VERSION: u32 = 1;
 /// Extension used for persistent waveform cache payload files.
 const CACHE_FILE_EXTENSION: &str = "bin";
 /// Relative app-data namespace that stores persistent waveform cache entries.
-const CACHE_NAMESPACE: &str = "cache/waveforms";
 
 /// Persistent waveform cache hit hydrated from disk and ready for controller use.
 #[derive(Clone)]
@@ -244,9 +243,7 @@ pub(crate) fn persist_waveform_cache_entry(
 
 /// Resolve the root directory that stores all persistent waveform cache entries.
 fn cache_root_dir() -> Result<PathBuf, String> {
-    Ok(app_dirs::app_root_dir()
-        .map_err(|err| format!("Failed to resolve app cache root: {err}"))?
-        .join(CACHE_NAMESPACE))
+    app_dirs::waveform_cache_dir().map_err(|err| format!("Failed to resolve waveform cache: {err}"))
 }
 
 /// Resolve the hashed directory for one source/path pair.

--- a/src/app_dirs_tests.rs
+++ b/src/app_dirs_tests.rs
@@ -96,6 +96,56 @@ fn dependency_handoff_staging_dir_stays_under_app_root() {
 }
 
 #[test]
+fn dependency_waveform_cache_dir_stays_under_rebuildable_cache_root() {
+    if explicit_persistence_env_present() {
+        return;
+    }
+    let base = tempdir().expect("create base dir");
+    let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+    let _profile_guard = PersistenceProfileGuard::live();
+
+    let cache_dir = app_dirs::waveform_cache_dir().expect("resolve waveform cache dir");
+
+    assert_eq!(
+        cache_dir,
+        base.path()
+            .join(".wavecrate")
+            .join("cache")
+            .join("waveforms")
+    );
+    assert!(cache_dir.is_dir());
+}
+
+#[test]
+fn dependency_clear_rebuildable_cache_payloads_preserves_non_cache_app_dirs() {
+    if explicit_persistence_env_present() {
+        return;
+    }
+    let base = tempdir().expect("create base dir");
+    let _base_guard = ConfigBaseGuard::set(base.path().to_path_buf());
+    let _profile_guard = PersistenceProfileGuard::live();
+
+    let waveform_cache = app_dirs::waveform_cache_dir().expect("resolve waveform cache dir");
+    let cached_file = waveform_cache.join("stale.bin");
+    std::fs::write(&cached_file, b"cache").expect("write cache payload");
+    let logs_dir = app_dirs::logs_dir().expect("resolve logs dir");
+    let log_file = logs_dir.join("wavecrate.log");
+    std::fs::write(&log_file, b"log").expect("write log payload");
+    let handoff_dir = app_dirs::handoff_staging_dir().expect("resolve handoff dir");
+    let handoff_file = handoff_dir.join("clip.wav");
+    std::fs::write(&handoff_file, b"clip").expect("write handoff payload");
+
+    let cache_root =
+        app_dirs::clear_rebuildable_cache_payloads().expect("clear rebuildable cache payloads");
+
+    assert_eq!(cache_root, base.path().join(".wavecrate").join("cache"));
+    assert!(cache_root.is_dir());
+    assert!(!cached_file.exists());
+    assert!(log_file.exists());
+    assert!(handoff_file.exists());
+}
+
+#[test]
 fn dependency_explicit_app_root_override_wins_over_test_default() {
     if explicit_persistence_env_present() {
         return;

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -58,7 +58,7 @@ const AUDIO_ENGINE_PILL_ID: u64 = 31_100;
 const AUDIO_ENGINE_PILL_WIDTH: f32 = 54.0;
 const AUDIO_ENGINE_PILL_HEIGHT: f32 = 18.0;
 const AUDIO_SETTINGS_POPUP_WIDTH: f32 = 360.0;
-const AUDIO_SETTINGS_POPUP_HEIGHT: f32 = 316.0;
+const AUDIO_SETTINGS_POPUP_HEIGHT: f32 = 344.0;
 const DRAG_PREVIEW_MAX_WIDTH: f32 = 280.0;
 const DRAG_PREVIEW_HEIGHT: f32 = 24.0;
 const WAVEFORM_VIEW_HEIGHT: f32 = 172.0;
@@ -95,6 +95,7 @@ enum GuiMessage {
     SetAudioOutputHost(Option<String>),
     SetAudioOutputDevice(Option<String>),
     SetAudioOutputSampleRate(Option<u32>),
+    ClearRebuildableCaches,
     NormalizeSelectedSamples,
     CopySelectedFiles,
     CopyContextPath,
@@ -454,6 +455,7 @@ impl GuiAppState {
             GuiMessage::SetAudioOutputSampleRate(sample_rate) => {
                 self.set_audio_output_sample_rate(sample_rate);
             }
+            GuiMessage::ClearRebuildableCaches => self.clear_rebuildable_caches(),
             GuiMessage::NormalizeSelectedSamples => self.normalize_selected_samples(),
             GuiMessage::CopySelectedFiles => self.copy_selected_files(),
             GuiMessage::CopyContextPath => self.copy_context_path(),
@@ -1748,6 +1750,37 @@ impl GuiAppState {
         self.apply_audio_output_config_change(started_at, "audio.output.sample_rate.set");
     }
 
+    fn clear_rebuildable_caches(&mut self) {
+        let started_at = Instant::now();
+        match wavecrate::app_dirs::clear_rebuildable_cache_payloads() {
+            Ok(path) => {
+                self.audio_settings_error = None;
+                self.sample_status = format!("Rebuildable caches cleared: {}", path.display());
+                let target = path.display().to_string();
+                emit_gui_action(
+                    "settings.cache.clear_rebuildable",
+                    Some("settings"),
+                    Some(target.as_str()),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Err(err) => {
+                self.audio_settings_error = Some(err.clone());
+                self.sample_status = err.clone();
+                emit_gui_action(
+                    "settings.cache.clear_rebuildable",
+                    Some("settings"),
+                    None,
+                    "failed",
+                    started_at,
+                    Some(err.as_str()),
+                );
+            }
+        }
+    }
+
     fn apply_audio_output_config_change(&mut self, started_at: Instant, action: &'static str) {
         let restart_span = self
             .waveform
@@ -2836,7 +2869,28 @@ fn audio_settings_panel_rows(state: &GuiAppState) -> Vec<ui::View<GuiMessage>> {
         audio_sample_rate_option_buttons(state),
         4,
     ));
+    rows.push(cache_maintenance_section());
     rows
+}
+
+fn cache_maintenance_section() -> ui::View<GuiMessage> {
+    ui::column(vec![
+        ui::text("Maintenance")
+            .style(ui::WidgetStyle {
+                tone: ui::WidgetTone::Accent,
+                prominence: ui::WidgetProminence::Subtle,
+            })
+            .fill_width()
+            .height(18.0),
+        ui::button("Clear Rebuildable Caches")
+            .message(GuiMessage::ClearRebuildableCaches)
+            .key("settings-clear-rebuildable-caches")
+            .fill_width()
+            .height(24.0),
+    ])
+    .spacing(3.0)
+    .fill_width()
+    .height(45.0)
 }
 
 fn audio_settings_section(
@@ -4925,8 +4979,46 @@ mod tests {
         assert!(texts.iter().any(|text| text == "Output"), "{texts:?}");
         assert!(texts.iter().any(|text| text == "Sample Rate"), "{texts:?}");
         assert!(
+            texts.iter().any(|text| text == "Clear Rebuildable Caches"),
+            "{texts:?}"
+        );
+        assert!(
             !texts.iter().any(|text| text.contains("Input")),
             "{texts:?}"
+        );
+    }
+
+    #[test]
+    fn clear_rebuildable_caches_action_removes_cache_payloads_only() {
+        if std::env::var_os("WAVECRATE_CONFIG_HOME").is_some()
+            || std::env::var_os("WAVECRATE_CONFIG_PROFILE").is_some()
+        {
+            return;
+        }
+        let base = tempfile::tempdir().expect("create config base");
+        let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
+        let _profile_guard = wavecrate::app_dirs::PersistenceProfileGuard::live();
+        let waveform_cache = wavecrate::app_dirs::waveform_cache_dir().expect("waveform cache dir");
+        let cache_payload = waveform_cache.join("cached.bin");
+        std::fs::write(&cache_payload, b"cache").expect("write cache payload");
+        let handoff_dir = wavecrate::app_dirs::handoff_staging_dir().expect("handoff staging dir");
+        let handoff_payload = handoff_dir.join("clip.wav");
+        std::fs::write(&handoff_payload, b"clip").expect("write handoff payload");
+        let mut state = GuiAppState::load_default().expect("default state loads");
+        state.sample_status = String::from("ready");
+
+        state.apply_message(
+            super::GuiMessage::ClearRebuildableCaches,
+            &mut ui::UpdateContext::default(),
+        );
+
+        assert!(!cache_payload.exists());
+        assert!(handoff_payload.exists());
+        assert_eq!(state.audio_settings_error, None);
+        assert!(
+            state.sample_status.contains("Rebuildable caches cleared"),
+            "{}",
+            state.sample_status
         );
     }
 


### PR DESCRIPTION
## Summary
- adds a settings action to clear rebuildable cache payloads
- centralizes cache cleanup under the Wavecrate cache root while preserving durable app data
- updates persistent waveform cache handling and regression coverage for rebuildable cache cleanup

## Validation
- `cargo fmt --all`
- `powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent`