### PR TITLE
Fix sticky sample drag preview

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,10 @@ dispatcher maps. These are the public entrypoints people should run directly:
   `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -Internal -AppArgs --log`
   and
   `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -Internal -Profile debug -AppArgs --log`.
+- `internal-run.ps1`: run a release-profile internal Wavecrate build with
+  registration disabled and logging enabled. It runs from the repo root and does
+  not need the website checkout. Example:
+  `powershell -ExecutionPolicy Bypass -File scripts/internal-run.ps1`.
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
 - `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,8 +6,10 @@ dispatcher maps. These are the public entrypoints people should run directly:
 
 - `bootstrap.{sh,ps1}`: set up the repo and install hooks.
 - `registered-run.ps1`: build a registered Wavecrate release binary,
-  stage/deploy it through `X:\portalsurfer.org`, then launch the built app with
-  forwarded args. Build ids use the server-side build counter format
+  stage/deploy it through a local `portalsurfer.org` checkout, then launch the
+  built app with forwarded args. The script finds `portalsurfer.org` beside the
+  Wavecrate checkout, or you can set `WAVECRATE_PORTALSURFER_ROOT` / pass
+  `-PortalSurferRoot`. Build ids use the server-side build counter format
   `wavecrate-b<N>-<timestamp>-<gitsha>`. Example:
   `powershell -ExecutionPolicy Bypass -File scripts/registered-run.ps1 -AppArgs --log`.
   For local-only testing, add `-Internal` to build without registration,

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -56,6 +56,11 @@
       "windows_supported": true
     },
     {
+      "path": "scripts/internal-run.ps1",
+      "role": "Run a release-profile internal Wavecrate build with registration disabled and logging enabled.",
+      "windows_supported": true
+    },
+    {
       "path": "scripts/perf.ps1",
       "role": "PowerShell runtime performance helpers.",
       "windows_supported": true

--- a/scripts/internal-run.ps1
+++ b/scripts/internal-run.ps1
@@ -1,0 +1,32 @@
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]] $AppArgs
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
+  $AppArgs = @($AppArgs | Select-Object -Skip 1)
+}
+
+$forwardedArgs = @("--log") + $AppArgs
+$hadInternalBuildEnv = Test-Path Env:\WAVECRATE_INTERNAL_BUILD
+$previousInternalBuildEnv = [Environment]::GetEnvironmentVariable("WAVECRATE_INTERNAL_BUILD", "Process")
+
+Push-Location $repoRoot
+try {
+  $env:WAVECRATE_INTERNAL_BUILD = "1"
+  cargo run -r -- @forwardedArgs
+  exit $LASTEXITCODE
+}
+finally {
+  if ($hadInternalBuildEnv) {
+    $env:WAVECRATE_INTERNAL_BUILD = $previousInternalBuildEnv
+  } else {
+    Remove-Item Env:\WAVECRATE_INTERNAL_BUILD -ErrorAction SilentlyContinue
+  }
+  Pop-Location
+}

--- a/scripts/registered-run.ps1
+++ b/scripts/registered-run.ps1
@@ -1,5 +1,5 @@
 param(
-  [string] $PortalSurferRoot = "X:\portalsurfer.org",
+  [string] $PortalSurferRoot = "",
   [string] $Server = "188.245.106.212",
   [string] $KeyPath = "$env:USERPROFILE\.ssh\portalsurfer_org_codex",
   [string] $RemotePath = "/opt/portalsurfer",
@@ -25,6 +25,47 @@ function Get-EnvValue([string] $Path, [string] $Name) {
     throw "Missing $Name in $Path"
   }
   return $line.Substring($Name.Length + 1)
+}
+
+function Test-PortalSurferRoot([string] $Path) {
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    return $false
+  }
+  return (Test-Path -LiteralPath (Join-Path $Path "scripts\stage-wavecrate-release.ps1")) -and
+    (Test-Path -LiteralPath (Join-Path $Path "scripts\deploy.ps1"))
+}
+
+function Resolve-PortalSurferRoot([string] $ExplicitRoot, [string] $WavecrateRoot) {
+  if (-not [string]::IsNullOrWhiteSpace($ExplicitRoot)) {
+    return (Resolve-Path -LiteralPath $ExplicitRoot).Path
+  }
+
+  foreach ($envName in @("WAVECRATE_PORTALSURFER_ROOT", "PORTALSURFER_ROOT")) {
+    $envValue = [Environment]::GetEnvironmentVariable($envName)
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+      return (Resolve-Path -LiteralPath $envValue).Path
+    }
+  }
+
+  $candidates = [System.Collections.Generic.List[string]]::new()
+  $current = (Resolve-Path -LiteralPath $WavecrateRoot).Path
+  while (-not [string]::IsNullOrWhiteSpace($current)) {
+    $parent = Split-Path -Parent $current
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $current) {
+      break
+    }
+    $candidates.Add((Join-Path $parent "portalsurfer.org"))
+    $current = $parent
+  }
+
+  foreach ($candidate in ($candidates | Select-Object -Unique)) {
+    if (Test-PortalSurferRoot $candidate) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+
+  $candidateList = ($candidates | Select-Object -Unique) -join ", "
+  throw "Could not locate the portalsurfer.org repo. Put it beside this Wavecrate checkout, set WAVECRATE_PORTALSURFER_ROOT, or pass -PortalSurferRoot. Checked: $candidateList"
 }
 
 function New-Base64UrlToken([int] $ByteCount) {
@@ -154,8 +195,7 @@ if ($Profile -ne "release") {
   throw "Registered release builds must use -Profile release. Use -Internal -Profile debug for debug test builds."
 }
 
-$portalRootPath = Resolve-Path -LiteralPath $PortalSurferRoot
-$portalRoot = $portalRootPath.Path
+$portalRoot = Resolve-PortalSurferRoot $PortalSurferRoot $repoRoot
 $signingEnv = Join-Path $portalRoot ".deploy\wavecrate-signing.env"
 $stageScript = Join-Path $portalRoot "scripts\stage-wavecrate-release.ps1"
 $deployScript = Join-Path $portalRoot "scripts\deploy.ps1"

--- a/src/gui_app/folder_browser/drag_drop.rs
+++ b/src/gui_app/folder_browser/drag_drop.rs
@@ -38,6 +38,17 @@ impl FolderBrowserState {
         })
     }
 
+    pub(in crate::gui_app) fn file_drag_active(&self) -> bool {
+        matches!(self.drag, Some(FolderBrowserDrag::Files { .. }))
+    }
+
+    pub(in crate::gui_app) fn file_drag_source(&self, file_id: &str) -> bool {
+        match &self.drag {
+            Some(FolderBrowserDrag::Files { file_ids }) => file_ids.iter().any(|id| id == file_id),
+            _ => false,
+        }
+    }
+
     pub(in crate::gui_app) fn external_drag_request(&self) -> Option<ui::ExternalDragRequest> {
         let drag = self.drag.as_ref()?;
         let label = self.drag_preview_label(drag)?;

--- a/src/gui_app/sample_browser_view/hit_target.rs
+++ b/src/gui_app/sample_browser_view/hit_target.rs
@@ -11,6 +11,8 @@ use radiant::widgets::{
 pub(in crate::gui_app) struct SampleFileHitTarget {
     common: WidgetCommon,
     selected: bool,
+    drag_active: bool,
+    drag_source: bool,
     dragged: bool,
 }
 
@@ -22,7 +24,7 @@ pub(in crate::gui_app) enum SampleFileHitMessage {
 }
 
 impl SampleFileHitTarget {
-    pub(in crate::gui_app) fn new(selected: bool) -> Self {
+    pub(in crate::gui_app) fn new(selected: bool, drag_active: bool, drag_source: bool) -> Self {
         let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 22.0)));
         common.focus = FocusBehavior::None;
         common.paint.bounds = PaintBounds::ClipToRect;
@@ -31,8 +33,92 @@ impl SampleFileHitTarget {
         Self {
             common,
             selected,
+            drag_active,
+            drag_source,
             dragged: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message_from(output: Option<WidgetOutput>) -> SampleFileHitMessage {
+        *output
+            .expect("expected widget output")
+            .typed_ref::<SampleFileHitMessage>()
+            .expect("expected sample file message")
+    }
+
+    #[test]
+    fn active_drag_survives_widget_refresh_as_moved() {
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
+        let mut first = SampleFileHitTarget::new(false, false, false);
+        first.handle_input(
+            bounds,
+            WidgetInput::PointerPress {
+                position: Point::new(6.0, 6.0),
+                button: PointerButton::Primary,
+                modifiers: PointerModifiers::default(),
+            },
+        );
+        assert_eq!(
+            message_from(first.handle_input(
+                bounds,
+                WidgetInput::PointerMove {
+                    position: Point::new(16.0, 7.0),
+                },
+            )),
+            SampleFileHitMessage::Drag(DragHandleMessage::Started {
+                position: Point::new(16.0, 7.0),
+            })
+        );
+
+        let mut refreshed = SampleFileHitTarget::new(false, true, true);
+        refreshed.common.state = first.common.state;
+        assert_eq!(
+            message_from(refreshed.handle_input(
+                bounds,
+                WidgetInput::PointerMove {
+                    position: Point::new(34.0, 8.0),
+                },
+            )),
+            SampleFileHitMessage::Drag(DragHandleMessage::Moved {
+                position: Point::new(34.0, 8.0),
+            })
+        );
+    }
+
+    #[test]
+    fn active_drag_source_does_not_depend_on_retained_pressed_state() {
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
+        let mut refreshed = SampleFileHitTarget::new(false, true, true);
+
+        assert_eq!(
+            message_from(refreshed.handle_input(
+                bounds,
+                WidgetInput::PointerMove {
+                    position: Point::new(34.0, 8.0),
+                },
+            )),
+            SampleFileHitMessage::Drag(DragHandleMessage::Moved {
+                position: Point::new(34.0, 8.0),
+            })
+        );
+        assert_eq!(
+            message_from(refreshed.handle_input(
+                bounds,
+                WidgetInput::PointerRelease {
+                    position: Point::new(220.0, 90.0),
+                    button: PointerButton::Primary,
+                    modifiers: PointerModifiers::default(),
+                },
+            )),
+            SampleFileHitMessage::Drag(DragHandleMessage::Ended {
+                position: Point::new(220.0, 90.0),
+            })
+        );
     }
 }
 
@@ -105,10 +191,10 @@ impl Widget for SampleFileHitTarget {
 impl SampleFileHitTarget {
     fn handle_pointer_move(&mut self, bounds: Rect, position: Point) -> Option<WidgetOutput> {
         self.common.state.hovered = bounds.contains(position);
-        if !self.common.state.pressed {
+        if !self.common.state.pressed && !self.drag_source {
             return None;
         }
-        let message = if self.dragged {
+        let message = if self.dragged || self.drag_active {
             DragHandleMessage::Moved { position }
         } else {
             self.dragged = true;
@@ -124,7 +210,8 @@ impl SampleFileHitTarget {
         modifiers: PointerModifiers,
     ) -> Option<WidgetOutput> {
         let activated = self.common.state.pressed && !self.dragged && bounds.contains(position);
-        let dragged = self.common.state.pressed && self.dragged;
+        let dragged =
+            self.drag_source || (self.common.state.pressed && (self.dragged || self.drag_active));
         self.common.state.pressed = false;
         self.common.state.hovered = bounds.contains(position);
         self.dragged = false;

--- a/src/gui_app/sample_browser_view/rows.rs
+++ b/src/gui_app/sample_browser_view/rows.rs
@@ -29,6 +29,8 @@ pub(super) fn sample_browser_rows(
                 folder_browser.is_file_selected(&file.id),
                 folder_browser.file_rename_view(&file.id),
                 folder_browser.drag_revision(),
+                folder_browser.file_drag_active(),
+                folder_browser.file_drag_source(&file.id),
                 columns,
             )
         },
@@ -43,10 +45,19 @@ fn sample_browser_row(
     selected: bool,
     rename: Option<folder_browser::FileRenameView>,
     drag_revision: u64,
+    drag_active: bool,
+    drag_source: bool,
     columns: &[&FileColumn],
 ) -> ui::View<GuiMessage> {
     let hit_path = file.id.clone();
-    let hit_target = sample_file_hit_target(file, selected, drag_revision, hit_path);
+    let hit_target = sample_file_hit_target(
+        file,
+        selected,
+        drag_revision,
+        drag_active,
+        drag_source,
+        hit_path,
+    );
     let row = ui::stack([
         hit_target,
         compact_details_row(
@@ -65,10 +76,12 @@ fn sample_file_hit_target(
     file: &FileEntry,
     selected: bool,
     drag_revision: u64,
+    drag_active: bool,
+    drag_source: bool,
     hit_path: String,
 ) -> ui::View<GuiMessage> {
     ui::custom_widget_mapped(
-        SampleFileHitTarget::new(selected),
+        SampleFileHitTarget::new(selected, drag_active, drag_source),
         move |message| match message {
             SampleFileHitMessage::Activate(modifiers) => GuiMessage::SelectSampleWithModifiers {
                 path: hit_path.clone(),

--- a/src/gui_app/tests/sample_browser.rs
+++ b/src/gui_app/tests/sample_browser.rs
@@ -8,7 +8,8 @@ use radiant::{
 #[test]
 fn sample_row_hit_target_survives_frame_refresh_between_press_and_release() {
     let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(160.0, 22.0));
-    let mut hit_target = crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false);
+    let mut hit_target =
+        crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false, false, false);
 
     assert_eq!(
         hit_target.handle_input(
@@ -23,7 +24,7 @@ fn sample_row_hit_target_survives_frame_refresh_between_press_and_release() {
     );
 
     let mut refreshed_hit_target =
-        crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false);
+        crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false, false, false);
     refreshed_hit_target.common_mut().state = hit_target.common().state;
     let output = refreshed_hit_target
         .handle_input(
@@ -122,7 +123,7 @@ fn sample_browser_keyboard_scroll_keeps_two_context_rows() {
 
 #[test]
 fn selected_sample_browser_row_paints_strong_fill_and_left_marker() {
-    let widget = crate::gui_app::sample_browser_view::SampleFileHitTarget::new(true);
+    let widget = crate::gui_app::sample_browser_view::SampleFileHitTarget::new(true, false, false);
     let bounds = Rect::from_min_size(Point::new(12.0, 8.0), Vector2::new(240.0, 22.0));
     let mut primitives = Vec::new();
     widget.append_paint(
@@ -162,7 +163,8 @@ fn selected_sample_browser_row_paints_strong_fill_and_left_marker() {
 #[test]
 fn sample_browser_row_hover_paints_bright_background_without_marker() {
     let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(180.0, 22.0));
-    let mut hit_target = crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false);
+    let mut hit_target =
+        crate::gui_app::sample_browser_view::SampleFileHitTarget::new(false, false, false);
 
     assert_eq!(
         hit_target.handle_input(


### PR DESCRIPTION
## Summary
- keep sample browser file rows aware of active file drag state so rebuilt rows still emit drag move/end messages
- add focused regression tests for retained sample drag source behavior
- add the internal run helper and make registered-run resolve the portalsurfer checkout without a hardcoded drive path

## Validation
- cargo fmt -- --check
- cargo test -p wavecrate gui_app::sample_browser_view::hit_target::tests
- cargo test -p wavecrate gui_app::folder_browser::tests::drag_drop
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent