### PR TITLE
Move scrollbar hit slop to hit testing

### DIFF
--- a/src/app_core/native_shell/composition/state.rs
+++ b/src/app_core/native_shell/composition/state.rs
@@ -101,11 +101,6 @@ pub(crate) use self::{
     text_fields::TextFieldVisualState,
 };
 
-/// Additional hit slop for the narrow content-list scrollbar thumb.
-const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
-/// Additional hit slop for the narrow folder scrollbar thumb.
-const FOLDER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
-
 /// Mutable interaction + animation state for the native shell façade.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct NativeShellState {

--- a/src/app_core/native_shell/composition/state/hit_testing/browser.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser.rs
@@ -6,6 +6,9 @@ use crate::gui::list::{
     virtual_list_scrollbar_view_start_at_point,
 };
 
+/// Additional hit slop for the narrow content-list scrollbar thumb.
+const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
+
 impl NativeShellState {
     /// Return a browser column-chip rect for one column index in tests.
     #[cfg(test)]

--- a/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/scrollbar.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/scrollbar.rs
@@ -5,6 +5,9 @@ use crate::gui::list::{
     virtual_list_scrollbar_view_start_at_point,
 };
 
+/// Additional hit slop for the narrow folder scrollbar thumb.
+const FOLDER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
+
 impl NativeShellState {
     pub(crate) fn folder_viewport_len(
         &mut self,


### PR DESCRIPTION
## Summary
- move browser scrollbar hit slop into browser hit-testing
- move folder scrollbar hit slop into folder scrollbar hit-testing
- remove the last root-level tuning constants from the native shell state facade

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent