### PR TITLE
OPT-879: add transaction inspector shortcut

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2189,6 +2189,7 @@ Core default shortcuts:
 | `Home` / `End` | Jump to start/end of list or audio file according to focus | Browser or waveform |
 | `Ctrl+Z` | Undo the latest undoable action | Global |
 | `Ctrl+Y` or `Ctrl+Shift+Z` | Redo the latest undone action | Global |
+| `Ctrl+Shift+\` | Toggle the transaction inspector | Global debugging |
 | `Ctrl+C` | Copy selected files or selected waveform audio | Browser or waveform |
 | `Ctrl+V` | Paste copied audio at waveform insertion point or paste files where supported | Waveform or folder target |
 | `Ctrl+X` | Cut selected waveform audio where destructive editing is allowed | Waveform |

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -250,6 +250,8 @@ pub(in crate::native_app) enum GuiMessage {
     SimilarSectionsResolved(SimilarSectionsResult),
     UndoTransaction,
     RedoTransaction,
+    UndoTransactionsThrough(u64),
+    RedoTransactionsThrough(u64),
     ToggleTransactionList,
     CloseTransactionList,
     FocusRenameInput(u64),

--- a/src/native_app/app_chrome/modals.rs
+++ b/src/native_app/app_chrome/modals.rs
@@ -21,6 +21,9 @@ use crate::native_app::app::NativeAppState;
 const SHORTCUT_HELP_MODAL_WIDTH: f32 = 860.0;
 const SHORTCUT_HELP_MODAL_HEIGHT: f32 = 640.0;
 const SHORTCUT_HELP_KEY_WIDTH: f32 = 190.0;
+const TRANSACTION_LIST_MODAL_WIDTH: f32 = 760.0;
+const TRANSACTION_LIST_MODAL_HEIGHT: f32 = 520.0;
+const TRANSACTION_LIST_ACTION_WIDTH: f32 = 70.0;
 
 pub(in crate::native_app) fn transaction_list(state: &NativeAppState) -> ui::View<GuiMessage> {
     let projection = TransactionListProjection::from_state(state);
@@ -56,7 +59,7 @@ pub(in crate::native_app) fn transaction_list(state: &NativeAppState) -> ui::Vie
         "Transactions",
         content,
         ui::WidgetTone::Neutral,
-        ui::Vector2::new(420.0, 300.0),
+        ui::Vector2::new(TRANSACTION_LIST_MODAL_WIDTH, TRANSACTION_LIST_MODAL_HEIGHT),
         GuiMessage::CloseTransactionList,
     )
     .id(identity::TRANSACTION_LIST_MODAL_ID)
@@ -262,11 +265,10 @@ fn shortcut_help_row(item: ShortcutHelpItem) -> ui::View<GuiMessage> {
 
 fn transaction_list_row(row: TransactionListRowProjection) -> ui::View<GuiMessage> {
     ui::row([
-        ui::passive_badge(row.state.label().to_string())
-            .style(transaction_list_state_style(row.state))
-            .size(58.0, 20.0),
+        transaction_list_row_action(&row),
+        ui::text_line(row.order_label, 22.0).width(58.0),
         ui::text_line(row.label, 22.0).fill_width(),
-        ui::text_line(row.action_summary, 22.0).width(150.0),
+        ui::text_line(row.action_summary, 22.0).width(240.0),
     ])
     .key(identity::transaction_list_row_key(row.id))
     .style(ui::WidgetStyle::subtle(ui::WidgetTone::Neutral))
@@ -274,6 +276,23 @@ fn transaction_list_row(row: TransactionListRowProjection) -> ui::View<GuiMessag
     .spacing(6.0)
     .fill_width()
     .height(26.0)
+}
+
+fn transaction_list_row_action(row: &TransactionListRowProjection) -> ui::View<GuiMessage> {
+    match row.state {
+        TransactionListState::Active => ui::passive_badge(row.state.label().to_string())
+            .style(transaction_list_state_style(row.state))
+            .size(TRANSACTION_LIST_ACTION_WIDTH, 20.0),
+        TransactionListState::Undoable => ui::button(row.state.label().to_string())
+            .message(GuiMessage::UndoTransactionsThrough(row.id))
+            .primary()
+            .width(TRANSACTION_LIST_ACTION_WIDTH)
+            .height(20.0),
+        TransactionListState::Redoable => ui::button(row.state.label().to_string())
+            .message(GuiMessage::RedoTransactionsThrough(row.id))
+            .width(TRANSACTION_LIST_ACTION_WIDTH)
+            .height(20.0),
+    }
 }
 
 fn transaction_list_state_style(state: TransactionListState) -> ui::WidgetStyle {

--- a/src/native_app/app_chrome/modals/projection.rs
+++ b/src/native_app/app_chrome/modals/projection.rs
@@ -29,6 +29,7 @@ impl TransactionListProjection {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct TransactionListRowProjection {
     pub(super) id: u64,
+    pub(super) order_label: String,
     pub(super) label: String,
     pub(super) action_summary: String,
     pub(super) state: TransactionListState,
@@ -37,8 +38,15 @@ pub(super) struct TransactionListRowProjection {
 impl TransactionListRowProjection {
     fn from_item(item: TransactionListItem) -> Self {
         let action_summary = transaction_action_summary(&item);
+        let order_label = match item.state {
+            TransactionListState::Active => String::from("Draft"),
+            TransactionListState::Undoable | TransactionListState::Redoable => {
+                format!("#{}", item.id)
+            }
+        };
         Self {
             id: item.id,
+            order_label,
             label: item.label,
             action_summary,
             state: item.state,

--- a/src/native_app/app_chrome/modals/tests.rs
+++ b/src/native_app/app_chrome/modals/tests.rs
@@ -20,9 +20,11 @@ fn transaction_list_projection_formats_summary_and_rows() {
         "undo ready | no redo | open transaction"
     );
     assert_eq!(projection.rows.len(), 2);
+    assert_eq!(projection.rows[0].order_label, "Draft");
     assert_eq!(projection.rows[0].label, "Open batch");
     assert_eq!(projection.rows[0].action_summary, "1 action: First action");
     assert_eq!(projection.rows[0].state.label(), "Open");
+    assert_eq!(projection.rows[1].order_label, "#1");
     assert_eq!(projection.rows[1].label, "Rename sample");
     assert_eq!(projection.rows[1].action_summary, "1 action: Rename sample");
     assert_eq!(projection.rows[1].state.label(), "Undo");

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -154,6 +154,8 @@ impl NativeAppState {
             | GuiMessage::SimilarSectionsResolved(_)
             | GuiMessage::UndoTransaction
             | GuiMessage::RedoTransaction
+            | GuiMessage::UndoTransactionsThrough(_)
+            | GuiMessage::RedoTransactionsThrough(_)
             | GuiMessage::ToggleTransactionList
             | GuiMessage::CloseTransactionList
             | GuiMessage::FocusRenameInput(_)

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -63,6 +63,12 @@ impl NativeAppState {
             }
             GuiMessage::UndoTransaction => self.undo_transaction(),
             GuiMessage::RedoTransaction => self.redo_transaction(),
+            GuiMessage::UndoTransactionsThrough(target_id) => {
+                self.undo_transactions_through(target_id);
+            }
+            GuiMessage::RedoTransactionsThrough(target_id) => {
+                self.redo_transactions_through(target_id);
+            }
             GuiMessage::ToggleTransactionList => self.toggle_transaction_list(),
             GuiMessage::CloseTransactionList => {
                 self.ui.chrome.transaction_list_open = false;

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -191,7 +191,7 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             GuiMessage::ToggleLoopPlayback,
         )
         .bind(
-            ui::KeyPress::with_shift(ui::KeyCode::U),
+            transaction_list_shortcut(),
             GuiMessage::ToggleTransactionList,
         )
         .bind(ui::KeyPress::new(ui::KeyCode::N), new_item_action(state))
@@ -276,6 +276,16 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             GuiMessage::CollapseSelectedFolder,
         );
     bind_undo_shortcuts(bind_collection_shortcuts(layer))
+}
+
+fn transaction_list_shortcut() -> ui::KeyPress {
+    ui::KeyPress {
+        key: ui::KeyCode::Backslash,
+        command: true,
+        control: false,
+        shift: true,
+        alt: false,
+    }
 }
 
 fn bind_undo_shortcuts(layer: ui::ShortcutLayer<GuiMessage>) -> ui::ShortcutLayer<GuiMessage> {

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -183,7 +183,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
                 shortcut_help_item("Command-Z", "Undo"),
                 shortcut_help_item("Command-Shift-Z", "Redo"),
                 shortcut_help_item("Command-Y", "Redo"),
-                shortcut_help_item("Shift-U", "Toggle transaction list"),
+                shortcut_help_item("Command-Shift-\\", "Toggle transaction list"),
             ],
         ),
         shortcut_help_section(

--- a/src/native_app/tests/shortcuts_context/transactions.rs
+++ b/src/native_app/tests/shortcuts_context/transactions.rs
@@ -1,13 +1,33 @@
 use crate::native_app::test_support::state::{GuiMessage, NativeAppState, default_gui_shortcuts};
 use radiant::prelude as ui;
 
+fn transaction_list_shortcut() -> ui::KeyPress {
+    ui::KeyPress {
+        key: ui::KeyCode::Backslash,
+        command: true,
+        control: false,
+        shift: true,
+        alt: false,
+    }
+}
+
 #[test]
-fn shift_u_shortcut_toggles_transaction_list() {
+fn command_shift_backslash_shortcut_toggles_transaction_list() {
     let state = NativeAppState::load_default().expect("default state loads");
-    let resolution =
-        default_gui_shortcuts(&state).resolve(ui::KeyPress::with_shift(ui::KeyCode::U));
+    let resolution = default_gui_shortcuts(&state).resolve(transaction_list_shortcut());
 
     assert_eq!(resolution.action, Some(GuiMessage::ToggleTransactionList));
+    assert!(resolution.handled);
+}
+
+#[test]
+fn transaction_list_modal_escape_closes_transaction_list() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.chrome.transaction_list_open = true;
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Escape));
+
+    assert_eq!(resolution.action, Some(GuiMessage::CloseTransactionList));
     assert!(resolution.handled);
 }
 

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -1,4 +1,5 @@
 use super::gui_state_for_span_tests;
+use crate::native_app::test_support::state::GuiMessage;
 use radiant::prelude::{self as ui, IntoView};
 
 #[test]
@@ -37,6 +38,69 @@ fn transaction_group_undoes_and_redoes_as_one_entry() {
     state.redo_transaction();
     assert_eq!(state.ui.status.sample, "Redid Grouped edit");
     assert_eq!(state.audio.volume, 0.8);
+}
+
+#[test]
+fn transaction_list_modal_open_close_updates_chrome_state() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+
+    assert!(!state.ui.chrome.transaction_list_open);
+    state.apply_message(GuiMessage::ToggleTransactionList, &mut context);
+    assert!(state.ui.chrome.transaction_list_open);
+
+    state.apply_message(GuiMessage::CloseTransactionList, &mut context);
+    assert!(!state.ui.chrome.transaction_list_open);
+}
+
+#[test]
+fn transaction_list_target_undo_and_redo_walk_through_selected_row() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    state.audio.volume = 0.3;
+    state.register_transaction_action(
+        "First volume",
+        |transaction| {
+            transaction.set_audio_volume(0.0);
+            Ok(())
+        },
+        |transaction| {
+            transaction.set_audio_volume(0.1);
+            Ok(())
+        },
+    );
+    state.register_transaction_action(
+        "Second volume",
+        |transaction| {
+            transaction.set_audio_volume(0.1);
+            Ok(())
+        },
+        |transaction| {
+            transaction.set_audio_volume(0.2);
+            Ok(())
+        },
+    );
+    state.register_transaction_action(
+        "Third volume",
+        |transaction| {
+            transaction.set_audio_volume(0.2);
+            Ok(())
+        },
+        |transaction| {
+            transaction.set_audio_volume(0.3);
+            Ok(())
+        },
+    );
+
+    state.apply_message(GuiMessage::UndoTransactionsThrough(2), &mut context);
+
+    assert_eq!(state.audio.volume, 0.1);
+    assert_eq!(state.ui.status.sample, "Undid 2 through Second volume");
+
+    state.apply_message(GuiMessage::RedoTransactionsThrough(3), &mut context);
+
+    assert_eq!(state.audio.volume, 0.3);
+    assert_eq!(state.ui.status.sample, "Redid 2 through Third volume");
 }
 
 #[test]

--- a/src/native_app/transaction_history/app_state.rs
+++ b/src/native_app/transaction_history/app_state.rs
@@ -47,6 +47,31 @@ impl NativeAppState {
         }
     }
 
+    pub(in crate::native_app) fn undo_transactions_through(&mut self, target_id: u64) {
+        let mut history = std::mem::take(&mut self.transactions.history);
+        let was_restoring = self.transactions.restoring;
+        self.transactions.restoring = true;
+        let result = history.undo_through(target_id, self);
+        self.transactions.restoring = was_restoring;
+        self.transactions.history = history;
+        match result {
+            Ok(applied) if applied.is_empty() => {
+                self.ui.status.sample = format!("Transaction #{target_id} is not undoable");
+            }
+            Ok(applied) => {
+                let count = applied.len();
+                let label = applied
+                    .last()
+                    .map(|transaction| transaction.label.as_str())
+                    .unwrap_or("transaction");
+                self.ui.status.sample = format!("Undid {count} through {label}");
+            }
+            Err(error) => {
+                self.ui.status.sample = format!("Undo failed: {error}");
+            }
+        }
+    }
+
     pub(in crate::native_app) fn redo_transaction(&mut self) {
         let mut history = std::mem::take(&mut self.transactions.history);
         let was_restoring = self.transactions.restoring;
@@ -60,6 +85,31 @@ impl NativeAppState {
             }
             Ok(None) => {
                 self.ui.status.sample = String::from("Nothing to redo");
+            }
+            Err(error) => {
+                self.ui.status.sample = format!("Redo failed: {error}");
+            }
+        }
+    }
+
+    pub(in crate::native_app) fn redo_transactions_through(&mut self, target_id: u64) {
+        let mut history = std::mem::take(&mut self.transactions.history);
+        let was_restoring = self.transactions.restoring;
+        self.transactions.restoring = true;
+        let result = history.redo_through(target_id, self);
+        self.transactions.restoring = was_restoring;
+        self.transactions.history = history;
+        match result {
+            Ok(applied) if applied.is_empty() => {
+                self.ui.status.sample = format!("Transaction #{target_id} is not redoable");
+            }
+            Ok(applied) => {
+                let count = applied.len();
+                let label = applied
+                    .last()
+                    .map(|transaction| transaction.label.as_str())
+                    .unwrap_or("transaction");
+                self.ui.status.sample = format!("Redid {count} through {label}");
             }
             Err(error) => {
                 self.ui.status.sample = format!("Redo failed: {error}");

--- a/src/native_app/transaction_history/native.rs
+++ b/src/native_app/transaction_history/native.rs
@@ -207,6 +207,62 @@ impl NativeTransactionHistory {
         Ok(Some(applied))
     }
 
+    pub(in crate::native_app) fn undo_through(
+        &mut self,
+        target_id: u64,
+        state: &mut NativeAppState,
+    ) -> Result<Vec<TransactionApplied>, String> {
+        if !self
+            .undo
+            .iter()
+            .any(|transaction| transaction.id == target_id)
+        {
+            return Ok(Vec::new());
+        }
+
+        let mut applied = Vec::new();
+        loop {
+            let Some(next_id) = self.undo.back().map(|transaction| transaction.id) else {
+                return Ok(applied);
+            };
+            let target_reached = next_id == target_id;
+            if let Some(transaction) = self.undo(state)? {
+                applied.push(transaction);
+            }
+            if target_reached {
+                return Ok(applied);
+            }
+        }
+    }
+
+    pub(in crate::native_app) fn redo_through(
+        &mut self,
+        target_id: u64,
+        state: &mut NativeAppState,
+    ) -> Result<Vec<TransactionApplied>, String> {
+        if !self
+            .redo
+            .iter()
+            .any(|transaction| transaction.id == target_id)
+        {
+            return Ok(Vec::new());
+        }
+
+        let mut applied = Vec::new();
+        loop {
+            let Some(next_id) = self.redo.back().map(|transaction| transaction.id) else {
+                return Ok(applied);
+            };
+            let target_reached = next_id == target_id;
+            if let Some(transaction) = self.redo(state)? {
+                applied.push(transaction);
+            }
+            if target_reached {
+                return Ok(applied);
+            }
+        }
+    }
+
     pub(in crate::native_app) fn can_undo(&self) -> bool {
         !self.undo.is_empty()
     }


### PR DESCRIPTION
## Scope

- Route the transaction inspector modal through `Command-Shift-\` using the native shortcut abstraction.
- Enlarge the transaction inspector modal so transaction labels and action summaries have room to breathe.
- Update shortcut help and `docs/TARGET.md` so the debug shortcut is discoverable and documented.
- Improve the transaction list projection by showing a transaction id column (`#id`) or `Draft` for an open transaction, alongside the stack state, label, and action summary.
- Turn undoable/redoable transaction rows into action buttons: `Undo` walks the normal undo stack through the selected row, and `Redo` walks the normal redo stack through the selected row.
- Add automated coverage for shortcut routing, Escape close routing, modal open/close state, transaction-list projection/rendering, and target-row undo/redo behavior.

## Definition of Done

- Pressing `Command-Shift-\` opens/toggles the transaction inspector modal.
- The modal lists registered transactions in stack order with undo/redo/open state, transaction id/draft state, labels, and action summaries.
- The modal is large enough to read transaction labels and action summaries comfortably.
- Clicking an undoable row undoes everything through that row using normal linear undo semantics.
- Clicking a redoable row redoes everything through that row using normal linear redo semantics.
- Escape and the existing closeable dialog affordance dismiss the modal.
- Tests cover shortcut routing, modal open/close state, projection/rendering with registered transactions, and undo/redo-through-row behavior.

## Validation commands

- `cargo fmt --check` - passed
- `git diff --check` - passed
- `cargo test -p wavecrate transaction_list -- --test-threads=1` - passed
- `cargo test -p wavecrate transaction -- --test-threads=1` - passed
- Prior run: `cargo test -p wavecrate shortcuts_context -- --test-threads=1` - failed in two unrelated fixture tests that expect default assets to include an audio sample:
  - `native_app::tests::shortcuts_context::folder_browser::escape_shortcut_cancels_rename_while_renaming`
  - `native_app::tests::shortcuts_context::transport::x_shortcut_is_consumed_while_renaming`
- Prior run: `cargo test -p wavecrate native_app -- --test-threads=1` - failed in existing/unrelated native-app tests outside this change; transaction-list tests in this run passed.
- Prior run: `bash scripts/agent.sh request` - failed in the existing non-blocking guardrail on unrelated filesystem/database calls in `drag_drop_move.rs`, `sample_map.rs`, `harvest_tracking.rs`, duplicate workflow, and sidebar test setup.

## Known limitations

Broader repo validation currently has unrelated failing tests/guardrails noted above.

## Review requirement

User review is required before merge unless the user has already signed off.
