### PR TITLE
Fix audio backend labels to reflect the selected host

### DIFF
--- a/src/app_core/native_shell/options_panel_projection.rs
+++ b/src/app_core/native_shell/options_panel_projection.rs
@@ -154,28 +154,37 @@ fn output_selection_mismatch(ui: &UiState) -> bool {
 
 fn output_host_value(ui: &UiState) -> String {
     ui.audio
-        .applied
-        .as_ref()
-        .map(|output| output.host_id.clone())
-        .or_else(|| ui.audio.selected.host.clone())
+        .selected
+        .host
+        .clone()
+        .or_else(|| {
+            ui.audio
+                .applied
+                .as_ref()
+                .map(|output| output.host_id.clone())
+        })
         .unwrap_or_else(|| String::from("System default"))
 }
 
 fn output_device_value(ui: &UiState) -> String {
     ui.audio
-        .applied
-        .as_ref()
-        .map(|output| output.device_name.clone())
-        .or_else(|| ui.audio.selected.device.clone())
+        .selected
+        .device
+        .clone()
+        .or_else(|| {
+            ui.audio
+                .applied
+                .as_ref()
+                .map(|output| output.device_name.clone())
+        })
         .unwrap_or_else(|| String::from("Host default"))
 }
 
 fn output_sample_rate_value(ui: &UiState) -> String {
     ui.audio
-        .applied
-        .as_ref()
-        .map(|output| output.sample_rate)
-        .or(ui.audio.selected.sample_rate)
+        .selected
+        .sample_rate
+        .or_else(|| ui.audio.applied.as_ref().map(|output| output.sample_rate))
         .map(format_sample_rate_label)
         .unwrap_or_else(|| String::from("Device default"))
 }
@@ -519,5 +528,8 @@ mod tests {
             projected.detail_label.as_deref(),
             Some("Selected output differs from the active engine")
         );
+        assert_eq!(projected.output_host.value_label, "asio");
+        assert_eq!(projected.output_device.value_label, "Studio");
+        assert_eq!(projected.output_sample_rate.value_label, "96 kHz");
     }
 }

--- a/src/audio/output/discovery.rs
+++ b/src/audio/output/discovery.rs
@@ -87,7 +87,9 @@ pub(super) fn resolve_host(
         .into_iter()
         .find(|candidate| candidate.name() == requested)
         .and_then(|id| cpal::host_from_id(id).ok())
-        .unwrap_or(default_host);
+        .ok_or_else(|| AudioOutputError::HostUnavailable {
+            host_id: requested.to_string(),
+        })?;
     let resolved_id = host.id().name().to_string();
     let used_fallback = resolved_id != requested;
     Ok((host, resolved_id, used_fallback))
@@ -127,4 +129,20 @@ pub(super) fn sample_rates_in_range(min: u32, max: u32) -> Vec<u32> {
         .copied()
         .filter(|rate| *rate >= min && *rate <= max)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_unavailable_host_does_not_fall_back_to_default_host() {
+        let result = resolve_host(Some("__wavecrate_missing_host__"));
+
+        assert!(matches!(
+            result,
+            Err(AudioOutputError::HostUnavailable { host_id })
+                if host_id == "__wavecrate_missing_host__"
+        ));
+    }
 }

--- a/src/audio/output/mod.rs
+++ b/src/audio/output/mod.rs
@@ -31,6 +31,12 @@ pub enum AudioOutputError {
         /// Underlying cpal error.
         source: cpal::DevicesError,
     },
+    /// The requested output host is not available.
+    #[error("Audio host {host_id} is unavailable")]
+    HostUnavailable {
+        /// Requested host identifier.
+        host_id: String,
+    },
     /// Failed to query supported output configs for a host.
     #[error("Failed to read supported configs for {host_id}: {source}")]
     SupportedOutputConfigs {

--- a/src/audio/output/stream.rs
+++ b/src/audio/output/stream.rs
@@ -239,6 +239,9 @@ pub fn open_output_stream(
     ) {
         Ok(stream) => stream,
         Err(err) => {
+            if config.host.is_some() {
+                return Err(AudioOutputError::BuildStream { source: err });
+            }
             used_fallback = true;
             let default_host = cpal::default_host();
             let fallback_device = default_host.default_output_device().ok_or_else(|| {

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -3308,6 +3308,37 @@ mod tests {
     }
 
     #[test]
+    fn audio_engine_detail_distinguishes_selected_host_from_runtime_fallback() {
+        let mut state = gui_state_for_span_tests();
+        state.audio_output_config.host = Some(String::from("asio"));
+        state.audio_hosts = vec![
+            super::AudioHostSummary {
+                id: String::from("wasapi"),
+                label: String::from("WASAPI"),
+                is_default: true,
+            },
+            super::AudioHostSummary {
+                id: String::from("asio"),
+                label: String::from("ASIO"),
+                is_default: false,
+            },
+        ];
+        state.audio_output_resolved = Some(super::ResolvedOutput {
+            host_id: String::from("wasapi"),
+            device_name: String::from("Studio"),
+            sample_rate: 48_000,
+            buffer_size_frames: None,
+            channel_count: 2,
+            used_fallback: true,
+        });
+
+        assert_eq!(
+            state.audio_engine_detail_label(),
+            "ASIO selected | using WASAPI | Studio | 48 kHz"
+        );
+    }
+
+    #[test]
     fn audio_sample_rate_label_matches_status_chip_format() {
         assert_eq!(super::format_sample_rate_label(48_000), "48 kHz");
         assert_eq!(super::format_sample_rate_label(44_100), "44.1 kHz");

--- a/src/gui_app/audio_engine/options.rs
+++ b/src/gui_app/audio_engine/options.rs
@@ -68,9 +68,19 @@ impl GuiAppState {
         self.audio_output_resolved
             .as_ref()
             .map(|output| {
+                let running_host = self.audio_host_label(output.host_id.as_str());
+                let selected_host = self
+                    .audio_output_config
+                    .host
+                    .as_deref()
+                    .map(|host| self.audio_host_label(host));
+                let host_label = selected_host
+                    .filter(|host| *host != running_host)
+                    .map(|host| format!("{host} selected | using {running_host}"))
+                    .unwrap_or(running_host);
                 format!(
                     "{} | {} | {}",
-                    self.audio_host_label(output.host_id.as_str()),
+                    host_label,
                     output.device_name,
                     format_sample_rate_label(output.sample_rate)
                 )


### PR DESCRIPTION
## Summary
- Show the configured audio host/device/sample-rate selection in the settings projection instead of overwriting it with the applied runtime host.
- Make the runtime detail text explicit when the selected host differs from the host actually in use.
- Stop silently falling back to the system default host when an explicit host selection cannot be opened, and add a regression test for that failure path.

## Testing
- Not run (not requested)