### PR TITLE
Refine GUI and source watcher routing

### DIFF
--- a/src/app/controller/source_watcher.rs
+++ b/src/app/controller/source_watcher.rs
@@ -15,6 +15,10 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
 
+mod state;
+
+use state::SourceWatcherState;
+
 const COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const SOURCE_WATCH_DEBOUNCE: Duration = Duration::from_millis(400);
 
@@ -117,47 +121,15 @@ fn run_source_watcher(command_rx: Receiver<SourceWatchCommand>, message_tx: JobM
             return;
         }
     };
-    let mut watched_roots: HashSet<PathBuf> = HashSet::new();
-    let mut sources: Vec<SourceWatchEntry> = Vec::new();
-    let mut pending: HashMap<SourceId, PendingSourceWatch> = HashMap::new();
-    let mut controller_file_ops: HashMap<SourceId, HashSet<PathBuf>> = HashMap::new();
-    let mut scan_in_progress = false;
+    let mut state = SourceWatcherState::default();
 
     loop {
         match command_rx.recv_timeout(COMMAND_POLL_INTERVAL) {
-            Ok(command) => match command {
-                SourceWatchCommand::ReplaceSources(next_sources) => {
-                    update_watched_sources(&mut watcher, &mut watched_roots, &next_sources);
-                    sources = next_sources;
-                    prune_pending_sources(&mut pending, &sources);
+            Ok(command) => {
+                if !state.handle_command(command, &mut watcher) {
+                    break;
                 }
-                SourceWatchCommand::SetScanInProgress { in_progress } => {
-                    scan_in_progress = in_progress;
-                }
-                SourceWatchCommand::BeginControllerFileOp {
-                    source_id,
-                    relative_paths,
-                } => {
-                    controller_file_ops
-                        .entry(source_id)
-                        .or_default()
-                        .extend(relative_paths);
-                }
-                SourceWatchCommand::FinishControllerFileOp {
-                    source_id,
-                    relative_paths,
-                } => {
-                    if let Some(paths) = controller_file_ops.get_mut(&source_id) {
-                        for path in relative_paths {
-                            paths.remove(&path);
-                        }
-                        if paths.is_empty() {
-                            controller_file_ops.remove(&source_id);
-                        }
-                    }
-                }
-                SourceWatchCommand::Shutdown => break,
-            },
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
@@ -173,91 +145,13 @@ fn run_source_watcher(command_rx: Receiver<SourceWatchCommand>, message_tx: JobM
             if !event_triggers_sync(&event) {
                 continue;
             }
-            let mut impacted = HashMap::new();
-            for path in &event.paths {
-                if !path_is_candidate(path) {
-                    continue;
-                }
-                if let Some(source) = select_source_entry_for_path(&sources, path) {
-                    let cause = source_watch_cause_for_path(&controller_file_ops, source, path);
-                    impacted
-                        .entry(source.source_id.clone())
-                        .and_modify(|pending_cause| {
-                            *pending_cause = combine_source_watch_causes(*pending_cause, cause);
-                        })
-                        .or_insert(cause);
-                }
-            }
-            for (source_id, cause) in impacted {
-                update_pending_watch(&mut pending, source_id, cause, Instant::now());
-            }
+            state.collect_event(event, Instant::now());
         }
 
-        let ready = drain_ready_sources(
-            &mut pending,
-            Instant::now(),
-            SOURCE_WATCH_DEBOUNCE,
-            scan_in_progress,
-        );
-        for event in ready {
+        for event in state.drain_ready_sources(Instant::now(), SOURCE_WATCH_DEBOUNCE) {
             let _ = message_tx.send(JobMessage::SourceWatch(event));
         }
     }
-}
-
-#[derive(Debug, Copy, Clone)]
-struct PendingSourceWatch {
-    last_event: Instant,
-    cause: SourceWatchCause,
-}
-
-fn update_pending_watch(
-    pending: &mut HashMap<SourceId, PendingSourceWatch>,
-    source_id: SourceId,
-    cause: SourceWatchCause,
-    now: Instant,
-) {
-    pending
-        .entry(source_id)
-        .and_modify(|entry| {
-            entry.last_event = now;
-            entry.cause = combine_source_watch_causes(entry.cause, cause);
-        })
-        .or_insert(PendingSourceWatch {
-            last_event: now,
-            cause,
-        });
-}
-
-fn drain_ready_sources(
-    pending: &mut HashMap<SourceId, PendingSourceWatch>,
-    now: Instant,
-    debounce: Duration,
-    scan_in_progress: bool,
-) -> Vec<SourceWatchEvent> {
-    if scan_in_progress {
-        return Vec::new();
-    }
-    let ready: Vec<SourceWatchEvent> = pending
-        .iter()
-        .filter(|&(_source_id, entry)| now.saturating_duration_since(entry.last_event) >= debounce)
-        .map(|(source_id, entry)| SourceWatchEvent {
-            source_id: source_id.clone(),
-            cause: entry.cause,
-        })
-        .collect();
-    for event in &ready {
-        pending.remove(&event.source_id);
-    }
-    ready
-}
-
-fn prune_pending_sources(
-    pending: &mut HashMap<SourceId, PendingSourceWatch>,
-    sources: &[SourceWatchEntry],
-) {
-    let allowed: HashSet<&SourceId> = sources.iter().map(|entry| &entry.source_id).collect();
-    pending.retain(|source_id, _| allowed.contains(source_id));
 }
 
 fn update_watched_sources(
@@ -419,29 +313,25 @@ mod tests {
 
     #[test]
     fn drain_ready_sources_waits_for_debounce() {
-        let mut pending = HashMap::new();
+        let mut state = SourceWatcherState::default();
         let source_id = SourceId::from_string("a");
         let start = Instant::now();
-        update_pending_watch(
-            &mut pending,
+        state.update_pending_watch(
             source_id.clone(),
             SourceWatchCause::ExternalFileChange,
             start,
         );
         assert!(
-            drain_ready_sources(
-                &mut pending,
-                start + Duration::from_millis(200),
-                Duration::from_millis(400),
-                false
-            )
-            .is_empty()
+            state
+                .drain_ready_sources(
+                    start + Duration::from_millis(200),
+                    Duration::from_millis(400)
+                )
+                .is_empty()
         );
-        let ready = drain_ready_sources(
-            &mut pending,
+        let ready = state.drain_ready_sources(
             start + Duration::from_millis(500),
             Duration::from_millis(400),
-            false,
         );
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].source_id, source_id);
@@ -450,23 +340,17 @@ mod tests {
 
     #[test]
     fn drain_ready_sources_honors_scan_in_progress() {
-        let mut pending = HashMap::new();
+        let mut state = SourceWatcherState::default();
+        state.scan_in_progress = true;
         let source_id = SourceId::from_string("a");
         let start = Instant::now();
-        update_pending_watch(
-            &mut pending,
-            source_id,
-            SourceWatchCause::ExternalFileChange,
-            start,
-        );
-        let ready = drain_ready_sources(
-            &mut pending,
+        state.update_pending_watch(source_id, SourceWatchCause::ExternalFileChange, start);
+        let ready = state.drain_ready_sources(
             start + Duration::from_millis(500),
             Duration::from_millis(400),
-            true,
         );
         assert!(ready.is_empty());
-        assert_eq!(pending.len(), 1);
+        assert_eq!(state.pending.len(), 1);
     }
 
     #[test]
@@ -507,27 +391,19 @@ mod tests {
 
     #[test]
     fn pending_source_watch_prefers_external_fallback() {
-        let mut pending = HashMap::new();
+        let mut state = SourceWatcherState::default();
         let source_id = SourceId::from_string("a");
         let start = Instant::now();
-        update_pending_watch(
-            &mut pending,
-            source_id.clone(),
-            SourceWatchCause::ControllerFileOp,
-            start,
-        );
-        update_pending_watch(
-            &mut pending,
+        state.update_pending_watch(source_id.clone(), SourceWatchCause::ControllerFileOp, start);
+        state.update_pending_watch(
             source_id.clone(),
             SourceWatchCause::ExternalFileChange,
             start + Duration::from_millis(1),
         );
 
-        let ready = drain_ready_sources(
-            &mut pending,
+        let ready = state.drain_ready_sources(
             start + Duration::from_millis(500),
             Duration::from_millis(400),
-            false,
         );
 
         assert_eq!(ready.len(), 1);

--- a/src/app/controller/source_watcher/state.rs
+++ b/src/app/controller/source_watcher/state.rs
@@ -1,0 +1,142 @@
+use super::{
+    SourceId, SourceWatchCause, SourceWatchCommand, SourceWatchEntry, SourceWatchEvent,
+    combine_source_watch_causes, path_is_candidate, select_source_entry_for_path,
+    source_watch_cause_for_path, update_watched_sources,
+};
+use notify::{Event, RecommendedWatcher};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+#[derive(Default)]
+pub(super) struct SourceWatcherState {
+    watched_roots: HashSet<PathBuf>,
+    sources: Vec<SourceWatchEntry>,
+    pub(super) pending: HashMap<SourceId, PendingSourceWatch>,
+    controller_file_ops: HashMap<SourceId, HashSet<PathBuf>>,
+    pub(super) scan_in_progress: bool,
+}
+
+impl SourceWatcherState {
+    pub(super) fn handle_command(
+        &mut self,
+        command: SourceWatchCommand,
+        watcher: &mut RecommendedWatcher,
+    ) -> bool {
+        match command {
+            SourceWatchCommand::ReplaceSources(next_sources) => {
+                update_watched_sources(watcher, &mut self.watched_roots, &next_sources);
+                self.sources = next_sources;
+                self.prune_pending_sources();
+            }
+            SourceWatchCommand::SetScanInProgress { in_progress } => {
+                self.scan_in_progress = in_progress;
+            }
+            SourceWatchCommand::BeginControllerFileOp {
+                source_id,
+                relative_paths,
+            } => {
+                self.controller_file_ops
+                    .entry(source_id)
+                    .or_default()
+                    .extend(relative_paths);
+            }
+            SourceWatchCommand::FinishControllerFileOp {
+                source_id,
+                relative_paths,
+            } => self.finish_controller_file_op(source_id, relative_paths),
+            SourceWatchCommand::Shutdown => return false,
+        }
+        true
+    }
+
+    fn finish_controller_file_op(&mut self, source_id: SourceId, relative_paths: Vec<PathBuf>) {
+        if let Some(paths) = self.controller_file_ops.get_mut(&source_id) {
+            for path in relative_paths {
+                paths.remove(&path);
+            }
+            if paths.is_empty() {
+                self.controller_file_ops.remove(&source_id);
+            }
+        }
+    }
+
+    pub(super) fn collect_event(&mut self, event: Event, now: Instant) {
+        let mut impacted = HashMap::new();
+        for path in &event.paths {
+            if !path_is_candidate(path) {
+                continue;
+            }
+            if let Some(source) = select_source_entry_for_path(&self.sources, path) {
+                let cause = source_watch_cause_for_path(&self.controller_file_ops, source, path);
+                impacted
+                    .entry(source.source_id.clone())
+                    .and_modify(|pending_cause| {
+                        *pending_cause = combine_source_watch_causes(*pending_cause, cause);
+                    })
+                    .or_insert(cause);
+            }
+        }
+        for (source_id, cause) in impacted {
+            self.update_pending_watch(source_id, cause, now);
+        }
+    }
+
+    pub(super) fn update_pending_watch(
+        &mut self,
+        source_id: SourceId,
+        cause: SourceWatchCause,
+        now: Instant,
+    ) {
+        self.pending
+            .entry(source_id)
+            .and_modify(|entry| {
+                entry.last_event = now;
+                entry.cause = combine_source_watch_causes(entry.cause, cause);
+            })
+            .or_insert(PendingSourceWatch {
+                last_event: now,
+                cause,
+            });
+    }
+
+    pub(super) fn drain_ready_sources(
+        &mut self,
+        now: Instant,
+        debounce: Duration,
+    ) -> Vec<SourceWatchEvent> {
+        if self.scan_in_progress {
+            return Vec::new();
+        }
+        let ready: Vec<SourceWatchEvent> = self
+            .pending
+            .iter()
+            .filter(|&(_source_id, entry)| {
+                now.saturating_duration_since(entry.last_event) >= debounce
+            })
+            .map(|(source_id, entry)| SourceWatchEvent {
+                source_id: source_id.clone(),
+                cause: entry.cause,
+            })
+            .collect();
+        for event in &ready {
+            self.pending.remove(&event.source_id);
+        }
+        ready
+    }
+
+    fn prune_pending_sources(&mut self) {
+        let allowed: HashSet<&SourceId> =
+            self.sources.iter().map(|entry| &entry.source_id).collect();
+        self.pending
+            .retain(|source_id, _| allowed.contains(source_id));
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(super) struct PendingSourceWatch {
+    last_event: Instant,
+    cause: SourceWatchCause,
+}

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -296,152 +296,228 @@ impl GuiAppState {
         );
     }
 
-    fn apply_message(&mut self, message: GuiMessage, context: &mut ui::UpdateContext<GuiMessage>) {
+    fn apply_folder_browser_message(
+        &mut self,
+        message: FolderBrowserMessage,
+        context: &mut ui::UpdateContext<GuiMessage>,
+    ) {
         match message {
-            GuiMessage::ResizeFolder(message) => self.resize_folder_browser(message),
-            GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource) => {
-                self.add_source_from_dialog(context);
-            }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::SelectSource(id)) => {
+            FolderBrowserMessage::AddSource => self.add_source_from_dialog(context),
+            FolderBrowserMessage::SelectSource(id) => {
                 self.context_menu = None;
                 self.select_source(id, context);
             }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::OpenSourceContextMenu(
-                source_id,
-                position,
-            )) => self.open_source_context_menu(source_id, position),
-            GuiMessage::FolderBrowser(FolderBrowserMessage::BeginRenameSelected) => {
-                let started_at = Instant::now();
-                let target = self.folder_browser.selected_rename_target();
-                if logging::debug_logging_enabled() {
-                    tracing::debug!(
-                        target: logging::ACTION_EVENT_TARGET,
-                        event = "action_detail",
-                        action = "folder_browser.rename.begin",
-                        pane = "folder_browser",
-                        target_kind = target.kind,
-                        target_label = target.label,
-                        is_source_root = target.is_source_root,
-                        "Folder browser rename requested"
-                    );
-                }
-                let renaming_file = self.folder_browser.selected_file_id().is_some();
-                match self.folder_browser.begin_rename_selected() {
-                    Ok(Some(input_id)) => {
-                        self.sample_status = if renaming_file {
-                            String::from("Renaming selected file")
-                        } else {
-                            String::from("Renaming selected folder")
-                        };
-                        context.after(
-                            Duration::from_millis(1),
-                            GuiMessage::FocusRenameInput(input_id),
-                        );
-                        emit_gui_action(
-                            "folder_browser.rename.begin",
-                            Some("folder_browser"),
-                            Some(target.kind),
-                            "success",
-                            started_at,
-                            None,
-                        );
-                    }
-                    Ok(None) => {
-                        self.sample_status = String::from("Select a folder to rename");
-                        emit_gui_action(
-                            "folder_browser.rename.begin",
-                            Some("folder_browser"),
-                            None,
-                            "short_circuit",
-                            started_at,
-                            Some("nothing_selected"),
-                        );
-                    }
-                    Err(error) => {
-                        self.sample_status = error;
-                        emit_gui_action(
-                            "folder_browser.rename.begin",
-                            Some("folder_browser"),
-                            None,
-                            "error",
-                            started_at,
-                            Some("rename_begin_failed"),
-                        );
-                    }
-                }
+            FolderBrowserMessage::OpenSourceContextMenu(source_id, position) => {
+                self.open_source_context_menu(source_id, position);
             }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::BeginCreateSubfolder) => {
-                let started_at = Instant::now();
-                match self.folder_browser.begin_create_subfolder() {
-                    Ok(Some(input_id)) => {
-                        self.sample_status = String::from("Creating new folder");
-                        context.after(
-                            Duration::from_millis(1),
-                            GuiMessage::FocusRenameInput(input_id),
-                        );
-                        emit_gui_action(
-                            "folder_browser.folder.create_begin",
-                            Some("folder_browser"),
-                            Some("folder"),
-                            "success",
-                            started_at,
-                            None,
-                        );
-                    }
-                    Ok(None) => {
-                        self.sample_status = String::from("Select a folder to add a subfolder");
-                        emit_gui_action(
-                            "folder_browser.folder.create_begin",
-                            Some("folder_browser"),
-                            None,
-                            "short_circuit",
-                            started_at,
-                            Some("nothing_selected"),
-                        );
-                    }
-                    Err(error) => {
-                        self.sample_status = error;
-                        emit_gui_action(
-                            "folder_browser.folder.create_begin",
-                            Some("folder_browser"),
-                            None,
-                            "error",
-                            started_at,
-                            Some("create_begin_failed"),
-                        );
-                    }
-                }
+            FolderBrowserMessage::BeginRenameSelected => self.begin_folder_browser_rename(context),
+            FolderBrowserMessage::BeginCreateSubfolder => {
+                self.begin_folder_browser_subfolder_creation(context);
             }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::RenameInput(message)) => {
-                let started_at = Instant::now();
-                let input_action = rename_input_action(&message);
-                if let Some(status) = self.folder_browser.apply_rename_input(message) {
-                    self.sample_status = status;
-                }
-                if let Some(action) = input_action {
-                    emit_gui_action(
-                        action,
-                        Some("folder_browser"),
-                        None,
-                        "applied",
-                        started_at,
-                        None,
-                    );
-                }
+            FolderBrowserMessage::RenameInput(message) => {
+                self.apply_folder_browser_rename_input(message);
             }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::DropOnFolder(folder_id)) => {
+            FolderBrowserMessage::DropOnFolder(folder_id) => {
                 self.context_menu = None;
                 self.drop_browser_drag_on_folder(folder_id, context);
             }
-            GuiMessage::FolderBrowser(FolderBrowserMessage::OpenFolderContextMenu(
-                folder_id,
-                position,
-            )) => self.open_folder_context_menu(folder_id, position),
-            GuiMessage::FolderBrowser(FolderBrowserMessage::DragFolder(folder_id, drag)) => {
+            FolderBrowserMessage::OpenFolderContextMenu(folder_id, position) => {
+                self.open_folder_context_menu(folder_id, position);
+            }
+            FolderBrowserMessage::DragFolder(folder_id, drag) => {
                 self.context_menu = None;
                 self.drag_folder(folder_id, drag, context);
             }
-            GuiMessage::FolderBrowser(message) => self.folder_browser.apply_message(message),
+            message => self.folder_browser.apply_message(message),
+        }
+    }
+
+    fn begin_folder_browser_rename(&mut self, context: &mut ui::UpdateContext<GuiMessage>) {
+        let started_at = Instant::now();
+        let target = self.folder_browser.selected_rename_target();
+        if logging::debug_logging_enabled() {
+            tracing::debug!(
+                target: logging::ACTION_EVENT_TARGET,
+                event = "action_detail",
+                action = "folder_browser.rename.begin",
+                pane = "folder_browser",
+                target_kind = target.kind,
+                target_label = target.label,
+                is_source_root = target.is_source_root,
+                "Folder browser rename requested"
+            );
+        }
+        let renaming_file = self.folder_browser.selected_file_id().is_some();
+        match self.folder_browser.begin_rename_selected() {
+            Ok(Some(input_id)) => {
+                self.sample_status = if renaming_file {
+                    String::from("Renaming selected file")
+                } else {
+                    String::from("Renaming selected folder")
+                };
+                context.after(
+                    Duration::from_millis(1),
+                    GuiMessage::FocusRenameInput(input_id),
+                );
+                emit_gui_action(
+                    "folder_browser.rename.begin",
+                    Some("folder_browser"),
+                    Some(target.kind),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Ok(None) => {
+                self.sample_status = String::from("Select a folder to rename");
+                emit_gui_action(
+                    "folder_browser.rename.begin",
+                    Some("folder_browser"),
+                    None,
+                    "short_circuit",
+                    started_at,
+                    Some("nothing_selected"),
+                );
+            }
+            Err(error) => {
+                self.sample_status = error;
+                emit_gui_action(
+                    "folder_browser.rename.begin",
+                    Some("folder_browser"),
+                    None,
+                    "error",
+                    started_at,
+                    Some("rename_begin_failed"),
+                );
+            }
+        }
+    }
+
+    fn begin_folder_browser_subfolder_creation(
+        &mut self,
+        context: &mut ui::UpdateContext<GuiMessage>,
+    ) {
+        let started_at = Instant::now();
+        match self.folder_browser.begin_create_subfolder() {
+            Ok(Some(input_id)) => {
+                self.sample_status = String::from("Creating new folder");
+                context.after(
+                    Duration::from_millis(1),
+                    GuiMessage::FocusRenameInput(input_id),
+                );
+                emit_gui_action(
+                    "folder_browser.folder.create_begin",
+                    Some("folder_browser"),
+                    Some("folder"),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Ok(None) => {
+                self.sample_status = String::from("Select a folder to add a subfolder");
+                emit_gui_action(
+                    "folder_browser.folder.create_begin",
+                    Some("folder_browser"),
+                    None,
+                    "short_circuit",
+                    started_at,
+                    Some("nothing_selected"),
+                );
+            }
+            Err(error) => {
+                self.sample_status = error;
+                emit_gui_action(
+                    "folder_browser.folder.create_begin",
+                    Some("folder_browser"),
+                    None,
+                    "error",
+                    started_at,
+                    Some("create_begin_failed"),
+                );
+            }
+        }
+    }
+
+    fn apply_folder_browser_rename_input(&mut self, message: radiant::widgets::TextInputMessage) {
+        let started_at = Instant::now();
+        let input_action = rename_input_action(&message);
+        if let Some(status) = self.folder_browser.apply_rename_input(message) {
+            self.sample_status = status;
+        }
+        if let Some(action) = input_action {
+            emit_gui_action(
+                action,
+                Some("folder_browser"),
+                None,
+                "applied",
+                started_at,
+                None,
+            );
+        }
+    }
+
+    fn navigate_browser(
+        &mut self,
+        delta: i32,
+        extend: bool,
+        context: &mut ui::UpdateContext<GuiMessage>,
+    ) {
+        let started_at = Instant::now();
+        let direction = if delta < 0 { "previous" } else { "next" };
+        let Some(path) = self.folder_browser.navigate_vertical(delta, extend) else {
+            emit_gui_action(
+                "folder_browser.navigate",
+                Some("browser"),
+                Some(direction),
+                "edge",
+                started_at,
+                None,
+            );
+            return;
+        };
+
+        if let Some(index) = self.folder_browser.selected_audio_file_index() {
+            context.scroll_fixed_row_into_view(
+                SAMPLE_BROWSER_LIST_ID,
+                index,
+                SAMPLE_BROWSER_ROW_HEIGHT,
+                SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
+                SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
+                delta,
+            );
+        }
+        emit_gui_action(
+            "folder_browser.navigate",
+            Some("browser"),
+            Some(direction),
+            "selected",
+            started_at,
+            None,
+        );
+        self.select_sample(path, context);
+    }
+
+    fn advance_frame(&mut self) {
+        self.waveform.apply_interaction(WaveformInteraction::Frame);
+        self.refresh_playback_progress();
+        if self.folder_progress.is_some() {
+            self.progress_tick = (self.progress_tick + 0.035) % 1.0;
+        }
+        if self.waveform_loading_label.is_some() {
+            let remaining = self.waveform_loading_target_progress - self.waveform_loading_progress;
+            if remaining > 0.0 {
+                self.waveform_loading_progress += remaining.min(0.03);
+            }
+        }
+    }
+
+    fn apply_message(&mut self, message: GuiMessage, context: &mut ui::UpdateContext<GuiMessage>) {
+        match message {
+            GuiMessage::ResizeFolder(message) => self.resize_folder_browser(message),
+            GuiMessage::FolderBrowser(message) => {
+                self.apply_folder_browser_message(message, context);
+            }
             GuiMessage::FolderScanProgress(progress) => {
                 let started_at = Instant::now();
                 if self
@@ -565,37 +641,7 @@ impl GuiAppState {
             GuiMessage::DeleteSelectedItem => self.delete_selected_item(),
             GuiMessage::ExtractPlaymarkedRange => self.extract_playmarked_range(),
             GuiMessage::NavigateBrowser { delta, extend } => {
-                let started_at = Instant::now();
-                if let Some(path) = self.folder_browser.navigate_vertical(delta, extend) {
-                    if let Some(index) = self.folder_browser.selected_audio_file_index() {
-                        context.scroll_fixed_row_into_view(
-                            SAMPLE_BROWSER_LIST_ID,
-                            index,
-                            SAMPLE_BROWSER_ROW_HEIGHT,
-                            SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
-                            SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
-                            delta,
-                        );
-                    }
-                    emit_gui_action(
-                        "folder_browser.navigate",
-                        Some("browser"),
-                        Some(if delta < 0 { "previous" } else { "next" }),
-                        "selected",
-                        started_at,
-                        None,
-                    );
-                    self.select_sample(path, context);
-                } else {
-                    emit_gui_action(
-                        "folder_browser.navigate",
-                        Some("browser"),
-                        Some(if delta < 0 { "previous" } else { "next" }),
-                        "edge",
-                        started_at,
-                        None,
-                    );
-                }
+                self.navigate_browser(delta, extend, context);
             }
             GuiMessage::SelectAllSamples => {
                 let started_at = Instant::now();
@@ -654,18 +700,7 @@ impl GuiAppState {
                 }
             }
             GuiMessage::Frame => {
-                self.waveform.apply_interaction(WaveformInteraction::Frame);
-                self.refresh_playback_progress();
-                if self.folder_progress.is_some() {
-                    self.progress_tick = (self.progress_tick + 0.035) % 1.0;
-                }
-                if self.waveform_loading_label.is_some() {
-                    let remaining =
-                        self.waveform_loading_target_progress - self.waveform_loading_progress;
-                    if remaining > 0.0 {
-                        self.waveform_loading_progress += remaining.min(0.03);
-                    }
-                }
+                self.advance_frame();
             }
         }
     }


### PR DESCRIPTION
## Summary
- Split default GUI message routing so folder-browser workflows, browser navigation, and frame ticks live behind focused methods instead of the main dispatcher.
- Move source-watcher mutable runtime state into a dedicated child module and keep the polling loop focused on command/event flow.
- Update source-watcher tests to exercise the new state boundary directly.

## Validation
- cargo test -p wavecrate --lib source_watcher
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent

Notes: Windows incremental-cache finalization warnings appeared during validation, matching the known non-fatal local environment pattern; all lanes exited successfully.