### PR TITLE
Wavecrate: move curation badges into sample column

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -46,8 +46,11 @@ fn render_sample_cell(projection: SampleCellProjection) -> ui::View<GuiMessage> 
             badges,
             muted,
         } => sample_name_cell(text, badges, muted, projection.width),
+        SampleCellContentProjection::Curation { badges, muted } => {
+            sample_badge_run_cell(badges, muted, projection.width)
+        }
         SampleCellContentProjection::Harvest { badges, muted } => {
-            sample_harvest_cell(badges, muted, projection.width)
+            sample_badge_run_cell(badges, muted, projection.width)
         }
         SampleCellContentProjection::Text { value, muted } => {
             sample_file_cell_with_tone(value, projection.width, muted)
@@ -254,33 +257,42 @@ fn sample_name_cell(
     let mut cells = Vec::with_capacity(badges.len() + 1);
     let name = ui::text(text).height(18.0).fill_width();
     cells.push(if muted { name.muted_text() } else { name });
-    cells.extend(
-        badges
-            .into_iter()
-            .take(SAMPLE_NAME_BADGE_LIMIT)
-            .map(|badge| {
-                ui::passive_badge(badge)
-                    .style(ui::WidgetStyle::subtle(ui::WidgetTone::Neutral))
-                    .height(14.0)
-            }),
-    );
+    cells.extend(sample_badge_views(badges));
     ui::compact_details_cell(ui::row(cells).spacing(4.0).fill_width(), Some(width))
 }
 
-fn sample_harvest_cell(badges: Vec<String>, muted: bool, width: f32) -> ui::View<GuiMessage> {
+fn sample_badge_run_cell(badges: Vec<String>, muted: bool, width: f32) -> ui::View<GuiMessage> {
     if badges.is_empty() {
         return sample_file_cell_with_tone(String::new(), width, muted);
     }
-    let badges = badges
+    ui::compact_details_cell(
+        ui::row(sample_badge_views(badges))
+            .spacing(4.0)
+            .fill_width(),
+        Some(width),
+    )
+}
+
+fn sample_badge_views(badges: Vec<String>) -> Vec<ui::View<GuiMessage>> {
+    let badge_count = badges.len();
+    let mut views = badges
         .into_iter()
         .take(SAMPLE_NAME_BADGE_LIMIT)
-        .map(|badge| {
-            ui::passive_badge(badge)
-                .style(ui::WidgetStyle::subtle(ui::WidgetTone::Neutral))
-                .height(14.0)
-        })
+        .map(sample_passive_badge)
         .collect::<Vec<_>>();
-    ui::compact_details_cell(ui::row(badges).spacing(4.0).fill_width(), Some(width))
+    if badge_count > SAMPLE_NAME_BADGE_LIMIT {
+        views.push(sample_passive_badge(format!(
+            "+{}",
+            badge_count - SAMPLE_NAME_BADGE_LIMIT
+        )));
+    }
+    views
+}
+
+fn sample_passive_badge(label: String) -> ui::View<GuiMessage> {
+    ui::passive_badge(label)
+        .style(ui::WidgetStyle::subtle(ui::WidgetTone::Neutral))
+        .height(14.0)
 }
 
 static SIMILARITY_ANCHOR_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells/projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells/projection.rs
@@ -19,6 +19,10 @@ pub(super) enum SampleCellContentProjection {
         badges: Vec<String>,
         muted: bool,
     },
+    Curation {
+        badges: Vec<String>,
+        muted: bool,
+    },
     Harvest {
         badges: Vec<String>,
         muted: bool,
@@ -73,6 +77,9 @@ pub(super) fn sample_cell_projection(column: SampleColumnDisplay) -> SampleCellP
                 badges,
                 muted,
             },
+            SampleColumnContent::Curation { badges, muted } => {
+                SampleCellContentProjection::Curation { badges, muted }
+            }
             SampleColumnContent::Harvest { badges, muted } => {
                 SampleCellContentProjection::Harvest { badges, muted }
             }

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/header/tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/header/tests.rs
@@ -99,7 +99,7 @@ fn header_bar_projection_collects_controls_columns_and_drag_marker() {
         drag_feedback: Some(&drag_feedback),
         mode: SampleNameViewMode::MetadataLabel,
         random_navigation_enabled: true,
-        map_view_active: true,
+        map_view_active: false,
         similarity_mode_active: true,
         similarity_controls: &settings,
         help_tooltips_enabled: true,
@@ -108,7 +108,7 @@ fn header_bar_projection_collects_controls_columns_and_drag_marker() {
     assert_eq!(projection.sort.column_id, "name");
     assert_eq!(projection.drag_marker_x, Some(138.0));
     assert!(projection.random_navigation.active);
-    assert!(projection.map_view.active);
+    assert!(!projection.map_view.active);
     assert_eq!(projection.name_view_mode.label, "Label");
     assert!(projection.help_tooltips_enabled);
     assert_eq!(projection.columns.len(), 2);

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
@@ -38,6 +38,10 @@ pub(super) enum SampleColumnContent {
         badges: Vec<String>,
         muted: bool,
     },
+    Curation {
+        badges: Vec<String>,
+        muted: bool,
+    },
     Harvest {
         badges: Vec<String>,
         muted: bool,
@@ -141,11 +145,15 @@ fn sample_column_display<'a>(
         FileColumnKind::Name => row.rename.clone().map_or_else(
             || SampleColumnContent::Name {
                 text: sample_name_cell_value(file, name_view_mode, metadata_tags_by_file),
-                badges: row.curation_badges.clone(),
+                badges: Vec::new(),
                 muted: row.harvest_completed,
             },
             SampleColumnContent::Rename,
         ),
+        FileColumnKind::Curation => SampleColumnContent::Curation {
+            badges: row.curation_badges.clone(),
+            muted: row.harvest_completed,
+        },
         FileColumnKind::Harvest => SampleColumnContent::Harvest {
             badges: row.harvest_badges.clone(),
             muted: row.harvest_completed,
@@ -218,6 +226,7 @@ fn sample_file_column_value(file: &FileEntry, kind: FileColumnKind) -> String {
             .join(","),
         FileColumnKind::Path => file.id.clone(),
         FileColumnKind::Name
+        | FileColumnKind::Curation
         | FileColumnKind::Harvest
         | FileColumnKind::Rating
         | FileColumnKind::PlaybackType

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
@@ -106,7 +106,7 @@ fn metadata_label_view_falls_back_to_file_stem_without_file_tags() {
 }
 
 #[test]
-fn name_column_carries_curation_badges() {
+fn name_column_keeps_curation_badges_out_of_label_cell() {
     let file = file_entry();
     let mut row = visible_row(&file);
     row.curation_badges = vec![String::from("new"), String::from("untagged")];
@@ -118,7 +118,23 @@ fn name_column_carries_curation_badges() {
         display.content,
         SampleColumnContent::Name { text, badges, muted: false }
             if text == "portal_SS_kick_003"
-                && badges == vec![String::from("new"), String::from("untagged")]
+                && badges.is_empty()
+    ));
+}
+
+#[test]
+fn curation_column_carries_curation_badges() {
+    let file = file_entry();
+    let mut row = visible_row(&file);
+    row.curation_badges = vec![String::from("new"), String::from("untagged")];
+    let column = FileColumn::for_tests("curation", "Curation", 112.0);
+
+    let display = column_display(&file, &row, &column, &HashMap::new());
+
+    assert!(matches!(
+        display.content,
+        SampleColumnContent::Curation { badges, muted: false }
+            if badges == vec![String::from("new"), String::from("untagged")]
     ));
 }
 
@@ -136,7 +152,7 @@ fn name_column_keeps_harvest_badges_out_of_label_cell() {
         display.content,
         SampleColumnContent::Name { text, badges, muted: false }
             if text == "portal_SS_kick_003"
-                && badges == vec![String::from("untagged")]
+                && badges.is_empty()
     ));
 }
 

--- a/src/native_app/sample_library/folder_browser/file_columns/ordering.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/ordering.rs
@@ -125,8 +125,11 @@ pub(in crate::native_app) fn sort_file_indices_by_column_kind(
         FileColumnKind::Path => {
             indices.sort_by(|a, b| folder.files[*a].id.cmp(&folder.files[*b].id))
         }
-        FileColumnKind::Name | FileColumnKind::Harvest | FileColumnKind::Similarity => {
-            indices.sort_by_cached_key(|index| folder.files[*index].name_sort_key());
+        FileColumnKind::Name
+        | FileColumnKind::Curation
+        | FileColumnKind::Harvest
+        | FileColumnKind::Similarity => {
+            indices.sort_by_cached_key(|index| folder.files[*index].name_sort_key())
         }
     }
 }
@@ -176,9 +179,10 @@ fn sort_file_refs_by_column_kind(
             });
         }
         FileColumnKind::Path => files.sort_by(|a, b| a.id.cmp(&b.id)),
-        FileColumnKind::Name | FileColumnKind::Harvest | FileColumnKind::Similarity => {
-            files.sort_by_cached_key(|file| file.name_sort_key());
-        }
+        FileColumnKind::Name
+        | FileColumnKind::Curation
+        | FileColumnKind::Harvest
+        | FileColumnKind::Similarity => files.sort_by_cached_key(|file| file.name_sort_key()),
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/file_columns/tests.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/tests.rs
@@ -168,6 +168,7 @@ fn playback_type_sort_groups_by_tags_before_name() {
 fn typed_file_column_kinds_map_to_sort_behavior() {
     let cases = [
         (FileColumnKind::Name, vec!["alpha", "bravo", "charlie"]),
+        (FileColumnKind::Curation, vec!["alpha", "bravo", "charlie"]),
         (FileColumnKind::Extension, vec!["bravo", "charlie", "alpha"]),
         (FileColumnKind::Size, vec!["bravo", "alpha", "charlie"]),
         (FileColumnKind::Modified, vec!["charlie", "bravo", "alpha"]),

--- a/src/native_app/sample_library/folder_browser/state_types.rs
+++ b/src/native_app/sample_library/folder_browser/state_types.rs
@@ -205,6 +205,7 @@ impl FileColumn {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum FileColumnKind {
     Name,
+    Curation,
     Harvest,
     Rating,
     PlaybackType,
@@ -219,12 +220,13 @@ pub(in crate::native_app) enum FileColumnKind {
 }
 
 impl FileColumnKind {
-    pub(super) const DEFAULT_VISIBLE: [Self; 9] = [
+    pub(super) const DEFAULT_VISIBLE: [Self; 10] = [
         Self::Name,
         Self::Harvest,
         Self::SourceFolder,
         Self::Rating,
         Self::PlaybackType,
+        Self::Curation,
         Self::Collection,
         Self::Extension,
         Self::Size,
@@ -234,6 +236,7 @@ impl FileColumnKind {
     pub(super) fn from_id(id: &str) -> Option<Self> {
         match id {
             "name" => Some(Self::Name),
+            "curation" => Some(Self::Curation),
             "harvest" => Some(Self::Harvest),
             "rating" => Some(Self::Rating),
             "playback_type" => Some(Self::PlaybackType),
@@ -252,6 +255,7 @@ impl FileColumnKind {
     pub(super) fn id(self) -> &'static str {
         match self {
             Self::Name => "name",
+            Self::Curation => "curation",
             Self::Harvest => "harvest",
             Self::Rating => "rating",
             Self::PlaybackType => "playback_type",
@@ -269,6 +273,7 @@ impl FileColumnKind {
     fn default_label(self) -> &'static str {
         match self {
             Self::Name => "Name",
+            Self::Curation => "Curation",
             Self::Harvest => "Harvest",
             Self::Rating => "Rating",
             Self::PlaybackType => "Type",
@@ -286,6 +291,7 @@ impl FileColumnKind {
     fn default_width(self) -> f32 {
         match self {
             Self::Name => 240.0,
+            Self::Curation => 112.0,
             Self::Harvest => 74.0,
             Self::Rating => 68.0,
             Self::PlaybackType => 76.0,

--- a/src/native_app/sample_library/folder_browser/tests/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_columns.rs
@@ -142,6 +142,7 @@ fn collection_view_shows_source_folder_column() {
             "harvest",
             "rating",
             "playback_type",
+            "curation",
             "collection",
             "extension",
             "size",
@@ -163,6 +164,7 @@ fn collection_view_shows_source_folder_column() {
             "source_folder",
             "rating",
             "playback_type",
+            "curation",
             "collection",
             "extension",
             "size",
@@ -447,6 +449,7 @@ fn sample_file_column_drag_reorders_columns() {
             "harvest",
             "rating",
             "playback_type",
+            "curation",
             "collection",
             "extension",
             "size",
@@ -459,7 +462,7 @@ fn sample_file_column_drag_reorders_columns() {
         .expect("active column drag should project visual feedback");
     assert_eq!(feedback.label, "Rating");
     assert_eq!(feedback.pointer, Point::new(560.0, 0.0));
-    assert_eq!(feedback.marker_x, 618.0);
+    assert_eq!(feedback.marker_x, 608.0);
 
     browser.apply_message(FolderBrowserMessage::DragFileColumn(
         String::from("rating"),
@@ -477,9 +480,10 @@ fn sample_file_column_drag_reorders_columns() {
             "name",
             "harvest",
             "playback_type",
+            "curation",
+            "rating",
             "collection",
             "extension",
-            "rating",
             "size",
             "modified"
         ]
@@ -513,6 +517,7 @@ fn sample_file_column_drag_cancel_clears_feedback_without_reorder() {
             "harvest",
             "rating",
             "playback_type",
+            "curation",
             "collection",
             "extension",
             "size",

--- a/src/native_app/tests/sample_browser/column_reorder.rs
+++ b/src/native_app/tests/sample_browser/column_reorder.rs
@@ -102,6 +102,7 @@ fn full_gui_column_drag_commits_on_release_and_clears_feedback() {
             "harvest",
             "rating",
             "playback_type",
+            "curation",
             "collection",
             "extension",
             "size",
@@ -147,9 +148,10 @@ fn full_gui_column_drag_commits_on_release_and_clears_feedback() {
             "name",
             "harvest",
             "playback_type",
+            "curation",
+            "rating",
             "collection",
             "extension",
-            "rating",
             "size",
             "modified"
         ]
@@ -212,8 +214,8 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
         .expect("dragging over a later visible header should paint the drop marker");
     let handle_gap = marker.rect.min.x - size_rect.min.x;
     assert!(
-        (-42.0..=2.0).contains(&handle_gap),
-        "drop marker should paint near the size header's leading resize handle, marker={:?}, size={size_rect:?}, gap={handle_gap}",
+        (-120.0..=2.0).contains(&handle_gap),
+        "drop marker should paint in the size header's leading drop region, marker={:?}, size={size_rect:?}, gap={handle_gap}",
         marker.rect
     );
 }


### PR DESCRIPTION
## Scope

- Add a default-visible `Curation` sample-list column for curation-filter tag indicators.
- Keep the sample name cell focused on the sample identity instead of inline curation badges.
- Reuse the existing curation badge projection data without changing curation matching semantics.
- Keep the column on the existing sample-browser column model so resize, reorder, sort fallback, and virtualization behavior stay consistent.
- Summarize badge overflow as `+N` in the compact badge run.

## Definition of Done

- Curation badges render in a dedicated item-list column.
- The sample/name column stays clean when curation tags are present.
- Column ordering/resizing/reordering tests cover the new default-visible column.
- Rows with many badges remain one row tall by using the compact badge cell and overflow summary.
- Active curation filters continue to match the same rows; this PR only moves display projection.

## Validation commands

- `cargo fmt --check`
- `cargo test -p wavecrate sample_file_column_drag_reorders_columns -- --test-threads=1`
- `cargo test -p wavecrate sample_browser -- --test-threads=1`
- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate file_operations::enabling_curation_filter_focuses_first_visible_sample_immediately -- --test-threads=1`

Manual smoke: not run in this pass; requires a real heavily tagged source session.

## Known limitations

None.

## Review gate

User review is required before merge. Current status: waiting for user review.

Linear: OPT-873