### PR TITLE
Move playhead trail config to motion overlay

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -105,23 +105,6 @@ pub(crate) use self::{
 const BROWSER_ROW_TRUNCATION_CACHE_CAPACITY: usize = 1024;
 /// Text glyph shown before browser item labels whose backing content is missing.
 const BROWSER_MISSING_CONTENT_MARKER: &str = "!";
-/// Maximum retained ghost lines for the dynamic waveform playhead trail.
-const PLAYHEAD_TRAIL_MAX_POINTS: usize = 768;
-/// Number of seconds used to fade one retained playhead ghost line.
-///
-/// Time-based aging avoids visible fade quantization when redraw cadence varies.
-const PLAYHEAD_TRAIL_FADE_SECONDS: f32 = 1.2;
-/// Maximum opacity used for the newest retained trail point behind the live playhead.
-///
-/// The active playhead line itself remains fully opaque; only the ghost trail fades from
-/// this half-strength head value down to zero.
-const PLAYHEAD_TRAIL_HEAD_ALPHA: f32 = 0.2;
-/// Maximum inserted in-between points per motion frame for smooth trails.
-const PLAYHEAD_TRAIL_MAX_INTERPOLATED_STEPS: usize = 192;
-/// Largest contiguous frame delta treated as normal transport motion.
-const PLAYHEAD_TRAIL_MAX_CONTIGUOUS_DELTA_MICROS: u64 = 120_000;
-/// Minimum synthetic time delta used when motion redraws arrive in the same tick.
-const PLAYHEAD_TRAIL_MIN_INTERPOLATED_DELTA_SECONDS: f32 = 1.0 / 240.0;
 /// Number of animation ticks used for one waveform-toolbar click flash.
 const WAVEFORM_TOOLBAR_FLASH_TICKS: u8 = 6;
 /// Number of animation ticks used for one waveform-selection export success flash.

--- a/src/app_core/native_shell/composition/state/motion_overlay.rs
+++ b/src/app_core/native_shell/composition/state/motion_overlay.rs
@@ -4,6 +4,8 @@ use super::*;
 
 #[path = "motion_overlay/playhead_trail.rs"]
 mod playhead_trail;
+#[cfg(test)]
+pub(crate) use playhead_trail::PLAYHEAD_TRAIL_FADE_SECONDS;
 
 impl NativeShellState {
     /// Build only waveform cursor/playhead motion overlays into reusable buffers.

--- a/src/app_core/native_shell/composition/state/motion_overlay/playhead_trail.rs
+++ b/src/app_core/native_shell/composition/state/motion_overlay/playhead_trail.rs
@@ -2,6 +2,24 @@
 
 use super::*;
 
+/// Maximum retained ghost lines for the dynamic waveform playhead trail.
+const PLAYHEAD_TRAIL_MAX_POINTS: usize = 768;
+/// Number of seconds used to fade one retained playhead ghost line.
+///
+/// Time-based aging avoids visible fade quantization when redraw cadence varies.
+pub(crate) const PLAYHEAD_TRAIL_FADE_SECONDS: f32 = 1.2;
+/// Maximum opacity used for the newest retained trail point behind the live playhead.
+///
+/// The active playhead line itself remains fully opaque; only the ghost trail fades from
+/// this half-strength head value down to zero.
+const PLAYHEAD_TRAIL_HEAD_ALPHA: f32 = 0.2;
+/// Maximum inserted in-between points per motion frame for smooth trails.
+const PLAYHEAD_TRAIL_MAX_INTERPOLATED_STEPS: usize = 192;
+/// Largest contiguous frame delta treated as normal transport motion.
+const PLAYHEAD_TRAIL_MAX_CONTIGUOUS_DELTA_MICROS: u64 = 120_000;
+/// Minimum synthetic time delta used when motion redraws arrive in the same tick.
+const PLAYHEAD_TRAIL_MIN_INTERPOLATED_DELTA_SECONDS: f32 = 1.0 / 240.0;
+
 impl NativeShellState {
     /// Update retained playhead-trail points and return drawable ghost lines.
     pub(in crate::app_core::native_shell::composition::state) fn update_playhead_trail(


### PR DESCRIPTION
## Summary
- move playhead trail tuning constants into the motion overlay implementation area
- keep the state facade from owning motion-overlay-specific configuration
- preserve existing test access to the fade-duration constant under cfg(test)

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent