### PR TITLE
Wavecrate: keep editmark slide preview aligned during drag

### DIFF
--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -679,6 +679,120 @@ fn moved_selection_drag_preview_survives_widget_rebuild_after_press() {
 }
 
 #[test]
+fn moved_selection_drag_preview_uses_original_baseline_after_live_update() {
+    for (kind, button) in [
+        (WaveformSelectionKind::Play, PointerButton::Primary),
+        (WaveformSelectionKind::Edit, PointerButton::Secondary),
+    ] {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.viewport = super::WaveformViewport {
+            start: 12_000,
+            end: 36_000,
+        };
+        let baseline = wavecrate::selection::SelectionRange::new(0.35, 0.55);
+        match kind {
+            WaveformSelectionKind::Play => {
+                state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.35, 0.55));
+                state.play_mark_ratio = Some(0.35);
+            }
+            WaveformSelectionKind::Edit => {
+                state.edit_selection = Some(baseline);
+                state.edit_mark_ratio = Some(0.35);
+            }
+        }
+        let bounds = Rect::from_size(200.0, 80.0);
+        let press = Point::new(60.0, 3.0);
+        let first_drag = Point::new(80.0, 3.0);
+        let second_drag = Point::new(90.0, 3.0);
+
+        let mut initial = waveform_widget_for_state(&state);
+        let begin = initial
+            .handle_input(
+                bounds,
+                WidgetInput::pointer_press(press, button, Default::default()),
+            )
+            .expect("press should begin moving selection")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            begin,
+            WaveformInteraction::BeginSelectionMove {
+                kind,
+                visible_ratio: 0.3,
+            }
+        );
+        state.apply_interaction(begin);
+
+        let mut first = waveform_widget_for_state(&state);
+        Widget::synchronize_from_previous(&mut first, &initial);
+        let first_update = first
+            .handle_input(bounds, WidgetInput::pointer_move(first_drag))
+            .expect("first drag should emit live update")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            first_update,
+            WaveformInteraction::UpdateSelection { visible_ratio: 0.4 }
+        );
+        state.apply_interaction(first_update);
+
+        let mut second = waveform_widget_for_state(&state);
+        Widget::synchronize_from_previous(&mut second, &first);
+        let second_update = second
+            .handle_input(bounds, WidgetInput::pointer_move(second_drag))
+            .expect("second drag should emit live update")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            second_update,
+            WaveformInteraction::UpdateSelection {
+                visible_ratio: 0.45
+            }
+        );
+
+        let preview = second
+            .live_selection_preview
+            .expect("rebuilt widget should keep previewing from original baseline");
+        assert_eq!(preview.kind, kind);
+        assert!(
+            (preview.selection.start() - 0.425).abs() < 0.0001,
+            "{kind:?} preview should apply the total drag delta once"
+        );
+        assert!(
+            (preview.selection.end() - 0.625).abs() < 0.0001,
+            "{kind:?} preview should apply the total drag delta once"
+        );
+
+        state.apply_interaction(second_update);
+        let live_selection = match kind {
+            WaveformSelectionKind::Play => state.play_selection(),
+            WaveformSelectionKind::Edit => state.edit_selection(),
+        }
+        .expect("live selection should update");
+        assert!((live_selection.start() - preview.selection.start()).abs() < 0.0001);
+        assert!((live_selection.end() - preview.selection.end()).abs() < 0.0001);
+
+        let finish = second
+            .handle_input(
+                bounds,
+                WidgetInput::pointer_release(second_drag, button, Default::default()),
+            )
+            .expect("release should finish the move")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        state.apply_interaction(finish);
+
+        let committed = match kind {
+            WaveformSelectionKind::Play => state.play_selection(),
+            WaveformSelectionKind::Edit => state.edit_selection(),
+        }
+        .expect("selection should remain after release");
+        assert!((committed.start() - preview.selection.start()).abs() < 0.0001);
+        assert!((committed.end() - preview.selection.end()).abs() < 0.0001);
+    }
+}
+
+#[test]
 fn three_pixel_drag_starts_play_and_edit_selections_while_zoomed_in() {
     for (button, kind) in [
         (PointerButton::Primary, WaveformSelectionKind::Play),

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -26,6 +26,13 @@ pub(in crate::native_app::waveform) struct LiveSelectionPreview {
     pub(super) selection: wavecrate::selection::SelectionRange,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app::waveform) struct LiveSelectionPreviewAnchor {
+    pub(super) kind: WaveformSelectionKind,
+    pub(super) visible_ratio: f32,
+    pub(super) baseline: Option<wavecrate::selection::SelectionRange>,
+}
+
 pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     state: &WaveformState,
     tooltip: Option<&'static str>,
@@ -220,7 +227,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) beat_guide_count: u8,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
-    pub(super) live_selection_preview_anchor: Option<(WaveformSelectionKind, f32)>,
+    pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
     pub(super) live_selection_preview: Option<LiveSelectionPreview>,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
@@ -377,11 +384,11 @@ impl WaveformWidget {
         if self.active_drag_kind == previous.active_drag_kind {
             return true;
         }
-        let Some((anchor_kind, _)) = previous.live_selection_preview_anchor else {
+        let Some(anchor) = previous.live_selection_preview_anchor else {
             return false;
         };
         self.active_drag_kind
             .and_then(WaveformActiveDragKind::selection_kind)
-            == Some(anchor_kind)
+            == Some(anchor.kind)
     }
 }

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -8,7 +8,8 @@ use radiant::{
 
 use super::{
     WaveformActiveDragKind, WaveformEditFadeHandle, WaveformInteraction, WaveformSelectionEdge,
-    WaveformSelectionKind, WaveformWidget, widget::LiveSelectionPreview,
+    WaveformSelectionKind, WaveformWidget,
+    widget::{LiveSelectionPreview, LiveSelectionPreviewAnchor},
 };
 
 const SELECTION_CLICK_SLOP_PX: f32 = 2.0;
@@ -489,7 +490,11 @@ impl WaveformWidget {
     }
 
     fn begin_live_selection_preview(&mut self, kind: WaveformSelectionKind, visible_ratio: f32) {
-        self.live_selection_preview_anchor = Some((kind, visible_ratio));
+        self.live_selection_preview_anchor = Some(LiveSelectionPreviewAnchor {
+            kind,
+            visible_ratio,
+            baseline: self.selection_for_kind(kind),
+        });
         self.live_selection_preview = None;
     }
 
@@ -536,14 +541,14 @@ impl WaveformWidget {
         kind: WaveformSelectionKind,
         visible_ratio: f32,
     ) -> Option<wavecrate::selection::SelectionRange> {
-        let Some((anchor_kind, anchor_visible_ratio)) = self.live_selection_preview_anchor else {
+        let Some(anchor) = self.live_selection_preview_anchor else {
             return None;
         };
-        if anchor_kind != kind {
+        if anchor.kind != kind {
             self.clear_live_selection_preview();
             return None;
         }
-        let anchor_ratio = self.absolute_ratio_for_visible(anchor_visible_ratio)?;
+        let anchor_ratio = self.absolute_ratio_for_visible(anchor.visible_ratio)?;
         let current_ratio = self.absolute_ratio_for_visible(visible_ratio)?;
         Some(wavecrate::selection::SelectionRange::new(
             anchor_ratio,
@@ -557,7 +562,11 @@ impl WaveformWidget {
         edge: WaveformSelectionEdge,
         visible_ratio: f32,
     ) -> Option<wavecrate::selection::SelectionRange> {
-        let selection = self.selection_for_kind(kind)?;
+        let selection = self
+            .live_selection_preview_anchor
+            .filter(|anchor| anchor.kind == kind)
+            .and_then(|anchor| anchor.baseline)
+            .or_else(|| self.selection_for_kind(kind))?;
         let ratio = self.absolute_ratio_for_visible(visible_ratio)?;
         let fixed_ratio = match edge {
             WaveformSelectionEdge::Start => selection.end(),
@@ -571,9 +580,12 @@ impl WaveformWidget {
         kind: WaveformSelectionKind,
         visible_ratio: f32,
     ) -> Option<wavecrate::selection::SelectionRange> {
-        let selection = self.selection_for_kind(kind)?;
-        let (_, anchor_visible_ratio) = self.live_selection_preview_anchor?;
-        let anchor_ratio = self.absolute_ratio_for_visible(anchor_visible_ratio)?;
+        let anchor = self.live_selection_preview_anchor?;
+        if anchor.kind != kind {
+            return None;
+        }
+        let selection = anchor.baseline.or_else(|| self.selection_for_kind(kind))?;
+        let anchor_ratio = self.absolute_ratio_for_visible(anchor.visible_ratio)?;
         let ratio = self.absolute_ratio_for_visible(visible_ratio)?;
         let delta = ratio - anchor_ratio;
         Some(if self.allows_out_of_bounds_selection_preview() {


### PR DESCRIPTION
## Scope
- Retain the original selection baseline in the waveform widget's live selection preview anchor.
- Use that baseline for moved and resized preview geometry across widget rebuilds, so preview and app-state commit apply pointer delta to the same source selection.
- Add a zoomed/panned regression covering both playmark and editmark slide preview alignment after a live update and on release.

## Definition of Done
- Editmark slide preview applies the drag delta once from the original selection baseline.
- Live preview, live app state, and release/commit geometry agree during zoomed/panned waveform views.
- Playmark slide behavior and nearby editmark resize/gain gestures remain covered by focused tests.

## Validation commands
- cargo fmt --check
- git diff --check
- cargo test -p wavecrate moved_selection_drag_preview_uses_original_baseline_after_live_update -- --test-threads=1
- cargo test -p wavecrate moved_selection_drag_preview -- --test-threads=1
- cargo test -p wavecrate native_app::waveform::tests::state -- --test-threads=1
- cargo test -p wavecrate playmark_move_motion_updates_live_until_release -- --test-threads=1
- cargo test -p wavecrate playmark_resize_motion_updates_live_until_release -- --test-threads=1
- cargo test -p wavecrate secondary_press_on_edit_top_handle_starts_move -- --test-threads=1
- cargo test -p wavecrate edit_gain_drag -- --test-threads=1
- cargo test -p wavecrate editmark_selection_drag_does_not_churn_signal_preview -- --test-threads=1

## Known limitations
- bash scripts/agent.sh request fails on current main before this change in the non-blocking guardrail, reporting unrelated filesystem/database violations in folder-browser, sample-map, duplicate, harvest, and sidebar paths.
- cargo test -p wavecrate native_app::waveform::tests::widget_input -- --test-threads=1 fails in the pre-existing playback_cache_backed_waveform_accepts_primary_click fixture with a playback-ready waveform cache miss; the slide-focused tests pass.
- Manual smoke testing in the running app was not performed in this pass.

User review is required before merge.