### PR TITLE
Wavecrate: make filter row labels toggle filter families

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -10,7 +10,9 @@ use self::projection::{
 };
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::view_models::library_sidebar::FilterSectionViewModel;
-use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
+use crate::native_app::sample_library::folder_browser::commands::{
+    FilterFamily, FolderBrowserMessage,
+};
 use crate::native_app::ui::ids as widget_ids;
 
 pub(super) const FILTER_ROW_HEIGHT: f32 = 24.0;
@@ -61,6 +63,9 @@ const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 =
 /// Scope for automation-facing rating filter toggle ids.
 const AUTOMATION_RATING_FILTER_TOGGLE_SCOPE: u64 =
     widget_ids::AUTOMATION_RATING_FILTER_TOGGLE_SCOPE;
+/// Scope for automation-facing filter family label toggles.
+const AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE: u64 =
+    widget_ids::AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE;
 
 pub(super) fn filter_rows(model: &FilterSectionViewModel) -> [ui::View<GuiMessage>; 6] {
     let projection = filter_rows_projection(model);
@@ -86,7 +91,7 @@ pub(super) fn tag_filter_clear_button_id() -> u64 {
 
 fn text_filter_row(projection: TextFilterRowProjection) -> ui::View<GuiMessage> {
     filter_input_row(
-        projection.label,
+        filter_row_label(projection.label, projection.family, projection.enabled),
         filter_text_input(
             projection.value,
             projection.placeholder,
@@ -136,7 +141,7 @@ fn text_filter_row_key(field: TextFilterField) -> &'static str {
 }
 
 fn playback_type_filter_row(row: PlaybackTypeFilterRowProjection) -> ui::View<GuiMessage> {
-    let label = filter_row_label(row.label);
+    let label = filter_row_label(row.label, row.family, row.enabled);
     filter_labeled_control_row(
         label,
         ui::row(
@@ -154,7 +159,7 @@ fn playback_type_filter_row(row: PlaybackTypeFilterRowProjection) -> ui::View<Gu
 
 fn curation_filter_row(row: CurationFilterRowProjection) -> ui::View<GuiMessage> {
     filter_labeled_control_row(
-        filter_row_label(row.label),
+        filter_row_label(row.label, row.family, row.enabled),
         ui::row(
             row.toggles
                 .iter()
@@ -223,7 +228,7 @@ fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     .height(HARVEST_FILTER_CONTROL_HEIGHT);
 
     filter_labeled_control_row_with_height(
-        filter_row_label(row.label),
+        filter_row_label(row.label, row.family, row.enabled),
         controls,
         "filter-harvest-row",
         HARVEST_FILTER_CONTROL_HEIGHT,
@@ -293,7 +298,7 @@ pub(super) fn automation_playback_type_filter_toggle_id(label: &str) -> u64 {
 }
 
 fn rating_filter_row(row: RatingFilterRowProjection) -> ui::View<GuiMessage> {
-    let label = filter_row_label(row.label);
+    let label = filter_row_label(row.label, row.family, row.enabled);
     filter_labeled_control_row(
         label,
         ui::row(
@@ -355,15 +360,32 @@ pub(super) fn automation_rating_filter_toggle_id(label: &str) -> u64 {
 }
 
 fn filter_input_row(
-    label: &'static str,
+    label: ui::View<GuiMessage>,
     control: ui::View<GuiMessage>,
     key: &'static str,
 ) -> ui::View<GuiMessage> {
-    filter_labeled_control_row(filter_row_label(label), control, key)
+    filter_labeled_control_row(label, control, key)
 }
 
-fn filter_row_label(label: &'static str) -> ui::View<GuiMessage> {
-    ui::text_line(label, FILTER_CLEAR_BUTTON_SIZE)
+fn filter_row_label(
+    label: &'static str,
+    family: FilterFamily,
+    enabled: bool,
+) -> ui::View<GuiMessage> {
+    ui::selectable(label, enabled)
+        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
+        .message(move |enabled| {
+            GuiMessage::FolderBrowser(FolderBrowserMessage::SetFilterFamilyEnabled(
+                family, enabled,
+            ))
+        })
+        .id(automation_filter_family_label_toggle_id(label))
+        .size(FILTER_LABEL_WIDTH, FILTER_CLEAR_BUTTON_SIZE)
+}
+
+/// Automation-facing id for a filter family label toggle.
+pub(super) fn automation_filter_family_label_toggle_id(label: &str) -> u64 {
+    ui::stable_widget_id(AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE, label)
 }
 
 fn filter_labeled_control_row(
@@ -448,8 +470,11 @@ mod tests {
     fn filter_model(help_tooltips_enabled: bool) -> FilterSectionViewModel {
         FilterSectionViewModel {
             name_filter: String::new(),
+            name_filter_enabled: false,
             tag_filter: String::new(),
+            tag_filter_enabled: false,
             curation: CurationFilterViewModel {
+                enabled: false,
                 toggles: vec![CurationFilterToggleViewModel {
                     scope: BrowserCurationScope::All,
                     label: "All",
@@ -457,6 +482,7 @@ mod tests {
                 }],
             },
             harvest: HarvestFilterViewModel {
+                enabled: false,
                 toggles: vec![HarvestFilterToggleViewModel {
                     filter: HarvestFilter::NeedsReview,
                     label: "Need",
@@ -466,11 +492,13 @@ mod tests {
                 family_open: false,
                 help_tooltips_enabled,
             },
+            playback_type_enabled: false,
             playback_type_filters: vec![PlaybackTypeFilterToggleViewModel {
                 filter: PlaybackTypeFilter::OneShot,
                 label: "1-Shot",
                 active: false,
             }],
+            rating_enabled: false,
             rating_filters: vec![RatingFilterToggleViewModel {
                 level: 0,
                 label: "U",

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -3,6 +3,7 @@ use crate::native_app::app_chrome::view_models::library_sidebar::{
     HarvestFilterToggleViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
     RatingFilterToggleViewModel,
 };
+use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
     BrowserCurationScope, HarvestFilter, PlaybackTypeFilter,
 };
@@ -26,20 +27,26 @@ pub(super) enum TextFilterField {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct TextFilterRowProjection {
     pub(super) field: TextFilterField,
+    pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) value: String,
+    pub(super) enabled: bool,
     pub(super) placeholder: &'static str,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct PlaybackTypeFilterRowProjection {
+    pub(super) family: FilterFamily,
     pub(super) label: &'static str,
+    pub(super) enabled: bool,
     pub(super) toggles: Vec<PlaybackTypeFilterToggleProjection>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct CurationFilterRowProjection {
+    pub(super) family: FilterFamily,
     pub(super) label: &'static str,
+    pub(super) enabled: bool,
     pub(super) toggles: Vec<CurationFilterToggleProjection>,
 }
 
@@ -52,7 +59,9 @@ pub(super) struct CurationFilterToggleProjection {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct HarvestFilterRowProjection {
+    pub(super) family: FilterFamily,
     pub(super) label: &'static str,
+    pub(super) enabled: bool,
     pub(super) toggles: Vec<HarvestFilterToggleProjection>,
     pub(super) family_available: bool,
     pub(super) family_open: bool,
@@ -76,7 +85,9 @@ pub(super) struct PlaybackTypeFilterToggleProjection {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct RatingFilterRowProjection {
+    pub(super) family: FilterFamily,
     pub(super) label: &'static str,
+    pub(super) enabled: bool,
     pub(super) toggles: Vec<RatingFilterToggleProjection>,
 }
 
@@ -91,20 +102,26 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
     FilterRowsProjection {
         name_filter: TextFilterRowProjection {
             field: TextFilterField::Name,
+            family: FilterFamily::Name,
             label: "Name",
             value: model.name_filter.clone(),
+            enabled: model.name_filter_enabled,
             placeholder: "Any",
         },
         tag_filter: TextFilterRowProjection {
             field: TextFilterField::Tags,
+            family: FilterFamily::Tags,
             label: "Tags",
             value: model.tag_filter.clone(),
+            enabled: model.tag_filter_enabled,
             placeholder: "Any",
         },
         curation: CurationFilterRowProjection::from_view_model(&model.curation),
         harvest: HarvestFilterRowProjection::from_view_model(&model.harvest),
         playback_type: PlaybackTypeFilterRowProjection {
+            family: FilterFamily::PlaybackType,
             label: "Type",
+            enabled: model.playback_type_enabled,
             toggles: model
                 .playback_type_filters
                 .iter()
@@ -112,7 +129,9 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
                 .collect(),
         },
         rating: RatingFilterRowProjection {
+            family: FilterFamily::Rating,
             label: "Ratin",
+            enabled: model.rating_enabled,
             toggles: model
                 .rating_filters
                 .iter()
@@ -125,7 +144,9 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
 impl CurationFilterRowProjection {
     fn from_view_model(model: &CurationFilterViewModel) -> Self {
         Self {
+            family: FilterFamily::Curation,
             label: "Curat",
+            enabled: model.enabled,
             toggles: model
                 .toggles
                 .iter()
@@ -148,7 +169,9 @@ impl CurationFilterToggleProjection {
 impl HarvestFilterRowProjection {
     fn from_view_model(model: &HarvestFilterViewModel) -> Self {
         Self {
+            family: FilterFamily::Harvest,
             label: "Harve",
+            enabled: model.enabled,
             toggles: model
                 .toggles
                 .iter()
@@ -222,8 +245,10 @@ mod tests {
             projection.name_filter,
             TextFilterRowProjection {
                 field: TextFilterField::Name,
+                family: FilterFamily::Name,
                 label: "Name",
                 value: "kick".to_string(),
+                enabled: true,
                 placeholder: "Any",
             }
         );
@@ -231,8 +256,10 @@ mod tests {
             projection.tag_filter,
             TextFilterRowProjection {
                 field: TextFilterField::Tags,
+                family: FilterFamily::Tags,
                 label: "Tags",
                 value: "drum".to_string(),
+                enabled: true,
                 placeholder: "Any",
             }
         );
@@ -243,6 +270,7 @@ mod tests {
         let projection = filter_rows_projection(&filter_model());
 
         assert_eq!(projection.curation.label, "Curat");
+        assert!(projection.curation.enabled);
         assert_eq!(
             projection
                 .curation
@@ -257,6 +285,7 @@ mod tests {
             ]
         );
         assert_eq!(projection.harvest.label, "Harve");
+        assert!(projection.harvest.enabled);
         assert_eq!(
             projection
                 .harvest
@@ -317,6 +346,7 @@ mod tests {
             ]
         );
         assert_eq!(projection.playback_type.label, "Type");
+        assert!(projection.playback_type.enabled);
         assert_eq!(
             projection
                 .playback_type
@@ -330,6 +360,7 @@ mod tests {
             ]
         );
         assert_eq!(projection.rating.label, "Ratin");
+        assert!(projection.rating.enabled);
         assert_eq!(
             projection
                 .rating
@@ -344,8 +375,11 @@ mod tests {
     fn filter_model() -> FilterSectionViewModel {
         FilterSectionViewModel {
             name_filter: "kick".to_string(),
+            name_filter_enabled: true,
             tag_filter: "drum".to_string(),
+            tag_filter_enabled: true,
             curation: CurationFilterViewModel {
+                enabled: true,
                 toggles: vec![
                     CurationFilterToggleViewModel {
                         scope: BrowserCurationScope::All,
@@ -365,6 +399,7 @@ mod tests {
                 ],
             },
             harvest: HarvestFilterViewModel {
+                enabled: true,
                 toggles: vec![
                     HarvestFilterToggleViewModel {
                         filter: HarvestFilter::New,
@@ -416,6 +451,7 @@ mod tests {
                 family_open: false,
                 help_tooltips_enabled: true,
             },
+            playback_type_enabled: true,
             playback_type_filters: vec![
                 PlaybackTypeFilterToggleViewModel {
                     filter: PlaybackTypeFilter::OneShot,
@@ -428,6 +464,7 @@ mod tests {
                     active: true,
                 },
             ],
+            rating_enabled: true,
             rating_filters: vec![
                 RatingFilterToggleViewModel {
                     level: -1,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -1,17 +1,19 @@
 use super::rows::{
     NAME_FILTER_INPUT_ID, RATING_FILTER_SWATCH_SIZE, TAG_FILTER_INPUT_ID,
-    automation_curation_filter_toggle_id, automation_playback_type_filter_toggle_id,
-    automation_rating_filter_toggle_id, empty_filter_message, name_filter_clear_button_id,
-    rating_filter_swatch_color, tag_filter_clear_button_id,
+    automation_curation_filter_toggle_id, automation_filter_family_label_toggle_id,
+    automation_playback_type_filter_toggle_id, automation_rating_filter_toggle_id,
+    empty_filter_message, name_filter_clear_button_id, rating_filter_swatch_color,
+    tag_filter_clear_button_id,
 };
 use super::*;
 use crate::native_app::sample_library::folder_browser::FolderBrowserState;
+use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
     BrowserCurationScope, PlaybackTypeFilter,
 };
 use crate::native_app::ui::ids::HARVEST_FAMILY_TOGGLE_ID;
 use radiant::prelude::IntoView;
-use radiant::widgets::{ButtonMessage, SelectableMessage};
+use radiant::widgets::{ButtonMessage, SelectableMessage, TextInputMessage};
 
 const FILTER_SECTION_TEST_FRAME_HEIGHT: f32 = 220.0;
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -87,6 +87,46 @@ fn filter_section_filter_name_labels_are_compact_and_same_size() {
 }
 
 #[test]
+fn filter_section_filter_labels_dispatch_family_enable_changes() {
+    let mut state = FolderBrowserState::load_default();
+    state.apply_message(FolderBrowserMessage::NameFilterInput(
+        TextInputMessage::Changed {
+            value: String::from("kick"),
+        },
+    ));
+    state.set_rating_filter(1, true);
+    let model = FilterSectionViewModel::from_folder_browser(&state, false);
+
+    assert_eq!(
+        filter_section(&model).view_dispatch_widget_output(
+            automation_filter_family_label_toggle_id("Name"),
+            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
+        ),
+        Some(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Name, false)
+        ))
+    );
+    assert_eq!(
+        filter_section(&model).view_dispatch_widget_output(
+            automation_filter_family_label_toggle_id("Ratin"),
+            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
+        ),
+        Some(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Rating, false)
+        ))
+    );
+    assert_eq!(
+        filter_section(&model).view_dispatch_widget_output(
+            automation_filter_family_label_toggle_id("Tags"),
+            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: true }),
+        ),
+        Some(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::SetFilterFamilyEnabled(FilterFamily::Tags, true)
+        ))
+    );
+}
+
+#[test]
 fn filter_section_projects_curation_scope_toggles_and_dispatches_changes() {
     let mut state = FolderBrowserState::load_default();
     state.set_curation_scope(BrowserCurationScope::Ratings, true);

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -66,10 +66,14 @@ pub(in crate::native_app) struct CollectionRowViewModel {
 
 pub(in crate::native_app) struct FilterSectionViewModel {
     pub(in crate::native_app) name_filter: String,
+    pub(in crate::native_app) name_filter_enabled: bool,
     pub(in crate::native_app) tag_filter: String,
+    pub(in crate::native_app) tag_filter_enabled: bool,
     pub(in crate::native_app) curation: CurationFilterViewModel,
     pub(in crate::native_app) harvest: HarvestFilterViewModel,
+    pub(in crate::native_app) playback_type_enabled: bool,
     pub(in crate::native_app) playback_type_filters: Vec<PlaybackTypeFilterToggleViewModel>,
+    pub(in crate::native_app) rating_enabled: bool,
     pub(in crate::native_app) rating_filters: Vec<RatingFilterToggleViewModel>,
     pub(in crate::native_app) panel_height: f32,
 }
@@ -86,6 +90,7 @@ pub(in crate::native_app) struct HarvestFamilyViewModel {
 }
 
 pub(in crate::native_app) struct CurationFilterViewModel {
+    pub(in crate::native_app) enabled: bool,
     pub(in crate::native_app) toggles: Vec<CurationFilterToggleViewModel>,
 }
 
@@ -96,6 +101,7 @@ pub(in crate::native_app) struct CurationFilterToggleViewModel {
 }
 
 pub(in crate::native_app) struct HarvestFilterViewModel {
+    pub(in crate::native_app) enabled: bool,
     pub(in crate::native_app) toggles: Vec<HarvestFilterToggleViewModel>,
     pub(in crate::native_app) family_available: bool,
     pub(in crate::native_app) family_open: bool,
@@ -251,19 +257,22 @@ impl FilterSectionViewModel {
     ) -> Self {
         Self {
             name_filter: folder_browser.name_filter().to_owned(),
+            name_filter_enabled: folder_browser.name_filter_enabled(),
             tag_filter: folder_browser.tag_filter().to_owned(),
+            tag_filter_enabled: folder_browser.tag_filter_enabled(),
             curation: CurationFilterViewModel {
+                enabled: folder_browser.curation_mode_enabled(),
                 toggles: BROWSER_CURATION_SCOPES
                     .into_iter()
                     .map(|scope| CurationFilterToggleViewModel {
                         scope,
                         label: scope.label(),
-                        active: folder_browser.curation_mode_enabled()
-                            && folder_browser.curation_scope() == scope,
+                        active: folder_browser.curation_scope() == scope,
                     })
                     .collect(),
             },
             harvest: HarvestFilterViewModel {
+                enabled: folder_browser.harvest_filter_enabled(),
                 toggles: HARVEST_FILTERS
                     .into_iter()
                     .map(|filter| HarvestFilterToggleViewModel {
@@ -276,6 +285,7 @@ impl FilterSectionViewModel {
                 family_open: false,
                 help_tooltips_enabled,
             },
+            playback_type_enabled: folder_browser.playback_type_filter_enabled(),
             playback_type_filters: PLAYBACK_TYPE_FILTERS
                 .into_iter()
                 .map(|filter| PlaybackTypeFilterToggleViewModel {
@@ -284,6 +294,7 @@ impl FilterSectionViewModel {
                     active: folder_browser.playback_type_filter().contains(&filter),
                 })
                 .collect(),
+            rating_enabled: folder_browser.rating_filter_enabled(),
             rating_filters: RATING_FILTER_LEVELS
                 .into_iter()
                 .map(|level| RatingFilterToggleViewModel {

--- a/src/native_app/sample_library/folder_browser/commands.rs
+++ b/src/native_app/sample_library/folder_browser/commands.rs
@@ -10,7 +10,7 @@ pub(in crate::native_app) use super::file_move_progress::{
     file_move_conflict_progress_label, file_move_conflict_progress_total,
     folder_move_progress_label, folder_move_progress_total,
 };
-pub(in crate::native_app) use super::messages::FolderBrowserMessage;
+pub(in crate::native_app) use super::messages::{FilterFamily, FolderBrowserMessage};
 pub(in crate::native_app) use super::move_types::{
     FileMoveConflictCompletion, FileMoveConflictResolution, FileMoveConflictResolutionRequest,
     FolderMoveCompletion, FolderMoveDropInput, FolderMoveRequest,

--- a/src/native_app/sample_library/folder_browser/harvest_filter.rs
+++ b/src/native_app/sample_library/folder_browser/harvest_filter.rs
@@ -54,7 +54,7 @@ impl FolderBrowserState {
         files: &mut Vec<&FileEntry>,
         reveal_id: Option<&str>,
     ) {
-        let Some(filter) = self.filters.harvest else {
+        let Some(filter) = self.active_harvest_filter() else {
             return;
         };
         if filter == HarvestFilter::All {

--- a/src/native_app/sample_library/folder_browser/messages.rs
+++ b/src/native_app/sample_library/folder_browser/messages.rs
@@ -8,6 +8,16 @@ use super::curation::BrowserCurationScope;
 use super::harvest_filter::HarvestFilter;
 use super::playback_type_filter::PlaybackTypeFilter;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum FilterFamily {
+    Name,
+    Tags,
+    Curation,
+    Harvest,
+    PlaybackType,
+    Rating,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) enum FolderBrowserMessage {
     AddSource,
@@ -37,6 +47,7 @@ pub(in crate::native_app) enum FolderBrowserMessage {
     RenameInput(TextInputMessage),
     NameFilterInput(TextInputMessage),
     TagFilterInput(TextInputMessage),
+    SetFilterFamilyEnabled(FilterFamily, bool),
     TogglePlaybackTypeFilter(PlaybackTypeFilter, bool),
     ToggleRatingFilter(i8, bool),
     SetCurationScope(BrowserCurationScope, bool),

--- a/src/native_app/sample_library/folder_browser/panel_state.rs
+++ b/src/native_app/sample_library/folder_browser/panel_state.rs
@@ -5,6 +5,7 @@ use super::{
     DEFAULT_COLLECTIONS_PANEL_HEIGHT, FolderBrowserState,
     curation::{BrowserCurationMode, BrowserCurationScope},
     harvest_filter::{HARVEST_FILTERS, HarvestFilter},
+    messages::FilterFamily,
     playback_type_filter::{PLAYBACK_TYPE_FILTERS, PlaybackTypeFilter},
     rating_filter::RATING_FILTER_LEVELS,
 };
@@ -44,11 +45,16 @@ const fn metadata_panel_geometry() -> ui::PanelSectionGeometry {
 #[derive(Clone, Debug, Default)]
 pub(super) struct BrowserFilterState {
     pub(super) name_filter: String,
+    pub(super) name_enabled: bool,
     pub(super) tag_filter: String,
+    pub(super) tags_enabled: bool,
     pub(super) playback_type_filter: BTreeSet<PlaybackTypeFilter>,
+    pub(super) playback_type_enabled: bool,
     pub(super) rating_filter: BTreeSet<i8>,
+    pub(super) rating_enabled: bool,
     pub(super) curation: BrowserCurationMode,
     pub(super) harvest: Option<HarvestFilter>,
+    pub(super) harvest_enabled: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -88,16 +94,32 @@ impl FolderBrowserState {
         self.filters.name_filter.as_str()
     }
 
+    pub(in crate::native_app) fn name_filter_enabled(&self) -> bool {
+        self.filters.name_enabled
+    }
+
     pub(in crate::native_app) fn tag_filter(&self) -> &str {
         self.filters.tag_filter.as_str()
+    }
+
+    pub(in crate::native_app) fn tag_filter_enabled(&self) -> bool {
+        self.filters.tags_enabled
     }
 
     pub(in crate::native_app) fn rating_filter(&self) -> &BTreeSet<i8> {
         &self.filters.rating_filter
     }
 
+    pub(in crate::native_app) fn rating_filter_enabled(&self) -> bool {
+        self.filters.rating_enabled
+    }
+
     pub(in crate::native_app) fn playback_type_filter(&self) -> &BTreeSet<PlaybackTypeFilter> {
         &self.filters.playback_type_filter
+    }
+
+    pub(in crate::native_app) fn playback_type_filter_enabled(&self) -> bool {
+        self.filters.playback_type_enabled
     }
 
     pub(in crate::native_app) fn curation_mode(&self) -> &BrowserCurationMode {
@@ -116,6 +138,10 @@ impl FolderBrowserState {
         self.filters.harvest
     }
 
+    pub(in crate::native_app) fn harvest_filter_enabled(&self) -> bool {
+        self.filters.harvest_enabled
+    }
+
     pub(in crate::native_app) fn apply_name_filter_input(
         &mut self,
         message: radiant::widgets::TextInputMessage,
@@ -128,6 +154,7 @@ impl FolderBrowserState {
             return;
         }
         self.filters.name_filter = value;
+        self.filters.name_enabled = !self.filters.name_filter.trim().is_empty();
         self.clear_listing_reveals();
         self.retain_visible_file_selection_after_filter();
         self.reset_file_view();
@@ -145,7 +172,31 @@ impl FolderBrowserState {
             return;
         }
         self.filters.tag_filter = value;
+        self.filters.tags_enabled = !self.filters.tag_filter.trim().is_empty();
         self.clear_listing_reveals();
+        self.reset_file_view();
+    }
+
+    pub(in crate::native_app) fn set_filter_family_enabled(
+        &mut self,
+        family: FilterFamily,
+        enabled: bool,
+    ) {
+        let changed = match family {
+            FilterFamily::Name => set_bool(&mut self.filters.name_enabled, enabled),
+            FilterFamily::Tags => set_bool(&mut self.filters.tags_enabled, enabled),
+            FilterFamily::Curation => set_bool(&mut self.filters.curation.enabled, enabled),
+            FilterFamily::Harvest => set_bool(&mut self.filters.harvest_enabled, enabled),
+            FilterFamily::PlaybackType => {
+                set_bool(&mut self.filters.playback_type_enabled, enabled)
+            }
+            FilterFamily::Rating => set_bool(&mut self.filters.rating_enabled, enabled),
+        };
+        if !changed {
+            return;
+        }
+        self.clear_listing_reveals();
+        self.retain_visible_file_selection_after_filter();
         self.reset_file_view();
     }
 
@@ -161,6 +212,7 @@ impl FolderBrowserState {
         if !changed {
             return;
         }
+        self.filters.rating_enabled = !self.filters.rating_filter.is_empty();
         self.clear_listing_reveals();
         self.retain_visible_file_selection_after_filter();
         self.reset_file_view();
@@ -180,6 +232,7 @@ impl FolderBrowserState {
             self.filters.playback_type_filter.remove(&filter)
         };
         if changed {
+            self.filters.playback_type_enabled = !self.filters.playback_type_filter.is_empty();
             self.clear_listing_reveals();
             self.reset_file_view();
         }
@@ -214,6 +267,7 @@ impl FolderBrowserState {
             return;
         }
         self.filters.harvest = next;
+        self.filters.harvest_enabled = self.filters.harvest.is_some();
         self.clear_listing_reveals();
         self.retain_visible_file_selection_after_filter();
         self.reset_file_view();
@@ -261,4 +315,12 @@ impl FolderBrowserState {
             ),
         );
     }
+}
+
+fn set_bool(target: &mut bool, value: bool) -> bool {
+    if *target == value {
+        return false;
+    }
+    *target = value;
+    true
 }

--- a/src/native_app/sample_library/folder_browser/sample_queries.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries.rs
@@ -1,8 +1,13 @@
-use std::{cell::Ref, collections::HashMap, path::PathBuf};
+use std::{
+    cell::Ref,
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+};
 
 use super::{
     FileColumnKind, FileEntry, FolderBrowserState, FolderEntry, curation,
     file_columns::sort_kind_for_details_sort,
+    harvest_filter,
     listing::{BrowserListingRevealReason, BrowserListingSnapshot},
     playback_type_filter, rating_filter,
     visible_samples::{VisibleSampleProjectionRequest, VisibleSampleWindowFiles},
@@ -17,6 +22,47 @@ mod subtree;
 mod traversal;
 
 impl FolderBrowserState {
+    pub(super) fn active_name_filter(&self) -> &str {
+        if self.filters.name_enabled {
+            self.filters.name_filter.as_str()
+        } else {
+            ""
+        }
+    }
+
+    pub(super) fn active_required_tags(&self) -> Vec<String> {
+        if self.filters.tags_enabled {
+            filters::parsed_tag_filter(&self.filters.tag_filter)
+        } else {
+            Vec::new()
+        }
+    }
+
+    pub(super) fn active_playback_type_filters(
+        &self,
+    ) -> BTreeSet<playback_type_filter::PlaybackTypeFilter> {
+        if self.filters.playback_type_enabled {
+            self.filters.playback_type_filter.clone()
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    pub(super) fn active_rating_filter(&self) -> BTreeSet<i8> {
+        if self.filters.rating_enabled {
+            self.filters.rating_filter.clone()
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    pub(super) fn active_harvest_filter(&self) -> Option<harvest_filter::HarvestFilter> {
+        self.filters
+            .harvest_enabled
+            .then_some(self.filters.harvest)
+            .flatten()
+    }
+
     pub(in crate::native_app) fn selected_files(&self) -> &[FileEntry] {
         self.selected_folder()
             .map(|folder| folder.files.as_slice())
@@ -31,7 +77,7 @@ impl FolderBrowserState {
         &self,
         sort_tags: Option<&HashMap<String, Vec<String>>>,
     ) -> Vec<&FileEntry> {
-        if self.filters.harvest.is_some() {
+        if self.active_harvest_filter().is_some() {
             let empty_tags = HashMap::new();
             let tags_by_file = sort_tags.unwrap_or(&empty_tags);
             return self.browser_listing_snapshot(tags_by_file).rows().to_vec();
@@ -57,7 +103,7 @@ impl FolderBrowserState {
             return Vec::new();
         }
 
-        let name_query = filters::normalized_name_filter(&self.filters.name_filter);
+        let name_query = filters::normalized_name_filter(self.active_name_filter());
         if let Some(collection) = self.selection.selected_collection {
             let mut paths = Vec::new();
             for folder in self.loaded_source_root_folders() {
@@ -116,8 +162,10 @@ impl FolderBrowserState {
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> BrowserListingSnapshot<'a> {
         let reveal_id = self.active_listing_reveal_id(Some(tags_by_file));
-        let name_query = filters::normalized_name_filter(&self.filters.name_filter);
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
+        let name_query = filters::normalized_name_filter(self.active_name_filter());
+        let required_tags = self.active_required_tags();
+        let playback_type_filters = self.active_playback_type_filters();
+        let rating_filter = self.active_rating_filter();
         let curation_now = curation::now_epoch_seconds();
         let mut files = self.scoped_audio_files_for_listing();
         files.retain(|file| {
@@ -129,9 +177,9 @@ impl FolderBrowserState {
                 && playback_type_filter::playback_type_filter_matches(
                     file,
                     tags_by_file,
-                    &self.filters.playback_type_filter,
+                    &playback_type_filters,
                 )
-                && rating_filter::rating_filter_matches(file, &self.filters.rating_filter)
+                && rating_filter::rating_filter_matches(file, &rating_filter)
                 && curation_filter_allows_file(
                     file,
                     Some(tags_by_file),
@@ -254,14 +302,16 @@ impl FolderBrowserState {
         if self.active_listing_reveal_id(Some(tags_by_file)).is_some() {
             return self.browser_listing_snapshot(tags_by_file).len();
         }
-        let name_query = filters::normalized_name_filter(&self.filters.name_filter);
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filter = &self.filters.playback_type_filter;
+        let name_query = filters::normalized_name_filter(self.active_name_filter());
+        let required_tags = self.active_required_tags();
+        let playback_type_filter = self.active_playback_type_filters();
+        let rating_filter = self.active_rating_filter();
+        let harvest_active = self.active_harvest_filter().is_some();
         if required_tags.is_empty()
             && playback_type_filter.is_empty()
             && self.selection.selected_collection.is_none()
             && !self.filters.curation.enabled
-            && self.filters.harvest.is_none()
+            && !harvest_active
         {
             return self.selected_folder_audio_file_count();
         }
@@ -269,7 +319,7 @@ impl FolderBrowserState {
             if required_tags.is_empty()
                 && playback_type_filter.is_empty()
                 && !self.filters.curation.enabled
-                && self.filters.harvest.is_none()
+                && !harvest_active
             {
                 return self
                     .selected_collection_audio_file_ids_ref(collection)
@@ -277,7 +327,7 @@ impl FolderBrowserState {
             }
             return self.selected_audio_files_matching_tags(tags_by_file).len();
         }
-        if self.filters.curation.enabled || self.filters.harvest.is_some() {
+        if self.filters.curation.enabled || harvest_active {
             return self.selected_audio_files_matching_tags(tags_by_file).len();
         }
         if self.folder_subtree_listing_enabled() {
@@ -289,8 +339,8 @@ impl FolderBrowserState {
                         &name_query,
                         &required_tags,
                         tags_by_file,
-                        &self.filters.rating_filter,
-                        playback_type_filter,
+                        &rating_filter,
+                        &playback_type_filter,
                         None,
                     )
                 })
@@ -306,9 +356,9 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filter,
+                        &playback_type_filter,
                     )
-                    && rating_filter::rating_filter_matches(file, &self.filters.rating_filter)
+                    && rating_filter::rating_filter_matches(file, &rating_filter)
             })
             .count()
     }
@@ -336,7 +386,7 @@ impl FolderBrowserState {
         if self.active_listing_reveal_id(Some(tags_by_file)).is_some() {
             return self.window_from_browser_listing_snapshot(window, tags_by_file);
         }
-        if self.filters.harvest.is_some() {
+        if self.active_harvest_filter().is_some() {
             return self.window_from_browser_listing_snapshot(window, tags_by_file);
         }
         if let Some(collection) = self.selection.selected_collection {
@@ -361,8 +411,8 @@ impl FolderBrowserState {
             );
         }
 
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filter = &self.filters.playback_type_filter;
+        let required_tags = self.active_required_tags();
+        let playback_type_filter = self.active_playback_type_filters();
         let indices =
             self.selected_folder_audio_file_indices_ref_with_sort_tags(folder, Some(tags_by_file));
         if required_tags.is_empty()
@@ -391,7 +441,7 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filter,
+                        &playback_type_filter,
                     )
             })
             .filter_map(|file| {
@@ -423,13 +473,13 @@ impl FolderBrowserState {
                 .browser_listing_snapshot(tags_by_file)
                 .index_of(selected);
         }
-        if self.filters.harvest.is_some() {
+        if self.active_harvest_filter().is_some() {
             return self
                 .browser_listing_snapshot(tags_by_file)
                 .index_of(selected);
         }
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filter = &self.filters.playback_type_filter;
+        let required_tags = self.active_required_tags();
+        let playback_type_filter = self.active_playback_type_filters();
         if let Some(collection) = self.selection.selected_collection {
             if required_tags.is_empty() && playback_type_filter.is_empty() {
                 return self
@@ -463,7 +513,7 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filter,
+                        &playback_type_filter,
                     )
             })
             .position(|file| file.id == selected)
@@ -543,8 +593,9 @@ impl FolderBrowserState {
         folder: &FolderEntry,
         sort_tags: Option<&HashMap<String, Vec<String>>>,
     ) -> Ref<'_, Vec<usize>> {
-        let name_filter = filters::normalized_name_filter(&self.filters.name_filter);
-        let rating_filter_key = rating_filter::rating_filter_key(&self.filters.rating_filter);
+        let name_filter = filters::normalized_name_filter(self.active_name_filter());
+        let active_rating_filter = self.active_rating_filter();
+        let rating_filter_key = rating_filter::rating_filter_key(&active_rating_filter);
         let listing_reveal_id = self.active_listing_reveal_id(sort_tags);
         let curation_key = if sort_tags.is_some() {
             self.filters.curation.cache_key()
@@ -575,7 +626,7 @@ impl FolderBrowserState {
                             && filters::audio_file_matches_name_query(file, &name_filter)
                             && rating_filter_allows_file(
                                 file,
-                                &self.filters.rating_filter,
+                                &active_rating_filter,
                                 listing_reveal_id,
                             )
                             && curation_filter_allows_file(

--- a/src/native_app/sample_library/folder_browser/sample_queries/collection.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries/collection.rs
@@ -31,8 +31,8 @@ impl FolderBrowserState {
         window: ui::VirtualListWindow,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> VisibleSampleWindowFiles<'_> {
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filters = &self.filters.playback_type_filter;
+        let required_tags = self.active_required_tags();
+        let playback_type_filters = self.active_playback_type_filters();
         let ids = self
             .selected_collection_audio_file_ids_ref_with_sort_tags(collection, Some(tags_by_file));
         if required_tags.is_empty()
@@ -60,7 +60,7 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filters,
+                        &playback_type_filters,
                     )
             })
             .filter_map(|file| {
@@ -86,8 +86,9 @@ impl FolderBrowserState {
         collection: SampleCollection,
         sort_tags: Option<&HashMap<String, Vec<String>>>,
     ) -> Ref<'_, Vec<String>> {
-        let name_filter = filters::normalized_name_filter(&self.filters.name_filter);
-        let rating_filter_key = rating_filter::rating_filter_key(&self.filters.rating_filter);
+        let name_filter = filters::normalized_name_filter(self.active_name_filter());
+        let active_rating_filter = self.active_rating_filter();
+        let rating_filter_key = rating_filter::rating_filter_key(&active_rating_filter);
         let collection_key = format!("collection:{}", collection.index());
         let listing_reveal_id = self.active_listing_reveal_id(sort_tags);
         let curation_key = if sort_tags.is_some() {
@@ -118,9 +119,9 @@ impl FolderBrowserState {
                     .iter()
                     .filter(|file| file.belongs_to_collection(collection)),
             );
-            filters::filter_audio_files_by_name(&mut files, &self.filters.name_filter);
+            filters::filter_audio_files_by_name(&mut files, self.active_name_filter());
             files.retain(|file| {
-                rating_filter_allows_file(file, &self.filters.rating_filter, listing_reveal_id)
+                rating_filter_allows_file(file, &active_rating_filter, listing_reveal_id)
             });
             if self.filters.curation.enabled
                 && let Some(tags_by_file) = sort_tags

--- a/src/native_app/sample_library/folder_browser/sample_queries/subtree.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries/subtree.rs
@@ -32,8 +32,8 @@ impl FolderBrowserState {
         window: ui::VirtualListWindow,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> VisibleSampleWindowFiles<'a> {
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filters = &self.filters.playback_type_filter;
+        let required_tags = self.active_required_tags();
+        let playback_type_filters = self.active_playback_type_filters();
         let ids = self.selected_folder_recursive_audio_file_ids_ref_with_sort_tags(
             folder,
             Some(tags_by_file),
@@ -64,7 +64,7 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filters,
+                        &playback_type_filters,
                     )
             })
             .filter_map(|file| {
@@ -84,8 +84,8 @@ impl FolderBrowserState {
         selected: &str,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> Option<usize> {
-        let required_tags = filters::parsed_tag_filter(&self.filters.tag_filter);
-        let playback_type_filters = &self.filters.playback_type_filter;
+        let required_tags = self.active_required_tags();
+        let playback_type_filters = self.active_playback_type_filters();
         let ids = self.selected_folder_recursive_audio_file_ids_ref_with_sort_tags(
             folder,
             Some(tags_by_file),
@@ -105,7 +105,7 @@ impl FolderBrowserState {
                     && playback_type_filter::playback_type_filter_matches(
                         file,
                         tags_by_file,
-                        playback_type_filters,
+                        &playback_type_filters,
                     )
             })
             .position(|file| file.id == selected)
@@ -123,8 +123,9 @@ impl FolderBrowserState {
         folder: &FolderEntry,
         sort_tags: Option<&HashMap<String, Vec<String>>>,
     ) -> Ref<'_, Vec<String>> {
-        let name_filter = filters::normalized_name_filter(&self.filters.name_filter);
-        let rating_filter_key = rating_filter::rating_filter_key(&self.filters.rating_filter);
+        let name_filter = filters::normalized_name_filter(self.active_name_filter());
+        let active_rating_filter = self.active_rating_filter();
+        let rating_filter_key = rating_filter::rating_filter_key(&active_rating_filter);
         let listing_reveal_id = self.active_listing_reveal_id(sort_tags);
         let curation_key = if sort_tags.is_some() {
             self.filters.curation.cache_key()
@@ -146,9 +147,9 @@ impl FolderBrowserState {
             let curation_now = curation::now_epoch_seconds();
             let mut files = Vec::new();
             traversal::collect_audio_files(folder, &mut files);
-            filters::filter_audio_files_by_name(&mut files, &self.filters.name_filter);
+            filters::filter_audio_files_by_name(&mut files, self.active_name_filter());
             files.retain(|file| {
-                rating_filter_allows_file(file, &self.filters.rating_filter, listing_reveal_id)
+                rating_filter_allows_file(file, &active_rating_filter, listing_reveal_id)
                     && curation_filter_allows_file(
                         file,
                         sort_tags,

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -309,6 +309,9 @@ impl FolderBrowserState {
             FolderBrowserMessage::TagFilterInput(message) => {
                 self.apply_tag_filter_input(message);
             }
+            FolderBrowserMessage::SetFilterFamilyEnabled(family, enabled) => {
+                self.set_filter_family_enabled(family, enabled);
+            }
             FolderBrowserMessage::TogglePlaybackTypeFilter(filter, enabled) => {
                 self.set_playback_type_filter(filter, enabled);
             }

--- a/src/native_app/sample_library/folder_browser/tests/file_filters.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_filters.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
     BrowserCurationScope, PlaybackTypeFilter,
 };
@@ -657,6 +658,82 @@ fn name_filter_limits_selected_audio_files_and_clears_hidden_selection() {
             .map(|file| file.name.as_str())
             .collect::<Vec<_>>(),
         vec!["Deep Kick.wav", "Hat.wav", "Snare.wav"]
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn filter_family_labels_disable_filters_without_discarding_selected_values() {
+    let root = temp_source_root("wavecrate-gui-filter-family-enabled");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let kick = drums.join("Deep Kick.wav");
+    let snare = drums.join("Snare.wav");
+    let hat = drums.join("Hat.wav");
+    for file in [&kick, &snare, &hat] {
+        fs::write(file, []).expect("write sample file");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    assert!(browser.set_file_rating_state(&kick, Rating::KEEP_1, false));
+    assert!(browser.set_file_rating_state(&snare, Rating::KEEP_1, false));
+    let tags_by_file = HashMap::from([
+        (path_id(&kick), vec![String::from("drum")]),
+        (path_id(&snare), vec![String::from("drum")]),
+        (path_id(&hat), vec![String::from("metal")]),
+    ]);
+
+    browser.apply_message(FolderBrowserMessage::NameFilterInput(
+        TextInputMessage::Changed {
+            value: String::from("kick"),
+        },
+    ));
+    browser.apply_message(FolderBrowserMessage::TagFilterInput(
+        TextInputMessage::Changed {
+            value: String::from("drum"),
+        },
+    ));
+    browser.apply_message(FolderBrowserMessage::ToggleRatingFilter(1, true));
+
+    assert_eq!(
+        browser
+            .selected_audio_files_matching_tags(&tags_by_file)
+            .into_iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Deep Kick.wav"],
+        "enabled name, tag, and rating rows should combine"
+    );
+
+    browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+        FilterFamily::Name,
+        false,
+    ));
+
+    assert_eq!(browser.name_filter(), "kick");
+    assert_eq!(
+        browser
+            .selected_audio_files_matching_tags(&tags_by_file)
+            .into_iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Deep Kick.wav", "Snare.wav"],
+        "disabled name row should be ignored while tag and rating rows stay active"
+    );
+
+    browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+        FilterFamily::Name,
+        true,
+    ));
+
+    assert_eq!(
+        browser
+            .selected_audio_files_matching_tags(&tags_by_file)
+            .into_iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Deep Kick.wav"],
+        "re-enabling should restore the preserved name filter value"
     );
     let _ = fs::remove_dir_all(root);
 }

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -108,6 +108,9 @@ pub(in crate::native_app) const AUTOMATION_CURATION_FILTER_TOGGLE_SCOPE: u64 =
 /// Scope for automation-facing harvest filter toggle ids.
 pub(in crate::native_app) const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 = FOLDER_FILTERS.id(23);
 pub(in crate::native_app) const HARVEST_FAMILY_TOGGLE_ID: u64 = FOLDER_FILTERS.id(24);
+/// Scope for automation-facing filter family label toggles.
+pub(in crate::native_app) const AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE: u64 =
+    FOLDER_FILTERS.id(25);
 
 pub(in crate::native_app) const COLLECTIONS_SECTION_NODE_ID: u64 = COLLECTIONS.id(2);
 pub(in crate::native_app) const COLLECTIONS_LIST_SCROLL_NODE_ID: u64 = COLLECTIONS.id(3);


### PR DESCRIPTION
## Scope

- Add explicit enabled state for filter families so Name, Tags, Curation, Harvest, Playback Type, and Rating can be toggled independently from their selected values.
- Make filter row labels selectable controls that enable/disable each family while preserving row control values.
- Apply effective filters through folder, subtree, collection, harvest, and cached projection query paths so multiple active families combine and disabled families are ignored.
- Add UI dispatch coverage and folder-browser behavior coverage for combining filters, disabling one family, and restoring preserved values.

## Definition of Done

- Filter labels visibly behave as on/off toggles for their filter family.
- Multiple active filters combine predictably in the sample list.
- Turning a filter off removes only that filter family from matching while preserving its selected value/state.
- Turning it back on restores the previous filter behavior.
- Active/inactive row states are visually clear through the label selectable state in normal and cramped layouts.
- Automated tests cover label dispatch plus combined Name/Tags/Rating filtering, disabled-family ignore behavior, and value preservation.

## Validation commands

- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate file_operations -- --test-threads=1`
- `cargo test -p wavecrate filter_family_labels_disable_filters_without_discarding_selected_values -- --test-threads=1`

## Known limitations

None.

## Review

User review is required before merge.