### PR TITLE
[codex] Fix waveform loading progress overlay

### DIFF
--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -3,14 +3,11 @@
 use radiant::gui::types::{Point, Rect, Rgba8};
 use radiant::layout::{LayoutOutput, Vector2};
 use radiant::prelude as ui;
-use radiant::runtime::{
-    NativeRunOptions, NativeTextOptions, PaintFillRect, PaintPrimitive, PaintText, PaintTextAlign,
-    PaintTextRun,
-};
+use radiant::runtime::{NativeRunOptions, NativeTextOptions, PaintFillRect, PaintPrimitive};
 use radiant::theme::ThemeTokens;
 use radiant::widgets::{
-    DragHandleMessage, FocusBehavior, PointerModifiers, TextWrap, Widget, WidgetCommon,
-    WidgetInput, WidgetOutput, WidgetSizing,
+    DragHandleMessage, FocusBehavior, PointerModifiers, Widget, WidgetCommon, WidgetInput,
+    WidgetOutput, WidgetSizing,
 };
 use rfd::FileDialog;
 use std::{
@@ -96,6 +93,7 @@ enum GuiMessage {
         drag: DragHandleMessage,
     },
     ExternalDragCompleted(Result<ui::ExternalDragOutcome, String>),
+    SampleLoadProgress(ui::TaskTicket, f32),
     SampleLoadFinished(ui::TaskCompletion<SampleLoadResult>),
     PlaySelectedSample,
     StopPlayback,
@@ -153,6 +151,8 @@ struct GuiAppState {
     sample_load_task: ui::LatestTask,
     folder_progress: Option<FolderScanProgress>,
     progress_tick: f32,
+    waveform_loading_progress: f32,
+    waveform_loading_target_progress: f32,
     audio_player: Option<AudioPlayer>,
     loop_playback: bool,
     volume: f32,
@@ -185,6 +185,8 @@ impl GuiAppState {
             sample_load_task: ui::LatestTask::new(),
             folder_progress: None,
             progress_tick: 0.0,
+            waveform_loading_progress: 0.0,
+            waveform_loading_target_progress: 0.0,
             audio_player: None,
             loop_playback: false,
             volume: DEFAULT_VOLUME,
@@ -451,6 +453,11 @@ impl GuiAppState {
                 self.drag_sample_file(path, drag, context);
             }
             GuiMessage::ExternalDragCompleted(result) => self.external_drag_completed(result),
+            GuiMessage::SampleLoadProgress(ticket, progress) => {
+                if self.sample_load_task.is_active(ticket) {
+                    self.waveform_loading_target_progress = progress.clamp(0.0, 0.995);
+                }
+            }
             GuiMessage::SampleLoadFinished(result) => self.finish_sample_load(result),
             GuiMessage::PlaySelectedSample => self.play_selected_sample(context),
             GuiMessage::StopPlayback => self.stop_playback(),
@@ -601,6 +608,13 @@ impl GuiAppState {
                 self.refresh_playback_progress();
                 if self.folder_progress.is_some() {
                     self.progress_tick = (self.progress_tick + 0.035) % 1.0;
+                }
+                if self.waveform_loading_label.is_some() {
+                    let remaining =
+                        self.waveform_loading_target_progress - self.waveform_loading_progress;
+                    if remaining > 0.0 {
+                        self.waveform_loading_progress += remaining.min(0.03);
+                    }
                 }
             }
         }
@@ -1428,6 +1442,8 @@ impl GuiAppState {
         self.sample_status = format!("Loading {}", sample_path_label(path.as_str()));
         let label = sample_path_label(path.as_str());
         self.waveform_loading_label = Some(label.clone());
+        self.waveform_loading_progress = 0.0;
+        self.waveform_loading_target_progress = 0.0;
         emit_gui_action(
             "browser.select_sample",
             Some("browser"),
@@ -1436,12 +1452,19 @@ impl GuiAppState {
             started_at,
             None,
         );
-        context.spawn_latest(
-            &mut self.sample_load_task,
+        let ticket = self.sample_load_task.begin();
+        let sender = self.worker_sender.clone();
+        context.spawn(
             "gui-sample-load",
             move || {
-                let result = WaveformState::load_path(PathBuf::from(&path));
-                SampleLoadResult { path, result }
+                let result =
+                    WaveformState::load_path_with_progress(PathBuf::from(&path), |progress| {
+                        let _ = sender.send(GuiMessage::SampleLoadProgress(ticket, progress));
+                    });
+                ui::TaskCompletion {
+                    ticket,
+                    output: SampleLoadResult { path, result },
+                }
             },
             GuiMessage::SampleLoadFinished,
         );
@@ -1464,6 +1487,8 @@ impl GuiAppState {
             return;
         }
         self.waveform_loading_label = None;
+        self.waveform_loading_progress = 0.0;
+        self.waveform_loading_target_progress = 0.0;
         match load.result {
             Ok(waveform) => {
                 let file_name = waveform.file_name();
@@ -1584,6 +1609,7 @@ pub(crate) fn run() -> Result<(), String> {
                 state.waveform.is_playing()
                     || state.waveform.play_selection_flash_active()
                     || state.folder_progress.is_some()
+                    || state.waveform_loading_label.is_some()
             })
             .on_frame(|| GuiMessage::Frame)
             .subscriptions(GuiAppState::worker_subscription)
@@ -2057,7 +2083,7 @@ fn waveform_viewport_with_loading_state(state: &GuiAppState) -> ui::View<GuiMess
     };
     ui::stack([
         viewport,
-        waveform_loading_visual(label, state.progress_tick),
+        waveform_loading_visual(label, state.waveform_loading_progress),
         ui::custom_widget_mapped(WaveformLoadingInputBlocker::new(), |message: GuiMessage| {
             message
         })
@@ -2070,8 +2096,8 @@ fn waveform_viewport_with_loading_state(state: &GuiAppState) -> ui::View<GuiMess
     .height(WAVEFORM_VIEW_HEIGHT)
 }
 
-fn waveform_loading_visual(label: &str, tick: f32) -> ui::View<GuiMessage> {
-    ui::custom_widget(WaveformLoadingVisual::new(label, tick), |_| None)
+fn waveform_loading_visual(_label: &str, progress: f32) -> ui::View<GuiMessage> {
+    ui::custom_widget(WaveformLoadingVisual::new(progress), |_| None)
         .key("waveform-loading-visual")
         .fill_width()
         .height(WAVEFORM_VIEW_HEIGHT)
@@ -2080,20 +2106,18 @@ fn waveform_loading_visual(label: &str, tick: f32) -> ui::View<GuiMessage> {
 #[derive(Clone, Debug)]
 struct WaveformLoadingVisual {
     common: WidgetCommon,
-    label: String,
-    tick: f32,
+    progress: f32,
 }
 
 impl WaveformLoadingVisual {
-    fn new(label: &str, tick: f32) -> Self {
+    fn new(progress: f32) -> Self {
         let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 1.0)));
         common.focus = FocusBehavior::None;
         common.paint.paints_focus = false;
         common.paint.paints_state_layers = false;
         Self {
             common,
-            label: label.to_string(),
-            tick,
+            progress: progress.clamp(0.0, 1.0),
         }
     }
 }
@@ -2126,63 +2150,29 @@ impl Widget for WaveformLoadingVisual {
             widget_id: self.common.id,
             rect: bounds,
             color: Rgba8 {
-                r: 24,
-                g: 27,
-                b: 28,
-                a: 128,
+                r: 22,
+                g: 24,
+                b: 25,
+                a: 72,
             },
         }));
 
-        let content = Rect::from_min_max(
-            Point::new(bounds.min.x + 8.0, bounds.min.y + 48.0),
-            Point::new(bounds.max.x - 8.0, bounds.min.y + 70.0),
-        );
-        primitives.push(PaintPrimitive::Text(PaintTextRun {
-            widget_id: self.common.id,
-            text: PaintText::from(format!("Loading waveform | {}", self.label)),
-            rect: content,
-            font_size: 10.0,
-            baseline: Some(14.0),
-            color: Rgba8 {
-                r: 218,
-                g: 219,
-                b: 219,
-                a: 235,
-            },
-            align: PaintTextAlign::Left,
-            wrap: TextWrap::None,
-        }));
-
-        let phase = ((self.tick.sin() + 1.0) * 0.5).clamp(0.0, 1.0);
-        let track = Rect::from_min_max(
-            Point::new(bounds.min.x + 8.0, bounds.min.y + 74.0),
-            Point::new(bounds.max.x - 8.0, bounds.min.y + 79.0),
-        );
-        primitives.push(PaintPrimitive::FillRect(PaintFillRect {
-            widget_id: self.common.id,
-            rect: track,
-            color: Rgba8 {
-                r: 72,
-                g: 76,
-                b: 78,
-                a: 130,
-            },
-        }));
-        let shimmer_width = track.width().min(120.0).max(48.0);
-        let shimmer_x = track.min.x + (track.width() - shimmer_width).max(0.0) * phase;
-        primitives.push(PaintPrimitive::FillRect(PaintFillRect {
-            widget_id: self.common.id,
-            rect: Rect::from_min_max(
-                Point::new(shimmer_x, track.min.y),
-                Point::new((shimmer_x + shimmer_width).min(track.max.x), track.max.y),
-            ),
-            color: Rgba8 {
-                r: 255,
-                g: 112,
-                b: 86,
-                a: 172,
-            },
-        }));
+        let fill_width = bounds.width() * self.progress;
+        if fill_width > 0.5 {
+            primitives.push(PaintPrimitive::FillRect(PaintFillRect {
+                widget_id: self.common.id,
+                rect: Rect::from_min_max(
+                    bounds.min,
+                    Point::new((bounds.min.x + fill_width).min(bounds.max.x), bounds.max.y),
+                ),
+                color: Rgba8 {
+                    r: 174,
+                    g: 178,
+                    b: 181,
+                    a: 118,
+                },
+            }));
+        }
     }
 }
 
@@ -2306,6 +2296,8 @@ mod tests {
             sample_load_task: ui::LatestTask::new(),
             folder_progress: None,
             progress_tick: 0.0,
+            waveform_loading_progress: 0.0,
+            waveform_loading_target_progress: 0.0,
             audio_player: None,
             loop_playback: false,
             volume: super::DEFAULT_VOLUME,
@@ -2544,6 +2536,8 @@ mod tests {
             sample_load_task: ui::LatestTask::new(),
             folder_progress: None,
             progress_tick: 0.0,
+            waveform_loading_progress: 0.0,
+            waveform_loading_target_progress: 0.0,
             audio_player: None,
             loop_playback: false,
             volume: super::DEFAULT_VOLUME,
@@ -2672,6 +2666,8 @@ mod tests {
             sample_load_task: ui::LatestTask::new(),
             folder_progress: None,
             progress_tick: 0.0,
+            waveform_loading_progress: 0.0,
+            waveform_loading_target_progress: 0.0,
             audio_player: None,
             loop_playback: false,
             volume: super::DEFAULT_VOLUME,
@@ -3629,7 +3625,7 @@ mod tests {
     }
 
     #[test]
-    fn waveform_loading_visual_does_not_paint_layout_borders() {
+    fn waveform_loading_visual_paints_full_height_gray_fill_without_chrome() {
         let frame = radiant::runtime::UiSurface::new(
             super::waveform_loading_visual("kick.wav", 0.25).into_node(),
         )
@@ -3638,17 +3634,34 @@ mod tests {
             &radiant::theme::ThemeTokens::default(),
         );
 
-        assert!(frame.paint_plan.primitives.iter().any(|primitive| matches!(
-            primitive,
-            PaintPrimitive::Text(text)
-                if text.text.as_str() == "Loading waveform | kick.wav"
-        )));
+        let fill_rects = frame
+            .paint_plan
+            .primitives
+            .iter()
+            .filter_map(|primitive| match primitive {
+                PaintPrimitive::FillRect(rect) => Some(rect),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(fill_rects.iter().any(|fill| {
+            (fill.rect.width() - 180.0).abs() < 0.01
+                && (fill.rect.height() - 172.0).abs() < 0.01
+                && fill.rect.min.x == 0.0
+                && fill.rect.min.y == 0.0
+                && fill.color.r == 174
+                && fill.color.g == 178
+                && fill.color.b == 181
+        }));
         assert!(
             frame
                 .paint_plan
                 .primitives
                 .iter()
-                .all(|primitive| !matches!(primitive, PaintPrimitive::StrokeRect(_)))
+                .all(|primitive| !matches!(
+                    primitive,
+                    PaintPrimitive::StrokeRect(_) | PaintPrimitive::Text(_)
+                ))
         );
     }
 

--- a/src/gui_app/waveform.rs
+++ b/src/gui_app/waveform.rs
@@ -40,6 +40,14 @@ impl WaveformState {
         Ok(Self::from_file(file))
     }
 
+    pub(super) fn load_path_with_progress(
+        path: PathBuf,
+        progress: impl Fn(f32),
+    ) -> Result<Self, String> {
+        let file = Arc::new(load_waveform_file_with_progress(path, progress)?);
+        Ok(Self::from_file(file))
+    }
+
     pub(super) fn empty() -> Self {
         Self::from_file(Arc::new(empty_waveform_file()))
     }
@@ -240,7 +248,7 @@ mod state_viewport;
 mod audio_file;
 use audio_file::{
     WaveformFile, empty_waveform_file, extract_wav_range_to_sibling, is_wav_path,
-    load_waveform_file,
+    load_waveform_file, load_waveform_file_with_progress,
 };
 #[cfg(test)]
 use audio_file::{

--- a/src/gui_app/waveform/audio_file.rs
+++ b/src/gui_app/waveform/audio_file.rs
@@ -1,9 +1,10 @@
-use radiant::runtime::{GpuSignalGainPreview, GpuSignalSummary};
+use radiant::runtime::{
+    GpuSignalGainPreview, GpuSignalSummary, GpuSignalSummaryBucket, GpuSignalSummaryLevel,
+};
 use std::{
     collections::hash_map::DefaultHasher,
-    fs,
     hash::{Hash, Hasher},
-    io::Cursor,
+    io::{Cursor, Read},
     path::PathBuf,
     sync::Arc,
 };
@@ -16,7 +17,9 @@ mod extraction;
 pub(super) use extraction::extract_wav_range_to_sibling;
 
 mod visual_bands;
+#[cfg(test)]
 pub(super) use visual_bands::split_frequency_bands;
+pub(super) use visual_bands::split_frequency_bands_with_progress;
 
 #[derive(Clone, Debug)]
 pub(in crate::gui_app) struct WaveformFile {
@@ -45,11 +48,19 @@ impl WaveformFile {
 }
 
 pub(super) fn load_waveform_file(path: PathBuf) -> Result<WaveformFile, String> {
-    let bytes: Arc<[u8]> = fs::read(&path)
-        .map_err(|err| format!("failed to read audio file: {err}"))?
-        .into();
+    load_waveform_file_with_progress(path, |_| {})
+}
+
+pub(super) fn load_waveform_file_with_progress(
+    path: PathBuf,
+    progress: impl Fn(f32),
+) -> Result<WaveformFile, String> {
+    progress(0.0);
+    let bytes = read_audio_file_with_progress(&path, 0.0, 0.08, &progress)?;
     if is_wav_path(&path) {
-        if let Ok(file) = load_wav_waveform_file(path.clone(), Arc::clone(&bytes)) {
+        if let Ok(file) =
+            load_wav_waveform_file_with_progress(path.clone(), Arc::clone(&bytes), &progress)
+        {
             return Ok(file);
         }
     }
@@ -57,23 +68,54 @@ pub(super) fn load_waveform_file(path: PathBuf) -> Result<WaveformFile, String> 
         wavecrate::waveform::WaveformRenderer::new(WAVEFORM_WIDTH as u32, WAVEFORM_HEIGHT as u32)
             .decode_from_bytes(&bytes)
             .map_err(|err| format!("failed to decode audio file: {err}"))?;
+    progress(0.48);
     let channels = decoded.channel_count();
     let frames = decoded.frame_count();
     let mono_samples = if decoded.samples.is_empty() {
         decoded.analysis_samples.iter().copied().collect::<Vec<_>>()
     } else {
-        downmix_to_mono(&decoded.samples, channels, frames)
+        downmix_to_mono_with_progress(&decoded.samples, channels, frames, 0.48, 0.62, &progress)
     };
     if mono_samples.is_empty() {
         return Err(String::from("audio file contains no complete frames"));
     }
-    Ok(waveform_file_from_mono_samples(
+    Ok(waveform_file_from_mono_samples_with_progress(
         path,
         bytes,
         decoded.sample_rate,
         channels,
         mono_samples,
+        &progress,
     ))
+}
+
+fn read_audio_file_with_progress(
+    path: &std::path::Path,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> Result<Arc<[u8]>, String> {
+    let mut file =
+        std::fs::File::open(path).map_err(|err| format!("failed to read audio file: {err}"))?;
+    let total = file.metadata().ok().map(|metadata| metadata.len() as usize);
+    let mut bytes = Vec::with_capacity(total.unwrap_or_default().min(64 * 1024 * 1024));
+    let mut buffer = [0_u8; 256 * 1024];
+    let mut read = 0usize;
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|err| format!("failed to read audio file: {err}"))?;
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+        read = read.saturating_add(count);
+        if let Some(total) = total.filter(|total| *total > 0) {
+            report_phase_progress(start, end, read, total, progress);
+        }
+    }
+    progress(end);
+    Ok(bytes.into())
 }
 
 #[cfg(test)]
@@ -109,14 +151,34 @@ pub(super) fn waveform_file_from_mono_samples(
     channels: usize,
     mono_samples: Vec<f32>,
 ) -> WaveformFile {
-    let gpu_signal_samples = split_frequency_bands(&mono_samples, sample_rate);
-    let gpu_signal_summary = Arc::new(
-        radiant::runtime::GpuSignalSummary::from_interleaved_samples(
-            &gpu_signal_samples,
-            mono_samples.len(),
-            BAND_COUNT,
-        ),
-    );
+    waveform_file_from_mono_samples_with_progress(
+        path,
+        audio_bytes,
+        sample_rate,
+        channels,
+        mono_samples,
+        &|_| {},
+    )
+}
+
+fn waveform_file_from_mono_samples_with_progress(
+    path: PathBuf,
+    audio_bytes: Arc<[u8]>,
+    sample_rate: u32,
+    channels: usize,
+    mono_samples: Vec<f32>,
+    progress: &impl Fn(f32),
+) -> WaveformFile {
+    let gpu_signal_samples =
+        split_frequency_bands_with_progress(&mono_samples, sample_rate, 0.62, 0.9, progress);
+    let gpu_signal_summary = Arc::new(gpu_signal_summary_with_progress(
+        &gpu_signal_samples,
+        mono_samples.len(),
+        BAND_COUNT,
+        0.9,
+        0.99,
+        progress,
+    ));
     WaveformFile {
         path,
         content_revision: content_revision_for_audio_bytes(&audio_bytes),
@@ -126,6 +188,129 @@ pub(super) fn waveform_file_from_mono_samples(
         frames: mono_samples.len(),
         gpu_signal_summary,
     }
+}
+
+fn gpu_signal_summary_with_progress(
+    samples: &[f32],
+    frames: usize,
+    band_count: usize,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> GpuSignalSummary {
+    let frames = frames.min(samples.len() / band_count.max(1));
+    let band_count = band_count.max(1);
+    let mut levels = Vec::with_capacity(signal_summary_level_count(frames));
+    let mut bucket_frames = 1usize;
+    let mut previous_buckets: Option<Arc<[GpuSignalSummaryBucket]>> = None;
+    let total_levels = signal_summary_level_count(frames).max(1);
+    while bucket_frames <= frames.max(1) {
+        let level_index = levels.len();
+        let level_start = start + (end - start) * (level_index as f32 / total_levels as f32);
+        let level_end = start + (end - start) * ((level_index + 1) as f32 / total_levels as f32);
+        let buckets = match previous_buckets.as_deref() {
+            Some(previous) => merge_signal_summary_level_with_progress(
+                previous,
+                frames,
+                band_count,
+                bucket_frames,
+                level_start,
+                level_end,
+                progress,
+            ),
+            None => build_signal_summary_base_level_with_progress(
+                samples,
+                frames,
+                band_count,
+                level_start,
+                level_end,
+                progress,
+            ),
+        };
+        levels.push(GpuSignalSummaryLevel {
+            bucket_frames,
+            buckets: Arc::clone(&buckets),
+        });
+        previous_buckets = Some(buckets);
+        if bucket_frames >= frames.max(1) {
+            break;
+        }
+        bucket_frames = bucket_frames.saturating_mul(2).max(bucket_frames + 1);
+    }
+    progress(end);
+    GpuSignalSummary {
+        frames,
+        band_count,
+        levels,
+    }
+}
+
+fn signal_summary_level_count(frames: usize) -> usize {
+    let frames = frames.max(1);
+    usize::BITS as usize - frames.leading_zeros() as usize
+}
+
+fn build_signal_summary_base_level_with_progress(
+    samples: &[f32],
+    frames: usize,
+    band_count: usize,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> Arc<[GpuSignalSummaryBucket]> {
+    if frames == 0 {
+        return vec![GpuSignalSummaryBucket::default(); band_count].into();
+    }
+    let sample_count = frames.saturating_mul(band_count);
+    let mut buckets = Vec::with_capacity(sample_count);
+    for (index, value) in samples.iter().copied().take(sample_count).enumerate() {
+        if value.is_finite() {
+            buckets.push(GpuSignalSummaryBucket {
+                min: value,
+                max: value,
+            });
+        } else {
+            buckets.push(GpuSignalSummaryBucket::default());
+        }
+        report_phase_progress_throttled(start, end, index + 1, sample_count, progress);
+    }
+    progress(end);
+    buckets.into()
+}
+
+fn merge_signal_summary_level_with_progress(
+    previous: &[GpuSignalSummaryBucket],
+    frames: usize,
+    band_count: usize,
+    bucket_frames: usize,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> Arc<[GpuSignalSummaryBucket]> {
+    let bucket_count = frames.div_ceil(bucket_frames.max(1)).max(1);
+    let previous_bucket_count = previous.len() / band_count.max(1);
+    let mut buckets = Vec::with_capacity(bucket_count.saturating_mul(band_count));
+    for bucket in 0..bucket_count {
+        let first = bucket.saturating_mul(2);
+        let second = first + 1;
+        for band in 0..band_count {
+            let mut summary = previous
+                .get(first.saturating_mul(band_count).saturating_add(band))
+                .copied()
+                .unwrap_or_default();
+            if second < previous_bucket_count
+                && let Some(next) =
+                    previous.get(second.saturating_mul(band_count).saturating_add(band))
+            {
+                summary.min = summary.min.min(next.min);
+                summary.max = summary.max.max(next.max);
+            }
+            buckets.push(summary);
+        }
+        report_phase_progress_throttled(start, end, bucket + 1, bucket_count, progress);
+    }
+    progress(end);
+    buckets.into()
 }
 
 pub(super) fn gain_preview_for_selection(
@@ -159,47 +344,57 @@ pub(super) fn content_revision_for_audio_bytes(bytes: &[u8]) -> u64 {
     hasher.finish().max(1)
 }
 
-pub(super) fn load_wav_waveform_file(
+pub(super) fn load_wav_waveform_file_with_progress(
     path: PathBuf,
     bytes: Arc<[u8]>,
+    progress: &impl Fn(f32),
 ) -> Result<WaveformFile, String> {
     let cursor = Cursor::new(bytes.as_ref());
     let mut reader =
         hound::WavReader::new(cursor).map_err(|err| format!("failed to open WAV: {err}"))?;
     let spec = reader.spec();
     let channels = usize::from(spec.channels).max(1);
+    let total_samples = reader.duration() as usize * channels;
     let samples = match spec.sample_format {
-        hound::SampleFormat::Float => reader
-            .samples::<f32>()
-            .map(|sample| {
-                sample
+        hound::SampleFormat::Float => {
+            let mut samples = Vec::with_capacity(total_samples);
+            for (index, sample) in reader.samples::<f32>().enumerate() {
+                let sample = sample
                     .map(|value| value.clamp(-1.0, 1.0))
-                    .map_err(|err| format!("failed to read float sample: {err}"))
-            })
-            .collect::<Result<Vec<_>, _>>()?,
+                    .map_err(|err| format!("failed to read float sample: {err}"))?;
+                samples.push(sample);
+                report_phase_progress_throttled(0.08, 0.46, index + 1, total_samples, progress);
+            }
+            progress(0.46);
+            samples
+        }
         hound::SampleFormat::Int if spec.bits_per_sample <= 16 => {
             let max =
                 ((1_i32 << (u32::from(spec.bits_per_sample).saturating_sub(1))) - 1).max(1) as f32;
-            reader
-                .samples::<i16>()
-                .map(|sample| {
-                    sample
-                        .map(|value| (f32::from(value) / max).clamp(-1.0, 1.0))
-                        .map_err(|err| format!("failed to read integer sample: {err}"))
-                })
-                .collect::<Result<Vec<_>, _>>()?
+            let mut samples = Vec::with_capacity(total_samples);
+            for (index, sample) in reader.samples::<i16>().enumerate() {
+                let sample = sample
+                    .map(|value| (f32::from(value) / max).clamp(-1.0, 1.0))
+                    .map_err(|err| format!("failed to read integer sample: {err}"))?;
+                samples.push(sample);
+                report_phase_progress_throttled(0.08, 0.46, index + 1, total_samples, progress);
+            }
+            progress(0.46);
+            samples
         }
         hound::SampleFormat::Int => {
             let max =
                 ((1_i64 << (u32::from(spec.bits_per_sample).saturating_sub(1))) - 1).max(1) as f32;
-            reader
-                .samples::<i32>()
-                .map(|sample| {
-                    sample
-                        .map(|value| ((value as f32) / max).clamp(-1.0, 1.0))
-                        .map_err(|err| format!("failed to read integer sample: {err}"))
-                })
-                .collect::<Result<Vec<_>, _>>()?
+            let mut samples = Vec::with_capacity(total_samples);
+            for (index, sample) in reader.samples::<i32>().enumerate() {
+                let sample = sample
+                    .map(|value| ((value as f32) / max).clamp(-1.0, 1.0))
+                    .map_err(|err| format!("failed to read integer sample: {err}"))?;
+                samples.push(sample);
+                report_phase_progress_throttled(0.08, 0.46, index + 1, total_samples, progress);
+            }
+            progress(0.46);
+            samples
         }
     };
     if samples.is_empty() {
@@ -207,31 +402,76 @@ pub(super) fn load_wav_waveform_file(
     }
 
     let frames = samples.len() / channels;
-    let mono_samples = downmix_to_mono(&samples, channels, frames);
+    let mono_samples =
+        downmix_to_mono_with_progress(&samples, channels, frames, 0.46, 0.62, progress);
     if mono_samples.is_empty() {
         return Err(String::from("WAV contains no complete frames"));
     }
-    Ok(waveform_file_from_mono_samples(
+    Ok(waveform_file_from_mono_samples_with_progress(
         path,
         bytes,
         spec.sample_rate,
         channels,
         mono_samples,
+        progress,
     ))
 }
 
+#[cfg(test)]
 pub(super) fn downmix_to_mono(samples: &[f32], channels: usize, frames: usize) -> Vec<f32> {
+    downmix_to_mono_with_progress(samples, channels, frames, 0.0, 1.0, &|_| {})
+}
+
+fn downmix_to_mono_with_progress(
+    samples: &[f32],
+    channels: usize,
+    frames: usize,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> Vec<f32> {
     let channels = channels.max(1);
-    (0..frames)
-        .map(|frame| {
-            let start = frame * channels;
-            let mut peak = 0.0_f32;
-            for sample in samples[start..start + channels].iter().copied() {
-                if sample.abs() > peak.abs() {
-                    peak = sample;
-                }
+    let mut mono = Vec::with_capacity(frames);
+    for frame in 0..frames {
+        let sample_start = frame * channels;
+        let mut peak = 0.0_f32;
+        for sample in samples[sample_start..sample_start + channels]
+            .iter()
+            .copied()
+        {
+            if sample.abs() > peak.abs() {
+                peak = sample;
             }
-            peak.clamp(-1.0, 1.0)
-        })
-        .collect()
+        }
+        mono.push(peak.clamp(-1.0, 1.0));
+        report_phase_progress_throttled(start, end, frame + 1, frames, progress);
+    }
+    progress(end);
+    mono
+}
+
+pub(super) fn report_phase_progress_throttled(
+    start: f32,
+    end: f32,
+    completed: usize,
+    total: usize,
+    progress: &impl Fn(f32),
+) {
+    if completed == total || completed % 16_384 == 0 {
+        report_phase_progress(start, end, completed, total, progress);
+    }
+}
+
+fn report_phase_progress(
+    start: f32,
+    end: f32,
+    completed: usize,
+    total: usize,
+    progress: &impl Fn(f32),
+) {
+    if total == 0 {
+        return;
+    }
+    let ratio = completed as f32 / total as f32;
+    progress(start + (end - start) * ratio.clamp(0.0, 1.0));
 }

--- a/src/gui_app/waveform/audio_file/visual_bands.rs
+++ b/src/gui_app/waveform/audio_file/visual_bands.rs
@@ -2,13 +2,26 @@ use std::sync::Arc;
 
 use super::super::BAND_COUNT;
 
+#[cfg(test)]
 pub(in crate::gui_app::waveform) fn split_frequency_bands(
     samples: &[f32],
     sample_rate: u32,
 ) -> Arc<[f32]> {
+    split_frequency_bands_with_progress(samples, sample_rate, 0.0, 1.0, &|_| {})
+}
+
+pub(in crate::gui_app::waveform) fn split_frequency_bands_with_progress(
+    samples: &[f32],
+    sample_rate: u32,
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) -> Arc<[f32]> {
     if samples.is_empty() {
         return Arc::from([]);
     }
+    let filter_end = start + (end - start) * 0.76;
+    let normalize_end = start + (end - start) * 0.98;
     let alpha_low = lowpass_alpha(sample_rate, 150.0);
     let alpha_mid = lowpass_alpha(sample_rate, 2_200.0);
     let mut low = 0.0_f32;
@@ -20,7 +33,7 @@ pub(in crate::gui_app::waveform) fn split_frequency_bands(
     let mid_release = envelope_release_alpha(sample_rate, 5.5);
     let high_release = envelope_release_alpha(sample_rate, 2.2);
     let mut bands = Vec::with_capacity(samples.len().saturating_mul(BAND_COUNT));
-    for sample in samples {
+    for (index, sample) in samples.iter().enumerate() {
         let sample = sample.clamp(-1.0, 1.0);
         low += alpha_low * (sample - low);
         mid_low += alpha_mid * (sample - mid_low);
@@ -34,12 +47,26 @@ pub(in crate::gui_app::waveform) fn split_frequency_bands(
         bands.push(mid_envelope);
         bands.push(high_envelope);
         bands.push(sample);
+        super::report_phase_progress_throttled(
+            start,
+            filter_end,
+            index + 1,
+            samples.len(),
+            progress,
+        );
     }
-    normalize_visual_band_peaks(&mut bands);
+    progress(filter_end);
+    normalize_visual_band_peaks_with_progress(&mut bands, filter_end, normalize_end, progress);
+    progress(end);
     bands.into()
 }
 
-fn normalize_visual_band_peaks(bands: &mut [f32]) {
+fn normalize_visual_band_peaks_with_progress(
+    bands: &mut [f32],
+    start: f32,
+    end: f32,
+    progress: &impl Fn(f32),
+) {
     let raw_peak = bands
         .chunks_exact(BAND_COUNT)
         .map(|frame| frame[3].abs())
@@ -69,10 +96,21 @@ fn normalize_visual_band_peaks(bands: &mut [f32]) {
             max_gains[band]
         };
         let gain = (target / peak).clamp(0.25, max_gain);
-        for frame in bands.chunks_exact_mut(BAND_COUNT) {
+        let frame_count = bands.len() / BAND_COUNT;
+        for (index, frame) in bands.chunks_exact_mut(BAND_COUNT).enumerate() {
             frame[band] = (frame[band] * gain).clamp(-1.0, 1.0);
+            let band_start = start + (end - start) * (band as f32 / 3.0);
+            let band_end = start + (end - start) * ((band + 1) as f32 / 3.0);
+            super::report_phase_progress_throttled(
+                band_start,
+                band_end,
+                index + 1,
+                frame_count,
+                progress,
+            );
         }
     }
+    progress(end);
 }
 
 fn visual_band_peak(bands: &[f32], band: usize) -> f32 {

--- a/src/gui_app/waveform/tests/audio.rs
+++ b/src/gui_app/waveform/tests/audio.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::cell::RefCell;
 
 #[test]
 fn waveform_summary_preserves_raw_transient_detail() {
@@ -39,6 +40,42 @@ fn waveform_summary_preserves_raw_transient_detail() {
         .map(|bucket| bucket.min.abs().max(bucket.max.abs()))
         .fold(0.0_f32, f32::max);
     assert!(frame_peak > 0.89);
+}
+
+#[test]
+fn waveform_load_progress_tracks_late_summary_work() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("long.wav");
+    let samples = (0..65_536)
+        .map(|index| {
+            let phase = index as f32 / 64.0;
+            (phase.sin() * i16::MAX as f32 * 0.75) as i16
+        })
+        .collect::<Vec<_>>();
+    write_test_wav_i16(&path, &samples);
+
+    let updates = RefCell::new(Vec::new());
+    let state = WaveformState::load_path_with_progress(path, |progress| {
+        updates.borrow_mut().push(progress);
+    })
+    .expect("waveform loads");
+    let updates = updates.into_inner();
+
+    assert!(state.has_loaded_sample());
+    assert!(
+        updates.windows(2).all(|pair| pair[1] >= pair[0] - 0.000_1),
+        "progress should be monotonic: {updates:?}"
+    );
+    assert!(
+        updates
+            .iter()
+            .any(|progress| (0.90..0.99).contains(progress)),
+        "progress should advance during final summary work: {updates:?}"
+    );
+    assert!(
+        updates.last().copied().unwrap_or_default() >= 0.99,
+        "progress should reach the ready boundary: {updates:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace the static waveform loading shimmer with a full-height gray fill overlay.
- Report background sample-load progress from the worker through disk read, WAV decode, downmix, visual-band generation, and GPU summary construction.
- Smooth the visible overlay toward real worker progress so long files do not race to near-complete and stall.

## Validation
- cargo test -p wavecrate --all-targets waveform_load_progress_tracks_late_summary_work
- cargo test -p wavecrate --all-targets waveform_loading_visual_paints_full_height_gray_fill_without_chrome
- cargo test -p wavecrate --all-targets sample_selection_loads_selected_file_into_waveform
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent