### PR TITLE
Extract waveform state selection helpers

### DIFF
--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -234,6 +234,7 @@ mod interaction;
 use interaction::{WaveformDrag, edit_preview_for_selection};
 
 mod state_interaction;
+mod state_selection;
 mod state_viewport;
 
 mod audio_file;

--- a/src/gui_app/waveform/state_interaction.rs
+++ b/src/gui_app/waveform/state_interaction.rs
@@ -177,21 +177,6 @@ impl WaveformState {
         }
     }
 
-    fn set_selection_for_drag(&mut self, drag: WaveformSelectionDrag) {
-        let range =
-            wavecrate::selection::SelectionRange::new(drag.anchor_ratio, drag.current_ratio);
-        match drag.kind {
-            WaveformSelectionKind::Play => {
-                self.play_mark_ratio = Some(drag.anchor_ratio);
-                self.play_selection = Some(range);
-            }
-            WaveformSelectionKind::Edit => {
-                self.edit_mark_ratio = Some(drag.anchor_ratio);
-                self.edit_selection = Some(range);
-            }
-        }
-    }
-
     fn update_active_edit_fade(&mut self, ratio: f32) {
         let Some(WaveformDrag::EditFade(drag)) = self.active_drag else {
             return;
@@ -217,53 +202,6 @@ impl WaveformState {
         };
         if let Some(next) = next {
             self.edit_selection = Some(next);
-        }
-    }
-
-    fn update_active_selection_resize(&mut self, ratio: f32) {
-        let Some(WaveformDrag::SelectionResize(drag)) = self.active_drag else {
-            return;
-        };
-        let Some(selection) = self.selection_for_kind(drag.kind) else {
-            return;
-        };
-        let selection = drag.apply(selection, ratio);
-        match drag.kind {
-            WaveformSelectionKind::Play => {
-                self.play_mark_ratio = Some(selection.start());
-                self.play_selection = Some(selection);
-            }
-            WaveformSelectionKind::Edit => {
-                self.edit_mark_ratio = Some(selection.start());
-                self.edit_selection = Some(selection);
-            }
-        }
-    }
-
-    fn update_active_selection_move(&mut self, ratio: f32) {
-        let Some(WaveformDrag::SelectionMove(drag)) = self.active_drag else {
-            return;
-        };
-        let selection = drag.apply(ratio);
-        match drag.kind {
-            WaveformSelectionKind::Play => {
-                self.play_mark_ratio = Some(selection.start());
-                self.play_selection = Some(selection);
-            }
-            WaveformSelectionKind::Edit => {
-                self.edit_mark_ratio = Some(selection.start());
-                self.edit_selection = Some(selection);
-            }
-        }
-    }
-
-    fn selection_for_kind(
-        &self,
-        kind: WaveformSelectionKind,
-    ) -> Option<wavecrate::selection::SelectionRange> {
-        match kind {
-            WaveformSelectionKind::Play => self.play_selection,
-            WaveformSelectionKind::Edit => self.edit_selection,
         }
     }
 }

--- a/src/gui_app/waveform/state_selection.rs
+++ b/src/gui_app/waveform/state_selection.rs
@@ -1,0 +1,57 @@
+use super::{
+    WaveformSelectionKind, WaveformState,
+    interaction::{WaveformDrag, WaveformSelectionDrag},
+};
+
+type SelectionRange = wavecrate::selection::SelectionRange;
+
+impl WaveformState {
+    pub(super) fn set_selection_for_drag(&mut self, drag: WaveformSelectionDrag) {
+        let range = SelectionRange::new(drag.anchor_ratio, drag.current_ratio);
+        self.set_selection_for_kind(drag.kind, drag.anchor_ratio, range);
+    }
+
+    pub(super) fn update_active_selection_resize(&mut self, ratio: f32) {
+        let Some(WaveformDrag::SelectionResize(drag)) = self.active_drag else {
+            return;
+        };
+        let Some(selection) = self.selection_for_kind(drag.kind) else {
+            return;
+        };
+        let selection = drag.apply(selection, ratio);
+        self.set_selection_for_kind(drag.kind, selection.start(), selection);
+    }
+
+    pub(super) fn update_active_selection_move(&mut self, ratio: f32) {
+        let Some(WaveformDrag::SelectionMove(drag)) = self.active_drag else {
+            return;
+        };
+        let selection = drag.apply(ratio);
+        self.set_selection_for_kind(drag.kind, selection.start(), selection);
+    }
+
+    pub(super) fn selection_for_kind(&self, kind: WaveformSelectionKind) -> Option<SelectionRange> {
+        match kind {
+            WaveformSelectionKind::Play => self.play_selection,
+            WaveformSelectionKind::Edit => self.edit_selection,
+        }
+    }
+
+    fn set_selection_for_kind(
+        &mut self,
+        kind: WaveformSelectionKind,
+        mark_ratio: f32,
+        selection: SelectionRange,
+    ) {
+        match kind {
+            WaveformSelectionKind::Play => {
+                self.play_mark_ratio = Some(mark_ratio);
+                self.play_selection = Some(selection);
+            }
+            WaveformSelectionKind::Edit => {
+                self.edit_mark_ratio = Some(mark_ratio);
+                self.edit_selection = Some(selection);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move waveform selection lookup and mutation helpers into `state_selection.rs`
- Keep `state_interaction.rs` focused on the interaction state machine and drag dispatch
- Reuse a single `set_selection_for_kind` helper for drag, resize, and move updates

## Validation
- `cargo test -p wavecrate gui_app::waveform`
- `cargo test --manifest-path vendor/radiant/Cargo.toml --test app_runtime_api lifecycle::app_startup_commands_use_full_runtime_dispatch --no-default-features -- --test-threads=1`
- `powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent`

Note: an initial broad `cargo test -p wavecrate selection --lib` hit an unrelated auto-rename log assertion outside this Wavecrate UI refactor. The focused waveform suite and final agent gate passed.