### PR TITLE
Wavecrate: keep playmark resize overlays live

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -101,7 +101,25 @@ impl WaveformWidget {
     }
 
     fn should_paint_committed_selection(&self, kind: WaveformSelectionKind) -> bool {
-        active_selection_drag_kind(self.active_drag_kind) != Some(kind)
+        match self.active_drag_kind {
+            Some(WaveformActiveDragKind::SelectionResize(active_kind, _))
+                if active_kind == kind =>
+            {
+                true
+            }
+            _ => {
+                active_selection_drag_kind(self.active_drag_kind) != Some(kind)
+                    || self.live_selection_preview_for_kind(kind).is_none()
+            }
+        }
+    }
+
+    fn live_selection_preview_for_kind(
+        &self,
+        kind: WaveformSelectionKind,
+    ) -> Option<super::widget::LiveSelectionPreview> {
+        self.live_selection_preview
+            .filter(|preview| preview.kind == kind)
     }
 
     fn append_extracted_range_rails(
@@ -161,7 +179,12 @@ impl WaveformWidget {
             1.0,
             style.fill_color(),
         );
-        self.append_beat_guide_paint(paint, bounds, self.play_selection);
+        self.append_committed_beat_guide_paint(
+            paint,
+            bounds,
+            WaveformSelectionKind::Play,
+            self.play_selection,
+        );
         self.append_selection_boundary_cursors(paint, bounds, self.play_selection, style, 1.25);
         self.append_selection_affordance_paint(
             paint,
@@ -176,16 +199,62 @@ impl WaveformWidget {
         );
     }
 
+    fn append_committed_beat_guide_paint(
+        &self,
+        paint: &mut WidgetPaint<'_>,
+        bounds: Rect,
+        kind: WaveformSelectionKind,
+        selection: Option<wavecrate::selection::SelectionRange>,
+    ) {
+        match active_selection_drag_kind(self.active_drag_kind) {
+            None if self.active_drag_kind.is_none() => {
+                self.append_beat_guide_paint(paint, bounds, selection);
+            }
+            Some(active_kind)
+                if active_kind == kind
+                    && matches!(
+                        self.active_drag_kind,
+                        Some(WaveformActiveDragKind::SelectionResize(_, _))
+                    ) =>
+            {
+                self.append_beat_guide_paint(paint, bounds, selection);
+            }
+            Some(active_kind)
+                if active_kind == kind && self.live_selection_preview_for_kind(kind).is_none() =>
+            {
+                self.append_beat_guide_paint(paint, bounds, selection);
+            }
+            _ => {}
+        }
+    }
+
+    fn append_live_playmark_resize_beat_guide_paint(
+        &self,
+        paint: &mut WidgetPaint<'_>,
+        bounds: Rect,
+        preview: super::widget::LiveSelectionPreview,
+    ) {
+        if preview.kind != WaveformSelectionKind::Play
+            || !matches!(
+                self.active_drag_kind,
+                Some(WaveformActiveDragKind::SelectionResize(
+                    WaveformSelectionKind::Play,
+                    _
+                ))
+            )
+        {
+            return;
+        }
+        self.append_beat_guide_paint(paint, bounds, Some(preview.selection));
+    }
+
     fn append_beat_guide_paint(
         &self,
         paint: &mut WidgetPaint<'_>,
         bounds: Rect,
         selection: Option<wavecrate::selection::SelectionRange>,
     ) {
-        if self.active_drag_kind.is_some()
-            || !self.beat_guides_enabled
-            || self.beat_guide_count <= 1
-        {
+        if !self.beat_guides_enabled || self.beat_guide_count <= 1 {
             return;
         }
         let Some(selection) = selection.filter(|selection| selection.width() > 0.0) else {
@@ -210,6 +279,12 @@ impl WaveformWidget {
         let Some(preview) = self.live_selection_preview else {
             return;
         };
+        if matches!(
+            self.active_drag_kind,
+            Some(WaveformActiveDragKind::SelectionResize(kind, _)) if kind == preview.kind
+        ) {
+            return;
+        }
         let Some(geometry) = self.selection_geometry(bounds, Some(preview.selection)) else {
             return;
         };
@@ -231,6 +306,7 @@ impl WaveformWidget {
                     Some(preview.selection),
                     style,
                 );
+                self.append_live_playmark_resize_beat_guide_paint(&mut paint, bounds, preview);
                 self.append_selection_affordance_paint(
                     &mut paint,
                     geometry,
@@ -326,7 +402,12 @@ impl WaveformWidget {
             1.0,
             style.fill_color(),
         );
-        self.append_beat_guide_paint(paint, bounds, self.edit_selection);
+        self.append_committed_beat_guide_paint(
+            paint,
+            bounds,
+            WaveformSelectionKind::Edit,
+            self.edit_selection,
+        );
         self.append_selection_boundary_cursors(paint, bounds, self.edit_selection, style, 1.25);
         self.append_selection_affordance_paint(
             paint,

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -697,7 +697,46 @@ fn extracted_ranges_paint_while_editmark_selection_drag_is_active() {
 }
 
 #[test]
-fn committed_selection_paint_pauses_while_selection_preview_is_live() {
+fn resize_selection_paints_once_from_base_layer_when_preview_is_live() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.8));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state(&state);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionResize(
+        WaveformSelectionKind::Play,
+        WaveformSelectionEdge::End,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.2, 0.8),
+    });
+
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 160.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
+        }),
+        "app-state play selection should paint the current resize range"
+    );
+
+    let runtime_plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let runtime_fills = fill_rects(&runtime_plan);
+    assert!(
+        runtime_fills.iter().all(|fill| {
+            !((fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 160.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48))
+        }),
+        "runtime resize preview should not double-paint the same translucent selection"
+    );
+}
+
+#[test]
+fn committed_selection_paints_as_resize_fallback_until_preview_is_live() {
     let mut state = WaveformState::synthetic_for_tests();
     state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
     state.play_mark_ratio = Some(0.2);
@@ -711,17 +750,17 @@ fn committed_selection_paint_pauses_while_selection_preview_is_live() {
     let fills = fill_rects(&plan);
 
     assert!(
-        !fills.iter().any(|fill| {
+        fills.iter().any(|fill| {
             (fill.rect.min.x - 40.0).abs() < 0.001
                 && (fill.rect.max.x - 120.0).abs() < 0.001
                 && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
         }),
-        "committed play selection should not repaint under the live drag preview"
+        "committed play selection should remain visible until the live resize preview paints"
     );
 }
 
 #[test]
-fn beat_guides_do_not_paint_during_live_selection_preview() {
+fn beat_guides_do_not_paint_during_live_selection_creation_preview() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state_with_beat_guides(&state, true, 16);
     widget.active_drag_kind = Some(WaveformActiveDragKind::Selection(
@@ -739,7 +778,7 @@ fn beat_guides_do_not_paint_during_live_selection_preview() {
         fills.iter().all(
             |fill| (fill.color.r, fill.color.g, fill.color.b, fill.color.a) != (255, 214, 188, 170)
         ),
-        "beat guides should wait for drag release instead of painting every pointer update"
+        "beat guides should wait for drag release during fresh selection creation"
     );
     assert!(
         fills.iter().any(|fill| {
@@ -749,6 +788,93 @@ fn beat_guides_do_not_paint_during_live_selection_preview() {
         }),
         "the live selection preview should still paint"
     );
+}
+
+#[test]
+fn beat_guides_paint_from_base_layer_during_live_playmark_resize() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.8));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state_with_beat_guides(&state, true, 4);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionResize(
+        WaveformSelectionKind::Play,
+        WaveformSelectionEdge::End,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.2, 0.8),
+    });
+
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+    let guides = fills
+        .iter()
+        .filter(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 214, 188, 170)
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(guides.len(), 3);
+    for expected_x in [70.0, 100.0, 130.0] {
+        assert!(
+            guides.iter().any(|fill| {
+                (fill.rect.center().x - expected_x).abs() < 0.01
+                    && (fill.rect.min.y - 11.0).abs() < 0.01
+                    && (fill.rect.max.y - 69.0).abs() < 0.01
+            }),
+            "expected live resize beat guide at x={expected_x}, got {guides:?}"
+        );
+    }
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 160.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
+        }),
+        "the live resized playmark selection should still paint"
+    );
+
+    let runtime_plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let runtime_fills = fill_rects(&runtime_plan);
+    assert!(
+        runtime_fills.iter().all(
+            |fill| (fill.color.r, fill.color.g, fill.color.b, fill.color.a) != (255, 214, 188, 170)
+        ),
+        "runtime resize preview should not double-paint beat guides over the base layer"
+    );
+}
+
+#[test]
+fn beat_guides_paint_as_resize_fallback_until_preview_is_live() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state_with_beat_guides(&state, true, 4);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionResize(
+        WaveformSelectionKind::Play,
+        WaveformSelectionEdge::End,
+    ));
+
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+    let guides = fills
+        .iter()
+        .filter(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 214, 188, 170)
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(guides.len(), 3);
+    for expected_x in [60.0, 80.0, 100.0] {
+        assert!(
+            guides.iter().any(|fill| {
+                (fill.rect.center().x - expected_x).abs() < 0.01
+                    && (fill.rect.min.y - 11.0).abs() < 0.01
+                    && (fill.rect.max.y - 69.0).abs() < 0.01
+            }),
+            "expected fallback beat guide at x={expected_x}, got {guides:?}"
+        );
+    }
 }
 
 #[test]

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -619,6 +619,42 @@ fn created_selection_drag_preview_survives_widget_rebuild_after_press() {
 }
 
 #[test]
+fn resized_playmark_preview_survives_widget_rebuild_after_press() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut previous = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let begin = previous
+        .handle_input(bounds, WidgetInput::primary_press(Point::new(120.0, 8.0)))
+        .expect("press should begin resizing the playmark")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        begin,
+        WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Play,
+            edge: WaveformSelectionEdge::End,
+            visible_ratio: 0.6,
+        }
+    );
+    state.apply_interaction(begin);
+
+    let mut current = waveform_widget_for_state(&state);
+    Widget::synchronize_from_previous(&mut current, &previous);
+    let preview = current
+        .live_selection_preview
+        .expect("rebuilt widget should immediately keep the playmark resize preview");
+
+    assert_eq!(preview.kind, WaveformSelectionKind::Play);
+    assert_eq!(
+        preview.selection,
+        wavecrate::selection::SelectionRange::new(0.2, 0.6)
+    );
+}
+
+#[test]
 fn playmark_drag_suppresses_duplicate_live_updates_inside_same_step() {
     let mut state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);
@@ -1112,6 +1148,73 @@ fn playmark_resize_motion_updates_live_until_release() {
     assert_eq!(
         state.play_selection(),
         Some(wavecrate::selection::SelectionRange::new(0.2, 0.8))
+    );
+}
+
+#[test]
+fn zoomed_playmark_resize_preview_matches_committed_transform() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.viewport = super::WaveformViewport {
+        start: 12_000,
+        end: 36_000,
+    };
+    let fixed = state.absolute_ratio_from_visible(0.25);
+    let initial_end = state.absolute_ratio_from_visible(0.5);
+    let released = state.absolute_ratio_from_visible(0.75);
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(
+        fixed,
+        initial_end,
+    ));
+    state.play_mark_ratio = Some(fixed);
+    let mut previous = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let begin = previous
+        .handle_input(bounds, WidgetInput::primary_press(Point::new(100.0, 8.0)))
+        .expect("press should begin zoomed playmark resize")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(begin);
+    let mut current = waveform_widget_for_state(&state);
+    Widget::synchronize_from_previous(&mut current, &previous);
+
+    let update = current
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 8.0)))
+        .expect("resize motion should update preview")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        update,
+        WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.75
+        }
+    );
+    let preview = current
+        .live_selection_preview
+        .expect("zoomed resize should paint live preview");
+    assert_eq!(
+        preview.selection,
+        wavecrate::selection::SelectionRange::new(fixed, released)
+    );
+
+    state.apply_interaction(update);
+    let finish = current
+        .handle_input(
+            bounds,
+            WidgetInput::pointer_release(
+                Point::new(150.0, 8.0),
+                PointerButton::Primary,
+                Default::default(),
+            ),
+        )
+        .expect("release should finish zoomed resize")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(finish);
+
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(fixed, released))
     );
 }
 

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -311,6 +311,7 @@ impl WaveformWidget {
         if let Some(edge) =
             self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Edit)
         {
+            self.begin_live_selection_preview(WaveformSelectionKind::Edit, visible_ratio);
             return Some(WidgetOutput::typed(
                 WaveformInteraction::BeginSelectionResize {
                     kind: WaveformSelectionKind::Edit,
@@ -322,6 +323,7 @@ impl WaveformWidget {
         if let Some(edge) =
             self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Play)
         {
+            self.begin_live_selection_preview(WaveformSelectionKind::Play, visible_ratio);
             return Some(WidgetOutput::typed(
                 WaveformInteraction::BeginSelectionResize {
                     kind: WaveformSelectionKind::Play,
@@ -435,6 +437,7 @@ impl WaveformWidget {
         if let Some(edge) =
             self.selection_resize_handle_at(bounds, position, WaveformSelectionKind::Edit)
         {
+            self.begin_live_selection_preview(WaveformSelectionKind::Edit, visible_ratio);
             return Some(WidgetOutput::typed(
                 WaveformInteraction::BeginSelectionResize {
                     kind: WaveformSelectionKind::Edit,
@@ -535,12 +538,14 @@ impl WaveformWidget {
     }
 
     fn begin_live_selection_preview(&mut self, kind: WaveformSelectionKind, visible_ratio: f32) {
+        let baseline = self.selection_for_kind(kind);
         self.live_selection_preview_anchor = Some(LiveSelectionPreviewAnchor {
             kind,
             visible_ratio,
-            baseline: self.selection_for_kind(kind),
+            baseline,
         });
-        self.live_selection_preview = None;
+        self.live_selection_preview =
+            baseline.map(|selection| LiveSelectionPreview { kind, selection });
     }
 
     fn clear_live_selection_preview(&mut self) {


### PR DESCRIPTION
## Scope

- Keep an active playmark resize preview alive immediately after the resize handle press and across widget rebuilds.
- Render beat guides from the in-progress playmark resize preview so guide lines remain visible and move with the live range.
- Preserve existing creation, slide, playback, committed beat-guide, and editmark rendering behavior outside the shared preview-anchor path.

## Definition of Done

- Playmark resize no longer drops the selection overlay during the press-to-drag transition.
- Beat guides remain visible from the live playmark resize preview while the boundary is dragged.
- Zoomed playmark resize preview and final committed range use the same visible-ratio transform.
- Focused regression coverage protects resize preview retention and live beat-guide projection.

## Validation commands

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p wavecrate resized_playmark_preview_survives_widget_rebuild_after_press -- --test-threads=1`
- `cargo test -p wavecrate zoomed_playmark_resize_preview_matches_committed_transform -- --test-threads=1`
- `cargo test -p wavecrate beat_guides_paint_during_live_playmark_resize_preview -- --test-threads=1`
- `cargo test -p wavecrate native_app::waveform::tests::paint -- --test-threads=1`
- `cargo test -p wavecrate playmark_resize_motion_updates_live_until_release -- --test-threads=1`
- `cargo test -p wavecrate primary_press_on_playmark_handle_starts_resize_instead_of_new_selection -- --test-threads=1`

Additional checks attempted:

- `bash scripts/agent.sh request` fails on current `main` baseline non-blocking guardrail violations in unrelated folder-browser/starmap/harvest/duplicate/sidebar paths.
- `cargo test -p wavecrate native_app::waveform::tests::widget_input -- --test-threads=1` passes 44 tests and fails the unrelated existing `playback_cache_backed_waveform_accepts_primary_click` cache-miss fixture.

## Known limitations

- Manual DAW/app smoke testing was not run in this pass.
- Existing baseline validation failures listed above are not addressed by this PR.

User review is required before merge.
