### PR TITLE
OPT-895 Keep extracted waveform overlays during selection drags

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -57,8 +57,10 @@ impl WaveformWidget {
         bounds: Rect,
     ) {
         let mut paint = WidgetPaint::new(primitives, self.common.id);
-        if self.static_range_overlays_visible() {
+        if self.extracted_range_overlays_visible() {
             self.append_extracted_range_paint(&mut paint, bounds);
+        }
+        if self.similar_section_overlays_visible() {
             self.append_similar_section_paint(&mut paint, bounds);
         }
         if self.should_paint_committed_selection(WaveformSelectionKind::Play)
@@ -89,7 +91,12 @@ impl WaveformWidget {
         }
     }
 
-    fn static_range_overlays_visible(&self) -> bool {
+    fn extracted_range_overlays_visible(&self) -> bool {
+        self.active_drag_kind.is_none()
+            || active_selection_drag_kind(self.active_drag_kind).is_some()
+    }
+
+    fn similar_section_overlays_visible(&self) -> bool {
         self.active_drag_kind.is_none()
     }
 

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -607,7 +607,7 @@ fn extracted_ranges_paint_as_gray_waveform_overlays() {
 }
 
 #[test]
-fn static_range_overlays_pause_while_playmark_selection_drag_is_active() {
+fn extracted_ranges_paint_while_playmark_selection_drag_is_active() {
     let mut state = WaveformState::synthetic_for_tests();
     state
         .extracted_ranges
@@ -630,13 +630,18 @@ fn static_range_overlays_pause_while_playmark_selection_drag_is_active() {
 
     let fills = fill_rects(&plan);
     assert!(
-        !fills.iter().any(|fill| {
-            matches!(
-                (fill.color.r, fill.color.g, fill.color.b, fill.color.a),
-                (156, 160, 168, 108) | (114, 235, 184, 54)
-            )
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 120.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (156, 160, 168, 108)
         }),
-        "static extracted/similar overlays should not paint during live playmark drags"
+        "extracted overlays should remain visible during live playmark drags"
+    );
+    assert!(
+        !fills.iter().any(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (114, 235, 184, 54)
+        }),
+        "similar-section overlays should still pause during live playmark drags"
     );
     let runtime_plan = runtime_overlay_plan(&widget, bounds);
     let runtime_fills = fill_rects(&runtime_plan);
@@ -647,6 +652,47 @@ fn static_range_overlays_pause_while_playmark_selection_drag_is_active() {
                 && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
         }),
         "the live playmark selection itself should keep painting"
+    );
+}
+
+#[test]
+fn extracted_ranges_paint_while_editmark_selection_drag_is_active() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state
+        .extracted_ranges
+        .push(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.edit_selection = Some(wavecrate::selection::SelectionRange::new(0.4, 0.8));
+    state.edit_mark_ratio = Some(0.4);
+
+    let mut widget = waveform_widget_for_state(&state);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::Selection(
+        WaveformSelectionKind::Edit,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Edit,
+        selection: wavecrate::selection::SelectionRange::new(0.4, 0.8),
+    });
+    let bounds = Rect::from_size(200.0, 80.0);
+    let plan = widget.paint_plan_with_defaults(bounds);
+
+    let fills = fill_rects(&plan);
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 120.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (156, 160, 168, 108)
+        }),
+        "extracted overlays should remain visible during live editmark drags"
+    );
+    let runtime_plan = runtime_overlay_plan(&widget, bounds);
+    let runtime_fills = fill_rects(&runtime_plan);
+    assert!(
+        runtime_fills.iter().any(|fill| {
+            (fill.rect.min.x - 80.0).abs() < 0.001
+                && (fill.rect.max.x - 160.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 46)
+        }),
+        "the live editmark selection itself should keep painting"
     );
 }
 
@@ -706,7 +752,7 @@ fn beat_guides_do_not_paint_during_live_selection_preview() {
 }
 
 #[test]
-fn active_drag_widget_props_do_not_clone_static_range_overlays() {
+fn active_selection_drag_widget_props_keep_extracted_range_overlays_only() {
     let mut state = WaveformState::synthetic_for_tests();
     state
         .extracted_ranges
@@ -721,7 +767,7 @@ fn active_drag_widget_props_do_not_clone_static_range_overlays() {
 
     let props = WaveformWidgetProps::from_state(&state, false, 4);
 
-    assert_eq!(props.static_range_overlay_counts(), (0, 0));
+    assert_eq!(props.static_range_overlay_counts(), (1, 0));
     assert_eq!(
         props.active_drag_kind,
         Some(WaveformActiveDragKind::Selection(

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -158,7 +158,6 @@ impl WaveformWidgetProps {
         beat_guide_count: u8,
     ) -> Self {
         let active_drag_kind = state.active_drag_kind();
-        let static_range_overlays_visible = active_drag_kind.is_none();
         Self {
             file: state.file(),
             viewport: state.viewport(),
@@ -177,12 +176,12 @@ impl WaveformWidgetProps {
             hovered_edit_fade_outer_gain_handle: None,
             hovered_edit_gain_handle: false,
             hovered_similar_section: None,
-            extracted_ranges: if static_range_overlays_visible {
+            extracted_ranges: if extracted_range_overlays_visible(active_drag_kind) {
                 state.extracted_ranges().to_vec()
             } else {
                 Vec::new()
             },
-            similar_section_ranges: if static_range_overlays_visible {
+            similar_section_ranges: if similar_section_overlays_visible(active_drag_kind) {
                 state.similar_section_ranges().to_vec()
             } else {
                 Vec::new()
@@ -206,6 +205,17 @@ impl WaveformWidgetProps {
             self.similar_section_ranges.len(),
         )
     }
+}
+
+fn extracted_range_overlays_visible(active_drag_kind: Option<WaveformActiveDragKind>) -> bool {
+    active_drag_kind.is_none()
+        || active_drag_kind
+            .and_then(WaveformActiveDragKind::selection_kind)
+            .is_some()
+}
+
+fn similar_section_overlays_visible(active_drag_kind: Option<WaveformActiveDragKind>) -> bool {
+    active_drag_kind.is_none()
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Scope
- Keep extracted-region waveform overlays in the widget props during playmark/editmark selection drags.
- Paint extracted-region overlays independently from similar-section overlays so active selection previews can layer over persistent extracted fields.
- Add focused paint regressions for playmark and editmark drag-time overlay state.

## Definition of Done
- Grey extracted-region overlays remain visible while playmark selection drags are active.
- Grey extracted-region overlays remain visible while editmark selection drags are active.
- Active selection previews still paint in the runtime overlay with their existing interactive chrome.
- Focused automated coverage protects the projection/paint state.

## Validation Commands
- `cargo fmt --check` - passed
- `cargo test -p wavecrate waveform::tests::paint -- --test-threads=1` - passed
- `git diff --check` - passed
- `bash scripts/agent.sh request` - failed on `native_app_ui_update_paths_do_not_call_blocking_business_apis` due existing unrelated non-blocking guardrail violations on `main` in folder-browser/starmap/harvest/duplicate/sidebar paths before this branch's changes.

## Known Limitations
- Manual live-app smoke was not run in this turn.
- The repo request preflight currently has unrelated baseline guardrail failures noted above.

User review is required before merge.
