### PR TITLE
OPT-896 Add M hotkey for waveform mute selection

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -272,6 +272,7 @@ pub(in crate::native_app) enum GuiMessage {
     RequestCropWaveformSelection,
     RequestTrimWaveformSelection,
     RequestReverseWaveformSelection,
+    RequestMuteWaveformSelection,
     RequestExtractAndTrimWaveformSelection,
     RequestCropPlaymarkSelection,
     RequestTrimPlaymarkSelection,

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -389,6 +389,7 @@ pub(in crate::native_app) enum WaveformDestructiveEditKind {
     CropSelection,
     TrimSelection,
     ReverseSelection,
+    MuteSelection,
     ExtractAndTrimSelection,
     ApplyEditSelectionEffects,
     SlideSampleAudio { frame_offset: i64 },

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -171,6 +171,7 @@ impl NativeAppState {
             | GuiMessage::RequestCropWaveformSelection
             | GuiMessage::RequestTrimWaveformSelection
             | GuiMessage::RequestReverseWaveformSelection
+            | GuiMessage::RequestMuteWaveformSelection
             | GuiMessage::RequestExtractAndTrimWaveformSelection
             | GuiMessage::RequestCropPlaymarkSelection
             | GuiMessage::RequestTrimPlaymarkSelection

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -108,6 +108,9 @@ impl NativeAppState {
             GuiMessage::RequestReverseWaveformSelection => {
                 self.request_reverse_waveform_selection(context);
             }
+            GuiMessage::RequestMuteWaveformSelection => {
+                self.request_mute_waveform_selection(context);
+            }
             GuiMessage::RequestExtractAndTrimWaveformSelection => {
                 self.request_extract_and_trim_waveform_selection(context);
             }

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -195,6 +195,10 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             GuiMessage::RequestReverseWaveformSelection,
         )
         .bind(
+            ui::KeyPress::new(ui::KeyCode::M),
+            GuiMessage::RequestMuteWaveformSelection,
+        )
+        .bind(
             ui::KeyPress::new(ui::KeyCode::L),
             GuiMessage::ToggleLoopPlayback,
         )

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -146,6 +146,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
                 shortcut_help_item("C", "Crop selection"),
                 shortcut_help_item("D", "Trim selection"),
                 shortcut_help_item("R", "Reverse selection"),
+                shortcut_help_item("M", "Mute selection"),
                 shortcut_help_item("X", "Zoom out"),
                 shortcut_help_item("Shift-X", "Zoom out with silence margin"),
                 shortcut_help_item("L", "Toggle loop playback"),

--- a/src/native_app/tests/waveform_destructive_edit_tests.rs
+++ b/src/native_app/tests/waveform_destructive_edit_tests.rs
@@ -41,6 +41,37 @@ fn reverse_shortcut_routes_to_waveform_reverse_request() {
 }
 
 #[test]
+fn mute_shortcut_routes_to_waveform_mute_request() {
+    let state = crate::native_app::test_support::state::NativeAppStateFixture::default().build();
+    let resolution = crate::native_app::test_support::state::default_gui_shortcuts(&state)
+        .resolve(ui::KeyPress::new(ui::KeyCode::M));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::RequestMuteWaveformSelection)
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn mute_shortcut_is_consumed_while_renaming() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("mute-rename.wav");
+    state.library.folder_browser.select_file(selected_file);
+    state
+        .library
+        .folder_browser
+        .begin_rename_selected()
+        .expect("begin rename should not fail");
+
+    let resolution = crate::native_app::test_support::state::default_gui_shortcuts(&state)
+        .resolve(ui::KeyPress::new(ui::KeyCode::M));
+
+    assert_eq!(resolution.action, None);
+    assert!(resolution.handled);
+}
+
+#[test]
 fn command_extract_shortcut_routes_to_extract_and_trim_request() {
     let state = crate::native_app::test_support::state::NativeAppStateFixture::default().build();
     let resolution = crate::native_app::test_support::state::default_gui_shortcuts(&state)
@@ -488,6 +519,88 @@ fn protected_reverse_selection_renders_reverse_copy_to_primary_without_mutating_
 }
 
 #[test]
+fn protected_mute_selection_renders_edit_copy_to_primary_without_mutating_origin() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let (mut state, source_root, selected_file) =
+        native_app_state_with_temp_sample("protected-mute.wav");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            primary_source.clone(),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(selected_file.clone());
+    let path = PathBuf::from(&selected_file);
+    let harvest_source_folder = source_root
+        .path()
+        .file_name()
+        .expect("source root folder name");
+    let mute_copy = primary_root
+        .path()
+        .join("_Harvests")
+        .join(harvest_source_folder)
+        .join("protected-mute_mute.wav");
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+    select_waveform_range(&mut state, WaveformSelectionKind::Play, 0.25, 0.75);
+    let mut context = ui::UiUpdateContext::default();
+
+    state.apply_message(GuiMessage::RequestMuteWaveformSelection, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert_samples_close(
+        &read_test_wav_f32(&path),
+        &[
+            0.0, 1_000.0, 2_000.0, 3_000.0, 4_000.0, 5_000.0, 6_000.0, 7_000.0,
+        ],
+    );
+    assert_samples_close(
+        &read_test_wav_f32(&mute_copy),
+        &[0.0, 1_000.0, 0.0, 0.0, 0.0, 0.0, 6_000.0, 7_000.0],
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(mute_copy.to_string_lossy().as_ref())
+    );
+    let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        protected_source.id.clone(),
+        PathBuf::from("protected-mute.wav"),
+    );
+    let parent = wavecrate::sample_sources::library::harvest_file(&parent_key)
+        .expect("load harvest parent")
+        .expect("harvest parent");
+    assert_eq!(
+        parent.state,
+        wavecrate::sample_sources::HarvestState::Touched
+    );
+    let edges = wavecrate::sample_sources::library::harvest_derivations_for_parent(&parent_key)
+        .expect("load harvest derivations");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].operation,
+        wavecrate::sample_sources::HarvestDerivationOperation::EditCopy
+    );
+    assert_eq!(edges[0].child.key.source_id, primary_source.id);
+    assert_eq!(
+        edges[0].child.key.relative_path,
+        PathBuf::from("_Harvests")
+            .join(harvest_source_folder)
+            .join("protected-mute_mute.wav")
+    );
+}
+
+#[test]
 fn protected_sample_slide_renders_slide_copy_to_primary_without_mutating_origin() {
     let config_base = tempfile::tempdir().expect("config base");
     let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
@@ -922,6 +1035,103 @@ fn trim_request_uses_edit_selection_before_play_selection() {
 }
 
 #[test]
+fn mute_request_uses_play_selection_when_no_edit_selection_exists() {
+    let (mut state, _source_root, selected_file) = native_app_state_with_temp_sample("mute.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = false;
+
+    select_waveform_range(&mut state, WaveformSelectionKind::Play, 0.25, 0.5);
+
+    state.apply_message(
+        GuiMessage::RequestMuteWaveformSelection,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let pending = state
+        .ui
+        .browser_interaction
+        .pending_waveform_destructive_edit
+        .as_ref()
+        .expect("mute request should prompt");
+    assert_eq!(
+        pending.prompt.edit,
+        crate::native_app::app::WaveformDestructiveEditKind::MuteSelection
+    );
+    assert_range_close(pending.selection, 0.25, 0.5);
+}
+
+#[test]
+fn mute_request_uses_edit_selection_before_play_selection() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("mute-edit.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = false;
+
+    select_waveform_range(&mut state, WaveformSelectionKind::Play, 0.25, 0.5);
+    state
+        .waveform
+        .current
+        .set_edit_selection_range(wavecrate::selection::SelectionRange::new(0.5, 0.75));
+
+    state.apply_message(
+        GuiMessage::RequestMuteWaveformSelection,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let pending = state
+        .ui
+        .browser_interaction
+        .pending_waveform_destructive_edit
+        .as_ref()
+        .expect("mute request should prompt");
+    assert_eq!(
+        pending.prompt.edit,
+        crate::native_app::app::WaveformDestructiveEditKind::MuteSelection
+    );
+    assert_range_close(pending.selection, 0.5, 0.75);
+}
+
+#[test]
+fn mute_request_without_valid_selection_is_safe_noop() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("mute-no-selection.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+
+    state.apply_message(
+        GuiMessage::RequestMuteWaveformSelection,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(
+        state
+            .ui
+            .browser_interaction
+            .pending_waveform_destructive_edit
+            .is_none()
+    );
+    assert_samples_close(&read_test_wav_f32(&path), &[0.0, 1_000.0, 2_000.0, 3_000.0]);
+    assert!(
+        state
+            .ui
+            .status
+            .sample
+            .contains("Mark an edit or play range")
+    );
+}
+
+#[test]
 fn reverse_request_uses_edit_selection_before_play_selection() {
     let (mut state, _source_root, selected_file) =
         native_app_state_with_temp_sample("reverse-edit.wav");
@@ -1108,6 +1318,72 @@ fn crop_request_rewrites_file_and_undo_restores_original_audio() {
             0.0, 1_000.0, 2_000.0, 3_000.0, 4_000.0, 5_000.0, 6_000.0, 7_000.0,
         ],
     );
+}
+
+#[test]
+fn mute_request_rewrites_play_selection_without_moving_bounds() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("mute-play.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    select_waveform_range(&mut state, WaveformSelectionKind::Play, 0.25, 0.5);
+
+    apply_message_and_run_command(&mut state, GuiMessage::RequestMuteWaveformSelection);
+
+    assert_samples_close(
+        &read_test_wav_f32(&path),
+        &[0.0, 1_000.0, 0.0, 0.0, 4_000.0, 5_000.0, 6_000.0, 7_000.0],
+    );
+    assert_range_close(
+        state
+            .waveform
+            .current
+            .play_selection()
+            .expect("play selection survives mute"),
+        0.25,
+        0.5,
+    );
+    assert!(state.ui.status.sample.contains("Muted"));
+}
+
+#[test]
+fn mute_request_rewrites_edit_selection_without_moving_bounds() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("mute-edit.wav");
+    let path = PathBuf::from(&selected_file);
+    write_test_wav_i16(&path, &[0, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(path.clone())
+            .expect("load waveform");
+    state.ui.settings.persisted.controls.destructive_yolo_mode = true;
+
+    select_waveform_range(&mut state, WaveformSelectionKind::Play, 0.0, 0.25);
+    state
+        .waveform
+        .current
+        .set_edit_selection_range(wavecrate::selection::SelectionRange::new(0.5, 0.75));
+
+    apply_message_and_run_command(&mut state, GuiMessage::RequestMuteWaveformSelection);
+
+    assert_samples_close(
+        &read_test_wav_f32(&path),
+        &[0.0, 1_000.0, 2_000.0, 3_000.0, 0.0, 0.0, 6_000.0, 7_000.0],
+    );
+    assert_range_close(
+        state
+            .waveform
+            .current
+            .edit_selection()
+            .expect("edit selection survives mute"),
+        0.5,
+        0.75,
+    );
+    assert!(state.ui.status.sample.contains("Muted"));
 }
 
 #[test]

--- a/src/native_app/waveform_edits.rs
+++ b/src/native_app/waveform_edits.rs
@@ -68,6 +68,7 @@ fn harvest_region_copy_operation(
         }
         WaveformDestructiveEditKind::TrimSelection
         | WaveformDestructiveEditKind::ReverseSelection
+        | WaveformDestructiveEditKind::MuteSelection
         | WaveformDestructiveEditKind::ApplyEditSelectionEffects
         | WaveformDestructiveEditKind::SlideSampleAudio { .. } => None,
     }
@@ -81,6 +82,7 @@ fn harvest_whole_file_copy_operation(
         WaveformDestructiveEditKind::ReverseSelection => {
             Some(HarvestDerivationOperation::ReverseCopy)
         }
+        WaveformDestructiveEditKind::MuteSelection => Some(HarvestDerivationOperation::EditCopy),
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => {
             Some(HarvestDerivationOperation::EditCopy)
         }
@@ -121,6 +123,17 @@ impl NativeAppState {
     ) {
         self.request_waveform_destructive_edit(
             WaveformDestructiveEditKind::ReverseSelection,
+            WaveformDestructiveEditTarget::ActiveSelection,
+            context,
+        );
+    }
+
+    pub(in crate::native_app) fn request_mute_waveform_selection(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.request_waveform_destructive_edit(
+            WaveformDestructiveEditKind::MuteSelection,
             WaveformDestructiveEditTarget::ActiveSelection,
             context,
         );
@@ -715,6 +728,7 @@ impl NativeAppState {
                     .preserved_marks_after_crop(request.selection),
             ),
             WaveformDestructiveEditKind::ReverseSelection
+            | WaveformDestructiveEditKind::MuteSelection
             | WaveformDestructiveEditKind::SlideSampleAudio { .. } => {
                 Some(self.waveform.current.preserved_marks_unchanged())
             }
@@ -863,6 +877,7 @@ impl WaveformDestructiveEditKind {
             Self::CropSelection => "Crop",
             Self::TrimSelection => "Trim",
             Self::ReverseSelection => "Reverse",
+            Self::MuteSelection => "Mute",
             Self::ExtractAndTrimSelection => "Extract and trim",
             Self::ApplyEditSelectionEffects => "Apply edit mark edits",
             Self::SlideSampleAudio { .. } => "Slide",
@@ -874,6 +889,7 @@ impl WaveformDestructiveEditKind {
             Self::CropSelection => "cropping",
             Self::TrimSelection => "trimming",
             Self::ReverseSelection => "reversing",
+            Self::MuteSelection => "muting",
             Self::ExtractAndTrimSelection => "extracting and trimming",
             Self::ApplyEditSelectionEffects => "applying edit mark edits",
             Self::SlideSampleAudio { .. } => "sliding",
@@ -885,6 +901,7 @@ impl WaveformDestructiveEditKind {
             Self::CropSelection => "Cropped",
             Self::TrimSelection => "Trimmed",
             Self::ReverseSelection => "Reversed",
+            Self::MuteSelection => "Muted",
             Self::ExtractAndTrimSelection => "Extracted and trimmed",
             Self::ApplyEditSelectionEffects => "Applied edit mark edits to",
             Self::SlideSampleAudio { .. } => "Slid",
@@ -896,6 +913,7 @@ impl WaveformDestructiveEditKind {
             Self::CropSelection => "Crop waveform selection",
             Self::TrimSelection => "Trim waveform selection",
             Self::ReverseSelection => "Reverse waveform selection",
+            Self::MuteSelection => "Mute waveform selection",
             Self::ExtractAndTrimSelection => "Extract and trim waveform selection",
             Self::ApplyEditSelectionEffects => "Apply edit mark edits",
             Self::SlideSampleAudio { .. } => "Slide sample audio",
@@ -907,6 +925,7 @@ impl WaveformDestructiveEditKind {
             Self::CropSelection => "Restore cropped audio",
             Self::TrimSelection => "Restore trimmed audio",
             Self::ReverseSelection => "Restore reversed audio",
+            Self::MuteSelection => "Restore muted audio",
             Self::ExtractAndTrimSelection => "Restore extracted and trimmed audio",
             Self::ApplyEditSelectionEffects => "Restore edit mark edits",
             Self::SlideSampleAudio { .. } => "Restore slid audio",
@@ -927,6 +946,9 @@ fn destructive_edit_prompt(
         }
         WaveformDestructiveEditKind::ReverseSelection => {
             "This will reverse the selected region in place, or the selected file when no region is marked."
+        }
+        WaveformDestructiveEditKind::MuteSelection => {
+            "This will silence the selected region in place without changing its duration."
         }
         WaveformDestructiveEditKind::ExtractAndTrimSelection => {
             "This will extract the selected region into a new sibling file, then remove that region and close the gap in the source file."
@@ -970,6 +992,7 @@ fn next_copy_edit_path(
     let base_suffix = match kind {
         WaveformDestructiveEditKind::TrimSelection => "_trim",
         WaveformDestructiveEditKind::ReverseSelection => "_reverse",
+        WaveformDestructiveEditKind::MuteSelection => "_mute",
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => "_edit",
         WaveformDestructiveEditKind::SlideSampleAudio { .. } => "_slide",
         WaveformDestructiveEditKind::CropSelection

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -302,6 +302,15 @@ fn apply_destructive_edit_to_wav(
             let end = end_frame * wav.channels;
             reverse_interleaved_frames(&mut wav.samples[start..end], wav.channels);
         }
+        WaveformDestructiveEditKind::MuteSelection => {
+            let (start_frame, end_frame) =
+                selection_existing_frame_bounds(total_frames, selection)?;
+            let start = start_frame * wav.channels;
+            let end = end_frame * wav.channels;
+            for sample in &mut wav.samples[start..end] {
+                *sample = 0.0;
+            }
+        }
         WaveformDestructiveEditKind::ApplyEditSelectionEffects => {
             let (start_frame, end_frame) =
                 selection_existing_frame_bounds(total_frames, selection)?;


### PR DESCRIPTION
## Scope
- Add waveform-scoped `M` shortcut routing for muting the active waveform selection.
- Support both playmark and editmark selections through the existing active-selection destructive edit path.
- Preserve selection bounds while zeroing the selected audio frames.
- Keep protected-source behavior non-destructive by rendering mute edits as Primary edit copies.
- Add shortcut help text for the new waveform command.

## Definition of Done
- Pressing `M` with a valid playmark selection mutes that selected region.
- Pressing `M` with a valid editmark selection mutes that selected region, with edit selection taking precedence over play selection.
- Pressing `M` while rename/text-entry owns keyboard input is consumed without firing the mute command.
- Pressing `M` with no valid waveform range is a safe no-op.
- Existing waveform destructive edit and protected-source behavior remains intact.

## Validation Commands
- `cargo fmt && cargo test -p wavecrate waveform_destructive_edit_tests -- --test-threads=1 && cargo test -p wavecrate mute -- --test-threads=1 && cargo test -p wavecrate shortcut_help_model_includes_global_and_active_context_sections -- --test-threads=1 && git diff --check`

## Known Limitations
- Manual native-app smoke testing was not run in this pass.
- Baseline repo preflight `bash scripts/agent.sh request` currently fails on unrelated `tests/gui_boundary.rs::native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail violations in existing folder-browser/sidebar/workflow code.
- Broader `cargo test -p wavecrate shortcuts_context -- --test-threads=1` currently fails on pre-existing default-asset fixture assumptions in `escape_shortcut_cancels_rename_while_renaming` and `x_shortcut_is_consumed_while_renaming`; the new focused rename-consumption mute test uses an explicit temp sample fixture and passes.

User review is required before merge.