### PR TITLE
Extract scan discovery merge helpers

### DIFF
--- a/src/gui_app/folder_browser/scanning.rs
+++ b/src/gui_app/folder_browser/scanning.rs
@@ -12,7 +12,9 @@ use super::{
     },
 };
 
+mod discovery_merge;
 mod file_entry_metadata;
+pub(super) use discovery_merge::{merge_scan_discovery, upsert_file, upsert_folder};
 pub(super) use file_entry_metadata::file_entry;
 
 const MAX_SCAN_DEPTH: usize = 3;
@@ -217,54 +219,6 @@ where
         children,
         files,
     })
-}
-
-pub(super) fn merge_scan_discovery(root: &mut FolderEntry, event: &FolderScanDiscovery) -> bool {
-    let Some(parent) = root.find_mut(&event.parent_id) else {
-        return false;
-    };
-    match &event.item {
-        FolderScanItem::Folder(folder) => upsert_folder(&mut parent.children, folder.clone()),
-        FolderScanItem::File(file) => upsert_file(&mut parent.files, file.clone()),
-    }
-}
-
-pub(super) fn upsert_folder(folders: &mut Vec<FolderEntry>, folder: FolderEntry) -> bool {
-    match folders.binary_search_by(|candidate| {
-        candidate
-            .name
-            .to_ascii_lowercase()
-            .cmp(&folder.name.to_ascii_lowercase())
-    }) {
-        Ok(index) if folders[index] == folder => false,
-        Ok(index) => {
-            folders[index] = folder;
-            true
-        }
-        Err(index) => {
-            folders.insert(index, folder);
-            true
-        }
-    }
-}
-
-pub(super) fn upsert_file(files: &mut Vec<FileEntry>, file: FileEntry) -> bool {
-    match files.binary_search_by(|candidate| {
-        candidate
-            .name
-            .to_ascii_lowercase()
-            .cmp(&file.name.to_ascii_lowercase())
-    }) {
-        Ok(index) if files[index] == file => false,
-        Ok(index) => {
-            files[index] = file;
-            true
-        }
-        Err(index) => {
-            files.insert(index, file);
-            true
-        }
-    }
 }
 
 fn read_sorted_entries(path: &Path) -> Vec<PathBuf> {

--- a/src/gui_app/folder_browser/scanning/discovery_merge.rs
+++ b/src/gui_app/folder_browser/scanning/discovery_merge.rs
@@ -1,0 +1,58 @@
+use super::{FileEntry, FolderEntry, FolderScanDiscovery, FolderScanItem};
+
+pub(in crate::gui_app::folder_browser) fn merge_scan_discovery(
+    root: &mut FolderEntry,
+    event: &FolderScanDiscovery,
+) -> bool {
+    let Some(parent) = root.find_mut(&event.parent_id) else {
+        return false;
+    };
+    match &event.item {
+        FolderScanItem::Folder(folder) => upsert_folder(&mut parent.children, folder.clone()),
+        FolderScanItem::File(file) => upsert_file(&mut parent.files, file.clone()),
+    }
+}
+
+pub(in crate::gui_app::folder_browser) fn upsert_folder(
+    folders: &mut Vec<FolderEntry>,
+    folder: FolderEntry,
+) -> bool {
+    match folders.binary_search_by(|candidate| {
+        candidate
+            .name
+            .to_ascii_lowercase()
+            .cmp(&folder.name.to_ascii_lowercase())
+    }) {
+        Ok(index) if folders[index] == folder => false,
+        Ok(index) => {
+            folders[index] = folder;
+            true
+        }
+        Err(index) => {
+            folders.insert(index, folder);
+            true
+        }
+    }
+}
+
+pub(in crate::gui_app::folder_browser) fn upsert_file(
+    files: &mut Vec<FileEntry>,
+    file: FileEntry,
+) -> bool {
+    match files.binary_search_by(|candidate| {
+        candidate
+            .name
+            .to_ascii_lowercase()
+            .cmp(&file.name.to_ascii_lowercase())
+    }) {
+        Ok(index) if files[index] == file => false,
+        Ok(index) => {
+            files[index] = file;
+            true
+        }
+        Err(index) => {
+            files.insert(index, file);
+            true
+        }
+    }
+}


### PR DESCRIPTION
Summary
- Move scan discovery merge and sorted upsert helpers into scanning/discovery_merge.rs.
- Keep scanning.rs focused on folder traversal, progress emission, and scan result construction.
- Preserve existing scanning module re-exports for folder-browser callers.

Validation
- cargo test -p wavecrate folder_browser::tests::scanning
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent