### PR TITLE
Extract GUI launch boundary

### DIFF
--- a/src/gui_app.rs
+++ b/src/gui_app.rs
@@ -2,22 +2,18 @@
 
 use radiant::gui::types::Point;
 use radiant::prelude as ui;
-use radiant::runtime::{NativeFileDrop, NativeRunOptions, NativeTextOptions};
+use radiant::runtime::NativeFileDrop;
 use radiant::widgets::{DragHandleMessage, PointerModifiers};
 use std::{
-    ffi::OsString,
-    panic::{self, AssertUnwindSafe},
     path::PathBuf,
-    process,
     sync::mpsc::{self, Receiver, Sender},
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 use wavecrate::audio::{
     AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, AudioPlayer, ResolvedOutput,
     available_devices, available_hosts, supported_sample_rates,
 };
-use wavecrate::gui_runtime::wavecrate_ui_font_path;
-use wavecrate::logging::{self, ActionDebugEvent, emit_action_debug_event};
+use wavecrate::logging;
 use wavecrate::sample_sources::config::{AppConfig, AppSettingsCore};
 
 mod audio_engine;
@@ -30,6 +26,7 @@ mod folder_browser;
 mod folder_browser_actions;
 mod folder_browser_rename_actions;
 mod folder_scan_actions;
+mod launch;
 mod playback;
 mod sample_browser_view;
 mod sample_load_actions;
@@ -51,6 +48,10 @@ use folder_browser::{
     FolderBrowserMessage, FolderBrowserState, FolderScanDiscoveryBatch, FolderScanProgress,
     FolderScanResult,
 };
+use launch::emit_gui_action;
+pub(crate) use launch::run;
+#[cfg(test)]
+use launch::{DEBUG_LAYOUT_ARG, DEBUG_LAYOUT_SHORT_ARG, debug_layout_requested};
 use sample_browser_view::sample_browser;
 use sample_load_actions::{NormalizedWaveformReload, WaveformPlaybackResume};
 use shortcuts::default_gui_shortcut_resolution;
@@ -60,8 +61,6 @@ use toolbar::{ToolbarIcon, toolbar_icon_button};
 use waveform::{WaveformActiveDragKind, WaveformInteraction, WaveformSelectionKind, WaveformState};
 use waveform_panel::waveform_panel;
 
-const DEBUG_LAYOUT_ARG: &str = "--debug-layout";
-const DEBUG_LAYOUT_SHORT_ARG: &str = "-debug-layout";
 const DEFAULT_FOLDER_WIDTH: f32 = 260.0;
 const MIN_FOLDER_WIDTH: f32 = 180.0;
 const MAX_FOLDER_WIDTH: f32 = 420.0;
@@ -690,179 +689,6 @@ struct FolderResize {
     start_width: f32,
 }
 
-/// Run the default Radiant GUI application shell.
-pub(crate) fn run() -> Result<(), String> {
-    logging::install_panic_hook();
-    let args: Vec<OsString> = std::env::args_os().collect();
-    let startup_started_at = Instant::now();
-
-    #[cfg(all(target_os = "windows", not(debug_assertions)))]
-    if log_console_requested(&args) {
-        enable_windows_console();
-    }
-
-    if let Err(err) = logging::init(args.iter().cloned()) {
-        eprintln!("logging disabled: {err}");
-    }
-
-    log_default_gui_startup(&args);
-    let state = GuiAppState::load_default()?;
-    let options = NativeRunOptions {
-        title: String::from("Wavecrate"),
-        inner_size: Some([960.0, 540.0]),
-        min_inner_size: Some([640.0, 360.0]),
-        drag_and_drop: true,
-        debug_layout: debug_layout_requested(args.iter().cloned()),
-        text: NativeTextOptions {
-            embedded_fonts: Vec::new(),
-            font_paths: vec![wavecrate_ui_font_path()],
-        },
-        ..NativeRunOptions::default()
-    };
-    tracing::info!(
-        debug_layout = options.debug_layout,
-        "default gui: preparing Radiant application"
-    );
-    emit_gui_action(
-        "runtime.startup.prepare_radiant_app",
-        Some("background"),
-        None,
-        "running",
-        startup_started_at,
-        None,
-    );
-
-    let run_result = panic::catch_unwind(AssertUnwindSafe(|| {
-        radiant::app(state)
-            .options(options)
-            .view(view)
-            .animation(|state| {
-                state.waveform.is_playing()
-                    || state.waveform.play_selection_flash_active()
-                    || state.folder_progress.is_some()
-                    || state.waveform_loading_label.is_some()
-            })
-            .on_frame(|| GuiMessage::Frame)
-            .subscriptions(GuiAppState::worker_subscription)
-            .auxiliary_windows(audio_settings::auxiliary_windows)
-            .on_scroll(|state, update, _context| {
-                if update.node_id == SAMPLE_BROWSER_LIST_ID {
-                    state.folder_browser.set_file_view_start_from_scroll_offset(
-                        update.offset.y,
-                        SAMPLE_BROWSER_ROW_HEIGHT,
-                    );
-                }
-            })
-            .on_native_file_drop(|_state, drop, context| {
-                context.emit(GuiMessage::NativeFileDrop(drop));
-            })
-            .shortcuts(|state, _, press, _| default_gui_shortcut_resolution(state, press))
-            .update_with(|state, message, context| {
-                state.apply_message(message, context);
-                context.request_repaint();
-            })
-            .run()
-    }));
-
-    match run_result {
-        Ok(Ok(())) => {
-            tracing::info!("default gui: Radiant runtime exited normally");
-            emit_gui_action(
-                "runtime.exit.radiant_app",
-                Some("background"),
-                None,
-                "success",
-                startup_started_at,
-                None,
-            );
-            Ok(())
-        }
-        Ok(Err(err)) => {
-            tracing::error!(err = %err, "default gui: Radiant runtime exited with error");
-            emit_gui_action(
-                "runtime.exit.radiant_app",
-                Some("background"),
-                None,
-                "error",
-                startup_started_at,
-                Some(&err),
-            );
-            Err(err)
-        }
-        Err(payload) => {
-            let message = panic_payload_to_string(payload);
-            tracing::error!("default gui: panic captured while running: {message}");
-            emit_gui_action(
-                "runtime.exit.radiant_app",
-                Some("background"),
-                None,
-                "panic",
-                startup_started_at,
-                Some(&message),
-            );
-            Err(format!("startup panic: {message}"))
-        }
-    }
-}
-
-fn debug_layout_requested<I>(args: I) -> bool
-where
-    I: IntoIterator<Item = OsString>,
-{
-    args.into_iter()
-        .any(|arg| arg == DEBUG_LAYOUT_ARG || arg == DEBUG_LAYOUT_SHORT_ARG)
-}
-
-fn log_default_gui_startup(args: &[OsString]) {
-    let exe = std::env::current_exe()
-        .ok()
-        .and_then(|path| path.into_os_string().into_string().ok())
-        .unwrap_or_else(|| String::from("<unknown>"));
-    let cwd = std::env::current_dir()
-        .map(|cwd| cwd.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| String::from("<unknown>"));
-    tracing::info!(
-        pid = process::id(),
-        exe = exe,
-        cwd = cwd,
-        arg_count = args.len(),
-        timestamp = ?SystemTime::now(),
-        debug = cfg!(debug_assertions),
-        "default gui startup: process metadata captured"
-    );
-    match wavecrate::app_dirs::resolve_persistence() {
-        Ok(persistence) => {
-            tracing::info!(
-                persistence_mode = %persistence.mode,
-                config_base = %persistence.config_base.display(),
-                app_root = %persistence.app_root.display(),
-                "default gui startup: persistence profile resolved"
-            );
-        }
-        Err(err) => {
-            tracing::error!(err = %err, "default gui startup: failed to resolve persistence profile");
-        }
-    }
-}
-
-fn emit_gui_action(
-    action: &'static str,
-    pane: Option<&'static str>,
-    source: Option<&str>,
-    outcome: &'static str,
-    started_at: Instant,
-    error: Option<&str>,
-) {
-    emit_action_debug_event(ActionDebugEvent {
-        action,
-        pane,
-        source,
-        outcome,
-        elapsed: started_at.elapsed(),
-        error,
-    });
-}
-
 fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'static str> {
     match interaction {
         WaveformInteraction::Wheel { .. } => Some("waveform.zoom_wheel"),
@@ -877,61 +703,6 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::BeginPan { .. } => Some("waveform.pan_begin"),
         WaveformInteraction::FinishSelection { .. } => Some("waveform.selection.finish"),
         WaveformInteraction::UpdateSelection { .. } | WaveformInteraction::Frame => None,
-    }
-}
-
-fn panic_payload_to_string(panic_payload: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(message) = panic_payload.downcast_ref::<&str>() {
-        return message.to_string();
-    }
-    if let Some(message) = panic_payload.downcast_ref::<String>() {
-        return message.clone();
-    }
-
-    "<non-string panic payload>".to_string()
-}
-
-#[cfg(all(target_os = "windows", not(debug_assertions)))]
-fn log_console_requested(args: &[OsString]) -> bool {
-    args.iter().any(|arg| {
-        arg == &OsString::from(logging::DEBUG_LOGGING_SHORT_ARG)
-            || arg == &OsString::from(logging::DEBUG_LOGGING_ARG)
-    })
-}
-
-#[cfg(all(target_os = "windows", not(debug_assertions)))]
-fn enable_windows_console() {
-    use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_SHARE_READ, FILE_SHARE_WRITE,
-        OPEN_EXISTING,
-    };
-    use windows::Win32::System::Console::{
-        ATTACH_PARENT_PROCESS, AllocConsole, AttachConsole, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE,
-        SetStdHandle,
-    };
-
-    unsafe {
-        let attached = AttachConsole(ATTACH_PARENT_PROCESS).is_ok();
-        if !attached {
-            let _ = AllocConsole();
-        }
-
-        let Ok(handle) = CreateFileW(
-            windows::core::w!("CONOUT$"),
-            FILE_GENERIC_WRITE.0,
-            FILE_SHARE_READ | FILE_SHARE_WRITE,
-            None,
-            OPEN_EXISTING,
-            FILE_ATTRIBUTE_NORMAL,
-            None,
-        ) else {
-            return;
-        };
-
-        let handle = HANDLE(handle.0);
-        let _ = SetStdHandle(STD_OUTPUT_HANDLE, handle);
-        let _ = SetStdHandle(STD_ERROR_HANDLE, handle);
     }
 }
 

--- a/src/gui_app/launch.rs
+++ b/src/gui_app/launch.rs
@@ -1,0 +1,242 @@
+use super::{GuiAppState, GuiMessage, SAMPLE_BROWSER_LIST_ID, SAMPLE_BROWSER_ROW_HEIGHT, view};
+use crate::gui_app::{audio_settings, default_gui_shortcut_resolution};
+use radiant::runtime::{NativeRunOptions, NativeTextOptions};
+use std::{
+    ffi::OsString,
+    panic::{self, AssertUnwindSafe},
+    process,
+    time::{Instant, SystemTime},
+};
+use wavecrate::gui_runtime::wavecrate_ui_font_path;
+use wavecrate::logging::{self, ActionDebugEvent, emit_action_debug_event};
+
+pub(super) const DEBUG_LAYOUT_ARG: &str = "--debug-layout";
+pub(super) const DEBUG_LAYOUT_SHORT_ARG: &str = "-debug-layout";
+
+/// Run the default Radiant GUI application shell.
+pub(crate) fn run() -> Result<(), String> {
+    logging::install_panic_hook();
+    let args: Vec<OsString> = std::env::args_os().collect();
+    let startup_started_at = Instant::now();
+
+    #[cfg(all(target_os = "windows", not(debug_assertions)))]
+    if log_console_requested(&args) {
+        enable_windows_console();
+    }
+
+    if let Err(err) = logging::init(args.iter().cloned()) {
+        eprintln!("logging disabled: {err}");
+    }
+
+    log_default_gui_startup(&args);
+    let state = GuiAppState::load_default()?;
+    let options = NativeRunOptions {
+        title: String::from("Wavecrate"),
+        inner_size: Some([960.0, 540.0]),
+        min_inner_size: Some([640.0, 360.0]),
+        drag_and_drop: true,
+        debug_layout: debug_layout_requested(args.iter().cloned()),
+        text: NativeTextOptions {
+            embedded_fonts: Vec::new(),
+            font_paths: vec![wavecrate_ui_font_path()],
+        },
+        ..NativeRunOptions::default()
+    };
+    tracing::info!(
+        debug_layout = options.debug_layout,
+        "default gui: preparing Radiant application"
+    );
+    emit_gui_action(
+        "runtime.startup.prepare_radiant_app",
+        Some("background"),
+        None,
+        "running",
+        startup_started_at,
+        None,
+    );
+
+    let run_result = panic::catch_unwind(AssertUnwindSafe(|| {
+        radiant::app(state)
+            .options(options)
+            .view(view)
+            .animation(|state| {
+                state.waveform.is_playing()
+                    || state.waveform.play_selection_flash_active()
+                    || state.folder_progress.is_some()
+                    || state.waveform_loading_label.is_some()
+            })
+            .on_frame(|| GuiMessage::Frame)
+            .subscriptions(GuiAppState::worker_subscription)
+            .auxiliary_windows(audio_settings::auxiliary_windows)
+            .on_scroll(|state, update, _context| {
+                if update.node_id == SAMPLE_BROWSER_LIST_ID {
+                    state.folder_browser.set_file_view_start_from_scroll_offset(
+                        update.offset.y,
+                        SAMPLE_BROWSER_ROW_HEIGHT,
+                    );
+                }
+            })
+            .on_native_file_drop(|_state, drop, context| {
+                context.emit(GuiMessage::NativeFileDrop(drop));
+            })
+            .shortcuts(|state, _, press, _| default_gui_shortcut_resolution(state, press))
+            .update_with(|state, message, context| {
+                state.apply_message(message, context);
+                context.request_repaint();
+            })
+            .run()
+    }));
+
+    match run_result {
+        Ok(Ok(())) => {
+            tracing::info!("default gui: Radiant runtime exited normally");
+            emit_gui_action(
+                "runtime.exit.radiant_app",
+                Some("background"),
+                None,
+                "success",
+                startup_started_at,
+                None,
+            );
+            Ok(())
+        }
+        Ok(Err(err)) => {
+            tracing::error!(err = %err, "default gui: Radiant runtime exited with error");
+            emit_gui_action(
+                "runtime.exit.radiant_app",
+                Some("background"),
+                None,
+                "error",
+                startup_started_at,
+                Some(&err),
+            );
+            Err(err)
+        }
+        Err(payload) => {
+            let message = panic_payload_to_string(payload);
+            tracing::error!("default gui: panic captured while running: {message}");
+            emit_gui_action(
+                "runtime.exit.radiant_app",
+                Some("background"),
+                None,
+                "panic",
+                startup_started_at,
+                Some(&message),
+            );
+            Err(format!("startup panic: {message}"))
+        }
+    }
+}
+
+pub(super) fn debug_layout_requested<I>(args: I) -> bool
+where
+    I: IntoIterator<Item = OsString>,
+{
+    args.into_iter()
+        .any(|arg| arg == DEBUG_LAYOUT_ARG || arg == DEBUG_LAYOUT_SHORT_ARG)
+}
+
+fn log_default_gui_startup(args: &[OsString]) {
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.into_os_string().into_string().ok())
+        .unwrap_or_else(|| String::from("<unknown>"));
+    let cwd = std::env::current_dir()
+        .map(|cwd| cwd.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| String::from("<unknown>"));
+    tracing::info!(
+        pid = process::id(),
+        exe = exe,
+        cwd = cwd,
+        arg_count = args.len(),
+        timestamp = ?SystemTime::now(),
+        debug = cfg!(debug_assertions),
+        "default gui startup: process metadata captured"
+    );
+    match wavecrate::app_dirs::resolve_persistence() {
+        Ok(persistence) => {
+            tracing::info!(
+                persistence_mode = %persistence.mode,
+                config_base = %persistence.config_base.display(),
+                app_root = %persistence.app_root.display(),
+                "default gui startup: persistence profile resolved"
+            );
+        }
+        Err(err) => {
+            tracing::error!(err = %err, "default gui startup: failed to resolve persistence profile");
+        }
+    }
+}
+
+pub(super) fn emit_gui_action(
+    action: &'static str,
+    pane: Option<&'static str>,
+    source: Option<&str>,
+    outcome: &'static str,
+    started_at: Instant,
+    error: Option<&str>,
+) {
+    emit_action_debug_event(ActionDebugEvent {
+        action,
+        pane,
+        source,
+        outcome,
+        elapsed: started_at.elapsed(),
+        error,
+    });
+}
+
+fn panic_payload_to_string(panic_payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = panic_payload.downcast_ref::<&str>() {
+        return message.to_string();
+    }
+    if let Some(message) = panic_payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+
+    "<non-string panic payload>".to_string()
+}
+
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
+fn log_console_requested(args: &[OsString]) -> bool {
+    args.iter().any(|arg| {
+        arg == &OsString::from(logging::DEBUG_LOGGING_SHORT_ARG)
+            || arg == &OsString::from(logging::DEBUG_LOGGING_ARG)
+    })
+}
+
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
+fn enable_windows_console() {
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
+    };
+    use windows::Win32::System::Console::{
+        ATTACH_PARENT_PROCESS, AllocConsole, AttachConsole, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE,
+        SetStdHandle,
+    };
+
+    unsafe {
+        let attached = AttachConsole(ATTACH_PARENT_PROCESS).is_ok();
+        if !attached {
+            let _ = AllocConsole();
+        }
+
+        let Ok(handle) = CreateFileW(
+            windows::core::w!("CONOUT$"),
+            FILE_GENERIC_WRITE.0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            None,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        ) else {
+            return;
+        };
+
+        let handle = HANDLE(handle.0);
+        let _ = SetStdHandle(STD_OUTPUT_HANDLE, handle);
+        let _ = SetStdHandle(STD_ERROR_HANDLE, handle);
+    }
+}


### PR DESCRIPTION
## Summary
- move default GUI runtime startup and process-side setup into a dedicated launch module
- keep GUI state/message handling and view composition in gui_app.rs
- preserve internal debug-layout and action logging seams without widening public API

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent