### PR TITLE
Split waveform fade overlay helpers

### DIFF
--- a/src/app_core/native_shell/composition/state/waveform_segments/fades.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/fades.rs
@@ -1,370 +1,39 @@
 use super::*;
 use crate::app_core::native_shell::runtime_contract::NormalizedRangeModel;
-use crate::gui::{
-    range::NormalizedPixelSnap,
-    visualization::{TimelineCoordinateMapper, TimelineViewport},
+
+#[path = "fades/curve.rs"]
+mod curve;
+#[path = "fades/handles.rs"]
+mod handles;
+#[path = "fades/model.rs"]
+mod model;
+#[path = "fades/shading.rs"]
+mod shading;
+
+use self::{handles::emit_fade_handles, model::EditFadePositions, shading::emit_fade_shading};
+
+pub(super) use self::model::{
+    EditFadeOverlayGeometry, EditFadeSelection, EditFadeSide, EditFadeTime,
 };
 
 /// Width in logical pixels for edit-fade drag handles.
-const EDIT_FADE_HANDLE_WIDTH: f32 = 3.0;
+pub(super) const EDIT_FADE_HANDLE_WIDTH: f32 = 3.0;
 /// Width/height in logical pixels for square edit-fade grab tabs.
-const EDIT_FADE_HANDLE_TAB_SIZE: f32 = 10.0;
+pub(super) const EDIT_FADE_HANDLE_TAB_SIZE: f32 = 10.0;
 
 /// Emit edit-fade shading and draggable handle markers for the active edit selection.
 pub(super) fn emit_edit_fade_overlays(
     primitives: &mut impl PrimitiveSink,
     style: &StyleTokens,
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    edit_selection: NormalizedRangeModel,
-    fade_in_end_milli: Option<u16>,
-    fade_in_end_micros: Option<u32>,
-    fade_in_mute_start_milli: Option<u16>,
-    fade_in_mute_start_micros: Option<u32>,
-    fade_in_curve_milli: Option<u16>,
-    fade_out_start_milli: Option<u16>,
-    fade_out_start_micros: Option<u32>,
-    fade_out_mute_end_milli: Option<u16>,
-    fade_out_mute_end_micros: Option<u32>,
-    fade_out_curve_milli: Option<u16>,
-    view_start_micros: u32,
-    view_end_micros: u32,
+    geometry: EditFadeOverlayGeometry,
+    selection: EditFadeSelection,
     accent_blue: Rgba8,
 ) {
-    let selection_start = edit_selection.start_micros.min(edit_selection.end_micros);
-    let selection_end = edit_selection.start_micros.max(edit_selection.end_micros);
-    if selection_end <= selection_start {
-        return;
-    }
-    let fade_in_end = fade_in_end_micros
-        .or_else(|| fade_in_end_milli.map(|value| u32::from(value) * 1000))
-        .unwrap_or(selection_start)
-        .clamp(selection_start, selection_end);
-    let fade_out_start = fade_out_start_micros
-        .or_else(|| fade_out_start_milli.map(|value| u32::from(value) * 1000))
-        .unwrap_or(selection_end)
-        .clamp(selection_start, selection_end);
-
-    if waveform_plot.width() <= 0.0 {
+    if selection.is_empty() || geometry.waveform_plot.width() <= 0.0 {
         return;
     }
 
-    let mapper = TimelineCoordinateMapper::new(
-        TimelineViewport::new(
-            (view_start_micros / 1000).min(1000) as u16,
-            (view_end_micros / 1000).min(1000) as u16,
-            view_start_micros,
-            view_end_micros,
-            view_start_micros.saturating_mul(1000),
-            view_end_micros.saturating_mul(1000),
-        ),
-        waveform_plot,
-        NormalizedPixelSnap::None,
-    );
-    let x_for_micros = |micros: u32| mapper.x_for_micros(micros);
-    let fade_in_mute_start = fade_in_mute_start_micros
-        .or_else(|| fade_in_mute_start_milli.map(|value| u32::from(value) * 1000))
-        .unwrap_or(selection_start)
-        .min(selection_start);
-    let fade_in_x = x_for_micros(fade_in_end).clamp(waveform_plot.min.x, waveform_plot.max.x);
-    let has_fade_in = fade_in_end > selection_start;
-    let fade_in_mute_x =
-        x_for_micros(fade_in_mute_start).clamp(waveform_plot.min.x, waveform_plot.max.x);
-    let fade_out_x = x_for_micros(fade_out_start).clamp(waveform_plot.min.x, waveform_plot.max.x);
-    let fade_out_mute_end = fade_out_mute_end_micros
-        .or_else(|| fade_out_mute_end_milli.map(|value| u32::from(value) * 1000))
-        .unwrap_or(selection_end)
-        .max(selection_end);
-    let has_fade_out = fade_out_start < selection_end;
-    let fade_out_mute_x =
-        x_for_micros(fade_out_mute_end).clamp(waveform_plot.min.x, waveform_plot.max.x);
-
-    if fade_in_x > edit_selection_rect.min.x {
-        emit_primitive(
-            primitives,
-            Primitive::Rect(FillRect {
-                rect: Rect::from_min_max(
-                    Point::new(edit_selection_rect.min.x, edit_selection_rect.min.y),
-                    Point::new(fade_in_x, edit_selection_rect.max.y),
-                ),
-                color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.22),
-            }),
-        );
-        emit_edit_fade_curve_trace(
-            primitives,
-            style,
-            waveform_plot,
-            edit_selection_rect,
-            fade_in_mute_x,
-            fade_in_x,
-            fade_in_curve_milli.unwrap_or(500),
-            true,
-            accent_blue,
-        );
-    }
-    if fade_in_mute_x < edit_selection_rect.min.x {
-        emit_primitive(
-            primitives,
-            Primitive::Rect(FillRect {
-                rect: Rect::from_min_max(
-                    Point::new(fade_in_mute_x, edit_selection_rect.min.y),
-                    Point::new(edit_selection_rect.min.x, edit_selection_rect.max.y),
-                ),
-                color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.16),
-            }),
-        );
-    }
-    if fade_out_x < edit_selection_rect.max.x {
-        emit_primitive(
-            primitives,
-            Primitive::Rect(FillRect {
-                rect: Rect::from_min_max(
-                    Point::new(fade_out_x, edit_selection_rect.min.y),
-                    Point::new(edit_selection_rect.max.x, edit_selection_rect.max.y),
-                ),
-                color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.22),
-            }),
-        );
-        emit_edit_fade_curve_trace(
-            primitives,
-            style,
-            waveform_plot,
-            edit_selection_rect,
-            fade_out_x,
-            fade_out_mute_x,
-            fade_out_curve_milli.unwrap_or(500),
-            false,
-            accent_blue,
-        );
-    }
-    if fade_out_mute_x > edit_selection_rect.max.x {
-        emit_primitive(
-            primitives,
-            Primitive::Rect(FillRect {
-                rect: Rect::from_min_max(
-                    Point::new(edit_selection_rect.max.x, edit_selection_rect.min.y),
-                    Point::new(fade_out_mute_x, edit_selection_rect.max.y),
-                ),
-                color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.16),
-            }),
-        );
-    }
-
-    emit_edit_fade_handle(
-        primitives,
-        style,
-        waveform_plot,
-        edit_selection_rect,
-        fade_in_x,
-        accent_blue,
-    );
-    if has_fade_in {
-        emit_edit_fade_bottom_handle(
-            primitives,
-            style,
-            waveform_plot,
-            edit_selection_rect,
-            fade_in_mute_x,
-            accent_blue,
-        );
-    }
-    emit_edit_fade_handle(
-        primitives,
-        style,
-        waveform_plot,
-        edit_selection_rect,
-        fade_out_x,
-        accent_blue,
-    );
-    if has_fade_out {
-        emit_edit_fade_bottom_handle(
-            primitives,
-            style,
-            waveform_plot,
-            edit_selection_rect,
-            fade_out_mute_x,
-            accent_blue,
-        );
-    }
-}
-
-fn emit_edit_fade_handle(
-    primitives: &mut impl PrimitiveSink,
-    style: &StyleTokens,
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    x: f32,
-    accent_blue: Rgba8,
-) {
-    let tab = edit_fade_handle_tab_rect(
-        waveform_plot,
-        edit_selection_rect,
-        x,
-        style.sizing.border_width,
-    );
-    emit_primitive(
-        primitives,
-        Primitive::Rect(FillRect {
-            rect: tab,
-            color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.78),
-        }),
-    );
-    push_border(
-        primitives,
-        tab,
-        blend_color(accent_blue, style.text_primary, 0.5),
-        style.sizing.border_width,
-    );
-}
-
-fn emit_edit_fade_bottom_handle(
-    primitives: &mut impl PrimitiveSink,
-    style: &StyleTokens,
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    x: f32,
-    accent_blue: Rgba8,
-) {
-    let width = EDIT_FADE_HANDLE_WIDTH
-        .max(style.sizing.border_width)
-        .max(1.0);
-    let half = width * 0.5;
-    let left = (x - half).clamp(waveform_plot.min.x, waveform_plot.max.x - 1.0);
-    let right = (left + width).min(waveform_plot.max.x).max(left + 1.0);
-    let handle = Rect::from_min_max(
-        Point::new(left, edit_selection_rect.min.y),
-        Point::new(right, edit_selection_rect.max.y),
-    );
-    emit_primitive(
-        primitives,
-        Primitive::Rect(FillRect {
-            rect: handle,
-            color: translucent_overlay_color(style.bg_secondary, accent_blue, 0.38),
-        }),
-    );
-    let bottom_tab = edit_fade_handle_bottom_tab_rect(
-        waveform_plot,
-        edit_selection_rect,
-        x,
-        style.sizing.border_width,
-    );
-    emit_primitive(
-        primitives,
-        Primitive::Rect(FillRect {
-            rect: bottom_tab,
-            color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.78),
-        }),
-    );
-    push_border(
-        primitives,
-        bottom_tab,
-        blend_color(accent_blue, style.text_primary, 0.5),
-        style.sizing.border_width,
-    );
-}
-
-fn edit_fade_handle_tab_rect(
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    x: f32,
-    border_width: f32,
-) -> Rect {
-    let size = EDIT_FADE_HANDLE_TAB_SIZE
-        .max(EDIT_FADE_HANDLE_WIDTH)
-        .max(border_width + 2.0)
-        .min(edit_selection_rect.height().max(1.0))
-        .min(waveform_plot.width().max(1.0));
-    let half = size * 0.5;
-    let left = (x - half).clamp(waveform_plot.min.x, waveform_plot.max.x - size.max(1.0));
-    let right = (left + size).min(waveform_plot.max.x).max(left + 1.0);
-    let bottom = (edit_selection_rect.min.y + size)
-        .min(edit_selection_rect.max.y)
-        .max(edit_selection_rect.min.y + 1.0);
-    Rect::from_min_max(
-        Point::new(left, edit_selection_rect.min.y),
-        Point::new(right, bottom),
-    )
-}
-
-fn edit_fade_handle_bottom_tab_rect(
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    x: f32,
-    border_width: f32,
-) -> Rect {
-    let size = EDIT_FADE_HANDLE_TAB_SIZE
-        .max(EDIT_FADE_HANDLE_WIDTH)
-        .max(border_width + 2.0)
-        .min(edit_selection_rect.height().max(1.0));
-    let half = size * 0.5;
-    let left = (x - half).clamp(waveform_plot.min.x, waveform_plot.max.x - size.max(1.0));
-    let right = (left + size).min(waveform_plot.max.x).max(left + 1.0);
-    let top = (edit_selection_rect.max.y - size)
-        .max(edit_selection_rect.min.y)
-        .min(edit_selection_rect.max.y - 1.0);
-    Rect::from_min_max(
-        Point::new(left, top),
-        Point::new(right, edit_selection_rect.max.y),
-    )
-}
-
-fn emit_edit_fade_curve_trace(
-    primitives: &mut impl PrimitiveSink,
-    style: &StyleTokens,
-    waveform_plot: Rect,
-    edit_selection_rect: Rect,
-    start_x: f32,
-    end_x: f32,
-    curve_milli: u16,
-    fade_in: bool,
-    accent_blue: Rgba8,
-) {
-    let width = (end_x - start_x).abs();
-    let height = edit_selection_rect.height();
-    if width <= 1.0 || height <= 1.0 {
-        return;
-    }
-    let curve = (f32::from(curve_milli.min(1000)) / 1000.0).clamp(0.0, 1.0);
-    let steps = ((width / 6.0).round() as usize).clamp(6, 28);
-    let marker_size = style.sizing.border_width.max(1.0) + 1.0;
-    for step in 0..=steps {
-        let t = step as f32 / steps as f32;
-        let eased = fade_curve_sample(t, curve);
-        let x = start_x + ((end_x - start_x) * t);
-        let y = if fade_in {
-            edit_selection_rect.max.y - (height * eased)
-        } else {
-            edit_selection_rect.min.y + (height * eased)
-        };
-        let rect = Rect::from_min_max(
-            Point::new(
-                (x - (marker_size * 0.5)).clamp(waveform_plot.min.x, waveform_plot.max.x),
-                (y - (marker_size * 0.5))
-                    .clamp(edit_selection_rect.min.y, edit_selection_rect.max.y),
-            ),
-            Point::new(
-                (x + (marker_size * 0.5)).clamp(waveform_plot.min.x, waveform_plot.max.x),
-                (y + (marker_size * 0.5))
-                    .clamp(edit_selection_rect.min.y, edit_selection_rect.max.y),
-            ),
-        );
-        emit_primitive(
-            primitives,
-            Primitive::Rect(FillRect {
-                rect,
-                color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.88),
-            }),
-        );
-    }
-}
-
-fn fade_curve_sample(t: f32, curve: f32) -> f32 {
-    if curve <= 0.0 {
-        return t.clamp(0.0, 1.0);
-    }
-    let t = t.clamp(0.0, 1.0);
-    let t2 = t * t;
-    let t3 = t2 * t;
-    let smootherstep = t3 * (t * (t * 6.0 - 15.0) + 10.0);
-    t * (1.0 - curve) + smootherstep * curve
+    let positions = EditFadePositions::resolve(selection, geometry);
+    emit_fade_shading(primitives, style, geometry, positions, accent_blue);
+    emit_fade_handles(primitives, style, geometry, positions, accent_blue);
 }

--- a/src/app_core/native_shell/composition/state/waveform_segments/fades/curve.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/fades/curve.rs
@@ -1,0 +1,109 @@
+use super::super::*;
+
+pub(super) fn emit_edit_fade_curve_trace(
+    primitives: &mut impl PrimitiveSink,
+    trace: FadeCurveTrace,
+    accent_blue: Rgba8,
+    style: &StyleTokens,
+) {
+    let width = (trace.end_x - trace.start_x).abs();
+    let height = trace.selection.height();
+    if width <= 1.0 || height <= 1.0 {
+        return;
+    }
+
+    let curve = (f32::from(trace.curve_milli.min(1000)) / 1000.0).clamp(0.0, 1.0);
+    let steps = ((width / 6.0).round() as usize).clamp(6, 28);
+    let marker_size = style.sizing.border_width.max(1.0) + 1.0;
+    for step in 0..=steps {
+        emit_curve_marker(
+            primitives,
+            trace,
+            CurveMarker {
+                t: step as f32 / steps as f32,
+                curve,
+                marker_size,
+            },
+            accent_blue,
+            style,
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FadeCurveTrace {
+    pub waveform_plot: Rect,
+    pub selection: Rect,
+    pub start_x: f32,
+    pub end_x: f32,
+    pub curve_milli: u16,
+    pub direction: FadeCurveDirection,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum FadeCurveDirection {
+    In,
+    Out,
+}
+
+impl FadeCurveDirection {
+    fn y_for(self, selection: Rect, height: f32, eased: f32) -> f32 {
+        match self {
+            Self::In => selection.max.y - (height * eased),
+            Self::Out => selection.min.y + (height * eased),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CurveMarker {
+    t: f32,
+    curve: f32,
+    marker_size: f32,
+}
+
+fn emit_curve_marker(
+    primitives: &mut impl PrimitiveSink,
+    trace: FadeCurveTrace,
+    marker: CurveMarker,
+    accent_blue: Rgba8,
+    style: &StyleTokens,
+) {
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: curve_marker_rect(trace, marker),
+            color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.88),
+        }),
+    );
+}
+
+fn curve_marker_rect(trace: FadeCurveTrace, marker: CurveMarker) -> Rect {
+    let eased = fade_curve_sample(marker.t, marker.curve);
+    let x = trace.start_x + ((trace.end_x - trace.start_x) * marker.t);
+    let y = trace
+        .direction
+        .y_for(trace.selection, trace.selection.height(), eased);
+    let half = marker.marker_size * 0.5;
+    Rect::from_min_max(
+        Point::new(
+            (x - half).clamp(trace.waveform_plot.min.x, trace.waveform_plot.max.x),
+            (y - half).clamp(trace.selection.min.y, trace.selection.max.y),
+        ),
+        Point::new(
+            (x + half).clamp(trace.waveform_plot.min.x, trace.waveform_plot.max.x),
+            (y + half).clamp(trace.selection.min.y, trace.selection.max.y),
+        ),
+    )
+}
+
+fn fade_curve_sample(t: f32, curve: f32) -> f32 {
+    if curve <= 0.0 {
+        return t.clamp(0.0, 1.0);
+    }
+    let t = t.clamp(0.0, 1.0);
+    let t2 = t * t;
+    let t3 = t2 * t;
+    let smootherstep = t3 * (t * (t * 6.0 - 15.0) + 10.0);
+    t * (1.0 - curve) + smootherstep * curve
+}

--- a/src/app_core/native_shell/composition/state/waveform_segments/fades/handles.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/fades/handles.rs
@@ -1,0 +1,166 @@
+use super::super::*;
+use super::model::{EditFadeOverlayGeometry, EditFadePositions};
+use super::{EDIT_FADE_HANDLE_TAB_SIZE, EDIT_FADE_HANDLE_WIDTH};
+
+pub(super) fn emit_fade_handles(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    positions: EditFadePositions,
+    accent_blue: Rgba8,
+) {
+    emit_edit_fade_handle(
+        primitives,
+        style,
+        geometry,
+        positions.fade_in_x,
+        accent_blue,
+    );
+    if positions.has_fade_in {
+        emit_edit_fade_bottom_handle(
+            primitives,
+            style,
+            geometry,
+            positions.fade_in_mute_x,
+            accent_blue,
+        );
+    }
+
+    emit_edit_fade_handle(
+        primitives,
+        style,
+        geometry,
+        positions.fade_out_x,
+        accent_blue,
+    );
+    if positions.has_fade_out {
+        emit_edit_fade_bottom_handle(
+            primitives,
+            style,
+            geometry,
+            positions.fade_out_mute_x,
+            accent_blue,
+        );
+    }
+}
+
+fn emit_edit_fade_handle(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    x: f32,
+    accent_blue: Rgba8,
+) {
+    let tab = edit_fade_handle_tab_rect(geometry, x, style.sizing.border_width);
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: tab,
+            color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.78),
+        }),
+    );
+    push_border(
+        primitives,
+        tab,
+        blend_color(accent_blue, style.text_primary, 0.5),
+        style.sizing.border_width,
+    );
+}
+
+fn emit_edit_fade_bottom_handle(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    x: f32,
+    accent_blue: Rgba8,
+) {
+    let handle = edit_fade_bottom_handle_rect(geometry, x, style.sizing.border_width);
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: handle,
+            color: translucent_overlay_color(style.bg_secondary, accent_blue, 0.38),
+        }),
+    );
+
+    let bottom_tab = edit_fade_handle_bottom_tab_rect(geometry, x, style.sizing.border_width);
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: bottom_tab,
+            color: translucent_overlay_color(style.surface_overlay, accent_blue, 0.78),
+        }),
+    );
+    push_border(
+        primitives,
+        bottom_tab,
+        blend_color(accent_blue, style.text_primary, 0.5),
+        style.sizing.border_width,
+    );
+}
+
+fn edit_fade_bottom_handle_rect(
+    geometry: EditFadeOverlayGeometry,
+    x: f32,
+    border_width: f32,
+) -> Rect {
+    let width = EDIT_FADE_HANDLE_WIDTH.max(border_width).max(1.0);
+    let half = width * 0.5;
+    let left = (x - half).clamp(
+        geometry.waveform_plot.min.x,
+        geometry.waveform_plot.max.x - 1.0,
+    );
+    let right = (left + width)
+        .min(geometry.waveform_plot.max.x)
+        .max(left + 1.0);
+    Rect::from_min_max(
+        Point::new(left, geometry.edit_selection_rect.min.y),
+        Point::new(right, geometry.edit_selection_rect.max.y),
+    )
+}
+
+fn edit_fade_handle_tab_rect(geometry: EditFadeOverlayGeometry, x: f32, border_width: f32) -> Rect {
+    let size = handle_tab_size(geometry, border_width);
+    let left = handle_tab_left(geometry, x, size);
+    let bottom = (geometry.edit_selection_rect.min.y + size)
+        .min(geometry.edit_selection_rect.max.y)
+        .max(geometry.edit_selection_rect.min.y + 1.0);
+    Rect::from_min_max(
+        Point::new(left, geometry.edit_selection_rect.min.y),
+        Point::new((left + size).min(geometry.waveform_plot.max.x), bottom),
+    )
+}
+
+fn edit_fade_handle_bottom_tab_rect(
+    geometry: EditFadeOverlayGeometry,
+    x: f32,
+    border_width: f32,
+) -> Rect {
+    let size = handle_tab_size(geometry, border_width);
+    let left = handle_tab_left(geometry, x, size);
+    let top = (geometry.edit_selection_rect.max.y - size)
+        .max(geometry.edit_selection_rect.min.y)
+        .min(geometry.edit_selection_rect.max.y - 1.0);
+    Rect::from_min_max(
+        Point::new(left, top),
+        Point::new(
+            (left + size).min(geometry.waveform_plot.max.x),
+            geometry.edit_selection_rect.max.y,
+        ),
+    )
+}
+
+fn handle_tab_size(geometry: EditFadeOverlayGeometry, border_width: f32) -> f32 {
+    EDIT_FADE_HANDLE_TAB_SIZE
+        .max(EDIT_FADE_HANDLE_WIDTH)
+        .max(border_width + 2.0)
+        .min(geometry.edit_selection_rect.height().max(1.0))
+        .min(geometry.waveform_plot.width().max(1.0))
+}
+
+fn handle_tab_left(geometry: EditFadeOverlayGeometry, x: f32, size: f32) -> f32 {
+    (x - (size * 0.5)).clamp(
+        geometry.waveform_plot.min.x,
+        geometry.waveform_plot.max.x - size.max(1.0),
+    )
+}

--- a/src/app_core/native_shell/composition/state/waveform_segments/fades/model.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/fades/model.rs
@@ -1,0 +1,152 @@
+use super::super::*;
+use crate::app_core::native_shell::runtime_contract::NormalizedRangeModel;
+use crate::gui::{
+    range::NormalizedPixelSnap,
+    visualization::{TimelineCoordinateMapper, TimelineViewport},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::app_core::native_shell::composition::state::waveform_segments) struct EditFadeOverlayGeometry
+{
+    pub waveform_plot: Rect,
+    pub edit_selection_rect: Rect,
+    pub view_start_micros: u32,
+    pub view_end_micros: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::app_core::native_shell::composition::state::waveform_segments) struct EditFadeSelection
+{
+    pub range: NormalizedRangeModel,
+    pub fade_in: EditFadeSide,
+    pub fade_out: EditFadeSide,
+}
+
+impl EditFadeSelection {
+    pub(in crate::app_core::native_shell::composition::state::waveform_segments) fn is_empty(
+        self,
+    ) -> bool {
+        self.end() <= self.start()
+    }
+
+    fn start(self) -> u32 {
+        self.range.start_micros.min(self.range.end_micros)
+    }
+
+    fn end(self) -> u32 {
+        self.range.start_micros.max(self.range.end_micros)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::app_core::native_shell::composition::state::waveform_segments) struct EditFadeSide {
+    pub inner: EditFadeTime,
+    pub outer: EditFadeTime,
+    pub curve_milli: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::app_core::native_shell::composition::state::waveform_segments) struct EditFadeTime {
+    pub milli: Option<u16>,
+    pub micros: Option<u32>,
+}
+
+impl EditFadeTime {
+    pub(in crate::app_core::native_shell::composition::state::waveform_segments) fn new(
+        milli: Option<u16>,
+        micros: Option<u32>,
+    ) -> Self {
+        Self { milli, micros }
+    }
+
+    fn micros(self) -> Option<u32> {
+        self.micros
+            .or_else(|| self.milli.map(|value| u32::from(value) * 1000))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct EditFadePositions {
+    pub fade_in_x: f32,
+    pub fade_in_mute_x: f32,
+    pub fade_in_curve_milli: u16,
+    pub fade_out_x: f32,
+    pub fade_out_mute_x: f32,
+    pub fade_out_curve_milli: u16,
+    pub has_fade_in: bool,
+    pub has_fade_out: bool,
+}
+
+impl EditFadePositions {
+    pub(super) fn resolve(selection: EditFadeSelection, geometry: EditFadeOverlayGeometry) -> Self {
+        let mapper = timeline_mapper(geometry);
+        let selection_start = selection.start();
+        let selection_end = selection.end();
+        let fade_in_end = selection
+            .fade_in
+            .inner
+            .micros()
+            .unwrap_or(selection_start)
+            .clamp(selection_start, selection_end);
+        let fade_out_start = selection
+            .fade_out
+            .inner
+            .micros()
+            .unwrap_or(selection_end)
+            .clamp(selection_start, selection_end);
+
+        Self {
+            fade_in_x: clamp_timeline_x(mapper.x_for_micros(fade_in_end), geometry),
+            fade_in_mute_x: clamp_timeline_x(
+                mapper.x_for_micros(fade_in_mute_start(selection)),
+                geometry,
+            ),
+            fade_in_curve_milli: selection.fade_in.curve_milli.unwrap_or(500),
+            fade_out_x: clamp_timeline_x(mapper.x_for_micros(fade_out_start), geometry),
+            fade_out_mute_x: clamp_timeline_x(
+                mapper.x_for_micros(fade_out_mute_end(selection)),
+                geometry,
+            ),
+            fade_out_curve_milli: selection.fade_out.curve_milli.unwrap_or(500),
+            has_fade_in: fade_in_end > selection_start,
+            has_fade_out: fade_out_start < selection_end,
+        }
+    }
+}
+
+fn fade_in_mute_start(selection: EditFadeSelection) -> u32 {
+    selection
+        .fade_in
+        .outer
+        .micros()
+        .unwrap_or(selection.start())
+        .min(selection.start())
+}
+
+fn fade_out_mute_end(selection: EditFadeSelection) -> u32 {
+    selection
+        .fade_out
+        .outer
+        .micros()
+        .unwrap_or(selection.end())
+        .max(selection.end())
+}
+
+fn timeline_mapper(geometry: EditFadeOverlayGeometry) -> TimelineCoordinateMapper {
+    TimelineCoordinateMapper::new(
+        TimelineViewport::new(
+            (geometry.view_start_micros / 1000).min(1000) as u16,
+            (geometry.view_end_micros / 1000).min(1000) as u16,
+            geometry.view_start_micros,
+            geometry.view_end_micros,
+            geometry.view_start_micros.saturating_mul(1000),
+            geometry.view_end_micros.saturating_mul(1000),
+        ),
+        geometry.waveform_plot,
+        NormalizedPixelSnap::None,
+    )
+}
+
+fn clamp_timeline_x(x: f32, geometry: EditFadeOverlayGeometry) -> f32 {
+    x.clamp(geometry.waveform_plot.min.x, geometry.waveform_plot.max.x)
+}

--- a/src/app_core/native_shell/composition/state/waveform_segments/fades/shading.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/fades/shading.rs
@@ -1,0 +1,129 @@
+use super::super::*;
+use super::curve::{FadeCurveDirection, FadeCurveTrace, emit_edit_fade_curve_trace};
+use super::model::{EditFadeOverlayGeometry, EditFadePositions};
+
+pub(super) fn emit_fade_shading(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    positions: EditFadePositions,
+    accent_blue: Rgba8,
+) {
+    emit_fade_in_shading(primitives, style, geometry, positions, accent_blue);
+    emit_fade_out_shading(primitives, style, geometry, positions, accent_blue);
+}
+
+fn emit_fade_in_shading(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    positions: EditFadePositions,
+    accent_blue: Rgba8,
+) {
+    let selection = geometry.edit_selection_rect;
+    if positions.fade_in_x > selection.min.x {
+        emit_fade_rect(
+            primitives,
+            style,
+            FadeRect::new(selection.min.x, positions.fade_in_x, selection, 0.22),
+            accent_blue,
+        );
+        emit_edit_fade_curve_trace(
+            primitives,
+            FadeCurveTrace {
+                waveform_plot: geometry.waveform_plot,
+                selection,
+                start_x: positions.fade_in_mute_x,
+                end_x: positions.fade_in_x,
+                curve_milli: positions.fade_in_curve_milli,
+                direction: FadeCurveDirection::In,
+            },
+            accent_blue,
+            style,
+        );
+    }
+    if positions.fade_in_mute_x < selection.min.x {
+        emit_fade_rect(
+            primitives,
+            style,
+            FadeRect::new(positions.fade_in_mute_x, selection.min.x, selection, 0.16),
+            accent_blue,
+        );
+    }
+}
+
+fn emit_fade_out_shading(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    geometry: EditFadeOverlayGeometry,
+    positions: EditFadePositions,
+    accent_blue: Rgba8,
+) {
+    let selection = geometry.edit_selection_rect;
+    if positions.fade_out_x < selection.max.x {
+        emit_fade_rect(
+            primitives,
+            style,
+            FadeRect::new(positions.fade_out_x, selection.max.x, selection, 0.22),
+            accent_blue,
+        );
+        emit_edit_fade_curve_trace(
+            primitives,
+            FadeCurveTrace {
+                waveform_plot: geometry.waveform_plot,
+                selection,
+                start_x: positions.fade_out_x,
+                end_x: positions.fade_out_mute_x,
+                curve_milli: positions.fade_out_curve_milli,
+                direction: FadeCurveDirection::Out,
+            },
+            accent_blue,
+            style,
+        );
+    }
+    if positions.fade_out_mute_x > selection.max.x {
+        emit_fade_rect(
+            primitives,
+            style,
+            FadeRect::new(selection.max.x, positions.fade_out_mute_x, selection, 0.16),
+            accent_blue,
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FadeRect {
+    left: f32,
+    right: f32,
+    selection: Rect,
+    alpha: f32,
+}
+
+impl FadeRect {
+    fn new(left: f32, right: f32, selection: Rect, alpha: f32) -> Self {
+        Self {
+            left,
+            right,
+            selection,
+            alpha,
+        }
+    }
+}
+
+fn emit_fade_rect(
+    primitives: &mut impl PrimitiveSink,
+    style: &StyleTokens,
+    fade_rect: FadeRect,
+    accent_blue: Rgba8,
+) {
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: Rect::from_min_max(
+                Point::new(fade_rect.left, fade_rect.selection.min.y),
+                Point::new(fade_rect.right, fade_rect.selection.max.y),
+            ),
+            color: translucent_overlay_color(style.surface_overlay, accent_blue, fade_rect.alpha),
+        }),
+    );
+}

--- a/src/app_core/native_shell/composition/state/waveform_segments/mod.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/mod.rs
@@ -13,7 +13,10 @@ mod surface;
 mod trail;
 
 use self::{
-    fades::emit_edit_fade_overlays,
+    fades::{
+        EditFadeOverlayGeometry, EditFadeSelection, EditFadeSide, EditFadeTime,
+        emit_edit_fade_overlays,
+    },
     selection::{
         emit_hovered_edit_resize_edge, emit_hovered_selection_resize_edge,
         emit_selection_drag_handle, emit_selection_shift_handle, emit_waveform_loop_bar,

--- a/src/app_core/native_shell/composition/state/waveform_segments/overlay.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/overlay.rs
@@ -126,21 +126,37 @@ pub(in crate::app_core::native_shell::composition::state) fn push_waveform_playh
             emit_edit_fade_overlays(
                 primitives,
                 style,
-                layout.waveform_plot,
-                rect,
-                edit_selection,
-                edit_preview.leading_end_milli,
-                edit_preview.leading_end_micros,
-                edit_preview.leading_inner_start_milli,
-                edit_preview.leading_inner_start_micros,
-                edit_preview.leading_curve_milli,
-                edit_preview.trailing_start_milli,
-                edit_preview.trailing_start_micros,
-                edit_preview.trailing_inner_end_milli,
-                edit_preview.trailing_inner_end_micros,
-                edit_preview.trailing_curve_milli,
-                viewport.start_micros,
-                viewport.end_micros,
+                EditFadeOverlayGeometry {
+                    waveform_plot: layout.waveform_plot,
+                    edit_selection_rect: rect,
+                    view_start_micros: viewport.start_micros,
+                    view_end_micros: viewport.end_micros,
+                },
+                EditFadeSelection {
+                    range: edit_selection,
+                    fade_in: EditFadeSide {
+                        inner: EditFadeTime::new(
+                            edit_preview.leading_end_milli,
+                            edit_preview.leading_end_micros,
+                        ),
+                        outer: EditFadeTime::new(
+                            edit_preview.leading_inner_start_milli,
+                            edit_preview.leading_inner_start_micros,
+                        ),
+                        curve_milli: edit_preview.leading_curve_milli,
+                    },
+                    fade_out: EditFadeSide {
+                        inner: EditFadeTime::new(
+                            edit_preview.trailing_start_milli,
+                            edit_preview.trailing_start_micros,
+                        ),
+                        outer: EditFadeTime::new(
+                            edit_preview.trailing_inner_end_milli,
+                            edit_preview.trailing_inner_end_micros,
+                        ),
+                        curve_milli: edit_preview.trailing_curve_milli,
+                    },
+                },
                 style.highlight_blue,
             );
             emit_hovered_edit_resize_edge(


### PR DESCRIPTION
## Summary
- split edit fade overlay rendering into focused model, shading, handle, and curve helpers
- replace the long overlay parameter list with explicit geometry, selection, side, and time structs
- keep waveform overlay behavior unchanged while reducing the former hotspot facade to a small entrypoint

## Validation
- `cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 cleanup-hotspots`
- `RUST_TEST_THREADS=1 CARGO_TARGET_DIR=X:\wavecrate\target powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent` from clean validation worktree with recorded Radiant submodule