### PR TITLE
Reset sample row drag preview on cancel

### DIFF
--- a/src/gui_app/folder_browser.rs
+++ b/src/gui_app/folder_browser.rs
@@ -22,6 +22,7 @@ pub(super) struct FolderBrowserState {
     drag: Option<FolderBrowserDrag>,
     drag_pointer: Option<Point>,
     drop_target_folder: Option<String>,
+    drag_revision: u64,
     file_columns: Vec<FileColumn>,
     file_sort: ui::DetailsSort,
     file_column_resize: Option<FileColumnResize>,
@@ -61,6 +62,7 @@ impl FolderBrowserState {
             drag: None,
             drag_pointer: None,
             drop_target_folder: None,
+            drag_revision: 0,
             file_columns: default_file_columns(),
             file_sort: ui::DetailsSort::new("name", ui::SortDirection::Ascending),
             file_column_resize: None,
@@ -125,6 +127,10 @@ impl FolderBrowserState {
             return self.selected_file.as_deref() == Some(file_id);
         }
         self.selected_file_ids.contains(file_id)
+    }
+
+    pub(super) fn drag_revision(&self) -> u64 {
+        self.drag_revision
     }
 
     pub(super) fn scan_is_active(&self, source_id: &str, task_id: u64) -> bool {

--- a/src/gui_app/folder_browser/drag_drop.rs
+++ b/src/gui_app/folder_browser/drag_drop.rs
@@ -49,6 +49,9 @@ impl FolderBrowserState {
     }
 
     pub(in crate::gui_app) fn clear_drag(&mut self) {
+        if self.drag.is_some() || self.drag_pointer.is_some() || self.drop_target_folder.is_some() {
+            self.drag_revision = self.drag_revision.wrapping_add(1);
+        }
         self.drag = None;
         self.drag_pointer = None;
         self.drop_target_folder = None;

--- a/src/gui_app/folder_browser/tests/drag_drop.rs
+++ b/src/gui_app/folder_browser/tests/drag_drop.rs
@@ -164,6 +164,41 @@ fn file_drag_external_request_uses_selected_file_paths() {
 }
 
 #[test]
+fn clearing_file_drag_advances_drag_revision_for_retained_row_reset() {
+    let root = temp_source_root("wavecrate-gui-file-drag-revision");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let kick = drums.join("kick.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&kick));
+
+    let initial_revision = browser.drag_revision();
+    browser.begin_file_drag(path_id(&kick), Point::new(4.0, 8.0));
+    assert_eq!(
+        browser.drag_revision(),
+        initial_revision,
+        "starting a drag should keep existing row widget state until the drag is cleared"
+    );
+
+    browser.clear_drag();
+    assert_eq!(
+        browser.drag_revision(),
+        initial_revision + 1,
+        "clearing a drag must refresh retained sample-row hit targets so stale pressed/drag paint cannot survive cancellation"
+    );
+
+    browser.clear_drag();
+    assert_eq!(
+        browser.drag_revision(),
+        initial_revision + 1,
+        "clearing already-idle drag state should not churn row identity"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn file_drag_drop_moves_selected_files_into_target_folder() {
     let root = temp_source_root("wavecrate-gui-file-drag-drop");
     let drums = root.join("drums");

--- a/src/gui_app/sample_browser_view/rows.rs
+++ b/src/gui_app/sample_browser_view/rows.rs
@@ -28,6 +28,7 @@ pub(super) fn sample_browser_rows(
                 file,
                 folder_browser.is_file_selected(&file.id),
                 folder_browser.file_rename_view(&file.id),
+                folder_browser.drag_revision(),
                 columns,
             )
         },
@@ -41,10 +42,11 @@ fn sample_browser_row(
     file: &FileEntry,
     selected: bool,
     rename: Option<folder_browser::FileRenameView>,
+    drag_revision: u64,
     columns: &[&FileColumn],
 ) -> ui::View<GuiMessage> {
     let hit_path = file.id.clone();
-    let hit_target = sample_file_hit_target(file, selected, hit_path);
+    let hit_target = sample_file_hit_target(file, selected, drag_revision, hit_path);
     let row = ui::stack([
         hit_target,
         compact_details_row(
@@ -62,6 +64,7 @@ fn sample_browser_row(
 fn sample_file_hit_target(
     file: &FileEntry,
     selected: bool,
+    drag_revision: u64,
     hit_path: String,
 ) -> ui::View<GuiMessage> {
     ui::custom_widget_mapped(
@@ -81,7 +84,7 @@ fn sample_file_hit_target(
             },
         },
     )
-    .key(format!("sample-row-hit-{}", file.id))
+    .key(format!("sample-row-hit-{}-{drag_revision}", file.id))
     .fill_width()
     .height(22.0)
 }


### PR DESCRIPTION
## Summary
- reset retained sample row drag preview state when a file drag is cancelled
- add a drag revision to force egui hit-target state refreshes for retained rows
- cover the cancel/reset path with a focused folder browser drag-drop test

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\ci.ps1 agent