### PR TITLE
Move truncation cache capacity to cache type

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -101,8 +101,6 @@ pub(crate) use self::{
     text_fields::TextFieldVisualState,
 };
 
-/// Maximum retained entries for browser-row text truncation outputs.
-const BROWSER_ROW_TRUNCATION_CACHE_CAPACITY: usize = 1024;
 /// Text glyph shown before browser item labels whose backing content is missing.
 const BROWSER_MISSING_CONTENT_MARKER: &str = "!";
 /// Additional hit slop for the narrow content-list scrollbar thumb.

--- a/src/app_core/native_shell/composition/state/cache_types/truncation.rs
+++ b/src/app_core/native_shell/composition/state/cache_types/truncation.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Maximum retained entries for browser-row text truncation outputs.
+pub(in crate::app_core::native_shell::composition::state) const BROWSER_ROW_TRUNCATION_CACHE_CAPACITY:
+    usize = 1024;
+
 /// Per-build browser-row truncation cache lookup counts.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct BrowserRowTruncationFrameCounts {


### PR DESCRIPTION
## Summary
- move browser-row truncation cache capacity out of the native shell state facade
- keep the capacity beside the truncation cache eviction logic that consumes it
- preserve existing cache tests through the state-local cache type re-export

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent