### PR TITLE
Fix nightly publish checkout

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -311,6 +311,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-main, release-log, build]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-main.outputs.target_sha }}
       - uses: actions/download-artifact@v4
         with:
           path: dist/artifacts


### PR DESCRIPTION
Scope
- Check out the resolved nightly target in the `publish-github` job before the job calls repo-local release scripts.
- Fixes the `Publish nightly tags` failure where `scripts/internal/release/github_ref_sha.sh` was missing from the publish job workspace.

Definition of Done
- `publish-github` has repository files available before tag publication.
- The immutable `nightly-b<build>-<short-sha>` tag lookup continues to use the shared helper script.
- Release artifacts and release-log download behavior remain unchanged.

Validation commands
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-build.yml"); puts "release-build.yml parsed"'`
- `bash -n scripts/internal/release/github_ref_sha.sh`
- `bash scripts/agent.sh request` (failed before this edit on an unrelated existing `native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail in native-app files)
- Inspected failed run: https://github.com/PORTALSURFER/wavecrate/actions/runs/28317631553

Known limitations
- `actionlint` is not installed in the local environment, so workflow validation is YAML parsing plus targeted syntax checks.
- The nightly release action still needs to be rerun after this lands to prove the publish job end to end.

User review is required before merge unless the user has already signed off.