### PR TITLE
Extract waveform widget input

### DIFF
--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -255,6 +255,7 @@ pub(super) use widget::WaveformWidgetProps;
 pub(super) use widget::{WaveformWidget, waveform_viewport_view};
 
 mod widget_geometry;
+mod widget_input;
 
 mod edit_fade_curve_paint;
 mod edit_fade_paint;

--- a/src/gui_app/waveform/widget.rs
+++ b/src/gui_app/waveform/widget.rs
@@ -1,13 +1,12 @@
 use radiant::{
-    gui::types::{Point, Rect, Vector2},
+    gui::types::{Rect, Vector2},
     gui::visualization::TimelineEditPreview,
     layout::LayoutOutput,
     prelude as ui,
     runtime::PaintPrimitive,
     theme::ThemeTokens,
     widgets::{
-        FocusBehavior, PaintBounds, PointerButton, Widget, WidgetCommon, WidgetInput, WidgetOutput,
-        WidgetSizing,
+        FocusBehavior, PaintBounds, Widget, WidgetCommon, WidgetInput, WidgetOutput, WidgetSizing,
     },
 };
 use std::sync::Arc;
@@ -15,9 +14,8 @@ use std::sync::Arc;
 use crate::gui_app::GuiMessage;
 
 use super::{
-    WAVEFORM_HEIGHT, WAVEFORM_WIDTH, WaveformActiveDragKind, WaveformEditFadeHandle, WaveformFile,
-    WaveformInteraction, WaveformSelectionKind, WaveformSignalWidget, WaveformState,
-    WaveformViewport, edit_preview_for_selection,
+    WAVEFORM_HEIGHT, WAVEFORM_WIDTH, WaveformActiveDragKind, WaveformFile, WaveformInteraction,
+    WaveformSignalWidget, WaveformState, WaveformViewport, edit_preview_for_selection,
 };
 
 pub(in crate::gui_app) fn waveform_viewport_view(state: &WaveformState) -> ui::View<GuiMessage> {
@@ -59,7 +57,7 @@ pub(in crate::gui_app) struct WaveformWidgetProps {
     play_selection: Option<wavecrate::selection::SelectionRange>,
     edit_selection: Option<wavecrate::selection::SelectionRange>,
     play_selection_flash_frames: u8,
-    active_drag_kind: Option<WaveformActiveDragKind>,
+    pub(in crate::gui_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
 impl WaveformWidgetProps {
@@ -90,7 +88,7 @@ pub(in crate::gui_app) struct WaveformWidget {
     pub(super) edit_selection: Option<wavecrate::selection::SelectionRange>,
     pub(super) play_selection_flash_frames: u8,
     pub(super) edit_preview: TimelineEditPreview,
-    active_drag_kind: Option<WaveformActiveDragKind>,
+    pub(in crate::gui_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
 impl WaveformWidget {
@@ -128,10 +126,6 @@ impl WaveformWidget {
             active_drag_kind,
         }
     }
-
-    fn ratio_from_position(&self, bounds: Rect, position: Point) -> f32 {
-        ((position.x - bounds.min.x) / bounds.width().max(1.0)).clamp(0.0, 1.0)
-    }
 }
 
 impl Widget for WaveformWidget {
@@ -144,74 +138,7 @@ impl Widget for WaveformWidget {
     }
 
     fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
-        match input {
-            WidgetInput::PointerMove { position } => {
-                self.common.state.hovered = bounds.contains(position);
-                self.active_drag_kind.map(|_| {
-                    WidgetOutput::typed(WaveformInteraction::UpdateSelection {
-                        visible_ratio: self.ratio_from_position(bounds, position),
-                    })
-                })
-            }
-            WidgetInput::Wheel { position, delta } if bounds.contains(position) => {
-                Some(WidgetOutput::typed(WaveformInteraction::Wheel {
-                    delta,
-                    anchor_ratio: self.ratio_from_position(bounds, position),
-                }))
-            }
-            WidgetInput::PointerPress {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } if bounds.contains(position) => self.handle_primary_press(bounds, position),
-            WidgetInput::PointerDoubleClick {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } if bounds.contains(position) => self.handle_primary_double_click(bounds, position),
-            WidgetInput::PointerPress {
-                position,
-                button: PointerButton::Secondary,
-                ..
-            } if bounds.contains(position) => self.handle_secondary_press(bounds, position),
-            WidgetInput::PointerPress {
-                position,
-                button: PointerButton::Auxiliary,
-                ..
-            } if bounds.contains(position) => {
-                Some(WidgetOutput::typed(WaveformInteraction::BeginPan {
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                }))
-            }
-            WidgetInput::PointerRelease {
-                position,
-                button: PointerButton::Primary,
-                ..
-            } if self.primary_release_finishes_drag() => {
-                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                }))
-            }
-            WidgetInput::PointerRelease {
-                position,
-                button: PointerButton::Secondary,
-                ..
-            } if self.secondary_release_finishes_drag() => {
-                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                }))
-            }
-            WidgetInput::PointerRelease {
-                position,
-                button: PointerButton::Auxiliary,
-                ..
-            } if self.active_drag_kind == Some(WaveformActiveDragKind::Pan) => {
-                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                }))
-            }
-            _ => None,
-        }
+        self.handle_waveform_input(bounds, input)
     }
 
     fn accepts_wheel_input(&self) -> bool {
@@ -227,110 +154,5 @@ impl Widget for WaveformWidget {
     ) {
         self.append_selection_and_marker_paint(primitives, bounds);
         self.append_edit_fade_paint(primitives, bounds);
-    }
-}
-
-impl WaveformWidget {
-    fn handle_primary_press(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
-        if let Some(handle) = self.edit_fade_handle_at(bounds, position) {
-            return Some(WidgetOutput::typed(WaveformInteraction::BeginEditFade {
-                handle,
-                visible_ratio: self.ratio_from_position(bounds, position),
-            }));
-        }
-        if let Some(edge) =
-            self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Play)
-        {
-            return Some(WidgetOutput::typed(
-                WaveformInteraction::BeginSelectionResize {
-                    kind: WaveformSelectionKind::Play,
-                    edge,
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                },
-            ));
-        }
-        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Play) {
-            return Some(WidgetOutput::typed(
-                WaveformInteraction::BeginSelectionMove {
-                    kind: WaveformSelectionKind::Play,
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                },
-            ));
-        }
-        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Edit) {
-            return Some(WidgetOutput::typed(
-                WaveformInteraction::BeginSelectionMove {
-                    kind: WaveformSelectionKind::Edit,
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                },
-            ));
-        }
-        Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
-            kind: WaveformSelectionKind::Play,
-            visible_ratio: self.ratio_from_position(bounds, position),
-        }))
-    }
-
-    fn handle_primary_double_click(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
-        if let Some(
-            handle @ (WaveformEditFadeHandle::FadeInOuterStart
-            | WaveformEditFadeHandle::FadeOutOuterEnd),
-        ) = self.edit_fade_handle_at(bounds, position)
-        {
-            return Some(WidgetOutput::typed(
-                WaveformInteraction::ClearEditFadeSilence { handle },
-            ));
-        }
-        None
-    }
-
-    fn handle_secondary_press(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
-        if let Some(handle) = self.edit_fade_handle_at(bounds, position) {
-            return Some(WidgetOutput::typed(WaveformInteraction::BeginEditFade {
-                handle,
-                visible_ratio: self.ratio_from_position(bounds, position),
-            }));
-        }
-        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Edit) {
-            return Some(WidgetOutput::typed(
-                WaveformInteraction::BeginSelectionMove {
-                    kind: WaveformSelectionKind::Edit,
-                    visible_ratio: self.ratio_from_position(bounds, position),
-                },
-            ));
-        }
-        Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
-            kind: WaveformSelectionKind::Edit,
-            visible_ratio: self.ratio_from_position(bounds, position),
-        }))
-    }
-
-    fn primary_release_finishes_drag(&self) -> bool {
-        self.active_drag_kind
-            == Some(WaveformActiveDragKind::Selection(
-                WaveformSelectionKind::Play,
-            ))
-            || matches!(
-                self.active_drag_kind,
-                Some(
-                    WaveformActiveDragKind::EditFade(_)
-                        | WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, _)
-                        | WaveformActiveDragKind::SelectionMove(_)
-                )
-            )
-    }
-
-    fn secondary_release_finishes_drag(&self) -> bool {
-        self.active_drag_kind
-            == Some(WaveformActiveDragKind::Selection(
-                WaveformSelectionKind::Edit,
-            ))
-            || matches!(
-                self.active_drag_kind,
-                Some(
-                    WaveformActiveDragKind::EditFade(_)
-                        | WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Edit)
-                )
-            )
     }
 }

--- a/src/gui_app/waveform/widget_input.rs
+++ b/src/gui_app/waveform/widget_input.rs
@@ -1,0 +1,193 @@
+use radiant::{
+    gui::types::{Point, Rect},
+    widgets::{PointerButton, WidgetInput, WidgetOutput},
+};
+
+use super::{
+    WaveformActiveDragKind, WaveformEditFadeHandle, WaveformInteraction, WaveformSelectionKind,
+    WaveformWidget,
+};
+
+impl WaveformWidget {
+    pub(in crate::gui_app::waveform) fn handle_waveform_input(
+        &mut self,
+        bounds: Rect,
+        input: WidgetInput,
+    ) -> Option<WidgetOutput> {
+        match input {
+            WidgetInput::PointerMove { position } => {
+                self.common.state.hovered = bounds.contains(position);
+                self.active_drag_kind.map(|_| {
+                    WidgetOutput::typed(WaveformInteraction::UpdateSelection {
+                        visible_ratio: self.ratio_from_position(bounds, position),
+                    })
+                })
+            }
+            WidgetInput::Wheel { position, delta } if bounds.contains(position) => {
+                Some(WidgetOutput::typed(WaveformInteraction::Wheel {
+                    delta,
+                    anchor_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if bounds.contains(position) => self.handle_primary_press(bounds, position),
+            WidgetInput::PointerDoubleClick {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if bounds.contains(position) => self.handle_primary_double_click(bounds, position),
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Secondary,
+                ..
+            } if bounds.contains(position) => self.handle_secondary_press(bounds, position),
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Auxiliary,
+                ..
+            } if bounds.contains(position) => {
+                Some(WidgetOutput::typed(WaveformInteraction::BeginPan {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if self.primary_release_finishes_drag() => {
+                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Secondary,
+                ..
+            } if self.secondary_release_finishes_drag() => {
+                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Auxiliary,
+                ..
+            } if self.active_drag_kind == Some(WaveformActiveDragKind::Pan) => {
+                Some(WidgetOutput::typed(WaveformInteraction::FinishSelection {
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                }))
+            }
+            _ => None,
+        }
+    }
+
+    fn ratio_from_position(&self, bounds: Rect, position: Point) -> f32 {
+        ((position.x - bounds.min.x) / bounds.width().max(1.0)).clamp(0.0, 1.0)
+    }
+
+    fn handle_primary_press(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
+        if let Some(handle) = self.edit_fade_handle_at(bounds, position) {
+            return Some(WidgetOutput::typed(WaveformInteraction::BeginEditFade {
+                handle,
+                visible_ratio: self.ratio_from_position(bounds, position),
+            }));
+        }
+        if let Some(edge) =
+            self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Play)
+        {
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::BeginSelectionResize {
+                    kind: WaveformSelectionKind::Play,
+                    edge,
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                },
+            ));
+        }
+        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Play) {
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::BeginSelectionMove {
+                    kind: WaveformSelectionKind::Play,
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                },
+            ));
+        }
+        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Edit) {
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::BeginSelectionMove {
+                    kind: WaveformSelectionKind::Edit,
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                },
+            ));
+        }
+        Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Play,
+            visible_ratio: self.ratio_from_position(bounds, position),
+        }))
+    }
+
+    fn handle_primary_double_click(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
+        if let Some(
+            handle @ (WaveformEditFadeHandle::FadeInOuterStart
+            | WaveformEditFadeHandle::FadeOutOuterEnd),
+        ) = self.edit_fade_handle_at(bounds, position)
+        {
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::ClearEditFadeSilence { handle },
+            ));
+        }
+        None
+    }
+
+    fn handle_secondary_press(&self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
+        if let Some(handle) = self.edit_fade_handle_at(bounds, position) {
+            return Some(WidgetOutput::typed(WaveformInteraction::BeginEditFade {
+                handle,
+                visible_ratio: self.ratio_from_position(bounds, position),
+            }));
+        }
+        if self.selection_move_handle_at(bounds, position, WaveformSelectionKind::Edit) {
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::BeginSelectionMove {
+                    kind: WaveformSelectionKind::Edit,
+                    visible_ratio: self.ratio_from_position(bounds, position),
+                },
+            ));
+        }
+        Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Edit,
+            visible_ratio: self.ratio_from_position(bounds, position),
+        }))
+    }
+
+    fn primary_release_finishes_drag(&self) -> bool {
+        self.active_drag_kind
+            == Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Play,
+            ))
+            || matches!(
+                self.active_drag_kind,
+                Some(
+                    WaveformActiveDragKind::EditFade(_)
+                        | WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, _)
+                        | WaveformActiveDragKind::SelectionMove(_)
+                )
+            )
+    }
+
+    fn secondary_release_finishes_drag(&self) -> bool {
+        self.active_drag_kind
+            == Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Edit,
+            ))
+            || matches!(
+                self.active_drag_kind,
+                Some(
+                    WaveformActiveDragKind::EditFade(_)
+                        | WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Edit)
+                )
+            )
+    }
+}


### PR DESCRIPTION
## Summary
- move pointer and wheel input routing into waveform/widget_input.rs
- keep widget.rs focused on view construction, widget state, trait shell, and paint hookup
- reduce widget.rs from 336 lines to 158 lines

## Validation
- cargo test widget_input --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent