### PR TITLE
Optimize agent GUI test coverage lanes

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -17,6 +17,8 @@ Use the lightest lane that still gives trustworthy coverage for the change.
      `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`
    - macOS/Linux/WSL:
      `bash scripts/ci.sh agent`
+   - load-sensitive selection-export background-job tests run serially here
+     after the default library test pass.
 3. Broader integrated local checks
    - Windows PowerShell:
      `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 quick`
@@ -138,9 +140,10 @@ Use for semantic GUI contracts, CLI scenarios, and desktop AIV loops.
   - contract scenario anchor: `browser_focus_transition_stability`
 - contract loop:
   - `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 contract`
-  - this lane explicitly runs the ignored `contract_smoke_pack_runs_cleanly`
-    scenario-pack execution; the default library test lane keeps only the
-    cheaper GUI runner and fixture checks.
+  - this lane explicitly runs ignored fixture-backed GUI and bridge-runtime
+    checks, including action parity and `contract_smoke_pack_runs_cleanly`; the
+    default library test lane keeps only the cheaper runner and assertion
+    checks.
 - broader GUI suite:
   - `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 suite`
 - live AIV smoke:

--- a/scripts/internal/ci/ci_agent.ps1
+++ b/scripts/internal/ci/ci_agent.ps1
@@ -64,6 +64,21 @@ try {
     Invoke-WavecrateCargo test -p wavecrate --lib
   }
 
+  Write-Host "[ci_agent] cargo test selection export background jobs -- --ignored --test-threads=1"
+  Invoke-NativeStep -Label "cargo test selection export background jobs -- --ignored --test-threads=1" -Command {
+    $selectionExportArgs = @(
+      "test",
+      "-p",
+      "wavecrate",
+      "--lib",
+      "selection_export_tests",
+      "--",
+      "--ignored",
+      "--test-threads=1"
+    )
+    & cargo @(Get-WavecrateCargoConfigOverrideArgs) @selectionExportArgs
+  }
+
   Write-Host "[ci_agent] OK"
 } finally {
   Pop-Location

--- a/scripts/internal/gui/run_gui_contract.ps1
+++ b/scripts/internal/gui/run_gui_contract.ps1
@@ -49,6 +49,48 @@ try {
     Invoke-WavecrateCargo test gui_test::
   }
 
+  Write-Host "[gui-contract] cargo test gui_test::fixtures::tests -- --ignored"
+  Invoke-NativeStep -Label "cargo test gui_test::fixtures::tests -- --ignored" -Command {
+    $guiFixtureArgs = @(
+      "test",
+      "-p",
+      "wavecrate",
+      "--lib",
+      "gui_test::fixtures::tests",
+      "--",
+      "--ignored"
+    )
+    & cargo @(Get-WavecrateCargoConfigOverrideArgs) @guiFixtureArgs
+  }
+
+  Write-Host "[gui-contract] cargo test gui_test::runner::tests -- --ignored"
+  Invoke-NativeStep -Label "cargo test gui_test::runner::tests -- --ignored" -Command {
+    $guiRunnerArgs = @(
+      "test",
+      "-p",
+      "wavecrate",
+      "--lib",
+      "gui_test::runner::tests",
+      "--",
+      "--ignored"
+    )
+    & cargo @(Get-WavecrateCargoConfigOverrideArgs) @guiRunnerArgs
+  }
+
+  Write-Host "[gui-contract] cargo test bridge_runtime fixture checks -- --ignored"
+  Invoke-NativeStep -Label "cargo test bridge_runtime fixture checks -- --ignored" -Command {
+    $bridgeRuntimeArgs = @(
+      "test",
+      "-p",
+      "wavecrate",
+      "--lib",
+      "app_core::native_bridge::tests::bridge_runtime",
+      "--",
+      "--ignored"
+    )
+    & cargo @(Get-WavecrateCargoConfigOverrideArgs) @bridgeRuntimeArgs
+  }
+
   Write-Host "[gui-contract] cargo test contract_smoke_pack_runs_cleanly -- --ignored --exact"
   Invoke-NativeStep -Label "cargo test contract_smoke_pack_runs_cleanly -- --ignored --exact" -Command {
     $contractSmokeArgs = @(

--- a/src/app/controller/library/selection_export/selection_export_tests/crop_export_history_tests.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests/crop_export_history_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[test]
+#[ignore = "runs serially through scripts/ci.ps1 agent; background job polling is load-sensitive in the full parallel lib lane"]
 fn crop_waveform_selection_to_new_sample_registers_pending_history_and_supports_undo() {
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source");

--- a/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/browser_save.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/browser_save.rs
@@ -260,6 +260,7 @@ fn save_waveform_selection_to_browser_records_failure_flash_when_worker_fails() 
 }
 
 #[test]
+#[ignore = "runs serially through scripts/ci.ps1 agent; background job polling is load-sensitive in the full parallel lib lane"]
 fn save_waveform_selection_to_browser_removes_clip_when_source_db_registration_fails() {
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source");

--- a/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/history.rs
+++ b/src/app/controller/library/selection_export/selection_export_tests/waveform_selection_export_tests/history.rs
@@ -1,6 +1,7 @@
 use super::super::*;
 
 #[test]
+#[ignore = "runs serially through scripts/ci.ps1 agent; background job polling is load-sensitive in the full parallel lib lane"]
 fn save_waveform_selection_to_browser_success_finishes_pending_history_and_supports_undo() {
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source");

--- a/src/app_core/native_bridge/tests/bridge_runtime/projection.rs
+++ b/src/app_core/native_bridge/tests/bridge_runtime/projection.rs
@@ -62,6 +62,7 @@ fn bridge_reprojects_after_async_waveform_image_arrival() {
 
 /// Projecting an arrived async image should not immediately schedule another image render.
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn async_waveform_image_arrival_is_projection_only_dirty_work() {
     let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
         WaveformRenderer::new(32, 16),
@@ -168,6 +169,7 @@ fn random_navigation_toggle_updates_projected_browser_actions_immediately() {
 
 /// Duplicate cleanup should project active toolbar state plus transient row badges.
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn duplicate_cleanup_projects_active_browser_state_and_row_badges() {
     let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
@@ -226,6 +228,7 @@ fn duplicate_cleanup_projects_active_browser_state_and_row_badges() {
 /// Loop-toggle metadata writes should refresh the visible browser badge in the
 /// same projection cycle for the loaded waveform sample.
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn toggle_loop_playback_refreshes_loaded_sample_loop_badge_immediately() {
     let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
@@ -263,6 +266,7 @@ fn toggle_loop_playback_refreshes_loaded_sample_loop_badge_immediately() {
 
 /// Enabling loop should project persisted BPM metadata alongside the new loop badge.
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn toggle_loop_playback_refreshes_loaded_sample_bpm_and_loop_badges_immediately() {
     let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),

--- a/src/app_core/native_bridge/tests/bridge_runtime/pull_prep.rs
+++ b/src/app_core/native_bridge/tests/bridge_runtime/pull_prep.rs
@@ -149,6 +149,7 @@ fn startup_work_uses_startup_retained_pull_plan() {
 
 /// Deferred metadata persistence should use the metadata-retained preparation lane.
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn metadata_work_uses_metadata_retained_pull_plan() {
     let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),

--- a/src/app_core/native_shell/tests/map.rs
+++ b/src/app_core/native_shell/tests/map.rs
@@ -1,18 +1,17 @@
 use super::*;
 use crate::app::state::MapSimilarityPrepStatus;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::PathBuf;
 
 fn add_selected_source(controller: &mut AppController) {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock")
-        .as_nanos();
-    let root = std::env::temp_dir().join(format!("wavecrate-map-projection-{unique}"));
-    std::fs::create_dir_all(&root).expect("create source root");
-    controller
-        .add_source_from_path(root)
-        .expect("add selected source");
-    controller.select_first_source();
+    let source = crate::sample_sources::SampleSource::new(PathBuf::from("map-projection-source"));
+    let source_id = source.id.clone();
+    controller.register_source_for_tests(source);
+    controller.select_browser_source_for_tests(source_id);
+    controller.ui.map.cached_bounds_source_id = controller
+        .selected_source_id()
+        .map(|id| id.as_str().to_string());
+    controller.ui.map.cached_bounds_umap_version = Some(controller.ui.map.umap_version.clone());
+    controller.ui.map.bounds = None;
 }
 
 /// Map projection should expose legend, selection, hover, cluster, and viewport summary text.

--- a/src/gui_test/fixtures.rs
+++ b/src/gui_test/fixtures.rs
@@ -200,6 +200,7 @@ mod tests {
     use crate::gui_test::GUI_TEST_ISOLATED_STARTUP_FIXTURE_TAG;
 
     #[test]
+    #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
     fn default_fixture_alias_matches_isolated_startup_behavior() {
         let default_bridge = GuiFixtureBridge::new("default").expect("default fixture bridge");
         let isolated_bridge = GuiFixtureBridge::new(GUI_TEST_ISOLATED_STARTUP_FIXTURE_TAG)
@@ -213,6 +214,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
     fn named_fixtures_stay_controller_backed() {
         let bridge = GuiFixtureBridge::new("browser").expect("browser fixture bridge");
         assert!(bridge._profile_guard.is_none());

--- a/src/gui_test/runner/tests.rs
+++ b/src/gui_test/runner/tests.rs
@@ -83,6 +83,7 @@ fn collect_advertised_actions<'a>(
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
 fn capture_default_bundle_exposes_root_snapshot_and_catalog() {
     let bundle = capture_default_bundle(&deterministic_test_config("browser"))
         .expect("capture should succeed");
@@ -91,6 +92,7 @@ fn capture_default_bundle_exposes_root_snapshot_and_catalog() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
 fn scenario_runner_accepts_root_presence_assertion() {
     let scenario = GuiScenario {
         name: String::from("root-smoke"),
@@ -107,6 +109,7 @@ fn scenario_runner_accepts_root_presence_assertion() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
 fn dispatch_action_bundle_rejects_runtime_internal_actions() {
     let err = dispatch_action_bundle(
         &deterministic_test_config("waveform"),
@@ -122,6 +125,7 @@ fn dispatch_action_bundle_rejects_runtime_internal_actions() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
 fn scenario_runner_rejects_runtime_internal_actions() {
     let scenario = GuiScenario {
         name: String::from("reject-runtime-internal"),

--- a/src/gui_test/runner/tests/action_parity.rs
+++ b/src/gui_test/runner/tests/action_parity.rs
@@ -58,6 +58,7 @@ fn capture_case_fixtures<'a>(
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; too expensive for the default lib test lane"]
 fn browser_nodes_advertise_expected_action_ids() {
     let cases: &[(&str, &str, &[&str])] = &[
         ("browser", "browser.panel", &["focus_browser_panel"]),
@@ -196,6 +197,7 @@ fn browser_nodes_advertise_expected_action_ids() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; too expensive for the default lib test lane"]
 fn sidebar_nodes_advertise_expected_action_ids() {
     let cases: &[(&str, &str, &[&str])] = &[
         ("browser", "sources.add_button", &["open_add_source_dialog"]),
@@ -237,6 +239,7 @@ fn sidebar_nodes_advertise_expected_action_ids() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; too expensive for the default lib test lane"]
 fn waveform_nodes_advertise_expected_action_ids() {
     let cases: &[(&str, &str, &[&str])] = &[
         ("waveform", "waveform.panel", &["focus_waveform_panel"]),
@@ -279,6 +282,7 @@ fn waveform_nodes_advertise_expected_action_ids() {
 }
 
 #[test]
+#[ignore = "runs through scripts/gui.ps1 contract; too expensive for the default lib test lane"]
 fn dialog_nodes_advertise_expected_action_ids() {
     let cases: &[(&str, &str, &[&str])] = &[
         ("options", "overlay.options_panel", &["close_options_panel"]),


### PR DESCRIPTION
## Summary
- move fixture-backed GUI runner/action-parity and bridge-runtime checks into the explicit GUI contract lane
- keep load-sensitive selection-export background-job coverage in ci_agent, but run it serially after the default lib pass
- avoid full source lifecycle setup in map projection label tests by registering a direct test source
- document the adjusted lane ownership in docs/TEST.md

## Validation
- cargo check -p wavecrate --tests --bins
- cargo test -p wavecrate --lib app_core::native_shell::tests::map
- cargo test -p wavecrate --lib gui_test::runner::tests -- --ignored
- cargo test -p wavecrate --lib app_core::native_bridge::tests::bridge_runtime -- --ignored
- cargo test -p wavecrate --lib selection_export_tests -- --ignored --test-threads=1
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent
- powershell -ExecutionPolicy Bypass -File scripts\gui.ps1 contract