### PR TITLE
OPT-898: Add Command-Option sample slide gesture

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/library/harvest.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/harvest.rs
@@ -149,6 +149,8 @@ pub enum HarvestDerivationOperation {
     ReverseCopy,
     /// Edit effects rendered to a copy.
     EditCopy,
+    /// Circular sample slide rendered to a copy.
+    SlideCopy,
     /// Normalize rendered to a copy.
     NormalizeCopy,
     /// Whole-file duplicate rendered with the audio repeated twice.
@@ -171,6 +173,7 @@ impl HarvestDerivationOperation {
             Self::TrimCopy => "trim_copy",
             Self::ReverseCopy => "reverse_copy",
             Self::EditCopy => "edit_copy",
+            Self::SlideCopy => "slide_copy",
             Self::NormalizeCopy => "normalize_copy",
             Self::DuplicateDoubleCopy => "duplicate_double_copy",
             Self::Export => "export",
@@ -188,6 +191,7 @@ impl HarvestDerivationOperation {
             "trim_copy" => Self::TrimCopy,
             "reverse_copy" => Self::ReverseCopy,
             "edit_copy" => Self::EditCopy,
+            "slide_copy" => Self::SlideCopy,
             "normalize_copy" => Self::NormalizeCopy,
             "duplicate_double_copy" => Self::DuplicateDoubleCopy,
             "export" => Self::Export,

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -391,6 +391,7 @@ pub(in crate::native_app) enum WaveformDestructiveEditKind {
     ReverseSelection,
     ExtractAndTrimSelection,
     ApplyEditSelectionEffects,
+    SlideSampleAudio { frame_offset: i64 },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -41,6 +41,14 @@ impl NativeAppState {
             return;
         }
         self.waveform.current.apply_interaction(message);
+        if matches!(message, WaveformInteraction::FinishSampleSlide { .. })
+            && let Some(frame_offset) = self
+                .waveform
+                .current
+                .take_pending_sample_slide_frame_offset()
+        {
+            self.request_slide_loaded_sample_audio(frame_offset, context);
+        }
         self.mark_harvest_touched_after_waveform_mark_change(harvest_mark_before);
         if let Some(before) = play_selection_before {
             self.waveform.pending_play_selection_transaction =
@@ -385,6 +393,8 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::SelectSimilarSection { .. } => Some("waveform.similar_section.select"),
         WaveformInteraction::BeginSelectionResize { .. } => Some("waveform.selection.resize_begin"),
         WaveformInteraction::BeginSelectionMove { .. } => Some("waveform.selection.move_begin"),
+        WaveformInteraction::BeginSampleSlide { .. } => Some("waveform.sample_slide.begin"),
+        WaveformInteraction::FinishSampleSlide { .. } => Some("waveform.sample_slide.finish"),
         WaveformInteraction::BeginPan { .. } => Some("waveform.pan_begin"),
         WaveformInteraction::DragPlaySelectionExport(drag) => match drag.phase() {
             ui::DragHandlePhase::Started => Some("waveform.selection_export_drag.begin"),
@@ -396,6 +406,7 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::DragLoadedSample(_) => None,
         WaveformInteraction::FinishSelection { .. } => Some("waveform.selection.finish"),
         WaveformInteraction::UpdateSelection { .. }
+        | WaveformInteraction::UpdateSampleSlide { .. }
         | WaveformInteraction::UpdateEditFadeOuterGain { .. }
         | WaveformInteraction::UpdateEditGain { .. }
         | WaveformInteraction::Frame => None,

--- a/src/native_app/tests/waveform_destructive_edit_tests.rs
+++ b/src/native_app/tests/waveform_destructive_edit_tests.rs
@@ -488,6 +488,82 @@ fn protected_reverse_selection_renders_reverse_copy_to_primary_without_mutating_
 }
 
 #[test]
+fn protected_sample_slide_renders_slide_copy_to_primary_without_mutating_origin() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let (mut state, source_root, selected_file) =
+        native_app_state_with_temp_sample("protected-slide.wav");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            primary_source.clone(),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(selected_file.clone());
+    let path = PathBuf::from(&selected_file);
+    let harvest_source_folder = source_root
+        .path()
+        .file_name()
+        .expect("source root folder name");
+    let slide_copy = primary_root
+        .path()
+        .join("_Harvests")
+        .join(harvest_source_folder)
+        .join("protected-slide_slide.wav");
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSampleSlide { visible_ratio: 0.0 }),
+        &mut ui::UiUpdateContext::default(),
+    );
+    apply_message_and_run_command(
+        &mut state,
+        GuiMessage::Waveform(WaveformInteraction::FinishSampleSlide {
+            visible_ratio: 0.25,
+        }),
+    );
+
+    assert_samples_close(&read_test_wav_f32(&path), &[0.0, 1_000.0, 2_000.0, 3_000.0]);
+    assert_samples_close(
+        &read_test_wav_f32(&slide_copy),
+        &[3_000.0, 0.0, 1_000.0, 2_000.0],
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(slide_copy.to_string_lossy().as_ref())
+    );
+    let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        protected_source.id.clone(),
+        PathBuf::from("protected-slide.wav"),
+    );
+    let edges = wavecrate::sample_sources::library::harvest_derivations_for_parent(&parent_key)
+        .expect("load harvest derivations");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].operation,
+        wavecrate::sample_sources::HarvestDerivationOperation::SlideCopy
+    );
+    assert_eq!(edges[0].child.key.source_id, primary_source.id);
+    assert_eq!(
+        edges[0].child.key.relative_path,
+        PathBuf::from("_Harvests")
+            .join(harvest_source_folder)
+            .join("protected-slide_slide.wav")
+    );
+}
+
+#[test]
 fn normal_harvest_mode_reverse_selection_renders_reverse_copy_to_primary_without_mutating_origin() {
     let config_base = tempfile::tempdir().expect("config base");
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
@@ -1441,6 +1517,100 @@ fn extract_and_trim_request_extracts_selection_trims_source_and_undo_redo_roundt
     );
 }
 
+#[test]
+fn sample_slide_positive_offset_wraps_end_to_beginning() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("slide-positive.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSampleSlide { visible_ratio: 0.0 }),
+        &mut ui::UiUpdateContext::default(),
+    );
+    apply_message_and_run_command(
+        &mut state,
+        GuiMessage::Waveform(WaveformInteraction::FinishSampleSlide {
+            visible_ratio: 0.25,
+        }),
+    );
+
+    assert_samples_close(&read_test_wav_f32(&path), &[3_000.0, 0.0, 1_000.0, 2_000.0]);
+    assert_eq!(
+        state.waveform.current.frames(),
+        4,
+        "sample slide should preserve duration"
+    );
+    assert!(state.ui.status.sample.contains("Slid"));
+}
+
+#[test]
+fn sample_slide_negative_offset_wraps_beginning_to_end() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("slide-negative.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSampleSlide { visible_ratio: 0.5 }),
+        &mut ui::UiUpdateContext::default(),
+    );
+    apply_message_and_run_command(
+        &mut state,
+        GuiMessage::Waveform(WaveformInteraction::FinishSampleSlide {
+            visible_ratio: 0.25,
+        }),
+    );
+
+    assert_samples_close(&read_test_wav_f32(&path), &[1_000.0, 2_000.0, 3_000.0, 0.0]);
+    assert_eq!(
+        state.waveform.current.frames(),
+        4,
+        "sample slide should preserve duration"
+    );
+}
+
+#[test]
+fn sample_slide_wraps_stereo_audio_by_frame() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("slide-stereo.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16_stereo_for_destructive_tests(
+        &path,
+        &[(1_000, 10_000), (2_000, 20_000), (3_000, 30_000)],
+    );
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSampleSlide { visible_ratio: 0.0 }),
+        &mut ui::UiUpdateContext::default(),
+    );
+    apply_message_and_run_command(
+        &mut state,
+        GuiMessage::Waveform(WaveformInteraction::FinishSampleSlide {
+            visible_ratio: 1.0 / 3.0,
+        }),
+    );
+
+    assert_samples_close(
+        &read_test_wav_f32(&path),
+        &[3_000.0, 30_000.0, 1_000.0, 10_000.0, 2_000.0, 20_000.0],
+    );
+    assert_eq!(state.waveform.current.channels(), 2);
+    assert_eq!(state.waveform.current.frames(), 3);
+}
+
 fn select_waveform_range(
     state: &mut crate::native_app::test_support::state::NativeAppState,
     kind: WaveformSelectionKind,
@@ -1530,4 +1700,19 @@ fn assert_range_close(range: wavecrate::selection::SelectionRange, start: f32, e
         "expected range end {end}, got {}",
         range.end()
     );
+}
+
+fn write_test_wav_i16_stereo_for_destructive_tests(path: &std::path::Path, frames: &[(i16, i16)]) {
+    let spec = hound::WavSpec {
+        channels: 2,
+        sample_rate: 48_000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+    for (left, right) in frames {
+        writer.write_sample(*left).expect("write left sample");
+        writer.write_sample(*right).expect("write right sample");
+    }
+    writer.finalize().expect("finalize wav");
 }

--- a/src/native_app/waveform/interaction.rs
+++ b/src/native_app/waveform/interaction.rs
@@ -22,6 +22,7 @@ pub(super) enum WaveformDrag {
     EditFade(WaveformEditFadeDrag),
     EditFadeOuterGain(WaveformEditFadeOuterGainDrag),
     EditGain(WaveformEditGainDrag),
+    SampleSlide(WaveformSampleSlideDrag),
     Pan(WaveformPanDrag),
 }
 
@@ -39,8 +40,29 @@ impl WaveformDrag {
                 WaveformActiveDragKind::EditFadeOuterGain(drag.handle)
             }
             WaveformDrag::EditGain(_) => WaveformActiveDragKind::EditGain,
+            WaveformDrag::SampleSlide(_) => WaveformActiveDragKind::SampleSlide,
             WaveformDrag::Pan(_) => WaveformActiveDragKind::Pan,
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct WaveformSampleSlideDrag {
+    anchor_visible_ratio: f32,
+    visible_frames: usize,
+}
+
+impl WaveformSampleSlideDrag {
+    pub(super) fn new(anchor_visible_ratio: f32, viewport: WaveformViewport) -> Self {
+        Self {
+            anchor_visible_ratio: finite_or_zero(anchor_visible_ratio),
+            visible_frames: viewport.visible_items(),
+        }
+    }
+
+    pub(super) fn frame_offset(self, visible_ratio: f32) -> i64 {
+        let visible_ratio = finite_or_zero(visible_ratio);
+        ((visible_ratio - self.anchor_visible_ratio) * self.visible_frames as f32).round() as i64
     }
 }
 

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -26,6 +26,7 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) copy_flash_frames: u8,
     pub(in crate::native_app::waveform) active_drag: Option<WaveformDrag>,
     pub(in crate::native_app::waveform) pending_playback_start: Option<f32>,
+    pub(in crate::native_app::waveform) pending_sample_slide_frame_offset: Option<i64>,
     pub(in crate::native_app::waveform) context_menu_pointer_position:
         Option<radiant::gui::types::Point>,
 }

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -3,7 +3,7 @@ use super::{
     WaveformSelectionKind, WaveformState,
     interaction::{
         WaveformDrag, WaveformEditFadeDrag, WaveformEditFadeOuterGainDrag, WaveformEditGainDrag,
-        WaveformPanDrag, WaveformSelectionDrag, WaveformSelectionMoveDrag,
+        WaveformPanDrag, WaveformSampleSlideDrag, WaveformSelectionDrag, WaveformSelectionMoveDrag,
         WaveformSelectionResizeDrag,
     },
 };
@@ -150,6 +150,19 @@ impl WaveformState {
                 ));
                 self.update_active_selection_move(ratio, false);
             }
+            WaveformInteraction::BeginSampleSlide { visible_ratio } => {
+                self.active_drag = Some(WaveformDrag::SampleSlide(WaveformSampleSlideDrag::new(
+                    visible_ratio,
+                    self.viewport,
+                )));
+                self.pending_sample_slide_frame_offset = None;
+            }
+            WaveformInteraction::UpdateSampleSlide { visible_ratio } => {
+                self.update_active_sample_slide(visible_ratio);
+            }
+            WaveformInteraction::FinishSampleSlide { visible_ratio } => {
+                self.finish_active_sample_slide(visible_ratio);
+            }
             WaveformInteraction::BeginPan { visible_ratio } => {
                 self.active_drag = Some(WaveformDrag::Pan(WaveformPanDrag::new(
                     visible_ratio,
@@ -206,6 +219,9 @@ impl WaveformState {
                 self.update_active_selection_move(ratio, false);
             }
             WaveformDrag::PlaySelectionExport => {}
+            WaveformDrag::SampleSlide(_) => {
+                self.update_active_sample_slide(visible_ratio);
+            }
             WaveformDrag::Pan(drag) => {
                 self.update_active_pan(drag, visible_ratio);
             }
@@ -271,6 +287,9 @@ impl WaveformState {
                 }
             }
             WaveformDrag::PlaySelectionExport => {}
+            WaveformDrag::SampleSlide(drag) => {
+                self.pending_sample_slide_frame_offset = Some(drag.frame_offset(visible_ratio));
+            }
             WaveformDrag::Pan(drag) => {
                 self.update_active_pan(drag, visible_ratio);
             }
@@ -337,6 +356,22 @@ impl WaveformState {
         };
         self.active_drag = Some(drag);
         self.update_active_edit_gain(pointer_y);
+        self.active_drag = None;
+    }
+
+    fn update_active_sample_slide(&mut self, visible_ratio: f32) {
+        let Some(WaveformDrag::SampleSlide(drag)) = self.active_drag else {
+            return;
+        };
+        self.pending_sample_slide_frame_offset = Some(drag.frame_offset(visible_ratio));
+    }
+
+    fn finish_active_sample_slide(&mut self, visible_ratio: f32) {
+        let Some(drag @ WaveformDrag::SampleSlide(_)) = self.active_drag.take() else {
+            return;
+        };
+        self.active_drag = Some(drag);
+        self.update_active_sample_slide(visible_ratio);
         self.active_drag = None;
     }
 

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -136,6 +136,7 @@ impl WaveformState {
             copy_flash_frames: 0,
             active_drag: None::<WaveformDrag>,
             pending_playback_start: None,
+            pending_sample_slide_frame_offset: None,
             context_menu_pointer_position: None,
         }
     }

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -17,6 +17,10 @@ impl WaveformState {
         self.pending_playback_start.take()
     }
 
+    pub(in crate::native_app) fn take_pending_sample_slide_frame_offset(&mut self) -> Option<i64> {
+        self.pending_sample_slide_frame_offset.take()
+    }
+
     pub(in crate::native_app) fn start_playback(&mut self, ratio: f32) {
         self.start_playback_with_marker(ratio, true);
     }

--- a/src/native_app/waveform/state_preserved_marks.rs
+++ b/src/native_app/waveform/state_preserved_marks.rs
@@ -49,6 +49,7 @@ impl WaveformState {
         self.edit_selection_denied_flash_frames = 0;
         self.active_drag = None;
         self.pending_playback_start = None;
+        self.pending_sample_slide_frame_offset = None;
     }
 
     fn preserved_marks_with_transform(

--- a/src/native_app/waveform/tests/mod.rs
+++ b/src/native_app/waveform/tests/mod.rs
@@ -10,7 +10,7 @@ use radiant::{
     prelude::IntoView,
     runtime::{GpuSurfaceContent, PaintFillRect, PaintStrokePolyline, SurfacePaintPlan},
     theme::ThemeTokens,
-    widgets::{PointerButton, Widget, WidgetInput, WidgetOutput},
+    widgets::{PointerButton, PointerModifiers, Widget, WidgetInput, WidgetOutput},
 };
 use std::{fs, sync::Arc};
 

--- a/src/native_app/waveform/tests/mod.rs
+++ b/src/native_app/waveform/tests/mod.rs
@@ -54,7 +54,7 @@ fn assert_pointer_location_output(output: Option<WidgetOutput>) {
 
 fn gpu_surface_revision_for_file(file: Arc<super::WaveformFile>) -> u64 {
     let viewport = super::WaveformViewport::full(file.frames);
-    let plan = waveform_signal_surface_plan(file, viewport, None);
+    let plan = waveform_signal_surface_plan(file, viewport, None, None);
     plan.gpu_surfaces()
         .map(|surface| surface.revision)
         .next()
@@ -65,10 +65,12 @@ fn waveform_signal_surface_plan(
     file: Arc<super::WaveformFile>,
     viewport: super::WaveformViewport,
     edit_selection: Option<wavecrate::selection::SelectionRange>,
+    sample_slide_frame_offset: Option<i64>,
 ) -> SurfacePaintPlan {
-    let view = waveform_signal_surface_view(file, viewport, edit_selection)
-        .id(crate::native_app::test_support::waveform::WAVEFORM_SIGNAL_WIDGET_ID)
-        .size(200.0, 80.0);
+    let view =
+        waveform_signal_surface_view(file, viewport, edit_selection, sample_slide_frame_offset)
+            .id(crate::native_app::test_support::waveform::WAVEFORM_SIGNAL_WIDGET_ID)
+            .size(200.0, 80.0);
     let surface = view.into_surface();
     let bounds = Rect::from_size(200.0, 80.0);
     let layout = radiant::layout::layout_tree(&surface.layout_node(), bounds);

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -755,6 +755,35 @@ fn live_selection_preview_paints_in_runtime_overlay() {
 }
 
 #[test]
+fn sample_slide_preview_paints_thin_bottom_strip() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.apply_interaction(WaveformInteraction::BeginSampleSlide { visible_ratio: 0.0 });
+    state.apply_interaction(WaveformInteraction::UpdateSampleSlide {
+        visible_ratio: 0.25,
+    });
+    let widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let plan = runtime_overlay_plan(&widget, bounds);
+    let fills = fill_rects(&plan);
+
+    assert!(fills.iter().any(|fill| {
+        (fill.rect.min.y - 76.0).abs() < 0.001
+            && (fill.rect.max.y - 80.0).abs() < 0.001
+            && (fill.rect.min.x - 0.0).abs() < 0.001
+            && (fill.rect.max.x - 200.0).abs() < 0.001
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 202, 112, 120)
+    }));
+    assert!(
+        fills.iter().all(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b) != (255, 202, 112)
+                || fill.rect.height() <= 4.0
+        }),
+        "sample slide preview should stay a bottom strip"
+    );
+}
+
+#[test]
 fn live_playmark_preview_paints_full_interactive_chrome() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -3,7 +3,8 @@ use super::*;
 #[test]
 fn signal_widget_paints_gpu_surface_without_app_overlay_handles() {
     let state = WaveformState::synthetic_for_tests();
-    let plan = waveform_signal_surface_plan(state.file(), state.viewport(), state.edit_selection());
+    let plan =
+        waveform_signal_surface_plan(state.file(), state.viewport(), state.edit_selection(), None);
 
     let surface = plan
         .gpu_surfaces()
@@ -21,7 +22,8 @@ fn signal_widget_paints_gpu_surface_without_app_overlay_handles() {
 #[test]
 fn signal_widget_leaves_hover_cursor_to_waveform_widget_overlay() {
     let state = WaveformState::synthetic_for_tests();
-    let plan = waveform_signal_surface_plan(state.file(), state.viewport(), state.edit_selection());
+    let plan =
+        waveform_signal_surface_plan(state.file(), state.viewport(), state.edit_selection(), None);
 
     let surface = plan
         .gpu_surfaces()
@@ -57,7 +59,7 @@ fn signal_widget_attaches_active_edit_fade_gain_preview() {
             .with_fade_in_mute(0.2)
             .with_fade_in_outer_gain(0.35),
     );
-    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection);
+    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection, None);
 
     let surface = plan.gpu_surfaces().next().expect("waveform gpu surface");
 
@@ -91,7 +93,7 @@ fn signal_widget_attaches_active_edit_gain_preview_without_fades() {
     ));
     let viewport = super::WaveformViewport::full(file.frames);
     let edit_selection = Some(wavecrate::selection::SelectionRange::new(0.25, 0.75).with_gain(0.5));
-    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection);
+    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection, None);
 
     let surface = plan.gpu_surfaces().next().expect("waveform gpu surface");
 
@@ -104,6 +106,28 @@ fn signal_widget_attaches_active_edit_gain_preview_without_fades() {
     assert_eq!(preview.gain, 0.5);
     assert_eq!(preview.fade_in_length, 0.0);
     assert_eq!(preview.fade_out_length, 0.0);
+}
+
+#[test]
+fn signal_widget_attaches_sample_slide_preview_offset() {
+    let state = WaveformState::synthetic_for_tests();
+    let plan = waveform_signal_surface_plan(
+        state.file(),
+        state.viewport(),
+        state.edit_selection(),
+        Some(6_000),
+    );
+
+    let surface = plan.gpu_surfaces().next().expect("waveform gpu surface");
+    let GpuSurfaceContent::SignalSummaryBands {
+        sample_slide_frame_offset,
+        ..
+    } = &surface.content
+    else {
+        panic!("expected signal summary bands");
+    };
+
+    assert_eq!(*sample_slide_frame_offset, 6_000);
 }
 
 #[test]
@@ -141,7 +165,7 @@ fn signal_widget_keeps_summary_cached_during_live_edit_fade_drag() {
     let viewport = super::WaveformViewport::full(file.frames);
     let edit_selection =
         Some(wavecrate::selection::SelectionRange::new(0.0, 1.0).with_fade_in(1.0, 0.0));
-    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection);
+    let plan = waveform_signal_surface_plan(Arc::clone(&file), viewport, edit_selection, None);
 
     let surface = plan.gpu_surfaces().next().expect("waveform gpu surface");
 

--- a/src/native_app/waveform/tests/state.rs
+++ b/src/native_app/waveform/tests/state.rs
@@ -466,6 +466,24 @@ fn edit_top_handle_moves_range_and_preserves_edit_effects() {
 }
 
 #[test]
+fn sample_slide_drag_uses_visible_viewport_frames_for_offset() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.viewport = super::WaveformViewport {
+        start: 12_000,
+        end: 36_000,
+    };
+
+    state.apply_interaction(WaveformInteraction::BeginSampleSlide {
+        visible_ratio: 0.25,
+    });
+    state.apply_interaction(WaveformInteraction::UpdateSampleSlide { visible_ratio: 0.5 });
+    assert_eq!(state.take_pending_sample_slide_frame_offset(), Some(6_000));
+
+    state.apply_interaction(WaveformInteraction::FinishSampleSlide { visible_ratio: 0.0 });
+    assert_eq!(state.take_pending_sample_slide_frame_offset(), Some(-6_000));
+}
+
+#[test]
 fn dragging_secondary_creates_edit_selection() {
     let mut state = WaveformState::synthetic_for_tests();
 

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -128,6 +128,93 @@ fn primary_press_emits_playback_ratio_matching_hover_cursor_ratio() {
 }
 
 #[test]
+fn command_option_primary_drag_starts_sample_slide_instead_of_selection() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.viewport = super::WaveformViewport {
+        start: 12_000,
+        end: 36_000,
+    };
+    let mut widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+    let modifiers = PointerModifiers {
+        command: true,
+        alt: true,
+        ..Default::default()
+    };
+
+    let begin = widget
+        .handle_input(
+            bounds,
+            WidgetInput::pointer_press(Point::new(50.0, 40.0), PointerButton::Primary, modifiers),
+        )
+        .expect("command-option press should begin sample slide")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        begin,
+        WaveformInteraction::BeginSampleSlide {
+            visible_ratio: 0.25
+        }
+    );
+    state.apply_interaction(begin);
+
+    let mut current = waveform_widget_for_state(&state);
+    Widget::synchronize_from_previous(&mut current, &widget);
+    let update = current
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(100.0, 40.0)))
+        .expect("sample slide drag should update")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        update,
+        WaveformInteraction::UpdateSampleSlide { visible_ratio: 0.5 }
+    );
+    assert_eq!(
+        current.sample_slide_frame_offset,
+        Some(6_000),
+        "slide preview should use current viewport frames"
+    );
+
+    let finish = current
+        .handle_input(
+            bounds,
+            WidgetInput::pointer_release(
+                Point::new(100.0, 40.0),
+                PointerButton::Primary,
+                modifiers,
+            ),
+        )
+        .expect("sample slide release should finish")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        finish,
+        WaveformInteraction::FinishSampleSlide { visible_ratio: 0.5 }
+    );
+}
+
+#[test]
+fn ordinary_primary_drag_still_starts_play_selection() {
+    let state = WaveformState::synthetic_for_tests();
+    let mut widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let output = widget
+        .handle_input(bounds, WidgetInput::primary_press(Point::new(50.0, 40.0)))
+        .expect("plain primary press should begin play selection")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+
+    assert_eq!(
+        output,
+        WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Play,
+            visible_ratio: 0.25
+        }
+    );
+}
+
+#[test]
 fn pointer_move_outside_loaded_waveform_clears_hover_cursor() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);

--- a/src/native_app/waveform/types.rs
+++ b/src/native_app/waveform/types.rs
@@ -61,6 +61,15 @@ pub(in crate::native_app) enum WaveformInteraction {
         kind: WaveformSelectionKind,
         visible_ratio: f32,
     },
+    BeginSampleSlide {
+        visible_ratio: f32,
+    },
+    UpdateSampleSlide {
+        visible_ratio: f32,
+    },
+    FinishSampleSlide {
+        visible_ratio: f32,
+    },
     BeginPan {
         visible_ratio: f32,
     },
@@ -119,5 +128,6 @@ pub(in crate::native_app) enum WaveformActiveDragKind {
     EditFade(WaveformEditFadeHandle),
     EditFadeOuterGain(WaveformEditFadeOuterGainHandle),
     EditGain,
+    SampleSlide,
     Pan,
 }

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -64,6 +64,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
             state.file(),
             state.viewport(),
             signal_edit_selection_for_state(state),
+            state.pending_sample_slide_frame_offset,
         )
         .id(WAVEFORM_SIGNAL_WIDGET_ID)
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32),
@@ -101,6 +102,7 @@ pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
     file: Arc<WaveformFile>,
     viewport: WaveformViewport,
     edit_selection: Option<wavecrate::selection::SelectionRange>,
+    sample_slide_frame_offset: Option<i64>,
 ) -> ui::View<GuiMessage> {
     ui::gpu_surface_with_capabilities(
         file.path_hash(),
@@ -111,6 +113,7 @@ pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
             frame_range: viewport.frame_range(),
             summary: Arc::clone(&file.gpu_signal_summary),
             gain_preview: gain_preview_for_selection(edit_selection),
+            sample_slide_frame_offset: sample_slide_frame_offset.unwrap_or(0),
         },
         GpuSurfaceCapabilities {
             fast_pointer_move: true,
@@ -406,11 +409,18 @@ impl WaveformWidget {
         let Some(frame_offset) = self.sample_slide_frame_offset else {
             return;
         };
+        let strip_height = bounds.height().min(4.0);
+        let strip = Rect::from_xy_size(
+            bounds.min.x,
+            bounds.max.y - strip_height,
+            bounds.width(),
+            strip_height,
+        );
         push_fill_rect(
             primitives,
             self.common.id,
-            bounds,
-            Rgba8::new(255, 202, 112, 42),
+            strip,
+            Rgba8::new(255, 202, 112, 120),
         );
         let width = ((frame_offset.unsigned_abs() as f32 / self.viewport.visible_items() as f32)
             * bounds.width())
@@ -424,8 +434,8 @@ impl WaveformWidget {
         push_fill_rect(
             primitives,
             self.common.id,
-            Rect::from_xy_size(x, bounds.min.y, width, bounds.height()),
-            Rgba8::new(255, 202, 112, 112),
+            Rect::from_xy_size(x, strip.min.y, width, strip.height()),
+            Rgba8::new(255, 202, 112, 210),
         );
     }
 

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -1,5 +1,5 @@
 use radiant::{
-    gui::types::Rect,
+    gui::types::{Rect, Rgba8},
     gui::visualization::TimelineEditPreview,
     layout::LayoutOutput,
     prelude as ui,
@@ -142,6 +142,7 @@ pub(in crate::native_app) struct WaveformWidgetProps {
     play_selection_denied_flash_frames: u8,
     edit_selection_denied_flash_frames: u8,
     copy_flash_frames: u8,
+    sample_slide_frame_offset: Option<i64>,
     beat_guides_enabled: bool,
     beat_guide_count: u8,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
@@ -184,6 +185,7 @@ impl WaveformWidgetProps {
             play_selection_denied_flash_frames: state.play_selection_denied_flash_frames(),
             edit_selection_denied_flash_frames: state.edit_selection_denied_flash_frames(),
             copy_flash_frames: state.copy_flash_frames(),
+            sample_slide_frame_offset: state.pending_sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
             active_drag_kind,
@@ -223,12 +225,14 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) play_selection_denied_flash_frames: u8,
     pub(super) edit_selection_denied_flash_frames: u8,
     pub(super) copy_flash_frames: u8,
+    pub(super) sample_slide_frame_offset: Option<i64>,
     pub(super) beat_guides_enabled: bool,
     pub(super) beat_guide_count: u8,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
     pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
     pub(super) live_selection_preview: Option<LiveSelectionPreview>,
+    pub(super) live_sample_slide_anchor_visible_ratio: Option<f32>,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
@@ -255,6 +259,7 @@ impl WaveformWidget {
             play_selection_denied_flash_frames,
             edit_selection_denied_flash_frames,
             copy_flash_frames,
+            sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
             active_drag_kind,
@@ -285,12 +290,14 @@ impl WaveformWidget {
             play_selection_denied_flash_frames,
             edit_selection_denied_flash_frames,
             copy_flash_frames,
+            sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
             edit_preview: edit_preview_for_selection(edit_selection),
             last_live_selection_update_visible_ratio: None,
             live_selection_preview_anchor: None,
             live_selection_preview: None,
+            live_sample_slide_anchor_visible_ratio: None,
             active_drag_kind,
         }
     }
@@ -324,6 +331,13 @@ impl Widget for WaveformWidget {
                 previous.last_live_selection_update_visible_ratio;
             self.live_selection_preview_anchor = previous.live_selection_preview_anchor;
             self.live_selection_preview = previous.live_selection_preview;
+        }
+        if self.should_preserve_sample_slide_preview_from(previous) {
+            self.live_sample_slide_anchor_visible_ratio =
+                previous.live_sample_slide_anchor_visible_ratio;
+            if self.sample_slide_frame_offset.is_none() {
+                self.sample_slide_frame_offset = previous.sample_slide_frame_offset;
+            }
         }
     }
 
@@ -359,6 +373,7 @@ impl Widget for WaveformWidget {
         _theme: &ThemeTokens,
     ) {
         self.append_live_selection_preview_paint(primitives, bounds);
+        self.append_sample_slide_preview_paint(primitives, bounds);
         self.append_hover_edit_fade_handle_paint(primitives, bounds);
         self.append_hover_edit_fade_outer_gain_handle_paint(primitives, bounds);
         self.append_hover_selection_handle_paint(primitives, bounds);
@@ -380,6 +395,40 @@ impl WaveformWidget {
         );
     }
 
+    fn append_sample_slide_preview_paint(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+    ) {
+        if self.active_drag_kind != Some(WaveformActiveDragKind::SampleSlide) {
+            return;
+        }
+        let Some(frame_offset) = self.sample_slide_frame_offset else {
+            return;
+        };
+        push_fill_rect(
+            primitives,
+            self.common.id,
+            bounds,
+            Rgba8::new(255, 202, 112, 42),
+        );
+        let width = ((frame_offset.unsigned_abs() as f32 / self.viewport.visible_items() as f32)
+            * bounds.width())
+        .round()
+        .clamp(2.0, bounds.width().max(2.0));
+        let x = if frame_offset >= 0 {
+            bounds.max.x - width
+        } else {
+            bounds.min.x
+        };
+        push_fill_rect(
+            primitives,
+            self.common.id,
+            Rect::from_xy_size(x, bounds.min.y, width, bounds.height()),
+            Rgba8::new(255, 202, 112, 112),
+        );
+    }
+
     fn should_preserve_live_selection_preview_from(&self, previous: &Self) -> bool {
         if self.active_drag_kind == previous.active_drag_kind {
             return true;
@@ -390,5 +439,10 @@ impl WaveformWidget {
         self.active_drag_kind
             .and_then(WaveformActiveDragKind::selection_kind)
             == Some(anchor.kind)
+    }
+
+    fn should_preserve_sample_slide_preview_from(&self, previous: &Self) -> bool {
+        self.active_drag_kind == Some(WaveformActiveDragKind::SampleSlide)
+            && previous.active_drag_kind == Some(WaveformActiveDragKind::SampleSlide)
     }
 }

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -1,8 +1,8 @@
 use radiant::{
     gui::types::{Rect, Vector2},
     widgets::{
-        CanvasGestureEvent, CanvasPointer, DragHandleMessage, PointerButton, WidgetInput,
-        WidgetOutput,
+        CanvasGestureEvent, CanvasPointer, DragHandleMessage, PointerButton, PointerModifiers,
+        WidgetInput, WidgetOutput,
     },
 };
 
@@ -105,6 +105,9 @@ impl WaveformWidget {
         if !has_loaded_sample {
             return None;
         }
+        if let Some(output) = self.command_option_sample_slide_press_output(bounds, &event) {
+            return Some(output);
+        }
         if let Some(pointer) = event.press_pointer_inside(bounds, PointerButton::Primary) {
             return self.handle_primary_press(bounds, pointer);
         }
@@ -141,6 +144,14 @@ impl WaveformWidget {
                 return Some(WidgetOutput::typed(
                     WaveformInteraction::FinishEditFadeOuterGain {
                         vertical_ratio: pointer.normalized_y(),
+                    },
+                ));
+            }
+            if self.active_drag_kind == Some(WaveformActiveDragKind::SampleSlide) {
+                self.clear_sample_slide_preview();
+                return Some(WidgetOutput::typed(
+                    WaveformInteraction::FinishSampleSlide {
+                        visible_ratio: pointer.normalized_x(),
                     },
                 ));
             }
@@ -240,6 +251,14 @@ impl WaveformWidget {
                 },
             ));
         }
+        if self.active_drag_kind == Some(WaveformActiveDragKind::SampleSlide) {
+            let visible_ratio =
+                quantized_live_selection_visible_ratio(bounds, pointer.normalized_x());
+            self.update_sample_slide_preview(visible_ratio);
+            return Some(WidgetOutput::typed(
+                WaveformInteraction::UpdateSampleSlide { visible_ratio },
+            ));
+        }
         if self.selection_drag_is_inside_click_slop(event) {
             self.live_selection_preview = None;
             return None;
@@ -337,6 +356,32 @@ impl WaveformWidget {
         self.begin_live_selection_preview(WaveformSelectionKind::Play, visible_ratio);
         Some(WidgetOutput::typed(WaveformInteraction::BeginSelection {
             kind: WaveformSelectionKind::Play,
+            visible_ratio,
+        }))
+    }
+
+    fn command_option_sample_slide_press_output(
+        &mut self,
+        bounds: Rect,
+        event: &CanvasGestureEvent,
+    ) -> Option<WidgetOutput> {
+        let CanvasGestureEvent::Press {
+            pointer,
+            button: PointerButton::Primary,
+            modifiers,
+        } = event
+        else {
+            return None;
+        };
+        if !pointer.is_inside(bounds) || !sample_slide_modifiers(*modifiers) {
+            return None;
+        }
+        let visible_ratio = pointer.normalized_x();
+        self.last_live_selection_update_visible_ratio = None;
+        self.clear_live_selection_preview();
+        self.clear_waveform_hover();
+        self.begin_sample_slide_preview(visible_ratio);
+        Some(WidgetOutput::typed(WaveformInteraction::BeginSampleSlide {
             visible_ratio,
         }))
     }
@@ -503,6 +548,28 @@ impl WaveformWidget {
         self.live_selection_preview = None;
     }
 
+    fn begin_sample_slide_preview(&mut self, visible_ratio: f32) {
+        self.active_drag_kind = Some(WaveformActiveDragKind::SampleSlide);
+        self.live_sample_slide_anchor_visible_ratio = Some(visible_ratio);
+        self.sample_slide_frame_offset = Some(0);
+    }
+
+    fn update_sample_slide_preview(&mut self, visible_ratio: f32) {
+        let Some(anchor) = self.live_sample_slide_anchor_visible_ratio else {
+            return;
+        };
+        self.sample_slide_frame_offset = Some(sample_slide_frame_offset(
+            anchor,
+            visible_ratio,
+            self.viewport.visible_items(),
+        ));
+    }
+
+    fn clear_sample_slide_preview(&mut self) {
+        self.live_sample_slide_anchor_visible_ratio = None;
+        self.sample_slide_frame_offset = None;
+    }
+
     fn update_live_selection_preview_for_active_drag(&mut self, visible_ratio: f32) {
         let Some(active_kind) = self.active_drag_kind else {
             return;
@@ -645,6 +712,21 @@ fn quantized_live_selection_visible_ratio(bounds: Rect, visible_ratio: f32) -> f
         .round()
         .max(1.0);
     (visible_ratio.clamp(0.0, 1.0) * steps).round() / steps
+}
+
+fn sample_slide_modifiers(modifiers: PointerModifiers) -> bool {
+    modifiers.command && modifiers.alt && !modifiers.shift
+}
+
+fn sample_slide_frame_offset(
+    anchor_visible_ratio: f32,
+    visible_ratio: f32,
+    visible_frames: usize,
+) -> i64 {
+    if !anchor_visible_ratio.is_finite() || !visible_ratio.is_finite() {
+        return 0;
+    }
+    ((visible_ratio - anchor_visible_ratio) * visible_frames.max(1) as f32).round() as i64
 }
 
 fn pointer_location_output(pointer: CanvasPointer) -> WidgetOutput {

--- a/src/native_app/waveform_edits.rs
+++ b/src/native_app/waveform_edits.rs
@@ -68,7 +68,8 @@ fn harvest_region_copy_operation(
         }
         WaveformDestructiveEditKind::TrimSelection
         | WaveformDestructiveEditKind::ReverseSelection
-        | WaveformDestructiveEditKind::ApplyEditSelectionEffects => None,
+        | WaveformDestructiveEditKind::ApplyEditSelectionEffects
+        | WaveformDestructiveEditKind::SlideSampleAudio { .. } => None,
     }
 }
 
@@ -82,6 +83,9 @@ fn harvest_whole_file_copy_operation(
         }
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => {
             Some(HarvestDerivationOperation::EditCopy)
+        }
+        WaveformDestructiveEditKind::SlideSampleAudio { .. } => {
+            Some(HarvestDerivationOperation::SlideCopy)
         }
         WaveformDestructiveEditKind::CropSelection
         | WaveformDestructiveEditKind::ExtractAndTrimSelection => None,
@@ -183,6 +187,22 @@ impl NativeAppState {
     ) {
         self.request_waveform_destructive_edit(
             WaveformDestructiveEditKind::ApplyEditSelectionEffects,
+            WaveformDestructiveEditTarget::ActiveSelection,
+            context,
+        );
+    }
+
+    pub(in crate::native_app) fn request_slide_loaded_sample_audio(
+        &mut self,
+        frame_offset: i64,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if frame_offset == 0 {
+            self.ui.status.sample = String::from("Sample slide cancelled");
+            return;
+        }
+        self.request_waveform_destructive_edit(
+            WaveformDestructiveEditKind::SlideSampleAudio { frame_offset },
             WaveformDestructiveEditTarget::ActiveSelection,
             context,
         );
@@ -662,8 +682,10 @@ impl NativeAppState {
         {
             self.waveform.current.restore_preserved_marks(marks);
         }
-        if request.prompt.edit == WaveformDestructiveEditKind::ApplyEditSelectionEffects
-            && self.waveform.current.path() == applied.absolute_path
+        if matches!(
+            request.prompt.edit,
+            WaveformDestructiveEditKind::ApplyEditSelectionEffects
+        ) && self.waveform.current.path() == applied.absolute_path
         {
             self.waveform
                 .current
@@ -692,7 +714,8 @@ impl NativeAppState {
                     .current
                     .preserved_marks_after_crop(request.selection),
             ),
-            WaveformDestructiveEditKind::ReverseSelection => {
+            WaveformDestructiveEditKind::ReverseSelection
+            | WaveformDestructiveEditKind::SlideSampleAudio { .. } => {
                 Some(self.waveform.current.preserved_marks_unchanged())
             }
             WaveformDestructiveEditKind::ApplyEditSelectionEffects => None,
@@ -712,13 +735,13 @@ impl NativeAppState {
             if let Some(selection) = self.destructive_edit_selection_for_kind(kind, target)? {
                 return Ok((absolute_path, selection));
             }
-        } else if kind != WaveformDestructiveEditKind::ReverseSelection
+        } else if !matches!(kind, WaveformDestructiveEditKind::ReverseSelection)
             || target == WaveformDestructiveEditTarget::PlaySelection
         {
             return Err(format!("Load a sample before {}", kind.gerund_label()));
         }
 
-        if kind == WaveformDestructiveEditKind::ReverseSelection
+        if matches!(kind, WaveformDestructiveEditKind::ReverseSelection)
             && target == WaveformDestructiveEditTarget::ActiveSelection
         {
             return self.selected_file_reverse_edit_target();
@@ -751,7 +774,10 @@ impl NativeAppState {
                 .play_selection()
                 .filter(|selection| selection.width() > 0.0));
         }
-        if kind == WaveformDestructiveEditKind::ApplyEditSelectionEffects {
+        if matches!(kind, WaveformDestructiveEditKind::SlideSampleAudio { .. }) {
+            return Ok(Some(SelectionRange::new(0.0, 1.0)));
+        }
+        if matches!(kind, WaveformDestructiveEditKind::ApplyEditSelectionEffects) {
             let selection = self
                 .waveform
                 .current
@@ -839,6 +865,7 @@ impl WaveformDestructiveEditKind {
             Self::ReverseSelection => "Reverse",
             Self::ExtractAndTrimSelection => "Extract and trim",
             Self::ApplyEditSelectionEffects => "Apply edit mark edits",
+            Self::SlideSampleAudio { .. } => "Slide",
         }
     }
 
@@ -849,6 +876,7 @@ impl WaveformDestructiveEditKind {
             Self::ReverseSelection => "reversing",
             Self::ExtractAndTrimSelection => "extracting and trimming",
             Self::ApplyEditSelectionEffects => "applying edit mark edits",
+            Self::SlideSampleAudio { .. } => "sliding",
         }
     }
 
@@ -859,6 +887,7 @@ impl WaveformDestructiveEditKind {
             Self::ReverseSelection => "Reversed",
             Self::ExtractAndTrimSelection => "Extracted and trimmed",
             Self::ApplyEditSelectionEffects => "Applied edit mark edits to",
+            Self::SlideSampleAudio { .. } => "Slid",
         }
     }
 
@@ -869,6 +898,7 @@ impl WaveformDestructiveEditKind {
             Self::ReverseSelection => "Reverse waveform selection",
             Self::ExtractAndTrimSelection => "Extract and trim waveform selection",
             Self::ApplyEditSelectionEffects => "Apply edit mark edits",
+            Self::SlideSampleAudio { .. } => "Slide sample audio",
         }
     }
 
@@ -879,6 +909,7 @@ impl WaveformDestructiveEditKind {
             Self::ReverseSelection => "Restore reversed audio",
             Self::ExtractAndTrimSelection => "Restore extracted and trimmed audio",
             Self::ApplyEditSelectionEffects => "Restore edit mark edits",
+            Self::SlideSampleAudio { .. } => "Restore slid audio",
         }
     }
 }
@@ -903,6 +934,23 @@ fn destructive_edit_prompt(
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => {
             "This will overwrite the edit selection with the currently previewed fade and gain edits."
         }
+        WaveformDestructiveEditKind::SlideSampleAudio { frame_offset } => {
+            let direction = if frame_offset > 0 { "right" } else { "left" };
+            return crate::native_app::app::WaveformDestructiveEditPrompt {
+                edit,
+                title: destructive_edit_title(edit),
+                message: format!(
+                    "This will circularly slide the source file audio {direction} by {} frame{} without changing its duration. Wavecrate will rewrite the file using the current write format: {}.",
+                    frame_offset.unsigned_abs(),
+                    if frame_offset.unsigned_abs() == 1 {
+                        ""
+                    } else {
+                        "s"
+                    },
+                    write_format.summary_label()
+                ),
+            };
+        }
     };
     crate::native_app::app::WaveformDestructiveEditPrompt {
         edit,
@@ -923,6 +971,7 @@ fn next_copy_edit_path(
         WaveformDestructiveEditKind::TrimSelection => "_trim",
         WaveformDestructiveEditKind::ReverseSelection => "_reverse",
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => "_edit",
+        WaveformDestructiveEditKind::SlideSampleAudio { .. } => "_slide",
         WaveformDestructiveEditKind::CropSelection
         | WaveformDestructiveEditKind::ExtractAndTrimSelection => {
             return Err(String::from("Unsupported protected copy edit"));

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -314,6 +314,9 @@ fn apply_destructive_edit_to_wav(
                 end_frame,
             );
         }
+        WaveformDestructiveEditKind::SlideSampleAudio { frame_offset } => {
+            slide_interleaved_frames(&mut wav.samples, wav.channels, frame_offset);
+        }
     }
     if wav.samples.is_empty() {
         return Err(format!("No audio data after {}", edit.gerund_label()));
@@ -360,6 +363,19 @@ fn reverse_interleaved_frames(samples: &mut [f32], channels: usize) {
             );
         }
     }
+}
+
+fn slide_interleaved_frames(samples: &mut [f32], channels: usize, frame_offset: i64) {
+    let channels = channels.max(1);
+    let frame_count = samples.len() / channels;
+    if frame_count <= 1 {
+        return;
+    }
+    let right_frames = frame_offset.rem_euclid(frame_count as i64) as usize;
+    if right_frames == 0 {
+        return;
+    }
+    samples.rotate_right(right_frames * channels);
 }
 
 fn load_editable_wav(path: &Path) -> Result<EditableWav, String> {


### PR DESCRIPTION
## Scope

- Add a `Command+Option` primary waveform drag gesture that slides the loaded sample audio by the dragged visible-frame offset.
- Commit the gesture on mouse release through a new `SlideSampleAudio` destructive edit that circularly rotates interleaved audio frames, preserving duration and channel alignment.
- Route protected-source sample slides through the existing primary harvest copy path with a persisted `slide_copy` derivation operation.
- Add live waveform drag feedback: the waveform signal itself previews the circular slide during drag, and the yellow gesture cue is a thin bottom strip instead of a full-height overlay.
- Add regression coverage for wraparound direction, stereo frame alignment, zoomed/panned viewport offset math, gesture routing, ordinary primary drag behavior, protected-source copy safety, bottom-strip paint, and signal-surface slide preview state.

## Definition of Done

- Users can hold `Command+Option` and left-drag on the waveform to slide the sample audio.
- Sliding wraps around both ends and preserves total duration.
- The gesture does not interfere with ordinary waveform selection gestures.
- The in-progress preview visibly moves the rendered waveform using the same frame offset that is committed on release.
- Protected samples are not mutated in place; slide output is written to the primary harvest destination and selected after completion.
- Automated coverage protects wraparound correctness, gesture routing, viewport offset math, visual feedback, and source-safety behavior.

## Validation Commands

Passed:

- `cargo test -p wavecrate sample_slide -- --test-threads=1`
- `cargo test -p wavecrate ordinary_primary_drag_still_starts_play_selection -- --test-threads=1`
- `cargo test -p wavecrate waveform_destructive_edit_tests -- --test-threads=1`
- `cargo test -p wavecrate signal_widget -- --test-threads=1`
- `cargo test -p wavecrate sample_slide_preview_paints_thin_bottom_strip -- --test-threads=1`
- `cargo test -p radiant signal -- --test-threads=1`
- `cargo fmt --check && git diff --check`

Known baseline failures observed during validation:

- `bash scripts/agent.sh request` fails on existing `native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail findings outside this issue's scope.
- `cargo test -p wavecrate waveform::tests::widget_input -- --test-threads=1` runs the new sample-slide and ordinary-drag tests successfully, but the module still fails at `playback_cache_backed_waveform_accepts_primary_click` with a persisted playback cache miss.
- `cargo test -p wavecrate playback_cache_backed_waveform_accepts_primary_click -- --test-threads=1` confirms the same cache-miss failure in isolation.

## Known Limitations

- Manual desktop smoke testing was not run in this pass.
- Full widget-input module validation is currently blocked by the unrelated playback-cache fixture failure noted above.
- This branch updates the `vendor/radiant` gitlink to companion Radiant PR https://github.com/PORTALSURFER/radiant/pull/1380 for the signal-surface slide preview renderer support.

User review is required before merge.
