### PR TITLE
Fix Harvest filter arrow dropdown

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -241,7 +241,6 @@ pub(in crate::native_app) enum GuiMessage {
     OpenReleaseDownloadPage,
     ToggleShortcutHelp,
     CloseShortcutHelp,
-    ToggleHarvestFamilyPanel,
     ToggleCurationFilterDropdown,
     CloseCurationFilterDropdown,
     ToggleHarvestFilterDropdown,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -237,7 +237,7 @@ pub(super) fn automation_curation_filter_dropdown_option_id(label: &str) -> u64 
 fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     let help_tooltips_enabled = row.help_tooltips_enabled;
     let controls = ui::row([
-        harvest_family_toggle(row.family_available, row.family_open, help_tooltips_enabled),
+        harvest_filter_arrow_toggle(row.dropdown_open, help_tooltips_enabled),
         ui::dropdown_trigger(row.selected_label, row.dropdown_open)
             .toggle_message(GuiMessage::ToggleHarvestFilterDropdown)
             .build()
@@ -257,25 +257,16 @@ fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     )
 }
 
-fn harvest_family_toggle(
-    available: bool,
+fn harvest_filter_arrow_toggle(
     open: bool,
     help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     ui::disclosure_button(open)
-        .enabled(available)
         .active(open)
-        .message(GuiMessage::ToggleHarvestFamilyPanel)
+        .message(GuiMessage::ToggleHarvestFilterDropdown)
         .id(widget_ids::HARVEST_FAMILY_TOGGLE_ID)
         .size(HARVEST_FAMILY_TOGGLE_WIDTH, FILTER_CLEAR_BUTTON_SIZE)
-        .tooltip_if(
-            help_tooltips_enabled,
-            if available {
-                "Show harvest family details for the selected sample."
-            } else {
-                "Select a harvest-tracked sample to show harvest family details."
-            },
-        )
+        .tooltip_if(help_tooltips_enabled, "Choose the Harvest queue to show.")
 }
 
 pub(super) fn harvest_filter_dropdown_menu(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -225,17 +225,32 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
 }
 
 #[test]
-fn filter_section_projects_harvest_family_toggle_button() {
+fn filter_section_projects_harvest_arrow_button_opens_filter_dropdown() {
     let state = FolderBrowserState::load_default();
     let mut model = FilterSectionViewModel::from_folder_browser(&state, false);
-    model.harvest.family_available = true;
-    model.harvest.family_open = true;
+    model.harvest.selected_filter = Some(HarvestFilter::NeedsReview);
+    model.harvest.family_available = false;
+    model.harvest.family_open = false;
+    model.harvest.dropdown_open = false;
+    let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+
+    assert!(
+        frame
+            .paint_plan
+            .first_widget_rect(HARVEST_FAMILY_TOGGLE_ID)
+            .is_some(),
+        "Harvest arrow hit target should remain clickable even without a selected harvest family"
+    );
+    assert!(frame.paint_plan.contains_text("Needs Review  v"));
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
             HARVEST_FAMILY_TOGGLE_ID,
             ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
-        Some(GuiMessage::ToggleHarvestFamilyPanel)
+        Some(GuiMessage::ToggleHarvestFilterDropdown)
     );
 }
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -146,7 +146,6 @@ impl NativeAppState {
             | GuiMessage::ToggleShortcutHelp
             | GuiMessage::CloseShortcutHelp
             | GuiMessage::ToggleStickyRandomSampleRangePlayback
-            | GuiMessage::ToggleHarvestFamilyPanel
             | GuiMessage::ToggleCurationFilterDropdown
             | GuiMessage::CloseCurationFilterDropdown
             | GuiMessage::ToggleHarvestFilterDropdown

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -38,9 +38,6 @@ impl NativeAppState {
                     String::from("Sticky random playback off: Space plays selected samples")
                 };
             }
-            GuiMessage::ToggleHarvestFamilyPanel => {
-                self.ui.chrome.harvest_family_open = !self.ui.chrome.harvest_family_open;
-            }
             GuiMessage::ToggleCurationFilterDropdown => {
                 self.ui.chrome.curation_filter_dropdown_open =
                     !self.ui.chrome.curation_filter_dropdown_open;


### PR DESCRIPTION
## Scope
- Route the visible Harvest filter arrow affordance to the Harvest filter dropdown toggle.
- Keep the currently selected Harvest mode readable in the row while making the arrow hit target responsive even when no harvest family is selected.
- Remove the now-unused Harvest family panel toggle message path.
- Add projection/widget dispatch coverage for the arrow hit target.

## Definition of Done
- Clicking the Harvest filter arrow dispatches the same dropdown action as the Harvest mode chooser.
- The selected Harvest filter mode remains visible after rendering the row.
- Existing Harvest filter modes and selection messages remain unchanged.
- Focus/list behavior is preserved by leaving Harvest filter state and row matching unchanged.
- Automated coverage verifies the arrow hit target dispatches `ToggleHarvestFilterDropdown`.

## Validation Commands
- `bash scripts/agent.sh request` *(fails on existing architecture guardrail issues in folder move/harvest tracking/sidebar files before this branch's focused change; see Known limitations)*
- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate file_operations -- --test-threads=1`
- `git diff --check`

## Known Limitations
- Manual UI smoke was not run in the desktop app during this pass.
- Repo preflight currently fails on pre-existing architecture guardrail findings unrelated to this patch, including `drag_drop_move.rs`, `sample_map.rs`, `harvest_tracking.rs`, `duplicate.rs`, and `library_sidebar.rs`.

User review is required before merge.
