### PR TITLE
OPT-915: Keep focus on protected-source files after extraction

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -461,7 +461,7 @@ Derivation edges should be global/app-level state because they can cross sources
 
 Harvest state should be tracked per origin file as New, Seen, Touched, Done, or Ignored. “Has Derivatives” should be computed from the derivation graph rather than stored as the only state. Automatic transitions may move New to Seen or Touched, but must not override user Done or Ignored states. Manual actions may reset or override state.
 
-Protected-source extraction should create the derived file in the harvest destination by default, usually `Primary Source/_Harvests/<Source Name>/`, then focus/load the derived file so the user can immediately rate, tag, and organize it. Normal writable sources may keep current in-place behavior while Harvest Mode still tracks state and graph edges. The waveform should show immediate extraction success feedback for the selected range, such as a short pulse or flash.
+Protected-source extraction should create the derived file in the harvest destination by default, usually `Primary Source/_Harvests/<Source Name>/`, while keeping focus and the loaded waveform on the protected source file so the user's browsing and audition context stays intact. The derived file should still be registered and visible when the user navigates to the Harvest destination. Normal writable sources may keep current in-place behavior while Harvest Mode still tracks state and graph edges. The waveform should show immediate extraction success feedback for the selected range, such as a short pulse or flash.
 
 ### Wavecrate Sample ID
 

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -333,7 +333,7 @@ impl NativeAppState {
                     .path_is_in_protected_source(&completion.source_path);
                 let cross_source_derivative =
                     self.extraction_derivative_crosses_sources(&completion.source_path, &path);
-                let focus_derivative = protected_origin || cross_source_derivative;
+                let focus_derivative = cross_source_derivative && !protected_origin;
                 if focus_derivative {
                     self.library
                         .folder_browser

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -759,6 +759,7 @@ fn playmark_extraction_writes_new_file_into_protected_source() {
     );
     protect_selected_source_for_test(&mut scenario.state);
     load_selected_sample_into_waveform(&mut scenario);
+    let source_path = scenario.state.waveform.current.path();
     let source_parent = scenario
         .state
         .waveform
@@ -773,19 +774,20 @@ fn playmark_extraction_writes_new_file_into_protected_source() {
 
     assert!(extracted.is_file());
     assert_eq!(extracted.parent(), Some(source_parent.as_path()));
-    let ticket = active_sample_load_ticket(&scenario.state).expect("extracted sample load queued");
-    scenario.state.apply_message(
-        crate::native_app::test_support::state::GuiMessage::SampleLoadFinished(
-            sample_load_completion(
-                ticket,
-                extracted.to_string_lossy().to_string(),
-                crate::native_app::test_support::state::WaveformState::load_path(extracted.clone()),
-                true,
-            ),
-        ),
-        &mut ui::UiUpdateContext::default(),
+    assert_eq!(
+        scenario.state.library.folder_browser.selected_file_id(),
+        Some(source_path.to_string_lossy().as_ref()),
+        "protected-source extraction should keep browser focus on the source sample"
     );
-    assert_eq!(scenario.state.waveform.current.path(), extracted);
+    assert_eq!(
+        scenario.state.waveform.current.path(),
+        source_path,
+        "protected-source extraction should keep the source sample loaded"
+    );
+    assert!(
+        active_sample_load_ticket(&scenario.state).is_none(),
+        "protected-source extraction should not load the derivative automatically"
+    );
     assert_extracted_file_metadata(&scenario.state, &extracted, &["one-shot"]);
 }
 
@@ -849,26 +851,19 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
     );
     assert_eq!(
         scenario.state.library.folder_browser.selected_file_id(),
-        Some(extracted.to_string_lossy().as_ref())
+        Some(source_path.to_string_lossy().as_ref()),
+        "protected-source extraction should preserve source-file focus"
     );
     assert!(
         active_sample_load_validation_ticket(&scenario.state).is_none(),
-        "newly created derivatives should skip redundant path validation"
+        "protected-source extraction should not validate the derivative for auto-load"
     );
-    let ticket = active_sample_load_ticket(&scenario.state).expect("derivative sample load queued");
-    scenario.state.apply_message(
-        crate::native_app::test_support::state::GuiMessage::SampleLoadFinished(
-            sample_load_completion(
-                ticket,
-                extracted.to_string_lossy().to_string(),
-                crate::native_app::test_support::state::WaveformState::load_path(extracted.clone()),
-                true,
-            ),
-        ),
-        &mut ui::UiUpdateContext::default(),
+    assert!(
+        active_sample_load_ticket(&scenario.state).is_none(),
+        "protected-source extraction should not load the derivative automatically"
     );
-    assert_eq!(scenario.state.waveform.current.path(), extracted);
-    assert_extracted_file_metadata(&scenario.state, &extracted, &["one-shot"]);
+    assert_eq!(scenario.state.waveform.current.path(), source_path);
+    assert_extracted_metadata_tags(&scenario.state, &extracted, &["one-shot"]);
     let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
         protected_source.id.clone(),
         PathBuf::from("playmark-extract-protected-primary.wav"),
@@ -1102,6 +1097,15 @@ fn assert_extracted_file_metadata(
     extracted: &std::path::Path,
     tags: &[&str],
 ) {
+    assert_extracted_metadata_tags(state, extracted, tags);
+    assert_extracted_file_keep_1_rating(state, extracted);
+}
+
+fn assert_extracted_metadata_tags(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    extracted: &std::path::Path,
+    tags: &[&str],
+) {
     let file_id = extracted.to_string_lossy().to_string();
     let expected_tags = tags
         .iter()
@@ -1111,7 +1115,6 @@ fn assert_extracted_file_metadata(
         state.metadata.tags_by_file.get(&file_id),
         Some(&expected_tags)
     );
-    assert_extracted_file_keep_1_rating(state, extracted);
 }
 
 fn assert_extracted_file_keep_1_rating(


### PR DESCRIPTION
## Summary
- Keeps protected-source extraction focused on the original source file while still creating Harvest outputs.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
