### PR TITLE
OPT-882: Add map-selected copy flash regression

### DIFF
--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -415,6 +415,58 @@ fn map_audition_selection_is_revealed_when_returning_to_list_mode() {
 }
 
 #[test]
+fn copying_sample_selected_from_map_flashes_map_node_and_waveform() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let first = source_root.path().join("a.wav");
+    let second = source_root.path().join("b.wav");
+    write_test_wav_i16(&first, &[0, 100, -100]);
+    write_test_wav_i16(&second, &[0, 120, -120]);
+    let first_id = first.display().to_string();
+    let second_id = second.display().to_string();
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(
+            crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+                wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+            ]),
+        )
+        .build();
+    state.library.folder_browser.select_file(first_id);
+    state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::BeginSampleMapAuditionDrag {
+            path: Some(second_id.clone()),
+            position: Point::new(10.0, 10.0),
+            modifiers: PointerModifiers::default(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    state.copy_selected_files(&mut radiant::prelude::UiUpdateContext::default());
+
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(second_id.as_str()),
+        "copy feedback must not disturb map-driven selection"
+    );
+    assert!(
+        state.waveform.current.copy_flash_frames() > 0,
+        "copying the map-selected sample should flash the waveform"
+    );
+    let items = state.library.folder_browser.sample_map_projection(
+        crate::native_app::sample_library::folder_browser::sample_map::SampleMapProjection {
+            tags_by_file: &state.metadata.tags_by_file,
+            instant_audition_sample_paths: &state.waveform.cache.instant_audition_sample_paths,
+        },
+    );
+    assert!(
+        items
+            .iter()
+            .any(|item| item.file_id == second_id && item.selected && item.copy_flash),
+        "copying the map-selected sample should flash the selected map node"
+    );
+}
+
+#[test]
 fn sample_map_drag_keeps_only_latest_pending_hit() {
     let source_root = tempfile::tempdir().expect("source root");
     let first = source_root.path().join("a.wav");


### PR DESCRIPTION
## Active PR Tracking

- Current branch: `wsvasek/opt-882-wavecrate-flash-waveform-and-similarity-map-node-after`
- PR link: https://github.com/PORTALSURFER/wavecrate/pull/590
- Scope: Add coverage for similarity-map selected sample copy feedback across map node and waveform flash state.
- Current status: waiting for user review

## Scope

- Add coverage for copying a sample selected through the similarity map.
- Verify the copy confirmation projects to both the selected similarity-map node and the loaded waveform copy flash state.
- Preserve existing copy behavior, destination handling, selection state, and sample-map navigation.

## Definition of Done

- Copying a sample selected via the similarity map leaves that sample selected.
- The waveform copy flash state is active after the map-selected copy.
- The selected map node projects `copy_flash` for the same confirmation moment.
- Existing focused sample-map and file-operation validation remains green.

## Validation commands

- `cargo test -p wavecrate copying_sample_selected_from_map_flashes_map_node_and_waveform -- --test-threads=1`
- `cargo test -p wavecrate sample_map -- --test-threads=1`
- `cargo test -p wavecrate file_operations -- --test-threads=1`
- `rustfmt --edition 2024 --check src/native_app/tests/sample_browser.rs`
- `git diff --check`

## Known limitations

- Manual smoke on a real source was not run in this session.
- Baseline repo preflight is not clean on `main`: `bash scripts/agent.sh request` fails in `native_app_ui_update_paths_do_not_call_blocking_business_apis` due pre-existing non-blocking guardrail violations outside this change.
- Baseline repo-wide format check is not clean on `main`: `cargo fmt --all --check` reports an unrelated formatting diff in `src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs`.

## Review

User review is required before merge.