### PR TITLE
OPT-897 Add double-length sample duplicate action

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/library/harvest.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/harvest.rs
@@ -151,6 +151,8 @@ pub enum HarvestDerivationOperation {
     EditCopy,
     /// Normalize rendered to a copy.
     NormalizeCopy,
+    /// Whole-file duplicate rendered with the audio repeated twice.
+    DuplicateDoubleCopy,
     /// Export or handoff render.
     Export,
     /// Copy into the primary library.
@@ -170,6 +172,7 @@ impl HarvestDerivationOperation {
             Self::ReverseCopy => "reverse_copy",
             Self::EditCopy => "edit_copy",
             Self::NormalizeCopy => "normalize_copy",
+            Self::DuplicateDoubleCopy => "duplicate_double_copy",
             Self::Export => "export",
             Self::CopyToPrimary => "copy_to_primary",
             Self::Other(value) => value.as_str(),
@@ -186,6 +189,7 @@ impl HarvestDerivationOperation {
             "reverse_copy" => Self::ReverseCopy,
             "edit_copy" => Self::EditCopy,
             "normalize_copy" => Self::NormalizeCopy,
+            "duplicate_double_copy" => Self::DuplicateDoubleCopy,
             "export" => Self::Export,
             "copy_to_primary" => Self::CopyToPrimary,
             _ => Self::Other(value),

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -40,6 +40,7 @@ use crate::native_app::sample_library::similarity_scores::SimilarityScoresResult
 use crate::native_app::waveform::WaveformInteraction;
 use crate::native_app::waveform::{SimilarSectionsResult, WaveformExtractionCompletion};
 use crate::native_app::waveform_edits::WaveformDestructiveEditResult;
+use crate::native_app::workflows::context_menu_actions::ContextSampleDoubleResult;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) enum TrashMoveTarget {
@@ -175,6 +176,12 @@ pub(in crate::native_app) enum GuiMessage {
     CutSelectedFiles,
     PasteCutFiles,
     DuplicateContextSampleSame,
+    DuplicateContextSampleDouble,
+    ContextSampleDoubleFinished {
+        source_path: PathBuf,
+        started_at: Instant,
+        result: Result<ContextSampleDoubleResult, String>,
+    },
     SelectedFilesCopyFinished {
         count: usize,
         started_at: Instant,

--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -72,6 +72,10 @@ fn context_menu_commands(menu: &BrowserContextMenu) -> Vec<ui::MenuCommand<GuiMe
             GuiMessage::DuplicateContextSampleSame,
         ));
         actions.push(ui::MenuCommand::new(
+            "Duplicate Double",
+            GuiMessage::DuplicateContextSampleDouble,
+        ));
+        actions.push(ui::MenuCommand::new(
             "Mark Harvest Done",
             GuiMessage::MarkContextSampleHarvestDone,
         ));

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -106,6 +106,8 @@ impl NativeAppState {
             | GuiMessage::CutSelectedFiles
             | GuiMessage::PasteCutFiles
             | GuiMessage::DuplicateContextSampleSame
+            | GuiMessage::DuplicateContextSampleDouble
+            | GuiMessage::ContextSampleDoubleFinished { .. }
             | GuiMessage::SelectedFilesCopyFinished { .. }
             | GuiMessage::WaveformSelectionCopyExtracted { .. }
             | GuiMessage::WaveformSelectionCopyFinished { .. }

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -51,6 +51,14 @@ impl NativeAppState {
             GuiMessage::CutSelectedFiles => self.cut_selected_files(),
             GuiMessage::PasteCutFiles => self.paste_cut_files(context),
             GuiMessage::DuplicateContextSampleSame => self.duplicate_context_sample_same(),
+            GuiMessage::DuplicateContextSampleDouble => {
+                self.duplicate_context_sample_double(context)
+            }
+            GuiMessage::ContextSampleDoubleFinished {
+                source_path,
+                started_at,
+                result,
+            } => self.finish_context_sample_double(source_path, started_at, result, context),
             GuiMessage::SelectedFilesCopyFinished {
                 count,
                 started_at,

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -329,6 +329,14 @@ fn write_sparse_test_wav_i16(path: &std::path::Path, channels: u16, frames: u32)
         .expect("extend sparse wav");
 }
 
+fn read_test_wav_i16(path: &std::path::Path) -> Vec<i16> {
+    let mut reader = hound::WavReader::open(path).expect("open wav");
+    reader
+        .samples::<i16>()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read i16 samples")
+}
+
 fn read_test_wav_f32(path: &std::path::Path) -> Vec<f32> {
     let mut reader = hound::WavReader::open(path).expect("open wav");
     let spec = reader.spec();

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -622,7 +622,88 @@ fn sample_context_menu_paints_remove_from_collection_action_in_collection_view()
     assert!(frame.paint_plan.contains_text("Show Harvest Derivatives"));
     assert!(frame.paint_plan.contains_text("Open Harvest Destination"));
     assert!(frame.paint_plan.contains_text("Duplicate Same"));
+    assert!(frame.paint_plan.contains_text("Duplicate Double"));
     assert!(frame.paint_plan.contains_text("Move to Trash"));
+}
+
+#[test]
+fn duplicate_double_context_action_routes_protected_source_to_primary_derivative() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let (mut state, source_root, selected_file) =
+        native_app_state_with_temp_sample("protected-double.wav");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            primary_source.clone(),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(selected_file.clone());
+    let source_path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&source_path, &[0, 1_000, -1_000, 2_000]);
+    let harvest_source_folder = source_root
+        .path()
+        .file_name()
+        .expect("source root folder name");
+    let doubled = primary_root
+        .path()
+        .join("_Harvests")
+        .join(harvest_source_folder)
+        .join("protected-double_doubled.wav");
+    let mut context = ui::UiUpdateContext::default();
+
+    state.open_sample_context_menu(selected_file, Point::new(40.0, 120.0));
+    state.apply_message(GuiMessage::DuplicateContextSampleDouble, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert_eq!(
+        read_test_wav_i16(&source_path),
+        vec![0, 1_000, -1_000, 2_000]
+    );
+    assert_eq!(
+        read_test_wav_i16(&doubled),
+        vec![0, 1_000, -1_000, 2_000, 0, 1_000, -1_000, 2_000],
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(doubled.to_string_lossy().as_ref())
+    );
+    let primary_db = primary_source.open_db().expect("open primary db");
+    assert!(
+        primary_db
+            .entry_for_path(
+                &PathBuf::from("_Harvests")
+                    .join(harvest_source_folder)
+                    .join("protected-double_doubled.wav")
+            )
+            .expect("query doubled row")
+            .is_some()
+    );
+    let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        protected_source.id.clone(),
+        PathBuf::from("protected-double.wav"),
+    );
+    let edges = wavecrate::sample_sources::library::harvest_derivations_for_parent(&parent_key)
+        .expect("load harvest derivations");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].operation,
+        wavecrate::sample_sources::HarvestDerivationOperation::DuplicateDoubleCopy
+    );
+    assert_eq!(edges[0].child.key.source_id, primary_source.id);
+    assert_eq!(
+        edges[0].child.key.relative_path,
+        PathBuf::from("_Harvests")
+            .join(harvest_source_folder)
+            .join("protected-double_doubled.wav")
+    );
 }
 
 #[test]

--- a/src/native_app/workflows/context_menu_actions.rs
+++ b/src/native_app/workflows/context_menu_actions.rs
@@ -2,3 +2,5 @@ mod duplicate;
 mod mutation;
 mod open;
 mod platform;
+
+pub(in crate::native_app) use duplicate::ContextSampleDoubleResult;

--- a/src/native_app/workflows/context_menu_actions/duplicate.rs
+++ b/src/native_app/workflows/context_menu_actions/duplicate.rs
@@ -1,12 +1,28 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use crate::native_app::app::{NativeAppState, emit_gui_action};
+use radiant::prelude as ui;
+use wavecrate::sample_sources::{HarvestDerivationOperation, SampleSource, SourceDatabase};
+
+use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::context_menu_target as context_menu;
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextMenu, BrowserContextTargetKind,
 };
 use crate::native_app::sample_library::file_actions::sample_path_label;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct ContextSampleDoubleResult {
+    pub(in crate::native_app) destination: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct DuplicateDoubleRequest {
+    source_path: PathBuf,
+    target_folder: PathBuf,
+    target_source_root: PathBuf,
+    target_database_root: PathBuf,
+}
 
 impl NativeAppState {
     pub(in crate::native_app) fn duplicate_context_sample_same(&mut self) {
@@ -82,6 +98,157 @@ impl NativeAppState {
             .and_then(|source_id| self.library.folder_browser.source_roots(source_id))
             .or_else(|| self.library.folder_browser.source_roots_for_path(path))
     }
+
+    pub(in crate::native_app) fn duplicate_context_sample_double(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let started_at = Instant::now();
+        let Some(menu) = self.ui.browser_interaction.context_menu.take() else {
+            return;
+        };
+        let source_path = menu.path.clone();
+        match self.duplicate_context_sample_double_request(&menu) {
+            Ok(request) => {
+                self.ui.status.sample = format!("Duplicating {}", sample_path_label(&source_path));
+                context
+                    .business()
+                    .background("gui-sample-duplicate-double")
+                    .run(
+                        move |_| execute_duplicate_double(request),
+                        move |result| GuiMessage::ContextSampleDoubleFinished {
+                            source_path,
+                            started_at,
+                            result,
+                        },
+                    );
+            }
+            Err(error) => {
+                self.ui.status.sample = error.clone();
+                emit_gui_action(
+                    "browser.context_menu.sample.duplicate_double",
+                    Some("browser"),
+                    Some(context_menu::target_label(&menu.path).as_str()),
+                    "error",
+                    started_at,
+                    Some(&error),
+                );
+            }
+        }
+    }
+
+    fn duplicate_context_sample_double_request(
+        &self,
+        menu: &BrowserContextMenu,
+    ) -> Result<DuplicateDoubleRequest, String> {
+        if menu.kind != BrowserContextTargetKind::Sample {
+            return Err(String::from("Choose a sample to duplicate"));
+        }
+        if menu.sample_missing {
+            return Err(String::from("Sample file is missing"));
+        }
+        let Some((origin_source, _)) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(&menu.path)
+        else {
+            return Err(String::from("Sample source is unavailable"));
+        };
+        let (target_folder, target_source) =
+            self.double_duplicate_target(&menu.path, &origin_source)?;
+        if let Some(error) = self
+            .library
+            .folder_browser
+            .folder_target_lock_error(&target_folder, "Duplicate")
+        {
+            return Err(error);
+        }
+        let target_database_root = target_source
+            .database_root()
+            .map_err(|err| format!("Resolve target metadata location failed: {err}"))?;
+        Ok(DuplicateDoubleRequest {
+            source_path: menu.path.clone(),
+            target_folder,
+            target_source_root: target_source.root,
+            target_database_root,
+        })
+    }
+
+    fn double_duplicate_target(
+        &self,
+        source_path: &Path,
+        origin_source: &SampleSource,
+    ) -> Result<(PathBuf, SampleSource), String> {
+        if origin_source.is_protected() {
+            let Some(primary_source) = self.library.folder_browser.primary_sample_source() else {
+                return Err(String::from(
+                    "Set a Primary source before duplicating from a protected source",
+                ));
+            };
+            let target_folder = self
+                .harvest_destination_for_protected_origin(source_path)?
+                .unwrap_or_else(|| primary_source.primary_import_path());
+            return Ok((target_folder, primary_source));
+        }
+        let target_folder = source_path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| String::from("Sample file has no destination folder"))?;
+        Ok((target_folder, origin_source.clone()))
+    }
+
+    pub(in crate::native_app) fn finish_context_sample_double(
+        &mut self,
+        source_path: PathBuf,
+        started_at: Instant,
+        result: Result<ContextSampleDoubleResult, String>,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        match result {
+            Ok(completion) => {
+                self.library
+                    .folder_browser
+                    .refresh_file_path_across_sources(&completion.destination);
+                self.library
+                    .folder_browser
+                    .focus_file_across_sources_matching_tags(
+                        &completion.destination,
+                        &self.metadata.tags_by_file,
+                    );
+                self.record_harvest_whole_file_derivation(
+                    &source_path,
+                    &completion.destination,
+                    HarvestDerivationOperation::DuplicateDoubleCopy,
+                );
+                self.load_navigation_sample_validated(
+                    completion.destination.to_string_lossy().to_string(),
+                    context,
+                    started_at,
+                );
+                self.ui.status.sample =
+                    format!("Duplicated {}", sample_path_label(&completion.destination));
+                emit_gui_action(
+                    "browser.context_menu.sample.duplicate_double",
+                    Some("browser"),
+                    Some(context_menu::target_label(&completion.destination).as_str()),
+                    "success",
+                    started_at,
+                    None,
+                );
+            }
+            Err(error) => {
+                self.ui.status.sample = error.clone();
+                emit_gui_action(
+                    "browser.context_menu.sample.duplicate_double",
+                    Some("browser"),
+                    Some(context_menu::target_label(&source_path).as_str()),
+                    "error",
+                    started_at,
+                    Some(&error),
+                );
+            }
+        }
+    }
 }
 
 fn duplicate_same_destination(source: &Path) -> PathBuf {
@@ -125,4 +292,175 @@ fn duplicate_sample_file_with_metadata(
         return Err(error);
     }
     Ok(())
+}
+
+fn execute_duplicate_double(
+    request: DuplicateDoubleRequest,
+) -> Result<ContextSampleDoubleResult, String> {
+    wavecrate::sample_sources::harvest_file_ops::ensure_dir(
+        &request.target_folder,
+        "Create duplicate destination failed",
+    )?;
+    let destination = next_doubled_destination(&request.source_path, &request.target_folder)?;
+    let result = write_doubled_wav(&request.source_path, &destination)
+        .and_then(|()| register_fresh_duplicate(&request, &destination));
+    if result.is_err() {
+        let _ = std::fs::remove_file(&destination);
+    }
+    result.map(|()| ContextSampleDoubleResult { destination })
+}
+
+fn next_doubled_destination(source: &Path, target_folder: &Path) -> Result<PathBuf, String> {
+    let stem = source
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| String::from("Source sample has no file name"))?;
+    for index in 0..10_000 {
+        let suffix = if index == 0 {
+            String::from("_doubled")
+        } else {
+            format!("_doubled_{index:03}")
+        };
+        let candidate = target_folder.join(format!("{stem}{suffix}.wav"));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(String::from("Unable to find a duplicate file name"))
+}
+
+fn write_doubled_wav(source: &Path, destination: &Path) -> Result<(), String> {
+    let first_reader = open_wav_reader(source)?;
+    let spec = first_reader.spec();
+    if first_reader.duration() == 0 {
+        return Err(String::from("Source WAV contains no audio"));
+    }
+    let file = std::fs::File::create(destination)
+        .map_err(|err| format!("Failed to create doubled sample: {err}"))?;
+    let writer = std::io::BufWriter::with_capacity(1024 * 1024, file);
+    let mut writer = hound::WavWriter::new(writer, spec)
+        .map_err(|err| format!("Failed to write doubled sample: {err}"))?;
+    write_reader_samples(first_reader, spec, &mut writer)?;
+    let second_reader = open_wav_reader(source)?;
+    write_reader_samples(second_reader, spec, &mut writer)?;
+    writer
+        .finalize()
+        .map_err(|err| format!("Failed to finalize doubled sample: {err}"))
+}
+
+fn open_wav_reader(source: &Path) -> Result<hound::WavReader<impl std::io::Read>, String> {
+    let file = wavecrate::wav_sanitize::open_sanitized_wav(source)
+        .map_err(|err| format!("Invalid WAV: {err}"))?;
+    Ok(
+        hound::WavReader::new(std::io::BufReader::with_capacity(1024 * 1024, file))
+            .map_err(|err| format!("Invalid WAV: {err}"))?,
+    )
+}
+
+fn write_reader_samples<W: std::io::Write + std::io::Seek, R: std::io::Read>(
+    mut reader: hound::WavReader<R>,
+    spec: hound::WavSpec,
+    writer: &mut hound::WavWriter<W>,
+) -> Result<(), String> {
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            for sample in reader.samples::<f32>() {
+                writer
+                    .write_sample(sample.map_err(|err| format!("Invalid WAV sample data: {err}"))?)
+                    .map_err(|err| format!("Failed to write doubled sample: {err}"))?;
+            }
+        }
+        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => {
+            for sample in reader.samples::<i16>() {
+                writer
+                    .write_sample(sample.map_err(|err| format!("Invalid WAV sample data: {err}"))?)
+                    .map_err(|err| format!("Failed to write doubled sample: {err}"))?;
+            }
+        }
+        hound::SampleFormat::Int => {
+            for sample in reader.samples::<i32>() {
+                writer
+                    .write_sample(sample.map_err(|err| format!("Invalid WAV sample data: {err}"))?)
+                    .map_err(|err| format!("Failed to write doubled sample: {err}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn register_fresh_duplicate(
+    request: &DuplicateDoubleRequest,
+    destination: &Path,
+) -> Result<(), String> {
+    let relative_path = destination
+        .strip_prefix(&request.target_source_root)
+        .map_err(|_| String::from("Duplicate metadata update failed: target file mismatch"))?;
+    let metadata = std::fs::metadata(destination)
+        .map_err(|err| format!("Duplicate metadata update failed: {err}"))?;
+    let modified_ns = metadata
+        .modified()
+        .map_err(|err| format!("Duplicate metadata update failed: {err}"))?
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map_err(|_| String::from("Duplicate modified time is before epoch"))?
+        .as_nanos() as i64;
+    let db = SourceDatabase::open_for_user_metadata_write_with_database_root(
+        &request.target_source_root,
+        &request.target_database_root,
+    )
+    .map_err(|err| format!("Duplicate metadata update failed: {err}"))?;
+    db.upsert_file(relative_path, metadata.len(), modified_ns)
+        .map_err(|err| format!("Duplicate metadata update failed: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_i16_wav(path: &Path, samples: &[i16]) {
+        let spec = hound::WavSpec {
+            channels: 2,
+            sample_rate: 48_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        for sample in samples {
+            writer.write_sample(*sample).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    #[test]
+    fn doubled_wav_repeats_audio_and_preserves_spec() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("loop.wav");
+        let destination = temp.path().join("loop_doubled.wav");
+        write_i16_wav(&source, &[1, -2, 3, -4, 5, -6]);
+
+        write_doubled_wav(&source, &destination).expect("double wav");
+
+        let mut reader = hound::WavReader::open(&destination).expect("open doubled wav");
+        let spec = reader.spec();
+        assert_eq!(spec.channels, 2);
+        assert_eq!(spec.sample_rate, 48_000);
+        assert_eq!(spec.bits_per_sample, 16);
+        assert_eq!(reader.duration(), 6);
+        let samples = reader
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("read samples");
+        assert_eq!(samples, vec![1, -2, 3, -4, 5, -6, 1, -2, 3, -4, 5, -6]);
+    }
+
+    #[test]
+    fn doubled_destination_numbers_collisions() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let source = temp.path().join("kick.wav");
+        std::fs::write(temp.path().join("kick_doubled.wav"), []).expect("collision");
+
+        let destination = next_doubled_destination(&source, temp.path()).expect("destination");
+
+        assert_eq!(destination, temp.path().join("kick_doubled_001.wav"));
+    }
 }


### PR DESCRIPTION
## Scope

- Add a sample context-menu action, `Duplicate Double`, that writes a new WAV whose audio is the original sample repeated twice end-to-end.
- Preserve the original sample and register the doubled derivative as a fresh source DB row without copying the original content hash.
- Route protected-source duplicates into the Primary source harvest destination and record a dedicated `duplicate_double_copy` harvest derivation.
- Focus/load the new derivative after completion so it is immediately visible and usable.

## Definition of Done

- Users can invoke a sample action that creates a doubled-length duplicate of the selected/context sample.
- The original sample is never modified.
- The new file is written with a clear collision-safe `_doubled` / `_doubled_NNN` name.
- Protected-source writes route through the configured Primary harvest destination.
- Browser state refreshes and focuses the new derivative after success.
- Automated coverage protects doubled audio content/spec, collision naming, protected-source routing, fresh DB registration, and derivation metadata.

## Validation commands

- `cargo test -p wavecrate doubled_wav_repeats_audio_and_preserves_spec`
- `cargo test -p wavecrate doubled_destination_numbers_collisions`
- `cargo test -p wavecrate duplicate_double_context_action_routes_protected_source_to_primary_derivative`
- `cargo test -p wavecrate sample_context_menu_paints_remove_from_collection_action_in_collection_view`
- `bash scripts/ci.sh smoke`

## Known limitations

- This adds only a fixed 2x duplicate action; arbitrary repeat counts, stretching, tempo matching, crossfades, and loop playback behavior are unchanged.
- WAV input is supported through the existing sanitized WAV/hound pipeline.

User review is required before merge.
