### PR TITLE
OPT-875: Match playback type filter toggle styling

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -359,7 +359,7 @@ fn playback_type_filter_toggle(
 ) -> ui::View<GuiMessage> {
     let filter = toggle.filter;
     ui::selectable(toggle.label, toggle.active)
-        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
+        .style(playback_type_filter_toggle_style())
         .message(move |enabled| {
             GuiMessage::FolderBrowser(FolderBrowserMessage::TogglePlaybackTypeFilter(
                 filter, enabled,
@@ -367,6 +367,10 @@ fn playback_type_filter_toggle(
         })
         .id(automation_playback_type_filter_toggle_id(toggle.label))
         .size(PLAYBACK_TYPE_FILTER_TOGGLE_WIDTH, FILTER_CLEAR_BUTTON_SIZE)
+}
+
+fn playback_type_filter_toggle_style() -> ui::WidgetStyle {
+    ui::WidgetStyle::subtle(ui::WidgetTone::Accent)
 }
 
 /// Automation-facing id for a playback-type filter toggle.

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -13,7 +13,9 @@ use crate::native_app::sample_library::folder_browser::model::{
     BrowserCurationScope, HarvestFilter, PlaybackTypeFilter,
 };
 use crate::native_app::ui::ids::HARVEST_FAMILY_TOGGLE_ID;
+use radiant::gui::types::Rgba8;
 use radiant::prelude::IntoView;
+use radiant::runtime::{SurfaceFrame, SurfacePaintPlan};
 use radiant::widgets::{ButtonMessage, SelectableMessage, TextInputMessage};
 
 const FILTER_SECTION_TEST_FRAME_HEIGHT: f32 = 220.0;

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -442,6 +442,65 @@ fn filter_section_projects_playback_type_toggles_and_dispatches_changes() {
 }
 
 #[test]
+fn filter_section_playback_type_toggles_share_style_family() {
+    let inactive_frame = playback_type_filter_frame(&[]);
+    let inactive_one_shot = playback_type_toggle_chrome(&inactive_frame.paint_plan, "1-Shot");
+    let inactive_loop = playback_type_toggle_chrome(&inactive_frame.paint_plan, "Loop");
+    assert_eq!(
+        inactive_one_shot, inactive_loop,
+        "inactive playback-type toggles should render with matching chrome and text colors"
+    );
+
+    let active_frame =
+        playback_type_filter_frame(&[PlaybackTypeFilter::OneShot, PlaybackTypeFilter::Loop]);
+    let active_one_shot = playback_type_toggle_chrome(&active_frame.paint_plan, "1-Shot");
+    let active_loop = playback_type_toggle_chrome(&active_frame.paint_plan, "Loop");
+    assert_eq!(
+        active_one_shot, active_loop,
+        "active playback-type toggles should render with matching chrome and text colors"
+    );
+    assert_ne!(
+        inactive_one_shot, active_one_shot,
+        "active and inactive playback-type toggle states should remain visually distinct"
+    );
+}
+
+fn playback_type_filter_frame(active_filters: &[PlaybackTypeFilter]) -> SurfaceFrame {
+    let mut state = FolderBrowserState::load_default();
+    for filter in active_filters {
+        state.set_playback_type_filter(*filter, true);
+    }
+    let model = FilterSectionViewModel::from_folder_browser(&state, false);
+    filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ))
+}
+
+fn playback_type_toggle_chrome(
+    plan: &SurfacePaintPlan,
+    label: &'static str,
+) -> (Rgba8, Rgba8, Rgba8) {
+    let widget_id = automation_playback_type_filter_toggle_id(label);
+    let fill = plan
+        .fill_rects_for_widget(widget_id)
+        .next()
+        .unwrap_or_else(|| panic!("missing fill for {label} playback-type toggle"))
+        .color;
+    let stroke = plan
+        .stroke_rects_for_widget(widget_id)
+        .next()
+        .unwrap_or_else(|| panic!("missing stroke for {label} playback-type toggle"))
+        .color;
+    let text = plan
+        .text_runs()
+        .find(|run| run.widget_id == widget_id && run.text.as_str() == label)
+        .unwrap_or_else(|| panic!("missing label for {label} playback-type toggle"))
+        .color;
+    (fill, stroke, text)
+}
+
+#[test]
 fn filter_section_projects_rating_toggles_and_dispatches_changes() {
     let mut state = FolderBrowserState::load_default();
     state.set_rating_filter(-3, true);


### PR DESCRIPTION
## Scope

- Make the library sidebar playback-type filter toggle style explicit through a shared helper used by both `1-Shot` and `Loop`.
- Add paint-plan regression coverage asserting `1-Shot` and `Loop` render with matching fill, stroke, and label colors when they are in the same active or inactive state.
- Preserve distinct labels and `TogglePlaybackTypeFilter` dispatch semantics for `PlaybackTypeFilter::OneShot` and `PlaybackTypeFilter::Loop`.

## Definition of Done

- `1-Shot` and `Loop` use the same playback-type filter toggle style family.
- Active and inactive states remain visually distinct.
- Clicking either toggle still dispatches the correct `TogglePlaybackTypeFilter` message.
- Automated coverage protects the style/projection contract against another mismatch.

## Validation commands

- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `git diff --check`

## Known limitations

- Manual smoke was not run in this session.

## Review

User review is required before merge.
