### PR TITLE
[codex] Use native audio settings window

### DIFF
--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -25,6 +25,7 @@ use wavecrate::audio::{
 use wavecrate::external_clipboard;
 use wavecrate::gui_runtime::wavecrate_ui_font_path;
 use wavecrate::logging::{self, ActionDebugEvent, emit_action_debug_event};
+use wavecrate::sample_sources::config::{AppConfig, AppSettingsCore};
 
 mod audio_engine;
 mod audio_settings;
@@ -35,7 +36,9 @@ mod playback;
 mod sample_browser_view;
 mod status_bar;
 mod waveform;
-use audio_settings::{audio_settings_popover, format_sample_rate_label, top_status_bar};
+#[cfg(test)]
+use audio_settings::audio_settings_popover;
+use audio_settings::{format_sample_rate_label, top_status_bar};
 use context_menu::{BrowserContextMenu, BrowserContextTargetKind};
 use file_actions::{
     format_copy_path, normalize_wav_file_in_place, open_folder_in_file_explorer,
@@ -58,6 +61,7 @@ const SAMPLE_BROWSER_ROW_HEIGHT: f32 = 22.0;
 const SAMPLE_BROWSER_EDGE_CONTEXT_ROWS: usize = 2;
 const SAMPLE_BROWSER_OVERSCAN_ROWS: usize = 4;
 const SAMPLE_BROWSER_PROJECTED_VIEWPORT_ROWS: usize = 128;
+#[cfg(test)]
 const DEFAULT_VOLUME: f32 = 1.0;
 const VOLUME_SLIDER_ID: u64 = 31_000;
 const VOLUME_SLIDER_WIDTH: f32 = 92.0;
@@ -161,6 +165,7 @@ struct GuiAppState {
     audio_hosts: Vec<AudioHostSummary>,
     audio_devices: Vec<AudioDeviceSummary>,
     audio_sample_rates: Vec<u32>,
+    persisted_settings: AppSettingsCore,
     audio_settings_open: bool,
     job_details_open: bool,
     context_menu: Option<BrowserContextMenu>,
@@ -172,11 +177,13 @@ struct GuiAppState {
 impl GuiAppState {
     fn load_default() -> Result<Self, String> {
         let started_at = Instant::now();
+        let config = wavecrate::sample_sources::config::load_or_default()
+            .map_err(|err| format!("load app configuration: {err}"))?;
         let (worker_sender, worker_receiver) = mpsc::channel();
         let mut state = Self {
             folder_width: DEFAULT_FOLDER_WIDTH,
             folder_resize: None,
-            folder_browser: FolderBrowserState::load_default(),
+            folder_browser: FolderBrowserState::from_sample_sources(&config.sources),
             waveform: WaveformState::load_default()?,
             sample_status: String::from("Select a sample to load"),
             worker_sender,
@@ -189,12 +196,13 @@ impl GuiAppState {
             waveform_loading_target_progress: 0.0,
             audio_player: None,
             loop_playback: false,
-            volume: DEFAULT_VOLUME,
-            audio_output_config: AudioOutputConfig::default(),
+            volume: config.core.volume.clamp(0.0, 1.0),
+            audio_output_config: config.core.audio_output.clone(),
             audio_output_resolved: None,
             audio_hosts: Vec::new(),
             audio_devices: Vec::new(),
             audio_sample_rates: Vec::new(),
+            persisted_settings: config.core,
             audio_settings_open: false,
             job_details_open: false,
             context_menu: None,
@@ -215,6 +223,31 @@ impl GuiAppState {
             None,
         );
         Ok(state)
+    }
+
+    fn persist_user_configuration(&mut self, action: &'static str, started_at: Instant) {
+        if let Err(error) = self.save_user_configuration() {
+            self.sample_status = format!("Settings not saved: {error}");
+            emit_gui_action(
+                action,
+                Some("settings"),
+                None,
+                "persist_error",
+                started_at,
+                Some(&error),
+            );
+        }
+    }
+
+    fn save_user_configuration(&self) -> Result<(), String> {
+        let mut core = self.persisted_settings.clone();
+        core.audio_output = self.audio_output_config.clone();
+        core.volume = self.volume;
+        wavecrate::sample_sources::config::save(&AppConfig {
+            sources: self.folder_browser.configured_sample_sources(),
+            core,
+        })
+        .map_err(|err| err.to_string())
     }
 
     fn resize_folder_browser(&mut self, message: DragHandleMessage) {
@@ -465,7 +498,7 @@ impl GuiAppState {
             GuiMessage::SetVolume(volume) => self.set_volume(volume),
             GuiMessage::ToggleAudioSettings => self.toggle_audio_settings(),
             GuiMessage::CloseAudioSettings => {
-                self.audio_settings_open = false;
+                self.close_audio_settings_window();
             }
             GuiMessage::SetAudioOutputHost(host) => self.set_audio_output_host(host),
             GuiMessage::SetAudioOutputDevice(device) => self.set_audio_output_device(device),
@@ -578,19 +611,6 @@ impl GuiAppState {
                 let started_at = Instant::now();
                 let action = waveform_interaction_action(&message);
                 let active_drag = self.waveform.active_drag_kind();
-                if self.audio_settings_open {
-                    if let Some(action) = action {
-                        emit_gui_action(
-                            action,
-                            Some("waveform"),
-                            None,
-                            "ignored",
-                            started_at,
-                            Some("audio_settings_open"),
-                        );
-                    }
-                    return;
-                }
                 self.waveform.apply_interaction(message);
                 self.sync_edit_fade_audio_state();
                 if waveform_interaction_finishes_play_selection_edit(&message, active_drag) {
@@ -1040,6 +1060,7 @@ impl GuiAppState {
                 started_at,
                 None,
             );
+            self.persist_user_configuration("folder_browser.sources.persist", started_at);
         } else {
             emit_gui_action(
                 "folder_browser.scan.finish",
@@ -1613,6 +1634,7 @@ pub(crate) fn run() -> Result<(), String> {
             })
             .on_frame(|| GuiMessage::Frame)
             .subscriptions(GuiAppState::worker_subscription)
+            .auxiliary_windows(audio_settings::auxiliary_windows)
             .on_scroll(|state, update, _context| {
                 if update.node_id == SAMPLE_BROWSER_LIST_ID {
                     state.folder_browser.set_file_view_start_from_scroll_offset(
@@ -1821,9 +1843,6 @@ fn view(state: &mut GuiAppState) -> ui::View<GuiMessage> {
     if let Some(preview) = state.folder_browser.drag_preview() {
         layers.push(folder_drag_preview_overlay(preview));
     }
-    if state.audio_settings_open {
-        layers.push(audio_settings_popover(state));
-    }
     if state.job_details_open {
         if let Some(progress) = state.folder_progress.as_ref() {
             layers.push(status_bar::job_details_popover(progress));
@@ -1868,13 +1887,6 @@ fn default_gui_shortcut_resolution(
             .bind(
                 ui::KeyPress::new(ui::KeyCode::Escape),
                 GuiMessage::CloseJobDetails,
-            )
-            .resolve(press)
-    } else if state.audio_settings_open {
-        ui::ShortcutLayer::modal()
-            .bind(
-                ui::KeyPress::new(ui::KeyCode::Escape),
-                GuiMessage::CloseAudioSettings,
             )
             .resolve(press)
     } else {
@@ -2306,6 +2318,7 @@ mod tests {
             audio_hosts: Vec::new(),
             audio_devices: Vec::new(),
             audio_sample_rates: Vec::new(),
+            persisted_settings: super::AppSettingsCore::default(),
             audio_settings_open: false,
             job_details_open: false,
             context_menu: None,
@@ -2366,29 +2379,31 @@ mod tests {
     }
 
     #[test]
-    fn audio_settings_escape_shortcut_closes_modal() {
+    fn audio_settings_window_does_not_capture_main_escape_shortcut() {
         let mut state = GuiAppState::load_default().expect("default state loads");
         state.audio_settings_open = true;
 
         let resolution =
             super::default_gui_shortcut_resolution(&state, ui::KeyPress::new(ui::KeyCode::Escape));
 
-        assert_eq!(
-            resolution.action,
-            Some(super::GuiMessage::CloseAudioSettings)
-        );
+        assert_eq!(resolution.action, Some(super::GuiMessage::StopPlayback));
         assert!(resolution.handled);
     }
 
     #[test]
-    fn audio_settings_modal_blocks_background_shortcuts() {
+    fn audio_settings_window_does_not_block_main_shortcuts() {
         let mut state = GuiAppState::load_default().expect("default state loads");
         state.audio_settings_open = true;
 
         let resolution =
             super::default_gui_shortcut_resolution(&state, ui::KeyPress::new(ui::KeyCode::N));
 
-        assert_eq!(resolution.action, None);
+        assert!(matches!(
+            resolution.action,
+            Some(super::GuiMessage::FolderBrowser(
+                super::FolderBrowserMessage::BeginCreateSubfolder
+            ))
+        ));
         assert!(resolution.handled);
     }
 
@@ -2546,6 +2561,7 @@ mod tests {
             audio_hosts: Vec::new(),
             audio_devices: Vec::new(),
             audio_sample_rates: Vec::new(),
+            persisted_settings: super::AppSettingsCore::default(),
             audio_settings_open: false,
             job_details_open: false,
             context_menu: None,
@@ -2676,6 +2692,7 @@ mod tests {
             audio_hosts: Vec::new(),
             audio_devices: Vec::new(),
             audio_sample_rates: Vec::new(),
+            persisted_settings: super::AppSettingsCore::default(),
             audio_settings_open: false,
             job_details_open: false,
             context_menu: None,
@@ -3241,7 +3258,7 @@ mod tests {
     }
 
     #[test]
-    fn audio_settings_toggle_uses_cached_device_options() {
+    fn audio_settings_snapshot_uses_cached_device_options() {
         let mut state = gui_state_for_span_tests();
         state.audio_hosts = vec![super::AudioHostSummary {
             id: String::from("cached-host"),
@@ -3249,11 +3266,10 @@ mod tests {
             is_default: true,
         }];
 
-        state.toggle_audio_settings();
+        let snapshot = super::audio_settings::AudioSettingsSnapshot::from_app_state(&state);
 
-        assert!(state.audio_settings_open);
-        assert_eq!(state.audio_hosts.len(), 1);
-        assert_eq!(state.audio_hosts[0].id, "cached-host");
+        assert_eq!(snapshot.audio_hosts.len(), 1);
+        assert_eq!(snapshot.audio_hosts[0].id, "cached-host");
     }
 
     #[test]
@@ -3343,7 +3359,7 @@ mod tests {
     }
 
     #[test]
-    fn audio_settings_popover_anchors_panel_top_right() {
+    fn audio_settings_popover_opens_as_centered_floating_window() {
         let mut state = GuiAppState::load_default().expect("default state loads");
         state.audio_settings_error = None;
         let frame =
@@ -3364,15 +3380,12 @@ mod tests {
             })
             .expect("audio settings title paints");
 
-        assert!(
-            (112.0..=128.0).contains(&title_rect.min.x),
-            "{title_rect:?}"
-        );
-        assert!((48.0..=58.0).contains(&title_rect.min.y), "{title_rect:?}");
+        assert!((66.0..=74.0).contains(&title_rect.min.x), "{title_rect:?}");
+        assert!((14.0..=20.0).contains(&title_rect.min.y), "{title_rect:?}");
     }
 
     #[test]
-    fn audio_settings_popover_does_not_add_full_height_panel_chrome() {
+    fn audio_settings_window_does_not_add_full_height_panel_chrome() {
         let mut state = GuiAppState::load_default().expect("default state loads");
         state.audio_settings_open = true;
         let frame = radiant::runtime::UiSurface::new(super::view(&mut state).into_node()).frame(
@@ -3386,7 +3399,8 @@ mod tests {
             .filter_map(|primitive| match primitive {
                 PaintPrimitive::FillRect(fill)
                     if fill.widget_id == 0
-                        && fill.rect.min.x >= 580.0
+                        && fill.rect.min.x >= 250.0
+                        && fill.rect.max.x <= 710.0
                         && fill.rect.width() >= 300.0 =>
                 {
                     Some(fill.rect)
@@ -3404,7 +3418,7 @@ mod tests {
     }
 
     #[test]
-    fn audio_settings_modal_ignores_waveform_selection_messages() {
+    fn audio_settings_window_does_not_block_waveform_selection_messages() {
         let mut state = gui_state_for_span_tests();
         state.audio_settings_open = true;
         let mut context = ui::UpdateContext::default();
@@ -3416,9 +3430,24 @@ mod tests {
             }),
             &mut context,
         );
+        state.apply_message(
+            super::GuiMessage::Waveform(WaveformInteraction::UpdateSelection {
+                visible_ratio: 0.65,
+            }),
+            &mut context,
+        );
+        state.apply_message(
+            super::GuiMessage::Waveform(WaveformInteraction::FinishSelection {
+                visible_ratio: 0.65,
+            }),
+            &mut context,
+        );
 
-        assert_eq!(state.waveform.play_mark_ratio(), None);
-        assert_eq!(state.waveform.play_selection(), None);
+        assert_eq!(state.waveform.play_mark_ratio(), Some(0.45));
+        assert_eq!(
+            state.waveform.play_selection(),
+            Some(wavecrate::selection::SelectionRange::new(0.45, 0.65))
+        );
     }
 
     #[test]
@@ -3438,6 +3467,77 @@ mod tests {
                 .iter()
                 .any(|file| file.name == "portal_SS_kick_003.wav")
         );
+    }
+
+    #[test]
+    fn default_gui_loads_persisted_sources_and_audio_output() {
+        let config_base = tempfile::tempdir().expect("config base");
+        let _base_guard =
+            wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+        let source_root = tempfile::tempdir().expect("source root");
+        let source_id = wavecrate::sample_sources::SourceId::from_string("source_id::gui-test");
+        wavecrate::sample_sources::config::save(&super::AppConfig {
+            sources: vec![wavecrate::sample_sources::SampleSource::new_with_id(
+                source_id,
+                source_root.path().to_path_buf(),
+            )],
+            core: super::AppSettingsCore {
+                audio_output: super::AudioOutputConfig {
+                    host: Some(String::from("test-host")),
+                    device: Some(String::from("Test Device")),
+                    sample_rate: Some(48_000),
+                    buffer_size: Some(256),
+                },
+                volume: 0.42,
+                ..super::AppSettingsCore::default()
+            },
+        })
+        .expect("seed config");
+
+        let state = GuiAppState::load_default().expect("default state loads persisted config");
+
+        assert_eq!(state.folder_browser.root_path(), source_root.path());
+        assert_eq!(state.audio_output_config.host.as_deref(), Some("test-host"));
+        assert_eq!(
+            state.audio_output_config.device.as_deref(),
+            Some("Test Device")
+        );
+        assert_eq!(state.audio_output_config.sample_rate, Some(48_000));
+        assert!((state.volume - 0.42).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn default_gui_saves_sources_and_audio_output_to_app_config() {
+        let config_base = tempfile::tempdir().expect("config base");
+        let _base_guard =
+            wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+        let source_root = tempfile::tempdir().expect("source root");
+        let mut state = gui_state_for_span_tests();
+        state.audio_output_config = super::AudioOutputConfig {
+            host: Some(String::from("wasapi")),
+            device: Some(String::from("Interface")),
+            sample_rate: Some(96_000),
+            buffer_size: None,
+        };
+        state.volume = 0.5;
+
+        let request = state
+            .folder_browser
+            .begin_add_source_path(source_root.path().to_path_buf(), 100)
+            .expect("new source requests scan");
+        let result = super::folder_browser::scan_source_with_progress(request, |_| {}, |_| {});
+        state.finish_folder_scan(result);
+
+        let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
+        assert_eq!(loaded.sources.len(), 1);
+        assert_eq!(loaded.sources[0].root, source_root.path());
+        assert_eq!(loaded.core.audio_output.host.as_deref(), Some("wasapi"));
+        assert_eq!(
+            loaded.core.audio_output.device.as_deref(),
+            Some("Interface")
+        );
+        assert_eq!(loaded.core.audio_output.sample_rate, Some(96_000));
+        assert!((loaded.core.volume - 0.5).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/gui_app/audio_engine.rs
+++ b/src/gui_app/audio_engine.rs
@@ -9,6 +9,7 @@ impl GuiAppState {
         if let Some(player) = self.audio_player.as_mut() {
             player.set_volume(self.volume);
         }
+        self.persist_user_configuration("playback.volume.persist", started_at);
         emit_gui_action(
             "playback.volume.set",
             Some("transport"),
@@ -21,7 +22,11 @@ impl GuiAppState {
 
     pub(super) fn toggle_audio_settings(&mut self) {
         let started_at = Instant::now();
-        self.audio_settings_open = !self.audio_settings_open;
+        if self.audio_settings_open {
+            self.close_audio_settings_window();
+        } else {
+            self.open_audio_settings_window();
+        }
         emit_gui_action(
             "audio.settings.toggle",
             Some("top_bar"),
@@ -34,6 +39,15 @@ impl GuiAppState {
             started_at,
             None,
         );
+    }
+
+    pub(super) fn open_audio_settings_window(&mut self) {
+        self.audio_settings_open = true;
+        self.audio_settings_error = None;
+    }
+
+    pub(super) fn close_audio_settings_window(&mut self) {
+        self.audio_settings_open = false;
     }
 
     pub(super) fn set_audio_output_host(&mut self, host: Option<String>) {
@@ -141,6 +155,7 @@ impl GuiAppState {
                 error = Some(err);
             }
         }
+        self.persist_user_configuration("audio.output.persist", started_at);
         emit_gui_action(
             action,
             Some("audio_settings"),

--- a/src/gui_app/audio_settings.rs
+++ b/src/gui_app/audio_settings.rs
@@ -1,4 +1,7 @@
 use radiant::prelude as ui;
+use radiant::prelude::IntoView;
+use std::sync::Arc;
+use wavecrate::audio::{AudioDeviceSummary, AudioHostSummary, AudioOutputConfig};
 
 use super::{
     AUDIO_ENGINE_PILL_HEIGHT, AUDIO_ENGINE_PILL_ID, AUDIO_ENGINE_PILL_WIDTH,
@@ -10,7 +13,52 @@ mod audio_engine_pill;
 pub(super) use audio_engine_pill::AudioEnginePill;
 
 mod popover;
-pub(super) use popover::{audio_settings_popover, format_sample_rate_label};
+#[cfg(test)]
+pub(super) use popover::audio_settings_popover;
+pub(super) use popover::{audio_settings_window_view, format_sample_rate_label};
+
+#[derive(Clone, Debug)]
+pub(super) struct AudioSettingsSnapshot {
+    pub(super) detail_label: String,
+    pub(super) error: Option<String>,
+    pub(super) audio_output_config: AudioOutputConfig,
+    pub(super) audio_hosts: Vec<AudioHostSummary>,
+    pub(super) audio_devices: Vec<AudioDeviceSummary>,
+    pub(super) audio_sample_rates: Vec<u32>,
+}
+
+impl AudioSettingsSnapshot {
+    pub(super) fn from_app_state(state: &GuiAppState) -> Self {
+        Self {
+            detail_label: state.audio_engine_detail_label(),
+            error: state.audio_settings_error.clone(),
+            audio_output_config: state.audio_output_config.clone(),
+            audio_hosts: state.audio_hosts.clone(),
+            audio_devices: state.audio_devices.clone(),
+            audio_sample_rates: state.audio_sample_rates.clone(),
+        }
+    }
+}
+
+pub(super) fn auxiliary_windows(state: &mut GuiAppState) -> Vec<ui::AuxiliaryWindow<GuiMessage>> {
+    if !state.audio_settings_open {
+        return Vec::new();
+    }
+    let snapshot = AudioSettingsSnapshot::from_app_state(state);
+    let options = ui::NativeRunOptions {
+        title: String::from("Audio Engine"),
+        inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
+        min_inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
+        skip_taskbar: true,
+        decorations: true,
+        ..ui::NativeRunOptions::default()
+    };
+    let surface = ui::UiSurface::new(audio_settings_window_view(&snapshot).into_node());
+    vec![
+        ui::AuxiliaryWindow::new("audio-settings", options, Arc::new(surface))
+            .on_close(GuiMessage::CloseAudioSettings),
+    ]
+}
 
 pub(super) fn top_status_bar(state: &GuiAppState) -> ui::View<GuiMessage> {
     ui::row([

--- a/src/gui_app/audio_settings/popover.rs
+++ b/src/gui_app/audio_settings/popover.rs
@@ -1,10 +1,22 @@
 use radiant::prelude as ui;
 
-use super::{AUDIO_SETTINGS_POPUP_HEIGHT, AUDIO_SETTINGS_POPUP_WIDTH, GuiAppState, GuiMessage};
+#[cfg(test)]
+use super::GuiAppState;
+use super::{
+    AUDIO_SETTINGS_POPUP_HEIGHT, AUDIO_SETTINGS_POPUP_WIDTH, AudioSettingsSnapshot, GuiMessage,
+};
 
+#[cfg(test)]
 pub(in crate::gui_app) fn audio_settings_popover(state: &GuiAppState) -> ui::View<GuiMessage> {
-    let panel = ui::column(audio_settings_panel_rows(state))
-        .key("audio-settings-panel")
+    let snapshot = AudioSettingsSnapshot::from_app_state(state);
+    audio_settings_window_view(&snapshot)
+}
+
+pub(in crate::gui_app) fn audio_settings_window_view(
+    snapshot: &AudioSettingsSnapshot,
+) -> ui::View<GuiMessage> {
+    let panel = ui::column(audio_settings_panel_rows(snapshot))
+        .key("audio-settings-window")
         .style(ui::WidgetStyle {
             tone: ui::WidgetTone::Neutral,
             prominence: ui::WidgetProminence::Strong,
@@ -14,34 +26,40 @@ pub(in crate::gui_app) fn audio_settings_popover(state: &GuiAppState) -> ui::Vie
         .width(AUDIO_SETTINGS_POPUP_WIDTH)
         .height(AUDIO_SETTINGS_POPUP_HEIGHT);
     ui::column(vec![
-        ui::spacer().height(42.0),
-        ui::row(vec![ui::spacer().fill_width(), panel])
-            .padding_x(14.0)
-            .fill_width()
-            .height(AUDIO_SETTINGS_POPUP_HEIGHT),
+        ui::spacer().fill_height(),
+        ui::row(vec![
+            ui::spacer().fill_width(),
+            panel,
+            ui::spacer().fill_width(),
+        ])
+        .fill_width()
+        .height(AUDIO_SETTINGS_POPUP_HEIGHT),
         ui::spacer().fill_height(),
     ])
     .fill()
 }
 
-fn audio_settings_panel_rows(state: &GuiAppState) -> Vec<ui::View<GuiMessage>> {
-    let mut rows = vec![audio_settings_title_row(), audio_engine_detail_row(state)];
-    if let Some(error) = state.audio_settings_error.as_ref() {
+fn audio_settings_panel_rows(snapshot: &AudioSettingsSnapshot) -> Vec<ui::View<GuiMessage>> {
+    let mut rows = vec![
+        audio_settings_title_row(),
+        audio_engine_detail_row(snapshot),
+    ];
+    if let Some(error) = snapshot.error.as_ref() {
         rows.push(audio_settings_error_row(error));
     }
     rows.push(audio_settings_section(
         "Backend",
-        audio_host_option_buttons(state),
+        audio_host_option_buttons(snapshot),
         2,
     ));
     rows.push(audio_settings_section(
         "Output",
-        audio_device_option_buttons(state),
+        audio_device_option_buttons(snapshot),
         2,
     ));
     rows.push(audio_settings_section(
         "Sample Rate",
-        audio_sample_rate_option_buttons(state),
+        audio_sample_rate_option_buttons(snapshot),
         4,
     ));
     rows.push(cache_maintenance_section());
@@ -61,8 +79,8 @@ fn audio_settings_title_row() -> ui::View<GuiMessage> {
     .height(22.0)
 }
 
-fn audio_engine_detail_row(state: &GuiAppState) -> ui::View<GuiMessage> {
-    ui::text(state.audio_engine_detail_label())
+fn audio_engine_detail_row(snapshot: &AudioSettingsSnapshot) -> ui::View<GuiMessage> {
+    ui::text(snapshot.detail_label.clone())
         .key("audio-settings-detail")
         .fill_width()
         .height(20.0)
@@ -127,48 +145,48 @@ fn section_label(label: &'static str) -> ui::View<GuiMessage> {
         .height(18.0)
 }
 
-fn audio_host_option_buttons(state: &GuiAppState) -> Vec<ui::View<GuiMessage>> {
+fn audio_host_option_buttons(snapshot: &AudioSettingsSnapshot) -> Vec<ui::View<GuiMessage>> {
     let mut buttons = vec![audio_option_button(
         "System default".to_string(),
-        state.audio_output_config.host.is_none(),
+        snapshot.audio_output_config.host.is_none(),
         GuiMessage::SetAudioOutputHost(None),
     )];
-    buttons.extend(state.audio_hosts.iter().map(|host| {
+    buttons.extend(snapshot.audio_hosts.iter().map(|host| {
         audio_option_button(
             default_option_label(host.label.as_str(), host.is_default),
-            state.audio_output_config.host.as_deref() == Some(host.id.as_str()),
+            snapshot.audio_output_config.host.as_deref() == Some(host.id.as_str()),
             GuiMessage::SetAudioOutputHost(Some(host.id.clone())),
         )
     }));
     buttons
 }
 
-fn audio_device_option_buttons(state: &GuiAppState) -> Vec<ui::View<GuiMessage>> {
+fn audio_device_option_buttons(snapshot: &AudioSettingsSnapshot) -> Vec<ui::View<GuiMessage>> {
     let mut buttons = vec![audio_option_button(
         "Host default".to_string(),
-        state.audio_output_config.device.is_none(),
+        snapshot.audio_output_config.device.is_none(),
         GuiMessage::SetAudioOutputDevice(None),
     )];
-    buttons.extend(state.audio_devices.iter().map(|device| {
+    buttons.extend(snapshot.audio_devices.iter().map(|device| {
         audio_option_button(
             default_option_label(device.name.as_str(), device.is_default),
-            state.audio_output_config.device.as_deref() == Some(device.name.as_str()),
+            snapshot.audio_output_config.device.as_deref() == Some(device.name.as_str()),
             GuiMessage::SetAudioOutputDevice(Some(device.name.clone())),
         )
     }));
     buttons
 }
 
-fn audio_sample_rate_option_buttons(state: &GuiAppState) -> Vec<ui::View<GuiMessage>> {
+fn audio_sample_rate_option_buttons(snapshot: &AudioSettingsSnapshot) -> Vec<ui::View<GuiMessage>> {
     let mut buttons = vec![audio_option_button(
         "Device default".to_string(),
-        state.audio_output_config.sample_rate.is_none(),
+        snapshot.audio_output_config.sample_rate.is_none(),
         GuiMessage::SetAudioOutputSampleRate(None),
     )];
-    buttons.extend(state.audio_sample_rates.iter().copied().map(|rate| {
+    buttons.extend(snapshot.audio_sample_rates.iter().copied().map(|rate| {
         audio_option_button(
             format_sample_rate_label(rate),
-            state.audio_output_config.sample_rate == Some(rate),
+            snapshot.audio_output_config.sample_rate == Some(rate),
             GuiMessage::SetAudioOutputSampleRate(Some(rate)),
         )
     }));

--- a/src/gui_app/folder_browser/source_management.rs
+++ b/src/gui_app/folder_browser/source_management.rs
@@ -6,8 +6,39 @@ use super::{
     scanning::{merge_scan_discovery, placeholder_folder},
     types::{FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult},
 };
+use wavecrate::sample_sources::{SampleSource, SourceId};
 
 impl FolderBrowserState {
+    pub(in crate::gui_app) fn from_sample_sources(sources: &[SampleSource]) -> Self {
+        if sources.is_empty() {
+            return Self::load_default();
+        }
+        let entries = sources
+            .iter()
+            .map(|source| {
+                SourceEntry::new(
+                    source.id.as_str().to_string(),
+                    folder_label(&source.root),
+                    source.root.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        Self::from_sources(entries, sources[0].id.as_str().to_string())
+    }
+
+    pub(in crate::gui_app) fn configured_sample_sources(&self) -> Vec<SampleSource> {
+        self.sources
+            .iter()
+            .filter(|source| !source.is_default_assets_source())
+            .map(|source| {
+                SampleSource::new_with_id(
+                    SourceId::from_string(source.id.clone()),
+                    source.root.clone(),
+                )
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     pub(super) fn source_labels_for_tests(&self) -> Vec<String> {
         self.sources

--- a/src/gui_app/folder_browser/state_types.rs
+++ b/src/gui_app/folder_browser/state_types.rs
@@ -21,6 +21,10 @@ impl SourceEntry {
             loading_task: None,
         }
     }
+
+    pub(super) fn is_default_assets_source(&self) -> bool {
+        self.id == "assets" && self.root.ends_with("assets")
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -137,6 +137,39 @@ impl RetainedTextEditState {
         true
     }
 
+    fn move_word_left(&mut self, selecting: bool) {
+        self.move_caret(previous_word_boundary(&self.value, self.caret), selecting);
+    }
+
+    fn move_word_right(&mut self, selecting: bool) {
+        self.move_caret(next_word_boundary(&self.value, self.caret), selecting);
+    }
+
+    fn delete_word_left(&mut self) -> bool {
+        if self.replace_selection("") {
+            return true;
+        }
+        let start = previous_word_boundary(&self.value, self.caret);
+        if start == self.caret {
+            return false;
+        }
+        replace_char_range(&mut self.value, start, self.caret, "");
+        self.caret = start;
+        true
+    }
+
+    fn delete_word_right(&mut self) -> bool {
+        if self.replace_selection("") {
+            return true;
+        }
+        let end = next_word_boundary(&self.value, self.caret);
+        if end == self.caret {
+            return false;
+        }
+        replace_char_range(&mut self.value, self.caret, end, "");
+        true
+    }
+
     fn move_caret(&mut self, caret: usize, selecting: bool) {
         let caret = caret.min(self.value.chars().count());
         if selecting {
@@ -463,6 +496,16 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
                 edit.move_caret(edit.caret + 1, extend_selection);
                 false
             }),
+            TextEditCommand::MoveWordLeft { extend_selection } => self.edit_retained_text(|edit| {
+                edit.move_word_left(extend_selection);
+                false
+            }),
+            TextEditCommand::MoveWordRight { extend_selection } => {
+                self.edit_retained_text(|edit| {
+                    edit.move_word_right(extend_selection);
+                    false
+                })
+            }
             TextEditCommand::MoveHome { extend_selection } => self.edit_retained_text(|edit| {
                 edit.move_caret(0, extend_selection);
                 false
@@ -487,6 +530,12 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
             }
             TextEditCommand::Backspace => self.handle_retained_key_press(WidgetKey::Backspace),
             TextEditCommand::Delete => self.handle_retained_key_press(WidgetKey::Delete),
+            TextEditCommand::DeleteWordLeft => {
+                self.edit_retained_text(RetainedTextEditState::delete_word_left)
+            }
+            TextEditCommand::DeleteWordRight => {
+                self.edit_retained_text(RetainedTextEditState::delete_word_right)
+            }
             TextEditCommand::CutSelection => self.edit_retained_text(|edit| {
                 edit.replace_selection("");
                 true
@@ -747,6 +796,34 @@ fn byte_index_for_char(text: &str, char_index: usize) -> usize {
         .nth(char_index)
         .map(|(index, _)| index)
         .unwrap_or(text.len())
+}
+
+fn previous_word_boundary(text: &str, caret: usize) -> usize {
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut index = caret.min(chars.len());
+    while index > 0 && !is_word_char(chars[index - 1]) {
+        index -= 1;
+    }
+    while index > 0 && is_word_char(chars[index - 1]) {
+        index -= 1;
+    }
+    index
+}
+
+fn next_word_boundary(text: &str, caret: usize) -> usize {
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut index = caret.min(chars.len());
+    while index < chars.len() && !is_word_char(chars[index]) {
+        index += 1;
+    }
+    while index < chars.len() && is_word_char(chars[index]) {
+        index += 1;
+    }
+    index
+}
+
+fn is_word_char(character: char) -> bool {
+    character.is_alphanumeric() || character == '_'
 }
 
 fn replace_char_range(text: &mut String, start: usize, end: usize, replacement: &str) {

--- a/src/gui_runtime/native_shell_runtime/launch.rs
+++ b/src/gui_runtime/native_shell_runtime/launch.rs
@@ -9,6 +9,7 @@ impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
         Self {
             title: value.title,
             inner_size: value.inner_size,
+            position: None,
             min_inner_size: value.min_inner_size,
             maximized: value.maximized,
             decorations: value.decorations,
@@ -16,6 +17,8 @@ impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
             target_fps: value.target_fps,
             debug_layout: value.debug_layout,
             drag_and_drop: true,
+            owner_window_handle: None,
+            skip_taskbar: false,
             gpu: radiant::gui_runtime::NativeGpuOptions::default(),
             retained_surface_cache: radiant::runtime::RetainedSurfaceCachePolicy::default(),
             text: radiant::gui_runtime::NativeTextOptions {


### PR DESCRIPTION
## Summary
- use Radiant auxiliary native windows for the audio settings panel instead of an in-app overlay
- sync Wavecrate to the merged Radiant multi-window hosting update
- preserve current workspace changes for persisted audio/source settings and retained text word navigation

## Validation
- cargo check -p wavecrate --bin wavecrate
- cargo test -p wavecrate --bin wavecrate audio_settings
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent
