### PR TITLE
Split waveform overlay entrypoint

### DIFF
--- a/src/app_core/native_shell/composition/state/motion_overlay.rs
+++ b/src/app_core/native_shell/composition/state/motion_overlay.rs
@@ -25,15 +25,19 @@ impl NativeShellState {
         let playhead_trail_lines = self.update_playhead_trail(layout.waveform_plot, model);
         push_waveform_playhead_overlay(
             primitives,
-            layout,
-            style,
-            model,
-            self.waveform_selection_flash_ticks > 0,
-            self.waveform_edit_selection_flash_ticks > 0,
-            self.waveform_selection_flash_tone,
-            motion_wave,
-            &playhead_trail_lines,
-            self.hovered_waveform_resize_edge,
+            WaveformOverlayInput {
+                layout,
+                style,
+                model,
+                flashes: WaveformOverlayFlashes {
+                    selection_active: self.waveform_selection_flash_ticks > 0,
+                    edit_selection_active: self.waveform_edit_selection_flash_ticks > 0,
+                    selection_tone: self.waveform_selection_flash_tone,
+                },
+                motion_wave,
+                playhead_trail_lines: &playhead_trail_lines,
+                hovered_resize_edge: self.hovered_waveform_resize_edge,
+            },
         );
         if let Some(hover_x) = self.waveform_hover_x {
             // Keep hover preview cursor visually obvious against dense waveform content.

--- a/src/app_core/native_shell/composition/state/waveform_segments/mod.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/mod.rs
@@ -25,7 +25,7 @@ use self::{
 };
 pub(in crate::app_core::native_shell::composition::state) use self::{
     header::push_waveform_header_overlay,
-    overlay::push_waveform_playhead_overlay,
+    overlay::{WaveformOverlayFlashes, WaveformOverlayInput, push_waveform_playhead_overlay},
     routing::{static_segment_for_primitive, static_segment_for_text, static_segment_matches},
     scrollbar::{waveform_scrollbar_center_for_pointer, waveform_scrollbar_layout},
     surface::push_waveform_image,

--- a/src/app_core/native_shell/composition/state/waveform_segments/overlay.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/overlay.rs
@@ -1,36 +1,63 @@
 //! Waveform overlay emission for playhead, selection, loop, and scrollbar chrome.
 
+mod edit;
+mod selection;
+
 use super::scrollbar::emit_waveform_scrollbar;
 use super::surface::emit_waveform_loading_placeholder;
 use super::trail::emit_waveform_playhead_trail;
 use super::*;
 
+use self::{
+    edit::emit_waveform_edit_selection,
+    selection::{WaveformSelectionOverlay, emit_waveform_selection},
+};
+
+pub(in crate::app_core::native_shell::composition::state) struct WaveformOverlayFlashes {
+    pub(in crate::app_core::native_shell::composition::state) selection_active: bool,
+    pub(in crate::app_core::native_shell::composition::state) edit_selection_active: bool,
+    pub(in crate::app_core::native_shell::composition::state) selection_tone:
+        WaveformSelectionFlashTone,
+}
+
+pub(in crate::app_core::native_shell::composition::state) struct WaveformOverlayInput<'a> {
+    pub(in crate::app_core::native_shell::composition::state) layout: &'a ShellLayout,
+    pub(in crate::app_core::native_shell::composition::state) style: &'a StyleTokens,
+    pub(in crate::app_core::native_shell::composition::state) model: &'a NativeMotionModel,
+    pub(in crate::app_core::native_shell::composition::state) flashes: WaveformOverlayFlashes,
+    pub(in crate::app_core::native_shell::composition::state) motion_wave: f32,
+    pub(in crate::app_core::native_shell::composition::state) playhead_trail_lines:
+        &'a [PlayheadTrailLine],
+    pub(in crate::app_core::native_shell::composition::state) hovered_resize_edge:
+        Option<WaveformResizeHoverEdge>,
+}
+
 pub(in crate::app_core::native_shell::composition::state) fn push_waveform_playhead_overlay(
     primitives: &mut impl PrimitiveSink,
-    layout: &ShellLayout,
-    style: &StyleTokens,
-    model: &NativeMotionModel,
-    selection_flash_active: bool,
-    edit_selection_flash_active: bool,
-    selection_flash_tone: WaveformSelectionFlashTone,
-    motion_wave: f32,
-    playhead_trail_lines: &[PlayheadTrailLine],
-    hovered_resize_edge: Option<WaveformResizeHoverEdge>,
+    input: WaveformOverlayInput<'_>,
 ) {
-    let transport = model.waveform_transport();
-    let viewport = model.waveform_viewport();
-    let edit_preview = model.waveform_edit_preview();
-    let presentation = model.waveform_presentation();
-    let image_preview = model.waveform_image_preview();
+    let transport = input.model.waveform_transport();
+    let viewport = input.model.waveform_viewport();
+    let image_preview = input.model.waveform_image_preview();
 
     if image_preview.loading {
-        emit_waveform_loading_placeholder(primitives, layout.waveform_plot, style, motion_wave);
+        emit_waveform_loading_placeholder(
+            primitives,
+            input.layout.waveform_plot,
+            input.style,
+            input.motion_wave,
+        );
         return;
     }
-    emit_waveform_slice_previews(primitives, layout.waveform_plot, style, model);
+    emit_waveform_slice_previews(
+        primitives,
+        input.layout.waveform_plot,
+        input.style,
+        input.model,
+    );
     let annotations = compute_waveform_annotation_rects_with_nanos(
-        layout.waveform_plot,
-        style.sizing.border_width,
+        input.layout.waveform_plot,
+        input.style.sizing.border_width,
         transport.selection,
         transport.cursor_milli,
         None,
@@ -39,153 +66,43 @@ pub(in crate::app_core::native_shell::composition::state) fn push_waveform_playh
         viewport.start_nanos,
         viewport.end_nanos,
     );
-    let playhead_rect =
-        playhead_marker_rect(layout.waveform_plot, style.sizing.border_width, model);
+    let playhead_rect = playhead_marker_rect(
+        input.layout.waveform_plot,
+        input.style.sizing.border_width,
+        input.model,
+    );
 
     if let Some(rect) = annotations.selection {
-        let selection_fill = if selection_flash_active {
-            let flash_accent = match selection_flash_tone {
-                WaveformSelectionFlashTone::Optimistic => style.accent_warning,
-                WaveformSelectionFlashTone::Error => style.accent_danger,
-            };
-            translucent_overlay_color(style.surface_overlay, flash_accent, 0.78)
-        } else {
-            translucent_overlay_color(style.bg_secondary, style.accent_warning, 0.52)
-        };
-        let selection_border = if selection_flash_active {
-            match selection_flash_tone {
-                WaveformSelectionFlashTone::Optimistic => {
-                    blend_color(style.accent_warning, style.text_primary, 0.5)
-                }
-                WaveformSelectionFlashTone::Error => {
-                    blend_color(style.accent_danger, style.text_primary, 0.5)
-                }
-            }
-        } else {
-            blend_color(style.accent_warning, style.text_primary, 0.28)
-        };
-        emit_primitive(
+        emit_waveform_selection(
             primitives,
-            Primitive::Rect(FillRect {
+            WaveformSelectionOverlay {
+                style: input.style,
                 rect,
-                color: selection_fill,
-            }),
+                flashes: &input.flashes,
+                repeat_enabled: input.model.waveform_presentation().repeat_enabled,
+                hovered_resize_edge: input.hovered_resize_edge,
+            },
         );
-        push_border(
-            primitives,
-            rect,
-            selection_border,
-            style.sizing.border_width,
-        );
-        emit_hovered_selection_resize_edge(
-            primitives,
-            style,
-            rect,
-            style.accent_warning,
-            hovered_resize_edge,
-        );
-        if presentation.repeat_enabled {
-            emit_waveform_loop_bar(primitives, style, rect);
-        }
-        emit_selection_shift_handle(primitives, style, rect, style.accent_warning);
-        emit_selection_drag_handle(primitives, style, rect);
     }
 
-    if let Some(edit_selection) = edit_preview.selection {
-        let edit_selection_rect = compute_waveform_annotation_rects_with_nanos(
-            layout.waveform_plot,
-            style.sizing.border_width,
-            Some(edit_selection),
-            None,
-            None,
-            viewport.start_micros,
-            viewport.end_micros,
-            viewport.start_nanos,
-            viewport.end_nanos,
-        )
-        .selection;
-        if let Some(rect) = edit_selection_rect {
-            let edit_fill = if edit_selection_flash_active {
-                translucent_overlay_color(style.surface_overlay, style.highlight_blue, 0.82)
-            } else {
-                translucent_overlay_color(style.bg_secondary, style.highlight_blue, 0.5)
-            };
-            let edit_border = if edit_selection_flash_active {
-                blend_color(style.highlight_blue, style.text_primary, 0.5)
-            } else {
-                blend_color(style.highlight_blue, style.text_primary, 0.24)
-            };
-            emit_primitive(
-                primitives,
-                Primitive::Rect(FillRect {
-                    rect,
-                    color: edit_fill,
-                }),
-            );
-            push_border(primitives, rect, edit_border, style.sizing.border_width);
-            emit_edit_fade_overlays(
-                primitives,
-                style,
-                EditFadeOverlayGeometry {
-                    waveform_plot: layout.waveform_plot,
-                    edit_selection_rect: rect,
-                    view_start_micros: viewport.start_micros,
-                    view_end_micros: viewport.end_micros,
-                },
-                EditFadeSelection {
-                    range: edit_selection,
-                    fade_in: EditFadeSide {
-                        inner: EditFadeTime::new(
-                            edit_preview.leading_end_milli,
-                            edit_preview.leading_end_micros,
-                        ),
-                        outer: EditFadeTime::new(
-                            edit_preview.leading_inner_start_milli,
-                            edit_preview.leading_inner_start_micros,
-                        ),
-                        curve_milli: edit_preview.leading_curve_milli,
-                    },
-                    fade_out: EditFadeSide {
-                        inner: EditFadeTime::new(
-                            edit_preview.trailing_start_milli,
-                            edit_preview.trailing_start_micros,
-                        ),
-                        outer: EditFadeTime::new(
-                            edit_preview.trailing_inner_end_milli,
-                            edit_preview.trailing_inner_end_micros,
-                        ),
-                        curve_milli: edit_preview.trailing_curve_milli,
-                    },
-                },
-                style.highlight_blue,
-            );
-            emit_hovered_edit_resize_edge(
-                primitives,
-                style,
-                rect,
-                style.highlight_blue,
-                hovered_resize_edge,
-            );
-            emit_selection_shift_handle(primitives, style, rect, style.highlight_blue);
-        }
-    }
+    emit_waveform_edit_selection(primitives, &input, &viewport);
 
     if let Some(rect) = annotations.cursor {
         emit_primitive(
             primitives,
             Primitive::Rect(FillRect {
                 rect,
-                color: style.accent_warning,
+                color: input.style.accent_warning,
             }),
         );
     }
     if let Some(rect) = playhead_rect {
         emit_waveform_playhead_trail(
             primitives,
-            layout.waveform_plot,
-            style,
-            style.sizing.border_width,
-            playhead_trail_lines,
+            input.layout.waveform_plot,
+            input.style,
+            input.style.sizing.border_width,
+            input.playhead_trail_lines,
             viewport.start_micros,
             viewport.end_micros,
             viewport.start_nanos,
@@ -195,9 +112,14 @@ pub(in crate::app_core::native_shell::composition::state) fn push_waveform_playh
             primitives,
             Primitive::Rect(FillRect {
                 rect,
-                color: style.accent_copper,
+                color: input.style.accent_copper,
             }),
         );
     }
-    emit_waveform_scrollbar(primitives, layout.waveform_scrollbar_lane, style, model);
+    emit_waveform_scrollbar(
+        primitives,
+        input.layout.waveform_scrollbar_lane,
+        input.style,
+        input.model,
+    );
 }

--- a/src/app_core/native_shell/composition/state/waveform_segments/overlay/edit.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/overlay/edit.rs
@@ -1,0 +1,114 @@
+//! Edit-selection overlay emission.
+
+use super::*;
+use crate::{
+    app_core::native_shell::runtime_contract::NormalizedRangeModel,
+    gui::{types::Rgba8, visualization::TimelineViewport},
+};
+
+pub(super) fn emit_waveform_edit_selection(
+    primitives: &mut impl PrimitiveSink,
+    input: &WaveformOverlayInput<'_>,
+    viewport: &TimelineViewport,
+) {
+    let edit_preview = input.model.waveform_edit_preview();
+    let Some(edit_selection) = edit_preview.selection else {
+        return;
+    };
+    let Some(rect) = edit_selection_rect(input, edit_selection, viewport) else {
+        return;
+    };
+
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect,
+            color: edit_selection_fill(input.style, &input.flashes),
+        }),
+    );
+    push_border(
+        primitives,
+        rect,
+        edit_selection_border(input.style, &input.flashes),
+        input.style.sizing.border_width,
+    );
+    emit_edit_fade_overlays(
+        primitives,
+        input.style,
+        EditFadeOverlayGeometry {
+            waveform_plot: input.layout.waveform_plot,
+            edit_selection_rect: rect,
+            view_start_micros: viewport.start_micros,
+            view_end_micros: viewport.end_micros,
+        },
+        EditFadeSelection {
+            range: edit_selection,
+            fade_in: EditFadeSide {
+                inner: EditFadeTime::new(
+                    edit_preview.leading_end_milli,
+                    edit_preview.leading_end_micros,
+                ),
+                outer: EditFadeTime::new(
+                    edit_preview.leading_inner_start_milli,
+                    edit_preview.leading_inner_start_micros,
+                ),
+                curve_milli: edit_preview.leading_curve_milli,
+            },
+            fade_out: EditFadeSide {
+                inner: EditFadeTime::new(
+                    edit_preview.trailing_start_milli,
+                    edit_preview.trailing_start_micros,
+                ),
+                outer: EditFadeTime::new(
+                    edit_preview.trailing_inner_end_milli,
+                    edit_preview.trailing_inner_end_micros,
+                ),
+                curve_milli: edit_preview.trailing_curve_milli,
+            },
+        },
+        input.style.highlight_blue,
+    );
+    emit_hovered_edit_resize_edge(
+        primitives,
+        input.style,
+        rect,
+        input.style.highlight_blue,
+        input.hovered_resize_edge,
+    );
+    emit_selection_shift_handle(primitives, input.style, rect, input.style.highlight_blue);
+}
+
+fn edit_selection_rect(
+    input: &WaveformOverlayInput<'_>,
+    edit_selection: NormalizedRangeModel,
+    viewport: &TimelineViewport,
+) -> Option<Rect> {
+    compute_waveform_annotation_rects_with_nanos(
+        input.layout.waveform_plot,
+        input.style.sizing.border_width,
+        Some(edit_selection),
+        None,
+        None,
+        viewport.start_micros,
+        viewport.end_micros,
+        viewport.start_nanos,
+        viewport.end_nanos,
+    )
+    .selection
+}
+
+fn edit_selection_fill(style: &StyleTokens, flashes: &WaveformOverlayFlashes) -> Rgba8 {
+    if flashes.edit_selection_active {
+        return translucent_overlay_color(style.surface_overlay, style.highlight_blue, 0.82);
+    }
+
+    translucent_overlay_color(style.bg_secondary, style.highlight_blue, 0.5)
+}
+
+fn edit_selection_border(style: &StyleTokens, flashes: &WaveformOverlayFlashes) -> Rgba8 {
+    if flashes.edit_selection_active {
+        return blend_color(style.highlight_blue, style.text_primary, 0.5);
+    }
+
+    blend_color(style.highlight_blue, style.text_primary, 0.24)
+}

--- a/src/app_core/native_shell/composition/state/waveform_segments/overlay/selection.rs
+++ b/src/app_core/native_shell/composition/state/waveform_segments/overlay/selection.rs
@@ -1,0 +1,75 @@
+//! Play-selection overlay emission.
+
+use super::*;
+use crate::gui::types::Rgba8;
+
+pub(super) struct WaveformSelectionOverlay<'a> {
+    pub(super) style: &'a StyleTokens,
+    pub(super) rect: Rect,
+    pub(super) flashes: &'a WaveformOverlayFlashes,
+    pub(super) repeat_enabled: bool,
+    pub(super) hovered_resize_edge: Option<WaveformResizeHoverEdge>,
+}
+
+pub(super) fn emit_waveform_selection(
+    primitives: &mut impl PrimitiveSink,
+    overlay: WaveformSelectionOverlay<'_>,
+) {
+    let style = overlay.style;
+    emit_primitive(
+        primitives,
+        Primitive::Rect(FillRect {
+            rect: overlay.rect,
+            color: selection_fill(style, overlay.flashes),
+        }),
+    );
+    push_border(
+        primitives,
+        overlay.rect,
+        selection_border(style, overlay.flashes),
+        style.sizing.border_width,
+    );
+    emit_hovered_selection_resize_edge(
+        primitives,
+        style,
+        overlay.rect,
+        style.accent_warning,
+        overlay.hovered_resize_edge,
+    );
+    if overlay.repeat_enabled {
+        emit_waveform_loop_bar(primitives, style, overlay.rect);
+    }
+    emit_selection_shift_handle(primitives, style, overlay.rect, style.accent_warning);
+    emit_selection_drag_handle(primitives, style, overlay.rect);
+}
+
+fn selection_fill(style: &StyleTokens, flashes: &WaveformOverlayFlashes) -> Rgba8 {
+    if !flashes.selection_active {
+        return translucent_overlay_color(style.bg_secondary, style.accent_warning, 0.52);
+    }
+
+    translucent_overlay_color(
+        style.surface_overlay,
+        selection_flash_accent(style, flashes),
+        0.78,
+    )
+}
+
+fn selection_border(style: &StyleTokens, flashes: &WaveformOverlayFlashes) -> Rgba8 {
+    if !flashes.selection_active {
+        return blend_color(style.accent_warning, style.text_primary, 0.28);
+    }
+
+    blend_color(
+        selection_flash_accent(style, flashes),
+        style.text_primary,
+        0.5,
+    )
+}
+
+fn selection_flash_accent(style: &StyleTokens, flashes: &WaveformOverlayFlashes) -> Rgba8 {
+    match flashes.selection_tone {
+        WaveformSelectionFlashTone::Optimistic => style.accent_warning,
+        WaveformSelectionFlashTone::Error => style.accent_danger,
+    }
+}


### PR DESCRIPTION
## Summary
- replace the long waveform overlay entrypoint parameter list with an explicit overlay input struct
- split play-selection and edit-selection overlay emission into focused child modules
- keep cursor, playhead trail, scrollbar, and slice-preview orchestration in the small facade

## Validation
- `cargo test -p wavecrate --lib app_core::native_shell::composition -- --nocapture`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 cleanup-hotspots`
- `RUST_TEST_THREADS=1 powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`