### PR TITLE
OPT-917: Add H hotkey to toggle selected files as harvested

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -166,6 +166,7 @@ pub(in crate::native_app) enum GuiMessage {
     MarkContextSampleHarvestDone,
     MarkContextSampleHarvestIgnored,
     ResetContextSampleHarvest,
+    ToggleSelectedHarvestDone,
     ShowContextSampleHarvestOrigin,
     ShowContextSampleHarvestDerivatives,
     OpenContextSampleHarvestDestination,

--- a/src/native_app/sample_library/harvest_tracking.rs
+++ b/src/native_app/sample_library/harvest_tracking.rs
@@ -54,6 +54,7 @@ struct HarvestSeenPersistRequest {
 struct HarvestStateTarget {
     path: PathBuf,
     identity: HarvestFileIdentity,
+    state: HarvestState,
 }
 
 impl NativeAppState {
@@ -444,6 +445,64 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn reset_context_sample_harvest(&mut self) {
         self.set_context_sample_harvest_state(HarvestState::New, "Reset harvest state", "reset");
+    }
+
+    pub(in crate::native_app) fn toggle_selected_harvest_done(&mut self) {
+        let started_at = std::time::Instant::now();
+        let Some(targets) =
+            self.selected_harvest_state_targets("browser.harvest.toggle_done", started_at)
+        else {
+            return;
+        };
+        let target_state = if targets
+            .iter()
+            .all(|target| target.state == HarvestState::Done)
+        {
+            HarvestState::New
+        } else {
+            HarvestState::Done
+        };
+        let mut applied_any = false;
+        for target in &targets {
+            if let Err(error) =
+                wavecrate::sample_sources::library::upsert_harvest_file(&target.identity)
+            {
+                self.finish_toggle_selected_harvest_done_error(
+                    &targets,
+                    applied_any,
+                    started_at,
+                    error.to_string(),
+                );
+                return;
+            }
+            if let Err(error) = wavecrate::sample_sources::library::set_harvest_state(
+                &target.identity.key,
+                target_state,
+            ) {
+                self.finish_toggle_selected_harvest_done_error(
+                    &targets,
+                    applied_any,
+                    started_at,
+                    error.to_string(),
+                );
+                return;
+            }
+            applied_any = true;
+        }
+
+        self.library
+            .folder_browser
+            .refresh_after_harvest_state_change();
+        let target_label = harvest_state_targets_label(&targets);
+        self.ui.status.sample = harvest_state_toggle_status(target_state, &targets);
+        emit_gui_action(
+            "browser.harvest.toggle_done",
+            Some("browser"),
+            Some(target_label.as_str()),
+            harvest_state_toggle_outcome(target_state),
+            started_at,
+            None,
+        );
     }
 
     pub(in crate::native_app) fn show_context_sample_harvest_origin(
@@ -1024,7 +1083,11 @@ impl NativeAppState {
                 );
                 return None;
             };
-            targets.push(HarvestStateTarget { path, identity });
+            targets.push(HarvestStateTarget {
+                path,
+                identity,
+                state: HarvestState::New,
+            });
         }
         Some(targets)
     }
@@ -1108,6 +1171,98 @@ impl NativeAppState {
             return None;
         };
         Some((path, identity))
+    }
+
+    fn selected_harvest_state_targets(
+        &mut self,
+        action: &'static str,
+        started_at: std::time::Instant,
+    ) -> Option<Vec<HarvestStateTarget>> {
+        let mut paths = self.library.folder_browser.explicit_selected_file_paths();
+        if paths.is_empty() {
+            let Some(path) = self
+                .library
+                .folder_browser
+                .selected_file_id()
+                .map(PathBuf::from)
+            else {
+                self.ui.status.sample = String::from("Select a sample for harvest actions");
+                emit_gui_action(
+                    action,
+                    Some("browser"),
+                    None,
+                    "blocked",
+                    started_at,
+                    Some("no selected sample"),
+                );
+                return None;
+            };
+            paths.push(path);
+        }
+
+        let mut targets = Vec::with_capacity(paths.len());
+        for path in paths {
+            let Some(identity) = self.harvest_identity_for_path(&path) else {
+                self.ui.status.sample =
+                    String::from("Sample is not in a configured harvest source");
+                emit_gui_action(
+                    action,
+                    Some("browser"),
+                    Some(context_menu::target_label(&path).as_str()),
+                    "not_found",
+                    started_at,
+                    Some("harvest identity unavailable"),
+                );
+                return None;
+            };
+            let state = match wavecrate::sample_sources::library::harvest_file(&identity.key) {
+                Ok(record) => record
+                    .map(|record| record.state)
+                    .unwrap_or(HarvestState::New),
+                Err(error) => {
+                    self.ui.status.sample = format!("Update harvest state failed: {error}");
+                    emit_gui_action(
+                        action,
+                        Some("browser"),
+                        Some(context_menu::target_label(&path).as_str()),
+                        "error",
+                        started_at,
+                        Some(&error.to_string()),
+                    );
+                    return None;
+                }
+            };
+            targets.push(HarvestStateTarget {
+                path,
+                identity,
+                state,
+            });
+        }
+        Some(targets)
+    }
+
+    fn finish_toggle_selected_harvest_done_error(
+        &mut self,
+        targets: &[HarvestStateTarget],
+        applied_any: bool,
+        started_at: std::time::Instant,
+        error: String,
+    ) {
+        if applied_any {
+            self.library
+                .folder_browser
+                .refresh_after_harvest_state_change();
+        }
+        let target_label = harvest_state_targets_label(targets);
+        self.ui.status.sample = format!("Update harvest state failed: {error}");
+        emit_gui_action(
+            "browser.harvest.toggle_done",
+            Some("browser"),
+            Some(target_label.as_str()),
+            "error",
+            started_at,
+            Some(error.as_str()),
+        );
     }
 
     fn harvest_path_for_key(&self, key: &HarvestFileKey) -> Option<PathBuf> {
@@ -1210,6 +1365,27 @@ fn harvest_state_display_label(state: HarvestState) -> &'static str {
         HarvestState::Touched => "Touched",
         HarvestState::Done => "Done",
         HarvestState::Ignored => "Ignored",
+    }
+}
+
+fn harvest_state_toggle_status(state: HarvestState, targets: &[HarvestStateTarget]) -> String {
+    let prefix = match state {
+        HarvestState::Done => "Marked harvest done",
+        HarvestState::New => "Reset harvest state",
+        _ => "Updated harvest state",
+    };
+    if targets.len() == 1 {
+        format!("{prefix} {}", sample_path_label(&targets[0].path))
+    } else {
+        format!("{prefix} {} samples", targets.len())
+    }
+}
+
+fn harvest_state_toggle_outcome(state: HarvestState) -> &'static str {
+    match state {
+        HarvestState::Done => "done",
+        HarvestState::New => "reset",
+        _ => "updated",
     }
 }
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -95,6 +95,7 @@ impl NativeAppState {
             | GuiMessage::MarkContextSampleHarvestDone
             | GuiMessage::MarkContextSampleHarvestIgnored
             | GuiMessage::ResetContextSampleHarvest
+            | GuiMessage::ToggleSelectedHarvestDone
             | GuiMessage::ShowContextSampleHarvestOrigin
             | GuiMessage::ShowContextSampleHarvestDerivatives
             | GuiMessage::OpenContextSampleHarvestDestination

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -28,6 +28,7 @@ impl NativeAppState {
                 self.mark_context_sample_harvest_ignored()
             }
             GuiMessage::ResetContextSampleHarvest => self.reset_context_sample_harvest(),
+            GuiMessage::ToggleSelectedHarvestDone => self.toggle_selected_harvest_done(),
             GuiMessage::ShowContextSampleHarvestOrigin => {
                 self.show_context_sample_harvest_origin(context)
             }

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -203,6 +203,10 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             GuiMessage::ToggleLoopPlayback,
         )
         .bind(
+            ui::ShortcutGesture::any_shift(ui::KeyCode::H),
+            GuiMessage::ToggleSelectedHarvestDone,
+        )
+        .bind(
             transaction_list_shortcut(),
             GuiMessage::ToggleTransactionList,
         )

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -126,6 +126,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
                     "Step through playback history",
                 ),
                 shortcut_help_item("X", x_help_label(state)),
+                shortcut_help_item("H", "Toggle harvest done"),
                 shortcut_help_item("Command-A", "Select all listed samples"),
                 shortcut_help_item("Command-C", "Copy play selection or selected file"),
                 shortcut_help_item("Command-X", "Cut selected files"),

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -769,6 +769,191 @@ fn sample_context_menu_harvest_state_actions_update_durable_state() {
 }
 
 #[test]
+fn h_shortcut_toggles_focused_sample_harvest_done_without_moving_focus() {
+    let root = tempfile::tempdir().expect("source root");
+    let sample = root.path().join("kick.wav");
+    fs::write(&sample, [0_u8; 8]).expect("write sample");
+    let source_id = unique_source_id("harvest-hotkey-focused");
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let harvest_key =
+        wavecrate::sample_sources::HarvestFileKey::new(source_id, PathBuf::from("kick.wav"));
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    let focused_id = sample.display().to_string();
+    state.library.folder_browser.select_file(focused_id.clone());
+    let mut context = ui::UiUpdateContext::default();
+
+    state.apply_message(GuiMessage::ToggleSelectedHarvestDone, &mut context);
+
+    assert_eq!(
+        harvest_state_for_key(&harvest_key),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(focused_id.as_str())
+    );
+
+    state.apply_message(GuiMessage::ToggleSelectedHarvestDone, &mut context);
+
+    assert_eq!(
+        harvest_state_for_key(&harvest_key),
+        Some(wavecrate::sample_sources::HarvestState::New)
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(focused_id.as_str())
+    );
+}
+
+#[test]
+fn h_shortcut_marks_mixed_explicit_selection_harvest_done() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    let hat = root.path().join("hat.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    fs::write(&snare, [0_u8; 8]).expect("write snare");
+    fs::write(&hat, [0_u8; 8]).expect("write hat");
+    let source_id = unique_source_id("harvest-hotkey-mixed");
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let kick_key = wavecrate::sample_sources::HarvestFileKey::new(
+        source_id.clone(),
+        PathBuf::from("kick.wav"),
+    );
+    let snare_key = wavecrate::sample_sources::HarvestFileKey::new(
+        source_id.clone(),
+        PathBuf::from("snare.wav"),
+    );
+    let hat_key =
+        wavecrate::sample_sources::HarvestFileKey::new(source_id, PathBuf::from("hat.wav"));
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..Default::default()
+        },
+    );
+    seed_harvest_state(&snare_key, wavecrate::sample_sources::HarvestState::Done);
+
+    state.apply_message(
+        GuiMessage::ToggleSelectedHarvestDone,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(
+        harvest_state_for_key(&kick_key),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(
+        harvest_state_for_key(&snare_key),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(harvest_state_for_key(&hat_key), None);
+}
+
+#[test]
+fn h_shortcut_resets_all_done_explicit_selection() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    fs::write(&snare, [0_u8; 8]).expect("write snare");
+    let source_id = unique_source_id("harvest-hotkey-all-done");
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let kick_key = wavecrate::sample_sources::HarvestFileKey::new(
+        source_id.clone(),
+        PathBuf::from("kick.wav"),
+    );
+    let snare_key =
+        wavecrate::sample_sources::HarvestFileKey::new(source_id, PathBuf::from("snare.wav"));
+    seed_harvest_state(&kick_key, wavecrate::sample_sources::HarvestState::Done);
+    seed_harvest_state(&snare_key, wavecrate::sample_sources::HarvestState::Done);
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..Default::default()
+        },
+    );
+
+    state.apply_message(
+        GuiMessage::ToggleSelectedHarvestDone,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(
+        harvest_state_for_key(&kick_key),
+        Some(wavecrate::sample_sources::HarvestState::New)
+    );
+    assert_eq!(
+        harvest_state_for_key(&snare_key),
+        Some(wavecrate::sample_sources::HarvestState::New)
+    );
+}
+
+#[test]
+fn h_shortcut_refreshes_active_harvest_projection() {
+    let root = tempfile::tempdir().expect("source root");
+    let sample = root.path().join("kick.wav");
+    fs::write(&sample, [0_u8; 8]).expect("write sample");
+    let source_id = unique_source_id("harvest-hotkey-refresh");
+    let source =
+        wavecrate::sample_sources::SampleSource::new_with_id(source_id, root.path().to_path_buf());
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state
+        .library
+        .folder_browser
+        .select_file(sample.display().to_string());
+    state.library.folder_browser.set_harvest_filter(
+        crate::native_app::sample_library::folder_browser::model::HarvestFilter::NeedsReview,
+        true,
+    );
+    assert_eq!(visible_sample_names(&state), vec!["kick.wav"]);
+
+    state.apply_message(
+        GuiMessage::ToggleSelectedHarvestDone,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(
+        visible_sample_names(&state).is_empty(),
+        "Done files should immediately leave the active harvest review queue"
+    );
+    state.library.folder_browser.set_harvest_filter(
+        crate::native_app::sample_library::folder_browser::model::HarvestFilter::Done,
+        true,
+    );
+    assert_eq!(visible_sample_names(&state), vec!["kick.wav"]);
+}
+
+#[test]
 fn sample_context_menu_harvest_state_actions_refresh_active_queue_visibility() {
     let root = tempfile::tempdir().expect("source root");
     let sample = root.path().join("kick.wav");
@@ -859,6 +1044,38 @@ fn visible_sample_names(state: &NativeAppState) -> Vec<String> {
         .collect()
 }
 
+fn unique_source_id(prefix: &str) -> wavecrate::sample_sources::SourceId {
+    wavecrate::sample_sources::SourceId::from_string(format!(
+        "{prefix}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ))
+}
+
+fn seed_harvest_state(
+    key: &wavecrate::sample_sources::HarvestFileKey,
+    state: wavecrate::sample_sources::HarvestState,
+) {
+    let identity = wavecrate::sample_sources::HarvestFileIdentity {
+        key: key.clone(),
+        file_size: Some(8),
+        modified_ns: Some(1),
+        content_hash: None,
+    };
+    wavecrate::sample_sources::library::upsert_harvest_file(&identity).expect("upsert harvest");
+    wavecrate::sample_sources::library::set_harvest_state(key, state).expect("set harvest state");
+}
+
+fn harvest_state_for_key(
+    key: &wavecrate::sample_sources::HarvestFileKey,
+) -> Option<wavecrate::sample_sources::HarvestState> {
+    wavecrate::sample_sources::library::harvest_file(key)
+        .expect("load harvest row")
+        .map(|record| record.state)
+}
+
 fn harvest_state_for(
     source_id: &wavecrate::sample_sources::SourceId,
     relative_path: &str,
@@ -867,9 +1084,7 @@ fn harvest_state_for(
         source_id.clone(),
         PathBuf::from(relative_path),
     );
-    wavecrate::sample_sources::library::harvest_file(&key)
-        .expect("load harvest row")
-        .map(|record| record.state)
+    harvest_state_for_key(&key)
 }
 
 #[test]

--- a/src/native_app/tests/shortcuts_context/help.rs
+++ b/src/native_app/tests/shortcuts_context/help.rs
@@ -90,6 +90,12 @@ fn shortcut_help_model_includes_global_and_active_context_sections() {
         sections
             .iter()
             .flat_map(|section| &section.items)
+            .any(|item| item.keys == "H" && item.action == "Toggle harvest done")
+    );
+    assert!(
+        sections
+            .iter()
+            .flat_map(|section| &section.items)
             .any(|item| item.keys == "Left" && item.action == "Collapse selected folder")
     );
     assert!(

--- a/src/native_app/tests/shortcuts_context/transport.rs
+++ b/src/native_app/tests/shortcuts_context/transport.rs
@@ -23,6 +23,31 @@ fn loop_shortcut_routes_to_loop_toggle() {
 }
 
 #[test]
+fn h_shortcut_routes_to_harvest_done_toggle() {
+    let state = NativeAppState::load_default().expect("default state loads");
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::H));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::ToggleSelectedHarvestDone)
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn shift_h_shortcut_routes_to_harvest_done_toggle() {
+    let state = NativeAppState::load_default().expect("default state loads");
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::with_shift(ui::KeyCode::H));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::ToggleSelectedHarvestDone)
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
 fn space_shortcut_routes_to_play_selected_sample() {
     let state = NativeAppState::load_default().expect("default state loads");
     let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Space));
@@ -333,6 +358,21 @@ fn e_shortcut_is_consumed_while_renaming() {
         .expect("begin rename should not fail");
 
     let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::E));
+
+    assert_eq!(resolution.action, None);
+    assert!(resolution.handled);
+}
+
+#[test]
+fn h_shortcut_is_consumed_while_renaming() {
+    let (mut state, _source_root) = state_with_renamable_temp_sample("h-rename-hotkey.wav");
+    state
+        .library
+        .folder_browser
+        .begin_rename_selected()
+        .expect("begin rename should not fail");
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::H));
 
     assert_eq!(resolution.action, None);
     assert!(resolution.handled);


### PR DESCRIPTION
## Scope
- Add a focus-aware `H` / `Shift-H` shortcut that toggles Harvest Done for the focused sample or explicit selected sample set.
- Reuse the existing selected-harvest state flow so mixed selections become Done and all-Done selections reset to New.
- Keep rename/edit contexts consuming the shortcut instead of firing harvest actions while text editing is active.

## Definition of Done
- `H` and `Shift-H` route to `ToggleSelectedHarvestDone` from normal browser context.
- The shortcut updates harvest metadata without moving sample focus.
- Explicit multi-selection harvest state updates refresh active Harvest projections immediately.
- Rename context consumes `H` without dispatching a harvest command.

## Validation Commands
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt917-target cargo test -p wavecrate h_shortcut -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt917-target cargo test -p wavecrate mark_harvest_done -- --test-threads=1`

## Known Limitations
None.

## Review Status
User review was completed in chat, and the user explicitly requested merge on 2026-06-29.