### PR TITLE
OPT-888: Refine settings gear icon

### DIFF
--- a/src/native_app/app_chrome/settings/top_bar.rs
+++ b/src/native_app/app_chrome/settings/top_bar.rs
@@ -159,12 +159,11 @@ static HELP_TOOLTIPS_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
 </svg>"#,
 );
 
-static SETTINGS_GEAR_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
-    r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <path d="M7.2 1.5h1.6l.4 1.8c.4.1.8.3 1.2.5l1.6-1 1.1 1.1-1 1.6c.2.4.4.8.5 1.2l1.8.4v1.6l-1.8.4c-.1.4-.3.8-.5 1.2l1 1.6-1.1 1.1-1.6-1c-.4.2-.8.4-1.2.5l-.4 1.8H7.2l-.4-1.8c-.4-.1-.8-.3-1.2-.5l-1.6 1-1.1-1.1 1-1.6c-.2-.4-.4-.8-.5-1.2l-1.8-.4V7.2l1.8-.4c.1-.4.3-.8.5-1.2l-1-1.6L4 2.9l1.6 1c.4-.2.8-.4 1.2-.5z"/>
-  <circle cx="8" cy="8" r="2.2" fill="none" stroke="currentColor" stroke-width="1.4"/>
-</svg>"#,
-);
+const SETTINGS_GEAR_ICON_SVG: &str = r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M6.9 1.5h2.2l.35 1.45c.31.09.61.22.9.37l1.25-.78 1.56 1.56-.78 1.25c.15.29.28.59.37.9l1.45.35v2.2l-1.45.35c-.09.31-.22.61-.37.9l.78 1.25-1.56 1.56-1.25-.78c-.29.15-.59.28-.9.37L9.1 14.2H6.9l-.35-1.45c-.31-.09-.61-.22-.9-.37l-1.25.78-1.56-1.56.78-1.25c-.15-.29-.28-.59-.37-.9L1.8 9.1V6.9l1.45-.35c.09-.31.22-.61.37-.9L2.84 4.4 4.4 2.84l1.25.78c.29-.15.59-.28.9-.37L6.9 1.5zM8 5.6a2.4 2.4 0 1 0 0 4.8 2.4 2.4 0 0 0 0-4.8z"/>
+</svg>"#;
+
+static SETTINGS_GEAR_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(SETTINGS_GEAR_ICON_SVG);
 
 static RELEASE_UPDATE_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
     r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">

--- a/src/native_app/app_chrome/settings/top_bar/tests.rs
+++ b/src/native_app/app_chrome/settings/top_bar/tests.rs
@@ -2,7 +2,12 @@ use super::projection::{
     AUDIO_ENGINE_TOOLTIP, GENERAL_SETTINGS_TOOLTIP, HELP_TOOLTIPS_ACTIVE_TOOLTIP,
     RELEASE_UPDATE_TOOLTIP, TopControlBarProjection, VOLUME_SLIDER_TOOLTIP,
 };
+use super::{GENERAL_SETTINGS_BUTTON_ID, SETTINGS_GEAR_ICON_SVG, settings_gear_icon};
 use crate::native_app::test_support::state::{AppSettingsTab, NativeAppStateFixture};
+use radiant::{
+    prelude::{Point, Rect, Vector2},
+    runtime::PaintPrimitive,
+};
 
 #[test]
 fn top_control_bar_projection_keeps_product_copy_and_volume() {
@@ -98,4 +103,29 @@ fn top_control_bar_projection_lights_release_update_indicator_when_available() {
 
     assert!(projection.settings_controls.release_update.visible);
     assert!(projection.settings_controls.release_update.active);
+}
+
+#[test]
+fn settings_gear_icon_uses_cog_silhouette_with_center_hole() {
+    assert!(SETTINGS_GEAR_ICON_SVG.contains(r#"fill-rule="evenodd""#));
+    assert!(SETTINGS_GEAR_ICON_SVG.contains("M8 5.6a2.4 2.4"));
+    assert!(!SETTINGS_GEAR_ICON_SVG.contains("<circle"));
+    assert!(!SETTINGS_GEAR_ICON_SVG.contains("stroke-width"));
+
+    let icon = settings_gear_icon(false);
+    let mut primitives = Vec::<PaintPrimitive>::new();
+    icon.append_paint(
+        &mut primitives,
+        GENERAL_SETTINGS_BUTTON_ID,
+        Rect::from_min_size(Point::new(0.0, 0.0), Vector2::new(16.0, 16.0)),
+    );
+
+    assert_eq!(
+        primitives
+            .iter()
+            .filter_map(PaintPrimitive::svg)
+            .filter(|svg| svg.widget_id == GENERAL_SETTINGS_BUTTON_ID)
+            .count(),
+        1
+    );
 }


### PR DESCRIPTION
## Scope

- Refines the settings top-bar gear SVG so it reads as a conventional cog at Wavecrate chrome size.
- Preserves the existing settings button behavior, widget ID, hit target, active state, sizing, and surrounding toolbar layout.
- Adds a focused icon contract test for the cog silhouette and center-hole rendering path.

## Definition of Done

- Settings icon no longer uses the prior spiky/star-like filled outline plus stroked circle.
- Icon is recognizable as a gear at the actual rendered app size.
- Settings button behavior and hit target are unchanged.
- Relevant focused tests and visual checks are documented below.

## Validation commands

- `cargo fmt`
- `git diff --check`
- `cargo test -p wavecrate settings_gear_icon_uses_cog_silhouette_with_center_hole`
- `cargo test -p wavecrate top_control_bar_projection_`
- `cargo test -p wavecrate general_settings_button_opens_general_tab`
- `cargo test -p wavecrate top_control_bar_places_help_button_after_settings_gear`
- `cargo test -p wavecrate top_control_bar`
- `bash scripts/ci.sh smoke`
- Manual sandbox launch via `bash scripts/run.sh sandbox --`; screenshot verified the normal chrome-size settings glyph reads as a cog with visible center hole.

## Known limitations

- `bash scripts/agent.sh request` was run before changes and failed on an existing unrelated `native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail violation on `main` involving folder move/sample map/duplicate filesystem access. This PR does not touch those files.
- Hover/active visual states were not separately screen-captured; existing focused tests cover active state and unchanged routing/layout.

## Review

User review is required before merge unless the user has already signed off.

Closes OPT-888