### PR TITLE
Align native shell models with Radiant DTOs

### DIFF
--- a/src/app/controller/jobs/source_db_maintenance.rs
+++ b/src/app/controller/jobs/source_db_maintenance.rs
@@ -3,6 +3,7 @@ use super::{SourceDbMaintenanceJob, SourceDbMaintenanceOutcome, SourceDbMaintena
 use crate::app::controller::library::analysis_jobs;
 use crate::sample_sources::db::file_ops_journal;
 use crate::sample_sources::scanner::{scan_once, schedule_deep_hash_scan};
+use crate::sample_sources::{SourceDatabase, SourceDatabaseConnectionRole};
 
 mod markers;
 mod refresh;
@@ -19,158 +20,61 @@ pub(super) fn run_source_db_maintenance_job(
     if source_file_op_active(&job) {
         return deferred_for_file_op(job);
     }
-    let probe = match crate::sample_sources::SourceDatabase::open_with_role(
-        &job.source_root,
-        crate::sample_sources::SourceDatabaseConnectionRole::Maintenance,
-    ) {
+
+    let probe = match open_maintenance_probe(&job) {
         Ok(db) => db,
+        Err(err) => return maintenance_error(job, SourceDbMaintenanceRefresh::None, err),
+    };
+    let reconcile_summary = match reconcile_deferred_file_ops(&job, &probe) {
+        Ok(summary) => summary,
+        Err(err) => return maintenance_error(job, SourceDbMaintenanceRefresh::None, err),
+    };
+    let empty_source_rescanned = match rescan_empty_source_if_needed(&job, &probe) {
+        Ok(rescanned) => rescanned,
         Err(err) => {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: false,
-                orphan_rows_removed: 0,
-                refresh: SourceDbMaintenanceRefresh::None,
-                error: Some(format!("Open source DB failed: {err}")),
-            };
+            return maintenance_error(job, maintenance_refresh(&reconcile_summary, false), err);
         }
     };
-    let reconcile_summary = match file_ops_journal::reconcile_pending_ops(&probe) {
-        Ok(summary) => {
-            for err in &summary.errors {
-                tracing::warn!(
-                    "Deferred file-op recovery issue for {} ({}): {}",
-                    job.source_id,
-                    job.source_root.display(),
-                    err
-                );
-            }
-            summary
-        }
-        Err(err) => {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: false,
-                orphan_rows_removed: 0,
-                refresh: SourceDbMaintenanceRefresh::None,
-                error: Some(format!("Deferred file-op recovery failed: {err}")),
-            };
-        }
-    };
-    let mut empty_source_rescanned = false;
-    match probe.count_files() {
-        Ok(0) => match scan_once(&probe) {
-            Ok(stats) => {
-                empty_source_rescanned = scan_changed_source(&stats);
-                if stats.hashes_pending > 0 {
-                    schedule_deep_hash_scan(job.source_root.clone());
-                }
-            }
-            Err(err) => {
-                return SourceDbMaintenanceOutcome {
-                    source_id: job.source_id,
-                    source_root: job.source_root,
-                    skipped: false,
-                    deferred_due_to_file_op: false,
-                    orphan_rows_removed: 0,
-                    refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                    error: Some(format!("Deferred empty-source scan failed: {err}")),
-                };
-            }
-        },
-        Ok(_) => {}
-        Err(err) => {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: false,
-                orphan_rows_removed: 0,
-                refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                error: Some(format!("Read source DB count failed: {err}")),
-            };
-        }
-    }
+    let refresh = maintenance_refresh(&reconcile_summary, empty_source_rescanned);
     let revision = match probe.get_revision() {
         Ok(value) => value,
         Err(err) => {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: false,
-                orphan_rows_removed: 0,
-                refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                error: Some(format!("Read source DB revision failed: {err}")),
-            };
+            return maintenance_error(
+                job,
+                refresh,
+                format!("Read source DB revision failed: {err}"),
+            );
         }
     };
     let should_skip = match deferred_maintenance_is_up_to_date(&probe, revision) {
         Ok(value) => value,
-        Err(err) => {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: false,
-                orphan_rows_removed: 0,
-                refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                error: Some(err),
-            };
-        }
+        Err(err) => return maintenance_error(job, refresh, err),
     };
     drop(probe);
     if should_skip {
-        return SourceDbMaintenanceOutcome {
-            source_id: job.source_id,
-            source_root: job.source_root,
-            skipped: true,
-            deferred_due_to_file_op: false,
-            orphan_rows_removed: 0,
-            refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-            error: None,
-        };
+        return maintenance_skipped(job, refresh);
     }
 
     if source_file_op_active(&job) {
-        return SourceDbMaintenanceOutcome {
-            source_id: job.source_id,
-            source_root: job.source_root,
-            skipped: false,
-            deferred_due_to_file_op: true,
-            orphan_rows_removed: 0,
-            refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-            error: None,
-        };
+        return maintenance_deferred(job, refresh);
     }
 
+    run_source_db_maintenance_with_retries(job, revision, refresh)
+}
+
+fn run_source_db_maintenance_with_retries(
+    job: SourceDbMaintenanceJob,
+    revision: u64,
+    refresh: SourceDbMaintenanceRefresh,
+) -> SourceDbMaintenanceOutcome {
     let mut last_error: Option<String> = None;
     for attempt in 1..=DEFERRED_MAINTENANCE_MAX_ATTEMPTS {
         if source_file_op_active(&job) {
-            return SourceDbMaintenanceOutcome {
-                source_id: job.source_id,
-                source_root: job.source_root,
-                skipped: false,
-                deferred_due_to_file_op: true,
-                orphan_rows_removed: 0,
-                refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                error: None,
-            };
+            return maintenance_deferred(job, refresh);
         }
         match run_source_db_maintenance_once(&job, revision) {
             Ok(orphan_rows_removed) => {
-                return SourceDbMaintenanceOutcome {
-                    source_id: job.source_id,
-                    source_root: job.source_root,
-                    skipped: false,
-                    deferred_due_to_file_op: false,
-                    orphan_rows_removed,
-                    refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-                    error: None,
-                };
+                return maintenance_completed(job, refresh, orphan_rows_removed);
             }
             Err(err) => {
                 if attempt < DEFERRED_MAINTENANCE_MAX_ATTEMPTS {
@@ -184,14 +88,149 @@ pub(super) fn run_source_db_maintenance_job(
         }
     }
 
+    maintenance_finished(job, MaintenanceCompletion::error(refresh, last_error))
+}
+
+fn open_maintenance_probe(job: &SourceDbMaintenanceJob) -> Result<SourceDatabase, String> {
+    SourceDatabase::open_with_role(&job.source_root, SourceDatabaseConnectionRole::Maintenance)
+        .map_err(|err| format!("Open source DB failed: {err}"))
+}
+
+fn reconcile_deferred_file_ops(
+    job: &SourceDbMaintenanceJob,
+    probe: &SourceDatabase,
+) -> Result<file_ops_journal::FileOpReconcileSummary, String> {
+    let summary = file_ops_journal::reconcile_pending_ops(probe)
+        .map_err(|err| format!("Deferred file-op recovery failed: {err}"))?;
+    for err in &summary.errors {
+        tracing::warn!(
+            "Deferred file-op recovery issue for {} ({}): {}",
+            job.source_id,
+            job.source_root.display(),
+            err
+        );
+    }
+    Ok(summary)
+}
+
+fn rescan_empty_source_if_needed(
+    job: &SourceDbMaintenanceJob,
+    probe: &SourceDatabase,
+) -> Result<bool, String> {
+    match probe.count_files() {
+        Ok(0) => rescan_empty_source(job, probe),
+        Ok(_) => Ok(false),
+        Err(err) => Err(format!("Read source DB count failed: {err}")),
+    }
+}
+
+fn rescan_empty_source(
+    job: &SourceDbMaintenanceJob,
+    probe: &SourceDatabase,
+) -> Result<bool, String> {
+    let stats =
+        scan_once(probe).map_err(|err| format!("Deferred empty-source scan failed: {err}"))?;
+    if stats.hashes_pending > 0 {
+        schedule_deep_hash_scan(job.source_root.clone());
+    }
+    Ok(scan_changed_source(&stats))
+}
+
+fn maintenance_error(
+    job: SourceDbMaintenanceJob,
+    refresh: SourceDbMaintenanceRefresh,
+    error: String,
+) -> SourceDbMaintenanceOutcome {
+    maintenance_finished(job, MaintenanceCompletion::error(refresh, Some(error)))
+}
+
+fn maintenance_skipped(
+    job: SourceDbMaintenanceJob,
+    refresh: SourceDbMaintenanceRefresh,
+) -> SourceDbMaintenanceOutcome {
+    maintenance_finished(job, MaintenanceCompletion::skipped(refresh))
+}
+
+fn maintenance_deferred(
+    job: SourceDbMaintenanceJob,
+    refresh: SourceDbMaintenanceRefresh,
+) -> SourceDbMaintenanceOutcome {
+    maintenance_finished(job, MaintenanceCompletion::deferred(refresh))
+}
+
+fn maintenance_completed(
+    job: SourceDbMaintenanceJob,
+    refresh: SourceDbMaintenanceRefresh,
+    orphan_rows_removed: usize,
+) -> SourceDbMaintenanceOutcome {
+    maintenance_finished(
+        job,
+        MaintenanceCompletion::completed(refresh, orphan_rows_removed),
+    )
+}
+
+struct MaintenanceCompletion {
+    refresh: SourceDbMaintenanceRefresh,
+    orphan_rows_removed: usize,
+    skipped: bool,
+    deferred_due_to_file_op: bool,
+    error: Option<String>,
+}
+
+impl MaintenanceCompletion {
+    fn completed(refresh: SourceDbMaintenanceRefresh, orphan_rows_removed: usize) -> Self {
+        Self {
+            refresh,
+            orphan_rows_removed,
+            skipped: false,
+            deferred_due_to_file_op: false,
+            error: None,
+        }
+    }
+
+    fn skipped(refresh: SourceDbMaintenanceRefresh) -> Self {
+        Self {
+            refresh,
+            orphan_rows_removed: 0,
+            skipped: true,
+            deferred_due_to_file_op: false,
+            error: None,
+        }
+    }
+
+    fn deferred(refresh: SourceDbMaintenanceRefresh) -> Self {
+        Self {
+            refresh,
+            orphan_rows_removed: 0,
+            skipped: false,
+            deferred_due_to_file_op: true,
+            error: None,
+        }
+    }
+
+    fn error(refresh: SourceDbMaintenanceRefresh, error: Option<String>) -> Self {
+        Self {
+            refresh,
+            orphan_rows_removed: 0,
+            skipped: false,
+            deferred_due_to_file_op: false,
+            error,
+        }
+    }
+}
+
+fn maintenance_finished(
+    job: SourceDbMaintenanceJob,
+    completion: MaintenanceCompletion,
+) -> SourceDbMaintenanceOutcome {
     SourceDbMaintenanceOutcome {
         source_id: job.source_id,
         source_root: job.source_root,
-        skipped: false,
-        deferred_due_to_file_op: false,
-        orphan_rows_removed: 0,
-        refresh: maintenance_refresh(&reconcile_summary, empty_source_rescanned),
-        error: last_error,
+        skipped: completion.skipped,
+        deferred_due_to_file_op: completion.deferred_due_to_file_op,
+        orphan_rows_removed: completion.orphan_rows_removed,
+        refresh: completion.refresh,
+        error: completion.error,
     }
 }
 

--- a/src/app/controller/undo_jobs.rs
+++ b/src/app/controller/undo_jobs.rs
@@ -22,104 +22,49 @@ pub(crate) fn run_undo_file_job(
     sender: Option<&Sender<FileOpMessage>>,
 ) -> UndoFileOpResult {
     if cancel.load(Ordering::Relaxed) {
-        return UndoFileOpResult {
-            result: Err("Undo cancelled".to_string()),
-            cancelled: true,
-        };
+        return undo_job_cancelled();
     }
-    let result = match job {
+    let result = run_undo_file_job_inner(job);
+    report_undo_file_progress(sender);
+    UndoFileOpResult {
+        result,
+        cancelled: false,
+    }
+}
+
+fn undo_job_cancelled() -> UndoFileOpResult {
+    UndoFileOpResult {
+        result: Err("Undo cancelled".to_string()),
+        cancelled: true,
+    }
+}
+
+fn run_undo_file_job_inner(job: UndoFileJob) -> Result<UndoFileOutcome, String> {
+    match job {
         UndoFileJob::Overwrite {
             source_id,
             source_root,
             relative_path,
             absolute_path,
             backup_path,
-        } => {
-            if let Some(parent) = absolute_path.parent()
-                && let Err(err) = std::fs::create_dir_all(parent)
-            {
-                return UndoFileOpResult {
-                    result: Err(format!(
-                        "Failed to create folder {}: {err}",
-                        parent.display()
-                    )),
-                    cancelled: false,
-                };
-            }
-            std::fs::copy(&backup_path, &absolute_path)
-                .map_err(|err| format!("Failed to restore audio: {err}"))
-                .and_then(|_| {
-                    let (file_size, modified_ns) = file_metadata(&absolute_path)?;
-                    let db = SourceDatabase::open(&source_root)
-                        .map_err(|err| format!("Database unavailable: {err}"))?;
-                    let tag = db
-                        .tag_for_path(&relative_path)
-                        .map_err(|err| format!("Failed to read database: {err}"))?
-                        .ok_or_else(|| "Sample not found in database".to_string())?;
-                    let looped = db
-                        .looped_for_path(&relative_path)
-                        .map_err(|err| format!("Failed to read database: {err}"))?
-                        .ok_or_else(|| "Sample not found in database".to_string())?;
-                    let last_played_at = db
-                        .last_played_at_for_path(&relative_path)
-                        .map_err(|err| format!("Failed to read database: {err}"))?;
-                    let normal_tags = db
-                        .tag_labels_for_path(&relative_path)
-                        .map_err(|err| format!("Failed to read database: {err}"))?;
-                    Ok(UndoFileOutcome::Overwrite {
-                        source_id,
-                        relative_path,
-                        file_size,
-                        modified_ns,
-                        tag,
-                        looped,
-                        last_played_at,
-                        normal_tags,
-                    })
-                })
-        }
+        } => restore_overwrite_sample(
+            source_id,
+            source_root.as_path(),
+            relative_path.as_path(),
+            absolute_path.as_path(),
+            backup_path.as_path(),
+        ),
         UndoFileJob::RemoveSample {
             source_id,
             source_root,
             relative_path,
             absolute_path,
-        } => {
-            let db = match SourceDatabase::open(&source_root) {
-                Ok(db) => db,
-                Err(err) => {
-                    return UndoFileOpResult {
-                        result: Err(format!("Database unavailable: {err}")),
-                        cancelled: false,
-                    };
-                }
-            };
-            match remove_sample_file_with_retry(&absolute_path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == ErrorKind::NotFound => {}
-                Err(err) => {
-                    return UndoFileOpResult {
-                        result: Err(format!(
-                            "Failed to delete sample {}: {err}",
-                            absolute_path.display()
-                        )),
-                        cancelled: false,
-                    };
-                }
-            }
-            if let Err(err) = db.remove_file(&relative_path) {
-                return UndoFileOpResult {
-                    result: Err(format!(
-                        "Failed to drop database row for {}: {err}",
-                        relative_path.display()
-                    )),
-                    cancelled: false,
-                };
-            }
-            Ok(UndoFileOutcome::Removed {
-                source_id,
-                relative_path,
-            })
-        }
+        } => remove_restored_sample(
+            source_id,
+            source_root.as_path(),
+            relative_path.as_path(),
+            absolute_path.as_path(),
+        ),
         UndoFileJob::RestoreSample {
             source_id,
             source_root,
@@ -130,59 +75,21 @@ pub(crate) fn run_undo_file_job(
             looped,
             last_played_at,
             normal_tags,
-        } => {
-            if let Some(parent) = absolute_path.parent()
-                && let Err(err) = std::fs::create_dir_all(parent)
-            {
-                return UndoFileOpResult {
-                    result: Err(format!(
-                        "Failed to create folder {}: {err}",
-                        parent.display()
-                    )),
-                    cancelled: false,
-                };
-            }
-            std::fs::copy(&backup_path, &absolute_path)
-                .map_err(|err| format!("Failed to restore audio: {err}"))
-                .and_then(|_| {
-                    let (file_size, modified_ns) = file_metadata(&absolute_path)?;
-                    let db = SourceDatabase::open(&source_root)
-                        .map_err(|err| format!("Database unavailable: {err}"))?;
-                    db.upsert_file(&relative_path, file_size, modified_ns)
-                        .map_err(|err| format!("Failed to sync database entry: {err}"))?;
-                    db.set_tag(&relative_path, tag)
-                        .map_err(|err| format!("Failed to sync tag: {err}"))?;
-                    db.set_looped(&relative_path, looped)
-                        .map_err(|err| format!("Failed to sync loop metadata: {err}"))?;
-                    if let Some(last_played_at) = last_played_at {
-                        db.set_last_played_at(&relative_path, last_played_at)
-                            .map_err(|err| format!("Failed to sync playback age: {err}"))?;
-                    } else {
-                        db.clear_last_played_at(&relative_path)
-                            .map_err(|err| format!("Failed to sync playback age: {err}"))?;
-                    }
-                    let mut batch = db
-                        .write_batch()
-                        .map_err(|err| format!("Failed to sync normal tags: {err}"))?;
-                    batch
-                        .replace_tags_for_path(&relative_path, &normal_tags)
-                        .map_err(|err| format!("Failed to sync normal tags: {err}"))?;
-                    batch
-                        .commit()
-                        .map_err(|err| format!("Failed to sync normal tags: {err}"))?;
-                    Ok(UndoFileOutcome::Restored {
-                        source_id,
-                        relative_path,
-                        file_size,
-                        modified_ns,
-                        tag,
-                        looped,
-                        last_played_at,
-                        normal_tags,
-                    })
-                })
-        }
-    };
+        } => restore_removed_sample(RestoreSampleInput {
+            source_id,
+            source_root: source_root.as_path(),
+            relative_path: relative_path.as_path(),
+            absolute_path: absolute_path.as_path(),
+            backup_path: backup_path.as_path(),
+            tag,
+            looped,
+            last_played_at,
+            normal_tags,
+        }),
+    }
+}
+
+fn report_undo_file_progress(sender: Option<&Sender<FileOpMessage>>) {
     if let Some(tx) = sender {
         let _ = tx.send(FileOpMessage::Progress {
             completed: 1,
@@ -190,9 +97,185 @@ pub(crate) fn run_undo_file_job(
             item: None,
         });
     }
-    UndoFileOpResult {
-        result,
-        cancelled: false,
+}
+
+fn restore_overwrite_sample(
+    source_id: crate::sample_sources::SourceId,
+    source_root: &Path,
+    relative_path: &Path,
+    absolute_path: &Path,
+    backup_path: &Path,
+) -> Result<UndoFileOutcome, String> {
+    ensure_parent_dir(absolute_path)?;
+    std::fs::copy(backup_path, absolute_path)
+        .map_err(|err| format!("Failed to restore audio: {err}"))?;
+
+    let (file_size, modified_ns) = file_metadata(absolute_path)?;
+    let db = open_source_db(source_root)?;
+    let snapshot = read_sample_metadata(&db, relative_path)?;
+
+    Ok(UndoFileOutcome::Overwrite {
+        source_id,
+        relative_path: relative_path.to_path_buf(),
+        file_size,
+        modified_ns,
+        tag: snapshot.tag,
+        looped: snapshot.looped,
+        last_played_at: snapshot.last_played_at,
+        normal_tags: snapshot.normal_tags,
+    })
+}
+
+fn remove_restored_sample(
+    source_id: crate::sample_sources::SourceId,
+    source_root: &Path,
+    relative_path: &Path,
+    absolute_path: &Path,
+) -> Result<UndoFileOutcome, String> {
+    let db = open_source_db(source_root)?;
+    delete_sample_file_if_present(absolute_path)?;
+    db.remove_file(relative_path).map_err(|err| {
+        format!(
+            "Failed to drop database row for {}: {err}",
+            relative_path.display()
+        )
+    })?;
+
+    Ok(UndoFileOutcome::Removed {
+        source_id,
+        relative_path: relative_path.to_path_buf(),
+    })
+}
+
+struct RestoreSampleInput<'a> {
+    source_id: crate::sample_sources::SourceId,
+    source_root: &'a Path,
+    relative_path: &'a Path,
+    absolute_path: &'a Path,
+    backup_path: &'a Path,
+    tag: crate::sample_sources::Rating,
+    looped: bool,
+    last_played_at: Option<i64>,
+    normal_tags: Vec<String>,
+}
+
+fn restore_removed_sample(input: RestoreSampleInput<'_>) -> Result<UndoFileOutcome, String> {
+    ensure_parent_dir(input.absolute_path)?;
+    std::fs::copy(input.backup_path, input.absolute_path)
+        .map_err(|err| format!("Failed to restore audio: {err}"))?;
+
+    let (file_size, modified_ns) = file_metadata(input.absolute_path)?;
+    let db = open_source_db(input.source_root)?;
+    write_restored_sample_metadata(&db, &input, file_size, modified_ns)?;
+
+    Ok(UndoFileOutcome::Restored {
+        source_id: input.source_id,
+        relative_path: input.relative_path.to_path_buf(),
+        file_size,
+        modified_ns,
+        tag: input.tag,
+        looped: input.looped,
+        last_played_at: input.last_played_at,
+        normal_tags: input.normal_tags,
+    })
+}
+
+struct SampleMetadataSnapshot {
+    tag: crate::sample_sources::Rating,
+    looped: bool,
+    last_played_at: Option<i64>,
+    normal_tags: Vec<String>,
+}
+
+fn read_sample_metadata(
+    db: &SourceDatabase,
+    relative_path: &Path,
+) -> Result<SampleMetadataSnapshot, String> {
+    let tag = db
+        .tag_for_path(relative_path)
+        .map_err(|err| format!("Failed to read database: {err}"))?
+        .ok_or_else(|| "Sample not found in database".to_string())?;
+    let looped = db
+        .looped_for_path(relative_path)
+        .map_err(|err| format!("Failed to read database: {err}"))?
+        .ok_or_else(|| "Sample not found in database".to_string())?;
+    let last_played_at = db
+        .last_played_at_for_path(relative_path)
+        .map_err(|err| format!("Failed to read database: {err}"))?;
+    let normal_tags = db
+        .tag_labels_for_path(relative_path)
+        .map_err(|err| format!("Failed to read database: {err}"))?;
+
+    Ok(SampleMetadataSnapshot {
+        tag,
+        looped,
+        last_played_at,
+        normal_tags,
+    })
+}
+
+fn write_restored_sample_metadata(
+    db: &SourceDatabase,
+    input: &RestoreSampleInput<'_>,
+    file_size: u64,
+    modified_ns: i64,
+) -> Result<(), String> {
+    db.upsert_file(input.relative_path, file_size, modified_ns)
+        .map_err(|err| format!("Failed to sync database entry: {err}"))?;
+    db.set_tag(input.relative_path, input.tag)
+        .map_err(|err| format!("Failed to sync tag: {err}"))?;
+    db.set_looped(input.relative_path, input.looped)
+        .map_err(|err| format!("Failed to sync loop metadata: {err}"))?;
+    write_playback_age(db, input.relative_path, input.last_played_at)?;
+    write_normal_tags(db, input.relative_path, &input.normal_tags)
+}
+
+fn write_playback_age(
+    db: &SourceDatabase,
+    relative_path: &Path,
+    last_played_at: Option<i64>,
+) -> Result<(), String> {
+    if let Some(last_played_at) = last_played_at {
+        db.set_last_played_at(relative_path, last_played_at)
+    } else {
+        db.clear_last_played_at(relative_path)
+    }
+    .map_err(|err| format!("Failed to sync playback age: {err}"))
+}
+
+fn write_normal_tags(
+    db: &SourceDatabase,
+    relative_path: &Path,
+    normal_tags: &[String],
+) -> Result<(), String> {
+    let mut batch = db
+        .write_batch()
+        .map_err(|err| format!("Failed to sync normal tags: {err}"))?;
+    batch
+        .replace_tags_for_path(relative_path, normal_tags)
+        .map_err(|err| format!("Failed to sync normal tags: {err}"))?;
+    batch
+        .commit()
+        .map_err(|err| format!("Failed to sync normal tags: {err}"))
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create folder {}: {err}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn open_source_db(source_root: &Path) -> Result<SourceDatabase, String> {
+    SourceDatabase::open(source_root).map_err(|err| format!("Database unavailable: {err}"))
+}
+
+fn delete_sample_file_if_present(path: &Path) -> Result<(), String> {
+    match remove_sample_file_with_retry(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!("Failed to delete sample {}: {err}", path.display())),
     }
 }
 
@@ -208,5 +291,5 @@ fn remove_sample_file_with_retry(path: &Path) -> std::io::Result<()> {
             result => return result,
         }
     }
-    unreachable!("retry loop always returns on its final attempt")
+    std::fs::remove_file(path)
 }

--- a/src/app_core/actions/native_shell_dtos/app_shell.rs
+++ b/src/app_core/actions/native_shell_dtos/app_shell.rs
@@ -27,7 +27,98 @@ pub type ColumnModel = list::ColumnSummary;
 pub type MapRenderModeModel = visualization::PointRenderMode;
 
 /// Summary of map state consumed by the native shell map tab.
-pub type MapPanelModel = visualization::SpatialPanel;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MapPanelModel {
+    /// Whether the map panel is currently active.
+    pub active: bool,
+    /// Human-readable map summary line.
+    pub summary: String,
+    /// Legend/status label for render mode and point density.
+    pub legend_label: String,
+    /// Selection/focus label for the currently highlighted sample.
+    pub selection_label: String,
+    /// Hover label for the currently hovered sample, when any.
+    pub hover_label: String,
+    /// Cluster summary label for projected points.
+    pub cluster_label: String,
+    /// Viewport label describing zoom/pan state.
+    pub viewport_label: String,
+    /// Optional map error text.
+    pub error: Option<String>,
+    /// Current point render mode.
+    pub render_mode: MapRenderModeModel,
+    /// Host item id currently selected in map state, when any.
+    pub selected_item_id: Option<String>,
+    /// Host item id currently focused from a related list, when any.
+    pub focused_item_id: Option<String>,
+    /// Points available for rendering in normalized map coordinates.
+    pub points: std::sync::Arc<[MapPointModel]>,
+}
+
+impl Default for MapPanelModel {
+    fn default() -> Self {
+        Self {
+            active: false,
+            summary: String::new(),
+            legend_label: String::new(),
+            selection_label: String::new(),
+            hover_label: String::new(),
+            cluster_label: String::new(),
+            viewport_label: String::new(),
+            error: None,
+            render_mode: MapRenderModeModel::default(),
+            selected_item_id: None,
+            focused_item_id: None,
+            points: std::sync::Arc::default(),
+        }
+    }
+}
+
+impl From<MapPanelModel> for visualization::SpatialPanel {
+    fn from(value: MapPanelModel) -> Self {
+        Self {
+            status: visualization::SpatialPanelStatus {
+                active: value.active,
+                summary: value.summary,
+                error: value.error,
+            },
+            labels: visualization::SpatialPanelLabels {
+                legend_label: value.legend_label,
+                selection_label: value.selection_label,
+                hover_label: value.hover_label,
+                cluster_label: value.cluster_label,
+                viewport_label: value.viewport_label,
+            },
+            selection: visualization::SpatialPanelSelection {
+                selected_item_id: value.selected_item_id,
+                focused_item_id: value.focused_item_id,
+            },
+            points: visualization::SpatialPanelPoints {
+                render_mode: value.render_mode,
+                points: value.points,
+            },
+        }
+    }
+}
+
+impl From<visualization::SpatialPanel> for MapPanelModel {
+    fn from(value: visualization::SpatialPanel) -> Self {
+        Self {
+            active: value.status.active,
+            summary: value.status.summary,
+            legend_label: value.labels.legend_label,
+            selection_label: value.labels.selection_label,
+            hover_label: value.labels.hover_label,
+            cluster_label: value.labels.cluster_label,
+            viewport_label: value.labels.viewport_label,
+            error: value.status.error,
+            render_mode: value.points.render_mode,
+            selected_item_id: value.selection.selected_item_id,
+            focused_item_id: value.selection.focused_item_id,
+            points: value.points.points,
+        }
+    }
+}
 
 /// Render data for one point shown in the native map canvas.
 pub type MapPointModel = visualization::SpatialPoint;

--- a/src/app_core/actions/native_shell_dtos/browser.rs
+++ b/src/app_core/actions/native_shell_dtos/browser.rs
@@ -17,7 +17,104 @@ pub type BrowserTagState = selection::TriState;
 pub type BrowserTagPillModel = badge::SelectablePill<BrowserTagState>;
 
 /// Browser-local metadata sidebar shown beside the sample list.
-pub type BrowserTagSidebarModel = badge::PillEditorPanel<BrowserTagState>;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrowserTagSidebarModel {
+    /// Whether the panel should render in the current view.
+    pub open: bool,
+    /// Count of selected rows represented by the panel target set.
+    pub selected_count: usize,
+    /// Header line describing the current selection/focus context.
+    pub header_label: String,
+    /// Whether auto-rename is enabled for tag edits.
+    pub primary_action_enabled: bool,
+    /// Current tag search/create input value.
+    pub input_value: String,
+    /// Placeholder shown for the input when empty.
+    pub input_placeholder: String,
+    /// Whether the tag input currently owns text-editing focus.
+    pub input_focused: bool,
+    /// Caret position measured in Unicode scalar values from the start.
+    pub input_caret: usize,
+    /// Selected text range measured in Unicode scalar values, when any.
+    pub input_selection: Option<(usize, usize)>,
+    /// Mutually exclusive playback-mode pills.
+    pub exclusive_pills: [BrowserTagPillModel; 2],
+    /// Tags already applied to the represented target set.
+    pub accepted_pills: Vec<BrowserTagPillModel>,
+    /// Normal tag candidates from common usage or search.
+    pub option_pills: Vec<BrowserTagPillModel>,
+    /// Create-new tag candidate when the input does not match an existing option.
+    pub create_pill: Option<BrowserTagPillModel>,
+}
+
+impl Default for BrowserTagSidebarModel {
+    fn default() -> Self {
+        Self {
+            open: false,
+            selected_count: 0,
+            header_label: String::new(),
+            primary_action_enabled: false,
+            input_value: String::new(),
+            input_placeholder: String::new(),
+            input_focused: false,
+            input_caret: 0,
+            input_selection: None,
+            exclusive_pills: [
+                BrowserTagPillModel::default(),
+                BrowserTagPillModel::default(),
+            ],
+            accepted_pills: Vec::new(),
+            option_pills: Vec::new(),
+            create_pill: None,
+        }
+    }
+}
+
+impl From<BrowserTagSidebarModel> for badge::PillEditorPanel<BrowserTagState> {
+    fn from(value: BrowserTagSidebarModel) -> Self {
+        Self {
+            status: badge::PillEditorStatus {
+                open: value.open,
+                selected_count: value.selected_count,
+                header_label: value.header_label,
+                primary_action_enabled: value.primary_action_enabled,
+            },
+            input: badge::PillEditorInput {
+                input_value: value.input_value,
+                input_placeholder: value.input_placeholder,
+                input_focused: value.input_focused,
+                input_caret: value.input_caret,
+                input_selection: value.input_selection,
+            },
+            choices: badge::PillEditorChoices {
+                exclusive_pills: value.exclusive_pills,
+                accepted_pills: value.accepted_pills,
+                option_pills: value.option_pills,
+                create_pill: value.create_pill,
+            },
+        }
+    }
+}
+
+impl From<badge::PillEditorPanel<BrowserTagState>> for BrowserTagSidebarModel {
+    fn from(value: badge::PillEditorPanel<BrowserTagState>) -> Self {
+        Self {
+            open: value.status.open,
+            selected_count: value.status.selected_count,
+            header_label: value.status.header_label,
+            primary_action_enabled: value.status.primary_action_enabled,
+            input_value: value.input.input_value,
+            input_placeholder: value.input.input_placeholder,
+            input_focused: value.input.input_focused,
+            input_caret: value.input.input_caret,
+            input_selection: value.input.input_selection,
+            exclusive_pills: value.choices.exclusive_pills,
+            accepted_pills: value.choices.accepted_pills,
+            option_pills: value.choices.option_pills,
+            create_pill: value.choices.create_pill,
+        }
+    }
+}
 
 /// Summary of browser/list state consumed by the native shell.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]

--- a/src/app_core/actions/native_shell_dtos/sidebar.rs
+++ b/src/app_core/actions/native_shell_dtos/sidebar.rs
@@ -42,7 +42,105 @@ pub type FolderActionsModel = list::EditableTreeActions;
 pub type FolderPaneIdModel = panel::SplitPaneSlot;
 
 /// Projected data for one fixed folder pane shown in the sidebar.
-pub type FolderPaneModel = panel::SplitPaneTreePanel<FolderRowModel>;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FolderPaneModel {
+    /// Stable pane identity used by routing.
+    pub pane: FolderPaneIdModel,
+    /// Short title shown in the pane header.
+    pub title: String,
+    /// Label for the source assigned to this pane.
+    pub item_label: String,
+    /// Secondary detail for the source assigned to this pane.
+    pub item_detail: String,
+    /// Whether this pane currently drives browser and waveform state.
+    pub active: bool,
+    /// Whether a source is assigned to this pane.
+    pub has_item: bool,
+    /// Whether this pane is hydrating its assigned source.
+    pub loading: bool,
+    /// Whether this pane is asynchronously rebuilding its folder rows.
+    pub projecting: bool,
+    /// Whether this pane's assigned source currently owns a background mutation.
+    pub mutation_busy: bool,
+    /// Active folder-search query.
+    pub tree_search_query: String,
+    /// Whether the folder browser currently includes empty on-disk folders.
+    pub show_all_items: bool,
+    /// Whether the folder-visibility toggle is currently actionable.
+    pub can_toggle_show_all_items: bool,
+    /// Whether folder filtering includes descendant files in a flattened list.
+    pub flattened_view: bool,
+    /// Whether the folder flattened-view toggle is currently actionable.
+    pub can_toggle_flattened_view: bool,
+    /// Focused folder row index, if any.
+    pub focused_tree_row: Option<usize>,
+    /// Folder rows to render in this pane.
+    pub tree_rows: RetainedVec<FolderRowModel>,
+    /// Folder action availability for native sidebar controls.
+    pub tree_actions: FolderActionsModel,
+    /// Folder delete-recovery summary for native sidebar status.
+    pub recovery: FolderRecoveryModel,
+}
+
+impl Default for FolderPaneModel {
+    fn default() -> Self {
+        Self {
+            pane: FolderPaneIdModel::default(),
+            title: String::new(),
+            item_label: String::new(),
+            item_detail: String::new(),
+            active: false,
+            has_item: false,
+            loading: false,
+            projecting: false,
+            mutation_busy: false,
+            tree_search_query: String::new(),
+            show_all_items: false,
+            can_toggle_show_all_items: false,
+            flattened_view: false,
+            can_toggle_flattened_view: false,
+            focused_tree_row: None,
+            tree_rows: RetainedVec::new(),
+            tree_actions: FolderActionsModel::default(),
+            recovery: FolderRecoveryModel::default(),
+        }
+    }
+}
+
+impl From<FolderPaneModel> for panel::SplitPaneTreePanel<FolderRowModel> {
+    fn from(value: FolderPaneModel) -> Self {
+        Self {
+            identity: panel::SplitPaneTreePanelIdentity {
+                pane: value.pane,
+                title: value.title,
+            },
+            assignment: panel::SplitPaneTreePanelAssignment {
+                item_label: value.item_label,
+                item_detail: value.item_detail,
+                active: value.active,
+                has_item: value.has_item,
+            },
+            activity: panel::SplitPaneTreePanelActivity {
+                loading: value.loading,
+                projecting: value.projecting,
+                mutation_busy: value.mutation_busy,
+            },
+            controls: panel::SplitPaneTreePanelControls {
+                tree_search_query: value.tree_search_query,
+                show_all_items: value.show_all_items,
+                can_toggle_show_all_items: value.can_toggle_show_all_items,
+                flattened_view: value.flattened_view,
+                can_toggle_flattened_view: value.can_toggle_flattened_view,
+            },
+            content: panel::SplitPaneTreePanelContent {
+                focused_tree_row: value.focused_tree_row,
+                tree_rows: value.tree_rows,
+                tree_actions: value.tree_actions,
+                recovery: value.recovery,
+            },
+        }
+    }
+}
 
 /// Render data for one source row shown in the sidebar.
 pub type SourceRowModel = panel::SplitPaneAssignedRow;
@@ -107,24 +205,34 @@ impl SourcesPanelModel {
         &self,
     ) -> panel::SplitPaneSidebarState<SourceRowModel, FolderRowModel> {
         panel::SplitPaneSidebarState {
-            header: self.header.clone(),
-            search_query: self.search_query.clone(),
-            active_pane: self.active_folder_pane,
-            upper_pane: self.upper_folder_pane.clone(),
-            lower_pane: self.lower_folder_pane.clone(),
-            tree_search_query: self.tree_search_query.clone(),
-            show_all_items: self.show_all_items,
-            can_toggle_show_all_items: self.can_toggle_show_all_items,
-            flattened_view: self.flattened_view,
-            can_toggle_flattened_view: self.can_toggle_flattened_view,
-            selected_row: self.selected_row,
-            loading_row: self.loading_row,
-            mutation_busy_row: self.mutation_busy_row,
-            focused_tree_row: self.focused_tree_row,
-            rows: self.rows.clone(),
-            tree_rows: self.tree_rows.clone(),
-            tree_actions: self.tree_actions.clone(),
-            recovery: self.recovery.clone(),
+            chrome: panel::SplitPaneSidebarChrome {
+                header: self.header.clone(),
+                search_query: self.search_query.clone(),
+            },
+            panes: panel::SplitPaneSidebarPanes {
+                active_pane: self.active_folder_pane,
+                upper_pane: self.upper_folder_pane.clone().into(),
+                lower_pane: self.lower_folder_pane.clone().into(),
+            },
+            tree_controls: panel::SplitPaneSidebarTreeControls {
+                tree_search_query: self.tree_search_query.clone(),
+                show_all_items: self.show_all_items,
+                can_toggle_show_all_items: self.can_toggle_show_all_items,
+                flattened_view: self.flattened_view,
+                can_toggle_flattened_view: self.can_toggle_flattened_view,
+            },
+            selection: panel::SplitPaneSidebarSelection {
+                selected_row: self.selected_row,
+                loading_row: self.loading_row,
+                mutation_busy_row: self.mutation_busy_row,
+                focused_tree_row: self.focused_tree_row,
+            },
+            content: panel::SplitPaneSidebarContent {
+                rows: self.rows.clone(),
+                tree_rows: self.tree_rows.clone(),
+                tree_actions: self.tree_actions.clone(),
+                recovery: self.recovery.clone(),
+            },
         }
     }
 }

--- a/src/app_core/native_bridge/tests/bridge_runtime/mod.rs
+++ b/src/app_core/native_bridge/tests/bridge_runtime/mod.rs
@@ -103,7 +103,7 @@ mod projection_folder_edits {
             .iter()
             .find(|row| row.kind == crate::app_core::actions::NativeFolderRowKind::CreateDraft)
             .expect("folder create draft should be projected");
-        assert_eq!(initial_draft.input_value.as_deref(), Some(""));
+        assert_eq!(initial_draft.input.value.as_deref(), Some(""));
 
         bridge.on_action(NativeUiAction::SetFolderCreateInput {
             value: String::from("drums"),
@@ -116,7 +116,7 @@ mod projection_folder_edits {
             .iter()
             .find(|row| row.kind == crate::app_core::actions::NativeFolderRowKind::CreateDraft)
             .expect("folder create draft should still be projected");
-        assert_eq!(updated_draft.input_value.as_deref(), Some("drums"));
+        assert_eq!(updated_draft.input.value.as_deref(), Some("drums"));
     }
 
     /// Canceling folder-create should remove the draft from the next projected model immediately.
@@ -222,7 +222,7 @@ mod projection_folder_edits {
             .iter()
             .find(|row| row.kind == crate::app_core::actions::NativeFolderRowKind::RenameDraft)
             .expect("folder rename draft should be projected");
-        assert_eq!(draft.input_value.as_deref(), Some("drums"));
-        assert!(draft.select_all_on_focus);
+        assert_eq!(draft.input.value.as_deref(), Some("drums"));
+        assert!(draft.input.select_all_on_focus);
     }
 }

--- a/src/app_core/native_shell/composition/layout_adapter.rs
+++ b/src/app_core/native_shell/composition/layout_adapter.rs
@@ -17,9 +17,9 @@ mod status_bar;
 mod waveform_annotations;
 use super::style::StyleTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutDebugOptions,
-    LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain,
-    SlotChild, SlotParams,
+    Constraints, ConstraintsParts, ContainerKind, ContainerPolicy, CrossAlign, Insets,
+    LayoutDebugOptions, LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy,
+    SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
 use crate::gui::types::{Point, Rect, Vector2};
 pub(super) use bands::compute_top_bar_band_sections;
@@ -76,6 +76,15 @@ pub(crate) use waveform_annotations::{
     waveform_plot_x_for_absolute_ratio, waveform_plot_x_for_micros,
     waveform_view_window_from_bounds,
 };
+
+pub(super) fn constraints(min_w: f32, max_w: f32, min_h: f32, max_h: f32) -> Constraints {
+    Constraints::from_parts(ConstraintsParts {
+        min_w,
+        max_w,
+        min_h,
+        max_h,
+    })
+}
 
 pub(crate) const SHELL_ROOT_ID: u64 = 1;
 pub(crate) const TOP_BAR_ID: u64 = 2;
@@ -146,7 +155,7 @@ pub(crate) fn build_shell_sections_tree(style: &StyleTokens, viewport_width: f32
                 slot: SlotParams {
                     size_main: SizeModeMain::Percent(sizing.sidebar_ratio),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         sizing.sidebar_min_width,
                         sizing.sidebar_max_width,
                         0.0,
@@ -162,7 +171,7 @@ pub(crate) fn build_shell_sections_tree(style: &StyleTokens, viewport_width: f32
                 slot: SlotParams {
                     size_main: SizeModeMain::Fill(1.0),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         sizing.content_min_width,
                         f32::INFINITY,
                         0.0,
@@ -193,7 +202,7 @@ pub(crate) fn build_shell_sections_tree(style: &StyleTokens, viewport_width: f32
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(sizing.top_bar_height),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         0.0,
                         f32::INFINITY,
                         sizing.top_bar_height,
@@ -212,7 +221,7 @@ pub(crate) fn build_shell_sections_tree(style: &StyleTokens, viewport_width: f32
                 slot: SlotParams {
                     size_main: SizeModeMain::Fill(1.0),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(0.0, f32::INFINITY, 0.0, f32::INFINITY),
+                    constraints: constraints(0.0, f32::INFINITY, 0.0, f32::INFINITY),
                     margin: Insets::default(),
                     align_cross_override: None,
                     allow_fixed_compress: false,
@@ -223,7 +232,7 @@ pub(crate) fn build_shell_sections_tree(style: &StyleTokens, viewport_width: f32
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(sizing.status_bar_height),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         0.0,
                         f32::INFINITY,
                         sizing.status_bar_height,
@@ -260,7 +269,7 @@ fn build_content_tree(style: &StyleTokens) -> LayoutNode {
                 slot: SlotParams {
                     size_main: SizeModeMain::Percent(sizing.waveform_ratio),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         0.0,
                         f32::INFINITY,
                         sizing.waveform_min_height,
@@ -279,7 +288,7 @@ fn build_content_tree(style: &StyleTokens) -> LayoutNode {
                 slot: SlotParams {
                     size_main: SizeModeMain::Fill(1.0),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: constraints(
                         0.0,
                         f32::INFINITY,
                         sizing.content_browser_min_height,

--- a/src/app_core/native_shell/composition/layout_adapter/bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/bands.rs
@@ -243,7 +243,7 @@ fn fixed_height_slot(height: f32, bottom_margin: f32) -> SlotParams {
     SlotParams {
         size_main: SizeModeMain::Fixed(height.max(0.0)),
         size_cross: SizeModeCross::Fill,
-        constraints: Constraints::new(0.0, f32::INFINITY, 0.0, height.max(0.0)),
+        constraints: super::constraints(0.0, f32::INFINITY, 0.0, height.max(0.0)),
         margin: Insets {
             bottom: bottom_margin.max(0.0),
             ..Insets::default()
@@ -257,7 +257,7 @@ fn fixed_width_slot(width: f32) -> SlotParams {
     SlotParams {
         size_main: SizeModeMain::Fixed(width.max(0.0)),
         size_cross: SizeModeCross::Fill,
-        constraints: Constraints::new(0.0, width.max(0.0), 0.0, f32::INFINITY),
+        constraints: super::constraints(0.0, width.max(0.0), 0.0, f32::INFINITY),
         margin: Insets::default(),
         align_cross_override: None,
         allow_fixed_compress: true,

--- a/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
@@ -59,7 +59,7 @@ fn fill_tab_slot(node_id: u64, min_width: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fill(1.0),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(min_width, f32::INFINITY, 0.0, f32::INFINITY),
+            constraints: super::constraints(min_width, f32::INFINITY, 0.0, f32::INFINITY),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -140,7 +140,7 @@ fn fixed_width_child(node_id: u64, width: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(width),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(width, width, 0.0, f32::INFINITY),
+            constraints: super::constraints(width, width, 0.0, f32::INFINITY),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
@@ -122,7 +122,12 @@ fn fixed_width_child(node_id: u64, width: f32, left_margin: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(width.max(0.0)),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(width.max(0.0), width.max(0.0), 0.0, f32::INFINITY),
+            constraints: super::super::constraints(
+                width.max(0.0),
+                width.max(0.0),
+                0.0,
+                f32::INFINITY,
+            ),
             margin: Insets {
                 left: left_margin.max(0.0),
                 ..Insets::default()

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -87,7 +87,7 @@ fn fixed_width_child(node_id: u64, width: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(width),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(width, width, 0.0, f32::INFINITY),
+            constraints: super::constraints(width, width, 0.0, f32::INFINITY),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
@@ -105,7 +105,12 @@ fn compute_progress_bar_rect(dialog: Rect, sizing: SizingTokens) -> Rect {
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(top.max(0.0)),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(0.0, f32::INFINITY, top.max(0.0), top.max(0.0)),
+                    constraints: super::super::constraints(
+                        0.0,
+                        f32::INFINITY,
+                        top.max(0.0),
+                        top.max(0.0),
+                    ),
                     margin: Insets::default(),
                     align_cross_override: None,
                     allow_fixed_compress: true,
@@ -119,7 +124,7 @@ fn compute_progress_bar_rect(dialog: Rect, sizing: SizingTokens) -> Rect {
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(sizing.progress_bar_height.max(0.0)),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: super::super::constraints(
                         0.0,
                         f32::INFINITY,
                         sizing.progress_bar_height.max(0.0),
@@ -166,7 +171,12 @@ fn compute_progress_cancel_button_rect(dialog: Rect, sizing: SizingTokens) -> Re
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(button_height),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(0.0, f32::INFINITY, button_height, button_height),
+                    constraints: super::super::constraints(
+                        0.0,
+                        f32::INFINITY,
+                        button_height,
+                        button_height,
+                    ),
                     margin: Insets {
                         bottom: sizing.text_inset_y.max(0.0),
                         ..Insets::default()

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
@@ -97,7 +97,12 @@ fn compute_prompt_buttons(dialog: Rect, sizing: SizingTokens) -> (Rect, Rect) {
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(button_height),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(0.0, f32::INFINITY, button_height, button_height),
+                    constraints: super::super::constraints(
+                        0.0,
+                        f32::INFINITY,
+                        button_height,
+                        button_height,
+                    ),
                     margin: Insets {
                         bottom: sizing.text_inset_y.max(0.0),
                         ..Insets::default()
@@ -182,7 +187,12 @@ fn compute_prompt_input_rect(
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(top.max(0.0)),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(0.0, f32::INFINITY, top.max(0.0), top.max(0.0)),
+                    constraints: super::super::constraints(
+                        0.0,
+                        f32::INFINITY,
+                        top.max(0.0),
+                        top.max(0.0),
+                    ),
                     margin: Insets::default(),
                     align_cross_override: None,
                     allow_fixed_compress: true,
@@ -196,7 +206,7 @@ fn compute_prompt_input_rect(
                 slot: SlotParams {
                     size_main: SizeModeMain::Fixed(input_height),
                     size_cross: SizeModeCross::Fill,
-                    constraints: Constraints::new(
+                    constraints: super::super::constraints(
                         0.0,
                         f32::INFINITY,
                         input_height.max(0.0),

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
@@ -11,7 +11,7 @@ pub(super) fn fill_child(node_id: u64, weight: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fill(weight.max(0.0001)),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, 0.0, f32::INFINITY),
+            constraints: super::super::constraints(0.0, f32::INFINITY, 0.0, f32::INFINITY),
             margin: Insets::default(),
             align_cross_override: None,
             allow_fixed_compress: false,
@@ -31,7 +31,7 @@ pub(super) fn fixed_child(
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(height.max(0.0)),
             size_cross: SizeModeCross::Fixed(width.max(0.0)),
-            constraints: Constraints::new(
+            constraints: super::super::constraints(
                 width.max(0.0),
                 width.max(0.0),
                 height.max(0.0),
@@ -51,7 +51,12 @@ pub(super) fn fixed_width_button(node_id: u64, width: f32, left_margin: f32) -> 
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(width.max(0.0)),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(width.max(0.0), width.max(0.0), 0.0, f32::INFINITY),
+            constraints: super::super::constraints(
+                width.max(0.0),
+                width.max(0.0),
+                0.0,
+                f32::INFINITY,
+            ),
             margin: Insets {
                 left: left_margin.max(0.0),
                 ..Insets::default()

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
@@ -25,7 +25,12 @@ pub(super) fn fixed_height_child(node_id: u64, height: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(height.max(0.0)),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, height.max(0.0), height.max(0.0)),
+            constraints: super::super::super::constraints(
+                0.0,
+                f32::INFINITY,
+                height.max(0.0),
+                height.max(0.0),
+            ),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: true,

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
@@ -81,7 +81,7 @@ fn fixed_height_child(node_id: u64, height: f32, bottom_margin: f32) -> SlotChil
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(height.max(0.0)),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, 0.0, height.max(0.0)),
+            constraints: super::constraints(0.0, f32::INFINITY, 0.0, height.max(0.0)),
             margin: Insets {
                 bottom: bottom_margin.max(0.0),
                 ..Insets::default()

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
@@ -138,7 +138,7 @@ fn line_slot_child(node_id: u64, line_height: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(line_height),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, line_height, line_height),
+            constraints: super::constraints(0.0, f32::INFINITY, line_height, line_height),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
@@ -215,7 +215,7 @@ pub(crate) fn compute_source_section_divider_rect(
             slot: SlotParams {
                 size_main: SizeModeMain::Fixed(divider_height),
                 size_cross: SizeModeCross::Fill,
-                constraints: Constraints::new(0.0, f32::INFINITY, divider_height, divider_height),
+                constraints: super::constraints(0.0, f32::INFINITY, divider_height, divider_height),
                 margin: Insets::default(),
                 align_cross_override: Some(CrossAlign::Stretch),
                 allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
@@ -51,7 +51,12 @@ pub(crate) fn compute_recovery_badge_layout(
             slot: SlotParams {
                 size_main: SizeModeMain::Fixed(badge_height),
                 size_cross: SizeModeCross::Fixed(badge_width),
-                constraints: Constraints::new(badge_width, badge_width, badge_height, badge_height),
+                constraints: super::super::constraints(
+                    badge_width,
+                    badge_width,
+                    badge_height,
+                    badge_height,
+                ),
                 margin: Insets::default(),
                 align_cross_override: Some(CrossAlign::End),
                 allow_fixed_compress: false,
@@ -204,7 +209,7 @@ fn fixed_height_child(node_id: u64, height: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(height),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, height, height),
+            constraints: super::super::constraints(0.0, f32::INFINITY, height, height),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
@@ -95,7 +95,7 @@ fn fixed_height_row(node_id: u64, height: f32) -> SlotChild {
         slot: SlotParams {
             size_main: SizeModeMain::Fixed(height),
             size_cross: SizeModeCross::Fill,
-            constraints: Constraints::new(0.0, f32::INFINITY, height, height),
+            constraints: super::constraints(0.0, f32::INFINITY, height, height),
             margin: Insets::default(),
             align_cross_override: Some(CrossAlign::Stretch),
             allow_fixed_compress: false,

--- a/src/app_core/native_shell/composition/state/automation/browser.rs
+++ b/src/app_core/native_shell/composition/state/automation/browser.rs
@@ -11,10 +11,13 @@ mod map;
 mod pill_editor;
 #[path = "browser/table.rs"]
 mod table;
+#[path = "browser/toolbar.rs"]
+mod toolbar;
 
 use map::map_canvas_automation;
 use pill_editor::build_browser_pill_editor_automation;
 use table::build_browser_table_automation;
+use toolbar::{browser_action_nodes, toolbar_control_nodes};
 
 /// Build semantic automation for the browser panel and its active content.
 pub(super) fn build_browser_automation(
@@ -25,12 +28,26 @@ pub(super) fn build_browser_automation(
 ) -> AutomationNodeSnapshot {
     let toolbar = browser_toolbar_layout(layout, style, model);
     let buttons = browser_action_buttons(layout, style, model, &toolbar);
+    let mut children = browser_tab_nodes(layout, model, style);
+    children.extend(toolbar_control_nodes(&toolbar, model));
+    children.extend(browser_action_nodes(buttons));
+    children.extend(browser_content_nodes(shell, layout, model, style));
+
+    browser_panel_node(layout, model, children)
+}
+
+fn browser_tab_nodes(
+    layout: &ShellLayout,
+    model: &AppModel,
+    style: &StyleTokens,
+) -> Vec<AutomationNodeSnapshot> {
     let tabs = resolve_browser_tabs_surface_layout(
         layout.browser_tabs,
         style.sizing,
         &browser_tabs_surface_content(model),
     );
-    let mut children = vec![
+
+    vec![
         simple_node(
             "browser.tab.items",
             AutomationRole::Tab,
@@ -51,106 +68,16 @@ pub(super) fn build_browser_automation(
             model.map.active,
             vec![String::from("set_browser_tab")],
         ),
-    ];
-    if toolbar.search_field.width() > 1.0 {
-        children.push(simple_node(
-            "browser.search_field",
-            AutomationRole::SearchField,
-            Some(String::from("Browser search")),
-            toolbar.search_field,
-            Some(model.browser.search_query.clone()),
-            true,
-            false,
-            vec![
-                String::from("focus_browser_search"),
-                String::from("set_browser_search"),
-            ],
-        ));
-    }
-    for (index, chip) in toolbar.rating_filter_chips.iter().copied().enumerate() {
-        if chip.width() <= 1.0 {
-            continue;
-        }
-        let level = super::super::BROWSER_RATING_FILTER_LEVELS[index];
-        children.push(simple_node(
-            format!("browser.rating_filter.{level}"),
-            AutomationRole::Button,
-            Some(format!("Rating filter {level}")),
-            chip,
-            None,
-            true,
-            model.browser.active_rating_filters[index],
-            vec![String::from("toggle_browser_rating_filter")],
-        ));
-    }
-    for (index, chip) in toolbar
-        .playback_age_filter_chips
-        .iter()
-        .copied()
-        .enumerate()
-    {
-        if chip.width() <= 1.0 {
-            continue;
-        }
-        let bucket = super::super::BROWSER_PLAYBACK_AGE_FILTER_CHIPS[index];
-        let (slug, label) = match bucket {
-            crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::NeverPlayed => {
-                ("never", "Never played")
-            }
-            crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::OlderThanMonth => {
-                ("month", "Older than month")
-            }
-            crate::app_core::native_shell::runtime_contract::PlaybackAgeFilterChip::OlderThanWeek => {
-                ("week", "Older than week")
-            }
-        };
-        children.push(simple_node(
-            format!("browser.playback_age_filter.{slug}"),
-            AutomationRole::Button,
-            Some(String::from(label)),
-            chip,
-            None,
-            true,
-            model.browser.active_recency_filters[index],
-            vec![String::from("toggle_browser_playback_age_filter")],
-        ));
-    }
-    if toolbar.marked_filter_chip.width() > 1.0 {
-        children.push(simple_node(
-            "browser.marked_filter",
-            AutomationRole::Button,
-            Some(String::from("Marked filter")),
-            toolbar.marked_filter_chip,
-            None,
-            true,
-            model.browser.marked_filter_active,
-            vec![String::from("toggle_browser_marked_filter")],
-        ));
-    }
-    if toolbar.derived_label_filter_chip.width() > 1.0 {
-        children.push(simple_node(
-            "browser.derived_label_filter",
-            AutomationRole::Button,
-            Some(String::from("Derived-label filter")),
-            toolbar.derived_label_filter_chip,
-            None,
-            true,
-            model.browser.derived_label_filter_active,
-            vec![String::from("toggle_browser_derived_label_filter")],
-        ));
-    }
-    for button in buttons {
-        children.push(simple_node(
-            format!("browser.action.{}", slug(button.label)),
-            AutomationRole::Button,
-            Some(String::from(button.label)),
-            button.rect,
-            None,
-            button.enabled,
-            button.active,
-            vec![action_slug(&button.action)],
-        ));
-    }
+    ]
+}
+
+fn browser_content_nodes(
+    shell: &mut NativeShellState,
+    layout: &ShellLayout,
+    model: &AppModel,
+    style: &StyleTokens,
+) -> Vec<AutomationNodeSnapshot> {
+    let mut children = Vec::new();
     if model.map.active {
         children.push(map_canvas_automation(layout, model, style));
     } else {
@@ -159,6 +86,15 @@ pub(super) fn build_browser_automation(
             children.push(pill_editor);
         }
     }
+
+    children
+}
+
+fn browser_panel_node(
+    layout: &ShellLayout,
+    model: &AppModel,
+    children: Vec<AutomationNodeSnapshot>,
+) -> AutomationNodeSnapshot {
     AutomationNodeSnapshot {
         id: node_id("browser.panel"),
         role: AutomationRole::Panel,

--- a/src/app_core/native_shell/composition/state/automation/browser/toolbar.rs
+++ b/src/app_core/native_shell/composition/state/automation/browser/toolbar.rs
@@ -1,0 +1,143 @@
+//! Browser toolbar automation nodes.
+
+use super::*;
+use crate::app_core::native_shell::runtime_contract::{AutomationRole, PlaybackAgeFilterChip};
+
+pub(super) fn toolbar_control_nodes(
+    toolbar: &BrowserToolbarLayout,
+    model: &AppModel,
+) -> Vec<AutomationNodeSnapshot> {
+    let mut children = Vec::new();
+    if toolbar.search_field.width() > 1.0 {
+        children.push(simple_node(
+            "browser.search_field",
+            AutomationRole::SearchField,
+            Some(String::from("Browser search")),
+            toolbar.search_field,
+            Some(model.browser.search_query.clone()),
+            true,
+            false,
+            vec![
+                String::from("focus_browser_search"),
+                String::from("set_browser_search"),
+            ],
+        ));
+    }
+    children.extend(rating_filter_nodes(toolbar, model));
+    children.extend(playback_age_filter_nodes(toolbar, model));
+    children.extend(toggle_filter_nodes(toolbar, model));
+
+    children
+}
+
+fn rating_filter_nodes(
+    toolbar: &BrowserToolbarLayout,
+    model: &AppModel,
+) -> Vec<AutomationNodeSnapshot> {
+    let mut children = Vec::new();
+    for (index, chip) in toolbar.rating_filter_chips.iter().copied().enumerate() {
+        if chip.width() <= 1.0 {
+            continue;
+        }
+        let level = super::super::super::BROWSER_RATING_FILTER_LEVELS[index];
+        children.push(simple_node(
+            format!("browser.rating_filter.{level}"),
+            AutomationRole::Button,
+            Some(format!("Rating filter {level}")),
+            chip,
+            None,
+            true,
+            model.browser.active_rating_filters[index],
+            vec![String::from("toggle_browser_rating_filter")],
+        ));
+    }
+    children
+}
+
+fn playback_age_filter_nodes(
+    toolbar: &BrowserToolbarLayout,
+    model: &AppModel,
+) -> Vec<AutomationNodeSnapshot> {
+    let mut children = Vec::new();
+    for (index, chip) in toolbar
+        .playback_age_filter_chips
+        .iter()
+        .copied()
+        .enumerate()
+    {
+        if chip.width() <= 1.0 {
+            continue;
+        }
+        let bucket = super::super::super::BROWSER_PLAYBACK_AGE_FILTER_CHIPS[index];
+        let (slug, label) = playback_age_filter_label(bucket);
+        children.push(simple_node(
+            format!("browser.playback_age_filter.{slug}"),
+            AutomationRole::Button,
+            Some(String::from(label)),
+            chip,
+            None,
+            true,
+            model.browser.active_recency_filters[index],
+            vec![String::from("toggle_browser_playback_age_filter")],
+        ));
+    }
+    children
+}
+
+fn playback_age_filter_label(bucket: PlaybackAgeFilterChip) -> (&'static str, &'static str) {
+    match bucket {
+        PlaybackAgeFilterChip::NeverPlayed => ("never", "Never played"),
+        PlaybackAgeFilterChip::OlderThanMonth => ("month", "Older than month"),
+        PlaybackAgeFilterChip::OlderThanWeek => ("week", "Older than week"),
+    }
+}
+
+fn toggle_filter_nodes(
+    toolbar: &BrowserToolbarLayout,
+    model: &AppModel,
+) -> Vec<AutomationNodeSnapshot> {
+    let mut children = Vec::new();
+    if toolbar.marked_filter_chip.width() > 1.0 {
+        children.push(simple_node(
+            "browser.marked_filter",
+            AutomationRole::Button,
+            Some(String::from("Marked filter")),
+            toolbar.marked_filter_chip,
+            None,
+            true,
+            model.browser.marked_filter_active,
+            vec![String::from("toggle_browser_marked_filter")],
+        ));
+    }
+    if toolbar.derived_label_filter_chip.width() > 1.0 {
+        children.push(simple_node(
+            "browser.derived_label_filter",
+            AutomationRole::Button,
+            Some(String::from("Derived-label filter")),
+            toolbar.derived_label_filter_chip,
+            None,
+            true,
+            model.browser.derived_label_filter_active,
+            vec![String::from("toggle_browser_derived_label_filter")],
+        ));
+    }
+    children
+}
+
+pub(super) fn browser_action_nodes(buttons: Vec<ActionButton>) -> Vec<AutomationNodeSnapshot> {
+    buttons
+        .into_iter()
+        .map(|button| {
+            simple_node(
+                format!("browser.action.{}", slug(button.label)),
+                AutomationRole::Button,
+                Some(String::from(button.label)),
+                button.rect,
+                None,
+                button.enabled,
+                button.active,
+                vec![action_slug(&button.action)],
+            )
+        })
+        .collect()
+}

--- a/src/app_core/native_shell/composition/state/automation/sidebar.rs
+++ b/src/app_core/native_shell/composition/state/automation/sidebar.rs
@@ -253,7 +253,7 @@ fn folder_browser_group(
                                 String::from("New folder")
                             },
                         ),
-                        row.input_value.clone(),
+                        row.input.value.clone(),
                         vec![
                             String::from("focus_folder_create_input"),
                             String::from("set_folder_create_input"),
@@ -267,7 +267,7 @@ fn folder_browser_group(
                         String::from("activate_folder_row"),
                         String::from("start_new_folder_at_folder_row"),
                     ];
-                    if row.has_children && !row.is_root {
+                    if row.flags.has_children && !row.flags.is_root {
                         available_actions.push(String::from("toggle_folder_row_expanded"));
                     }
                     (
@@ -284,13 +284,13 @@ fn folder_browser_group(
                     bounds: bounds(rect),
                     value,
                     enabled: true,
-                    selected: row.selected || row.focused || row.input_focused,
+                    selected: row.flags.selected || row.flags.focused || row.input.focused,
                     available_actions,
                     metadata: metadata(&[
                         ("depth", &row.depth.to_string()),
-                        ("focused", bool_text(row.focused)),
-                        ("root", bool_text(row.is_root)),
-                        ("expanded", bool_text(row.expanded)),
+                        ("focused", bool_text(row.flags.focused)),
+                        ("root", bool_text(row.flags.is_root)),
+                        ("expanded", bool_text(row.flags.expanded)),
                         (
                             "kind",
                             match row.kind {
@@ -303,8 +303,11 @@ fn folder_browser_group(
                                 crate::app_core::native_shell::runtime_contract::FolderRowKind::Existing => "existing",
                             },
                         ),
-                        ("input_error", row.input_error.as_deref().unwrap_or("")),
-                        ("select_all_on_focus", bool_text(row.select_all_on_focus)),
+                        ("input_error", row.input.error.as_deref().unwrap_or("")),
+                        (
+                            "select_all_on_focus",
+                            bool_text(row.input.select_all_on_focus),
+                        ),
                     ]),
                     children: Vec::new(),
                 }

--- a/src/app_core/native_shell/composition/state/frame_build/chrome/sidebar_parts/folders/rows.rs
+++ b/src/app_core/native_shell/composition/state/frame_build/chrome/sidebar_parts/folders/rows.rs
@@ -39,9 +39,9 @@ pub(super) fn render_tree_rows(
             folder_row_border_width(ctx, row),
             BorderSides {
                 top: true,
-                bottom: row.focused || Some(visual_rect.max.y) == last_row_max_y,
-                left: row.focused,
-                right: row.focused,
+                bottom: row.flags.focused || Some(visual_rect.max.y) == last_row_max_y,
+                left: row.flags.focused,
+                right: row.flags.focused,
             },
         );
         emit_folder_row_disclosure(ctx, primitives, row_rect, row);
@@ -60,7 +60,8 @@ fn render_folder_inline_draft_row(
     let field_rect = create_draft_field_rect(row_rect, ctx.sizing, row.depth);
     let text_rect = create_draft_text_rect(field_rect, ctx.sizing);
     let has_error = row
-        .input_error
+        .input
+        .error
         .as_deref()
         .is_some_and(|error| !error.trim().is_empty());
     emit_primitive(
@@ -87,10 +88,11 @@ fn render_folder_inline_draft_row(
         },
         ctx.sizing.border_width,
     );
-    let text = row.input_value.as_deref().unwrap_or_default();
+    let text = row.input.value.as_deref().unwrap_or_default();
     let (display_text, color) = if text.is_empty() {
         (
-            row.input_placeholder
+            row.input
+                .placeholder
                 .as_deref()
                 .unwrap_or("New folder name")
                 .to_string(),
@@ -128,14 +130,14 @@ fn render_folder_inline_draft_row(
 }
 
 fn folder_row_fill(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> Rgba8 {
-    if row.focused {
+    if row.flags.focused {
         translucent_overlay_color(
             ctx.style.bg_tertiary,
             ctx.style.grid_strong,
             (ctx.style.state_hover_soft + (ctx.motion_wave * ctx.style.motion_focus_wave_amp))
                 .clamp(0.0, 1.0),
         )
-    } else if row.selected {
+    } else if row.flags.selected {
         translucent_overlay_color(
             ctx.style.bg_tertiary,
             ctx.style.grid_soft,
@@ -147,13 +149,13 @@ fn folder_row_fill(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> Rgba8 {
 }
 
 fn folder_row_border(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> Rgba8 {
-    if row.focused {
+    if row.flags.focused {
         blend_color(
             ctx.style.accent_warning,
             ctx.style.text_primary,
             ctx.motion_wave * ctx.style.state_focus_pulse_blend,
         )
-    } else if row.selected {
+    } else if row.flags.selected {
         blend_color(
             ctx.style.accent_mint,
             ctx.style.text_primary,
@@ -165,7 +167,7 @@ fn folder_row_border(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> Rgba8 {
 }
 
 fn folder_row_border_width(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> f32 {
-    if row.focused {
+    if row.flags.focused {
         ctx.sizing.focus_stroke_width
     } else {
         ctx.sizing.border_width
@@ -173,9 +175,9 @@ fn folder_row_border_width(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> f3
 }
 
 fn folder_row_text_color(ctx: &StaticFrameCtx<'_>, row: &FolderRowModel) -> Rgba8 {
-    if row.focused {
+    if row.flags.focused {
         ctx.style.accent_warning
-    } else if row.selected {
+    } else if row.flags.selected {
         ctx.style.accent_mint
     } else {
         ctx.style.text_primary
@@ -188,14 +190,14 @@ fn emit_folder_row_disclosure(
     row_rect: Rect,
     row: &FolderRowModel,
 ) {
-    if row.is_root || !row.has_children {
+    if row.flags.is_root || !row.flags.has_children {
         return;
     }
     let layout = folder_row_layout(ctx, row_rect, row);
     let Some(icon_rect) = centered_tree_icon_rect(layout.disclosure_rect) else {
         return;
     };
-    if row.expanded {
+    if row.flags.expanded {
         emit_down_triangle(primitives, icon_rect, folder_row_text_color(ctx, row));
     } else {
         emit_right_triangle(primitives, icon_rect, folder_row_text_color(ctx, row));

--- a/src/app_core/native_shell/composition/state/frame_build/overlay/focus.rs
+++ b/src/app_core/native_shell/composition/state/frame_build/overlay/focus.rs
@@ -125,10 +125,10 @@ pub(super) fn render_folder_focus_overlay(
             };
             let row_rect = rendered_row.rect;
             let visual_rect = folder_row_visual_rect(row_rect, sizing);
-            if !(row.selected || row.focused) {
+            if !(row.flags.selected || row.flags.focused) {
                 continue;
             }
-            if row.focused {
+            if row.flags.focused {
                 emit_primitive(
                     primitives,
                     Primitive::Rect(FillRect {
@@ -141,11 +141,11 @@ pub(super) fn render_folder_focus_overlay(
                     }),
                 );
             }
-            if row.focused || row.selected {
+            if row.flags.focused || row.flags.selected {
                 push_browser_row_border(
                     primitives,
                     visual_rect,
-                    if row.focused {
+                    if row.flags.focused {
                         blend_color(
                             style.accent_warning,
                             style.text_primary,
@@ -158,20 +158,21 @@ pub(super) fn render_folder_focus_overlay(
                             style.state_selected_blend,
                         )
                     },
-                    if row.focused {
+                    if row.flags.focused {
                         sizing.focus_stroke_width
                     } else {
                         sizing.border_width
                     },
                     BorderSides {
                         top: true,
-                        bottom: row.focused || Some(visual_rect.max.y) == last_folder_row_max_y,
-                        left: row.focused,
-                        right: row.focused,
+                        bottom: row.flags.focused
+                            || Some(visual_rect.max.y) == last_folder_row_max_y,
+                        left: row.flags.focused,
+                        right: row.flags.focused,
                     },
                 );
             }
-            if row.focused {
+            if row.flags.focused {
                 let depth_indent =
                     compute_sidebar_folder_row_depth_indent(row_rect, sizing, row.depth);
                 let row_text_rect =

--- a/src/app_core/native_shell/composition/state/frame_build/overlay/mod.rs
+++ b/src/app_core/native_shell/composition/state/frame_build/overlay/mod.rs
@@ -108,7 +108,8 @@ pub(super) fn render_hover_overlay(
             text_rect,
             visual,
             draft_row
-                .input_error
+                .input
+                .error
                 .as_ref()
                 .is_some_and(|error| !error.trim().is_empty()),
         );

--- a/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/rows.rs
+++ b/src/app_core/native_shell/composition/state/hit_testing/chrome/folders/rows.rs
@@ -120,6 +120,6 @@ fn row_has_disclosure_target(row: &FolderRowModel) -> bool {
     matches!(
         row.kind,
         FolderRowKind::CreateDraft | FolderRowKind::RenameDraft
-    ) || row.is_root
-        || !row.has_children
+    ) || row.flags.is_root
+        || !row.flags.has_children
 }

--- a/src/app_core/native_shell/composition/state/model_sync.rs
+++ b/src/app_core/native_shell/composition/state/model_sync.rs
@@ -66,7 +66,7 @@ impl NativeShellState {
                 .active_folder_pane_model()
                 .tree_rows
                 .iter()
-                .any(|row| row.focused || row.selected);
+                .any(|row| row.flags.focused || row.flags.selected);
     }
 
     /// Synchronize motion-sensitive state from a dedicated motion model projection.

--- a/src/app_core/native_shell/composition/state/tests/opt_272/toolbar_options.rs
+++ b/src/app_core/native_shell/composition/state/tests/opt_272/toolbar_options.rs
@@ -96,27 +96,33 @@ fn options_panel_picker_mode_expands_inline_dropdown_actions() {
             ..crate::app_core::native_shell::runtime_contract::OptionsPanelModel::default()
         },
         paired_device: crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel {
-            active_picker: Some(
-                crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
-            ),
-            primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
-                label: String::from("Sample Rate"),
-                value_label: String::from("48 kHz"),
+            summaries: radiant::gui::form::PairedStatusSummaries {
+                primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
+                    label: String::from("Sample Rate"),
+                    value_label: String::from("48 kHz"),
+                },
+                ..radiant::gui::form::PairedStatusSummaries::default()
             },
-            primary_number_options: vec![
-                crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
-                    label: String::from("Device default"),
-                    selected: false,
-                    value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(None),
-                },
-                crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
-                    label: String::from("48 kHz"),
-                    selected: true,
-                    value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(Some(
-                        48_000,
-                    )),
-                },
-            ],
+            options: radiant::gui::form::PairedPickerOptions {
+                active_picker: Some(
+                    crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
+                ),
+                primary_number: vec![
+                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                        label: String::from("Device default"),
+                        selected: false,
+                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(None),
+                    },
+                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                        label: String::from("48 kHz"),
+                        selected: true,
+                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(Some(
+                            48_000,
+                        )),
+                    },
+                ],
+                ..radiant::gui::form::PairedPickerOptions::default()
+            },
             ..crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel::default()
         },
         ..AppModel::default()

--- a/src/app_core/native_shell/composition/state/text_fields.rs
+++ b/src/app_core/native_shell/composition/state/text_fields.rs
@@ -28,18 +28,26 @@ pub(crate) fn render_active_text_field(
     caret_color: Rgba8,
 ) {
     let output = crate::gui::paint::text_field_paint(crate::gui::paint::TextFieldPaint {
-        field_rect,
-        text_rect,
-        text: visual.text.clone(),
-        caret_offset: visual.caret_offset,
-        selection_offsets: visual.selection_offsets,
-        font_size: sizing.font_meta,
-        fill_color,
-        border_color,
-        selection_color,
-        caret_color,
-        text_color: style.text_primary,
-        stroke_width: sizing.border_width,
+        geometry: crate::gui::paint::TextFieldPaintGeometry {
+            field_rect,
+            text_rect,
+        },
+        content: crate::gui::paint::TextFieldPaintContent {
+            text: visual.text.clone(),
+            caret_offset: visual.caret_offset,
+            selection_offsets: visual.selection_offsets,
+            font_size: sizing.font_meta,
+        },
+        colors: crate::gui::paint::TextFieldPaintColors {
+            fill_color,
+            border_color,
+            selection_color,
+            caret_color,
+            text_color: style.text_primary,
+        },
+        stroke: crate::gui::paint::TextFieldPaintStroke {
+            stroke_width: sizing.border_width,
+        },
     });
 
     for primitive in output.primitives {

--- a/src/app_core/native_shell/sources_projection.rs
+++ b/src/app_core/native_shell/sources_projection.rs
@@ -269,23 +269,26 @@ fn inline_folder_draft_row(
     select_all_on_focus: bool,
     backing_index: Option<usize>,
 ) -> FolderRowModel {
-    FolderRowModel {
-        label: String::new(),
-        detail: String::new(),
-        depth,
-        selected: false,
-        focused: false,
-        is_root: false,
-        has_children: false,
-        expanded: false,
-        kind,
-        backing_index,
-        input_value: Some(input_value),
-        input_placeholder: Some(input_placeholder),
-        input_error,
-        input_focused,
-        select_all_on_focus,
-    }
+    let mut row = match kind {
+        FolderRowKind::CreateDraft => FolderRowModel::create_draft(
+            depth,
+            input_value,
+            input_placeholder,
+            input_error,
+            input_focused,
+        ),
+        FolderRowKind::RenameDraft => FolderRowModel::rename_draft(
+            depth,
+            input_value,
+            input_placeholder,
+            input_error,
+            input_focused,
+        ),
+        FolderRowKind::Existing => FolderRowModel::from_parts(Default::default()),
+    };
+    row.backing_index = backing_index;
+    row.input.select_all_on_focus = select_all_on_focus;
+    row
 }
 
 fn normalize_folder_name_input(name: &str) -> Result<String, String> {

--- a/src/app_core/native_shell/tests/mod.rs
+++ b/src/app_core/native_shell/tests/mod.rs
@@ -76,10 +76,10 @@ mod overlay_tree_rows {
             .expect("inline draft row should be projected");
         assert_eq!(projected.focused_tree_row, Some(1));
         assert_eq!(draft.depth, 2);
-        assert_eq!(draft.input_value.as_deref(), Some("existing"));
-        assert_eq!(draft.input_placeholder.as_deref(), Some("New folder name"));
+        assert_eq!(draft.input.value.as_deref(), Some("existing"));
+        assert_eq!(draft.input.placeholder.as_deref(), Some("New folder name"));
         assert_eq!(
-            draft.input_error.as_deref(),
+            draft.input.error.as_deref(),
             Some("Folder already exists: drums/existing")
         );
         assert_eq!(projected.tree_rows[2].kind, FolderRowKind::CreateDraft);
@@ -94,7 +94,7 @@ mod overlay_tree_rows {
             .find(|row| row.kind == FolderRowKind::CreateDraft)
             .expect("inline draft row should still be projected");
         assert_eq!(
-            draft.input_error.as_deref(),
+            draft.input.error.as_deref(),
             Some("Folder name cannot contain path separators")
         );
     }
@@ -185,13 +185,13 @@ mod overlay_tree_rows {
         let draft = &projected.tree_rows[0];
         assert_eq!(draft.kind, FolderRowKind::RenameDraft);
         assert_eq!(
-            draft.input_error.as_deref(),
+            draft.input.error.as_deref(),
             Some("Folder already exists: kicks")
         );
-        assert_eq!(draft.input_value.as_deref(), Some("kicks"));
-        assert_eq!(draft.input_placeholder.as_deref(), Some("Folder name"));
-        assert!(draft.input_focused);
-        assert!(draft.select_all_on_focus);
+        assert_eq!(draft.input.value.as_deref(), Some("kicks"));
+        assert_eq!(draft.input.placeholder.as_deref(), Some("Folder name"));
+        assert!(draft.input.focused);
+        assert!(draft.input.select_all_on_focus);
         assert_eq!(draft.backing_index, Some(0));
 
         if let Some(edit) = ui.sources.folders.inline_edit.as_mut() {
@@ -201,7 +201,7 @@ mod overlay_tree_rows {
         let projected = project_sources_for_ui(&ui);
         let draft = &projected.tree_rows[0];
         assert_eq!(
-            draft.input_error.as_deref(),
+            draft.input.error.as_deref(),
             Some("Folder name cannot contain path separators")
         );
     }

--- a/src/gui_app/audio_settings.rs
+++ b/src/gui_app/audio_settings.rs
@@ -52,11 +52,20 @@ pub(super) fn auxiliary_windows(state: &mut GuiAppState) -> Vec<ui::AuxiliaryWin
     }
     let snapshot = AudioSettingsSnapshot::from_app_state(state);
     let options = ui::NativeRunOptions {
-        title: String::from("Audio Engine"),
-        inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
-        min_inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
-        skip_taskbar: true,
-        decorations: true,
+        window: ui::NativeWindowOptions {
+            title: String::from("Audio Engine"),
+            geometry: ui::NativeWindowGeometry {
+                inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
+                min_inner_size: Some([AUDIO_SETTINGS_POPUP_WIDTH, AUDIO_SETTINGS_POPUP_HEIGHT]),
+                ..ui::NativeWindowGeometry::default()
+            },
+            behavior: ui::NativeWindowBehavior {
+                skip_taskbar: true,
+                decorations: true,
+                ..ui::NativeWindowBehavior::default()
+            },
+            ..ui::NativeWindowOptions::default()
+        },
         ..ui::NativeRunOptions::default()
     };
     let surface = ui::UiSurface::new(audio_settings_window_view(&snapshot).into_node());

--- a/src/gui_app/launch.rs
+++ b/src/gui_app/launch.rs
@@ -1,6 +1,9 @@
 use super::{GuiAppState, GuiMessage, SAMPLE_BROWSER_LIST_ID, SAMPLE_BROWSER_ROW_HEIGHT, view};
 use crate::gui_app::{audio_settings, default_gui_shortcut_resolution};
-use radiant::runtime::{NativeRunOptions, NativeTextOptions};
+use radiant::runtime::{
+    NativeFrameOptions, NativeRunOptions, NativeTextOptions, NativeWindowBehavior,
+    NativeWindowGeometry, NativeWindowOptions,
+};
 use std::{
     ffi::OsString,
     panic::{self, AssertUnwindSafe},
@@ -30,12 +33,25 @@ pub(crate) fn run() -> Result<(), String> {
 
     log_default_gui_startup(&args);
     let state = GuiAppState::load_default()?;
+    let debug_layout = debug_layout_requested(args.iter().cloned());
     let options = NativeRunOptions {
-        title: String::from("Wavecrate"),
-        inner_size: Some([960.0, 540.0]),
-        min_inner_size: Some([640.0, 360.0]),
-        drag_and_drop: true,
-        debug_layout: debug_layout_requested(args.iter().cloned()),
+        window: NativeWindowOptions {
+            title: String::from("Wavecrate"),
+            geometry: NativeWindowGeometry {
+                inner_size: Some([960.0, 540.0]),
+                min_inner_size: Some([640.0, 360.0]),
+                ..NativeWindowGeometry::default()
+            },
+            behavior: NativeWindowBehavior {
+                drag_and_drop: true,
+                ..NativeWindowBehavior::default()
+            },
+            ..NativeWindowOptions::default()
+        },
+        frame: NativeFrameOptions {
+            debug_layout,
+            ..NativeFrameOptions::default()
+        },
         text: NativeTextOptions {
             embedded_fonts: Vec::new(),
             font_paths: vec![wavecrate_ui_font_path()],
@@ -43,7 +59,7 @@ pub(crate) fn run() -> Result<(), String> {
         ..NativeRunOptions::default()
     };
     tracing::info!(
-        debug_layout = options.debug_layout,
+        debug_layout = options.frame.debug_layout,
         "default gui: preparing Radiant application"
     );
     emit_gui_action(

--- a/src/gui_runtime/native_shell_runtime/bridge/text_input.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/text_input.rs
@@ -46,7 +46,7 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
                 Some(self.model.sources.tree_search_query.clone())
             }
             RetainedTextInputTarget::BrowserPillEditor => {
-                Some(self.model.browser.pill_editor.input_value.clone())
+                Some(self.model.browser.pill_editor().input_value.clone())
             }
             RetainedTextInputTarget::FolderCreate => self.folder_inline_editor_value(),
             RetainedTextInputTarget::Prompt => self.model.confirm_prompt.input_value.clone(),
@@ -65,7 +65,7 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
                         | runtime_contract::FolderRowKind::RenameDraft
                 )
             })
-            .and_then(|row| row.input_value.clone())
+            .and_then(|row| row.input.value.clone())
     }
 
     /// Keep the local retained text target synchronized with host focus actions.

--- a/src/gui_runtime/native_shell_runtime/input_routing.rs
+++ b/src/gui_runtime/native_shell_runtime/input_routing.rs
@@ -266,8 +266,8 @@ fn folder_row_disclosure_toggles_expansion(
     let Some(row) = pane_model.tree_rows.get(index) else {
         return false;
     };
-    row.has_children
-        && !row.is_root
+    row.flags.has_children
+        && !row.flags.is_root
         && !matches!(
             row.kind,
             runtime_contract::FolderRowKind::CreateDraft

--- a/src/gui_runtime/native_shell_runtime/launch.rs
+++ b/src/gui_runtime/native_shell_runtime/launch.rs
@@ -7,25 +7,33 @@ use super::*;
 impl From<NativeRunOptions> for radiant::gui_runtime::NativeRunOptions {
     fn from(value: NativeRunOptions) -> Self {
         Self {
-            title: value.title,
-            inner_size: value.inner_size,
-            position: None,
-            min_inner_size: value.min_inner_size,
-            maximized: value.maximized,
-            decorations: value.decorations,
-            icon: value.icon.map(Into::into),
-            target_fps: value.target_fps,
-            debug_layout: value.debug_layout,
-            drag_and_drop: true,
-            owner_window_handle: None,
-            skip_taskbar: false,
+            window: radiant::gui_runtime::NativeWindowOptions {
+                title: value.title,
+                geometry: radiant::gui_runtime::NativeWindowGeometry {
+                    inner_size: value.inner_size,
+                    position: None,
+                    min_inner_size: value.min_inner_size,
+                },
+                behavior: radiant::gui_runtime::NativeWindowBehavior {
+                    maximized: value.maximized,
+                    decorations: value.decorations,
+                    drag_and_drop: true,
+                    owner_window_handle: None,
+                    skip_taskbar: false,
+                    mode: radiant::gui_runtime::NativeWindowMode::default(),
+                },
+                icon: value.icon.map(Into::into),
+            },
+            frame: radiant::gui_runtime::NativeFrameOptions {
+                target_fps: value.target_fps,
+                debug_layout: value.debug_layout,
+                retained_surface_cache: radiant::runtime::RetainedSurfaceCachePolicy::default(),
+            },
             gpu: radiant::gui_runtime::NativeGpuOptions::default(),
-            retained_surface_cache: radiant::runtime::RetainedSurfaceCachePolicy::default(),
             text: radiant::gui_runtime::NativeTextOptions {
                 embedded_fonts: Vec::new(),
                 font_paths: vec![crate::gui_runtime::wavecrate_ui_font_path()],
             },
-            window_mode: radiant::gui_runtime::NativeWindowMode::default(),
         }
     }
 }

--- a/src/gui_runtime/native_shell_runtime/model_mapping/audio.rs
+++ b/src/gui_runtime/native_shell_runtime/model_mapping/audio.rs
@@ -87,43 +87,49 @@ fn audio_option_item_to_compat(
 impl From<runtime_contract::PairedDevicePanelModel> for AudioEngineModel {
     fn from(value: runtime_contract::PairedDevicePanelModel) -> Self {
         Self {
-            chip_state: value.status_state,
-            chip_label: value.status_label,
-            detail_label: value.detail_label,
-            output_host: value.primary_group,
-            output_device: value.primary_item,
-            output_sample_rate: value.primary_number,
-            input_host: value.secondary_group,
-            input_device: value.secondary_item,
-            input_sample_rate: value.secondary_number,
-            active_picker: value.active_picker.map(Into::into),
+            chip_state: value.header.status_state,
+            chip_label: value.header.status_label,
+            detail_label: value.header.detail_label,
+            output_host: value.summaries.primary_group,
+            output_device: value.summaries.primary_item,
+            output_sample_rate: value.summaries.primary_number,
+            input_host: value.summaries.secondary_group,
+            input_device: value.summaries.secondary_item,
+            input_sample_rate: value.summaries.secondary_number,
+            active_picker: value.options.active_picker.map(Into::into),
             output_host_options: value
-                .primary_group_options
+                .options
+                .primary_group
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             output_device_options: value
-                .primary_item_options
+                .options
+                .primary_item
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             output_sample_rate_options: value
-                .primary_number_options
+                .options
+                .primary_number
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_host_options: value
-                .secondary_group_options
+                .options
+                .secondary_group
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_device_options: value
-                .secondary_item_options
+                .options
+                .secondary_item
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_sample_rate_options: value
-                .secondary_number_options
+                .options
+                .secondary_number
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
@@ -134,46 +140,52 @@ impl From<runtime_contract::PairedDevicePanelModel> for AudioEngineModel {
 impl From<AudioEngineModel> for runtime_contract::PairedDevicePanelModel {
     fn from(value: AudioEngineModel) -> Self {
         Self {
-            status_state: value.chip_state,
-            status_label: value.chip_label,
-            detail_label: value.detail_label,
-            primary_group: value.output_host,
-            primary_item: value.output_device,
-            primary_number: value.output_sample_rate,
-            secondary_group: value.input_host,
-            secondary_item: value.input_device,
-            secondary_number: value.input_sample_rate,
-            active_picker: value.active_picker.map(Into::into),
-            primary_group_options: value
-                .output_host_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
-            primary_item_options: value
-                .output_device_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
-            primary_number_options: value
-                .output_sample_rate_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
-            secondary_group_options: value
-                .input_host_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
-            secondary_item_options: value
-                .input_device_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
-            secondary_number_options: value
-                .input_sample_rate_options
-                .into_iter()
-                .map(audio_option_item_to_compat)
-                .collect(),
+            header: radiant::gui::form::PairedStatusHeader {
+                status_state: value.chip_state,
+                status_label: value.chip_label,
+                detail_label: value.detail_label,
+            },
+            summaries: radiant::gui::form::PairedStatusSummaries {
+                primary_group: value.output_host,
+                primary_item: value.output_device,
+                primary_number: value.output_sample_rate,
+                secondary_group: value.input_host,
+                secondary_item: value.input_device,
+                secondary_number: value.input_sample_rate,
+            },
+            options: radiant::gui::form::PairedPickerOptions {
+                active_picker: value.active_picker.map(Into::into),
+                primary_group: value
+                    .output_host_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+                primary_item: value
+                    .output_device_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+                primary_number: value
+                    .output_sample_rate_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+                secondary_group: value
+                    .input_host_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+                secondary_item: value
+                    .input_device_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+                secondary_number: value
+                    .input_sample_rate_options
+                    .into_iter()
+                    .map(audio_option_item_to_compat)
+                    .collect(),
+            },
         }
     }
 }

--- a/src/gui_runtime/native_shell_runtime/model_mapping/browser.rs
+++ b/src/gui_runtime/native_shell_runtime/model_mapping/browser.rs
@@ -55,7 +55,7 @@ impl From<runtime_contract::BrowserPanelModel> for BrowserPanelModel {
             sort_label: value.sort_label,
             active_tab_label: value.active_tab_label,
             focused_sample_label: value.focused_item_label,
-            tag_sidebar: value.pill_editor,
+            tag_sidebar: value.pill_editor.into(),
             anchor_visible_row: value.anchor_visible_row,
             rows: retained_vec_from_compat(value.rows),
         }
@@ -86,7 +86,7 @@ impl From<BrowserPanelModel> for runtime_contract::BrowserPanelModel {
             sort_label: value.sort_label,
             active_tab_label: value.active_tab_label,
             focused_item_label: value.focused_sample_label,
-            pill_editor: value.tag_sidebar,
+            pill_editor: value.tag_sidebar.into(),
             anchor_visible_row: value.anchor_visible_row,
             rows: retained_vec_to_compat(value.rows),
         }

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -35,14 +35,14 @@ mod tests {
 
         let compat: radiant::gui_runtime::NativeRunOptions = options.into();
 
-        assert_eq!(compat.title, "Wavecrate test host");
-        assert_eq!(compat.inner_size, Some([1280.0, 720.0]));
-        assert_eq!(compat.min_inner_size, Some([640.0, 360.0]));
-        assert!(compat.maximized);
-        assert!(!compat.decorations);
-        assert_eq!(compat.target_fps, 90);
-        assert!(compat.debug_layout);
-        assert!(compat.drag_and_drop);
+        assert_eq!(compat.window.title, "Wavecrate test host");
+        assert_eq!(compat.window.geometry.inner_size, Some([1280.0, 720.0]));
+        assert_eq!(compat.window.geometry.min_inner_size, Some([640.0, 360.0]));
+        assert!(compat.window.behavior.maximized);
+        assert!(!compat.window.behavior.decorations);
+        assert_eq!(compat.frame.target_fps, 90);
+        assert!(compat.frame.debug_layout);
+        assert!(compat.window.behavior.drag_and_drop);
         assert_eq!(
             compat.gpu,
             radiant::gui_runtime::NativeGpuOptions::default()
@@ -52,7 +52,7 @@ mod tests {
             vec![crate::gui_runtime::wavecrate_ui_font_path()]
         );
         assert!(compat.text.font_paths[0].exists());
-        let icon = compat.icon.expect("icon should be forwarded");
+        let icon = compat.window.icon.expect("icon should be forwarded");
         assert_eq!(icon.rgba, vec![255, 0, 0, 255]);
         assert_eq!(icon.width, 1);
         assert_eq!(icon.height, 1);
@@ -607,15 +607,15 @@ mod tests {
         let repaint_installed = Arc::new(AtomicBool::new(false));
         let mut model = runtime_contract::AppModel::default();
         model.options_panel.visible = true;
-        model.paired_device.primary_group = runtime_contract::SummaryFieldModel {
+        model.paired_device.summaries.primary_group = runtime_contract::SummaryFieldModel {
             label: String::from("Output Host"),
             value_label: String::from("WASAPI"),
         };
-        model.paired_device.primary_item = runtime_contract::SummaryFieldModel {
+        model.paired_device.summaries.primary_item = runtime_contract::SummaryFieldModel {
             label: String::from("Output"),
             value_label: String::from("Speakers"),
         };
-        model.paired_device.primary_number = runtime_contract::SummaryFieldModel {
+        model.paired_device.summaries.primary_number = runtime_contract::SummaryFieldModel {
             label: String::from("Sample Rate"),
             value_label: String::from("48 kHz"),
         };


### PR DESCRIPTION
## Summary
- refactor undo and source DB maintenance jobs into smaller focused helpers
- add Wavecrate-owned flat native-shell DTO wrappers with explicit Radiant boundary conversions
- update layout, launch, text-field, folder-row, audio, and browser mappings for Radiant grouped DTOs
- update vendor/radiant submodule to include explicit native scene imports required by validation

## Validation
- cargo test -p wavecrate native_shell --lib
- cargo test -p wavecrate app::controller::tests::browser_actions::focus_navigation --lib
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent