### PR TITLE
Extract drag drop relocation

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -362,6 +362,7 @@ mod folder_entry;
 use folder_entry::FolderEntry;
 
 mod drag_drop;
+mod drag_drop_relocation;
 
 mod delete_workflow;
 

--- a/src/gui_app/folder_browser/drag_drop.rs
+++ b/src/gui_app/folder_browser/drag_drop.rs
@@ -7,9 +7,7 @@ use std::{
 
 use super::{
     FolderBrowserDrag, FolderBrowserState, FolderDragPreview, FolderDropResult,
-    path_helpers::{file_label, path_id, rewrite_path_id},
-    plural,
-    scanning::{file_entry, upsert_file, upsert_folder},
+    path_helpers::file_label, plural,
 };
 
 impl FolderBrowserState {
@@ -293,126 +291,5 @@ impl FolderBrowserState {
                 plural(completed.len())
             )),
         })
-    }
-
-    fn relocate_moved_folder(
-        &mut self,
-        old_path: &Path,
-        new_path: &Path,
-        target_parent: &Path,
-    ) -> Result<(), String> {
-        let old_id = path_id(old_path);
-        let target_parent_id = path_id(target_parent);
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return Err(String::from(
-                "Folder move failed: selected source is unavailable",
-            ));
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return Err(String::from(
-                "Folder move failed: source tree is unavailable",
-            ));
-        };
-        let Some(mut moved_folder) = root_folder.take_child_by_id(&old_id) else {
-            return Err(String::from(
-                "Folder move failed: source folder is unavailable",
-            ));
-        };
-        moved_folder.rewrite_path_prefix(old_path, new_path);
-        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
-            return Err(String::from(
-                "Folder move failed: target folder is unavailable",
-            ));
-        };
-        upsert_folder(&mut target_folder.children, moved_folder);
-        self.folders = vec![root_folder.clone()];
-
-        self.selected_folder = rewrite_path_id(&self.selected_folder, old_path, new_path);
-        self.selected_file = self
-            .selected_file
-            .take()
-            .map(|id| rewrite_path_id(&id, old_path, new_path));
-        self.selected_file_ids = self
-            .selected_file_ids
-            .iter()
-            .map(|id| rewrite_path_id(id, old_path, new_path))
-            .collect();
-        self.expanded_folders = self
-            .expanded_folders
-            .iter()
-            .map(|id| rewrite_path_id(id, old_path, new_path))
-            .collect();
-        self.expanded_folders.insert(target_parent_id);
-        Ok(())
-    }
-
-    fn relocate_moved_files(
-        &mut self,
-        moves: &[(PathBuf, PathBuf)],
-        target_parent: &Path,
-    ) -> Result<(), String> {
-        let old_ids = moves
-            .iter()
-            .map(|(old_path, _)| path_id(old_path))
-            .collect::<HashSet<_>>();
-        let target_parent_id = path_id(target_parent);
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return Err(String::from(
-                "File move failed: selected source is unavailable",
-            ));
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return Err(String::from("File move failed: source tree is unavailable"));
-        };
-        root_folder.remove_files_by_ids(&old_ids);
-        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
-            return Err(String::from(
-                "File move failed: target folder is unavailable",
-            ));
-        };
-        for (_, new_path) in moves {
-            upsert_file(&mut target_folder.files, file_entry(new_path));
-        }
-        self.folders = vec![root_folder.clone()];
-        let moved_ids = moves
-            .iter()
-            .map(|(_, new_path)| path_id(new_path))
-            .collect::<Vec<_>>();
-        let rewrite_file_id = |id: &str| {
-            moves
-                .iter()
-                .find(|(old_path, _)| path_id(old_path) == id)
-                .map(|(_, new_path)| path_id(new_path))
-                .unwrap_or_else(|| id.to_string())
-        };
-        let selected_file_was_moved = self
-            .selected_file
-            .as_ref()
-            .is_some_and(|id| old_ids.contains(id));
-        self.selected_file = if selected_file_was_moved {
-            self.selected_file.take().map(|id| rewrite_file_id(&id))
-        } else {
-            moved_ids.first().cloned()
-        };
-        self.selected_file_ids = if self.selected_file_ids.iter().any(|id| old_ids.contains(id)) {
-            self.selected_file_ids
-                .iter()
-                .map(|id| rewrite_file_id(id))
-                .collect()
-        } else {
-            moved_ids.iter().cloned().collect()
-        };
-        self.selected_folder = target_parent_id.clone();
-        self.file_view_start = 0;
-        self.expanded_folders.insert(target_parent_id);
-        Ok(())
     }
 }

--- a/src/gui_app/folder_browser/drag_drop_relocation.rs
+++ b/src/gui_app/folder_browser/drag_drop_relocation.rs
@@ -1,0 +1,133 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use super::{
+    FolderBrowserState,
+    path_helpers::{path_id, rewrite_path_id},
+    scanning::{file_entry, upsert_file, upsert_folder},
+};
+
+impl FolderBrowserState {
+    pub(super) fn relocate_moved_folder(
+        &mut self,
+        old_path: &Path,
+        new_path: &Path,
+        target_parent: &Path,
+    ) -> Result<(), String> {
+        let old_id = path_id(old_path);
+        let target_parent_id = path_id(target_parent);
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return Err(String::from(
+                "Folder move failed: selected source is unavailable",
+            ));
+        };
+        let Some(root_folder) = &mut source.root_folder else {
+            return Err(String::from(
+                "Folder move failed: source tree is unavailable",
+            ));
+        };
+        let Some(mut moved_folder) = root_folder.take_child_by_id(&old_id) else {
+            return Err(String::from(
+                "Folder move failed: source folder is unavailable",
+            ));
+        };
+        moved_folder.rewrite_path_prefix(old_path, new_path);
+        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
+            return Err(String::from(
+                "Folder move failed: target folder is unavailable",
+            ));
+        };
+        upsert_folder(&mut target_folder.children, moved_folder);
+        self.folders = vec![root_folder.clone()];
+
+        self.selected_folder = rewrite_path_id(&self.selected_folder, old_path, new_path);
+        self.selected_file = self
+            .selected_file
+            .take()
+            .map(|id| rewrite_path_id(&id, old_path, new_path));
+        self.selected_file_ids = self
+            .selected_file_ids
+            .iter()
+            .map(|id| rewrite_path_id(id, old_path, new_path))
+            .collect();
+        self.expanded_folders = self
+            .expanded_folders
+            .iter()
+            .map(|id| rewrite_path_id(id, old_path, new_path))
+            .collect();
+        self.expanded_folders.insert(target_parent_id);
+        Ok(())
+    }
+
+    pub(super) fn relocate_moved_files(
+        &mut self,
+        moves: &[(PathBuf, PathBuf)],
+        target_parent: &Path,
+    ) -> Result<(), String> {
+        let old_ids = moves
+            .iter()
+            .map(|(old_path, _)| path_id(old_path))
+            .collect::<HashSet<_>>();
+        let target_parent_id = path_id(target_parent);
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return Err(String::from(
+                "File move failed: selected source is unavailable",
+            ));
+        };
+        let Some(root_folder) = &mut source.root_folder else {
+            return Err(String::from("File move failed: source tree is unavailable"));
+        };
+        root_folder.remove_files_by_ids(&old_ids);
+        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
+            return Err(String::from(
+                "File move failed: target folder is unavailable",
+            ));
+        };
+        for (_, new_path) in moves {
+            upsert_file(&mut target_folder.files, file_entry(new_path));
+        }
+        self.folders = vec![root_folder.clone()];
+        let moved_ids = moves
+            .iter()
+            .map(|(_, new_path)| path_id(new_path))
+            .collect::<Vec<_>>();
+        let rewrite_file_id = |id: &str| {
+            moves
+                .iter()
+                .find(|(old_path, _)| path_id(old_path) == id)
+                .map(|(_, new_path)| path_id(new_path))
+                .unwrap_or_else(|| id.to_string())
+        };
+        let selected_file_was_moved = self
+            .selected_file
+            .as_ref()
+            .is_some_and(|id| old_ids.contains(id));
+        self.selected_file = if selected_file_was_moved {
+            self.selected_file.take().map(|id| rewrite_file_id(&id))
+        } else {
+            moved_ids.first().cloned()
+        };
+        self.selected_file_ids = if self.selected_file_ids.iter().any(|id| old_ids.contains(id)) {
+            self.selected_file_ids
+                .iter()
+                .map(|id| rewrite_file_id(id))
+                .collect()
+        } else {
+            moved_ids.iter().cloned().collect()
+        };
+        self.selected_folder = target_parent_id.clone();
+        self.file_view_start = 0;
+        self.expanded_folders.insert(target_parent_id);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- move folder/file drag-drop relocation bookkeeping into folder_browser/drag_drop_relocation.rs
- keep drag_drop.rs focused on drag state, previews, validation, and filesystem move orchestration
- reduce drag_drop.rs below the 400-line guideline

## Validation
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent