### PR TITLE
Fix folder drag cancel target

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
@@ -123,6 +123,9 @@ fn standard_folder_row(folder: &VisibleFolder, id: String) -> ui::View<GuiMessag
         move || GuiMessage::FolderBrowser(FolderBrowserMessage::ToggleFolderExpansion(id.clone()))
     })
     .interactive_actions(folder_row_actions(id))
+    .pointer_target_if(folder.drag_source && folder.drop_target_active, || {
+        folder_source_drag_cancel_target(folder.id.clone())
+    })
 }
 
 fn folder_row_actions(id: String) -> ui::InteractiveRowActions<GuiMessage> {
@@ -149,6 +152,17 @@ fn folder_row_actions(id: String) -> ui::InteractiveRowActions<GuiMessage> {
                 GuiMessage::FolderBrowser(FolderBrowserMessage::ClearDropTargetUnless(id, position))
             },
         )
+}
+
+fn folder_source_drag_cancel_target(id: String) -> ui::PointerTarget<GuiMessage> {
+    ui::pointer_move_target(true)
+        .on_pointer_move(move |position| {
+            GuiMessage::FolderBrowser(FolderBrowserMessage::ClearDropTargetUnless(
+                id.clone(),
+                position,
+            ))
+        })
+        .key("folder-source-drag-cancel-target")
 }
 
 pub(super) fn folder_tree_label_color(folder: &VisibleFolder) -> Option<ui::Rgba8> {

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/tests.rs
@@ -11,6 +11,7 @@ use crate::native_app::sample_library::folder_browser::model::VisibleFolder;
 use crate::native_app::sample_library::folder_browser::view_contract::TREE_ROW_HEIGHT;
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
+use radiant::runtime::{DeclarativeOwnedRuntimeBridge, SurfaceRuntime};
 use radiant::widgets::TextInputMessage;
 
 #[test]
@@ -225,6 +226,31 @@ fn standard_folder_rows_derive_stable_input_id_from_row_key() {
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::ActivateFolder(folder.id.clone(), Default::default())
         ))
+    );
+}
+
+#[test]
+fn dragged_source_folder_row_clears_active_drop_target_on_hover() {
+    let mut folder = visible_folder_for_tests(false);
+    folder.drag_active = true;
+    folder.drag_source = true;
+    folder.drop_target_active = true;
+    let folder_id = folder.id.clone();
+    let position = ui::Point::new(8.0, 10.0);
+    let bridge = DeclarativeOwnedRuntimeBridge::new(
+        Vec::<GuiMessage>::new(),
+        move |_| folder_row(&folder).fill_width().into_surface(),
+        |state: &mut Vec<GuiMessage>, message| state.push(message),
+    );
+    let mut runtime = SurfaceRuntime::new(bridge, ui::Vector2::new(220.0, TREE_ROW_HEIGHT));
+
+    runtime.dispatch_input_at(position, ui::WidgetInput::pointer_move(position));
+
+    assert_eq!(
+        runtime.bridge().state(),
+        &[GuiMessage::FolderBrowser(
+            FolderBrowserMessage::ClearDropTargetUnless(folder_id, position)
+        )]
     );
 }
 

--- a/src/native_app/sample_library/folder_browser/tests/folder_drag_drop.rs
+++ b/src/native_app/sample_library/folder_browser/tests/folder_drag_drop.rs
@@ -234,6 +234,57 @@ fn folder_drag_preview_tracks_pointer_and_hover_target() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn folder_drag_back_over_source_clears_previous_subfolder_target() {
+    let root = temp_source_root("wavecrate-gui-folder-drag-source-cancel");
+    let drums = root.join("drums");
+    let kicks = drums.join("kicks");
+    let loops = root.join("loops");
+    let nested = loops.join("nested");
+    fs::create_dir_all(&kicks).expect("create kicks folder");
+    fs::create_dir_all(&nested).expect("create nested target folder");
+    fs::write(kicks.join("kick.wav"), [0_u8; 8]).expect("write kick");
+    fs::write(nested.join("loop.wav"), [0_u8; 8]).expect("write loop");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.expand_selected_folder();
+    browser.activate_folder(path_id(&loops));
+    browser.expand_selected_folder();
+
+    browser.apply_folder_drag(
+        path_id(&kicks),
+        DragHandleMessage::started(Point::new(10.0, 20.0)),
+    );
+    browser.apply_message(FolderBrowserMessage::HoverDropTarget(
+        path_id(&nested),
+        Point::new(30.0, 42.0),
+    ));
+    assert_eq!(
+        browser.hovered_drop_target_folder_id(),
+        Some(path_id(&nested)),
+        "the nested folder should initially become the active drop target"
+    );
+
+    browser.apply_message(FolderBrowserMessage::HoverDropTarget(
+        path_id(&kicks),
+        Point::new(30.0, 18.0),
+    ));
+    assert_eq!(
+        browser.hovered_drop_target_folder_id(),
+        None,
+        "hovering the dragged source folder should clear the previous child target"
+    );
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .all(|folder| !folder.drop_target),
+        "no stale folder row should remain the active drop target"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
 #[test]
 fn folder_drag_does_not_arm_external_file_drag() {
     let root = temp_source_root("wavecrate-gui-folder-no-external-drag");


### PR DESCRIPTION
Scope
- Clear stale folder-tree drop targets when a dragged source folder is hovered again.
- Add rendered-row coverage for the source-row clear target.
- Add folder-browser state coverage for dragging to a nested target, then back over the source to cancel.

Definition of Done
- Starting a folder drag, hovering a valid nested folder target, then moving back over the dragged source row clears the active drop target.
- Dropping after returning to the original item cancels instead of using the stale nested target.
- Existing folder drag/drop behavior remains covered.

Validation commands
- cargo fmt
- cargo test -p wavecrate dragged_source_folder_row_clears_active_drop_target_on_hover
- cargo test -p wavecrate folder_drag_drop
- git diff --check

Known limitations
- None

User review is required before merge.