### PR TITLE
Wavecrate: replace clipped filter row labels

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -139,7 +139,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
         },
         rating: RatingFilterRowProjection {
             family: FilterFamily::Rating,
-            label: "Ratin",
+            label: "Rating",
             enabled: model.rating_enabled,
             toggles: model
                 .rating_filters
@@ -154,7 +154,7 @@ impl CurationFilterRowProjection {
     fn from_view_model(model: &CurationFilterViewModel, sidebar_width: f32) -> Self {
         Self {
             family: FilterFamily::Curation,
-            label: "Curat",
+            label: "Curate",
             enabled: model.enabled,
             dropdown_open: model.dropdown_open,
             menu_width: curation_dropdown_menu_width(sidebar_width),
@@ -316,7 +316,7 @@ mod tests {
     fn filter_rows_projection_preserves_dropdown_options_and_filter_state() {
         let projection = filter_rows_projection(&filter_model());
 
-        assert_eq!(projection.curation.label, "Curat");
+        assert_eq!(projection.curation.label, "Curate");
         assert!(projection.curation.enabled);
         assert!(projection.curation.dropdown_open);
         assert_eq!(projection.curation.selected_label, "All");
@@ -410,7 +410,7 @@ mod tests {
                 (PlaybackTypeFilter::Loop, "Loop", true),
             ]
         );
-        assert_eq!(projection.rating.label, "Ratin");
+        assert_eq!(projection.rating.label, "Rating");
         assert!(projection.rating.enabled);
         assert_eq!(
             projection

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/layout.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/layout.rs
@@ -48,7 +48,7 @@ fn filter_section_default_viewport_leaves_bottom_guard_after_rows() {
         .expect("filter scroll layout rect");
     let rating = layout
         .rects
-        .get(&automation_filter_family_label_toggle_id("Ratin"))
+        .get(&automation_filter_family_label_toggle_id("Rating"))
         .expect("rating filter label layout rect");
 
     assert!(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -41,14 +41,14 @@ fn filter_section_projects_tag_text_input_with_row_labels() {
 
     assert!(frame.paint_plan.contains_text("Name"));
     assert!(frame.paint_plan.contains_text("Tags"));
-    assert!(frame.paint_plan.contains_text("Curat"));
+    assert!(frame.paint_plan.contains_text("Curate"));
     assert!(frame.paint_plan.contains_text("Harvest"));
     assert!(frame.paint_plan.contains_text("Type"));
-    assert!(frame.paint_plan.contains_text("Ratin"));
+    assert!(frame.paint_plan.contains_text("Rating"));
     assert!(
-        !frame.paint_plan.contains_text("Curate")
+        !frame.paint_plan.contains_text("Curat")
             && !frame.paint_plan.contains_text("Harve")
-            && !frame.paint_plan.contains_text("Rating")
+            && !frame.paint_plan.contains_text("Ratin")
     );
     assert_eq!(
         inputs
@@ -60,14 +60,14 @@ fn filter_section_projects_tag_text_input_with_row_labels() {
 }
 
 #[test]
-fn filter_section_filter_name_labels_are_compact_and_same_size() {
+fn filter_section_filter_name_labels_are_readable_and_fit_label_cells() {
     let state = FolderBrowserState::load_default();
     let model = FilterSectionViewModel::from_folder_browser(&state, false);
     let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
         240.0,
         FILTER_SECTION_TEST_FRAME_HEIGHT,
     ));
-    let labels = ["Name", "Tags", "Curat", "Harvest", "Type", "Ratin"];
+    let labels = ["Name", "Tags", "Curate", "Harvest", "Type", "Rating"];
     let label_runs = labels
         .iter()
         .map(|label| {
@@ -77,28 +77,27 @@ fn filter_section_filter_name_labels_are_compact_and_same_size() {
                 .unwrap_or_else(|| panic!("missing filter label {label}"))
         })
         .collect::<Vec<_>>();
-    let harvest_label_rect = frame
-        .paint_plan
-        .first_widget_rect(automation_filter_family_label_toggle_id("Harvest"))
-        .expect("Harvest label should have a toggle rect");
-    let harvest_text_rect = label_runs
-        .iter()
-        .find(|run| run.text.as_str() == "Harvest")
-        .expect("Harvest text should be projected")
-        .rect;
 
-    assert!(label_runs.iter().all(|run| run.text.len() <= 7));
     assert!(
         label_runs
             .iter()
             .all(|run| run.font_size == label_runs[0].font_size)
     );
-    assert_eq!(harvest_label_rect.width(), FILTER_LABEL_WIDTH);
-    assert!(
-        harvest_text_rect.min.x >= harvest_label_rect.min.x
-            && harvest_text_rect.max.x <= harvest_label_rect.max.x,
-        "Harvest label text should fit inside the filter label cell, label={harvest_label_rect:?}, text={harvest_text_rect:?}"
-    );
+    for run in label_runs {
+        let label_rect = frame
+            .paint_plan
+            .first_widget_rect(automation_filter_family_label_toggle_id(&run.text))
+            .unwrap_or_else(|| panic!("missing {} label hit target", run.text));
+
+        assert_eq!(label_rect.width(), FILTER_LABEL_WIDTH);
+        assert!(
+            run.rect.min.x >= label_rect.min.x && run.rect.max.x <= label_rect.max.x,
+            "{} label text should fit inside the filter label cell, label={:?}, text={:?}",
+            run.text,
+            label_rect,
+            run.rect
+        );
+    }
 }
 
 #[test]
@@ -110,10 +109,10 @@ fn filter_section_rows_share_uniform_height_contract() {
     let rows = [
         ("Name", NAME_FILTER_INPUT_ID),
         ("Tags", TAG_FILTER_INPUT_ID),
-        ("Curat", CURATION_FILTER_DROPDOWN_TRIGGER_ID),
+        ("Curate", CURATION_FILTER_DROPDOWN_TRIGGER_ID),
         ("Harvest", HARVEST_FILTER_DROPDOWN_TRIGGER_ID),
         ("Type", automation_playback_type_filter_toggle_id("1-Shot")),
-        ("Ratin", automation_rating_filter_toggle_id("T3")),
+        ("Rating", automation_rating_filter_toggle_id("T3")),
     ];
     let mut previous_row_top = None;
 
@@ -171,7 +170,7 @@ fn filter_section_filter_labels_dispatch_family_enable_changes() {
     );
     assert_eq!(
         filter_section(&model).view_dispatch_widget_output(
-            automation_filter_family_label_toggle_id("Ratin"),
+            automation_filter_family_label_toggle_id("Rating"),
             ui::WidgetOutput::typed(SelectableMessage::SelectionChanged { selected: false }),
         ),
         Some(GuiMessage::FolderBrowser(


### PR DESCRIPTION
## Scope

- Replace clipped sidebar filter row labels with readable labels: `Curat` becomes `Curate`, and `Ratin` becomes `Rating`.
- Keep `Type` as the deliberate concise playback-type family label because the row controls (`1-Shot`, `Loop`) make the meaning clear within the compact sidebar width.
- Update filter-section projection, layout, fit, and dispatch tests to assert the new readable label contract.

## Definition of Done

- Sidebar filter row labels no longer project accidental clipped names such as `Curat` or `Ratin`.
- Label toggles still dispatch enable/disable changes to the correct filter families.
- Filter-section tests assert readable labels fit inside the configured label cell.
- Dropdown options and selected-value labels for Curation/Harvest/Rating/Playback Type are unchanged.

## Validation Commands

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p wavecrate filter_section -- --test-threads=1`
- `cargo test -p wavecrate filter_family_labels_disable_filters_without_discarding_selected_values -- --test-threads=1`

## Known Limitations

- The issue-listed command `cargo test -p wavecrate_filter_section -- --test-threads=1` is not runnable in this checkout because there is no `wavecrate_filter_section` package. The focused `wavecrate filter_section` tests were run instead.
- Manual native app visual verification against this branch build was not completed: Computer Use attached to the installed `/Applications/Wavecrate.app` instead of the sandbox-built binary. Automated paint/layout tests verify label text bounds in the filter label cells.
- Repo request preflight `bash scripts/agent.sh request` failed on pre-existing non-blocking guardrail violations outside this PR scope.

## User Review

User review is required before merge.

Fixes OPT-886.