### PR TITLE
Fix sample row hover state

### DIFF
--- a/src/gui_app/sample_browser_view/hit_target.rs
+++ b/src/gui_app/sample_browser_view/hit_target.rs
@@ -7,6 +7,19 @@ use radiant::widgets::{
     WidgetCommon, WidgetInput, WidgetOutput, WidgetSizing,
 };
 
+const HOVER_FILL: Rgba8 = Rgba8 {
+    r: 255,
+    g: 255,
+    b: 255,
+    a: 24,
+};
+const PRESSED_FILL: Rgba8 = Rgba8 {
+    r: 255,
+    g: 108,
+    b: 88,
+    a: 170,
+};
+
 #[derive(Clone, Debug)]
 pub(in crate::gui_app) struct SampleFileHitTarget {
     common: WidgetCommon,
@@ -108,9 +121,7 @@ impl Widget for SampleFileHitTarget {
             return;
         };
         self.common.state = previous.common.state;
-        if self.suppress_hover || previous.suppress_hover {
-            self.common.state.hovered = false;
-        }
+        self.common.state.hovered = false;
         self.dragged = previous.dragged;
     }
 
@@ -219,16 +230,15 @@ impl SampleFileHitTarget {
         if !self.common.state.pressed && !self.common.state.hovered {
             return;
         }
-        let alpha = if self.common.state.pressed { 170 } else { 155 };
+        let color = if self.common.state.pressed {
+            PRESSED_FILL
+        } else {
+            HOVER_FILL
+        };
         primitives.push(PaintPrimitive::FillRect(PaintFillRect {
             widget_id: self.common.id,
             rect: bounds,
-            color: Rgba8 {
-                r: 255,
-                g: 108,
-                b: 88,
-                a: alpha,
-            },
+            color,
         }));
     }
 

--- a/src/gui_app/sample_browser_view/hit_target_tests.rs
+++ b/src/gui_app/sample_browser_view/hit_target_tests.rs
@@ -7,6 +7,12 @@ fn message_from(output: Option<WidgetOutput>) -> SampleFileHitMessage {
         .expect("expected sample file message")
 }
 
+fn paints_hover_fill(primitives: &[PaintPrimitive]) -> bool {
+    primitives.iter().any(
+        |primitive| matches!(primitive, PaintPrimitive::FillRect(fill) if fill.color == HOVER_FILL),
+    )
+}
+
 #[test]
 fn active_drag_uses_runtime_preview_after_widget_refresh() {
     let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
@@ -106,15 +112,13 @@ fn active_drag_non_source_rows_do_not_keep_hover_highlight() {
         &ThemeTokens::default(),
     );
     assert!(
-        !primitives.iter().any(
-            |primitive| matches!(primitive, PaintPrimitive::FillRect(fill) if fill.color.a == 155)
-        ),
+        !paints_hover_fill(&primitives),
         "non-source rows should not paint hover highlights during active file drags"
     );
 }
 
 #[test]
-fn hover_state_survives_retained_widget_refresh() {
+fn hover_state_clears_on_retained_widget_refresh() {
     let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
     let mut previous = SampleFileHitTarget::new(false, false, false, false, false);
     previous.handle_input(
@@ -129,8 +133,8 @@ fn hover_state_survives_retained_widget_refresh() {
     refreshed.synchronize_from_previous(&previous);
 
     assert!(
-        refreshed.common.state.hovered,
-        "sample row hover paint should not blink off between retained projections"
+        !refreshed.common.state.hovered,
+        "sample row hover paint must not stick after retained projections"
     );
     let mut primitives = Vec::new();
     refreshed.append_paint(
@@ -140,11 +144,63 @@ fn hover_state_survives_retained_widget_refresh() {
         &ThemeTokens::default(),
     );
     assert!(
-        primitives.iter().any(
-            |primitive| matches!(primitive, PaintPrimitive::FillRect(fill) if fill.color.a == 155)
-        ),
-        "refreshed hovered row should keep painting the hover highlight"
+        !paints_hover_fill(&primitives),
+        "refreshed rows should not paint stale hover highlights"
     );
+}
+
+#[test]
+fn hover_fill_is_neutral_not_selection_red() {
+    let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
+    let mut target = SampleFileHitTarget::new(false, false, false, false, false);
+    target.handle_input(
+        bounds,
+        WidgetInput::PointerMove {
+            position: Point::new(34.0, 8.0),
+        },
+    );
+
+    let mut primitives = Vec::new();
+    target.append_paint(
+        &mut primitives,
+        bounds,
+        &LayoutOutput::default(),
+        &ThemeTokens::default(),
+    );
+
+    assert!(paints_hover_fill(&primitives));
+    assert!(!primitives.iter().any(|primitive| matches!(
+        primitive,
+        PaintPrimitive::FillRect(fill)
+            if fill.color == Rgba8 {
+                r: 255,
+                g: 82,
+                b: 62,
+                a: 120
+            }
+    )));
+}
+
+#[test]
+fn pressed_state_survives_retained_widget_refresh_without_hover() {
+    let bounds = Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(120.0, 22.0));
+    let mut previous = SampleFileHitTarget::new(false, false, false, false, false);
+    previous.handle_input(
+        bounds,
+        WidgetInput::PointerPress {
+            position: Point::new(34.0, 8.0),
+            button: PointerButton::Primary,
+            modifiers: PointerModifiers::default(),
+        },
+    );
+    assert!(previous.common.state.hovered);
+    assert!(previous.common.state.pressed);
+
+    let mut refreshed = SampleFileHitTarget::new(false, false, false, false, false);
+    refreshed.synchronize_from_previous(&previous);
+
+    assert!(!refreshed.common.state.hovered);
+    assert!(refreshed.common.state.pressed);
 }
 
 #[test]
@@ -178,9 +234,7 @@ fn suppressed_hover_clears_and_omits_stale_hover_paint() {
         &ThemeTokens::default(),
     );
     assert!(
-        !primitives.iter().any(
-            |primitive| matches!(primitive, PaintPrimitive::FillRect(fill) if fill.color.a == 155)
-        ),
+        !paints_hover_fill(&primitives),
         "suppressed rows should not paint hover highlights during sidebar resize"
     );
 }


### PR DESCRIPTION
## Summary
- Clear retained sample row hover on widget refresh so stale hover fills do not stick to virtualized rows
- Make hover fill a subtle neutral overlay instead of reusing selection red
- Keep pressed state synchronized for drag/release correctness

## Validation
- cargo fmt
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test -p wavecrate sample_browser_view::hit_target::tests
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent