### PR TITLE
Extract folder browser entry models

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -1,10 +1,7 @@
 #![allow(missing_docs)]
 
 use radiant::{gui::types::Point, prelude as ui, widgets::DragHandleMessage};
-use std::{
-    collections::HashSet,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashSet, path::PathBuf};
 
 use super::GuiMessage;
 
@@ -74,11 +71,11 @@ impl FolderBrowserState {
     }
 
     #[cfg(test)]
-    pub(super) fn root_path(&self) -> &Path {
+    pub(super) fn root_path(&self) -> &std::path::Path {
         self.folders
             .first()
-            .map(|folder| Path::new(&folder.id))
-            .unwrap_or_else(|| Path::new(""))
+            .map(|folder| std::path::Path::new(&folder.id))
+            .unwrap_or_else(|| std::path::Path::new(""))
     }
 
     #[cfg(test)]
@@ -358,104 +355,21 @@ impl FolderBrowserState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct FolderEntry {
-    id: String,
-    name: String,
-    children: Vec<FolderEntry>,
-    files: Vec<FileEntry>,
-}
-
-impl FolderEntry {
-    fn find(&self, id: &str) -> Option<&FolderEntry> {
-        if self.id == id {
-            return Some(self);
-        }
-        self.children.iter().find_map(|child| child.find(id))
-    }
-
-    fn find_mut(&mut self, id: &str) -> Option<&mut FolderEntry> {
-        if self.id == id {
-            return Some(self);
-        }
-        self.children
-            .iter_mut()
-            .find_map(|child| child.find_mut(id))
-    }
-
-    fn has_children(&self) -> bool {
-        !self.children.is_empty()
-    }
-
-    fn rewrite_path_prefix(&mut self, old_path: &Path, new_path: &Path) {
-        self.id = rewrite_path_id(&self.id, old_path, new_path);
-        if Path::new(&self.id) == new_path {
-            self.name = folder_label(new_path);
-        }
-        for child in &mut self.children {
-            child.rewrite_path_prefix(old_path, new_path);
-        }
-        for file in &mut self.files {
-            file.id = rewrite_path_id(&file.id, old_path, new_path);
-        }
-    }
-
-    fn rewrite_file_path(&mut self, old_path: &Path, new_path: &Path) -> bool {
-        let old_id = path_id(old_path);
-        for file in &mut self.files {
-            if file.id == old_id {
-                *file = file_entry(&new_path.to_path_buf());
-                self.files.sort_by(|a, b| {
-                    a.name
-                        .to_ascii_lowercase()
-                        .cmp(&b.name.to_ascii_lowercase())
-                });
-                return true;
-            }
-        }
-        self.children
-            .iter_mut()
-            .any(|child| child.rewrite_file_path(old_path, new_path))
-    }
-
-    fn remove_child_by_id(&mut self, target_id: &str) -> bool {
-        if let Some(index) = self.children.iter().position(|child| child.id == target_id) {
-            self.children.remove(index);
-            return true;
-        }
-        self.children
-            .iter_mut()
-            .any(|child| child.remove_child_by_id(target_id))
-    }
-
-    fn take_child_by_id(&mut self, target_id: &str) -> Option<FolderEntry> {
-        if let Some(index) = self.children.iter().position(|child| child.id == target_id) {
-            return Some(self.children.remove(index));
-        }
-        self.children
-            .iter_mut()
-            .find_map(|child| child.take_child_by_id(target_id))
-    }
-
-    fn remove_files_by_ids(&mut self, target_ids: &HashSet<String>) -> bool {
-        let before = self.files.len();
-        self.files.retain(|file| !target_ids.contains(&file.id));
-        let mut changed = self.files.len() != before;
-        for child in &mut self.children {
-            changed |= child.remove_files_by_ids(target_ids);
-        }
-        changed
-    }
-}
-
 mod path_helpers;
 use path_helpers::{folder_label, path_id, rewrite_path_id};
+
+mod folder_entry;
+use folder_entry::FolderEntry;
 
 mod drag_drop;
 
 mod delete_workflow;
 
 mod file_selection;
+
+mod file_model;
+pub(in crate::gui_app) use file_model::FileEntry;
+use file_model::plural;
 
 mod scanning;
 pub(super) use scanning::scan_source_with_progress;
@@ -483,29 +397,6 @@ pub(super) use types::{
 
 mod view;
 pub(super) use view::folder_browser_view;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct FileEntry {
-    pub(super) id: String,
-    pub(super) name: String,
-    pub(super) stem: String,
-    pub(super) extension: String,
-    pub(super) kind: String,
-    pub(super) size: String,
-    pub(super) size_bytes: u64,
-    pub(super) modified: String,
-    pub(super) modified_rank: u64,
-}
-
-impl FileEntry {
-    fn is_audio(&self) -> bool {
-        self.kind == "Audio"
-    }
-}
-
-fn plural(count: usize) -> &'static str {
-    if count == 1 { "" } else { "s" }
-}
 
 #[cfg(test)]
 mod tests;

--- a/src/gui_app/folder_browser/file_model.rs
+++ b/src/gui_app/folder_browser/file_model.rs
@@ -1,0 +1,22 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) struct FileEntry {
+    pub(in crate::gui_app) id: String,
+    pub(in crate::gui_app) name: String,
+    pub(in crate::gui_app) stem: String,
+    pub(in crate::gui_app) extension: String,
+    pub(in crate::gui_app) kind: String,
+    pub(in crate::gui_app) size: String,
+    pub(in crate::gui_app) size_bytes: u64,
+    pub(in crate::gui_app) modified: String,
+    pub(in crate::gui_app) modified_rank: u64,
+}
+
+impl FileEntry {
+    pub(super) fn is_audio(&self) -> bool {
+        self.kind == "Audio"
+    }
+}
+
+pub(super) fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}

--- a/src/gui_app/folder_browser/folder_entry.rs
+++ b/src/gui_app/folder_browser/folder_entry.rs
@@ -1,0 +1,96 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use super::{FileEntry, file_entry, folder_label, path_id, rewrite_path_id};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::gui_app) struct FolderEntry {
+    pub(super) id: String,
+    pub(super) name: String,
+    pub(super) children: Vec<FolderEntry>,
+    pub(super) files: Vec<FileEntry>,
+}
+
+impl FolderEntry {
+    pub(super) fn find(&self, id: &str) -> Option<&FolderEntry> {
+        if self.id == id {
+            return Some(self);
+        }
+        self.children.iter().find_map(|child| child.find(id))
+    }
+
+    pub(super) fn find_mut(&mut self, id: &str) -> Option<&mut FolderEntry> {
+        if self.id == id {
+            return Some(self);
+        }
+        self.children
+            .iter_mut()
+            .find_map(|child| child.find_mut(id))
+    }
+
+    pub(super) fn has_children(&self) -> bool {
+        !self.children.is_empty()
+    }
+
+    pub(super) fn rewrite_path_prefix(&mut self, old_path: &Path, new_path: &Path) {
+        self.id = rewrite_path_id(&self.id, old_path, new_path);
+        if Path::new(&self.id) == new_path {
+            self.name = folder_label(new_path);
+        }
+        for child in &mut self.children {
+            child.rewrite_path_prefix(old_path, new_path);
+        }
+        for file in &mut self.files {
+            file.id = rewrite_path_id(&file.id, old_path, new_path);
+        }
+    }
+
+    pub(super) fn rewrite_file_path(&mut self, old_path: &Path, new_path: &Path) -> bool {
+        let old_id = path_id(old_path);
+        for file in &mut self.files {
+            if file.id == old_id {
+                *file = file_entry(&PathBuf::from(new_path));
+                self.files.sort_by(|a, b| {
+                    a.name
+                        .to_ascii_lowercase()
+                        .cmp(&b.name.to_ascii_lowercase())
+                });
+                return true;
+            }
+        }
+        self.children
+            .iter_mut()
+            .any(|child| child.rewrite_file_path(old_path, new_path))
+    }
+
+    pub(super) fn remove_child_by_id(&mut self, target_id: &str) -> bool {
+        if let Some(index) = self.children.iter().position(|child| child.id == target_id) {
+            self.children.remove(index);
+            return true;
+        }
+        self.children
+            .iter_mut()
+            .any(|child| child.remove_child_by_id(target_id))
+    }
+
+    pub(super) fn take_child_by_id(&mut self, target_id: &str) -> Option<FolderEntry> {
+        if let Some(index) = self.children.iter().position(|child| child.id == target_id) {
+            return Some(self.children.remove(index));
+        }
+        self.children
+            .iter_mut()
+            .find_map(|child| child.take_child_by_id(target_id))
+    }
+
+    pub(super) fn remove_files_by_ids(&mut self, target_ids: &HashSet<String>) -> bool {
+        let before = self.files.len();
+        self.files.retain(|file| !target_ids.contains(&file.id));
+        let mut changed = self.files.len() != before;
+        for child in &mut self.children {
+            changed |= child.remove_files_by_ids(target_ids);
+        }
+        changed
+    }
+}


### PR DESCRIPTION
## Summary
- move FolderEntry and tree mutation helpers into folder_browser/folder_entry.rs
- move FileEntry and the plural label helper into folder_browser/file_model.rs
- keep folder_browser.rs focused on state coordination and module wiring

## Validation
- cargo test folder_browser --bin wavecrate
- cargo test --manifest-path vendor/radiant/Cargo.toml --test app_runtime_api lifecycle::app_startup_commands_use_full_runtime_dispatch --no-default-features
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent