### PR TITLE
Split source DB maintenance job

### DIFF
--- a/src/app/controller/jobs/source_db_maintenance.rs
+++ b/src/app/controller/jobs/source_db_maintenance.rs
@@ -1,11 +1,16 @@
-use super::retry_policy::{
-    DEFERRED_MAINTENANCE_MAX_ATTEMPTS, DEFERRED_MAINTENANCE_RETRY_DELAY,
-    DEFERRED_MAINTENANCE_SCHEMA_TOKEN,
-};
+use super::retry_policy::{DEFERRED_MAINTENANCE_MAX_ATTEMPTS, DEFERRED_MAINTENANCE_RETRY_DELAY};
 use super::{SourceDbMaintenanceJob, SourceDbMaintenanceOutcome, SourceDbMaintenanceRefresh};
 use crate::app::controller::library::analysis_jobs;
 use crate::sample_sources::db::file_ops_journal;
 use crate::sample_sources::scanner::{scan_once, schedule_deep_hash_scan};
+
+mod markers;
+mod refresh;
+mod retry;
+
+use markers::{deferred_maintenance_is_up_to_date, update_deferred_maintenance_markers};
+use refresh::{maintenance_refresh, scan_changed_source};
+use retry::{deferred_for_file_op, record_deferred_maintenance_retry, source_file_op_active};
 
 /// Run one deferred source-db maintenance job with fixed-delay retries.
 pub(super) fn run_source_db_maintenance_job(
@@ -190,39 +195,6 @@ pub(super) fn run_source_db_maintenance_job(
     }
 }
 
-fn source_file_op_active(job: &SourceDbMaintenanceJob) -> bool {
-    crate::app::controller::library::source_write_priority::file_op_write_priority_active(
-        &job.source_id,
-    )
-}
-
-fn deferred_for_file_op(job: SourceDbMaintenanceJob) -> SourceDbMaintenanceOutcome {
-    SourceDbMaintenanceOutcome {
-        source_id: job.source_id,
-        source_root: job.source_root,
-        skipped: false,
-        deferred_due_to_file_op: true,
-        orphan_rows_removed: 0,
-        refresh: SourceDbMaintenanceRefresh::None,
-        error: None,
-    }
-}
-
-fn maintenance_refresh(
-    reconcile_summary: &file_ops_journal::FileOpReconcileSummary,
-    empty_source_rescanned: bool,
-) -> SourceDbMaintenanceRefresh {
-    SourceDbMaintenanceRefresh::from_parts(reconcile_summary.completed > 0, empty_source_rescanned)
-}
-
-fn scan_changed_source(stats: &crate::sample_sources::scanner::ScanStats) -> bool {
-    stats.added > 0
-        || stats.updated > 0
-        || stats.missing > 0
-        || stats.content_changed > 0
-        || stats.renames_reconciled > 0
-}
-
 /// Run a single deferred source-db maintenance attempt without retries.
 fn run_source_db_maintenance_once(
     job: &SourceDbMaintenanceJob,
@@ -242,174 +214,5 @@ fn run_source_db_maintenance_once(
     Ok(removed)
 }
 
-/// Records deferred source DB maintenance retry telemetry.
-fn record_deferred_maintenance_retry(job: &SourceDbMaintenanceJob, attempt: usize, err: &str) {
-    analysis_jobs::db::telemetry::record_retry(
-        "analysis_deferred_maintenance",
-        &job.source_root,
-        attempt,
-        DEFERRED_MAINTENANCE_MAX_ATTEMPTS,
-        DEFERRED_MAINTENANCE_RETRY_DELAY,
-        err,
-    );
-}
-
-/// Return whether deferred source-db maintenance markers match the current revision/schema.
-fn deferred_maintenance_is_up_to_date(
-    db: &crate::sample_sources::SourceDatabase,
-    revision: u64,
-) -> Result<bool, String> {
-    let revision_marker = db
-        .get_metadata(crate::sample_sources::db::META_DEFERRED_MAINTENANCE_REVISION)
-        .map_err(|err| format!("Read deferred maintenance revision failed: {err}"))?;
-    let schema_marker = db
-        .get_metadata(crate::sample_sources::db::META_DEFERRED_MAINTENANCE_SCHEMA)
-        .map_err(|err| format!("Read deferred maintenance schema marker failed: {err}"))?;
-    let revision_string = revision.to_string();
-    let schema_string = DEFERRED_MAINTENANCE_SCHEMA_TOKEN.to_string();
-    Ok(revision_marker.as_deref() == Some(revision_string.as_str())
-        && schema_marker.as_deref() == Some(schema_string.as_str()))
-}
-
-/// Persist deferred source-db maintenance revision/schema markers.
-fn update_deferred_maintenance_markers(
-    conn: &rusqlite::Connection,
-    revision: u64,
-) -> Result<(), String> {
-    conn.execute(
-        "INSERT INTO metadata (key, value)
-         VALUES (?1, ?2)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        rusqlite::params![
-            crate::sample_sources::db::META_DEFERRED_MAINTENANCE_REVISION,
-            revision.to_string()
-        ],
-    )
-    .map_err(|err| format!("Update deferred maintenance revision failed: {err}"))?;
-    conn.execute(
-        "INSERT INTO metadata (key, value)
-         VALUES (?1, ?2)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        rusqlite::params![
-            crate::sample_sources::db::META_DEFERRED_MAINTENANCE_SCHEMA,
-            DEFERRED_MAINTENANCE_SCHEMA_TOKEN.to_string()
-        ],
-    )
-    .map_err(|err| format!("Update deferred maintenance schema marker failed: {err}"))?;
-    Ok(())
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::app::controller::library::source_write_priority::FileOpWritePriorityGuard;
-    use crate::sample_sources::SampleSource;
-    use std::io;
-    use std::sync::{Arc, Mutex};
-    use tempfile::tempdir;
-    use tracing_subscriber::fmt::MakeWriter;
-
-    #[derive(Clone, Default)]
-    /// Stores state for shared buffer.
-    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
-
-    impl SharedBuffer {
-        /// Handles captured.
-        fn captured(&self) -> String {
-            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for SharedBuffer {
-        /// Names the writer type.
-        type Writer = SharedBufferWriter;
-
-        /// Handles make writer.
-        fn make_writer(&'a self) -> Self::Writer {
-            SharedBufferWriter(self.0.clone())
-        }
-    }
-
-    /// Stores state for shared buffer writer.
-    struct SharedBufferWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl io::Write for SharedBufferWriter {
-        /// Handles write.
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        /// Handles flush.
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    /// Handles capture debug logs.
-    fn capture_debug_logs(run: impl FnOnce()) -> String {
-        let buffer = SharedBuffer::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_ansi(false)
-            .without_time()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(buffer.clone())
-            .finish();
-        crate::logging::set_debug_logging_enabled_for_tests(true);
-        tracing::subscriber::with_default(subscriber, run);
-        crate::logging::set_debug_logging_enabled_for_tests(false);
-        buffer.captured()
-    }
-
-    #[test]
-    fn source_db_maintenance_defers_quietly_during_same_source_file_op() {
-        let temp = tempdir().expect("create temp dir");
-        let source = SampleSource::new(temp.path().join("source"));
-        std::fs::create_dir_all(&source.root).expect("create source root");
-        let _db = crate::sample_sources::SourceDatabase::open(&source.root).expect("open db");
-        let _guard = FileOpWritePriorityGuard::new(&source.id);
-
-        let outcome = run_source_db_maintenance_job(SourceDbMaintenanceJob {
-            source_id: source.id.clone(),
-            source_root: source.root.clone(),
-        });
-
-        assert!(outcome.deferred_due_to_file_op);
-        assert_eq!(outcome.source_id, source.id);
-        assert!(outcome.error.is_none());
-        assert_eq!(outcome.refresh, SourceDbMaintenanceRefresh::None);
-    }
-
-    #[test]
-    /// Verifies deferred maintenance retry records source scoped telemetry.
-    fn deferred_maintenance_retry_records_source_scoped_telemetry() {
-        let temp = tempdir().expect("create temp dir");
-        let source = SampleSource::new(temp.path().join("source"));
-        std::fs::create_dir_all(&source.root).expect("create source root");
-        let job = SourceDbMaintenanceJob {
-            source_id: source.id,
-            source_root: source.root.clone(),
-        };
-
-        let captured = capture_debug_logs(|| {
-            record_deferred_maintenance_retry(&job, 1, "database is locked");
-        });
-
-        assert!(
-            captured.contains("Retrying source DB work after failure"),
-            "retry should be visible in logs: {captured}"
-        );
-        assert!(
-            captured.contains("operation=\"analysis_deferred_maintenance\""),
-            "retry should preserve the maintenance operation name: {captured}"
-        );
-        assert!(
-            captured.contains("source_root=") && captured.contains("source"),
-            "retry should include source-root context: {captured}"
-        );
-        assert!(
-            captured.contains("busy=true"),
-            "retry should classify locked DB failures as busy: {captured}"
-        );
-    }
-}
+mod tests;

--- a/src/app/controller/jobs/source_db_maintenance/markers.rs
+++ b/src/app/controller/jobs/source_db_maintenance/markers.rs
@@ -1,0 +1,53 @@
+use super::super::retry_policy::DEFERRED_MAINTENANCE_SCHEMA_TOKEN;
+
+/// Return whether deferred source-db maintenance markers match the current revision/schema.
+pub(super) fn deferred_maintenance_is_up_to_date(
+    db: &crate::sample_sources::SourceDatabase,
+    revision: u64,
+) -> Result<bool, String> {
+    let revision_marker = db
+        .get_metadata(crate::sample_sources::db::META_DEFERRED_MAINTENANCE_REVISION)
+        .map_err(|err| format!("Read deferred maintenance revision failed: {err}"))?;
+    let schema_marker = db
+        .get_metadata(crate::sample_sources::db::META_DEFERRED_MAINTENANCE_SCHEMA)
+        .map_err(|err| format!("Read deferred maintenance schema marker failed: {err}"))?;
+    let revision_string = revision.to_string();
+    let schema_string = DEFERRED_MAINTENANCE_SCHEMA_TOKEN.to_string();
+    Ok(revision_marker.as_deref() == Some(revision_string.as_str())
+        && schema_marker.as_deref() == Some(schema_string.as_str()))
+}
+
+/// Persist deferred source-db maintenance revision/schema markers.
+pub(super) fn update_deferred_maintenance_markers(
+    conn: &rusqlite::Connection,
+    revision: u64,
+) -> Result<(), String> {
+    update_metadata_value(
+        conn,
+        crate::sample_sources::db::META_DEFERRED_MAINTENANCE_REVISION,
+        revision.to_string(),
+        "revision",
+    )?;
+    update_metadata_value(
+        conn,
+        crate::sample_sources::db::META_DEFERRED_MAINTENANCE_SCHEMA,
+        DEFERRED_MAINTENANCE_SCHEMA_TOKEN.to_string(),
+        "schema marker",
+    )
+}
+
+fn update_metadata_value(
+    conn: &rusqlite::Connection,
+    key: &str,
+    value: String,
+    label: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO metadata (key, value)
+         VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![key, value],
+    )
+    .map_err(|err| format!("Update deferred maintenance {label} failed: {err}"))?;
+    Ok(())
+}

--- a/src/app/controller/jobs/source_db_maintenance/refresh.rs
+++ b/src/app/controller/jobs/source_db_maintenance/refresh.rs
@@ -1,0 +1,16 @@
+use super::*;
+
+pub(super) fn maintenance_refresh(
+    reconcile_summary: &file_ops_journal::FileOpReconcileSummary,
+    empty_source_rescanned: bool,
+) -> SourceDbMaintenanceRefresh {
+    SourceDbMaintenanceRefresh::from_parts(reconcile_summary.completed > 0, empty_source_rescanned)
+}
+
+pub(super) fn scan_changed_source(stats: &crate::sample_sources::scanner::ScanStats) -> bool {
+    stats.added > 0
+        || stats.updated > 0
+        || stats.missing > 0
+        || stats.content_changed > 0
+        || stats.renames_reconciled > 0
+}

--- a/src/app/controller/jobs/source_db_maintenance/retry.rs
+++ b/src/app/controller/jobs/source_db_maintenance/retry.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+pub(super) fn source_file_op_active(job: &SourceDbMaintenanceJob) -> bool {
+    crate::app::controller::library::source_write_priority::file_op_write_priority_active(
+        &job.source_id,
+    )
+}
+
+pub(super) fn deferred_for_file_op(job: SourceDbMaintenanceJob) -> SourceDbMaintenanceOutcome {
+    SourceDbMaintenanceOutcome {
+        source_id: job.source_id,
+        source_root: job.source_root,
+        skipped: false,
+        deferred_due_to_file_op: true,
+        orphan_rows_removed: 0,
+        refresh: SourceDbMaintenanceRefresh::None,
+        error: None,
+    }
+}
+
+/// Records deferred source DB maintenance retry telemetry.
+pub(super) fn record_deferred_maintenance_retry(
+    job: &SourceDbMaintenanceJob,
+    attempt: usize,
+    err: &str,
+) {
+    analysis_jobs::db::telemetry::record_retry(
+        "analysis_deferred_maintenance",
+        &job.source_root,
+        attempt,
+        DEFERRED_MAINTENANCE_MAX_ATTEMPTS,
+        DEFERRED_MAINTENANCE_RETRY_DELAY,
+        err,
+    );
+}

--- a/src/app/controller/jobs/source_db_maintenance/tests.rs
+++ b/src/app/controller/jobs/source_db_maintenance/tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::app::controller::library::source_write_priority::FileOpWritePriorityGuard;
+use crate::sample_sources::SampleSource;
+use std::io;
+use std::sync::{Arc, Mutex};
+use tempfile::tempdir;
+use tracing_subscriber::fmt::MakeWriter;
+
+#[derive(Clone, Default)]
+/// Stores state for shared buffer.
+struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl SharedBuffer {
+    /// Handles captured.
+    fn captured(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedBuffer {
+    /// Names the writer type.
+    type Writer = SharedBufferWriter;
+
+    /// Handles make writer.
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedBufferWriter(self.0.clone())
+    }
+}
+
+/// Stores state for shared buffer writer.
+struct SharedBufferWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for SharedBufferWriter {
+    /// Handles write.
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    /// Handles flush.
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Handles capture debug logs.
+fn capture_debug_logs(run: impl FnOnce()) -> String {
+    let buffer = SharedBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(buffer.clone())
+        .finish();
+    crate::logging::set_debug_logging_enabled_for_tests(true);
+    tracing::subscriber::with_default(subscriber, run);
+    crate::logging::set_debug_logging_enabled_for_tests(false);
+    buffer.captured()
+}
+
+#[test]
+fn source_db_maintenance_defers_quietly_during_same_source_file_op() {
+    let temp = tempdir().expect("create temp dir");
+    let source = SampleSource::new(temp.path().join("source"));
+    std::fs::create_dir_all(&source.root).expect("create source root");
+    let _db = crate::sample_sources::SourceDatabase::open(&source.root).expect("open db");
+    let _guard = FileOpWritePriorityGuard::new(&source.id);
+
+    let outcome = run_source_db_maintenance_job(SourceDbMaintenanceJob {
+        source_id: source.id.clone(),
+        source_root: source.root.clone(),
+    });
+
+    assert!(outcome.deferred_due_to_file_op);
+    assert_eq!(outcome.source_id, source.id);
+    assert!(outcome.error.is_none());
+    assert_eq!(outcome.refresh, SourceDbMaintenanceRefresh::None);
+}
+
+#[test]
+/// Verifies deferred maintenance retry records source scoped telemetry.
+fn deferred_maintenance_retry_records_source_scoped_telemetry() {
+    let temp = tempdir().expect("create temp dir");
+    let source = SampleSource::new(temp.path().join("source"));
+    std::fs::create_dir_all(&source.root).expect("create source root");
+    let job = SourceDbMaintenanceJob {
+        source_id: source.id,
+        source_root: source.root.clone(),
+    };
+
+    let captured = capture_debug_logs(|| {
+        record_deferred_maintenance_retry(&job, 1, "database is locked");
+    });
+
+    assert!(
+        captured.contains("Retrying source DB work after failure"),
+        "retry should be visible in logs: {captured}"
+    );
+    assert!(
+        captured.contains("operation=\"analysis_deferred_maintenance\""),
+        "retry should preserve the maintenance operation name: {captured}"
+    );
+    assert!(
+        captured.contains("source_root=") && captured.contains("source"),
+        "retry should include source-root context: {captured}"
+    );
+    assert!(
+        captured.contains("busy=true"),
+        "retry should classify locked DB failures as busy: {captured}"
+    );
+}


### PR DESCRIPTION
## Summary
- Split source DB maintenance helpers into focused marker, refresh, retry, and test modules.
- Kept the top-level deferred maintenance flow visible in the root module while reducing it below the target size.
- Preserved file-op deferral, retry telemetry, and marker persistence behavior.

## Validation
- cargo test -p wavecrate --lib source_db_maintenance
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent