### PR TITLE
OPT-966: Activate default Harvest filter mode

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section/tests/row_projection.rs
@@ -390,6 +390,23 @@ fn filter_section_projects_harvest_filter_dropdown_and_dispatches_changes() {
 }
 
 #[test]
+fn filter_section_projects_default_harvest_all_after_family_toggle() {
+    let mut state = FolderBrowserState::load_default();
+    state.set_filter_family_enabled(FilterFamily::Harvest, true);
+    let model = FilterSectionViewModel::from_folder_browser(&state, false);
+
+    assert!(model.harvest.enabled);
+    assert_eq!(model.harvest.selected_filter, Some(HarvestFilter::All));
+
+    let frame = filter_section(&model).view_frame_at_size_with_default_theme(ui::Vector2::new(
+        240.0,
+        FILTER_SECTION_TEST_FRAME_HEIGHT,
+    ));
+
+    assert!(frame.paint_plan.contains_text("All  v"));
+}
+
+#[test]
 fn filter_section_hides_clear_buttons_when_filters_are_empty() {
     let state = FolderBrowserState::load_default();
     let model = FilterSectionViewModel::from_folder_browser(&state, false);

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -296,7 +296,7 @@ impl FilterSectionViewModel {
             harvest: HarvestFilterViewModel {
                 enabled: folder_browser.harvest_filter_enabled(),
                 dropdown_open: false,
-                selected_filter: folder_browser.harvest_filter(),
+                selected_filter: Some(folder_browser.selected_harvest_filter()),
                 options: HARVEST_FILTERS
                     .into_iter()
                     .map(|filter| HarvestFilterOptionViewModel {

--- a/src/native_app/sample_library/folder_browser/harvest_filter.rs
+++ b/src/native_app/sample_library/folder_browser/harvest_filter.rs
@@ -7,6 +7,8 @@ use wavecrate::sample_sources::{HarvestState, SourceId};
 
 use super::{FileEntry, FolderBrowserState};
 
+pub(in crate::native_app) const DEFAULT_HARVEST_FILTER: HarvestFilter = HarvestFilter::All;
+
 pub(in crate::native_app) const HARVEST_FILTERS: [HarvestFilter; 9] = [
     HarvestFilter::New,
     HarvestFilter::NewAndTouched,

--- a/src/native_app/sample_library/folder_browser/panel_state.rs
+++ b/src/native_app/sample_library/folder_browser/panel_state.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use super::{
     DEFAULT_COLLECTIONS_PANEL_HEIGHT, FolderBrowserState,
     curation::{BrowserCurationMode, BrowserCurationScope},
-    harvest_filter::{HARVEST_FILTERS, HarvestFilter},
+    harvest_filter::{DEFAULT_HARVEST_FILTER, HARVEST_FILTERS, HarvestFilter},
     messages::FilterFamily,
     playback_type_filter::{PLAYBACK_TYPE_FILTERS, PlaybackTypeFilter},
     rating_filter::RATING_FILTER_LEVELS,
@@ -139,7 +139,13 @@ impl FolderBrowserState {
     }
 
     pub(in crate::native_app) fn harvest_filter(&self) -> Option<HarvestFilter> {
-        self.filters.harvest
+        self.filters
+            .harvest_enabled
+            .then_some(self.selected_harvest_filter())
+    }
+
+    pub(in crate::native_app) fn selected_harvest_filter(&self) -> HarvestFilter {
+        self.filters.harvest.unwrap_or(DEFAULT_HARVEST_FILTER)
     }
 
     pub(in crate::native_app) fn harvest_filter_enabled(&self) -> bool {
@@ -190,7 +196,12 @@ impl FolderBrowserState {
             FilterFamily::Name => set_bool(&mut self.filters.name_enabled, enabled),
             FilterFamily::Tags => set_bool(&mut self.filters.tags_enabled, enabled),
             FilterFamily::Curation => set_bool(&mut self.filters.curation.enabled, enabled),
-            FilterFamily::Harvest => set_bool(&mut self.filters.harvest_enabled, enabled),
+            FilterFamily::Harvest => {
+                if enabled && self.filters.harvest.is_none() {
+                    self.filters.harvest = Some(DEFAULT_HARVEST_FILTER);
+                }
+                set_bool(&mut self.filters.harvest_enabled, enabled)
+            }
             FilterFamily::PlaybackType => {
                 set_bool(&mut self.filters.playback_type_enabled, enabled)
             }
@@ -266,12 +277,11 @@ impl FolderBrowserState {
         if !HARVEST_FILTERS.contains(&filter) {
             return;
         }
-        let next = enabled.then_some(filter);
-        if self.filters.harvest == next {
+        if self.filters.harvest == Some(filter) && self.filters.harvest_enabled == enabled {
             return;
         }
-        self.filters.harvest = next;
-        self.filters.harvest_enabled = self.filters.harvest.is_some();
+        self.filters.harvest = Some(filter);
+        self.filters.harvest_enabled = enabled;
         self.clear_listing_reveals();
         self.retain_visible_file_selection_after_filter();
         self.reset_file_view();

--- a/src/native_app/sample_library/folder_browser/sample_queries.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries.rs
@@ -59,8 +59,7 @@ impl FolderBrowserState {
     pub(super) fn active_harvest_filter(&self) -> Option<harvest_filter::HarvestFilter> {
         self.filters
             .harvest_enabled
-            .then_some(self.filters.harvest)
-            .flatten()
+            .then_some(self.selected_harvest_filter())
     }
 
     pub(in crate::native_app) fn harvest_context_menu_actions_active(&self) -> bool {

--- a/src/native_app/sample_library/folder_browser/tests/file_filters.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_filters.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
 use crate::native_app::sample_library::folder_browser::model::{
-    BrowserCurationScope, PlaybackTypeFilter,
+    BrowserCurationScope, HARVEST_FILTERS, HarvestFilter, PlaybackTypeFilter,
 };
 use crate::native_app::sample_library::folder_browser::projection::VisibleSampleQuery;
 use std::collections::{HashMap, HashSet};
@@ -736,6 +736,87 @@ fn filter_family_labels_disable_filters_without_discarding_selected_values() {
         "re-enabling should restore the preserved name filter value"
     );
     let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn enabling_harvest_filter_family_activates_default_all_mode() {
+    let mut browser = FolderBrowserState::load_default();
+
+    assert_eq!(browser.selected_harvest_filter(), HarvestFilter::All);
+    assert_eq!(browser.harvest_filter(), None);
+    assert!(!browser.harvest_mode_active());
+    assert!(!browser.harvest_context_menu_actions_active());
+    assert!(
+        browser
+            .visible_file_columns()
+            .into_iter()
+            .all(|column| column.id != "harvest"),
+        "normal browsing should not show the Harvest column"
+    );
+
+    browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+        FilterFamily::Harvest,
+        true,
+    ));
+
+    assert_eq!(browser.selected_harvest_filter(), HarvestFilter::All);
+    assert_eq!(browser.harvest_filter(), Some(HarvestFilter::All));
+    assert!(browser.harvest_mode_active());
+    assert!(browser.harvest_context_menu_actions_active());
+    assert!(
+        browser
+            .visible_file_columns()
+            .into_iter()
+            .any(|column| column.id == "harvest"),
+        "enabling Harvest with default All should immediately expose Harvest-gated UI"
+    );
+
+    browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+        FilterFamily::Harvest,
+        false,
+    ));
+
+    assert_eq!(browser.selected_harvest_filter(), HarvestFilter::All);
+    assert_eq!(browser.harvest_filter(), None);
+    assert!(!browser.harvest_mode_active());
+    assert!(!browser.harvest_context_menu_actions_active());
+    assert!(
+        browser
+            .visible_file_columns()
+            .into_iter()
+            .all(|column| column.id != "harvest"),
+        "disabling Harvest should return to normal browsing"
+    );
+}
+
+#[test]
+fn harvest_filter_family_reactivation_preserves_each_selected_mode() {
+    for filter in HARVEST_FILTERS {
+        if filter == HarvestFilter::All {
+            continue;
+        }
+        let mut browser = FolderBrowserState::load_default();
+
+        browser.apply_message(FolderBrowserMessage::SetHarvestFilter(filter, true));
+        assert_eq!(browser.selected_harvest_filter(), filter);
+        assert_eq!(browser.harvest_filter(), Some(filter));
+
+        browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+            FilterFamily::Harvest,
+            false,
+        ));
+        assert_eq!(browser.selected_harvest_filter(), filter);
+        assert_eq!(browser.harvest_filter(), None);
+        assert!(!browser.harvest_mode_active());
+
+        browser.apply_message(FolderBrowserMessage::SetFilterFamilyEnabled(
+            FilterFamily::Harvest,
+            true,
+        ));
+        assert_eq!(browser.selected_harvest_filter(), filter);
+        assert_eq!(browser.harvest_filter(), Some(filter));
+        assert!(browser.harvest_mode_active());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Scope
- Fix OPT-966 so enabling the Harvest filter family immediately activates the currently selected Harvest mode.
- Treat `All` as the stored default Harvest mode, while keeping row enabled/disabled state as the control for filter participation.
- Preserve the selected Harvest mode when the row is disabled and re-enabled.
- Keep Harvest-gated UI surfaces aligned with the active-state contract, including context menu actions and the Harvest column.
- Audit Curation's matching dropdown-backed path; it already stores `scope` separately from `enabled`, and the existing Curation activation smoke test still passes.

## Definition of Done
- Toggling Harvest on immediately activates default `All` without requiring a dropdown selection.
- Selecting any non-default Harvest mode, disabling Harvest, and re-enabling Harvest restores that same active mode.
- Disabling Harvest removes active Harvest filtering and hides Harvest-gated UI while preserving the selected mode.
- The sidebar projection shows `All` as the selected Harvest option after default activation.

## Validation commands
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate harvest_filter_family -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate filter_section_projects_default_harvest_all_after_family_toggle -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate filter_family_labels_disable_filters_without_discarding_selected_values -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate enabling_curation_filter_focuses_first_visible_sample_immediately -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate file_columns -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate browser_context_menu -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate filter_section -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate file_filters -- --test-threads=1 --nocapture`

## Known limitations
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt966-target cargo test -p wavecrate waveform_destructive_edit -- --test-threads=1 --nocapture` still fails two protected-source tests. I verified `protected_extract_and_trim_extracts_to_primary_without_mutating_origin` also fails on `origin/main` at `30ee603ed9756e50e4cfce5bf3be80d673967581`, so this is treated as an existing baseline failure outside OPT-966.

User review is required before merge.
