### PR TITLE
Extract folder rename tree updates

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -290,6 +290,7 @@ use scanning::{default_root_path, file_entry, load_root_folder};
 
 mod source_management;
 
+mod rename_tree;
 mod rename_workflow;
 
 mod state_types;

--- a/src/gui_app/folder_browser/rename_tree.rs
+++ b/src/gui_app/folder_browser/rename_tree.rs
@@ -1,0 +1,124 @@
+use std::path::Path;
+
+use super::{
+    FolderBrowserState, FolderEntry, FolderRenameKind,
+    path_helpers::{path_id, rewrite_path_id},
+    scanning::upsert_folder,
+};
+
+impl FolderBrowserState {
+    pub(super) fn rewrite_renamed_folder_paths(&mut self, old_path: &Path, new_path: &Path) {
+        let old_id = path_id(old_path);
+        let new_id = path_id(new_path);
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return;
+        };
+        if let Some(root_folder) = &mut source.root_folder {
+            root_folder.rewrite_path_prefix(old_path, new_path);
+            self.folders = vec![root_folder.clone()];
+        }
+        self.selected_folder = rewrite_path_id(&self.selected_folder, old_path, new_path);
+        if self.selected_folder == old_id {
+            self.selected_folder = new_id;
+        }
+        self.selected_file = self
+            .selected_file
+            .take()
+            .map(|id| rewrite_path_id(&id, old_path, new_path));
+        self.selected_file_ids = self
+            .selected_file_ids
+            .iter()
+            .map(|id| rewrite_path_id(id, old_path, new_path))
+            .collect();
+        self.expanded_folders = self
+            .expanded_folders
+            .iter()
+            .map(|id| rewrite_path_id(id, old_path, new_path))
+            .collect();
+    }
+
+    pub(super) fn rewrite_renamed_file_path(&mut self, old_path: &Path, new_path: &Path) {
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return;
+        };
+        if let Some(root_folder) = &mut source.root_folder {
+            root_folder.rewrite_file_path(old_path, new_path);
+            self.folders = vec![root_folder.clone()];
+        }
+        let new_id = path_id(new_path);
+        self.selected_file = Some(new_id);
+        self.selected_file_ids.clear();
+        self.selected_file_ids.insert(path_id(new_path));
+    }
+
+    pub(super) fn discard_pending_created_folder(&mut self) {
+        let Some(edit) = self.rename_edit.take() else {
+            return;
+        };
+        if let FolderRenameKind::Create { parent_id } = edit.kind {
+            self.remove_pending_created_folder(&edit.folder_id, &parent_id);
+        }
+    }
+
+    pub(super) fn remove_pending_created_folder(&mut self, folder_id: &str, parent_id: &str) {
+        self.remove_folder_by_id(folder_id);
+        if self.selected_folder == folder_id {
+            self.selected_folder = if self.find_folder(parent_id).is_some() {
+                parent_id.to_string()
+            } else {
+                self.folders
+                    .first()
+                    .map(|folder| folder.id.clone())
+                    .unwrap_or_default()
+            };
+        }
+        self.expanded_folders.remove(folder_id);
+    }
+
+    fn remove_folder_by_id(&mut self, folder_id: &str) -> bool {
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return false;
+        };
+        let Some(root_folder) = &mut source.root_folder else {
+            return false;
+        };
+        let changed = root_folder.remove_child_by_id(folder_id);
+        if changed {
+            self.folders = vec![root_folder.clone()];
+        }
+        changed
+    }
+
+    pub(super) fn upsert_child_folder(&mut self, parent_id: &str, folder: FolderEntry) -> bool {
+        let Some(source) = self
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.selected_source)
+        else {
+            return false;
+        };
+        let Some(root_folder) = &mut source.root_folder else {
+            return false;
+        };
+        let Some(parent) = root_folder.find_mut(parent_id) else {
+            return false;
+        };
+        let changed = upsert_folder(&mut parent.children, folder);
+        if changed {
+            self.folders = vec![root_folder.clone()];
+        }
+        changed
+    }
+}

--- a/src/gui_app/folder_browser/rename_workflow.rs
+++ b/src/gui_app/folder_browser/rename_workflow.rs
@@ -1,17 +1,13 @@
 use radiant::widgets::TextInputMessage;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 
 use super::{
     FileRenameEdit, FileRenameView, FolderBrowserState, FolderEntry, FolderRenameEdit,
     FolderRenameKind, RenameTargetView,
     path_helpers::{
         file_rename_draft, file_rename_input_id, folder_label, next_available_folder_name, path_id,
-        rename_input_id, resolved_file_rename, rewrite_path_id, valid_file_name, valid_folder_name,
+        rename_input_id, resolved_file_rename, valid_file_name, valid_folder_name,
     },
-    scanning::upsert_folder,
 };
 
 impl FolderBrowserState {
@@ -276,120 +272,5 @@ impl FolderBrowserState {
         }
         self.rewrite_renamed_file_path(&old_path, &new_path);
         format!("Renamed file to {new_name}")
-    }
-
-    fn rewrite_renamed_folder_paths(&mut self, old_path: &Path, new_path: &Path) {
-        let old_id = path_id(old_path);
-        let new_id = path_id(new_path);
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return;
-        };
-        if let Some(root_folder) = &mut source.root_folder {
-            root_folder.rewrite_path_prefix(old_path, new_path);
-            self.folders = vec![root_folder.clone()];
-        }
-        self.selected_folder = rewrite_path_id(&self.selected_folder, old_path, new_path);
-        if self.selected_folder == old_id {
-            self.selected_folder = new_id;
-        }
-        self.selected_file = self
-            .selected_file
-            .take()
-            .map(|id| rewrite_path_id(&id, old_path, new_path));
-        self.selected_file_ids = self
-            .selected_file_ids
-            .iter()
-            .map(|id| rewrite_path_id(id, old_path, new_path))
-            .collect();
-        self.expanded_folders = self
-            .expanded_folders
-            .iter()
-            .map(|id| rewrite_path_id(id, old_path, new_path))
-            .collect();
-    }
-
-    fn rewrite_renamed_file_path(&mut self, old_path: &Path, new_path: &Path) {
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return;
-        };
-        if let Some(root_folder) = &mut source.root_folder {
-            root_folder.rewrite_file_path(old_path, new_path);
-            self.folders = vec![root_folder.clone()];
-        }
-        let new_id = path_id(new_path);
-        self.selected_file = Some(new_id);
-        self.selected_file_ids.clear();
-        self.selected_file_ids.insert(path_id(new_path));
-    }
-
-    fn discard_pending_created_folder(&mut self) {
-        let Some(edit) = self.rename_edit.take() else {
-            return;
-        };
-        if let FolderRenameKind::Create { parent_id } = edit.kind {
-            self.remove_pending_created_folder(&edit.folder_id, &parent_id);
-        }
-    }
-
-    fn remove_pending_created_folder(&mut self, folder_id: &str, parent_id: &str) {
-        self.remove_folder_by_id(folder_id);
-        if self.selected_folder == folder_id {
-            self.selected_folder = if self.find_folder(parent_id).is_some() {
-                parent_id.to_string()
-            } else {
-                self.folders
-                    .first()
-                    .map(|folder| folder.id.clone())
-                    .unwrap_or_default()
-            };
-        }
-        self.expanded_folders.remove(folder_id);
-    }
-
-    fn remove_folder_by_id(&mut self, folder_id: &str) -> bool {
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let changed = root_folder.remove_child_by_id(folder_id);
-        if changed {
-            self.folders = vec![root_folder.clone()];
-        }
-        changed
-    }
-
-    fn upsert_child_folder(&mut self, parent_id: &str, folder: FolderEntry) -> bool {
-        let Some(source) = self
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let Some(parent) = root_folder.find_mut(parent_id) else {
-            return false;
-        };
-        let changed = upsert_folder(&mut parent.children, folder);
-        if changed {
-            self.folders = vec![root_folder.clone()];
-        }
-        changed
     }
 }


### PR DESCRIPTION
## Summary
- move rename tree-cache rewrite and pending-created-folder bookkeeping into folder_browser/rename_tree.rs
- keep rename_workflow.rs focused on rename/create flow and filesystem commit decisions
- reduce rename_workflow.rs from 395 lines to 276 lines

## Validation
- cargo test folder_browser --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent