### PR TITLE
Show write format in destructive edit prompts

### DIFF
--- a/src/app/controller/library/selection_edits/controller_actions.rs
+++ b/src/app/controller/library/selection_edits/controller_actions.rs
@@ -15,7 +15,10 @@ impl AppController {
             self.apply_selection_edit_kind(edit)?;
             return Ok(SelectionEditRequest::Applied);
         }
-        self.ui.waveform.pending_destructive = Some(prompt::prompt_for_edit(edit));
+        self.ui.waveform.pending_destructive = Some(prompt::prompt_for_edit(
+            edit,
+            &self.settings.audio_write_format,
+        ));
         Ok(SelectionEditRequest::Prompted)
     }
 

--- a/src/app/controller/library/selection_edits/prompt.rs
+++ b/src/app/controller/library/selection_edits/prompt.rs
@@ -1,4 +1,5 @@
 use crate::app::state::{DestructiveEditPrompt, DestructiveSelectionEdit};
+use crate::sample_sources::config::AudioWriteFormatConfig;
 
 impl DestructiveSelectionEdit {
     fn title(&self) -> &'static str {
@@ -56,10 +57,17 @@ impl DestructiveSelectionEdit {
     }
 }
 
-pub(crate) fn prompt_for_edit(edit: DestructiveSelectionEdit) -> DestructiveEditPrompt {
+pub(crate) fn prompt_for_edit(
+    edit: DestructiveSelectionEdit,
+    write_format: &AudioWriteFormatConfig,
+) -> DestructiveEditPrompt {
     DestructiveEditPrompt {
         edit,
         title: edit.title().to_string(),
-        message: edit.warning().to_string(),
+        message: format!(
+            "{} Wavecrate will rewrite the file using the current write format: {}.",
+            edit.warning(),
+            write_format.summary_label()
+        ),
     }
 }

--- a/src/app/controller/tests/waveform/destructive_edits.rs
+++ b/src/app/controller/tests/waveform/destructive_edits.rs
@@ -353,7 +353,14 @@ fn destructive_edit_request_prompts_without_yolo_mode() {
         .unwrap();
 
     assert!(matches!(outcome, SelectionEditRequest::Prompted));
-    assert!(controller.ui.waveform.pending_destructive.is_some());
+    let prompt = controller
+        .ui
+        .waveform
+        .pending_destructive
+        .as_ref()
+        .expect("pending destructive prompt");
+    assert!(prompt.message.contains("current write format"));
+    assert!(prompt.message.contains("Source rate, 32-bit float"));
     let samples: Vec<f32> = WavReader::open(&wav_path)
         .unwrap()
         .samples::<f32>()


### PR DESCRIPTION
## Summary
- include the configured Wavecrate write-format policy in destructive edit confirmation messages
- thread the persisted audio write-format config into destructive prompt construction
- add regression coverage that destructive prompts expose the current write format

## Alignment Estimate
- Overall target alignment: ~61-66%
- Audio write-format section: ~40% after this change, because the policy is persistent, visible in settings, used by selection exports, and now visible before destructive edits; remaining gaps include resampling and applying the policy across every write path.

## Validation
- cargo test -p wavecrate app::controller::tests::waveform::destructive_edits::destructive_edit_request_prompts_without_yolo_mode -- --nocapture
- cargo fmt --all
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent