### PR TITLE
Move flash timing config into model sync

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -105,14 +105,6 @@ pub(crate) use self::{
 const BROWSER_ROW_TRUNCATION_CACHE_CAPACITY: usize = 1024;
 /// Text glyph shown before browser item labels whose backing content is missing.
 const BROWSER_MISSING_CONTENT_MARKER: &str = "!";
-/// Number of animation ticks used for one waveform-toolbar click flash.
-const WAVEFORM_TOOLBAR_FLASH_TICKS: u8 = 6;
-/// Number of animation ticks used for one waveform-selection export success flash.
-const WAVEFORM_SELECTION_FLASH_TICKS: u8 = 6;
-/// Number of animation ticks used for one waveform edit-selection apply flash.
-const WAVEFORM_EDIT_SELECTION_FLASH_TICKS: u8 = 6;
-/// Number of animation ticks used for the sidebar source-add button click flash.
-const SOURCE_ADD_BUTTON_FLASH_TICKS: u8 = 6;
 /// Rating-filter chip levels shown left-to-right in the browser toolbar.
 const BROWSER_RATING_FILTER_LEVELS: [i8; 8] = [-3, -2, -1, 0, 1, 2, 3, 4];
 /// Playback-age filter chips shown left-to-right in the browser toolbar.

--- a/src/app_core/native_shell/composition/state/model_sync.rs
+++ b/src/app_core/native_shell/composition/state/model_sync.rs
@@ -3,6 +3,15 @@
 use super::*;
 use crate::app_core::native_shell::runtime_contract::{FolderPaneIdModel, StatusChipStateModel};
 
+/// Number of animation ticks used for one waveform-toolbar click flash.
+const WAVEFORM_TOOLBAR_FLASH_TICKS: u8 = 6;
+/// Number of animation ticks used for one waveform-selection export success flash.
+const WAVEFORM_SELECTION_FLASH_TICKS: u8 = 6;
+/// Number of animation ticks used for one waveform edit-selection apply flash.
+const WAVEFORM_EDIT_SELECTION_FLASH_TICKS: u8 = 6;
+/// Number of animation ticks used for source-add and status-options click flashes.
+const BUTTON_FLASH_TICKS: u8 = 6;
+
 impl NativeShellState {
     /// Synchronize local interaction state from the latest app model.
     pub(crate) fn sync_from_model(&mut self, model: &AppModel) {
@@ -150,11 +159,11 @@ impl NativeShellState {
     }
 
     pub(super) fn trigger_source_add_button_flash(&mut self) {
-        self.source_add_button_flash_ticks = SOURCE_ADD_BUTTON_FLASH_TICKS;
+        self.source_add_button_flash_ticks = BUTTON_FLASH_TICKS;
     }
 
     pub(super) fn trigger_status_options_button_flash(&mut self) {
-        self.status_options_button_flash_ticks = SOURCE_ADD_BUTTON_FLASH_TICKS;
+        self.status_options_button_flash_ticks = BUTTON_FLASH_TICKS;
     }
 
     /// Return the current state-overlay fingerprint.


### PR DESCRIPTION
## Summary
- move transient flash tick constants out of the native shell state facade
- keep animation timing configuration beside the model-sync triggers that consume it
- rename the shared source/status button flash duration to match its actual use

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent