### PR TITLE
Split browser toolbar layout helpers

### DIFF
--- a/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar.rs
@@ -1,16 +1,24 @@
 #![allow(dead_code)]
+#[path = "browser_toolbar/actions.rs"]
+mod actions;
+#[path = "browser_toolbar/filters.rs"]
+mod filters;
+#[path = "browser_toolbar/metrics.rs"]
+mod metrics;
+
+use self::actions::compute_action_slot_rects;
+use self::filters::{compute_playback_age_filter_chip_rects, compute_rating_filter_chip_rects};
+use self::metrics::{FilterLayout, ToolbarLayoutMetrics};
 use super::super::super::style::SizingTokens;
-use super::shared::{
-    center_square_rect, clamp_rect_to_bounds, empty_rect, layout_left_aligned_fixed_widths,
-};
+use super::shared::{clamp_rect_to_bounds, empty_rect};
 use crate::gui::types::{Point, Rect};
 
-const TOOLBAR_FILTER_ID: u64 = 801;
-const TOOLBAR_FILTER_CHIP_BASE_ID: u64 = 820;
-const RATING_FILTER_CHIP_COUNT: usize = 8;
-const PLAYBACK_AGE_FILTER_CHIP_COUNT: usize = 3;
-const MARKED_FILTER_CHIP_COUNT: usize = 1;
-const DERIVED_LABEL_FILTER_CHIP_COUNT: usize = 1;
+pub(super) const TOOLBAR_FILTER_ID: u64 = 801;
+pub(super) const TOOLBAR_FILTER_CHIP_BASE_ID: u64 = 820;
+pub(super) const RATING_FILTER_CHIP_COUNT: usize = 8;
+pub(super) const PLAYBACK_AGE_FILTER_CHIP_COUNT: usize = 3;
+pub(super) const MARKED_FILTER_CHIP_COUNT: usize = 1;
+pub(super) const DERIVED_LABEL_FILTER_CHIP_COUNT: usize = 1;
 
 /// Slot-resolved browser toolbar sections for search and chip controls.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -32,121 +40,24 @@ pub(crate) fn compute_browser_toolbar_sections(
     sizing: SizingTokens,
 ) -> BrowserToolbarSections {
     let empty = empty_rect(toolbar);
-    let empty_chips = [empty; 3];
-    let empty_filter_chips = [empty; RATING_FILTER_CHIP_COUNT];
-    let empty_playback_age_filter_chips = [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT];
-    let empty_action_slots = [empty; 3];
     if toolbar.width() <= 0.0 || toolbar.height() <= 0.0 {
-        return BrowserToolbarSections {
-            rating_filter_chips: empty_filter_chips,
-            playback_age_filter_chips: empty_playback_age_filter_chips,
-            marked_filter_chip: empty,
-            derived_label_filter_chip: empty,
-            action_slots: empty_action_slots,
-            search_field: empty,
-            activity_chip: empty,
-            sort_chip: empty,
-            triage_chips: empty_chips,
-        };
+        return empty_sections(empty);
     }
     let gap = sizing.action_button_gap.max(1.0);
     let host = toolbar;
     if host.width() <= 1.0 || host.height() <= 0.0 {
-        return BrowserToolbarSections {
-            rating_filter_chips: empty_filter_chips,
-            playback_age_filter_chips: empty_playback_age_filter_chips,
-            marked_filter_chip: empty,
-            derived_label_filter_chip: empty,
-            action_slots: empty_action_slots,
-            search_field: empty,
-            activity_chip: empty,
-            sort_chip: empty,
-            triage_chips: empty_chips,
-        };
+        return empty_sections(empty);
     }
     let left_min = host.min.x + sizing.text_inset_x;
     let left_max = (host.max.x - sizing.text_inset_x).max(left_min);
     let available = (left_max - left_min).max(0.0);
     if available <= 1.0 {
-        return BrowserToolbarSections {
-            rating_filter_chips: empty_filter_chips,
-            playback_age_filter_chips: empty_playback_age_filter_chips,
-            marked_filter_chip: empty,
-            derived_label_filter_chip: empty,
-            action_slots: empty_action_slots,
-            search_field: empty,
-            activity_chip: empty,
-            sort_chip: empty,
-            triage_chips: empty_chips,
-        };
+        return empty_sections(empty);
     }
-    let filter_gap = sizing.border_width.max(1.0) + 1.0;
-    let filter_group_gap = filter_gap + sizing.border_width.max(1.0) + 2.0;
-    let max_filter_side = (host.height() - (sizing.text_inset_y * 2.0))
-        .floor()
-        .clamp(6.0, 14.0);
-    let desired_search_width = ((host.width() * sizing.browser_search_field_ratio)
-        .max(sizing.browser_search_field_min_width))
-    .min(
-        (available * sizing.browser_search_field_ratio).max(sizing.browser_search_field_min_width),
-    );
-    let action_side = (host.height() - (sizing.text_inset_y * 0.4))
-        .floor()
-        .clamp(14.0, 24.0)
-        .min((available - gap).max(0.0));
-    let action_button_count = 2usize;
-    let action_cluster_gap = gap;
-    let action_cluster_width = if action_side > 0.0 {
-        (action_side * action_button_count as f32)
-            + (action_cluster_gap * action_button_count.saturating_sub(1) as f32)
-    } else {
-        0.0
-    };
-    let min_search_width = sizing.browser_search_field_min_width.min(available);
-    let mut filter_side = compute_filter_control_side(
-        (available - desired_search_width - action_cluster_width - (gap * 2.0)).max(0.0),
-        max_filter_side,
-        filter_gap,
-        filter_group_gap,
-    );
-    let mut filter_total_width =
-        browser_filter_cluster_width(filter_side, filter_gap, filter_group_gap).min(available);
-    let marked_chip_side = filter_side.max(0.0);
-    let marked_chip_width = if marked_chip_side > 0.0 {
-        marked_chip_side + filter_group_gap
-    } else {
-        0.0
-    };
-    let derived_label_chip_width = marked_chip_width;
-    let mut remaining_after_filters = (available
-        - filter_total_width
-        - marked_chip_width
-        - derived_label_chip_width
-        - action_cluster_width
-        - (gap * 2.0))
-        .max(0.0);
-    if remaining_after_filters < min_search_width && desired_search_width > min_search_width {
-        filter_side = compute_filter_control_side(
-            (available - min_search_width - action_cluster_width - (gap * 2.0)).max(0.0),
-            max_filter_side,
-            filter_gap,
-            filter_group_gap,
-        );
-        filter_total_width =
-            browser_filter_cluster_width(filter_side, filter_gap, filter_group_gap).min(available);
-        remaining_after_filters = (available
-            - filter_total_width
-            - if filter_side > 0.0 {
-                (filter_side + filter_group_gap) * 2.0
-            } else {
-                0.0
-            }
-            - action_cluster_width
-            - (gap * 2.0))
-            .max(0.0);
-    }
-    let right_tag_width = (action_side * 2.4).clamp(44.0, 72.0).min(available);
-    let right_tag_slot = if action_side > 0.0 && right_tag_width > 0.0 {
+    let metrics = ToolbarLayoutMetrics::new(host, sizing, available, gap);
+    let filter_layout = FilterLayout::fit(available, metrics);
+    let right_tag_width = (metrics.action_side * 2.4).clamp(44.0, 72.0).min(available);
+    let right_tag_slot = if metrics.action_side > 0.0 && right_tag_width > 0.0 {
         clamp_rect_to_bounds(
             Rect::from_min_max(
                 Point::new((left_max - right_tag_width).max(left_min), host.min.y),
@@ -162,14 +73,18 @@ pub(crate) fn compute_browser_toolbar_sections(
     } else {
         left_max
     };
-    let search_width = desired_search_width
-        .min(remaining_after_filters.max(min_search_width))
+    let search_width = metrics
+        .desired_search_width
+        .min(filter_layout.remaining_width.max(metrics.min_search_width))
         .max(0.0);
     let filter_bounds = Rect::from_min_max(
         Point::new(left_min, host.min.y),
-        Point::new((left_min + filter_total_width).min(left_max), host.max.y),
+        Point::new(
+            (left_min + filter_layout.total_width).min(left_max),
+            host.max.y,
+        ),
     );
-    let filter_strip = if filter_total_width > 0.0 {
+    let filter_strip = if filter_layout.total_width > 0.0 {
         clamp_rect_to_bounds(filter_bounds, host)
     } else {
         empty
@@ -182,28 +97,28 @@ pub(crate) fn compute_browser_toolbar_sections(
     } else {
         empty
     };
-    let marked_filter_chip = if marked_chip_side > 0.0 {
-        let min_x = (filter_strip.max.x + filter_group_gap).min(left_max);
+    let marked_filter_chip = if filter_layout.chip_side > 0.0 {
+        let min_x = (filter_strip.max.x + metrics.filter_group_gap).min(left_max);
         clamp_rect_to_bounds(
             Rect::from_min_max(
                 Point::new(min_x, host.min.y),
-                Point::new((min_x + marked_chip_side).min(left_max), host.max.y),
+                Point::new((min_x + filter_layout.chip_side).min(left_max), host.max.y),
             ),
             host,
         )
     } else {
         empty
     };
-    let derived_label_filter_chip = if marked_chip_side > 0.0 {
+    let derived_label_filter_chip = if filter_layout.chip_side > 0.0 {
         let min_x = if marked_filter_chip.width() > 1.0 {
-            (marked_filter_chip.max.x + filter_group_gap).min(left_max)
+            (marked_filter_chip.max.x + metrics.filter_group_gap).min(left_max)
         } else {
-            (filter_strip.max.x + filter_group_gap).min(left_max)
+            (filter_strip.max.x + metrics.filter_group_gap).min(left_max)
         };
         clamp_rect_to_bounds(
             Rect::from_min_max(
                 Point::new(min_x, host.min.y),
-                Point::new((min_x + marked_chip_side).min(left_max), host.max.y),
+                Point::new((min_x + filter_layout.chip_side).min(left_max), host.max.y),
             ),
             host,
         )
@@ -217,11 +132,11 @@ pub(crate) fn compute_browser_toolbar_sections(
     } else {
         filter_strip.max.x
     };
-    let action_cluster = if action_side > 0.0 && search_field.width() > 1.0 {
+    let action_cluster = if metrics.action_side > 0.0 && search_field.width() > 1.0 {
         let action_max_x = (search_field.min.x - gap).max(left_min);
         Rect::from_min_max(
             Point::new(
-                (action_max_x - action_cluster_width).max(controls_right_edge + gap),
+                (action_max_x - metrics.action_cluster_width).max(controls_right_edge + gap),
                 host.min.y,
             ),
             Point::new(action_max_x, host.max.y),
@@ -231,21 +146,21 @@ pub(crate) fn compute_browser_toolbar_sections(
     };
     let mut action_slots = compute_action_slot_rects(
         clamp_rect_to_bounds(action_cluster, host),
-        action_side,
-        action_cluster_gap,
+        metrics.action_side,
+        metrics.action_cluster_gap,
     );
     action_slots[2] = right_tag_slot;
     let rating_filter_chips = compute_rating_filter_chip_rects(
         filter_strip,
-        filter_side,
-        filter_gap,
+        filter_layout.chip_side,
+        metrics.filter_gap,
         TOOLBAR_FILTER_CHIP_BASE_ID,
     );
     let playback_age_filter_chips = compute_playback_age_filter_chip_rects(
         filter_strip,
-        filter_side,
-        filter_gap,
-        filter_group_gap,
+        filter_layout.chip_side,
+        metrics.filter_gap,
+        metrics.filter_group_gap,
     );
     BrowserToolbarSections {
         rating_filter_chips,
@@ -256,132 +171,20 @@ pub(crate) fn compute_browser_toolbar_sections(
         search_field,
         activity_chip: empty,
         sort_chip: empty,
-        triage_chips: empty_chips,
+        triage_chips: [empty; 3],
     }
 }
 
-fn compute_filter_control_side(
-    available_width: f32,
-    max_filter_side: f32,
-    filter_gap: f32,
-    filter_group_gap: f32,
-) -> f32 {
-    if available_width <= 0.0 {
-        return 0.0;
+fn empty_sections(empty: Rect) -> BrowserToolbarSections {
+    BrowserToolbarSections {
+        rating_filter_chips: [empty; RATING_FILTER_CHIP_COUNT],
+        playback_age_filter_chips: [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT],
+        marked_filter_chip: empty,
+        derived_label_filter_chip: empty,
+        action_slots: [empty; 3],
+        search_field: empty,
+        activity_chip: empty,
+        sort_chip: empty,
+        triage_chips: [empty; 3],
     }
-    let chip_count = (RATING_FILTER_CHIP_COUNT
-        + PLAYBACK_AGE_FILTER_CHIP_COUNT
-        + MARKED_FILTER_CHIP_COUNT
-        + DERIVED_LABEL_FILTER_CHIP_COUNT) as f32;
-    let intra_group_gap_count = (RATING_FILTER_CHIP_COUNT.saturating_sub(1)
-        + PLAYBACK_AGE_FILTER_CHIP_COUNT.saturating_sub(1)) as f32;
-    let raw_side =
-        (available_width - (filter_gap * intra_group_gap_count) - (filter_group_gap * 2.0))
-            / chip_count;
-    if raw_side <= 0.0 {
-        0.0
-    } else {
-        raw_side.floor().clamp(6.0, max_filter_side)
-    }
-}
-
-fn rating_filter_strip_width(chip_side: f32, gap: f32) -> f32 {
-    if chip_side <= 0.0 {
-        return 0.0;
-    }
-    (chip_side * RATING_FILTER_CHIP_COUNT as f32)
-        + (gap * (RATING_FILTER_CHIP_COUNT.saturating_sub(1) as f32))
-}
-
-fn playback_age_filter_strip_width(chip_side: f32, gap: f32) -> f32 {
-    if chip_side <= 0.0 {
-        return 0.0;
-    }
-    (chip_side * PLAYBACK_AGE_FILTER_CHIP_COUNT as f32)
-        + (gap * (PLAYBACK_AGE_FILTER_CHIP_COUNT.saturating_sub(1) as f32))
-}
-
-fn browser_filter_cluster_width(chip_side: f32, gap: f32, group_gap: f32) -> f32 {
-    if chip_side <= 0.0 {
-        return 0.0;
-    }
-    rating_filter_strip_width(chip_side, gap)
-        + group_gap
-        + playback_age_filter_strip_width(chip_side, gap)
-}
-
-fn compute_action_slot_rects(cluster: Rect, action_side: f32, gap: f32) -> [Rect; 3] {
-    let empty = empty_rect(cluster);
-    if cluster.width() <= 1.0 || cluster.height() <= 0.0 || action_side <= 0.0 {
-        return [empty; 3];
-    }
-    let widths = [action_side; 3];
-    let rects = layout_left_aligned_fixed_widths(cluster, gap, &widths, TOOLBAR_FILTER_ID + 30, 0);
-    let mut slots = [empty; 3];
-    for (index, rect) in rects.into_iter().take(3).enumerate() {
-        slots[index] = center_square_rect(rect, action_side);
-    }
-    slots
-}
-
-fn compute_rating_filter_chip_rects(
-    strip: Rect,
-    chip_side: f32,
-    gap: f32,
-    first_chip_id: u64,
-) -> [Rect; 8] {
-    let empty = empty_rect(strip);
-    if strip.width() <= 1.0 || strip.height() <= 0.0 || chip_side <= 0.0 {
-        return [empty; RATING_FILTER_CHIP_COUNT];
-    }
-    let widths = [chip_side; RATING_FILTER_CHIP_COUNT];
-    let rects = layout_left_aligned_fixed_widths(
-        strip,
-        gap,
-        &widths,
-        TOOLBAR_FILTER_ID + 10,
-        first_chip_id,
-    );
-    let mut chips = [empty; RATING_FILTER_CHIP_COUNT];
-    for (index, rect) in rects.into_iter().take(RATING_FILTER_CHIP_COUNT).enumerate() {
-        chips[index] = center_square_rect(rect, chip_side);
-    }
-    chips
-}
-
-fn compute_playback_age_filter_chip_rects(
-    strip: Rect,
-    chip_side: f32,
-    gap: f32,
-    group_gap: f32,
-) -> [Rect; 3] {
-    let empty = empty_rect(strip);
-    if strip.width() <= 1.0 || strip.height() <= 0.0 || chip_side <= 0.0 {
-        return [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT];
-    }
-    let widths = [chip_side; PLAYBACK_AGE_FILTER_CHIP_COUNT];
-    let rating_strip_width = rating_filter_strip_width(chip_side, gap);
-    let age_strip = Rect::from_min_max(
-        Point::new(
-            (strip.min.x + rating_strip_width + group_gap).min(strip.max.x),
-            strip.min.y,
-        ),
-        strip.max,
-    );
-    let rects = layout_left_aligned_fixed_widths(
-        age_strip,
-        gap,
-        &widths,
-        TOOLBAR_FILTER_ID + 20,
-        TOOLBAR_FILTER_CHIP_BASE_ID + RATING_FILTER_CHIP_COUNT as u64,
-    );
-    let mut chips = [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT];
-    for (index, rect) in rects
-        .into_iter()
-        .take(PLAYBACK_AGE_FILTER_CHIP_COUNT)
-        .enumerate()
-    {
-        chips[index] = center_square_rect(rect, chip_side);
-    }
-    chips
 }

--- a/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/actions.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/actions.rs
@@ -1,0 +1,18 @@
+use super::super::shared::{center_square_rect, empty_rect, layout_left_aligned_fixed_widths};
+use super::TOOLBAR_FILTER_ID;
+use crate::gui::types::Rect;
+
+pub(super) fn compute_action_slot_rects(cluster: Rect, action_side: f32, gap: f32) -> [Rect; 3] {
+    let empty = empty_rect(cluster);
+    if cluster.width() <= 1.0 || cluster.height() <= 0.0 || action_side <= 0.0 {
+        return [empty; 3];
+    }
+
+    let widths = [action_side; 3];
+    let rects = layout_left_aligned_fixed_widths(cluster, gap, &widths, TOOLBAR_FILTER_ID + 30, 0);
+    let mut slots = [empty; 3];
+    for (index, rect) in rects.into_iter().take(3).enumerate() {
+        slots[index] = center_square_rect(rect, action_side);
+    }
+    slots
+}

--- a/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/filters.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/filters.rs
@@ -1,0 +1,125 @@
+use super::super::shared::{center_square_rect, empty_rect, layout_left_aligned_fixed_widths};
+use super::{
+    DERIVED_LABEL_FILTER_CHIP_COUNT, MARKED_FILTER_CHIP_COUNT, PLAYBACK_AGE_FILTER_CHIP_COUNT,
+    RATING_FILTER_CHIP_COUNT, TOOLBAR_FILTER_CHIP_BASE_ID, TOOLBAR_FILTER_ID,
+};
+use crate::gui::types::{Point, Rect};
+
+pub(super) fn compute_filter_control_side(
+    available_width: f32,
+    max_filter_side: f32,
+    filter_gap: f32,
+    filter_group_gap: f32,
+) -> f32 {
+    if available_width <= 0.0 {
+        return 0.0;
+    }
+
+    let chip_count = (RATING_FILTER_CHIP_COUNT
+        + PLAYBACK_AGE_FILTER_CHIP_COUNT
+        + MARKED_FILTER_CHIP_COUNT
+        + DERIVED_LABEL_FILTER_CHIP_COUNT) as f32;
+    let intra_group_gap_count = (RATING_FILTER_CHIP_COUNT.saturating_sub(1)
+        + PLAYBACK_AGE_FILTER_CHIP_COUNT.saturating_sub(1)) as f32;
+    let raw_side =
+        (available_width - (filter_gap * intra_group_gap_count) - (filter_group_gap * 2.0))
+            / chip_count;
+
+    if raw_side <= 0.0 {
+        0.0
+    } else {
+        raw_side.floor().clamp(6.0, max_filter_side)
+    }
+}
+
+pub(super) fn browser_filter_cluster_width(chip_side: f32, gap: f32, group_gap: f32) -> f32 {
+    if chip_side <= 0.0 {
+        return 0.0;
+    }
+
+    rating_filter_strip_width(chip_side, gap)
+        + group_gap
+        + playback_age_filter_strip_width(chip_side, gap)
+}
+
+pub(super) fn compute_rating_filter_chip_rects(
+    strip: Rect,
+    chip_side: f32,
+    gap: f32,
+    first_chip_id: u64,
+) -> [Rect; RATING_FILTER_CHIP_COUNT] {
+    let empty = empty_rect(strip);
+    if strip.width() <= 1.0 || strip.height() <= 0.0 || chip_side <= 0.0 {
+        return [empty; RATING_FILTER_CHIP_COUNT];
+    }
+
+    let widths = [chip_side; RATING_FILTER_CHIP_COUNT];
+    let rects = layout_left_aligned_fixed_widths(
+        strip,
+        gap,
+        &widths,
+        TOOLBAR_FILTER_ID + 10,
+        first_chip_id,
+    );
+    let mut chips = [empty; RATING_FILTER_CHIP_COUNT];
+    for (index, rect) in rects.into_iter().take(RATING_FILTER_CHIP_COUNT).enumerate() {
+        chips[index] = center_square_rect(rect, chip_side);
+    }
+    chips
+}
+
+pub(super) fn compute_playback_age_filter_chip_rects(
+    strip: Rect,
+    chip_side: f32,
+    gap: f32,
+    group_gap: f32,
+) -> [Rect; PLAYBACK_AGE_FILTER_CHIP_COUNT] {
+    let empty = empty_rect(strip);
+    if strip.width() <= 1.0 || strip.height() <= 0.0 || chip_side <= 0.0 {
+        return [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT];
+    }
+
+    let widths = [chip_side; PLAYBACK_AGE_FILTER_CHIP_COUNT];
+    let rating_strip_width = rating_filter_strip_width(chip_side, gap);
+    let age_strip = Rect::from_min_max(
+        Point::new(
+            (strip.min.x + rating_strip_width + group_gap).min(strip.max.x),
+            strip.min.y,
+        ),
+        strip.max,
+    );
+    let rects = layout_left_aligned_fixed_widths(
+        age_strip,
+        gap,
+        &widths,
+        TOOLBAR_FILTER_ID + 20,
+        TOOLBAR_FILTER_CHIP_BASE_ID + RATING_FILTER_CHIP_COUNT as u64,
+    );
+    let mut chips = [empty; PLAYBACK_AGE_FILTER_CHIP_COUNT];
+    for (index, rect) in rects
+        .into_iter()
+        .take(PLAYBACK_AGE_FILTER_CHIP_COUNT)
+        .enumerate()
+    {
+        chips[index] = center_square_rect(rect, chip_side);
+    }
+    chips
+}
+
+fn rating_filter_strip_width(chip_side: f32, gap: f32) -> f32 {
+    if chip_side <= 0.0 {
+        return 0.0;
+    }
+
+    (chip_side * RATING_FILTER_CHIP_COUNT as f32)
+        + (gap * (RATING_FILTER_CHIP_COUNT.saturating_sub(1) as f32))
+}
+
+fn playback_age_filter_strip_width(chip_side: f32, gap: f32) -> f32 {
+    if chip_side <= 0.0 {
+        return 0.0;
+    }
+
+    (chip_side * PLAYBACK_AGE_FILTER_CHIP_COUNT as f32)
+        + (gap * (PLAYBACK_AGE_FILTER_CHIP_COUNT.saturating_sub(1) as f32))
+}

--- a/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/metrics.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/browser_toolbar/metrics.rs
@@ -1,0 +1,103 @@
+use super::super::super::super::style::SizingTokens;
+use super::filters::{browser_filter_cluster_width, compute_filter_control_side};
+use crate::gui::types::Rect;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ToolbarLayoutMetrics {
+    pub action_cluster_gap: f32,
+    pub action_cluster_width: f32,
+    pub action_side: f32,
+    pub desired_search_width: f32,
+    pub filter_gap: f32,
+    pub filter_group_gap: f32,
+    pub min_search_width: f32,
+    max_filter_side: f32,
+    outer_gap: f32,
+}
+
+impl ToolbarLayoutMetrics {
+    pub(super) fn new(host: Rect, sizing: SizingTokens, available: f32, gap: f32) -> Self {
+        let filter_gap = sizing.border_width.max(1.0) + 1.0;
+        let action_side = (host.height() - (sizing.text_inset_y * 0.4))
+            .floor()
+            .clamp(14.0, 24.0)
+            .min((available - gap).max(0.0));
+        let action_cluster_gap = gap;
+        let action_cluster_width = if action_side > 0.0 {
+            (action_side * 2.0) + action_cluster_gap
+        } else {
+            0.0
+        };
+
+        Self {
+            action_cluster_gap,
+            action_cluster_width,
+            action_side,
+            desired_search_width: desired_search_width(host, sizing, available),
+            filter_gap,
+            filter_group_gap: filter_gap + sizing.border_width.max(1.0) + 2.0,
+            min_search_width: sizing.browser_search_field_min_width.min(available),
+            max_filter_side: (host.height() - (sizing.text_inset_y * 2.0))
+                .floor()
+                .clamp(6.0, 14.0),
+            outer_gap: gap,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FilterLayout {
+    pub chip_side: f32,
+    pub remaining_width: f32,
+    pub total_width: f32,
+}
+
+impl FilterLayout {
+    pub(super) fn fit(available: f32, metrics: ToolbarLayoutMetrics) -> Self {
+        let mut layout = Self::for_search_width(available, metrics.desired_search_width, metrics);
+        if layout.remaining_width < metrics.min_search_width
+            && metrics.desired_search_width > metrics.min_search_width
+        {
+            layout = Self::for_search_width(available, metrics.min_search_width, metrics);
+        }
+        layout
+    }
+
+    fn for_search_width(available: f32, search_width: f32, metrics: ToolbarLayoutMetrics) -> Self {
+        let chip_side = compute_filter_control_side(
+            (available - search_width - metrics.action_cluster_width - (metrics.outer_gap * 2.0))
+                .max(0.0),
+            metrics.max_filter_side,
+            metrics.filter_gap,
+            metrics.filter_group_gap,
+        );
+        let total_width =
+            browser_filter_cluster_width(chip_side, metrics.filter_gap, metrics.filter_group_gap)
+                .min(available);
+        let extra_chip_width = if chip_side > 0.0 {
+            (chip_side + metrics.filter_group_gap) * 2.0
+        } else {
+            0.0
+        };
+        let remaining_width = (available
+            - total_width
+            - extra_chip_width
+            - metrics.action_cluster_width
+            - (metrics.outer_gap * 2.0))
+            .max(0.0);
+
+        Self {
+            chip_side,
+            remaining_width,
+            total_width,
+        }
+    }
+}
+
+fn desired_search_width(host: Rect, sizing: SizingTokens, available: f32) -> f32 {
+    ((host.width() * sizing.browser_search_field_ratio).max(sizing.browser_search_field_min_width))
+        .min(
+            (available * sizing.browser_search_field_ratio)
+                .max(sizing.browser_search_field_min_width),
+        )
+}

--- a/src/app_core/native_shell/composition/ownership_inventory.tsv
+++ b/src/app_core/native_shell/composition/ownership_inventory.tsv
@@ -28,6 +28,7 @@ layout_adapter/controls.rs	wavecrate_composition	OPT-187	Shared control layout f
 layout_adapter/controls/shared.rs	wavecrate_composition	OPT-187	Shared shell-control helper moves with the first chrome-control slice.
 layout_adapter/controls/update_buttons.rs	wavecrate_composition	OPT-187	Update/control button layout moves with top bar and options composition.
 layout_adapter/controls/browser_toolbar.rs	wavecrate_composition	OPT-188	Browser toolbar controls move with browser chrome composition.
+layout_adapter/controls/browser_toolbar/**	wavecrate_composition	OPT-188	Browser toolbar layout helpers move with browser chrome composition.
 layout_adapter/controls/sidebar_buttons.rs	wavecrate_composition	OPT-189	Sidebar and folder controls move with source/sidebar composition.
 layout_adapter/controls_tests.rs	wavecrate_fixture	OPT-191	Wavecrate shell control layout fixture now lives beside Wavecrate composition and must not return to Radiant native_shell.
 layout_adapter/map_canvas.rs	wavecrate_composition	OPT-188	Browser map canvas projection moves with browser map composition.


### PR DESCRIPTION
## Summary
- split browser toolbar layout math into focused action, filter, and metric helpers
- keep the existing browser toolbar facade and public layout contract intact
- add ownership inventory coverage for the helper directory

## Validation
- cargo test -p wavecrate --lib toolbar_sections -- --nocapture
- cargo test -p wavecrate --lib toolbar_search_field_uses_ratio_width_inside_full_host -- --nocapture
- cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent with RUST_TEST_THREADS=1
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 cleanup-hotspots