### PR TITLE
Refine the audio engine options panel

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -889,7 +889,7 @@ mod opt_272_tests {
     }
 
     #[test]
-    fn options_panel_can_be_repositioned_by_dragging_title_bar() {
+    fn options_panel_omits_inner_title_drag_surface() {
         let layout = ShellLayout::build(Vector2::new(1280.0, 720.0));
         let style = style_for_layout(&layout);
         let mut state = NativeShellState::new();
@@ -904,20 +904,9 @@ mod opt_272_tests {
             .expect("visible options panel should resolve layout");
         let grab = initial.title_rect.center();
 
-        assert!(state.begin_options_panel_drag(&layout, &model, grab));
-        assert!(state.update_options_panel_drag(
-            &layout,
-            &model,
-            Point::new(grab.x - 160.0, grab.y + 96.0),
-        ));
-        assert!(state.finish_options_panel_drag());
-
-        let moved = state
-            .options_panel_title_rect_live(&layout, &model)
-            .expect("moved options panel should still resolve");
-        assert!(moved.min.x < initial.title_rect.min.x - 80.0);
-        assert!(moved.min.y > initial.title_rect.min.y + 40.0);
-        assert!(state.options_panel_contains_point(&layout, &model, moved.center()));
+        assert!(initial.title.is_empty());
+        assert_eq!(initial.title_rect.height(), 0.0);
+        assert!(!state.begin_options_panel_drag(&layout, &model, grab));
     }
 
     #[test]
@@ -961,7 +950,7 @@ mod opt_272_tests {
                     crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
                 ),
                 primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
-                    label: String::from("Output Sample Rate"),
+                    label: String::from("Sample Rate"),
                     value_label: String::from("48 kHz"),
                 },
                 primary_number_options: vec![
@@ -985,18 +974,14 @@ mod opt_272_tests {
 
         let panel = options_panel_layout(&layout, &style, &model)
             .expect("visible picker panel should resolve layout");
-        assert_eq!(panel.title, "Audio Engine");
+        assert!(panel.title.is_empty());
         let dropdown_row = panel
             .buttons
             .iter()
             .position(|button| button.action == UiAction::OpenPrimaryNumberPicker)
             .expect("active picker row should remain in the overview");
         assert!(panel.buttons[dropdown_row].active);
-        assert!(
-            panel.buttons[dropdown_row]
-                .text
-                .starts_with("Output Sample Rate")
-        );
+        assert!(panel.buttons[dropdown_row].text.starts_with("Sample Rate"));
         assert_eq!(
             panel.buttons[dropdown_row + 1].action,
             UiAction::SetPrimaryNumber { value: None }

--- a/src/app_core/native_shell/composition/state/options_panel/actions.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/actions.rs
@@ -122,13 +122,12 @@ pub(super) fn legacy_options_panel_button_defs(model: &AppModel) -> Vec<(String,
             UiAction::ShowOptionsOverview,
         ),
         (String::from("Open Trash Folder"), UiAction::OpenTrashFolder),
-        (String::from("Close"), UiAction::CloseOptionsPanel),
     ]
 }
 
 pub(super) fn options_panel_title(model: &AppModel) -> String {
     let _ = model;
-    String::from("Audio Engine")
+    String::new()
 }
 
 pub(super) fn picker_options(
@@ -165,8 +164,8 @@ pub(super) fn picker_action(value: &PairedPickerValueModel) -> UiAction {
 pub(super) fn audio_picker_label(target: PairedPickerTargetModel) -> String {
     match target {
         PairedPickerTargetModel::PrimaryGroup => String::from("Output Host"),
-        PairedPickerTargetModel::PrimaryItem => String::from("Output Device"),
-        PairedPickerTargetModel::PrimaryNumber => String::from("Output Sample Rate"),
+        PairedPickerTargetModel::PrimaryItem => String::from("Output"),
+        PairedPickerTargetModel::PrimaryNumber => String::from("Sample Rate"),
         PairedPickerTargetModel::SecondaryGroup => String::from("Input Host"),
         PairedPickerTargetModel::SecondaryItem => String::from("Input Device"),
         PairedPickerTargetModel::SecondaryNumber => String::from("Input Sample Rate"),

--- a/src/app_core/native_shell/composition/state/options_panel/geometry.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/geometry.rs
@@ -32,7 +32,7 @@ pub(super) fn options_panel_layout(
     }
     let sizing = style.sizing;
     let panel_padding = sizing.overlay_padding.max(10.0);
-    let title_height = sizing.overlay_button_height.max(22.0);
+    let title_height = 0.0;
     let detail_height = if model.paired_device_panel().detail_label().is_some() {
         sizing.overlay_button_height.max(20.0)
     } else {
@@ -44,11 +44,13 @@ pub(super) fn options_panel_layout(
     let panel_width = button_width + (panel_padding * 2.0);
     let buttons = build_options_panel_buttons(model);
     let detail_gap = if detail_height > 0.0 { button_gap } else { 0.0 };
+    let title_gap = if title_height > 0.0 { button_gap } else { 0.0 };
     let panel_height = panel_padding
         + title_height
+        + title_gap
         + detail_gap
         + detail_height
-        + button_gap
+        + if detail_height > 0.0 { button_gap } else { 0.0 }
         + (button_height * buttons.len() as f32)
         + (button_gap * buttons.len().saturating_sub(1) as f32)
         + panel_padding;
@@ -89,10 +91,10 @@ pub(super) fn options_panel_layout(
     );
     let detail_rect = if detail_height > 0.0 {
         Some(Rect::from_min_max(
-            Point::new(title_rect.min.x, title_rect.max.y + detail_gap),
+            Point::new(title_rect.min.x, title_rect.max.y + title_gap + detail_gap),
             Point::new(
                 title_rect.max.x,
-                title_rect.max.y + detail_gap + detail_height,
+                title_rect.max.y + title_gap + detail_gap + detail_height,
             ),
         ))
     } else {
@@ -101,7 +103,7 @@ pub(super) fn options_panel_layout(
     let button_x = panel_rect.min.x + panel_padding;
     let mut button_y = detail_rect
         .map(|rect| rect.max.y + button_gap)
-        .unwrap_or(title_rect.max.y + button_gap);
+        .unwrap_or(title_rect.max.y + title_gap);
     let mut layout_buttons = Vec::with_capacity(buttons.len());
     for (text, action, active) in buttons {
         let rect = Rect::from_min_max(

--- a/src/app_core/native_shell/composition/state/options_panel/render.rs
+++ b/src/app_core/native_shell/composition/state/options_panel/render.rs
@@ -55,17 +55,19 @@ pub(super) fn render_options_panel(
         blend_color(style.border_emphasis, style.highlight_orange, 0.42),
         sizing.border_width,
     );
-    emit_text(
-        text_runs,
-        TextRun {
-            text: panel.title.clone(),
-            position: panel.title_rect.min,
-            font_size: sizing.font_title,
-            color: style.text_primary,
-            max_width: Some(panel.title_rect.width().max(36.0)),
-            align: TextAlign::Left,
-        },
-    );
+    if !panel.title.is_empty() {
+        emit_text(
+            text_runs,
+            TextRun {
+                text: panel.title.clone(),
+                position: panel.title_rect.min,
+                font_size: sizing.font_title,
+                color: style.text_primary,
+                max_width: Some(panel.title_rect.width().max(36.0)),
+                align: TextAlign::Left,
+            },
+        );
+    }
     if let (Some(detail_rect), Some(detail)) = (
         panel.detail_rect,
         model.paired_device_panel().detail_label(),

--- a/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
+++ b/src/app_core/native_shell/composition/state/tests/overlay_controls/context_and_controls.rs
@@ -444,11 +444,11 @@ fn options_panel_overview_lists_audio_rows_before_legacy_toggles() {
                 value_label: String::from("ASIO"),
             },
             primary_item: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
-                label: String::from("Output Device"),
+                label: String::from("Output"),
                 value_label: String::from("USB"),
             },
             primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
-                label: String::from("Output Sample Rate"),
+                label: String::from("Sample Rate"),
                 value_label: String::from("48 kHz"),
             },
             secondary_group: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
@@ -476,7 +476,7 @@ fn options_panel_overview_lists_audio_rows_before_legacy_toggles() {
         .map(|button| button.action.clone())
         .collect::<Vec<_>>();
 
-    assert_eq!(panel.title, "Audio Engine");
+    assert!(panel.title.is_empty());
     assert_eq!(
         actions[..6],
         [
@@ -488,7 +488,11 @@ fn options_panel_overview_lists_audio_rows_before_legacy_toggles() {
             UiAction::OpenSecondaryNumberPicker,
         ]
     );
-    assert_eq!(actions.last(), Some(&UiAction::CloseOptionsPanel));
+    assert!(
+        !actions
+            .iter()
+            .any(|action| action == &UiAction::CloseOptionsPanel)
+    );
 }
 
 #[test]
@@ -524,7 +528,7 @@ fn options_panel_picker_mode_expands_inline_dropdown_actions() {
 
     let panel = options_panel_layout(&layout, &style, &model)
         .expect("visible picker panel should resolve layout");
-    assert_eq!(panel.title, "Audio Engine");
+    assert!(panel.title.is_empty());
     let dropdown_row = panel
         .buttons
         .iter()
@@ -537,7 +541,7 @@ fn options_panel_picker_mode_expands_inline_dropdown_actions() {
             .starts_with("Sample Rate")
             || panel.buttons[dropdown_row]
                 .text
-                .starts_with("Output Sample Rate")
+                .starts_with("Sample Rate")
     );
     assert_eq!(
         panel.buttons[dropdown_row + 1].action,
@@ -612,12 +616,12 @@ fn options_panel_renders_after_other_modal_overlays() {
         .iter()
         .position(|run| run.text == "Background task")
         .expect("progress overlay title should render");
-    let panel_title_index = overlay
+    let panel_row_index = overlay
         .text_runs
         .iter()
-        .position(|run| run.text == "Audio Engine")
-        .expect("options panel title should render");
-    assert!(panel_title_index > progress_title_index);
+        .position(|run| run.text.starts_with("Output Host"))
+        .expect("options panel row should render");
+    assert!(panel_row_index > progress_title_index);
 
     let panel = options_panel_layout(&layout, &style, &model)
         .expect("visible options panel should resolve layout");

--- a/src/app_core/native_shell/composition/state/tests/overlay_controls/progress_and_drag.rs
+++ b/src/app_core/native_shell/composition/state/tests/overlay_controls/progress_and_drag.rs
@@ -278,7 +278,7 @@ fn state_overlay_renders_options_panel_when_visible() {
         overlay
             .text_runs
             .iter()
-            .any(|run| run.text == "Audio Engine")
+            .any(|run| run.text.starts_with("Output Host"))
     );
 }
 

--- a/src/app_core/native_shell/options_panel_projection.rs
+++ b/src/app_core/native_shell/options_panel_projection.rs
@@ -50,11 +50,11 @@ pub(crate) fn project_audio_engine_model(
             value_label: output_host_value(ui),
         },
         output_device: crate::app_core::actions::NativeAudioFieldModel {
-            label: String::from("Output Device"),
+            label: String::from("Output"),
             value_label: output_device_value(ui),
         },
         output_sample_rate: crate::app_core::actions::NativeAudioFieldModel {
-            label: String::from("Output Sample Rate"),
+            label: String::from("Sample Rate"),
             value_label: output_sample_rate_value(ui),
         },
         input_host: crate::app_core::actions::NativeAudioFieldModel {

--- a/src/audio/output/stream.rs
+++ b/src/audio/output/stream.rs
@@ -1,4 +1,5 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{FromSample, SizedSample};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
@@ -178,6 +179,12 @@ struct BuiltStreamState {
     command_generation: Arc<AtomicU64>,
 }
 
+struct ResolvedOutputStreamConfig {
+    stream_config: cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    used_fallback: bool,
+}
+
 /// Open an audio stream honoring user preferences with safe fallbacks.
 ///
 /// On test builds, set `WAVECRATE_TEST_AUDIO_OUTPUT=1` to exercise real output
@@ -195,25 +202,9 @@ pub fn open_output_stream(
     let (host, host_id, host_fallback) = resolve_host(config.host.as_deref())?;
     let (device, device_name, device_fallback) = resolve_device(&host, config.device.as_deref())?;
 
-    let stream_config = match device.default_output_config() {
-        Ok(c) => c,
-        Err(err) => {
-            return Err(AudioOutputError::DefaultConfig {
-                host_id,
-                source: err,
-            });
-        }
-    };
-
-    let mut stream_config: cpal::StreamConfig = stream_config.into();
-    if let Some(rate) = config.sample_rate {
-        stream_config.sample_rate = rate;
-    }
-    if let Some(size) = config.buffer_size.filter(|size| *size > 0) {
-        stream_config.buffer_size = cpal::BufferSize::Fixed(size);
-    }
-
     let mut used_fallback = host_fallback || device_fallback;
+    let resolved_config = resolve_output_stream_config(&device, &host_id, config)?;
+    used_fallback |= resolved_config.used_fallback;
     let mut resolved_host_id = host_id;
     let mut resolved_device_name = device_name;
 
@@ -222,7 +213,7 @@ pub fn open_output_stream(
     let clear_pending = Arc::new(AtomicBool::new(false));
     let command_generation = Arc::new(AtomicU64::new(1));
 
-    let mut resolved_stream_config = stream_config.clone();
+    let mut resolved_stream_config = resolved_config.stream_config.clone();
     let BuiltStreamState {
         stream,
         command_sender,
@@ -231,7 +222,8 @@ pub fn open_output_stream(
         command_generation,
     } = match build_stream_with_state(
         &device,
-        &stream_config,
+        &resolved_config.stream_config,
+        resolved_config.sample_format,
         volume_bits.clone(),
         active_sources.clone(),
         clear_pending.clone(),
@@ -253,19 +245,17 @@ pub fn open_output_stream(
             resolved_device_name =
                 device_label(&fallback_device).unwrap_or_else(|| "Default device".to_string());
 
-            let fallback_config = fallback_device.default_output_config().map_err(|source| {
-                AudioOutputError::DefaultConfig {
-                    host_id: resolved_host_id.clone(),
-                    source,
-                }
-            })?;
-
-            let fallback_stream_config: cpal::StreamConfig = fallback_config.into();
-            resolved_stream_config = fallback_stream_config.clone();
+            let fallback_config = resolve_output_stream_config(
+                &fallback_device,
+                &resolved_host_id,
+                &AudioOutputConfig::default(),
+            )?;
+            resolved_stream_config = fallback_config.stream_config.clone();
 
             build_stream_with_state(
                 &fallback_device,
-                &fallback_stream_config,
+                &fallback_config.stream_config,
+                fallback_config.sample_format,
                 volume_bits.clone(),
                 active_sources.clone(),
                 clear_pending.clone(),
@@ -328,9 +318,147 @@ pub(super) fn resolved_output_from_stream_config(
     }
 }
 
+fn resolve_output_stream_config(
+    device: &cpal::Device,
+    host_id: &str,
+    config: &AudioOutputConfig,
+) -> Result<ResolvedOutputStreamConfig, AudioOutputError> {
+    let default_config =
+        device
+            .default_output_config()
+            .map_err(|source| AudioOutputError::DefaultConfig {
+                host_id: host_id.to_string(),
+                source,
+            })?;
+    let supported: Vec<_> = device
+        .supported_output_configs()
+        .map_err(|source| AudioOutputError::SupportedOutputConfigs {
+            host_id: host_id.to_string(),
+            source,
+        })?
+        .collect();
+    let mut used_fallback = false;
+    let (stream_config, sample_format) =
+        pick_output_stream_config(&default_config, &supported, config, &mut used_fallback);
+    Ok(ResolvedOutputStreamConfig {
+        stream_config,
+        sample_format,
+        used_fallback,
+    })
+}
+
+fn pick_output_stream_config(
+    default_config: &cpal::SupportedStreamConfig,
+    supported: &[cpal::SupportedStreamConfigRange],
+    config: &AudioOutputConfig,
+    used_fallback: &mut bool,
+) -> (cpal::StreamConfig, cpal::SampleFormat) {
+    let default_rate = default_config.sample_rate();
+    let requested_rate = config.sample_rate;
+    let default_channels = default_config.channels();
+    let default_format = default_config.sample_format();
+    let matching_channels: Vec<&cpal::SupportedStreamConfigRange> = supported
+        .iter()
+        .filter(|range| range.channels() == default_channels)
+        .collect();
+    let channel_ranges = if matching_channels.is_empty() {
+        if !supported.is_empty() {
+            *used_fallback = true;
+        }
+        supported.iter().collect()
+    } else {
+        matching_channels
+    };
+    let matching_format: Vec<&cpal::SupportedStreamConfigRange> = channel_ranges
+        .iter()
+        .copied()
+        .filter(|range| range.sample_format() == default_format)
+        .collect();
+    let ranges = if matching_format.is_empty() {
+        if !channel_ranges.is_empty() {
+            *used_fallback = true;
+        }
+        channel_ranges
+    } else {
+        matching_format
+    };
+
+    let (range, sample_rate) = if ranges.is_empty() {
+        let mut stream_config = default_config.config();
+        apply_output_buffer_size(&mut stream_config, None, config.buffer_size, used_fallback);
+        return (stream_config, default_format);
+    } else {
+        choose_output_range_and_rate(&ranges, requested_rate, default_rate, used_fallback)
+    };
+
+    let mut stream_config = range.with_sample_rate(sample_rate).config();
+    apply_output_buffer_size(
+        &mut stream_config,
+        Some(range.buffer_size()),
+        config.buffer_size,
+        used_fallback,
+    );
+    (stream_config, range.sample_format())
+}
+
+fn choose_output_range_and_rate<'a>(
+    ranges: &'a [&'a cpal::SupportedStreamConfigRange],
+    requested_rate: Option<u32>,
+    default_rate: u32,
+    used_fallback: &mut bool,
+) -> (&'a cpal::SupportedStreamConfigRange, u32) {
+    if let Some(rate) = requested_rate {
+        if let Some(range) = ranges
+            .iter()
+            .find(|range| output_rate_in_range(rate, range))
+        {
+            return (*range, rate);
+        }
+        *used_fallback = true;
+    }
+    if let Some(range) = ranges
+        .iter()
+        .find(|range| output_rate_in_range(default_rate, range))
+    {
+        return (*range, default_rate);
+    }
+    *used_fallback = true;
+    let range = ranges[0];
+    (range, range.max_sample_rate())
+}
+
+fn output_rate_in_range(rate: u32, range: &cpal::SupportedStreamConfigRange) -> bool {
+    rate >= range.min_sample_rate() && rate <= range.max_sample_rate()
+}
+
+fn apply_output_buffer_size(
+    stream_config: &mut cpal::StreamConfig,
+    supported: Option<&cpal::SupportedBufferSize>,
+    requested_size: Option<u32>,
+    used_fallback: &mut bool,
+) {
+    let Some(size) = requested_size.filter(|size| *size > 0) else {
+        return;
+    };
+    if supported.is_some_and(|supported| output_buffer_size_supported(supported, size)) {
+        stream_config.buffer_size = cpal::BufferSize::Fixed(size);
+    } else {
+        *used_fallback = true;
+        stream_config.buffer_size = cpal::BufferSize::Default;
+    }
+}
+
+fn output_buffer_size_supported(supported: &cpal::SupportedBufferSize, size: u32) -> bool {
+    match supported {
+        cpal::SupportedBufferSize::Range { min, max } => size >= *min && size <= *max,
+        cpal::SupportedBufferSize::Unknown => false,
+    }
+}
+
 fn build_stream_with_state(
     device: &cpal::Device,
     stream_config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
     volume_bits: Arc<AtomicU32>,
     active_sources: Arc<AtomicUsize>,
     clear_pending: Arc<AtomicBool>,
@@ -339,7 +467,7 @@ fn build_stream_with_state(
     const COMMAND_QUEUE_CAPACITY: usize = 512;
     let (command_sender, command_receiver) = mpsc::sync_channel(COMMAND_QUEUE_CAPACITY);
     let (error_sender, error_receiver) = mpsc::channel();
-    let mut callback_state = CallbackState::new(
+    let callback_state = CallbackState::new(
         command_receiver,
         error_sender,
         volume_bits,
@@ -347,15 +475,48 @@ fn build_stream_with_state(
         clear_pending.clone(),
         command_generation.clone(),
     );
-    let callback = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        process_audio_callback(&mut callback_state, data);
+    let stream = match sample_format {
+        cpal::SampleFormat::F32 => {
+            build_typed_output_stream::<f32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::F64 => {
+            build_typed_output_stream::<f64>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I8 => {
+            build_typed_output_stream::<i8>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I16 => {
+            build_typed_output_stream::<i16>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I24 => {
+            build_typed_output_stream::<cpal::I24>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I32 => {
+            build_typed_output_stream::<i32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::I64 => {
+            build_typed_output_stream::<i64>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U8 => {
+            build_typed_output_stream::<u8>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U16 => {
+            build_typed_output_stream::<u16>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U24 => {
+            build_typed_output_stream::<cpal::U24>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U32 => {
+            build_typed_output_stream::<u32>(device, stream_config, callback_state)?
+        }
+        cpal::SampleFormat::U64 => {
+            build_typed_output_stream::<u64>(device, stream_config, callback_state)?
+        }
+        format => {
+            warn!("Unsupported output sample format {format:?}; trying f32 stream");
+            build_typed_output_stream::<f32>(device, stream_config, callback_state)?
+        }
     };
-    let stream = device.build_output_stream(
-        stream_config,
-        callback,
-        |err| tracing::error!("Stream error: {}", err),
-        None,
-    )?;
     Ok(BuiltStreamState {
         stream,
         command_sender,
@@ -363,6 +524,29 @@ fn build_stream_with_state(
         clear_pending,
         command_generation,
     })
+}
+
+fn build_typed_output_stream<T>(
+    device: &cpal::Device,
+    stream_config: &cpal::StreamConfig,
+    mut callback_state: CallbackState,
+) -> Result<cpal::Stream, cpal::BuildStreamError>
+where
+    T: SizedSample + FromSample<f32>,
+{
+    let mut scratch = Vec::new();
+    device.build_output_stream(
+        stream_config,
+        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+            scratch.resize(data.len(), 0.0);
+            process_audio_callback(&mut callback_state, &mut scratch);
+            for (sample_out, sample_in) in data.iter_mut().zip(scratch.iter().copied()) {
+                *sample_out = T::from_sample(sample_in.clamp(-1.0, 1.0));
+            }
+        },
+        |err| tracing::error!("Stream error: {}", err),
+        None,
+    )
 }
 
 fn request_clear(
@@ -373,6 +557,122 @@ fn request_clear(
     let generation = command_generation.fetch_add(1, Ordering::AcqRel) + 1;
     clear_pending.store(true, Ordering::Release);
     command_sender.try_send(StreamCommand::Clear { generation })
+}
+
+#[cfg(test)]
+mod stream_config_tests {
+    use super::*;
+    use cpal::{SampleFormat, SupportedBufferSize, SupportedStreamConfigRange};
+
+    fn range(
+        channels: u16,
+        min_rate: u32,
+        max_rate: u32,
+        buffer: SupportedBufferSize,
+        format: SampleFormat,
+    ) -> SupportedStreamConfigRange {
+        SupportedStreamConfigRange::new(channels, min_rate, max_rate, buffer, format)
+    }
+
+    #[test]
+    fn requested_output_rate_falls_back_to_supported_default_rate() {
+        let default = range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range {
+                min: 128,
+                max: 1024,
+            },
+            SampleFormat::F32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range {
+                min: 128,
+                max: 1024,
+            },
+            SampleFormat::F32,
+        )];
+        let mut used_fallback = false;
+        let (config, format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig {
+                sample_rate: Some(96_000),
+                ..AudioOutputConfig::default()
+            },
+            &mut used_fallback,
+        );
+
+        assert_eq!(config.sample_rate, 48_000);
+        assert_eq!(format, SampleFormat::F32);
+        assert!(used_fallback);
+    }
+
+    #[test]
+    fn unsupported_output_buffer_uses_driver_default() {
+        let default = range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range { min: 128, max: 256 },
+            SampleFormat::F32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            44_100,
+            48_000,
+            SupportedBufferSize::Range { min: 128, max: 256 },
+            SampleFormat::F32,
+        )];
+        let mut used_fallback = false;
+        let (config, _format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig {
+                buffer_size: Some(512),
+                ..AudioOutputConfig::default()
+            },
+            &mut used_fallback,
+        );
+
+        assert_eq!(config.buffer_size, cpal::BufferSize::Default);
+        assert!(used_fallback);
+    }
+
+    #[test]
+    fn output_config_uses_supported_non_f32_sample_format() {
+        let default = range(
+            2,
+            48_000,
+            48_000,
+            SupportedBufferSize::Range { min: 64, max: 512 },
+            SampleFormat::I32,
+        )
+        .with_sample_rate(48_000);
+        let supported = vec![range(
+            2,
+            48_000,
+            48_000,
+            SupportedBufferSize::Range { min: 64, max: 512 },
+            SampleFormat::I32,
+        )];
+        let mut used_fallback = false;
+        let (_config, format) = pick_output_stream_config(
+            &default,
+            &supported,
+            &AudioOutputConfig::default(),
+            &mut used_fallback,
+        );
+
+        assert_eq!(format, SampleFormat::I32);
+        assert!(!used_fallback);
+    }
 }
 
 #[cfg(test)]

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -607,11 +607,11 @@ mod tests {
             value_label: String::from("WASAPI"),
         };
         model.paired_device.primary_item = runtime_contract::SummaryFieldModel {
-            label: String::from("Output Device"),
+            label: String::from("Output"),
             value_label: String::from("Speakers"),
         };
         model.paired_device.primary_number = runtime_contract::SummaryFieldModel {
-            label: String::from("Output Sample Rate"),
+            label: String::from("Sample Rate"),
             value_label: String::from("48 kHz"),
         };
 
@@ -631,8 +631,8 @@ mod tests {
             .render_retained_surface(retained, rect, viewport)
             .expect("retained shell frame with options panel");
         assert!(
-            frame.text_runs.iter().any(|run| run.text == "Audio Engine"),
-            "retained frame should append the options panel overlay"
+            !frame.text_runs.iter().any(|run| run.text == "Audio Engine"),
+            "options panel should not render its old inner title"
         );
         let output_host_label = frame
             .text_runs


### PR DESCRIPTION
## Summary
- remove the inner close row and inner "Audio Engine" title from the floating options panel
- tighten the panel layout so it behaves like a windowed config surface instead of a nested dialog
- rename the output device and sample-rate rows to shorter dropdown-style labels
- update the matching native-shell and runtime tests to cover the new panel behavior

## Testing
- `cargo fmt`
- `cargo test -p wavecrate options_panel --lib`
- `cargo test -p wavecrate --lib`