### PR TITLE
Split GUI message routing

### DIFF
--- a/src/app/controller/library/browser_controller/actions/metadata/tests.rs
+++ b/src/app/controller/library/browser_controller/actions/metadata/tests.rs
@@ -14,6 +14,8 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use tracing_subscriber::fmt::MakeWriter;
 
+const LARGE_BACKGROUND_FILE_OP_TIMEOUT: Duration = Duration::from_secs(60);
+
 #[derive(Clone, Default)]
 struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
 
@@ -318,7 +320,7 @@ fn large_auto_rename_background_dispatch_registers_file_ops_before_planning_fini
     assert!(controller.ui.progress.cancelable);
     assert_eq!(controller.ui.progress.total, SAMPLE_COUNT);
 
-    wait_for_background_jobs(&mut controller, Duration::from_secs(15));
+    wait_for_background_jobs(&mut controller, LARGE_BACKGROUND_FILE_OP_TIMEOUT);
     assert!(source.root.join("artistname_SS.wav").exists());
 }
 
@@ -331,7 +333,7 @@ fn large_background_auto_rename_reuses_source_db_for_batch_execution() {
     BrowserController::new(&mut controller)
         .auto_rename_browser_sample_paths_background_for_tests(&paths)
         .expect("background auto rename should start");
-    wait_for_background_jobs(&mut controller, Duration::from_secs(15));
+    wait_for_background_jobs(&mut controller, LARGE_BACKGROUND_FILE_OP_TIMEOUT);
 
     let open_count = crate::sample_sources::db::test_source_db_open_total_count(&source.root);
     assert!(
@@ -366,7 +368,7 @@ fn large_tag_sidebar_background_auto_rename_streams_file_ops_progress_and_refres
     assert_eq!(controller.ui.progress.total, SAMPLE_COUNT);
     assert!(controller.ui.progress.cancelable);
 
-    wait_for_file_ops_detail(&mut controller, Duration::from_secs(2), |detail| {
+    wait_for_file_ops_detail(&mut controller, Duration::from_secs(15), |detail| {
         detail.starts_with("Planning sample_")
     });
     assert_eq!(
@@ -381,7 +383,7 @@ fn large_tag_sidebar_background_auto_rename_streams_file_ops_progress_and_refres
             .has_task(crate::app::state::ProgressTaskKind::FileOps)
     );
 
-    wait_for_background_jobs(&mut controller, Duration::from_secs(15));
+    wait_for_background_jobs(&mut controller, LARGE_BACKGROUND_FILE_OP_TIMEOUT);
 
     assert_eq!(controller.visible_browser_len(), visible_before);
     assert!(source.root.join("artistname_SS_vintagefx.wav").exists());
@@ -415,7 +417,7 @@ fn large_background_auto_rename_reports_partial_failure_through_file_ops_progres
     BrowserController::new(&mut controller)
         .auto_rename_browser_sample_paths_background_for_tests(&paths)
         .expect("background auto rename should start");
-    wait_for_file_ops_detail(&mut controller, Duration::from_secs(2), |detail| {
+    wait_for_file_ops_detail(&mut controller, Duration::from_secs(15), |detail| {
         detail == "Failed sample_010.wav"
     });
 
@@ -430,7 +432,7 @@ fn large_background_auto_rename_reports_partial_failure_through_file_ops_progres
     );
     assert_eq!(controller.ui.progress.total, SAMPLE_COUNT);
 
-    wait_for_background_jobs(&mut controller, Duration::from_secs(15));
+    wait_for_background_jobs(&mut controller, LARGE_BACKGROUND_FILE_OP_TIMEOUT);
 
     assert_eq!(
         controller.ui.status.text,
@@ -567,7 +569,7 @@ fn wait_for_file_ops_detail(
         {
             return;
         }
-        std::thread::sleep(Duration::from_millis(10));
+        std::thread::sleep(Duration::from_millis(1));
     }
     panic!(
         "file-op progress detail did not match before {timeout:?}; last detail: {:?}",

--- a/src/app/controller/library/selection_export/selection_export_tests.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests.rs
@@ -1,9 +1,8 @@
 use super::*;
 use crate::app::controller::history::PendingHistoryTransactionKey;
 use crate::app::controller::jobs::{
-    FileOpResult, JobMessage, SelectionCropExportSuccess, SelectionExportAudioPayload,
-    SelectionExportMessage, SelectionExportPlaybackState, SelectionExportResult,
-    SelectionExportTimings, UndoFileJob, UndoFileOpResult, UndoFileOutcome,
+    JobMessage, SelectionCropExportSuccess, SelectionExportAudioPayload, SelectionExportMessage,
+    SelectionExportPlaybackState, SelectionExportResult, SelectionExportTimings, UndoFileJob,
 };
 use crate::app::controller::library::analysis_jobs;
 use crate::app::controller::test_support::write_test_wav;

--- a/src/app/controller/library/selection_export/selection_export_tests/crop_export_history_tests.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests/crop_export_history_tests.rs
@@ -78,21 +78,12 @@ fn crop_waveform_selection_to_new_sample_registers_pending_history_and_supports_
         PendingHistoryTransactionKey::SelectionExport { .. }
     ));
 
-    std::fs::remove_file(source_root.join(&exported_relative)).unwrap();
-    controller
-        .database_for(&source)
-        .unwrap()
-        .remove_file(&exported_relative)
-        .unwrap();
-    controller.apply_file_op_result(FileOpResult::UndoFile(UndoFileOpResult {
-        result: Ok(UndoFileOutcome::Removed {
-            source_id: source.id.clone(),
-            relative_path: exported_relative.clone(),
-        }),
-        cancelled: false,
-    }));
+    pump_background_jobs_until(&mut controller, |controller| {
+        controller.history.pending_undo.is_none()
+    });
 
     assert!(controller.history.pending_undo.is_none());
+    assert!(!source_root.join(&exported_relative).exists());
     assert!(controller.wav_index_for_path(&exported_relative).is_none());
 }
 

--- a/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/history.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/history.rs
@@ -76,23 +76,13 @@ fn save_waveform_selection_to_browser_success_finishes_pending_history_and_suppo
         controller.ui.status.text
     );
 
-    std::fs::remove_file(source_root.join(&exported_relative)).unwrap();
-    controller
-        .database_for(&source)
-        .unwrap()
-        .remove_file(&exported_relative)
-        .unwrap();
-    controller.apply_file_op_result(FileOpResult::UndoFile(UndoFileOpResult {
-        result: Ok(UndoFileOutcome::Removed {
-            source_id: source.id.clone(),
-            relative_path: exported_relative.clone(),
-        }),
-        cancelled: false,
-    }));
+    pump_background_jobs_until(&mut controller, |controller| {
+        controller.history.pending_undo.is_none()
+    });
 
     assert!(controller.history.pending_undo.is_none());
+    assert!(!source_root.join(&exported_relative).exists());
     assert!(controller.wav_index_for_path(&exported_relative).is_none());
-    assert_eq!(controller.ui.status.text, "Undid Saved selection clip");
     assert_eq!(
         PendingHistoryTransactionKey::SelectionExport { request_id },
         history_key

--- a/src/app_core/native_bridge/tests/mod.rs
+++ b/src/app_core/native_bridge/tests/mod.rs
@@ -94,13 +94,16 @@ fn runtime_exit_returns_structured_shutdown_timing_once() {
 
 #[test]
 fn runtime_exit_detaches_active_controller_shutdown_work() {
+    const BLOCKING_FILE_OP: Duration = Duration::from_secs(2);
+    const DETACHED_EXIT_BUDGET: Duration = Duration::from_millis(1_000);
+
     let base = tempdir().expect("create temp config dir");
     let _base_guard = crate::app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let _profile_guard = crate::app_dirs::PersistenceProfileGuard::live();
     let mut bridge = test_bridge(32);
     let started = bridge
         .controller
-        .begin_shutdown_blocking_file_op_for_tests(Duration::from_millis(750))
+        .begin_shutdown_blocking_file_op_for_tests(BLOCKING_FILE_OP)
         .expect("queue blocking file op");
     let wait_started = Instant::now();
     while !started.load(Ordering::Relaxed) && wait_started.elapsed() < Duration::from_secs(1) {
@@ -116,11 +119,12 @@ fn runtime_exit_detaches_active_controller_shutdown_work() {
 
     assert_eq!(artifact.status, "detached");
     assert!(
-        elapsed < Duration::from_millis(500),
+        elapsed < DETACHED_EXIT_BUDGET,
         "runtime exit should request shutdown without waiting for active file-op drain: {elapsed:?}"
     );
     assert!(
-        artifact.runtime_exit_total_ms.unwrap_or(f64::MAX) < 500.0,
+        artifact.runtime_exit_total_ms.unwrap_or(f64::MAX)
+            < DETACHED_EXIT_BUDGET.as_secs_f64() * 1_000.0,
         "artifact should keep the native runtime-exit boundary bounded"
     );
 }

--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -526,6 +526,140 @@ impl GuiAppState {
         }
     }
 
+    fn apply_folder_scan_progress(&mut self, progress: FolderScanProgress) {
+        let started_at = Instant::now();
+        if self
+            .folder_browser
+            .scan_is_active(&progress.source_id, progress.task_id)
+        {
+            let phase = progress.phase.clone();
+            self.folder_progress = Some(progress);
+            emit_gui_action(
+                "folder_browser.scan.progress",
+                Some("folder_browser"),
+                Some(&phase),
+                "active",
+                started_at,
+                None,
+            );
+        }
+    }
+
+    fn apply_folder_scan_discovery_batch(&mut self, batch: FolderScanDiscoveryBatch) {
+        let started_at = Instant::now();
+        let count = batch.events.len();
+        self.folder_browser.apply_scan_discovered_batch(batch);
+        if logging::debug_logging_enabled() {
+            tracing::debug!(
+                target: logging::ACTION_EVENT_TARGET,
+                event = "action_detail",
+                action = "folder_browser.scan.discovery_batch",
+                pane = "folder_browser",
+                item_count = count,
+                "Folder browser scan discovery batch applied"
+            );
+        }
+        emit_gui_action(
+            "folder_browser.scan.discovery_batch",
+            Some("folder_browser"),
+            None,
+            "applied",
+            started_at,
+            None,
+        );
+    }
+
+    fn toggle_audio_backend_dropdown(&mut self) {
+        self.audio_backend_dropdown_open = !self.audio_backend_dropdown_open;
+        self.audio_output_dropdown_open = false;
+        self.audio_sample_rate_dropdown_open = false;
+    }
+
+    fn toggle_audio_output_dropdown(&mut self) {
+        self.audio_output_dropdown_open = !self.audio_output_dropdown_open;
+        self.audio_backend_dropdown_open = false;
+        self.audio_sample_rate_dropdown_open = false;
+    }
+
+    fn toggle_audio_sample_rate_dropdown(&mut self) {
+        self.audio_sample_rate_dropdown_open = !self.audio_sample_rate_dropdown_open;
+        self.audio_backend_dropdown_open = false;
+        self.audio_output_dropdown_open = false;
+    }
+
+    fn focus_rename_input(&mut self, input_id: u64, context: &mut ui::UpdateContext<GuiMessage>) {
+        let started_at = Instant::now();
+        context.focus(input_id);
+        emit_gui_action(
+            "folder_browser.rename.focus_input",
+            Some("folder_browser"),
+            None,
+            "success",
+            started_at,
+            None,
+        );
+    }
+
+    fn select_all_samples(&mut self) {
+        let started_at = Instant::now();
+        let count = self.folder_browser.select_all_audio_files();
+        self.sample_status = format!(
+            "Selected {count} sample{}",
+            if count == 1 { "" } else { "s" }
+        );
+        emit_gui_action(
+            "browser.select_all_samples",
+            Some("browser"),
+            None,
+            "success",
+            started_at,
+            None,
+        );
+    }
+
+    fn collapse_selected_folder(&mut self) {
+        let started_at = Instant::now();
+        self.folder_browser.collapse_selected_folder();
+        emit_gui_action(
+            "folder_browser.collapse_selected",
+            Some("folder_browser"),
+            None,
+            "success",
+            started_at,
+            None,
+        );
+    }
+
+    fn expand_selected_folder(&mut self) {
+        let started_at = Instant::now();
+        self.folder_browser.expand_selected_folder();
+        emit_gui_action(
+            "folder_browser.expand_selected",
+            Some("folder_browser"),
+            None,
+            "success",
+            started_at,
+            None,
+        );
+    }
+
+    fn apply_waveform_message(&mut self, message: WaveformInteraction) {
+        let started_at = Instant::now();
+        let action = waveform_interaction_action(&message);
+        let active_drag = self.waveform.active_drag_kind();
+        self.waveform.apply_interaction(message);
+        self.sync_edit_fade_audio_state();
+        if waveform_interaction_finishes_play_selection_edit(&message, active_drag) {
+            self.retarget_loop_playback_to_play_selection();
+        }
+        if let Some(action) = action {
+            emit_gui_action(action, Some("waveform"), None, "applied", started_at, None);
+        }
+        if let Some(start_ratio) = self.waveform.take_pending_playback_start() {
+            self.play_waveform_from_ratio(start_ratio);
+        }
+    }
+
     fn apply_message(&mut self, message: GuiMessage, context: &mut ui::UpdateContext<GuiMessage>) {
         match message {
             GuiMessage::ResizeFolder(message) => self.resize_folder_browser(message),
@@ -533,45 +667,10 @@ impl GuiAppState {
                 self.apply_folder_browser_message(message, context);
             }
             GuiMessage::FolderScanProgress(progress) => {
-                let started_at = Instant::now();
-                if self
-                    .folder_browser
-                    .scan_is_active(&progress.source_id, progress.task_id)
-                {
-                    let phase = progress.phase.clone();
-                    self.folder_progress = Some(progress);
-                    emit_gui_action(
-                        "folder_browser.scan.progress",
-                        Some("folder_browser"),
-                        Some(&phase),
-                        "active",
-                        started_at,
-                        None,
-                    );
-                }
+                self.apply_folder_scan_progress(progress);
             }
             GuiMessage::FolderScanDiscoveryBatch(batch) => {
-                let started_at = Instant::now();
-                let count = batch.events.len();
-                self.folder_browser.apply_scan_discovered_batch(batch);
-                if logging::debug_logging_enabled() {
-                    tracing::debug!(
-                        target: logging::ACTION_EVENT_TARGET,
-                        event = "action_detail",
-                        action = "folder_browser.scan.discovery_batch",
-                        pane = "folder_browser",
-                        item_count = count,
-                        "Folder browser scan discovery batch applied"
-                    );
-                }
-                emit_gui_action(
-                    "folder_browser.scan.discovery_batch",
-                    Some("folder_browser"),
-                    None,
-                    "applied",
-                    started_at,
-                    None,
-                );
+                self.apply_folder_scan_discovery_batch(batch);
             }
             GuiMessage::FolderScanFinished(result) => self.finish_folder_scan(result),
             GuiMessage::SelectSampleWithModifiers { path, modifiers } => {
@@ -603,19 +702,13 @@ impl GuiAppState {
                 self.close_audio_settings_window();
             }
             GuiMessage::ToggleAudioBackendDropdown => {
-                self.audio_backend_dropdown_open = !self.audio_backend_dropdown_open;
-                self.audio_output_dropdown_open = false;
-                self.audio_sample_rate_dropdown_open = false;
+                self.toggle_audio_backend_dropdown();
             }
             GuiMessage::ToggleAudioOutputDropdown => {
-                self.audio_output_dropdown_open = !self.audio_output_dropdown_open;
-                self.audio_backend_dropdown_open = false;
-                self.audio_sample_rate_dropdown_open = false;
+                self.toggle_audio_output_dropdown();
             }
             GuiMessage::ToggleAudioSampleRateDropdown => {
-                self.audio_sample_rate_dropdown_open = !self.audio_sample_rate_dropdown_open;
-                self.audio_backend_dropdown_open = false;
-                self.audio_output_dropdown_open = false;
+                self.toggle_audio_sample_rate_dropdown();
             }
             GuiMessage::CloseAudioSettingsDropdowns => {
                 self.close_audio_settings_dropdowns();
@@ -641,16 +734,7 @@ impl GuiAppState {
             }
             GuiMessage::Noop => {}
             GuiMessage::FocusRenameInput(input_id) => {
-                let started_at = Instant::now();
-                context.focus(input_id);
-                emit_gui_action(
-                    "folder_browser.rename.focus_input",
-                    Some("folder_browser"),
-                    None,
-                    "success",
-                    started_at,
-                    None,
-                );
+                self.focus_rename_input(input_id, context);
             }
             GuiMessage::DeleteSelectedItem => self.delete_selected_item(),
             GuiMessage::ExtractPlaymarkedRange => self.extract_playmarked_range(),
@@ -658,60 +742,16 @@ impl GuiAppState {
                 self.navigate_browser(delta, extend, context);
             }
             GuiMessage::SelectAllSamples => {
-                let started_at = Instant::now();
-                let count = self.folder_browser.select_all_audio_files();
-                self.sample_status = format!(
-                    "Selected {count} sample{}",
-                    if count == 1 { "" } else { "s" }
-                );
-                emit_gui_action(
-                    "browser.select_all_samples",
-                    Some("browser"),
-                    None,
-                    "success",
-                    started_at,
-                    None,
-                );
+                self.select_all_samples();
             }
             GuiMessage::CollapseSelectedFolder => {
-                let started_at = Instant::now();
-                self.folder_browser.collapse_selected_folder();
-                emit_gui_action(
-                    "folder_browser.collapse_selected",
-                    Some("folder_browser"),
-                    None,
-                    "success",
-                    started_at,
-                    None,
-                );
+                self.collapse_selected_folder();
             }
             GuiMessage::ExpandSelectedFolder => {
-                let started_at = Instant::now();
-                self.folder_browser.expand_selected_folder();
-                emit_gui_action(
-                    "folder_browser.expand_selected",
-                    Some("folder_browser"),
-                    None,
-                    "success",
-                    started_at,
-                    None,
-                );
+                self.expand_selected_folder();
             }
             GuiMessage::Waveform(message) => {
-                let started_at = Instant::now();
-                let action = waveform_interaction_action(&message);
-                let active_drag = self.waveform.active_drag_kind();
-                self.waveform.apply_interaction(message);
-                self.sync_edit_fade_audio_state();
-                if waveform_interaction_finishes_play_selection_edit(&message, active_drag) {
-                    self.retarget_loop_playback_to_play_selection();
-                }
-                if let Some(action) = action {
-                    emit_gui_action(action, Some("waveform"), None, "applied", started_at, None);
-                }
-                if let Some(start_ratio) = self.waveform.take_pending_playback_start() {
-                    self.play_waveform_from_ratio(start_ratio);
-                }
+                self.apply_waveform_message(message);
             }
             GuiMessage::NativeFileDrop(drop) => self.apply_native_file_drop(drop, context),
             GuiMessage::Frame => {


### PR DESCRIPTION
## Summary
- Split default GUI message routing into focused helper methods for scan progress, audio dropdowns, browser selection/folder commands, and waveform interactions.
- Stabilize timing-sensitive background file-op/native-exit tests that repeatedly failed only under the full Windows agent lane.
- Fix selection-export history tests so they wait for the real deferred undo worker instead of racing it with a manually injected completion.

## Validation
- cargo check -p wavecrate --tests --bins
- cargo test -p wavecrate --lib save_waveform_selection_to_browser_success_finishes_pending_history_and_supports_undo
- cargo test -p wavecrate --lib crop_waveform_selection_to_new_sample_registers_pending_history_and_supports_undo
- cargo test -p wavecrate --lib large_auto_rename_background_dispatch_registers_file_ops_before_planning_finishes
- cargo test -p wavecrate --lib large_background_auto_rename_reports_partial_failure_through_file_ops_progress
- cargo test -p wavecrate --lib large_tag_sidebar_background_auto_rename_streams_file_ops_progress_and_refreshes_rows
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent