### PR TITLE
Extract folder browser scanning module

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -12,13 +12,10 @@ use std::{
     collections::HashSet,
     fs,
     path::{Path, PathBuf},
-    time::{Duration, SystemTime},
 };
 
 use super::GuiMessage;
 
-const MAX_SCAN_DEPTH: usize = 3;
-const MAX_CHILD_FOLDERS: usize = 80;
 const TREE_ROW_HEIGHT: f32 = 23.0;
 const TREE_DEPTH_INDENT: f32 = 4.0;
 const MIN_FILE_COLUMN_WIDTH: f32 = 48.0;
@@ -704,7 +701,7 @@ impl FolderBrowserState {
     }
 
     #[cfg(test)]
-    pub(super) fn apply_scan_discovered(&mut self, event: FolderScanDiscovery) -> bool {
+    pub(super) fn apply_scan_discovered(&mut self, event: types::FolderScanDiscovery) -> bool {
         self.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
             task_id: event.task_id,
             source_id: event.source_id.clone(),
@@ -1738,9 +1735,16 @@ impl FolderEntry {
 
 mod path_helpers;
 use path_helpers::{
-    file_extension_label, file_label, file_rename_draft, file_rename_input_id, file_stem_label,
-    folder_label, next_available_folder_name, offset_index, path_id, rename_input_id,
-    resolved_file_rename, rewrite_path_id, valid_file_name, valid_folder_name,
+    file_label, file_rename_draft, file_rename_input_id, folder_label, next_available_folder_name,
+    offset_index, path_id, rename_input_id, resolved_file_rename, rewrite_path_id, valid_file_name,
+    valid_folder_name,
+};
+
+mod scanning;
+pub(super) use scanning::scan_source_with_progress;
+use scanning::{
+    default_root_path, file_entry, load_root_folder, merge_scan_discovery, placeholder_folder,
+    upsert_file, upsert_folder,
 };
 
 mod state_types;
@@ -1756,8 +1760,8 @@ use tree_widgets::{FolderDropClearTarget, FolderTreeHitMessage, FolderTreeHitTar
 mod types;
 pub(super) use types::{
     FileDeleteTargetView, FileRenameView, FolderBrowserMessage, FolderDeleteTargetView,
-    FolderDragPreview, FolderDropResult, FolderScanDiscovery, FolderScanDiscoveryBatch,
-    FolderScanItem, FolderScanProgress, FolderScanRequest, FolderScanResult, RenameTargetView,
+    FolderDragPreview, FolderDropResult, FolderScanDiscoveryBatch, FolderScanProgress,
+    FolderScanRequest, FolderScanResult, RenameTargetView,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1985,313 +1989,6 @@ fn selected_folder_status(state: &FolderBrowserState) -> ui::View<GuiMessage> {
 
 fn plural(count: usize) -> &'static str {
     if count == 1 { "" } else { "s" }
-}
-
-fn default_root_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets")
-}
-
-fn load_root_folder(root: PathBuf) -> FolderEntry {
-    load_folder(&root, 0).unwrap_or_else(|| FolderEntry {
-        id: path_id(&root),
-        name: folder_label(&root),
-        children: Vec::new(),
-        files: Vec::new(),
-    })
-}
-
-fn placeholder_folder(root: &Path) -> FolderEntry {
-    FolderEntry {
-        id: path_id(root),
-        name: folder_label(root),
-        children: Vec::new(),
-        files: Vec::new(),
-    }
-}
-
-pub(super) fn scan_source_with_progress(
-    request: FolderScanRequest,
-    mut progress: impl FnMut(FolderScanProgress),
-    mut discovered: impl FnMut(FolderScanDiscovery),
-) -> FolderScanResult {
-    let mut scan = ScanProgressCounter {
-        completed: 0,
-        files: 0,
-        folders: 0,
-    };
-    progress(FolderScanProgress {
-        task_id: request.task_id,
-        source_id: request.source_id.clone(),
-        label: request.label.clone(),
-        phase: String::from("Scanning"),
-        completed: 0,
-        total: 0,
-        detail: request.root.display().to_string(),
-    });
-    let folder = load_folder_with_progress(
-        &request.root,
-        0,
-        &request,
-        &mut scan,
-        &mut progress,
-        &mut discovered,
-    )
-    .unwrap_or_else(|| placeholder_folder(&request.root));
-    FolderScanResult {
-        task_id: request.task_id,
-        source_id: request.source_id,
-        label: request.label,
-        folder,
-        file_count: scan.files,
-        folder_count: scan.folders,
-    }
-}
-
-fn load_folder(path: &Path, depth: usize) -> Option<FolderEntry> {
-    if depth > MAX_SCAN_DEPTH {
-        return None;
-    }
-    let entries = read_sorted_entries(path);
-    let children = entries
-        .iter()
-        .filter(|entry| entry.is_dir())
-        .take(MAX_CHILD_FOLDERS)
-        .filter_map(|entry| load_folder(entry, depth + 1))
-        .collect::<Vec<_>>();
-    let files = entries
-        .iter()
-        .filter(|entry| entry.is_file())
-        .map(file_entry)
-        .collect::<Vec<_>>();
-    Some(FolderEntry {
-        id: path_id(path),
-        name: folder_label(path),
-        children,
-        files,
-    })
-}
-
-struct ScanProgressCounter {
-    completed: usize,
-    files: usize,
-    folders: usize,
-}
-
-fn load_folder_with_progress(
-    path: &Path,
-    depth: usize,
-    request: &FolderScanRequest,
-    scan: &mut ScanProgressCounter,
-    progress: &mut impl FnMut(FolderScanProgress),
-    discovered: &mut impl FnMut(FolderScanDiscovery),
-) -> Option<FolderEntry> {
-    if depth > MAX_SCAN_DEPTH {
-        return None;
-    }
-    let entries = read_sorted_entries(path);
-    let parent_id = path_id(path);
-    let children = entries
-        .iter()
-        .filter(|entry| entry.is_dir())
-        .take(MAX_CHILD_FOLDERS)
-        .filter_map(|entry| {
-            scan.completed += 1;
-            scan.folders += 1;
-            maybe_report_scan_progress(entry, request, scan, progress);
-            discovered(FolderScanDiscovery {
-                task_id: request.task_id,
-                source_id: request.source_id.clone(),
-                parent_id: parent_id.clone(),
-                item: FolderScanItem::Folder(placeholder_folder(entry)),
-            });
-            let child =
-                load_folder_with_progress(entry, depth + 1, request, scan, progress, discovered)?;
-            discovered(FolderScanDiscovery {
-                task_id: request.task_id,
-                source_id: request.source_id.clone(),
-                parent_id: parent_id.clone(),
-                item: FolderScanItem::Folder(child.clone()),
-            });
-            Some(child)
-        })
-        .collect::<Vec<_>>();
-    let files = entries
-        .iter()
-        .filter(|entry| entry.is_file())
-        .map(|entry| {
-            scan.completed += 1;
-            scan.files += 1;
-            maybe_report_scan_progress(entry, request, scan, progress);
-            let file = file_entry(entry);
-            discovered(FolderScanDiscovery {
-                task_id: request.task_id,
-                source_id: request.source_id.clone(),
-                parent_id: parent_id.clone(),
-                item: FolderScanItem::File(file.clone()),
-            });
-            file
-        })
-        .collect::<Vec<_>>();
-    Some(FolderEntry {
-        id: path_id(path),
-        name: folder_label(path),
-        children,
-        files,
-    })
-}
-
-fn maybe_report_scan_progress(
-    path: &Path,
-    request: &FolderScanRequest,
-    scan: &ScanProgressCounter,
-    progress: &mut impl FnMut(FolderScanProgress),
-) {
-    if scan.completed == 1 || scan.completed.is_multiple_of(64) {
-        progress(FolderScanProgress {
-            task_id: request.task_id,
-            source_id: request.source_id.clone(),
-            label: request.label.clone(),
-            phase: String::from("Scanning"),
-            completed: scan.completed,
-            total: 0,
-            detail: path.display().to_string(),
-        });
-    }
-}
-
-fn merge_scan_discovery(root: &mut FolderEntry, event: &FolderScanDiscovery) -> bool {
-    let Some(parent) = root.find_mut(&event.parent_id) else {
-        return false;
-    };
-    match &event.item {
-        FolderScanItem::Folder(folder) => upsert_folder(&mut parent.children, folder.clone()),
-        FolderScanItem::File(file) => upsert_file(&mut parent.files, file.clone()),
-    }
-}
-
-fn upsert_folder(folders: &mut Vec<FolderEntry>, folder: FolderEntry) -> bool {
-    match folders.binary_search_by(|candidate| {
-        candidate
-            .name
-            .to_ascii_lowercase()
-            .cmp(&folder.name.to_ascii_lowercase())
-    }) {
-        Ok(index) if folders[index] == folder => false,
-        Ok(index) => {
-            folders[index] = folder;
-            true
-        }
-        Err(index) => {
-            folders.insert(index, folder);
-            true
-        }
-    }
-}
-
-fn upsert_file(files: &mut Vec<FileEntry>, file: FileEntry) -> bool {
-    match files.binary_search_by(|candidate| {
-        candidate
-            .name
-            .to_ascii_lowercase()
-            .cmp(&file.name.to_ascii_lowercase())
-    }) {
-        Ok(index) if files[index] == file => false,
-        Ok(index) => {
-            files[index] = file;
-            true
-        }
-        Err(index) => {
-            files.insert(index, file);
-            true
-        }
-    }
-}
-
-fn file_entry(path: &PathBuf) -> FileEntry {
-    let metadata = fs::metadata(path).ok();
-    let size_bytes = metadata.as_ref().map(fs::Metadata::len).unwrap_or_default();
-    let modified = metadata.and_then(|metadata| metadata.modified().ok());
-    FileEntry {
-        id: path_id(path),
-        name: file_label(path),
-        stem: file_stem_label(path),
-        extension: file_extension_label(path),
-        kind: file_kind(path),
-        size: format_size(size_bytes),
-        size_bytes,
-        modified: modified_label(modified),
-        modified_rank: modified_rank(modified),
-    }
-}
-
-fn file_kind(path: &Path) -> String {
-    match path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("wav") => String::from("Audio"),
-        Some("aif" | "aiff" | "flac" | "mp3") => String::from("Unsupported audio"),
-        Some("png" | "jpg" | "jpeg" | "gif" | "webp") => String::from("Image"),
-        Some("json" | "txt" | "md" | "toml" | "rs") => String::from("Text"),
-        _ => String::from("File"),
-    }
-}
-
-fn format_size(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = KB * 1024;
-    const GB: u64 = MB * 1024;
-    if bytes >= GB {
-        format!("{} GB", bytes / GB)
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
-fn modified_label(modified: Option<SystemTime>) -> String {
-    let Some(modified) = modified else {
-        return String::from("-");
-    };
-    let age = SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or(Duration::ZERO);
-    let days = age.as_secs() / 86_400;
-    if days == 0 {
-        String::from("Today")
-    } else if days == 1 {
-        String::from("1 day")
-    } else {
-        format!("{days} days")
-    }
-}
-
-fn modified_rank(modified: Option<SystemTime>) -> u64 {
-    modified
-        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-        .map(|age| age.as_secs())
-        .unwrap_or(u64::MAX)
-}
-
-fn read_sorted_entries(path: &Path) -> Vec<PathBuf> {
-    let Ok(read_dir) = fs::read_dir(path) else {
-        return Vec::new();
-    };
-    let mut entries = read_dir
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .collect::<Vec<_>>();
-    entries.sort_by(|a, b| {
-        file_label(a)
-            .to_ascii_lowercase()
-            .cmp(&file_label(b).to_ascii_lowercase())
-    });
-    entries
 }
 
 #[cfg(test)]

--- a/src/gui_app/folder_browser/scanning.rs
+++ b/src/gui_app/folder_browser/scanning.rs
@@ -1,0 +1,324 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use super::{
+    FileEntry, FolderEntry,
+    path_helpers::{file_extension_label, file_label, file_stem_label, folder_label, path_id},
+    types::{
+        FolderScanDiscovery, FolderScanItem, FolderScanProgress, FolderScanRequest,
+        FolderScanResult,
+    },
+};
+
+const MAX_SCAN_DEPTH: usize = 3;
+const MAX_CHILD_FOLDERS: usize = 80;
+
+pub(super) fn default_root_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets")
+}
+
+pub(super) fn load_root_folder(root: PathBuf) -> FolderEntry {
+    load_folder(&root, 0).unwrap_or_else(|| FolderEntry {
+        id: path_id(&root),
+        name: folder_label(&root),
+        children: Vec::new(),
+        files: Vec::new(),
+    })
+}
+
+pub(super) fn placeholder_folder(root: &Path) -> FolderEntry {
+    FolderEntry {
+        id: path_id(root),
+        name: folder_label(root),
+        children: Vec::new(),
+        files: Vec::new(),
+    }
+}
+
+pub(in crate::gui_app) fn scan_source_with_progress(
+    request: FolderScanRequest,
+    mut progress: impl FnMut(FolderScanProgress),
+    mut discovered: impl FnMut(FolderScanDiscovery),
+) -> FolderScanResult {
+    let mut scan = ScanProgressCounter {
+        completed: 0,
+        files: 0,
+        folders: 0,
+    };
+    progress(FolderScanProgress {
+        task_id: request.task_id,
+        source_id: request.source_id.clone(),
+        label: request.label.clone(),
+        phase: String::from("Scanning"),
+        completed: 0,
+        total: 0,
+        detail: request.root.display().to_string(),
+    });
+    let folder = load_folder_with_progress(
+        &request.root,
+        0,
+        &request,
+        &mut scan,
+        &mut progress,
+        &mut discovered,
+    )
+    .unwrap_or_else(|| placeholder_folder(&request.root));
+    FolderScanResult {
+        task_id: request.task_id,
+        source_id: request.source_id,
+        label: request.label,
+        folder,
+        file_count: scan.files,
+        folder_count: scan.folders,
+    }
+}
+
+fn load_folder(path: &Path, depth: usize) -> Option<FolderEntry> {
+    if depth > MAX_SCAN_DEPTH {
+        return None;
+    }
+    let entries = read_sorted_entries(path);
+    let children = entries
+        .iter()
+        .filter(|entry| entry.is_dir())
+        .take(MAX_CHILD_FOLDERS)
+        .filter_map(|entry| load_folder(entry, depth + 1))
+        .collect::<Vec<_>>();
+    let files = entries
+        .iter()
+        .filter(|entry| entry.is_file())
+        .map(file_entry)
+        .collect::<Vec<_>>();
+    Some(FolderEntry {
+        id: path_id(path),
+        name: folder_label(path),
+        children,
+        files,
+    })
+}
+
+struct ScanProgressCounter {
+    completed: usize,
+    files: usize,
+    folders: usize,
+}
+
+fn load_folder_with_progress(
+    path: &Path,
+    depth: usize,
+    request: &FolderScanRequest,
+    scan: &mut ScanProgressCounter,
+    progress: &mut impl FnMut(FolderScanProgress),
+    discovered: &mut impl FnMut(FolderScanDiscovery),
+) -> Option<FolderEntry> {
+    if depth > MAX_SCAN_DEPTH {
+        return None;
+    }
+    let entries = read_sorted_entries(path);
+    let parent_id = path_id(path);
+    let children = entries
+        .iter()
+        .filter(|entry| entry.is_dir())
+        .take(MAX_CHILD_FOLDERS)
+        .filter_map(|entry| {
+            scan.completed += 1;
+            scan.folders += 1;
+            maybe_report_scan_progress(entry, request, scan, progress);
+            discovered(FolderScanDiscovery {
+                task_id: request.task_id,
+                source_id: request.source_id.clone(),
+                parent_id: parent_id.clone(),
+                item: FolderScanItem::Folder(placeholder_folder(entry)),
+            });
+            let child =
+                load_folder_with_progress(entry, depth + 1, request, scan, progress, discovered)?;
+            discovered(FolderScanDiscovery {
+                task_id: request.task_id,
+                source_id: request.source_id.clone(),
+                parent_id: parent_id.clone(),
+                item: FolderScanItem::Folder(child.clone()),
+            });
+            Some(child)
+        })
+        .collect::<Vec<_>>();
+    let files = entries
+        .iter()
+        .filter(|entry| entry.is_file())
+        .map(|entry| {
+            scan.completed += 1;
+            scan.files += 1;
+            maybe_report_scan_progress(entry, request, scan, progress);
+            let file = file_entry(entry);
+            discovered(FolderScanDiscovery {
+                task_id: request.task_id,
+                source_id: request.source_id.clone(),
+                parent_id: parent_id.clone(),
+                item: FolderScanItem::File(file.clone()),
+            });
+            file
+        })
+        .collect::<Vec<_>>();
+    Some(FolderEntry {
+        id: path_id(path),
+        name: folder_label(path),
+        children,
+        files,
+    })
+}
+
+fn maybe_report_scan_progress(
+    path: &Path,
+    request: &FolderScanRequest,
+    scan: &ScanProgressCounter,
+    progress: &mut impl FnMut(FolderScanProgress),
+) {
+    if scan.completed == 1 || scan.completed.is_multiple_of(64) {
+        progress(FolderScanProgress {
+            task_id: request.task_id,
+            source_id: request.source_id.clone(),
+            label: request.label.clone(),
+            phase: String::from("Scanning"),
+            completed: scan.completed,
+            total: 0,
+            detail: path.display().to_string(),
+        });
+    }
+}
+
+pub(super) fn merge_scan_discovery(root: &mut FolderEntry, event: &FolderScanDiscovery) -> bool {
+    let Some(parent) = root.find_mut(&event.parent_id) else {
+        return false;
+    };
+    match &event.item {
+        FolderScanItem::Folder(folder) => upsert_folder(&mut parent.children, folder.clone()),
+        FolderScanItem::File(file) => upsert_file(&mut parent.files, file.clone()),
+    }
+}
+
+pub(super) fn upsert_folder(folders: &mut Vec<FolderEntry>, folder: FolderEntry) -> bool {
+    match folders.binary_search_by(|candidate| {
+        candidate
+            .name
+            .to_ascii_lowercase()
+            .cmp(&folder.name.to_ascii_lowercase())
+    }) {
+        Ok(index) if folders[index] == folder => false,
+        Ok(index) => {
+            folders[index] = folder;
+            true
+        }
+        Err(index) => {
+            folders.insert(index, folder);
+            true
+        }
+    }
+}
+
+pub(super) fn upsert_file(files: &mut Vec<FileEntry>, file: FileEntry) -> bool {
+    match files.binary_search_by(|candidate| {
+        candidate
+            .name
+            .to_ascii_lowercase()
+            .cmp(&file.name.to_ascii_lowercase())
+    }) {
+        Ok(index) if files[index] == file => false,
+        Ok(index) => {
+            files[index] = file;
+            true
+        }
+        Err(index) => {
+            files.insert(index, file);
+            true
+        }
+    }
+}
+
+pub(super) fn file_entry(path: &PathBuf) -> FileEntry {
+    let metadata = fs::metadata(path).ok();
+    let size_bytes = metadata.as_ref().map(fs::Metadata::len).unwrap_or_default();
+    let modified = metadata.and_then(|metadata| metadata.modified().ok());
+    FileEntry {
+        id: path_id(path),
+        name: file_label(path),
+        stem: file_stem_label(path),
+        extension: file_extension_label(path),
+        kind: file_kind(path),
+        size: format_size(size_bytes),
+        size_bytes,
+        modified: modified_label(modified),
+        modified_rank: modified_rank(modified),
+    }
+}
+
+fn file_kind(path: &Path) -> String {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("wav") => String::from("Audio"),
+        Some("aif" | "aiff" | "flac" | "mp3") => String::from("Unsupported audio"),
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp") => String::from("Image"),
+        Some("json" | "txt" | "md" | "toml" | "rs") => String::from("Text"),
+        _ => String::from("File"),
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn modified_label(modified: Option<SystemTime>) -> String {
+    let Some(modified) = modified else {
+        return String::from("-");
+    };
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::ZERO);
+    let days = age.as_secs() / 86_400;
+    if days == 0 {
+        String::from("Today")
+    } else if days == 1 {
+        String::from("1 day")
+    } else {
+        format!("{days} days")
+    }
+}
+
+fn modified_rank(modified: Option<SystemTime>) -> u64 {
+    modified
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .map(|age| age.as_secs())
+        .unwrap_or(u64::MAX)
+}
+
+fn read_sorted_entries(path: &Path) -> Vec<PathBuf> {
+    let Ok(read_dir) = fs::read_dir(path) else {
+        return Vec::new();
+    };
+    let mut entries = read_dir
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| {
+        file_label(a)
+            .to_ascii_lowercase()
+            .cmp(&file_label(b).to_ascii_lowercase())
+    });
+    entries
+}


### PR DESCRIPTION
## Summary
- Move folder traversal, scan progress, scan discovery merge, and file-entry metadata helpers into folder_browser::scanning
- Keep folder browser state behavior unchanged while reducing the main module size
- Preserve the existing gui_app-visible scan entrypoint through the folder_browser module

## Validation
- cargo fmt -- src\\gui_app\\folder_browser.rs src\\gui_app\\folder_browser\\scanning.rs
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent