### PR TITLE
OPT-900: Group editmark resize undo transactions

### DIFF
--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -42,7 +42,7 @@ pub(in crate::native_app) use state::{
     SampleMapViewportChange, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshRequest,
     SourceScanFinish, StartupState, StatusState, UiAppState, WaveformAppState,
     WaveformDestructiveEditKind, WaveformDestructiveEditPrompt, WaveformDestructiveEditUiContext,
-    WaveformEditFadeSnapshot, WaveformPlaySelectionSnapshot, run_folder_scan_worker,
+    WaveformEditSelectionSnapshot, WaveformPlaySelectionSnapshot, run_folder_scan_worker,
 };
 
 pub(super) use crate::native_app::app_chrome::scene::view;

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -36,7 +36,7 @@ pub(in crate::native_app) use ui_state::{
     UiAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
 };
 pub(in crate::native_app) use waveform::{
-    PendingPlaySelectionRetargetCycle, WaveformAppState, WaveformEditFadeSnapshot,
+    PendingPlaySelectionRetargetCycle, WaveformAppState, WaveformEditSelectionSnapshot,
     WaveformPlaySelectionSnapshot,
 };
 

--- a/src/native_app/app/state/waveform.rs
+++ b/src/native_app/app/state/waveform.rs
@@ -18,7 +18,9 @@ pub(in crate::native_app) struct WaveformAppState {
     pub(in crate::native_app) cache: WaveformCacheState,
     pub(in crate::native_app) pending_play_selection_transaction:
         Option<WaveformPlaySelectionSnapshot>,
-    pub(in crate::native_app) pending_edit_fade_transaction: Option<WaveformEditFadeSnapshot>,
+    pub(in crate::native_app) pending_edit_fade_transaction: Option<WaveformEditSelectionSnapshot>,
+    pub(in crate::native_app) pending_edit_selection_transaction:
+        Option<WaveformEditSelectionSnapshot>,
     pub(in crate::native_app) pending_play_selection_retarget: bool,
     pub(in crate::native_app) pending_play_selection_retarget_cycle:
         Option<PendingPlaySelectionRetargetCycle>,
@@ -32,6 +34,7 @@ impl WaveformAppState {
             cache: WaveformCacheState::default(),
             pending_play_selection_transaction: None,
             pending_edit_fade_transaction: None,
+            pending_edit_selection_transaction: None,
             pending_play_selection_retarget: false,
             pending_play_selection_retarget_cycle: None,
         }
@@ -54,12 +57,12 @@ impl PendingPlaySelectionRetargetCycle {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(in crate::native_app) struct WaveformEditFadeSnapshot {
+pub(in crate::native_app) struct WaveformEditSelectionSnapshot {
     pub(in crate::native_app) path: PathBuf,
     pub(in crate::native_app) edit_selection: Option<SelectionRange>,
 }
 
-impl WaveformEditFadeSnapshot {
+impl WaveformEditSelectionSnapshot {
     pub(in crate::native_app) fn from_waveform(waveform: &WaveformState) -> Self {
         Self {
             path: waveform.path(),

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -4,7 +4,7 @@ use wavecrate::selection::SelectionRange;
 
 use crate::native_app::app::{
     ClipboardHandoffTarget, GuiMessage, NativeAppState, WaveformActiveDragKind,
-    WaveformContextMenu, WaveformEditFadeSnapshot, WaveformInteraction,
+    WaveformContextMenu, WaveformEditSelectionSnapshot, WaveformInteraction,
     WaveformPlaySelectionSnapshot, WaveformSelectionKind, emit_gui_action,
 };
 
@@ -12,6 +12,8 @@ pub(in crate::native_app) const PLAY_SELECTION_TRANSACTION_LABEL: &str =
     "Change play mark selection";
 const EDIT_FADE_TRANSACTION_LABEL: &str = "Waveform fade";
 const EDIT_GAIN_TRANSACTION_LABEL: &str = "Editmark volume";
+const EDIT_RESIZE_TRANSACTION_LABEL: &str = "Editmark resize";
+const EDIT_MOVE_TRANSACTION_LABEL: &str = "Editmark move";
 
 impl NativeAppState {
     pub(super) fn apply_waveform_message(
@@ -31,6 +33,7 @@ impl NativeAppState {
         let action = waveform_interaction_action(&message);
         let active_drag = self.waveform.current.active_drag_kind();
         let play_selection_before = self.play_selection_transaction_begin_snapshot(&message);
+        let edit_selection_before = self.edit_selection_transaction_begin_snapshot(&message);
         let edit_fade_before = self.edit_fade_transaction_begin_snapshot(&message);
         let harvest_mark_before = waveform_interaction_can_finish_mark_change(&message)
             .then(|| WaveformHarvestMarkSnapshot::from_state(self))
@@ -55,6 +58,11 @@ impl NativeAppState {
                 play_selection_drag_active(self.waveform.current.active_drag_kind())
                     .then_some(before);
         }
+        if let Some(before) = edit_selection_before {
+            self.waveform.pending_edit_selection_transaction =
+                edit_selection_drag_active(self.waveform.current.active_drag_kind())
+                    .then_some(before);
+        }
         if let Some(before) = edit_fade_before {
             self.waveform.pending_edit_fade_transaction = Some(before);
         }
@@ -70,6 +78,10 @@ impl NativeAppState {
         }
         if play_selection_transaction_finishes(&message, active_drag) {
             self.register_finished_play_selection_transaction();
+        }
+        if edit_selection_transaction_finishes(&message, active_drag) {
+            let label = edit_selection_transaction_label(active_drag);
+            self.register_finished_edit_selection_transaction(label);
         }
         if edit_fade_transaction_finishes(&message, active_drag) {
             let label =
@@ -109,7 +121,7 @@ impl NativeAppState {
     fn edit_fade_transaction_begin_snapshot(
         &self,
         interaction: &WaveformInteraction,
-    ) -> Option<WaveformEditFadeSnapshot> {
+    ) -> Option<WaveformEditSelectionSnapshot> {
         let begins_edit_fade_change = matches!(
             interaction,
             WaveformInteraction::BeginEditFade { .. }
@@ -118,7 +130,25 @@ impl NativeAppState {
                 | WaveformInteraction::ClearEditFadeSilence { .. }
         );
         begins_edit_fade_change
-            .then(|| WaveformEditFadeSnapshot::from_waveform(&self.waveform.current))
+            .then(|| WaveformEditSelectionSnapshot::from_waveform(&self.waveform.current))
+    }
+
+    fn edit_selection_transaction_begin_snapshot(
+        &self,
+        interaction: &WaveformInteraction,
+    ) -> Option<WaveformEditSelectionSnapshot> {
+        let begins_edit_selection_range_change = matches!(
+            interaction,
+            WaveformInteraction::BeginSelectionResize {
+                kind: WaveformSelectionKind::Edit,
+                ..
+            } | WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Edit,
+                ..
+            }
+        );
+        begins_edit_selection_range_change
+            .then(|| WaveformEditSelectionSnapshot::from_waveform(&self.waveform.current))
     }
 
     fn register_finished_play_selection_transaction(&mut self) {
@@ -142,7 +172,7 @@ impl NativeAppState {
         let Some(before) = self.waveform.pending_edit_fade_transaction.take() else {
             return;
         };
-        let after = WaveformEditFadeSnapshot::from_waveform(&self.waveform.current);
+        let after = WaveformEditSelectionSnapshot::from_waveform(&self.waveform.current);
         if before.path != after.path || before == after {
             return;
         }
@@ -150,8 +180,25 @@ impl NativeAppState {
         let redo_snapshot = after;
         self.register_transaction_action(
             label,
-            move |transaction| transaction.restore_edit_fade(undo_snapshot.clone()),
-            move |transaction| transaction.restore_edit_fade(redo_snapshot.clone()),
+            move |transaction| transaction.restore_edit_selection(undo_snapshot.clone()),
+            move |transaction| transaction.restore_edit_selection(redo_snapshot.clone()),
+        );
+    }
+
+    fn register_finished_edit_selection_transaction(&mut self, label: &'static str) {
+        let Some(before) = self.waveform.pending_edit_selection_transaction.take() else {
+            return;
+        };
+        let after = WaveformEditSelectionSnapshot::from_waveform(&self.waveform.current);
+        if before.path != after.path || before == after {
+            return;
+        }
+        let undo_snapshot = before.clone();
+        let redo_snapshot = after;
+        self.register_transaction_action(
+            label,
+            move |transaction| transaction.restore_edit_selection(undo_snapshot.clone()),
+            move |transaction| transaction.restore_edit_selection(redo_snapshot.clone()),
         );
     }
 
@@ -338,6 +385,35 @@ fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bo
             WaveformSelectionKind::Play
         ))
     )
+}
+
+fn edit_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bool {
+    matches!(
+        active_drag,
+        Some(WaveformActiveDragKind::SelectionResize(
+            WaveformSelectionKind::Edit,
+            _
+        )) | Some(WaveformActiveDragKind::SelectionMove(
+            WaveformSelectionKind::Edit
+        ))
+    )
+}
+
+fn edit_selection_transaction_finishes(
+    interaction: &WaveformInteraction,
+    active_drag: Option<WaveformActiveDragKind>,
+) -> bool {
+    matches!(interaction, WaveformInteraction::FinishSelection { .. })
+        && edit_selection_drag_active(active_drag)
+}
+
+fn edit_selection_transaction_label(active_drag: Option<WaveformActiveDragKind>) -> &'static str {
+    match active_drag {
+        Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Edit)) => {
+            EDIT_MOVE_TRANSACTION_LABEL
+        }
+        _ => EDIT_RESIZE_TRANSACTION_LABEL,
+    }
 }
 
 fn edit_fade_transaction_finishes(

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -1,7 +1,10 @@
 use super::gui_state_for_span_tests;
 use crate::native_app::{
     test_support::state::{GuiMessage, WaveformInteraction},
-    waveform::{WaveformEditFadeHandle, WaveformEditFadeOuterGainHandle},
+    waveform::{
+        WaveformEditFadeHandle, WaveformEditFadeOuterGainHandle, WaveformSelectionEdge,
+        WaveformSelectionKind,
+    },
 };
 use radiant::prelude::{self as ui, IntoView};
 use wavecrate::selection::SelectionRange;
@@ -186,6 +189,174 @@ fn waveform_edit_gain_drag_registers_one_transaction() {
     state.apply_message(GuiMessage::RedoTransaction, &mut context);
     assert_eq!(state.waveform.current.edit_selection(), Some(after));
     assert_eq!(state.ui.status.sample, "Redid Editmark volume");
+}
+
+#[test]
+fn editmark_resize_drag_registers_one_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6)
+        .with_gain(0.5)
+        .with_fade_in(0.25, 0.2);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Edit,
+            edge: WaveformSelectionEdge::End,
+            visible_ratio: 0.6,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateSelection { visible_ratio: 0.7 }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateSelection { visible_ratio: 0.8 }),
+        &mut context,
+    );
+    assert!(
+        state.transactions.history.list_items().is_empty(),
+        "live resize preview updates should not create undo history entries"
+    );
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishSelection { visible_ratio: 0.8 }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("edit selection after resize");
+    assert_ne!(after, before);
+    assert!((after.start() - 0.2).abs() < 0.001);
+    assert!((after.end() - 0.8).abs() < 0.001);
+    assert!((after.gain() - 0.5).abs() < 0.001);
+    let items = state.transactions.history.list_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].label, "Editmark resize");
+    assert_eq!(
+        items[0].action_labels,
+        vec![String::from("Editmark resize")]
+    );
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+    assert_eq!(state.ui.status.sample, "Undid Editmark resize");
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
+    assert_eq!(state.ui.status.sample, "Redid Editmark resize");
+}
+
+#[test]
+fn editmark_move_drag_registers_one_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6).with_fade_out(0.25, 0.7);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSelectionMove {
+            kind: WaveformSelectionKind::Edit,
+            visible_ratio: 0.4,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::UpdateSelection { visible_ratio: 0.5 }),
+        &mut context,
+    );
+    assert!(
+        state.transactions.history.list_items().is_empty(),
+        "live move preview updates should not create undo history entries"
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishSelection { visible_ratio: 0.5 }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("edit selection after move");
+    assert_ne!(after, before);
+    let items = state.transactions.history.list_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].label, "Editmark move");
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
+}
+
+#[test]
+fn no_op_editmark_resize_drag_does_not_register_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let selection = SelectionRange::new(0.2, 0.6);
+    state.waveform.current.set_edit_selection_range(selection);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Edit,
+            edge: WaveformSelectionEdge::End,
+            visible_ratio: 0.6,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishSelection { visible_ratio: 0.6 }),
+        &mut context,
+    );
+
+    assert_eq!(state.waveform.current.edit_selection(), Some(selection));
+    assert!(state.transactions.history.list_items().is_empty());
+}
+
+#[test]
+fn editmark_resize_transaction_preserves_boundary_validation() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let before = SelectionRange::new(0.2, 0.6).with_gain(0.5);
+    state.waveform.current.set_edit_selection_range(before);
+
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Edit,
+            edge: WaveformSelectionEdge::Start,
+            visible_ratio: 0.2,
+        }),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::Waveform(WaveformInteraction::FinishSelection {
+            visible_ratio: -0.5,
+        }),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .edit_selection()
+        .expect("clamped edit selection after resize");
+    assert!((after.start() - 0.0).abs() < 0.001);
+    assert!((after.end() - 0.6).abs() < 0.001);
+    assert!((after.gain() - 0.5).abs() < 0.001);
+    assert_eq!(state.transactions.history.list_items().len(), 1);
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(before));
+
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.edit_selection(), Some(after));
 }
 
 #[test]

--- a/src/native_app/transaction_history/context.rs
+++ b/src/native_app/transaction_history/context.rs
@@ -1,5 +1,5 @@
 use crate::native_app::app::{
-    NativeAppState, WaveformEditFadeSnapshot, WaveformPlaySelectionSnapshot,
+    NativeAppState, WaveformEditSelectionSnapshot, WaveformPlaySelectionSnapshot,
 };
 use crate::native_app::transaction_history::TransactionResult;
 
@@ -29,9 +29,9 @@ impl TransactionContext<'_> {
         Ok(())
     }
 
-    pub(in crate::native_app) fn restore_edit_fade(
+    pub(in crate::native_app) fn restore_edit_selection(
         &mut self,
-        snapshot: WaveformEditFadeSnapshot,
+        snapshot: WaveformEditSelectionSnapshot,
     ) -> TransactionResult {
         let current_path = self.state.waveform.current.path();
         if current_path != snapshot.path {


### PR DESCRIPTION
## Scope

- Register editmark boundary resize drags as one undo/redo transaction when the drag commits.
- Register editmark move drags as one undo/redo transaction when the drag commits, using the same edit-selection snapshot plumbing.
- Keep live resize/move preview updates out of the undo stack.
- Keep transaction labels readable in the transaction inspector: `Editmark resize` and `Editmark move`.
- Rename the edit-selection snapshot/restore helper so fades, gain, moves, and resizes all use edit-selection terminology.

## Definition of Done

- Editmark resizing is grouped into one undo/redo transaction per completed gesture/action.
- Undo and redo restore exact pre/post editmark bounds without repeated key presses.
- Live drag-preview updates do not create separate undo entries.
- Cancelled or no-op resize attempts do not create undo entries.
- Automated coverage protects transaction grouping, range restoration, validation, and refresh behavior.

## Validation commands

- `bash scripts/agent.sh request`
  - Baseline failed before implementation on `native_app_ui_update_paths_do_not_call_blocking_business_apis` due existing non-blocking guardrail violations in folder move/sample-map/harvest/duplicate/sidebar code.
- `cargo test -p wavecrate native_app::tests::transactions`
- `cargo test -p wavecrate native_app::shell::message_dispatch::waveform::tests`
- `cargo test -p wavecrate editmark`
  - New transaction tests passed, but the existing `native_app::tests::waveform_playback::editmark_selection_change_marks_harvest_file_touched` failed because the harvest file fixture was missing.
- `cargo test -p wavecrate native_app::tests::waveform_playback::editmark_selection_change_marks_harvest_file_touched -- --exact`
  - Failed with the same pre-existing harvest fixture error.
- `cargo test -p wavecrate native_app::tests::waveform_playback::playmark_selection_change_marks_harvest_file_touched -- --exact`
  - Failed with the same pre-existing harvest fixture error, confirming the paired playmark fixture path is also affected.

## Known limitations

- None in the OPT-900 implementation.
- Repository validation currently has unrelated baseline failures noted above.

User review is required before merge.
