### PR TITLE
Fix nightly tag ref lookup

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           target_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq '.sha')"
-          previous_nightly_sha="$(gh api "repos/$REPOSITORY/git/ref/tags/nightly" --jq '.object.sha' 2>/dev/null || true)"
+          previous_nightly_sha="$(scripts/internal/release/github_ref_sha.sh --allow-missing "$REPOSITORY" tags/nightly)"
           build_number="$(git rev-list --count "$target_sha")"
           short_sha="${target_sha::8}"
           nightly_version="nightly-b${build_number}-${short_sha}"
@@ -378,13 +378,15 @@ jobs:
       - name: Publish nightly tags
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
           TARGET_SHA: ${{ needs.resolve-main.outputs.target_sha }}
           NIGHTLY_VERSION: ${{ needs.resolve-main.outputs.nightly_version }}
         run: |
           set -euo pipefail
-          existing_version_sha="$(gh api \
-            "repos/${{ github.repository }}/git/ref/tags/${NIGHTLY_VERSION}" \
-            --jq '.object.sha' 2>/dev/null || true)"
+          existing_version_sha="$(scripts/internal/release/github_ref_sha.sh \
+            --allow-missing \
+            "$REPOSITORY" \
+            "tags/${NIGHTLY_VERSION}")"
           if [[ -n "$existing_version_sha" && "$existing_version_sha" != "$TARGET_SHA" ]]; then
             echo "Immutable nightly tag ${NIGHTLY_VERSION} points at ${existing_version_sha}, expected ${TARGET_SHA}." >&2
             exit 1

--- a/scripts/internal/release/github_ref_sha.sh
+++ b/scripts/internal/release/github_ref_sha.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: github_ref_sha.sh [--allow-missing] <owner/repo> <ref>
+
+Prints the commit SHA pointed to by a GitHub git ref, such as tags/nightly.
+When --allow-missing is set, a 404 is treated as an empty result.
+EOF
+}
+
+allow_missing=0
+if [[ "${1:-}" == "--allow-missing" ]]; then
+  allow_missing=1
+  shift
+fi
+
+if [[ $# -ne 2 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    exit 0
+  fi
+  exit 2
+fi
+
+repository="$1"
+ref="$2"
+error_log="$(mktemp)"
+trap 'rm -f "$error_log"' EXIT
+
+if sha="$(gh api "repos/${repository}/git/ref/${ref}" --jq '.object.sha' 2>"$error_log")"; then
+  printf '%s\n' "$sha"
+  exit 0
+else
+  status=$?
+fi
+
+if [[ "$allow_missing" -eq 1 ]] && grep -q "HTTP 404" "$error_log"; then
+  exit 0
+fi
+
+cat "$error_log" >&2
+exit "$status"


### PR DESCRIPTION
## Scope
- Fix the nightly release workflow's GitHub ref lookups so missing nightly refs are treated as absent tags instead of as JSON error payloads.
- Add `scripts/internal/release/github_ref_sha.sh` as the shared ref lookup helper for the rolling `nightly` tag and immutable `nightly-b<build>-<sha>` tag checks.

## Definition of Done
- Missing GitHub refs under `--allow-missing` produce empty output and exit successfully.
- Existing GitHub refs still resolve to their object SHA.
- Non-allowed missing refs still fail with the original `gh` error.
- The workflow YAML and shell helper pass syntax/guardrail checks.

## Validation commands
- `bash -n scripts/internal/release/github_ref_sha.sh && ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-build.yml"); puts "workflow yaml ok"'`
- `scripts/internal/release/github_ref_sha.sh --allow-missing PORTALSURFER/wavecrate tags/nightly-b6095-83be925d`
- `scripts/internal/release/github_ref_sha.sh PORTALSURFER/wavecrate tags/nightly`
- `scripts/internal/release/github_ref_sha.sh PORTALSURFER/wavecrate tags/nightly-b6095-83be925d` (expected failure without `--allow-missing`)
- `bash scripts/check.sh script-guardrails`
- `bash scripts/check.sh workflow-toolchain`
- `git diff --check`

## Known limitations
- `bash scripts/agent.sh request` currently fails on pre-existing native-app non-blocking guardrail violations in files outside this release workflow change. The focused script/workflow validation above passes.

## Review
User review is required before merge.
