### PR TITLE
Split top bar surface content

### DIFF
--- a/src/app_core/native_shell/composition/ownership_inventory.tsv
+++ b/src/app_core/native_shell/composition/ownership_inventory.tsv
@@ -54,6 +54,7 @@ sidebar_surface_helpers.rs	wavecrate_composition	OPT-189	Sidebar surface helpers
 sidebar_surface_tests.rs	wavecrate_fixture	OPT-191	Wavecrate sidebar fixture now lives beside Wavecrate composition and must not return to Radiant native_shell.
 status_surface.rs	wavecrate_composition	OPT-187	Status surface projection moves with top, status, options, and overlay composition.
 top_bar_surface.rs	wavecrate_composition	OPT-187	Top bar surface projection moves with top, status, options, and overlay composition.
+top_bar_surface/**	wavecrate_composition	OPT-187	Top bar content projection helpers move with top, status, options, and overlay composition.
 waveform_header_surface.rs	wavecrate_composition	OPT-190	Waveform header surface projection moves with waveform composition.
 waveform_toolbar_surface.rs	wavecrate_composition	OPT-190	Waveform toolbar surface projection moves with waveform composition.
 state.rs	compat_adapter	OPT-191	NativeShellState facade coordinates Wavecrate model sync, frame build, automation, and retained caches.

--- a/src/app_core/native_shell/composition/top_bar_surface.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface.rs
@@ -7,13 +7,20 @@
 
 use super::style::SizingTokens;
 use crate::{
-    app::{AppModel, UiAction, UpdateStatusModel},
+    app::UiAction,
     gui::layout_core::visible_suffix_widths,
     gui::types::{Point, Rect},
     runtime::UiSurface,
 };
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
+
+mod content;
+
+pub(crate) use content::{
+    TopBarSurfaceContent, TopBarSurfaceLayout, TopBarUpdateActionSpec, TopBarUpdateButtonLayout,
+    top_bar_surface_content, top_bar_update_action_specs,
+};
 
 const TOP_ROOT_ID: u64 = 1040;
 const TOP_ROW_ID: u64 = 1041;
@@ -28,118 +35,6 @@ const TOP_ACTION_ROW_ID: u64 = 1049;
 const TOP_ACTION_SPACER_ID: u64 = 1050;
 const TOP_OPTIONS_BUTTON_ID: u64 = 1051;
 const TOP_UPDATE_BUTTON_BASE_ID: u64 = 1060;
-
-/// User-facing content projected into the generic top-bar surface.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TopBarSurfaceContent {
-    /// Product title projected into the compact chrome band.
-    pub title: String,
-    /// Formatted master-volume value.
-    pub volume_value: String,
-    /// Short volume label paired with the meter.
-    pub volume_label: String,
-    /// Compact audio-engine chip label shown on the options button.
-    pub options_label: String,
-    /// Bounded update actions projected into the action cluster.
-    pub update_actions: Vec<TopBarUpdateActionSpec>,
-}
-
-/// One projected update action hosted inside the generic top-bar surface.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TopBarUpdateActionSpec {
-    /// Stable automation slug used for semantic node ids.
-    pub node_slug: &'static str,
-    /// User-facing action label.
-    pub label: &'static str,
-    /// Native action emitted when the button activates.
-    pub action: UiAction,
-    /// Whether the action is currently interactive.
-    pub enabled: bool,
-}
-
-/// Resolved button geometry for one projected update action.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TopBarUpdateButtonLayout {
-    /// Action metadata associated with the rendered button.
-    pub spec: TopBarUpdateActionSpec,
-    /// Resolved button bounds.
-    pub rect: Rect,
-}
-
-/// Resolved layout rectangles for the generic top-bar surface.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TopBarSurfaceLayout {
-    /// Left host cluster that contains the volume affordance and title copy.
-    pub title_cluster: Rect,
-    /// Right host cluster that contains update actions and the options button.
-    pub action_cluster: Rect,
-    /// Title text widget bounds.
-    pub title_text_rect: Rect,
-    /// Volume meter canvas bounds.
-    pub volume_meter_rect: Rect,
-    /// Volume value text bounds.
-    pub volume_value_rect: Rect,
-    /// Volume label text bounds.
-    pub volume_label_rect: Rect,
-    /// Options button bounds, when enough room remains.
-    pub options_button_rect: Option<Rect>,
-    /// Visible update action buttons resolved inside the action cluster.
-    pub update_buttons: Vec<TopBarUpdateButtonLayout>,
-}
-
-/// Build user-facing top-bar surface content from the projected app model.
-pub(crate) fn top_bar_surface_content(model: &AppModel) -> TopBarSurfaceContent {
-    TopBarSurfaceContent {
-        title: model.title.clone(),
-        volume_value: format!("{:.2}", model.volume.clamp(0.0, 1.0)),
-        volume_label: String::from("Vol"),
-        options_label: model.paired_device_panel().status_label().to_string(),
-        update_actions: top_bar_update_action_specs(model),
-    }
-}
-
-/// Build the update-action descriptors projected into the top-bar chrome.
-pub(crate) fn top_bar_update_action_specs(model: &AppModel) -> Vec<TopBarUpdateActionSpec> {
-    match model.update.status {
-        UpdateStatusModel::Idle => vec![TopBarUpdateActionSpec {
-            node_slug: "check",
-            label: "Check",
-            action: UiAction::CheckForUpdates,
-            enabled: true,
-        }],
-        UpdateStatusModel::Checking => Vec::new(),
-        UpdateStatusModel::Available => {
-            let mut buttons = Vec::new();
-            if model.update.available_url.is_some() {
-                buttons.push(TopBarUpdateActionSpec {
-                    node_slug: "open",
-                    label: "Open",
-                    action: UiAction::OpenUpdateLink,
-                    enabled: true,
-                });
-                buttons.push(TopBarUpdateActionSpec {
-                    node_slug: "install",
-                    label: "Install",
-                    action: UiAction::InstallUpdate,
-                    enabled: true,
-                });
-            }
-            buttons.push(TopBarUpdateActionSpec {
-                node_slug: "dismiss",
-                label: "Dismiss",
-                action: UiAction::DismissUpdate,
-                enabled: true,
-            });
-            buttons
-        }
-        UpdateStatusModel::Error => vec![TopBarUpdateActionSpec {
-            node_slug: "check",
-            label: "Retry",
-            action: UiAction::CheckForUpdates,
-            enabled: true,
-        }],
-    }
-}
 
 /// Resolve the generic top-bar surface layout inside one shell top-bar rect.
 pub(crate) fn resolve_top_bar_surface_layout(

--- a/src/app_core/native_shell/composition/top_bar_surface/content.rs
+++ b/src/app_core/native_shell/composition/top_bar_surface/content.rs
@@ -1,0 +1,116 @@
+use crate::{
+    app::{AppModel, UiAction, UpdateStatusModel},
+    gui::types::Rect,
+};
+
+/// User-facing content projected into the generic top-bar surface.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TopBarSurfaceContent {
+    /// Product title projected into the compact chrome band.
+    pub title: String,
+    /// Formatted master-volume value.
+    pub volume_value: String,
+    /// Short volume label paired with the meter.
+    pub volume_label: String,
+    /// Compact audio-engine chip label shown on the options button.
+    pub options_label: String,
+    /// Bounded update actions projected into the action cluster.
+    pub update_actions: Vec<TopBarUpdateActionSpec>,
+}
+
+/// One projected update action hosted inside the generic top-bar surface.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TopBarUpdateActionSpec {
+    /// Stable automation slug used for semantic node ids.
+    pub node_slug: &'static str,
+    /// User-facing action label.
+    pub label: &'static str,
+    /// Native action emitted when the button activates.
+    pub action: UiAction,
+    /// Whether the action is currently interactive.
+    pub enabled: bool,
+}
+
+/// Resolved button geometry for one projected update action.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TopBarUpdateButtonLayout {
+    /// Action metadata associated with the rendered button.
+    pub spec: TopBarUpdateActionSpec,
+    /// Resolved button bounds.
+    pub rect: Rect,
+}
+
+/// Resolved layout rectangles for the generic top-bar surface.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct TopBarSurfaceLayout {
+    /// Left host cluster that contains the volume affordance and title copy.
+    pub title_cluster: Rect,
+    /// Right host cluster that contains update actions and the options button.
+    pub action_cluster: Rect,
+    /// Title text widget bounds.
+    pub title_text_rect: Rect,
+    /// Volume meter canvas bounds.
+    pub volume_meter_rect: Rect,
+    /// Volume value text bounds.
+    pub volume_value_rect: Rect,
+    /// Volume label text bounds.
+    pub volume_label_rect: Rect,
+    /// Options button bounds, when enough room remains.
+    pub options_button_rect: Option<Rect>,
+    /// Visible update action buttons resolved inside the action cluster.
+    pub update_buttons: Vec<TopBarUpdateButtonLayout>,
+}
+
+/// Build user-facing top-bar surface content from the projected app model.
+pub(crate) fn top_bar_surface_content(model: &AppModel) -> TopBarSurfaceContent {
+    TopBarSurfaceContent {
+        title: model.title.clone(),
+        volume_value: format!("{:.2}", model.volume.clamp(0.0, 1.0)),
+        volume_label: String::from("Vol"),
+        options_label: model.paired_device_panel().status_label().to_string(),
+        update_actions: top_bar_update_action_specs(model),
+    }
+}
+
+/// Build the update-action descriptors projected into the top-bar chrome.
+pub(crate) fn top_bar_update_action_specs(model: &AppModel) -> Vec<TopBarUpdateActionSpec> {
+    match model.update.status {
+        UpdateStatusModel::Idle => vec![TopBarUpdateActionSpec {
+            node_slug: "check",
+            label: "Check",
+            action: UiAction::CheckForUpdates,
+            enabled: true,
+        }],
+        UpdateStatusModel::Checking => Vec::new(),
+        UpdateStatusModel::Available => {
+            let mut buttons = Vec::new();
+            if model.update.available_url.is_some() {
+                buttons.push(TopBarUpdateActionSpec {
+                    node_slug: "open",
+                    label: "Open",
+                    action: UiAction::OpenUpdateLink,
+                    enabled: true,
+                });
+                buttons.push(TopBarUpdateActionSpec {
+                    node_slug: "install",
+                    label: "Install",
+                    action: UiAction::InstallUpdate,
+                    enabled: true,
+                });
+            }
+            buttons.push(TopBarUpdateActionSpec {
+                node_slug: "dismiss",
+                label: "Dismiss",
+                action: UiAction::DismissUpdate,
+                enabled: true,
+            });
+            buttons
+        }
+        UpdateStatusModel::Error => vec![TopBarUpdateActionSpec {
+            node_slug: "check",
+            label: "Retry",
+            action: UiAction::CheckForUpdates,
+            enabled: true,
+        }],
+    }
+}


### PR DESCRIPTION
## Summary
- move top-bar content and update-action projection into a focused module
- keep top_bar_surface.rs focused on layout and generic surface construction
- update the native-shell ownership inventory for the new top-bar content module

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- RUST_TEST_THREADS=1 powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent