### PR TITLE
OPT-911: Gate loaded sample drag tooltip behind help mode

### DIFF
--- a/src/native_app/app_chrome/waveform_panel.rs
+++ b/src/native_app/app_chrome/waveform_panel.rs
@@ -14,7 +14,11 @@ pub(in crate::native_app) fn waveform_panel(
     model: WaveformPanelViewModel<'_>,
 ) -> ui::View<GuiMessage> {
     ui::column([
-        waveform_title_row(model.waveform, model.loading_label),
+        waveform_title_row(
+            model.waveform,
+            model.loading_label,
+            model.help_tooltips_enabled,
+        ),
         waveform_viewport_with_loading_state(&model),
         waveform_scrollbar(model.waveform),
     ])
@@ -92,13 +96,14 @@ fn waveform_drop_hover_visual(supported: bool) -> ui::View<GuiMessage> {
 fn waveform_title_row(
     waveform: &WaveformState,
     loading_label: Option<&str>,
+    help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     let title = waveform_title(waveform, loading_label);
     if loading_label.is_some() || !waveform.has_loaded_sample() {
         return ui::text_line(title, WAVEFORM_STATUS_HEIGHT);
     }
     ui::row([
-        loaded_sample_drag_handle(),
+        loaded_sample_drag_handle(help_tooltips_enabled),
         ui::text_line(title, WAVEFORM_STATUS_HEIGHT),
     ])
     .spacing(3.0)
@@ -106,12 +111,12 @@ fn waveform_title_row(
     .height(WAVEFORM_STATUS_HEIGHT)
 }
 
-fn loaded_sample_drag_handle() -> ui::View<GuiMessage> {
+fn loaded_sample_drag_handle(help_tooltips_enabled: bool) -> ui::View<GuiMessage> {
     ui::drag_handle()
         .mapped(|drag| GuiMessage::Waveform(WaveformInteraction::DragLoadedSample(drag)))
         .id(widget_ids::WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID)
         .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
-        .tooltip("Drag loaded sample")
+        .tooltip_if(help_tooltips_enabled, "Drag loaded sample")
         .size(WAVEFORM_SAMPLE_DRAG_HANDLE_WIDTH, WAVEFORM_STATUS_HEIGHT)
 }
 

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -8,6 +8,22 @@ use crate::native_app::{
 };
 use radiant::prelude::{self as ui, IntoView};
 
+fn loaded_sample_drag_handle_tooltip(
+    state: &crate::native_app::app::NativeAppState,
+) -> Option<String> {
+    waveform_panel(WaveformPanelViewModel::from_app_state(state))
+        .into_surface()
+        .find_widget(WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID)
+        .and_then(|widget| {
+            widget
+                .widget_object()
+                .common()
+                .tooltip
+                .as_deref()
+                .map(str::to_owned)
+        })
+}
+
 #[test]
 fn waveform_panel_omits_section_header_label() {
     let state = NativeAppStateFixture::default().build();
@@ -62,6 +78,28 @@ fn loaded_waveform_title_includes_sample_drag_handle_before_name() {
         .expect("loaded waveform title should include sample name");
 
     assert!(handle_right_edge < title_rect.min.x);
+}
+
+#[test]
+fn loaded_sample_drag_handle_omits_tooltip_when_help_is_inactive() {
+    let state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+
+    assert_eq!(loaded_sample_drag_handle_tooltip(&state), None);
+}
+
+#[test]
+fn loaded_sample_drag_handle_uses_help_tooltip_when_help_is_active() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.ui.chrome.help_tooltips_enabled = true;
+
+    assert_eq!(
+        loaded_sample_drag_handle_tooltip(&state).as_deref(),
+        Some("Drag loaded sample")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Gate the loaded-sample drag handle tooltip behind the existing help-tooltip mode.
- Preserve the drag handle widget, size, id, and drag message routing in normal and help modes.
- Add focused waveform-panel tests for help-inactive and help-active tooltip behavior.

## Definition of Done

- The `drag loaded sample` tooltip is hidden during normal use when help is inactive.
- The tooltip appears through the existing help system when help mode is active.
- Loaded-sample drag behavior and hit testing remain unchanged.
- The code follows the existing help-tooltip pattern rather than introducing separate tooltip state.

## Validation Commands

- `cargo fmt`
- `git diff --check`
- `cargo test -p wavecrate waveform_panel`
- `bash scripts/agent.sh request` (fails on pre-existing non-blocking guardrail violations in unrelated files: `src/native_app/sample_library/folder_browser/drag_drop_move.rs`, `src/native_app/sample_library/folder_browser/starmap.rs`, `src/native_app/sample_library/harvest_tracking.rs`, `src/native_app/workflows/context_menu_actions/duplicate.rs`, and `src/native_app/app_chrome/view_models/library_sidebar.rs`)

## Known Limitations

- Manual GUI smoke for hover/drag with help inactive and active has not been run in this pass.
- Existing unrelated agent preflight guardrail violations remain outside this PR scope.

User review is required before merge.