### PR TITLE
OPT-967: Gate Curation column by workflow state

### DIFF
--- a/src/native_app/sample_library/folder_browser/file_columns/drag.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/drag.rs
@@ -76,6 +76,7 @@ impl FolderBrowserState {
         };
         let placements = self.visible_file_column_placements();
         let collection_active = self.collection_focus_active();
+        let curation_active = self.curation_mode_enabled();
         let harvest_active = self.harvest_mode_active();
         ui::update_visible_details_column_reorder_drag(
             &mut self.sample_list.file_column_reorder,
@@ -85,7 +86,14 @@ impl FolderBrowserState {
             &placements,
             FILE_COLUMN_GAP,
             |column| column.id.as_str(),
-            |column| file_column_visible_in_context(column.kind, collection_active, harvest_active),
+            |column| {
+                file_column_visible_in_context(
+                    column.kind,
+                    collection_active,
+                    curation_active,
+                    harvest_active,
+                )
+            },
         );
     }
 

--- a/src/native_app/sample_library/folder_browser/file_columns/layout.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/layout.rs
@@ -5,12 +5,18 @@ use super::super::{FileColumn, FileColumnKind, FolderBrowserState};
 impl FolderBrowserState {
     pub(in crate::native_app) fn visible_file_columns(&self) -> Vec<&FileColumn> {
         let collection_active = self.collection_focus_active();
+        let curation_active = self.curation_mode_enabled();
         let harvest_active = self.harvest_mode_active();
         self.sample_list
             .file_columns
             .iter()
             .filter(|column| {
-                file_column_visible_in_context(column.kind, collection_active, harvest_active)
+                file_column_visible_in_context(
+                    column.kind,
+                    collection_active,
+                    curation_active,
+                    harvest_active,
+                )
             })
             .collect()
     }
@@ -27,9 +33,11 @@ impl FolderBrowserState {
 pub(super) fn file_column_visible_in_context(
     kind: FileColumnKind,
     collection_active: bool,
+    curation_active: bool,
     harvest_active: bool,
 ) -> bool {
     match kind {
+        FileColumnKind::Curation => curation_active,
         FileColumnKind::Harvest => harvest_active,
         FileColumnKind::SourceFolder => collection_active,
         _ => true,

--- a/src/native_app/sample_library/folder_browser/tests/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_columns.rs
@@ -1,7 +1,19 @@
-use super::super::harvest_filter::HarvestFilter;
 use super::*;
+use crate::native_app::sample_library::folder_browser::commands::FilterFamily;
+use crate::native_app::sample_library::folder_browser::model::{
+    BROWSER_CURATION_SCOPES, BrowserCurationScope, HarvestFilter,
+};
 use crate::native_app::sample_library::folder_browser::projection::VisibleSampleQuery;
 use std::path::Path;
+
+fn visible_column_ids(browser: &FolderBrowserState) -> Vec<&str> {
+    browser
+        .visible_file_columns()
+        .into_iter()
+        .map(|column| column.id.as_str())
+        .collect::<Vec<_>>()
+}
+
 #[test]
 fn sample_file_sort_toggles_by_column_and_navigation_uses_sorted_order() {
     let root = temp_source_root("wavecrate-gui-file-sort");
@@ -122,21 +134,16 @@ fn history_column_label_reflects_last_played_behavior() {
 }
 
 #[test]
-/// Normal browsing keeps Harvest metadata out of the sample-list column set.
-fn normal_browsing_hides_harvest_column() {
+/// Normal browsing keeps workflow metadata out of the sample-list column set.
+fn normal_browsing_hides_workflow_columns() {
     let browser = FolderBrowserState::load_default();
 
     assert_eq!(
-        browser
-            .visible_file_columns()
-            .into_iter()
-            .map(|column| column.id.as_str())
-            .collect::<Vec<_>>(),
+        visible_column_ids(&browser),
         vec![
             "name",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",
@@ -163,6 +170,27 @@ fn active_harvest_filter_shows_harvest_column() {
             "harvest",
             "rating",
             "playback_type",
+            "collection",
+            "extension",
+            "size",
+            "modified"
+        ]
+    );
+}
+
+#[test]
+/// Enabling Curation makes the Curation column visible in its stored position.
+fn active_curation_filter_shows_curation_column() {
+    let mut browser = FolderBrowserState::load_default();
+
+    browser.set_curation_scope(BrowserCurationScope::All, true);
+
+    assert_eq!(
+        visible_column_ids(&browser),
+        vec![
+            "name",
+            "rating",
+            "playback_type",
             "curation",
             "collection",
             "extension",
@@ -170,6 +198,40 @@ fn active_harvest_filter_shows_harvest_column() {
             "modified"
         ]
     );
+}
+
+#[test]
+/// Every Curation dropdown mode participates in the same column visibility contract.
+fn active_curation_scope_modes_show_curation_column() {
+    for scope in BROWSER_CURATION_SCOPES {
+        let mut browser = FolderBrowserState::load_default();
+
+        browser.set_curation_scope(scope, true);
+
+        assert!(
+            visible_column_ids(&browser).contains(&"curation"),
+            "{scope:?} should show the Curation column while active"
+        );
+    }
+}
+
+#[test]
+/// Disabling Curation hides the column without discarding the selected scope.
+fn inactive_curation_filter_hides_curation_column_and_preserves_scope() {
+    let mut browser = FolderBrowserState::load_default();
+
+    browser.set_curation_scope(BrowserCurationScope::Tags, true);
+    browser.set_filter_family_enabled(FilterFamily::Curation, false);
+
+    assert_eq!(browser.curation_scope(), BrowserCurationScope::Tags);
+    assert!(!browser.curation_mode_enabled());
+    assert!(!visible_column_ids(&browser).contains(&"curation"));
+
+    browser.set_filter_family_enabled(FilterFamily::Curation, true);
+
+    assert_eq!(browser.curation_scope(), BrowserCurationScope::Tags);
+    assert!(browser.curation_mode_enabled());
+    assert!(visible_column_ids(&browser).contains(&"curation"));
 }
 
 #[test]
@@ -199,16 +261,11 @@ fn collection_view_shows_source_folder_column() {
     browser.set_file_collection_state(&keep, collection);
 
     assert_eq!(
-        browser
-            .visible_file_columns()
-            .into_iter()
-            .map(|column| column.id.as_str())
-            .collect::<Vec<_>>(),
+        visible_column_ids(&browser),
         vec![
             "name",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",
@@ -219,17 +276,12 @@ fn collection_view_shows_source_folder_column() {
     browser.apply_message(FolderBrowserMessage::ActivateCollection(collection));
 
     assert_eq!(
-        browser
-            .visible_file_columns()
-            .into_iter()
-            .map(|column| column.id.as_str())
-            .collect::<Vec<_>>(),
+        visible_column_ids(&browser),
         vec![
             "name",
             "source_folder",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",
@@ -240,8 +292,8 @@ fn collection_view_shows_source_folder_column() {
 }
 
 #[test]
-/// Collection and Harvest workflows can surface both contextual columns.
-fn collection_view_with_active_harvest_shows_both_contextual_columns() {
+/// Collection and Harvest workflows can surface their contextual columns independently.
+fn collection_view_with_active_harvest_shows_contextual_columns() {
     let root = temp_source_root("wavecrate-gui-collection-harvest-columns");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
@@ -255,11 +307,40 @@ fn collection_view_with_active_harvest_shows_both_contextual_columns() {
     browser.apply_message(FolderBrowserMessage::ActivateCollection(collection));
 
     assert_eq!(
-        browser
-            .visible_file_columns()
-            .into_iter()
-            .map(|column| column.id.as_str())
-            .collect::<Vec<_>>(),
+        visible_column_ids(&browser),
+        vec![
+            "name",
+            "harvest",
+            "source_folder",
+            "rating",
+            "playback_type",
+            "collection",
+            "extension",
+            "size",
+            "modified"
+        ]
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+/// Harvest, Collection, and Curation each contribute their dynamic columns when active.
+fn collection_view_with_active_harvest_and_curation_shows_all_contextual_columns() {
+    let root = temp_source_root("wavecrate-gui-collection-harvest-curation-columns");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let keep = drums.join("keep.wav");
+    fs::write(&keep, []).expect("write sample");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    let collection = SampleCollection::new(0).expect("collection");
+    browser.set_file_collection_state(&keep, collection);
+
+    browser.set_harvest_filter(HarvestFilter::NeedsReview, true);
+    browser.set_curation_scope(BrowserCurationScope::All, true);
+    browser.apply_message(FolderBrowserMessage::ActivateCollection(collection));
+
+    assert_eq!(
+        visible_column_ids(&browser),
         vec![
             "name",
             "harvest",
@@ -550,7 +631,6 @@ fn sample_file_column_drag_reorders_columns() {
             "name",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",
@@ -563,7 +643,7 @@ fn sample_file_column_drag_reorders_columns() {
         .expect("active column drag should project visual feedback");
     assert_eq!(feedback.label, "Rating");
     assert_eq!(feedback.pointer, Point::new(560.0, 0.0));
-    assert_eq!(feedback.marker_x, 524.0);
+    assert_eq!(feedback.marker_x, 534.0);
 
     browser.apply_message(FolderBrowserMessage::DragFileColumn(
         String::from("rating"),
@@ -580,10 +660,9 @@ fn sample_file_column_drag_reorders_columns() {
         vec![
             "name",
             "playback_type",
-            "curation",
-            "rating",
             "collection",
             "extension",
+            "rating",
             "size",
             "modified"
         ]
@@ -633,9 +712,8 @@ fn hidden_harvest_column_preserves_resize_and_order_when_reactivated() {
             "name",
             "rating",
             "playback_type",
-            "harvest",
-            "curation",
             "collection",
+            "harvest",
             "extension",
             "size",
             "modified"
@@ -647,6 +725,58 @@ fn hidden_harvest_column_preserves_resize_and_order_when_reactivated() {
             .find(|column| column.id == "harvest")
             .map(|column| column.width),
         Some(144.0)
+    );
+}
+
+#[test]
+/// Hiding Curation preserves the stored width and position for later reactivation.
+fn hidden_curation_column_preserves_resize_and_order_when_reactivated() {
+    let mut browser = FolderBrowserState::load_default();
+
+    browser.set_curation_scope(BrowserCurationScope::All, true);
+    browser.resize_file_column(
+        String::from("curation"),
+        DragHandleMessage::started(Point::new(0.0, 0.0)),
+    );
+    browser.resize_file_column(
+        String::from("curation"),
+        DragHandleMessage::moved(Point::new(60.0, 0.0)),
+    );
+    browser.set_filter_family_enabled(FilterFamily::Curation, false);
+
+    assert!(
+        browser
+            .visible_file_columns()
+            .into_iter()
+            .all(|column| column.id != "curation"),
+        "inactive Curation mode should hide the stored Curation column"
+    );
+
+    browser.set_filter_family_enabled(FilterFamily::Curation, true);
+    let visible = browser.visible_file_columns();
+
+    assert_eq!(
+        visible
+            .iter()
+            .map(|column| column.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "name",
+            "rating",
+            "playback_type",
+            "curation",
+            "collection",
+            "extension",
+            "size",
+            "modified"
+        ]
+    );
+    assert_eq!(
+        visible
+            .iter()
+            .find(|column| column.id == "curation")
+            .map(|column| column.width),
+        Some(172.0)
     );
 }
 
@@ -677,7 +807,6 @@ fn sample_file_column_drag_cancel_clears_feedback_without_reorder() {
             "name",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",

--- a/src/native_app/tests/sample_browser/column_reorder.rs
+++ b/src/native_app/tests/sample_browser/column_reorder.rs
@@ -101,7 +101,6 @@ fn full_gui_column_drag_commits_on_release_and_clears_feedback() {
             "name",
             "rating",
             "playback_type",
-            "curation",
             "collection",
             "extension",
             "size",
@@ -146,10 +145,9 @@ fn full_gui_column_drag_commits_on_release_and_clears_feedback() {
         vec![
             "name",
             "playback_type",
-            "curation",
-            "rating",
             "collection",
             "extension",
+            "rating",
             "size",
             "modified"
         ]


### PR DESCRIPTION
## Scope

- Hide the Curation sample-list column whenever the Curation filter/workflow row is inactive.
- Show the Curation column immediately when Curation is active, including every stored dropdown scope.
- Keep dynamic column visibility in sync with drag/reorder projection so layout markers and persisted ordering remain aligned.
- Preserve Curation column width/order and the selected Curation scope while the row is disabled.

## Definition of Done

- The Curation column is hidden during normal browsing when Curation is inactive.
- The Curation column appears when Curation is active.
- Toggling Curation updates the item-list layout immediately and cleanly.
- Column order/width persistence and cell painting remain correct.
- Regression coverage covers inactive, active, mode, toggle, and stored width/order states.

## Validation commands

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt967-target cargo test -p wavecrate file_columns -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt967-target cargo test -p wavecrate column_reorder -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt967-target cargo test -p wavecrate file_filters -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt967-target cargo test -p wavecrate row_projection -- --test-threads=1 --nocapture`

## Known limitations

None.

## Review status

User review is required before merge.
