### PR TITLE
Handle unsupported ASIO output configs with CPAL fallbacks

### DIFF
--- a/src/audio/output/stream.rs
+++ b/src/audio/output/stream.rs
@@ -1,4 +1,5 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{FromSample, SizedSample};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
@@ -178,6 +179,12 @@ struct BuiltStreamState {
     command_generation: Arc<AtomicU64>,
 }
 
+struct ResolvedOutputStreamConfig {
+    stream_config: cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    used_fallback: bool,
+}
+
 /// Open an audio stream honoring user preferences with safe fallbacks.
 ///
 /// On test builds, set `WAVECRATE_TEST_AUDIO_OUTPUT=1` to exercise real output
@@ -195,25 +202,9 @@ pub fn open_output_stream(
     let (host, host_id, host_fallback) = resolve_host(config.host.as_deref())?;
     let (device, device_name, device_fallback) = resolve_device(&host, config.device.as_deref())?;
 
-    let stream_config = match device.default_output_config() {
-        Ok(c) => c,
-        Err(err) => {
-            return Err(AudioOutputError::DefaultConfig {
-                host_id,
-                source: err,
-            });
-        }
-    };
-
-    let mut stream_config: cpal::StreamConfig = stream_config.into();
-    if let Some(rate) = config.sample_rate {
-        stream_config.sample_rate = rate;
-    }
-    if let Some(size) = config.buffer_size.filter(|size| *size > 0) {
-        stream_config.buffer_size = cpal::BufferSize::Fixed(size);
-    }
-
     let mut used_fallback = host_fallback || device_fallback;
+    let resolved_config = resolve_output_stream_config(&device, &host_id, config)?;
+    used_fallback |= resolved_config.used_fallback;
     let mut resolved_host_id = host_id;
     let mut resolved_device_name = device_name;
 
@@ -222,7 +213,7 @@ pub fn open_output_stream(
     let clear_pending = Arc::new(AtomicBool::new(false));
     let command_generation = Arc::new(AtomicU64::new(1));
 
-    let mut resolved_stream_config = stream_config.clone();
+    let mut resolved_stream_config = resolved_config.stream_config.clone();
     let BuiltStreamState {
         stream,
         command_sender,
@@ -231,7 +222,8 @@ pub fn open_output_stream(
         command_generation,
     } = match build_stream_with_state(
         &device,
-        &stream_config,
+        &resolved_config.stream_config,
+        resolved_config.sample_format,
         volume_bits.clone(),
         active_sources.clone(),
         clear_pending.clone(),
@@ -253,19 +245,17 @@ pub fn open_output_stream(
             resolved_device_name =
                 device_label(&fallback_device).unwrap_or_else(|| "Default device".to_string());
 
-            let fallback_config = fallback_device.default_output_config().map_err(|source| {
-                AudioOutputError::DefaultConfig {
-                    host_id: resolved_host_id.clone(),
-                    source,
-                }
-            })?;
-
-            let fallback_stream_config: cpal::StreamConfig = fallback_config.into();
-            resolved_stream_config = fallback_stream_config.clone();
+            let fallback_config = resolve_output_stream_config(
+                &fallback_device,
+                &resolved_host_id,
+                &AudioOutputConfig::default(),
+            )?;
+            resolved_stream_config = fallback_config.stream_config.clone();
 
             build_stream_with_state(
                 &fallback_device,
-                &fallback_stream_config,
+                &fallback_config.stream_config,
+                fallback_config.sample_format,
                 volume_bits.clone(),
                 active_sources.clone(),
                 clear_pending.clone(),
@@ -328,9 +318,147 @@ pub(super) fn resolved_output_from_stream_config(
     }
 }
 
+fn resolve_output_stream_config(
+    device: &cpal::Device,
+    host_id: &str,
+    config: &AudioOutputConfig,
+) -> Result<ResolvedOutputStreamConfig, AudioOutputError> {
+    let default_config =
+        device
+            .default_output_config()
+            .map_err(|source| AudioOutputError::DefaultConfig {
+                host_id: host_id.to_string(),
+                source,
+            })?;
+    let supported: Vec<_> = device
+        .supported_output_configs()
+        .map_err(|source| AudioOutputError::SupportedOutputConfigs {
+            host_id: host_id.to_string(),
+            source,
+        })?
+        .collect();
+    let mut used_fallback = false;
+    let (stream_config, sample_format) =
+        pick_output_stream_config(&default_config, &supported, config, &mut used_fallback);
+    Ok(ResolvedOutputStreamConfig {
+        stream_config,
+        sample_format,
+        used_fallback,
+    })
+}
+
+fn pick_output_stream_config(
+    default_config: &cpal::SupportedStreamConfig,
+    supported: &[cpal::SupportedStreamConfigRange],
+    config: &AudioOutputConfig,
+    used_fallback: &mut bool,
+) -> (cpal::StreamConfig, cpal::SampleFormat) {
+    let default_rate = default_config.sample_rate();
+    let requested_rate = config.sample_rate;
+    let default_channels = default_config.channels();
+    let default_format = default_config.sample_format();
+    let matching_channels: Vec<&cpal::SupportedStreamConfigRange> = supported
+        .iter()
+        .filter(|range| range.channels() == default_channels)
+        .collect();
+    let channel_ranges = if matching_channels.is_empty() {
+        if !supported.is_empty() {
+            *used_fallback = true;
+        }
+        supported.iter().collect()
+    } else {
+        matching_channels
+    };
+    let matching_format: Vec<&cpal::SupportedStreamConfigRange> = channel_ranges
+        .iter()
+        .copied()
+        .filter(|range| range.sample_format() == default_format)
+        .collect();
+    let ranges = if matching_format.is_empty() {
+        if !channel_ranges.is_empty() {
+            *used_fallback = true;
+        }
+        channel_ranges
+    } else {
+        matching_format
+    };
+
+    let (range, sample_rate) = if ranges.is_empty() {
+        let mut stream_config = default_config.config();
+        apply_output_buffer_size(&mut stream_config, None, config.buffer_size, used_fallback);
+        return (stream_config, default_format);
+    } else {
+        choose_output_range_and_rate(&ranges, requested_rate, default_rate, used_fallback)
+    };
+
+    let mut stream_config = range.with_sample_rate(sample_rate).config();
+    apply_output_buffer_size(
+        &mut stream_config,
+        Some(range.buffer_size()),
+        config.buffer_size,
+        used_fallback,
+    );
+    (stream_config, range.sample_format())
+}
+
+fn choose_output_range_and_rate<'a>(
+    ranges: &'a [&'a cpal::SupportedStreamConfigRange],
+    requested_rate: Option<u32>,
+    default_rate: u32,
+    used_fallback: &mut bool,
+) -> (&'a cpal::SupportedStreamConfigRange, u32) {
+    if let Some(rate) = requested_rate {
+        if let Some(range) = ranges
+            .iter()
+            .find(|range| output_rate_in_range(rate, range))
+        {
+            return (*range, rate);
+        }
+        *used_fallback = true;
+    }
+    if let Some(range) = ranges
+        .iter()
+        .find(|range| output_rate_in_range(default_rate, range))
+    {
+        return (*range, default_rate);
+    }
+    *used_fallback = true;
+    let range = ranges[0];
+    (range, range.max_sample_rate())
+}
+
+fn output_rate_in_range(rate: u32, range: &cpal::SupportedStreamConfigRange) -> bool {
+    rate >= range.min_sample_rate() && rate <= range.max_sample_rate()
+}
+
+fn apply_output_buffer_size(
+    stream_config: &mut cpal::StreamConfig,
+    supported: Option<&cpal::SupportedBufferSize>,
+    requested_size: Option<u32>,
+    used_fallback: &mut bool,
+) {
+    let Some(size) = requested_size.filter(|size| *size > 0) else {
+        return;
+    };
+    if supported.is_some_and(|supported| output_buffer_size_supported(supported, size)) {
+        stream_config.buffer_size = cpal::BufferSize::Fixed(size);
+    } else {
+        *used_fallback = true;
+        stream_config.buffer_size = cpal::BufferSize::Default;
+    }
+}
+
+fn output_buffer_size_supported(supported: &cpal::SupportedBufferSize, size: u32) -> bool {
+    match supported {
+        cpal::SupportedBufferSize::Range { min, max } => size >= *min && size <= *max,
+        cpal::SupportedBufferSize::Unknown => false,
+    }
+}
+
 fn build_stream_with_state(
     device: &cpal::Device,
     stream_config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
     volume_bits: Arc<AtomicU32>,
     active_sources: Arc<AtomicUsize>,
     clear_pending: Arc<AtomicBool>,
@@ -339,7 +467,7 @@ fn build_stream_with_state(
     const COMMAND_QUEUE_CAPACITY: usize = 512;
     let (command_sender, command_receiver) = mpsc::sync_channel(COMMAND_QUEUE_CAPACITY);
     let (error_sender, error_receiver) = mpsc::channel();
-    let mut callback_state = CallbackState::new(
+    let callback_state = CallbackState::new(
         command_receiver,
         error_sender,
         volume_bits,
@@ -347,15 +475,48 @@ fn build_stream_with_state(
         clear_pending.clone(),
         command_generation.clone(),
     );
-    let callback = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        process_audio_callback(&mut callback_state, data);
+    let stream = match sample_format {
+        cpal::SampleFormat::F32 => {
+            build_typed_output_stream::<f32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::F64 => {
+            build_typed_output_stream::<f64>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I8 => {
+            build_typed_output_stream::<i8>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I16 => {
+            build_typed_output_stream::<i16>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I24 => {
+            build_typed_output_stream::<cpal::I24>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I32 => {
+            build_typed_output_stream::<i32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I64 => {
+            build_typed_output_stream::<i64>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U8 => {
+            build_typed_output_stream::<u8>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U16 => {
+            build_typed_output_stream::<u16>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U24 => {
+            build_typed_output_stream::<cpal::U24>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U32 => {
+            build_typed_output_stream::<u32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U64 => {
+            build_typed_output_stream::<u64>(device, stream_config, callback_state)?
+        }
+        format => {
+            warn!("Unsupported output sample format {format:?}; trying f32 stream");
+            build_typed_output_stream::<f32>(device, stream_config, callback_state)?
+        }
     };
-    let stream = device.build_output_stream(
-        stream_config,
-        callback,
-        |err| tracing::error!("Stream error: {}", err),
-        None,
-    )?;
     Ok(BuiltStreamState {
         stream,
         command_sender,
@@ -363,6 +524,29 @@ fn build_stream_with_state(
         clear_pending,
         command_generation,
     })
+}
+
+fn build_typed_output_stream<T>(
+    device: &cpal::Device,
+    stream_config: &cpal::StreamConfig,
+    mut callback_state: CallbackState,
+) -> Result<cpal::Stream, cpal::BuildStreamError>
+where
+    T: SizedSample + FromSample<f32>,
+{
+    let mut scratch = Vec::new();
+    device.build_output_stream(
+        stream_config,
+        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+            scratch.resize(data.len(), 0.0);
+            process_audio_callback(&mut callback_state, &mut scratch);
+            for (sample_out, sample_in) in data.iter_mut().zip(scratch.iter().copied()) {
+                *sample_out = T::from_sample(sample_in.clamp(-1.0, 1.0));
+            }
+        },
+        |err| tracing::error!("Stream error: {}", err),
+        None,
+    )
 }
 
 fn request_clear(
@@ -373,6 +557,122 @@ fn request_clear(
     let generation = command_generation.fetch_add(1, Ordering::AcqRel) + 1;
     clear_pending.store(true, Ordering::Release);
     command_sender.try_send(StreamCommand::Clear { generation })
+}
+
+#[cfg(test)]
+mod stream_config_tests {
+    use super::*;
+    use cpal::{SampleFormat, SupportedBufferSize, SupportedStreamConfigRange};
+
+    fn range(
+        channels: u16,
+        min_rate: u32,
+        max_rate: u32,
+        buffer: SupportedBufferSize,
+        format: SampleFormat,
+    ) -> SupportedStreamConfigRange {
+        SupportedStreamConfigRange::new(channels, min_rate, max_rate, buffer, format)
+    }
+
+    #[test]
+    fn requested_output_rate_falls_back_to_supported_default_rate() {
+        let default = range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range {
+                min: 128,
+                max: 1024,
+            },
+            SampleFormat::F32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range {
+                min: 128,
+                max: 1024,
+            },
+            SampleFormat::F32,
+        )];
+        let mut used_fallback = false;
+        let (config, format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig {
+                sample_rate: Some(96_000),
+                ..AudioOutputConfig::default()
+            },
+            &mut used_fallback,
+        );
+
+        assert_eq!(config.sample_rate, 48_000);
+        assert_eq!(format, SampleFormat::F32);
+        assert!(used_fallback);
+    }
+
+    #[test]
+    fn unsupported_output_buffer_uses_driver_default() {
+        let default = range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range { min: 128, max: 256 },
+            SampleFormat::F32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range { min: 128, max: 256 },
+            SampleFormat::F32,
+        )];
+        let mut used_fallback = false;
+        let (config, _format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig {
+                buffer_size: Some(512),
+                ..AudioOutputConfig::default()
+            },
+            &mut used_fallback,
+        );
+
+        assert_eq!(config.buffer_size, cpal::BufferSize::Default);
+        assert!(used_fallback);
+    }
+
+    #[test]
+    fn output_config_uses_supported_non_f32_sample_format() {
+        let default = range(
+            2,
+            48_000,
+            48_000,
+            SupportedBufferSize::Range { min: 64, max: 512 },
+            SampleFormat::I32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            48_000,
+            48_000,
+            SupportedBufferSize::Range { min: 64, max: 512 },
+            SampleFormat::I32,
+        )];
+        let mut used_fallback = false;
+        let (_config, format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig::default(),
+            &mut used_fallback,
+        );
+
+        assert_eq!(format, SampleFormat::I32);
+        assert!(!used_fallback);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Resolve output streams against CPAL-supported configs instead of blindly applying the persisted rate and buffer.
- Build output streams with the device’s reported sample format, including non-`f32` formats.
- Fall back to the driver/default-supported rate and buffer when the requested combination is not valid, so selecting ASIO does not fail just because the saved settings are incompatible.
- Add targeted unit coverage for rate fallback, buffer fallback, and non-`f32` output formats.

## Testing
- Added unit tests for output config resolution edge cases.
- `cargo test -p wavecrate stream_config_tests --lib` passed.
- `powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent` passed.