### PR TITLE
Optimize GUI contract test lanes

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -138,6 +138,9 @@ Use for semantic GUI contracts, CLI scenarios, and desktop AIV loops.
   - contract scenario anchor: `browser_focus_transition_stability`
 - contract loop:
   - `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 contract`
+  - this lane explicitly runs the ignored `contract_smoke_pack_runs_cleanly`
+    scenario-pack execution; the default library test lane keeps only the
+    cheaper GUI runner and fixture checks.
 - broader GUI suite:
   - `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 suite`
 - live AIV smoke:

--- a/scripts/internal/ci/ci_agent.ps1
+++ b/scripts/internal/ci/ci_agent.ps1
@@ -7,7 +7,7 @@ This lane avoids `cargo-nextest` and the broader GUI contract/integration
 wrappers so it can run in constrained Windows environments where Application
 Control blocks the `cargo-nextest.exe` binary. It keeps the edit loop grounded
 by running the normal compile smoke gate, Radiant's standalone no-default test
-suite, and the full wavecrate library test suite.
+suite, and Wavecrate's default non-ignored library test suite.
 #>
 
 param(

--- a/scripts/internal/gui/run_gui_contract.ps1
+++ b/scripts/internal/gui/run_gui_contract.ps1
@@ -49,6 +49,21 @@ try {
     Invoke-WavecrateCargo test gui_test::
   }
 
+  Write-Host "[gui-contract] cargo test contract_smoke_pack_runs_cleanly -- --ignored --exact"
+  Invoke-NativeStep -Label "cargo test contract_smoke_pack_runs_cleanly -- --ignored --exact" -Command {
+    $contractSmokeArgs = @(
+      "test",
+      "-p",
+      "wavecrate",
+      "--lib",
+      "gui_test::packs::tests::contract_smoke_pack_runs_cleanly",
+      "--",
+      "--ignored",
+      "--exact"
+    )
+    & cargo @(Get-WavecrateCargoConfigOverrideArgs) @contractSmokeArgs
+  }
+
   Write-Host "[gui-contract] cargo test app_core::controller::tests::persistence_boundary::"
   Invoke-NativeStep -Label "cargo test app_core::controller::tests::persistence_boundary::" -Command {
     Invoke-WavecrateCargo test app_core::controller::tests::persistence_boundary::

--- a/src/gui_test/mod.rs
+++ b/src/gui_test/mod.rs
@@ -36,3 +36,5 @@ pub use self::scenario::{GuiAssertion, GuiScenario, GuiScenarioStep};
 
 pub(crate) use self::artifacts::{catalog_report, trace_event_for_action};
 pub(crate) use self::automation::find_automation_node;
+#[cfg(test)]
+pub(crate) use self::runner::run_scenario_batch;

--- a/src/gui_test/packs/mod.rs
+++ b/src/gui_test/packs/mod.rs
@@ -48,22 +48,61 @@ fn contract_smoke_pack() -> GuiScenarioPack {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gui_test::{GuiTestModeConfig, run_scenario};
+    use crate::gui_test::{GuiTestModeConfig, run_scenario, run_scenario_batch};
+
+    fn assert_bundle_passed(bundle: &crate::gui_test::GuiTestArtifactBundle) {
+        let scenario_name = bundle.scenario_name.as_deref().unwrap_or("<unknown>");
+        assert!(
+            bundle.failure_summary.is_none(),
+            "scenario {} failed: {:?}",
+            scenario_name,
+            bundle.failure_summary
+        );
+    }
+
+    fn scenario_by_name<'a>(pack: &'a GuiScenarioPack, name: &str) -> &'a GuiScenario {
+        pack.scenarios
+            .iter()
+            .find(|scenario| scenario.name == name)
+            .unwrap_or_else(|| panic!("missing scenario {name}"))
+    }
 
     #[test]
+    #[ignore = "runs through scripts/gui.ps1 contract; too expensive for the default lib test lane"]
     fn contract_smoke_pack_runs_cleanly() {
         let pack = gui_scenario_pack("contract-smoke").expect("pack");
-        for scenario in &pack.scenarios {
-            let bundle =
-                run_scenario(&GuiTestModeConfig::default(), scenario).unwrap_or_else(|err| {
-                    panic!("scenario {} failed to execute: {err}", scenario.name)
-                });
-            assert!(
-                bundle.failure_summary.is_none(),
-                "scenario {} failed: {:?}",
-                scenario.name,
-                bundle.failure_summary
-            );
+        let config = GuiTestModeConfig::default();
+        let browser_search_options_batch = vec![
+            scenario_by_name(&pack, "browser_search_select_commit").clone(),
+            scenario_by_name(&pack, "options_open_close").clone(),
+        ];
+        let transport_batch = vec![
+            scenario_by_name(&pack, "transport_play_from_selection_start").clone(),
+            scenario_by_name(&pack, "transport_volume_slider").clone(),
+        ];
+
+        for batch in [&browser_search_options_batch[..], &transport_batch[..]] {
+            for bundle in run_scenario_batch(&config, batch)
+                .unwrap_or_else(|err| panic!("scenario batch failed to execute: {err}"))
+            {
+                assert_bundle_passed(&bundle);
+            }
+        }
+
+        for scenario_name in [
+            "browser_focus_transition_stability",
+            "left_sidebar_unified_tag_library",
+            "waveform_seek_zoom_selection",
+            "map_point_focus",
+            "prompt_confirm",
+            "prompt_cancel",
+            "update_panel_smoke",
+        ] {
+            let scenario = scenario_by_name(&pack, scenario_name);
+            let bundle = run_scenario(&config, scenario).unwrap_or_else(|err| {
+                panic!("scenario {} failed to execute: {err}", scenario.name)
+            });
+            assert_bundle_passed(&bundle);
         }
     }
 }

--- a/src/gui_test/runner/assertions.rs
+++ b/src/gui_test/runner/assertions.rs
@@ -103,13 +103,31 @@ pub(super) fn assert_scenario_state(
                 ))
             }
         }
-        GuiAssertion::ActionCataloged { action_id } => action_catalog_entry_by_id(action_id)
-            .map(|_| ())
-            .ok_or_else(|| format!("missing catalog action {action_id}")),
-        GuiAssertion::ActionRecorded { action_id } => trace
-            .iter()
-            .any(|event| event.action_id == *action_id && event.handled)
-            .then_some(())
-            .ok_or_else(|| format!("action trace does not contain handled action {action_id}")),
+        GuiAssertion::ActionCataloged { .. } | GuiAssertion::ActionRecorded { .. } => {
+            assert_trace_or_catalog_state(trace, assertion)
+                .expect("trace/catalog assertion should be handled without a snapshot")
+        }
+    }
+}
+
+/// Evaluate assertions that do not require an automation snapshot.
+pub(super) fn assert_trace_or_catalog_state(
+    trace: &[GuiActionTraceEvent],
+    assertion: &GuiAssertion,
+) -> Option<Result<(), String>> {
+    match assertion {
+        GuiAssertion::ActionCataloged { action_id } => Some(
+            action_catalog_entry_by_id(action_id)
+                .map(|_| ())
+                .ok_or_else(|| format!("missing catalog action {action_id}")),
+        ),
+        GuiAssertion::ActionRecorded { action_id } => Some(
+            trace
+                .iter()
+                .any(|event| event.action_id == *action_id && event.handled)
+                .then_some(())
+                .ok_or_else(|| format!("action trace does not contain handled action {action_id}")),
+        ),
+        _ => None,
     }
 }

--- a/src/gui_test/runner/mod.rs
+++ b/src/gui_test/runner/mod.rs
@@ -3,7 +3,7 @@
 mod assertions;
 mod bundle;
 
-use self::assertions::assert_scenario_state;
+use self::assertions::{assert_scenario_state, assert_trace_or_catalog_state};
 use self::bundle::snapshot_bundle;
 use super::{
     GuiScenario, GuiScenarioStep, GuiStepTimingSample, GuiTestArtifactBundle, GuiTestModeConfig,
@@ -58,6 +58,42 @@ pub fn run_scenario(
     scenario: &GuiScenario,
 ) -> Result<GuiTestArtifactBundle, String> {
     let mut bridge = make_bridge_for_fixture(&scenario.fixture_tag, config.viewport)?;
+    run_scenario_with_bridge(config, scenario, &mut bridge)
+}
+
+/// Run a sequence of scenarios against one shared fixture bridge.
+///
+/// Batch runs are intended for contract suites where setup dominates runtime and
+/// the scenarios form one deterministic journey from the same fixture state.
+#[cfg(test)]
+pub(crate) fn run_scenario_batch(
+    config: &GuiTestModeConfig,
+    scenarios: &[GuiScenario],
+) -> Result<Vec<GuiTestArtifactBundle>, String> {
+    let Some(first) = scenarios.first() else {
+        return Ok(Vec::new());
+    };
+    if let Some(mismatched) = scenarios
+        .iter()
+        .find(|scenario| scenario.fixture_tag != first.fixture_tag)
+    {
+        return Err(format!(
+            "scenario batch mixes fixture {} with {}",
+            first.fixture_tag, mismatched.fixture_tag
+        ));
+    }
+    let mut bridge = make_bridge_for_fixture(&first.fixture_tag, config.viewport)?;
+    scenarios
+        .iter()
+        .map(|scenario| run_scenario_with_bridge(config, scenario, &mut bridge))
+        .collect()
+}
+
+fn run_scenario_with_bridge(
+    config: &GuiTestModeConfig,
+    scenario: &GuiScenario,
+    bridge: &mut GuiFixtureBridge,
+) -> Result<GuiTestArtifactBundle, String> {
     let mut trace = Vec::new();
     let mut timings = Vec::new();
     let mut failure = None;
@@ -71,15 +107,20 @@ pub fn run_scenario(
                 trace.push(trace_event_for_action(action, handled));
             }
             GuiScenarioStep::Assert { assertion } => {
-                let deadline = Instant::now() + SCENARIO_ASSERT_TIMEOUT;
-                let failure_message = loop {
-                    let snapshot = bundle::current_snapshot(config, &mut bridge);
-                    match assert_scenario_state(&snapshot, &trace, assertion) {
-                        Ok(()) => break None,
-                        Err(err) if Instant::now() >= deadline => break Some(err),
-                        Err(_) => thread::sleep(SCENARIO_ASSERT_POLL_INTERVAL),
-                    }
-                };
+                let failure_message =
+                    if let Some(result) = assert_trace_or_catalog_state(&trace, assertion) {
+                        result.err()
+                    } else {
+                        let deadline = Instant::now() + SCENARIO_ASSERT_TIMEOUT;
+                        loop {
+                            let snapshot = bundle::current_snapshot(config, bridge);
+                            match assert_scenario_state(&snapshot, &trace, assertion) {
+                                Ok(()) => break None,
+                                Err(err) if Instant::now() >= deadline => break Some(err),
+                                Err(_) => thread::sleep(SCENARIO_ASSERT_POLL_INTERVAL),
+                            }
+                        }
+                    };
                 if let Some(err) = failure_message {
                     failure = Some(err);
                     timings.push(GuiStepTimingSample {
@@ -95,7 +136,7 @@ pub fn run_scenario(
             duration_ms: elapsed_ms(started),
         });
     }
-    let mut bundle = snapshot_bundle(config, &mut bridge, trace, failure, timings);
+    let mut bundle = snapshot_bundle(config, bridge, trace, failure, timings);
     bundle.scenario_name = Some(scenario.name.clone());
     bundle.fixture_tag = scenario.fixture_tag.clone();
     Ok(bundle)

--- a/src/gui_test/runner/tests.rs
+++ b/src/gui_test/runner/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::app_core::actions::NativeAutomationBounds as AutomationBounds;
 use crate::app_core::actions::{
     GUI_ACTION_CATALOG, NativeAutomationNodeId, NativeAutomationNodeSnapshot, NativeAutomationRole,
-    NativeGuiAutomationSnapshot, action_catalog_entry_by_id,
+    NativeGuiAutomationSnapshot,
 };
 use crate::gui_test::{GuiActionTraceEvent, GuiAssertion, GuiScenario, GuiScenarioStep};
 use std::collections::BTreeMap;
@@ -91,32 +91,6 @@ fn capture_default_bundle_exposes_root_snapshot_and_catalog() {
 }
 
 #[test]
-fn capture_default_bundle_advertises_only_cataloged_actions_across_named_fixtures() {
-    for fixture_tag in [
-        "browser",
-        "sources",
-        "transport",
-        "map",
-        "waveform",
-        "waveform_mixed",
-        "options",
-        "prompt",
-        "update",
-    ] {
-        let bundle = capture_default_bundle(&deterministic_test_config(fixture_tag))
-            .unwrap_or_else(|err| panic!("fixture {fixture_tag} capture failed: {err}"));
-        let mut advertised_actions = Vec::new();
-        collect_advertised_actions(&bundle.automation_snapshot.root, &mut advertised_actions);
-        for (node_id, action_id) in advertised_actions {
-            assert!(
-                action_catalog_entry_by_id(action_id).is_some(),
-                "fixture {fixture_tag} node {node_id} advertises uncataloged action {action_id}"
-            );
-        }
-    }
-}
-
-#[test]
 fn scenario_runner_accepts_root_presence_assertion() {
     let scenario = GuiScenario {
         name: String::from("root-smoke"),
@@ -198,6 +172,11 @@ fn assert_scenario_state_accepts_each_assertion_variant() {
             node_id: String::from("browser.search"),
             key: String::from("placeholder"),
             needle: String::from("samples"),
+        },
+        GuiAssertion::NodeMetadataEquals {
+            node_id: String::from("browser.search"),
+            key: String::from("placeholder"),
+            value: String::from("Search samples"),
         },
         GuiAssertion::ActionCataloged {
             action_id: String::from(catalog_action),

--- a/src/gui_test/runner/tests/action_parity.rs
+++ b/src/gui_test/runner/tests/action_parity.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::app_core::actions::action_catalog_entry_by_id;
 use crate::gui_test::{GuiTestArtifactBundle, find_automation_node};
 use std::collections::BTreeMap;
 
@@ -26,6 +27,20 @@ fn assert_fixture_node_actions(
     }
 }
 
+fn assert_fixture_advertises_only_cataloged_actions(
+    fixture_tag: &str,
+    bundle: &GuiTestArtifactBundle,
+) {
+    let mut advertised_actions = Vec::new();
+    collect_advertised_actions(&bundle.automation_snapshot.root, &mut advertised_actions);
+    for (node_id, action_id) in advertised_actions {
+        assert!(
+            action_catalog_entry_by_id(action_id).is_some(),
+            "fixture {fixture_tag} node {node_id} advertises uncataloged action {action_id}"
+        );
+    }
+}
+
 fn capture_case_fixtures<'a>(
     cases: &[(&'a str, &'a str, &'a [&'a str])],
 ) -> BTreeMap<&'a str, GuiTestArtifactBundle> {
@@ -36,6 +51,7 @@ fn capture_case_fixtures<'a>(
         }
         let bundle = capture_default_bundle(&deterministic_test_config(fixture_tag))
             .unwrap_or_else(|err| panic!("fixture {fixture_tag} capture failed: {err}"));
+        assert_fixture_advertises_only_cataloged_actions(fixture_tag, &bundle);
         bundles.insert(*fixture_tag, bundle);
     }
     bundles


### PR DESCRIPTION
## Summary
- fold advertised-action catalog checks into existing action-parity fixture captures
- skip snapshot rebuilding for trace/catalog-only GUI assertions
- move full contract-smoke scenario execution out of the default lib lane and into scripts/gui.ps1 contract
- batch compatible contract-smoke scenarios while preserving explicit full GUI contract coverage

## Validation
- cargo check -p wavecrate --tests --bins
- cargo test -p wavecrate --lib gui_test::runner::tests
- cargo test -p wavecrate --lib gui_test::packs::tests::contract_smoke_pack_runs_cleanly -- --ignored --exact
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent
- powershell -ExecutionPolicy Bypass -File scripts\gui.ps1 contract