### PR TITLE
Split browser action routing helpers

### DIFF
--- a/src/app_core/controller/browser_actions/browser.rs
+++ b/src/app_core/controller/browser_actions/browser.rs
@@ -1,15 +1,48 @@
 //! Browser-list routing for native browser actions.
 
+#[path = "browser/drag.rs"]
+mod drag;
+#[path = "browser/edits.rs"]
+mod edits;
+#[path = "browser/filters.rs"]
+mod filters;
+#[path = "browser/tagging.rs"]
+mod tagging;
+
 use super::super::AppController;
-use crate::app_core::actions::NativeFolderPaneIdModel as FolderPaneIdModel;
 use crate::app_core::actions::NativeUiAction;
-use crate::app_core::app_api::state::{
-    DragSource, DragTarget, FocusContext, FolderBrowserUiState, FolderPaneId, UiPoint,
-};
-use crate::app_core::state::{PlaybackAgeFilterChip, StatusTone};
+use crate::app_core::app_api::state::FocusContext;
+use crate::app_core::state::StatusTone;
 
 /// Try to dispatch browser-list native actions.
 pub(super) fn apply_browser_list_native_ui_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    let action = match apply_focus_and_selection_action(controller, action) {
+        Ok(()) => return Ok(()),
+        Err(action) => action,
+    };
+    let action = match drag::apply_drag_action(controller, action) {
+        Ok(()) => return Ok(()),
+        Err(action) => action,
+    };
+    let action = match filters::apply_filter_action(controller, action) {
+        Ok(()) => return Ok(()),
+        Err(action) => action,
+    };
+    let action = match apply_history_and_cleanup_action(controller, action) {
+        Ok(()) => return Ok(()),
+        Err(action) => action,
+    };
+    let action = match tagging::apply_tagging_action(controller, action) {
+        Ok(()) => return Ok(()),
+        Err(action) => action,
+    };
+    edits::apply_edit_action(controller, action)
+}
+
+fn apply_focus_and_selection_action(
     controller: &mut AppController,
     action: NativeUiAction,
 ) -> Result<(), NativeUiAction> {
@@ -30,39 +63,6 @@ pub(super) fn apply_browser_list_native_ui_action(
             controller.set_compare_anchor_from_focused_browser_sample()
         }
         NativeUiAction::CommitFocusedBrowserRow => handle_commit_focused_browser_row(controller),
-        NativeUiAction::ToggleBrowserRowSelection { visible_row } => {
-            controller.toggle_browser_row_selection(visible_row)
-        }
-        NativeUiAction::StartBrowserSampleDrag {
-            visible_row,
-            pointer_x,
-            pointer_y,
-        } => controller
-            .start_browser_sample_drag_action(visible_row, native_drag_point(pointer_x, pointer_y)),
-        NativeUiAction::UpdateBrowserSampleDrag {
-            pointer_x,
-            pointer_y,
-            hovered_folder_pane,
-            hovered_folder_row,
-            over_folder_panel,
-            shift_down,
-            alt_down,
-        } => {
-            let target = folder_drag_target(
-                controller,
-                hovered_folder_pane,
-                hovered_folder_row,
-                over_folder_panel,
-            );
-            controller.update_active_drag(
-                native_drag_point(pointer_x, pointer_y),
-                DragSource::Browser,
-                target,
-                shift_down,
-                alt_down,
-            );
-        }
-        NativeUiAction::FinishBrowserSampleDrag => controller.finish_active_drag(),
         NativeUiAction::ExtendBrowserSelectionToRow { visible_row } => {
             controller.extend_browser_selection_to_row(visible_row)
         }
@@ -75,61 +75,23 @@ pub(super) fn apply_browser_list_native_ui_action(
         NativeUiAction::AddRangeBrowserSelectionFromFocus { delta } => {
             controller.add_range_browser_selection_from_focus_action(delta)
         }
+        NativeUiAction::ToggleBrowserRowSelection { visible_row } => {
+            controller.toggle_browser_row_selection(visible_row)
+        }
         NativeUiAction::ToggleFocusedBrowserRowSelection => controller.toggle_focused_selection(),
         NativeUiAction::SelectAllBrowserRows => controller.select_all_browser_rows(),
         NativeUiAction::SetBrowserSearch { query } => controller.set_browser_search(query),
-        NativeUiAction::ToggleBrowserRatingFilter { level, invert } => {
-            controller.focus_browser_list();
-            if invert {
-                controller.invert_browser_rating_filter(level);
-            } else {
-                controller.set_browser_rating_filter(level, true);
-            }
-        }
-        NativeUiAction::ToggleBrowserPlaybackAgeFilter { bucket, invert } => {
-            controller.focus_browser_list();
-            let chip = match bucket {
-                crate::app_core::actions::NativePlaybackAgeFilterChip::NeverPlayed => {
-                    PlaybackAgeFilterChip::NeverPlayed
-                }
-                crate::app_core::actions::NativePlaybackAgeFilterChip::OlderThanMonth => {
-                    PlaybackAgeFilterChip::OlderThanMonth
-                }
-                crate::app_core::actions::NativePlaybackAgeFilterChip::OlderThanWeek => {
-                    PlaybackAgeFilterChip::OlderThanWeek
-                }
-            };
-            if invert {
-                controller.invert_browser_playback_age_filter(chip);
-            } else {
-                controller.set_browser_playback_age_filter(chip, true);
-            }
-        }
-        NativeUiAction::ToggleBrowserSidebarFilter { option, additive } => {
-            controller.focus_browser_list();
-            controller.toggle_browser_sidebar_filter(option, additive);
-        }
-        NativeUiAction::ClearBrowserSidebarFilter { facet } => {
-            controller.focus_browser_list();
-            controller.clear_browser_sidebar_filter(facet);
-        }
-        NativeUiAction::ToggleBrowserSampleMark => {
-            controller.focus_browser_list();
-            controller.toggle_browser_sample_mark();
-        }
-        NativeUiAction::ToggleBrowserMarkedFilter => {
-            controller.focus_browser_list();
-            controller.toggle_browser_marked_filter();
-        }
-        NativeUiAction::ToggleBrowserTagNamedFilter { invert } => {
-            controller.focus_browser_list();
-            controller.toggle_browser_tag_named_filter(invert);
-        }
+        action => return Err(action),
+    }
+    Ok(())
+}
+
+fn apply_history_and_cleanup_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    match action {
         NativeUiAction::ToggleRandomNavigationMode => controller.toggle_random_navigation_mode(),
-        NativeUiAction::ToggleBrowserTagSidebar => controller.toggle_browser_tag_sidebar(),
-        NativeUiAction::ToggleBrowserTagSidebarAutoRename => {
-            controller.toggle_browser_tag_sidebar_auto_rename()
-        }
         NativeUiAction::ToggleBrowserDuplicateCleanupMode => {
             controller.toggle_browser_duplicate_cleanup_mode()
         }
@@ -139,12 +101,13 @@ pub(super) fn apply_browser_list_native_ui_action(
             controller.toggle_find_similar_focused_sample()
         }
         NativeUiAction::ToggleBrowserDuplicateCleanupKeep { visible_row } => {
-            match controller.toggle_browser_duplicate_cleanup_keep_for_visible_row(visible_row) {
-                Ok(_) => {}
-                Err(err) => controller.set_status(
+            if let Err(err) =
+                controller.toggle_browser_duplicate_cleanup_keep_for_visible_row(visible_row)
+            {
+                controller.set_status(
                     format!("Duplicate cleanup keep toggle failed: {err}"),
                     StatusTone::Warning,
-                ),
+                );
             }
         }
         NativeUiAction::ConfirmBrowserDuplicateCleanup => {
@@ -160,60 +123,6 @@ pub(super) fn apply_browser_list_native_ui_action(
         NativeUiAction::AdjustSelectedBrowserRating { delta } => {
             controller.adjust_selected_rating(delta)
         }
-        NativeUiAction::FocusBrowserTagSidebarInput => {}
-        NativeUiAction::SetBrowserTagSidebarInput { value } => {
-            controller.set_browser_tag_sidebar_input(value)
-        }
-        NativeUiAction::CommitBrowserTagSidebarInput => {
-            if let Err(err) = controller.commit_browser_tag_sidebar_input() {
-                controller.set_status(format!("Could not apply tag: {err}"), StatusTone::Error);
-            }
-        }
-        NativeUiAction::SetBrowserSidebarLooped { looped } => {
-            if let Err(err) = controller.apply_browser_tag_sidebar_looped(looped) {
-                controller.set_status(
-                    format!("Could not update playback type: {err}"),
-                    StatusTone::Error,
-                );
-            }
-        }
-        NativeUiAction::ToggleBrowserSidebarNormalTag { label } => {
-            let result = if let Some(source) = controller.current_source() {
-                let target_paths = controller.browser_tag_sidebar_target_paths();
-                match controller.normal_tag_state_for_source(&source, &target_paths, &label) {
-                    Ok(crate::app_core::actions::NativeBrowserTagState::On) => {
-                        controller.remove_browser_tag_sidebar_normal_tag(&label)
-                    }
-                    Ok(_) => controller.apply_browser_tag_sidebar_normal_tag(&label),
-                    Err(err) => Err(err),
-                }
-            } else {
-                Err(String::from("No source selected"))
-            };
-            if let Err(err) = result {
-                controller.set_status(format!("Could not update tag: {err}"), StatusTone::Error);
-            }
-        }
-        NativeUiAction::StartBrowserRename => controller.start_browser_rename(),
-        NativeUiAction::ConfirmBrowserRename => controller.apply_pending_browser_rename(),
-        NativeUiAction::CancelBrowserRename => controller.cancel_browser_rename(),
-        NativeUiAction::AutoRenameBrowserSelection { visible_row } => {
-            controller.auto_rename_browser_selection_action(visible_row)
-        }
-        NativeUiAction::TagBrowserSelection { target } => {
-            controller.tag_selected_browser_target(target.into())
-        }
-        NativeUiAction::NormalizeFocusedBrowserSample => {
-            if let Some(row) = controller.focused_browser_row() {
-                let _ = controller.normalize_browser_sample(row);
-            } else {
-                controller.set_status("Focus a sample to normalize it", StatusTone::Info);
-            }
-        }
-        NativeUiAction::DeleteBrowserSelection => {
-            controller.delete_active_browser_selection_action()
-        }
-        NativeUiAction::MoveTrashedSamplesToFolder => controller.move_all_trashed_to_folder(),
         action => return Err(action),
     }
     Ok(())
@@ -225,63 +134,4 @@ fn handle_commit_focused_browser_row(controller: &mut AppController) {
         return;
     }
     controller.toggle_play_pause();
-}
-
-fn folder_drag_target(
-    controller: &AppController,
-    hovered_folder_pane: Option<FolderPaneIdModel>,
-    hovered_folder_row: Option<usize>,
-    over_folder_panel: Option<FolderPaneIdModel>,
-) -> DragTarget {
-    if let Some(folder) = hovered_folder_pane
-        .zip(hovered_folder_row)
-        .and_then(|(pane, row)| folder_row_path(controller, pane, row))
-    {
-        return DragTarget::FolderPanel {
-            pane: hovered_folder_pane
-                .map(folder_pane_id_from_native)
-                .unwrap_or_else(|| controller.active_folder_pane()),
-            folder: Some(folder),
-        };
-    }
-    if let Some(pane) = over_folder_panel.map(folder_pane_id_from_native) {
-        DragTarget::FolderPanel { pane, folder: None }
-    } else {
-        DragTarget::None
-    }
-}
-
-fn folder_row_path(
-    controller: &AppController,
-    pane: FolderPaneIdModel,
-    folder_row: usize,
-) -> Option<std::path::PathBuf> {
-    folder_browser_for_pane(controller, pane)
-        .rows
-        .get(folder_row)
-        .map(|row| row.path.clone())
-}
-
-/// Convert native action pointer coordinates into controller UI points.
-fn native_drag_point(pointer_x: u16, pointer_y: u16) -> UiPoint {
-    UiPoint::new(f32::from(pointer_x), f32::from(pointer_y))
-}
-
-fn folder_pane_id_from_native(pane: FolderPaneIdModel) -> FolderPaneId {
-    match pane {
-        FolderPaneIdModel::Upper => FolderPaneId::Upper,
-        FolderPaneIdModel::Lower => FolderPaneId::Lower,
-    }
-}
-
-fn folder_browser_for_pane(
-    controller: &AppController,
-    pane: FolderPaneIdModel,
-) -> &FolderBrowserUiState {
-    let pane = folder_pane_id_from_native(pane);
-    if controller.active_folder_pane() == pane {
-        &controller.ui.sources.folders
-    } else {
-        &controller.ui.sources.folder_pane(pane).browser
-    }
 }

--- a/src/app_core/controller/browser_actions/browser/drag.rs
+++ b/src/app_core/controller/browser_actions/browser/drag.rs
@@ -1,0 +1,104 @@
+use super::super::super::AppController;
+use crate::app_core::actions::{NativeFolderPaneIdModel as FolderPaneIdModel, NativeUiAction};
+use crate::app_core::app_api::state::{
+    DragSource, DragTarget, FolderBrowserUiState, FolderPaneId, UiPoint,
+};
+
+pub(super) fn apply_drag_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    match action {
+        NativeUiAction::StartBrowserSampleDrag {
+            visible_row,
+            pointer_x,
+            pointer_y,
+        } => controller
+            .start_browser_sample_drag_action(visible_row, native_drag_point(pointer_x, pointer_y)),
+        NativeUiAction::UpdateBrowserSampleDrag {
+            pointer_x,
+            pointer_y,
+            hovered_folder_pane,
+            hovered_folder_row,
+            over_folder_panel,
+            shift_down,
+            alt_down,
+        } => {
+            let target = folder_drag_target(
+                controller,
+                hovered_folder_pane,
+                hovered_folder_row,
+                over_folder_panel,
+            );
+            controller.update_active_drag(
+                native_drag_point(pointer_x, pointer_y),
+                DragSource::Browser,
+                target,
+                shift_down,
+                alt_down,
+            );
+        }
+        NativeUiAction::FinishBrowserSampleDrag => controller.finish_active_drag(),
+        action => return Err(action),
+    }
+    Ok(())
+}
+
+fn folder_drag_target(
+    controller: &AppController,
+    hovered_folder_pane: Option<FolderPaneIdModel>,
+    hovered_folder_row: Option<usize>,
+    over_folder_panel: Option<FolderPaneIdModel>,
+) -> DragTarget {
+    if let Some(folder) = hovered_folder_pane
+        .zip(hovered_folder_row)
+        .and_then(|(pane, row)| folder_row_path(controller, pane, row))
+    {
+        return DragTarget::FolderPanel {
+            pane: hovered_folder_pane
+                .map(folder_pane_id_from_native)
+                .unwrap_or_else(|| controller.active_folder_pane()),
+            folder: Some(folder),
+        };
+    }
+
+    if let Some(pane) = over_folder_panel.map(folder_pane_id_from_native) {
+        DragTarget::FolderPanel { pane, folder: None }
+    } else {
+        DragTarget::None
+    }
+}
+
+fn folder_row_path(
+    controller: &AppController,
+    pane: FolderPaneIdModel,
+    folder_row: usize,
+) -> Option<std::path::PathBuf> {
+    folder_browser_for_pane(controller, pane)
+        .rows
+        .get(folder_row)
+        .map(|row| row.path.clone())
+}
+
+fn native_drag_point(pointer_x: u16, pointer_y: u16) -> UiPoint {
+    UiPoint::new(f32::from(pointer_x), f32::from(pointer_y))
+}
+
+fn folder_pane_id_from_native(pane: FolderPaneIdModel) -> FolderPaneId {
+    match pane {
+        FolderPaneIdModel::Upper => FolderPaneId::Upper,
+        FolderPaneIdModel::Lower => FolderPaneId::Lower,
+    }
+}
+
+fn folder_browser_for_pane(
+    controller: &AppController,
+    pane: FolderPaneIdModel,
+) -> &FolderBrowserUiState {
+    let pane = folder_pane_id_from_native(pane);
+    if controller.active_folder_pane() == pane {
+        &controller.ui.sources.folders
+    } else {
+        &controller.ui.sources.folder_pane(pane).browser
+    }
+}

--- a/src/app_core/controller/browser_actions/browser/edits.rs
+++ b/src/app_core/controller/browser_actions/browser/edits.rs
@@ -1,0 +1,35 @@
+use super::super::super::AppController;
+use crate::app_core::actions::NativeUiAction;
+use crate::app_core::state::StatusTone;
+
+pub(super) fn apply_edit_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    match action {
+        NativeUiAction::StartBrowserRename => controller.start_browser_rename(),
+        NativeUiAction::ConfirmBrowserRename => controller.apply_pending_browser_rename(),
+        NativeUiAction::CancelBrowserRename => controller.cancel_browser_rename(),
+        NativeUiAction::AutoRenameBrowserSelection { visible_row } => {
+            controller.auto_rename_browser_selection_action(visible_row)
+        }
+        NativeUiAction::TagBrowserSelection { target } => {
+            controller.tag_selected_browser_target(target.into())
+        }
+        NativeUiAction::NormalizeFocusedBrowserSample => normalize_focused_sample(controller),
+        NativeUiAction::DeleteBrowserSelection => {
+            controller.delete_active_browser_selection_action()
+        }
+        NativeUiAction::MoveTrashedSamplesToFolder => controller.move_all_trashed_to_folder(),
+        action => return Err(action),
+    }
+    Ok(())
+}
+
+fn normalize_focused_sample(controller: &mut AppController) {
+    if let Some(row) = controller.focused_browser_row() {
+        let _ = controller.normalize_browser_sample(row);
+    } else {
+        controller.set_status("Focus a sample to normalize it", StatusTone::Info);
+    }
+}

--- a/src/app_core/controller/browser_actions/browser/filters.rs
+++ b/src/app_core/controller/browser_actions/browser/filters.rs
@@ -1,0 +1,58 @@
+use super::super::super::AppController;
+use crate::app_core::actions::{NativePlaybackAgeFilterChip, NativeUiAction};
+use crate::app_core::state::PlaybackAgeFilterChip;
+
+pub(super) fn apply_filter_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    match action {
+        NativeUiAction::ToggleBrowserRatingFilter { level, invert } => {
+            controller.focus_browser_list();
+            if invert {
+                controller.invert_browser_rating_filter(level);
+            } else {
+                controller.set_browser_rating_filter(level, true);
+            }
+        }
+        NativeUiAction::ToggleBrowserPlaybackAgeFilter { bucket, invert } => {
+            controller.focus_browser_list();
+            let chip = playback_age_filter_chip(bucket);
+            if invert {
+                controller.invert_browser_playback_age_filter(chip);
+            } else {
+                controller.set_browser_playback_age_filter(chip, true);
+            }
+        }
+        NativeUiAction::ToggleBrowserSidebarFilter { option, additive } => {
+            controller.focus_browser_list();
+            controller.toggle_browser_sidebar_filter(option, additive);
+        }
+        NativeUiAction::ClearBrowserSidebarFilter { facet } => {
+            controller.focus_browser_list();
+            controller.clear_browser_sidebar_filter(facet);
+        }
+        NativeUiAction::ToggleBrowserSampleMark => {
+            controller.focus_browser_list();
+            controller.toggle_browser_sample_mark();
+        }
+        NativeUiAction::ToggleBrowserMarkedFilter => {
+            controller.focus_browser_list();
+            controller.toggle_browser_marked_filter();
+        }
+        NativeUiAction::ToggleBrowserTagNamedFilter { invert } => {
+            controller.focus_browser_list();
+            controller.toggle_browser_tag_named_filter(invert);
+        }
+        action => return Err(action),
+    }
+    Ok(())
+}
+
+fn playback_age_filter_chip(bucket: NativePlaybackAgeFilterChip) -> PlaybackAgeFilterChip {
+    match bucket {
+        NativePlaybackAgeFilterChip::NeverPlayed => PlaybackAgeFilterChip::NeverPlayed,
+        NativePlaybackAgeFilterChip::OlderThanMonth => PlaybackAgeFilterChip::OlderThanMonth,
+        NativePlaybackAgeFilterChip::OlderThanWeek => PlaybackAgeFilterChip::OlderThanWeek,
+    }
+}

--- a/src/app_core/controller/browser_actions/browser/tagging.rs
+++ b/src/app_core/controller/browser_actions/browser/tagging.rs
@@ -1,0 +1,56 @@
+use super::super::super::AppController;
+use crate::app_core::actions::{NativeBrowserTagState, NativeUiAction};
+use crate::app_core::state::StatusTone;
+
+pub(super) fn apply_tagging_action(
+    controller: &mut AppController,
+    action: NativeUiAction,
+) -> Result<(), NativeUiAction> {
+    match action {
+        NativeUiAction::ToggleBrowserTagSidebar => controller.toggle_browser_tag_sidebar(),
+        NativeUiAction::ToggleBrowserTagSidebarAutoRename => {
+            controller.toggle_browser_tag_sidebar_auto_rename()
+        }
+        NativeUiAction::FocusBrowserTagSidebarInput => {}
+        NativeUiAction::SetBrowserTagSidebarInput { value } => {
+            controller.set_browser_tag_sidebar_input(value)
+        }
+        NativeUiAction::CommitBrowserTagSidebarInput => {
+            if let Err(err) = controller.commit_browser_tag_sidebar_input() {
+                controller.set_status(format!("Could not apply tag: {err}"), StatusTone::Error);
+            }
+        }
+        NativeUiAction::SetBrowserSidebarLooped { looped } => {
+            if let Err(err) = controller.apply_browser_tag_sidebar_looped(looped) {
+                controller.set_status(
+                    format!("Could not update playback type: {err}"),
+                    StatusTone::Error,
+                );
+            }
+        }
+        NativeUiAction::ToggleBrowserSidebarNormalTag { label } => {
+            apply_normal_tag_toggle(controller, &label);
+        }
+        action => return Err(action),
+    }
+    Ok(())
+}
+
+fn apply_normal_tag_toggle(controller: &mut AppController, label: &str) {
+    let result = if let Some(source) = controller.current_source() {
+        let target_paths = controller.browser_tag_sidebar_target_paths();
+        match controller.normal_tag_state_for_source(&source, &target_paths, label) {
+            Ok(NativeBrowserTagState::On) => {
+                controller.remove_browser_tag_sidebar_normal_tag(label)
+            }
+            Ok(_) => controller.apply_browser_tag_sidebar_normal_tag(label),
+            Err(err) => Err(err),
+        }
+    } else {
+        Err(String::from("No source selected"))
+    };
+
+    if let Err(err) = result {
+        controller.set_status(format!("Could not update tag: {err}"), StatusTone::Error);
+    }
+}


### PR DESCRIPTION
## Summary
- split the browser native-action dispatcher into focused drag, filter, tagging, and edit routers
- keep the ordered fallthrough dispatch contract for unhandled native actions
- reduce the browser dispatcher from a long mixed match into a small orchestration facade

## Validation
- cargo test -p wavecrate --lib app_core::controller -- --nocapture
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 cleanup-hotspots
- cargo test --manifest-path vendor/radiant/Cargo.toml --no-default-features
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent with RUST_TEST_THREADS=1