### PR TITLE
Wavecrate: widen filter labels for Harvest

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -18,14 +18,14 @@ use crate::native_app::ui::ids as widget_ids;
 pub(super) const FILTER_ROW_HEIGHT: f32 = 24.0;
 pub(super) const FILTER_ROW_SPACING: f32 = 1.0;
 pub(super) const FILTER_CLEAR_BUTTON_SIZE: f32 = 20.0;
-pub(super) const FILTER_LABEL_WIDTH: f32 = 54.0;
+pub(super) const FILTER_LABEL_WIDTH: f32 = 64.0;
 const FILTER_CONTROL_SPACING: f32 = 2.0;
 pub(super) const FILTER_LABEL_CONTROL_SPACING: f32 = 6.0;
 pub(super) const FILTER_CONTROLS_CONTENT_HEIGHT: f32 =
     FILTER_ROW_HEIGHT * 6.0 + FILTER_ROW_SPACING * 5.0;
 const HARVEST_FAMILY_TOGGLE_WIDTH: f32 = 22.0;
 const PLAYBACK_TYPE_FILTER_TOGGLE_WIDTH: f32 = 64.0;
-const RATING_FILTER_TOGGLE_WIDTH: f32 = 20.0;
+const RATING_FILTER_TOGGLE_WIDTH: f32 = 18.0;
 pub(super) const RATING_FILTER_SWATCH_SIZE: u8 = 12;
 const RATING_FILTER_TRASH_COLOR: ui::Rgba8 = ui::Rgba8 {
     r: 238,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -200,7 +200,7 @@ impl HarvestFilterRowProjection {
     fn from_view_model(model: &HarvestFilterViewModel, sidebar_width: f32) -> Self {
         Self {
             family: FilterFamily::Harvest,
-            label: "Harve",
+            label: "Harvest",
             enabled: model.enabled,
             dropdown_open: model.dropdown_open,
             menu_width: curation_dropdown_menu_width(sidebar_width),
@@ -333,7 +333,7 @@ mod tests {
                 (BrowserCurationScope::Tags, "Tags", false),
             ]
         );
-        assert_eq!(projection.harvest.label, "Harve");
+        assert_eq!(projection.harvest.label, "Harvest");
         assert!(projection.harvest.enabled);
         assert!(projection.harvest.dropdown_open);
         assert_eq!(projection.harvest.selected_label, "Touched");

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -1,10 +1,10 @@
 use super::rows::{
-    CURATION_FILTER_DROPDOWN_TRIGGER_ID, HARVEST_FILTER_DROPDOWN_TRIGGER_ID, NAME_FILTER_INPUT_ID,
-    RATING_FILTER_SWATCH_SIZE, TAG_FILTER_INPUT_ID, automation_curation_filter_dropdown_option_id,
-    automation_filter_family_label_toggle_id, automation_harvest_filter_dropdown_option_id,
-    automation_playback_type_filter_toggle_id, automation_rating_filter_toggle_id,
-    empty_filter_message, name_filter_clear_button_id, rating_filter_swatch_color,
-    tag_filter_clear_button_id,
+    CURATION_FILTER_DROPDOWN_TRIGGER_ID, FILTER_LABEL_WIDTH, HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
+    NAME_FILTER_INPUT_ID, RATING_FILTER_SWATCH_SIZE, TAG_FILTER_INPUT_ID,
+    automation_curation_filter_dropdown_option_id, automation_filter_family_label_toggle_id,
+    automation_harvest_filter_dropdown_option_id, automation_playback_type_filter_toggle_id,
+    automation_rating_filter_toggle_id, empty_filter_message, name_filter_clear_button_id,
+    rating_filter_swatch_color, tag_filter_clear_button_id,
 };
 use super::*;
 use crate::native_app::sample_library::folder_browser::FolderBrowserState;

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/layout.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/layout.rs
@@ -71,3 +71,40 @@ fn filter_section_controls_scroll_when_panel_is_cramped() {
         "cramped filter controls should scroll vertically"
     );
 }
+
+#[test]
+fn filter_section_wide_labels_keep_harvest_controls_aligned_in_cramped_width() {
+    let state = FolderBrowserState::load_default();
+    let model = FilterSectionViewModel::from_folder_browser(&state, false);
+    let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
+        180.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+    let harvest_label = frame
+        .paint_plan
+        .first_widget_rect(automation_filter_family_label_toggle_id("Harvest"))
+        .expect("Harvest label should render");
+    let harvest_text = frame
+        .paint_plan
+        .first_text_run("Harvest")
+        .expect("Harvest text should render")
+        .rect;
+    let harvest_dropdown = frame
+        .paint_plan
+        .first_widget_rect(HARVEST_FILTER_DROPDOWN_TRIGGER_ID)
+        .expect("Harvest dropdown should render");
+
+    assert_eq!(harvest_label.width(), FILTER_LABEL_WIDTH);
+    assert!(
+        harvest_text.min.x >= harvest_label.min.x && harvest_text.max.x <= harvest_label.max.x,
+        "Harvest text should remain inside the widened label cell, label={harvest_label:?}, text={harvest_text:?}"
+    );
+    assert!(
+        harvest_label.max.x <= harvest_dropdown.min.x,
+        "widened Harvest label should not overlap the dropdown controls, label={harvest_label:?}, dropdown={harvest_dropdown:?}"
+    );
+    assert!(
+        harvest_dropdown.width() > 0.0 && harvest_dropdown.max.x <= 180.0,
+        "cramped Harvest dropdown should stay readable inside the sidebar, dropdown={harvest_dropdown:?}"
+    );
+}

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -42,12 +42,12 @@ fn filter_section_projects_tag_text_input_with_row_labels() {
     assert!(frame.paint_plan.contains_text("Name"));
     assert!(frame.paint_plan.contains_text("Tags"));
     assert!(frame.paint_plan.contains_text("Curat"));
-    assert!(frame.paint_plan.contains_text("Harve"));
+    assert!(frame.paint_plan.contains_text("Harvest"));
     assert!(frame.paint_plan.contains_text("Type"));
     assert!(frame.paint_plan.contains_text("Ratin"));
     assert!(
         !frame.paint_plan.contains_text("Curate")
-            && !frame.paint_plan.contains_text("Harvest")
+            && !frame.paint_plan.contains_text("Harve")
             && !frame.paint_plan.contains_text("Rating")
     );
     assert_eq!(
@@ -67,7 +67,7 @@ fn filter_section_filter_name_labels_are_compact_and_same_size() {
         240.0,
         FILTER_SECTION_TEST_FRAME_HEIGHT,
     ));
-    let labels = ["Name", "Tags", "Curat", "Harve", "Type", "Ratin"];
+    let labels = ["Name", "Tags", "Curat", "Harvest", "Type", "Ratin"];
     let label_runs = labels
         .iter()
         .map(|label| {
@@ -77,12 +77,27 @@ fn filter_section_filter_name_labels_are_compact_and_same_size() {
                 .unwrap_or_else(|| panic!("missing filter label {label}"))
         })
         .collect::<Vec<_>>();
+    let harvest_label_rect = frame
+        .paint_plan
+        .first_widget_rect(automation_filter_family_label_toggle_id("Harvest"))
+        .expect("Harvest label should have a toggle rect");
+    let harvest_text_rect = label_runs
+        .iter()
+        .find(|run| run.text.as_str() == "Harvest")
+        .expect("Harvest text should be projected")
+        .rect;
 
-    assert!(label_runs.iter().all(|run| run.text.len() <= 5));
+    assert!(label_runs.iter().all(|run| run.text.len() <= 7));
     assert!(
         label_runs
             .iter()
             .all(|run| run.font_size == label_runs[0].font_size)
+    );
+    assert_eq!(harvest_label_rect.width(), FILTER_LABEL_WIDTH);
+    assert!(
+        harvest_text_rect.min.x >= harvest_label_rect.min.x
+            && harvest_text_rect.max.x <= harvest_label_rect.max.x,
+        "Harvest label text should fit inside the filter label cell, label={harvest_label_rect:?}, text={harvest_text_rect:?}"
     );
 }
 


### PR DESCRIPTION
## Scope

- Widen the shared library-sidebar filter label cell so the Harvest row can display the full `Harvest` label.
- Update the Harvest filter projection label from `Harve` to `Harvest`.
- Keep neighboring filter controls compact by reducing rating chip width while preserving the 12px rating swatch marker.
- Update projection/layout tests for the full Harvest label and cramped-width alignment.

## Definition of Done

- The filter section displays `Harvest` in full instead of `Harve`.
- Filter row labels remain consistently aligned after the width adjustment.
- Filter controls do not overlap or become unreadable in normal and cramped sidebar widths.
- Automated tests cover the full Harvest label and adjusted label sizing behavior.

## Validation commands

- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate library_sidebar -- --test-threads=1`

Manual smoke: attempted `bash scripts/run.sh sandbox --name opt-874 --`; the fresh raw binary launched, but Computer Use attached to the existing installed `/Applications/Wavecrate.app` window rather than the just-built `target/release/wavecrate` process, so fresh-window visual confirmation is inconclusive locally.

Baseline preflight note: `bash scripts/agent.sh request` currently fails before this change on unrelated non-blocking guardrail violations in existing files such as `drag_drop_move.rs`, `sample_map.rs`, `duplicate.rs`, and `library_sidebar.rs`.

## Known limitations

None.

## Review

User review is required before merge.

Fixes OPT-874