### PR TITLE
Split native shell runtime state support

### DIFF
--- a/src/app_core/native_shell/composition/ownership_inventory.tsv
+++ b/src/app_core/native_shell/composition/ownership_inventory.tsv
@@ -101,6 +101,7 @@ state/options_panel.rs	wavecrate_composition	OPT-187	Options panel facade moves 
 state/options_panel/**	wavecrate_composition	OPT-187	Options panel actions, geometry, render, and style move with options composition.
 state/overlays.rs	wavecrate_composition	OPT-187	Overlay facade moves with top, status, options, and overlay composition.
 state/overlays/**	wavecrate_composition	OPT-187	Drag, progress, prompt, and overlay geometry move with overlay composition.
+state/runtime_state.rs	compat_adapter	OPT-191	Small retained runtime-state support types stay with NativeShellState until final shell facade ownership is split.
 state/svg_icons.rs	wavecrate_composition	OPT-190	Toolbar icon identifiers and rasterization move with waveform/browser/sidebar toolbar composition; parser stays generic.
 state/tests/**	wavecrate_fixture	OPT-191	Wavecrate native-shell compatibility fixture pack; keep relocation separate from production surface moves.
 state/text_fields.rs	wavecrate_composition	OPT-188	Browser/search text-field state moves with browser chrome composition.

--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -81,11 +81,13 @@ mod model_sync;
 mod motion_overlay;
 mod options_panel;
 mod overlays;
+mod runtime_state;
 mod svg_icons;
 mod text_fields;
 mod toolbar_helpers;
 mod waveform_segments;
 
+use self::runtime_state::{FolderPaneRuntimeState, WaveformSelectionFlashTone};
 use self::{
     browser_rows::*, cache_types::*, hit_testing::*, options_panel::*, overlays::*, svg_icons::*,
     text_fields::*, toolbar_helpers::*, waveform_segments::*,
@@ -141,42 +143,6 @@ const BROWSER_PLAYBACK_AGE_FILTER_CHIPS:
 const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
 /// Additional hit slop for the narrow folder scrollbar thumb.
 const FOLDER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
-
-/// Color mode used for the transient waveform selection export flash.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum WaveformSelectionFlashTone {
-    /// Optimistic submit feedback shown as soon as the export is queued.
-    Optimistic,
-    /// Error feedback shown when an async export later fails.
-    Error,
-}
-
-/// Mutable interaction + animation state for the native shell façade.
-///
-/// The struct intentionally owns only the persisted shell interaction/cache
-/// state. Rendering, hit testing, text-field behavior, toolbar helpers, and
-/// overlay composition live in sibling modules and extend this type through
-/// additional `impl` blocks.
-#[derive(Clone, Debug, PartialEq)]
-struct FolderPaneRuntimeState {
-    rows: Vec<CachedFolderRow>,
-    window_start: usize,
-    autoscroll: bool,
-    last_focused_row: Option<usize>,
-    cache_key: Option<FolderRowsCacheKey>,
-}
-
-impl Default for FolderPaneRuntimeState {
-    fn default() -> Self {
-        Self {
-            rows: Vec::new(),
-            window_start: 0,
-            autoscroll: true,
-            last_focused_row: None,
-            cache_key: None,
-        }
-    }
-}
 
 /// Mutable interaction + animation state for the native shell façade.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/app_core/native_shell/composition/state/runtime_state.rs
+++ b/src/app_core/native_shell/composition/state/runtime_state.rs
@@ -1,0 +1,34 @@
+//! Small runtime-state types owned by the native shell state façade.
+
+use super::{CachedFolderRow, FolderRowsCacheKey};
+
+/// Color mode used for the transient waveform selection export flash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WaveformSelectionFlashTone {
+    /// Optimistic submit feedback shown as soon as the export is queued.
+    Optimistic,
+    /// Error feedback shown when an async export later fails.
+    Error,
+}
+
+/// Cached runtime state for one sidebar folder pane.
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::app_core::native_shell::composition::state) struct FolderPaneRuntimeState {
+    pub(in crate::app_core::native_shell::composition::state) rows: Vec<CachedFolderRow>,
+    pub(in crate::app_core::native_shell::composition::state) window_start: usize,
+    pub(in crate::app_core::native_shell::composition::state) autoscroll: bool,
+    pub(in crate::app_core::native_shell::composition::state) last_focused_row: Option<usize>,
+    pub(in crate::app_core::native_shell::composition::state) cache_key: Option<FolderRowsCacheKey>,
+}
+
+impl Default for FolderPaneRuntimeState {
+    fn default() -> Self {
+        Self {
+            rows: Vec::new(),
+            window_start: 0,
+            autoscroll: true,
+            last_focused_row: None,
+            cache_key: None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move native shell folder-pane runtime support state into a focused state/runtime_state module
- keep waveform selection flash tone visible for existing overlay fingerprints
- record the new module in the native shell ownership inventory

## Validation
- rustfmt --edition 2024 src/app_core/native_shell/composition/state.rs src/app_core/native_shell/composition/state/runtime_state.rs
- cargo test -p wavecrate app_core::native_shell::composition::state -- --nocapture
- cargo test -p wavecrate app_core::native_shell::composition::tests::contracts::native_shell_ownership_inventory_covers_every_module -- --nocapture
- cargo test -p wavecrate app::controller::library::selection_export::selection_export_tests::slice_batch_export_tests::save_waveform_slices_to_browser_runs_in_background_and_clears_on_success -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 report-file-budget
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent

Note: the first ci.ps1 agent run exposed an unrelated timing failure in the selection-export progress test; the isolated test passed and the full agent gate passed on rerun.