### PR TITLE
Extract folder browser view module

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -3,10 +3,7 @@
 use radiant::{
     gui::types::Point,
     prelude as ui,
-    widgets::{
-        ButtonMessage, DragHandleMessage, PointerModifiers, TextInputMessage, WidgetStyle,
-        WidgetTone,
-    },
+    widgets::{DragHandleMessage, PointerModifiers, TextInputMessage},
 };
 use std::{
     collections::HashSet,
@@ -1755,7 +1752,6 @@ use state_types::{
 };
 
 mod tree_widgets;
-use tree_widgets::{FolderDropClearTarget, FolderTreeHitMessage, FolderTreeHitTarget};
 
 mod types;
 pub(super) use types::{
@@ -1763,6 +1759,9 @@ pub(super) use types::{
     FolderDragPreview, FolderDropResult, FolderScanDiscoveryBatch, FolderScanProgress,
     FolderScanRequest, FolderScanResult, RenameTargetView,
 };
+
+mod view;
+pub(super) use view::folder_browser_view;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct FileEntry {
@@ -1781,210 +1780,6 @@ impl FileEntry {
     fn is_audio(&self) -> bool {
         self.kind == "Audio"
     }
-}
-
-pub(super) fn folder_browser_view(state: &FolderBrowserState) -> ui::View<GuiMessage> {
-    ui::column([
-        source_selector(state),
-        ui::text("Folders").height(22.0).fill_width(),
-        ui::scroll(folder_tree_view(state)).fill(),
-        selected_folder_status(state),
-    ])
-    .spacing(3.0)
-    .padding(4.0)
-    .style(WidgetStyle::default())
-    .fill_height()
-}
-
-fn folder_tree_view(state: &FolderBrowserState) -> ui::View<GuiMessage> {
-    ui::stack([
-        ui::custom_widget_mapped(
-            FolderDropClearTarget::new(state.drag.is_some()),
-            |message| GuiMessage::FolderBrowser(message),
-        )
-        .key("folder-drop-clear-target")
-        .input_only()
-        .fill(),
-        ui::column(
-            state
-                .visible_folders()
-                .into_iter()
-                .map(folder_row)
-                .collect::<Vec<_>>(),
-        )
-        .fill_width()
-        .spacing(1.0),
-    ])
-    .fill()
-}
-
-fn source_selector(state: &FolderBrowserState) -> ui::View<GuiMessage> {
-    ui::column([
-        ui::row([
-            ui::text("Sources").height(20.0).fill_width(),
-            ui::button("+")
-                .primary()
-                .message(GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource))
-                .key("source-add-button")
-                .size(28.0, 22.0),
-        ])
-        .spacing(3.0)
-        .fill_width()
-        .height(24.0),
-        ui::column(
-            state
-                .sources
-                .iter()
-                .map(|source| source_row(state, source))
-                .collect::<Vec<_>>(),
-        )
-        .spacing(2.0)
-        .fill_width(),
-    ])
-    .spacing(3.0)
-    .fill_width()
-}
-
-fn source_row(state: &FolderBrowserState, source: &SourceEntry) -> ui::View<GuiMessage> {
-    let id = source.id.clone();
-    let row_key = source.id.clone();
-    let menu_id = source.id.clone();
-    let selected = state.selected_source == source.id;
-    let label = if source.loading_task.is_some() {
-        format!("{} (scanning)", source.label)
-    } else {
-        source.label.clone()
-    };
-    let mut row = ui::button(label)
-        .secondary_clicks()
-        .mapped(move |message| match message {
-            ButtonMessage::SecondaryActivate { position } => GuiMessage::FolderBrowser(
-                FolderBrowserMessage::OpenSourceContextMenu(menu_id.clone(), position),
-            ),
-            _ => GuiMessage::FolderBrowser(FolderBrowserMessage::SelectSource(id.clone())),
-        })
-        .key(format!("source-row-{row_key}"))
-        .fill_width()
-        .height(24.0);
-    if selected {
-        row = row.primary();
-    } else {
-        row = row.subtle();
-    }
-    row.style(if selected {
-        WidgetStyle {
-            tone: WidgetTone::Accent,
-            prominence: ui::WidgetProminence::Subtle,
-        }
-    } else {
-        WidgetStyle::default()
-    })
-    .fill_width()
-}
-
-fn folder_row(folder: VisibleFolder) -> ui::View<GuiMessage> {
-    let id = folder.id.clone();
-    if let (Some(draft), Some(input_id)) = (folder.rename_draft.clone(), folder.rename_input_id) {
-        let caret = draft.chars().count();
-        let indent = (folder.depth as f32) * TREE_DEPTH_INDENT;
-        return ui::row([
-            ui::spacer().width(indent).height(22.0),
-            ui::text_input(draft)
-                .selection(0, caret)
-                .message_event(|message| {
-                    GuiMessage::FolderBrowser(FolderBrowserMessage::RenameInput(message))
-                })
-                .id(input_id)
-                .key(format!("folder-rename-input-{id}"))
-                .fill_width()
-                .height(22.0),
-        ])
-        .key(format!("folder-row-{id}"))
-        .style(WidgetStyle {
-            tone: WidgetTone::Accent,
-            prominence: ui::WidgetProminence::Subtle,
-        })
-        .fill_width()
-        .height(TREE_ROW_HEIGHT)
-        .spacing(1.0)
-        .hoverable();
-    }
-
-    let expander = if folder.expanded { "[-]" } else { "[+]" };
-    let indent = (folder.depth as f32) * TREE_DEPTH_INDENT;
-    let label_text = if folder.has_children {
-        format!("{expander} {}", folder.name)
-    } else {
-        format!("    {}", folder.name)
-    };
-    let hit_id = id.clone();
-    let hit_target = ui::custom_widget_mapped(
-        FolderTreeHitTarget::new(
-            folder.selected,
-            folder.drop_target,
-            folder.drag_active,
-            folder.drop_candidate,
-        ),
-        move |message| match message {
-            FolderTreeHitMessage::Activate => {
-                GuiMessage::FolderBrowser(FolderBrowserMessage::ActivateFolder(hit_id.clone()))
-            }
-            FolderTreeHitMessage::ContextMenu(position) => GuiMessage::FolderBrowser(
-                FolderBrowserMessage::OpenFolderContextMenu(hit_id.clone(), position),
-            ),
-            FolderTreeHitMessage::Drag(drag) => {
-                GuiMessage::FolderBrowser(FolderBrowserMessage::DragFolder(hit_id.clone(), drag))
-            }
-            FolderTreeHitMessage::Drop => {
-                GuiMessage::FolderBrowser(FolderBrowserMessage::DropOnFolder(hit_id.clone()))
-            }
-            FolderTreeHitMessage::HoverDropTarget => {
-                GuiMessage::FolderBrowser(FolderBrowserMessage::HoverDropTarget(hit_id.clone()))
-            }
-        },
-    )
-    .key(format!("folder-row-hit-{id}"))
-    .fill_width()
-    .height(22.0);
-    let label = ui::text(label_text)
-        .key(format!("folder-row-label-{id}"))
-        .fill_width()
-        .height(22.0)
-        .truncate();
-
-    ui::row([
-        ui::spacer().width(indent).height(22.0),
-        ui::stack([hit_target, label]).fill_width().height(22.0),
-    ])
-    .key(format!("folder-row-{id}"))
-    .style(if folder.selected || folder.drop_target {
-        WidgetStyle {
-            tone: WidgetTone::Accent,
-            prominence: ui::WidgetProminence::Subtle,
-        }
-    } else {
-        WidgetStyle::default()
-    })
-    .fill_width()
-    .height(TREE_ROW_HEIGHT)
-    .spacing(1.0)
-    .hoverable()
-}
-
-fn selected_folder_status(state: &FolderBrowserState) -> ui::View<GuiMessage> {
-    let file_count = state.selected_files().len();
-    let audio_count = state.selected_audio_files().len();
-    let label = state
-        .selected_folder()
-        .map(|folder| {
-            format!(
-                "{} | {audio_count} audio | {file_count} item{}",
-                folder.name,
-                plural(file_count)
-            )
-        })
-        .unwrap_or_else(|| String::from("No folder selected"));
-    ui::text(label).height(20.0).fill_width().truncate()
 }
 
 fn plural(count: usize) -> &'static str {

--- a/src/gui_app/folder_browser/view.rs
+++ b/src/gui_app/folder_browser/view.rs
@@ -1,0 +1,214 @@
+use radiant::{
+    prelude as ui,
+    widgets::{ButtonMessage, WidgetStyle, WidgetTone},
+};
+
+use super::{
+    FolderBrowserMessage, FolderBrowserState, GuiMessage, SourceEntry, TREE_DEPTH_INDENT,
+    TREE_ROW_HEIGHT, VisibleFolder, plural,
+    tree_widgets::{FolderDropClearTarget, FolderTreeHitMessage, FolderTreeHitTarget},
+};
+
+pub(in crate::gui_app) fn folder_browser_view(state: &FolderBrowserState) -> ui::View<GuiMessage> {
+    ui::column([
+        source_selector(state),
+        ui::text("Folders").height(22.0).fill_width(),
+        ui::scroll(folder_tree_view(state)).fill(),
+        selected_folder_status(state),
+    ])
+    .spacing(3.0)
+    .padding(4.0)
+    .style(WidgetStyle::default())
+    .fill_height()
+}
+
+fn folder_tree_view(state: &FolderBrowserState) -> ui::View<GuiMessage> {
+    ui::stack([
+        ui::custom_widget_mapped(
+            FolderDropClearTarget::new(state.drag.is_some()),
+            GuiMessage::FolderBrowser,
+        )
+        .key("folder-drop-clear-target")
+        .input_only()
+        .fill(),
+        ui::column(
+            state
+                .visible_folders()
+                .into_iter()
+                .map(folder_row)
+                .collect::<Vec<_>>(),
+        )
+        .fill_width()
+        .spacing(1.0),
+    ])
+    .fill()
+}
+
+fn source_selector(state: &FolderBrowserState) -> ui::View<GuiMessage> {
+    ui::column([
+        ui::row([
+            ui::text("Sources").height(20.0).fill_width(),
+            ui::button("+")
+                .primary()
+                .message(GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource))
+                .key("source-add-button")
+                .size(28.0, 22.0),
+        ])
+        .spacing(3.0)
+        .fill_width()
+        .height(24.0),
+        ui::column(
+            state
+                .sources
+                .iter()
+                .map(|source| source_row(state, source))
+                .collect::<Vec<_>>(),
+        )
+        .spacing(2.0)
+        .fill_width(),
+    ])
+    .spacing(3.0)
+    .fill_width()
+}
+
+fn source_row(state: &FolderBrowserState, source: &SourceEntry) -> ui::View<GuiMessage> {
+    let id = source.id.clone();
+    let row_key = source.id.clone();
+    let menu_id = source.id.clone();
+    let selected = state.selected_source == source.id;
+    let label = if source.loading_task.is_some() {
+        format!("{} (scanning)", source.label)
+    } else {
+        source.label.clone()
+    };
+    let mut row = ui::button(label)
+        .secondary_clicks()
+        .mapped(move |message| match message {
+            ButtonMessage::SecondaryActivate { position } => GuiMessage::FolderBrowser(
+                FolderBrowserMessage::OpenSourceContextMenu(menu_id.clone(), position),
+            ),
+            _ => GuiMessage::FolderBrowser(FolderBrowserMessage::SelectSource(id.clone())),
+        })
+        .key(format!("source-row-{row_key}"))
+        .fill_width()
+        .height(24.0);
+    if selected {
+        row = row.primary();
+    } else {
+        row = row.subtle();
+    }
+    row.style(if selected {
+        WidgetStyle {
+            tone: WidgetTone::Accent,
+            prominence: ui::WidgetProminence::Subtle,
+        }
+    } else {
+        WidgetStyle::default()
+    })
+    .fill_width()
+}
+
+fn folder_row(folder: VisibleFolder) -> ui::View<GuiMessage> {
+    let id = folder.id.clone();
+    if let (Some(draft), Some(input_id)) = (folder.rename_draft.clone(), folder.rename_input_id) {
+        let caret = draft.chars().count();
+        let indent = (folder.depth as f32) * TREE_DEPTH_INDENT;
+        return ui::row([
+            ui::spacer().width(indent).height(22.0),
+            ui::text_input(draft)
+                .selection(0, caret)
+                .message_event(|message| {
+                    GuiMessage::FolderBrowser(FolderBrowserMessage::RenameInput(message))
+                })
+                .id(input_id)
+                .key(format!("folder-rename-input-{id}"))
+                .fill_width()
+                .height(22.0),
+        ])
+        .key(format!("folder-row-{id}"))
+        .style(WidgetStyle {
+            tone: WidgetTone::Accent,
+            prominence: ui::WidgetProminence::Subtle,
+        })
+        .fill_width()
+        .height(TREE_ROW_HEIGHT)
+        .spacing(1.0)
+        .hoverable();
+    }
+
+    let expander = if folder.expanded { "[-]" } else { "[+]" };
+    let indent = (folder.depth as f32) * TREE_DEPTH_INDENT;
+    let label_text = if folder.has_children {
+        format!("{expander} {}", folder.name)
+    } else {
+        format!("    {}", folder.name)
+    };
+    let hit_id = id.clone();
+    let hit_target = ui::custom_widget_mapped(
+        FolderTreeHitTarget::new(
+            folder.selected,
+            folder.drop_target,
+            folder.drag_active,
+            folder.drop_candidate,
+        ),
+        move |message| match message {
+            FolderTreeHitMessage::Activate => {
+                GuiMessage::FolderBrowser(FolderBrowserMessage::ActivateFolder(hit_id.clone()))
+            }
+            FolderTreeHitMessage::ContextMenu(position) => GuiMessage::FolderBrowser(
+                FolderBrowserMessage::OpenFolderContextMenu(hit_id.clone(), position),
+            ),
+            FolderTreeHitMessage::Drag(drag) => {
+                GuiMessage::FolderBrowser(FolderBrowserMessage::DragFolder(hit_id.clone(), drag))
+            }
+            FolderTreeHitMessage::Drop => {
+                GuiMessage::FolderBrowser(FolderBrowserMessage::DropOnFolder(hit_id.clone()))
+            }
+            FolderTreeHitMessage::HoverDropTarget => {
+                GuiMessage::FolderBrowser(FolderBrowserMessage::HoverDropTarget(hit_id.clone()))
+            }
+        },
+    )
+    .key(format!("folder-row-hit-{id}"))
+    .fill_width()
+    .height(22.0);
+    let label = ui::text(label_text)
+        .key(format!("folder-row-label-{id}"))
+        .fill_width()
+        .height(22.0)
+        .truncate();
+
+    ui::row([
+        ui::spacer().width(indent).height(22.0),
+        ui::stack([hit_target, label]).fill_width().height(22.0),
+    ])
+    .key(format!("folder-row-{id}"))
+    .style(if folder.selected || folder.drop_target {
+        WidgetStyle {
+            tone: WidgetTone::Accent,
+            prominence: ui::WidgetProminence::Subtle,
+        }
+    } else {
+        WidgetStyle::default()
+    })
+    .fill_width()
+    .height(TREE_ROW_HEIGHT)
+    .spacing(1.0)
+    .hoverable()
+}
+
+fn selected_folder_status(state: &FolderBrowserState) -> ui::View<GuiMessage> {
+    let file_count = state.selected_files().len();
+    let audio_count = state.selected_audio_files().len();
+    let label = state
+        .selected_folder()
+        .map(|folder| {
+            format!(
+                "{} | {audio_count} audio | {file_count} item{}",
+                folder.name,
+                plural(file_count)
+            )
+        })
+        .unwrap_or_else(|| String::from("No folder selected"));
+    ui::text(label).height(20.0).fill_width().truncate()
+}


### PR DESCRIPTION
## Summary
- Move folder browser source selector, tree row, and selected-folder status view construction into folder_browser::view
- Keep state transition logic in folder_browser.rs while preserving the existing gui_app-visible view entrypoint
- Continue reducing the oversized folder browser module with a focused module under 400 lines

## Validation
- cargo fmt -- src\\gui_app\\folder_browser.rs src\\gui_app\\folder_browser\\view.rs
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent