### PR TITLE
Split shell layout section build

### DIFF
--- a/src/app_core/native_shell/composition/layout/mod.rs
+++ b/src/app_core/native_shell/composition/layout/mod.rs
@@ -1,26 +1,21 @@
 //! Retained view-tree layout and hit-testing for the native shell.
 
-use super::{
-    ShellLayoutRuntime,
-    layout_adapter::{compute_status_bar_segments, compute_top_bar_band_sections},
-    style::StyleTokens,
-};
+use super::{ShellLayoutRuntime, style::StyleTokens};
 use crate::gui::types::{Point, Rect, Vector2};
 
 mod contracts;
 mod geometry;
+mod sections;
 mod tree;
 
 #[cfg(test)]
 pub(crate) use contracts::LayoutContractSnapshot;
-use geometry::{
-    band_header, build_browser_compat_columns, build_column_sections,
-    waveform_scrollbar_lane_height,
+use geometry::{build_browser_compat_columns, build_column_sections};
+use sections::{
+    build_browser_layout, build_content_layout, build_layout_frame, build_sidebar_layout,
+    build_top_status_layout, build_waveform_layout,
 };
 use tree::build_shell_root;
-
-/// Horizontal inset applied to the waveform plot and scrollbar lane.
-const WAVEFORM_VIEW_SIDE_INSET: f32 = 10.0;
 
 /// Stable identifier for nodes in the retained shell tree.
 pub(crate) type ViewNodeId = u64;
@@ -119,184 +114,74 @@ impl ShellLayout {
         style: &StyleTokens,
         runtime: &mut ShellLayoutRuntime,
     ) -> Self {
-        let viewport_width = viewport.x.max(style.sizing.min_viewport_width);
-        let viewport_height = viewport.y.max(style.sizing.min_viewport_height);
         let sizing = style.sizing;
-        let base_style = StyleTokens::for_viewport_width(viewport_width);
-        let ui_scale = if base_style.sizing.font_title > 0.0 {
-            (sizing.font_title / base_style.sizing.font_title).clamp(1.0, 3.0)
-        } else {
-            1.0
-        };
-        let sections =
-            runtime.compute_shell_sections(Vector2::new(viewport_width, viewport_height), style);
-        let root_rect = sections.root;
-        let top_bar = Rect::from_min_max(
-            root_rect.min,
-            Point::new(root_rect.max.x, root_rect.min.y + sizing.top_bar_height),
+        let frame = build_layout_frame(viewport, style, runtime);
+        let top_status = build_top_status_layout(frame.root_rect, sizing);
+        let sidebar = build_sidebar_layout(
+            frame.sections.sidebar,
+            top_status.top_bar,
+            top_status.status_bar,
+            sizing,
+            runtime,
         );
-        let top_bar_bands = compute_top_bar_band_sections(top_bar, sizing);
-        let top_bar_title_row = top_bar_bands.top_bar_title_row;
-        let top_bar_controls_row = top_bar_bands.top_bar_controls_row;
-        let top_bar_title_cluster = top_bar_bands.top_bar_title_cluster;
-        let top_bar_action_cluster = top_bar_bands.top_bar_action_cluster;
-        let status_bar = Rect::from_min_max(
-            Point::new(root_rect.min.x, root_rect.max.y - sizing.status_bar_height),
-            root_rect.max,
+        let content = build_content_layout(
+            frame.root_rect,
+            sidebar.sidebar,
+            frame.sections.waveform_card,
+            top_status.top_bar,
+            top_status.status_bar,
         );
-        let status_segments = compute_status_bar_segments(status_bar, sizing);
-        let status_left_segment = status_segments.left;
-        let status_center_segment = status_segments.center;
-        let status_right_segment = status_segments.right;
-        let status_progress_segment = status_segments.progress;
-        let body_min_y = top_bar.max.y;
-        let body_max_y = status_bar.min.y;
-        let sidebar = Rect::from_min_max(
-            Point::new(sections.sidebar.min.x, body_min_y),
-            Point::new(sections.sidebar.max.x, body_max_y),
-        );
-        let sidebar_bands = runtime.compute_sidebar_band_sections(sidebar, sizing);
-        let sidebar_header = sidebar_bands.sidebar_header;
-        let sidebar_footer = sidebar_bands.sidebar_footer;
-        let sidebar_rows = Rect::from_min_max(
-            Point::new(
-                sidebar_bands.sidebar_rows.min.x,
-                sidebar_header.max.y.min(sidebar_footer.min.y),
-            ),
-            Point::new(
-                sidebar_bands.sidebar_rows.max.x,
-                sidebar_footer
-                    .min
-                    .y
-                    .max(sidebar_header.max.y.min(sidebar_footer.min.y)),
-            ),
-        );
-        let content = Rect::from_min_max(
-            Point::new(sidebar.max.x, body_min_y),
-            Point::new(root_rect.max.x, body_max_y),
-        );
-        let waveform_card = Rect::from_min_max(
-            Point::new(content.min.x, content.min.y),
-            Point::new(
-                content.max.x,
-                sections.waveform_card.max.y.min(content.max.y),
-            ),
-        );
-        let browser_panel =
-            Rect::from_min_max(Point::new(content.min.x, waveform_card.max.y), content.max);
-        let browser_bands = runtime.compute_browser_band_sections(browser_panel, sizing);
-        let browser_tabs = browser_bands.browser_tabs;
-        let browser_footer = browser_bands.browser_footer;
-        let browser_toolbar = Rect::from_min_max(
-            Point::new(browser_bands.browser_toolbar.min.x, browser_tabs.max.y),
-            Point::new(
-                browser_bands.browser_toolbar.max.x,
-                (browser_tabs.max.y + browser_bands.browser_toolbar.height())
-                    .min(browser_footer.min.y),
-            ),
-        );
-        let browser_table_header = Rect::from_min_max(
-            Point::new(
-                browser_bands.browser_table_header.min.x,
-                browser_toolbar.max.y,
-            ),
-            Point::new(
-                browser_bands.browser_table_header.max.x,
-                (browser_toolbar.max.y + browser_bands.browser_table_header.height())
-                    .min(browser_footer.min.y),
-            ),
-        );
-        let browser_rows = Rect::from_min_max(
-            Point::new(browser_bands.browser_rows.min.x, browser_table_header.max.y),
-            Point::new(
-                browser_bands.browser_rows.max.x,
-                browser_footer.min.y.max(browser_table_header.max.y),
-            ),
-        );
+        let browser = build_browser_layout(content.browser_panel, sizing, runtime);
 
         // Keep legacy triage partitions as invisible compatibility geometry for
         // routing actions that still speak in triage-column terms.
-        let columns = build_browser_compat_columns(browser_rows, sizing);
-
-        let waveform_header = band_header(waveform_card, sizing.waveform_header_block_height);
-        let waveform_body_top = waveform_header
-            .max
-            .y
-            .clamp(waveform_card.min.y, waveform_card.max.y);
-        let waveform_body = Rect::from_min_max(
-            Point::new(waveform_card.min.x, waveform_body_top),
-            waveform_card.max,
-        );
-        let waveform_side_inset =
-            WAVEFORM_VIEW_SIDE_INSET.min((waveform_body.width() - 1.0).max(0.0) * 0.5);
-        let waveform_view_body = Rect::from_min_max(
-            Point::new(
-                waveform_body.min.x + waveform_side_inset,
-                waveform_body.min.y,
-            ),
-            Point::new(
-                waveform_body.max.x - waveform_side_inset,
-                waveform_body.max.y,
-            ),
-        );
-        let waveform_scrollbar_lane_height =
-            waveform_scrollbar_lane_height(waveform_view_body, sizing.waveform_header_block_height);
-        let waveform_scrollbar_lane = Rect::from_min_max(
-            Point::new(
-                waveform_view_body.min.x,
-                waveform_view_body.max.y - waveform_scrollbar_lane_height,
-            ),
-            waveform_view_body.max,
-        );
-        let waveform_plot = Rect::from_min_max(
-            waveform_view_body.min,
-            Point::new(waveform_view_body.max.x, waveform_scrollbar_lane.min.y),
-        );
+        let columns = build_browser_compat_columns(browser.browser_rows, sizing);
+        let waveform = build_waveform_layout(content.waveform_card, sizing);
 
         let (column_headers, column_rows) = build_column_sections(columns, sizing);
         let root = build_shell_root(
-            root_rect,
-            top_bar,
-            sidebar,
-            content,
-            waveform_card,
-            browser_panel,
-            browser_tabs,
-            browser_rows,
-            status_bar,
+            frame.root_rect,
+            top_status.top_bar,
+            sidebar.sidebar,
+            content.content,
+            content.waveform_card,
+            content.browser_panel,
+            browser.browser_tabs,
+            browser.browser_rows,
+            top_status.status_bar,
         );
 
         Self {
             root,
-            top_bar,
-            top_bar_title_row,
-            top_bar_controls_row,
-            top_bar_title_cluster,
-            top_bar_action_cluster,
-            sidebar,
-            sidebar_header,
-            sidebar_rows,
-            sidebar_footer,
-            content,
-            waveform_card,
-            waveform_header,
-            waveform_plot,
-            waveform_scrollbar_lane,
-            browser_panel,
-            browser_tabs,
-            browser_toolbar,
-            browser_table_header,
-            browser_rows,
-            browser_footer,
+            top_bar: top_status.top_bar,
+            top_bar_title_row: top_status.top_bar_title_row,
+            top_bar_controls_row: top_status.top_bar_controls_row,
+            top_bar_title_cluster: top_status.top_bar_title_cluster,
+            top_bar_action_cluster: top_status.top_bar_action_cluster,
+            sidebar: sidebar.sidebar,
+            sidebar_header: sidebar.sidebar_header,
+            sidebar_rows: sidebar.sidebar_rows,
+            sidebar_footer: sidebar.sidebar_footer,
+            content: content.content,
+            waveform_card: content.waveform_card,
+            waveform_header: waveform.waveform_header,
+            waveform_plot: waveform.waveform_plot,
+            waveform_scrollbar_lane: waveform.waveform_scrollbar_lane,
+            browser_panel: content.browser_panel,
+            browser_tabs: browser.browser_tabs,
+            browser_toolbar: browser.browser_toolbar,
+            browser_table_header: browser.browser_table_header,
+            browser_rows: browser.browser_rows,
+            browser_footer: browser.browser_footer,
             columns,
             column_headers,
             column_rows,
-            status_bar,
-            status_left_segment,
-            status_center_segment,
-            status_right_segment,
-            status_progress_segment,
-            ui_scale,
+            status_bar: top_status.status_bar,
+            status_left_segment: top_status.status_left_segment,
+            status_center_segment: top_status.status_center_segment,
+            status_right_segment: top_status.status_right_segment,
+            status_progress_segment: top_status.status_progress_segment,
+            ui_scale: frame.ui_scale,
         }
     }
 

--- a/src/app_core/native_shell/composition/layout/sections.rs
+++ b/src/app_core/native_shell/composition/layout/sections.rs
@@ -1,0 +1,248 @@
+use crate::app_core::native_shell::composition::{
+    ShellLayoutRuntime,
+    layout_adapter::{
+        ShellSectionRects, compute_status_bar_segments, compute_top_bar_band_sections,
+    },
+    style::{SizingTokens, StyleTokens},
+};
+use crate::gui::types::{Point, Rect, Vector2};
+
+use super::geometry::{band_header, waveform_scrollbar_lane_height};
+
+pub(super) struct LayoutFrame {
+    pub(super) root_rect: Rect,
+    pub(super) sections: ShellSectionRects,
+    pub(super) ui_scale: f32,
+}
+
+pub(super) struct TopStatusLayout {
+    pub(super) top_bar: Rect,
+    pub(super) top_bar_title_row: Rect,
+    pub(super) top_bar_controls_row: Rect,
+    pub(super) top_bar_title_cluster: Rect,
+    pub(super) top_bar_action_cluster: Rect,
+    pub(super) status_bar: Rect,
+    pub(super) status_left_segment: Rect,
+    pub(super) status_center_segment: Rect,
+    pub(super) status_right_segment: Rect,
+    pub(super) status_progress_segment: Rect,
+}
+
+pub(super) struct SidebarLayout {
+    pub(super) sidebar: Rect,
+    pub(super) sidebar_header: Rect,
+    pub(super) sidebar_rows: Rect,
+    pub(super) sidebar_footer: Rect,
+}
+
+pub(super) struct ContentLayout {
+    pub(super) content: Rect,
+    pub(super) waveform_card: Rect,
+    pub(super) browser_panel: Rect,
+}
+
+pub(super) struct BrowserLayout {
+    pub(super) browser_tabs: Rect,
+    pub(super) browser_toolbar: Rect,
+    pub(super) browser_table_header: Rect,
+    pub(super) browser_rows: Rect,
+    pub(super) browser_footer: Rect,
+}
+
+pub(super) struct WaveformLayout {
+    pub(super) waveform_header: Rect,
+    pub(super) waveform_plot: Rect,
+    pub(super) waveform_scrollbar_lane: Rect,
+}
+
+pub(super) fn build_layout_frame(
+    viewport: Vector2,
+    style: &StyleTokens,
+    runtime: &mut ShellLayoutRuntime,
+) -> LayoutFrame {
+    let viewport_width = viewport.x.max(style.sizing.min_viewport_width);
+    let viewport_height = viewport.y.max(style.sizing.min_viewport_height);
+    let sections =
+        runtime.compute_shell_sections(Vector2::new(viewport_width, viewport_height), style);
+    LayoutFrame {
+        root_rect: sections.root,
+        sections,
+        ui_scale: compute_ui_scale(viewport_width, style),
+    }
+}
+
+pub(super) fn build_top_status_layout(root_rect: Rect, sizing: SizingTokens) -> TopStatusLayout {
+    let top_bar = Rect::from_min_max(
+        root_rect.min,
+        Point::new(root_rect.max.x, root_rect.min.y + sizing.top_bar_height),
+    );
+    let top_bar_bands = compute_top_bar_band_sections(top_bar, sizing);
+    let status_bar = Rect::from_min_max(
+        Point::new(root_rect.min.x, root_rect.max.y - sizing.status_bar_height),
+        root_rect.max,
+    );
+    let status_segments = compute_status_bar_segments(status_bar, sizing);
+
+    TopStatusLayout {
+        top_bar,
+        top_bar_title_row: top_bar_bands.top_bar_title_row,
+        top_bar_controls_row: top_bar_bands.top_bar_controls_row,
+        top_bar_title_cluster: top_bar_bands.top_bar_title_cluster,
+        top_bar_action_cluster: top_bar_bands.top_bar_action_cluster,
+        status_bar,
+        status_left_segment: status_segments.left,
+        status_center_segment: status_segments.center,
+        status_right_segment: status_segments.right,
+        status_progress_segment: status_segments.progress,
+    }
+}
+
+pub(super) fn build_sidebar_layout(
+    sidebar_seed: Rect,
+    top_bar: Rect,
+    status_bar: Rect,
+    sizing: SizingTokens,
+    runtime: &mut ShellLayoutRuntime,
+) -> SidebarLayout {
+    let sidebar = Rect::from_min_max(
+        Point::new(sidebar_seed.min.x, top_bar.max.y),
+        Point::new(sidebar_seed.max.x, status_bar.min.y),
+    );
+    let sidebar_bands = runtime.compute_sidebar_band_sections(sidebar, sizing);
+    let sidebar_header = sidebar_bands.sidebar_header;
+    let sidebar_footer = sidebar_bands.sidebar_footer;
+    let sidebar_rows_top = sidebar_header.max.y.min(sidebar_footer.min.y);
+    let sidebar_rows = Rect::from_min_max(
+        Point::new(sidebar_bands.sidebar_rows.min.x, sidebar_rows_top),
+        Point::new(
+            sidebar_bands.sidebar_rows.max.x,
+            sidebar_footer.min.y.max(sidebar_rows_top),
+        ),
+    );
+
+    SidebarLayout {
+        sidebar,
+        sidebar_header,
+        sidebar_rows,
+        sidebar_footer,
+    }
+}
+
+pub(super) fn build_content_layout(
+    root_rect: Rect,
+    sidebar: Rect,
+    waveform_card_seed: Rect,
+    top_bar: Rect,
+    status_bar: Rect,
+) -> ContentLayout {
+    let content = Rect::from_min_max(
+        Point::new(sidebar.max.x, top_bar.max.y),
+        Point::new(root_rect.max.x, status_bar.min.y),
+    );
+    let waveform_card = Rect::from_min_max(
+        Point::new(content.min.x, content.min.y),
+        Point::new(content.max.x, waveform_card_seed.max.y.min(content.max.y)),
+    );
+    let browser_panel =
+        Rect::from_min_max(Point::new(content.min.x, waveform_card.max.y), content.max);
+
+    ContentLayout {
+        content,
+        waveform_card,
+        browser_panel,
+    }
+}
+
+pub(super) fn build_browser_layout(
+    browser_panel: Rect,
+    sizing: SizingTokens,
+    runtime: &mut ShellLayoutRuntime,
+) -> BrowserLayout {
+    let browser_bands = runtime.compute_browser_band_sections(browser_panel, sizing);
+    let browser_tabs = browser_bands.browser_tabs;
+    let browser_footer = browser_bands.browser_footer;
+    let browser_toolbar = Rect::from_min_max(
+        Point::new(browser_bands.browser_toolbar.min.x, browser_tabs.max.y),
+        Point::new(
+            browser_bands.browser_toolbar.max.x,
+            (browser_tabs.max.y + browser_bands.browser_toolbar.height()).min(browser_footer.min.y),
+        ),
+    );
+    let browser_table_header = Rect::from_min_max(
+        Point::new(
+            browser_bands.browser_table_header.min.x,
+            browser_toolbar.max.y,
+        ),
+        Point::new(
+            browser_bands.browser_table_header.max.x,
+            (browser_toolbar.max.y + browser_bands.browser_table_header.height())
+                .min(browser_footer.min.y),
+        ),
+    );
+    let browser_rows = Rect::from_min_max(
+        Point::new(browser_bands.browser_rows.min.x, browser_table_header.max.y),
+        Point::new(
+            browser_bands.browser_rows.max.x,
+            browser_footer.min.y.max(browser_table_header.max.y),
+        ),
+    );
+
+    BrowserLayout {
+        browser_tabs,
+        browser_toolbar,
+        browser_table_header,
+        browser_rows,
+        browser_footer,
+    }
+}
+
+pub(super) fn build_waveform_layout(waveform_card: Rect, sizing: SizingTokens) -> WaveformLayout {
+    let waveform_header = band_header(waveform_card, sizing.waveform_header_block_height);
+    let waveform_body_top = waveform_header
+        .max
+        .y
+        .clamp(waveform_card.min.y, waveform_card.max.y);
+    let waveform_body = Rect::from_min_max(
+        Point::new(waveform_card.min.x, waveform_body_top),
+        waveform_card.max,
+    );
+    let waveform_side_inset = 10.0_f32.min((waveform_body.width() - 1.0).max(0.0) * 0.5);
+    let waveform_view_body = Rect::from_min_max(
+        Point::new(
+            waveform_body.min.x + waveform_side_inset,
+            waveform_body.min.y,
+        ),
+        Point::new(
+            waveform_body.max.x - waveform_side_inset,
+            waveform_body.max.y,
+        ),
+    );
+    let scrollbar_height =
+        waveform_scrollbar_lane_height(waveform_view_body, sizing.waveform_header_block_height);
+    let waveform_scrollbar_lane = Rect::from_min_max(
+        Point::new(
+            waveform_view_body.min.x,
+            waveform_view_body.max.y - scrollbar_height,
+        ),
+        waveform_view_body.max,
+    );
+    let waveform_plot = Rect::from_min_max(
+        waveform_view_body.min,
+        Point::new(waveform_view_body.max.x, waveform_scrollbar_lane.min.y),
+    );
+
+    WaveformLayout {
+        waveform_header,
+        waveform_plot,
+        waveform_scrollbar_lane,
+    }
+}
+
+fn compute_ui_scale(viewport_width: f32, style: &StyleTokens) -> f32 {
+    let base_style = StyleTokens::for_viewport_width(viewport_width);
+    if base_style.sizing.font_title <= 0.0 {
+        return 1.0;
+    }
+
+    (style.sizing.font_title / base_style.sizing.font_title).clamp(1.0, 3.0)
+}


### PR DESCRIPTION
## Summary
- split shell layout construction into focused frame, top/status, sidebar, content, browser, and waveform helpers
- keep the `ShellLayout` fields and retained-tree build contract unchanged
- bring `layout/mod.rs` and the new `layout/sections.rs` module inside the target-size range and remove `build_with_style_and_runtime` from the largest-function hotspot list

## Validation
- `cargo test -p wavecrate --lib app_core::native_shell::composition::tests::layout -- --nocapture` in clean validation worktree with recorded Radiant submodule
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 cleanup-hotspots`
- `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent` in clean validation worktree with recorded Radiant submodule