### PR TITLE
OPT-932: Make selected and focused sample-list rows visually distinct

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -54,6 +54,14 @@ const SELECTED_MARKER: ui::Rgba8 = ui::Rgba8 {
     b: 62,
     a: 245,
 };
+const FOCUSED_OUTLINE: ui::Rgba8 = ui::Rgba8 {
+    r: 80,
+    g: 190,
+    b: 255,
+    a: 235,
+};
+const FOCUSED_OUTLINE_INSET: f32 = 0.5;
+const FOCUSED_OUTLINE_WIDTH: f32 = 1.5;
 const CACHED_MARKER: ui::Rgba8 = ui::Rgba8 {
     r: 226,
     g: 226,
@@ -64,6 +72,7 @@ const CACHED_MARKER: ui::Rgba8 = ui::Rgba8 {
 pub(in crate::native_app) struct SampleFileHitTargetModel<'a> {
     pub(in crate::native_app) file_id: &'a str,
     pub(in crate::native_app) selected: bool,
+    pub(in crate::native_app) focused: bool,
     pub(in crate::native_app) copy_flash: bool,
     pub(in crate::native_app) cut_pending: bool,
     pub(in crate::native_app) drag_active: bool,
@@ -121,7 +130,8 @@ fn sample_file_hit_target_builder(
         .trailing_marker_if(
             model.cached && !model.selected && !model.copy_flash && !model.cut_pending,
             ui::DenseRowMarkerStyle::new(ui::DenseRowMarkerParts::trailing(2.0), CACHED_MARKER),
-        );
+        )
+        .outline_if(model.focused, sample_file_focus_outline());
     if let Some(palette) = sample_file_row_palette(model) {
         underlay.dense_chrome_palette(palette)
     } else {
@@ -170,6 +180,14 @@ fn sample_file_row_palette(model: &SampleFileHitTargetModel<'_>) -> Option<ui::D
         );
     }
     None
+}
+
+fn sample_file_focus_outline() -> ui::DenseRowOutlineStyle {
+    ui::DenseRowOutlineStyle::new(
+        FOCUSED_OUTLINE_INSET,
+        FOCUSED_OUTLINE,
+        FOCUSED_OUTLINE_WIDTH,
+    )
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
@@ -24,6 +24,7 @@ fn sample_hit_target(
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
         selected,
+        focused: false,
         copy_flash: false,
         cut_pending: false,
         drag_active,
@@ -35,10 +36,31 @@ fn sample_hit_target(
     })
 }
 
+fn sample_hit_target_with_focus(
+    selected: bool,
+    focused: bool,
+    cached: bool,
+) -> UiSurface<GuiMessage> {
+    sample_hit_target_with_model(SampleFileHitTargetModel {
+        file_id: "sample.wav",
+        selected,
+        focused,
+        copy_flash: false,
+        cut_pending: false,
+        drag_active: false,
+        drag_source: false,
+        cached,
+        missing: false,
+        hit_path: String::from("sample.wav"),
+        help_tooltips_enabled: false,
+    })
+}
+
 fn sample_hit_target_with_copy_flash(selected: bool, cached: bool) -> UiSurface<GuiMessage> {
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
         selected,
+        focused: false,
         copy_flash: true,
         cut_pending: false,
         drag_active: false,
@@ -54,6 +76,7 @@ fn sample_hit_target_with_cut_pending(selected: bool, cached: bool) -> UiSurface
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
         selected,
+        focused: false,
         copy_flash: false,
         cut_pending: true,
         drag_active: false,
@@ -121,6 +144,7 @@ fn production_hit_target_derives_stable_input_identity_from_sample_row_key() {
         SampleFileHitTargetModel {
             file_id: "sample.wav",
             selected: false,
+            focused: false,
             copy_flash: false,
             cut_pending: false,
             drag_active: false,
@@ -183,6 +207,102 @@ fn selected_fill() -> ui::Rgba8 {
     sample_row_palette_for_tests()
         .selected
         .expect("dense-row selected fill")
+}
+
+fn paints_selection_marker(plan: &SurfacePaintPlan, bounds: ui::Rect) -> bool {
+    plan.fill_rects().any(|fill| {
+        fill.rect.min.x == bounds.min.x + 1.0
+            && fill.rect.width() == 3.0
+            && fill.color == SELECTED_MARKER
+    })
+}
+
+fn paints_focus_outline(plan: &SurfacePaintPlan) -> bool {
+    plan.stroke_rects()
+        .any(|stroke| stroke.color == FOCUSED_OUTLINE && stroke.width == FOCUSED_OUTLINE_WIDTH)
+}
+
+#[test]
+/// Verifies selected rows keep the existing fill and leading marker without adding focus chrome.
+fn selected_rows_paint_selection_fill_and_marker_without_focus_outline() {
+    let bounds = ui::Rect::from_xy_size(10.0, 20.0, 120.0, 22.0);
+    let target = sample_hit_target_with_focus(true, false, false);
+    let plan = sample_widget_plan(&target, bounds);
+
+    assert!(
+        plan.fill_rects().any(|fill| fill.color == selected_fill()),
+        "selected rows should keep the selected fill"
+    );
+    assert!(
+        paints_selection_marker(&plan, bounds),
+        "selected rows should keep the leading selected marker"
+    );
+    assert!(
+        !paints_focus_outline(&plan),
+        "selection alone should not paint the focused-row outline"
+    );
+}
+
+#[test]
+/// Verifies focus can move independently from the selected set.
+fn focused_rows_paint_outline_without_selection_fill_or_marker() {
+    let bounds = ui::Rect::from_xy_size(10.0, 20.0, 120.0, 22.0);
+    let target = sample_hit_target_with_focus(false, true, false);
+    let plan = sample_widget_plan(&target, bounds);
+
+    assert!(
+        paints_focus_outline(&plan),
+        "focused rows should paint a crisp outline"
+    );
+    assert!(
+        !plan.fill_rects().any(|fill| fill.color == selected_fill()),
+        "focused-only rows should not borrow the selected fill"
+    );
+    assert!(
+        !paints_selection_marker(&plan, bounds),
+        "focused-only rows should not borrow the selected marker"
+    );
+}
+
+#[test]
+/// Verifies combined selected and focused state layers both visual treatments.
+fn selected_focused_rows_paint_selection_and_focus_together() {
+    let bounds = ui::Rect::from_xy_size(10.0, 20.0, 120.0, 22.0);
+    let target = sample_hit_target_with_focus(true, true, false);
+    let plan = sample_widget_plan(&target, bounds);
+
+    assert!(
+        plan.fill_rects().any(|fill| fill.color == selected_fill()),
+        "selected + focused rows should keep the selected fill"
+    );
+    assert!(
+        paints_selection_marker(&plan, bounds),
+        "selected + focused rows should keep the selected marker"
+    );
+    assert!(
+        paints_focus_outline(&plan),
+        "selected + focused rows should also paint the focus outline"
+    );
+}
+
+#[test]
+/// Verifies hover feedback does not mask the focus marker.
+fn focused_hover_rows_keep_focus_outline() {
+    let bounds = ui::Rect::from_size(120.0, 22.0);
+    let mut target = sample_hit_target_with_focus(false, true, false);
+    dispatch(
+        &mut target,
+        bounds,
+        WidgetInput::pointer_move(Point::new(34.0, 8.0)),
+    );
+
+    let plan = sample_widget_plan(&target, bounds);
+
+    assert!(paints_hover_fill(&plan));
+    assert!(
+        paints_focus_outline(&plan),
+        "hover feedback should not erase the focused-row outline"
+    );
 }
 
 #[test]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
@@ -15,6 +15,7 @@ use crate::native_app::sample_library::folder_browser::view_contract::collection
 pub(super) struct SampleRowDisplay<'a> {
     pub(super) file_id: &'a str,
     pub(super) selected: bool,
+    pub(super) focused: bool,
     pub(super) copy_flash: bool,
     pub(super) cut_pending: bool,
     pub(super) drag_active: bool,
@@ -74,6 +75,7 @@ pub(super) fn sample_row_display<'a>(
     SampleRowDisplay {
         file_id: file.id.as_str(),
         selected: row.selected,
+        focused: row.focused,
         copy_flash: row.copy_flash,
         cut_pending: cut_file_ids.is_some_and(|ids| ids.iter().any(|id| id == &file.id)),
         drag_active: row.drag_active,

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
@@ -26,6 +26,7 @@ fn visible_row(file: &FileEntry) -> VisibleSampleRow<'_> {
     VisibleSampleRow {
         file,
         selected: false,
+        focused: false,
         copy_flash: false,
         drag_active: false,
         drag_source: false,
@@ -41,6 +42,46 @@ fn visible_row(file: &FileEntry) -> VisibleSampleRow<'_> {
         harvest_completed: false,
         curation_badges: Vec::new(),
     }
+}
+
+#[test]
+fn sample_row_display_preserves_selection_and_focus_separately() {
+    let file = file_entry();
+    let mut row = visible_row(&file);
+    row.selected = true;
+    row.focused = false;
+    let column = FileColumn::for_tests("name", "Name", 160.0);
+
+    let selected_only = sample_row_display(
+        &row,
+        &[&column],
+        false,
+        [true; wavecrate_analysis::aspects::ASPECT_COUNT],
+        SampleNameViewMode::DiskFilename,
+        &HashMap::new(),
+        None,
+    );
+    let selected_only_selected = selected_only.selected;
+    let selected_only_focused = selected_only.focused;
+
+    row.selected = false;
+    row.focused = true;
+    let focused_only = sample_row_display(
+        &row,
+        &[&column],
+        false,
+        [true; wavecrate_analysis::aspects::ASPECT_COUNT],
+        SampleNameViewMode::DiskFilename,
+        &HashMap::new(),
+        None,
+    );
+    let focused_only_selected = focused_only.selected;
+    let focused_only_focused = focused_only.focused;
+
+    assert!(selected_only_selected);
+    assert!(!selected_only_focused);
+    assert!(!focused_only_selected);
+    assert!(focused_only_focused);
 }
 
 fn column_display<'a>(

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -85,6 +85,7 @@ fn sample_browser_row(
         SampleFileHitTargetModel {
             file_id: row.file_id,
             selected: row.selected,
+            focused: row.focused,
             copy_flash: row.copy_flash,
             cut_pending: row.cut_pending,
             drag_active: row.drag_active,

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -48,6 +48,7 @@ pub(super) struct VisibleSampleWindowFiles<'a> {
 pub(in crate::native_app) struct VisibleSampleRow<'a> {
     pub(in crate::native_app) file: &'a FileEntry,
     pub(in crate::native_app) selected: bool,
+    pub(in crate::native_app) focused: bool,
     pub(in crate::native_app) copy_flash: bool,
     pub(in crate::native_app) drag_active: bool,
     pub(in crate::native_app) drag_source: bool,
@@ -524,6 +525,7 @@ impl FolderBrowserState {
         VisibleSampleRow {
             file,
             selected: self.is_file_selected(&file.id),
+            focused: self.selected_file_id() == Some(file.id.as_str()),
             copy_flash: self.copied_file_flash_active(&file.id),
             drag_active: self.file_drag_active(),
             drag_source: self.file_drag_source(&file.id),

--- a/src/native_app/test_support/sample_browser.rs
+++ b/src/native_app/test_support/sample_browser.rs
@@ -49,6 +49,7 @@ pub(in crate::native_app) fn sample_file_hit_target(
         SampleFileHitTargetModel {
             file_id: "sample.wav",
             selected,
+            focused: false,
             copy_flash: false,
             cut_pending: false,
             drag_active,


### PR DESCRIPTION
## Summary
- Separates focused and selected row treatments so multi-selection and keyboard focus are visually distinct.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
