### PR TITLE
OPT-955: Remove Shift-X silence-margin zoom-out shortcut

### DIFF
--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -445,12 +445,6 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::Wheel { .. } => Some("waveform.zoom_wheel"),
         WaveformInteraction::ZoomToPlaySelection => Some("waveform.zoom_to_play_selection"),
         WaveformInteraction::ZoomFull => Some("waveform.zoom_full"),
-        WaveformInteraction::ZoomOut {
-            expand_silence_margin: true,
-        } => Some("waveform.zoom_out_silence_margin"),
-        WaveformInteraction::ZoomOut {
-            expand_silence_margin: false,
-        } => Some("waveform.zoom_out"),
         WaveformInteraction::RememberPointerLocation { .. } => None,
         WaveformInteraction::ScrollTo { .. } => Some("waveform.scroll"),
         WaveformInteraction::BeginSelection { .. } => Some("waveform.selection.begin"),

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -250,10 +250,6 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
             ui::KeyPress::new(ui::KeyCode::F),
             GuiMessage::FocusSelectedStarmapNode,
         )
-        .bind(
-            ui::KeyPress::with_shift(ui::KeyCode::X),
-            shifted_x_shortcut_action(state),
-        )
         .bind(ui::KeyPress::new(ui::KeyCode::X), x_shortcut_action(state))
         .bind(
             ui::KeyPress::new(ui::KeyCode::Backquote),
@@ -364,16 +360,6 @@ fn x_shortcut_action(state: &NativeAppState) -> GuiMessage {
         GuiMessage::Waveform(WaveformInteraction::ZoomFull)
     } else {
         GuiMessage::ToggleSelectedSampleAndAdvance
-    }
-}
-
-fn shifted_x_shortcut_action(state: &NativeAppState) -> GuiMessage {
-    if state.waveform.current.has_loaded_sample() {
-        GuiMessage::Waveform(WaveformInteraction::ZoomOut {
-            expand_silence_margin: true,
-        })
-    } else {
-        x_shortcut_action(state)
     }
 }
 

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -148,7 +148,6 @@ fn default_shortcut_help_sections(state: &NativeAppState) -> [ShortcutHelpSectio
                 shortcut_help_item("R", "Reverse selection"),
                 shortcut_help_item("M", "Mute selection"),
                 shortcut_help_item("X", "Zoom out"),
-                shortcut_help_item("Shift-X", "Zoom out with silence margin"),
                 shortcut_help_item("L", "Toggle loop playback"),
             ],
         ),

--- a/src/native_app/tests/shortcuts_context/help.rs
+++ b/src/native_app/tests/shortcuts_context/help.rs
@@ -117,10 +117,10 @@ fn shortcut_help_model_includes_global_and_active_context_sections() {
             .any(|item| item.keys == "X" && item.action == "Zoom out")
     );
     assert!(
-        sections
+        !sections
             .iter()
             .flat_map(|section| &section.items)
-            .any(|item| item.keys == "Shift-X" && item.action == "Zoom out with silence margin")
+            .any(|item| item.keys == "Shift-X" || item.action == "Zoom out with silence margin")
     );
     assert!(
         sections

--- a/src/native_app/tests/shortcuts_context/transport.rs
+++ b/src/native_app/tests/shortcuts_context/transport.rs
@@ -181,20 +181,16 @@ fn x_shortcut_routes_to_waveform_zoom_out_when_waveform_is_zoomed_in() {
 }
 
 #[test]
-fn shift_x_shortcut_routes_to_silence_margin_zoom_out_when_waveform_is_loaded() {
+/// Shift-X no longer routes to the removed silence-margin zoom-out command.
+fn shift_x_shortcut_is_unhandled_when_waveform_is_loaded() {
     let state = NativeAppStateFixture::default()
         .with_synthetic_waveform()
         .build();
     let resolution =
         default_gui_shortcuts(&state).resolve(ui::KeyPress::with_shift(ui::KeyCode::X));
 
-    assert_eq!(
-        resolution.action,
-        Some(GuiMessage::Waveform(WaveformInteraction::ZoomOut {
-            expand_silence_margin: true,
-        }))
-    );
-    assert!(resolution.handled);
+    assert_eq!(resolution.action, None);
+    assert!(!resolution.handled);
 }
 
 #[test]
@@ -205,7 +201,9 @@ fn x_shortcut_routes_to_waveform_zoom_full_from_silence_margin() {
     state
         .waveform
         .current
-        .apply_interaction(WaveformInteraction::ZoomOut {
+        .apply_interaction(WaveformInteraction::Wheel {
+            delta: radiant::gui::types::Vector2::new(0.0, 120.0),
+            anchor_ratio: 0.5,
             expand_silence_margin: true,
         });
     assert!(!state.waveform.current.fully_zoomed_out());

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -31,11 +31,6 @@ impl WaveformState {
             WaveformInteraction::ZoomFull => {
                 self.zoom_full();
             }
-            WaveformInteraction::ZoomOut {
-                expand_silence_margin,
-            } => {
-                self.zoom_out(expand_silence_margin);
-            }
             WaveformInteraction::RememberPointerLocation { position } => {
                 self.context_menu_pointer_position = position
                     .x

--- a/src/native_app/waveform/state_viewport.rs
+++ b/src/native_app/waveform/state_viewport.rs
@@ -71,10 +71,6 @@ impl WaveformState {
         self.viewport = super::WaveformViewport::full(self.file.frames);
     }
 
-    pub(in crate::native_app) fn zoom_out(&mut self, expand_silence_margin: bool) {
-        self.zoom_around_anchor(1.22, self.zoom_anchor_ratio, expand_silence_margin);
-    }
-
     pub(super) fn update_active_pan(&mut self, drag: WaveformPanDrag, visible_ratio: f32) {
         self.viewport = drag.viewport.pan_by_visible_ratio_drag(
             self.file.frames,

--- a/src/native_app/waveform/tests/state.rs
+++ b/src/native_app/waveform/tests/state.rs
@@ -52,19 +52,6 @@ fn shift_zoom_out_extends_viewport_beyond_audio_bounds() {
 }
 
 #[test]
-fn keyboard_silence_margin_zoom_out_extends_full_viewport() {
-    let mut state = WaveformState::synthetic_for_tests();
-
-    state.apply_interaction(WaveformInteraction::ZoomOut {
-        expand_silence_margin: true,
-    });
-
-    assert!(state.viewport().start < 0);
-    assert!(state.viewport().end > state.frames() as i64);
-    assert!(!state.fully_zoomed_out());
-}
-
-#[test]
 fn plain_zoom_out_keeps_full_view_at_audio_bounds() {
     let mut state = WaveformState::synthetic_for_tests();
 
@@ -208,7 +195,9 @@ fn restoring_play_selection_range_zooms_only_when_region_cannot_fit_current_view
 fn zoom_full_restores_complete_waveform_view() {
     let mut state = WaveformState::synthetic_for_tests();
     state.set_play_selection_range(0.25, 0.50);
-    state.apply_interaction(WaveformInteraction::ZoomOut {
+    state.apply_interaction(WaveformInteraction::Wheel {
+        delta: Vector2::new(0.0, 120.0),
+        anchor_ratio: 0.5,
         expand_silence_margin: true,
     });
     assert!(!state.fully_zoomed_out());

--- a/src/native_app/waveform/types.rs
+++ b/src/native_app/waveform/types.rs
@@ -10,9 +10,6 @@ pub(in crate::native_app) enum WaveformInteraction {
     },
     ZoomToPlaySelection,
     ZoomFull,
-    ZoomOut {
-        expand_silence_margin: bool,
-    },
     RememberPointerLocation {
         position: Point,
     },


### PR DESCRIPTION
## Summary
- Removes the Shift-X shortcut path for waveform silence-margin zoom-out.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
