### PR TITLE
Fix undo redo for folder moves

### DIFF
--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/apply_result.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/apply_result.rs
@@ -1,7 +1,14 @@
 use super::super::super::DragDropController;
+use super::worker::run_folder_move_task;
+use crate::app::controller::AppController;
 use crate::app::controller::StatusTone;
-use crate::app::controller::jobs::{FolderMoveResult, FolderSampleMoveResult};
-use crate::sample_sources::WavEntry;
+use crate::app::controller::jobs::{FolderMoveRequest, FolderMoveResult, FolderSampleMoveResult};
+use crate::app::controller::undo::{UndoEntry, UndoExecution};
+use crate::sample_sources::{SampleSource, WavEntry};
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, atomic::AtomicBool},
+};
 use tracing::{info, warn};
 
 impl DragDropController<'_> {
@@ -97,6 +104,14 @@ impl DragDropController<'_> {
 
     /// Apply a completed background folder move job.
     pub(crate) fn apply_folder_move_result(&mut self, result: FolderMoveResult) {
+        self.apply_folder_move_result_inner(result, true);
+    }
+
+    fn apply_folder_move_result_without_undo(&mut self, result: FolderMoveResult) {
+        self.apply_folder_move_result_inner(result, false);
+    }
+
+    fn apply_folder_move_result_inner(&mut self, result: FolderMoveResult, register_undo: bool) {
         let Some(source) = self
             .library
             .sources
@@ -171,6 +186,13 @@ impl DragDropController<'_> {
         self.remap_folder_state(&result.old_folder, &result.new_folder);
         self.remap_manual_folders(&result.old_folder, &result.new_folder);
         self.focus_drop_target_folder(&result.new_folder);
+        if register_undo {
+            self.push_undo_entry(folder_move_undo_entry(
+                source,
+                result.old_folder.clone(),
+                result.new_folder.clone(),
+            ));
+        }
         let tone = if result.errors.is_empty() && !result.cancelled {
             StatusTone::Info
         } else {
@@ -193,4 +215,52 @@ impl DragDropController<'_> {
             );
         }
     }
+}
+
+fn folder_move_undo_entry(
+    source: SampleSource,
+    old_folder: PathBuf,
+    new_folder: PathBuf,
+) -> UndoEntry<AppController> {
+    let label = format!("Move folder {}", old_folder.display());
+    let undo_source = source.clone();
+    let undo_old_folder = old_folder.clone();
+    let undo_new_folder = new_folder.clone();
+    let redo_source = source;
+    UndoEntry::new(
+        label,
+        move |controller| {
+            let target_parent = undo_old_folder.parent().unwrap_or_else(|| Path::new(""));
+            apply_folder_move_for_undo(controller, &undo_source, &undo_new_folder, target_parent)
+        },
+        move |controller| {
+            let target_parent = new_folder.parent().unwrap_or_else(|| Path::new(""));
+            apply_folder_move_for_undo(controller, &redo_source, &old_folder, target_parent)
+        },
+    )
+}
+
+fn apply_folder_move_for_undo(
+    controller: &mut AppController,
+    source: &SampleSource,
+    folder: &Path,
+    target_folder: &Path,
+) -> Result<UndoExecution, String> {
+    let request = FolderMoveRequest {
+        source_id: source.id.clone(),
+        source_root: source.root.clone(),
+        folder: folder.to_path_buf(),
+        target_folder: target_folder.to_path_buf(),
+    };
+    let result = run_folder_move_task(request, Arc::new(AtomicBool::new(false)), None);
+    if !result.folder_moved {
+        return Err(result
+            .errors
+            .first()
+            .cloned()
+            .unwrap_or_else(|| String::from("Folder move did not complete")));
+    }
+    let mut drag_drop = DragDropController::new(controller);
+    drag_drop.apply_folder_move_result_without_undo(result);
+    Ok(UndoExecution::Applied)
 }

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_move_task.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_move_task.rs
@@ -2,8 +2,11 @@ use super::super::worker::{run_folder_move_task, set_before_folder_move_batch_ho
 use super::support::{
     Must, folder_move_request, folder_move_test_guard, setup_folder_move_fixture,
 };
+use crate::app::controller::AppController;
+use crate::app::controller::ui::drag_drop_controller::DragDropController;
 use crate::sample_sources::db::DB_FILE_NAME;
 use crate::sample_sources::{Rating, SampleCollection, SourceDatabase};
+use crate::waveform::WaveformRenderer;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, atomic::AtomicBool};
 use std::time::Duration;
@@ -53,6 +56,56 @@ fn folder_move_updates_db_entries() {
     assert_eq!(
         db.collection_for_path(Path::new("dest/old/one.wav")).must(),
         Some(SampleCollection::new(1).must())
+    );
+}
+
+#[test]
+/// Folder-tree folder moves register undo and redo on the legacy controller stack.
+fn folder_tree_move_supports_undo_and_redo() {
+    let _guard = folder_move_test_guard();
+    set_before_folder_move_batch_hook(None);
+    let (_temp, source, source_root) = setup_folder_move_fixture();
+    let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
+    controller.library.sources.push(source.clone());
+    controller.selection_state.ctx.selected_source = Some(source.id.clone());
+
+    DragDropController::new(&mut controller).handle_folder_drop_to_folder(
+        source.id.clone(),
+        PathBuf::from("old"),
+        Path::new("dest"),
+    );
+
+    assert!(source_root.join("dest/old/one.wav").is_file());
+    assert!(!source_root.join("old").exists());
+    let db = SourceDatabase::open(&source_root).must();
+    assert!(db.tag_for_path(Path::new("old/one.wav")).must().is_none());
+    assert_eq!(
+        db.tag_for_path(Path::new("dest/old/one.wav")).must(),
+        Some(Rating::KEEP_1)
+    );
+
+    controller.undo();
+
+    assert!(source_root.join("old/one.wav").is_file());
+    assert!(!source_root.join("dest/old").exists());
+    assert_eq!(
+        db.tag_for_path(Path::new("old/one.wav")).must(),
+        Some(Rating::KEEP_1)
+    );
+    assert!(
+        db.tag_for_path(Path::new("dest/old/one.wav"))
+            .must()
+            .is_none()
+    );
+
+    controller.redo();
+
+    assert!(source_root.join("dest/old/one.wav").is_file());
+    assert!(!source_root.join("old").exists());
+    assert!(db.tag_for_path(Path::new("old/one.wav")).must().is_none());
+    assert_eq!(
+        db.tag_for_path(Path::new("dest/old/one.wav")).must(),
+        Some(Rating::KEEP_1)
     );
 }
 

--- a/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
+++ b/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, time::Instant};
+use std::{
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use radiant::prelude as ui;
 
@@ -13,6 +16,8 @@ use crate::native_app::sample_library::folder_browser::commands::{
     file_move_conflict_progress_total, folder_move_progress_label, folder_move_progress_total,
 };
 use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::shell::message_dispatch::waveform::PLAY_SELECTION_TRANSACTION_LABEL;
+use crate::native_app::transaction_history::TransactionContext;
 
 impl NativeAppState {
     pub(in crate::native_app) fn drop_browser_drag_on_folder(
@@ -261,6 +266,19 @@ impl NativeAppState {
                 &self.metadata.tags_by_file,
             );
             if result.is_ok() {
+                if let FolderMoveRequest::Folder {
+                    source_root,
+                    source_database_root,
+                    ..
+                } = &request
+                    && !moved_paths.is_empty()
+                {
+                    self.register_folder_move_transaction(
+                        source_root.clone(),
+                        source_database_root.clone(),
+                        moved_paths.clone(),
+                    );
+                }
                 self.reconcile_harvest_graph_after_folder_move(&request, &moved_paths);
             }
             result
@@ -454,5 +472,105 @@ impl NativeAppState {
         self.cancel_metadata_tag_entry();
         self.metadata.selected_tag = None;
         self.load_navigation_sample(selected, context);
+    }
+
+    fn register_folder_move_transaction(
+        &mut self,
+        source_root: PathBuf,
+        source_database_root: PathBuf,
+        moved_paths: Vec<(PathBuf, PathBuf)>,
+    ) {
+        self.discard_play_selection_transactions_for_moved_paths(&moved_paths);
+        let undo_moves = moved_paths
+            .iter()
+            .map(|(old_path, new_path)| (new_path.clone(), old_path.clone()))
+            .collect::<Vec<_>>();
+        let redo_moves = moved_paths;
+        let label = if redo_moves.len() == 1 {
+            String::from("Move folder")
+        } else {
+            format!("Move {} folders", redo_moves.len())
+        };
+        let undo_source_root = source_root.clone();
+        let undo_source_database_root = source_database_root.clone();
+        self.begin_transaction(label);
+        self.register_transaction_action(
+            "Move folders",
+            move |transaction| {
+                transaction.apply_folder_move_paths(
+                    &undo_source_root,
+                    &undo_source_database_root,
+                    &undo_moves,
+                )
+            },
+            move |transaction| {
+                transaction.apply_folder_move_paths(
+                    &source_root,
+                    &source_database_root,
+                    &redo_moves,
+                )
+            },
+        );
+        self.commit_transaction();
+    }
+
+    fn discard_play_selection_transactions_for_moved_paths(
+        &mut self,
+        moved_paths: &[(PathBuf, PathBuf)],
+    ) {
+        let loaded_path_moved = moved_paths
+            .iter()
+            .any(|(old_path, _)| self.waveform.current.path().starts_with(old_path));
+        if !loaded_path_moved {
+            return;
+        }
+        self.waveform.pending_play_selection_transaction = None;
+        self.transactions
+            .history
+            .remove_transactions_with_action_label(PLAY_SELECTION_TRANSACTION_LABEL);
+    }
+
+    fn apply_folder_move_paths_for_transaction(
+        &mut self,
+        source_root: &Path,
+        source_database_root: &Path,
+        moves: &[(PathBuf, PathBuf)],
+    ) -> Result<(), String> {
+        let metadata_error = self.library.folder_browser.apply_folder_move_transaction(
+            source_root,
+            source_database_root,
+            moves,
+        )?;
+        self.remap_metadata_tags_for_moved_files(moves);
+        self.apply_moved_sample_paths(moves);
+        let request = FolderMoveRequest::Folder {
+            source_root: source_root.to_path_buf(),
+            source_database_root: source_database_root.to_path_buf(),
+            moves: moves.to_vec(),
+            target_folder: moves
+                .first()
+                .and_then(|(_, new_path)| new_path.parent().map(Path::to_path_buf))
+                .unwrap_or_else(|| source_root.to_path_buf()),
+        };
+        self.reconcile_harvest_graph_after_folder_move(&request, moves);
+        if let Some(error) = metadata_error {
+            tracing::warn!("folder move transaction metadata update failed: {error}");
+        }
+        if let Err(error) = self.library.folder_browser.save_source_scan_cache() {
+            tracing::warn!("folder move transaction source cache save failed: {error}");
+        }
+        Ok(())
+    }
+}
+
+impl TransactionContext<'_> {
+    fn apply_folder_move_paths(
+        &mut self,
+        source_root: &Path,
+        source_database_root: &Path,
+        moves: &[(PathBuf, PathBuf)],
+    ) -> Result<(), String> {
+        self.state
+            .apply_folder_move_paths_for_transaction(source_root, source_database_root, moves)
     }
 }

--- a/src/native_app/sample_library/folder_browser/drag_drop_move.rs
+++ b/src/native_app/sample_library/folder_browser/drag_drop_move.rs
@@ -1,11 +1,13 @@
 use std::{
     collections::{HashMap, HashSet},
+    fs,
     path::{Path, PathBuf},
 };
 
 use super::{
     FileMoveConflictBatch, FileMoveItem, FolderBrowserState, FolderDropResult, FolderMoveDropInput,
     FolderMoveRequest, FolderMoveSuccess, delete_workflow::fallback_after_deleted_focus,
+    drag_drop_relocation::persist_moved_folders_metadata,
     drag_drop_sourced_files::sourced_moved_files_from_items, file_move_conflicts::file_move_status,
     path_helpers::path_id, selection_state::BrowserSelectionSnapshot,
 };
@@ -359,6 +361,59 @@ impl FolderBrowserState {
             .ok_or_else(|| format!("{error_prefix}: selected source is unavailable"))
     }
 
+    pub(in crate::native_app) fn apply_folder_move_transaction(
+        &mut self,
+        source_root: &Path,
+        source_database_root: &Path,
+        moves: &[(PathBuf, PathBuf)],
+    ) -> Result<Option<String>, String> {
+        self.select_source_root_for_folder_move_transaction(source_root)?;
+        let completed = rename_folders_with_rollback(moves)?;
+        let metadata_error =
+            persist_moved_folders_metadata(source_root, source_database_root, &completed).err();
+        for (old_path, new_path) in &completed {
+            let Some(target_parent) = new_path.parent() else {
+                return Err(format!(
+                    "Folder move failed: {} has no parent",
+                    new_path.display()
+                ));
+            };
+            self.relocate_moved_folder(old_path, new_path, target_parent)?;
+        }
+        Ok(metadata_error)
+    }
+
+    fn select_source_root_for_folder_move_transaction(
+        &mut self,
+        source_root: &Path,
+    ) -> Result<(), String> {
+        if self
+            .source
+            .sources
+            .iter()
+            .find(|source| source.id == self.source.selected_source)
+            .is_some_and(|source| source.root == source_root)
+        {
+            return Ok(());
+        }
+        let Some((id, root_folder)) = self
+            .source
+            .sources
+            .iter()
+            .find(|source| source.root == source_root)
+            .and_then(|source| {
+                source
+                    .root_folder
+                    .clone()
+                    .map(|root_folder| (source.id.clone(), root_folder))
+            })
+        else {
+            return Err(String::from("Folder move failed: source is unavailable"));
+        };
+        self.select_loaded_source(id, root_folder);
+        Ok(())
+    }
+
     fn apply_folder_move(
         &mut self,
         target_folder: &Path,
@@ -522,5 +577,42 @@ fn folder_move_status(moved_paths: &[(PathBuf, PathBuf)]) -> String {
             folders.len(),
             if folders.len() == 1 { "" } else { "s" }
         ),
+    }
+}
+
+fn rename_folders_with_rollback(
+    moves: &[(PathBuf, PathBuf)],
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    let mut completed = Vec::new();
+    for (old_path, new_path) in moves {
+        if !old_path.is_dir() {
+            rollback_moved_folders_for_transaction(&completed);
+            return Err(format!(
+                "Folder move failed: {} is missing",
+                old_path.display()
+            ));
+        }
+        if new_path.exists() {
+            rollback_moved_folders_for_transaction(&completed);
+            return Err(format!(
+                "Folder move failed: {} already exists",
+                new_path.display()
+            ));
+        }
+        if let Some(parent) = new_path.parent() {
+            fs::create_dir_all(parent).map_err(|err| format!("Folder move failed: {err}"))?;
+        }
+        if let Err(error) = fs::rename(old_path, new_path) {
+            rollback_moved_folders_for_transaction(&completed);
+            return Err(format!("Folder move failed: {error}"));
+        }
+        completed.push((old_path.clone(), new_path.clone()));
+    }
+    Ok(completed)
+}
+
+fn rollback_moved_folders_for_transaction(completed: &[(PathBuf, PathBuf)]) {
+    for (old_path, new_path) in completed.iter().rev() {
+        let _ = fs::rename(new_path, old_path);
     }
 }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -9,7 +9,7 @@ mod sample_loading;
 mod settings;
 #[cfg(test)]
 mod tests;
-mod waveform;
+pub(in crate::native_app) mod waveform;
 
 use radiant::prelude as ui;
 

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -8,6 +8,9 @@ use crate::native_app::app::{
     emit_gui_action,
 };
 
+pub(in crate::native_app) const PLAY_SELECTION_TRANSACTION_LABEL: &str =
+    "Change play mark selection";
+
 impl NativeAppState {
     pub(super) fn apply_waveform_message(
         &mut self,
@@ -95,7 +98,7 @@ impl NativeAppState {
         let undo_snapshot = before.clone();
         let redo_snapshot = after;
         self.register_transaction_action(
-            "Change play mark selection",
+            PLAY_SELECTION_TRANSACTION_LABEL,
             move |transaction| transaction.restore_play_selection(undo_snapshot.clone()),
             move |transaction| transaction.restore_play_selection(redo_snapshot.clone()),
         );

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -1,10 +1,11 @@
 use super::{
-    gui_state_for_span_tests, native_app_state_with_temp_sample, run_command_for_tests,
-    write_test_wav_i16,
+    gui_state_for_span_tests, native_app_state_with_temp_sample, reduce_gui_message_for_tests,
+    run_command_for_tests, write_test_wav_i16,
 };
+use crate::native_app::app::WaveformPlaySelectionSnapshot;
 use crate::native_app::sample_library::folder_browser::model::BrowserCurationScope;
 use crate::native_app::test_support::state::{
-    FolderBrowserMessage, FolderBrowserState, GuiMessage, view,
+    FolderBrowserMessage, FolderBrowserState, GuiMessage, WaveformState, view,
 };
 use radiant::{
     gui::types::{Point, Vector2},
@@ -14,6 +15,7 @@ use radiant::{
 };
 use std::{fs, path::Path, sync::Arc};
 use wavecrate::sample_sources::{Rating, SourceDatabase};
+use wavecrate::selection::SelectionRange;
 
 fn last_fixed_sample_browser_row_scroll(command: &Command<GuiMessage>) -> Option<(usize, i32)> {
     match command {
@@ -390,6 +392,90 @@ fn moving_selected_file_loads_next_visible_sample() {
         state.active_sample_load_task().is_some(),
         "moving the selected file should queue autoplay loading for the replacement selection"
     );
+}
+
+#[test]
+fn moving_folder_registers_undo_redo_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let drums = source_root.path().join("drums");
+    let kicks = drums.join("kicks");
+    let loops = source_root.path().join("loops");
+    fs::create_dir_all(&kicks).expect("create kicks folder");
+    fs::create_dir_all(&loops).expect("create loops folder");
+    let kick = kicks.join("kick.wav");
+    write_test_wav_i16(&kick, &[0, 256, -256, 512]);
+    state.waveform.current = WaveformState::load_path(kick.clone()).expect("load kick");
+    let stale_play_selection = WaveformPlaySelectionSnapshot {
+        path: kick.clone(),
+        play_mark_ratio: Some(0.25),
+        play_selection: Some(SelectionRange::new(0.25, 0.5)),
+        marked_play_ranges: Vec::new(),
+    };
+    let stale_undo = stale_play_selection.clone();
+    let stale_redo = stale_play_selection;
+    state.register_transaction_action(
+        "Change play mark selection",
+        move |transaction| transaction.restore_play_selection(stale_undo.clone()),
+        move |transaction| transaction.restore_play_selection(stale_redo.clone()),
+    );
+    assert_eq!(state.transactions.history.list_items().len(), 1);
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::ActivateFolder(
+            drums.display().to_string(),
+            Default::default(),
+        ));
+    state.library.folder_browser.expand_selected_folder();
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::DragFolder(
+            kicks.display().to_string(),
+            DragHandleMessage::started(Point::new(4.0, 8.0)),
+        ));
+    let request = match state
+        .library
+        .folder_browser
+        .drop_drag_on_folder(&loops.display().to_string())
+        .expect("drop should be accepted")
+    {
+        crate::native_app::sample_library::folder_browser::commands::FolderMoveDropInput::Request(
+            request,
+        ) => request,
+        other => panic!("expected folder move request, got {other:?}"),
+    };
+    let completion =
+        crate::native_app::sample_library::folder_browser::commands::execute_folder_move_request(
+            request,
+        );
+    let mut context = radiant::prelude::UiUpdateContext::default();
+
+    state.finish_folder_move(std::time::Instant::now(), completion, &mut context);
+
+    let moved_kicks = loops.join("kicks");
+    assert!(!kicks.exists());
+    assert!(moved_kicks.join("kick.wav").is_file());
+    assert_eq!(state.transactions.history.list_items().len(), 1);
+    assert_eq!(
+        state.transactions.history.list_items()[0].label,
+        "Move folder"
+    );
+
+    reduce_gui_message_for_tests(&mut state, GuiMessage::UndoTransaction);
+    assert_eq!(state.ui.status.sample, "Undid Move folder");
+    assert!(kicks.join("kick.wav").is_file());
+    assert!(!moved_kicks.exists());
+
+    reduce_gui_message_for_tests(&mut state, GuiMessage::RedoTransaction);
+    assert_eq!(state.ui.status.sample, "Redid Move folder");
+    assert!(!kicks.exists());
+    assert!(moved_kicks.join("kick.wav").is_file());
 }
 
 #[test]

--- a/src/native_app/transaction_history/native.rs
+++ b/src/native_app/transaction_history/native.rs
@@ -211,6 +211,20 @@ impl NativeTransactionHistory {
         !self.undo.is_empty()
     }
 
+    pub(in crate::native_app) fn remove_transactions_with_action_label(&mut self, label: &str) {
+        self.undo
+            .retain(|transaction| !transaction.has_action_label(label));
+        self.redo
+            .retain(|transaction| !transaction.has_action_label(label));
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|draft| draft.has_action_label(label))
+        {
+            self.active = None;
+        }
+    }
+
     pub(in crate::native_app) fn can_redo(&self) -> bool {
         !self.redo.is_empty()
     }
@@ -242,5 +256,17 @@ impl NativeTransactionHistory {
             .rev()
             .map(|transaction| transaction.snapshot(TransactionListState::Redoable));
         active.chain(undo).chain(redo).collect()
+    }
+}
+
+impl NativeTransaction {
+    fn has_action_label(&self, label: &str) -> bool {
+        self.actions.iter().any(|action| action.label == label)
+    }
+}
+
+impl NativeTransactionDraft {
+    fn has_action_label(&self, label: &str) -> bool {
+        self.actions.iter().any(|action| action.label == label)
     }
 }


### PR DESCRIPTION
Scope
- Add undo/redo support for folder moves performed through both the legacy folder-tree drag/drop controller and the native folder browser.
- Keep folder move history coherent when the moved folder contains the currently loaded sample by pruning stale play-selection transactions that captured the old loaded path.

Definition of Done
- Moving a folder into another folder registers an undoable transaction.
- Undo moves the folder back and restores database metadata paths.
- Redo moves the folder forward again.
- Stale play-selection transactions no longer block folder-move undo with a loaded-sample path mismatch.

Validation commands
- cargo test -p wavecrate folder_tree_move_supports_undo_and_redo
- cargo test -p wavecrate moving_folder_registers_undo_redo_transaction
- cargo test -p wavecrate folder_move
- cargo test -p wavecrate transaction_group_undoes_and_redoes_as_one_entry
- git diff --check

Known limitations
- None

User review
- User explicitly signed off before merge.