### PR TITLE
OPT-921: Map arrow keys to slide the current playmark

### DIFF
--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -112,7 +112,7 @@ impl NativeAppState {
             } | WaveformInteraction::BeginSelectionMove {
                 kind: WaveformSelectionKind::Play,
                 ..
-            }
+            } | WaveformInteraction::SlidePlaySelection { .. }
         );
         begins_play_selection_change
             .then(|| WaveformPlaySelectionSnapshot::from_waveform(&self.waveform.current))
@@ -294,9 +294,14 @@ fn waveform_interaction_updates_play_selection(
 ) -> bool {
     if !matches!(
         interaction,
-        WaveformInteraction::UpdateSelection { .. } | WaveformInteraction::FinishSelection { .. }
+        WaveformInteraction::UpdateSelection { .. }
+            | WaveformInteraction::FinishSelection { .. }
+            | WaveformInteraction::SlidePlaySelection { .. }
     ) {
         return false;
+    }
+    if matches!(interaction, WaveformInteraction::SlidePlaySelection { .. }) {
+        return true;
     }
     match active_drag {
         Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play)) => {
@@ -311,7 +316,11 @@ fn waveform_interaction_updates_play_selection(
 }
 
 fn waveform_interaction_finishes_play_selection_update(interaction: &WaveformInteraction) -> bool {
-    matches!(interaction, WaveformInteraction::FinishSelection { .. })
+    matches!(
+        interaction,
+        WaveformInteraction::FinishSelection { .. }
+            | WaveformInteraction::SlidePlaySelection { .. }
+    )
 }
 
 fn waveform_interaction_updates_edit_selection(
@@ -338,6 +347,7 @@ fn waveform_interaction_updates_edit_selection(
         | WaveformInteraction::FinishEditGain { .. }
         | WaveformInteraction::ClearEditFadeSilence { .. }
         | WaveformInteraction::SelectSimilarSection { .. } => true,
+        WaveformInteraction::SlidePlaySelection { .. } => false,
         WaveformInteraction::UpdateSelection { .. }
         | WaveformInteraction::FinishSelection { .. } => {
             matches!(
@@ -359,6 +369,7 @@ fn waveform_interaction_can_finish_mark_change(interaction: &WaveformInteraction
         interaction,
         WaveformInteraction::FinishSelection { .. }
             | WaveformInteraction::SelectSimilarSection { .. }
+            | WaveformInteraction::SlidePlaySelection { .. }
             | WaveformInteraction::ClearEditFadeSilence { .. }
             | WaveformInteraction::FinishEditFadeOuterGain { .. }
             | WaveformInteraction::FinishEditGain { .. }
@@ -369,8 +380,9 @@ fn play_selection_transaction_finishes(
     interaction: &WaveformInteraction,
     active_drag: Option<WaveformActiveDragKind>,
 ) -> bool {
-    matches!(interaction, WaveformInteraction::FinishSelection { .. })
-        && play_selection_drag_active(active_drag)
+    matches!(interaction, WaveformInteraction::SlidePlaySelection { .. })
+        || (matches!(interaction, WaveformInteraction::FinishSelection { .. })
+            && play_selection_drag_active(active_drag))
 }
 
 fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bool {
@@ -444,6 +456,7 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
     match interaction {
         WaveformInteraction::Wheel { .. } => Some("waveform.zoom_wheel"),
         WaveformInteraction::ZoomToPlaySelection => Some("waveform.zoom_to_play_selection"),
+        WaveformInteraction::SlidePlaySelection { .. } => Some("waveform.playmark.slide"),
         WaveformInteraction::ZoomFull => Some("waveform.zoom_full"),
         WaveformInteraction::ZoomOut {
             expand_silence_margin: true,

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -220,11 +220,12 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             space_playback_action(state),
         )
         .bind_all(
-            [
-                ui::KeyPress::with_shift(ui::KeyCode::Space),
-                ui::KeyPress::new(ui::KeyCode::ArrowRight),
-            ],
+            [ui::KeyPress::with_shift(ui::KeyCode::Space)],
             GuiMessage::PlayFromCurrentPlayStart,
+        )
+        .bind(
+            ui::KeyPress::new(ui::KeyCode::ArrowRight),
+            right_arrow_shortcut_action(state),
         )
         .bind(
             ui::KeyPress::with_alt(ui::KeyCode::Space),
@@ -285,7 +286,7 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
         )
         .bind(
             ui::KeyPress::new(ui::KeyCode::ArrowLeft),
-            GuiMessage::CollapseSelectedFolder,
+            left_arrow_shortcut_action(state),
         );
     bind_undo_shortcuts(bind_collection_shortcuts(layer))
 }
@@ -379,6 +380,31 @@ fn shifted_x_shortcut_action(state: &NativeAppState) -> GuiMessage {
 
 fn waveform_zoom_out_shortcut_active(state: &NativeAppState) -> bool {
     state.waveform.current.has_loaded_sample() && !state.waveform.current.fully_zoomed_out()
+}
+
+fn playmark_slide_shortcut_active(state: &NativeAppState) -> bool {
+    state.waveform.current.has_loaded_sample()
+        && state
+            .waveform
+            .current
+            .play_selection()
+            .is_some_and(|selection| selection.width() > 0.0)
+}
+
+fn left_arrow_shortcut_action(state: &NativeAppState) -> GuiMessage {
+    if playmark_slide_shortcut_active(state) {
+        GuiMessage::Waveform(WaveformInteraction::SlidePlaySelection { direction: -1 })
+    } else {
+        GuiMessage::CollapseSelectedFolder
+    }
+}
+
+fn right_arrow_shortcut_action(state: &NativeAppState) -> GuiMessage {
+    if playmark_slide_shortcut_active(state) {
+        GuiMessage::Waveform(WaveformInteraction::SlidePlaySelection { direction: 1 })
+    } else {
+        GuiMessage::PlayFromCurrentPlayStart
+    }
 }
 
 fn navigation_shortcut(press: ui::KeyPress) -> ui::ShortcutResolution<GuiMessage> {

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -119,7 +119,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
             "Samples",
             [
                 shortcut_help_item("Space", space_help_label(state)),
-                shortcut_help_item("Shift-Space / Right", "Play from current play start"),
+                shortcut_help_item("Shift-Space", "Play from current play start"),
                 shortcut_help_item("Control-Space / Option-Space", "Play random sample section"),
                 shortcut_help_item(
                     "Command-Left / Command-Right",
@@ -143,6 +143,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
                 shortcut_help_item("W", "Open context menu"),
                 shortcut_help_item("Command-E", "Extract and trim selection"),
                 shortcut_help_item("Z", "Zoom to play selection"),
+                shortcut_help_item("Left / Right", "Slide play selection"),
                 shortcut_help_item("C", "Crop selection"),
                 shortcut_help_item("D", "Trim selection"),
                 shortcut_help_item("R", "Reverse selection"),

--- a/src/native_app/tests/shortcuts_context/help.rs
+++ b/src/native_app/tests/shortcuts_context/help.rs
@@ -65,7 +65,7 @@ fn shortcut_help_model_includes_global_and_active_context_sections() {
             .iter()
             .flat_map(|section| &section.items)
             .any(|item| {
-                item.keys == "Shift-Space / Right" && item.action == "Play from current play start"
+                item.keys == "Shift-Space" && item.action == "Play from current play start"
             })
     );
     assert!(
@@ -103,6 +103,12 @@ fn shortcut_help_model_includes_global_and_active_context_sections() {
             .iter()
             .flat_map(|section| &section.items)
             .any(|item| item.keys == "Z" && item.action == "Zoom to play selection")
+    );
+    assert!(
+        sections
+            .iter()
+            .flat_map(|section| &section.items)
+            .any(|item| item.keys == "Left / Right" && item.action == "Slide play selection")
     );
     assert!(
         sections

--- a/src/native_app/tests/shortcuts_context/transport.rs
+++ b/src/native_app/tests/shortcuts_context/transport.rs
@@ -68,6 +68,68 @@ fn right_arrow_shortcut_routes_to_current_play_start() {
 }
 
 #[test]
+fn right_arrow_shortcut_routes_to_playmark_slide_when_playmark_is_active() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.2, 0.4);
+
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowRight));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::Waveform(
+            WaveformInteraction::SlidePlaySelection { direction: 1 }
+        ))
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn left_arrow_shortcut_routes_to_playmark_slide_when_playmark_is_active() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.4, 0.6);
+
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowLeft));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::Waveform(
+            WaveformInteraction::SlidePlaySelection { direction: -1 }
+        ))
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn right_arrow_shortcut_dispatch_slides_active_playmark_by_width() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.2, 0.4);
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowRight));
+
+    state.apply_message(
+        resolution.action.expect("right arrow action"),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let selection = state
+        .waveform
+        .current
+        .play_selection()
+        .expect("playmark should remain active");
+    assert!((selection.start() - 0.4).abs() < 0.001);
+    assert!((selection.end() - 0.6).abs() < 0.001);
+    assert!((selection.width() - 0.2).abs() < 0.001);
+}
+
+#[test]
 fn option_space_shortcut_routes_to_random_sample_range() {
     let state = NativeAppState::load_default().expect("default state loads");
     let resolution =

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -28,6 +28,10 @@ impl WaveformState {
             WaveformInteraction::ZoomToPlaySelection => {
                 self.zoom_to_play_selection();
             }
+            WaveformInteraction::SlidePlaySelection { direction } => {
+                self.active_drag = None;
+                self.slide_play_selection_by_width(direction);
+            }
             WaveformInteraction::ZoomFull => {
                 self.zoom_full();
             }

--- a/src/native_app/waveform/state_selection.rs
+++ b/src/native_app/waveform/state_selection.rs
@@ -58,6 +58,30 @@ impl WaveformState {
         self.record_current_play_selection_mark();
     }
 
+    pub(in crate::native_app) fn slide_play_selection_by_width(&mut self, direction: i8) -> bool {
+        let direction = direction.signum();
+        let Some(selection) = self
+            .play_selection
+            .filter(|selection| selection.width_f64() > f64::EPSILON)
+        else {
+            return false;
+        };
+        if direction == 0 {
+            return false;
+        }
+        let width = selection.width_f64().min(1.0);
+        let max_start = (1.0 - width).max(0.0);
+        let start = (selection.start_f64() + width * f64::from(direction)).clamp(0.0, max_start);
+        let next = selection.with_bounds_precise(start, start + width);
+        if next == selection {
+            return false;
+        }
+        self.set_selection_for_kind(WaveformSelectionKind::Play, next.start(), next);
+        self.record_current_play_selection_mark();
+        self.ensure_play_selection_visible();
+        true
+    }
+
     pub(in crate::native_app) fn restore_play_selection_state(
         &mut self,
         play_mark_ratio: Option<f32>,

--- a/src/native_app/waveform/tests/state.rs
+++ b/src/native_app/waveform/tests/state.rs
@@ -441,6 +441,43 @@ fn playmark_top_handle_moves_range_without_resizing() {
 }
 
 #[test]
+fn keyboard_slide_moves_playmark_by_its_current_width_without_resizing() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.set_play_selection_range(0.2, 0.35);
+
+    assert!(state.slide_play_selection_by_width(1));
+
+    let selection = state.play_selection().expect("slid playmark selection");
+    assert!((selection.start() - 0.35).abs() < 0.001);
+    assert!((selection.end() - 0.50).abs() < 0.001);
+    assert!((selection.width() - 0.15).abs() < 0.001);
+    assert_eq!(state.play_mark_ratio(), Some(selection.start()));
+
+    assert!(state.slide_play_selection_by_width(-1));
+    let selection = state.play_selection().expect("slid playmark selection");
+    assert!((selection.start() - 0.20).abs() < 0.001);
+    assert!((selection.end() - 0.35).abs() < 0.001);
+}
+
+#[test]
+fn keyboard_slide_clamps_playmark_at_sample_boundaries() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.set_play_selection_range(0.75, 1.0);
+
+    assert!(!state.slide_play_selection_by_width(1));
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.75, 1.0))
+    );
+
+    assert!(state.slide_play_selection_by_width(-1));
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.5, 0.75))
+    );
+}
+
+#[test]
 fn edit_top_handle_moves_range_and_preserves_edit_effects() {
     let mut state = WaveformState::synthetic_for_tests();
     state.edit_selection = Some(

--- a/src/native_app/waveform/types.rs
+++ b/src/native_app/waveform/types.rs
@@ -9,6 +9,9 @@ pub(in crate::native_app) enum WaveformInteraction {
         expand_silence_margin: bool,
     },
     ZoomToPlaySelection,
+    SlidePlaySelection {
+        direction: i8,
+    },
     ZoomFull,
     ZoomOut {
         expand_silence_margin: bool,


### PR DESCRIPTION
## Summary
- Maps Left and Right Arrow to shift the active playmark by its current width.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
