### PR TITLE
Normalize run script app args

### DIFF
--- a/scripts/internal-run.ps1
+++ b/scripts/internal-run.ps1
@@ -8,6 +8,12 @@ Set-StrictMode -Version Latest
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 
+if ($null -eq $AppArgs) {
+  $AppArgs = @()
+} else {
+  $AppArgs = @($AppArgs)
+}
+
 if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
   $AppArgs = @($AppArgs | Select-Object -Skip 1)
 }

--- a/scripts/registered-run.ps1
+++ b/scripts/registered-run.ps1
@@ -147,6 +147,12 @@ function Get-WavecrateExe([string] $BuildProfile) {
   return Join-Path $repoRoot "target\$targetProfile\wavecrate.exe"
 }
 
+if ($null -eq $AppArgs) {
+  $AppArgs = @()
+} else {
+  $AppArgs = @($AppArgs)
+}
+
 if ($AppArgs.Count -gt 0 -and $AppArgs[0] -eq "--") {
   $AppArgs = @($AppArgs | Select-Object -Skip 1)
 }


### PR DESCRIPTION
## Summary
- normalize remaining PowerShell app args to an array before checking Count
- apply the same no-arg fix to internal-run and registered-run

## Validation
- scripts parse cleanly
- intercepted no-arg internal-run invocation reaches cargo run path
- intercepted registered-run -Internal -NoRun invocation reaches cargo build path
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 smoke
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent