### PR TITLE
OPT-906: Keep the playhead line behind the W context menu

### DIFF
--- a/src/native_app/app_chrome/view_models/waveform_panel.rs
+++ b/src/native_app/app_chrome/view_models/waveform_panel.rs
@@ -1,4 +1,7 @@
+use radiant::prelude as ui;
+
 use crate::native_app::app::{NativeAppState, NativeFileDropHover};
+use crate::native_app::app_chrome::waveform_context_menu;
 use crate::native_app::waveform::WaveformState;
 
 pub(in crate::native_app) struct WaveformPanelViewModel<'a> {
@@ -10,7 +13,7 @@ pub(in crate::native_app) struct WaveformPanelViewModel<'a> {
     pub(in crate::native_app) beat_guides_enabled: bool,
     pub(in crate::native_app) beat_guide_count: u8,
     pub(in crate::native_app) normalized_audition_enabled: bool,
-    pub(in crate::native_app) context_menu_open: bool,
+    pub(in crate::native_app) playhead_occlusion_rect: Option<ui::Rect>,
 }
 
 impl<'a> WaveformPanelViewModel<'a> {
@@ -24,8 +27,12 @@ impl<'a> WaveformPanelViewModel<'a> {
             beat_guides_enabled: state.ui.chrome.beat_guides_enabled,
             beat_guide_count: state.ui.chrome.beat_guide_count,
             normalized_audition_enabled: state.audio.normalized_audition_enabled,
-            context_menu_open: state.ui.browser_interaction.context_menu.is_some()
-                || state.ui.browser_interaction.waveform_context_menu.is_some(),
+            playhead_occlusion_rect: state
+                .ui
+                .browser_interaction
+                .waveform_context_menu
+                .as_ref()
+                .map(waveform_context_menu::overlay_rect),
         }
     }
 }

--- a/src/native_app/app_chrome/view_models/waveform_panel.rs
+++ b/src/native_app/app_chrome/view_models/waveform_panel.rs
@@ -10,6 +10,7 @@ pub(in crate::native_app) struct WaveformPanelViewModel<'a> {
     pub(in crate::native_app) beat_guides_enabled: bool,
     pub(in crate::native_app) beat_guide_count: u8,
     pub(in crate::native_app) normalized_audition_enabled: bool,
+    pub(in crate::native_app) context_menu_open: bool,
 }
 
 impl<'a> WaveformPanelViewModel<'a> {
@@ -23,6 +24,8 @@ impl<'a> WaveformPanelViewModel<'a> {
             beat_guides_enabled: state.ui.chrome.beat_guides_enabled,
             beat_guide_count: state.ui.chrome.beat_guide_count,
             normalized_audition_enabled: state.audio.normalized_audition_enabled,
+            context_menu_open: state.ui.browser_interaction.context_menu.is_some()
+                || state.ui.browser_interaction.waveform_context_menu.is_some(),
         }
     }
 }

--- a/src/native_app/app_chrome/waveform_context_menu.rs
+++ b/src/native_app/app_chrome/waveform_context_menu.rs
@@ -6,10 +6,20 @@ use crate::native_app::app::GuiMessage;
 use crate::native_app::waveform::{WaveformContextMenu, WaveformInteraction};
 
 pub(in crate::native_app) fn overlay(menu: &WaveformContextMenu) -> ui::View<GuiMessage> {
-    ui::message_context_menu_overlay_auto_width(
-        menu.anchor,
-        menu.title.clone(),
-        playmark_context_menu_commands(menu.extract_to_harvest_destination),
+    let commands = playmark_context_menu_commands(menu.extract_to_harvest_destination);
+    let size = overlay_size(&menu.title, &commands);
+    ui::message_context_menu_overlay(menu.anchor, size, menu.title.clone(), commands)
+}
+
+pub(in crate::native_app) fn overlay_rect(menu: &WaveformContextMenu) -> ui::Rect {
+    let commands = playmark_context_menu_commands(menu.extract_to_harvest_destination);
+    ui::Rect::from_min_size(menu.anchor, overlay_size(&menu.title, &commands))
+}
+
+fn overlay_size(title: &str, commands: &[ui::MenuCommand<GuiMessage>]) -> ui::Vector2 {
+    ui::Vector2::new(
+        ui::MessageMenuWidthPolicy::compact().width_for_title_and_commands(title, commands),
+        ui::message_menu_height(commands.len()),
     )
 }
 

--- a/src/native_app/app_chrome/waveform_panel.rs
+++ b/src/native_app/app_chrome/waveform_panel.rs
@@ -40,7 +40,7 @@ fn waveform_viewport_with_loading_state(
         model.beat_guides_enabled,
         model.beat_guide_count,
         model.normalized_audition_enabled,
-        model.context_menu_open,
+        model.playhead_occlusion_rect,
     )
     .fill_width()
     .height(WAVEFORM_VIEW_HEIGHT);

--- a/src/native_app/app_chrome/waveform_panel.rs
+++ b/src/native_app/app_chrome/waveform_panel.rs
@@ -40,6 +40,7 @@ fn waveform_viewport_with_loading_state(
         model.beat_guides_enabled,
         model.beat_guide_count,
         model.normalized_audition_enabled,
+        model.context_menu_open,
     )
     .fill_width()
     .height(WAVEFORM_VIEW_HEIGHT);

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -250,7 +250,7 @@ impl NativeAppState {
         context: TransientOverlayContext<'_>,
         primitives: &mut Vec<PaintPrimitive>,
     ) {
-        if self.blocking_modal_suppresses_waveform_transient_overlay() {
+        if self.chrome_overlay_suppresses_waveform_transient_overlay() {
             return;
         }
         let Some(progress) = self.current_audio_progress_ratio() else {
@@ -273,7 +273,7 @@ impl NativeAppState {
         context: TransientOverlayContext<'_>,
         primitives: &mut Vec<PaintPrimitive>,
     ) {
-        if self.blocking_modal_suppresses_waveform_transient_overlay() {
+        if self.chrome_overlay_suppresses_waveform_transient_overlay() {
             return;
         }
         self.paint_loading_overlay(context, primitives);
@@ -281,13 +281,15 @@ impl NativeAppState {
     }
 
     pub(in crate::native_app) fn should_paint_waveform_transient_overlay(&self) -> bool {
-        !self.blocking_modal_suppresses_waveform_transient_overlay()
+        !self.chrome_overlay_suppresses_waveform_transient_overlay()
             && (self.waveform.current.is_playing() || self.waveform.load.label.is_some())
     }
 
-    fn blocking_modal_suppresses_waveform_transient_overlay(&self) -> bool {
+    fn chrome_overlay_suppresses_waveform_transient_overlay(&self) -> bool {
         self.ui.chrome.shortcut_help_open
             || self.ui.chrome.transaction_list_open
+            || self.ui.browser_interaction.context_menu.is_some()
+            || self.ui.browser_interaction.waveform_context_menu.is_some()
             || self
                 .library
                 .folder_browser

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -347,6 +347,32 @@ fn waveform_context_menu_suppresses_waveform_transient_overlay() {
     );
 }
 
+#[test]
+fn waveform_context_menu_suppresses_stopped_playhead_surface_marker() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.25);
+    state.waveform.current.stop_playback();
+    state.waveform.current.set_playhead_ratio(0.25);
+    state.ui.browser_interaction.waveform_context_menu = Some(
+        crate::native_app::test_support::context_menu::WaveformContextMenu {
+            anchor: radiant::gui::types::Point::new(240.0, 160.0),
+            title: String::from("Playmark Selection"),
+            extract_to_harvest_destination: false,
+        },
+    );
+    let theme = radiant::theme::ThemeTokens::default();
+    let runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+
+    assert!(
+        !frame
+            .paint_plan
+            .fill_rects_for_widget(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+            .any(|fill| { fill.color.r == 71 && fill.color.g == 220 && fill.color.b == 255 }),
+        "waveform context menus should also hide the stopped playhead marker baked into waveform paint"
+    );
+}
+
 fn apply_gui_message_for_presentation_test(
     state: &mut NativeAppState,
     message: GuiMessage,

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -304,6 +304,49 @@ fn shortcut_help_modal_suppresses_waveform_transient_overlay() {
     );
 }
 
+#[test]
+fn waveform_context_menu_suppresses_waveform_transient_overlay() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.25);
+    state.ui.browser_interaction.waveform_context_menu = Some(
+        crate::native_app::test_support::context_menu::WaveformContextMenu {
+            anchor: radiant::gui::types::Point::new(240.0, 160.0),
+            title: String::from("Playmark Selection"),
+            extract_to_harvest_destination: false,
+        },
+    );
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(apply_gui_message_for_presentation_test)
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+    let theme = radiant::theme::ThemeTokens::default();
+    let frame = runtime.frame(&theme);
+    let mut primitives = Vec::new();
+
+    runtime.bridge_mut().paint_transient_overlay(
+        TransientOverlayContext::new(
+            &frame.paint_plan,
+            Vector2::new(900.0, 620.0),
+            Duration::ZERO,
+        ),
+        &mut primitives,
+    );
+    assert!(
+        !primitives
+            .iter()
+            .filter_map(|primitive| primitive.fill_rect())
+            .any(|fill| {
+                fill.widget_id == crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID
+                    && fill.color.r == 71
+                    && fill.color.g == 220
+                    && fill.color.b == 255
+            }),
+        "waveform context menus should keep live playback cursor overlays behind menu chrome"
+    );
+}
+
 fn apply_gui_message_for_presentation_test(
     state: &mut NativeAppState,
     message: GuiMessage,

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -348,28 +348,36 @@ fn waveform_context_menu_suppresses_waveform_transient_overlay() {
 }
 
 #[test]
-fn waveform_context_menu_suppresses_stopped_playhead_surface_marker() {
+fn waveform_context_menu_occludes_stopped_playhead_surface_marker() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
     state.waveform.current.stop_playback();
     state.waveform.current.set_playhead_ratio(0.25);
-    state.ui.browser_interaction.waveform_context_menu = Some(
-        crate::native_app::test_support::context_menu::WaveformContextMenu {
-            anchor: radiant::gui::types::Point::new(240.0, 160.0),
-            title: String::from("Playmark Selection"),
-            extract_to_harvest_destination: false,
-        },
-    );
+    let menu = crate::native_app::test_support::context_menu::WaveformContextMenu {
+        anchor: radiant::gui::types::Point::new(240.0, 160.0),
+        title: String::from("Playmark Selection"),
+        extract_to_harvest_destination: false,
+    };
+    let menu_rect = crate::native_app::app_chrome::waveform_context_menu::overlay_rect(&menu);
+    state.ui.browser_interaction.waveform_context_menu = Some(menu);
     let theme = radiant::theme::ThemeTokens::default();
     let runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
     let frame = runtime.frame(&theme);
+    let stopped_playhead_fills = frame
+        .paint_plan
+        .fill_rects_for_widget(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+        .filter(|fill| fill.color.r == 71 && fill.color.g == 220 && fill.color.b == 255)
+        .collect::<Vec<_>>();
 
     assert!(
-        !frame
-            .paint_plan
-            .fill_rects_for_widget(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
-            .any(|fill| { fill.color.r == 71 && fill.color.g == 220 && fill.color.b == 255 }),
-        "waveform context menus should also hide the stopped playhead marker baked into waveform paint"
+        !stopped_playhead_fills.is_empty(),
+        "waveform context menus should keep the stopped playhead visible outside menu chrome"
+    );
+    assert!(
+        !stopped_playhead_fills
+            .iter()
+            .any(|fill| rects_overlap(fill.rect, menu_rect)),
+        "stopped playhead marker should not paint through the context-menu rectangle"
     );
 }
 
@@ -383,6 +391,10 @@ fn apply_gui_message_for_presentation_test(
     if !frame_message {
         context.request_repaint();
     }
+}
+
+fn rects_overlap(a: radiant::gui::types::Rect, b: radiant::gui::types::Rect) -> bool {
+    a.min.x < b.max.x && a.max.x > b.min.x && a.min.y < b.max.y && a.max.y > b.min.y
 }
 
 #[test]

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -455,7 +455,9 @@ impl WaveformWidget {
                 EDIT_SELECTION_COLOR.with_alpha(230),
             );
         }
-        if let Some(playhead_ratio) = self.visible_ratio_for_absolute(self.playhead_ratio) {
+        if !self.context_menu_open
+            && let Some(playhead_ratio) = self.visible_ratio_for_absolute(self.playhead_ratio)
+        {
             paint.push_horizontal_value_cursor_fill(bounds, playhead_ratio, 2.0, PLAYHEAD_COLOR);
         }
     }

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -1,5 +1,6 @@
 use radiant::{
-    gui::types::{Rect, Rgba8},
+    gui::feedback::horizontal_value_cursor_rect,
+    gui::types::{Point, Rect, Rgba8},
     gui::visualization::{
         CanvasSelectionAffordancePaintParts, CanvasSelectionAffordanceStyle,
         CanvasSelectionGeometry, CanvasSelectionPaintStyle, DragHandleRole,
@@ -455,10 +456,45 @@ impl WaveformWidget {
                 EDIT_SELECTION_COLOR.with_alpha(230),
             );
         }
-        if !self.context_menu_open
-            && let Some(playhead_ratio) = self.visible_ratio_for_absolute(self.playhead_ratio)
-        {
-            paint.push_horizontal_value_cursor_fill(bounds, playhead_ratio, 2.0, PLAYHEAD_COLOR);
+        if let Some(playhead_ratio) = self.visible_ratio_for_absolute(self.playhead_ratio) {
+            self.append_playhead_marker_paint(paint, bounds, playhead_ratio);
+        }
+    }
+
+    fn append_playhead_marker_paint(
+        &self,
+        paint: &mut WidgetPaint<'_>,
+        bounds: Rect,
+        playhead_ratio: f32,
+    ) {
+        const PLAYHEAD_WIDTH: f32 = 2.0;
+        let Some(cursor) = horizontal_value_cursor_rect(bounds, playhead_ratio, PLAYHEAD_WIDTH)
+        else {
+            return;
+        };
+        let Some(occlusion) = self.playhead_occlusion_rect else {
+            paint.push_visible_fill_rect(cursor, PLAYHEAD_COLOR);
+            return;
+        };
+        if !rects_overlap(cursor, occlusion) {
+            paint.push_visible_fill_rect(cursor, PLAYHEAD_COLOR);
+            return;
+        }
+
+        let top_max_y = occlusion.min.y.clamp(cursor.min.y, cursor.max.y);
+        if top_max_y > cursor.min.y {
+            paint.push_visible_fill_rect(
+                Rect::from_min_max(cursor.min, Point::new(cursor.max.x, top_max_y)),
+                PLAYHEAD_COLOR,
+            );
+        }
+
+        let bottom_min_y = occlusion.max.y.clamp(cursor.min.y, cursor.max.y);
+        if bottom_min_y < cursor.max.y {
+            paint.push_visible_fill_rect(
+                Rect::from_min_max(Point::new(cursor.min.x, bottom_min_y), cursor.max),
+                PLAYHEAD_COLOR,
+            );
         }
     }
 
@@ -683,6 +719,10 @@ impl WaveformWidget {
             DragHandleRole::LeadingControl => {}
         }
     }
+}
+
+fn rects_overlap(a: Rect, b: Rect) -> bool {
+    a.min.x < b.max.x && a.max.x > b.min.x && a.min.y < b.max.y && a.max.y > b.min.y
 }
 
 fn active_selection_drag_kind(

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -87,6 +87,42 @@ fn playhead_cursor_paints_for_static_small_playmark_selection() {
 }
 
 #[test]
+fn playhead_cursor_paints_around_occlusion_rect() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.set_playhead_ratio(0.25);
+    let props = WaveformWidgetProps::from_state_with_playhead_occlusion(
+        &state,
+        false,
+        4,
+        Some(Rect::from_min_max(
+            Point::new(99.0, 20.0),
+            Point::new(101.0, 60.0),
+        )),
+    );
+    let widget = WaveformWidget::new(props);
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(400.0, 80.0));
+
+    let playhead_segments = fill_rects(&plan)
+        .into_iter()
+        .filter(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (71, 220, 255, 245)
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(playhead_segments.len(), 2);
+    assert!(
+        playhead_segments
+            .iter()
+            .any(|fill| fill.rect.min.y == 0.0 && fill.rect.max.y == 20.0)
+    );
+    assert!(
+        playhead_segments
+            .iter()
+            .any(|fill| fill.rect.min.y == 60.0 && fill.rect.max.y == 80.0)
+    );
+}
+
+#[test]
 fn hover_cursor_paints_thin_white_overlay_line() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -41,12 +41,14 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     beat_guides_enabled: bool,
     beat_guide_count: u8,
     normalized_audition_enabled: bool,
+    context_menu_open: bool,
 ) -> ui::View<GuiMessage> {
     let interaction = ui::custom_widget(
-        WaveformWidget::new(WaveformWidgetProps::from_state(
+        WaveformWidget::new(WaveformWidgetProps::from_state_with_context_menu(
             state,
             beat_guides_enabled,
             beat_guide_count,
+            context_menu_open,
         )),
         |output| {
             output
@@ -163,14 +165,25 @@ pub(in crate::native_app) struct WaveformWidgetProps {
     sample_slide_frame_offset: Option<i64>,
     beat_guides_enabled: bool,
     beat_guide_count: u8,
+    context_menu_open: bool,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
 impl WaveformWidgetProps {
+    #[cfg(test)]
     pub(super) fn from_state(
         state: &WaveformState,
         beat_guides_enabled: bool,
         beat_guide_count: u8,
+    ) -> Self {
+        Self::from_state_with_context_menu(state, beat_guides_enabled, beat_guide_count, false)
+    }
+
+    pub(super) fn from_state_with_context_menu(
+        state: &WaveformState,
+        beat_guides_enabled: bool,
+        beat_guide_count: u8,
+        context_menu_open: bool,
     ) -> Self {
         let active_drag_kind = state.active_drag_kind();
         Self {
@@ -209,6 +222,7 @@ impl WaveformWidgetProps {
             sample_slide_frame_offset: state.pending_sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
+            context_menu_open,
             active_drag_kind,
         }
     }
@@ -260,6 +274,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) sample_slide_frame_offset: Option<i64>,
     pub(super) beat_guides_enabled: bool,
     pub(super) beat_guide_count: u8,
+    pub(super) context_menu_open: bool,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
     pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
@@ -294,6 +309,7 @@ impl WaveformWidget {
             sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
+            context_menu_open,
             active_drag_kind,
         } = props;
         let common = WidgetCommon::fixed(0, WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
@@ -325,6 +341,7 @@ impl WaveformWidget {
             sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
+            context_menu_open,
             edit_preview: edit_preview_for_selection(edit_selection),
             last_live_selection_update_visible_ratio: None,
             live_selection_preview_anchor: None,

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -41,14 +41,14 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     beat_guides_enabled: bool,
     beat_guide_count: u8,
     normalized_audition_enabled: bool,
-    context_menu_open: bool,
+    playhead_occlusion_rect: Option<Rect>,
 ) -> ui::View<GuiMessage> {
     let interaction = ui::custom_widget(
-        WaveformWidget::new(WaveformWidgetProps::from_state_with_context_menu(
+        WaveformWidget::new(WaveformWidgetProps::from_state_with_playhead_occlusion(
             state,
             beat_guides_enabled,
             beat_guide_count,
-            context_menu_open,
+            playhead_occlusion_rect,
         )),
         |output| {
             output
@@ -165,7 +165,7 @@ pub(in crate::native_app) struct WaveformWidgetProps {
     sample_slide_frame_offset: Option<i64>,
     beat_guides_enabled: bool,
     beat_guide_count: u8,
-    context_menu_open: bool,
+    playhead_occlusion_rect: Option<Rect>,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
@@ -176,14 +176,14 @@ impl WaveformWidgetProps {
         beat_guides_enabled: bool,
         beat_guide_count: u8,
     ) -> Self {
-        Self::from_state_with_context_menu(state, beat_guides_enabled, beat_guide_count, false)
+        Self::from_state_with_playhead_occlusion(state, beat_guides_enabled, beat_guide_count, None)
     }
 
-    pub(super) fn from_state_with_context_menu(
+    pub(super) fn from_state_with_playhead_occlusion(
         state: &WaveformState,
         beat_guides_enabled: bool,
         beat_guide_count: u8,
-        context_menu_open: bool,
+        playhead_occlusion_rect: Option<Rect>,
     ) -> Self {
         let active_drag_kind = state.active_drag_kind();
         Self {
@@ -222,7 +222,7 @@ impl WaveformWidgetProps {
             sample_slide_frame_offset: state.pending_sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
-            context_menu_open,
+            playhead_occlusion_rect,
             active_drag_kind,
         }
     }
@@ -274,7 +274,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) sample_slide_frame_offset: Option<i64>,
     pub(super) beat_guides_enabled: bool,
     pub(super) beat_guide_count: u8,
-    pub(super) context_menu_open: bool,
+    pub(super) playhead_occlusion_rect: Option<Rect>,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
     pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
@@ -309,7 +309,7 @@ impl WaveformWidget {
             sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
-            context_menu_open,
+            playhead_occlusion_rect,
             active_drag_kind,
         } = props;
         let common = WidgetCommon::fixed(0, WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
@@ -341,7 +341,7 @@ impl WaveformWidget {
             sample_slide_frame_offset,
             beat_guides_enabled,
             beat_guide_count,
-            context_menu_open,
+            playhead_occlusion_rect,
             edit_preview: edit_preview_for_selection(edit_selection),
             last_live_selection_update_visible_ratio: None,
             live_selection_preview_anchor: None,


### PR DESCRIPTION
## Summary
- Prevents the paint-only waveform playhead overlay from drawing above active context-menu chrome.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
