### PR TITLE
Extract waveform interaction types

### DIFF
--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -557,77 +557,11 @@ impl WaveformState {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(super) enum WaveformInteraction {
-    Wheel {
-        delta: Vector2,
-        anchor_ratio: f32,
-    },
-    ScrollTo {
-        offset_fraction: f32,
-    },
-    BeginSelection {
-        kind: WaveformSelectionKind,
-        visible_ratio: f32,
-    },
-    BeginEditFade {
-        handle: WaveformEditFadeHandle,
-        visible_ratio: f32,
-    },
-    ClearEditFadeSilence {
-        handle: WaveformEditFadeHandle,
-    },
-    BeginSelectionResize {
-        kind: WaveformSelectionKind,
-        edge: WaveformSelectionEdge,
-        visible_ratio: f32,
-    },
-    BeginSelectionMove {
-        kind: WaveformSelectionKind,
-        visible_ratio: f32,
-    },
-    BeginPan {
-        visible_ratio: f32,
-    },
-    UpdateSelection {
-        visible_ratio: f32,
-    },
-    FinishSelection {
-        visible_ratio: f32,
-    },
-    Frame,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum WaveformSelectionKind {
-    Play,
-    Edit,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum WaveformSelectionEdge {
-    Start,
-    End,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum WaveformEditFadeHandle {
-    FadeInEnd,
-    FadeInStart,
-    FadeInOuterStart,
-    FadeOutStart,
-    FadeOutEnd,
-    FadeOutOuterEnd,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum WaveformActiveDragKind {
-    Selection(WaveformSelectionKind),
-    SelectionResize(WaveformSelectionKind, WaveformSelectionEdge),
-    SelectionMove(WaveformSelectionKind),
-    EditFade(WaveformEditFadeHandle),
-    Pan,
-}
+mod types;
+pub(super) use types::{
+    WaveformActiveDragKind, WaveformEditFadeHandle, WaveformInteraction, WaveformSelectionEdge,
+    WaveformSelectionKind,
+};
 
 mod interaction;
 use interaction::{

--- a/src/gui_app/waveform/types.rs
+++ b/src/gui_app/waveform/types.rs
@@ -1,0 +1,73 @@
+use radiant::gui::types::Vector2;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::gui_app) enum WaveformInteraction {
+    Wheel {
+        delta: Vector2,
+        anchor_ratio: f32,
+    },
+    ScrollTo {
+        offset_fraction: f32,
+    },
+    BeginSelection {
+        kind: WaveformSelectionKind,
+        visible_ratio: f32,
+    },
+    BeginEditFade {
+        handle: WaveformEditFadeHandle,
+        visible_ratio: f32,
+    },
+    ClearEditFadeSilence {
+        handle: WaveformEditFadeHandle,
+    },
+    BeginSelectionResize {
+        kind: WaveformSelectionKind,
+        edge: WaveformSelectionEdge,
+        visible_ratio: f32,
+    },
+    BeginSelectionMove {
+        kind: WaveformSelectionKind,
+        visible_ratio: f32,
+    },
+    BeginPan {
+        visible_ratio: f32,
+    },
+    UpdateSelection {
+        visible_ratio: f32,
+    },
+    FinishSelection {
+        visible_ratio: f32,
+    },
+    Frame,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) enum WaveformSelectionKind {
+    Play,
+    Edit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) enum WaveformSelectionEdge {
+    Start,
+    End,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) enum WaveformEditFadeHandle {
+    FadeInEnd,
+    FadeInStart,
+    FadeInOuterStart,
+    FadeOutStart,
+    FadeOutEnd,
+    FadeOutOuterEnd,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) enum WaveformActiveDragKind {
+    Selection(WaveformSelectionKind),
+    SelectionResize(WaveformSelectionKind, WaveformSelectionEdge),
+    SelectionMove(WaveformSelectionKind),
+    EditFade(WaveformEditFadeHandle),
+    Pan,
+}


### PR DESCRIPTION
## Summary
- move waveform interaction and selection enums into a focused waveform/types module
- keep waveform.rs as the re-export surface for existing callers
- reduce src/gui_app/waveform.rs from 3255 to 3189 lines

## Validation
- cargo test waveform --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent