### PR TITLE
OPT-934: Apply Mark Harvest Done to all selected files

### DIFF
--- a/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
@@ -13,6 +13,26 @@ impl FolderBrowserState {
             .collect()
     }
 
+    pub(in crate::native_app) fn explicit_multi_file_selection_active(&self) -> bool {
+        self.selection.selected_file_ids_explicit && self.selection.selected_file_ids.len() > 1
+    }
+
+    pub(in crate::native_app) fn explicit_selected_file_paths(&self) -> Vec<PathBuf> {
+        if !self.explicit_multi_file_selection_active() {
+            return Vec::new();
+        }
+        let selected = &self.selection.selected_file_ids;
+        let mut paths = self
+            .loaded_source_audio_files()
+            .into_iter()
+            .filter(|file| selected.contains(&file.id))
+            .filter(|file| !file.is_missing())
+            .map(|file| PathBuf::from(&file.id))
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+
     pub(in crate::native_app) fn selected_normalization_paths(&self) -> Vec<PathBuf> {
         if self.selection.selected_collection.is_some() {
             return self.selected_file_paths();

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -264,7 +264,7 @@ impl FolderBrowserState {
         }
 
         let requested_path = Path::new(file_id);
-        self.selected_audio_files()
+        self.loaded_source_audio_files()
             .into_iter()
             .find(|file| path_id_matches(&file.id, requested_path))
             .map(|file| PathBuf::from(&file.id))

--- a/src/native_app/sample_library/harvest_tracking.rs
+++ b/src/native_app/sample_library/harvest_tracking.rs
@@ -50,6 +50,12 @@ struct HarvestSeenPersistRequest {
     relative_path: PathBuf,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HarvestStateTarget {
+    path: PathBuf,
+    identity: HarvestFileIdentity,
+}
+
 impl NativeAppState {
     pub(in crate::native_app) fn selected_harvest_family_summary(
         &self,
@@ -923,50 +929,104 @@ impl NativeAppState {
         outcome: &'static str,
     ) {
         let started_at = std::time::Instant::now();
-        let Some((path, identity)) = self
-            .take_context_sample_harvest_target("browser.context_menu.harvest.state", started_at)
-        else {
+        let Some(targets) = self.take_context_sample_harvest_state_targets(
+            "browser.context_menu.harvest.state",
+            started_at,
+        ) else {
             return;
         };
-        if let Err(error) = wavecrate::sample_sources::library::upsert_harvest_file(&identity) {
-            self.ui.status.sample = format!("Update harvest state failed: {error}");
-            emit_gui_action(
-                "browser.context_menu.harvest.state",
-                Some("browser"),
-                Some(context_menu::target_label(&path).as_str()),
-                "error",
-                started_at,
-                Some(&error.to_string()),
-            );
-            return;
-        }
-        match wavecrate::sample_sources::library::set_harvest_state(&identity.key, state) {
-            Ok(_) => {
-                self.library
-                    .folder_browser
-                    .refresh_after_harvest_state_change();
-                self.ui.status.sample = format!("{status_prefix} {}", sample_path_label(&path));
-                emit_gui_action(
-                    "browser.context_menu.harvest.state",
-                    Some("browser"),
-                    Some(context_menu::target_label(&path).as_str()),
-                    outcome,
-                    started_at,
-                    None,
-                );
-            }
-            Err(error) => {
+
+        let mut changed = false;
+        for target in &targets {
+            if let Err(error) =
+                wavecrate::sample_sources::library::upsert_harvest_file(&target.identity)
+            {
+                if changed {
+                    self.library
+                        .folder_browser
+                        .refresh_after_harvest_state_change();
+                }
                 self.ui.status.sample = format!("Update harvest state failed: {error}");
                 emit_gui_action(
                     "browser.context_menu.harvest.state",
                     Some("browser"),
-                    Some(context_menu::target_label(&path).as_str()),
+                    Some(context_menu::target_label(&target.path).as_str()),
                     "error",
                     started_at,
                     Some(&error.to_string()),
                 );
+                return;
+            }
+            match wavecrate::sample_sources::library::set_harvest_state(&target.identity.key, state)
+            {
+                Ok(_) => {
+                    changed = true;
+                }
+                Err(error) => {
+                    if changed {
+                        self.library
+                            .folder_browser
+                            .refresh_after_harvest_state_change();
+                    }
+                    self.ui.status.sample = format!("Update harvest state failed: {error}");
+                    emit_gui_action(
+                        "browser.context_menu.harvest.state",
+                        Some("browser"),
+                        Some(context_menu::target_label(&target.path).as_str()),
+                        "error",
+                        started_at,
+                        Some(&error.to_string()),
+                    );
+                    return;
+                }
             }
         }
+
+        self.library
+            .folder_browser
+            .refresh_after_harvest_state_change();
+        let target_label = harvest_state_targets_label(&targets);
+        self.ui.status.sample = format!("{status_prefix} {target_label}");
+        emit_gui_action(
+            "browser.context_menu.harvest.state",
+            Some("browser"),
+            Some(&target_label),
+            outcome,
+            started_at,
+            None,
+        );
+    }
+
+    fn take_context_sample_harvest_state_targets(
+        &mut self,
+        action: &'static str,
+        started_at: std::time::Instant,
+    ) -> Option<Vec<HarvestStateTarget>> {
+        let menu = self.take_sample_context_menu(action, started_at)?;
+        let selected_paths = self.library.folder_browser.explicit_selected_file_paths();
+        let paths = if selected_paths.len() > 1 {
+            selected_paths
+        } else {
+            vec![menu.path]
+        };
+        let mut targets = Vec::with_capacity(paths.len());
+        for path in paths {
+            let Some(identity) = self.harvest_identity_for_path(&path) else {
+                self.ui.status.sample =
+                    String::from("Sample is not in a configured harvest source");
+                emit_gui_action(
+                    action,
+                    Some("browser"),
+                    Some(context_menu::target_label(&path).as_str()),
+                    "not_found",
+                    started_at,
+                    Some("harvest identity unavailable"),
+                );
+                return None;
+            };
+            targets.push(HarvestStateTarget { path, identity });
+        }
+        Some(targets)
     }
 
     fn take_context_sample_harvest_target(
@@ -974,6 +1034,27 @@ impl NativeAppState {
         action: &'static str,
         started_at: std::time::Instant,
     ) -> Option<(PathBuf, HarvestFileIdentity)> {
+        let menu = self.take_sample_context_menu(action, started_at)?;
+        let Some(identity) = self.harvest_identity_for_path(&menu.path) else {
+            self.ui.status.sample = String::from("Sample is not in a configured harvest source");
+            emit_gui_action(
+                action,
+                Some("browser"),
+                Some(context_menu::target_label(&menu.path).as_str()),
+                "not_found",
+                started_at,
+                Some("harvest identity unavailable"),
+            );
+            return None;
+        };
+        Some((menu.path, identity))
+    }
+
+    fn take_sample_context_menu(
+        &mut self,
+        action: &'static str,
+        started_at: std::time::Instant,
+    ) -> Option<context_menu::BrowserContextMenu> {
         let Some(menu) = self.ui.browser_interaction.context_menu.take() else {
             return None;
         };
@@ -989,19 +1070,7 @@ impl NativeAppState {
             );
             return None;
         }
-        let Some(identity) = self.harvest_identity_for_path(&menu.path) else {
-            self.ui.status.sample = String::from("Sample is not in a configured harvest source");
-            emit_gui_action(
-                action,
-                Some("browser"),
-                Some(context_menu::target_label(&menu.path).as_str()),
-                "not_found",
-                started_at,
-                Some("harvest identity unavailable"),
-            );
-            return None;
-        };
-        Some((menu.path, identity))
+        Some(menu)
     }
 
     fn selected_sample_harvest_target(
@@ -1150,6 +1219,14 @@ fn harvest_family_path_label(path: &Path) -> String {
         .filter(|name| !name.trim().is_empty())
         .map(str::to_owned)
         .unwrap_or_else(|| path.display().to_string())
+}
+
+fn harvest_state_targets_label(targets: &[HarvestStateTarget]) -> String {
+    match targets {
+        [] => String::from("0 samples"),
+        [target] => sample_path_label(&target.path),
+        targets => format!("{} samples", targets.len()),
+    }
 }
 
 fn source_db_entry_for_path(source: &SampleSource, relative_path: &Path) -> Option<WavEntry> {

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -859,6 +859,19 @@ fn visible_sample_names(state: &NativeAppState) -> Vec<String> {
         .collect()
 }
 
+fn harvest_state_for(
+    source_id: &wavecrate::sample_sources::SourceId,
+    relative_path: &str,
+) -> Option<wavecrate::sample_sources::HarvestState> {
+    let key = wavecrate::sample_sources::HarvestFileKey::new(
+        source_id.clone(),
+        PathBuf::from(relative_path),
+    );
+    wavecrate::sample_sources::library::harvest_file(&key)
+        .expect("load harvest row")
+        .map(|record| record.state)
+}
+
 #[test]
 fn sample_context_menu_open_harvest_destination_requires_primary_source() {
     let root = tempfile::tempdir().expect("source root");
@@ -884,6 +897,150 @@ fn sample_context_menu_open_harvest_destination_requires_primary_source() {
         "Set a Primary source before using a harvest destination"
     );
     assert!(state.ui.browser_interaction.context_menu.is_none());
+}
+
+#[test]
+fn mark_harvest_done_applies_to_explicit_selected_files() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    let hat = root.path().join("hat.wav");
+    for sample in [&kick, &snare, &hat] {
+        fs::write(sample, [0_u8; 8]).expect("write sample");
+    }
+    let source_id = wavecrate::sample_sources::SourceId::from_string(format!(
+        "harvest-context-menu-bulk-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state.library.folder_browser.set_harvest_filter(
+        crate::native_app::sample_library::folder_browser::model::HarvestFilter::NeedsReview,
+        true,
+    );
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..Default::default()
+        },
+    );
+    let mut context = ui::UiUpdateContext::default();
+
+    state.open_sample_context_menu(kick.display().to_string(), Point::new(40.0, 120.0));
+    state.apply_message(GuiMessage::MarkContextSampleHarvestDone, &mut context);
+
+    assert_eq!(
+        harvest_state_for(&source_id, "kick.wav"),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(
+        harvest_state_for(&source_id, "snare.wav"),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(harvest_state_for(&source_id, "hat.wav"), None);
+    assert_eq!(state.ui.status.sample, "Marked harvest done 2 samples");
+    assert_eq!(visible_sample_names(&state), vec!["hat.wav"]);
+}
+
+#[test]
+fn mark_harvest_done_uses_selected_set_when_context_click_is_outside_selection() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    let hat = root.path().join("hat.wav");
+    for sample in [&kick, &snare, &hat] {
+        fs::write(sample, [0_u8; 8]).expect("write sample");
+    }
+    let source_id = wavecrate::sample_sources::SourceId::from_string(format!(
+        "harvest-context-menu-bulk-outside-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state.library.folder_browser.select_file_with_modifiers(
+        snare.display().to_string(),
+        PointerModifiers {
+            command: true,
+            ..Default::default()
+        },
+    );
+    let mut context = ui::UiUpdateContext::default();
+
+    state.open_sample_context_menu(hat.display().to_string(), Point::new(40.0, 120.0));
+    state.apply_message(GuiMessage::MarkContextSampleHarvestDone, &mut context);
+
+    assert_eq!(
+        harvest_state_for(&source_id, "kick.wav"),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(
+        harvest_state_for(&source_id, "snare.wav"),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
+    assert_eq!(harvest_state_for(&source_id, "hat.wav"), None);
+}
+
+#[test]
+fn mark_harvest_done_without_multi_selection_uses_context_clicked_sample() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let hat = root.path().join("hat.wav");
+    for sample in [&kick, &hat] {
+        fs::write(sample, [0_u8; 8]).expect("write sample");
+    }
+    let source_id = wavecrate::sample_sources::SourceId::from_string(format!(
+        "harvest-context-menu-single-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        source_id.clone(),
+        root.path().to_path_buf(),
+    );
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[source]);
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    let mut context = ui::UiUpdateContext::default();
+
+    state.open_sample_context_menu(hat.display().to_string(), Point::new(40.0, 120.0));
+    state.apply_message(GuiMessage::MarkContextSampleHarvestDone, &mut context);
+
+    assert_eq!(harvest_state_for(&source_id, "kick.wav"), None);
+    assert_eq!(
+        harvest_state_for(&source_id, "hat.wav"),
+        Some(wavecrate::sample_sources::HarvestState::Done)
+    );
 }
 
 #[test]

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -182,9 +182,16 @@ impl NativeAppState {
         position: Point,
     ) {
         let started_at = Instant::now();
-        self.library
+        if !self
+            .library
             .folder_browser
-            .focus_file_preserving_selection(path.clone());
+            .explicit_multi_file_selection_active()
+            || self.library.folder_browser.is_file_selected(&path)
+        {
+            self.library
+                .folder_browser
+                .focus_file_preserving_selection(path.clone());
+        }
         let Some(path) = self.library.folder_browser.context_sample_path(&path) else {
             self.ui.status.sample = String::from("Sample is unavailable");
             emit_gui_action(


### PR DESCRIPTION
## Summary
- Makes Mark Harvest Done operate on the selected file set while preserving single-file fallback behavior.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
