### PR TITLE
Split native runtime bridge helpers

### DIFF
--- a/src/gui_runtime/native_shell_runtime.rs
+++ b/src/gui_runtime/native_shell_runtime.rs
@@ -15,9 +15,11 @@ use crate::app_core::actions::{
 };
 use crate::app_core::app_api::controller_ui_hotkeys::KeyPress;
 use crate::app_core::app_api::{controller_ui_hotkeys as hotkeys, state::FocusContext};
+#[cfg(test)]
+use crate::app_core::native_shell::composition::StaticFrameSegment;
 use crate::app_core::native_shell::composition::{
-    NativeShellState, ShellLayout, ShellLayoutRuntime, ShellNodeKind, StaticFrameSegment,
-    StaticFrameSegments, StyleTokens,
+    NativeShellState, ShellLayout, ShellLayoutRuntime, ShellNodeKind, StaticFrameSegments,
+    StyleTokens,
 };
 use crate::app_core::native_shell::runtime_contract;
 use crate::gui::automation as gui_automation;
@@ -30,11 +32,10 @@ use radiant::gui::{
     input::{KeyCode as RadiantKeyCode, KeyPress as RadiantKeyPress},
     shortcuts::ShortcutResolution as RadiantShortcutResolution,
 };
-use radiant::runtime::{Command, RuntimeBridge, SurfaceNode, UiSurface};
-use radiant::widgets::{
-    CanvasMessage, PointerButton, RetainedSurfaceDescriptor, TextEditCommand, WidgetInput,
-    WidgetKey, WidgetSizing,
-};
+use radiant::runtime::{Command, RuntimeBridge, UiSurface};
+#[cfg(test)]
+use radiant::widgets::PointerButton;
+use radiant::widgets::{RetainedSurfaceDescriptor, TextEditCommand, WidgetInput, WidgetKey};
 use std::{collections::BTreeMap, sync::Arc};
 
 mod action_mapping;
@@ -50,10 +51,7 @@ pub(super) use automation::capture_native_shell_shot_snapshot;
 use bridge::WavecrateRuntimeBridge;
 #[cfg(test)]
 use bridge::WavecrateRuntimeMessage;
-use input_routing::{
-    action_from_retained_pointer, keypress_from_radiant, keypress_to_radiant,
-    wavecrate_focus_context,
-};
+use input_routing::{keypress_from_radiant, keypress_to_radiant, wavecrate_focus_context};
 pub(super) use launch::{run_native_vello_app, run_native_vello_app_with_artifacts};
 use model_mapping::local_app_model_from_native_model;
 

--- a/src/gui_runtime/native_shell_runtime/bridge.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge.rs
@@ -1,8 +1,12 @@
 use self::pan_drag::WaveformPanDrag;
+use self::surface::{generic_shell_surface, retained_surface_revision};
 use self::text_edit::{RetainedTextEditState, RetainedTextInputTarget};
 use super::*;
 
+mod input;
 mod pan_drag;
+mod render;
+mod surface;
 mod text_edit;
 mod text_input;
 
@@ -59,20 +63,6 @@ impl<B> WavecrateRuntimeBridge<B> {
             text_edit: RetainedTextEditState::default(),
             waveform_pan_drag: None,
         }
-    }
-
-    /// Build the generic retained canvas surface that Radiant owns around Wavecrate rendering.
-    fn generic_shell_surface(
-        retained: RetainedSurfaceDescriptor,
-    ) -> Arc<UiSurface<WavecrateRuntimeMessage>> {
-        Arc::new(UiSurface::new(SurfaceNode::retained_canvas_mapped(
-            1,
-            WidgetSizing::fixed(Vector2::new(1280.0, 720.0)),
-            retained,
-            |message: CanvasMessage| match message {
-                CanvasMessage::Input { input } => WavecrateRuntimeMessage::RetainedInput(input),
-            },
-        )))
     }
 
     #[cfg(test)]
@@ -148,121 +138,6 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
                 .unwrap_or(descriptor),
         );
     }
-
-    /// Translate retained-canvas input into Wavecrate actions or local repaint-only state.
-    fn handle_retained_canvas_input(&mut self, input: WidgetInput) -> bool {
-        match input {
-            WidgetInput::PointerMove { position } => {
-                let layout = self.build_current_layout();
-                if self
-                    .shell_state
-                    .update_options_panel_drag(&layout, &self.model, position)
-                {
-                    self.local_overlay_surface_refresh = true;
-                    return true;
-                }
-                if let Some(action) = self.waveform_pan_drag_action(&layout, position) {
-                    self.emit_action(action);
-                    self.local_overlay_surface_refresh = true;
-                    return true;
-                }
-                let _effect =
-                    self.shell_state
-                        .handle_cursor_move_effect(&layout, &self.model, position);
-                self.local_overlay_surface_refresh = true;
-                true
-            }
-            WidgetInput::PointerPress {
-                position, button, ..
-            } => {
-                let layout = self.build_current_layout();
-                if button == PointerButton::Auxiliary {
-                    self.begin_waveform_pan_drag(&layout, position);
-                    self.local_overlay_surface_refresh = true;
-                    return true;
-                }
-                if button != PointerButton::Primary {
-                    return true;
-                }
-                if self
-                    .shell_state
-                    .begin_options_panel_drag(&layout, &self.model, position)
-                {
-                    self.local_overlay_surface_refresh = true;
-                    return true;
-                }
-                if let Some(action) = action_from_retained_pointer(
-                    &layout,
-                    &self.model,
-                    &mut self.shell_state,
-                    position,
-                ) {
-                    self.emit_action(action.into());
-                    if self.text_input_target != RetainedTextInputTarget::None {
-                        self.sync_text_edit_from_model();
-                    }
-                }
-                true
-            }
-            WidgetInput::PointerDoubleClick {
-                position, button, ..
-            } => {
-                let layout = self.build_current_layout();
-                if button != PointerButton::Primary {
-                    return true;
-                }
-                if let Some(action) = action_from_retained_pointer(
-                    &layout,
-                    &self.model,
-                    &mut self.shell_state,
-                    position,
-                ) {
-                    self.emit_action(action.into());
-                    if self.text_input_target != RetainedTextInputTarget::None {
-                        self.sync_text_edit_from_model();
-                    }
-                }
-                true
-            }
-            WidgetInput::PointerRelease {
-                button: PointerButton::Auxiliary,
-                ..
-            } => {
-                self.waveform_pan_drag = None;
-                self.shell_state.finish_options_panel_drag();
-                self.local_overlay_surface_refresh = true;
-                true
-            }
-            WidgetInput::PointerRelease {
-                button: PointerButton::Primary,
-                ..
-            } => {
-                self.shell_state.finish_options_panel_drag();
-                self.local_overlay_surface_refresh = true;
-                true
-            }
-            WidgetInput::PointerRelease { .. }
-            | WidgetInput::PointerDrop { .. }
-            | WidgetInput::FocusChanged(_) => {
-                self.shell_state.finish_options_panel_drag();
-                self.local_overlay_surface_refresh = true;
-                true
-            }
-            WidgetInput::Wheel { .. } => true,
-            WidgetInput::KeyPress(key) => self.handle_retained_key_press(key),
-            WidgetInput::Character(character) => self.handle_retained_character(character),
-            WidgetInput::TextEdit(command) => self.handle_retained_text_edit(command),
-        }
-    }
-
-    /// Build the current shell layout used by retained input hit-testing.
-    fn build_current_layout(&mut self) -> ShellLayout {
-        let viewport = self
-            .layout_viewport
-            .unwrap_or_else(|| Vector2::new(1280.0, 720.0));
-        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
-        ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime)
-    }
 }
 
 impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRuntimeBridge<B> {
@@ -271,12 +146,12 @@ impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRun
         if let Some(descriptor) = self.pending_surface_descriptor.take() {
             self.local_overlay_surface_refresh = false;
             self.motion_only_surface_refresh = false;
-            return Self::generic_shell_surface(descriptor);
+            return generic_shell_surface(descriptor);
         }
         if self.local_overlay_surface_refresh {
             self.local_overlay_surface_refresh = false;
             let revisions = self.inner.take_segment_revisions();
-            return Self::generic_shell_surface(RetainedSurfaceDescriptor {
+            return generic_shell_surface(RetainedSurfaceDescriptor {
                 key: 1,
                 revision: retained_surface_revision(revisions),
                 dirty_mask: 0,
@@ -286,7 +161,7 @@ impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRun
         if self.motion_only_surface_refresh {
             self.motion_only_surface_refresh = false;
             let revisions = self.inner.take_segment_revisions();
-            return Self::generic_shell_surface(RetainedSurfaceDescriptor {
+            return generic_shell_surface(RetainedSurfaceDescriptor {
                 key: 1,
                 revision: retained_surface_revision(revisions),
                 dirty_mask: 0,
@@ -297,7 +172,7 @@ impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRun
         self.model = Arc::new(model.as_ref().into());
         let dirty = self.inner.take_dirty_segments();
         let revisions = self.inner.take_segment_revisions();
-        Self::generic_shell_surface(RetainedSurfaceDescriptor {
+        generic_shell_surface(RetainedSurfaceDescriptor {
             key: 1,
             revision: retained_surface_revision(revisions),
             dirty_mask: u64::from(dirty.bits()),
@@ -401,49 +276,7 @@ impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRun
         _rect: Rect,
         viewport: Vector2,
     ) -> Option<PaintFrame> {
-        if descriptor.key != 1 {
-            return None;
-        }
-        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
-        if self.layout_viewport != Some(viewport) {
-            self.layout_runtime.reset();
-            self.layout_viewport = Some(viewport);
-            self.static_segments_initialized = false;
-        }
-        let layout =
-            ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime);
-        self.shell_state.sync_from_model(&self.model);
-        let mut model = self.model.as_ref().clone();
-        self.apply_local_text_projection(&mut model);
-        let motion_model = self
-            .pending_motion_model
-            .take()
-            .unwrap_or_else(|| runtime_contract::NativeMotionModel::from_app_model(&model));
-        self.shell_state.sync_from_motion_model(&motion_model);
-        let dirty_bits = descriptor.dirty_mask.min(u64::from(u16::MAX)) as u16;
-        for segment in StaticFrameSegment::ALL {
-            if !self.static_segments_initialized || dirty_bits & segment.dirty_mask() != 0 {
-                self.shell_state.build_static_segment_with_style_into(
-                    &layout,
-                    &style,
-                    &model,
-                    Some(&motion_model),
-                    segment,
-                    &mut self.static_segments,
-                );
-            }
-        }
-        self.static_segments_initialized = true;
-        self.static_segments.compose_into(&mut self.frame);
-        append_retained_shell_overlays(
-            &mut self.shell_state,
-            &layout,
-            &style,
-            &model,
-            &motion_model,
-            &mut self.frame,
-        );
-        Some(self.frame.clone())
+        self.render_retained_surface_frame(descriptor, viewport)
     }
 
     fn on_runtime_exit(&mut self) -> Option<serde_json::Value> {
@@ -451,43 +284,4 @@ impl<B: NativeAppBridge> RuntimeBridge<WavecrateRuntimeMessage> for WavecrateRun
             .on_runtime_exit()
             .and_then(|artifact| serde_json::to_value(artifact).ok())
     }
-}
-
-/// Append state and motion overlays that are local to the retained shell bridge.
-fn append_retained_shell_overlays(
-    shell_state: &mut NativeShellState,
-    layout: &ShellLayout,
-    style: &StyleTokens,
-    model: &runtime_contract::AppModel,
-    motion_model: &runtime_contract::NativeMotionModel,
-    frame: &mut PaintFrame,
-) {
-    let mut overlay = PaintFrame::default();
-    shell_state.build_waveform_motion_overlay_into(layout, style, motion_model, &mut overlay);
-    append_paint_frame(frame, &overlay);
-    shell_state.build_chrome_motion_overlay_into(layout, style, motion_model, &mut overlay);
-    append_paint_frame(frame, &overlay);
-    shell_state.build_hover_overlay_into(layout, style, model, &mut overlay);
-    append_paint_frame(frame, &overlay);
-    shell_state.build_focus_overlay_into(layout, style, model, &mut overlay);
-    append_paint_frame(frame, &overlay);
-    shell_state.build_modal_overlay_into(layout, style, model, &mut overlay);
-    append_paint_frame(frame, &overlay);
-}
-
-/// Append one overlay frame into the retained shell paint buffer.
-fn append_paint_frame(frame: &mut PaintFrame, overlay: &PaintFrame) {
-    frame.primitives.extend(overlay.primitives.iter().cloned());
-    frame.text_runs.extend(overlay.text_runs.iter().cloned());
-    frame.clear_color = overlay.clear_color;
-}
-
-/// Collapse per-segment revisions into the retained canvas revision Radiant observes.
-fn retained_surface_revision(revisions: crate::app_core::actions::NativeSegmentRevisions) -> u64 {
-    revisions.status_bar
-        ^ revisions.browser_frame.rotate_left(7)
-        ^ revisions.browser_rows_window.rotate_left(13)
-        ^ revisions.map_panel.rotate_left(19)
-        ^ revisions.waveform_overlay.rotate_left(29)
-        ^ revisions.global_static.rotate_left(37)
 }

--- a/src/gui_runtime/native_shell_runtime/bridge/input.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/input.rs
@@ -1,0 +1,120 @@
+use super::{RetainedTextInputTarget, WavecrateRuntimeBridge};
+use crate::{
+    app_core::{
+        actions::NativeAppBridge,
+        native_shell::composition::{ShellLayout, StyleTokens},
+    },
+    gui::types::{Point, Vector2},
+    gui_runtime::native_shell_runtime::input_routing::action_from_retained_pointer,
+};
+use radiant::widgets::{PointerButton, WidgetInput};
+
+impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
+    /// Translate retained-canvas input into Wavecrate actions or local repaint-only state.
+    pub(super) fn handle_retained_canvas_input(&mut self, input: WidgetInput) -> bool {
+        match input {
+            WidgetInput::PointerMove { position } => self.handle_pointer_move(position),
+            WidgetInput::PointerPress {
+                position, button, ..
+            } => self.handle_pointer_press(position, button),
+            WidgetInput::PointerDoubleClick {
+                position, button, ..
+            } => self.handle_pointer_double_click(position, button),
+            WidgetInput::PointerRelease {
+                button: PointerButton::Auxiliary,
+                ..
+            } => self.finish_pointer_drag(true),
+            WidgetInput::PointerRelease {
+                button: PointerButton::Primary,
+                ..
+            } => self.finish_pointer_drag(false),
+            WidgetInput::PointerRelease { .. }
+            | WidgetInput::PointerDrop { .. }
+            | WidgetInput::FocusChanged(_) => self.finish_pointer_drag(false),
+            WidgetInput::Wheel { .. } => true,
+            WidgetInput::KeyPress(key) => self.handle_retained_key_press(key),
+            WidgetInput::Character(character) => self.handle_retained_character(character),
+            WidgetInput::TextEdit(command) => self.handle_retained_text_edit(command),
+        }
+    }
+
+    fn handle_pointer_move(&mut self, position: Point) -> bool {
+        let layout = self.build_current_layout();
+        if self
+            .shell_state
+            .update_options_panel_drag(&layout, &self.model, position)
+        {
+            self.local_overlay_surface_refresh = true;
+            return true;
+        }
+        if let Some(action) = self.waveform_pan_drag_action(&layout, position) {
+            self.emit_action(action);
+            self.local_overlay_surface_refresh = true;
+            return true;
+        }
+        let _effect = self
+            .shell_state
+            .handle_cursor_move_effect(&layout, &self.model, position);
+        self.local_overlay_surface_refresh = true;
+        true
+    }
+
+    fn handle_pointer_press(&mut self, position: Point, button: PointerButton) -> bool {
+        let layout = self.build_current_layout();
+        if button == PointerButton::Auxiliary {
+            self.begin_waveform_pan_drag(&layout, position);
+            self.local_overlay_surface_refresh = true;
+            return true;
+        }
+        if button != PointerButton::Primary {
+            return true;
+        }
+        if self
+            .shell_state
+            .begin_options_panel_drag(&layout, &self.model, position)
+        {
+            self.local_overlay_surface_refresh = true;
+            return true;
+        }
+        self.emit_pointer_action(&layout, position);
+        true
+    }
+
+    fn handle_pointer_double_click(&mut self, position: Point, button: PointerButton) -> bool {
+        if button != PointerButton::Primary {
+            return true;
+        }
+        let layout = self.build_current_layout();
+        self.emit_pointer_action(&layout, position);
+        true
+    }
+
+    fn emit_pointer_action(&mut self, layout: &ShellLayout, position: Point) {
+        let Some(action) =
+            action_from_retained_pointer(layout, &self.model, &mut self.shell_state, position)
+        else {
+            return;
+        };
+        self.emit_action(action.into());
+        if self.text_input_target != RetainedTextInputTarget::None {
+            self.sync_text_edit_from_model();
+        }
+    }
+
+    fn finish_pointer_drag(&mut self, clear_pan_drag: bool) -> bool {
+        if clear_pan_drag {
+            self.waveform_pan_drag = None;
+        }
+        self.shell_state.finish_options_panel_drag();
+        self.local_overlay_surface_refresh = true;
+        true
+    }
+
+    fn build_current_layout(&mut self) -> ShellLayout {
+        let viewport = self
+            .layout_viewport
+            .unwrap_or_else(|| Vector2::new(1280.0, 720.0));
+        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
+        ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime)
+    }
+}

--- a/src/gui_runtime/native_shell_runtime/bridge/render.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/render.rs
@@ -1,0 +1,115 @@
+use crate::{
+    app_core::native_shell::{
+        composition::{NativeShellState, ShellLayout, StyleTokens},
+        runtime_contract,
+    },
+    app_core::{actions::NativeAppBridge, native_shell::composition::StaticFrameSegment},
+    gui::{paint::PaintFrame, types::Vector2},
+};
+use radiant::widgets::RetainedSurfaceDescriptor;
+
+use super::WavecrateRuntimeBridge;
+
+impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
+    pub(super) fn render_retained_surface_frame(
+        &mut self,
+        descriptor: RetainedSurfaceDescriptor,
+        viewport: Vector2,
+    ) -> Option<PaintFrame> {
+        if descriptor.key != 1 {
+            return None;
+        }
+        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
+        self.sync_layout_viewport(viewport);
+        let layout =
+            ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime);
+        self.shell_state.sync_from_model(&self.model);
+
+        let mut model = self.model.as_ref().clone();
+        self.apply_local_text_projection(&mut model);
+        let motion_model = self
+            .pending_motion_model
+            .take()
+            .unwrap_or_else(|| runtime_contract::NativeMotionModel::from_app_model(&model));
+        self.shell_state.sync_from_motion_model(&motion_model);
+
+        self.refresh_static_segments(
+            descriptor.dirty_mask,
+            &layout,
+            &style,
+            &model,
+            &motion_model,
+        );
+        self.static_segments.compose_into(&mut self.frame);
+        append_retained_shell_overlays(
+            &mut self.shell_state,
+            &layout,
+            &style,
+            &model,
+            &motion_model,
+            &mut self.frame,
+        );
+        Some(self.frame.clone())
+    }
+
+    fn sync_layout_viewport(&mut self, viewport: Vector2) {
+        if self.layout_viewport == Some(viewport) {
+            return;
+        }
+        self.layout_runtime.reset();
+        self.layout_viewport = Some(viewport);
+        self.static_segments_initialized = false;
+    }
+
+    fn refresh_static_segments(
+        &mut self,
+        dirty_mask: u64,
+        layout: &ShellLayout,
+        style: &StyleTokens,
+        model: &runtime_contract::AppModel,
+        motion_model: &runtime_contract::NativeMotionModel,
+    ) {
+        let dirty_bits = dirty_mask.min(u64::from(u16::MAX)) as u16;
+        for segment in StaticFrameSegment::ALL {
+            if !self.static_segments_initialized || dirty_bits & segment.dirty_mask() != 0 {
+                self.shell_state.build_static_segment_with_style_into(
+                    layout,
+                    style,
+                    model,
+                    Some(motion_model),
+                    segment,
+                    &mut self.static_segments,
+                );
+            }
+        }
+        self.static_segments_initialized = true;
+    }
+}
+
+/// Append state and motion overlays that are local to the retained shell bridge.
+pub(super) fn append_retained_shell_overlays(
+    shell_state: &mut NativeShellState,
+    layout: &ShellLayout,
+    style: &StyleTokens,
+    model: &runtime_contract::AppModel,
+    motion_model: &runtime_contract::NativeMotionModel,
+    frame: &mut PaintFrame,
+) {
+    let mut overlay = PaintFrame::default();
+    shell_state.build_waveform_motion_overlay_into(layout, style, motion_model, &mut overlay);
+    append_paint_frame(frame, &overlay);
+    shell_state.build_chrome_motion_overlay_into(layout, style, motion_model, &mut overlay);
+    append_paint_frame(frame, &overlay);
+    shell_state.build_hover_overlay_into(layout, style, model, &mut overlay);
+    append_paint_frame(frame, &overlay);
+    shell_state.build_focus_overlay_into(layout, style, model, &mut overlay);
+    append_paint_frame(frame, &overlay);
+    shell_state.build_modal_overlay_into(layout, style, model, &mut overlay);
+    append_paint_frame(frame, &overlay);
+}
+
+fn append_paint_frame(frame: &mut PaintFrame, overlay: &PaintFrame) {
+    frame.primitives.extend(overlay.primitives.iter().cloned());
+    frame.text_runs.extend(overlay.text_runs.iter().cloned());
+    frame.clear_color = overlay.clear_color;
+}

--- a/src/gui_runtime/native_shell_runtime/bridge/surface.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/surface.rs
@@ -1,0 +1,31 @@
+use super::WavecrateRuntimeMessage;
+use crate::{app_core::actions::NativeSegmentRevisions, gui::types::Vector2};
+use radiant::{
+    runtime::{SurfaceNode, UiSurface},
+    widgets::{CanvasMessage, RetainedSurfaceDescriptor, WidgetSizing},
+};
+use std::sync::Arc;
+
+/// Build the generic retained canvas surface that Radiant owns around Wavecrate rendering.
+pub(super) fn generic_shell_surface(
+    retained: RetainedSurfaceDescriptor,
+) -> Arc<UiSurface<WavecrateRuntimeMessage>> {
+    Arc::new(UiSurface::new(SurfaceNode::retained_canvas_mapped(
+        1,
+        WidgetSizing::fixed(Vector2::new(1280.0, 720.0)),
+        retained,
+        |message: CanvasMessage| match message {
+            CanvasMessage::Input { input } => WavecrateRuntimeMessage::RetainedInput(input),
+        },
+    )))
+}
+
+/// Collapse per-segment revisions into the retained canvas revision Radiant observes.
+pub(super) fn retained_surface_revision(revisions: NativeSegmentRevisions) -> u64 {
+    revisions.status_bar
+        ^ revisions.browser_frame.rotate_left(7)
+        ^ revisions.browser_rows_window.rotate_left(13)
+        ^ revisions.map_panel.rotate_left(19)
+        ^ revisions.waveform_overlay.rotate_left(29)
+        ^ revisions.global_static.rotate_left(37)
+}


### PR DESCRIPTION
## Summary
- move retained input dispatch out of the native runtime bridge root
- move retained render helpers and surface descriptor construction into focused bridge modules
- reduce bridge.rs from 493 lines to 268 lines while keeping the runtime bridge contract unchanged

## Validation
- cargo fmt
- cargo check -p wavecrate --tests --bins
- RUST_TEST_THREADS=1 powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent