### PR TITLE
Move browser filter config to toolbar layout

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -105,15 +105,6 @@ pub(crate) use self::{
 const BROWSER_ROW_TRUNCATION_CACHE_CAPACITY: usize = 1024;
 /// Text glyph shown before browser item labels whose backing content is missing.
 const BROWSER_MISSING_CONTENT_MARKER: &str = "!";
-/// Rating-filter chip levels shown left-to-right in the browser toolbar.
-const BROWSER_RATING_FILTER_LEVELS: [i8; 8] = [-3, -2, -1, 0, 1, 2, 3, 4];
-/// Playback-age filter chips shown left-to-right in the browser toolbar.
-const BROWSER_PLAYBACK_AGE_FILTER_CHIPS:
-    [crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip; 3] = [
-    crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::NeverPlayed,
-    crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::OlderThanMonth,
-    crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::OlderThanWeek,
-];
 /// Additional hit slop for the narrow content-list scrollbar thumb.
 const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
 /// Additional hit slop for the narrow folder scrollbar thumb.

--- a/src/app_core/native_shell/composition/state/toolbar_helpers/browser_toolbar/layout.rs
+++ b/src/app_core/native_shell/composition/state/toolbar_helpers/browser_toolbar/layout.rs
@@ -3,6 +3,18 @@
 use super::super::super::*;
 use crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip;
 
+/// Rating-filter chip levels shown left-to-right in the browser toolbar.
+pub(in crate::app_core::native_shell::composition::state) const BROWSER_RATING_FILTER_LEVELS: [i8;
+    8] = [-3, -2, -1, 0, 1, 2, 3, 4];
+
+/// Playback-age filter chips shown left-to-right in the browser toolbar.
+pub(in crate::app_core::native_shell::composition::state) const BROWSER_PLAYBACK_AGE_FILTER_CHIPS:
+    [PlaybackAgeFilterChip; 3] = [
+    PlaybackAgeFilterChip::NeverPlayed,
+    PlaybackAgeFilterChip::OlderThanMonth,
+    PlaybackAgeFilterChip::OlderThanWeek,
+];
+
 pub(in crate::app_core::native_shell::composition::state) fn browser_toolbar_layout(
     layout: &ShellLayout,
     style: &StyleTokens,

--- a/src/app_core/native_shell/composition/state/toolbar_helpers/browser_toolbar/mod.rs
+++ b/src/app_core/native_shell/composition/state/toolbar_helpers/browser_toolbar/mod.rs
@@ -20,7 +20,7 @@ pub(in crate::app_core::native_shell::composition::state) use colors::{
 };
 #[allow(unused_imports)]
 pub(in crate::app_core::native_shell::composition::state) use layout::{
-    browser_column_chips, browser_playback_age_filter_chip_at_point,
-    browser_playback_age_filter_chip_index, browser_rating_filter_chip_index,
-    browser_rating_filter_level_at_point, browser_toolbar_layout,
+    BROWSER_PLAYBACK_AGE_FILTER_CHIPS, BROWSER_RATING_FILTER_LEVELS, browser_column_chips,
+    browser_playback_age_filter_chip_at_point, browser_playback_age_filter_chip_index,
+    browser_rating_filter_chip_index, browser_rating_filter_level_at_point, browser_toolbar_layout,
 };


### PR DESCRIPTION
## Summary
- move browser rating and playback-age filter chip definitions out of the state facade
- keep browser-toolbar filter configuration beside the toolbar layout helpers that consume it
- re-export the constants only inside the native shell state boundary for existing rendering and automation callers

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent