### PR TITLE
Split playback span helpers

### DIFF
--- a/src/gui_app/playback.rs
+++ b/src/gui_app/playback.rs
@@ -1,4 +1,9 @@
 use super::*;
+use span::{
+    ResolvedPlaybackSpan, loop_retarget_offset_for_selection, playback_span_matches_selection,
+};
+
+mod span;
 
 impl GuiAppState {
     pub(super) fn play_selected_sample(&mut self, context: &mut ui::UpdateContext<GuiMessage>) {
@@ -369,33 +374,4 @@ impl GuiAppState {
             );
         }
     }
-}
-
-pub(super) struct ResolvedPlaybackSpan {
-    pub(super) start_ratio: f32,
-    pub(super) end_ratio: f32,
-    pub(super) offset_ratio: f32,
-}
-
-fn loop_retarget_offset_for_selection(
-    playhead: f32,
-    selection: wavecrate::selection::SelectionRange,
-) -> f32 {
-    let start = selection.start();
-    let end = selection.end();
-    if (start..=end).contains(&playhead) {
-        playhead
-    } else {
-        start
-    }
-}
-
-fn playback_span_matches_selection(
-    span: Option<(f32, f32)>,
-    selection: wavecrate::selection::SelectionRange,
-) -> bool {
-    let Some((start, end)) = span else {
-        return false;
-    };
-    (start - selection.start()).abs() <= 0.000_1 && (end - selection.end()).abs() <= 0.000_1
 }

--- a/src/gui_app/playback/span.rs
+++ b/src/gui_app/playback/span.rs
@@ -1,0 +1,27 @@
+use wavecrate::selection::SelectionRange;
+
+pub(in crate::gui_app) struct ResolvedPlaybackSpan {
+    pub(in crate::gui_app) start_ratio: f32,
+    pub(in crate::gui_app) end_ratio: f32,
+    pub(in crate::gui_app) offset_ratio: f32,
+}
+
+pub(super) fn loop_retarget_offset_for_selection(playhead: f32, selection: SelectionRange) -> f32 {
+    let start = selection.start();
+    let end = selection.end();
+    if (start..=end).contains(&playhead) {
+        playhead
+    } else {
+        start
+    }
+}
+
+pub(super) fn playback_span_matches_selection(
+    span: Option<(f32, f32)>,
+    selection: SelectionRange,
+) -> bool {
+    let Some((start, end)) = span else {
+        return false;
+    };
+    (start - selection.start()).abs() <= 0.000_1 && (end - selection.end()).abs() <= 0.000_1
+}


### PR DESCRIPTION
## Summary
- move playback span data and pure loop retarget helpers into a focused playback/span module
- keep playback.rs focused on app-state side effects and transport orchestration
- reduce src/gui_app/playback.rs from 401 to 377 lines

## Validation
- cargo test playmark_selection --bin wavecrate
- cargo test -p wavecrate loop_crossfade_undo_removes_looped_metadata_for_generated_copy --lib
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent

Note: the first ci_agent run hit loop_crossfade_undo_removes_looped_metadata_for_generated_copy once; that exact test passed on rerun and the second full ci_agent run was green.