### PR TITLE
Add internal Wavecrate build mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_ID");
     println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_SIGNATURE");
     println!("cargo:rerun-if-env-changed=WAVECRATE_SIGNING_PUBLIC_KEY_B64");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_INTERNAL_BUILD");
 
     emit_git_rerun_hints();
     emit_git_sha();
@@ -29,12 +30,33 @@ fn main() {
 
 fn emit_registration_cfg() {
     println!("cargo:rustc-check-cfg=cfg(wavecrate_registered_build)");
-    if env::var("WAVECRATE_BUILD_ID").is_ok()
+    println!("cargo:rustc-check-cfg=cfg(wavecrate_internal_build)");
+
+    let registered_metadata_present = env::var("WAVECRATE_BUILD_ID").is_ok()
         || env::var("WAVECRATE_BUILD_SIGNATURE").is_ok()
-        || env::var("WAVECRATE_SIGNING_PUBLIC_KEY_B64").is_ok()
-    {
+        || env::var("WAVECRATE_SIGNING_PUBLIC_KEY_B64").is_ok();
+    let internal_build = env::var("WAVECRATE_INTERNAL_BUILD")
+        .map(|value| is_truthy_env_value(&value))
+        .unwrap_or(false);
+
+    if internal_build && registered_metadata_present {
+        eprintln!("WAVECRATE_INTERNAL_BUILD cannot be combined with registered release metadata.");
+        std::process::exit(1);
+    }
+
+    if registered_metadata_present {
         println!("cargo:rustc-cfg=wavecrate_registered_build");
     }
+    if internal_build {
+        println!("cargo:rustc-cfg=wavecrate_internal_build");
+    }
+}
+
+fn is_truthy_env_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 fn compiling_for_windows_target() -> bool {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,11 +5,16 @@ is the checked inventory for public entrypoints, compatibility wrappers, and
 dispatcher maps. These are the public entrypoints people should run directly:
 
 - `bootstrap.{sh,ps1}`: set up the repo and install hooks.
-- `registered-run.ps1`: build a registered Wavecrate binary, stage/deploy it
-  through `X:\portalsurfer.org`, then launch the built app with forwarded args.
-  Build ids use the server-side build counter format
+- `registered-run.ps1`: build a registered Wavecrate release binary,
+  stage/deploy it through `X:\portalsurfer.org`, then launch the built app with
+  forwarded args. Build ids use the server-side build counter format
   `wavecrate-b<N>-<timestamp>-<gitsha>`. Example:
   `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -AppArgs --log`.
+  For local-only testing, add `-Internal` to build without registration,
+  staging, or deployment. Examples:
+  `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -Internal -AppArgs --log`
+  and
+  `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -Internal -Profile debug -AppArgs --log`.
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
 - `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -67,7 +67,7 @@
     },
     {
       "path": "scripts/registered-run.ps1",
-      "role": "Build, register, deploy, and launch one Wavecrate release binary for local validation.",
+      "role": "Build, register, deploy, and launch one Wavecrate release binary, or build and launch an explicit internal binary with registration disabled.",
       "windows_supported": true
     },
     {

--- a/scripts/registered-run.ps1
+++ b/scripts/registered-run.ps1
@@ -5,6 +5,9 @@ param(
   [string] $RemotePath = "/opt/portalsurfer",
   [string] $Version = "",
   [string] $BuildId = "",
+  [ValidateSet("release", "debug")]
+  [string] $Profile = "release",
+  [switch] $Internal,
   [switch] $SkipDeploy,
   [switch] $NoRun,
   [Parameter(ValueFromRemainingArguments = $true)]
@@ -15,22 +18,6 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$portalRootPath = Resolve-Path -LiteralPath $PortalSurferRoot
-$portalRoot = $portalRootPath.Path
-$signingEnv = Join-Path $portalRoot ".deploy\wavecrate-signing.env"
-$stageScript = Join-Path $portalRoot "scripts\stage-wavecrate-release.ps1"
-$deployScript = Join-Path $portalRoot "scripts\deploy.ps1"
-$counterFile = Join-Path $portalRoot "hosting\wavecrate-build-counter.json"
-
-if (-not (Test-Path -LiteralPath $signingEnv)) {
-  throw "Missing Wavecrate signing env file: $signingEnv. Deploy the website once, or copy WAVECRATE_SIGNING_PUBLIC_KEY_B64 into that file."
-}
-if (-not (Test-Path -LiteralPath $stageScript)) {
-  throw "Missing stage script: $stageScript"
-}
-if (-not (Test-Path -LiteralPath $deployScript)) {
-  throw "Missing deploy script: $deployScript"
-}
 
 function Get-EnvValue([string] $Path, [string] $Name) {
   $line = Get-Content -LiteralPath $Path | Where-Object { $_ -like "$Name=*" } | Select-Object -First 1
@@ -106,6 +93,23 @@ function Write-BuildCounter([string] $Path, [int] $NextBuildNumber) {
   [System.IO.File]::WriteAllText($Path, $json, $encoding)
 }
 
+function Invoke-WavecrateCargoBuild([string] $BuildProfile) {
+  if ($BuildProfile -eq "release") {
+    cargo build -r
+  } else {
+    cargo build
+  }
+}
+
+function Get-WavecrateExe([string] $BuildProfile) {
+  $targetProfile = if ($BuildProfile -eq "release") { "release" } else { "debug" }
+  return Join-Path $repoRoot "target\$targetProfile\wavecrate.exe"
+}
+
+if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
+  $AppArgs = @($AppArgs | Select-Object -Skip 1)
+}
+
 if (-not $Version) {
   Push-Location $repoRoot
   try {
@@ -116,6 +120,55 @@ if (-not $Version) {
   finally {
     Pop-Location
   }
+}
+
+if ($Internal) {
+  Write-Host "Wavecrate internal run"
+  Write-Host "  Profile: $Profile"
+  Write-Host "  Version: $Version"
+
+  Push-Location $repoRoot
+  try {
+    $env:WAVECRATE_INTERNAL_BUILD = "1"
+    Invoke-WavecrateCargoBuild $Profile
+  }
+  finally {
+    Remove-Item Env:\WAVECRATE_INTERNAL_BUILD -ErrorAction SilentlyContinue
+    Pop-Location
+  }
+
+  $internalExe = Get-WavecrateExe $Profile
+  if (-not (Test-Path -LiteralPath $internalExe)) {
+    throw "Internal binary was not produced: $internalExe"
+  }
+
+  if (-not $NoRun) {
+    Write-Host "Launching $internalExe $($AppArgs -join ' ')"
+    & $internalExe @AppArgs
+  }
+
+  exit 0
+}
+
+if ($Profile -ne "release") {
+  throw "Registered release builds must use -Profile release. Use -Internal -Profile debug for debug test builds."
+}
+
+$portalRootPath = Resolve-Path -LiteralPath $PortalSurferRoot
+$portalRoot = $portalRootPath.Path
+$signingEnv = Join-Path $portalRoot ".deploy\wavecrate-signing.env"
+$stageScript = Join-Path $portalRoot "scripts\stage-wavecrate-release.ps1"
+$deployScript = Join-Path $portalRoot "scripts\deploy.ps1"
+$counterFile = Join-Path $portalRoot "hosting\wavecrate-build-counter.json"
+
+if (-not (Test-Path -LiteralPath $signingEnv)) {
+  throw "Missing Wavecrate signing env file: $signingEnv. Deploy the website once, or copy WAVECRATE_SIGNING_PUBLIC_KEY_B64 into that file."
+}
+if (-not (Test-Path -LiteralPath $stageScript)) {
+  throw "Missing stage script: $stageScript"
+}
+if (-not (Test-Path -LiteralPath $deployScript)) {
+  throw "Missing deploy script: $deployScript"
 }
 
 if (-not $BuildId) {
@@ -131,9 +184,6 @@ if (-not $BuildId) {
 $BuildId = ConvertTo-SafeBuildId $BuildId
 $BuildSignature = New-Base64UrlToken 32
 $PublicKey = Get-EnvValue $signingEnv "WAVECRATE_SIGNING_PUBLIC_KEY_B64"
-if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
-  $AppArgs = @($AppArgs | Select-Object -Skip 1)
-}
 
 Write-Host "Wavecrate registered run"
 Write-Host "  Build id:        $BuildId"
@@ -148,7 +198,7 @@ try {
   $env:WAVECRATE_BUILD_ID = $BuildId
   $env:WAVECRATE_BUILD_SIGNATURE = $BuildSignature
   $env:WAVECRATE_SIGNING_PUBLIC_KEY_B64 = $PublicKey
-  cargo build -r
+  Invoke-WavecrateCargoBuild $Profile
 }
 finally {
   Remove-Item Env:\WAVECRATE_BUILD_ID -ErrorAction SilentlyContinue
@@ -157,7 +207,7 @@ finally {
   Pop-Location
 }
 
-$exe = Join-Path $repoRoot "target\release\wavecrate.exe"
+$exe = Get-WavecrateExe $Profile
 if (-not (Test-Path -LiteralPath $exe)) {
   throw "Release binary was not produced: $exe"
 }

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation_tests.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation_tests.rs
@@ -582,6 +582,9 @@ fn sample_auto_rename_streams_per_item_progress() {
 
 #[test]
 fn sample_auto_rename_cancel_stops_after_partial_completion() {
+    const WORKER_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
+    const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(60);
+
     let (_temp, source) = setup_fixture(&["alpha.wav", "beta.wav", "gamma.wav"]);
     let cancel = Arc::new(AtomicBool::new(false));
     let (progress, rx) = file_op_progress_capture();
@@ -605,7 +608,7 @@ fn sample_auto_rename_cancel_stops_after_partial_completion() {
 
     loop {
         match rx
-            .recv_timeout(Duration::from_secs(10))
+            .recv_timeout(WORKER_PROGRESS_TIMEOUT)
             .expect("wait for first progress")
         {
             JobMessage::FileOps(FileOpMessage::Progress { completed: 1, .. }) => {
@@ -617,7 +620,7 @@ fn sample_auto_rename_cancel_stops_after_partial_completion() {
     }
 
     let result = result_rx
-        .recv_timeout(Duration::from_secs(10))
+        .recv_timeout(WORKER_STOP_TIMEOUT)
         .expect("worker should stop after cancellation");
 
     assert!(!result.renamed.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@
     windows_subsystem = "windows"
 )]
 
+#[cfg(not(wavecrate_internal_build))]
 mod app_registration;
 mod gui_app;
 
 fn main() -> Result<(), String> {
+    #[cfg(not(wavecrate_internal_build))]
     app_registration::ensure_registration()?;
     gui_app::run()
 }


### PR DESCRIPTION
## Summary
- add an explicit internal build cfg that skips app registration only when requested at build time
- extend scripts/registered-run.ps1 with -Internal and -Profile debug/release modes for local test builds
- keep registered release builds release-only and reject mixed internal/release metadata
- widen the auto-rename cancellation test worker timeout that was flaky under the full Windows agent gate

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\\registered-run.ps1 -Internal -NoRun -AppArgs --log
- powershell -ExecutionPolicy Bypass -File scripts\\registered-run.ps1 -Internal -Profile debug -NoRun -AppArgs --log
- cargo check -p wavecrate --bin wavecrate with registered build metadata
- mixed internal/registered metadata rejects at build time
- cargo test -p wavecrate app::controller::library::browser_controller::helpers::sample_mutation_tests::sample_auto_rename_cancel_stops_after_partial_completion
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent