### PR TITLE
Extract folder browser source management

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -88,10 +88,7 @@ impl FolderBrowserState {
 
     #[cfg(test)]
     pub(super) fn source_labels(&self) -> Vec<String> {
-        self.sources
-            .iter()
-            .map(|source| source.label.clone())
-            .collect()
+        self.source_labels_for_tests()
     }
 
     pub(super) fn selected_files(&self) -> &[FileEntry] {
@@ -151,13 +148,6 @@ impl FolderBrowserState {
             .into_iter()
             .filter(|file| selected.contains(&file.id))
             .count()
-    }
-
-    pub(super) fn source_root_path(&self, source_id: &str) -> Option<PathBuf> {
-        self.sources
-            .iter()
-            .find(|source| source.id == source_id)
-            .map(|source| source.root.clone())
     }
 
     pub(super) fn folder_path(&self, folder_id: &str) -> Option<PathBuf> {
@@ -622,139 +612,6 @@ impl FolderBrowserState {
         } else {
             false
         }
-    }
-
-    pub(super) fn begin_add_source_path(
-        &mut self,
-        root: PathBuf,
-        task_id: u64,
-    ) -> Option<FolderScanRequest> {
-        if let Some(index) = self.sources.iter().position(|source| source.root == root) {
-            let id = self.sources[index].id.clone();
-            return self.begin_select_source(id, task_id);
-        }
-        let id = path_id(&root);
-        let label = folder_label(&root);
-        let mut source = SourceEntry::new(id.clone(), label.clone(), root.clone());
-        source.loading_task = Some(task_id);
-        self.sources.push(source);
-        self.select_pending_source(id.clone(), placeholder_folder(&root));
-        Some(FolderScanRequest {
-            task_id,
-            source_id: id,
-            label,
-            root,
-        })
-    }
-
-    pub(super) fn begin_select_source(
-        &mut self,
-        id: String,
-        task_id: u64,
-    ) -> Option<FolderScanRequest> {
-        let index = self.sources.iter().position(|source| source.id == id)?;
-        if self.selected_source == id && self.sources[index].root_folder.is_some() {
-            return None;
-        }
-        if let Some(root_folder) = self.sources[index].root_folder.clone() {
-            self.select_loaded_source(id, root_folder);
-            return None;
-        }
-        if self.sources[index].loading_task.is_some() {
-            let root = self.sources[index].root.clone();
-            self.select_pending_source(id, placeholder_folder(&root));
-            return None;
-        }
-        self.sources[index].loading_task = Some(task_id);
-        let source = self.sources[index].clone();
-        self.select_pending_source(source.id.clone(), placeholder_folder(&source.root));
-        Some(FolderScanRequest {
-            task_id,
-            source_id: source.id,
-            label: source.label,
-            root: source.root,
-        })
-    }
-
-    pub(super) fn apply_scan_finished(&mut self, result: FolderScanResult) -> bool {
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == result.source_id)
-        else {
-            return false;
-        };
-        if source.loading_task != Some(result.task_id) {
-            return false;
-        }
-        let source_id = source.id.clone();
-        let should_select = self.selected_source == source_id;
-        source.loading_task = None;
-        source.root_folder = Some(result.folder.clone());
-        if should_select {
-            self.select_loaded_source(source_id, result.folder);
-        }
-        true
-    }
-
-    #[cfg(test)]
-    pub(super) fn apply_scan_discovered(&mut self, event: types::FolderScanDiscovery) -> bool {
-        self.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
-            task_id: event.task_id,
-            source_id: event.source_id.clone(),
-            events: vec![event],
-        })
-    }
-
-    pub(super) fn apply_scan_discovered_batch(&mut self, batch: FolderScanDiscoveryBatch) -> bool {
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == batch.source_id)
-        else {
-            return false;
-        };
-        if source.loading_task != Some(batch.task_id) {
-            return false;
-        }
-
-        let root_folder = source
-            .root_folder
-            .get_or_insert_with(|| placeholder_folder(&source.root));
-        let mut changed = false;
-        for event in &batch.events {
-            changed |= merge_scan_discovery(root_folder, event);
-        }
-        if changed && self.selected_source == batch.source_id {
-            self.folders = vec![root_folder.clone()];
-        }
-        changed
-    }
-
-    fn select_pending_source(&mut self, id: String, folder: FolderEntry) {
-        self.cancel_rename();
-        let root_id = folder.id.clone();
-        self.selected_source = id;
-        self.selected_folder = root_id.clone();
-        self.selected_file = None;
-        self.selected_file_ids.clear();
-        self.file_view_start = 0;
-        self.expanded_folders.clear();
-        self.expanded_folders.insert(root_id);
-        self.folders = vec![folder];
-    }
-
-    fn select_loaded_source(&mut self, id: String, root_folder: FolderEntry) {
-        self.cancel_rename();
-        let root_id = root_folder.id.clone();
-        self.selected_source = id;
-        self.selected_folder = root_id.clone();
-        self.selected_file = None;
-        self.selected_file_ids.clear();
-        self.file_view_start = 0;
-        self.expanded_folders.clear();
-        self.expanded_folders.insert(root_id);
-        self.folders = vec![root_folder];
     }
 
     fn selected_folder(&self) -> Option<&FolderEntry> {
@@ -1739,10 +1596,9 @@ use path_helpers::{
 
 mod scanning;
 pub(super) use scanning::scan_source_with_progress;
-use scanning::{
-    default_root_path, file_entry, load_root_folder, merge_scan_discovery, placeholder_folder,
-    upsert_file, upsert_folder,
-};
+use scanning::{default_root_path, file_entry, load_root_folder, upsert_file, upsert_folder};
+
+mod source_management;
 
 mod state_types;
 pub(super) use state_types::FileColumn;

--- a/src/gui_app/folder_browser/source_management.rs
+++ b/src/gui_app/folder_browser/source_management.rs
@@ -1,0 +1,164 @@
+use std::path::PathBuf;
+
+use super::{
+    FolderBrowserState, FolderEntry, SourceEntry,
+    path_helpers::{folder_label, path_id},
+    scanning::{merge_scan_discovery, placeholder_folder},
+    types::{FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult},
+};
+
+impl FolderBrowserState {
+    #[cfg(test)]
+    pub(super) fn source_labels_for_tests(&self) -> Vec<String> {
+        self.sources
+            .iter()
+            .map(|source| source.label.clone())
+            .collect()
+    }
+
+    pub(in crate::gui_app) fn source_root_path(&self, source_id: &str) -> Option<PathBuf> {
+        self.sources
+            .iter()
+            .find(|source| source.id == source_id)
+            .map(|source| source.root.clone())
+    }
+
+    pub(in crate::gui_app) fn begin_add_source_path(
+        &mut self,
+        root: PathBuf,
+        task_id: u64,
+    ) -> Option<FolderScanRequest> {
+        if let Some(index) = self.sources.iter().position(|source| source.root == root) {
+            let id = self.sources[index].id.clone();
+            return self.begin_select_source(id, task_id);
+        }
+        let id = path_id(&root);
+        let label = folder_label(&root);
+        let mut source = SourceEntry::new(id.clone(), label.clone(), root.clone());
+        source.loading_task = Some(task_id);
+        self.sources.push(source);
+        self.select_pending_source(id.clone(), placeholder_folder(&root));
+        Some(FolderScanRequest {
+            task_id,
+            source_id: id,
+            label,
+            root,
+        })
+    }
+
+    pub(in crate::gui_app) fn begin_select_source(
+        &mut self,
+        id: String,
+        task_id: u64,
+    ) -> Option<FolderScanRequest> {
+        let index = self.sources.iter().position(|source| source.id == id)?;
+        if self.selected_source == id && self.sources[index].root_folder.is_some() {
+            return None;
+        }
+        if let Some(root_folder) = self.sources[index].root_folder.clone() {
+            self.select_loaded_source(id, root_folder);
+            return None;
+        }
+        if self.sources[index].loading_task.is_some() {
+            let root = self.sources[index].root.clone();
+            self.select_pending_source(id, placeholder_folder(&root));
+            return None;
+        }
+        self.sources[index].loading_task = Some(task_id);
+        let source = self.sources[index].clone();
+        self.select_pending_source(source.id.clone(), placeholder_folder(&source.root));
+        Some(FolderScanRequest {
+            task_id,
+            source_id: source.id,
+            label: source.label,
+            root: source.root,
+        })
+    }
+
+    pub(in crate::gui_app) fn apply_scan_finished(&mut self, result: FolderScanResult) -> bool {
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == result.source_id)
+        else {
+            return false;
+        };
+        if source.loading_task != Some(result.task_id) {
+            return false;
+        }
+        let source_id = source.id.clone();
+        let should_select = self.selected_source == source_id;
+        source.loading_task = None;
+        source.root_folder = Some(result.folder.clone());
+        if should_select {
+            self.select_loaded_source(source_id, result.folder);
+        }
+        true
+    }
+
+    #[cfg(test)]
+    pub(super) fn apply_scan_discovered(
+        &mut self,
+        event: super::types::FolderScanDiscovery,
+    ) -> bool {
+        self.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
+            task_id: event.task_id,
+            source_id: event.source_id.clone(),
+            events: vec![event],
+        })
+    }
+
+    pub(in crate::gui_app) fn apply_scan_discovered_batch(
+        &mut self,
+        batch: FolderScanDiscoveryBatch,
+    ) -> bool {
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == batch.source_id)
+        else {
+            return false;
+        };
+        if source.loading_task != Some(batch.task_id) {
+            return false;
+        }
+
+        let root_folder = source
+            .root_folder
+            .get_or_insert_with(|| placeholder_folder(&source.root));
+        let mut changed = false;
+        for event in &batch.events {
+            changed |= merge_scan_discovery(root_folder, event);
+        }
+        if changed && self.selected_source == batch.source_id {
+            self.folders = vec![root_folder.clone()];
+        }
+        changed
+    }
+
+    fn select_pending_source(&mut self, id: String, folder: FolderEntry) {
+        self.cancel_rename();
+        let root_id = folder.id.clone();
+        self.selected_source = id;
+        self.selected_folder = root_id.clone();
+        self.selected_file = None;
+        self.selected_file_ids.clear();
+        self.file_view_start = 0;
+        self.expanded_folders.clear();
+        self.expanded_folders.insert(root_id);
+        self.folders = vec![folder];
+    }
+
+    fn select_loaded_source(&mut self, id: String, root_folder: FolderEntry) {
+        self.cancel_rename();
+        let root_id = root_folder.id.clone();
+        self.selected_source = id;
+        self.selected_folder = root_id.clone();
+        self.selected_file = None;
+        self.selected_file_ids.clear();
+        self.file_view_start = 0;
+        self.expanded_folders.clear();
+        self.expanded_folders.insert(root_id);
+        self.folders = vec![root_folder];
+    }
+}


### PR DESCRIPTION
## Summary
- move folder source selection and scan-result mutation helpers into folder_browser/source_management.rs
- keep folder_browser.rs focused on browser state, view helpers, and remaining file/folder operations

## Validation
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent