### PR TITLE
Extract file rename workflow

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -182,6 +182,8 @@ mod file_selection;
 
 mod file_view_window;
 
+mod file_rename_workflow;
+
 mod file_columns;
 #[cfg(test)]
 pub(super) use file_columns::MIN_FILE_COLUMN_WIDTH;

--- a/src/gui_app/folder_browser/file_rename_workflow.rs
+++ b/src/gui_app/folder_browser/file_rename_workflow.rs
@@ -1,0 +1,71 @@
+use std::{fs, path::PathBuf};
+
+use super::{
+    FileRenameEdit, FileRenameView, FolderBrowserState,
+    path_helpers::{
+        file_rename_draft, file_rename_input_id, resolved_file_rename, valid_file_name,
+    },
+};
+
+impl FolderBrowserState {
+    pub(in crate::gui_app) fn file_rename_view(&self, file_id: &str) -> Option<FileRenameView> {
+        self.file_rename_edit
+            .as_ref()
+            .filter(|edit| edit.file_id == file_id)
+            .map(|edit| FileRenameView {
+                draft: edit.draft.clone(),
+                input_id: edit.input_id,
+                selection_start: edit.selection_start,
+                selection_end: edit.selection_end,
+            })
+    }
+
+    pub(super) fn begin_file_rename_selected(&mut self) -> Option<u64> {
+        let file_id = self.selected_file.clone()?;
+        let (file_id, file_name) = self
+            .selected_audio_files()
+            .into_iter()
+            .find(|file| file.id == file_id)
+            .map(|file| (file.id.clone(), file.name.clone()))?;
+
+        let input_id = file_rename_input_id(&file_id);
+        let draft = file_rename_draft(&file_name);
+        let selection_end = draft.chars().count();
+        self.file_rename_edit = Some(FileRenameEdit {
+            file_id,
+            draft,
+            input_id,
+            selection_start: 0,
+            selection_end,
+        });
+        Some(input_id)
+    }
+
+    pub(super) fn commit_file_rename(&mut self, value: String) -> String {
+        let Some(edit) = self.file_rename_edit.take() else {
+            return String::from("No file rename in progress");
+        };
+        let old_path = PathBuf::from(&edit.file_id);
+        let Some(parent) = old_path.parent() else {
+            return String::from("File rename failed: selected file has no parent");
+        };
+        let Some(new_name) = resolved_file_rename(&old_path, value.trim()) else {
+            return String::from("File rename failed: use a plain file name");
+        };
+        if !valid_file_name(&new_name) {
+            return String::from("File rename failed: use a plain file name");
+        }
+        let new_path = parent.join(&new_name);
+        if old_path == new_path {
+            return String::from("File rename unchanged");
+        }
+        if new_path.exists() {
+            return format!("File rename failed: {new_name} already exists");
+        }
+        if let Err(error) = fs::rename(&old_path, &new_path) {
+            return format!("File rename failed: {error}");
+        }
+        self.rewrite_renamed_file_path(&old_path, &new_path);
+        format!("Renamed file to {new_name}")
+    }
+}

--- a/src/gui_app/folder_browser/rename_workflow.rs
+++ b/src/gui_app/folder_browser/rename_workflow.rs
@@ -2,11 +2,9 @@ use radiant::widgets::TextInputMessage;
 use std::{fs, path::PathBuf};
 
 use super::{
-    FileRenameEdit, FileRenameView, FolderBrowserState, FolderEntry, FolderRenameEdit,
-    FolderRenameKind, RenameTargetView,
+    FolderBrowserState, FolderEntry, FolderRenameEdit, FolderRenameKind, RenameTargetView,
     path_helpers::{
-        file_rename_draft, file_rename_input_id, folder_label, next_available_folder_name, path_id,
-        rename_input_id, resolved_file_rename, valid_file_name, valid_folder_name,
+        folder_label, next_available_folder_name, path_id, rename_input_id, valid_folder_name,
     },
 };
 
@@ -42,39 +40,10 @@ impl FolderBrowserState {
         }
     }
 
-    pub(in crate::gui_app) fn file_rename_view(&self, file_id: &str) -> Option<FileRenameView> {
-        self.file_rename_edit
-            .as_ref()
-            .filter(|edit| edit.file_id == file_id)
-            .map(|edit| FileRenameView {
-                draft: edit.draft.clone(),
-                input_id: edit.input_id,
-                selection_start: edit.selection_start,
-                selection_end: edit.selection_end,
-            })
-    }
-
     pub(in crate::gui_app) fn begin_rename_selected(&mut self) -> Result<Option<u64>, String> {
         self.discard_pending_created_folder();
-        if let Some(file_id) = self.selected_file.clone() {
-            if let Some((file_id, file_name)) = self
-                .selected_audio_files()
-                .into_iter()
-                .find(|file| file.id == file_id)
-                .map(|file| (file.id.clone(), file.name.clone()))
-            {
-                let input_id = file_rename_input_id(&file_id);
-                let draft = file_rename_draft(&file_name);
-                let selection_end = draft.chars().count();
-                self.file_rename_edit = Some(FileRenameEdit {
-                    file_id,
-                    draft,
-                    input_id,
-                    selection_start: 0,
-                    selection_end,
-                });
-                return Ok(Some(input_id));
-            }
+        if let Some(input_id) = self.begin_file_rename_selected() {
+            return Ok(Some(input_id));
         }
 
         let Some(folder) = self.find_folder(&self.selected_folder) else {
@@ -244,33 +213,5 @@ impl FolderBrowserState {
         self.selected_file_ids.clear();
         self.file_view_start = 0;
         format!("Created folder {new_name}")
-    }
-
-    fn commit_file_rename(&mut self, value: String) -> String {
-        let Some(edit) = self.file_rename_edit.take() else {
-            return String::from("No file rename in progress");
-        };
-        let old_path = PathBuf::from(&edit.file_id);
-        let Some(parent) = old_path.parent() else {
-            return String::from("File rename failed: selected file has no parent");
-        };
-        let Some(new_name) = resolved_file_rename(&old_path, value.trim()) else {
-            return String::from("File rename failed: use a plain file name");
-        };
-        if !valid_file_name(&new_name) {
-            return String::from("File rename failed: use a plain file name");
-        }
-        let new_path = parent.join(&new_name);
-        if old_path == new_path {
-            return String::from("File rename unchanged");
-        }
-        if new_path.exists() {
-            return format!("File rename failed: {new_name} already exists");
-        }
-        if let Err(error) = fs::rename(&old_path, &new_path) {
-            return format!("File rename failed: {error}");
-        }
-        self.rewrite_renamed_file_path(&old_path, &new_path);
-        format!("Renamed file to {new_name}")
     }
 }


### PR DESCRIPTION
## Summary
- Move file rename view/setup/commit behavior into `file_rename_workflow.rs`
- Keep `rename_workflow.rs` focused on shared rename input dispatch plus folder rename/create behavior
- Register the new focused folder-browser module beside the existing file-selection/view-window seams

## Validation
- `cargo test rename --bin wavecrate`
- `powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent`