### PR TITLE
OPT-908/909/910: Add sidebar help tooltips

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows.rs
@@ -13,6 +13,9 @@ use crate::native_app::app_chrome::view_models::library_sidebar::FilterSectionVi
 use crate::native_app::sample_library::folder_browser::commands::{
     FilterFamily, FolderBrowserMessage,
 };
+use crate::native_app::sample_library::folder_browser::model::{
+    BrowserCurationScope, PlaybackTypeFilter,
+};
 pub(super) use crate::native_app::sample_library::folder_browser::view_contract::{
     FILTER_CONTROLS_CONTENT_HEIGHT, FILTER_ROW_CONTROL_HEIGHT, FILTER_ROW_HEIGHT,
     FILTER_ROW_SPACING,
@@ -90,12 +93,19 @@ pub(super) fn tag_filter_clear_button_id() -> u64 {
 
 fn text_filter_row(projection: TextFilterRowProjection) -> ui::View<GuiMessage> {
     filter_input_row(
-        filter_row_label(projection.label, projection.family, projection.enabled),
+        filter_row_label(
+            projection.label,
+            projection.family,
+            projection.enabled,
+            projection.help_tooltips_enabled,
+        ),
         filter_text_input(
             projection.value,
             projection.placeholder,
             text_filter_input_id(projection.field),
             text_filter_message_mapper(projection.field),
+            text_filter_tooltip(projection.field),
+            projection.help_tooltips_enabled,
         ),
         text_filter_row_key(projection.field),
     )
@@ -106,6 +116,8 @@ fn filter_text_input(
     placeholder: &'static str,
     input_id: u64,
     map_message: fn(TextInputMessage) -> FolderBrowserMessage,
+    tooltip: &'static str,
+    help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     ui::text_input(value)
         .placeholder(placeholder)
@@ -114,6 +126,7 @@ fn filter_text_input(
         )))
         .id(input_id)
         .message_event(move |message| GuiMessage::FolderBrowser(map_message(message)))
+        .tooltip_if(help_tooltips_enabled, tooltip)
 }
 
 fn text_filter_input_id(field: TextFilterField) -> u64 {
@@ -139,14 +152,22 @@ fn text_filter_row_key(field: TextFilterField) -> &'static str {
     }
 }
 
+fn text_filter_tooltip(field: TextFilterField) -> &'static str {
+    match field {
+        TextFilterField::Name => "Show samples whose filename contains this text.",
+        TextFilterField::Tags => "Show samples with matching tags.",
+    }
+}
+
 fn playback_type_filter_row(row: PlaybackTypeFilterRowProjection) -> ui::View<GuiMessage> {
-    let label = filter_row_label(row.label, row.family, row.enabled);
+    let help_tooltips_enabled = row.help_tooltips_enabled;
+    let label = filter_row_label(row.label, row.family, row.enabled, help_tooltips_enabled);
     filter_labeled_control_row(
         label,
         ui::row(
             row.toggles
                 .iter()
-                .map(playback_type_filter_toggle)
+                .map(|toggle| playback_type_filter_toggle(toggle, help_tooltips_enabled))
                 .collect::<Vec<_>>(),
         )
         .spacing(FILTER_CONTROL_SPACING)
@@ -157,12 +178,14 @@ fn playback_type_filter_row(row: PlaybackTypeFilterRowProjection) -> ui::View<Gu
 }
 
 fn curation_filter_row(row: CurationFilterRowProjection) -> ui::View<GuiMessage> {
+    let help_tooltips_enabled = row.help_tooltips_enabled;
     filter_labeled_control_row(
-        filter_row_label(row.label, row.family, row.enabled),
+        filter_row_label(row.label, row.family, row.enabled, help_tooltips_enabled),
         ui::dropdown_trigger(row.selected_label, row.dropdown_open)
             .toggle_message(GuiMessage::ToggleCurationFilterDropdown)
             .build()
             .id(CURATION_FILTER_DROPDOWN_TRIGGER_ID)
+            .tooltip_if(help_tooltips_enabled, "Choose the curation queue to show.")
             .fill_width()
             .height(FILTER_ROW_CONTROL_HEIGHT),
         "filter-curation-row",
@@ -179,7 +202,11 @@ pub(super) fn curation_filter_dropdown_menu(
             ui::dropdown_menu_height(row.options.len()),
         );
         Some((
-            curation_filter_dropdown_menu_from_options(&row.options, size.x),
+            curation_filter_dropdown_menu_from_options(
+                &row.options,
+                row.help_tooltips_enabled,
+                size.x,
+            ),
             size,
         ))
     } else {
@@ -189,23 +216,29 @@ pub(super) fn curation_filter_dropdown_menu(
 
 fn curation_filter_dropdown_menu_from_options(
     options: &[CurationFilterOptionProjection],
+    help_tooltips_enabled: bool,
     menu_width: f32,
 ) -> ui::View<GuiMessage> {
     let option_count = options.len();
-    ui::column(options.iter().map(curation_filter_dropdown_option))
-        .key("curation-filter-dropdown-menu")
-        .style(ui::WidgetStyle {
-            tone: ui::WidgetTone::Neutral,
-            prominence: ui::WidgetProminence::Strong,
-        })
-        .padding(4.0)
-        .spacing(3.0)
-        .width(menu_width.max(1.0))
-        .height(ui::dropdown_menu_height(option_count))
+    ui::column(
+        options
+            .iter()
+            .map(|option| curation_filter_dropdown_option(option, help_tooltips_enabled)),
+    )
+    .key("curation-filter-dropdown-menu")
+    .style(ui::WidgetStyle {
+        tone: ui::WidgetTone::Neutral,
+        prominence: ui::WidgetProminence::Strong,
+    })
+    .padding(4.0)
+    .spacing(3.0)
+    .width(menu_width.max(1.0))
+    .height(ui::dropdown_menu_height(option_count))
 }
 
 fn curation_filter_dropdown_option(
     option: &CurationFilterOptionProjection,
+    help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     let scope = option.scope;
     ui::button(option.label)
@@ -227,6 +260,7 @@ fn curation_filter_dropdown_option(
         })
         .fill_width()
         .height(22.0)
+        .tooltip_if(help_tooltips_enabled, curation_scope_tooltip(scope))
 }
 
 /// Automation-facing id for a curation dropdown option.
@@ -237,7 +271,7 @@ pub(super) fn automation_curation_filter_dropdown_option_id(label: &str) -> u64 
 fn harvest_filter_row(row: HarvestFilterRowProjection) -> ui::View<GuiMessage> {
     let help_tooltips_enabled = row.help_tooltips_enabled;
     filter_labeled_control_row(
-        filter_row_label(row.label, row.family, row.enabled),
+        filter_row_label(row.label, row.family, row.enabled, help_tooltips_enabled),
         ui::dropdown_trigger(row.selected_label, row.dropdown_open)
             .toggle_message(GuiMessage::ToggleHarvestFilterDropdown)
             .build()
@@ -327,6 +361,7 @@ pub(super) fn automation_harvest_filter_dropdown_option_id(label: &str) -> u64 {
 
 fn playback_type_filter_toggle(
     toggle: &PlaybackTypeFilterToggleProjection,
+    help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     let filter = toggle.filter;
     ui::selectable(toggle.label, toggle.active)
@@ -338,6 +373,7 @@ fn playback_type_filter_toggle(
         })
         .id(automation_playback_type_filter_toggle_id(toggle.label))
         .size(PLAYBACK_TYPE_FILTER_TOGGLE_WIDTH, FILTER_ROW_CONTROL_HEIGHT)
+        .tooltip_if(help_tooltips_enabled, playback_type_filter_tooltip(filter))
 }
 
 fn playback_type_filter_toggle_style() -> ui::WidgetStyle {
@@ -350,13 +386,14 @@ pub(super) fn automation_playback_type_filter_toggle_id(label: &str) -> u64 {
 }
 
 fn rating_filter_row(row: RatingFilterRowProjection) -> ui::View<GuiMessage> {
-    let label = filter_row_label(row.label, row.family, row.enabled);
+    let help_tooltips_enabled = row.help_tooltips_enabled;
+    let label = filter_row_label(row.label, row.family, row.enabled, help_tooltips_enabled);
     filter_labeled_control_row(
         label,
         ui::row(
             row.toggles
                 .iter()
-                .map(rating_filter_toggle)
+                .map(|toggle| rating_filter_toggle(toggle, help_tooltips_enabled))
                 .collect::<Vec<_>>(),
         )
         .spacing(1.0)
@@ -366,7 +403,10 @@ fn rating_filter_row(row: RatingFilterRowProjection) -> ui::View<GuiMessage> {
     )
 }
 
-fn rating_filter_toggle(toggle: &RatingFilterToggleProjection) -> ui::View<GuiMessage> {
+fn rating_filter_toggle(
+    toggle: &RatingFilterToggleProjection,
+    help_tooltips_enabled: bool,
+) -> ui::View<GuiMessage> {
     let level = toggle.level;
     ui::selectable("", toggle.active)
         .style(ui::WidgetStyle::subtle(rating_filter_tone(level)))
@@ -379,6 +419,7 @@ fn rating_filter_toggle(toggle: &RatingFilterToggleProjection) -> ui::View<GuiMe
         })
         .id(automation_rating_filter_toggle_id(toggle.label))
         .size(RATING_FILTER_TOGGLE_WIDTH, FILTER_ROW_CONTROL_HEIGHT)
+        .tooltip_if(help_tooltips_enabled, rating_filter_tooltip(level))
 }
 
 fn rating_filter_tone(level: i8) -> ui::WidgetTone {
@@ -423,6 +464,7 @@ fn filter_row_label(
     label: &'static str,
     family: FilterFamily,
     enabled: bool,
+    help_tooltips_enabled: bool,
 ) -> ui::View<GuiMessage> {
     ui::selectable(label, enabled)
         .style(ui::WidgetStyle::subtle(ui::WidgetTone::Accent))
@@ -433,6 +475,47 @@ fn filter_row_label(
         })
         .id(automation_filter_family_label_toggle_id(label))
         .size(FILTER_LABEL_WIDTH, FILTER_ROW_CONTROL_HEIGHT)
+        .tooltip_if(help_tooltips_enabled, filter_family_label_tooltip(family))
+}
+
+fn filter_family_label_tooltip(family: FilterFamily) -> &'static str {
+    match family {
+        FilterFamily::Name => "Turn filename filtering on or off.",
+        FilterFamily::Tags => "Turn tag text filtering on or off.",
+        FilterFamily::Curation => "Turn curation queue filtering on or off.",
+        FilterFamily::Harvest => "Turn Harvest queue filtering on or off.",
+        FilterFamily::PlaybackType => "Turn playback-type filtering on or off.",
+        FilterFamily::Rating => "Turn rating filtering on or off.",
+    }
+}
+
+fn curation_scope_tooltip(scope: BrowserCurationScope) -> &'static str {
+    match scope {
+        BrowserCurationScope::All => "Show all curation work.",
+        BrowserCurationScope::Ratings => "Show samples that need rating decisions.",
+        BrowserCurationScope::Tags => "Show samples that need tag cleanup.",
+    }
+}
+
+fn playback_type_filter_tooltip(filter: PlaybackTypeFilter) -> &'static str {
+    match filter {
+        PlaybackTypeFilter::OneShot => "Show samples tagged as one-shots.",
+        PlaybackTypeFilter::Loop => "Show samples tagged as loops.",
+    }
+}
+
+fn rating_filter_tooltip(level: i8) -> &'static str {
+    match level {
+        -3 => "Show T3 trash-rated samples.",
+        -2 => "Show T2 trash-rated samples.",
+        -1 => "Show T1 trash-rated samples.",
+        0 => "Show unrated samples.",
+        1 => "Show K1 keep-rated samples.",
+        2 => "Show K2 keep-rated samples.",
+        3 => "Show K3 keep-rated samples.",
+        4 => "Show locked K4 samples.",
+        _ => "Show samples with this rating.",
+    }
 }
 
 /// Automation-facing id for a filter family label toggle.
@@ -522,6 +605,7 @@ mod tests {
     fn filter_model(help_tooltips_enabled: bool) -> FilterSectionViewModel {
         FilterSectionViewModel {
             sidebar_width: 240.0,
+            help_tooltips_enabled,
             name_filter: String::new(),
             name_filter_enabled: false,
             tag_filter: String::new(),
@@ -534,6 +618,7 @@ mod tests {
                     scope: BrowserCurationScope::All,
                     label: "All",
                 }],
+                help_tooltips_enabled,
             },
             harvest: HarvestFilterViewModel {
                 enabled: false,
@@ -561,5 +646,75 @@ mod tests {
             }],
             panel_height: 120.0,
         }
+    }
+
+    #[test]
+    fn filter_controls_expose_help_tooltips_on_interactive_targets() {
+        let surface = ui::column(filter_rows(&filter_model(true))).into_surface();
+
+        assert_eq!(
+            widget_tooltip(&surface, automation_filter_family_label_toggle_id("Name")).as_deref(),
+            Some("Turn filename filtering on or off.")
+        );
+        assert_eq!(
+            widget_tooltip(&surface, CURATION_FILTER_DROPDOWN_TRIGGER_ID).as_deref(),
+            Some("Choose the curation queue to show.")
+        );
+        assert_eq!(
+            widget_tooltip(
+                &surface,
+                automation_playback_type_filter_toggle_id("1-Shot")
+            )
+            .as_deref(),
+            Some("Show samples tagged as one-shots.")
+        );
+        assert_eq!(
+            widget_tooltip(&surface, automation_rating_filter_toggle_id("U")).as_deref(),
+            Some("Show unrated samples.")
+        );
+    }
+
+    #[test]
+    fn curation_dropdown_options_expose_help_tooltips() {
+        let mut model = filter_model(true);
+        model.curation.dropdown_open = true;
+        model.curation.options = vec![CurationFilterOptionViewModel {
+            scope: BrowserCurationScope::Ratings,
+            label: "Rate",
+        }];
+        let menu = curation_filter_dropdown_menu(&model)
+            .expect("open curation dropdown menu")
+            .0
+            .into_surface();
+
+        assert_eq!(
+            widget_tooltip(&menu, automation_curation_filter_dropdown_option_id("Rate")).as_deref(),
+            Some("Show samples that need rating decisions.")
+        );
+    }
+
+    #[test]
+    fn filter_controls_omit_help_tooltips_when_help_is_disabled() {
+        let surface = ui::column(filter_rows(&filter_model(false))).into_surface();
+
+        assert_eq!(
+            widget_tooltip(&surface, automation_filter_family_label_toggle_id("Name")),
+            None
+        );
+        assert_eq!(
+            widget_tooltip(&surface, CURATION_FILTER_DROPDOWN_TRIGGER_ID),
+            None
+        );
+        assert_eq!(
+            widget_tooltip(&surface, automation_rating_filter_toggle_id("U")),
+            None
+        );
+    }
+
+    fn widget_tooltip(surface: &ui::UiSurface<GuiMessage>, widget_id: u64) -> Option<String> {
+        surface
+            .find_widget(widget_id)
+            .and_then(|widget| widget.widget_object().common().tooltip.as_deref())
+            .map(str::to_string)
     }
 }

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/rows/projection.rs
@@ -32,6 +32,7 @@ pub(super) struct TextFilterRowProjection {
     pub(super) value: String,
     pub(super) enabled: bool,
     pub(super) placeholder: &'static str,
+    pub(super) help_tooltips_enabled: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,6 +40,7 @@ pub(super) struct PlaybackTypeFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
+    pub(super) help_tooltips_enabled: bool,
     pub(super) toggles: Vec<PlaybackTypeFilterToggleProjection>,
 }
 
@@ -47,6 +49,7 @@ pub(super) struct CurationFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
+    pub(super) help_tooltips_enabled: bool,
     pub(super) dropdown_open: bool,
     pub(super) menu_width: u16,
     pub(super) selected_label: &'static str,
@@ -65,13 +68,13 @@ pub(super) struct HarvestFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
+    pub(super) help_tooltips_enabled: bool,
     pub(super) dropdown_open: bool,
     pub(super) menu_width: u16,
     pub(super) selected_label: &'static str,
     pub(super) options: Vec<HarvestFilterOptionProjection>,
     pub(super) family_available: bool,
     pub(super) family_open: bool,
-    pub(super) help_tooltips_enabled: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -94,6 +97,7 @@ pub(super) struct RatingFilterRowProjection {
     pub(super) family: FilterFamily,
     pub(super) label: &'static str,
     pub(super) enabled: bool,
+    pub(super) help_tooltips_enabled: bool,
     pub(super) toggles: Vec<RatingFilterToggleProjection>,
 }
 
@@ -113,6 +117,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             value: model.name_filter.clone(),
             enabled: model.name_filter_enabled,
             placeholder: "Any",
+            help_tooltips_enabled: model.help_tooltips_enabled,
         },
         tag_filter: TextFilterRowProjection {
             field: TextFilterField::Tags,
@@ -121,6 +126,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             value: model.tag_filter.clone(),
             enabled: model.tag_filter_enabled,
             placeholder: "Any",
+            help_tooltips_enabled: model.help_tooltips_enabled,
         },
         curation: CurationFilterRowProjection::from_view_model(
             &model.curation,
@@ -131,6 +137,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             family: FilterFamily::PlaybackType,
             label: "Type",
             enabled: model.playback_type_enabled,
+            help_tooltips_enabled: model.help_tooltips_enabled,
             toggles: model
                 .playback_type_filters
                 .iter()
@@ -141,6 +148,7 @@ pub(super) fn filter_rows_projection(model: &FilterSectionViewModel) -> FilterRo
             family: FilterFamily::Rating,
             label: "Rating",
             enabled: model.rating_enabled,
+            help_tooltips_enabled: model.help_tooltips_enabled,
             toggles: model
                 .rating_filters
                 .iter()
@@ -156,6 +164,7 @@ impl CurationFilterRowProjection {
             family: FilterFamily::Curation,
             label: "Curate",
             enabled: model.enabled,
+            help_tooltips_enabled: model.help_tooltips_enabled,
             dropdown_open: model.dropdown_open,
             menu_width: curation_dropdown_menu_width(sidebar_width),
             selected_label: model
@@ -202,6 +211,7 @@ impl HarvestFilterRowProjection {
             family: FilterFamily::Harvest,
             label: "Harvest",
             enabled: model.enabled,
+            help_tooltips_enabled: model.help_tooltips_enabled,
             dropdown_open: model.dropdown_open,
             menu_width: curation_dropdown_menu_width(sidebar_width),
             selected_label: model
@@ -223,7 +233,6 @@ impl HarvestFilterRowProjection {
                 .collect(),
             family_available: model.family_available,
             family_open: model.family_open && model.family_available,
-            help_tooltips_enabled: model.help_tooltips_enabled,
         }
     }
 }
@@ -297,6 +306,7 @@ mod tests {
                 value: "kick".to_string(),
                 enabled: true,
                 placeholder: "Any",
+                help_tooltips_enabled: true,
             }
         );
         assert_eq!(
@@ -308,6 +318,7 @@ mod tests {
                 value: "drum".to_string(),
                 enabled: true,
                 placeholder: "Any",
+                help_tooltips_enabled: true,
             }
         );
     }
@@ -426,6 +437,7 @@ mod tests {
     fn filter_model() -> FilterSectionViewModel {
         FilterSectionViewModel {
             sidebar_width: 240.0,
+            help_tooltips_enabled: true,
             name_filter: "kick".to_string(),
             name_filter_enabled: true,
             tag_filter: "drum".to_string(),
@@ -448,6 +460,7 @@ mod tests {
                         label: "Tags",
                     },
                 ],
+                help_tooltips_enabled: true,
             },
             harvest: HarvestFilterViewModel {
                 enabled: true,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section.rs
@@ -12,10 +12,13 @@ use rows::{source_add_button, source_missing_color, source_row};
 
 pub(super) fn source_selector(model: &SourceSelectorViewModel) -> ui::View<GuiMessage> {
     ui::column([
-        ui::row([source_section_title(model), source_add_button()])
-            .spacing(3.0)
-            .fill_width()
-            .height(24.0),
+        ui::row([
+            source_section_title(model),
+            source_add_button(model.help_tooltips_enabled),
+        ])
+        .spacing(3.0)
+        .fill_width()
+        .height(24.0),
         ui::column(model.rows.iter().map(source_row).collect::<Vec<_>>())
             .spacing(2.0)
             .fill_width(),

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -21,12 +21,14 @@ const SOURCE_ROLE_ICON_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 255);
 const SOURCE_ROW_OUTLINE_INSET: f32 = 0.5;
 const SOURCE_ROW_OUTLINE_WIDTH: f32 = 1.0;
 const SOURCE_ROW_OUTLINE_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 30);
+const SOURCE_ADD_BUTTON_TOOLTIP: &str = "Add source";
 
-pub(super) fn source_add_button() -> ui::View<GuiMessage> {
+pub(super) fn source_add_button(help_tooltips_enabled: bool) -> ui::View<GuiMessage> {
     ui::icon_button(source_add_icon())
         .message(GuiMessage::FolderBrowser(FolderBrowserMessage::AddSource))
         .id(AUTOMATION_SOURCE_ADD_BUTTON_ID)
         .size(SOURCE_ADD_BUTTON_WIDTH, SOURCE_ADD_BUTTON_HEIGHT)
+        .tooltip_if(help_tooltips_enabled, SOURCE_ADD_BUTTON_TOOLTIP)
 }
 
 fn source_add_icon() -> ui::SvgIcon {
@@ -134,6 +136,11 @@ pub(super) fn source_role_icon_color_for_tests() -> ui::Rgba8 {
 #[cfg(test)]
 pub(super) fn source_row_outline_for_tests() -> ui::DenseRowOutlineStyle {
     source_row_outline()
+}
+
+#[cfg(test)]
+pub(super) fn source_add_button_tooltip_for_tests() -> &'static str {
+    SOURCE_ADD_BUTTON_TOOLTIP
 }
 
 static SOURCE_ADD_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -1,8 +1,9 @@
 use super::identity::{AUTOMATION_SOURCE_ADD_BUTTON_ID, retained_source_row_input_id};
 use super::rows::{
     SOURCE_ADD_BUTTON_HEIGHT, SOURCE_ADD_BUTTON_WIDTH, SOURCE_ROW_HEIGHT,
-    SOURCE_ROW_LABEL_PADDING_X, source_add_button, source_missing_color_for_tests,
-    source_role_icon_color_for_tests, source_row, source_row_outline_for_tests,
+    SOURCE_ROW_LABEL_PADDING_X, source_add_button, source_add_button_tooltip_for_tests,
+    source_missing_color_for_tests, source_role_icon_color_for_tests, source_row,
+    source_row_outline_for_tests,
 };
 use super::source_selector;
 use crate::native_app::app::GuiMessage;
@@ -38,7 +39,7 @@ macro_rules! assert_no_left_source_marker {
 #[test]
 fn source_add_button_routes_add_source_message() {
     assert_eq!(
-        source_add_button().view_dispatch_widget_output(
+        source_add_button(false).view_dispatch_widget_output(
             AUTOMATION_SOURCE_ADD_BUTTON_ID,
             ui::WidgetOutput::typed(ButtonMessage::Activate),
         ),
@@ -48,7 +49,7 @@ fn source_add_button_routes_add_source_message() {
 
 #[test]
 fn source_add_button_uses_regular_icon_button_chrome() {
-    let frame = source_add_button().view_frame_at_size_with_default_theme(ui::Vector2::new(
+    let frame = source_add_button(false).view_frame_at_size_with_default_theme(ui::Vector2::new(
         SOURCE_ADD_BUTTON_WIDTH,
         SOURCE_ADD_BUTTON_HEIGHT,
     ));
@@ -66,10 +67,43 @@ fn source_add_button_uses_regular_icon_button_chrome() {
 }
 
 #[test]
+fn source_add_button_exposes_tooltip_when_help_tooltips_are_enabled() {
+    let surface = source_add_button(true).into_surface();
+    let tooltip = surface
+        .find_widget(AUTOMATION_SOURCE_ADD_BUTTON_ID)
+        .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+    assert_eq!(tooltip, Some(source_add_button_tooltip_for_tests()));
+}
+
+#[test]
+fn source_add_button_omits_tooltip_when_help_tooltips_are_disabled() {
+    let surface = source_add_button(false).into_surface();
+    let tooltip = surface
+        .find_widget(AUTOMATION_SOURCE_ADD_BUTTON_ID)
+        .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+    assert_eq!(tooltip, None);
+}
+
+#[test]
+fn source_selector_threads_help_tooltips_to_add_button() {
+    let source = test_source("source-with-tooltip");
+    let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
+    let model = SourceSelectorViewModel::from_folder_browser(&state, true);
+    let surface = source_selector(&model).into_surface();
+    let tooltip = surface
+        .find_widget(AUTOMATION_SOURCE_ADD_BUTTON_ID)
+        .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+    assert_eq!(tooltip, Some(source_add_button_tooltip_for_tests()));
+}
+
+#[test]
 fn source_row_routes_primary_activation_through_interactive_row() {
     let source = test_source("source-a");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
 
     assert_eq!(
@@ -88,7 +122,7 @@ fn source_row_routes_secondary_activation_to_context_menu() {
     let source = test_source("source-b");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
     let position = ui::Point::new(12.0, 20.0);
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
 
     assert_eq!(
@@ -106,7 +140,7 @@ fn source_row_routes_secondary_activation_to_context_menu() {
 fn selected_source_row_paints_selected_highlight_without_left_active_marker() {
     let source = test_source("source-active");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
@@ -133,7 +167,7 @@ fn selected_source_row_paints_selected_highlight_without_left_active_marker() {
 fn source_rows_use_slim_outlined_item_chrome() {
     let source = test_source("source-bordered");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
@@ -167,7 +201,7 @@ fn inactive_source_row_does_not_paint_active_marker() {
         vec![source.clone(), selected.clone()],
         selected.id.clone(),
     );
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
@@ -185,7 +219,7 @@ fn inactive_source_row_does_not_paint_active_marker() {
 fn source_row_label_keeps_left_breathing_room() {
     let source = test_source("source-padded");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
@@ -213,7 +247,7 @@ fn missing_source_row_paints_missing_badge_without_left_marker() {
     let mut source = test_source("source-missing");
     source.mark_missing_for_tests();
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, SOURCE_ROW_HEIGHT));
@@ -240,7 +274,7 @@ fn primary_source_row_uses_role_icon_instead_of_text_badge() {
     let mut source = test_source("source-primary");
     source.role = SourceRole::Primary;
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, SOURCE_ROW_HEIGHT));
@@ -269,7 +303,7 @@ fn protected_source_row_uses_role_icon_instead_of_text_badge() {
     let mut source = test_source("source-protected");
     source.role = SourceRole::Protected;
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, SOURCE_ROW_HEIGHT));
@@ -297,7 +331,7 @@ fn protected_source_row_uses_role_icon_instead_of_text_badge() {
 fn normal_source_row_keeps_role_slot_neutral() {
     let source = test_source("source-normal");
     let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first().expect("source row");
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, SOURCE_ROW_HEIGHT));
@@ -329,7 +363,7 @@ fn source_selector_header_reports_missing_sources() {
         vec![missing.clone(), present],
         missing.id.clone(),
     );
-    let model = SourceSelectorViewModel::from_folder_browser(&state);
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let frame = source_selector(&model)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(220.0, 76.0));
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor/projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor/projection.rs
@@ -61,6 +61,8 @@ pub(super) struct TagInputProjection {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) struct TagLibraryToggleProjection {
     pub(super) width: f32,
+    pub(super) open: bool,
+    pub(super) help_tooltips_enabled: bool,
 }
 
 impl TagEditorProjection {
@@ -129,7 +131,11 @@ fn project_row_item(item: TagEntryRowItem, model: &TagEditorViewModel) -> TagEnt
             width,
         }),
         TagEntryRowItem::LibraryToggle(width) => {
-            TagEntryItemProjection::LibraryToggle(TagLibraryToggleProjection { width })
+            TagEntryItemProjection::LibraryToggle(TagLibraryToggleProjection {
+                width,
+                open: model.tag_library_open,
+                help_tooltips_enabled: model.help_tooltips_enabled,
+            })
         }
     }
 }
@@ -218,8 +224,11 @@ mod tests {
                 .flat_map(|row| row.items.iter())
                 .any(|item| matches!(
                     item,
-                    TagEntryItemProjection::LibraryToggle(TagLibraryToggleProjection { width })
-                    if *width == 22.0
+                    TagEntryItemProjection::LibraryToggle(TagLibraryToggleProjection {
+                        width,
+                        open: false,
+                        help_tooltips_enabled: false,
+                    }) if *width == 22.0
                 ))
         );
         assert!(field.layout.field_height >= field.layout.content_height);
@@ -254,6 +263,8 @@ mod tests {
     fn tag_editor_model() -> TagEditorViewModel {
         TagEditorViewModel {
             has_selected_file: true,
+            help_tooltips_enabled: false,
+            tag_library_open: false,
             draft: "sou".to_string(),
             tokens: vec!["loop".to_string()],
             pending_category_tag: None,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor/rows.rs
@@ -7,7 +7,8 @@ use crate::native_app::metadata::{
 
 use super::identity;
 use super::projection::{
-    TagEntryItemProjection, TagEntryRowProjection, TagInputProjection, TagTokenProjection,
+    TagEntryItemProjection, TagEntryRowProjection, TagInputProjection, TagLibraryToggleProjection,
+    TagTokenProjection,
 };
 use crate::native_app::app_chrome::library_browser::library_sidebar::tag_entry_layout::{
     TAG_FIELD_CONTROL_HEIGHT, TAG_FIELD_ITEM_GAP, tag_pill_width,
@@ -24,7 +25,7 @@ pub(super) fn tag_entry_row(row: TagEntryRowProjection, row_index: usize) -> ui:
                 }
                 TagEntryItemProjection::Input(input) => tag_text_input(input),
                 TagEntryItemProjection::LibraryToggle(toggle) => {
-                    metadata_tag_library_toggle(toggle.width)
+                    metadata_tag_library_toggle(toggle)
                 }
             })
             .collect::<Vec<_>>(),
@@ -88,13 +89,19 @@ fn pending_category_tag_token(tag: &str) -> ui::View<GuiMessage> {
         .size(tag_pill_width(tag), TAG_FIELD_CONTROL_HEIGHT)
 }
 
-fn metadata_tag_library_toggle(width: f32) -> ui::View<GuiMessage> {
-    let toggle = ui::disclosure_button(false)
+fn metadata_tag_library_toggle(projection: TagLibraryToggleProjection) -> ui::View<GuiMessage> {
+    let tooltip = if projection.open {
+        "Hide tag library"
+    } else {
+        "Show tag library"
+    };
+    let toggle = ui::disclosure_button(projection.open)
         .message(GuiMessage::Metadata(
             MetadataMessage::ToggleMetadataTagLibrary,
         ))
         .key(identity::TAG_LIBRARY_TOGGLE_KEY)
-        .size(width, TAG_FIELD_CONTROL_HEIGHT);
+        .size(projection.width, TAG_FIELD_CONTROL_HEIGHT)
+        .tooltip_if(projection.help_tooltips_enabled, tooltip);
     #[cfg(test)]
     {
         toggle.id(identity::metadata_tag_library_toggle_id())

--- a/src/native_app/app_chrome/library_browser/library_sidebar/test_support.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/test_support.rs
@@ -54,6 +54,8 @@ pub(in crate::native_app) fn library_sidebar_view(
         harvest_family: None,
         tag_editor: TagEditorViewModel {
             has_selected_file,
+            help_tooltips_enabled: false,
+            tag_library_open: false,
             draft: metadata_tag_draft.to_string(),
             tokens: metadata_tag_tokens.to_vec(),
             pending_category_tag: metadata_tag_pending_category_tag.map(str::to_string),

--- a/src/native_app/app_chrome/library_browser/library_sidebar/test_support.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/test_support.rs
@@ -38,7 +38,7 @@ pub(in crate::native_app) fn library_sidebar_view(
     library_sidebar_content(LibrarySidebarViewModel {
         sidebar_width,
         metadata_panel_height: state.metadata_panel_height(),
-        source_selector: SourceSelectorViewModel::from_folder_browser(state),
+        source_selector: SourceSelectorViewModel::from_folder_browser(state, false),
         folder_tree: FolderTreeViewModel {
             visible_folders,
             window: tree_window,

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -67,6 +67,7 @@ pub(in crate::native_app) struct CollectionRowViewModel {
 
 pub(in crate::native_app) struct FilterSectionViewModel {
     pub(in crate::native_app) sidebar_width: f32,
+    pub(in crate::native_app) help_tooltips_enabled: bool,
     pub(in crate::native_app) name_filter: String,
     pub(in crate::native_app) name_filter_enabled: bool,
     pub(in crate::native_app) tag_filter: String,
@@ -96,6 +97,7 @@ pub(in crate::native_app) struct CurationFilterViewModel {
     pub(in crate::native_app) dropdown_open: bool,
     pub(in crate::native_app) selected_scope: BrowserCurationScope,
     pub(in crate::native_app) options: Vec<CurationFilterOptionViewModel>,
+    pub(in crate::native_app) help_tooltips_enabled: bool,
 }
 
 pub(in crate::native_app) struct CurationFilterOptionViewModel {
@@ -132,6 +134,8 @@ pub(in crate::native_app) struct RatingFilterToggleViewModel {
 
 pub(in crate::native_app) struct TagEditorViewModel {
     pub(in crate::native_app) has_selected_file: bool,
+    pub(in crate::native_app) help_tooltips_enabled: bool,
+    pub(in crate::native_app) tag_library_open: bool,
     pub(in crate::native_app) draft: String,
     pub(in crate::native_app) tokens: Vec<String>,
     pub(in crate::native_app) pending_category_tag: Option<String>,
@@ -271,6 +275,7 @@ impl FilterSectionViewModel {
     ) -> Self {
         Self {
             sidebar_width: 240.0,
+            help_tooltips_enabled,
             name_filter: folder_browser.name_filter().to_owned(),
             name_filter_enabled: folder_browser.name_filter_enabled(),
             tag_filter: folder_browser.tag_filter().to_owned(),
@@ -286,6 +291,7 @@ impl FilterSectionViewModel {
                         label: curation_scope_dropdown_label(scope),
                     })
                     .collect(),
+                help_tooltips_enabled,
             },
             harvest: HarvestFilterViewModel {
                 enabled: folder_browser.harvest_filter_enabled(),
@@ -369,6 +375,8 @@ impl TagEditorViewModel {
     fn from_app_state(state: &NativeAppState) -> Self {
         Self {
             has_selected_file: state.library.folder_browser.selected_file_id().is_some(),
+            help_tooltips_enabled: state.ui.chrome.help_tooltips_enabled,
+            tag_library_open: state.metadata.tag_library_open,
             draft: state.metadata.tag_draft.clone(),
             tokens: state.metadata.tag_tokens.clone(),
             pending_category_tag: state

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -31,6 +31,7 @@ pub(in crate::native_app) struct LibrarySidebarViewModel {
 pub(in crate::native_app) struct SourceSelectorViewModel {
     pub(in crate::native_app) rows: Vec<SourceRowViewModel>,
     pub(in crate::native_app) missing_count: usize,
+    pub(in crate::native_app) help_tooltips_enabled: bool,
 }
 
 pub(in crate::native_app) struct SourceRowViewModel {
@@ -168,7 +169,10 @@ impl LibrarySidebarViewModel {
         Self {
             sidebar_width: state.ui.chrome.folder_panel.size(),
             metadata_panel_height: folder_browser.metadata_panel_height(),
-            source_selector: SourceSelectorViewModel::from_folder_browser(folder_browser),
+            source_selector: SourceSelectorViewModel::from_folder_browser(
+                folder_browser,
+                state.ui.chrome.help_tooltips_enabled,
+            ),
             folder_tree: FolderTreeViewModel::from_folder_browser(
                 folder_browser,
                 state.ui.chrome.help_tooltips_enabled,
@@ -182,7 +186,10 @@ impl LibrarySidebarViewModel {
 }
 
 impl SourceSelectorViewModel {
-    pub(in crate::native_app) fn from_folder_browser(folder_browser: &FolderBrowserState) -> Self {
+    pub(in crate::native_app) fn from_folder_browser(
+        folder_browser: &FolderBrowserState,
+        help_tooltips_enabled: bool,
+    ) -> Self {
         let selected_source_id = folder_browser.selected_source_id();
         let rows: Vec<_> = folder_browser
             .sources()
@@ -194,6 +201,7 @@ impl SourceSelectorViewModel {
         Self {
             rows,
             missing_count,
+            help_tooltips_enabled,
         }
     }
 }

--- a/src/native_app/tests/metadata_tag_tests/chips.rs
+++ b/src/native_app/tests/metadata_tag_tests/chips.rs
@@ -43,6 +43,36 @@ fn folder_browser_sidebar_paints_filter_and_metadata_sections() {
 }
 
 #[test]
+fn metadata_tag_library_toggle_exposes_state_aware_help_tooltip() {
+    let (mut closed_state, _source_root, _selected_file) =
+        native_app_state_with_temp_sample("tag-target.wav");
+    closed_state.ui.chrome.help_tooltips_enabled = true;
+    closed_state.metadata.tag_library_open = false;
+    let closed_surface =
+        crate::native_app::test_support::state::view(&mut closed_state).into_surface();
+    let closed_tooltip = closed_surface
+        .find_widget(
+            crate::native_app::test_support::metadata_sidebar::METADATA_TAG_LIBRARY_TOGGLE_ID,
+        )
+        .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+    assert_eq!(closed_tooltip, Some("Show tag library"));
+
+    let (mut open_state, _source_root, _selected_file) =
+        native_app_state_with_temp_sample("tag-target.wav");
+    open_state.ui.chrome.help_tooltips_enabled = true;
+    open_state.metadata.tag_library_open = true;
+    let open_surface = crate::native_app::test_support::state::view(&mut open_state).into_surface();
+    let open_tooltip = open_surface
+        .find_widget(
+            crate::native_app::test_support::metadata_sidebar::METADATA_TAG_LIBRARY_TOGGLE_ID,
+        )
+        .and_then(|widget| widget.widget_object().common().tooltip.as_deref());
+
+    assert_eq!(open_tooltip, Some("Hide tag library"));
+}
+
+#[test]
 fn folder_browser_metadata_selected_tag_chip_uses_strong_accent_style() {
     let browser = crate::native_app::test_support::state::FolderBrowserState::load_default();
     let tags = vec![String::from("hat")];


### PR DESCRIPTION
## Scope
- OPT-908: Add `Add source` help tooltip to the Sources `+` button.
- OPT-909: Add help tooltips to library sidebar filter label toggles, curation/harvest dropdowns and options, playback-type toggles, rating swatches, and text filter fields.
- OPT-910: Add state-aware `Show tag library` / `Hide tag library` tooltip copy to the tag editor library toggle.
- Preserve existing sidebar layout, button placement, dropdown behavior, and filter/tag interactions.

## Definition of Done
- Sources, filter controls, and tag editor toggle expose concise tooltip copy through the existing Radiant tooltip pattern when Help Tooltips are enabled.
- Tooltip copy explains each control effect without adding in-sidebar instructional text.
- Existing add-source, filter activation/dropdown, playback/rating toggle, and tag-library toggle routes remain unchanged.

## Validation Commands
- PASS: `git diff --check`
- PASS: `cargo test -p wavecrate source_section -- --test-threads=1`
- PASS: `cargo test -p wavecrate filter_section -- --test-threads=1`
- PASS: `cargo test -p wavecrate metadata_tag_library_toggle_exposes_state_aware_help_tooltip -- --test-threads=1`
- FAIL: `bash scripts/agent.sh request` currently fails on existing non-blocking guardrail findings in unrelated files (`drag_drop_move.rs`, `starmap.rs`, `harvest_tracking.rs`, `duplicate.rs`, and an existing test fixture in `library_sidebar.rs`).

## Known Limitations
- Manual live-app hover/focus/dropdown smoke was not run; automated tests verify the Radiant tooltip metadata on exposed widget ids and unchanged activation routes.
- Full agent preflight is blocked by unrelated existing guardrail violations listed above.

User review is required before merge.