### PR TITLE
Sync Radiant DPI scaling into Wavecrate

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ use std::{
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=build/windows/wavecrate.rc");
+    println!("cargo:rerun-if-changed=build/windows/wavecrate.exe.manifest");
     println!("cargo:rerun-if-changed=assets/logo3.ico");
     println!("cargo:rerun-if-env-changed=WAVECRATE_GIT_SHA");
     println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_ID");

--- a/build/windows/wavecrate.exe.manifest
+++ b/build/windows/wavecrate.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/build/windows/wavecrate.rc
+++ b/build/windows/wavecrate.rc
@@ -1,1 +1,2 @@
 1 ICON "assets\\logo3.ico"
+1 24 "build\\windows\\wavecrate.exe.manifest"

--- a/src/app_core/native_shell/composition/layout_adapter/bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/bands.rs
@@ -2,9 +2,9 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutDebugOptions,
-    LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain,
-    SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets,
+    LayoutDebugOptions, LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy,
+    SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Point, Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_tabs.rs
@@ -3,8 +3,8 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/browser_text.rs
@@ -2,8 +2,8 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::text_layout::{TextLineInsets, centered_text_line};
 use crate::gui::types::{Point, Rect, Vector2};

--- a/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/controls/shared.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/map_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/map_header.rs
@@ -2,8 +2,8 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::text_layout::{TextLineInsets, centered_text_line};
 use crate::gui::types::{Point, Rect, Vector2};

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/progress.rs
@@ -3,8 +3,8 @@
 use super::{ProgressOverlaySections, shared};
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/prompt.rs
@@ -3,8 +3,8 @@
 use super::{PromptOverlaySections, shared};
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/shared.rs
@@ -1,7 +1,8 @@
 //! Shared slot-tree helpers for overlay geometry modules.
 
 use crate::gui::layout_core::{
-    Constraints, Insets, LayoutNode, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
+    Constraints, ConstraintsCompat, Insets, LayoutNode, SizeModeCross, SizeModeMain, SlotChild,
+    SlotParams,
 };
 use crate::gui::types::{Point, Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/overlays/text/common.rs
@@ -1,8 +1,8 @@
 use super::super::shared;
 use crate::app_core::native_shell::composition::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
 use crate::gui::text_layout::{TextLineInsets, centered_text_line, top_text_line};
 use crate::gui::types::{Rect, Vector2};

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_bands.rs
@@ -2,9 +2,9 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutDebugOptions,
-    LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain,
-    SlotChild, SlotParams,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets,
+    LayoutDebugOptions, LayoutEngine, LayoutNode, LayoutState, MainAlign, OverflowPolicy,
+    SizeModeCross, SizeModeMain, SlotChild, SlotParams,
 };
 use crate::gui::types::{Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_chrome_text.rs
@@ -2,7 +2,7 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
     OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Point, Rect, Vector2};

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header.rs
@@ -2,8 +2,8 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Point, Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/sidebar_header/helpers.rs
@@ -5,8 +5,8 @@ use super::{
     RecoveryBadgeLayout,
 };
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
-    OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode,
+    MainAlign, OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Point, Rect, Vector2};
 

--- a/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
+++ b/src/app_core/native_shell/composition/layout_adapter/waveform_header.rs
@@ -2,7 +2,7 @@
 
 use super::super::style::SizingTokens;
 use crate::gui::layout_core::{
-    Constraints, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
+    Constraints, ConstraintsCompat, ContainerKind, ContainerPolicy, CrossAlign, Insets, LayoutNode, MainAlign,
     OverflowPolicy, SizeModeCross, SizeModeMain, SlotChild, SlotParams, layout_tree,
 };
 use crate::gui::types::{Point, Rect, Vector2};

--- a/src/app_core/native_shell/composition/runtime/shell.rs
+++ b/src/app_core/native_shell/composition/runtime/shell.rs
@@ -8,7 +8,6 @@ pub use crate::app_core::actions::{
 pub use crate::gui::feedback::HealthState as StatusChipStateModel;
 pub use crate::gui::feedback::PromptIntent as ConfirmPromptKind;
 pub use crate::gui::form::PairedPickerTarget as PairedPickerTargetModel;
-pub use crate::gui::form::PairedStatusPanel as PairedDevicePanelModel;
 pub use crate::gui::form::SummaryField as SummaryFieldModel;
 
 use super::{
@@ -25,6 +24,107 @@ pub type PairedPickerOptionModel = crate::gui::form::OptionItem<PairedPickerValu
 
 /// Modal confirmation prompt projected into the native shell.
 pub type ConfirmPromptModel = crate::gui::feedback::ConfirmPrompt<ConfirmPromptKind>;
+
+/// Output/input paired device state rendered by the native shell.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PairedDevicePanelModel {
+    /// Compact chip health state.
+    pub status_state: StatusChipStateModel,
+    /// Compact chip label shown in surrounding chrome.
+    pub status_label: String,
+    /// Optional detail or error text shown inside the panel overview.
+    pub detail_label: Option<String>,
+    /// Primary-side group summary row.
+    pub primary_group: SummaryFieldModel,
+    /// Primary-side item summary row.
+    pub primary_item: SummaryFieldModel,
+    /// Primary-side numeric-setting summary row.
+    pub primary_number: SummaryFieldModel,
+    /// Secondary-side group summary row.
+    pub secondary_group: SummaryFieldModel,
+    /// Secondary-side item summary row.
+    pub secondary_item: SummaryFieldModel,
+    /// Secondary-side numeric-setting summary row.
+    pub secondary_number: SummaryFieldModel,
+    /// Currently expanded picker, or `None` for the overview.
+    pub active_picker: Option<PairedPickerTargetModel>,
+    /// Primary-side group choices.
+    pub primary_group_options: Vec<PairedPickerOptionModel>,
+    /// Primary-side item choices.
+    pub primary_item_options: Vec<PairedPickerOptionModel>,
+    /// Primary-side numeric-setting choices.
+    pub primary_number_options: Vec<PairedPickerOptionModel>,
+    /// Secondary-side group choices.
+    pub secondary_group_options: Vec<PairedPickerOptionModel>,
+    /// Secondary-side item choices.
+    pub secondary_item_options: Vec<PairedPickerOptionModel>,
+    /// Secondary-side numeric-setting choices.
+    pub secondary_number_options: Vec<PairedPickerOptionModel>,
+}
+
+impl PairedDevicePanelModel {
+    /// Return the compact status chip state.
+    pub fn status_state(&self) -> StatusChipStateModel {
+        self.status_state
+    }
+
+    /// Return the compact status chip label.
+    pub fn status_label(&self) -> &str {
+        &self.status_label
+    }
+
+    /// Return optional detail text for the overview.
+    pub fn detail_label(&self) -> Option<&str> {
+        self.detail_label.as_deref()
+    }
+
+    /// Return the primary group summary field.
+    pub fn primary_group(&self) -> &SummaryFieldModel {
+        &self.primary_group
+    }
+
+    /// Return the primary item summary field.
+    pub fn primary_item(&self) -> &SummaryFieldModel {
+        &self.primary_item
+    }
+
+    /// Return the primary numeric-setting summary field.
+    pub fn primary_number(&self) -> &SummaryFieldModel {
+        &self.primary_number
+    }
+
+    /// Return the secondary group summary field.
+    pub fn secondary_group(&self) -> &SummaryFieldModel {
+        &self.secondary_group
+    }
+
+    /// Return the secondary item summary field.
+    pub fn secondary_item(&self) -> &SummaryFieldModel {
+        &self.secondary_item
+    }
+
+    /// Return the secondary numeric-setting summary field.
+    pub fn secondary_number(&self) -> &SummaryFieldModel {
+        &self.secondary_number
+    }
+
+    /// Return the currently expanded picker target, if any.
+    pub fn active_picker(&self) -> Option<PairedPickerTargetModel> {
+        self.active_picker
+    }
+
+    /// Return the option list associated with a paired-picker target.
+    pub fn options_for(&self, target: PairedPickerTargetModel) -> &[PairedPickerOptionModel] {
+        match target {
+            PairedPickerTargetModel::PrimaryGroup => &self.primary_group_options,
+            PairedPickerTargetModel::PrimaryItem => &self.primary_item_options,
+            PairedPickerTargetModel::PrimaryNumber => &self.primary_number_options,
+            PairedPickerTargetModel::SecondaryGroup => &self.secondary_group_options,
+            PairedPickerTargetModel::SecondaryItem => &self.secondary_item_options,
+            PairedPickerTargetModel::SecondaryNumber => &self.secondary_number_options,
+        }
+    }
+}
 
 /// Snapshot of app state required by the native shell renderer.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/app_core/native_shell/composition/state/tests/opt_272/toolbar_options.rs
+++ b/src/app_core/native_shell/composition/state/tests/opt_272/toolbar_options.rs
@@ -96,33 +96,27 @@ fn options_panel_picker_mode_expands_inline_dropdown_actions() {
             ..crate::app_core::native_shell::runtime_contract::OptionsPanelModel::default()
         },
         paired_device: crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel {
-            summaries: radiant::gui::form::PairedStatusSummaries {
-                primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
-                    label: String::from("Sample Rate"),
-                    value_label: String::from("48 kHz"),
+            primary_number: crate::app_core::native_shell::runtime_contract::SummaryFieldModel {
+                label: String::from("Sample Rate"),
+                value_label: String::from("48 kHz"),
+            },
+            active_picker: Some(
+                crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
+            ),
+            primary_number_options: vec![
+                crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                    label: String::from("Device default"),
+                    selected: false,
+                    value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(None),
                 },
-                ..radiant::gui::form::PairedStatusSummaries::default()
-            },
-            options: radiant::gui::form::PairedPickerOptions {
-                active_picker: Some(
-                    crate::app_core::native_shell::runtime_contract::PairedPickerTargetModel::PrimaryNumber,
-                ),
-                primary_number: vec![
-                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
-                        label: String::from("Device default"),
-                        selected: false,
-                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(None),
-                    },
-                    crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
-                        label: String::from("48 kHz"),
-                        selected: true,
-                        value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(Some(
-                            48_000,
-                        )),
-                    },
-                ],
-                ..radiant::gui::form::PairedPickerOptions::default()
-            },
+                crate::app_core::native_shell::runtime_contract::PairedPickerOptionModel {
+                    label: String::from("48 kHz"),
+                    selected: true,
+                    value: crate::app_core::native_shell::runtime_contract::PairedPickerValueModel::PrimaryNumber(Some(
+                        48_000,
+                    )),
+                },
+            ],
             ..crate::app_core::native_shell::runtime_contract::PairedDevicePanelModel::default()
         },
         ..AppModel::default()

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -23,6 +23,27 @@ pub mod input {
 pub mod layout_core {
     //! Generic slot-based layout primitives from `radiant`.
     pub use radiant::gui::layout_core::*;
+
+    /// Backwards-compatible constructor for Wavecrate layout adapter code.
+    ///
+    /// Radiant now exposes named `ConstraintsParts` construction publicly; this
+    /// keeps Wavecrate call sites concise while preserving the same normalization
+    /// behavior at the app boundary.
+    pub trait ConstraintsCompat {
+        /// Build normalized constraints from raw min/max bounds.
+        fn new(min_w: f32, max_w: f32, min_h: f32, max_h: f32) -> Self;
+    }
+
+    impl ConstraintsCompat for Constraints {
+        fn new(min_w: f32, max_w: f32, min_h: f32, max_h: f32) -> Self {
+            Self::from_parts(ConstraintsParts {
+                min_w,
+                max_w,
+                min_h,
+                max_h,
+            })
+        }
+    }
 }
 
 pub mod text_layout {

--- a/src/gui_app/waveform/widget_input.rs
+++ b/src/gui_app/waveform/widget_input.rs
@@ -23,7 +23,9 @@ impl WaveformWidget {
                     })
                 })
             }
-            WidgetInput::Wheel { position, delta } if bounds.contains(position) => {
+            WidgetInput::Wheel {
+                position, delta, ..
+            } if bounds.contains(position) => {
                 Some(WidgetOutput::typed(WaveformInteraction::Wheel {
                     delta,
                     anchor_ratio: self.ratio_from_position(bounds, position),

--- a/src/gui_runtime/native_shell_runtime/bridge/input.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/input.rs
@@ -1,9 +1,8 @@
-use super::{RetainedTextInputTarget, WavecrateRuntimeBridge};
+use super::{
+    RetainedTextInputTarget, WavecrateRuntimeBridge, render::retained_shell_style_for_viewport,
+};
 use crate::{
-    app_core::{
-        actions::NativeAppBridge,
-        native_shell::composition::{ShellLayout, StyleTokens},
-    },
+    app_core::{actions::NativeAppBridge, native_shell::composition::ShellLayout},
     gui::types::{Point, Vector2},
     gui_runtime::native_shell_runtime::input_routing::action_from_retained_pointer,
 };
@@ -114,7 +113,7 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
         let viewport = self
             .layout_viewport
             .unwrap_or_else(|| Vector2::new(1280.0, 720.0));
-        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
+        let style = retained_shell_style_for_viewport(viewport);
         ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime)
     }
 }

--- a/src/gui_runtime/native_shell_runtime/bridge/render.rs
+++ b/src/gui_runtime/native_shell_runtime/bridge/render.rs
@@ -19,7 +19,7 @@ impl<B: NativeAppBridge> WavecrateRuntimeBridge<B> {
         if descriptor.key != 1 {
             return None;
         }
-        let style = StyleTokens::for_viewport_with_scale(viewport.x, 1.0);
+        let style = retained_shell_style_for_viewport(viewport);
         self.sync_layout_viewport(viewport);
         let layout =
             ShellLayout::build_with_style_and_runtime(viewport, &style, &mut self.layout_runtime);
@@ -112,4 +112,9 @@ fn append_paint_frame(frame: &mut PaintFrame, overlay: &PaintFrame) {
     frame.primitives.extend(overlay.primitives.iter().cloned());
     frame.text_runs.extend(overlay.text_runs.iter().cloned());
     frame.clear_color = overlay.clear_color;
+}
+
+/// Build retained-shell style from Radiant's DPI-normalized logical viewport.
+pub(super) fn retained_shell_style_for_viewport(viewport: Vector2) -> StyleTokens {
+    StyleTokens::for_viewport_width(viewport.x)
 }

--- a/src/gui_runtime/native_shell_runtime/model_mapping/audio.rs
+++ b/src/gui_runtime/native_shell_runtime/model_mapping/audio.rs
@@ -87,49 +87,43 @@ fn audio_option_item_to_compat(
 impl From<runtime_contract::PairedDevicePanelModel> for AudioEngineModel {
     fn from(value: runtime_contract::PairedDevicePanelModel) -> Self {
         Self {
-            chip_state: value.header.status_state,
-            chip_label: value.header.status_label,
-            detail_label: value.header.detail_label,
-            output_host: value.summaries.primary_group,
-            output_device: value.summaries.primary_item,
-            output_sample_rate: value.summaries.primary_number,
-            input_host: value.summaries.secondary_group,
-            input_device: value.summaries.secondary_item,
-            input_sample_rate: value.summaries.secondary_number,
-            active_picker: value.options.active_picker.map(Into::into),
+            chip_state: value.status_state,
+            chip_label: value.status_label,
+            detail_label: value.detail_label,
+            output_host: value.primary_group,
+            output_device: value.primary_item,
+            output_sample_rate: value.primary_number,
+            input_host: value.secondary_group,
+            input_device: value.secondary_item,
+            input_sample_rate: value.secondary_number,
+            active_picker: value.active_picker.map(Into::into),
             output_host_options: value
-                .options
-                .primary_group
+                .primary_group_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             output_device_options: value
-                .options
-                .primary_item
+                .primary_item_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             output_sample_rate_options: value
-                .options
-                .primary_number
+                .primary_number_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_host_options: value
-                .options
-                .secondary_group
+                .secondary_group_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_device_options: value
-                .options
-                .secondary_item
+                .secondary_item_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
             input_sample_rate_options: value
-                .options
-                .secondary_number
+                .secondary_number_options
                 .into_iter()
                 .map(audio_option_item_from_compat)
                 .collect(),
@@ -140,52 +134,46 @@ impl From<runtime_contract::PairedDevicePanelModel> for AudioEngineModel {
 impl From<AudioEngineModel> for runtime_contract::PairedDevicePanelModel {
     fn from(value: AudioEngineModel) -> Self {
         Self {
-            header: radiant::gui::form::PairedStatusHeader {
-                status_state: value.chip_state,
-                status_label: value.chip_label,
-                detail_label: value.detail_label,
-            },
-            summaries: radiant::gui::form::PairedStatusSummaries {
-                primary_group: value.output_host,
-                primary_item: value.output_device,
-                primary_number: value.output_sample_rate,
-                secondary_group: value.input_host,
-                secondary_item: value.input_device,
-                secondary_number: value.input_sample_rate,
-            },
-            options: radiant::gui::form::PairedPickerOptions {
-                active_picker: value.active_picker.map(Into::into),
-                primary_group: value
-                    .output_host_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-                primary_item: value
-                    .output_device_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-                primary_number: value
-                    .output_sample_rate_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-                secondary_group: value
-                    .input_host_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-                secondary_item: value
-                    .input_device_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-                secondary_number: value
-                    .input_sample_rate_options
-                    .into_iter()
-                    .map(audio_option_item_to_compat)
-                    .collect(),
-            },
+            status_state: value.chip_state,
+            status_label: value.chip_label,
+            detail_label: value.detail_label,
+            primary_group: value.output_host,
+            primary_item: value.output_device,
+            primary_number: value.output_sample_rate,
+            secondary_group: value.input_host,
+            secondary_item: value.input_device,
+            secondary_number: value.input_sample_rate,
+            active_picker: value.active_picker.map(Into::into),
+            primary_group_options: value
+                .output_host_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
+            primary_item_options: value
+                .output_device_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
+            primary_number_options: value
+                .output_sample_rate_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
+            secondary_group_options: value
+                .input_host_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
+            secondary_item_options: value
+                .input_device_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
+            secondary_number_options: value
+                .input_sample_rate_options
+                .into_iter()
+                .map(audio_option_item_to_compat)
+                .collect(),
         }
     }
 }

--- a/src/gui_runtime/native_shell_runtime/tests.rs
+++ b/src/gui_runtime/native_shell_runtime/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 mod tests {
     use super::*;
     use radiant::runtime::PaintPrimitive;
-    use radiant::theme::ThemeTokens;
+    use radiant::theme::{DpiScale, ThemeTokens};
     use radiant::widgets::{CanvasMessage, WidgetInput, WidgetOutput};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::{
@@ -607,15 +607,15 @@ mod tests {
         let repaint_installed = Arc::new(AtomicBool::new(false));
         let mut model = runtime_contract::AppModel::default();
         model.options_panel.visible = true;
-        model.paired_device.summaries.primary_group = runtime_contract::SummaryFieldModel {
+        model.paired_device.primary_group = runtime_contract::SummaryFieldModel {
             label: String::from("Output Host"),
             value_label: String::from("WASAPI"),
         };
-        model.paired_device.summaries.primary_item = runtime_contract::SummaryFieldModel {
+        model.paired_device.primary_item = runtime_contract::SummaryFieldModel {
             label: String::from("Output"),
             value_label: String::from("Speakers"),
         };
-        model.paired_device.summaries.primary_number = runtime_contract::SummaryFieldModel {
+        model.paired_device.primary_number = runtime_contract::SummaryFieldModel {
             label: String::from("Sample Rate"),
             value_label: String::from("48 kHz"),
         };
@@ -826,6 +826,43 @@ mod tests {
     }
 
     #[test]
+    fn retained_shell_renders_against_radiant_logical_dpi_viewport() {
+        let dpi_scale = DpiScale::new(2.0);
+        let physical_framebuffer = radiant::gui::types::Vector2::new(1920.0, 1080.0);
+        let viewport = radiant::gui::types::Vector2::new(
+            dpi_scale.physical_to_logical(physical_framebuffer.x),
+            dpi_scale.physical_to_logical(physical_framebuffer.y),
+        );
+        let rect = radiant::gui::types::Rect::from_min_size(
+            radiant::gui::types::Point::new(0.0, 0.0),
+            viewport,
+        );
+        let mut bridge = WavecrateRuntimeBridge::new(RecordingBridge {
+            model: Arc::new(NativeAppModel::default()),
+            reduced: Vec::new(),
+            repaint_installed: Arc::new(AtomicBool::new(false)),
+            exit_status: None,
+        });
+
+        let retained = retained_shell_descriptor(&mut bridge);
+        let frame = bridge
+            .render_retained_surface(retained, rect, viewport)
+            .expect("retained shell frame");
+        let style = StyleTokens::for_viewport_width(viewport.x);
+        let layout = ShellLayout::build_with_style(viewport, &style);
+
+        assert_eq!(layout.root.rect.max, Point::new(viewport.x, viewport.y));
+        assert!((layout.ui_scale - 1.0).abs() < 0.0001);
+        assert!(
+            frame
+                .text_runs
+                .iter()
+                .all(|run| run.position.x <= viewport.x && run.position.y <= viewport.y),
+            "Wavecrate retained shell should paint in Radiant logical points, not physical pixels"
+        );
+    }
+
+    #[test]
     fn wavecrate_root_dependency_uses_default_radiant_package() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let cargo = fs::read_to_string(manifest_dir.join("Cargo.toml")).expect("root manifest");
@@ -833,6 +870,29 @@ mod tests {
         assert!(
             cargo.contains("radiant = { path = \"vendor/radiant\" }"),
             "Wavecrate should consume the local Radiant package directly"
+        );
+    }
+
+    #[test]
+    fn windows_resource_manifest_declares_per_monitor_dpi_awareness() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let rc = fs::read_to_string(manifest_dir.join("build/windows/wavecrate.rc"))
+            .expect("windows resource script");
+        let manifest =
+            fs::read_to_string(manifest_dir.join("build/windows/wavecrate.exe.manifest"))
+                .expect("windows application manifest");
+
+        assert!(
+            rc.contains("1 24 \"build\\\\windows\\\\wavecrate.exe.manifest\""),
+            "Windows resources should embed the app manifest"
+        );
+        assert!(
+            manifest.contains("PerMonitorV2, PerMonitor"),
+            "Windows app manifest should opt Wavecrate into per-monitor DPI awareness"
+        );
+        assert!(
+            manifest.contains(">true/pm</dpiAware>"),
+            "Windows app manifest should retain the legacy per-monitor DPI declaration"
         );
     }
 


### PR DESCRIPTION
## Summary
- sync vendor/radiant to the latest main with the merged DPI scaling example and runtime support
- update Wavecrate native run options and DTO/layout compatibility for the new Radiant APIs
- wire retained WaveGrid rendering/input to Radiant's DPI-normalized logical viewport
- embed a Windows per-monitor DPI-aware manifest for Wavecrate

## Validation
- powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent