### PR TITLE
Add Wavecrate registration gate

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,15 +11,29 @@ fn main() {
     println!("cargo:rerun-if-changed=build/windows/wavecrate.rc");
     println!("cargo:rerun-if-changed=assets/logo3.ico");
     println!("cargo:rerun-if-env-changed=WAVECRATE_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_ID");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_SIGNATURE");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_SIGNING_PUBLIC_KEY_B64");
 
     emit_git_rerun_hints();
     emit_git_sha();
+    emit_registration_cfg();
 
     if compiling_for_windows_target()
         && let Err(error) = compile_windows_resources()
     {
         eprintln!("Failed to embed Windows resources: {error}");
         std::process::exit(1);
+    }
+}
+
+fn emit_registration_cfg() {
+    println!("cargo:rustc-check-cfg=cfg(wavecrate_registered_build)");
+    if env::var("WAVECRATE_BUILD_ID").is_ok()
+        || env::var("WAVECRATE_BUILD_SIGNATURE").is_ok()
+        || env::var("WAVECRATE_SIGNING_PUBLIC_KEY_B64").is_ok()
+    {
+        println!("cargo:rustc-cfg=wavecrate_registered_build");
     }
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,9 @@ dispatcher maps. These are the public entrypoints people should run directly:
 - `bootstrap.{sh,ps1}`: set up the repo and install hooks.
 - `registered-run.ps1`: build a registered Wavecrate binary, stage/deploy it
   through `X:\portalsurfer.org`, then launch the built app with forwarded args.
-  Example: `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -AppArgs --log`.
+  Build ids use the server-side build counter format
+  `wavecrate-b<N>-<timestamp>-<gitsha>`. Example:
+  `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -AppArgs --log`.
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
 - `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,9 @@ is the checked inventory for public entrypoints, compatibility wrappers, and
 dispatcher maps. These are the public entrypoints people should run directly:
 
 - `bootstrap.{sh,ps1}`: set up the repo and install hooks.
+- `registered-run.ps1`: build a registered Wavecrate binary, stage/deploy it
+  through `X:\portalsurfer.org`, then launch the built app with forwarded args.
+  Example: `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -AppArgs --log`.
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
 - `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -66,6 +66,11 @@
       "windows_supported": false
     },
     {
+      "path": "scripts/registered-run.ps1",
+      "role": "Build, register, deploy, and launch one Wavecrate release binary for local validation.",
+      "windows_supported": true
+    },
+    {
       "path": "scripts/run.ps1",
       "role": "Sandbox, cleanup, log, and bug-bundle helpers.",
       "windows_supported": true

--- a/scripts/registered-run.ps1
+++ b/scripts/registered-run.ps1
@@ -1,0 +1,125 @@
+param(
+  [string] $PortalSurferRoot = "X:\portalsurfer.org",
+  [string] $Server = "188.245.106.212",
+  [string] $KeyPath = "$env:USERPROFILE\.ssh\portalsurfer_org_codex",
+  [string] $Version = "",
+  [string] $BuildId = "",
+  [switch] $SkipDeploy,
+  [switch] $NoRun,
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]] $AppArgs
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$portalRootPath = Resolve-Path -LiteralPath $PortalSurferRoot
+$portalRoot = $portalRootPath.Path
+$signingEnv = Join-Path $portalRoot ".deploy\wavecrate-signing.env"
+$stageScript = Join-Path $portalRoot "scripts\stage-wavecrate-release.ps1"
+$deployScript = Join-Path $portalRoot "scripts\deploy.ps1"
+
+if (-not (Test-Path -LiteralPath $signingEnv)) {
+  throw "Missing Wavecrate signing env file: $signingEnv. Deploy the website once, or copy WAVECRATE_SIGNING_PUBLIC_KEY_B64 into that file."
+}
+if (-not (Test-Path -LiteralPath $stageScript)) {
+  throw "Missing stage script: $stageScript"
+}
+if (-not (Test-Path -LiteralPath $deployScript)) {
+  throw "Missing deploy script: $deployScript"
+}
+
+function Get-EnvValue([string] $Path, [string] $Name) {
+  $line = Get-Content -LiteralPath $Path | Where-Object { $_ -like "$Name=*" } | Select-Object -First 1
+  if (-not $line) {
+    throw "Missing $Name in $Path"
+  }
+  return $line.Substring($Name.Length + 1)
+}
+
+function New-Base64UrlToken([int] $ByteCount) {
+  $bytes = [byte[]]::new($ByteCount)
+  $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+  try {
+    $rng.GetBytes($bytes)
+  }
+  finally {
+    $rng.Dispose()
+  }
+  return [Convert]::ToBase64String($bytes).TrimEnd("=").Replace("+", "-").Replace("/", "_")
+}
+
+function ConvertTo-SafeBuildId([string] $Value) {
+  $safe = $Value.ToLowerInvariant() -replace "[^a-z0-9._-]+", "-"
+  $safe = $safe.Trim("-._")
+  if (-not $safe) {
+    throw "Build id cannot be empty after sanitization."
+  }
+  return $safe
+}
+
+if (-not $Version) {
+  Push-Location $repoRoot
+  try {
+    $Version = (cargo metadata --no-deps --format-version 1 | ConvertFrom-Json).packages |
+      Where-Object { $_.name -eq "wavecrate" } |
+      Select-Object -ExpandProperty version -First 1
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+if (-not $BuildId) {
+  $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmmss")
+  $shortSha = (git -C $repoRoot rev-parse --short HEAD).Trim()
+  $BuildId = "wavecrate-$Version-$stamp-$shortSha"
+}
+$BuildId = ConvertTo-SafeBuildId $BuildId
+$BuildSignature = New-Base64UrlToken 32
+$PublicKey = Get-EnvValue $signingEnv "WAVECRATE_SIGNING_PUBLIC_KEY_B64"
+if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
+  $AppArgs = @($AppArgs | Select-Object -Skip 1)
+}
+
+Write-Host "Wavecrate registered run"
+Write-Host "  Build id:        $BuildId"
+Write-Host "  Build signature: $BuildSignature"
+Write-Host "  Version:         $Version"
+
+Push-Location $repoRoot
+try {
+  $env:WAVECRATE_BUILD_ID = $BuildId
+  $env:WAVECRATE_BUILD_SIGNATURE = $BuildSignature
+  $env:WAVECRATE_SIGNING_PUBLIC_KEY_B64 = $PublicKey
+  cargo build -r
+}
+finally {
+  Remove-Item Env:\WAVECRATE_BUILD_ID -ErrorAction SilentlyContinue
+  Remove-Item Env:\WAVECRATE_BUILD_SIGNATURE -ErrorAction SilentlyContinue
+  Remove-Item Env:\WAVECRATE_SIGNING_PUBLIC_KEY_B64 -ErrorAction SilentlyContinue
+  Pop-Location
+}
+
+$exe = Join-Path $repoRoot "target\release\wavecrate.exe"
+if (-not (Test-Path -LiteralPath $exe)) {
+  throw "Release binary was not produced: $exe"
+}
+
+& powershell -NoProfile -ExecutionPolicy Bypass -File $stageScript `
+  -File $exe `
+  -BuildId $BuildId `
+  -BuildSignature $BuildSignature `
+  -Version $Version
+
+if (-not $SkipDeploy) {
+  & powershell -NoProfile -ExecutionPolicy Bypass -File $deployScript `
+    -Server $Server `
+    -KeyPath $KeyPath
+}
+
+if (-not $NoRun) {
+  Write-Host "Launching $exe $($AppArgs -join ' ')"
+  & $exe @AppArgs
+}

--- a/scripts/registered-run.ps1
+++ b/scripts/registered-run.ps1
@@ -2,6 +2,7 @@ param(
   [string] $PortalSurferRoot = "X:\portalsurfer.org",
   [string] $Server = "188.245.106.212",
   [string] $KeyPath = "$env:USERPROFILE\.ssh\portalsurfer_org_codex",
+  [string] $RemotePath = "/opt/portalsurfer",
   [string] $Version = "",
   [string] $BuildId = "",
   [switch] $SkipDeploy,
@@ -19,6 +20,7 @@ $portalRoot = $portalRootPath.Path
 $signingEnv = Join-Path $portalRoot ".deploy\wavecrate-signing.env"
 $stageScript = Join-Path $portalRoot "scripts\stage-wavecrate-release.ps1"
 $deployScript = Join-Path $portalRoot "scripts\deploy.ps1"
+$counterFile = Join-Path $portalRoot "hosting\wavecrate-build-counter.json"
 
 if (-not (Test-Path -LiteralPath $signingEnv)) {
   throw "Missing Wavecrate signing env file: $signingEnv. Deploy the website once, or copy WAVECRATE_SIGNING_PUBLIC_KEY_B64 into that file."
@@ -59,6 +61,51 @@ function ConvertTo-SafeBuildId([string] $Value) {
   return $safe
 }
 
+function Read-BuildCounterJson([string] $Json, [string] $Source) {
+  if ([string]::IsNullOrWhiteSpace($Json)) {
+    return 1
+  }
+  $parsed = $Json | ConvertFrom-Json
+  $next = [int]$parsed.next_build_number
+  if ($next -lt 1) {
+    throw "Invalid next_build_number in ${Source}: $next"
+  }
+  return $next
+}
+
+function Read-LocalNextBuildNumber([string] $Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return 1
+  }
+  return Read-BuildCounterJson (Get-Content -LiteralPath $Path -Raw) $Path
+}
+
+function Read-RemoteNextBuildNumber() {
+  if ($SkipDeploy) {
+    return 1
+  }
+  $remoteCounterPath = "$RemotePath/hosting/wavecrate-build-counter.json"
+  $sshArgs = @()
+  if ($KeyPath) {
+    $sshArgs = @("-i", $KeyPath)
+  }
+  $raw = ssh @sshArgs "root@$Server" "test -f '$remoteCounterPath' && cat '$remoteCounterPath' || true"
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read remote Wavecrate build counter from root@${Server}:$remoteCounterPath"
+  }
+  return Read-BuildCounterJson ($raw -join "`n") "root@${Server}:$remoteCounterPath"
+}
+
+function Write-BuildCounter([string] $Path, [int] $NextBuildNumber) {
+  $payload = [pscustomobject]@{
+    next_build_number = $NextBuildNumber
+    updated_at = ([DateTimeOffset]::UtcNow.ToString("o"))
+  }
+  $json = $payload | ConvertTo-Json -Depth 4
+  $encoding = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText($Path, $json, $encoding)
+}
+
 if (-not $Version) {
   Push-Location $repoRoot
   try {
@@ -74,7 +121,12 @@ if (-not $Version) {
 if (-not $BuildId) {
   $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmmss")
   $shortSha = (git -C $repoRoot rev-parse --short HEAD).Trim()
-  $BuildId = "wavecrate-$Version-$stamp-$shortSha"
+  $remoteNextBuildNumber = Read-RemoteNextBuildNumber
+  $localNextBuildNumber = Read-LocalNextBuildNumber $counterFile
+  $BuildNumber = [Math]::Max($remoteNextBuildNumber, $localNextBuildNumber)
+  $BuildId = "wavecrate-b$BuildNumber-$stamp-$shortSha"
+} else {
+  $BuildNumber = 0
 }
 $BuildId = ConvertTo-SafeBuildId $BuildId
 $BuildSignature = New-Base64UrlToken 32
@@ -85,6 +137,9 @@ if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
 
 Write-Host "Wavecrate registered run"
 Write-Host "  Build id:        $BuildId"
+if ($BuildNumber -gt 0) {
+  Write-Host "  Build number:    b$BuildNumber"
+}
 Write-Host "  Build signature: $BuildSignature"
 Write-Host "  Version:         $Version"
 
@@ -111,12 +166,17 @@ if (-not (Test-Path -LiteralPath $exe)) {
   -File $exe `
   -BuildId $BuildId `
   -BuildSignature $BuildSignature `
+  -BuildNumber $BuildNumber `
   -Version $Version
 
 if (-not $SkipDeploy) {
+  if ($BuildNumber -gt 0) {
+    Write-BuildCounter $counterFile ($BuildNumber + 1)
+  }
   & powershell -NoProfile -ExecutionPolicy Bypass -File $deployScript `
     -Server $Server `
-    -KeyPath $KeyPath
+    -KeyPath $KeyPath `
+    -RemotePath $RemotePath
 }
 
 if (-not $NoRun) {

--- a/src/app_registration.rs
+++ b/src/app_registration.rs
@@ -7,6 +7,7 @@ use std::{fs, io::Read, path::PathBuf, time::Duration};
 use uuid::Uuid;
 
 const ACTIVATION_BASE_URL: &str = "https://portalsurfer.org/wavecrate/api/v1";
+const DOWNLOAD_URL: &str = "https://portalsurfer.org/wavecrate/releases/";
 const APP_ID: &str = "wavecrate";
 const MAX_LICENSE_RESPONSE_BYTES: usize = 32 * 1024;
 const RETRY_COUNT: usize = 2;
@@ -63,6 +64,9 @@ pub(crate) fn ensure_registration() -> Result<(), String> {
             Ok(())
         }
         Err(first_error) => {
+            if show_update_required_if_needed(build.build_id, &first_error) {
+                return Err(first_error);
+            }
             if !confirm_activation_request(build.build_id, &first_error) {
                 return Err(String::from("Wavecrate access was not activated"));
             }
@@ -342,6 +346,34 @@ fn activation_success_message(entitlement: &SignedEntitlement) -> String {
     )
 }
 
+fn show_update_required_if_needed(build_id: &str, reason: &str) -> bool {
+    if !is_update_required_reason(reason) {
+        return false;
+    }
+    let description = format!(
+        "This Wavecrate build is not registered for access or has expired.\n\nBuild: {build_id}\n\nDownload the latest Wavecrate version from portalsurfer.org and try again.\n\nIf this is a new test build, make sure it has been registered on the server before running it.\n\nOpen the download page now?"
+    );
+    if MessageDialog::new()
+        .set_level(MessageLevel::Info)
+        .set_title("Wavecrate update required")
+        .set_description(&description)
+        .set_buttons(MessageButtons::YesNo)
+        .show()
+        == MessageDialogResult::Yes
+        && let Err(err) = open::that(DOWNLOAD_URL)
+    {
+        show_error(
+            "Wavecrate update required",
+            &format!("Could not open the download page: {err}\n\n{DOWNLOAD_URL}"),
+        );
+    }
+    true
+}
+
+fn is_update_required_reason(reason: &str) -> bool {
+    reason.contains("unknown_build") || reason.contains("build_expired")
+}
+
 fn confirm_activation_request(build_id: &str, reason: &str) -> bool {
     let description = format!(
         "This Wavecrate build needs server access before it can launch.\n\nBuild: {build_id}\n\nReason: {reason}\n\nRequest access for this computer now?"
@@ -396,5 +428,16 @@ mod tests {
             .expect("decode public key");
 
         assert_eq!(key.to_bytes().len(), 32);
+    }
+
+    #[test]
+    fn update_required_reasons_are_build_registration_failures() {
+        assert!(is_update_required_reason(
+            r#"server returned HTTP 400: {"error":"unknown_build"}"#
+        ));
+        assert!(is_update_required_reason(
+            r#"server returned HTTP 400: {"error":"build_expired"}"#
+        ));
+        assert!(!is_update_required_reason("network error: timed out"));
     }
 }

--- a/src/app_registration.rs
+++ b/src/app_registration.rs
@@ -1,0 +1,400 @@
+use base64::{Engine as _, engine::general_purpose};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{fs, io::Read, path::PathBuf, time::Duration};
+use uuid::Uuid;
+
+const ACTIVATION_BASE_URL: &str = "https://portalsurfer.org/wavecrate/api/v1";
+const APP_ID: &str = "wavecrate";
+const MAX_LICENSE_RESPONSE_BYTES: usize = 32 * 1024;
+const RETRY_COUNT: usize = 2;
+
+const BUILD_ID: Option<&str> = option_env!("WAVECRATE_BUILD_ID");
+const BUILD_SIGNATURE: Option<&str> = option_env!("WAVECRATE_BUILD_SIGNATURE");
+const SIGNING_PUBLIC_KEY_B64: Option<&str> = option_env!("WAVECRATE_SIGNING_PUBLIC_KEY_B64");
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LocalActivation {
+    install_id: String,
+    device_id: String,
+    last_entitlement: Option<SignedEntitlement>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SignedEntitlement {
+    entitlement: Value,
+    signature: String,
+    signature_algorithm: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LicenseResponse {
+    entitlement: Value,
+    signature: String,
+    signature_algorithm: String,
+}
+
+#[derive(Debug, Serialize)]
+struct LicenseRequest<'a> {
+    app: &'a str,
+    install_id: &'a str,
+    device_id: &'a str,
+    app_version: &'a str,
+    build_id: &'a str,
+    build_signature: &'a str,
+}
+
+#[derive(Clone, Copy)]
+struct RegisteredBuild {
+    build_id: &'static str,
+    build_signature: &'static str,
+    public_key_b64: &'static str,
+}
+
+pub(crate) fn ensure_registration() -> Result<(), String> {
+    let build = registered_build()?;
+    let mut activation = load_or_create_activation()?;
+    match renew_or_activate(build, &activation, false) {
+        Ok(entitlement) => {
+            activation.last_entitlement = Some(entitlement);
+            save_activation(&activation)?;
+            Ok(())
+        }
+        Err(first_error) => {
+            if !confirm_activation_request(build.build_id, &first_error) {
+                return Err(String::from("Wavecrate access was not activated"));
+            }
+            match renew_or_activate(build, &activation, true) {
+                Ok(entitlement) => {
+                    show_info(
+                        "Wavecrate access",
+                        &activation_success_message(&entitlement),
+                    );
+                    activation.last_entitlement = Some(entitlement);
+                    save_activation(&activation)?;
+                    Ok(())
+                }
+                Err(err) => {
+                    show_error("Wavecrate access", &err);
+                    Err(err)
+                }
+            }
+        }
+    }
+}
+
+fn registered_build() -> Result<RegisteredBuild, String> {
+    match (BUILD_ID, BUILD_SIGNATURE, SIGNING_PUBLIC_KEY_B64) {
+        (Some(build_id), Some(build_signature), Some(public_key_b64)) => Ok(RegisteredBuild {
+            build_id,
+            build_signature,
+            public_key_b64,
+        }),
+        _ => Err(String::from(
+            "incomplete Wavecrate activation build metadata; set WAVECRATE_BUILD_ID, \
+             WAVECRATE_BUILD_SIGNATURE, and WAVECRATE_SIGNING_PUBLIC_KEY_B64",
+        )),
+    }
+}
+
+fn load_or_create_activation() -> Result<LocalActivation, String> {
+    let path = activation_file()?;
+    if path.exists() {
+        let bytes = fs::read(&path).map_err(|err| {
+            format!(
+                "failed to read Wavecrate registration file at {}: {err}",
+                path.display()
+            )
+        })?;
+        return serde_json::from_slice(&bytes).map_err(|err| {
+            format!(
+                "failed to parse Wavecrate registration file at {}: {err}",
+                path.display()
+            )
+        });
+    }
+
+    Ok(LocalActivation {
+        install_id: Uuid::new_v4().to_string(),
+        device_id: Uuid::new_v4().to_string(),
+        last_entitlement: None,
+    })
+}
+
+fn save_activation(activation: &LocalActivation) -> Result<(), String> {
+    let path = activation_file()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create Wavecrate registration directory at {}: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(activation)
+        .map_err(|err| format!("failed to encode Wavecrate registration file: {err}"))?;
+    fs::write(&path, bytes).map_err(|err| {
+        format!(
+            "failed to write Wavecrate registration file at {}: {err}",
+            path.display()
+        )
+    })
+}
+
+fn activation_file() -> Result<PathBuf, String> {
+    let dir = wavecrate::app_dirs::app_root_dir()
+        .map_err(|err| format!("failed to resolve Wavecrate app data directory: {err}"))?
+        .join("registration");
+    Ok(dir.join("activation.json"))
+}
+
+fn renew_or_activate(
+    build: RegisteredBuild,
+    activation: &LocalActivation,
+    force_activate: bool,
+) -> Result<SignedEntitlement, String> {
+    let request = LicenseRequest {
+        app: APP_ID,
+        install_id: &activation.install_id,
+        device_id: &activation.device_id,
+        app_version: env!("CARGO_PKG_VERSION"),
+        build_id: build.build_id,
+        build_signature: build.build_signature,
+    };
+    let endpoint = if force_activate || activation.last_entitlement.is_none() {
+        "activate"
+    } else {
+        "lease"
+    };
+    let response = post_license_request(endpoint, &request).or_else(|err| {
+        if endpoint == "lease" {
+            post_license_request("activate", &request)
+        } else {
+            Err(err)
+        }
+    })?;
+    verify_entitlement(build, response)
+}
+
+fn post_license_request(
+    endpoint: &str,
+    request: &LicenseRequest<'_>,
+) -> Result<LicenseResponse, String> {
+    let url = format!("{ACTIVATION_BASE_URL}/{endpoint}");
+    let mut last_error = None;
+    for attempt in 0..RETRY_COUNT {
+        match post_license_request_once(&url, request) {
+            Ok(response) => return Ok(response),
+            Err(err) => {
+                last_error = Some(err);
+                if attempt + 1 < RETRY_COUNT {
+                    std::thread::sleep(Duration::from_millis(350));
+                }
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| String::from("license request failed")))
+}
+
+fn post_license_request_once(
+    url: &str,
+    request: &LicenseRequest<'_>,
+) -> Result<LicenseResponse, String> {
+    let response = ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(10))
+        .timeout_read(Duration::from_secs(30))
+        .timeout_write(Duration::from_secs(30))
+        .build()
+        .post(url)
+        .set("Content-Type", "application/json")
+        .send_json(serde_json::to_value(request).map_err(|err| err.to_string())?);
+
+    match response {
+        Ok(response) => read_license_response(response),
+        Err(ureq::Error::Status(code, response)) => {
+            let body =
+                read_response_text(response).unwrap_or_else(|_| String::from("<unreadable>"));
+            Err(format!("server returned HTTP {code}: {body}"))
+        }
+        Err(ureq::Error::Transport(err)) => Err(format!("network error: {err}")),
+    }
+}
+
+fn read_license_response(response: ureq::Response) -> Result<LicenseResponse, String> {
+    let text = read_response_text(response)?;
+    serde_json::from_str(&text).map_err(|err| format!("invalid license response: {err}"))
+}
+
+fn read_response_text(response: ureq::Response) -> Result<String, String> {
+    let mut reader = response
+        .into_reader()
+        .take(u64::try_from(MAX_LICENSE_RESPONSE_BYTES).unwrap_or(u64::MAX) + 1);
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .map_err(|err| format!("failed to read license response: {err}"))?;
+    if bytes.len() > MAX_LICENSE_RESPONSE_BYTES {
+        return Err(String::from("license response was too large"));
+    }
+    String::from_utf8(bytes).map_err(|err| format!("license response was not UTF-8: {err}"))
+}
+
+fn verify_entitlement(
+    build: RegisteredBuild,
+    response: LicenseResponse,
+) -> Result<SignedEntitlement, String> {
+    if response.signature_algorithm != "Ed25519" {
+        return Err(format!(
+            "unsupported license signature algorithm: {}",
+            response.signature_algorithm
+        ));
+    }
+    let public_key = decode_public_key(build.public_key_b64)?;
+    let signature_bytes = general_purpose::STANDARD
+        .decode(&response.signature)
+        .map_err(|err| format!("invalid license signature encoding: {err}"))?;
+    let signature = Signature::from_slice(&signature_bytes)
+        .map_err(|err| format!("invalid license signature: {err}"))?;
+    let payload = stable_json(&response.entitlement);
+    public_key
+        .verify(payload.as_bytes(), &signature)
+        .map_err(|err| format!("license signature did not verify: {err}"))?;
+
+    let app = response
+        .entitlement
+        .get("app")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let status = response
+        .entitlement
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let response_build = response
+        .entitlement
+        .get("build_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if app != APP_ID || response_build != build.build_id || status != "active" {
+        return Err(format!(
+            "Wavecrate entitlement is not active for this build: app={app}, build={response_build}, status={status}"
+        ));
+    }
+
+    Ok(SignedEntitlement {
+        entitlement: response.entitlement,
+        signature: response.signature,
+        signature_algorithm: response.signature_algorithm,
+    })
+}
+
+fn decode_public_key(value: &str) -> Result<VerifyingKey, String> {
+    let bytes = general_purpose::STANDARD
+        .decode(value)
+        .map_err(|err| format!("invalid Wavecrate public key encoding: {err}"))?;
+    let key_bytes = bytes
+        .get(bytes.len().saturating_sub(32)..)
+        .ok_or_else(|| String::from("Wavecrate public key is too short"))?;
+    let key_array: [u8; 32] = key_bytes
+        .try_into()
+        .map_err(|_| String::from("Wavecrate public key has invalid length"))?;
+    VerifyingKey::from_bytes(&key_array)
+        .map_err(|err| format!("invalid Wavecrate public key: {err}"))
+}
+
+fn stable_json(value: &Value) -> String {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => value.to_string(),
+        Value::Array(values) => {
+            let inner = values.iter().map(stable_json).collect::<Vec<_>>().join(",");
+            format!("[{inner}]")
+        }
+        Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(right.0));
+            let inner = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    format!("{}:{}", Value::String(key.clone()), stable_json(value))
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{inner}}}")
+        }
+    }
+}
+
+fn activation_success_message(entitlement: &SignedEntitlement) -> String {
+    let lease = entitlement
+        .entitlement
+        .get("lease_expires_at")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let access = entitlement
+        .entitlement
+        .get("access_expires_at")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    format!(
+        "Wavecrate access granted. Lease expires {lease}; access expires {access}. Launching Wavecrate."
+    )
+}
+
+fn confirm_activation_request(build_id: &str, reason: &str) -> bool {
+    let description = format!(
+        "This Wavecrate build needs server access before it can launch.\n\nBuild: {build_id}\n\nReason: {reason}\n\nRequest access for this computer now?"
+    );
+    MessageDialog::new()
+        .set_level(MessageLevel::Info)
+        .set_title("Wavecrate access")
+        .set_description(&description)
+        .set_buttons(MessageButtons::OkCancel)
+        .show()
+        == MessageDialogResult::Ok
+}
+
+fn show_info(title: &str, description: &str) {
+    let _ = MessageDialog::new()
+        .set_level(MessageLevel::Info)
+        .set_title(title)
+        .set_description(description)
+        .set_buttons(MessageButtons::Ok)
+        .show();
+}
+
+fn show_error(title: &str, description: &str) {
+    let _ = MessageDialog::new()
+        .set_level(MessageLevel::Error)
+        .set_title(title)
+        .set_description(description)
+        .set_buttons(MessageButtons::Ok)
+        .show();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_json_sorts_object_keys_recursively() {
+        let value = serde_json::json!({
+            "z": 1,
+            "a": {
+                "b": true,
+                "a": "x"
+            }
+        });
+
+        assert_eq!(stable_json(&value), r#"{"a":{"a":"x","b":true},"z":1}"#);
+    }
+
+    #[test]
+    fn decode_public_key_accepts_server_spki_der_key() {
+        let key = decode_public_key("MCowBQYDK2VwAyEAzLdOE7DdxNJqx/5ay6kAERt/9yLnDZxn9yDHFYLDNfE=")
+            .expect("decode public key");
+
+        assert_eq!(key.to_bytes().len(), 32);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,10 @@
     windows_subsystem = "windows"
 )]
 
+mod app_registration;
 mod gui_app;
 
 fn main() -> Result<(), String> {
+    app_registration::ensure_registration()?;
     gui_app::run()
 }


### PR DESCRIPTION
## Summary
- require server-registered Wavecrate builds before app launch
- add signed lease verification and update-required GUI messaging
- add registered build/run tooling with server-backed beta build numbers

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent