### PR TITLE
OPT-892 Clear stale playhead visuals on restart

### DIFF
--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -123,6 +123,7 @@ impl NativeAppState {
                 .current
                 .start_playback_without_marker(playback_start);
         }
+        self.audio.playback_progress = Default::default();
         self.audio.current_playback_span =
             Some((command.resolved.start_ratio, command.resolved.end_ratio));
         self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart {

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -34,6 +34,7 @@ const AUDIO_OUTPUT_UNAVAILABLE_ERROR: &str = "Audio output stream is unavailable
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::native_app) struct FrameRepaintScopeSnapshot {
     playing: bool,
+    playback_visual_generation: u64,
     play_selection_flash_active: bool,
     copy_flash_frames: u8,
     drag_hover_auto_expand_pending: bool,
@@ -403,6 +404,7 @@ impl NativeAppState {
         let started_at = Instant::now();
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
+        self.audio.playback_progress = Default::default();
         emit_gui_action(
             "playback.progress",
             Some("transport"),
@@ -418,6 +420,7 @@ impl FrameRepaintScopeSnapshot {
     fn from_state(state: &NativeAppState) -> Self {
         Self {
             playing: state.waveform.current.is_playing(),
+            playback_visual_generation: state.waveform.current.playback_visual_generation(),
             play_selection_flash_active: state.waveform.current.play_selection_flash_active(),
             copy_flash_frames: state
                 .library
@@ -466,6 +469,7 @@ impl FrameRepaintScopeSnapshot {
 
     fn same_transient_frame_state(self, after: Self) -> bool {
         self.playing == after.playing
+            && self.playback_visual_generation == after.playback_visual_generation
             && self.play_selection_flash_active == after.play_selection_flash_active
             && self.copy_flash_frames == after.copy_flash_frames
             && self.drag_hover_auto_expand_pending == after.drag_hover_auto_expand_pending

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -15,6 +15,20 @@ fn playback_frame_uses_paint_only_when_only_playhead_changes() {
 }
 
 #[test]
+fn playback_restart_repaints_surface_to_clear_stale_playhead_visuals() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.62);
+
+    let before = state.frame_repaint_scope_before_update();
+    state.waveform.current.start_playback(0.12);
+
+    assert!(
+        !state.frame_can_use_paint_only(before),
+        "retriggering playback while already playing should clear retained playhead paint"
+    );
+}
+
+#[test]
 fn idle_frame_uses_paint_only_when_frame_state_is_stable() {
     let mut state = gui_state_for_span_tests();
 

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -10,6 +10,7 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) viewport: WaveformViewport,
     pub(in crate::native_app::waveform) zoom_anchor_ratio: f32,
     pub(in crate::native_app::waveform) playing: bool,
+    pub(in crate::native_app::waveform) playback_visual_generation: u64,
     pub(in crate::native_app::waveform) playhead_ratio: Option<f32>,
     pub(in crate::native_app::waveform) play_mark_ratio: Option<f32>,
     pub(in crate::native_app::waveform) edit_mark_ratio: Option<f32>,

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -120,6 +120,7 @@ impl WaveformState {
             viewport,
             zoom_anchor_ratio: 0.5,
             playing: false,
+            playback_visual_generation: 0,
             playhead_ratio: None,
             play_mark_ratio: None,
             edit_mark_ratio: None,

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -5,6 +5,10 @@ impl WaveformState {
         self.playing
     }
 
+    pub(in crate::native_app) fn playback_visual_generation(&self) -> u64 {
+        self.playback_visual_generation
+    }
+
     pub(in crate::native_app) fn playhead_ratio(&self) -> Option<f32> {
         self.playhead_ratio
     }
@@ -32,6 +36,7 @@ impl WaveformState {
     fn start_playback_with_marker(&mut self, ratio: f32, show_marker: bool) {
         let ratio = ratio.clamp(0.0, 1.0);
         self.playing = true;
+        self.playback_visual_generation = self.playback_visual_generation.wrapping_add(1);
         self.play_mark_ratio = show_marker.then_some(ratio);
         self.playhead_ratio = Some(ratio);
         self.zoom_anchor_ratio = ratio;
@@ -44,6 +49,9 @@ impl WaveformState {
     }
 
     pub(in crate::native_app) fn stop_playback(&mut self) {
+        if self.playing || self.playhead_ratio.is_some() {
+            self.playback_visual_generation = self.playback_visual_generation.wrapping_add(1);
+        }
         self.playing = false;
         self.playhead_ratio = None;
     }

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -69,10 +69,9 @@ fn playhead_cursor_paints_pixel_stable_rect_when_progress_is_subpixel() {
 }
 
 #[test]
-fn playhead_cursor_paints_while_playing_small_playmark_selection() {
+fn playhead_cursor_paints_for_static_small_playmark_selection() {
     let mut state = WaveformState::synthetic_for_tests();
     state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.500, 0.505));
-    state.start_playback(0.500);
     state.set_playhead_ratio(0.503);
 
     let widget = waveform_widget_for_state(&state);
@@ -83,7 +82,7 @@ fn playhead_cursor_paints_while_playing_small_playmark_selection() {
         .find(|fill| {
             (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (71, 220, 255, 245)
         })
-        .expect("playhead fill paints during playback");
+        .expect("static playhead fill paints");
     assert!((playhead.rect.center().x / 400.0 - 0.503).abs() < 0.01);
 }
 

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -162,7 +162,11 @@ impl WaveformWidgetProps {
         Self {
             file: state.file(),
             viewport: state.viewport(),
-            playhead_ratio: state.playhead_ratio(),
+            playhead_ratio: if state.is_playing() {
+                None
+            } else {
+                state.playhead_ratio()
+            },
             play_mark_ratio: state.play_mark_ratio(),
             edit_mark_ratio: state.edit_mark_ratio(),
             play_selection: state.play_selection(),


### PR DESCRIPTION
## Scope

- Keep active playback cursor paint out of the retained waveform widget surface while playback is running, so rapid retriggers cannot leave an old baked blue playhead behind.
- Track playback visual generations so restarting playback while already playing forces a retained surface repaint instead of using the paint-only path.
- Reset cached runtime progress when submitting/completing playback state so stale progress does not immediately reseed the new visual.
- Add a regression covering rapid playback restart invalidation while preserving paint-only frames for ordinary playhead progress.

## Definition of Done

- Rapid playback retriggering no longer leaves a stale retained blue playhead line behind.
- Current playback still paints through the transient overlay and animates without forcing full repaint on normal progress ticks.
- Static/paused playhead paint remains covered.
- Trail jitter behavior remains covered by focused tests.

## Validation commands

- `git diff --check`
- `cargo test -p wavecrate frame_overlay -- --test-threads=1`
- `cargo test -p wavecrate playhead_cursor_paints -- --test-threads=1`
- `cargo test -p wavecrate playhead_trail -- --test-threads=1`
- `cargo test -p wavecrate tick_playhead -- --test-threads=1`
- `cargo test -p wavecrate sync_playback_ui -- --test-threads=1`
- `cargo test -p wavecrate playback_start -- --test-threads=1`

## Known limitations

- Manual native-app rapid retrigger verification was not run in this Codex session.
- `bash scripts/agent.sh request` currently fails on pre-existing unrelated `gui_boundary` non-blocking guardrail violations in folder move/starmap/harvest/duplicate/sidebar paths.

## Review

User review is required before merge.