### PR TITLE
Move missing row marker into browser rows

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -101,8 +101,6 @@ pub(crate) use self::{
     text_fields::TextFieldVisualState,
 };
 
-/// Text glyph shown before browser item labels whose backing content is missing.
-const BROWSER_MISSING_CONTENT_MARKER: &str = "!";
 /// Additional hit slop for the narrow content-list scrollbar thumb.
 const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
 /// Additional hit slop for the narrow folder scrollbar thumb.

--- a/src/app_core/native_shell/composition/state/browser_rows.rs
+++ b/src/app_core/native_shell/composition/state/browser_rows.rs
@@ -20,6 +20,10 @@ pub(in crate::app_core::native_shell::composition::state) use self::{
     sidebar::*, truncation::*, visuals::*, windowing::*,
 };
 
+/// Text glyph shown before browser item labels whose backing content is missing.
+pub(in crate::app_core::native_shell::composition::state) const BROWSER_MISSING_CONTENT_MARKER:
+    &str = "!";
+
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct CachedBrowserRow {
     pub(super) visible_row: usize,


### PR DESCRIPTION
## Summary
- move the missing browser-row marker out of the native shell state facade
- keep the marker beside browser-row cache/rendering domain types
- preserve existing rendering and test access through state-local browser row exports

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent