### PR TITLE
Extract folder tree widgets

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -1,16 +1,11 @@
 #![allow(missing_docs)]
 
 use radiant::{
-    gui::types::{Point, Rect, Rgba8},
-    layout::LayoutOutput,
-    layout::Vector2,
+    gui::types::Point,
     prelude as ui,
-    runtime::{PaintFillRect, PaintPrimitive, PaintStrokeRect},
-    theme::ThemeTokens,
     widgets::{
-        ButtonMessage, DragHandleMessage, FocusBehavior, PaintBounds, PointerButton,
-        PointerModifiers, TextInputMessage, Widget, WidgetCommon, WidgetInput, WidgetOutput,
-        WidgetSizing, WidgetStyle, WidgetTone,
+        ButtonMessage, DragHandleMessage, PointerModifiers, TextInputMessage, WidgetStyle,
+        WidgetTone,
     },
 };
 use std::{
@@ -1750,6 +1745,9 @@ use state_types::{
     SourceEntry, VisibleFolder, default_file_columns,
 };
 
+mod tree_widgets;
+use tree_widgets::{FolderDropClearTarget, FolderTreeHitMessage, FolderTreeHitTarget};
+
 mod types;
 pub(super) use types::{
     FileDeleteTargetView, FileRenameView, FolderBrowserMessage, FolderDeleteTargetView,
@@ -1962,246 +1960,6 @@ fn folder_row(folder: VisibleFolder) -> ui::View<GuiMessage> {
     .height(TREE_ROW_HEIGHT)
     .spacing(1.0)
     .hoverable()
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum FolderTreeHitMessage {
-    Activate,
-    ContextMenu(Point),
-    Drag(DragHandleMessage),
-    Drop,
-    HoverDropTarget,
-}
-
-#[derive(Clone, Debug)]
-struct FolderTreeHitTarget {
-    common: WidgetCommon,
-    selected: bool,
-    drop_target: bool,
-    drag_active: bool,
-    drop_candidate: bool,
-    dragged: bool,
-}
-
-impl FolderTreeHitTarget {
-    fn new(selected: bool, drop_target: bool, drag_active: bool, drop_candidate: bool) -> Self {
-        let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 22.0)));
-        common.focus = FocusBehavior::None;
-        common.paint.bounds = PaintBounds::ClipToRect;
-        common.paint.paints_focus = false;
-        common.paint.paints_state_layers = false;
-        Self {
-            common,
-            selected,
-            drop_target,
-            drag_active,
-            drop_candidate,
-            dragged: false,
-        }
-    }
-}
-
-impl Widget for FolderTreeHitTarget {
-    fn common(&self) -> &WidgetCommon {
-        &self.common
-    }
-
-    fn common_mut(&mut self) -> &mut WidgetCommon {
-        &mut self.common
-    }
-
-    fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
-        match input {
-            WidgetInput::PointerMove { position } => {
-                self.common.state.hovered = bounds.contains(position);
-                if self.common.state.pressed {
-                    let message = if self.dragged {
-                        DragHandleMessage::Moved { position }
-                    } else {
-                        self.dragged = true;
-                        DragHandleMessage::Started { position }
-                    };
-                    return Some(WidgetOutput::typed(FolderTreeHitMessage::Drag(message)));
-                }
-                if self.common.state.hovered && self.drag_active {
-                    return Some(WidgetOutput::typed(FolderTreeHitMessage::HoverDropTarget));
-                }
-                None
-            }
-            WidgetInput::PointerPress {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } if bounds.contains(position) => {
-                self.common.state.hovered = true;
-                self.common.state.pressed = true;
-                self.dragged = false;
-                None
-            }
-            WidgetInput::PointerPress {
-                position,
-                button: PointerButton::Secondary,
-                ..
-            } if bounds.contains(position) => {
-                self.common.state.hovered = true;
-                self.common.state.pressed = false;
-                self.dragged = false;
-                Some(WidgetOutput::typed(FolderTreeHitMessage::ContextMenu(
-                    position,
-                )))
-            }
-            WidgetInput::PointerRelease {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } => {
-                let activated =
-                    self.common.state.pressed && !self.dragged && bounds.contains(position);
-                let dragged = self.common.state.pressed && self.dragged;
-                self.common.state.pressed = false;
-                self.common.state.hovered = bounds.contains(position);
-                self.dragged = false;
-                if dragged {
-                    return Some(WidgetOutput::typed(FolderTreeHitMessage::Drag(
-                        DragHandleMessage::Ended { position },
-                    )));
-                }
-                activated.then(|| WidgetOutput::typed(FolderTreeHitMessage::Activate))
-            }
-            WidgetInput::PointerDrop {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } if bounds.contains(position) => Some(WidgetOutput::typed(FolderTreeHitMessage::Drop)),
-            _ => {
-                if matches!(input, WidgetInput::PointerRelease { .. }) {
-                    self.common.state.pressed = false;
-                    self.dragged = false;
-                }
-                None
-            }
-        }
-    }
-
-    fn accepts_pointer_move(&self) -> bool {
-        true
-    }
-
-    fn append_paint(
-        &self,
-        primitives: &mut Vec<PaintPrimitive>,
-        bounds: Rect,
-        _layout: &LayoutOutput,
-        _theme: &ThemeTokens,
-    ) {
-        let mut fill = None;
-        if self.drop_target {
-            fill = Some(Rgba8 {
-                r: 255,
-                g: 130,
-                b: 78,
-                a: 150,
-            });
-        } else if self.common.state.hovered && self.drop_candidate {
-            fill = Some(Rgba8 {
-                r: 255,
-                g: 122,
-                b: 74,
-                a: 110,
-            });
-        } else if self.common.state.pressed || self.common.state.hovered {
-            fill = Some(Rgba8 {
-                r: 255,
-                g: 110,
-                b: 85,
-                a: if self.common.state.pressed { 120 } else { 80 },
-            });
-        } else if self.selected {
-            fill = Some(Rgba8 {
-                r: 255,
-                g: 82,
-                b: 62,
-                a: 105,
-            });
-        }
-        if let Some(color) = fill {
-            primitives.push(PaintPrimitive::FillRect(PaintFillRect {
-                widget_id: self.common.id,
-                rect: bounds,
-                color,
-            }));
-        }
-        if self.drop_target {
-            primitives.push(PaintPrimitive::StrokeRect(PaintStrokeRect {
-                widget_id: self.common.id,
-                rect: Rect::from_min_max(
-                    Point::new(bounds.min.x + 0.5, bounds.min.y + 0.5),
-                    Point::new(bounds.max.x - 0.5, bounds.max.y - 0.5),
-                ),
-                color: Rgba8 {
-                    r: 255,
-                    g: 180,
-                    b: 130,
-                    a: 210,
-                },
-                width: 1.0,
-            }));
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct FolderDropClearTarget {
-    common: WidgetCommon,
-    drag_active: bool,
-}
-
-impl FolderDropClearTarget {
-    fn new(drag_active: bool) -> Self {
-        let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 1.0)));
-        common.focus = FocusBehavior::None;
-        common.paint.bounds = PaintBounds::ClipToRect;
-        common.paint.paints_focus = false;
-        common.paint.paints_state_layers = false;
-        Self {
-            common,
-            drag_active,
-        }
-    }
-}
-
-impl Widget for FolderDropClearTarget {
-    fn common(&self) -> &WidgetCommon {
-        &self.common
-    }
-
-    fn common_mut(&mut self) -> &mut WidgetCommon {
-        &mut self.common
-    }
-
-    fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
-        match input {
-            WidgetInput::PointerMove { position }
-                if self.drag_active && bounds.contains(position) =>
-            {
-                Some(WidgetOutput::typed(FolderBrowserMessage::ClearDropTarget))
-            }
-            _ => None,
-        }
-    }
-
-    fn accepts_pointer_move(&self) -> bool {
-        true
-    }
-
-    fn append_paint(
-        &self,
-        _primitives: &mut Vec<PaintPrimitive>,
-        _bounds: Rect,
-        _layout: &LayoutOutput,
-        _theme: &ThemeTokens,
-    ) {
-    }
 }
 
 fn selected_folder_status(state: &FolderBrowserState) -> ui::View<GuiMessage> {

--- a/src/gui_app/folder_browser/tree_widgets.rs
+++ b/src/gui_app/folder_browser/tree_widgets.rs
@@ -1,0 +1,272 @@
+use radiant::{
+    gui::types::{Point, Rect, Rgba8},
+    layout::{LayoutOutput, Vector2},
+    runtime::{PaintFillRect, PaintPrimitive, PaintStrokeRect},
+    theme::ThemeTokens,
+    widgets::{
+        DragHandleMessage, FocusBehavior, PaintBounds, PointerButton, Widget, WidgetCommon,
+        WidgetInput, WidgetOutput, WidgetSizing,
+    },
+};
+
+use super::FolderBrowserMessage;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum FolderTreeHitMessage {
+    Activate,
+    ContextMenu(Point),
+    Drag(DragHandleMessage),
+    Drop,
+    HoverDropTarget,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct FolderTreeHitTarget {
+    common: WidgetCommon,
+    selected: bool,
+    drop_target: bool,
+    drag_active: bool,
+    drop_candidate: bool,
+    dragged: bool,
+}
+
+impl FolderTreeHitTarget {
+    pub(super) fn new(
+        selected: bool,
+        drop_target: bool,
+        drag_active: bool,
+        drop_candidate: bool,
+    ) -> Self {
+        let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 22.0)));
+        common.focus = FocusBehavior::None;
+        common.paint.bounds = PaintBounds::ClipToRect;
+        common.paint.paints_focus = false;
+        common.paint.paints_state_layers = false;
+        Self {
+            common,
+            selected,
+            drop_target,
+            drag_active,
+            drop_candidate,
+            dragged: false,
+        }
+    }
+}
+
+impl Widget for FolderTreeHitTarget {
+    fn common(&self) -> &WidgetCommon {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        &mut self.common
+    }
+
+    fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        match input {
+            WidgetInput::PointerMove { position } => self.handle_pointer_move(bounds, position),
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if bounds.contains(position) => {
+                self.common.state.hovered = true;
+                self.common.state.pressed = true;
+                self.dragged = false;
+                None
+            }
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Secondary,
+                ..
+            } if bounds.contains(position) => {
+                self.common.state.hovered = true;
+                self.common.state.pressed = false;
+                self.dragged = false;
+                Some(WidgetOutput::typed(FolderTreeHitMessage::ContextMenu(
+                    position,
+                )))
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } => self.handle_primary_release(bounds, position),
+            WidgetInput::PointerDrop {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if bounds.contains(position) => Some(WidgetOutput::typed(FolderTreeHitMessage::Drop)),
+            _ => {
+                if matches!(input, WidgetInput::PointerRelease { .. }) {
+                    self.common.state.pressed = false;
+                    self.dragged = false;
+                }
+                None
+            }
+        }
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        true
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+        _layout: &LayoutOutput,
+        _theme: &ThemeTokens,
+    ) {
+        self.paint_background(primitives, bounds);
+        self.paint_drop_target_outline(primitives, bounds);
+    }
+}
+
+impl FolderTreeHitTarget {
+    fn handle_pointer_move(&mut self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
+        self.common.state.hovered = bounds.contains(position);
+        if self.common.state.pressed {
+            let message = if self.dragged {
+                DragHandleMessage::Moved { position }
+            } else {
+                self.dragged = true;
+                DragHandleMessage::Started { position }
+            };
+            return Some(WidgetOutput::typed(FolderTreeHitMessage::Drag(message)));
+        }
+        if self.common.state.hovered && self.drag_active {
+            return Some(WidgetOutput::typed(FolderTreeHitMessage::HoverDropTarget));
+        }
+        None
+    }
+
+    fn handle_primary_release(&mut self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
+        let activated = self.common.state.pressed && !self.dragged && bounds.contains(position);
+        let dragged = self.common.state.pressed && self.dragged;
+        self.common.state.pressed = false;
+        self.common.state.hovered = bounds.contains(position);
+        self.dragged = false;
+        if dragged {
+            return Some(WidgetOutput::typed(FolderTreeHitMessage::Drag(
+                DragHandleMessage::Ended { position },
+            )));
+        }
+        activated.then(|| WidgetOutput::typed(FolderTreeHitMessage::Activate))
+    }
+
+    fn paint_background(&self, primitives: &mut Vec<PaintPrimitive>, bounds: Rect) {
+        let fill = if self.drop_target {
+            Some(Rgba8 {
+                r: 255,
+                g: 130,
+                b: 78,
+                a: 150,
+            })
+        } else if self.common.state.hovered && self.drop_candidate {
+            Some(Rgba8 {
+                r: 255,
+                g: 122,
+                b: 74,
+                a: 110,
+            })
+        } else if self.common.state.pressed || self.common.state.hovered {
+            Some(Rgba8 {
+                r: 255,
+                g: 110,
+                b: 85,
+                a: if self.common.state.pressed { 120 } else { 80 },
+            })
+        } else if self.selected {
+            Some(Rgba8 {
+                r: 255,
+                g: 82,
+                b: 62,
+                a: 105,
+            })
+        } else {
+            None
+        };
+        if let Some(color) = fill {
+            primitives.push(PaintPrimitive::FillRect(PaintFillRect {
+                widget_id: self.common.id,
+                rect: bounds,
+                color,
+            }));
+        }
+    }
+
+    fn paint_drop_target_outline(&self, primitives: &mut Vec<PaintPrimitive>, bounds: Rect) {
+        if !self.drop_target {
+            return;
+        }
+        primitives.push(PaintPrimitive::StrokeRect(PaintStrokeRect {
+            widget_id: self.common.id,
+            rect: Rect::from_min_max(
+                Point::new(bounds.min.x + 0.5, bounds.min.y + 0.5),
+                Point::new(bounds.max.x - 0.5, bounds.max.y - 0.5),
+            ),
+            color: Rgba8 {
+                r: 255,
+                g: 180,
+                b: 130,
+                a: 210,
+            },
+            width: 1.0,
+        }));
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct FolderDropClearTarget {
+    common: WidgetCommon,
+    drag_active: bool,
+}
+
+impl FolderDropClearTarget {
+    pub(super) fn new(drag_active: bool) -> Self {
+        let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 1.0)));
+        common.focus = FocusBehavior::None;
+        common.paint.bounds = PaintBounds::ClipToRect;
+        common.paint.paints_focus = false;
+        common.paint.paints_state_layers = false;
+        Self {
+            common,
+            drag_active,
+        }
+    }
+}
+
+impl Widget for FolderDropClearTarget {
+    fn common(&self) -> &WidgetCommon {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        &mut self.common
+    }
+
+    fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        match input {
+            WidgetInput::PointerMove { position }
+                if self.drag_active && bounds.contains(position) =>
+            {
+                Some(WidgetOutput::typed(FolderBrowserMessage::ClearDropTarget))
+            }
+            _ => None,
+        }
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        true
+    }
+
+    fn append_paint(
+        &self,
+        _primitives: &mut Vec<PaintPrimitive>,
+        _bounds: Rect,
+        _layout: &LayoutOutput,
+        _theme: &ThemeTokens,
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary
- move custom folder tree hit-target and drop-clear widgets into a focused tree_widgets module
- leave folder_row as the message mapping layer for folder-browser commands
- reduce src/gui_app/folder_browser.rs from 3641 to 3399 lines

## Validation
- cargo test folder_drag --bin wavecrate
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent