### PR TITLE
Split browser row window projection

### DIFF
--- a/src/app_core/native_shell/browser_projection/row_window.rs
+++ b/src/app_core/native_shell/browser_projection/row_window.rs
@@ -1,17 +1,17 @@
 use super::*;
 use crate::app_core::actions::NativeBrowserRowProcessingState as BrowserRowProcessingState;
-use crate::app_core::app_api::state::BrowserDuplicateCleanupState;
 use crate::app_core::controller::AutoRenameBatchRowState;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Number of rows kept between the focused row and the window edge before scrolling.
-///
-/// A margin of `3` means the browser starts scrolling once focus reaches the
-/// third visible row from the top or bottom, so edge-near selection keeps more
-/// look-ahead room during keyboard or pointer navigation.
-const BROWSER_RENDER_EDGE_MARGIN_ROWS: usize = 3;
+mod labels;
+mod row_model;
+mod windowing;
+
+pub(super) use labels::browser_bucket_label;
+use labels::browser_duplicate_cleanup_bucket_label;
+use row_model::{BrowserRowFlags, BrowserRowProjection, write_browser_row_into_slot};
+pub(crate) use windowing::browser_render_window;
 
 /// Project browser row content for the current visible window.
 ///
@@ -92,21 +92,23 @@ pub(crate) fn project_browser_rows_model_into(
             write_browser_row_into_slot(
                 rows,
                 offset,
-                (
+                BrowserRowProjection {
                     visible_row,
-                    &format!("row {}", visible_row + 1),
-                    1,
-                    0,
-                    PlaybackAgeBucket::Fresh,
-                    "",
-                    false,
-                    focused,
-                    false,
-                    false,
-                    false,
-                    BrowserRowProcessingState::None,
-                    None,
-                ),
+                    row_label: &format!("row {}", visible_row + 1),
+                    column_index: 1,
+                    rating_level: 0,
+                    playback_age_bucket: PlaybackAgeBucket::Fresh,
+                    bucket_label: "",
+                    flags: BrowserRowFlags {
+                        selected: false,
+                        focused,
+                        missing: false,
+                        locked: false,
+                        marked: false,
+                    },
+                    processing_state: BrowserRowProcessingState::None,
+                    similarity_display_strength: None,
+                },
             );
             continue;
         };
@@ -127,21 +129,23 @@ pub(crate) fn project_browser_rows_model_into(
         write_browser_row_into_slot(
             rows,
             offset,
-            (
+            BrowserRowProjection {
                 visible_row,
-                &cached_row.row_label,
-                cached_row.column_index,
-                cached_row.rating_level,
-                cached_row.playback_age_bucket,
-                &bucket_label,
-                selected,
-                focused,
-                cached_row.missing,
-                cached_row.locked,
-                cached_row.marked,
+                row_label: &cached_row.row_label,
+                column_index: cached_row.column_index,
+                rating_level: cached_row.rating_level,
+                playback_age_bucket: cached_row.playback_age_bucket,
+                bucket_label: &bucket_label,
+                flags: BrowserRowFlags {
+                    selected,
+                    focused,
+                    missing: cached_row.missing,
+                    locked: cached_row.locked,
+                    marked: cached_row.marked,
+                },
                 processing_state,
                 similarity_display_strength,
-            ),
+            },
         );
     }
     rows.truncate(window_len);
@@ -186,67 +190,11 @@ pub(crate) fn browser_column_index(tag: crate::sample_sources::Rating) -> usize 
     }
 }
 
-/// Resolve one inline browser metadata label for the sample lane.
-///
-/// Rating text is intentionally omitted because the row already renders keep/trash
-/// state via the right-edge indicator rectangles.
-pub(super) fn browser_bucket_label(
-    bpm_value: Option<f32>,
-    looped: bool,
-    long_sample_mark: bool,
-) -> String {
-    let mut tags = Vec::new();
-    if let Some(bpm) = bpm_value {
-        tags.push(format_bpm_badge_label(bpm));
-    }
-    if looped {
-        tags.push(String::from("LOOP"));
-    }
-    if long_sample_mark {
-        tags.push(String::from("LONG"));
-    }
-    tags.join(" · ")
-}
-
 /// Clear retained browser-row projection fields.
 pub(super) fn clear_projected_browser_row_cache(controller: &mut AppController) {
     controller.projected_browser_rows.clear();
     controller.projected_browser_row_cache_clock = 0;
     controller.projected_browser_preload_window = None;
-}
-
-/// Format one BPM metadata label for inline browser-row display.
-fn format_bpm_badge_label(bpm: f32) -> String {
-    if !bpm.is_finite() || bpm <= 0.0 {
-        return String::new();
-    }
-    let rounded = bpm.round();
-    if (bpm - rounded).abs() < 0.05 {
-        format!("{rounded:.0} BPM")
-    } else {
-        format!("{bpm:.1} BPM")
-    }
-}
-
-/// Append transient duplicate-cleanup badges to one browser-row metadata label.
-fn browser_duplicate_cleanup_bucket_label(
-    duplicate_cleanup: Option<&BrowserDuplicateCleanupState>,
-    absolute_index: usize,
-    base_label: &str,
-) -> String {
-    let Some(cleanup) = duplicate_cleanup else {
-        return base_label.to_owned();
-    };
-    let mut tags = Vec::new();
-    if !base_label.is_empty() {
-        tags.push(base_label.to_owned());
-    }
-    if cleanup.is_anchor(absolute_index) {
-        tags.push(String::from("ANCHOR"));
-    } else if cleanup.is_kept(absolute_index) {
-        tags.push(String::from("KEEP"));
-    }
-    tags.join(" · ")
 }
 
 fn browser_auto_rename_processing_states(
@@ -270,161 +218,4 @@ fn browser_auto_rename_processing_states(
         states.insert(row.current_path, processing_state);
     }
     Some(states)
-}
-
-/// Convert one app-core playback-age bucket into the native radiant contract enum.
-fn native_playback_age_bucket(
-    bucket: PlaybackAgeBucket,
-) -> crate::app_core::actions::NativePlaybackAgeBucket {
-    match bucket {
-        PlaybackAgeBucket::Fresh => crate::app_core::actions::NativePlaybackAgeBucket::Fresh,
-        PlaybackAgeBucket::OlderThanWeek => {
-            crate::app_core::actions::NativePlaybackAgeBucket::OlderThanWeek
-        }
-        PlaybackAgeBucket::OlderThanMonth => {
-            crate::app_core::actions::NativePlaybackAgeBucket::OlderThanMonth
-        }
-        PlaybackAgeBucket::NeverPlayed => {
-            crate::app_core::actions::NativePlaybackAgeBucket::NeverPlayed
-        }
-    }
-}
-
-/// Write one browser row into `rows[offset]`, reusing existing `String` buffers.
-fn write_browser_row_into_slot(
-    rows: &mut RetainedVec<BrowserRowModel>,
-    offset: usize,
-    projection: (
-        usize,
-        &str,
-        usize,
-        i8,
-        PlaybackAgeBucket,
-        &str,
-        bool,
-        bool,
-        bool,
-        bool,
-        bool,
-        BrowserRowProcessingState,
-        Option<u8>,
-    ),
-) {
-    let rows = rows.make_mut();
-    let (
-        visible_row,
-        row_label,
-        column_index,
-        rating_level,
-        playback_age_bucket,
-        bucket_label,
-        selected,
-        focused,
-        missing,
-        locked,
-        marked,
-        processing_state,
-        similarity_display_strength,
-    ) = projection;
-    let bucket_label = (!bucket_label.is_empty()).then_some(bucket_label);
-    let clamped_column_index = column_index.min(2);
-    let native_playback_age_bucket = native_playback_age_bucket(playback_age_bucket);
-    if let Some(row) = rows.get_mut(offset) {
-        if row.visible_row == visible_row && row.column == clamped_column_index {
-            row.selected = selected;
-            row.focused = focused;
-            row.missing = missing;
-            row.locked = locked;
-            row.marked = marked;
-            row.processing_state = processing_state;
-            row.similarity_display_strength = similarity_display_strength;
-            row.rating_level = rating_level.clamp(-3, 3);
-            row.playback_age_bucket = native_playback_age_bucket;
-            if row.label.as_ref() == row_label && row.bucket_label.as_deref() == bucket_label {
-                return;
-            }
-        }
-        row.visible_row = visible_row;
-        if row.label.as_ref() != row_label {
-            row.label = Arc::<str>::from(row_label);
-        }
-        row.column = clamped_column_index;
-        row.rating_level = rating_level.clamp(-3, 3);
-        row.playback_age_bucket = native_playback_age_bucket;
-        row.selected = selected;
-        row.focused = focused;
-        row.missing = missing;
-        row.locked = locked;
-        row.marked = marked;
-        row.processing_state = processing_state;
-        row.similarity_display_strength = similarity_display_strength;
-        if let Some(bucket_label) = bucket_label {
-            let next_bucket_label = Arc::<str>::from(bucket_label);
-            if row.bucket_label.as_deref() != Some(next_bucket_label.as_ref()) {
-                row.bucket_label = Some(next_bucket_label);
-            }
-        } else {
-            row.bucket_label = None;
-        }
-        return;
-    }
-    let mut row = BrowserRowModel::new(visible_row, row_label, column_index, selected, focused)
-        .with_rating_level(rating_level)
-        .with_playback_age_bucket(native_playback_age_bucket)
-        .with_missing(missing)
-        .with_locked(locked)
-        .with_marked(marked)
-        .with_processing_state(processing_state);
-    if let Some(similarity_display_strength) = similarity_display_strength {
-        row.similarity_display_strength = Some(similarity_display_strength);
-    }
-    if let Some(bucket_label) = bucket_label {
-        row = row.with_bucket_label(bucket_label);
-    }
-    rows.push(row);
-}
-
-pub(crate) fn browser_render_window(
-    visible_count: usize,
-    selected_visible_row: Option<usize>,
-    anchor_visible_row: Option<usize>,
-    autoscroll: bool,
-    current_window_start: usize,
-) -> (usize, usize) {
-    if visible_count == 0 {
-        return (0, 0);
-    }
-    let window_len = visible_count.min(MAX_RENDERED_BROWSER_ROWS);
-    if window_len == visible_count {
-        return if autoscroll {
-            (0, window_len)
-        } else {
-            (current_window_start.min(visible_count - 1), window_len)
-        };
-    }
-    if !autoscroll {
-        return (
-            current_window_start.min(visible_count - window_len),
-            window_len,
-        );
-    }
-    let pivot = selected_visible_row
-        .or(anchor_visible_row)
-        .unwrap_or(0)
-        .min(visible_count - 1);
-    let max_start = visible_count - window_len;
-    let edge_margin = BROWSER_RENDER_EDGE_MARGIN_ROWS.min(window_len.saturating_sub(1) / 2);
-    let mut window_start = current_window_start.min(max_start);
-    let window_end = window_start + window_len;
-    let top_guard = window_start + edge_margin;
-    let bottom_guard = window_end.saturating_sub(edge_margin);
-    if pivot < top_guard {
-        window_start = pivot.saturating_sub(edge_margin);
-    } else if pivot >= bottom_guard {
-        window_start = pivot
-            .saturating_add(edge_margin + 1)
-            .saturating_sub(window_len);
-    }
-    window_start = window_start.min(max_start);
-    (window_start, window_len)
 }

--- a/src/app_core/native_shell/browser_projection/row_window/labels.rs
+++ b/src/app_core/native_shell/browser_projection/row_window/labels.rs
@@ -1,0 +1,57 @@
+use crate::app_core::app_api::state::BrowserDuplicateCleanupState;
+
+/// Resolve one inline browser metadata label for the sample lane.
+///
+/// Rating text is intentionally omitted because the row already renders keep/trash
+/// state via the right-edge indicator rectangles.
+pub(in crate::app_core::native_shell::browser_projection) fn browser_bucket_label(
+    bpm_value: Option<f32>,
+    looped: bool,
+    long_sample_mark: bool,
+) -> String {
+    let mut tags = Vec::new();
+    if let Some(bpm) = bpm_value {
+        tags.push(format_bpm_badge_label(bpm));
+    }
+    if looped {
+        tags.push(String::from("LOOP"));
+    }
+    if long_sample_mark {
+        tags.push(String::from("LONG"));
+    }
+    tags.join(" · ")
+}
+
+/// Append transient duplicate-cleanup badges to one browser-row metadata label.
+pub(super) fn browser_duplicate_cleanup_bucket_label(
+    duplicate_cleanup: Option<&BrowserDuplicateCleanupState>,
+    absolute_index: usize,
+    base_label: &str,
+) -> String {
+    let Some(cleanup) = duplicate_cleanup else {
+        return base_label.to_owned();
+    };
+    let mut tags = Vec::new();
+    if !base_label.is_empty() {
+        tags.push(base_label.to_owned());
+    }
+    if cleanup.is_anchor(absolute_index) {
+        tags.push(String::from("ANCHOR"));
+    } else if cleanup.is_kept(absolute_index) {
+        tags.push(String::from("KEEP"));
+    }
+    tags.join(" · ")
+}
+
+/// Format one BPM metadata label for inline browser-row display.
+fn format_bpm_badge_label(bpm: f32) -> String {
+    if !bpm.is_finite() || bpm <= 0.0 {
+        return String::new();
+    }
+    let rounded = bpm.round();
+    if (bpm - rounded).abs() < 0.05 {
+        format!("{rounded:.0} BPM")
+    } else {
+        format!("{bpm:.1} BPM")
+    }
+}

--- a/src/app_core/native_shell/browser_projection/row_window/row_model.rs
+++ b/src/app_core/native_shell/browser_projection/row_window/row_model.rs
@@ -1,0 +1,146 @@
+use super::*;
+use crate::app_core::actions::NativeBrowserRowProcessingState as BrowserRowProcessingState;
+use std::sync::Arc;
+
+pub(super) struct BrowserRowProjection<'a> {
+    pub(super) visible_row: usize,
+    pub(super) row_label: &'a str,
+    pub(super) column_index: usize,
+    pub(super) rating_level: i8,
+    pub(super) playback_age_bucket: PlaybackAgeBucket,
+    pub(super) bucket_label: &'a str,
+    pub(super) flags: BrowserRowFlags,
+    pub(super) processing_state: BrowserRowProcessingState,
+    pub(super) similarity_display_strength: Option<u8>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct BrowserRowFlags {
+    pub(super) selected: bool,
+    pub(super) focused: bool,
+    pub(super) missing: bool,
+    pub(super) locked: bool,
+    pub(super) marked: bool,
+}
+
+/// Write one browser row into `rows[offset]`, reusing existing `String` buffers.
+pub(super) fn write_browser_row_into_slot(
+    rows: &mut RetainedVec<BrowserRowModel>,
+    offset: usize,
+    projection: BrowserRowProjection<'_>,
+) {
+    let rows = rows.make_mut();
+    let bucket_label = (!projection.bucket_label.is_empty()).then_some(projection.bucket_label);
+    let native_playback_age_bucket = native_playback_age_bucket(projection.playback_age_bucket);
+    if let Some(row) = rows.get_mut(offset) {
+        if update_existing_row(row, &projection, bucket_label, native_playback_age_bucket) {
+            return;
+        }
+        return rewrite_existing_row(row, &projection, bucket_label, native_playback_age_bucket);
+    }
+    rows.push(new_browser_row(
+        &projection,
+        bucket_label,
+        native_playback_age_bucket,
+    ));
+}
+
+fn update_existing_row(
+    row: &mut BrowserRowModel,
+    projection: &BrowserRowProjection<'_>,
+    bucket_label: Option<&str>,
+    native_playback_age_bucket: crate::app_core::actions::NativePlaybackAgeBucket,
+) -> bool {
+    if row.visible_row != projection.visible_row || row.column != projection.column_index.min(2) {
+        return false;
+    }
+    row.selected = projection.flags.selected;
+    row.focused = projection.flags.focused;
+    row.missing = projection.flags.missing;
+    row.locked = projection.flags.locked;
+    row.marked = projection.flags.marked;
+    row.processing_state = projection.processing_state;
+    row.similarity_display_strength = projection.similarity_display_strength;
+    row.rating_level = projection.rating_level.clamp(-3, 3);
+    row.playback_age_bucket = native_playback_age_bucket;
+    row.label.as_ref() == projection.row_label && row.bucket_label.as_deref() == bucket_label
+}
+
+fn rewrite_existing_row(
+    row: &mut BrowserRowModel,
+    projection: &BrowserRowProjection<'_>,
+    bucket_label: Option<&str>,
+    native_playback_age_bucket: crate::app_core::actions::NativePlaybackAgeBucket,
+) {
+    row.visible_row = projection.visible_row;
+    if row.label.as_ref() != projection.row_label {
+        row.label = Arc::<str>::from(projection.row_label);
+    }
+    row.column = projection.column_index.min(2);
+    row.rating_level = projection.rating_level.clamp(-3, 3);
+    row.playback_age_bucket = native_playback_age_bucket;
+    row.selected = projection.flags.selected;
+    row.focused = projection.flags.focused;
+    row.missing = projection.flags.missing;
+    row.locked = projection.flags.locked;
+    row.marked = projection.flags.marked;
+    row.processing_state = projection.processing_state;
+    row.similarity_display_strength = projection.similarity_display_strength;
+    set_bucket_label(row, bucket_label);
+}
+
+fn new_browser_row(
+    projection: &BrowserRowProjection<'_>,
+    bucket_label: Option<&str>,
+    native_playback_age_bucket: crate::app_core::actions::NativePlaybackAgeBucket,
+) -> BrowserRowModel {
+    let mut row = BrowserRowModel::new(
+        projection.visible_row,
+        projection.row_label,
+        projection.column_index,
+        projection.flags.selected,
+        projection.flags.focused,
+    )
+    .with_rating_level(projection.rating_level)
+    .with_playback_age_bucket(native_playback_age_bucket)
+    .with_missing(projection.flags.missing)
+    .with_locked(projection.flags.locked)
+    .with_marked(projection.flags.marked)
+    .with_processing_state(projection.processing_state);
+    if let Some(similarity_display_strength) = projection.similarity_display_strength {
+        row.similarity_display_strength = Some(similarity_display_strength);
+    }
+    if let Some(bucket_label) = bucket_label {
+        row = row.with_bucket_label(bucket_label);
+    }
+    row
+}
+
+fn set_bucket_label(row: &mut BrowserRowModel, bucket_label: Option<&str>) {
+    if let Some(bucket_label) = bucket_label {
+        let next_bucket_label = Arc::<str>::from(bucket_label);
+        if row.bucket_label.as_deref() != Some(next_bucket_label.as_ref()) {
+            row.bucket_label = Some(next_bucket_label);
+        }
+    } else {
+        row.bucket_label = None;
+    }
+}
+
+/// Convert one app-core playback-age bucket into the native radiant contract enum.
+fn native_playback_age_bucket(
+    bucket: PlaybackAgeBucket,
+) -> crate::app_core::actions::NativePlaybackAgeBucket {
+    match bucket {
+        PlaybackAgeBucket::Fresh => crate::app_core::actions::NativePlaybackAgeBucket::Fresh,
+        PlaybackAgeBucket::OlderThanWeek => {
+            crate::app_core::actions::NativePlaybackAgeBucket::OlderThanWeek
+        }
+        PlaybackAgeBucket::OlderThanMonth => {
+            crate::app_core::actions::NativePlaybackAgeBucket::OlderThanMonth
+        }
+        PlaybackAgeBucket::NeverPlayed => {
+            crate::app_core::actions::NativePlaybackAgeBucket::NeverPlayed
+        }
+    }
+}

--- a/src/app_core/native_shell/browser_projection/row_window/windowing.rs
+++ b/src/app_core/native_shell/browser_projection/row_window/windowing.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+/// Number of rows kept between the focused row and the window edge before scrolling.
+///
+/// A margin of `3` means the browser starts scrolling once focus reaches the
+/// third visible row from the top or bottom, so edge-near selection keeps more
+/// look-ahead room during keyboard or pointer navigation.
+const BROWSER_RENDER_EDGE_MARGIN_ROWS: usize = 3;
+
+pub(crate) fn browser_render_window(
+    visible_count: usize,
+    selected_visible_row: Option<usize>,
+    anchor_visible_row: Option<usize>,
+    autoscroll: bool,
+    current_window_start: usize,
+) -> (usize, usize) {
+    if visible_count == 0 {
+        return (0, 0);
+    }
+    let window_len = visible_count.min(MAX_RENDERED_BROWSER_ROWS);
+    if window_len == visible_count {
+        return if autoscroll {
+            (0, window_len)
+        } else {
+            (current_window_start.min(visible_count - 1), window_len)
+        };
+    }
+    if !autoscroll {
+        return (
+            current_window_start.min(visible_count - window_len),
+            window_len,
+        );
+    }
+    let pivot = selected_visible_row
+        .or(anchor_visible_row)
+        .unwrap_or(0)
+        .min(visible_count - 1);
+    let max_start = visible_count - window_len;
+    let edge_margin = BROWSER_RENDER_EDGE_MARGIN_ROWS.min(window_len.saturating_sub(1) / 2);
+    let mut window_start = current_window_start.min(max_start);
+    let window_end = window_start + window_len;
+    let top_guard = window_start + edge_margin;
+    let bottom_guard = window_end.saturating_sub(edge_margin);
+    if pivot < top_guard {
+        window_start = pivot.saturating_sub(edge_margin);
+    } else if pivot >= bottom_guard {
+        window_start = pivot
+            .saturating_add(edge_margin + 1)
+            .saturating_sub(window_len);
+    }
+    window_start = window_start.min(max_start);
+    (window_start, window_len)
+}


### PR DESCRIPTION
## Summary
- Split browser row-window projection helpers into focused label, row-model, and windowing modules.
- Kept the public browser projection API stable while reducing the root row-window module below the target size.
- Replaced the opaque browser-row projection tuple with named projection and flag structs.

## Validation
- cargo test -p wavecrate --lib browser_render_window
- cargo test -p wavecrate --lib browser_cache
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent