### PR TITLE
OPT-931: Map E to extract selected whole files when no playmark is active

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -33,6 +33,7 @@ use crate::native_app::sample_library::folder_browser::scan::{
 };
 use crate::native_app::sample_library::harvest_tracking::HarvestSeenPersistResult;
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
+use crate::native_app::sample_library::selected_file_actions::WholeFileHarvestExtractionResult;
 use crate::native_app::sample_library::similarity_prep::{
     SimilarityPrepEnqueueResult, SimilarityPrepStatusResult,
 };
@@ -291,6 +292,10 @@ pub(in crate::native_app) enum GuiMessage {
         playback_type: ExtractedFilePlaybackType,
         harvest_operation: HarvestDerivationOperation,
         started_at: Instant,
+    },
+    SelectedWholeFilesHarvestExtractionFinished {
+        started_at: Instant,
+        result: WholeFileHarvestExtractionResult,
     },
     NavigateBrowser {
         delta: i32,

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -8,7 +8,11 @@ use crate::native_app::waveform::{
     execute_waveform_extraction,
 };
 use radiant::gui::types::Point;
-use std::time::Instant;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 use wavecrate::sample_sources::HarvestDerivationOperation;
 
 #[derive(Clone, Copy)]
@@ -31,6 +35,30 @@ impl PlaymarkedExtractionTarget {
             Self::HarvestDestination => "Extracting play range to harvest destination",
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct WholeFileHarvestExtractionResult {
+    pub(in crate::native_app) copied: Vec<WholeFileHarvestExtractionCopy>,
+    pub(in crate::native_app) failed: Vec<WholeFileHarvestExtractionFailure>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct WholeFileHarvestExtractionCopy {
+    pub(in crate::native_app) source_path: PathBuf,
+    pub(in crate::native_app) output_path: PathBuf,
+    pub(in crate::native_app) operation: HarvestDerivationOperation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct WholeFileHarvestExtractionFailure {
+    pub(in crate::native_app) source_path: PathBuf,
+    pub(in crate::native_app) error: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WholeFileHarvestExtractionRequest {
+    copies: Vec<WholeFileHarvestExtractionCopy>,
 }
 
 impl NativeAppState {
@@ -178,6 +206,12 @@ impl NativeAppState {
     ) {
         let started_at = Instant::now();
         let action = target.action_name();
+        if matches!(target, PlaymarkedExtractionTarget::Default)
+            && self.waveform.current.play_selection().is_none()
+        {
+            self.extract_selected_whole_files_to_harvest(context, started_at);
+            return;
+        }
         match self
             .waveform
             .current
@@ -250,6 +284,103 @@ impl NativeAppState {
                     Some(&error),
                 );
             }
+        }
+    }
+
+    fn extract_selected_whole_files_to_harvest(
+        &mut self,
+        context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
+        started_at: Instant,
+    ) {
+        let action = "browser.extract_selected_whole_files_to_harvest";
+        let sources = self.library.folder_browser.selected_file_paths();
+        if sources.is_empty() {
+            let error = String::from("Mark a play range or select samples before extracting");
+            self.ui.status.sample = error.clone();
+            emit_gui_action(
+                action,
+                Some("browser"),
+                None,
+                "blocked",
+                started_at,
+                Some(&error),
+            );
+            return;
+        }
+        let request = match self.selected_whole_file_harvest_extraction_request(sources) {
+            Ok(request) => request,
+            Err(error) => {
+                self.ui.status.sample = error.clone();
+                emit_gui_action(
+                    action,
+                    Some("browser"),
+                    None,
+                    "blocked",
+                    started_at,
+                    Some(&error),
+                );
+                return;
+            }
+        };
+        let count = request.copies.len();
+        self.ui.status.sample = format!(
+            "Extracting {count} selected {} to Harvest",
+            if count == 1 { "file" } else { "files" }
+        );
+        context
+            .business()
+            .blocking_io("gui-whole-file-harvest-extract")
+            .run(
+                move |_| execute_whole_file_harvest_extraction(request),
+                move |result| GuiMessage::SelectedWholeFilesHarvestExtractionFinished {
+                    started_at,
+                    result,
+                },
+            );
+    }
+
+    fn selected_whole_file_harvest_extraction_request(
+        &self,
+        sources: Vec<PathBuf>,
+    ) -> Result<WholeFileHarvestExtractionRequest, String> {
+        let mut reserved_outputs = HashSet::new();
+        let mut copies = Vec::with_capacity(sources.len());
+        for source_path in sources {
+            let target_folder = self.harvest_destination_for_origin(&source_path)?;
+            if let Some(error) = self
+                .library
+                .folder_browser
+                .folder_target_lock_error(&target_folder, "Extraction")
+            {
+                return Err(error);
+            }
+            let output_path = next_available_reserved_whole_file_harvest_copy_path(
+                &source_path,
+                &target_folder,
+                &reserved_outputs,
+            )?;
+            reserved_outputs.insert(output_path.clone());
+            copies.push(WholeFileHarvestExtractionCopy {
+                source_path,
+                operation: self.harvest_copy_operation_for_child(&output_path),
+                output_path,
+            });
+        }
+        Ok(WholeFileHarvestExtractionRequest { copies })
+    }
+
+    fn harvest_copy_operation_for_child(&self, child_path: &Path) -> HarvestDerivationOperation {
+        let Some((child_source, _)) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(child_path)
+        else {
+            return HarvestDerivationOperation::Copy;
+        };
+        if child_source.is_primary() {
+            HarvestDerivationOperation::CopyToPrimary
+        } else {
+            HarvestDerivationOperation::Copy
         }
     }
 
@@ -421,6 +552,82 @@ impl NativeAppState {
         }
     }
 
+    pub(in crate::native_app) fn finish_selected_whole_files_harvest_extraction(
+        &mut self,
+        started_at: Instant,
+        result: WholeFileHarvestExtractionResult,
+    ) {
+        let action = "browser.extract_selected_whole_files_to_harvest";
+        for copy in &result.copied {
+            self.library
+                .folder_browser
+                .refresh_file_path_across_sources(&copy.output_path);
+            self.record_harvest_whole_file_derivation(
+                &copy.source_path,
+                &copy.output_path,
+                copy.operation.clone(),
+            );
+        }
+
+        let copied_count = result.copied.len();
+        let failed_count = result.failed.len();
+        if copied_count == 0 {
+            let error = result
+                .failed
+                .first()
+                .map(|failure| {
+                    format!(
+                        "Whole-file extraction failed for {}: {}",
+                        sample_path_label(&failure.source_path),
+                        failure.error
+                    )
+                })
+                .unwrap_or_else(|| String::from("No selected files were extracted"));
+            self.ui.status.sample = error.clone();
+            emit_gui_action(
+                action,
+                Some("browser"),
+                None,
+                "error",
+                started_at,
+                Some(&error),
+            );
+            return;
+        }
+
+        self.ui.status.sample = if failed_count == 0 {
+            format!(
+                "Extracted {copied_count} selected {} to Harvest",
+                if copied_count == 1 { "file" } else { "files" }
+            )
+        } else {
+            format!(
+                "Extracted {copied_count} selected {} to Harvest; {failed_count} failed",
+                if copied_count == 1 { "file" } else { "files" }
+            )
+        };
+        let label = if copied_count == 1 {
+            result
+                .copied
+                .first()
+                .map(|copy| sample_path_label(&copy.output_path))
+        } else {
+            Some(format!("{copied_count} files"))
+        };
+        emit_gui_action(
+            action,
+            Some("browser"),
+            label.as_deref(),
+            if failed_count == 0 {
+                "success"
+            } else {
+                "partial"
+            },
+            started_at,
+            result.failed.first().map(|failure| failure.error.as_str()),
+        );
+    }
+
     fn extraction_derivative_crosses_sources(
         &self,
         source_path: &std::path::Path,
@@ -438,4 +645,64 @@ impl NativeAppState {
             .map(|(source, _)| source.id);
         source_id.is_some() && child_id.is_some() && source_id != child_id
     }
+}
+
+fn execute_whole_file_harvest_extraction(
+    request: WholeFileHarvestExtractionRequest,
+) -> WholeFileHarvestExtractionResult {
+    let mut copied = Vec::with_capacity(request.copies.len());
+    let mut failed = Vec::new();
+    for copy in request.copies {
+        let result = copy
+            .output_path
+            .parent()
+            .ok_or_else(|| String::from("Harvest copy has no destination folder"))
+            .and_then(|parent| {
+                wavecrate::sample_sources::harvest_file_ops::ensure_dir(
+                    parent,
+                    "Could not create harvest destination",
+                )
+            })
+            .and_then(|_| {
+                wavecrate::sample_sources::harvest_file_ops::copy_file(
+                    &copy.source_path,
+                    &copy.output_path,
+                    "Could not copy selected sample",
+                )
+            });
+        match result {
+            Ok(()) => copied.push(copy),
+            Err(error) => failed.push(WholeFileHarvestExtractionFailure {
+                source_path: copy.source_path,
+                error,
+            }),
+        }
+    }
+    WholeFileHarvestExtractionResult { copied, failed }
+}
+
+fn next_available_reserved_whole_file_harvest_copy_path(
+    source_path: &Path,
+    target_folder: &Path,
+    reserved_outputs: &HashSet<PathBuf>,
+) -> Result<PathBuf, String> {
+    let stem = source_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| String::from("Source sample has no file name"))?;
+    for index in 0..10_000 {
+        let suffix = if index == 0 {
+            String::from("_copy")
+        } else {
+            format!("_copy_{index}")
+        };
+        let candidate = target_folder.join(format!("{stem}{suffix}.wav"));
+        if !candidate.exists() && !reserved_outputs.contains(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(String::from(
+        "Could not find an available harvest copy file name",
+    ))
 }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -184,7 +184,8 @@ impl NativeAppState {
             | GuiMessage::WaveformDestructiveEditFinished(_)
             | GuiMessage::ExtractPlaymarkedRange
             | GuiMessage::ExtractPlaymarkedRangeToHarvestDestination
-            | GuiMessage::PlaySelectionExtractionFinished { .. } => {
+            | GuiMessage::PlaySelectionExtractionFinished { .. }
+            | GuiMessage::SelectedWholeFilesHarvestExtractionFinished { .. } => {
                 self.apply_chrome_dispatch(message, context);
             }
             GuiMessage::NavigateBrowser { .. }

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -159,6 +159,9 @@ impl NativeAppState {
                 started_at,
                 context,
             ),
+            GuiMessage::SelectedWholeFilesHarvestExtractionFinished { started_at, result } => {
+                self.finish_selected_whole_files_harvest_extraction(started_at, result);
+            }
             _ => unreachable!("chrome dispatcher received a non-chrome message"),
         }
     }

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -139,7 +139,7 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
             "Waveform",
             [
                 shortcut_help_item("Enter", "Apply edit mark edits"),
-                shortcut_help_item("E", "Extract play selection"),
+                shortcut_help_item("E", "Extract play selection or selected files"),
                 shortcut_help_item("W", "Open context menu"),
                 shortcut_help_item("Command-E", "Extract and trim selection"),
                 shortcut_help_item("Z", "Zoom to play selection"),

--- a/src/native_app/tests/shortcuts_context/folder_browser.rs
+++ b/src/native_app/tests/shortcuts_context/folder_browser.rs
@@ -1,20 +1,12 @@
 use crate::native_app::test_support::state::{
-    FolderBrowserMessage, GuiMessage, NativeAppState, default_gui_shortcuts,
+    FolderBrowserMessage, FolderBrowserState, GuiMessage, NativeAppState, NativeAppStateFixture,
+    default_gui_shortcuts,
 };
 use radiant::{gui::types::Point, prelude as ui};
 
 #[test]
 fn escape_shortcut_cancels_rename_while_renaming() {
-    let mut state = NativeAppState::load_default().expect("default state loads");
-    let sample_path = state
-        .library
-        .folder_browser
-        .selected_audio_files()
-        .first()
-        .expect("default assets include an audio sample")
-        .id
-        .clone();
-    state.library.folder_browser.select_file(sample_path);
+    let (mut state, _source_root) = state_with_renamable_temp_sample("escape-rename.wav");
     state
         .library
         .folder_browser
@@ -30,6 +22,24 @@ fn escape_shortcut_cancels_rename_while_renaming() {
         ))
     );
     assert!(resolution.handled);
+}
+
+fn state_with_renamable_temp_sample(name: &str) -> (NativeAppState, tempfile::TempDir) {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join(name);
+    std::fs::write(&sample_path, []).expect("sample file");
+    let folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    let mut state = NativeAppStateFixture::default()
+        .with_folder_browser(folder_browser)
+        .build();
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path.display().to_string());
+    (state, source_root)
 }
 
 #[test]

--- a/src/native_app/tests/shortcuts_context/help.rs
+++ b/src/native_app/tests/shortcuts_context/help.rs
@@ -102,6 +102,14 @@ fn shortcut_help_model_includes_global_and_active_context_sections() {
         sections
             .iter()
             .flat_map(|section| &section.items)
+            .any(|item| {
+                item.keys == "E" && item.action == "Extract play selection or selected files"
+            })
+    );
+    assert!(
+        sections
+            .iter()
+            .flat_map(|section| &section.items)
             .any(|item| item.keys == "Z" && item.action == "Zoom to play selection")
     );
     assert!(

--- a/src/native_app/tests/shortcuts_context/transport.rs
+++ b/src/native_app/tests/shortcuts_context/transport.rs
@@ -1,6 +1,6 @@
 use crate::native_app::test_support::state::{
-    FolderBrowserMessage, GuiMessage, NativeAppState, NativeAppStateFixture, WaveformInteraction,
-    default_gui_shortcuts,
+    FolderBrowserMessage, FolderBrowserState, GuiMessage, NativeAppState, NativeAppStateFixture,
+    WaveformInteraction, default_gui_shortcuts,
 };
 use radiant::prelude as ui;
 
@@ -84,6 +84,15 @@ fn control_space_shortcut_routes_to_random_sample_range() {
         default_gui_shortcuts(&state).resolve(ui::KeyPress::with_control(ui::KeyCode::Space));
 
     assert_eq!(resolution.action, Some(GuiMessage::PlayRandomSampleRange));
+    assert!(resolution.handled);
+}
+
+#[test]
+fn e_shortcut_routes_to_extract_playmarked_range_command() {
+    let state = NativeAppState::load_default().expect("default state loads");
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::E));
+
+    assert_eq!(resolution.action, Some(GuiMessage::ExtractPlaymarkedRange));
     assert!(resolution.handled);
 }
 
@@ -241,16 +250,7 @@ fn command_v_shortcut_routes_to_paste_cut_files() {
 
 #[test]
 fn x_shortcut_is_consumed_while_renaming() {
-    let mut state = NativeAppState::load_default().expect("default state loads");
-    let sample_path = state
-        .library
-        .folder_browser
-        .selected_audio_files()
-        .first()
-        .expect("default assets include an audio sample")
-        .id
-        .clone();
-    state.library.folder_browser.select_file(sample_path);
+    let (mut state, _source_root) = state_with_renamable_temp_sample("x-rename.wav");
     state
         .library
         .folder_browser
@@ -261,6 +261,39 @@ fn x_shortcut_is_consumed_while_renaming() {
 
     assert_eq!(resolution.action, None);
     assert!(resolution.handled);
+}
+
+#[test]
+fn e_shortcut_is_consumed_while_renaming() {
+    let (mut state, _source_root) = state_with_renamable_temp_sample("e-rename.wav");
+    state
+        .library
+        .folder_browser
+        .begin_rename_selected()
+        .expect("begin rename should not fail");
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::E));
+
+    assert_eq!(resolution.action, None);
+    assert!(resolution.handled);
+}
+
+fn state_with_renamable_temp_sample(name: &str) -> (NativeAppState, tempfile::TempDir) {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join(name);
+    std::fs::write(&sample_path, []).expect("sample file");
+    let folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    let mut state = NativeAppStateFixture::default()
+        .with_folder_browser(folder_browser)
+        .build();
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path.display().to_string());
+    (state, source_root)
 }
 
 #[test]

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -1097,6 +1097,162 @@ fn normal_playmark_harvest_extraction_creates_focuses_and_records_primary_deriva
     );
 }
 
+#[test]
+fn e_without_playmark_copies_protected_whole_file_to_primary_harvest_and_keeps_focus() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let source_root = tempfile::tempdir().expect("protected source root");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let source_path = source_root.path().join("whole-protected.wav");
+    write_test_wav_i16(&source_path, &[0, 1024, -1024, 512]);
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()).protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    let harvest_source_folder = protected_source
+        .root
+        .file_name()
+        .expect("source root folder name")
+        .to_owned();
+    let expected = primary_root
+        .path()
+        .join("_Harvests")
+        .join(&harvest_source_folder)
+        .join("whole-protected_copy.wav");
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            primary_source.clone(),
+        ]);
+    let source_id = source_path.display().to_string();
+    state.library.folder_browser.select_file(source_id.clone());
+
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ExtractPlaymarkedRange,
+        &mut context,
+    );
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert!(
+        source_path.is_file(),
+        "protected origin should remain intact"
+    );
+    assert!(
+        expected.is_file(),
+        "whole-file copy should be written to Primary"
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(source_id.as_str()),
+        "whole-file fallback should preserve browser focus on the source sample"
+    );
+    assert!(
+        active_sample_load_ticket(&state).is_none(),
+        "whole-file fallback should not load the derivative automatically"
+    );
+    let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        protected_source.id.clone(),
+        PathBuf::from("whole-protected.wav"),
+    );
+    let parent = wavecrate::sample_sources::library::harvest_file(&parent_key)
+        .expect("load harvest parent")
+        .expect("harvest parent");
+    assert_eq!(
+        parent.state,
+        wavecrate::sample_sources::HarvestState::Touched
+    );
+    let edges = wavecrate::sample_sources::library::harvest_derivations_for_parent(&parent_key)
+        .expect("load harvest derivations");
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].operation,
+        wavecrate::sample_sources::HarvestDerivationOperation::CopyToPrimary
+    );
+    assert_eq!(edges[0].source_range, None);
+    assert_eq!(edges[0].child.key.source_id, primary_source.id);
+    assert_eq!(
+        edges[0].child.key.relative_path,
+        PathBuf::from("_Harvests")
+            .join(harvest_source_folder)
+            .join("whole-protected_copy.wav")
+    );
+}
+
+#[test]
+fn e_without_playmark_copies_multi_selected_whole_files_to_harvest() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let source_root = tempfile::tempdir().expect("source root");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let first = source_root.path().join("whole-first.wav");
+    let second = source_root.path().join("whole-second.wav");
+    write_test_wav_i16(&first, &[0, 1024, -1024, 512]);
+    write_test_wav_i16(&second, &[0, 512, -512, 256]);
+    let source = wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf());
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    let harvest_source_folder = source
+        .root
+        .file_name()
+        .expect("source root folder name")
+        .to_owned();
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            source.clone(),
+            primary_source,
+        ]);
+    assert_eq!(state.library.folder_browser.select_all_audio_files(), 2);
+    let selected_before = state.library.folder_browser.selected_file_paths();
+    let first_copy = primary_root
+        .path()
+        .join("_Harvests")
+        .join(&harvest_source_folder)
+        .join("whole-first_copy.wav");
+    let second_copy = primary_root
+        .path()
+        .join("_Harvests")
+        .join(&harvest_source_folder)
+        .join("whole-second_copy.wav");
+
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ExtractPlaymarkedRange,
+        &mut context,
+    );
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert!(first_copy.is_file());
+    assert!(second_copy.is_file());
+    assert_eq!(
+        state.library.folder_browser.selected_file_paths(),
+        selected_before,
+        "whole-file fallback should preserve the original multi-selection"
+    );
+    let first_parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        source.id.clone(),
+        PathBuf::from("whole-first.wav"),
+    );
+    let second_parent_key = wavecrate::sample_sources::HarvestFileKey::new(
+        source.id.clone(),
+        PathBuf::from("whole-second.wav"),
+    );
+    assert_eq!(
+        wavecrate::sample_sources::library::harvest_derivations_for_parent(&first_parent_key)
+            .expect("load first derivations")
+            .len(),
+        1
+    );
+    assert_eq!(
+        wavecrate::sample_sources::library::harvest_derivations_for_parent(&second_parent_key)
+            .expect("load second derivations")
+            .len(),
+        1
+    );
+}
+
 fn assert_extracted_file_metadata(
     state: &crate::native_app::test_support::state::NativeAppState,
     extracted: &std::path::Path,


### PR DESCRIPTION
## Summary
- Extends E extraction behavior to selected whole files when no playmark selection is active.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
