### PR TITLE
Split browser hit testing helpers

### DIFF
--- a/src/app_core/native_shell/composition/state/hit_testing/browser.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser.rs
@@ -1,41 +1,23 @@
 use super::super::browser_pill_editor::browser_pill_editor_layout;
 use super::*;
-#[cfg(test)]
-use crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip;
-use crate::gui::list::{
-    VirtualListScrollbar, virtual_list_scrollbar_thumb_offset_at_point,
-    virtual_list_scrollbar_view_start_at_point,
-};
 
+#[path = "browser/actions.rs"]
+mod actions;
 #[path = "browser/cache_key.rs"]
 mod cache_key;
 #[path = "browser/pill_editor.rs"]
 mod pill_editor;
+#[path = "browser/scrollbar.rs"]
+mod scrollbar;
+#[cfg(test)]
+#[path = "browser/test_accessors.rs"]
+mod test_accessors;
 
 pub(in crate::app_core::native_shell::composition::state) use cache_key::{
     browser_action_hit_test_cache_key, browser_action_model_signature,
 };
-use pill_editor::browser_pill_editor_action_at_point;
-
-/// Additional hit slop for the narrow content-list scrollbar thumb.
-const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
 
 impl NativeShellState {
-    /// Return a browser column-chip rect for one column index in tests.
-    #[cfg(test)]
-    pub(crate) fn browser_column_chip_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        column: usize,
-    ) -> Option<Rect> {
-        self.cached_browser_interaction_geometry(layout, model)
-            .chips
-            .iter()
-            .find(|chip| chip.column == column)
-            .map(|chip| chip.rect)
-    }
-
     /// Resolve a rendered browser visible-row index for a point in the triage pane.
     pub(crate) fn browser_row_at_point(
         &mut self,
@@ -153,264 +135,6 @@ impl NativeShellState {
             .map(|row| row.visible_row)
     }
 
-    /// Return the pointer's offset within the browser scrollbar thumb when hovered.
-    pub(crate) fn browser_scrollbar_thumb_offset_at_point(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        point: Point,
-    ) -> Option<f32> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        let scrollbar = geometry.scrollbar?;
-        virtual_list_scrollbar_thumb_offset_at_point(
-            VirtualListScrollbar {
-                track: scrollbar.track,
-                thumb: scrollbar.thumb,
-            },
-            point,
-            BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
-        )
-    }
-
-    /// Resolve the browser viewport start row for an active scrollbar-thumb drag.
-    pub(crate) fn browser_scrollbar_view_start_for_drag(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        pointer_y: f32,
-        thumb_pointer_offset_y: f32,
-    ) -> Option<usize> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        let scrollbar = geometry.scrollbar?;
-        browser_scrollbar_view_start_for_pointer(
-            scrollbar,
-            geometry.scrollbar_viewport_len,
-            model.browser.visible_count,
-            pointer_y,
-            thumb_pointer_offset_y,
-        )
-    }
-
-    /// Resolve the browser viewport start for a click inside the scrollbar track.
-    ///
-    /// Track clicks jump the thumb so its center aligns with the clicked
-    /// location, matching the visual expectation that the handle should move to
-    /// the requested position immediately.
-    pub(crate) fn browser_scrollbar_view_start_at_point(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        point: Point,
-    ) -> Option<usize> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        let scrollbar = geometry.scrollbar?;
-        virtual_list_scrollbar_view_start_at_point(
-            VirtualListScrollbar {
-                track: scrollbar.track,
-                thumb: scrollbar.thumb,
-            },
-            geometry.scrollbar_viewport_len,
-            model.browser.visible_count,
-            point,
-        )
-    }
-
-    /// Resolve a browser action-strip click into a native UI action.
-    pub(crate) fn browser_action_at_point(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        point: Point,
-        alt_down: bool,
-    ) -> Option<UiAction> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        if let Some(action) = browser_pill_editor_action_at_point(
-            layout.browser_rows,
-            geometry.style.sizing,
-            model,
-            point,
-        ) {
-            return Some(action);
-        }
-        if let Some(level) =
-            browser_rating_filter_level_at_point(geometry.toolbar.rating_filter_chips, point)
-        {
-            return Some(UiAction::ToggleBrowserRatingFilter {
-                level,
-                invert: alt_down,
-            });
-        }
-        if let Some(bucket) = browser_playback_age_filter_chip_at_point(
-            geometry.toolbar.playback_age_filter_chips,
-            point,
-        ) {
-            return Some(UiAction::ToggleBrowserPlaybackAgeFilter {
-                bucket,
-                invert: alt_down,
-            });
-        }
-        if browser_marked_filter_chip_contains_point(geometry.toolbar.marked_filter_chip, point) {
-            return Some(UiAction::ToggleBrowserMarkedFilter);
-        }
-        if browser_marked_filter_chip_contains_point(
-            geometry.toolbar.derived_label_filter_chip,
-            point,
-        ) {
-            return Some(UiAction::ToggleBrowserDerivedLabelFilter { invert: alt_down });
-        }
-        if geometry.toolbar.search_field.width() > 1.0
-            && geometry.toolbar.search_field.contains(point)
-        {
-            return Some(UiAction::FocusBrowserSearch);
-        }
-        if let Some(action) = geometry
-            .chips
-            .iter()
-            .find(|chip| chip.rect.contains(point))
-            .map(|chip| UiAction::SelectColumn { index: chip.column })
-        {
-            return Some(action);
-        }
-        geometry
-            .buttons
-            .iter()
-            .find(|button| button.enabled && button.rect.contains(point))
-            .map(|button| button.action.clone())
-    }
-
-    /// Resolve a browser tab click into a list/map tab selection action.
-    pub(crate) fn browser_tab_action_at_point(
-        &self,
-        layout: &ShellLayout,
-        point: Point,
-    ) -> Option<UiAction> {
-        let tabs: BrowserTabsRects = {
-            let style = style_for_layout(layout);
-            let tabs = resolve_browser_tabs_surface_layout(
-                layout.browser_tabs,
-                style.sizing,
-                &BrowserTabsSurfaceContent {
-                    items_label: String::new(),
-                    map_label: String::new(),
-                },
-            );
-            BrowserTabsRects {
-                items: tabs.items,
-                map: tabs.map,
-            }
-        };
-        if tabs.items.contains(point) {
-            return Some(UiAction::SetBrowserTab { map: false });
-        }
-        if tabs.map.contains(point) {
-            return Some(UiAction::SetBrowserTab { map: true });
-        }
-        None
-    }
-
-    /// Return the browser-search field rect when the toolbar is available.
-    pub(crate) fn browser_search_field_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-    ) -> Option<Rect> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        (geometry.toolbar.search_field.width() > 1.0).then_some(geometry.toolbar.search_field)
-    }
-
-    /// Return one browser rating-filter chip rect for the given signed level.
-    #[cfg(test)]
-    pub(crate) fn browser_rating_filter_chip_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        level: i8,
-    ) -> Option<Rect> {
-        let toolbar = self
-            .cached_browser_interaction_geometry(layout, model)
-            .toolbar;
-        let index = browser_rating_filter_chip_index(level)?;
-        let rect = toolbar.rating_filter_chips[index];
-        (rect.width() > 1.0).then_some(rect)
-    }
-
-    /// Return the marked-filter chip rect when the toolbar is available.
-    #[cfg(test)]
-    pub(crate) fn browser_marked_filter_chip_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-    ) -> Option<Rect> {
-        let toolbar = self
-            .cached_browser_interaction_geometry(layout, model)
-            .toolbar;
-        (toolbar.marked_filter_chip.width() > 1.0).then_some(toolbar.marked_filter_chip)
-    }
-
-    /// Return the derived-label-filter chip rect when the toolbar is available.
-    #[cfg(test)]
-    pub(crate) fn browser_derived_label_filter_chip_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-    ) -> Option<Rect> {
-        let toolbar = self
-            .cached_browser_interaction_geometry(layout, model)
-            .toolbar;
-        (toolbar.derived_label_filter_chip.width() > 1.0)
-            .then_some(toolbar.derived_label_filter_chip)
-    }
-
-    /// Return one browser playback-age filter chip rect for the given chip.
-    #[cfg(test)]
-    pub(crate) fn browser_playback_age_filter_chip_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        chip: PlaybackAgeFilterChip,
-    ) -> Option<Rect> {
-        let toolbar = self
-            .cached_browser_interaction_geometry(layout, model)
-            .toolbar;
-        let index = browser_playback_age_filter_chip_index(chip)?;
-        let rect = toolbar.playback_age_filter_chips[index];
-        (rect.width() > 1.0).then_some(rect)
-    }
-
-    /// Return one browser action-button rect for the given label.
-    #[cfg(test)]
-    pub(crate) fn browser_action_button_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-        label: &str,
-    ) -> Option<Rect> {
-        self.cached_browser_interaction_geometry(layout, model)
-            .buttons
-            .iter()
-            .find(|button| button.label == label)
-            .map(|button| button.rect)
-    }
-
-    /// Return the browser-search text rect used for rendering inside the field.
-    pub(crate) fn browser_search_text_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-    ) -> Option<Rect> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        if geometry.toolbar.search_field.width() <= 1.0 {
-            return None;
-        }
-        let toolbar_text_layout = compute_browser_toolbar_text_layout(
-            geometry.toolbar.search_field,
-            geometry.toolbar.activity_chip,
-            geometry.toolbar.sort_chip,
-            geometry.style.sizing,
-        );
-        Some(toolbar_text_layout.search_label)
-    }
-
     /// Return the browser tag-sidebar input rect when the sidebar is visible.
     pub(crate) fn browser_pill_editor_input_rect(
         &mut self,
@@ -437,23 +161,6 @@ impl NativeShellState {
         browser_pill_editor_layout(layout.browser_rows, style.sizing, model)
             .map(|layout| layout.input_text_rect)
             .or_else(|| self.sidebar_pill_editor_text_rect(layout, model))
-    }
-
-    /// Return the focused-row similarity button rect when present.
-    #[cfg(test)]
-    pub(crate) fn browser_similarity_button_rect(
-        &mut self,
-        layout: &ShellLayout,
-        model: &AppModel,
-    ) -> Option<Rect> {
-        let geometry = self.cached_browser_interaction_geometry(layout, model);
-        geometry
-            .rows
-            .iter()
-            .find(|row| row.focused)
-            .and_then(|row| {
-                super::super::browser_similarity_button_rect(row.rect, geometry.style.sizing)
-            })
     }
 
     /// Resolve a map-point click to a focus action when map tab is active.

--- a/src/app_core/native_shell/composition/state/hit_testing/browser/actions.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser/actions.rs
@@ -1,0 +1,131 @@
+use super::pill_editor::browser_pill_editor_action_at_point;
+use super::*;
+
+impl NativeShellState {
+    /// Resolve a browser action-strip click into a native UI action.
+    pub(crate) fn browser_action_at_point(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        point: Point,
+        alt_down: bool,
+    ) -> Option<UiAction> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        if let Some(action) = browser_pill_editor_action_at_point(
+            layout.browser_rows,
+            geometry.style.sizing,
+            model,
+            point,
+        ) {
+            return Some(action);
+        }
+        if let Some(action) = browser_toolbar_action_at_point(&geometry.toolbar, point, alt_down) {
+            return Some(action);
+        }
+        if let Some(action) = browser_column_action_at_point(geometry.chips, point) {
+            return Some(action);
+        }
+        geometry
+            .buttons
+            .iter()
+            .find(|button| button.enabled && button.rect.contains(point))
+            .map(|button| button.action.clone())
+    }
+
+    /// Resolve a browser tab click into a list/map tab selection action.
+    pub(crate) fn browser_tab_action_at_point(
+        &self,
+        layout: &ShellLayout,
+        point: Point,
+    ) -> Option<UiAction> {
+        let tabs = browser_tabs_rects(layout);
+        if tabs.items.contains(point) {
+            return Some(UiAction::SetBrowserTab { map: false });
+        }
+        if tabs.map.contains(point) {
+            return Some(UiAction::SetBrowserTab { map: true });
+        }
+        None
+    }
+
+    /// Return the browser-search field rect when the toolbar is available.
+    pub(crate) fn browser_search_field_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+    ) -> Option<Rect> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        (geometry.toolbar.search_field.width() > 1.0).then_some(geometry.toolbar.search_field)
+    }
+
+    /// Return the browser-search text rect used for rendering inside the field.
+    pub(crate) fn browser_search_text_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+    ) -> Option<Rect> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        if geometry.toolbar.search_field.width() <= 1.0 {
+            return None;
+        }
+        let toolbar_text_layout = compute_browser_toolbar_text_layout(
+            geometry.toolbar.search_field,
+            geometry.toolbar.activity_chip,
+            geometry.toolbar.sort_chip,
+            geometry.style.sizing,
+        );
+        Some(toolbar_text_layout.search_label)
+    }
+}
+
+fn browser_toolbar_action_at_point(
+    toolbar: &BrowserToolbarLayout,
+    point: Point,
+    alt_down: bool,
+) -> Option<UiAction> {
+    if let Some(level) = browser_rating_filter_level_at_point(toolbar.rating_filter_chips, point) {
+        return Some(UiAction::ToggleBrowserRatingFilter {
+            level,
+            invert: alt_down,
+        });
+    }
+    if let Some(bucket) =
+        browser_playback_age_filter_chip_at_point(toolbar.playback_age_filter_chips, point)
+    {
+        return Some(UiAction::ToggleBrowserPlaybackAgeFilter {
+            bucket,
+            invert: alt_down,
+        });
+    }
+    if browser_marked_filter_chip_contains_point(toolbar.marked_filter_chip, point) {
+        return Some(UiAction::ToggleBrowserMarkedFilter);
+    }
+    if browser_marked_filter_chip_contains_point(toolbar.derived_label_filter_chip, point) {
+        return Some(UiAction::ToggleBrowserDerivedLabelFilter { invert: alt_down });
+    }
+    (toolbar.search_field.width() > 1.0 && toolbar.search_field.contains(point))
+        .then_some(UiAction::FocusBrowserSearch)
+}
+
+fn browser_column_action_at_point(chips: &[BrowserColumnChip], point: Point) -> Option<UiAction> {
+    chips
+        .iter()
+        .find(|chip| chip.rect.contains(point))
+        .map(|chip| UiAction::SelectColumn { index: chip.column })
+}
+
+fn browser_tabs_rects(layout: &ShellLayout) -> BrowserTabsRects {
+    let style = style_for_layout(layout);
+    let tabs = resolve_browser_tabs_surface_layout(
+        layout.browser_tabs,
+        style.sizing,
+        &BrowserTabsSurfaceContent {
+            items_label: String::new(),
+            map_label: String::new(),
+        },
+    );
+    BrowserTabsRects {
+        items: tabs.items,
+        map: tabs.map,
+    }
+}

--- a/src/app_core/native_shell/composition/state/hit_testing/browser/scrollbar.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser/scrollbar.rs
@@ -1,0 +1,72 @@
+use super::*;
+use crate::gui::list::{
+    VirtualListScrollbar, virtual_list_scrollbar_thumb_offset_at_point,
+    virtual_list_scrollbar_view_start_at_point,
+};
+
+/// Additional hit slop for the narrow content-list scrollbar thumb.
+const BROWSER_SCROLLBAR_THUMB_HIT_SLOP: f32 = 3.0;
+
+impl NativeShellState {
+    /// Return the pointer's offset within the browser scrollbar thumb when hovered.
+    pub(crate) fn browser_scrollbar_thumb_offset_at_point(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        point: Point,
+    ) -> Option<f32> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        let scrollbar = geometry.scrollbar?;
+        virtual_list_scrollbar_thumb_offset_at_point(
+            VirtualListScrollbar {
+                track: scrollbar.track,
+                thumb: scrollbar.thumb,
+            },
+            point,
+            BROWSER_SCROLLBAR_THUMB_HIT_SLOP,
+        )
+    }
+
+    /// Resolve the browser viewport start row for an active scrollbar-thumb drag.
+    pub(crate) fn browser_scrollbar_view_start_for_drag(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        pointer_y: f32,
+        thumb_pointer_offset_y: f32,
+    ) -> Option<usize> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        let scrollbar = geometry.scrollbar?;
+        browser_scrollbar_view_start_for_pointer(
+            scrollbar,
+            geometry.scrollbar_viewport_len,
+            model.browser.visible_count,
+            pointer_y,
+            thumb_pointer_offset_y,
+        )
+    }
+
+    /// Resolve the browser viewport start for a click inside the scrollbar track.
+    ///
+    /// Track clicks jump the thumb so its center aligns with the clicked
+    /// location, matching the visual expectation that the handle should move to
+    /// the requested position immediately.
+    pub(crate) fn browser_scrollbar_view_start_at_point(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        point: Point,
+    ) -> Option<usize> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        let scrollbar = geometry.scrollbar?;
+        virtual_list_scrollbar_view_start_at_point(
+            VirtualListScrollbar {
+                track: scrollbar.track,
+                thumb: scrollbar.thumb,
+            },
+            geometry.scrollbar_viewport_len,
+            model.browser.visible_count,
+            point,
+        )
+    }
+}

--- a/src/app_core/native_shell/composition/state/hit_testing/browser/test_accessors.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/browser/test_accessors.rs
@@ -1,0 +1,103 @@
+use super::*;
+use crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip;
+
+impl NativeShellState {
+    /// Return a browser column-chip rect for one column index in tests.
+    pub(crate) fn browser_column_chip_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        column: usize,
+    ) -> Option<Rect> {
+        self.cached_browser_interaction_geometry(layout, model)
+            .chips
+            .iter()
+            .find(|chip| chip.column == column)
+            .map(|chip| chip.rect)
+    }
+
+    /// Return one browser rating-filter chip rect for the given signed level.
+    pub(crate) fn browser_rating_filter_chip_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        level: i8,
+    ) -> Option<Rect> {
+        let toolbar = self
+            .cached_browser_interaction_geometry(layout, model)
+            .toolbar;
+        let index = browser_rating_filter_chip_index(level)?;
+        let rect = toolbar.rating_filter_chips[index];
+        (rect.width() > 1.0).then_some(rect)
+    }
+
+    /// Return the marked-filter chip rect when the toolbar is available.
+    pub(crate) fn browser_marked_filter_chip_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+    ) -> Option<Rect> {
+        let toolbar = self
+            .cached_browser_interaction_geometry(layout, model)
+            .toolbar;
+        (toolbar.marked_filter_chip.width() > 1.0).then_some(toolbar.marked_filter_chip)
+    }
+
+    /// Return the derived-label-filter chip rect when the toolbar is available.
+    pub(crate) fn browser_derived_label_filter_chip_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+    ) -> Option<Rect> {
+        let toolbar = self
+            .cached_browser_interaction_geometry(layout, model)
+            .toolbar;
+        (toolbar.derived_label_filter_chip.width() > 1.0)
+            .then_some(toolbar.derived_label_filter_chip)
+    }
+
+    /// Return one browser playback-age filter chip rect for the given chip.
+    pub(crate) fn browser_playback_age_filter_chip_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        chip: PlaybackAgeFilterChip,
+    ) -> Option<Rect> {
+        let toolbar = self
+            .cached_browser_interaction_geometry(layout, model)
+            .toolbar;
+        let index = browser_playback_age_filter_chip_index(chip)?;
+        let rect = toolbar.playback_age_filter_chips[index];
+        (rect.width() > 1.0).then_some(rect)
+    }
+
+    /// Return one browser action-button rect for the given label.
+    pub(crate) fn browser_action_button_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+        label: &str,
+    ) -> Option<Rect> {
+        self.cached_browser_interaction_geometry(layout, model)
+            .buttons
+            .iter()
+            .find(|button| button.label == label)
+            .map(|button| button.rect)
+    }
+
+    /// Return the focused-row similarity button rect when present.
+    pub(crate) fn browser_similarity_button_rect(
+        &mut self,
+        layout: &ShellLayout,
+        model: &AppModel,
+    ) -> Option<Rect> {
+        let geometry = self.cached_browser_interaction_geometry(layout, model);
+        geometry
+            .rows
+            .iter()
+            .find(|row| row.focused)
+            .and_then(|row| {
+                super::super::super::browser_similarity_button_rect(row.rect, geometry.style.sizing)
+            })
+    }
+}


### PR DESCRIPTION
## Summary
- Split browser toolbar action hit-testing into a focused child module
- Moved browser scrollbar hit-testing/drag resolution into its own helper module
- Moved browser geometry test accessors behind a test-only child module

## Validation
- cargo fmt; cargo check -p wavecrate --tests --bins
- $env:RUST_TEST_THREADS='1'; powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent
  - Passed: 1932 regular tests and 3 required ignored selection-export tests

## Cycle Alignment Estimate
- 96/100 after this cycle: browser hit-testing is now under the preferred file-size target and separates production action routing, scrollbar math, and test-only accessors. Remaining debt is concentrated in the intentional central action DTO surfaces and several 400+ line controller/runtime implementation files.