### PR TITLE
OPT-960: Make the help button slightly larger

### DIFF
--- a/src/native_app/app_chrome/settings/top_bar.rs
+++ b/src/native_app/app_chrome/settings/top_bar.rs
@@ -26,8 +26,8 @@ const NORMALIZED_AUDITION_BUTTON_SIZE: ControlSize = ControlSize {
 };
 pub(in crate::native_app) const HELP_TOOLTIPS_BUTTON_ID: u64 = widget_ids::HELP_TOOLTIPS_BUTTON_ID;
 const HELP_TOOLTIPS_BUTTON_SIZE: ControlSize = ControlSize {
-    width: 12.0,
-    height: 18.0,
+    width: 18.0,
+    height: 22.0,
 };
 pub(in crate::native_app) const AUDIO_ENGINE_PILL_ID: u64 = widget_ids::AUDIO_ENGINE_PILL_ID;
 const AUDIO_ENGINE_PILL_SIZE: ControlSize = ControlSize {

--- a/src/native_app/tests/audio_settings_controls/top_bar.rs
+++ b/src/native_app/tests/audio_settings_controls/top_bar.rs
@@ -48,7 +48,8 @@ fn top_control_bar_places_help_button_after_settings_gear() {
         settings.max.x <= help.min.x,
         "help button should sit to the right of the settings gear"
     );
-    assert!(help.width() <= 12.0);
+    assert_eq!(help.width(), 18.0);
+    assert_eq!(help.height(), 22.0);
 }
 
 #[test]
@@ -102,7 +103,8 @@ fn top_help_tooltips_button_paints_as_bare_question_mark() {
         .paint_plan
         .first_svg_rect_for_widget(help_id)
         .expect("help button should paint the question mark icon");
-    assert!(icon_rect.width() <= 12.0);
+    assert!(icon_rect.width() > 12.0);
+    assert!(icon_rect.width() <= 18.0);
     assert!(
         !frame
             .paint_plan


### PR DESCRIPTION
## Summary
- Increases the help button size and target affordance while preserving its compact toolbar behavior.
- Parks the local OPT branch for review against main.

## Validation
- Not rerun during this PR-opening pass.
- Latest branch commit: $commit.
- GitHub CI should run as the review gate for this draft PR.
