### PR TITLE
Fix folder context menu behavior and styling

### DIFF
--- a/src/gui_app/context_menu.rs
+++ b/src/gui_app/context_menu.rs
@@ -1,7 +1,21 @@
 use super::GuiMessage;
-use radiant::gui::types::Point;
 use radiant::prelude as ui;
+use radiant::{
+    gui::types::{Point, Rect, Rgba8},
+    layout::{LayoutOutput, Vector2},
+    runtime::{
+        PaintFillRect, PaintPrimitive, PaintStrokeRect, PaintText, PaintTextAlign, PaintTextRun,
+    },
+    theme::ThemeTokens,
+    widgets::{
+        FocusBehavior, PaintBounds, PointerButton, TextWrap, Widget, WidgetCommon, WidgetInput,
+        WidgetOutput, WidgetSizing,
+    },
+};
 use std::path::{Path, PathBuf};
+
+const CONTEXT_MENU_WIDTH: f32 = 210.0;
+const CONTEXT_MENU_HEIGHT: f32 = 104.0;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum BrowserContextTargetKind {
@@ -54,48 +68,61 @@ pub(super) fn overlay(menu: &BrowserContextMenu) -> ui::View<GuiMessage> {
     };
     let top = menu.anchor.y.max(0.0);
     let left = menu.anchor.x.max(0.0);
-    ui::column([
-        dismiss_area("browser-context-dismiss-top")
-            .fill_width()
-            .height(top),
-        ui::row([
-            dismiss_area("browser-context-dismiss-left")
-                .width(left)
-                .height(104.0),
-            ui::column([
-                ui::text(menu.title.clone())
-                    .height(22.0)
-                    .fill_width()
-                    .truncate(),
-                ui::button(action_label)
-                    .message(GuiMessage::OpenContextTarget)
-                    .key("browser-context-open-explorer")
-                    .fill_width()
-                    .height(28.0),
-                ui::button("Copy Path")
-                    .message(GuiMessage::CopyContextPath)
-                    .key("browser-context-copy-path")
-                    .fill_width()
-                    .height(28.0),
+    ui::stack([
+        dismiss_area("browser-context-dismiss").fill(),
+        ui::column([
+            overlay_gap().fill_width().height(top),
+            ui::row([
+                overlay_gap().width(left).height(1.0),
+                context_menu_panel(menu, action_label),
+                overlay_gap().fill_width().height(1.0),
             ])
-            .style(ui::WidgetStyle {
-                tone: ui::WidgetTone::Accent,
-                prominence: ui::WidgetProminence::Strong,
-            })
-            .padding(8.0)
-            .spacing(5.0)
-            .size(210.0, 104.0),
-            dismiss_area("browser-context-dismiss-right")
-                .fill_width()
-                .height(104.0),
-        ])
-        .fill_width()
-        .height(104.0),
-        dismiss_area("browser-context-dismiss-bottom")
             .fill_width()
-            .fill_height(),
+            .height(CONTEXT_MENU_HEIGHT),
+            overlay_gap().fill_width().fill_height(),
+        ])
+        .fill(),
     ])
     .fill()
+}
+
+fn context_menu_panel(
+    menu: &BrowserContextMenu,
+    action_label: &'static str,
+) -> ui::View<GuiMessage> {
+    ui::column([
+        ui::text(menu.title.clone())
+            .height(22.0)
+            .fill_width()
+            .truncate(),
+        context_menu_action(action_label, GuiMessage::OpenContextTarget)
+            .key("browser-context-open-explorer")
+            .fill_width()
+            .height(28.0),
+        context_menu_action("Copy Path", GuiMessage::CopyContextPath)
+            .key("browser-context-copy-path")
+            .fill_width()
+            .height(28.0),
+    ])
+    .style(ui::WidgetStyle {
+        tone: ui::WidgetTone::Neutral,
+        prominence: ui::WidgetProminence::Strong,
+    })
+    .padding(8.0)
+    .spacing(5.0)
+    .width(CONTEXT_MENU_WIDTH)
+    .height(CONTEXT_MENU_HEIGHT)
+}
+
+fn context_menu_action(label: impl Into<String>, message: GuiMessage) -> ui::View<GuiMessage> {
+    ui::custom_widget_mapped(
+        ContextMenuActionButton::new(label.into(), message),
+        |message: GuiMessage| message,
+    )
+}
+
+fn overlay_gap() -> ui::View<GuiMessage> {
+    ui::text("")
 }
 
 fn dismiss_area(key: &'static str) -> ui::View<GuiMessage> {
@@ -103,4 +130,243 @@ fn dismiss_area(key: &'static str) -> ui::View<GuiMessage> {
         .message(GuiMessage::CloseContextMenu)
         .key(key)
         .input_only()
+}
+
+#[derive(Clone, Debug)]
+struct ContextMenuActionButton {
+    common: WidgetCommon,
+    label: String,
+    message: GuiMessage,
+}
+
+impl ContextMenuActionButton {
+    fn new(label: String, message: GuiMessage) -> Self {
+        let mut common = WidgetCommon::new(0, WidgetSizing::fixed(Vector2::new(1.0, 28.0)));
+        common.focus = FocusBehavior::None;
+        common.paint.bounds = PaintBounds::ClipToRect;
+        common.paint.paints_focus = false;
+        common.paint.paints_state_layers = false;
+        Self {
+            common,
+            label,
+            message,
+        }
+    }
+}
+
+impl Widget for ContextMenuActionButton {
+    fn common(&self) -> &WidgetCommon {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        &mut self.common
+    }
+
+    fn handle_input(&mut self, bounds: Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        match input {
+            WidgetInput::PointerMove { position } => {
+                self.common.state.hovered = bounds.contains(position);
+                None
+            }
+            WidgetInput::PointerPress {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } if bounds.contains(position) => {
+                self.common.state.hovered = true;
+                self.common.state.pressed = true;
+                None
+            }
+            WidgetInput::PointerRelease {
+                position,
+                button: PointerButton::Primary,
+                ..
+            } => {
+                let activated = self.common.state.pressed && bounds.contains(position);
+                self.common.state.pressed = false;
+                self.common.state.hovered = bounds.contains(position);
+                activated.then(|| WidgetOutput::typed(self.message.clone()))
+            }
+            _ => {
+                if matches!(input, WidgetInput::PointerRelease { .. }) {
+                    self.common.state.pressed = false;
+                }
+                None
+            }
+        }
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        true
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+        _layout: &LayoutOutput,
+        _theme: &ThemeTokens,
+    ) {
+        let hovered = self.common.state.hovered || self.common.state.pressed;
+        primitives.push(PaintPrimitive::FillRect(PaintFillRect {
+            widget_id: self.common.id,
+            rect: bounds,
+            color: context_menu_button_fill(),
+        }));
+        if hovered {
+            primitives.push(PaintPrimitive::FillRect(PaintFillRect {
+                widget_id: self.common.id,
+                rect: bounds,
+                color: context_menu_hover_fill(self.common.state.pressed),
+            }));
+        }
+        primitives.push(PaintPrimitive::StrokeRect(PaintStrokeRect {
+            widget_id: self.common.id,
+            rect: Rect::from_min_max(
+                Point::new(bounds.min.x + 0.5, bounds.min.y + 0.5),
+                Point::new(bounds.max.x - 0.5, bounds.max.y - 0.5),
+            ),
+            color: context_menu_button_border(),
+            width: 1.0,
+        }));
+
+        let text_rect = Rect::from_min_max(
+            Point::new(bounds.min.x + 8.0, bounds.min.y),
+            Point::new(bounds.max.x - 8.0, bounds.max.y),
+        );
+        let font_size = 11.0;
+        primitives.push(PaintPrimitive::Text(PaintTextRun {
+            widget_id: self.common.id,
+            text: PaintText::from(self.label.as_str()),
+            rect: text_rect,
+            font_size,
+            baseline: Some(((text_rect.height() - font_size) * 0.5 + font_size * 0.78).round()),
+            color: context_menu_text(),
+            align: PaintTextAlign::Left,
+            wrap: TextWrap::None,
+        }));
+    }
+}
+
+fn context_menu_button_fill() -> Rgba8 {
+    Rgba8 {
+        r: 30,
+        g: 31,
+        b: 31,
+        a: 235,
+    }
+}
+
+fn context_menu_button_border() -> Rgba8 {
+    Rgba8 {
+        r: 66,
+        g: 67,
+        b: 68,
+        a: 175,
+    }
+}
+
+fn context_menu_hover_fill(pressed: bool) -> Rgba8 {
+    Rgba8 {
+        r: 255,
+        g: 108,
+        b: 88,
+        a: if pressed { 170 } else { 155 },
+    }
+}
+
+fn context_menu_text() -> Rgba8 {
+    Rgba8 {
+        r: 218,
+        g: 219,
+        b: 219,
+        a: 238,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use radiant::widgets::PointerModifiers;
+
+    fn action_primitives(button: &ContextMenuActionButton) -> Vec<PaintPrimitive> {
+        let mut primitives = Vec::new();
+        button.append_paint(
+            &mut primitives,
+            Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(180.0, 28.0)),
+            &LayoutOutput::default(),
+            &ThemeTokens::default(),
+        );
+        primitives
+    }
+
+    #[test]
+    fn action_button_uses_hover_fill_without_recoloring_text() {
+        let mut button =
+            ContextMenuActionButton::new(String::from("Copy Path"), GuiMessage::CopyContextPath);
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(180.0, 28.0));
+
+        let default_primitives = action_primitives(&button);
+        assert!(
+            !default_primitives.iter().any(|primitive| matches!(
+                primitive,
+                PaintPrimitive::FillRect(fill) if fill.color == context_menu_hover_fill(false)
+            )),
+            "{default_primitives:?}"
+        );
+        assert!(default_primitives.iter().any(|primitive| matches!(
+            primitive,
+            PaintPrimitive::Text(text) if text.color == context_menu_text()
+        )));
+
+        button.handle_input(
+            bounds,
+            WidgetInput::PointerMove {
+                position: Point::new(20.0, 12.0),
+            },
+        );
+
+        let hover_primitives = action_primitives(&button);
+        assert!(hover_primitives.iter().any(|primitive| matches!(
+            primitive,
+            PaintPrimitive::FillRect(fill)
+                if fill.rect == bounds && fill.color == context_menu_hover_fill(false)
+        )));
+        assert!(hover_primitives.iter().any(|primitive| matches!(
+            primitive,
+            PaintPrimitive::Text(text) if text.color == context_menu_text()
+        )));
+    }
+
+    #[test]
+    fn action_button_emits_configured_message_on_click() {
+        let mut button =
+            ContextMenuActionButton::new(String::from("Copy Path"), GuiMessage::CopyContextPath);
+        let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(180.0, 28.0));
+
+        button.handle_input(
+            bounds,
+            WidgetInput::PointerPress {
+                position: Point::new(20.0, 12.0),
+                button: PointerButton::Primary,
+                modifiers: PointerModifiers::default(),
+            },
+        );
+        let output = button
+            .handle_input(
+                bounds,
+                WidgetInput::PointerRelease {
+                    position: Point::new(20.0, 12.0),
+                    button: PointerButton::Primary,
+                    modifiers: PointerModifiers::default(),
+                },
+            )
+            .expect("click should emit action message");
+
+        assert_eq!(
+            output.typed_ref::<GuiMessage>(),
+            Some(&GuiMessage::CopyContextPath)
+        );
+    }
 }

--- a/src/gui_app/context_menu_actions.rs
+++ b/src/gui_app/context_menu_actions.rs
@@ -5,7 +5,7 @@ use super::context_menu::{self, BrowserContextMenu, BrowserContextTargetKind};
 use super::file_actions::{
     format_copy_path, open_folder_in_file_explorer, reveal_in_file_explorer, sample_path_label,
 };
-use super::{FolderBrowserMessage, GuiAppState, emit_gui_action};
+use super::{GuiAppState, emit_gui_action};
 use wavecrate::external_clipboard;
 
 impl GuiAppState {
@@ -49,8 +49,6 @@ impl GuiAppState {
 
     pub(super) fn open_folder_context_menu(&mut self, folder_id: String, position: Point) {
         let started_at = Instant::now();
-        self.folder_browser
-            .apply_message(FolderBrowserMessage::ActivateFolder(folder_id.clone()));
         let Some(path) = self.folder_browser.folder_path(&folder_id) else {
             self.sample_status = String::from("Folder is unavailable");
             emit_gui_action(

--- a/src/gui_app/folder_browser/tree_state.rs
+++ b/src/gui_app/folder_browser/tree_state.rs
@@ -66,6 +66,24 @@ impl FolderBrowserState {
         folders
     }
 
+    #[cfg(test)]
+    pub(in crate::gui_app) fn first_visible_child_folder_expansion_for_tests(
+        &self,
+    ) -> Option<(String, bool)> {
+        self.visible_folders()
+            .into_iter()
+            .find(|folder| folder.has_children && !folder.selected)
+            .map(|folder| (folder.id, folder.expanded))
+    }
+
+    #[cfg(test)]
+    pub(in crate::gui_app) fn folder_expansion_for_tests(&self, folder_id: &str) -> Option<bool> {
+        self.visible_folders()
+            .into_iter()
+            .find(|folder| folder.id == folder_id)
+            .map(|folder| folder.expanded)
+    }
+
     fn push_visible_folder(
         &self,
         folder: &FolderEntry,

--- a/src/gui_app/tests.rs
+++ b/src/gui_app/tests.rs
@@ -6,8 +6,8 @@ use super::{
 use radiant::{
     gui::types::{Point, Rect, Vector2},
     prelude::{self as ui, IntoView},
-    runtime::PaintPrimitive,
-    widgets::DragHandleMessage,
+    runtime::{DeclarativeOwnedRuntimeBridge, Event, PaintPrimitive, SurfaceRuntime},
+    widgets::{DragHandleMessage, PointerButton, PointerModifiers},
 };
 use std::{fs, path::PathBuf, sync::mpsc};
 
@@ -719,6 +719,119 @@ fn default_gui_saves_sources_and_audio_output_to_app_config() {
     );
     assert_eq!(loaded.core.audio_output.sample_rate, Some(96_000));
     assert!((loaded.core.volume - 0.5).abs() < f32::EPSILON);
+}
+
+#[test]
+fn folder_context_menu_paints_as_full_width_overlay_panel() {
+    let menu = super::BrowserContextMenu {
+        kind: super::BrowserContextTargetKind::Folder,
+        path: PathBuf::from("Documents"),
+        anchor: Point::new(72.0, 142.0),
+        title: String::from("Documents"),
+    };
+    let frame = radiant::runtime::UiSurface::new(super::context_menu::overlay(&menu).into_node())
+        .frame(
+            Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(960.0, 540.0)),
+            &radiant::theme::ThemeTokens::default(),
+        );
+
+    let action_text_rect = frame
+        .paint_plan
+        .primitives
+        .iter()
+        .find_map(|primitive| match primitive {
+            PaintPrimitive::Text(text) if text.text.as_str() == "Open in Explorer" => {
+                Some(text.rect)
+            }
+            _ => None,
+        })
+        .expect("folder context menu action text should render");
+
+    assert!(action_text_rect.width() > 150.0, "{action_text_rect:?}");
+    assert!(
+        action_text_rect.min.x >= 80.0 && action_text_rect.min.x < 100.0,
+        "{action_text_rect:?}"
+    );
+}
+
+#[test]
+fn folder_context_menu_outside_click_closes_menu() {
+    let menu = super::BrowserContextMenu {
+        kind: super::BrowserContextTargetKind::Folder,
+        path: PathBuf::from("Documents"),
+        anchor: Point::new(72.0, 142.0),
+        title: String::from("Documents"),
+    };
+    let bridge = DeclarativeOwnedRuntimeBridge::new(
+        true,
+        move |open| {
+            if *open {
+                radiant::runtime::UiSurface::new(super::context_menu::overlay(&menu).into_node())
+            } else {
+                radiant::runtime::UiSurface::new(ui::text("").into_node())
+            }
+        },
+        |open, message| {
+            if matches!(message, super::GuiMessage::CloseContextMenu) {
+                *open = false;
+            }
+        },
+    );
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(960.0, 540.0));
+    let outside_menu = Point::new(18.0, 18.0);
+
+    runtime.dispatch_event(Event::PointerPress {
+        position: outside_menu,
+        button: PointerButton::Primary,
+        modifiers: PointerModifiers::default(),
+    });
+    runtime.dispatch_event(Event::PointerRelease {
+        position: outside_menu,
+        button: PointerButton::Primary,
+        modifiers: PointerModifiers::default(),
+    });
+
+    assert!(
+        !*runtime.bridge().state(),
+        "clicking outside the context menu should route to the dismiss layer"
+    );
+}
+
+#[test]
+fn folder_context_menu_open_does_not_toggle_folder_expansion() {
+    let root = std::env::temp_dir().join(format!(
+        "wavecrate-context-menu-right-click-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let parent = root.join("drums");
+    fs::create_dir_all(parent.join("kicks")).expect("create nested folder");
+
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .folder_browser
+        .begin_add_source_path(root.clone(), 100)
+        .expect("new source should request scan");
+    let result = super::folder_browser::scan_source_with_progress(request, |_| {}, |_| {});
+    state.finish_folder_scan(result);
+    let (folder_id, expanded_before) = state
+        .folder_browser
+        .first_visible_child_folder_expansion_for_tests()
+        .expect("test source should contain a child folder");
+
+    state.open_folder_context_menu(folder_id.clone(), Point::new(40.0, 120.0));
+
+    let expanded_after = state
+        .folder_browser
+        .folder_expansion_for_tests(&folder_id)
+        .expect("context-menu target should remain visible");
+    assert_eq!(
+        expanded_after, expanded_before,
+        "right-click context menu should not expand or collapse folders"
+    );
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- fix folder context menu sizing, outside-click dismissal, and right-click behavior
- replace generic accent menu buttons with neutral custom action rows and sample-style hover fill
- add regression coverage for menu paint, dismissal, and folder right-click expansion

## Validation
- powershell -ExecutionPolicy Bypass -File scripts\\ci.ps1 agent