### PR TITLE
Extract folder file entry metadata

### DIFF
--- a/src/gui_app/folder_browser/scanning.rs
+++ b/src/gui_app/folder_browser/scanning.rs
@@ -1,17 +1,19 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    time::{Duration, SystemTime},
 };
 
 use super::{
     FileEntry, FolderEntry,
-    path_helpers::{file_extension_label, file_label, file_stem_label, folder_label, path_id},
+    path_helpers::{file_label, folder_label, path_id},
     types::{
         FolderScanDiscovery, FolderScanItem, FolderScanProgress, FolderScanRequest,
         FolderScanResult,
     },
 };
+
+mod file_entry_metadata;
+pub(super) use file_entry_metadata::file_entry;
 
 const MAX_SCAN_DEPTH: usize = 3;
 const MAX_CHILD_FOLDERS: usize = 80;
@@ -234,77 +236,6 @@ pub(super) fn upsert_file(files: &mut Vec<FileEntry>, file: FileEntry) -> bool {
             true
         }
     }
-}
-
-pub(super) fn file_entry(path: &PathBuf) -> FileEntry {
-    let metadata = fs::metadata(path).ok();
-    let size_bytes = metadata.as_ref().map(fs::Metadata::len).unwrap_or_default();
-    let modified = metadata.and_then(|metadata| metadata.modified().ok());
-    FileEntry {
-        id: path_id(path),
-        name: file_label(path),
-        stem: file_stem_label(path),
-        extension: file_extension_label(path),
-        kind: file_kind(path),
-        size: format_size(size_bytes),
-        size_bytes,
-        modified: modified_label(modified),
-        modified_rank: modified_rank(modified),
-    }
-}
-
-fn file_kind(path: &Path) -> String {
-    match path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("wav") => String::from("Audio"),
-        Some("aif" | "aiff" | "flac" | "mp3") => String::from("Unsupported audio"),
-        Some("png" | "jpg" | "jpeg" | "gif" | "webp") => String::from("Image"),
-        Some("json" | "txt" | "md" | "toml" | "rs") => String::from("Text"),
-        _ => String::from("File"),
-    }
-}
-
-fn format_size(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = KB * 1024;
-    const GB: u64 = MB * 1024;
-    if bytes >= GB {
-        format!("{} GB", bytes / GB)
-    } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{} KB", bytes / KB)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
-fn modified_label(modified: Option<SystemTime>) -> String {
-    let Some(modified) = modified else {
-        return String::from("-");
-    };
-    let age = SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or(Duration::ZERO);
-    let days = age.as_secs() / 86_400;
-    if days == 0 {
-        String::from("Today")
-    } else if days == 1 {
-        String::from("1 day")
-    } else {
-        format!("{days} days")
-    }
-}
-
-fn modified_rank(modified: Option<SystemTime>) -> u64 {
-    modified
-        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-        .map(|age| age.as_secs())
-        .unwrap_or(u64::MAX)
 }
 
 fn read_sorted_entries(path: &Path) -> Vec<PathBuf> {

--- a/src/gui_app/folder_browser/scanning/file_entry_metadata.rs
+++ b/src/gui_app/folder_browser/scanning/file_entry_metadata.rs
@@ -1,0 +1,81 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+
+use super::super::{
+    FileEntry,
+    path_helpers::{file_extension_label, file_label, file_stem_label, path_id},
+};
+
+pub(in crate::gui_app::folder_browser) fn file_entry(path: &PathBuf) -> FileEntry {
+    let metadata = fs::metadata(path).ok();
+    let size_bytes = metadata.as_ref().map(fs::Metadata::len).unwrap_or_default();
+    let modified = metadata.and_then(|metadata| metadata.modified().ok());
+    FileEntry {
+        id: path_id(path),
+        name: file_label(path),
+        stem: file_stem_label(path),
+        extension: file_extension_label(path),
+        kind: file_kind(path),
+        size: format_size(size_bytes),
+        size_bytes,
+        modified: modified_label(modified),
+        modified_rank: modified_rank(modified),
+    }
+}
+
+fn file_kind(path: &Path) -> String {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("wav") => String::from("Audio"),
+        Some("aif" | "aiff" | "flac" | "mp3") => String::from("Unsupported audio"),
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp") => String::from("Image"),
+        Some("json" | "txt" | "md" | "toml" | "rs") => String::from("Text"),
+        _ => String::from("File"),
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{} GB", bytes / GB)
+    } else if bytes >= MB {
+        format!("{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn modified_label(modified: Option<SystemTime>) -> String {
+    let Some(modified) = modified else {
+        return String::from("-");
+    };
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::ZERO);
+    let days = age.as_secs() / 86_400;
+    if days == 0 {
+        String::from("Today")
+    } else if days == 1 {
+        String::from("1 day")
+    } else {
+        format!("{days} days")
+    }
+}
+
+fn modified_rank(modified: Option<SystemTime>) -> u64 {
+    modified
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .map(|age| age.as_secs())
+        .unwrap_or(u64::MAX)
+}


### PR DESCRIPTION
## Summary
- move filesystem file-row metadata construction into scanning/file_entry_metadata.rs
- keep scanning.rs focused on folder walking, progress, discovery, and tree merge helpers
- reduce scanning.rs from 324 lines to 255 lines

## Validation
- cargo test scanning --bin wavecrate
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent