### PR TITLE
Split native sidebar DTO module

### DIFF
--- a/src/app_core/actions/native_shell_dtos.rs
+++ b/src/app_core/actions/native_shell_dtos.rs
@@ -8,7 +8,6 @@ use radiant::gui::chrome;
 use radiant::gui::feedback;
 use radiant::gui::frame;
 use radiant::gui::list;
-use radiant::gui::panel;
 use radiant::gui::range;
 use radiant::gui::retained;
 use radiant::gui::visualization;
@@ -18,6 +17,7 @@ mod automation;
 mod browser;
 mod motion;
 mod retained_segments;
+mod sidebar;
 mod waveform;
 
 pub use self::audio_options::{
@@ -35,6 +35,10 @@ pub use self::browser::{
 };
 pub use self::motion::NativeMotionModel;
 pub use self::retained_segments::{DirtySegments, SegmentRevisions};
+pub use self::sidebar::{
+    folder_row_model, FolderActionsModel, FolderPaneIdModel, FolderPaneModel, FolderRecoveryModel,
+    FolderRowKind, FolderRowModel, SourceRowModel, SourcesPanelModel,
+};
 pub use self::waveform::{
     parse_waveform_tempo_number_text, WaveformChannelViewModel, WaveformChromeModel,
     WaveformChromeStateModel, WaveformEditPreviewModel, WaveformFeedbackEventsModel,
@@ -64,47 +68,6 @@ pub type DragOverlayModel = feedback::DragOverlay;
 /// Render data for one triage/browser column.
 pub type ColumnModel = list::ColumnSummary;
 
-/// Render data for one folder row shown in the sidebar folder tree.
-pub type FolderRowKind = list::EditableRowKind;
-
-/// Render data for one folder row shown in the sidebar folder tree.
-pub type FolderRowModel = list::EditableTreeRow;
-
-/// Build one folder row projection from Wavecrate folder-browser state.
-pub fn folder_row_model(
-    label: impl Into<String>,
-    detail: impl Into<String>,
-    depth: usize,
-    selected: bool,
-    focused: bool,
-    is_root: bool,
-    has_children: bool,
-    expanded: bool,
-) -> FolderRowModel {
-    FolderRowModel::from_parts(list::EditableTreeRowParts {
-        label: label.into(),
-        detail: detail.into(),
-        depth,
-        selected,
-        focused,
-        is_root,
-        has_children,
-        expanded,
-    })
-}
-
-/// Native folder-action availability consumed by sidebar action surfaces.
-pub type FolderActionsModel = list::EditableTreeActions;
-
-/// Stable identifier for one side of the split folder pane surface.
-pub type FolderPaneIdModel = panel::SplitPaneSlot;
-
-/// Projected data for one fixed folder pane shown in the sidebar.
-pub type FolderPaneModel = panel::SplitPaneTreePanel<FolderRowModel>;
-
-/// Render data for one source row shown in the sidebar.
-pub type SourceRowModel = panel::SplitPaneAssignedRow;
-
 /// Render mode label for the map panel.
 pub type MapRenderModeModel = visualization::PointRenderMode;
 
@@ -122,9 +85,6 @@ pub type UpdatePanelModel = feedback::UpdatePanel;
 
 /// Modal confirmation prompt projected into the native shell.
 pub type ConfirmPromptModel = feedback::ConfirmPrompt<ConfirmPromptKind>;
-
-/// Delete-recovery status for staged folder delete recovery in the sidebar.
-pub type FolderRecoveryModel = feedback::RecoverySummary;
 
 /// Prompt types that can block interaction in the native shell.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -159,85 +119,6 @@ pub enum FocusContextModel {
     SourceFolders,
     /// The source list handles source-row navigation and shortcuts.
     SourcesList,
-}
-
-/// Sidebar model for source browsing controls.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct SourcesPanelModel {
-    /// Header text for the source panel.
-    pub header: String,
-    /// Active source-search query.
-    pub search_query: String,
-    /// Pane that currently drives browser and waveform state.
-    pub active_folder_pane: FolderPaneIdModel,
-    /// Upper fixed folder pane.
-    pub upper_folder_pane: FolderPaneModel,
-    /// Lower fixed folder pane.
-    pub lower_folder_pane: FolderPaneModel,
-    /// Active folder-search query.
-    pub tree_search_query: String,
-    /// Whether the folder browser currently includes empty on-disk folders.
-    pub show_all_items: bool,
-    /// Whether the folder-visibility toggle is currently actionable.
-    pub can_toggle_show_all_items: bool,
-    /// Whether folder filtering includes descendant files in a flattened list.
-    pub flattened_view: bool,
-    /// Whether the folder flattened-view toggle is currently actionable.
-    pub can_toggle_flattened_view: bool,
-    /// Selected row index, if any.
-    pub selected_row: Option<usize>,
-    /// Source row currently hydrating in the background, if any.
-    pub loading_row: Option<usize>,
-    /// Source row currently running a background file or folder mutation, if any.
-    pub mutation_busy_row: Option<usize>,
-    /// Focused folder row index, if any.
-    pub focused_tree_row: Option<usize>,
-    /// Rows to render in the source panel.
-    pub rows: RetainedVec<SourceRowModel>,
-    /// Folder rows to render in the folder browser section.
-    pub tree_rows: RetainedVec<FolderRowModel>,
-    /// Folder action availability for native sidebar controls.
-    pub tree_actions: FolderActionsModel,
-    /// Folder delete-recovery summary for native sidebar status.
-    pub recovery: FolderRecoveryModel,
-}
-
-impl SourcesPanelModel {
-    /// Borrow one pane model by id.
-    pub fn folder_pane(&self, pane: FolderPaneIdModel) -> &FolderPaneModel {
-        pane.select(&self.upper_folder_pane, &self.lower_folder_pane)
-    }
-
-    /// Borrow the pane that currently drives browser and waveform state.
-    pub fn active_folder_pane_model(&self) -> &FolderPaneModel {
-        self.folder_pane(self.active_folder_pane)
-    }
-
-    /// Return this source/sidebar model as a generic split-pane sidebar state.
-    pub fn split_pane_sidebar(
-        &self,
-    ) -> panel::SplitPaneSidebarState<SourceRowModel, FolderRowModel> {
-        panel::SplitPaneSidebarState {
-            header: self.header.clone(),
-            search_query: self.search_query.clone(),
-            active_pane: self.active_folder_pane,
-            upper_pane: self.upper_folder_pane.clone(),
-            lower_pane: self.lower_folder_pane.clone(),
-            tree_search_query: self.tree_search_query.clone(),
-            show_all_items: self.show_all_items,
-            can_toggle_show_all_items: self.can_toggle_show_all_items,
-            flattened_view: self.flattened_view,
-            can_toggle_flattened_view: self.can_toggle_flattened_view,
-            selected_row: self.selected_row,
-            loading_row: self.loading_row,
-            mutation_busy_row: self.mutation_busy_row,
-            focused_tree_row: self.focused_tree_row,
-            rows: self.rows.clone(),
-            tree_rows: self.tree_rows.clone(),
-            tree_actions: self.tree_actions.clone(),
-            recovery: self.recovery.clone(),
-        }
-    }
 }
 
 /// Snapshot of Wavecrate state required by the native shell renderer.

--- a/src/app_core/actions/native_shell_dtos/sidebar.rs
+++ b/src/app_core/actions/native_shell_dtos/sidebar.rs
@@ -1,0 +1,130 @@
+//! Source list and folder-pane projection DTOs.
+
+use radiant::gui::feedback;
+use radiant::gui::list;
+use radiant::gui::panel;
+
+use super::RetainedVec;
+
+/// Render data for one folder row shown in the sidebar folder tree.
+pub type FolderRowKind = list::EditableRowKind;
+
+/// Render data for one folder row shown in the sidebar folder tree.
+pub type FolderRowModel = list::EditableTreeRow;
+
+/// Build one folder row projection from Wavecrate folder-browser state.
+pub fn folder_row_model(
+    label: impl Into<String>,
+    detail: impl Into<String>,
+    depth: usize,
+    selected: bool,
+    focused: bool,
+    is_root: bool,
+    has_children: bool,
+    expanded: bool,
+) -> FolderRowModel {
+    FolderRowModel::from_parts(list::EditableTreeRowParts {
+        label: label.into(),
+        detail: detail.into(),
+        depth,
+        selected,
+        focused,
+        is_root,
+        has_children,
+        expanded,
+    })
+}
+
+/// Native folder-action availability consumed by sidebar action surfaces.
+pub type FolderActionsModel = list::EditableTreeActions;
+
+/// Stable identifier for one side of the split folder pane surface.
+pub type FolderPaneIdModel = panel::SplitPaneSlot;
+
+/// Projected data for one fixed folder pane shown in the sidebar.
+pub type FolderPaneModel = panel::SplitPaneTreePanel<FolderRowModel>;
+
+/// Render data for one source row shown in the sidebar.
+pub type SourceRowModel = panel::SplitPaneAssignedRow;
+
+/// Delete-recovery status for staged folder delete recovery in the sidebar.
+pub type FolderRecoveryModel = feedback::RecoverySummary;
+
+/// Sidebar model for source browsing controls.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct SourcesPanelModel {
+    /// Header text for the source panel.
+    pub header: String,
+    /// Active source-search query.
+    pub search_query: String,
+    /// Pane that currently drives browser and waveform state.
+    pub active_folder_pane: FolderPaneIdModel,
+    /// Upper fixed folder pane.
+    pub upper_folder_pane: FolderPaneModel,
+    /// Lower fixed folder pane.
+    pub lower_folder_pane: FolderPaneModel,
+    /// Active folder-search query.
+    pub tree_search_query: String,
+    /// Whether the folder browser currently includes empty on-disk folders.
+    pub show_all_items: bool,
+    /// Whether the folder-visibility toggle is currently actionable.
+    pub can_toggle_show_all_items: bool,
+    /// Whether folder filtering includes descendant files in a flattened list.
+    pub flattened_view: bool,
+    /// Whether the folder flattened-view toggle is currently actionable.
+    pub can_toggle_flattened_view: bool,
+    /// Selected row index, if any.
+    pub selected_row: Option<usize>,
+    /// Source row currently hydrating in the background, if any.
+    pub loading_row: Option<usize>,
+    /// Source row currently running a background file or folder mutation, if any.
+    pub mutation_busy_row: Option<usize>,
+    /// Focused folder row index, if any.
+    pub focused_tree_row: Option<usize>,
+    /// Rows to render in the source panel.
+    pub rows: RetainedVec<SourceRowModel>,
+    /// Folder rows to render in the folder browser section.
+    pub tree_rows: RetainedVec<FolderRowModel>,
+    /// Folder action availability for native sidebar controls.
+    pub tree_actions: FolderActionsModel,
+    /// Folder delete-recovery summary for native sidebar status.
+    pub recovery: FolderRecoveryModel,
+}
+
+impl SourcesPanelModel {
+    /// Borrow one pane model by id.
+    pub fn folder_pane(&self, pane: FolderPaneIdModel) -> &FolderPaneModel {
+        pane.select(&self.upper_folder_pane, &self.lower_folder_pane)
+    }
+
+    /// Borrow the pane that currently drives browser and waveform state.
+    pub fn active_folder_pane_model(&self) -> &FolderPaneModel {
+        self.folder_pane(self.active_folder_pane)
+    }
+
+    /// Return this source/sidebar model as a generic split-pane sidebar state.
+    pub fn split_pane_sidebar(
+        &self,
+    ) -> panel::SplitPaneSidebarState<SourceRowModel, FolderRowModel> {
+        panel::SplitPaneSidebarState {
+            header: self.header.clone(),
+            search_query: self.search_query.clone(),
+            active_pane: self.active_folder_pane,
+            upper_pane: self.upper_folder_pane.clone(),
+            lower_pane: self.lower_folder_pane.clone(),
+            tree_search_query: self.tree_search_query.clone(),
+            show_all_items: self.show_all_items,
+            can_toggle_show_all_items: self.can_toggle_show_all_items,
+            flattened_view: self.flattened_view,
+            can_toggle_flattened_view: self.can_toggle_flattened_view,
+            selected_row: self.selected_row,
+            loading_row: self.loading_row,
+            mutation_busy_row: self.mutation_busy_row,
+            focused_tree_row: self.focused_tree_row,
+            rows: self.rows.clone(),
+            tree_rows: self.tree_rows.clone(),
+            tree_actions: self.tree_actions.clone(),
+            recovery: self.recovery.clone(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move source/sidebar folder row and pane DTOs into a focused sidebar module
- keep existing native_shell_dtos re-export names for current callers
- reduce the parent DTO hub from 549 lines to 430 lines while keeping the new module focused at 130 lines

## Validation
- rustfmt src/app_core/actions/native_shell_dtos.rs src/app_core/actions/native_shell_dtos/sidebar.rs
- cargo test -p wavecrate app_core::actions -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 report-file-budget
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent