### PR TITLE
Extract playback loop control

### DIFF
--- a/src/gui_app/playback.rs
+++ b/src/gui_app/playback.rs
@@ -1,8 +1,7 @@
 use super::*;
-use span::{
-    ResolvedPlaybackSpan, loop_retarget_offset_for_selection, playback_span_matches_selection,
-};
+use span::ResolvedPlaybackSpan;
 
+mod loop_control;
 mod span;
 
 impl GuiAppState {
@@ -188,115 +187,6 @@ impl GuiAppState {
             start_ratio,
             end_ratio,
             offset_ratio,
-        }
-    }
-
-    pub(super) fn toggle_loop_playback(&mut self) {
-        let started_at = Instant::now();
-        self.loop_playback = !self.loop_playback;
-        let mut outcome = "success";
-        let mut error = None;
-        if self.waveform.is_playing()
-            && let Some((start, end)) = self.current_playback_span
-        {
-            let current = self.current_audio_progress_ratio().unwrap_or(start);
-            let result = if self.loop_playback {
-                self.start_playback_span(start, end, Some(current))
-            } else {
-                self.start_playback_current_span(current.clamp(start, end), end)
-            };
-            if let Err(err) = result {
-                self.loop_playback = false;
-                self.sample_status = format!("Loop toggle failed: {err}");
-                outcome = "error";
-                error = Some(err);
-            }
-        }
-        if outcome == "success" {
-            self.sample_status = if self.loop_playback {
-                String::from("Loop playback enabled")
-            } else {
-                String::from("Loop playback disabled")
-            };
-        }
-        emit_gui_action(
-            "playback.loop.toggle",
-            Some("transport"),
-            None,
-            outcome,
-            started_at,
-            error.as_deref(),
-        );
-    }
-
-    pub(super) fn current_audio_progress_ratio(&self) -> Option<f32> {
-        self.audio_player
-            .as_ref()
-            .and_then(AudioPlayer::progress)
-            .or_else(|| self.waveform.playhead_ratio())
-    }
-
-    pub(super) fn recover_loop_playback(&mut self, reason: &'static str) -> Result<(), String> {
-        let Some((start, end)) = self.current_playback_span else {
-            return Err(String::from("No active playback span to loop"));
-        };
-        let offset = self.current_audio_progress_ratio().unwrap_or(start);
-        self.start_playback_span(start, end, Some(offset))?;
-        emit_gui_action(
-            "playback.loop.recover",
-            Some("transport"),
-            None,
-            reason,
-            Instant::now(),
-            None,
-        );
-        Ok(())
-    }
-
-    pub(super) fn retarget_loop_playback_to_play_selection(&mut self) {
-        if !self.loop_playback || !self.waveform.is_playing() {
-            return;
-        }
-        let Some(selection) = self
-            .waveform
-            .play_selection()
-            .filter(|selection| selection.width() > 0.0)
-        else {
-            return;
-        };
-        if playback_span_matches_selection(self.current_playback_span, selection) {
-            return;
-        }
-
-        let started_at = Instant::now();
-        let current = self
-            .current_audio_progress_ratio()
-            .unwrap_or_else(|| selection.start());
-        let offset = loop_retarget_offset_for_selection(current, selection);
-        match self.start_playback_span(selection.start(), selection.end(), Some(offset)) {
-            Ok(()) => {
-                let file_name = self.waveform.file_name();
-                self.sample_status = format!("Loop range updated | {file_name}");
-                emit_gui_action(
-                    "playback.loop.retarget",
-                    Some("waveform"),
-                    Some(&file_name),
-                    "success",
-                    started_at,
-                    None,
-                );
-            }
-            Err(err) => {
-                self.sample_status = format!("Loop retarget failed: {err}");
-                emit_gui_action(
-                    "playback.loop.retarget",
-                    Some("waveform"),
-                    None,
-                    "error",
-                    started_at,
-                    Some(&err),
-                );
-            }
         }
     }
 

--- a/src/gui_app/playback/loop_control.rs
+++ b/src/gui_app/playback/loop_control.rs
@@ -1,0 +1,115 @@
+use super::{
+    AudioPlayer, GuiAppState, Instant, emit_gui_action,
+    span::{loop_retarget_offset_for_selection, playback_span_matches_selection},
+};
+
+impl GuiAppState {
+    pub(in crate::gui_app) fn toggle_loop_playback(&mut self) {
+        let started_at = Instant::now();
+        self.loop_playback = !self.loop_playback;
+        let mut outcome = "success";
+        let mut error = None;
+        if self.waveform.is_playing()
+            && let Some((start, end)) = self.current_playback_span
+        {
+            let current = self.current_audio_progress_ratio().unwrap_or(start);
+            let result = if self.loop_playback {
+                self.start_playback_span(start, end, Some(current))
+            } else {
+                self.start_playback_current_span(current.clamp(start, end), end)
+            };
+            if let Err(err) = result {
+                self.loop_playback = false;
+                self.sample_status = format!("Loop toggle failed: {err}");
+                outcome = "error";
+                error = Some(err);
+            }
+        }
+        if outcome == "success" {
+            self.sample_status = if self.loop_playback {
+                String::from("Loop playback enabled")
+            } else {
+                String::from("Loop playback disabled")
+            };
+        }
+        emit_gui_action(
+            "playback.loop.toggle",
+            Some("transport"),
+            None,
+            outcome,
+            started_at,
+            error.as_deref(),
+        );
+    }
+
+    pub(in crate::gui_app) fn current_audio_progress_ratio(&self) -> Option<f32> {
+        self.audio_player
+            .as_ref()
+            .and_then(AudioPlayer::progress)
+            .or_else(|| self.waveform.playhead_ratio())
+    }
+
+    pub(super) fn recover_loop_playback(&mut self, reason: &'static str) -> Result<(), String> {
+        let Some((start, end)) = self.current_playback_span else {
+            return Err(String::from("No active playback span to loop"));
+        };
+        let offset = self.current_audio_progress_ratio().unwrap_or(start);
+        self.start_playback_span(start, end, Some(offset))?;
+        emit_gui_action(
+            "playback.loop.recover",
+            Some("transport"),
+            None,
+            reason,
+            Instant::now(),
+            None,
+        );
+        Ok(())
+    }
+
+    pub(in crate::gui_app) fn retarget_loop_playback_to_play_selection(&mut self) {
+        if !self.loop_playback || !self.waveform.is_playing() {
+            return;
+        }
+        let Some(selection) = self
+            .waveform
+            .play_selection()
+            .filter(|selection| selection.width() > 0.0)
+        else {
+            return;
+        };
+        if playback_span_matches_selection(self.current_playback_span, selection) {
+            return;
+        }
+
+        let started_at = Instant::now();
+        let current = self
+            .current_audio_progress_ratio()
+            .unwrap_or_else(|| selection.start());
+        let offset = loop_retarget_offset_for_selection(current, selection);
+        match self.start_playback_span(selection.start(), selection.end(), Some(offset)) {
+            Ok(()) => {
+                let file_name = self.waveform.file_name();
+                self.sample_status = format!("Loop range updated | {file_name}");
+                emit_gui_action(
+                    "playback.loop.retarget",
+                    Some("waveform"),
+                    Some(&file_name),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Err(err) => {
+                self.sample_status = format!("Loop retarget failed: {err}");
+                emit_gui_action(
+                    "playback.loop.retarget",
+                    Some("waveform"),
+                    None,
+                    "error",
+                    started_at,
+                    Some(&err),
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move loop toggle, recovery, progress lookup, and play-selection retargeting into playback/loop_control.rs
- keep playback.rs focused on transport start/stop, span resolution, player setup, and progress refresh
- reduce playback.rs from 377 lines to 267 lines

## Validation
- cargo test playback --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent