### PR TITLE
OPT-887: Replace source role text badges with icons

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -14,12 +14,10 @@ pub(super) const SOURCE_ROW_LABEL_PADDING_X: f32 = 12.0;
 pub(super) const SOURCE_ADD_BUTTON_WIDTH: f32 = 28.0;
 pub(super) const SOURCE_ADD_BUTTON_HEIGHT: f32 = 24.0;
 const SOURCE_ROW_HEIGHT: f32 = 24.0;
-const SOURCE_ROLE_MARKER_WIDTH: f32 = 10.0;
 const SOURCE_ROLE_ICON_WIDTH: f32 = 32.0;
 const SOURCE_MISSING_BADGE_WIDTH: f32 = 56.0;
 const SOURCE_MISSING_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 112, 86, 230);
-const SOURCE_ROLE_PROTECTED_COLOR: ui::Rgba8 = ui::Rgba8::new(234, 178, 73, 230);
-const SOURCE_ROLE_PRIMARY_COLOR: ui::Rgba8 = ui::Rgba8::new(72, 196, 162, 230);
+const SOURCE_ROLE_ICON_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 255);
 
 pub(super) fn source_add_button() -> ui::View<GuiMessage> {
     ui::icon_button(source_add_icon())
@@ -66,13 +64,6 @@ fn source_row_content(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
         ui::spacer()
             .width(SOURCE_ROW_LABEL_PADDING_X)
             .height(SOURCE_ROW_HEIGHT),
-        ui::color_marker(source_marker_color(source))
-            .side(7)
-            .inset(0)
-            .align(ui::ColorMarkerAlign::Center)
-            .view()
-            .width(SOURCE_ROLE_MARKER_WIDTH)
-            .height(SOURCE_ROW_HEIGHT),
         source_label(source),
         source_status_indicator(source),
     ])
@@ -98,38 +89,20 @@ fn source_status_indicator(source: &SourceRowViewModel) -> ui::View<GuiMessage> 
             .height(SOURCE_ROW_HEIGHT);
     }
     match source.role {
-        SourceRole::Protected => {
-            source_role_icon(&SOURCE_ROLE_PROTECTED_ICON, SOURCE_ROLE_PROTECTED_COLOR)
-        }
-        SourceRole::Primary => {
-            source_role_icon(&SOURCE_ROLE_PRIMARY_ICON, SOURCE_ROLE_PRIMARY_COLOR)
-        }
+        SourceRole::Protected => source_role_icon(&SOURCE_ROLE_PROTECTED_ICON),
+        SourceRole::Primary => source_role_icon(&SOURCE_ROLE_PRIMARY_ICON),
         SourceRole::Normal => ui::spacer()
             .width(SOURCE_ROLE_ICON_WIDTH)
             .height(SOURCE_ROW_HEIGHT),
     }
 }
 
-fn source_role_icon(
-    cache: &'static ui::SvgIconTintCache,
-    color: ui::Rgba8,
-) -> ui::View<GuiMessage> {
-    ui::icon_button(cache.icon(color))
+fn source_role_icon(cache: &'static ui::SvgIconTintCache) -> ui::View<GuiMessage> {
+    ui::icon_button(cache.icon(SOURCE_ROLE_ICON_COLOR))
         .bare()
         .passive()
         .width(SOURCE_ROLE_ICON_WIDTH)
         .height(SOURCE_ROW_HEIGHT)
-}
-
-fn source_marker_color(source: &SourceRowViewModel) -> Option<ui::Rgba8> {
-    if source.missing {
-        return Some(SOURCE_MISSING_COLOR);
-    }
-    match source.role {
-        SourceRole::Protected => Some(SOURCE_ROLE_PROTECTED_COLOR),
-        SourceRole::Primary => Some(SOURCE_ROLE_PRIMARY_COLOR),
-        SourceRole::Normal => None,
-    }
 }
 
 pub(super) fn source_missing_color() -> ui::Rgba8 {
@@ -139,6 +112,11 @@ pub(super) fn source_missing_color() -> ui::Rgba8 {
 #[cfg(test)]
 pub(super) fn source_missing_color_for_tests() -> ui::Rgba8 {
     source_missing_color()
+}
+
+#[cfg(test)]
+pub(super) fn source_role_icon_color_for_tests() -> ui::Rgba8 {
+    SOURCE_ROLE_ICON_COLOR
 }
 
 static SOURCE_ADD_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -15,7 +15,8 @@ pub(super) const SOURCE_ADD_BUTTON_WIDTH: f32 = 28.0;
 pub(super) const SOURCE_ADD_BUTTON_HEIGHT: f32 = 24.0;
 const SOURCE_ROW_HEIGHT: f32 = 24.0;
 const SOURCE_ROLE_MARKER_WIDTH: f32 = 10.0;
-const SOURCE_ROLE_BADGE_WIDTH: f32 = 56.0;
+const SOURCE_ROLE_ICON_WIDTH: f32 = 32.0;
+const SOURCE_MISSING_BADGE_WIDTH: f32 = 56.0;
 const SOURCE_MISSING_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 112, 86, 230);
 const SOURCE_ROLE_PROTECTED_COLOR: ui::Rgba8 = ui::Rgba8::new(234, 178, 73, 230);
 const SOURCE_ROLE_PRIMARY_COLOR: ui::Rgba8 = ui::Rgba8::new(72, 196, 162, 230);
@@ -73,7 +74,7 @@ fn source_row_content(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
             .width(SOURCE_ROLE_MARKER_WIDTH)
             .height(SOURCE_ROW_HEIGHT),
         source_label(source),
-        source_status_badge(source),
+        source_status_indicator(source),
     ])
     .spacing(0.0)
     .fill_width()
@@ -89,24 +90,34 @@ fn source_label(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
     }
 }
 
-fn source_status_badge(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
-    let label = if source.missing {
-        "MISSING"
-    } else {
-        match source.role {
-            SourceRole::Protected => "PROT",
-            SourceRole::Primary => "PRI",
-            SourceRole::Normal => "",
+fn source_status_indicator(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
+    if source.missing {
+        return ui::text_line("MISSING", SOURCE_ROW_HEIGHT)
+            .text_color(ui::TextColorRole::Custom(SOURCE_MISSING_COLOR))
+            .width(SOURCE_MISSING_BADGE_WIDTH)
+            .height(SOURCE_ROW_HEIGHT);
+    }
+    match source.role {
+        SourceRole::Protected => {
+            source_role_icon(&SOURCE_ROLE_PROTECTED_ICON, SOURCE_ROLE_PROTECTED_COLOR)
         }
-    };
-    let text_color = if source.missing {
-        ui::TextColorRole::Custom(SOURCE_MISSING_COLOR)
-    } else {
-        ui::TextColorRole::Muted
-    };
-    ui::text_line(label, SOURCE_ROW_HEIGHT)
-        .text_color(text_color)
-        .width(SOURCE_ROLE_BADGE_WIDTH)
+        SourceRole::Primary => {
+            source_role_icon(&SOURCE_ROLE_PRIMARY_ICON, SOURCE_ROLE_PRIMARY_COLOR)
+        }
+        SourceRole::Normal => ui::spacer()
+            .width(SOURCE_ROLE_ICON_WIDTH)
+            .height(SOURCE_ROW_HEIGHT),
+    }
+}
+
+fn source_role_icon(
+    cache: &'static ui::SvgIconTintCache,
+    color: ui::Rgba8,
+) -> ui::View<GuiMessage> {
+    ui::icon_button(cache.icon(color))
+        .bare()
+        .passive()
+        .width(SOURCE_ROLE_ICON_WIDTH)
         .height(SOURCE_ROW_HEIGHT)
 }
 
@@ -134,5 +145,20 @@ static SOURCE_ADD_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
     r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
   <rect x="4" y="7.25" width="8" height="1.5"/>
   <rect x="7.25" y="4" width="1.5" height="8"/>
+</svg>"#,
+);
+
+static SOURCE_ROLE_PRIMARY_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
+    r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2.25 7.15 8 2.35l5.75 4.8v1.95L8 4.25 2.25 9.1z" fill="currentColor"/>
+  <path d="M4 8.15h8v5.6H9.55V10.1h-3.1v3.65H4z" fill="currentColor"/>
+</svg>"#,
+);
+
+static SOURCE_ROLE_PROTECTED_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
+    r#"<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.1 7.1V5.6C4.1 3.45 5.65 2 8 2s3.9 1.45 3.9 3.6v1.5" fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round"/>
+  <rect x="3" y="6.75" width="10" height="7" rx="1.2" fill="currentColor"/>
+  <rect x="7.3" y="9" width="1.4" height="2.7" rx=".55" fill="rgb(24,24,24)"/>
 </svg>"#,
 );

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -15,6 +15,7 @@ use crate::native_app::sample_library::folder_browser::{FolderBrowserState, mode
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
 use radiant::widgets::ButtonMessage;
+use wavecrate::sample_sources::SourceRole;
 
 fn test_source(id: &str) -> SourceEntry {
     SourceEntry::new(id, "Source", std::path::PathBuf::from("C:/samples"))
@@ -193,6 +194,68 @@ fn missing_source_row_paints_missing_badge_and_marker() {
             .fill_rects()
             .any(|fill| fill.color == source_missing_color_for_tests()),
         "missing sources should get a danger-colored source marker"
+    );
+}
+
+#[test]
+fn primary_source_row_uses_role_icon_instead_of_text_badge() {
+    let mut source = test_source("source-primary");
+    source.role = SourceRole::Primary;
+    let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
+    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let row = model.rows.first().expect("source row");
+    let frame =
+        source_row(row).view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, 24.0));
+
+    assert!(
+        frame.paint_plan.svgs().next().is_some(),
+        "primary sources should paint a source-role SVG icon"
+    );
+    assert!(
+        !frame.paint_plan.contains_text("PRI"),
+        "primary sources should not render the old text badge"
+    );
+}
+
+#[test]
+fn protected_source_row_uses_role_icon_instead_of_text_badge() {
+    let mut source = test_source("source-protected");
+    source.role = SourceRole::Protected;
+    let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
+    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let row = model.rows.first().expect("source row");
+    let frame =
+        source_row(row).view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, 24.0));
+
+    assert!(
+        frame.paint_plan.svgs().next().is_some(),
+        "protected sources should paint a source-role SVG icon"
+    );
+    assert!(
+        !frame.paint_plan.contains_text("PRO") && !frame.paint_plan.contains_text("PROT"),
+        "protected sources should not render the old text badge"
+    );
+}
+
+#[test]
+fn normal_source_row_keeps_role_slot_neutral() {
+    let source = test_source("source-normal");
+    let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
+    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let row = model.rows.first().expect("source row");
+    let frame =
+        source_row(row).view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, 24.0));
+
+    assert_eq!(
+        frame.paint_plan.svgs().count(),
+        0,
+        "normal sources should not paint a role icon"
+    );
+    assert!(
+        !frame.paint_plan.contains_text("PRI")
+            && !frame.paint_plan.contains_text("PRO")
+            && !frame.paint_plan.contains_text("PROT"),
+        "normal sources should stay free of source-role text badges"
     );
 }
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -1,7 +1,8 @@
 use super::identity::{AUTOMATION_SOURCE_ADD_BUTTON_ID, retained_source_row_input_id};
 use super::rows::{
     SOURCE_ADD_BUTTON_HEIGHT, SOURCE_ADD_BUTTON_WIDTH, SOURCE_ROW_LABEL_PADDING_X,
-    source_add_button, source_missing_color_for_tests, source_row,
+    source_add_button, source_missing_color_for_tests, source_role_icon_color_for_tests,
+    source_row,
 };
 use super::source_selector;
 use crate::native_app::app::GuiMessage;
@@ -19,6 +20,19 @@ use wavecrate::sample_sources::SourceRole;
 
 fn test_source(id: &str) -> SourceEntry {
     SourceEntry::new(id, "Source", std::path::PathBuf::from("C:/samples"))
+}
+
+macro_rules! assert_no_left_source_marker {
+    ($frame:expr) => {
+        assert!(
+            !$frame.paint_plan.fill_rects().any(|fill| {
+                fill.rect.min.x <= SOURCE_ROW_LABEL_PADDING_X + 12.0
+                    && fill.rect.width() <= 10.0
+                    && fill.rect.height() <= 10.0
+            }),
+            "source rows should not paint a separate left color marker"
+        );
+    };
 }
 
 #[test]
@@ -165,7 +179,7 @@ fn source_rows_use_shared_grey_sidebar_hover_fill() {
 }
 
 #[test]
-fn missing_source_row_paints_missing_badge_and_marker() {
+fn missing_source_row_paints_missing_badge_without_left_marker() {
     let mut source = test_source("source-missing");
     source.mark_missing_for_tests();
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
@@ -188,13 +202,7 @@ fn missing_source_row_paints_missing_badge_and_marker() {
         Some(source_missing_color_for_tests()),
         "missing source badges should use warning text"
     );
-    assert!(
-        frame
-            .paint_plan
-            .fill_rects()
-            .any(|fill| fill.color == source_missing_color_for_tests()),
-        "missing sources should get a danger-colored source marker"
-    );
+    assert_no_left_source_marker!(frame);
 }
 
 #[test]
@@ -211,10 +219,16 @@ fn primary_source_row_uses_role_icon_instead_of_text_badge() {
         frame.paint_plan.svgs().next().is_some(),
         "primary sources should paint a source-role SVG icon"
     );
+    assert_eq!(
+        source_role_icon_color_for_tests(),
+        ui::Rgba8::new(255, 255, 255, 255),
+        "source role icons should use a white tint"
+    );
     assert!(
         !frame.paint_plan.contains_text("PRI"),
         "primary sources should not render the old text badge"
     );
+    assert_no_left_source_marker!(frame);
 }
 
 #[test]
@@ -231,10 +245,16 @@ fn protected_source_row_uses_role_icon_instead_of_text_badge() {
         frame.paint_plan.svgs().next().is_some(),
         "protected sources should paint a source-role SVG icon"
     );
+    assert_eq!(
+        source_role_icon_color_for_tests(),
+        ui::Rgba8::new(255, 255, 255, 255),
+        "source role icons should use a white tint"
+    );
     assert!(
         !frame.paint_plan.contains_text("PRO") && !frame.paint_plan.contains_text("PROT"),
         "protected sources should not render the old text badge"
     );
+    assert_no_left_source_marker!(frame);
 }
 
 #[test]
@@ -257,6 +277,7 @@ fn normal_source_row_keeps_role_slot_neutral() {
             && !frame.paint_plan.contains_text("PROT"),
         "normal sources should stay free of source-role text badges"
     );
+    assert_no_left_source_marker!(frame);
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Replace Primary source row text badge (`PRI`) with a compact primary/library SVG icon.
- Replace Protected source row text badge (`PRO`/`PROT`) with a compact lock SVG icon.
- Render source-role icons in white and remove the separate colored left marker rectangles from source rows.
- Keep missing-source warning text (`MISSING`) unchanged while removing its left marker as well.
- Add source-row rendering tests for Primary, Protected, Normal, and Missing role/marker behavior.

## Definition of Done

- Primary source rows no longer display `PRI` text.
- Protected source rows no longer display `PRO` or `PROT` text.
- Primary and Protected source roles paint distinct white SVG icons at the source-row level.
- Source rows no longer paint separate colored left marker rectangles.
- Normal source rows remain visually neutral.
- Source-role semantics and file-operation protections are unchanged.

## Validation commands

- `cargo test -p wavecrate source_row --all-targets`
- `git diff --check`
- `bash scripts/ci.sh agent` *(fails on pre-existing non-blocking guardrail violations in unrelated files: folder drag/drop move, sample_map test fixtures, harvest_tracking, duplicate action, and library_sidebar test fixture paths; same blocker reproduced before this branch work.)*

## Known limitations

- Manual native-app visual verification was not performed in this pass; the source-row paint-plan tests cover the icon/text/marker rendering contract.
- The repo-wide agent lane is currently blocked by unrelated non-blocking guardrail violations listed above.

## Review

User review is required before merge.

Linear: OPT-887