### PR TITLE
Split library database module

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/library.rs
+++ b/crates/wavecrate-library/src/sample_sources/library.rs
@@ -1,21 +1,34 @@
 //! Global SQLite storage for sources that should not live in the config file.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{LazyLock, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-use rusqlite::{Connection, Transaction, params};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use rusqlite::Connection;
 use tracing::warn;
 
+mod connection;
+mod error;
 mod migrations;
 mod schema_checks;
 mod schema_defs;
+mod sources;
+mod telemetry;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod telemetry_tests;
 
 use super::{SampleSource, SourceId};
-use crate::app_dirs;
-use crate::diagnostics::{DbDebugEvent, emit_db_debug_event};
+use connection::LibraryDatabase;
+use error::map_sql_error;
+use telemetry::record_library_db_event;
+
+pub use error::LibraryError;
+
+#[cfg(test)]
 use crate::sample_sources::normalize_path;
 
 /// Filename for the global library database stored under the user app directory.
@@ -31,43 +44,6 @@ pub struct LibraryState {
 const KNOWN_SOURCES_KEY: &str = "known_sources_v1";
 
 static LIBRARY_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-const SLOW_LIBRARY_DB_EVENT_THRESHOLD: Duration = Duration::from_millis(15);
-
-/// Errors returned when operating on the library database.
-#[derive(Debug, Error)]
-pub enum LibraryError {
-    /// No suitable application directory was available.
-    #[error("No suitable config directory available for library database")]
-    NoConfigDir,
-    /// Failed to create the directory for the database file.
-    #[error("Could not create library directory {path}: {source}")]
-    CreateDir {
-        /// Path that could not be created.
-        path: PathBuf,
-        /// Underlying IO error.
-        source: std::io::Error,
-    },
-    /// Failed to resolve the configured persistence profile.
-    #[error("Invalid library persistence profile '{profile}'")]
-    InvalidProfile {
-        /// Rejected profile name.
-        profile: String,
-    },
-    /// Failed to open or query the database.
-    #[error("Library database query failed: {0}")]
-    Sql(#[from] rusqlite::Error),
-    /// Failed to deserialize JSON metadata from the DB.
-    #[error("Library metadata parse failed: {0}")]
-    Json(#[from] serde_json::Error),
-    /// Failed to deserialize one named JSON metadata value from the DB.
-    #[error("Library metadata key '{key}' parse failed: {source}")]
-    MetadataJson {
-        /// Metadata key that contained invalid JSON.
-        key: &'static str,
-        /// Underlying JSON error.
-        source: serde_json::Error,
-    },
-}
 
 /// Load all sources from the global library database, creating it if missing.
 pub fn load() -> Result<LibraryState, LibraryError> {
@@ -127,281 +103,5 @@ fn lock_library() -> std::sync::MutexGuard<'static, ()> {
             warn!("Library DB mutex poisoned; recovering to keep the app running.");
             poisoned.into_inner()
         }
-    }
-}
-
-struct LibraryDatabase {
-    connection: Connection,
-}
-
-impl LibraryDatabase {
-    fn open() -> Result<Self, LibraryError> {
-        let db_path = database_path()?;
-        create_parent_if_needed(&db_path)?;
-        let connection = Connection::open(&db_path)?;
-        let mut db = Self { connection };
-        db.apply_pragmas()?;
-        db.apply_schema()?;
-        db.migrate_analysis_jobs_content_hash()?;
-        db.migrate_samples_analysis_metadata()?;
-        db.migrate_features_table()?;
-        db.migrate_layout_umap_table()?;
-        db.migrate_hdbscan_clusters_table()?;
-        db.migrate_embeddings_table()?;
-        db.migrate_ann_index_meta_table()?;
-        Ok(db)
-    }
-
-    fn into_connection(self) -> Connection {
-        self.connection
-    }
-
-    fn load_state(&self) -> Result<LibraryState, LibraryError> {
-        let started_at = Instant::now();
-        let sources = self.load_sources()?;
-        let state = LibraryState { sources };
-        record_library_db_event("library.load_state", started_at, Ok(()));
-        Ok(state)
-    }
-
-    fn replace_state(&mut self, state: &LibraryState) -> Result<(), LibraryError> {
-        let started_at = Instant::now();
-        let tx = self.connection.transaction().map_err(map_sql_error)?;
-        let mut mappings = Self::load_known_sources_from(&tx)?;
-        Self::replace_sources(&tx, &state.sources)?;
-        Self::remember_known_sources_in_tx(&tx, &mut mappings, &state.sources)?;
-        tx.commit().map_err(map_sql_error)?;
-        record_library_db_event("library.replace_state", started_at, Ok(()));
-        Ok(())
-    }
-
-    fn load_sources(&self) -> Result<Vec<SampleSource>, LibraryError> {
-        let started_at = Instant::now();
-        let mut stmt = self
-            .connection
-            .prepare(
-                "SELECT id, root
-                 FROM sources
-                 ORDER BY sort_order ASC, id ASC",
-            )
-            .map_err(map_sql_error)?;
-        let rows = stmt
-            .query_map([], |row| {
-                let id: String = row.get(0)?;
-                let root: String = row.get(1)?;
-                Ok(SampleSource {
-                    id: SourceId::from_string(id),
-                    root: PathBuf::from(root),
-                })
-            })
-            .map_err(map_sql_error)?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(map_sql_error)?;
-        record_library_db_event("library.load_sources", started_at, Ok(()));
-        Ok(rows)
-    }
-
-    fn replace_sources(tx: &Transaction<'_>, sources: &[SampleSource]) -> Result<(), LibraryError> {
-        tx.execute("DELETE FROM sources", [])
-            .map_err(map_sql_error)?;
-        if sources.is_empty() {
-            return Ok(());
-        }
-        let mut stmt = tx
-            .prepare("INSERT INTO sources (id, root, sort_order) VALUES (?1, ?2, ?3)")
-            .map_err(map_sql_error)?;
-        for (idx, source) in sources.iter().enumerate() {
-            stmt.execute(params![
-                source.id.as_str(),
-                source.root.to_string_lossy(),
-                idx as i64
-            ])
-            .map_err(map_sql_error)?;
-        }
-        Ok(())
-    }
-
-    fn lookup_known_source_id(&self, root: &Path) -> Result<Option<SourceId>, LibraryError> {
-        let started_at = Instant::now();
-        let normalized = normalize_path(root);
-        let needle = normalized.to_string_lossy().to_string();
-        let mappings = self.load_known_sources()?;
-        let result = mappings
-            .into_iter()
-            .find(|entry| entry.root == needle)
-            .map(|entry| SourceId::from_string(entry.source_id));
-        record_library_db_event("library.lookup_known_source_id", started_at, Ok(()));
-        Ok(result)
-    }
-
-    fn remember_known_sources_in_tx(
-        tx: &Transaction<'_>,
-        mappings: &mut Vec<KnownSourceMapping>,
-        sources: &[SampleSource],
-    ) -> Result<(), LibraryError> {
-        for source in sources {
-            let normalized = normalize_path(&source.root);
-            let root = normalized.to_string_lossy().to_string();
-            if let Some(existing) = mappings.iter_mut().find(|entry| entry.root == root) {
-                existing.source_id = source.id.as_str().to_string();
-            } else {
-                mappings.push(KnownSourceMapping {
-                    root,
-                    source_id: source.id.as_str().to_string(),
-                });
-            }
-        }
-        mappings.sort_by(|a, b| a.root.cmp(&b.root));
-        Self::set_metadata_in_tx(tx, KNOWN_SOURCES_KEY, &serde_json::to_string(&mappings)?)?;
-        Ok(())
-    }
-
-    fn load_known_sources(&self) -> Result<Vec<KnownSourceMapping>, LibraryError> {
-        let started_at = Instant::now();
-        let result = Self::load_known_sources_from(&self.connection);
-        record_library_db_event(
-            "library.load_known_sources",
-            started_at,
-            result.as_ref().map(|_| ()),
-        );
-        result
-    }
-
-    fn load_known_sources_from(conn: &Connection) -> Result<Vec<KnownSourceMapping>, LibraryError> {
-        let Some(value) = Self::get_metadata_from(conn, KNOWN_SOURCES_KEY)? else {
-            return Ok(Vec::new());
-        };
-        serde_json::from_str::<Vec<KnownSourceMapping>>(&value).map_err(|source| {
-            LibraryError::MetadataJson {
-                key: KNOWN_SOURCES_KEY,
-                source,
-            }
-        })
-    }
-
-    fn get_metadata_from(conn: &Connection, key: &str) -> Result<Option<String>, LibraryError> {
-        use rusqlite::OptionalExtension;
-        conn.query_row("SELECT value FROM metadata WHERE key = ?1", [key], |row| {
-            row.get(0)
-        })
-        .optional()
-        .map_err(map_sql_error)
-    }
-
-    fn set_metadata_in_tx(
-        tx: &Transaction<'_>,
-        key: &str,
-        value: &str,
-    ) -> Result<(), LibraryError> {
-        tx.execute(
-            "INSERT INTO metadata (key, value)
-             VALUES (?1, ?2)
-             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            [key, value],
-        )
-        .map_err(map_sql_error)?;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct KnownSourceMapping {
-    root: String,
-    source_id: String,
-}
-
-fn database_path() -> Result<PathBuf, LibraryError> {
-    app_dirs::app_root_dir()
-        .map_err(map_app_dir_error)
-        .map(|dir| dir.join(LIBRARY_DB_FILE_NAME))
-}
-
-fn create_parent_if_needed(path: &Path) -> Result<(), LibraryError> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|source| LibraryError::CreateDir {
-            path: parent.to_path_buf(),
-            source,
-        })?;
-    }
-    Ok(())
-}
-
-fn map_sql_error(err: rusqlite::Error) -> LibraryError {
-    LibraryError::Sql(err)
-}
-
-fn map_app_dir_error(error: app_dirs::AppDirError) -> LibraryError {
-    match error {
-        app_dirs::AppDirError::NoBaseDir => LibraryError::NoConfigDir,
-        app_dirs::AppDirError::CreateDir { path, source } => {
-            LibraryError::CreateDir { path, source }
-        }
-        app_dirs::AppDirError::InvalidProfileName { profile } => {
-            LibraryError::InvalidProfile { profile }
-        }
-    }
-}
-
-fn record_library_db_event(
-    operation: &str,
-    started_at: Instant,
-    result: Result<(), &LibraryError>,
-) {
-    let elapsed = started_at.elapsed();
-    let outcome = match library_db_debug_outcome(result.is_ok(), elapsed) {
-        Some(outcome) => outcome,
-        None => return,
-    };
-    let error = result.as_ref().err().map(ToString::to_string);
-    emit_db_debug_event(DbDebugEvent {
-        operation,
-        source: Some("library"),
-        outcome,
-        elapsed,
-        error: error.as_deref(),
-    });
-}
-
-fn library_db_debug_outcome(success: bool, elapsed: Duration) -> Option<&'static str> {
-    if success {
-        (elapsed >= SLOW_LIBRARY_DB_EVENT_THRESHOLD).then_some("slow")
-    } else {
-        Some("error")
-    }
-}
-
-#[cfg(test)]
-mod tests;
-
-#[cfg(test)]
-mod telemetry_tests {
-    use super::{SLOW_LIBRARY_DB_EVENT_THRESHOLD, library_db_debug_outcome};
-    use std::time::Duration;
-
-    #[test]
-    fn fast_successful_library_events_are_suppressed() {
-        assert_eq!(
-            library_db_debug_outcome(
-                true,
-                SLOW_LIBRARY_DB_EVENT_THRESHOLD.saturating_sub(Duration::from_millis(1)),
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn slow_successful_library_events_are_marked_slow() {
-        assert_eq!(
-            library_db_debug_outcome(true, SLOW_LIBRARY_DB_EVENT_THRESHOLD),
-            Some("slow")
-        );
-    }
-
-    #[test]
-    fn failed_library_events_are_kept() {
-        assert_eq!(
-            library_db_debug_outcome(false, Duration::from_millis(1)),
-            Some("error")
-        );
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/library/connection.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/connection.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+
+use super::error::map_app_dir_error;
+use super::{LIBRARY_DB_FILE_NAME, LibraryError};
+use crate::app_dirs;
+
+pub(super) struct LibraryDatabase {
+    pub(super) connection: Connection,
+}
+
+impl LibraryDatabase {
+    pub(super) fn open() -> Result<Self, LibraryError> {
+        let db_path = database_path()?;
+        create_parent_if_needed(&db_path)?;
+        let connection = Connection::open(&db_path)?;
+        let mut db = Self { connection };
+        db.apply_pragmas()?;
+        db.apply_schema()?;
+        db.migrate_analysis_jobs_content_hash()?;
+        db.migrate_samples_analysis_metadata()?;
+        db.migrate_features_table()?;
+        db.migrate_layout_umap_table()?;
+        db.migrate_hdbscan_clusters_table()?;
+        db.migrate_embeddings_table()?;
+        db.migrate_ann_index_meta_table()?;
+        Ok(db)
+    }
+
+    pub(super) fn into_connection(self) -> Connection {
+        self.connection
+    }
+}
+
+fn database_path() -> Result<PathBuf, LibraryError> {
+    app_dirs::app_root_dir()
+        .map_err(map_app_dir_error)
+        .map(|dir| dir.join(LIBRARY_DB_FILE_NAME))
+}
+
+fn create_parent_if_needed(path: &Path) -> Result<(), LibraryError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| LibraryError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}

--- a/crates/wavecrate-library/src/sample_sources/library/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/error.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::app_dirs;
+
+/// Errors returned when operating on the library database.
+#[derive(Debug, Error)]
+pub enum LibraryError {
+    /// No suitable application directory was available.
+    #[error("No suitable config directory available for library database")]
+    NoConfigDir,
+    /// Failed to create the directory for the database file.
+    #[error("Could not create library directory {path}: {source}")]
+    CreateDir {
+        /// Path that could not be created.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+    /// Failed to resolve the configured persistence profile.
+    #[error("Invalid library persistence profile '{profile}'")]
+    InvalidProfile {
+        /// Rejected profile name.
+        profile: String,
+    },
+    /// Failed to open or query the database.
+    #[error("Library database query failed: {0}")]
+    Sql(#[from] rusqlite::Error),
+    /// Failed to deserialize JSON metadata from the DB.
+    #[error("Library metadata parse failed: {0}")]
+    Json(#[from] serde_json::Error),
+    /// Failed to deserialize one named JSON metadata value from the DB.
+    #[error("Library metadata key '{key}' parse failed: {source}")]
+    MetadataJson {
+        /// Metadata key that contained invalid JSON.
+        key: &'static str,
+        /// Underlying JSON error.
+        source: serde_json::Error,
+    },
+}
+
+pub(super) fn map_sql_error(err: rusqlite::Error) -> LibraryError {
+    LibraryError::Sql(err)
+}
+
+pub(super) fn map_app_dir_error(error: app_dirs::AppDirError) -> LibraryError {
+    match error {
+        app_dirs::AppDirError::NoBaseDir => LibraryError::NoConfigDir,
+        app_dirs::AppDirError::CreateDir { path, source } => {
+            LibraryError::CreateDir { path, source }
+        }
+        app_dirs::AppDirError::InvalidProfileName { profile } => {
+            LibraryError::InvalidProfile { profile }
+        }
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/library/sources.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/sources.rs
@@ -1,0 +1,174 @@
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use serde::{Deserialize, Serialize};
+
+use super::connection::LibraryDatabase;
+use super::error::map_sql_error;
+use super::telemetry::record_library_db_event;
+use super::{KNOWN_SOURCES_KEY, LibraryError, LibraryState};
+use crate::sample_sources::normalize_path;
+use crate::sample_sources::{SampleSource, SourceId};
+
+impl LibraryDatabase {
+    pub(super) fn load_state(&self) -> Result<LibraryState, LibraryError> {
+        let started_at = Instant::now();
+        let sources = self.load_sources()?;
+        let state = LibraryState { sources };
+        record_library_db_event("library.load_state", started_at, Ok(()));
+        Ok(state)
+    }
+
+    pub(super) fn replace_state(&mut self, state: &LibraryState) -> Result<(), LibraryError> {
+        let started_at = Instant::now();
+        let tx = self.connection.transaction().map_err(map_sql_error)?;
+        let mut mappings = Self::load_known_sources_from(&tx)?;
+        Self::replace_sources(&tx, &state.sources)?;
+        Self::remember_known_sources_in_tx(&tx, &mut mappings, &state.sources)?;
+        tx.commit().map_err(map_sql_error)?;
+        record_library_db_event("library.replace_state", started_at, Ok(()));
+        Ok(())
+    }
+
+    pub(super) fn load_sources(&self) -> Result<Vec<SampleSource>, LibraryError> {
+        let started_at = Instant::now();
+        let mut stmt = self
+            .connection
+            .prepare(
+                "SELECT id, root
+                 FROM sources
+                 ORDER BY sort_order ASC, id ASC",
+            )
+            .map_err(map_sql_error)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let id: String = row.get(0)?;
+                let root: String = row.get(1)?;
+                Ok(SampleSource {
+                    id: SourceId::from_string(id),
+                    root: PathBuf::from(root),
+                })
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        record_library_db_event("library.load_sources", started_at, Ok(()));
+        Ok(rows)
+    }
+
+    pub(super) fn lookup_known_source_id(
+        &self,
+        root: &Path,
+    ) -> Result<Option<SourceId>, LibraryError> {
+        let started_at = Instant::now();
+        let normalized = normalize_path(root);
+        let needle = normalized.to_string_lossy().to_string();
+        let mappings = self.load_known_sources()?;
+        let result = mappings
+            .into_iter()
+            .find(|entry| entry.root == needle)
+            .map(|entry| SourceId::from_string(entry.source_id));
+        record_library_db_event("library.lookup_known_source_id", started_at, Ok(()));
+        Ok(result)
+    }
+
+    fn replace_sources(tx: &Transaction<'_>, sources: &[SampleSource]) -> Result<(), LibraryError> {
+        tx.execute("DELETE FROM sources", [])
+            .map_err(map_sql_error)?;
+        if sources.is_empty() {
+            return Ok(());
+        }
+
+        let mut stmt = tx
+            .prepare("INSERT INTO sources (id, root, sort_order) VALUES (?1, ?2, ?3)")
+            .map_err(map_sql_error)?;
+        for (idx, source) in sources.iter().enumerate() {
+            stmt.execute(params![
+                source.id.as_str(),
+                source.root.to_string_lossy(),
+                idx as i64
+            ])
+            .map_err(map_sql_error)?;
+        }
+        Ok(())
+    }
+
+    fn remember_known_sources_in_tx(
+        tx: &Transaction<'_>,
+        mappings: &mut Vec<KnownSourceMapping>,
+        sources: &[SampleSource],
+    ) -> Result<(), LibraryError> {
+        for source in sources {
+            upsert_known_source_mapping(mappings, source);
+        }
+        mappings.sort_by(|a, b| a.root.cmp(&b.root));
+        Self::set_metadata_in_tx(tx, KNOWN_SOURCES_KEY, &serde_json::to_string(&mappings)?)?;
+        Ok(())
+    }
+
+    fn load_known_sources(&self) -> Result<Vec<KnownSourceMapping>, LibraryError> {
+        let started_at = Instant::now();
+        let result = Self::load_known_sources_from(&self.connection);
+        record_library_db_event(
+            "library.load_known_sources",
+            started_at,
+            result.as_ref().map(|_| ()),
+        );
+        result
+    }
+
+    fn load_known_sources_from(conn: &Connection) -> Result<Vec<KnownSourceMapping>, LibraryError> {
+        let Some(value) = Self::get_metadata_from(conn, KNOWN_SOURCES_KEY)? else {
+            return Ok(Vec::new());
+        };
+        serde_json::from_str::<Vec<KnownSourceMapping>>(&value).map_err(|source| {
+            LibraryError::MetadataJson {
+                key: KNOWN_SOURCES_KEY,
+                source,
+            }
+        })
+    }
+
+    fn get_metadata_from(conn: &Connection, key: &str) -> Result<Option<String>, LibraryError> {
+        conn.query_row("SELECT value FROM metadata WHERE key = ?1", [key], |row| {
+            row.get(0)
+        })
+        .optional()
+        .map_err(map_sql_error)
+    }
+
+    fn set_metadata_in_tx(
+        tx: &Transaction<'_>,
+        key: &str,
+        value: &str,
+    ) -> Result<(), LibraryError> {
+        tx.execute(
+            "INSERT INTO metadata (key, value)
+             VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [key, value],
+        )
+        .map_err(map_sql_error)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct KnownSourceMapping {
+    root: String,
+    source_id: String,
+}
+
+fn upsert_known_source_mapping(mappings: &mut Vec<KnownSourceMapping>, source: &SampleSource) {
+    let normalized = normalize_path(&source.root);
+    let root = normalized.to_string_lossy().to_string();
+    if let Some(existing) = mappings.iter_mut().find(|entry| entry.root == root) {
+        existing.source_id = source.id.as_str().to_string();
+        return;
+    }
+    mappings.push(KnownSourceMapping {
+        root,
+        source_id: source.id.as_str().to_string(),
+    });
+}

--- a/crates/wavecrate-library/src/sample_sources/library/telemetry.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/telemetry.rs
@@ -1,0 +1,37 @@
+use std::time::{Duration, Instant};
+
+use crate::diagnostics::{DbDebugEvent, emit_db_debug_event};
+
+use super::LibraryError;
+
+const SLOW_LIBRARY_DB_EVENT_THRESHOLD: Duration = Duration::from_millis(15);
+
+pub(super) fn record_library_db_event(
+    operation: &str,
+    started_at: Instant,
+    result: Result<(), &LibraryError>,
+) {
+    let elapsed = started_at.elapsed();
+    let outcome = match library_db_debug_outcome(result.is_ok(), elapsed) {
+        Some(outcome) => outcome,
+        None => return,
+    };
+    let error = result.as_ref().err().map(ToString::to_string);
+    emit_db_debug_event(DbDebugEvent {
+        operation,
+        source: Some("library"),
+        outcome,
+        elapsed,
+        error: error.as_deref(),
+    });
+}
+
+pub(super) fn library_db_debug_outcome(success: bool, elapsed: Duration) -> Option<&'static str> {
+    if success {
+        return (elapsed >= SLOW_LIBRARY_DB_EVENT_THRESHOLD).then_some("slow");
+    }
+    Some("error")
+}
+
+#[cfg(test)]
+pub(super) const TEST_SLOW_LIBRARY_DB_EVENT_THRESHOLD: Duration = SLOW_LIBRARY_DB_EVENT_THRESHOLD;

--- a/crates/wavecrate-library/src/sample_sources/library/telemetry_tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/telemetry_tests.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+use super::telemetry::{TEST_SLOW_LIBRARY_DB_EVENT_THRESHOLD, library_db_debug_outcome};
+
+#[test]
+fn fast_successful_library_events_are_suppressed() {
+    assert_eq!(
+        library_db_debug_outcome(
+            true,
+            TEST_SLOW_LIBRARY_DB_EVENT_THRESHOLD.saturating_sub(Duration::from_millis(1)),
+        ),
+        None
+    );
+}
+
+#[test]
+fn slow_successful_library_events_are_marked_slow() {
+    assert_eq!(
+        library_db_debug_outcome(true, TEST_SLOW_LIBRARY_DB_EVENT_THRESHOLD),
+        Some("slow")
+    );
+}
+
+#[test]
+fn failed_library_events_are_kept() {
+    assert_eq!(
+        library_db_debug_outcome(false, Duration::from_millis(1)),
+        Some("error")
+    );
+}


### PR DESCRIPTION
## Summary
- Split the global sample-source library DB module into connection, error, source persistence, and telemetry modules
- Keep the public library API stable while reducing the root module to API orchestration and lock handling
- Move telemetry tests into their own focused module

## Validation
- cargo test -p wavecrate-library sample_sources::library
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent