### PR TITLE
OPT-899 Group editmark volume undo transactions

### DIFF
--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -11,6 +11,7 @@ use crate::native_app::app::{
 pub(in crate::native_app) const PLAY_SELECTION_TRANSACTION_LABEL: &str =
     "Change play mark selection";
 const EDIT_FADE_TRANSACTION_LABEL: &str = "Waveform fade";
+const EDIT_GAIN_TRANSACTION_LABEL: &str = "Editmark volume";
 
 impl NativeAppState {
     pub(super) fn apply_waveform_message(
@@ -63,7 +64,9 @@ impl NativeAppState {
             self.register_finished_play_selection_transaction();
         }
         if edit_fade_transaction_finishes(&message, active_drag) {
-            self.register_finished_edit_fade_transaction();
+            let label =
+                edit_fade_transaction_label(&message).unwrap_or(EDIT_FADE_TRANSACTION_LABEL);
+            self.register_finished_edit_fade_transaction(label);
         }
         if let Some(action) = action {
             emit_gui_action(action, Some("waveform"), None, "applied", started_at, None);
@@ -103,6 +106,7 @@ impl NativeAppState {
             interaction,
             WaveformInteraction::BeginEditFade { .. }
                 | WaveformInteraction::BeginEditFadeOuterGain { .. }
+                | WaveformInteraction::BeginEditGain { .. }
                 | WaveformInteraction::ClearEditFadeSilence { .. }
         );
         begins_edit_fade_change
@@ -126,7 +130,7 @@ impl NativeAppState {
         );
     }
 
-    fn register_finished_edit_fade_transaction(&mut self) {
+    fn register_finished_edit_fade_transaction(&mut self, label: &'static str) {
         let Some(before) = self.waveform.pending_edit_fade_transaction.take() else {
             return;
         };
@@ -137,7 +141,7 @@ impl NativeAppState {
         let undo_snapshot = before.clone();
         let redo_snapshot = after;
         self.register_transaction_action(
-            EDIT_FADE_TRANSACTION_LABEL,
+            label,
             move |transaction| transaction.restore_edit_fade(undo_snapshot.clone()),
             move |transaction| transaction.restore_edit_fade(redo_snapshot.clone()),
         );
@@ -338,6 +342,18 @@ fn edit_fade_transaction_finishes(
             | WaveformInteraction::FinishEditFadeOuterGain { .. }
     ) || (matches!(interaction, WaveformInteraction::FinishSelection { .. })
         && matches!(active_drag, Some(WaveformActiveDragKind::EditFade(_))))
+        || (matches!(interaction, WaveformInteraction::FinishEditGain { .. })
+            && active_drag == Some(WaveformActiveDragKind::EditGain))
+}
+
+fn edit_fade_transaction_label(interaction: &WaveformInteraction) -> Option<&'static str> {
+    match interaction {
+        WaveformInteraction::FinishEditGain { .. } => Some(EDIT_GAIN_TRANSACTION_LABEL),
+        WaveformInteraction::ClearEditFadeSilence { .. }
+        | WaveformInteraction::FinishEditFadeOuterGain { .. }
+        | WaveformInteraction::FinishSelection { .. } => Some(EDIT_FADE_TRANSACTION_LABEL),
+        _ => None,
+    }
 }
 
 fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'static str> {

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -137,6 +137,78 @@ fn waveform_fade_outer_gain_drag_registers_one_transaction() {
 }
 
 #[test]
+fn waveform_edit_gain_drag_registers_one_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6).with_gain(0.5);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginEditGain { pointer_y: 20.0 }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateEditGain { pointer_y: -20.0 }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateEditGain { pointer_y: 80.0 }),
+        &mut context,
+    );
+    assert!(
+        state.transactions.history.list_items().is_empty(),
+        "live preview updates should not create undo history entries"
+    );
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishEditGain { pointer_y: 80.0 }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("edit selection after gain drag");
+    assert_ne!(after, before);
+    let items = state.transactions.history.list_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].label, "Editmark volume");
+    assert_eq!(
+        items[0].action_labels,
+        vec![String::from("Editmark volume")]
+    );
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+    assert_eq!(state.ui.status.sample, "Undid Editmark volume");
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
+    assert_eq!(state.ui.status.sample, "Redid Editmark volume");
+}
+
+#[test]
+fn no_op_waveform_edit_gain_drag_does_not_register_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let selection = SelectionRange::new(0.2, 0.6).with_gain(0.5);
+    state.waveform.current.set_edit_selection_range(selection);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginEditGain { pointer_y: 20.0 }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishEditGain { pointer_y: 20.0 }),
+        &mut context,
+    );
+
+    assert_eq!(state.waveform.current.edit_selection(), Some(selection));
+    assert!(state.transactions.history.list_items().is_empty());
+}
+
+#[test]
 fn no_op_waveform_fade_clear_silence_does_not_register_transaction() {
     let mut state = gui_state_for_span_tests();
     let mut context = ui::UiUpdateContext::default();


### PR DESCRIPTION
## Active PR tracking

- Current branch: `wsvasek/opt-899-wavecrate-make-editmark-volume-adjustments-undo-and-redo-as`
- PR link: https://github.com/PORTALSURFER/wavecrate/pull/599
- Scope: group editmark volume/gain drag adjustments into one native undo/redo transaction per committed gesture.
- Definition of Done: editmark volume/gain drags create exactly one transaction, undo/redo restore exact pre/post edit selection state, live preview updates stay out of history, and no-op drags do not create history entries.
- Current status: waiting for user review

## Scope

- Capture editmark gain/volume drag begin state and commit the final state as one native undo/redo transaction.
- Label the transaction as `Editmark volume` so it is readable in the transaction inspector.
- Keep live drag preview updates out of the undo stack while preserving existing edit-preview audio sync.
- Add native transaction coverage for grouped undo/redo and no-op gain drags.

## Definition of Done

- Editmark volume/gain drags create exactly one undo/redo transaction when the gesture commits.
- Undo restores the pre-drag edit selection state in one step.
- Redo restores the committed post-drag edit selection state in one step.
- Live preview updates and no-op gain drags do not create undo entries.

## Validation commands

- `cargo fmt --check`
- `cargo test -p wavecrate edit_gain_drag -- --test-threads=1`
- `cargo test -p wavecrate native_app::tests::transactions -- --test-threads=1`
- `cargo test -p wavecrate native_app::shell::message_dispatch::waveform -- --test-threads=1`

Baseline note: `bash scripts/agent.sh request` was run before implementation and failed on existing unrelated `tests/gui_boundary.rs` non-blocking guardrail violations in folder move/sample-map/duplicate/harvest/sidebar code paths. `bash scripts/doctor.sh` returned OK with warnings for active toolchain mismatch and missing Git LFS.

## Known limitations

- Manual smoke testing in the running app was not performed in this pass.
- The existing main-branch preflight guardrail failure remains outside this PR scope.

User review is required before merge.