### PR TITLE
Wavecrate: replace Harvest filter toggles with dropdown

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -244,6 +244,8 @@ pub(in crate::native_app) enum GuiMessage {
     ToggleHarvestFamilyPanel,
     ToggleCurationFilterDropdown,
     CloseCurationFilterDropdown,
+    ToggleHarvestFilterDropdown,
+    CloseHarvestFilterDropdown,
     ToggleZeroCrossingSnap,
     ToggleBeatGuides,
     AdjustBeatGuideCount(i8),

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -58,6 +58,7 @@ pub(in crate::native_app) struct ChromeUiState {
     pub(in crate::native_app) sample_map_audition_queue: SampleMapAuditionQueueState,
     pub(in crate::native_app) harvest_family_open: bool,
     pub(in crate::native_app) curation_filter_dropdown_open: bool,
+    pub(in crate::native_app) harvest_filter_dropdown_open: bool,
     pub(in crate::native_app) beat_guides_enabled: bool,
     pub(in crate::native_app) beat_guide_count: u8,
 }
@@ -167,6 +168,7 @@ impl ChromeUiState {
             sample_map_audition_queue: SampleMapAuditionQueueState::default(),
             harvest_family_open: false,
             curation_filter_dropdown_open: false,
+            harvest_filter_dropdown_open: false,
             beat_guides_enabled: false,
             beat_guide_count: DEFAULT_BEAT_GUIDE_COUNT,
         }

--- a/src/native_app/app_chrome/center_panel.rs
+++ b/src/native_app/app_chrome/center_panel.rs
@@ -51,6 +51,10 @@ pub(in crate::native_app) fn library_sidebar_overlays(
             curation_filter_dropdown_overlay(state),
             GuiMessage::CloseCurationFilterDropdown,
         )
+        .dismissible_context_menu_opt(
+            harvest_filter_dropdown_overlay(state),
+            GuiMessage::CloseHarvestFilterDropdown,
+        )
 }
 
 fn metadata_completion_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
@@ -78,6 +82,11 @@ fn metadata_completion_overlay(state: &NativeAppState) -> Option<ui::View<GuiMes
 fn curation_filter_dropdown_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
     let model = LibrarySidebarViewModel::from_app_state(state);
     library_sidebar::curation_filter_dropdown_overlay(&model, BOTTOM_STATUS_BAR_HEIGHT)
+}
+
+fn harvest_filter_dropdown_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
+    let model = LibrarySidebarViewModel::from_app_state(state);
+    library_sidebar::harvest_filter_dropdown_overlay(&model, BOTTOM_STATUS_BAR_HEIGHT)
 }
 
 pub(in crate::native_app) fn sample_workspace_overlays(

--- a/src/native_app/app_chrome/library_browser/library_sidebar.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar.rs
@@ -1,7 +1,9 @@
 use radiant::prelude as ui;
 
 use crate::native_app::app::GuiMessage;
-use crate::native_app::app_chrome::view_models::library_sidebar::LibrarySidebarViewModel;
+use crate::native_app::app_chrome::view_models::library_sidebar::{
+    FilterSectionViewModel, LibrarySidebarViewModel,
+};
 
 mod collections_section;
 mod filter_section;
@@ -43,6 +45,33 @@ pub(in crate::native_app) fn curation_filter_dropdown_overlay(
     model: &LibrarySidebarViewModel,
     bottom_status_bar_height: f32,
 ) -> Option<ui::View<GuiMessage>> {
+    filter_dropdown_overlay(
+        model,
+        bottom_status_bar_height,
+        |filter, inset_x, bottom_inset| {
+            filter_section::curation_filter_dropdown_overlay(filter, inset_x, bottom_inset)
+        },
+    )
+}
+
+pub(in crate::native_app) fn harvest_filter_dropdown_overlay(
+    model: &LibrarySidebarViewModel,
+    bottom_status_bar_height: f32,
+) -> Option<ui::View<GuiMessage>> {
+    filter_dropdown_overlay(
+        model,
+        bottom_status_bar_height,
+        |filter, inset_x, bottom_inset| {
+            filter_section::harvest_filter_dropdown_overlay(filter, inset_x, bottom_inset)
+        },
+    )
+}
+
+fn filter_dropdown_overlay(
+    model: &LibrarySidebarViewModel,
+    bottom_status_bar_height: f32,
+    overlay: impl FnOnce(&FilterSectionViewModel, f32, f32) -> Option<ui::View<GuiMessage>>,
+) -> Option<ui::View<GuiMessage>> {
     let harvest_family_inset = model
         .harvest_family
         .is_some()
@@ -53,11 +82,7 @@ pub(in crate::native_app) fn curation_filter_dropdown_overlay(
         + model.metadata_panel_height
         + LIBRARY_SIDEBAR_SECTION_SPACING
         + harvest_family_inset;
-    filter_section::curation_filter_dropdown_overlay(
-        &model.filter,
-        LIBRARY_SIDEBAR_PADDING,
-        filter_bottom_inset,
-    )
+    overlay(&model.filter, LIBRARY_SIDEBAR_PADDING, filter_bottom_inset)
 }
 
 fn library_sidebar_content(model: LibrarySidebarViewModel) -> ui::View<GuiMessage> {

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
@@ -15,7 +15,7 @@ mod tests;
 use rows::{
     FILTER_CLEAR_BUTTON_SIZE, FILTER_CONTROLS_CONTENT_HEIGHT, FILTER_LABEL_CONTROL_SPACING,
     FILTER_LABEL_WIDTH, FILTER_ROW_HEIGHT, FILTER_ROW_SPACING, curation_filter_dropdown_menu,
-    filter_rows,
+    filter_rows, harvest_filter_dropdown_menu,
 };
 
 pub(super) const FILTER_PANEL_PADDING: f32 = 6.0;
@@ -28,6 +28,7 @@ const FILTER_RESIZE_HEADER_ID: u64 = widget_ids::FILTER_RESIZE_HEADER_ID;
 #[cfg(test)]
 const FILTER_SECTION_NODE_ID: u64 = widget_ids::FILTER_SECTION_NODE_ID;
 const CURATION_FILTER_ROW_INDEX: usize = 2;
+const HARVEST_FILTER_ROW_INDEX: usize = 3;
 
 pub(super) fn filter_section(model: &FilterSectionViewModel) -> ui::View<GuiMessage> {
     let panel = ui::panel_section_from_header_parts(
@@ -73,25 +74,60 @@ pub(super) fn curation_filter_dropdown_overlay(
     filter_bottom_inset: f32,
 ) -> Option<ui::View<GuiMessage>> {
     let (menu, size) = curation_filter_dropdown_menu(model)?;
+    Some(filter_dropdown_overlay(
+        menu,
+        size,
+        model,
+        sidebar_inset_x,
+        filter_bottom_inset,
+        CURATION_FILTER_ROW_INDEX,
+        "curation-filter-dropdown-overlay",
+    ))
+}
+
+pub(super) fn harvest_filter_dropdown_overlay(
+    model: &FilterSectionViewModel,
+    sidebar_inset_x: f32,
+    filter_bottom_inset: f32,
+) -> Option<ui::View<GuiMessage>> {
+    let (menu, size) = harvest_filter_dropdown_menu(model)?;
+    Some(filter_dropdown_overlay(
+        menu,
+        size,
+        model,
+        sidebar_inset_x,
+        filter_bottom_inset,
+        HARVEST_FILTER_ROW_INDEX,
+        "harvest-filter-dropdown-overlay",
+    ))
+}
+
+fn filter_dropdown_overlay(
+    menu: ui::View<GuiMessage>,
+    size: ui::Vector2,
+    model: &FilterSectionViewModel,
+    sidebar_inset_x: f32,
+    filter_bottom_inset: f32,
+    row_index: usize,
+    key: &'static str,
+) -> ui::View<GuiMessage> {
     let trigger_bottom_from_filter_top = FILTER_PANEL_PADDING
         + SIDEBAR_PANEL_HEADER_HEIGHT
         + FILTER_PANEL_HEADER_CONTENT_SPACING
-        + CURATION_FILTER_ROW_INDEX as f32 * (FILTER_ROW_HEIGHT + FILTER_ROW_SPACING)
+        + row_index as f32 * (FILTER_ROW_HEIGHT + FILTER_ROW_SPACING)
         + FILTER_CLEAR_BUTTON_SIZE;
     let trigger_bottom_inset =
         filter_bottom_inset + (model.panel_height - trigger_bottom_from_filter_top).max(0.0);
     let menu_bottom_inset = (trigger_bottom_inset - FILTER_ROW_SPACING - size.y).max(0.0);
     let menu_inset_x =
         sidebar_inset_x + FILTER_PANEL_PADDING + FILTER_LABEL_WIDTH + FILTER_LABEL_CONTROL_SPACING;
-    Some(
-        ui::anchored_layer(
-            menu,
-            size,
-            ui::LayerHorizontalAnchor::Start,
-            ui::LayerVerticalAnchor::End,
-            menu_inset_x,
-            menu_bottom_inset,
-        )
-        .key("curation-filter-dropdown-overlay"),
+    ui::anchored_layer(
+        menu,
+        size,
+        ui::LayerHorizontalAnchor::Start,
+        ui::LayerVerticalAnchor::End,
+        menu_inset_x,
+        menu_bottom_inset,
     )
+    .key(key)
 }

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -3,8 +3,8 @@ use radiant::{prelude as ui, widgets::TextInputMessage};
 mod projection;
 
 use self::projection::{
-    CurationFilterOptionProjection, CurationFilterRowProjection, HarvestFilterRowProjection,
-    HarvestFilterToggleProjection, PlaybackTypeFilterRowProjection,
+    CurationFilterOptionProjection, CurationFilterRowProjection, HarvestFilterOptionProjection,
+    HarvestFilterRowProjection, PlaybackTypeFilterRowProjection,
     PlaybackTypeFilterToggleProjection, RatingFilterRowProjection, RatingFilterToggleProjection,
     TextFilterField, TextFilterRowProjection, filter_rows_projection,
 };
@@ -21,12 +21,9 @@ pub(super) const FILTER_CLEAR_BUTTON_SIZE: f32 = 20.0;
 pub(super) const FILTER_LABEL_WIDTH: f32 = 54.0;
 const FILTER_CONTROL_SPACING: f32 = 2.0;
 pub(super) const FILTER_LABEL_CONTROL_SPACING: f32 = 6.0;
-const HARVEST_FILTER_CONTROL_HEIGHT: f32 = FILTER_CLEAR_BUTTON_SIZE * 2.0 + FILTER_CONTROL_SPACING;
 pub(super) const FILTER_CONTROLS_CONTENT_HEIGHT: f32 =
-    FILTER_ROW_HEIGHT * 5.0 + HARVEST_FILTER_CONTROL_HEIGHT + FILTER_ROW_SPACING * 5.0;
+    FILTER_ROW_HEIGHT * 6.0 + FILTER_ROW_SPACING * 5.0;
 const HARVEST_FAMILY_TOGGLE_WIDTH: f32 = 22.0;
-const HARVEST_FILTER_TOGGLE_WIDTH: f32 = 30.0;
-const HARVEST_FILTER_TOP_ROW_TOGGLE_COUNT: usize = 4;
 const PLAYBACK_TYPE_FILTER_TOGGLE_WIDTH: f32 = 64.0;
 const RATING_FILTER_TOGGLE_WIDTH: f32 = 20.0;
 pub(super) const RATING_FILTER_SWATCH_SIZE: u8 = 12;
@@ -57,9 +54,11 @@ const AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
     widget_ids::AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE;
 pub(super) const CURATION_FILTER_DROPDOWN_TRIGGER_ID: u64 =
     widget_ids::CURATION_FILTER_DROPDOWN_TRIGGER_ID;
-/// Scope for automation-facing harvest filter toggle ids.
-const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 =
-    widget_ids::AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE;
+pub(super) const HARVEST_FILTER_DROPDOWN_TRIGGER_ID: u64 =
+    widget_ids::HARVEST_FILTER_DROPDOWN_TRIGGER_ID;
+/// Scope for automation-facing harvest dropdown option ids.
+const AUTOMATION_HARVEST_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
+    widget_ids::AUTOMATION_HARVEST_FILTER_DROPDOWN_OPTION_SCOPE;
 /// Scope for automation-facing rating filter toggle ids.
 const AUTOMATION_RATING_FILTER_TOGGLE_SCOPE: u64 =
     widget_ids::AUTOMATION_RATING_FILTER_TOGGLE_SCOPE;
@@ -237,48 +236,24 @@ pub(super) fn automation_curation_filter_dropdown_option_id(label: &str) -> u64 
 
 fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     let help_tooltips_enabled = row.help_tooltips_enabled;
-    let mut top_controls = Vec::with_capacity(HARVEST_FILTER_TOP_ROW_TOGGLE_COUNT + 1);
-    let mut bottom_controls = Vec::with_capacity(
-        row.toggles
-            .len()
-            .saturating_sub(HARVEST_FILTER_TOP_ROW_TOGGLE_COUNT),
-    );
-
-    top_controls.push(harvest_family_toggle(
-        row.family_available,
-        row.family_open,
-        help_tooltips_enabled,
-    ));
-
-    for (index, toggle) in row.toggles.iter().enumerate() {
-        let control = harvest_filter_toggle(toggle, help_tooltips_enabled);
-        if index < HARVEST_FILTER_TOP_ROW_TOGGLE_COUNT {
-            top_controls.push(control);
-        } else {
-            bottom_controls.push(control);
-        }
-    }
-
-    let controls = ui::column([
-        ui::row(top_controls)
-            .spacing(FILTER_CONTROL_SPACING)
-            .fill_width()
-            .height(FILTER_CLEAR_BUTTON_SIZE),
-        ui::row(bottom_controls)
-            .spacing(FILTER_CONTROL_SPACING)
+    let controls = ui::row([
+        harvest_family_toggle(row.family_available, row.family_open, help_tooltips_enabled),
+        ui::dropdown_trigger(row.selected_label, row.dropdown_open)
+            .toggle_message(GuiMessage::ToggleHarvestFilterDropdown)
+            .build()
+            .id(HARVEST_FILTER_DROPDOWN_TRIGGER_ID)
+            .tooltip_if(help_tooltips_enabled, "Choose the Harvest queue to show.")
             .fill_width()
             .height(FILTER_CLEAR_BUTTON_SIZE),
     ])
     .spacing(FILTER_CONTROL_SPACING)
     .fill_width()
-    .height(HARVEST_FILTER_CONTROL_HEIGHT);
+    .height(FILTER_CLEAR_BUTTON_SIZE);
 
-    filter_labeled_control_row_with_height(
+    filter_labeled_control_row(
         filter_row_label(row.label, row.family, row.enabled),
         controls,
         "filter-harvest-row",
-        HARVEST_FILTER_CONTROL_HEIGHT,
-        HARVEST_FILTER_CONTROL_HEIGHT,
     )
 }
 
@@ -303,24 +278,80 @@ fn harvest_family_toggle(
         )
 }
 
-fn harvest_filter_toggle(
-    toggle: &HarvestFilterToggleProjection,
-    help_tooltips_enabled: bool,
-) -> ui::View<GuiMessage> {
-    let filter = toggle.filter;
-    ui::selectable(toggle.label, toggle.active)
-        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
-        .message(move |enabled| {
-            GuiMessage::FolderBrowser(FolderBrowserMessage::SetHarvestFilter(filter, enabled))
-        })
-        .id(automation_harvest_filter_toggle_id(toggle.label))
-        .size(HARVEST_FILTER_TOGGLE_WIDTH, FILTER_CLEAR_BUTTON_SIZE)
-        .tooltip_if(help_tooltips_enabled, toggle.tooltip)
+pub(super) fn harvest_filter_dropdown_menu(
+    model: &FilterSectionViewModel,
+) -> Option<(ui::View<GuiMessage>, ui::Vector2)> {
+    let row = filter_rows_projection(model).harvest;
+    if row.dropdown_open {
+        let size = ui::Vector2::new(
+            f32::from(row.menu_width).max(1.0),
+            ui::dropdown_menu_height(row.options.len()),
+        );
+        Some((
+            harvest_filter_dropdown_menu_from_options(
+                &row.options,
+                row.help_tooltips_enabled,
+                size.x,
+            ),
+            size,
+        ))
+    } else {
+        None
+    }
 }
 
-/// Automation-facing id for a harvest filter toggle.
-pub(super) fn automation_harvest_filter_toggle_id(label: &str) -> u64 {
-    ui::stable_widget_id(AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE, label)
+fn harvest_filter_dropdown_menu_from_options(
+    options: &[HarvestFilterOptionProjection],
+    help_tooltips_enabled: bool,
+    menu_width: f32,
+) -> ui::View<GuiMessage> {
+    let option_count = options.len();
+    ui::column(
+        options
+            .iter()
+            .map(|option| harvest_filter_dropdown_option(option, help_tooltips_enabled)),
+    )
+    .key("harvest-filter-dropdown-menu")
+    .style(ui::WidgetStyle {
+        tone: ui::WidgetTone::Neutral,
+        prominence: ui::WidgetProminence::Strong,
+    })
+    .padding(4.0)
+    .spacing(3.0)
+    .width(menu_width.max(1.0))
+    .height(ui::dropdown_menu_height(option_count))
+}
+
+fn harvest_filter_dropdown_option(
+    option: &HarvestFilterOptionProjection,
+    help_tooltips_enabled: bool,
+) -> ui::View<GuiMessage> {
+    let filter = option.filter;
+    ui::button(option.label)
+        .message(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::SetHarvestFilter(filter, true),
+        ))
+        .id(automation_harvest_filter_dropdown_option_id(option.label))
+        .style(ui::WidgetStyle {
+            tone: if option.selected {
+                ui::WidgetTone::Accent
+            } else {
+                ui::WidgetTone::Neutral
+            },
+            prominence: if option.selected {
+                ui::WidgetProminence::Strong
+            } else {
+                ui::WidgetProminence::Subtle
+            },
+        })
+        .fill_width()
+        .height(22.0)
+        .tooltip_if(help_tooltips_enabled, option.tooltip)
+}
+
+/// Automation-facing id for a harvest dropdown option.
+pub(super) fn automation_harvest_filter_dropdown_option_id(label: &str) -> u64 {
+    ui::stable_widget_id(AUTOMATION_HARVEST_FILTER_DROPDOWN_OPTION_SCOPE, label)
 }
 
 fn playback_type_filter_toggle(
@@ -492,7 +523,7 @@ mod tests {
     use super::*;
     use crate::native_app::app_chrome::view_models::library_sidebar::{
         CurationFilterOptionViewModel, CurationFilterViewModel, FilterSectionViewModel,
-        HarvestFilterToggleViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
+        HarvestFilterOptionViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
         RatingFilterToggleViewModel,
     };
     use crate::native_app::sample_library::folder_browser::model::{
@@ -501,14 +532,24 @@ mod tests {
     use radiant::prelude::IntoView;
 
     #[test]
-    fn harvest_filter_toggles_expose_full_help_tooltips() {
+    fn harvest_filter_dropdown_options_expose_full_help_tooltips() {
         let surface = ui::column(filter_rows(&filter_model(true))).into_surface();
         let tooltip = surface
-            .find_widget(automation_harvest_filter_toggle_id("Need"))
+            .find_widget(HARVEST_FILTER_DROPDOWN_TRIGGER_ID)
+            .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+        assert_eq!(tooltip, Some("Choose the Harvest queue to show."));
+
+        let menu = harvest_filter_dropdown_menu(&filter_model(true))
+            .expect("open harvest dropdown menu")
+            .0
+            .into_surface();
+        let option_tooltip = menu
+            .find_widget(automation_harvest_filter_dropdown_option_id("Needs Review"))
             .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
 
         assert_eq!(
-            tooltip,
+            option_tooltip,
             Some("Files not done or ignored that do not have derivatives yet.")
         );
     }
@@ -531,10 +572,11 @@ mod tests {
             },
             harvest: HarvestFilterViewModel {
                 enabled: false,
-                toggles: vec![HarvestFilterToggleViewModel {
+                dropdown_open: true,
+                selected_filter: Some(HarvestFilter::NeedsReview),
+                options: vec![HarvestFilterOptionViewModel {
                     filter: HarvestFilter::NeedsReview,
-                    label: "Need",
-                    active: false,
+                    label: "Needs Review",
                 }],
                 family_available: false,
                 family_open: false,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -1,6 +1,6 @@
 use crate::native_app::app_chrome::view_models::library_sidebar::{
     CurationFilterOptionViewModel, CurationFilterViewModel, FilterSectionViewModel,
-    HarvestFilterToggleViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
+    HarvestFilterOptionViewModel, HarvestFilterViewModel, PlaybackTypeFilterToggleViewModel,
     RatingFilterToggleViewModel,
 };
 use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
@@ -65,18 +65,21 @@ pub(super) struct HarvestFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
-    pub(super) toggles: Vec<HarvestFilterToggleProjection>,
+    pub(super) dropdown_open: bool,
+    pub(super) menu_width: u16,
+    pub(super) selected_label: &'static str,
+    pub(super) options: Vec<HarvestFilterOptionProjection>,
     pub(super) family_available: bool,
     pub(super) family_open: bool,
     pub(super) help_tooltips_enabled: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) struct HarvestFilterToggleProjection {
+pub(super) struct HarvestFilterOptionProjection {
     pub(super) filter: HarvestFilter,
     pub(super) label: &'static str,
     pub(super) tooltip: &'static str,
-    pub(super) active: bool,
+    pub(super) selected: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -123,7 +126,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             &model.curation,
             model.sidebar_width,
         ),
-        harvest: HarvestFilterRowProjection::from_view_model(&model.harvest),
+        harvest: HarvestFilterRowProjection::from_view_model(&model.harvest, model.sidebar_width),
         playback_type: PlaybackTypeFilterRowProjection {
             family: FilterFamily::PlaybackType,
             label: "Type",
@@ -194,15 +197,29 @@ impl CurationFilterOptionProjection {
 }
 
 impl HarvestFilterRowProjection {
-    fn from_view_model(model: &HarvestFilterViewModel) -> Self {
+    fn from_view_model(model: &HarvestFilterViewModel, sidebar_width: f32) -> Self {
         Self {
             family: FilterFamily::Harvest,
             label: "Harve",
             enabled: model.enabled,
-            toggles: model
-                .toggles
+            dropdown_open: model.dropdown_open,
+            menu_width: curation_dropdown_menu_width(sidebar_width),
+            selected_label: model
+                .selected_filter
+                .and_then(|selected_filter| {
+                    model
+                        .options
+                        .iter()
+                        .find(|option| option.filter == selected_filter)
+                        .map(|option| option.label)
+                })
+                .unwrap_or("Any"),
+            options: model
+                .options
                 .iter()
-                .map(HarvestFilterToggleProjection::from_view_model)
+                .map(|option| {
+                    HarvestFilterOptionProjection::from_view_model(option, model.selected_filter)
+                })
                 .collect(),
             family_available: model.family_available,
             family_open: model.family_open && model.family_available,
@@ -211,13 +228,16 @@ impl HarvestFilterRowProjection {
     }
 }
 
-impl HarvestFilterToggleProjection {
-    fn from_view_model(model: &HarvestFilterToggleViewModel) -> Self {
+impl HarvestFilterOptionProjection {
+    fn from_view_model(
+        model: &HarvestFilterOptionViewModel,
+        selected_filter: Option<HarvestFilter>,
+    ) -> Self {
         Self {
             filter: model.filter,
             label: model.label,
             tooltip: harvest_filter_tooltip(model.filter),
-            active: model.active,
+            selected: selected_filter == Some(model.filter),
         }
     }
 }
@@ -315,12 +335,14 @@ mod tests {
         );
         assert_eq!(projection.harvest.label, "Harve");
         assert!(projection.harvest.enabled);
+        assert!(projection.harvest.dropdown_open);
+        assert_eq!(projection.harvest.selected_label, "Touched");
         assert_eq!(
             projection
                 .harvest
-                .toggles
+                .options
                 .iter()
-                .map(|toggle| (toggle.filter, toggle.label, toggle.tooltip, toggle.active))
+                .map(|option| (option.filter, option.label, option.tooltip, option.selected))
                 .collect::<Vec<_>>(),
             vec![
                 (
@@ -331,38 +353,38 @@ mod tests {
                 ),
                 (
                     HarvestFilter::NewAndTouched,
-                    "N+T",
+                    "New + Touched",
                     "New, seen, and touched files still in the active queue.",
                     false
                 ),
                 (
                     HarvestFilter::NeedsReview,
-                    "Need",
+                    "Needs Review",
                     "Files not done or ignored that do not have derivatives yet.",
                     false
                 ),
                 (
                     HarvestFilter::Touched,
-                    "Tch",
+                    "Touched",
                     "Files you have rated, tagged, marked, edited, copied, or processed.",
                     true
                 ),
                 (
                     HarvestFilter::HasDerivatives,
-                    "Der",
+                    "Has Derivatives",
                     "Files with one or more derived files recorded in the harvest graph.",
                     false
                 ),
                 (
                     HarvestFilter::NoDerivatives,
-                    "NoD",
+                    "No Derivatives",
                     "Files without any derived files recorded yet.",
                     false
                 ),
                 (HarvestFilter::Done, "Done", "Files you marked done.", false),
                 (
                     HarvestFilter::Ignored,
-                    "Ign",
+                    "Ignored",
                     "Files you intentionally hid from harvest queues.",
                     false
                 ),
@@ -429,51 +451,44 @@ mod tests {
             },
             harvest: HarvestFilterViewModel {
                 enabled: true,
-                toggles: vec![
-                    HarvestFilterToggleViewModel {
+                dropdown_open: true,
+                selected_filter: Some(HarvestFilter::Touched),
+                options: vec![
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::New,
                         label: "New",
-                        active: false,
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::NewAndTouched,
-                        label: "N+T",
-                        active: false,
+                        label: "New + Touched",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::NeedsReview,
-                        label: "Need",
-                        active: false,
+                        label: "Needs Review",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::Touched,
-                        label: "Tch",
-                        active: true,
+                        label: "Touched",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::HasDerivatives,
-                        label: "Der",
-                        active: false,
+                        label: "Has Derivatives",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::NoDerivatives,
-                        label: "NoD",
-                        active: false,
+                        label: "No Derivatives",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::Done,
                         label: "Done",
-                        active: false,
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::Ignored,
-                        label: "Ign",
-                        active: false,
+                        label: "Ignored",
                     },
-                    HarvestFilterToggleViewModel {
+                    HarvestFilterOptionViewModel {
                         filter: HarvestFilter::All,
                         label: "All",
-                        active: false,
                     },
                 ],
                 family_available: true,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -1,15 +1,16 @@
 use super::rows::{
-    CURATION_FILTER_DROPDOWN_TRIGGER_ID, NAME_FILTER_INPUT_ID, RATING_FILTER_SWATCH_SIZE,
-    TAG_FILTER_INPUT_ID, automation_curation_filter_dropdown_option_id,
-    automation_filter_family_label_toggle_id, automation_playback_type_filter_toggle_id,
-    automation_rating_filter_toggle_id, empty_filter_message, name_filter_clear_button_id,
-    rating_filter_swatch_color, tag_filter_clear_button_id,
+    CURATION_FILTER_DROPDOWN_TRIGGER_ID, HARVEST_FILTER_DROPDOWN_TRIGGER_ID, NAME_FILTER_INPUT_ID,
+    RATING_FILTER_SWATCH_SIZE, TAG_FILTER_INPUT_ID, automation_curation_filter_dropdown_option_id,
+    automation_filter_family_label_toggle_id, automation_harvest_filter_dropdown_option_id,
+    automation_playback_type_filter_toggle_id, automation_rating_filter_toggle_id,
+    empty_filter_message, name_filter_clear_button_id, rating_filter_swatch_color,
+    tag_filter_clear_button_id,
 };
 use super::*;
 use crate::native_app::sample_library::folder_browser::FolderBrowserState;
 use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
-    BrowserCurationScope, PlaybackTypeFilter,
+    BrowserCurationScope, HarvestFilter, PlaybackTypeFilter,
 };
 use crate::native_app::ui::ids::HARVEST_FAMILY_TOGGLE_ID;
 use radiant::prelude::IntoView;

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -225,6 +225,76 @@ fn filter_section_projects_harvest_family_toggle_button() {
 }
 
 #[test]
+fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
+    let mut state = FolderBrowserState::load_default();
+    state.set_harvest_filter(HarvestFilter::NeedsReview, true);
+    let mut model = FilterSectionViewModel::from_folder_browser(&state, false);
+    let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+
+    assert!(
+        frame
+            .paint_plan
+            .first_widget_rect(HARVEST_FILTER_DROPDOWN_TRIGGER_ID)
+            .is_some()
+    );
+    assert!(frame.paint_plan.contains_text("Needs Review  v"));
+    assert_eq!(
+        filter_section(&model).view_dispatch_widget_output(
+            HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
+            ui::WidgetOutput::typed(ButtonMessage::Activate),
+        ),
+        Some(GuiMessage::ToggleHarvestFilterDropdown)
+    );
+
+    model.harvest.dropdown_open = true;
+    let open_frame = filter_section(&model).view_frame_at_size_with_default_theme(
+        ui::Vector2::new(240.0, FILTER_SECTION_TEST_FRAME_HEIGHT),
+    );
+    assert_eq!(
+        open_frame
+            .paint_plan
+            .first_widget_rect(automation_harvest_filter_dropdown_option_id("Needs Review")),
+        None,
+        "harvest menu options should render in the sidebar overlay, not inside the clipped filter section"
+    );
+
+    let overlay_frame = harvest_filter_dropdown_overlay(&model, 4.0, 167.0)
+        .expect("open harvest dropdown should project an overlay menu");
+    let overlay_frame = overlay_frame.view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+    for (label, filter) in [
+        ("Needs Review", HarvestFilter::NeedsReview),
+        ("Done", HarvestFilter::Done),
+        ("Ignored", HarvestFilter::Ignored),
+        ("All", HarvestFilter::All),
+    ] {
+        assert!(
+            overlay_frame
+                .paint_plan
+                .first_widget_rect(automation_harvest_filter_dropdown_option_id(label))
+                .is_some(),
+            "{label} option should render in the overlay"
+        );
+        assert_eq!(
+            harvest_filter_dropdown_overlay(&model, 4.0, 167.0)
+                .expect("open harvest dropdown should project an overlay menu")
+                .view_dispatch_widget_output(
+                    automation_harvest_filter_dropdown_option_id(label),
+                    ui::WidgetOutput::typed(ButtonMessage::Activate),
+                ),
+            Some(GuiMessage::FolderBrowser(
+                FolderBrowserMessage::SetHarvestFilter(filter, true)
+            ))
+        );
+    }
+}
+
+#[test]
 fn filter_section_hides_clear_buttons_when_filters_are_empty() {
     let state = FolderBrowserState::load_default();
     let model = FilterSectionViewModel::from_folder_browser(&state, false);

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -104,16 +104,17 @@ pub(in crate::native_app) struct CurationFilterOptionViewModel {
 
 pub(in crate::native_app) struct HarvestFilterViewModel {
     pub(in crate::native_app) enabled: bool,
-    pub(in crate::native_app) toggles: Vec<HarvestFilterToggleViewModel>,
+    pub(in crate::native_app) dropdown_open: bool,
+    pub(in crate::native_app) selected_filter: Option<HarvestFilter>,
+    pub(in crate::native_app) options: Vec<HarvestFilterOptionViewModel>,
     pub(in crate::native_app) family_available: bool,
     pub(in crate::native_app) family_open: bool,
     pub(in crate::native_app) help_tooltips_enabled: bool,
 }
 
-pub(in crate::native_app) struct HarvestFilterToggleViewModel {
+pub(in crate::native_app) struct HarvestFilterOptionViewModel {
     pub(in crate::native_app) filter: HarvestFilter,
     pub(in crate::native_app) label: &'static str,
-    pub(in crate::native_app) active: bool,
 }
 
 pub(in crate::native_app) struct PlaybackTypeFilterToggleViewModel {
@@ -162,6 +163,7 @@ impl LibrarySidebarViewModel {
             harvest_family.is_some() || state.selected_harvest_family_available();
         filter.harvest.family_open = state.ui.chrome.harvest_family_open;
         filter.curation.dropdown_open = state.ui.chrome.curation_filter_dropdown_open;
+        filter.harvest.dropdown_open = state.ui.chrome.harvest_filter_dropdown_open;
         filter.sidebar_width = state.ui.chrome.folder_panel.size();
         Self {
             sidebar_width: state.ui.chrome.folder_panel.size(),
@@ -279,12 +281,13 @@ impl FilterSectionViewModel {
             },
             harvest: HarvestFilterViewModel {
                 enabled: folder_browser.harvest_filter_enabled(),
-                toggles: HARVEST_FILTERS
+                dropdown_open: false,
+                selected_filter: folder_browser.harvest_filter(),
+                options: HARVEST_FILTERS
                     .into_iter()
-                    .map(|filter| HarvestFilterToggleViewModel {
+                    .map(|filter| HarvestFilterOptionViewModel {
                         filter,
-                        label: filter.label(),
-                        active: folder_browser.harvest_filter() == Some(filter),
+                        label: harvest_filter_dropdown_label(filter),
                     })
                     .collect(),
                 family_available: false,
@@ -311,6 +314,20 @@ impl FilterSectionViewModel {
                 .collect(),
             panel_height: folder_browser.filter_panel_height(),
         }
+    }
+}
+
+fn harvest_filter_dropdown_label(filter: HarvestFilter) -> &'static str {
+    match filter {
+        HarvestFilter::New => "New",
+        HarvestFilter::NewAndTouched => "New + Touched",
+        HarvestFilter::NeedsReview => "Needs Review",
+        HarvestFilter::Touched => "Touched",
+        HarvestFilter::HasDerivatives => "Has Derivatives",
+        HarvestFilter::NoDerivatives => "No Derivatives",
+        HarvestFilter::Done => "Done",
+        HarvestFilter::Ignored => "Ignored",
+        HarvestFilter::All => "All",
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/harvest_filter.rs
+++ b/src/native_app/sample_library/folder_browser/harvest_filter.rs
@@ -32,22 +32,6 @@ pub(in crate::native_app) enum HarvestFilter {
     All,
 }
 
-impl HarvestFilter {
-    pub(in crate::native_app) fn label(self) -> &'static str {
-        match self {
-            Self::New => "New",
-            Self::NewAndTouched => "N+T",
-            Self::NeedsReview => "Need",
-            Self::Touched => "Tch",
-            Self::HasDerivatives => "Der",
-            Self::NoDerivatives => "NoD",
-            Self::Done => "Done",
-            Self::Ignored => "Ign",
-            Self::All => "All",
-        }
-    }
-}
-
 impl FolderBrowserState {
     pub(in crate::native_app::sample_library::folder_browser) fn retain_harvest_filter_matches(
         &self,

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -149,6 +149,8 @@ impl NativeAppState {
             | GuiMessage::ToggleHarvestFamilyPanel
             | GuiMessage::ToggleCurationFilterDropdown
             | GuiMessage::CloseCurationFilterDropdown
+            | GuiMessage::ToggleHarvestFilterDropdown
+            | GuiMessage::CloseHarvestFilterDropdown
             | GuiMessage::ToggleZeroCrossingSnap
             | GuiMessage::ToggleBeatGuides
             | GuiMessage::AdjustBeatGuideCount(_)

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -18,6 +18,9 @@ impl NativeAppState {
                 if matches!(message, FolderBrowserMessage::SetCurationScope(_, _)) {
                     self.ui.chrome.curation_filter_dropdown_open = false;
                 }
+                if matches!(message, FolderBrowserMessage::SetHarvestFilter(_, _)) {
+                    self.ui.chrome.harvest_filter_dropdown_open = false;
+                }
                 self.apply_folder_browser_message(message, context);
             }
             GuiMessage::SetSimilarityAspectWeightingEnabled(enabled) => {

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -44,9 +44,18 @@ impl NativeAppState {
             GuiMessage::ToggleCurationFilterDropdown => {
                 self.ui.chrome.curation_filter_dropdown_open =
                     !self.ui.chrome.curation_filter_dropdown_open;
+                self.ui.chrome.harvest_filter_dropdown_open = false;
             }
             GuiMessage::CloseCurationFilterDropdown => {
                 self.ui.chrome.curation_filter_dropdown_open = false;
+            }
+            GuiMessage::ToggleHarvestFilterDropdown => {
+                self.ui.chrome.harvest_filter_dropdown_open =
+                    !self.ui.chrome.harvest_filter_dropdown_open;
+                self.ui.chrome.curation_filter_dropdown_open = false;
+            }
+            GuiMessage::CloseHarvestFilterDropdown => {
+                self.ui.chrome.harvest_filter_dropdown_open = false;
             }
             GuiMessage::ToggleZeroCrossingSnap => {
                 let enabled = self.waveform.current.toggle_zero_crossing_snap();

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -51,6 +51,14 @@ pub(in crate::native_app) fn default_gui_shortcuts(
             )),
         )
         .layer_when(
+            state.ui.chrome.curation_filter_dropdown_open,
+            ui::ShortcutLayer::modal_escape(GuiMessage::CloseCurationFilterDropdown),
+        )
+        .layer_when(
+            state.ui.chrome.harvest_filter_dropdown_open,
+            ui::ShortcutLayer::modal_escape(GuiMessage::CloseHarvestFilterDropdown),
+        )
+        .layer_when(
             state.ui.chrome.job_details_open,
             ui::ShortcutLayer::modal_escape(GuiMessage::CloseJobDetails),
         )

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -65,9 +65,12 @@ fn contextual_shortcut_help_sections(state: &NativeAppState) -> Vec<ShortcutHelp
             ],
         ));
     }
-    if state.audio_settings_dropdown_open() {
+    if state.audio_settings_dropdown_open()
+        || state.ui.chrome.curation_filter_dropdown_open
+        || state.ui.chrome.harvest_filter_dropdown_open
+    {
         sections.push(shortcut_help_section(
-            "Audio Settings",
+            "Dropdown",
             [shortcut_help_item("Esc", "Close dropdown")],
         ));
     }

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -97,6 +97,7 @@ pub(in crate::native_app) const NAME_FILTER_INPUT_ID: u64 = FOLDER_FILTERS.id(2)
 pub(in crate::native_app) const TAG_FILTER_INPUT_ID: u64 = FOLDER_FILTERS.id(3);
 pub(in crate::native_app) const FILTER_SECTION_SCROLL_NODE_ID: u64 = FOLDER_FILTERS.id(4);
 pub(in crate::native_app) const CURATION_FILTER_DROPDOWN_TRIGGER_ID: u64 = FOLDER_FILTERS.id(5);
+pub(in crate::native_app) const HARVEST_FILTER_DROPDOWN_TRIGGER_ID: u64 = FOLDER_FILTERS.id(6);
 pub(in crate::native_app) const FILTER_RESIZE_HEADER_ID: u64 = FOLDER_FILTERS.id(7);
 /// Scope for automation-facing rating filter toggle ids.
 pub(in crate::native_app) const AUTOMATION_RATING_FILTER_TOGGLE_SCOPE: u64 = FOLDER_FILTERS.id(20);
@@ -106,8 +107,9 @@ pub(in crate::native_app) const AUTOMATION_PLAYBACK_TYPE_FILTER_TOGGLE_SCOPE: u6
 /// Scope for automation-facing curation dropdown option ids.
 pub(in crate::native_app) const AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
     FOLDER_FILTERS.id(22);
-/// Scope for automation-facing harvest filter toggle ids.
-pub(in crate::native_app) const AUTOMATION_HARVEST_FILTER_TOGGLE_SCOPE: u64 = FOLDER_FILTERS.id(23);
+/// Scope for automation-facing harvest dropdown option ids.
+pub(in crate::native_app) const AUTOMATION_HARVEST_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
+    FOLDER_FILTERS.id(23);
 pub(in crate::native_app) const HARVEST_FAMILY_TOGGLE_ID: u64 = FOLDER_FILTERS.id(24);
 /// Scope for automation-facing filter family label toggles.
 pub(in crate::native_app) const AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE: u64 =

--- a/src/native_app/ui/ids/registry.rs
+++ b/src/native_app/ui/ids/registry.rs
@@ -189,6 +189,11 @@ const REGISTERED_WIDGET_IDS: &[RegisteredWidgetId] = &[
     ),
     registered_widget_id!(
         FolderFilters,
+        HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
+        "folder_filters.harvest_dropdown_trigger"
+    ),
+    registered_widget_id!(
+        FolderFilters,
         FILTER_RESIZE_HEADER_ID,
         "folder_filters.resize_header"
     ),


### PR DESCRIPTION
## Scope

- Replace the compact Harvest filter toggle row with a dropdown trigger and overlay menu in the library sidebar filter section.
- Show readable Harvest option labels, including Needs Review, New + Touched, Has Derivatives, No Derivatives, Done, Ignored, and All.
- Preserve existing `HarvestFilter` values and dispatch selection through `SetHarvestFilter(filter, true)`.
- Keep the Harvest family disclosure button beside the dropdown and preserve dropdown close behavior through selection, outside dismiss, and Escape.

## Definition of Done

- Harvest filtering is controlled by a dropdown instead of a row of compact toggles.
- Every existing Harvest filter option remains selectable.
- Selecting a dropdown option dispatches the correct `SetHarvestFilter` state mutation.
- The dropdown selected label is readable without memorizing abbreviations.
- Automated coverage verifies dropdown open/select behavior and preserved selected Harvest filter state.

## Validation Commands

- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate browser_context_menu -- --test-threads=1`

## Known Limitations

None.

## Review

User review is required before merge.