### PR TITLE
OPT-901 Make waveform fades undoable transactions

### DIFF
--- a/src/app/controller/playback/waveform_actions/edit.rs
+++ b/src/app/controller/playback/waveform_actions/edit.rs
@@ -4,6 +4,8 @@ use super::*;
 use crate::app::controller::state::selection::EditFadeDragKind;
 use crate::selection::SelectionRange;
 
+const WAVEFORM_FADE_UNDO_LABEL: &str = "Waveform fade";
+
 impl AppController {
     /// Begin a right-click edit selection drag on the waveform.
     pub fn start_edit_selection_drag(&mut self, position: f32) {
@@ -222,7 +224,7 @@ impl AppController {
         let drag_range = edit_selection::prepare_edit_fade_drag_range(self, kind, existing_range);
         let next_range = update(drag_range);
         if existing_range != next_range {
-            self.begin_edit_selection_undo("Edit selection");
+            self.begin_edit_selection_undo(WAVEFORM_FADE_UNDO_LABEL);
         }
         apply_edit_selection_update(self, Some(existing_range), next_range);
     }

--- a/src/app_core/controller/tests/waveform/undo.rs
+++ b/src/app_core/controller/tests/waveform/undo.rs
@@ -58,7 +58,10 @@ fn apply_ui_waveform_edit_selection_finish_commits_one_undo_step() {
 #[test]
 fn apply_ui_waveform_edit_fade_finish_commits_one_undo_step() {
     let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
-    let before = crate::selection::SelectionRange::new(0.2, 0.6).with_fade_out(0.25, 0.2);
+    let before = crate::selection::SelectionRange::new(0.2, 0.6)
+        .with_fade_out(0.25, 0.2)
+        .with_fade_out_mute(0.1)
+        .with_fade_out_outer_gain(0.35);
     controller.set_edit_selection_range(before);
 
     controller.apply_ui_action(NativeUiAction::Waveform(
@@ -67,34 +70,53 @@ fn apply_ui_waveform_edit_fade_finish_commits_one_undo_step() {
         },
     ));
     controller.apply_ui_action(NativeUiAction::Waveform(
+        crate::app_core::actions::NativeWaveformAction::SetWaveformEditFadeOutCurve {
+            curve_milli: 500,
+        },
+    ));
+    controller.apply_ui_action(NativeUiAction::Waveform(
         crate::app_core::actions::NativeWaveformAction::FinishWaveformEditFadeDrag,
     ));
 
-    let updated = controller
-        .ui
-        .waveform
-        .edit_selection
-        .and_then(|selection| selection.fade_out())
-        .expect("fade-out after drag");
-    assert!((updated.curve - 0.75).abs() < 0.001);
+    let after = before.with_fade_out(0.25, 0.5);
+    assert_eq!(controller.ui.waveform.edit_selection, Some(after));
 
     controller.undo();
-    let undone = controller
-        .ui
-        .waveform
-        .edit_selection
-        .and_then(|selection| selection.fade_out())
-        .expect("fade-out after undo");
-    assert!((undone.curve - 0.2).abs() < 0.001);
+    assert_eq!(controller.ui.status.text, "Undid Waveform fade");
+    assert_eq!(controller.ui.waveform.edit_selection, Some(before));
+
+    controller.undo();
+    assert_eq!(controller.ui.status.text, "Nothing to undo");
+    assert_eq!(controller.ui.waveform.edit_selection, Some(before));
 
     controller.redo();
-    let redone = controller
-        .ui
-        .waveform
-        .edit_selection
-        .and_then(|selection| selection.fade_out())
-        .expect("fade-out after redo");
-    assert!((redone.curve - 0.75).abs() < 0.001);
+    assert_eq!(controller.ui.status.text, "Redid Waveform fade");
+    assert_eq!(controller.ui.waveform.edit_selection, Some(after));
+}
+
+#[test]
+fn apply_ui_waveform_edit_fade_creation_undoes_and_redoes_one_step() {
+    let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
+    let before = crate::selection::SelectionRange::new(0.2, 0.6);
+    controller.set_edit_selection_range(before);
+
+    controller.apply_ui_action(NativeUiAction::Waveform(
+        crate::app_core::actions::NativeWaveformAction::SetWaveformEditFadeInEnd {
+            position_micros: 300_000,
+        },
+    ));
+    controller.apply_ui_action(NativeUiAction::Waveform(
+        crate::app_core::actions::NativeWaveformAction::FinishWaveformEditFadeDrag,
+    ));
+
+    let after = before.with_fade_in(0.25, 0.5);
+    assert_eq!(controller.ui.waveform.edit_selection, Some(after));
+
+    controller.undo();
+    assert_eq!(controller.ui.waveform.edit_selection, Some(before));
+
+    controller.redo();
+    assert_eq!(controller.ui.waveform.edit_selection, Some(after));
 }
 
 #[test]

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -42,7 +42,7 @@ pub(in crate::native_app) use state::{
     SampleMapViewportChange, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshRequest,
     SourceScanFinish, StartupState, StatusState, UiAppState, WaveformAppState,
     WaveformDestructiveEditKind, WaveformDestructiveEditPrompt, WaveformDestructiveEditUiContext,
-    WaveformPlaySelectionSnapshot, run_folder_scan_worker,
+    WaveformEditFadeSnapshot, WaveformPlaySelectionSnapshot, run_folder_scan_worker,
 };
 
 pub(super) use crate::native_app::app_chrome::scene::view;

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -36,7 +36,8 @@ pub(in crate::native_app) use ui_state::{
     UiAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
 };
 pub(in crate::native_app) use waveform::{
-    PendingPlaySelectionRetargetCycle, WaveformAppState, WaveformPlaySelectionSnapshot,
+    PendingPlaySelectionRetargetCycle, WaveformAppState, WaveformEditFadeSnapshot,
+    WaveformPlaySelectionSnapshot,
 };
 
 pub(in crate::native_app) struct NativeAppState {

--- a/src/native_app/app/state/waveform.rs
+++ b/src/native_app/app/state/waveform.rs
@@ -18,6 +18,7 @@ pub(in crate::native_app) struct WaveformAppState {
     pub(in crate::native_app) cache: WaveformCacheState,
     pub(in crate::native_app) pending_play_selection_transaction:
         Option<WaveformPlaySelectionSnapshot>,
+    pub(in crate::native_app) pending_edit_fade_transaction: Option<WaveformEditFadeSnapshot>,
     pub(in crate::native_app) pending_play_selection_retarget: bool,
     pub(in crate::native_app) pending_play_selection_retarget_cycle:
         Option<PendingPlaySelectionRetargetCycle>,
@@ -30,6 +31,7 @@ impl WaveformAppState {
             load: WaveformLoadState::default(),
             cache: WaveformCacheState::default(),
             pending_play_selection_transaction: None,
+            pending_edit_fade_transaction: None,
             pending_play_selection_retarget: false,
             pending_play_selection_retarget_cycle: None,
         }
@@ -47,6 +49,21 @@ impl PendingPlaySelectionRetargetCycle {
         Self {
             end_ratio,
             last_progress_ratio,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct WaveformEditFadeSnapshot {
+    pub(in crate::native_app) path: PathBuf,
+    pub(in crate::native_app) edit_selection: Option<SelectionRange>,
+}
+
+impl WaveformEditFadeSnapshot {
+    pub(in crate::native_app) fn from_waveform(waveform: &WaveformState) -> Self {
+        Self {
+            path: waveform.path(),
+            edit_selection: waveform.edit_selection(),
         }
     }
 }

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -4,12 +4,13 @@ use wavecrate::selection::SelectionRange;
 
 use crate::native_app::app::{
     ClipboardHandoffTarget, GuiMessage, NativeAppState, WaveformActiveDragKind,
-    WaveformContextMenu, WaveformInteraction, WaveformPlaySelectionSnapshot, WaveformSelectionKind,
-    emit_gui_action,
+    WaveformContextMenu, WaveformEditFadeSnapshot, WaveformInteraction,
+    WaveformPlaySelectionSnapshot, WaveformSelectionKind, emit_gui_action,
 };
 
 pub(in crate::native_app) const PLAY_SELECTION_TRANSACTION_LABEL: &str =
     "Change play mark selection";
+const EDIT_FADE_TRANSACTION_LABEL: &str = "Waveform fade";
 
 impl NativeAppState {
     pub(super) fn apply_waveform_message(
@@ -29,6 +30,7 @@ impl NativeAppState {
         let action = waveform_interaction_action(&message);
         let active_drag = self.waveform.current.active_drag_kind();
         let play_selection_before = self.play_selection_transaction_begin_snapshot(&message);
+        let edit_fade_before = self.edit_fade_transaction_begin_snapshot(&message);
         let harvest_mark_before = waveform_interaction_can_finish_mark_change(&message)
             .then(|| WaveformHarvestMarkSnapshot::from_state(self))
             .flatten();
@@ -44,6 +46,9 @@ impl NativeAppState {
                 play_selection_drag_active(self.waveform.current.active_drag_kind())
                     .then_some(before);
         }
+        if let Some(before) = edit_fade_before {
+            self.waveform.pending_edit_fade_transaction = Some(before);
+        }
         if waveform_interaction_updates_edit_selection(&message, active_drag) {
             self.sync_edit_fade_audio_state();
         }
@@ -56,6 +61,9 @@ impl NativeAppState {
         }
         if play_selection_transaction_finishes(&message, active_drag) {
             self.register_finished_play_selection_transaction();
+        }
+        if edit_fade_transaction_finishes(&message, active_drag) {
+            self.register_finished_edit_fade_transaction();
         }
         if let Some(action) = action {
             emit_gui_action(action, Some("waveform"), None, "applied", started_at, None);
@@ -87,6 +95,20 @@ impl NativeAppState {
             .then(|| WaveformPlaySelectionSnapshot::from_waveform(&self.waveform.current))
     }
 
+    fn edit_fade_transaction_begin_snapshot(
+        &self,
+        interaction: &WaveformInteraction,
+    ) -> Option<WaveformEditFadeSnapshot> {
+        let begins_edit_fade_change = matches!(
+            interaction,
+            WaveformInteraction::BeginEditFade { .. }
+                | WaveformInteraction::BeginEditFadeOuterGain { .. }
+                | WaveformInteraction::ClearEditFadeSilence { .. }
+        );
+        begins_edit_fade_change
+            .then(|| WaveformEditFadeSnapshot::from_waveform(&self.waveform.current))
+    }
+
     fn register_finished_play_selection_transaction(&mut self) {
         let Some(before) = self.waveform.pending_play_selection_transaction.take() else {
             return;
@@ -101,6 +123,23 @@ impl NativeAppState {
             PLAY_SELECTION_TRANSACTION_LABEL,
             move |transaction| transaction.restore_play_selection(undo_snapshot.clone()),
             move |transaction| transaction.restore_play_selection(redo_snapshot.clone()),
+        );
+    }
+
+    fn register_finished_edit_fade_transaction(&mut self) {
+        let Some(before) = self.waveform.pending_edit_fade_transaction.take() else {
+            return;
+        };
+        let after = WaveformEditFadeSnapshot::from_waveform(&self.waveform.current);
+        if before.path != after.path || before == after {
+            return;
+        }
+        let undo_snapshot = before.clone();
+        let redo_snapshot = after;
+        self.register_transaction_action(
+            EDIT_FADE_TRANSACTION_LABEL,
+            move |transaction| transaction.restore_edit_fade(undo_snapshot.clone()),
+            move |transaction| transaction.restore_edit_fade(redo_snapshot.clone()),
         );
     }
 
@@ -287,6 +326,18 @@ fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bo
             WaveformSelectionKind::Play
         ))
     )
+}
+
+fn edit_fade_transaction_finishes(
+    interaction: &WaveformInteraction,
+    active_drag: Option<WaveformActiveDragKind>,
+) -> bool {
+    matches!(
+        interaction,
+        WaveformInteraction::ClearEditFadeSilence { .. }
+            | WaveformInteraction::FinishEditFadeOuterGain { .. }
+    ) || (matches!(interaction, WaveformInteraction::FinishSelection { .. })
+        && matches!(active_drag, Some(WaveformActiveDragKind::EditFade(_))))
 }
 
 fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'static str> {

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -1,6 +1,10 @@
 use super::gui_state_for_span_tests;
-use crate::native_app::test_support::state::GuiMessage;
+use crate::native_app::{
+    test_support::state::{GuiMessage, WaveformInteraction},
+    waveform::{WaveformEditFadeHandle, WaveformEditFadeOuterGainHandle},
+};
 use radiant::prelude::{self as ui, IntoView};
+use wavecrate::selection::SelectionRange;
 
 #[test]
 fn transaction_group_undoes_and_redoes_as_one_entry() {
@@ -38,6 +42,116 @@ fn transaction_group_undoes_and_redoes_as_one_entry() {
     state.redo_transaction();
     assert_eq!(state.ui.status.sample, "Redid Grouped edit");
     assert_eq!(state.audio.volume, 0.8);
+}
+
+#[test]
+fn waveform_fade_drag_registers_one_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6).with_fade_out(0.25, 0.2);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginEditFade {
+            handle: WaveformEditFadeHandle::OutStart,
+            visible_ratio: 0.5,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.45,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishSelection {
+            visible_ratio: 0.45,
+        }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("edit selection after fade drag");
+    assert_ne!(after, before);
+    let items = state.transactions.history.list_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].label, "Waveform fade");
+    assert_eq!(items[0].action_labels, vec![String::from("Waveform fade")]);
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+    assert_eq!(state.ui.status.sample, "Undid Waveform fade");
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
+    assert_eq!(state.ui.status.sample, "Redid Waveform fade");
+}
+
+#[test]
+fn waveform_fade_outer_gain_drag_registers_one_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6)
+        .with_fade_in(0.25, 0.2)
+        .with_fade_in_mute(0.2)
+        .with_fade_in_outer_gain(0.25);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginEditFadeOuterGain {
+            handle: WaveformEditFadeOuterGainHandle::In,
+            vertical_ratio: 0.25,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateEditFadeOuterGain {
+            vertical_ratio: 0.5,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishEditFadeOuterGain {
+            vertical_ratio: 0.5,
+        }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("edit selection after outer gain drag");
+    assert_ne!(after, before);
+    assert_eq!(state.transactions.history.list_items().len(), 1);
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
+}
+
+#[test]
+fn no_op_waveform_fade_clear_silence_does_not_register_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let selection = SelectionRange::new(0.2, 0.6).with_fade_out(0.25, 0.2);
+    state.waveform.current.set_edit_selection_range(selection);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::ClearEditFadeSilence {
+            handle: WaveformEditFadeHandle::OutOuterEnd,
+        }),
+        &mut context,
+    );
+
+    assert_eq!(state.waveform.current.edit_selection(), Some(selection));
+    assert!(state.transactions.history.list_items().is_empty());
 }
 
 #[test]

--- a/src/native_app/transaction_history/context.rs
+++ b/src/native_app/transaction_history/context.rs
@@ -1,4 +1,6 @@
-use crate::native_app::app::{NativeAppState, WaveformPlaySelectionSnapshot};
+use crate::native_app::app::{
+    NativeAppState, WaveformEditFadeSnapshot, WaveformPlaySelectionSnapshot,
+};
 use crate::native_app::transaction_history::TransactionResult;
 
 pub(in crate::native_app) struct TransactionContext<'a> {
@@ -24,6 +26,25 @@ impl TransactionContext<'_> {
         );
         self.state.waveform.current.ensure_play_selection_visible();
         self.state.retarget_playback_to_play_selection();
+        Ok(())
+    }
+
+    pub(in crate::native_app) fn restore_edit_fade(
+        &mut self,
+        snapshot: WaveformEditFadeSnapshot,
+    ) -> TransactionResult {
+        let current_path = self.state.waveform.current.path();
+        if current_path != snapshot.path {
+            return Err(format!(
+                "Loaded sample changed; expected {}",
+                snapshot.path.display()
+            ));
+        }
+        self.state
+            .waveform
+            .current
+            .restore_edit_selection_state(snapshot.edit_selection);
+        self.state.sync_edit_fade_audio_state();
         Ok(())
     }
 

--- a/src/native_app/waveform/state_selection.rs
+++ b/src/native_app/waveform/state_selection.rs
@@ -73,6 +73,15 @@ impl WaveformState {
         self.marked_play_ranges = marked_play_ranges;
     }
 
+    pub(in crate::native_app) fn restore_edit_selection_state(
+        &mut self,
+        edit_selection: Option<SelectionRange>,
+    ) {
+        self.active_drag = None;
+        self.edit_mark_ratio = edit_selection.map(|selection| selection.start());
+        self.edit_selection = edit_selection;
+    }
+
     pub(in crate::native_app) fn restore_play_selection_range_in_focus(
         &mut self,
         start: f32,


### PR DESCRIPTION
## Scope
- Register waveform edit fade creation and adjustment as readable undo/redo transactions.
- Capture native fade pre/post state around completed fade gestures so the transaction inspector shows one `Waveform fade` entry.
- Keep controller-level fade UI actions grouped into one `Waveform fade` undo step with exact pre/post edit-selection restoration.
- Cover fade handle drags, outer-gain fade adjustment, fade creation, repeated live preview updates, and no-op fade paths.

## Definition of Done
- Fade creation is undoable and redoable as one transaction.
- Fade adjustments are grouped into one undo/redo transaction per completed gesture/action.
- Undo and redo restore exact pre/post fade states without repeated key presses.
- Live preview updates do not pollute the undo stack.
- Cancelled or no-op fade interactions do not create undo entries.
- Automated coverage protects fade creation, adjustment grouping, state restoration, validation, and refresh behavior.

## Validation Commands
- `bash scripts/agent.sh request` (baseline failure: existing unrelated non-blocking guardrail violations in `src/native_app/sample_library/folder_browser/drag_drop_move.rs`, `sample_map.rs`, `harvest_tracking.rs`, duplicate workflow code, and sidebar test helper code)
- `cargo test -p wavecrate app_core::controller::tests::waveform::undo -- --test-threads=1`
- `cargo test -p wavecrate native_app::tests::transactions -- --test-threads=1`
- `cargo test -p wavecrate native_app::waveform::tests::edit_fade -- --test-threads=1`
- `cargo test -p wavecrate app::controller::playback::waveform_action_tests -- --test-threads=1`
- `bash scripts/ci.sh smoke`

## Known Limitations
- None for the OPT-901 implementation scope.

## Review
User review is required before merge.