### PR TITLE
Throttle live playmark retargets

### DIFF
--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -36,12 +36,13 @@ pub(in crate::native_app) use state::{
     AudioAppState, AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,
     ChromeUiState, ClipboardHandoffTarget, CutFileClipboard, ExtractedFilePlaybackType,
     FolderScanWorkerEvent, LibraryAppState, MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT,
-    MetadataAppState, NativeAppState, PendingFolderDelete, PendingPlaybackStart,
-    PendingRuntimePlaybackStart, PendingWaveformDestructiveEdit, SampleBrowserDisplayMode,
-    SampleMapAuditionDragState, SampleMapViewport, SampleMapViewportChange, SettingsAppState,
-    SourceFilesystemChangePlan, SourceRefreshRequest, SourceScanFinish, StartupState, StatusState,
-    UiAppState, WaveformAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
-    WaveformDestructiveEditUiContext, WaveformPlaySelectionSnapshot, run_folder_scan_worker,
+    MetadataAppState, NativeAppState, PendingFolderDelete, PendingPlaySelectionRetargetCycle,
+    PendingPlaybackStart, PendingRuntimePlaybackStart, PendingWaveformDestructiveEdit,
+    SampleBrowserDisplayMode, SampleMapAuditionDragState, SampleMapViewport,
+    SampleMapViewportChange, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshRequest,
+    SourceScanFinish, StartupState, StatusState, UiAppState, WaveformAppState,
+    WaveformDestructiveEditKind, WaveformDestructiveEditPrompt, WaveformDestructiveEditUiContext,
+    WaveformPlaySelectionSnapshot, run_folder_scan_worker,
 };
 
 pub(super) use crate::native_app::app_chrome::scene::view;

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -35,7 +35,9 @@ pub(in crate::native_app) use ui_state::{
     SampleMapViewport, SampleMapViewportChange, SettingsAppState, StartupState, StatusState,
     UiAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
 };
-pub(in crate::native_app) use waveform::{WaveformAppState, WaveformPlaySelectionSnapshot};
+pub(in crate::native_app) use waveform::{
+    PendingPlaySelectionRetargetCycle, WaveformAppState, WaveformPlaySelectionSnapshot,
+};
 
 pub(in crate::native_app) struct NativeAppState {
     pub(in crate::native_app) ui: UiAppState,

--- a/src/native_app/app/state/waveform.rs
+++ b/src/native_app/app/state/waveform.rs
@@ -19,6 +19,8 @@ pub(in crate::native_app) struct WaveformAppState {
     pub(in crate::native_app) pending_play_selection_transaction:
         Option<WaveformPlaySelectionSnapshot>,
     pub(in crate::native_app) pending_play_selection_retarget: bool,
+    pub(in crate::native_app) pending_play_selection_retarget_cycle:
+        Option<PendingPlaySelectionRetargetCycle>,
 }
 
 impl WaveformAppState {
@@ -29,6 +31,22 @@ impl WaveformAppState {
             cache: WaveformCacheState::default(),
             pending_play_selection_transaction: None,
             pending_play_selection_retarget: false,
+            pending_play_selection_retarget_cycle: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app) struct PendingPlaySelectionRetargetCycle {
+    pub(in crate::native_app) end_ratio: f32,
+    pub(in crate::native_app) last_progress_ratio: Option<f32>,
+}
+
+impl PendingPlaySelectionRetargetCycle {
+    pub(in crate::native_app) fn new(end_ratio: f32, last_progress_ratio: Option<f32>) -> Self {
+        Self {
+            end_ratio,
+            last_progress_ratio,
         }
     }
 }

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -1,8 +1,11 @@
 use std::time::Instant;
 
 use super::span::{playback_span_matches_selection, retarget_offset_for_selection};
-use crate::native_app::app::{NativeAppState, emit_gui_action};
+use crate::native_app::app::{NativeAppState, PendingPlaySelectionRetargetCycle, emit_gui_action};
 use wavecrate::audio::{AudioPlayer, PlaybackRuntimeSpanUpdate};
+
+const LIVE_LOOP_BOUNDARY_EPSILON: f32 = 0.01;
+const LIVE_LOOP_WRAP_EPSILON: f32 = 0.02;
 
 impl NativeAppState {
     pub(in crate::native_app) fn toggle_loop_playback(&mut self) {
@@ -72,8 +75,12 @@ impl NativeAppState {
     }
 
     pub(in crate::native_app) fn retarget_playback_to_play_selection(&mut self) {
+        self.retarget_playback_to_play_selection_with_seek(true);
+    }
+
+    fn retarget_playback_to_play_selection_with_seek(&mut self, seek_when_outside: bool) -> bool {
         if !self.waveform.current.is_playing() {
-            return;
+            return false;
         }
         let Some(selection) = self
             .waveform
@@ -81,18 +88,20 @@ impl NativeAppState {
             .play_selection()
             .filter(|selection| selection.width() > 0.0)
         else {
-            return;
+            return false;
         };
         if playback_span_matches_selection(self.audio.current_playback_span, selection) {
-            return;
+            return false;
         }
 
         let started_at = Instant::now();
         let current = self
             .current_audio_progress_ratio()
             .unwrap_or_else(|| selection.start());
+        let current_inside_selection =
+            current >= selection.start() && current < selection.end() - LIVE_LOOP_BOUNDARY_EPSILON;
         let offset = retarget_offset_for_selection(current, selection);
-        let seek_to_offset = !(selection.start()..=selection.end()).contains(&current);
+        let seek_to_offset = seek_when_outside && !current_inside_selection;
         let looped = self.audio.loop_playback;
         match self.retarget_active_playback_span(
             selection.start(),
@@ -137,16 +146,30 @@ impl NativeAppState {
                 );
             }
         }
+        true
     }
 
     pub(in crate::native_app) fn schedule_play_selection_playback_retarget(&mut self) {
         if self.waveform.current.is_playing() {
             self.waveform.pending_play_selection_retarget = true;
+            if self
+                .waveform
+                .pending_play_selection_retarget_cycle
+                .is_none()
+                && let Some((_, end_ratio)) = self.audio.current_playback_span
+            {
+                self.waveform.pending_play_selection_retarget_cycle =
+                    Some(PendingPlaySelectionRetargetCycle::new(
+                        end_ratio,
+                        self.current_audio_progress_ratio(),
+                    ));
+            }
         }
     }
 
     pub(in crate::native_app) fn retarget_playback_to_play_selection_now(&mut self) {
         self.waveform.pending_play_selection_retarget = false;
+        self.waveform.pending_play_selection_retarget_cycle = None;
         self.retarget_playback_to_play_selection();
     }
 
@@ -154,8 +177,58 @@ impl NativeAppState {
         if !self.waveform.pending_play_selection_retarget {
             return;
         }
+        if !self.waveform.current.is_playing() {
+            self.clear_pending_play_selection_retarget();
+            return;
+        }
+        let Some(selection) = self
+            .waveform
+            .current
+            .play_selection()
+            .filter(|selection| selection.width() > 0.0)
+        else {
+            self.clear_pending_play_selection_retarget();
+            return;
+        };
+        let Some(current) = self.current_audio_progress_ratio() else {
+            return;
+        };
+        if !self.audio.loop_playback {
+            self.remember_pending_play_selection_retarget_progress(current);
+            return;
+        }
+        if self.pending_play_selection_retarget_boundary_reached(current, selection.end()) {
+            self.clear_pending_play_selection_retarget();
+            self.retarget_playback_to_play_selection();
+            return;
+        }
+        self.remember_pending_play_selection_retarget_progress(current);
+    }
+
+    fn clear_pending_play_selection_retarget(&mut self) {
         self.waveform.pending_play_selection_retarget = false;
-        self.retarget_playback_to_play_selection();
+        self.waveform.pending_play_selection_retarget_cycle = None;
+    }
+
+    fn remember_pending_play_selection_retarget_progress(&mut self, current: f32) {
+        if let Some(cycle) = self.waveform.pending_play_selection_retarget_cycle.as_mut() {
+            cycle.last_progress_ratio = Some(current);
+        }
+    }
+
+    fn pending_play_selection_retarget_boundary_reached(
+        &self,
+        current: f32,
+        target_end: f32,
+    ) -> bool {
+        let Some(cycle) = self.waveform.pending_play_selection_retarget_cycle else {
+            return false;
+        };
+        let boundary = target_end.min(cycle.end_ratio);
+        current >= boundary - LIVE_LOOP_BOUNDARY_EPSILON
+            || cycle
+                .last_progress_ratio
+                .is_some_and(|last| current + LIVE_LOOP_WRAP_EPSILON < last)
     }
 
     fn retarget_active_playback_span(

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -1617,10 +1617,13 @@ fn looped_playback_retargets_when_playmark_selection_is_created_and_resized() {
     scenario.begin_play_range(0.25);
     scenario.update_play_range_drag(0.60);
 
-    assert_playback_span_state(&scenario.state, 0.25, 0.60);
-    assert_waveform_progress_inside_span(&scenario.state, 0.25, 0.60);
+    assert_playback_span_state(&scenario.state, 0.0, 1.0);
+    assert_waveform_progress_inside_span(&scenario.state, 0.0, 1.0);
     assert!(scenario.state.audio.loop_playback);
     scenario.finish_play_range_drag(0.60);
+
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert_waveform_progress_inside_span(&scenario.state, 0.25, 0.60);
 
     scenario.begin_play_range_start_resize(0.25);
     scenario.update_play_range_drag(0.10);
@@ -1629,8 +1632,14 @@ fn looped_playback_retargets_when_playmark_selection_is_created_and_resized() {
     assert!(scenario.state.waveform.pending_play_selection_retarget);
     scenario.apply_frame();
 
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.state.waveform.current.set_playhead_ratio(0.595);
+    scenario.apply_frame();
+
     assert_playback_span_state(&scenario.state, 0.10, 0.60);
-    assert_waveform_progress_inside_span(&scenario.state, 0.10, 0.60);
+    assert_waveform_progress_near(&scenario.state, 0.10);
     scenario.finish_play_range_drag(0.10);
 }
 
@@ -1655,8 +1664,15 @@ fn looped_playback_retarget_keeps_current_cycle_when_playhead_still_fits() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
-    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_playback_span_state(&scenario.state, 0.20, 0.60);
     assert_waveform_progress_near(&scenario.state, 0.50);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.state.waveform.current.set_playhead_ratio(0.595);
+    scenario.apply_frame();
+
+    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_waveform_progress_near(&scenario.state, 0.595);
 
     scenario.state.waveform.current.set_playhead_ratio(0.50);
     let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
@@ -1670,13 +1686,24 @@ fn looped_playback_retarget_keeps_current_cycle_when_playhead_still_fits() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
+    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.state.waveform.current.set_playhead_ratio(0.645);
+    scenario.apply_frame();
+
     assert_playback_span_state(&scenario.state, 0.20, 0.65);
-    assert_waveform_progress_near(&scenario.state, 0.50);
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        playback_start_id
+    );
+    assert_playback_span_state(&scenario.state, 0.20, 0.65);
+    assert_waveform_progress_near(&scenario.state, 0.20);
     scenario.finish_play_range_drag(0.65);
 }
 
 #[test]
-fn looped_playback_retarget_restarts_when_playhead_is_past_new_end() {
+fn looped_playback_retarget_waits_until_playhead_reaches_new_end() {
     let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
         return;
     };
@@ -1684,7 +1711,7 @@ fn looped_playback_retarget_restarts_when_playhead_is_past_new_end() {
     scenario.select_play_range(0.20, 0.80);
     scenario.begin_play_range_end_resize(0.80);
 
-    scenario.state.waveform.current.set_playhead_ratio(0.70);
+    scenario.state.waveform.current.set_playhead_ratio(0.40);
     let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
     scenario.update_play_range_drag(0.55);
 
@@ -1696,6 +1723,13 @@ fn looped_playback_retarget_restarts_when_playhead_is_past_new_end() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
+    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_waveform_progress_near(&scenario.state, 0.40);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.state.waveform.current.set_playhead_ratio(0.545);
+    scenario.apply_frame();
+
     assert_playback_span_state(&scenario.state, 0.20, 0.55);
     assert_waveform_progress_near(&scenario.state, 0.20);
     scenario.finish_play_range_drag(0.55);
@@ -1715,10 +1749,13 @@ fn one_shot_playback_retargets_when_playmark_selection_is_created_and_resized() 
     scenario.begin_play_range(0.25);
     scenario.update_play_range_drag(0.60);
 
-    assert_playback_span_state(&scenario.state, 0.25, 0.60);
-    assert_waveform_progress_near(&scenario.state, 0.25);
+    assert_playback_span_state(&scenario.state, 0.0, 1.0);
+    assert_waveform_progress_inside_span(&scenario.state, 0.0, 1.0);
     assert!(!scenario.state.audio.loop_playback);
     scenario.finish_play_range_drag(0.60);
+
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert_waveform_progress_near(&scenario.state, 0.25);
 
     scenario.begin_play_range_start_resize(0.25);
     scenario.update_play_range_drag(0.10);
@@ -1727,9 +1764,13 @@ fn one_shot_playback_retargets_when_playmark_selection_is_created_and_resized() 
     assert!(scenario.state.waveform.pending_play_selection_retarget);
     scenario.apply_frame();
 
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.finish_play_range_drag(0.10);
+
     assert_playback_span_state(&scenario.state, 0.10, 0.60);
     assert_waveform_progress_near(&scenario.state, 0.25);
-    scenario.finish_play_range_drag(0.10);
 }
 
 #[test]
@@ -1756,14 +1797,15 @@ fn one_shot_playback_retarget_keeps_current_pass_when_playhead_still_fits() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
-    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_playback_span_state(&scenario.state, 0.20, 0.60);
     assert_waveform_progress_near(&scenario.state, 0.50);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
 
     scenario.state.waveform.current.set_playhead_ratio(0.50);
     let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
     scenario.update_play_range_drag(0.65);
 
-    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_playback_span_state(&scenario.state, 0.20, 0.60);
     assert!(scenario.state.waveform.pending_play_selection_retarget);
     scenario.apply_frame();
 
@@ -1771,13 +1813,22 @@ fn one_shot_playback_retarget_keeps_current_pass_when_playhead_still_fits() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
+    assert_playback_span_state(&scenario.state, 0.20, 0.60);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.finish_play_range_drag(0.65);
+
+    assert_playback_span_state(&scenario.state, 0.20, 0.65);
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        playback_start_id
+    );
     assert_playback_span_state(&scenario.state, 0.20, 0.65);
     assert_waveform_progress_near(&scenario.state, 0.50);
-    scenario.finish_play_range_drag(0.65);
 }
 
 #[test]
-fn one_shot_playback_retarget_restarts_when_playhead_is_past_new_end() {
+fn one_shot_playback_retarget_waits_when_live_drag_excludes_playhead() {
     let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
         return;
     };
@@ -1800,6 +1851,29 @@ fn one_shot_playback_retarget_restarts_when_playhead_is_past_new_end() {
         pending_runtime_playback_start_id(&scenario.state),
         playback_start_id
     );
+    assert_playback_span_state(&scenario.state, 0.20, 0.80);
+    assert_waveform_progress_near(&scenario.state, 0.70);
+    assert!(scenario.state.waveform.pending_play_selection_retarget);
+
+    scenario.finish_play_range_drag(0.55);
+
+    assert_playback_span_state(&scenario.state, 0.20, 0.55);
+    assert_waveform_progress_near(&scenario.state, 0.20);
+}
+
+#[test]
+fn looped_playback_retarget_restarts_when_playhead_is_already_beyond_new_end() {
+    let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
+        return;
+    };
+    scenario.start_full_sample_loop();
+    scenario.select_play_range(0.20, 0.80);
+    scenario.begin_play_range_end_resize(0.80);
+
+    scenario.state.waveform.current.set_playhead_ratio(0.70);
+    scenario.update_play_range_drag(0.55);
+    scenario.apply_frame();
+
     assert_playback_span_state(&scenario.state, 0.20, 0.55);
     assert_waveform_progress_near(&scenario.state, 0.20);
     scenario.finish_play_range_drag(0.55);


### PR DESCRIPTION
## Scope
- Stop playback glitching while resizing or moving an active playmark/loop selection.
- Keep playmark visuals live during pointer drag.
- Existing playmark resize/move schedules live retargeting, but audio is not retargeted every frame.
- For loop playback, apply the resized loop only when playback reaches the new loop end, or immediately if the playhead is already beyond that new end.
- Preserve release-time retargeting so the completed playmark range is exact.
- Extend native playback tests for looped and one-shot playmark retarget behavior.

## Definition of Done
- Fresh playmark painting still does not retarget playback during the initial tiny `UpdateSelection` drag.
- Existing playmark resize/move can update visuals continuously without restarting playback every frame.
- If the playhead is before the resized loop end, playback keeps the current pass until it reaches that new end.
- If the playhead is already beyond the resized loop end, playback restarts at the loop start immediately.
- Extending a loop waits until the previous loop end before applying the larger loop, avoiding repeated retargets while dragging.
- Finished playmark edits retarget immediately on `FinishSelection`.

## Validation commands
- `cargo fmt --all`
- `cargo test -p wavecrate shell::message_dispatch::waveform::tests -- --test-threads=1`
- `cargo test -p wavecrate waveform_playback::looped_playback_retarget -- --test-threads=1`
- `cargo test -p wavecrate waveform_playback::one_shot_playback_retarget -- --test-threads=1`
- `git diff --check`

## Known limitations
- Broader repo preflight is currently red on existing unrelated non-blocking guardrail violations in `src/native_app/sample_library/folder_browser/drag_drop_move.rs`, `src/native_app/sample_library/folder_browser/sample_map.rs`, `src/native_app/sample_library/harvest_tracking.rs`, `src/native_app/workflows/context_menu_actions/duplicate.rs`, and `src/native_app/app_chrome/view_models/library_sidebar.rs`.
- `cargo test -p wavecrate waveform_playback -- --test-threads=1` currently fails in unrelated harvest persistence tests that reproduce in isolation, e.g. `waveform_playback::playmark_selection_change_marks_harvest_file_touched` reports `harvest file should exist`.

## Review
User signed off for merge.

