### PR TITLE
[codex] Block multichannel destructive edits

### DIFF
--- a/src/app/controller/library/selection_edits/controller_actions.rs
+++ b/src/app/controller/library/selection_edits/controller_actions.rs
@@ -363,10 +363,27 @@ impl AppController {
     ) -> Result<(), String> {
         match edit {
             DestructiveSelectionEdit::CleanExactDuplicateBeats => {
+                if let Some(audio) = self.sample_view.wav.loaded_audio.as_ref() {
+                    let source = self
+                        .library
+                        .sources
+                        .iter()
+                        .find(|source| source.id == audio.source_id)
+                        .ok_or_else(|| "Source not available for loaded sample".to_string())?;
+                    let absolute_path = source.root.join(&audio.relative_path);
+                    crate::app::controller::library::wav_io::ensure_mono_stereo_wav_destructive_edit_target(
+                        &absolute_path,
+                        "This edit",
+                    )?;
+                }
                 self.exact_duplicate_cleanup_ranges().map(|_| ())
             }
             DestructiveSelectionEdit::CommitEditSelectionFades => {
-                self.selection_target()?;
+                let target = self.selection_target()?;
+                crate::app::controller::library::wav_io::ensure_mono_stereo_wav_destructive_edit_target(
+                    &target.absolute_path,
+                    "This edit",
+                )?;
                 let Some(selection) = self.ui.waveform.edit_selection else {
                     return Err("Set an edit selection with a fade before applying it".to_string());
                 };
@@ -376,7 +393,11 @@ impl AppController {
                 Ok(())
             }
             _ => {
-                self.selection_target()?;
+                let target = self.selection_target()?;
+                crate::app::controller::library::wav_io::ensure_mono_stereo_wav_destructive_edit_target(
+                    &target.absolute_path,
+                    "This edit",
+                )?;
                 Ok(())
             }
         }

--- a/src/app/controller/library/wav_io.rs
+++ b/src/app/controller/library/wav_io.rs
@@ -28,6 +28,25 @@ pub(crate) fn ensure_wav_destructive_edit_target(
     ))
 }
 
+/// Reject multichannel WAV files for ordinary destructive edit flows.
+pub(crate) fn ensure_mono_stereo_wav_destructive_edit_target(
+    path: &Path,
+    action_label: &str,
+) -> Result<hound::WavSpec, String> {
+    ensure_wav_destructive_edit_target(path, action_label)?;
+    let reader_source = crate::wav_sanitize::open_sanitized_wav(path)?;
+    let buf_reader = std::io::BufReader::with_capacity(1024 * 1024, reader_source);
+    let reader = hound::WavReader::new(buf_reader).map_err(|err| format!("Invalid wav: {err}"))?;
+    let spec = reader.spec();
+    if spec.channels > 2 {
+        return Err(format!(
+            "{action_label} only supports mono or stereo WAV files; {} channels are not currently editable",
+            spec.channels
+        ));
+    }
+    Ok(spec)
+}
+
 /// Read WAV samples for normalization workflows.
 pub(crate) fn read_samples_for_normalization(
     path: &Path,
@@ -38,6 +57,12 @@ pub(crate) fn read_samples_for_normalization(
     let mut reader =
         hound::WavReader::new(buf_reader).map_err(|err| format!("Invalid wav: {err}"))?;
     let spec = reader.spec();
+    if spec.channels > 2 {
+        return Err(format!(
+            "This edit only supports mono or stereo WAV files; {} channels are not currently editable",
+            spec.channels
+        ));
+    }
     let samples = match spec.sample_format {
         SampleFormat::Float => reader
             .samples::<f32>()

--- a/src/app/controller/tests/waveform/destructive_edits.rs
+++ b/src/app/controller/tests/waveform/destructive_edits.rs
@@ -9,7 +9,7 @@ use crate::app_core::native_shell::project_browser_model;
 use crate::app_core::state::StatusTone;
 use crate::sample_sources::SampleSoundType;
 use crate::selection::SelectionRange;
-use hound::WavReader;
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -370,6 +370,41 @@ fn destructive_edit_request_prompts_without_yolo_mode() {
 }
 
 #[test]
+fn destructive_edit_request_blocks_multichannel_wav_before_prompt() {
+    let (mut controller, source) = prepare_with_source_and_wav_entries(vec![sample_entry(
+        "surround.wav",
+        crate::sample_sources::Rating::NEUTRAL,
+    )]);
+    let wav_path = source.root.join("surround.wav");
+    write_test_wav_with_spec(
+        &wav_path,
+        WavSpec {
+            channels: 3,
+            sample_rate: 44_100,
+            bits_per_sample: 32,
+            sample_format: SampleFormat::Float,
+        },
+        &[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+    );
+    controller
+        .load_waveform_for_selection(&source, Path::new("surround.wav"))
+        .unwrap();
+    controller.ui.waveform.selection = Some(SelectionRange::new(0.0, 0.5));
+    controller.set_destructive_yolo_mode(false);
+
+    let err = match controller
+        .request_destructive_selection_edit(DestructiveSelectionEdit::CropSelection)
+    {
+        Ok(_) => panic!("multichannel destructive edit should be blocked"),
+        Err(err) => err,
+    };
+
+    assert!(err.contains("mono or stereo"));
+    assert!(err.contains("3 channels"));
+    assert!(controller.ui.waveform.pending_destructive.is_none());
+}
+
+#[test]
 fn yolo_mode_applies_destructive_edit_immediately() {
     let (mut controller, source) = prepare_with_source_and_wav_entries(vec![sample_entry(
         "yolo.wav",
@@ -396,6 +431,14 @@ fn yolo_mode_applies_destructive_edit_immediately() {
         .map(|sample| sample.unwrap())
         .collect();
     assert_eq!(samples, vec![0.2, 0.3]);
+}
+
+fn write_test_wav_with_spec(path: &Path, spec: WavSpec, samples: &[f32]) {
+    let mut writer = WavWriter::create(path, spec).expect("create wav");
+    for sample in samples {
+        writer.write_sample(*sample).expect("write sample");
+    }
+    writer.finalize().expect("finalize wav");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- block ordinary destructive WAV edit requests when the loaded target has more than two channels
- reuse the same mono/stereo guard for normalization reads so direct destructive normalization cannot rewrite multichannel WAVs
- add regression coverage that a 3-channel WAV is rejected before a destructive edit prompt is created

## Alignment
This advances the target requirement that multichannel files remain playable/visible while ordinary destructive editing is blocked with a clear warning. Current overall target alignment estimate: ~62-67%. The audio compatibility/multichannel-safety slice is now ~40-45%; remaining gaps include explicit downmix conversion, broader extraction/export policy for multichannel sources, and richer browser affordances for multichannel-limited files.

## Validation
- `cargo test -p wavecrate app::controller::tests::waveform::destructive_edits::destructive_edit_request_blocks_multichannel_wav_before_prompt -- --nocapture`
- `cargo test -p wavecrate app::controller::tests::waveform::destructive_edits:: -- --nocapture`
- `cargo test -p wavecrate app_core::controller::tests::waveform::routing::apply_native_waveform_clean_duplicates_routes_to_controller_behavior -- --nocapture`
- `cargo fmt --all`
- `powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent`
