### PR TITLE
OPT-885 Remove redundant Harvest filter arrow

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -24,7 +24,6 @@ pub(super) const FILTER_ROW_VERTICAL_INSET: f32 =
 pub(super) const FILTER_LABEL_WIDTH: f32 = 64.0;
 const FILTER_CONTROL_SPACING: f32 = 2.0;
 pub(super) const FILTER_LABEL_CONTROL_SPACING: f32 = 6.0;
-const HARVEST_FAMILY_TOGGLE_WIDTH: f32 = 22.0;
 const PLAYBACK_TYPE_FILTER_TOGGLE_WIDTH: f32 = 64.0;
 const RATING_FILTER_TOGGLE_WIDTH: f32 = 18.0;
 pub(super) const RATING_FILTER_SWATCH_SIZE: u8 = 12;
@@ -237,8 +236,8 @@ pub(super) fn automation_curation_filter_dropdown_option_id(label: &str) -> u64 
 
 fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     let help_tooltips_enabled = row.help_tooltips_enabled;
-    let controls = ui::row([
-        harvest_filter_arrow_toggle(row.dropdown_open, help_tooltips_enabled),
+    filter_labeled_control_row(
+        filter_row_label(row.label, row.family, row.enabled),
         ui::dropdown_trigger(row.selected_label, row.dropdown_open)
             .toggle_message(GuiMessage::ToggleHarvestFilterDropdown)
             .build()
@@ -246,25 +245,8 @@ fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
             .tooltip_if(help_tooltips_enabled, "Choose the Harvest queue to show.")
             .fill_width()
             .height(FILTER_ROW_CONTROL_HEIGHT),
-    ])
-    .spacing(FILTER_CONTROL_SPACING)
-    .fill_width()
-    .height(FILTER_ROW_CONTROL_HEIGHT);
-
-    filter_labeled_control_row(
-        filter_row_label(row.label, row.family, row.enabled),
-        controls,
         "filter-harvest-row",
     )
-}
-
-fn harvest_filter_arrow_toggle(open: bool, help_tooltips_enabled: bool) -> ui::View<GuiMessage> {
-    ui::disclosure_button(open)
-        .active(open)
-        .message(GuiMessage::ToggleHarvestFilterDropdown)
-        .id(widget_ids::HARVEST_FAMILY_TOGGLE_ID)
-        .size(HARVEST_FAMILY_TOGGLE_WIDTH, FILTER_ROW_CONTROL_HEIGHT)
-        .tooltip_if(help_tooltips_enabled, "Choose the Harvest queue to show.")
 }
 
 pub(super) fn harvest_filter_dropdown_menu(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests.rs
@@ -14,7 +14,7 @@ use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
     BrowserCurationScope, HarvestFilter, PlaybackTypeFilter,
 };
-use crate::native_app::ui::ids::HARVEST_FAMILY_TOGGLE_ID;
+use crate::native_app::ui::ids::RETIRED_HARVEST_FILTER_ARROW_TOGGLE_ID;
 use radiant::gui::types::Rgba8;
 use radiant::prelude::IntoView;
 use radiant::runtime::{SurfaceFrame, SurfacePaintPlan};

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -280,7 +280,7 @@ fn filter_section_projects_curation_scope_dropdown_and_dispatches_changes() {
 }
 
 #[test]
-fn filter_section_projects_harvest_arrow_button_opens_filter_dropdown() {
+fn filter_section_uses_harvest_dropdown_as_only_filter_mode_trigger() {
     let state = FolderBrowserState::load_default();
     let mut model = FilterSectionViewModel::from_folder_browser(&state, false);
     model.harvest.selected_filter = Some(HarvestFilter::NeedsReview);
@@ -292,17 +292,28 @@ fn filter_section_projects_harvest_arrow_button_opens_filter_dropdown() {
         FILTER_SECTION_TEST_FRAME_HEIGHT,
     ));
 
-    assert!(
+    let curation_rect = frame
+        .paint_plan
+        .first_widget_rect(CURATION_FILTER_DROPDOWN_TRIGGER_ID)
+        .expect("Curation dropdown should render");
+    let harvest_rect = frame
+        .paint_plan
+        .first_widget_rect(HARVEST_FILTER_DROPDOWN_TRIGGER_ID)
+        .expect("Harvest dropdown should render");
+
+    assert_eq!(
         frame
             .paint_plan
-            .first_widget_rect(HARVEST_FAMILY_TOGGLE_ID)
-            .is_some(),
-        "Harvest arrow hit target should remain clickable even without a selected harvest family"
+            .first_widget_rect(RETIRED_HARVEST_FILTER_ARROW_TOGGLE_ID),
+        None,
+        "Harvest should not render a separate arrow button for the dropdown mode"
     );
     assert!(frame.paint_plan.contains_text("Needs Review  v"));
+    assert_close(harvest_rect.min.x, curation_rect.min.x);
+    assert_close(harvest_rect.width(), curation_rect.width());
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
-            HARVEST_FAMILY_TOGGLE_ID,
+            HARVEST_FILTER_DROPDOWN_TRIGGER_ID,
             ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
         Some(GuiMessage::ToggleHarvestFilterDropdown)

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -110,7 +110,8 @@ pub(in crate::native_app) const AUTOMATION_CURATION_FILTER_DROPDOWN_OPTION_SCOPE
 /// Scope for automation-facing harvest dropdown option ids.
 pub(in crate::native_app) const AUTOMATION_HARVEST_FILTER_DROPDOWN_OPTION_SCOPE: u64 =
     FOLDER_FILTERS.id(23);
-pub(in crate::native_app) const HARVEST_FAMILY_TOGGLE_ID: u64 = FOLDER_FILTERS.id(24);
+#[cfg(test)]
+pub(in crate::native_app) const RETIRED_HARVEST_FILTER_ARROW_TOGGLE_ID: u64 = FOLDER_FILTERS.id(24);
 /// Scope for automation-facing filter family label toggles.
 pub(in crate::native_app) const AUTOMATION_FILTER_FAMILY_LABEL_TOGGLE_SCOPE: u64 =
     FOLDER_FILTERS.id(25);

--- a/src/native_app/ui/ids/registry.rs
+++ b/src/native_app/ui/ids/registry.rs
@@ -198,11 +198,6 @@ const REGISTERED_WIDGET_IDS: &[RegisteredWidgetId] = &[
         "folder_filters.resize_header"
     ),
     registered_widget_id!(
-        FolderFilters,
-        HARVEST_FAMILY_TOGGLE_ID,
-        "folder_filters.harvest_family_toggle"
-    ),
-    registered_widget_id!(
         Collections,
         COLLECTIONS_SECTION_NODE_ID,
         "collections.section"


### PR DESCRIPTION
## Scope

- Remove the separate Harvest filter disclosure/arrow button from the library sidebar filter row.
- Keep the Harvest dropdown trigger as the only control for opening/changing the Harvest filter mode.
- Retire the old Harvest arrow widget id from the production widget registry while keeping a test-only retired id for regression coverage.
- Update filter-section projection tests to assert the old arrow target is absent and the Harvest dropdown aligns with the Curation dropdown.

## Definition of Done

- The Harvest filter row no longer renders a separate arrow button.
- The dropdown remains clear, clickable, and functionally unchanged.
- Harvest filter enable/disable and selected-mode behavior are preserved.
- Validation passes or any remaining limitation is documented before PR review.

## Validation commands

- `cargo fmt --check`
- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate harvest_filter -- --test-threads=1`
- `cargo test -p wavecrate widget_id -- --test-threads=1`

## Known limitations

- `cargo test -p wavecrate_filter_section -- --test-threads=1` was attempted, but this workspace has no package named `wavecrate_filter_section`.
- Native-app manual click verification was not completed in this session.
- Baseline `bash scripts/agent.sh request` failed before this change on unrelated existing non-blocking guardrail violations in folder-browser/context-menu paths.

User review is required before merge.