### PR TITLE
Add persisted audio write format policy

### DIFF
--- a/src/app/controller/config.rs
+++ b/src/app/controller/config.rs
@@ -38,6 +38,8 @@ impl AppController {
         self.ui.audio.selected = self.settings.audio_output.clone();
         self.settings.audio_input = cfg.core.audio_input.clone();
         self.ui.audio.input_selected = self.settings.audio_input.clone();
+        self.settings.audio_write_format = cfg.core.audio_write_format.clone();
+        self.ui.audio.write_format = self.settings.audio_write_format.clone();
         self.settings.controls = cfg.core.controls.clone();
         self.settings.default_identifier = if cfg.core.default_identifier.trim().is_empty() {
             String::from("portal")
@@ -349,6 +351,7 @@ impl AppController {
                     }),
                 audio_output: self.settings.audio_output.clone(),
                 audio_input: self.settings.audio_input.clone(),
+                audio_write_format: self.settings.audio_write_format.clone(),
                 volume: self.ui.volume,
                 controls: self.settings.controls.clone(),
                 default_identifier: self.settings.default_identifier.clone(),

--- a/src/app/controller/jobs/selection_export_types.rs
+++ b/src/app/controller/jobs/selection_export_types.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::sample_sources::Rating;
 use crate::sample_sources::WavEntry;
+use crate::sample_sources::config::AudioWriteFormatConfig;
 use crate::selection::SelectionRange;
 use crate::waveform::DecodedWaveform;
 use std::path::PathBuf;
@@ -45,6 +46,8 @@ pub(crate) struct SelectionExportSnapshot {
     pub(crate) apply_edge_fades: bool,
     /// Edge-fade duration in milliseconds when enabled.
     pub(crate) edge_fade_ms: f32,
+    /// Configured WAV write policy captured with the export request.
+    pub(crate) write_format: AudioWriteFormatConfig,
     /// Tag to assign to the written clip.
     pub(crate) target_tag: Option<Rating>,
     /// Whether loop metadata should be persisted for the new clip.
@@ -74,6 +77,8 @@ pub(crate) struct SelectionSliceBatchExportSnapshot {
     pub(crate) apply_edge_fades: bool,
     /// Edge-fade duration in milliseconds when enabled.
     pub(crate) edge_fade_ms: f32,
+    /// Configured WAV write policy captured with the export request.
+    pub(crate) write_format: AudioWriteFormatConfig,
 }
 
 /// Destination-specific job configuration for selection clip exports.

--- a/src/app/controller/library/selection_export.rs
+++ b/src/app/controller/library/selection_export.rs
@@ -30,7 +30,7 @@ use crate::app::controller::jobs::{
     SelectionExportJob, SelectionExportSnapshot, SelectionExportTimings,
     build_selection_export_audio_payload,
 };
-use crate::app::controller::playback::audio_samples::write_wav;
+use crate::app::controller::playback::audio_samples::write_wav_with_spec;
 use crate::sample_sources::Rating;
 
 impl AppController {
@@ -101,7 +101,13 @@ impl AppController {
             spec.sample_rate,
             spec.channels,
         );
-        write_wav(&target_abs, &samples, spec.sample_rate, spec.channels)?;
+        write_wav_with_spec(
+            &target_abs,
+            &samples,
+            self.settings
+                .audio_write_format
+                .wav_spec_for_source(spec.channels, spec.sample_rate),
+        )?;
         let (looped, bpm) = self.selection_export_metadata();
         self.record_selection_entry(SelectionEntryRecordRequest {
             source: &source,
@@ -143,7 +149,13 @@ impl AppController {
             spec.sample_rate,
             spec.channels,
         );
-        write_wav(&target_abs, &samples, spec.sample_rate, spec.channels)?;
+        write_wav_with_spec(
+            &target_abs,
+            &samples,
+            self.settings
+                .audio_write_format
+                .wav_spec_for_source(spec.channels, spec.sample_rate),
+        )?;
         let (looped, bpm) = self.selection_export_metadata();
         self.record_selection_entry(SelectionEntryRecordRequest {
             source: &source,
@@ -226,7 +238,13 @@ impl AppController {
             spec.sample_rate,
             spec.channels,
         );
-        write_wav(&target_abs, &samples, spec.sample_rate, spec.channels)?;
+        write_wav_with_spec(
+            &target_abs,
+            &samples,
+            self.settings
+                .audio_write_format
+                .wav_spec_for_source(spec.channels, spec.sample_rate),
+        )?;
         let source = SampleSource {
             id: SourceId::new(),
             root: clip_root.to_path_buf(),
@@ -282,6 +300,7 @@ impl AppController {
             ),
             apply_edge_fades: self.settings.controls.auto_edge_fades_on_selection_exports,
             edge_fade_ms: self.settings.controls.anti_clip_fade_ms.max(0.0),
+            write_format: self.settings.audio_write_format.clone(),
             target_tag,
             looped,
             bpm,

--- a/src/app/controller/library/selection_export/background.rs
+++ b/src/app/controller/library/selection_export/background.rs
@@ -317,13 +317,14 @@ fn prepare_selection_clip(
 fn write_selection_clip(
     absolute_path: &Path,
     prepared: &mut PreparedSelectionClip,
-    _snapshot: &SelectionExportSnapshot,
+    snapshot: &SelectionExportSnapshot,
 ) -> Result<(), String> {
-    super::write_wav(
+    crate::app::controller::playback::audio_samples::write_wav_with_spec(
         absolute_path,
         &prepared.samples,
-        prepared.sample_rate,
-        prepared.channels,
+        snapshot
+            .write_format
+            .wav_spec_for_source(prepared.channels, prepared.sample_rate),
     )
 }
 
@@ -348,10 +349,11 @@ fn write_slice_batch_clip(
             fade_duration,
         );
     }
-    super::write_wav(
+    crate::app::controller::playback::audio_samples::write_wav_with_spec(
         absolute_path,
         &prepared.samples,
-        prepared.sample_rate,
-        prepared.channels,
+        snapshot
+            .write_format
+            .wav_spec_for_source(prepared.channels, prepared.sample_rate),
     )
 }

--- a/src/app/controller/library/selection_export/slice_batch.rs
+++ b/src/app/controller/library/selection_export/slice_batch.rs
@@ -95,6 +95,7 @@ impl AppController {
             ),
             apply_edge_fades: self.settings.controls.auto_edge_fades_on_selection_exports,
             edge_fade_ms: self.settings.controls.anti_clip_fade_ms.max(0.0),
+            write_format: self.settings.audio_write_format.clone(),
         })
     }
 

--- a/src/app/controller/playback/audio_samples.rs
+++ b/src/app/controller/playback/audio_samples.rs
@@ -61,24 +61,54 @@ pub(crate) fn write_wav(
     sample_rate: u32,
     channels: u16,
 ) -> Result<(), String> {
-    if let Some(parent) = target.parent()
-        && !parent.exists()
-    {
-        fs::create_dir_all(parent)
-            .map_err(|err| format!("Failed to create folder {}: {err}", parent.display()))?;
-    }
     let spec = hound::WavSpec {
         channels: channels.max(1),
         sample_rate: sample_rate.max(1),
         bits_per_sample: 32,
         sample_format: SampleFormat::Float,
     };
+    write_wav_with_spec(target, samples, spec)
+}
+
+/// Write interleaved f32 samples to a WAV file using a configured WAV spec.
+pub(crate) fn write_wav_with_spec(
+    target: &Path,
+    samples: &[f32],
+    spec: hound::WavSpec,
+) -> Result<(), String> {
+    if let Some(parent) = target.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create folder {}: {err}", parent.display()))?;
+    }
     let mut writer = hound::WavWriter::create(target, spec)
         .map_err(|err| format!("Failed to create clip: {err}"))?;
-    for sample in samples {
-        writer
-            .write_sample(*sample)
-            .map_err(|err| format!("Failed to write clip: {err}"))?;
+    match spec.sample_format {
+        SampleFormat::Float => {
+            for sample in samples {
+                writer
+                    .write_sample(*sample)
+                    .map_err(|err| format!("Failed to write clip: {err}"))?;
+            }
+        }
+        SampleFormat::Int if spec.bits_per_sample <= 16 => {
+            for sample in samples {
+                let scaled = (sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16;
+                writer
+                    .write_sample(scaled)
+                    .map_err(|err| format!("Failed to write clip: {err}"))?;
+            }
+        }
+        SampleFormat::Int => {
+            let max = ((1_i64 << (spec.bits_per_sample.saturating_sub(1) as u32)) - 1) as f32;
+            for sample in samples {
+                let scaled = (sample.clamp(-1.0, 1.0) * max).round() as i32;
+                writer
+                    .write_sample(scaled)
+                    .map_err(|err| format!("Failed to write clip: {err}"))?;
+            }
+        }
     }
     writer
         .finalize()
@@ -170,4 +200,30 @@ fn slice_frames(
         cropped.extend_from_slice(&samples[offset..offset + channels]);
     }
     cropped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_wav_with_spec_writes_configured_pcm24_header() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("clip.wav");
+        let spec = hound::WavSpec {
+            channels: 2,
+            sample_rate: 48_000,
+            bits_per_sample: 24,
+            sample_format: SampleFormat::Int,
+        };
+
+        write_wav_with_spec(&path, &[-1.0, 0.0, 0.5, 1.0], spec).expect("write wav");
+
+        let reader = hound::WavReader::open(path).expect("read wav");
+        let written = reader.spec();
+        assert_eq!(written.channels, 2);
+        assert_eq!(written.sample_rate, 48_000);
+        assert_eq!(written.bits_per_sample, 24);
+        assert_eq!(written.sample_format, SampleFormat::Int);
+    }
 }

--- a/src/app/controller/state/settings.rs
+++ b/src/app/controller/state/settings.rs
@@ -1,7 +1,7 @@
 //! Persistent settings state for the controller.
 
 use crate::audio::{AudioInputConfig, AudioOutputConfig};
-use crate::sample_sources::config::DropTargetConfig;
+use crate::sample_sources::config::{AudioWriteFormatConfig, DropTargetConfig};
 use std::path::PathBuf;
 
 pub(crate) struct AppSettingsState {
@@ -13,6 +13,7 @@ pub(crate) struct AppSettingsState {
     pub(crate) app_data_dir: Option<PathBuf>,
     pub(crate) audio_output: AudioOutputConfig,
     pub(crate) audio_input: AudioInputConfig,
+    pub(crate) audio_write_format: AudioWriteFormatConfig,
     pub(crate) controls: crate::sample_sources::config::InteractionOptions,
     pub(crate) trash_folder: Option<PathBuf>,
     pub(crate) drop_targets: Vec<DropTargetConfig>,
@@ -31,6 +32,7 @@ impl AppSettingsState {
             app_data_dir: None,
             audio_output: AudioOutputConfig::default(),
             audio_input: AudioInputConfig::default(),
+            audio_write_format: AudioWriteFormatConfig::default(),
             controls: crate::sample_sources::config::InteractionOptions::default(),
             trash_folder: None,
             drop_targets: Vec::new(),

--- a/src/app/state/audio.rs
+++ b/src/app/state/audio.rs
@@ -1,4 +1,5 @@
 use crate::audio::{AudioInputConfig, AudioOutputConfig, ResolvedInput, ResolvedOutput};
+use crate::sample_sources::config::AudioWriteFormatConfig;
 
 /// UI state for audio host/device selection.
 #[derive(Clone, Debug, Default)]
@@ -31,6 +32,8 @@ pub struct AudioOptionsState {
     pub input_applied: Option<ActiveAudioInput>,
     /// Warning message for input selection, if any.
     pub input_warning: Option<String>,
+    /// Persistent write-format policy used for Wavecrate-created WAV files.
+    pub write_format: AudioWriteFormatConfig,
     /// Whether the audio options panel is open.
     pub panel_open: bool,
 }

--- a/src/app_core/actions/native_shell_dtos.rs
+++ b/src/app_core/actions/native_shell_dtos.rs
@@ -1250,6 +1250,8 @@ pub struct OptionsPanelModel {
     pub invert_waveform_scroll_enabled: bool,
     /// Short display label for the configured trash folder, when available.
     pub trash_folder_label: Option<String>,
+    /// Short display label for the configured audio write format.
+    pub audio_write_format_label: Option<String>,
 }
 
 impl OptionsPanelModel {
@@ -1807,6 +1809,7 @@ mod tests {
             destructive_yolo_mode_enabled: true,
             invert_waveform_scroll_enabled: false,
             trash_folder_label: Some(String::from("Trash")),
+            audio_write_format_label: Some(String::from("Source rate, 32-bit float")),
         };
         let preferences = model.preference_state();
 

--- a/src/app_core/native_bridge/projection_cache/projection_key/non_segment.rs
+++ b/src/app_core/native_bridge/projection_cache/projection_key/non_segment.rs
@@ -166,6 +166,7 @@ fn hash_options_panel_model(model: &crate::app_core::actions::NativeOptionsPanel
     preferences.primary_text_value.hash(&mut hasher);
     preferences.toggles.hash(&mut hasher);
     preferences.auxiliary_label.hash(&mut hasher);
+    model.audio_write_format_label.hash(&mut hasher);
     hasher.finish()
 }
 

--- a/src/app_core/native_shell/composition/state/options_panel/actions.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/actions.rs
@@ -110,6 +110,17 @@ pub(super) fn legacy_options_panel_button_defs(model: &AppModel) -> Vec<(String,
             ),
             UiAction::PickTrashFolder,
         ),
+        (
+            format!(
+                "Write Format: {}",
+                model
+                    .options_panel
+                    .audio_write_format_label
+                    .as_deref()
+                    .unwrap_or("Not configured")
+            ),
+            UiAction::ShowOptionsOverview,
+        ),
         (String::from("Open Trash Folder"), UiAction::OpenTrashFolder),
         (String::from("Close"), UiAction::CloseOptionsPanel),
     ]

--- a/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
+++ b/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
@@ -307,6 +307,29 @@ fn options_panel_trash_folder_buttons_emit_expected_actions() {
 }
 
 #[test]
+fn options_panel_surfaces_audio_write_format_policy() {
+    let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
+    let style = style_for_layout(&layout);
+    let model = AppModel {
+        options_panel: crate::app_core::native_shell::runtime_contract::OptionsPanelModel {
+            visible: true,
+            audio_write_format_label: Some(String::from(
+                "Source rate, 32-bit float, Preserve mono/stereo, No dither",
+            )),
+            ..crate::app_core::native_shell::runtime_contract::OptionsPanelModel::default()
+        },
+        ..AppModel::default()
+    };
+
+    let panel = options_panel_layout(&layout, &style, &model)
+        .expect("visible options panel should resolve layout");
+
+    assert!(panel.buttons.iter().any(|button| {
+        button.label == "Write Format: Source rate, 32-bit float, Preserve mono/stereo, No dither"
+    }));
+}
+
+#[test]
 fn options_panel_default_identifier_button_emits_edit_action() {
     let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
     let style = style_for_layout(&layout);

--- a/src/app_core/native_shell/options_panel_projection.rs
+++ b/src/app_core/native_shell/options_panel_projection.rs
@@ -94,6 +94,7 @@ pub(crate) fn project_options_panel_model(
         destructive_yolo_mode_enabled: ui.controls.destructive_yolo_mode,
         invert_waveform_scroll_enabled: ui.controls.invert_waveform_scroll,
         trash_folder_label: ui.trash_folder.as_deref().map(project_trash_folder_label),
+        audio_write_format_label: Some(ui.audio.write_format.summary_label()),
     }
 }
 
@@ -448,6 +449,20 @@ mod tests {
         assert_eq!(projected.output_sample_rate_options.len(), 3);
         assert!(projected.output_sample_rate_options[1].selected);
         assert_eq!(projected.output_sample_rate_options[1].label, "44.1 kHz");
+    }
+
+    #[test]
+    fn options_panel_projection_surfaces_audio_write_format() {
+        let mut ui = UiState::default();
+        ui.audio.write_format.sample_format =
+            crate::sample_sources::config::AudioWriteSampleFormat::Pcm24;
+
+        let projected = project_options_panel_model(&ui);
+
+        assert_eq!(
+            projected.audio_write_format_label.as_deref(),
+            Some("Source rate, 24-bit PCM, Preserve mono/stereo, No dither")
+        );
     }
 
     #[test]

--- a/src/sample_sources/config.rs
+++ b/src/sample_sources/config.rs
@@ -10,6 +10,8 @@ pub use config_io::{
     save_to_path,
 };
 pub use config_types::{
-    AnalysisSettings, AppConfig, AppSettingsCore, ConfigError, DropTargetColor, DropTargetConfig,
-    FeatureFlags, InteractionOptions, TooltipMode, UpdateChannel, UpdateSettings,
+    AnalysisSettings, AppConfig, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,
+    AudioWriteFormatConfig, AudioWriteSampleFormat, AudioWriteSampleRate, ConfigError,
+    DropTargetColor, DropTargetConfig, FeatureFlags, InteractionOptions, TooltipMode,
+    UpdateChannel, UpdateSettings,
 };

--- a/src/sample_sources/config_io/tests/legacy.rs
+++ b/src/sample_sources/config_io/tests/legacy.rs
@@ -7,7 +7,7 @@ use super::super::load::load_or_default;
 use super::TestConfigEnv;
 use crate::audio::{AudioInputConfig, AudioOutputConfig};
 use crate::sample_sources::SampleSource;
-use crate::sample_sources::config::AppConfig;
+use crate::sample_sources::config::{AppConfig, AudioWriteFormatConfig};
 
 #[test]
 fn migrates_from_legacy_json() {
@@ -31,6 +31,7 @@ fn migrates_from_legacy_json() {
             active_folder_pane: None,
             audio_output: AudioOutputConfig::default(),
             audio_input: AudioInputConfig::default(),
+            audio_write_format: AudioWriteFormatConfig::default(),
             volume: 0.9,
             controls: InteractionOptions::default(),
             default_identifier: String::from("legacy"),

--- a/src/sample_sources/config_io/tests/save.rs
+++ b/src/sample_sources/config_io/tests/save.rs
@@ -1,8 +1,9 @@
 #[cfg(unix)]
 use super::super::super::config_types::AppSettings;
 use super::super::super::config_types::{
-    AnalysisSettings, AppSettingsCore, DropTargetColor, DropTargetConfig, FeatureFlags,
-    InteractionOptions, TooltipMode, UpdateChannel, UpdateSettings,
+    AnalysisSettings, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,
+    AudioWriteFormatConfig, AudioWriteSampleFormat, AudioWriteSampleRate, DropTargetColor,
+    DropTargetConfig, FeatureFlags, InteractionOptions, TooltipMode, UpdateChannel, UpdateSettings,
 };
 use super::super::load::load_settings_from;
 #[cfg(unix)]
@@ -104,6 +105,33 @@ fn audio_input_defaults_and_persists() {
 }
 
 #[test]
+fn audio_write_format_defaults_and_persists() {
+    let env = TestConfigEnv::new();
+    let path = env.path("cfg.toml");
+    let cfg = AppConfig {
+        core: AppSettingsCore {
+            audio_write_format: AudioWriteFormatConfig {
+                sample_rate: AudioWriteSampleRate::Hz(48_000),
+                sample_format: AudioWriteSampleFormat::Pcm24,
+                channel_behavior: AudioWriteChannelBehavior::PreserveMonoStereo,
+                dither: AudioWriteDither::None,
+            },
+            ..AppSettingsCore::default()
+        },
+        ..AppConfig::default()
+    };
+
+    save_to_path(&cfg, &path).unwrap();
+    let loaded = load_settings_from(&path).unwrap();
+
+    assert_eq!(loaded.core.audio_write_format, cfg.core.audio_write_format);
+    assert_eq!(
+        loaded.core.audio_write_format.summary_label(),
+        "48 kHz, 24-bit PCM, Preserve mono/stereo, No dither"
+    );
+}
+
+#[test]
 fn trash_folder_round_trips() {
     let env = TestConfigEnv::new();
     let path = env.path("cfg.toml");
@@ -173,6 +201,12 @@ fn settings_round_trip_preserves_fields() {
                 sample_rate: Some(44_100),
                 buffer_size: Some(256),
                 channels: vec![1],
+            },
+            audio_write_format: AudioWriteFormatConfig {
+                sample_rate: AudioWriteSampleRate::Hz(48_000),
+                sample_format: AudioWriteSampleFormat::Pcm16,
+                channel_behavior: AudioWriteChannelBehavior::PreserveMonoStereo,
+                dither: AudioWriteDither::None,
             },
             volume: 0.75,
             controls: InteractionOptions {
@@ -257,6 +291,10 @@ fn settings_round_trip_preserves_fields() {
         cfg.core.last_selected_source
     );
     assert_eq!(round_trip.core.audio_output, cfg.core.audio_output);
+    assert_eq!(
+        round_trip.core.audio_write_format,
+        cfg.core.audio_write_format
+    );
     assert!((round_trip.core.volume - cfg.core.volume).abs() < f32::EPSILON);
     assert_eq!(
         round_trip.core.controls.invert_waveform_scroll,

--- a/src/sample_sources/config_types/app.rs
+++ b/src/sample_sources/config_types/app.rs
@@ -13,15 +13,15 @@ use super::super::config_defaults::{
     default_audio_input, default_audio_output, default_job_message_queue_capacity, default_true,
     default_volume,
 };
-use super::{AnalysisSettings, InteractionOptions, UpdateSettings};
+use super::{AnalysisSettings, AudioWriteFormatConfig, InteractionOptions, UpdateSettings};
 
 /// Aggregate application state loaded from disk.
 ///
 /// Config keys (TOML): `feature_flags`, `analysis`, `updates`, `app_data_dir`,
 /// `trash_folder`, `drop_targets`, `last_selected_source`,
 /// `upper_folder_pane_source`, `lower_folder_pane_source`, `active_folder_pane`,
-/// `volume`, `audio_output`, `audio_input`, `controls`, `job_message_queue_capacity`,
-/// `default_identifier`.
+/// `volume`, `audio_output`, `audio_input`, `audio_write_format`, `controls`,
+/// `job_message_queue_capacity`, `default_identifier`.
 ///
 /// `sources` are stored in the library database.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -108,6 +108,9 @@ pub struct AppSettingsCore {
     #[serde(default = "default_audio_input")]
     /// Input audio configuration.
     pub audio_input: AudioInputConfig,
+    #[serde(default)]
+    /// Audio write-format policy for Wavecrate-created WAV files.
+    pub audio_write_format: AudioWriteFormatConfig,
     #[serde(default = "default_volume")]
     /// Master volume (0.0-1.0).
     pub volume: f32,
@@ -202,6 +205,7 @@ impl Default for AppSettingsCore {
             active_folder_pane: None,
             audio_output: default_audio_output(),
             audio_input: default_audio_input(),
+            audio_write_format: AudioWriteFormatConfig::default(),
             volume: default_volume(),
             controls: InteractionOptions::default(),
             default_identifier: default_identifier(),

--- a/src/sample_sources/config_types/audio_write.rs
+++ b/src/sample_sources/config_types/audio_write.rs
@@ -1,0 +1,201 @@
+use serde::{Deserialize, Serialize};
+
+/// Persistent audio-write policy for Wavecrate-created WAV files.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AudioWriteFormatConfig {
+    /// Sample-rate policy used for new or rewritten audio files.
+    #[serde(default)]
+    pub sample_rate: AudioWriteSampleRate,
+    /// Sample representation used for WAV writes.
+    #[serde(default)]
+    pub sample_format: AudioWriteSampleFormat,
+    /// Channel policy used for ordinary mono/stereo writes.
+    #[serde(default)]
+    pub channel_behavior: AudioWriteChannelBehavior,
+    /// Dither policy used when reducing to integer PCM formats.
+    #[serde(default)]
+    pub dither: AudioWriteDither,
+}
+
+impl AudioWriteFormatConfig {
+    /// Build a WAV spec for interleaved samples already rendered at the source rate.
+    pub fn wav_spec_for_source(&self, channels: u16, source_sample_rate: u32) -> hound::WavSpec {
+        let (bits_per_sample, sample_format) = self.sample_format.wav_parts();
+        hound::WavSpec {
+            channels: self.channel_behavior.output_channels(channels),
+            sample_rate: self.sample_rate.output_sample_rate(source_sample_rate),
+            bits_per_sample,
+            sample_format,
+        }
+    }
+
+    /// Concise settings label for options panels and warnings.
+    pub fn summary_label(&self) -> String {
+        format!(
+            "{}, {}, {}, {}",
+            self.sample_rate.label(),
+            self.sample_format.label(),
+            self.channel_behavior.label(),
+            self.dither.label()
+        )
+    }
+}
+
+impl Default for AudioWriteFormatConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate: AudioWriteSampleRate::Source,
+            sample_format: AudioWriteSampleFormat::Float32,
+            channel_behavior: AudioWriteChannelBehavior::PreserveMonoStereo,
+            dither: AudioWriteDither::None,
+        }
+    }
+}
+
+/// Sample-rate policy used when Wavecrate writes audio.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioWriteSampleRate {
+    /// Preserve the loaded/rendered source rate.
+    Source,
+    /// Write at a fixed sample rate. Resampling support is staged separately.
+    Hz(u32),
+}
+
+impl AudioWriteSampleRate {
+    fn output_sample_rate(&self, source_sample_rate: u32) -> u32 {
+        match self {
+            Self::Source => source_sample_rate.max(1),
+            Self::Hz(sample_rate) => (*sample_rate).max(1),
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Self::Source => String::from("Source rate"),
+            Self::Hz(sample_rate) => format_sample_rate_label(*sample_rate),
+        }
+    }
+}
+
+impl Default for AudioWriteSampleRate {
+    fn default() -> Self {
+        Self::Source
+    }
+}
+
+/// WAV sample encoding used when Wavecrate creates files.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioWriteSampleFormat {
+    /// 16-bit signed integer PCM.
+    Pcm16,
+    /// 24-bit signed integer PCM.
+    Pcm24,
+    /// 32-bit IEEE float.
+    Float32,
+}
+
+impl AudioWriteSampleFormat {
+    pub(crate) fn wav_parts(&self) -> (u16, hound::SampleFormat) {
+        match self {
+            Self::Pcm16 => (16, hound::SampleFormat::Int),
+            Self::Pcm24 => (24, hound::SampleFormat::Int),
+            Self::Float32 => (32, hound::SampleFormat::Float),
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Pcm16 => "16-bit PCM",
+            Self::Pcm24 => "24-bit PCM",
+            Self::Float32 => "32-bit float",
+        }
+    }
+}
+
+impl Default for AudioWriteSampleFormat {
+    fn default() -> Self {
+        Self::Float32
+    }
+}
+
+/// Channel policy for normal Wavecrate-created audio.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioWriteChannelBehavior {
+    /// Preserve mono/stereo source layout for ordinary writes.
+    PreserveMonoStereo,
+}
+
+impl AudioWriteChannelBehavior {
+    fn output_channels(&self, channels: u16) -> u16 {
+        match self {
+            Self::PreserveMonoStereo => channels.clamp(1, 2),
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::PreserveMonoStereo => "Preserve mono/stereo",
+        }
+    }
+}
+
+impl Default for AudioWriteChannelBehavior {
+    fn default() -> Self {
+        Self::PreserveMonoStereo
+    }
+}
+
+/// Dither policy for integer PCM writes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioWriteDither {
+    /// Do not add dither during integer PCM quantization.
+    None,
+}
+
+impl AudioWriteDither {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::None => "No dither",
+        }
+    }
+}
+
+impl Default for AudioWriteDither {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+fn format_sample_rate_label(sample_rate: u32) -> String {
+    if sample_rate >= 1000 && sample_rate.is_multiple_of(1000) {
+        format!("{} kHz", sample_rate / 1000)
+    } else if sample_rate >= 1000 {
+        format!("{:.1} kHz", sample_rate as f32 / 1000.0)
+    } else {
+        format!("{sample_rate} Hz")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_write_format_matches_existing_wavecrate_wav_writes() {
+        let config = AudioWriteFormatConfig::default();
+        let spec = config.wav_spec_for_source(2, 48_000);
+
+        assert_eq!(spec.channels, 2);
+        assert_eq!(spec.sample_rate, 48_000);
+        assert_eq!(spec.bits_per_sample, 32);
+        assert_eq!(spec.sample_format, hound::SampleFormat::Float);
+        assert_eq!(
+            config.summary_label(),
+            "Source rate, 32-bit float, Preserve mono/stereo, No dither"
+        );
+    }
+}

--- a/src/sample_sources/config_types/mod.rs
+++ b/src/sample_sources/config_types/mod.rs
@@ -1,5 +1,6 @@
 mod analysis;
 mod app;
+mod audio_write;
 mod errors;
 mod interaction;
 mod updates;
@@ -7,6 +8,10 @@ mod updates;
 pub use analysis::AnalysisSettings;
 pub(crate) use app::AppSettings;
 pub use app::{AppConfig, AppSettingsCore, DropTargetColor, DropTargetConfig, FeatureFlags};
+pub use audio_write::{
+    AudioWriteChannelBehavior, AudioWriteDither, AudioWriteFormatConfig, AudioWriteSampleFormat,
+    AudioWriteSampleRate,
+};
 pub use errors::ConfigError;
 pub use interaction::{InteractionOptions, TooltipMode};
 pub use updates::{UpdateChannel, UpdateSettings};


### PR DESCRIPTION
## Summary
- add persisted Wavecrate audio write-format settings for source rate, sample format, channel behavior, and dither policy
- surface the configured write-format summary in the native options panel
- route selection-export WAV writes through the configured write policy and add PCM writer coverage

## Validation
- cargo test -p wavecrate audio_write_format -- --nocapture
- cargo test -p wavecrate selection_export -- --nocapture
- cargo test -p wavecrate audio_samples::tests::write_wav_with_spec_writes_configured_pcm24_header -- --nocapture
- cargo fmt --all
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent