### PR TITLE
Wavecrate: replace Curation filter options with a dropdown

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -242,6 +242,8 @@ pub(in crate::native_app) enum GuiMessage {
     ToggleShortcutHelp,
     CloseShortcutHelp,
     ToggleHarvestFamilyPanel,
+    ToggleCurationFilterDropdown,
+    CloseCurationFilterDropdown,
     ToggleZeroCrossingSnap,
     ToggleBeatGuides,
     AdjustBeatGuideCount(i8),

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -57,6 +57,7 @@ pub(in crate::native_app) struct ChromeUiState {
     pub(in crate::native_app) sample_map_audition_drag: Option<SampleMapAuditionDragState>,
     pub(in crate::native_app) sample_map_audition_queue: SampleMapAuditionQueueState,
     pub(in crate::native_app) harvest_family_open: bool,
+    pub(in crate::native_app) curation_filter_dropdown_open: bool,
     pub(in crate::native_app) beat_guides_enabled: bool,
     pub(in crate::native_app) beat_guide_count: u8,
 }
@@ -165,6 +166,7 @@ impl ChromeUiState {
             sample_map_audition_drag: None,
             sample_map_audition_queue: SampleMapAuditionQueueState::default(),
             harvest_family_open: false,
+            curation_filter_dropdown_open: false,
             beat_guides_enabled: false,
             beat_guide_count: DEFAULT_BEAT_GUIDE_COUNT,
         }

--- a/src/native_app/app_chrome/center_panel.rs
+++ b/src/native_app/app_chrome/center_panel.rs
@@ -11,7 +11,6 @@ use crate::native_app::app_chrome::view_models::{
 };
 use crate::native_app::app_chrome::waveform_context_menu;
 
-const LIBRARY_SIDEBAR_PADDING: f32 = 4.0;
 const METADATA_PANEL_PADDING: f32 = 6.0;
 const BOTTOM_STATUS_BAR_HEIGHT: f32 = 30.0;
 
@@ -46,7 +45,12 @@ pub(in crate::native_app) fn sample_workspace_region(
 pub(in crate::native_app) fn library_sidebar_overlays(
     state: &NativeAppState,
 ) -> ui::Overlays<GuiMessage> {
-    ui::overlays().floating_opt(metadata_completion_overlay(state))
+    ui::overlays()
+        .floating_opt(metadata_completion_overlay(state))
+        .dismissible_context_menu_opt(
+            curation_filter_dropdown_overlay(state),
+            GuiMessage::CloseCurationFilterDropdown,
+        )
 }
 
 fn metadata_completion_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
@@ -57,10 +61,10 @@ fn metadata_completion_overlay(state: &NativeAppState) -> Option<ui::View<GuiMes
     }
     let tag_field_content_width =
         library_sidebar::tag_field_content_width(state.ui.chrome.folder_panel.size());
-    let inset_x = LIBRARY_SIDEBAR_PADDING + METADATA_PANEL_PADDING;
+    let inset_x = library_sidebar::LIBRARY_SIDEBAR_PADDING + METADATA_PANEL_PADDING;
     let metadata_panel_height = state.library.folder_browser.metadata_panel_height();
     let inset_y = BOTTOM_STATUS_BAR_HEIGHT
-        + LIBRARY_SIDEBAR_PADDING
+        + library_sidebar::LIBRARY_SIDEBAR_PADDING
         + metadata_panel_height
         + library_sidebar::TAG_COMPLETION_POPUP_GAP;
     Some(library_sidebar::tag_completion_overlay(
@@ -69,6 +73,11 @@ fn metadata_completion_overlay(state: &NativeAppState) -> Option<ui::View<GuiMes
         inset_x,
         inset_y,
     ))
+}
+
+fn curation_filter_dropdown_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
+    let model = LibrarySidebarViewModel::from_app_state(state);
+    library_sidebar::curation_filter_dropdown_overlay(&model, BOTTOM_STATUS_BAR_HEIGHT)
 }
 
 pub(in crate::native_app) fn sample_workspace_overlays(

--- a/src/native_app/app_chrome/library_browser/library_sidebar.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar.rs
@@ -22,6 +22,9 @@ use harvest_family::harvest_family_section;
 use source_section::source_selector;
 use tag_editor::tag_editor_section;
 
+pub(in crate::native_app) const LIBRARY_SIDEBAR_PADDING: f32 = 4.0;
+const LIBRARY_SIDEBAR_SECTION_SPACING: f32 = 3.0;
+
 pub(in crate::native_app) use tag_completion::{TAG_COMPLETION_POPUP_GAP, tag_completion_overlay};
 pub(in crate::native_app) use tag_entry_layout::tag_field_content_width;
 #[cfg(test)]
@@ -34,6 +37,27 @@ pub(in crate::native_app) fn library_sidebar(
     library_sidebar_content(model)
         .width(sidebar_width)
         .fill_height()
+}
+
+pub(in crate::native_app) fn curation_filter_dropdown_overlay(
+    model: &LibrarySidebarViewModel,
+    bottom_status_bar_height: f32,
+) -> Option<ui::View<GuiMessage>> {
+    let harvest_family_inset = model
+        .harvest_family
+        .is_some()
+        .then_some(harvest_family::HARVEST_FAMILY_SECTION_HEIGHT + LIBRARY_SIDEBAR_SECTION_SPACING)
+        .unwrap_or(0.0);
+    let filter_bottom_inset = bottom_status_bar_height
+        + LIBRARY_SIDEBAR_PADDING
+        + model.metadata_panel_height
+        + LIBRARY_SIDEBAR_SECTION_SPACING
+        + harvest_family_inset;
+    filter_section::curation_filter_dropdown_overlay(
+        &model.filter,
+        LIBRARY_SIDEBAR_PADDING,
+        filter_bottom_inset,
+    )
 }
 
 fn library_sidebar_content(model: LibrarySidebarViewModel) -> ui::View<GuiMessage> {
@@ -53,9 +77,9 @@ fn library_sidebar_content(model: LibrarySidebarViewModel) -> ui::View<GuiMessag
         model.metadata_panel_height,
     ));
     ui::column(sections)
-        .spacing(3.0)
+        .spacing(LIBRARY_SIDEBAR_SECTION_SPACING)
         .fill_width()
-        .padding_x(4.0)
+        .padding_x(LIBRARY_SIDEBAR_PADDING)
         .style(ui::WidgetStyle::default())
         .fill_height()
 }

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
@@ -12,9 +12,13 @@ mod rows;
 #[cfg(test)]
 mod tests;
 
-use rows::{FILTER_CONTROLS_CONTENT_HEIGHT, FILTER_ROW_SPACING, filter_rows};
+use rows::{
+    FILTER_CLEAR_BUTTON_SIZE, FILTER_CONTROLS_CONTENT_HEIGHT, FILTER_LABEL_CONTROL_SPACING,
+    FILTER_LABEL_WIDTH, FILTER_ROW_HEIGHT, FILTER_ROW_SPACING, curation_filter_dropdown_menu,
+    filter_rows,
+};
 
-const FILTER_PANEL_PADDING: f32 = 6.0;
+pub(super) const FILTER_PANEL_PADDING: f32 = 6.0;
 #[cfg(test)]
 const FILTER_PANEL_HEADER_HEIGHT: f32 = SIDEBAR_PANEL_HEADER_HEIGHT;
 const FILTER_PANEL_HEADER_CONTENT_SPACING: f32 = SIDEBAR_PANEL_HEADER_CONTENT_SPACING;
@@ -23,6 +27,7 @@ const FILTER_RESIZE_HEADER_ID: u64 = widget_ids::FILTER_RESIZE_HEADER_ID;
 
 #[cfg(test)]
 const FILTER_SECTION_NODE_ID: u64 = widget_ids::FILTER_SECTION_NODE_ID;
+const CURATION_FILTER_ROW_INDEX: usize = 2;
 
 pub(super) fn filter_section(model: &FilterSectionViewModel) -> ui::View<GuiMessage> {
     let panel = ui::panel_section_from_header_parts(
@@ -38,7 +43,6 @@ pub(super) fn filter_section(model: &FilterSectionViewModel) -> ui::View<GuiMess
         .spacing(FILTER_PANEL_HEADER_CONTENT_SPACING),
     )
     .fill_width();
-
     #[cfg(test)]
     {
         panel.id(FILTER_SECTION_NODE_ID)
@@ -51,7 +55,6 @@ pub(super) fn filter_section(model: &FilterSectionViewModel) -> ui::View<GuiMess
 
 fn filter_controls(model: &FilterSectionViewModel) -> ui::View<GuiMessage> {
     let rows = filter_rows(model);
-
     ui::scroll(
         ui::column(rows)
             .fill_width()
@@ -62,4 +65,33 @@ fn filter_controls(model: &FilterSectionViewModel) -> ui::View<GuiMessage> {
     .id(FILTER_SECTION_SCROLL_NODE_ID)
     .fill_width()
     .fill_height()
+}
+
+pub(super) fn curation_filter_dropdown_overlay(
+    model: &FilterSectionViewModel,
+    sidebar_inset_x: f32,
+    filter_bottom_inset: f32,
+) -> Option<ui::View<GuiMessage>> {
+    let (menu, size) = curation_filter_dropdown_menu(model)?;
+    let trigger_bottom_from_filter_top = FILTER_PANEL_PADDING
+        + SIDEBAR_PANEL_HEADER_HEIGHT
+        + FILTER_PANEL_HEADER_CONTENT_SPACING
+        + CURATION_FILTER_ROW_INDEX as f32 * (FILTER_ROW_HEIGHT + FILTER_ROW_SPACING)
+        + FILTER_CLEAR_BUTTON_SIZE;
+    let trigger_bottom_inset =
+        filter_bottom_inset + (model.panel_height - trigger_bottom_from_filter_top).max(0.0);
+    let menu_bottom_inset = (trigger_bottom_inset - FILTER_ROW_SPACING - size.y).max(0.0);
+    let menu_inset_x =
+        sidebar_inset_x + FILTER_PANEL_PADDING + FILTER_LABEL_WIDTH + FILTER_LABEL_CONTROL_SPACING;
+    Some(
+        ui::anchored_layer(
+            menu,
+            size,
+            ui::LayerHorizontalAnchor::Start,
+            ui::LayerVerticalAnchor::End,
+            menu_inset_x,
+            menu_bottom_inset,
+        )
+        .key("curation-filter-dropdown-overlay"),
+    )
 }

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -3,7 +3,7 @@ use radiant::{prelude as ui, widgets::TextInputMessage};
 mod projection;
 
 use self::projection::{
-    CurationFilterRowProjection, CurationFilterToggleProjection, HarvestFilterRowProjection,
+    CurationFilterOptionProjection, CurationFilterRowProjection, HarvestFilterRowProjection,
     HarvestFilterToggleProjection, PlaybackTypeFilterRowProjection,
     PlaybackTypeFilterToggleProjection, RatingFilterRowProjection, RatingFilterToggleProjection,
     TextFilterField, TextFilterRowProjection, filter_rows_projection,
@@ -17,14 +17,13 @@ use crate::native_app::ui::ids as widget_ids;
 
 pub(super) const FILTER_ROW_HEIGHT: f32 = 24.0;
 pub(super) const FILTER_ROW_SPACING: f32 = 1.0;
-const FILTER_CLEAR_BUTTON_SIZE: f32 = 20.0;
-const FILTER_LABEL_WIDTH: f32 = 54.0;
+pub(super) const FILTER_CLEAR_BUTTON_SIZE: f32 = 20.0;
+pub(super) const FILTER_LABEL_WIDTH: f32 = 54.0;
 const FILTER_CONTROL_SPACING: f32 = 2.0;
-const FILTER_LABEL_CONTROL_SPACING: f32 = 6.0;
+pub(super) const FILTER_LABEL_CONTROL_SPACING: f32 = 6.0;
 const HARVEST_FILTER_CONTROL_HEIGHT: f32 = FILTER_CLEAR_BUTTON_SIZE * 2.0 + FILTER_CONTROL_SPACING;
 pub(super) const FILTER_CONTROLS_CONTENT_HEIGHT: f32 =
     FILTER_ROW_HEIGHT * 5.0 + HARVEST_FILTER_CONTROL_HEIGHT + FILTER_ROW_SPACING * 5.0;
-const CURATION_FILTER_TOGGLE_WIDTH: f32 = 46.0;
 const HARVEST_FAMILY_TOGGLE_WIDTH: f32 = 22.0;
 const HARVEST_FILTER_TOGGLE_WIDTH: f32 = 30.0;
 const HARVEST_FILTER_TOP_ROW_TOGGLE_COUNT: usize = 4;
@@ -54,9 +53,10 @@ pub(super) const TAG_FILTER_INPUT_ID: u64 = widget_ids::TAG_FILTER_INPUT_ID;
 /// Scope for automation-facing playback-type filter toggle ids.
 const AUTOMATION_PLAYBACK_TYPE_FILTER_TOGGLE_SCOPE: u64 =
     widget_ids::AUTOMATION_PLAYBACK_TYPE_FILTER_TOGGLE_SCOPE;
-/// Scope for automation-facing curation filter toggle ids.
-const AUTOMATION_CURATION_FILTER_TOGGLE_SCOPE: u64 =
-    widget_ids::AUTOMATION_CURATION_FILTER_TOGGLE_SCOPE;
+const AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
+    widget_ids::AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE;
+pub(super) const CURATION_FILTER_DROPDOWN_TRIGGER_ID: u64 =
+    widget_ids::CURATION_FILTER_DROPDOWN_TRIGGER_ID;
 /// Scope for automation-facing harvest filter toggle ids.
 const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 =
     widget_ids::AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE;
@@ -160,33 +160,79 @@ fn playback_type_filter_row(row: PlaybackTypeFilterRowProjection) -> ui::View<Gu
 fn curation_filter_row(row: CurationFilterRowProjection) -> ui::View<GuiMessage> {
     filter_labeled_control_row(
         filter_row_label(row.label, row.family, row.enabled),
-        ui::row(
-            row.toggles
-                .iter()
-                .map(curation_filter_toggle)
-                .collect::<Vec<_>>(),
-        )
-        .spacing(FILTER_CONTROL_SPACING)
-        .fill_width()
-        .height(FILTER_CLEAR_BUTTON_SIZE),
+        ui::dropdown_trigger(row.selected_label, row.dropdown_open)
+            .toggle_message(GuiMessage::ToggleCurationFilterDropdown)
+            .build()
+            .id(CURATION_FILTER_DROPDOWN_TRIGGER_ID)
+            .fill_width()
+            .height(FILTER_CLEAR_BUTTON_SIZE),
         "filter-curation-row",
     )
 }
 
-fn curation_filter_toggle(toggle: &CurationFilterToggleProjection) -> ui::View<GuiMessage> {
-    let scope = toggle.scope;
-    ui::selectable(toggle.label, toggle.active)
-        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
-        .message(move |enabled| {
-            GuiMessage::FolderBrowser(FolderBrowserMessage::SetCurationScope(scope, enabled))
-        })
-        .id(automation_curation_filter_toggle_id(toggle.label))
-        .size(CURATION_FILTER_TOGGLE_WIDTH, FILTER_CLEAR_BUTTON_SIZE)
+pub(super) fn curation_filter_dropdown_menu(
+    model: &FilterSectionViewModel,
+) -> Option<(ui::View<GuiMessage>, ui::Vector2)> {
+    let row = filter_rows_projection(model).curation;
+    if row.dropdown_open {
+        let size = ui::Vector2::new(
+            f32::from(row.menu_width).max(1.0),
+            ui::dropdown_menu_height(row.options.len()),
+        );
+        Some((
+            curation_filter_dropdown_menu_from_options(&row.options, size.x),
+            size,
+        ))
+    } else {
+        None
+    }
 }
 
-/// Automation-facing id for a curation filter toggle.
-pub(super) fn automation_curation_filter_toggle_id(label: &str) -> u64 {
-    ui::stable_widget_id(AUTOMATION_CURATION_FILTER_TOGGLE_SCOPE, label)
+fn curation_filter_dropdown_menu_from_options(
+    options: &[CurationFilterOptionProjection],
+    menu_width: f32,
+) -> ui::View<GuiMessage> {
+    let option_count = options.len();
+    ui::column(options.iter().map(curation_filter_dropdown_option))
+        .key("curation-filter-dropdown-menu")
+        .style(ui::WidgetStyle {
+            tone: ui::WidgetTone::Neutral,
+            prominence: ui::WidgetProminence::Strong,
+        })
+        .padding(4.0)
+        .spacing(3.0)
+        .width(menu_width.max(1.0))
+        .height(ui::dropdown_menu_height(option_count))
+}
+
+fn curation_filter_dropdown_option(
+    option: &CurationFilterOptionProjection,
+) -> ui::View<GuiMessage> {
+    let scope = option.scope;
+    ui::button(option.label)
+        .message(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::SetCurationScope(scope, true),
+        ))
+        .id(automation_curation_filter_dropdown_option_id(option.label))
+        .style(ui::WidgetStyle {
+            tone: if option.selected {
+                ui::WidgetTone::Accent
+            } else {
+                ui::WidgetTone::Neutral
+            },
+            prominence: if option.selected {
+                ui::WidgetProminence::Strong
+            } else {
+                ui::WidgetProminence::Subtle
+            },
+        })
+        .fill_width()
+        .height(22.0)
+}
+
+/// Automation-facing id for a curation dropdown option.
+pub(super) fn automation_curation_filter_dropdown_option_id(label: &str) -> u64 {
+    ui::stable_widget_id(AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE, label)
 }
 
 fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
@@ -445,7 +491,7 @@ pub(super) fn empty_filter_message() -> TextInputMessage {
 mod tests {
     use super::*;
     use crate::native_app::app_chrome::view_models::library_sidebar::{
-        CurationFilterToggleViewModel, CurationFilterViewModel, FilterSectionViewModel,
+        CurationFilterOptionViewModel, CurationFilterViewModel, FilterSectionViewModel,
         HarvestFilterToggleViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
         RatingFilterToggleViewModel,
     };
@@ -469,16 +515,18 @@ mod tests {
 
     fn filter_model(help_tooltips_enabled: bool) -> FilterSectionViewModel {
         FilterSectionViewModel {
+            sidebar_width: 240.0,
             name_filter: String::new(),
             name_filter_enabled: false,
             tag_filter: String::new(),
             tag_filter_enabled: false,
             curation: CurationFilterViewModel {
                 enabled: false,
-                toggles: vec![CurationFilterToggleViewModel {
+                dropdown_open: false,
+                selected_scope: BrowserCurationScope::All,
+                options: vec![CurationFilterOptionViewModel {
                     scope: BrowserCurationScope::All,
                     label: "All",
-                    active: false,
                 }],
             },
             harvest: HarvestFilterViewModel {

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -1,5 +1,5 @@
 use crate::native_app::app_chrome::view_models::library_sidebar::{
-    CurationFilterToggleViewModel, CurationFilterViewModel, FilterSectionViewModel,
+    CurationFilterOptionViewModel, CurationFilterViewModel, FilterSectionViewModel,
     HarvestFilterToggleViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
     RatingFilterToggleViewModel,
 };
@@ -47,14 +47,17 @@ pub(super) struct CurationFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
-    pub(super) toggles: Vec<CurationFilterToggleProjection>,
+    pub(super) dropdown_open: bool,
+    pub(super) menu_width: u16,
+    pub(super) selected_label: &'static str,
+    pub(super) options: Vec<CurationFilterOptionProjection>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct CurationFilterToggleProjection {
+pub(super) struct CurationFilterOptionProjection {
     pub(super) scope: BrowserCurationScope,
     pub(super) label: &'static str,
-    pub(super) active: bool,
+    pub(super) selected: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -116,7 +119,10 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             enabled: model.tag_filter_enabled,
             placeholder: "Any",
         },
-        curation: CurationFilterRowProjection::from_view_model(&model.curation),
+        curation: CurationFilterRowProjection::from_view_model(
+            &model.curation,
+            model.sidebar_width,
+        ),
         harvest: HarvestFilterRowProjection::from_view_model(&model.harvest),
         playback_type: PlaybackTypeFilterRowProjection {
             family: FilterFamily::PlaybackType,
@@ -142,26 +148,47 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
 }
 
 impl CurationFilterRowProjection {
-    fn from_view_model(model: &CurationFilterViewModel) -> Self {
+    fn from_view_model(model: &CurationFilterViewModel, sidebar_width: f32) -> Self {
         Self {
             family: FilterFamily::Curation,
             label: "Curat",
             enabled: model.enabled,
-            toggles: model
-                .toggles
+            dropdown_open: model.dropdown_open,
+            menu_width: curation_dropdown_menu_width(sidebar_width),
+            selected_label: model
+                .options
                 .iter()
-                .map(CurationFilterToggleProjection::from_view_model)
+                .find(|option| option.scope == model.selected_scope)
+                .map(|option| option.label)
+                .unwrap_or_else(|| model.selected_scope.label()),
+            options: model
+                .options
+                .iter()
+                .map(|option| {
+                    CurationFilterOptionProjection::from_view_model(option, model.selected_scope)
+                })
                 .collect(),
         }
     }
 }
 
-impl CurationFilterToggleProjection {
-    fn from_view_model(model: &CurationFilterToggleViewModel) -> Self {
+fn curation_dropdown_menu_width(sidebar_width: f32) -> u16 {
+    let section_padding = super::super::FILTER_PANEL_PADDING * 2.0;
+    let content_width = sidebar_width - section_padding;
+    (content_width - super::FILTER_LABEL_WIDTH - super::FILTER_LABEL_CONTROL_SPACING)
+        .max(1.0)
+        .round() as u16
+}
+
+impl CurationFilterOptionProjection {
+    fn from_view_model(
+        model: &CurationFilterOptionViewModel,
+        selected_scope: BrowserCurationScope,
+    ) -> Self {
         Self {
             scope: model.scope,
             label: model.label,
-            active: model.active,
+            selected: model.scope == selected_scope,
         }
     }
 }
@@ -266,17 +293,19 @@ mod tests {
     }
 
     #[test]
-    fn filter_rows_projection_preserves_toggle_order_and_state() {
+    fn filter_rows_projection_preserves_dropdown_options_and_filter_state() {
         let projection = filter_rows_projection(&filter_model());
 
         assert_eq!(projection.curation.label, "Curat");
         assert!(projection.curation.enabled);
+        assert!(projection.curation.dropdown_open);
+        assert_eq!(projection.curation.selected_label, "All");
         assert_eq!(
             projection
                 .curation
-                .toggles
+                .options
                 .iter()
-                .map(|toggle| (toggle.scope, toggle.label, toggle.active))
+                .map(|option| (option.scope, option.label, option.selected))
                 .collect::<Vec<_>>(),
             vec![
                 (BrowserCurationScope::All, "All", true),
@@ -374,27 +403,27 @@ mod tests {
 
     fn filter_model() -> FilterSectionViewModel {
         FilterSectionViewModel {
+            sidebar_width: 240.0,
             name_filter: "kick".to_string(),
             name_filter_enabled: true,
             tag_filter: "drum".to_string(),
             tag_filter_enabled: true,
             curation: CurationFilterViewModel {
                 enabled: true,
-                toggles: vec![
-                    CurationFilterToggleViewModel {
+                dropdown_open: true,
+                selected_scope: BrowserCurationScope::All,
+                options: vec![
+                    CurationFilterOptionViewModel {
                         scope: BrowserCurationScope::All,
                         label: "All",
-                        active: true,
                     },
-                    CurationFilterToggleViewModel {
+                    CurationFilterOptionViewModel {
                         scope: BrowserCurationScope::Ratings,
                         label: "Rate",
-                        active: false,
                     },
-                    CurationFilterToggleViewModel {
+                    CurationFilterOptionViewModel {
                         scope: BrowserCurationScope::Tags,
                         label: "Tags",
-                        active: false,
                     },
                 ],
             },

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -1,9 +1,9 @@
 use super::rows::{
-    NAME_FILTER_INPUT_ID, RATING_FILTER_SWATCH_SIZE, TAG_FILTER_INPUT_ID,
-    automation_curation_filter_toggle_id, automation_filter_family_label_toggle_id,
-    automation_playback_type_filter_toggle_id, automation_rating_filter_toggle_id,
-    empty_filter_message, name_filter_clear_button_id, rating_filter_swatch_color,
-    tag_filter_clear_button_id,
+    CURATION_FILTER_DROPDOWN_TRIGGER_ID, NAME_FILTER_INPUT_ID, RATING_FILTER_SWATCH_SIZE,
+    TAG_FILTER_INPUT_ID, automation_curation_filter_dropdown_option_id,
+    automation_filter_family_label_toggle_id, automation_playback_type_filter_toggle_id,
+    automation_rating_filter_toggle_id, empty_filter_message, name_filter_clear_button_id,
+    rating_filter_swatch_color, tag_filter_clear_button_id,
 };
 use super::*;
 use crate::native_app::sample_library::folder_browser::FolderBrowserState;

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -127,10 +127,10 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
 }
 
 #[test]
-fn filter_section_projects_curation_scope_toggles_and_dispatches_changes() {
+fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
     let mut state = FolderBrowserState::load_default();
     state.set_curation_scope(BrowserCurationScope::Ratings, true);
-    let model = FilterSectionViewModel::from_folder_browser(&state, false);
+    let mut model = FilterSectionViewModel::from_folder_browser(&state, false);
     let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
         240.0,
         FILTER_SECTION_TEST_FRAME_HEIGHT,
@@ -139,40 +139,72 @@ fn filter_section_projects_curation_scope_toggles_and_dispatches_changes() {
     assert!(
         frame
             .paint_plan
-            .first_widget_rect(automation_curation_filter_toggle_id("All"))
+            .first_widget_rect(CURATION_FILTER_DROPDOWN_TRIGGER_ID)
             .is_some()
     );
-    assert!(
-        frame
-            .paint_plan
-            .first_widget_rect(automation_curation_filter_toggle_id("Rate"))
-            .is_some()
-    );
-    assert!(
-        frame
-            .paint_plan
-            .first_widget_rect(automation_curation_filter_toggle_id("Tags"))
-            .is_some()
-    );
-    assert!(frame.paint_plan.contains_text("All"));
-    assert!(frame.paint_plan.contains_text("Rate"));
-    assert!(frame.paint_plan.contains_text("Tags"));
+    assert!(frame.paint_plan.contains_text("Rate  v"));
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
-            automation_curation_filter_toggle_id("Tags"),
-            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: true }),
+            CURATION_FILTER_DROPDOWN_TRIGGER_ID,
+            ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
+        Some(GuiMessage::ToggleCurationFilterDropdown)
+    );
+
+    model.curation.dropdown_open = true;
+    let open_frame = filter_section(&model).view_frame_at_size_with_default_theme(
+        ui::Vector2::new(240.0, FILTER_SECTION_TEST_FRAME_HEIGHT),
+    );
+    assert!(
+        open_frame
+            .paint_plan
+            .first_widget_rect(CURATION_FILTER_DROPDOWN_TRIGGER_ID)
+            .is_some()
+    );
+    assert_eq!(
+        open_frame
+            .paint_plan
+            .first_widget_rect(automation_curation_filter_dropdown_option_id("All")),
+        None,
+        "curation menu options should render in the sidebar overlay, not inside the clipped filter section"
+    );
+
+    let overlay_frame = curation_filter_dropdown_overlay(&model, 4.0, 167.0)
+        .expect("open curation dropdown should project an overlay menu");
+    let overlay_frame = overlay_frame.view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+    let all_rect = overlay_frame
+        .paint_plan
+        .first_widget_rect(automation_curation_filter_dropdown_option_id("All"))
+        .expect("All option should render in the overlay");
+    let rate_rect = overlay_frame
+        .paint_plan
+        .first_widget_rect(automation_curation_filter_dropdown_option_id("Rate"))
+        .expect("Rate option should render in the overlay");
+    let tags_rect = overlay_frame
+        .paint_plan
+        .first_widget_rect(automation_curation_filter_dropdown_option_id("Tags"))
+        .expect("Tags option should render in the overlay");
+    assert!(all_rect.min.x > 0.0);
+    assert!(
+        (120.0..=180.0).contains(&all_rect.width()),
+        "curation overlay options should stay fixed to the compact sidebar control width, got {}",
+        all_rect.width()
+    );
+    assert!(all_rect.max.x <= 240.0);
+    assert!(rate_rect.min.y > all_rect.min.y);
+    assert!(tags_rect.min.y > rate_rect.min.y);
+    assert_eq!(
+        curation_filter_dropdown_overlay(&model, 4.0, 167.0)
+            .expect("open curation dropdown should project an overlay menu")
+            .view_dispatch_widget_output(
+                automation_curation_filter_dropdown_option_id("Tags"),
+                ui::WidgetOutput::typed(ButtonMessage::Activate),
+            ),
         Some(GuiMessage::FolderBrowser(
             FolderBrowserMessage::SetCurationScope(BrowserCurationScope::Tags, true)
-        ))
-    );
-    assert_eq!(
-        filter_section(&model).view_dispatch_widget_output(
-            automation_curation_filter_toggle_id("Rate"),
-            ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
-        ),
-        Some(GuiMessage::FolderBrowser(
-            FolderBrowserMessage::SetCurationScope(BrowserCurationScope::Ratings, false)
         ))
     );
 }

--- a/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/harvest_family.rs
@@ -4,7 +4,7 @@ use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::view_models::library_sidebar::HarvestFamilyViewModel;
 use crate::native_app::ui::ids as widget_ids;
 
-const HARVEST_FAMILY_SECTION_HEIGHT: f32 = 106.0;
+pub(super) const HARVEST_FAMILY_SECTION_HEIGHT: f32 = 106.0;
 const HARVEST_FAMILY_ROW_HEIGHT: f32 = 18.0;
 const HARVEST_FAMILY_ACTION_HEIGHT: f32 = 20.0;
 const HARVEST_FAMILY_LABEL_WIDTH: f32 = 50.0;

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -65,6 +65,7 @@ pub(in crate::native_app) struct CollectionRowViewModel {
 }
 
 pub(in crate::native_app) struct FilterSectionViewModel {
+    pub(in crate::native_app) sidebar_width: f32,
     pub(in crate::native_app) name_filter: String,
     pub(in crate::native_app) name_filter_enabled: bool,
     pub(in crate::native_app) tag_filter: String,
@@ -91,13 +92,14 @@ pub(in crate::native_app) struct HarvestFamilyViewModel {
 
 pub(in crate::native_app) struct CurationFilterViewModel {
     pub(in crate::native_app) enabled: bool,
-    pub(in crate::native_app) toggles: Vec<CurationFilterToggleViewModel>,
+    pub(in crate::native_app) dropdown_open: bool,
+    pub(in crate::native_app) selected_scope: BrowserCurationScope,
+    pub(in crate::native_app) options: Vec<CurationFilterOptionViewModel>,
 }
 
-pub(in crate::native_app) struct CurationFilterToggleViewModel {
+pub(in crate::native_app) struct CurationFilterOptionViewModel {
     pub(in crate::native_app) scope: BrowserCurationScope,
     pub(in crate::native_app) label: &'static str,
-    pub(in crate::native_app) active: bool,
 }
 
 pub(in crate::native_app) struct HarvestFilterViewModel {
@@ -159,6 +161,8 @@ impl LibrarySidebarViewModel {
         filter.harvest.family_available =
             harvest_family.is_some() || state.selected_harvest_family_available();
         filter.harvest.family_open = state.ui.chrome.harvest_family_open;
+        filter.curation.dropdown_open = state.ui.chrome.curation_filter_dropdown_open;
+        filter.sidebar_width = state.ui.chrome.folder_panel.size();
         Self {
             sidebar_width: state.ui.chrome.folder_panel.size(),
             metadata_panel_height: folder_browser.metadata_panel_height(),
@@ -256,18 +260,20 @@ impl FilterSectionViewModel {
         help_tooltips_enabled: bool,
     ) -> Self {
         Self {
+            sidebar_width: 240.0,
             name_filter: folder_browser.name_filter().to_owned(),
             name_filter_enabled: folder_browser.name_filter_enabled(),
             tag_filter: folder_browser.tag_filter().to_owned(),
             tag_filter_enabled: folder_browser.tag_filter_enabled(),
             curation: CurationFilterViewModel {
                 enabled: folder_browser.curation_mode_enabled(),
-                toggles: BROWSER_CURATION_SCOPES
+                dropdown_open: false,
+                selected_scope: folder_browser.curation_scope(),
+                options: BROWSER_CURATION_SCOPES
                     .into_iter()
-                    .map(|scope| CurationFilterToggleViewModel {
+                    .map(|scope| CurationFilterOptionViewModel {
                         scope,
-                        label: scope.label(),
-                        active: folder_browser.curation_scope() == scope,
+                        label: curation_scope_dropdown_label(scope),
                     })
                     .collect(),
             },
@@ -305,6 +311,14 @@ impl FilterSectionViewModel {
                 .collect(),
             panel_height: folder_browser.filter_panel_height(),
         }
+    }
+}
+
+fn curation_scope_dropdown_label(scope: BrowserCurationScope) -> &'static str {
+    match scope {
+        BrowserCurationScope::All => "All",
+        BrowserCurationScope::Ratings => "Rate",
+        BrowserCurationScope::Tags => "Tags",
     }
 }
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -147,6 +147,8 @@ impl NativeAppState {
             | GuiMessage::CloseShortcutHelp
             | GuiMessage::ToggleStickyRandomSampleRangePlayback
             | GuiMessage::ToggleHarvestFamilyPanel
+            | GuiMessage::ToggleCurationFilterDropdown
+            | GuiMessage::CloseCurationFilterDropdown
             | GuiMessage::ToggleZeroCrossingSnap
             | GuiMessage::ToggleBeatGuides
             | GuiMessage::AdjustBeatGuideCount(_)

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -1,6 +1,7 @@
 use radiant::prelude as ui;
 
 use crate::native_app::app::{ClipboardHandoffTarget, GuiMessage, NativeAppState};
+use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 
 impl NativeAppState {
     pub(super) fn apply_browser_dispatch(
@@ -14,6 +15,9 @@ impl NativeAppState {
                 self.finish_add_source_dialog(result, context);
             }
             GuiMessage::FolderBrowser(message) => {
+                if matches!(message, FolderBrowserMessage::SetCurationScope(_, _)) {
+                    self.ui.chrome.curation_filter_dropdown_open = false;
+                }
                 self.apply_folder_browser_message(message, context);
             }
             GuiMessage::SetSimilarityAspectWeightingEnabled(enabled) => {

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -41,6 +41,13 @@ impl NativeAppState {
             GuiMessage::ToggleHarvestFamilyPanel => {
                 self.ui.chrome.harvest_family_open = !self.ui.chrome.harvest_family_open;
             }
+            GuiMessage::ToggleCurationFilterDropdown => {
+                self.ui.chrome.curation_filter_dropdown_open =
+                    !self.ui.chrome.curation_filter_dropdown_open;
+            }
+            GuiMessage::CloseCurationFilterDropdown => {
+                self.ui.chrome.curation_filter_dropdown_open = false;
+            }
             GuiMessage::ToggleZeroCrossingSnap => {
                 let enabled = self.waveform.current.toggle_zero_crossing_snap();
                 self.ui.status.sample = if enabled {

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -96,14 +96,15 @@ pub(in crate::native_app) const FILTER_SECTION_NODE_ID: u64 = FOLDER_FILTERS.id(
 pub(in crate::native_app) const NAME_FILTER_INPUT_ID: u64 = FOLDER_FILTERS.id(2);
 pub(in crate::native_app) const TAG_FILTER_INPUT_ID: u64 = FOLDER_FILTERS.id(3);
 pub(in crate::native_app) const FILTER_SECTION_SCROLL_NODE_ID: u64 = FOLDER_FILTERS.id(4);
+pub(in crate::native_app) const CURATION_FILTER_DROPDOWN_TRIGGER_ID: u64 = FOLDER_FILTERS.id(5);
 pub(in crate::native_app) const FILTER_RESIZE_HEADER_ID: u64 = FOLDER_FILTERS.id(7);
 /// Scope for automation-facing rating filter toggle ids.
 pub(in crate::native_app) const AUTOMATION_RATING_FILTER_TOGGLE_SCOPE: u64 = FOLDER_FILTERS.id(20);
 /// Scope for automation-facing playback-type filter toggle ids.
 pub(in crate::native_app) const AUTOMATION_PLAYBACK_TYPE_FILTER_TOGGLE_SCOPE: u64 =
     FOLDER_FILTERS.id(21);
-/// Scope for automation-facing curation filter toggle ids.
-pub(in crate::native_app) const AUTOMATION_CURATION_FILTER_TOGGLE_SCOPE: u64 =
+/// Scope for automation-facing curation dropdown option ids.
+pub(in crate::native_app) const AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
     FOLDER_FILTERS.id(22);
 /// Scope for automation-facing harvest filter toggle ids.
 pub(in crate::native_app) const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 = FOLDER_FILTERS.id(23);

--- a/src/native_app/ui/ids/registry.rs
+++ b/src/native_app/ui/ids/registry.rs
@@ -184,6 +184,11 @@ const REGISTERED_WIDGET_IDS: &[RegisteredWidgetId] = &[
     ),
     registered_widget_id!(
         FolderFilters,
+        CURATION_FILTER_DROPDOWN_TRIGGER_ID,
+        "folder_filters.curation_dropdown_trigger"
+    ),
+    registered_widget_id!(
+        FolderFilters,
         FILTER_RESIZE_HEADER_ID,
         "folder_filters.resize_header"
     ),


### PR DESCRIPTION
## Scope

- Replace the Curation filter's compact side-by-side `All` / `Rate` / `Tags` toggle buttons with a compact dropdown trigger in the library sidebar filter section.
- Show the current curation mode in the dropdown trigger and expose the same `All`, `Rate`, and `Tags` choices in the opened menu.
- Keep the dropdown menu anchored inside the Curation row so it stays within the sidebar control width.
- Preserve the existing `BrowserCurationScope` values and continue dispatching through `FolderBrowserMessage::SetCurationScope`.
- Keep curation mode selection closing the dropdown while preserving existing list/focus behavior through the existing folder-browser setter.

## Definition of Done

- Curation filtering is controlled by a dropdown instead of three compact toggles.
- All existing curation modes remain selectable.
- Selecting a dropdown option updates the visible sample list via the same `SetCurationScope` path as before.
- The selected curation mode is readable in a dropdown control without side-by-side abbreviated buttons.
- Automated coverage verifies dropdown trigger projection, option projection, dispatch, current curation-mode projection, and open-menu geometry within the trigger bounds.

## Validation commands

- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate file_operations::enabling_curation_filter_focuses_first_visible_sample_immediately -- --test-threads=1`

Manual smoke not run in this environment.

## Known limitations

None.

## Review

User review is required before merge.
