### PR TITLE
add mac scripts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: ./run.sh [--] [app args...]
+
+Builds and runs a release-profile internal Wavecrate dev build with logging
+enabled. App args are forwarded after the built-in --log flag.
+EOF
+}
+
+if (( $# > 0 )); then
+  case "$1" in
+    -h|--help|-Help|help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      ;;
+  esac
+fi
+
+cd "$ROOT_DIR"
+
+if [[ ! -f "$ROOT_DIR/vendor/radiant/Cargo.toml" ]]; then
+  echo "[run] Radiant submodule is missing; initializing vendor/radiant..."
+  git submodule update --init --recursive vendor/radiant
+fi
+
+export WAVECRATE_INTERNAL_BUILD=1
+exec cargo run -r -- --log "$@"

--- a/scripts/internal/check/check_rust_dead_deps_advisory.sh
+++ b/scripts/internal/check/check_rust_dead_deps_advisory.sh
@@ -37,7 +37,8 @@ USAGE
 }
 
 is_truthy() {
-  local value="${1,,}"
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   [[ "$value" == "1" || "$value" == "true" || "$value" == "yes" || "$value" == "on" ]]
 }
 

--- a/scripts/internal/perf/run_perf_guard.sh
+++ b/scripts/internal/perf/run_perf_guard.sh
@@ -48,15 +48,19 @@ STARTUP_LOCK_ENV_IN="${WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_IN:-$ROOT_DIR/scrip
 FRAME_QUALITY_LOCK_ENV_OUT="${WAVECRATE_PERF_GUARD_FRAME_QUALITY_LOCK_ENV_OUT:-}"
 CARGO_BIN="${CARGO_BIN:-cargo}"
 
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 startup_profile_enabled=0
-case "${STARTUP_PROFILE_RAW,,}" in
+case "$(lowercase "$STARTUP_PROFILE_RAW")" in
   1|true|yes|on)
     startup_profile_enabled=1
     ;;
 esac
 
 startup_require_valid_runs=0
-case "${STARTUP_REQUIRE_VALID_RAW,,}" in
+case "$(lowercase "$STARTUP_REQUIRE_VALID_RAW")" in
   1|true|yes|on)
     startup_require_valid_runs=1
     ;;

--- a/scripts/internal/release/build_release_zip.sh
+++ b/scripts/internal/release/build_release_zip.sh
@@ -13,8 +13,9 @@ CHANNEL=""
 VERSION=""
 
 is_truthy() {
-  local value="$1"
-  case "${value,,}" in
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
     1|true|yes|on) return 0 ;;
     *) return 1 ;;
   esac

--- a/scripts/internal/run/bug_bundle.sh
+++ b/scripts/internal/run/bug_bundle.sh
@@ -19,18 +19,19 @@ OUT_DIR="dist/bug_bundles"
 USE_SANDBOX=0
 
 usage() {
-  cat <<'EOF'
-Usage: scripts/run.sh bug-bundle [--out-dir <dir>] [--logs <n>] [--sandbox]
+  local entrypoint="${WAVECRATE_RUN_ENTRYPOINT:-scripts/run.sh}"
+  cat <<EOF
+Usage: ${entrypoint} bug-bundle [--out-dir <dir>] [--logs <n>] [--sandbox]
 
 Creates an archive under <out-dir> containing:
 - the newest N log files (default: 5)
-- `config.toml` (if present)
+- config.toml (if present)
 - version/system info
 
 Sandbox behavior:
-- If `WAVECRATE_CONFIG_HOME` is set, it is always used.
-- Otherwise, if `<repo>/.sandbox/wavecrate` exists, this script prefers it.
-- Pass `--sandbox` to force using `<repo>/.sandbox/wavecrate`.
+- If WAVECRATE_CONFIG_HOME is set, it is always used.
+- Otherwise, if <repo>/.sandbox/wavecrate exists, this script prefers it.
+- Pass --sandbox to force using <repo>/.sandbox/wavecrate.
 EOF
 }
 
@@ -164,8 +165,11 @@ fi
 
 if [[ -d "$logs_dir" ]]; then
   mkdir -p "${bundle_dir}/logs"
-  mapfile -t logs < <(ls -1t "$logs_dir"/*.log 2>/dev/null | head -n "$MAX_LOGS" || true)
-  for log_file in "${logs[@]:-}"; do
+  logs=()
+  while IFS= read -r log_file; do
+    logs+=("$log_file")
+  done < <(ls -1t "$logs_dir"/*.log 2>/dev/null | head -n "$MAX_LOGS" || true)
+  for log_file in "${logs[@]}"; do
     [[ -f "$log_file" ]] || continue
     cp "$log_file" "${bundle_dir}/logs/$(basename "$log_file")"
   done

--- a/scripts/internal/run/clean_sandbox.sh
+++ b/scripts/internal/run/clean_sandbox.sh
@@ -9,6 +9,29 @@
 
 set -euo pipefail
 
+usage() {
+  local entrypoint="${WAVECRATE_RUN_ENTRYPOINT:-scripts/run.sh}"
+  cat <<EOF
+Usage: ${entrypoint} clean
+
+Deletes the repo-local sandbox used by ${entrypoint} sandbox.
+EOF
+}
+
+if (( $# > 0 )); then
+  case "$1" in
+    -h|--help|-Help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[clean_sandbox] Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT_DIR"
 
@@ -22,4 +45,3 @@ fi
 echo "[clean_sandbox] removing: $SANDBOX_DIR"
 rm -rf "$SANDBOX_DIR"
 echo "[clean_sandbox] OK"
-

--- a/scripts/internal/run/latest_log.sh
+++ b/scripts/internal/run/latest_log.sh
@@ -19,19 +19,20 @@ LINES=200
 USE_SANDBOX=0
 
 usage() {
-  cat <<'EOF'
-Usage: scripts/run.sh logs [--lines <n>] [--sandbox]
+  local entrypoint="${WAVECRATE_RUN_ENTRYPOINT:-scripts/run.sh}"
+  cat <<EOF
+Usage: ${entrypoint} logs [--lines <n>] [--sandbox]
 
 Prints:
-- resolved `.wavecrate` root (best-effort)
+- resolved .wavecrate root (best-effort)
 - resolved logs dir
-- newest `*.log` file under logs dir (if any)
+- newest *.log file under logs dir (if any)
 - tail snippet from that newest log (default: 200 lines)
 
 Sandbox behavior:
-- If `WAVECRATE_CONFIG_HOME` is set, it is always used.
-- Otherwise, if `<repo>/.sandbox/wavecrate` exists, this script prefers it.
-- Pass `--sandbox` to force using `<repo>/.sandbox/wavecrate`.
+- If WAVECRATE_CONFIG_HOME is set, it is always used.
+- Otherwise, if <repo>/.sandbox/wavecrate exists, this script prefers it.
+- Pass --sandbox to force using <repo>/.sandbox/wavecrate.
 EOF
 }
 

--- a/scripts/internal/run/run_sandbox.sh
+++ b/scripts/internal/run/run_sandbox.sh
@@ -20,12 +20,13 @@ WRITE_DB=0
 ALLOW_USER_LIBRARY_DB_WRITE=0
 
 usage() {
-  cat <<'EOF'
-Usage: scripts/run.sh sandbox [--dir <sandbox_base>] [--name <id>] [--temp] [--clean] [--write-db] [--allow-user-library-db-write] [--] [app args...]
+  local entrypoint="${WAVECRATE_RUN_ENTRYPOINT:-scripts/run.sh}"
+  cat <<EOF
+Usage: ${entrypoint} sandbox [--dir <sandbox_base>] [--name <id>] [--temp] [--clean] [--write-db] [--allow-user-library-db-write] [--] [app args...]
 
-Runs `cargo run --release` with:
-- `WAVECRATE_CONFIG_HOME` set to an isolated sandbox base directory
-- `WAVECRATE_CONFIG_PROFILE=sandbox`
+Runs cargo run --release with:
+- WAVECRATE_CONFIG_HOME set to an isolated sandbox base directory
+- WAVECRATE_CONFIG_PROFILE=sandbox
 
 Derived paths:
 - app root:  <WAVECRATE_CONFIG_HOME>/.wavecrate/profiles/sandbox

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,8 +3,15 @@
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
-Usage: scripts/run.sh <sandbox|clean|logs|bug-bundle> [args...]
+  local entrypoint="${WAVECRATE_RUN_ENTRYPOINT:-scripts/run.sh}"
+  cat <<EOF
+Usage: ${entrypoint} <sandbox|clean|logs|bug-bundle> [args...]
+
+Commands:
+  sandbox      Run Wavecrate with an isolated sandbox profile.
+  clean        Delete the repo-local sandbox profile.
+  logs         Print the newest resolved Wavecrate log.
+  bug-bundle   Create a small diagnostic bundle.
 EOF
 }
 
@@ -23,7 +30,7 @@ case "$command" in
   clean) exec "$script_dir/clean_sandbox.sh" "$@" ;;
   logs) exec "$script_dir/latest_log.sh" "$@" ;;
   bug-bundle) exec "$script_dir/bug_bundle.sh" "$@" ;;
-  -h|--help) usage ;;
+  -h|--help|-Help|help) usage ;;
   *)
     echo "Unknown run command: $command" >&2
     usage >&2


### PR DESCRIPTION
## Summary

- What:
- Why:

## Scope

- Single responsibility:
- Out of scope:

## Risk

- Behavior changes:
- Edge cases:
- Rollback plan:

## Validation

- Smoke local checks: `bash scripts/ci.sh smoke` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 smoke`
- Fast local checks: `bash scripts/ci.sh quick` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 quick`
- Required CI parity: `bash scripts/ci.sh local` / `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 local`
- Advisory quarantined tests (when relevant): `cargo nextest run --workspace --profile ci-quarantine --all-targets --no-fail-fast`
- Tests added/updated:
- Manual QA notes:
  - Prefer running the app via `scripts/run.sh sandbox` / `scripts/run.ps1 sandbox` so tests and manual QA do not touch real user data.

## Docs

- User-facing docs updated (if needed): `manual/usage.md`
- Developer docs updated (if needed): `docs/`

## Throughput norms

- Keep PRs small and easy to review. If this is large, split into follow-up PRs.
- Prefer short-lived branches and merging quickly over long-running mega-branches.

## Diagnostics (when reporting bugs)

- Attach a minimal repro and (when useful) a bundle from `scripts/run.sh bug-bundle` / `scripts/run.ps1 bug-bundle` (review before sharing; may contain local paths).
