### PR TITLE
Split native app shell DTO module

### DIFF
--- a/src/app_core/actions/native_shell_dtos.rs
+++ b/src/app_core/actions/native_shell_dtos.rs
@@ -4,14 +4,11 @@
 //! native shell. The runtime adapter in `gui_runtime` converts these app-core
 //! DTOs into the Wavecrate-owned native runtime contract consumed by Radiant.
 
-use radiant::gui::chrome;
-use radiant::gui::feedback;
 use radiant::gui::frame;
-use radiant::gui::list;
 use radiant::gui::range;
 use radiant::gui::retained;
-use radiant::gui::visualization;
 
+mod app_shell;
 mod audio_options;
 mod automation;
 mod browser;
@@ -20,6 +17,11 @@ mod retained_segments;
 mod sidebar;
 mod waveform;
 
+pub use self::app_shell::{
+    AppModel, ColumnModel, ConfirmPromptKind, ConfirmPromptModel, DragOverlayModel,
+    FocusContextModel, MapPanelModel, MapPointModel, MapRenderModeModel, ProgressOverlayModel,
+    StatusBarModel, UpdatePanelModel, UpdateStatusModel,
+};
 pub use self::audio_options::{
     AudioEngineChipStateModel, AudioEngineModel, AudioFieldModel, AudioOptionItemModel,
     AudioOptionValueModel, AudioPickerTargetModel, OptionsPanelModel,
@@ -55,187 +57,6 @@ pub type FrameBuildResult = frame::FrameBuildResult;
 
 /// Normalized interval with deterministic milli, micro, and nano projections.
 pub type NormalizedRangeModel = range::NormalizedRange;
-
-/// Structured footer status content for left/center/right status segments.
-pub type StatusBarModel = chrome::StatusSegments;
-
-/// Progress overlay state projected into the native shell.
-pub type ProgressOverlayModel = feedback::ProgressOverlay;
-
-/// Drag/drop overlay content for native-shell feedback.
-pub type DragOverlayModel = feedback::DragOverlay;
-
-/// Render data for one triage/browser column.
-pub type ColumnModel = list::ColumnSummary;
-
-/// Render mode label for the map panel.
-pub type MapRenderModeModel = visualization::PointRenderMode;
-
-/// Summary of map state consumed by the native shell map tab.
-pub type MapPanelModel = visualization::SpatialPanel;
-
-/// Render data for one point shown in the native map canvas.
-pub type MapPointModel = visualization::SpatialPoint;
-
-/// Update-check status projected into the native shell.
-pub type UpdateStatusModel = feedback::UpdateStatus;
-
-/// Update panel state used by native top-bar actions.
-pub type UpdatePanelModel = feedback::UpdatePanel;
-
-/// Modal confirmation prompt projected into the native shell.
-pub type ConfirmPromptModel = feedback::ConfirmPrompt<ConfirmPromptKind>;
-
-/// Prompt types that can block interaction in the native shell.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ConfirmPromptKind {
-    /// Pending destructive waveform edit prompt.
-    DestructiveEdit,
-    /// Pending browser rename prompt.
-    BrowserRename,
-    /// Pending folder rename prompt.
-    FolderRename,
-    /// Pending folder creation prompt.
-    FolderCreate,
-    /// Pending retained folder-delete restore prompt.
-    RestoreRetainedFolderDeletes,
-    /// Pending retained folder-delete purge prompt.
-    PurgeRetainedFolderDeletes,
-    /// Pending options-panel default-identifier prompt.
-    OptionsDefaultIdentifier,
-}
-
-/// Logical focus buckets projected into the native runtime.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-pub enum FocusContextModel {
-    /// No UI surface currently owns keyboard focus.
-    #[default]
-    None,
-    /// The waveform viewer handles navigation and shortcuts.
-    Waveform,
-    /// The sample browser handles row navigation and browser shortcuts.
-    SampleBrowser,
-    /// The folder tree handles folder navigation and folder shortcuts.
-    SourceFolders,
-    /// The source list handles source-row navigation and shortcuts.
-    SourcesList,
-}
-
-/// Snapshot of Wavecrate state required by the native shell renderer.
-#[derive(Clone, Debug, PartialEq)]
-pub struct AppModel {
-    /// Main title rendered in the top bar.
-    pub title: String,
-    /// Backend description shown in top-bar metadata.
-    pub backend_label: String,
-    /// Sidebar header label.
-    pub sources_label: String,
-    /// Footer status text.
-    pub status_text: String,
-    /// Structured footer status segments used by the native shell footer.
-    pub status: StatusBarModel,
-    /// Output/input audio engine state rendered in the top-right chrome and options panel.
-    pub audio_engine: AudioEngineModel,
-    /// Browser action availability for native action surfaces.
-    pub browser_actions: BrowserActionsModel,
-    /// Options-panel overlay projection.
-    pub options_panel: OptionsPanelModel,
-    /// Progress overlay projection.
-    pub progress_overlay: ProgressOverlayModel,
-    /// Modal confirm prompt projection.
-    pub confirm_prompt: ConfirmPromptModel,
-    /// Drag/drop overlay projection.
-    pub drag_overlay: DragOverlayModel,
-    /// Logical triage/browser columns.
-    pub columns: [ColumnModel; 3],
-    /// Selected column index (0..=2).
-    pub selected_column: usize,
-    /// Master output volume normalized to `0.0..=1.0`.
-    pub volume: f32,
-    /// Whether transport/animation should be considered running.
-    pub transport_running: bool,
-    /// Source panel model consumed by the native renderer.
-    pub sources: SourcesPanelModel,
-    /// Browser panel summary consumed by the native renderer.
-    pub browser: BrowserPanelModel,
-    /// Browser chrome labels consumed by native tabs/toolbar/footer text.
-    pub browser_chrome: BrowserChromeModel,
-    /// Map panel summary consumed by the native renderer.
-    pub map: MapPanelModel,
-    /// Waveform panel summary consumed by the native renderer.
-    pub waveform: WaveformPanelModel,
-    /// Waveform chrome labels consumed by the native waveform header.
-    pub waveform_chrome: WaveformChromeModel,
-    /// Update surface summary consumed by the native top bar.
-    pub update: UpdatePanelModel,
-    /// Current keyboard focus bucket used for contextual native key routing.
-    pub focus_context: FocusContextModel,
-}
-
-impl Default for AppModel {
-    fn default() -> Self {
-        Self {
-            title: String::from(crate::gui_runtime::DEFAULT_NATIVE_WINDOW_TITLE),
-            backend_label: String::from("backend: native_vello"),
-            sources_label: String::from("Sources"),
-            status_text: String::new(),
-            status: StatusBarModel {
-                left: String::new(),
-                center: String::from("rows: 0 | selected: 0 | anchor: - | search: -"),
-                right: String::from("col: 2/3"),
-            },
-            audio_engine: AudioEngineModel::default(),
-            browser_actions: BrowserActionsModel::default(),
-            options_panel: OptionsPanelModel::default(),
-            progress_overlay: ProgressOverlayModel::default(),
-            confirm_prompt: ConfirmPromptModel::default(),
-            drag_overlay: DragOverlayModel::default(),
-            columns: [
-                ColumnModel::new("Trash", 0),
-                ColumnModel::new("Samples", 0),
-                ColumnModel::new("Keep", 0),
-            ],
-            selected_column: 1,
-            volume: 1.0,
-            transport_running: true,
-            sources: SourcesPanelModel {
-                header: String::from("Sources"),
-                search_query: String::new(),
-                active_folder_pane: FolderPaneIdModel::Upper,
-                upper_folder_pane: FolderPaneModel {
-                    pane: FolderPaneIdModel::Upper,
-                    title: String::from("Upper"),
-                    ..FolderPaneModel::default()
-                },
-                lower_folder_pane: FolderPaneModel {
-                    pane: FolderPaneIdModel::Lower,
-                    title: String::from("Lower"),
-                    ..FolderPaneModel::default()
-                },
-                tree_search_query: String::new(),
-                show_all_items: false,
-                can_toggle_show_all_items: false,
-                flattened_view: false,
-                can_toggle_flattened_view: false,
-                selected_row: None,
-                loading_row: None,
-                mutation_busy_row: None,
-                focused_tree_row: None,
-                rows: RetainedVec::new(),
-                tree_rows: RetainedVec::new(),
-                tree_actions: FolderActionsModel::default(),
-                recovery: FolderRecoveryModel::default(),
-            },
-            browser: BrowserPanelModel::default(),
-            browser_chrome: BrowserChromeModel::default(),
-            map: MapPanelModel::default(),
-            waveform: WaveformPanelModel::default(),
-            waveform_chrome: WaveformChromeModel::default(),
-            update: UpdatePanelModel::default(),
-            focus_context: FocusContextModel::None,
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/app_core/actions/native_shell_dtos/app_shell.rs
+++ b/src/app_core/actions/native_shell_dtos/app_shell.rs
@@ -1,0 +1,193 @@
+//! Top-level native shell application projection DTOs.
+
+use radiant::gui::chrome;
+use radiant::gui::feedback;
+use radiant::gui::list;
+use radiant::gui::visualization;
+
+use super::{
+    AudioEngineModel, BrowserActionsModel, BrowserChromeModel, BrowserPanelModel,
+    FolderActionsModel, FolderPaneIdModel, FolderPaneModel, FolderRecoveryModel, OptionsPanelModel,
+    RetainedVec, SourcesPanelModel, WaveformChromeModel, WaveformPanelModel,
+};
+
+/// Structured footer status content for left/center/right status segments.
+pub type StatusBarModel = chrome::StatusSegments;
+
+/// Progress overlay state projected into the native shell.
+pub type ProgressOverlayModel = feedback::ProgressOverlay;
+
+/// Drag/drop overlay content for native-shell feedback.
+pub type DragOverlayModel = feedback::DragOverlay;
+
+/// Render data for one triage/browser column.
+pub type ColumnModel = list::ColumnSummary;
+
+/// Render mode label for the map panel.
+pub type MapRenderModeModel = visualization::PointRenderMode;
+
+/// Summary of map state consumed by the native shell map tab.
+pub type MapPanelModel = visualization::SpatialPanel;
+
+/// Render data for one point shown in the native map canvas.
+pub type MapPointModel = visualization::SpatialPoint;
+
+/// Update-check status projected into the native shell.
+pub type UpdateStatusModel = feedback::UpdateStatus;
+
+/// Update panel state used by native top-bar actions.
+pub type UpdatePanelModel = feedback::UpdatePanel;
+
+/// Modal confirmation prompt projected into the native shell.
+pub type ConfirmPromptModel = feedback::ConfirmPrompt<ConfirmPromptKind>;
+
+/// Prompt types that can block interaction in the native shell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfirmPromptKind {
+    /// Pending destructive waveform edit prompt.
+    DestructiveEdit,
+    /// Pending browser rename prompt.
+    BrowserRename,
+    /// Pending folder rename prompt.
+    FolderRename,
+    /// Pending folder creation prompt.
+    FolderCreate,
+    /// Pending retained folder-delete restore prompt.
+    RestoreRetainedFolderDeletes,
+    /// Pending retained folder-delete purge prompt.
+    PurgeRetainedFolderDeletes,
+    /// Pending options-panel default-identifier prompt.
+    OptionsDefaultIdentifier,
+}
+
+/// Logical focus buckets projected into the native runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum FocusContextModel {
+    /// No UI surface currently owns keyboard focus.
+    #[default]
+    None,
+    /// The waveform viewer handles navigation and shortcuts.
+    Waveform,
+    /// The sample browser handles row navigation and browser shortcuts.
+    SampleBrowser,
+    /// The folder tree handles folder navigation and folder shortcuts.
+    SourceFolders,
+    /// The source list handles source-row navigation and shortcuts.
+    SourcesList,
+}
+
+/// Snapshot of Wavecrate state required by the native shell renderer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AppModel {
+    /// Main title rendered in the top bar.
+    pub title: String,
+    /// Backend description shown in top-bar metadata.
+    pub backend_label: String,
+    /// Sidebar header label.
+    pub sources_label: String,
+    /// Footer status text.
+    pub status_text: String,
+    /// Structured footer status segments used by the native shell footer.
+    pub status: StatusBarModel,
+    /// Output/input audio engine state rendered in the top-right chrome and options panel.
+    pub audio_engine: AudioEngineModel,
+    /// Browser action availability for native action surfaces.
+    pub browser_actions: BrowserActionsModel,
+    /// Options-panel overlay projection.
+    pub options_panel: OptionsPanelModel,
+    /// Progress overlay projection.
+    pub progress_overlay: ProgressOverlayModel,
+    /// Modal confirm prompt projection.
+    pub confirm_prompt: ConfirmPromptModel,
+    /// Drag/drop overlay projection.
+    pub drag_overlay: DragOverlayModel,
+    /// Logical triage/browser columns.
+    pub columns: [ColumnModel; 3],
+    /// Selected column index (0..=2).
+    pub selected_column: usize,
+    /// Master output volume normalized to `0.0..=1.0`.
+    pub volume: f32,
+    /// Whether transport/animation should be considered running.
+    pub transport_running: bool,
+    /// Source panel model consumed by the native renderer.
+    pub sources: SourcesPanelModel,
+    /// Browser panel summary consumed by the native renderer.
+    pub browser: BrowserPanelModel,
+    /// Browser chrome labels consumed by native tabs/toolbar/footer text.
+    pub browser_chrome: BrowserChromeModel,
+    /// Map panel summary consumed by the native renderer.
+    pub map: MapPanelModel,
+    /// Waveform panel summary consumed by the native renderer.
+    pub waveform: WaveformPanelModel,
+    /// Waveform chrome labels consumed by the native waveform header.
+    pub waveform_chrome: WaveformChromeModel,
+    /// Update surface summary consumed by the native top bar.
+    pub update: UpdatePanelModel,
+    /// Current keyboard focus bucket used for contextual native key routing.
+    pub focus_context: FocusContextModel,
+}
+
+impl Default for AppModel {
+    fn default() -> Self {
+        Self {
+            title: String::from(crate::gui_runtime::DEFAULT_NATIVE_WINDOW_TITLE),
+            backend_label: String::from("backend: native_vello"),
+            sources_label: String::from("Sources"),
+            status_text: String::new(),
+            status: StatusBarModel {
+                left: String::new(),
+                center: String::from("rows: 0 | selected: 0 | anchor: - | search: -"),
+                right: String::from("col: 2/3"),
+            },
+            audio_engine: AudioEngineModel::default(),
+            browser_actions: BrowserActionsModel::default(),
+            options_panel: OptionsPanelModel::default(),
+            progress_overlay: ProgressOverlayModel::default(),
+            confirm_prompt: ConfirmPromptModel::default(),
+            drag_overlay: DragOverlayModel::default(),
+            columns: [
+                ColumnModel::new("Trash", 0),
+                ColumnModel::new("Samples", 0),
+                ColumnModel::new("Keep", 0),
+            ],
+            selected_column: 1,
+            volume: 1.0,
+            transport_running: true,
+            sources: SourcesPanelModel {
+                header: String::from("Sources"),
+                search_query: String::new(),
+                active_folder_pane: FolderPaneIdModel::Upper,
+                upper_folder_pane: FolderPaneModel {
+                    pane: FolderPaneIdModel::Upper,
+                    title: String::from("Upper"),
+                    ..FolderPaneModel::default()
+                },
+                lower_folder_pane: FolderPaneModel {
+                    pane: FolderPaneIdModel::Lower,
+                    title: String::from("Lower"),
+                    ..FolderPaneModel::default()
+                },
+                tree_search_query: String::new(),
+                show_all_items: false,
+                can_toggle_show_all_items: false,
+                flattened_view: false,
+                can_toggle_flattened_view: false,
+                selected_row: None,
+                loading_row: None,
+                mutation_busy_row: None,
+                focused_tree_row: None,
+                rows: RetainedVec::new(),
+                tree_rows: RetainedVec::new(),
+                tree_actions: FolderActionsModel::default(),
+                recovery: FolderRecoveryModel::default(),
+            },
+            browser: BrowserPanelModel::default(),
+            browser_chrome: BrowserChromeModel::default(),
+            map: MapPanelModel::default(),
+            waveform: WaveformPanelModel::default(),
+            waveform_chrome: WaveformChromeModel::default(),
+            update: UpdatePanelModel::default(),
+            focus_context: FocusContextModel::None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move top-level native app shell DTOs into a focused app_shell module
- keep existing native_shell_dtos re-export names for current callers
- reduce the parent DTO facade from 430 lines to 251 lines while keeping the new module focused at 193 lines

## Validation
- rustfmt src/app_core/actions/native_shell_dtos.rs src/app_core/actions/native_shell_dtos/app_shell.rs
- cargo test -p wavecrate app_core::actions -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 report-file-budget
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent