### PR TITLE
OPT-916: Switch active playback to looped mode immediately

### DIFF
--- a/crates/reson/src/player/playback.rs
+++ b/crates/reson/src/player/playback.rs
@@ -147,6 +147,26 @@ impl AudioPlayer {
             PlaybackSeekBehavior::FrameOffset(offset_frames),
         )?;
 
+        if self.looping != looped {
+            return if looped {
+                self.start_with_looped_span_offset(
+                    bounded_start,
+                    bounded_end,
+                    duration,
+                    offset_seconds,
+                    metronome,
+                )
+            } else {
+                self.start_with_span_offset(
+                    bounded_start,
+                    bounded_end,
+                    duration,
+                    offset_seconds,
+                    metronome,
+                )
+            };
+        }
+
         let Some(playback_span) = self.active_playback_span.clone() else {
             return if looped {
                 self.start_with_looped_span_offset(

--- a/crates/reson/src/tests/player.rs
+++ b/crates/reson/src/tests/player.rs
@@ -160,6 +160,29 @@ fn play_looped_range_from_keeps_full_span() {
 }
 
 #[test]
+fn retarget_looped_range_keeps_one_shot_playback_alive_past_original_end() {
+    let Ok(mut player) = AudioPlayer::new() else {
+        return;
+    };
+    let duration = 0.08;
+    player.set_audio(silent_wav_bytes(duration, 44_100, 1), duration);
+
+    assert!(player.play_range(0.0, 0.25, false).is_ok());
+    assert!(
+        player
+            .retarget_looped_range_with_metronome(0.0, 0.25, 0.0, false, None)
+            .is_ok()
+    );
+    std::thread::sleep(Duration::from_millis(60));
+
+    assert!(
+        player.is_playing(),
+        "retargeting one-shot playback to looped should rebuild a looping source"
+    );
+    assert!(player.is_looping());
+}
+
+#[test]
 fn set_audio_prefers_provided_duration() {
     let Ok(mut player) = AudioPlayer::new() else {
         return;

--- a/src/native_app/audio/playback/intent.rs
+++ b/src/native_app/audio/playback/intent.rs
@@ -63,6 +63,17 @@ impl PlaybackIntent {
             ..Self::new(start_ratio, end_ratio)
         }
     }
+
+    pub(in crate::native_app) fn fixed_region_with_loop_offset(
+        start_ratio: f32,
+        end_ratio: f32,
+        loop_offset_ratio: Option<f32>,
+    ) -> Self {
+        Self {
+            loop_region_policy: PlaybackLoopRegionPolicy::UseIntentSpan,
+            ..Self::with_loop_offset(start_ratio, end_ratio, loop_offset_ratio)
+        }
+    }
 }
 
 impl PlaybackCommand {

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -1,6 +1,9 @@
 use std::time::Instant;
 
-use super::span::{playback_span_matches_selection, retarget_offset_for_selection};
+use super::{
+    PlaybackIntent,
+    span::{playback_span_matches_selection, retarget_offset_for_selection},
+};
 use crate::native_app::app::{NativeAppState, PendingPlaySelectionRetargetCycle, emit_gui_action};
 use wavecrate::audio::{AudioPlayer, PlaybackRuntimeSpanUpdate};
 
@@ -16,23 +19,23 @@ impl NativeAppState {
         let mut outcome = "success";
         let mut error = None;
         if self.waveform.current.is_playing()
-            && let Some((start, end)) = self.audio.current_playback_span
+            && let Some((start, end)) = self.active_playback_span_for_loop_toggle()
         {
             let current = self.current_audio_progress_ratio().unwrap_or(start);
-            let result = if self.audio.loop_playback {
-                self.start_playback_span(start, end, Some(current))
-            } else {
-                self.start_playback_current_span(current.clamp(start, end), end)
-            };
+            let result = self.apply_active_loop_toggle_mode(start, end, current);
             if let Err(err) = result {
-                self.audio.loop_playback = false;
-                self.audio.loop_playback_manual_override_path = previous_override;
-                self.ui.status.sample = format!("Loop toggle failed: {err}");
-                outcome = "error";
+                if self.audio.loop_playback {
+                    outcome = "pending";
+                } else {
+                    self.audio.loop_playback = true;
+                    self.audio.loop_playback_manual_override_path = previous_override;
+                    self.ui.status.sample = format!("Loop toggle failed: {err}");
+                    outcome = "error";
+                }
                 error = Some(err);
             }
         }
-        if outcome == "success" {
+        if outcome == "success" || outcome == "pending" {
             self.ui.status.sample = if self.audio.loop_playback {
                 String::from("Loop playback enabled")
             } else {
@@ -49,6 +52,32 @@ impl NativeAppState {
         );
     }
 
+    fn apply_active_loop_toggle_mode(
+        &mut self,
+        start: f32,
+        end: f32,
+        current: f32,
+    ) -> Result<(), String> {
+        if self.audio.loop_playback {
+            let offset = if current >= start && current < end {
+                current
+            } else {
+                start.clamp(0.0, 1.0)
+            };
+            self.start_playback_intent_with_history(
+                PlaybackIntent::fixed_region_with_loop_offset(start, end, Some(offset)),
+                false,
+            )?;
+            self.audio.current_playback_span = Some((start, end));
+            if let Some(pending) = self.audio.pending_runtime_start.as_mut() {
+                pending.span = (start, end);
+            }
+            Ok(())
+        } else {
+            self.retarget_active_playback_mode(start, end, current)
+        }
+    }
+
     pub(in crate::native_app) fn current_audio_progress_ratio(&self) -> Option<f32> {
         self.audio
             .player
@@ -58,7 +87,7 @@ impl NativeAppState {
     }
 
     pub(super) fn recover_loop_playback(&mut self, reason: &'static str) -> Result<(), String> {
-        let Some((start, end)) = self.audio.current_playback_span else {
+        let Some((start, end)) = self.active_playback_span_for_loop_toggle() else {
             return Err(String::from("No active playback span to loop"));
         };
         let offset = self.current_audio_progress_ratio().unwrap_or(start);
@@ -72,6 +101,42 @@ impl NativeAppState {
             None,
         );
         Ok(())
+    }
+
+    fn active_playback_span_for_loop_toggle(&self) -> Option<(f32, f32)> {
+        self.audio.current_playback_span.or_else(|| {
+            self.waveform
+                .current
+                .play_selection()
+                .filter(|selection| selection.width() > 0.0)
+                .map(|selection| (selection.start(), selection.end()))
+                .or_else(|| {
+                    self.waveform
+                        .current
+                        .has_loaded_sample()
+                        .then_some((0.0, 1.0))
+                })
+        })
+    }
+
+    pub(super) fn retarget_active_playback_mode(
+        &mut self,
+        start: f32,
+        end: f32,
+        current: f32,
+    ) -> Result<(), String> {
+        if self.audio.loop_playback {
+            let current_inside_span = current >= start && current < end;
+            let offset = if current_inside_span {
+                current
+            } else {
+                start.clamp(0.0, 1.0)
+            };
+            self.retarget_active_playback_span(start, end, offset, true, true)
+        } else {
+            let one_shot_start = current.clamp(start, end);
+            self.retarget_active_playback_span(one_shot_start, end, one_shot_start, true, false)
+        }
     }
 
     pub(in crate::native_app) fn retarget_playback_to_play_selection(&mut self) {

--- a/src/native_app/audio/playback/policy.rs
+++ b/src/native_app/audio/playback/policy.rs
@@ -92,11 +92,7 @@ impl NativeAppState {
             return;
         };
         let current = self.current_audio_progress_ratio().unwrap_or(start);
-        let result = if self.audio.loop_playback {
-            self.start_playback_span(start, end, Some(current))
-        } else {
-            self.start_playback_current_span(current.clamp(start, end), end)
-        };
+        let result = self.retarget_active_playback_mode(start, end, current);
         if let Err(err) = result {
             self.audio.loop_playback = was_looping;
             self.ui.status.sample = format!("Playback mode update failed: {err}");

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, time::Instant};
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
 
 use super::PLAYBACK_START_ACTIVE_SOURCE_GRACE;
 use crate::native_app::app::{NativeAppState, emit_gui_action, sample_path_label};
@@ -113,6 +116,11 @@ impl NativeAppState {
         }
         self.audio.output_resolved = Some(started.output);
         self.audio.current_playback_span = Some(pending.span);
+        self.audio.playback_progress.active = true;
+        self.audio.playback_progress.elapsed = Some(Duration::ZERO);
+        self.audio.playback_progress.looping = self.audio.loop_playback;
+        self.audio.playback_progress.progress = Some(started.playback_start);
+        self.audio.playback_progress.error = None;
         if self.waveform.current.path() == Path::new(&pending.path) {
             if pending.show_start_marker {
                 self.waveform.current.start_playback(started.playback_start);
@@ -215,6 +223,12 @@ impl NativeAppState {
     fn refresh_runtime_playback_progress(&mut self) {
         if let Some(error) = self.audio.playback_progress.error.take() {
             self.stop_playback_after_progress_error(error);
+            return;
+        }
+        if self.audio.pending_runtime_start.is_some() {
+            if let Some(progress) = self.audio.playback_progress.progress {
+                self.waveform.current.set_playhead_ratio(progress);
+            }
             return;
         }
 

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -561,6 +561,49 @@ fn loop_toggle_after_spacebar_keeps_runtime_looping_past_original_end() {
 }
 
 #[test]
+fn loop_toggle_waits_for_pending_runtime_start_before_recovering() {
+    let Some(mut scenario) =
+        WaveformPlaybackScenario::loaded_with_player("loop-toggle-pending-start.wav", &[0; 4800])
+    else {
+        return;
+    };
+    scenario.play_selected_sample();
+    scenario.apply_playback_frame();
+
+    scenario.state.toggle_loop_playback();
+    let pending_loop_start = pending_runtime_playback_start_id(&scenario.state)
+        .expect("loop toggle should submit a looped runtime start");
+    scenario.state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: false,
+        elapsed: Some(std::time::Duration::from_millis(250)),
+        looping: false,
+        progress: Some(0.98),
+        error: None,
+    };
+
+    scenario.state.refresh_playback_progress();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        Some(pending_loop_start),
+        "stale one-shot progress must not trigger another loop recovery while the loop start is pending"
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    scenario.apply_playback_frame();
+
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        None,
+        "accepted loop starts must replace stale one-shot progress instead of immediately recovering again"
+    );
+    assert!(scenario.state.audio.playback_progress.active);
+    assert!(scenario.state.audio.playback_progress.looping);
+}
+
+#[test]
 fn loop_toggle_while_playing_recovers_when_current_span_is_missing() {
     let Some(mut scenario) =
         WaveformPlaybackScenario::loaded_with_player("loop-toggle-missing-span.wav", &[0; 4800])

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -490,6 +490,136 @@ fn play_selected_sample_uses_active_playmark_selection_span() {
 }
 
 #[test]
+fn enabling_loop_during_active_fixed_range_playback_preserves_current_span() {
+    let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
+        return;
+    };
+    scenario
+        .state
+        .start_playback_fixed_span_without_history(0.25, 0.60)
+        .expect("fixed range playback starts");
+    scenario.state.waveform.current.set_playhead_ratio(0.40);
+    let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
+
+    scenario.state.toggle_loop_playback();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert_waveform_progress_near(&scenario.state, 0.40);
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        playback_start_id,
+        "loop toggle should retarget the active source instead of queuing another play start"
+    );
+}
+
+#[test]
+fn enabling_loop_during_active_playmark_playback_keeps_selected_range_active() {
+    let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
+        return;
+    };
+    scenario.select_play_range(0.25, 0.60);
+    scenario.play_selected_sample();
+    scenario.state.waveform.current.set_playhead_ratio(0.40);
+    let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
+
+    scenario.state.toggle_loop_playback();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert_playback_span_state(&scenario.state, 0.25, 0.60);
+    assert_waveform_progress_near(&scenario.state, 0.40);
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        playback_start_id,
+        "loop toggle should not require a second play command"
+    );
+}
+
+#[test]
+fn loop_toggle_after_spacebar_keeps_runtime_looping_past_original_end() {
+    let Some(mut scenario) =
+        WaveformPlaybackScenario::loaded_with_player("loop-toggle-runtime.wav", &[0; 4800])
+    else {
+        return;
+    };
+    scenario.play_selected_sample();
+    scenario.apply_playback_frame();
+
+    scenario.state.toggle_loop_playback();
+    scenario.apply_playback_frame();
+    std::thread::sleep(std::time::Duration::from_millis(140));
+    scenario.apply_playback_frame();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert!(
+        scenario.state.audio.playback_progress.looping,
+        "runtime playback should switch to looped mode after toggling Loop during spacebar playback"
+    );
+}
+
+#[test]
+fn loop_toggle_while_playing_recovers_when_current_span_is_missing() {
+    let Some(mut scenario) =
+        WaveformPlaybackScenario::loaded_with_player("loop-toggle-missing-span.wav", &[0; 4800])
+    else {
+        return;
+    };
+    scenario.play_selected_sample();
+    scenario.apply_playback_frame();
+    scenario.state.audio.current_playback_span = None;
+
+    scenario.state.toggle_loop_playback();
+    scenario.apply_playback_frame();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert_eq!(scenario.state.audio.current_playback_span, Some((0.0, 1.0)));
+    assert!(
+        scenario.state.audio.playback_progress.looping,
+        "loop toggle should retarget from the visible loaded sample when span state is missing"
+    );
+}
+
+#[test]
+fn disabling_loop_during_active_playback_retargets_to_one_shot_tail() {
+    let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
+        return;
+    };
+    scenario.start_full_sample_loop();
+    scenario.state.waveform.current.set_playhead_ratio(0.40);
+    let playback_start_id = pending_runtime_playback_start_id(&scenario.state);
+
+    scenario.state.toggle_loop_playback();
+
+    assert!(!scenario.state.audio.loop_playback);
+    assert!(scenario.state.waveform.current.is_playing());
+    assert_playback_span_state(&scenario.state, 0.40, 1.0);
+    assert_waveform_progress_near(&scenario.state, 0.40);
+    assert_eq!(
+        pending_runtime_playback_start_id(&scenario.state),
+        playback_start_id,
+        "loop-off should retarget the active source into one-shot playback"
+    );
+}
+
+#[test]
+fn idle_loop_toggle_does_not_start_playback() {
+    let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
+        return;
+    };
+
+    scenario.state.toggle_loop_playback();
+
+    assert!(scenario.state.audio.loop_playback);
+    assert!(!scenario.state.waveform.current.is_playing());
+    assert_eq!(scenario.state.audio.current_playback_span, None);
+    assert_eq!(pending_runtime_playback_start_id(&scenario.state), None);
+}
+
+#[test]
 fn playmark_selection_copy_uses_interactive_handoff_worker() {
     let mut scenario =
         WaveformPlaybackScenario::with_temp_wav("playmark-copy.wav", &[0, 1024, -1024, 512]);

--- a/src/native_app/tests/waveform_playback/fixture.rs
+++ b/src/native_app/tests/waveform_playback/fixture.rs
@@ -110,6 +110,12 @@ impl WaveformPlaybackScenario {
         );
     }
 
+    pub(super) fn apply_playback_frame(&mut self) {
+        self.state.drain_playback_runtime_events();
+        self.state.refresh_playback_progress();
+        self.state.drain_playback_runtime_events();
+    }
+
     pub(super) fn play_random_range_with_units(&mut self, start_unit: f32, length_unit: f32) {
         self.state.play_random_sample_range_with_units(
             crate::native_app::audio::playback::RandomAuditionUnits::new(start_unit, length_unit),


### PR DESCRIPTION
## Summary
- Retargets active playback into loop mode as soon as looping is enabled.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
