### PR TITLE
OPT-965: Remove sticky playmark resize slop

### DIFF
--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -1152,6 +1152,215 @@ fn playmark_resize_motion_updates_live_until_release() {
 }
 
 #[test]
+fn playmark_right_resize_updates_when_returning_through_original_handle() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let begin = widget
+        .handle_input(bounds, WidgetInput::primary_press(Point::new(120.0, 8.0)))
+        .expect("right-edge resize should begin")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        begin,
+        WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Play,
+            edge: WaveformSelectionEdge::End,
+            visible_ratio: 0.6,
+        }
+    );
+    state.apply_interaction(begin);
+    widget.active_drag_kind = state.active_drag_kind();
+
+    let away = widget
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
+        .expect("dragging away should update the right edge")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(away);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.2, 0.8))
+    );
+
+    let near_origin = widget
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(121.0, 8.0)))
+        .expect("returning through the original handle must still update")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        near_origin,
+        WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.605
+        }
+    );
+    state.apply_interaction(near_origin);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.2, 0.605))
+    );
+
+    let finish = widget
+        .handle_input(
+            bounds,
+            WidgetInput::pointer_release(
+                Point::new(121.0, 8.0),
+                PointerButton::Primary,
+                Default::default(),
+            ),
+        )
+        .expect("right-edge resize should finish at the live preview")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(finish);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.2, 0.605))
+    );
+}
+
+#[test]
+fn playmark_left_resize_updates_when_returning_through_original_handle() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    let begin = widget
+        .handle_input(bounds, WidgetInput::primary_press(Point::new(40.0, 8.0)))
+        .expect("left-edge resize should begin")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        begin,
+        WaveformInteraction::BeginSelectionResize {
+            kind: WaveformSelectionKind::Play,
+            edge: WaveformSelectionEdge::Start,
+            visible_ratio: 0.2,
+        }
+    );
+    state.apply_interaction(begin);
+    widget.active_drag_kind = state.active_drag_kind();
+
+    let away = widget
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 8.0)))
+        .expect("dragging away should update the left edge")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(away);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.0, 0.6))
+    );
+
+    let near_origin = widget
+        .handle_input(bounds, WidgetInput::pointer_move(Point::new(41.0, 8.0)))
+        .expect("returning through the original handle must still update")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        near_origin,
+        WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.205
+        }
+    );
+    state.apply_interaction(near_origin);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.205, 0.6))
+    );
+
+    let finish = widget
+        .handle_input(
+            bounds,
+            WidgetInput::pointer_release(
+                Point::new(41.0, 8.0),
+                PointerButton::Primary,
+                Default::default(),
+            ),
+        )
+        .expect("left-edge resize should finish at the live preview")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    state.apply_interaction(finish);
+    assert_eq!(
+        state.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.205, 0.6))
+    );
+}
+
+#[test]
+fn playmark_resize_crosses_opposite_edge_without_dead_zone() {
+    for (press, drag, edge, expected_visible_ratio, expected_selection) in [
+        (
+            Point::new(120.0, 8.0),
+            Point::new(20.0, 8.0),
+            WaveformSelectionEdge::End,
+            0.1,
+            wavecrate::selection::SelectionRange::new(0.1, 0.2),
+        ),
+        (
+            Point::new(40.0, 8.0),
+            Point::new(160.0, 8.0),
+            WaveformSelectionEdge::Start,
+            0.8,
+            wavecrate::selection::SelectionRange::new(0.6, 0.8),
+        ),
+    ] {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+        state.play_mark_ratio = Some(0.2);
+        let mut widget = waveform_widget_for_state(&state);
+        let bounds = Rect::from_size(200.0, 80.0);
+
+        let begin = widget
+            .handle_input(bounds, WidgetInput::primary_press(press))
+            .expect("playmark resize should begin")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            begin,
+            WaveformInteraction::BeginSelectionResize {
+                kind: WaveformSelectionKind::Play,
+                edge,
+                visible_ratio: press.x / bounds.width(),
+            }
+        );
+        state.apply_interaction(begin);
+        widget.active_drag_kind = state.active_drag_kind();
+
+        let update = widget
+            .handle_input(bounds, WidgetInput::pointer_move(drag))
+            .expect("crossing the opposite edge should emit a live update")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            update,
+            WaveformInteraction::UpdateSelection {
+                visible_ratio: expected_visible_ratio,
+            }
+        );
+        state.apply_interaction(update);
+        assert_eq!(state.play_selection(), Some(expected_selection));
+
+        let finish = widget
+            .handle_input(
+                bounds,
+                WidgetInput::pointer_release(drag, PointerButton::Primary, Default::default()),
+            )
+            .expect("crossed-edge resize should finish")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        state.apply_interaction(finish);
+        assert_eq!(state.play_selection(), Some(expected_selection));
+    }
+}
+
+#[test]
 fn zoomed_playmark_resize_preview_matches_committed_transform() {
     let mut state = WaveformState::synthetic_for_tests();
     state.viewport = super::WaveformViewport {

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -498,7 +498,7 @@ impl WaveformWidget {
     }
 
     fn selection_drag_is_inside_click_slop(&self, event: &CanvasGestureEvent) -> bool {
-        if !self.active_drag_is_selection_like() {
+        if !self.active_drag_uses_click_slop() {
             return false;
         }
         matches!(
@@ -513,7 +513,7 @@ impl WaveformWidget {
         event: &CanvasGestureEvent,
         fallback: CanvasPointer,
     ) -> f32 {
-        if !self.active_drag_is_selection_like() {
+        if !self.active_drag_uses_click_slop() {
             return fallback.normalized_x();
         }
         match event {
@@ -526,14 +526,10 @@ impl WaveformWidget {
         }
     }
 
-    fn active_drag_is_selection_like(&self) -> bool {
+    fn active_drag_uses_click_slop(&self) -> bool {
         matches!(
             self.active_drag_kind,
-            Some(
-                WaveformActiveDragKind::Selection(_)
-                    | WaveformActiveDragKind::SelectionResize(_, _)
-                    | WaveformActiveDragKind::SelectionMove(_)
-            )
+            Some(WaveformActiveDragKind::Selection(_))
         )
     }
 


### PR DESCRIPTION
## Scope

- Stop applying new-selection click slop to existing selection resize and move gestures.
- Keep playmark resize updates continuous when the dragged edge returns through the original handle coordinate.
- Preserve the existing click/tiny-motion behavior for creating a new selection.
- Add regression coverage for both playmark edges and deterministic edge crossing.

## Root cause

The waveform widget classified selection creation, resize, and move gestures together for click-slop handling. That was correct for distinguishing a click from a new drag selection, but it also suppressed resize updates whenever the pointer moved back within a few pixels of the original handle position. During an active resize, that creates a dead zone around the original edge instead of letting the edge follow the pointer.

## Definition of Done

- Playmark edges no longer stick at their original position during resize drags.
- Resizing remains smooth when dragging across the original edge position.
- Edge-crossing behavior is deterministic and has no dead zone.
- The live preview and committed playmark bounds match.
- Tests cover both edges, snapping/clamping-adjacent behavior, and release behavior.

## Validation commands

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate resize -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate native_app::waveform::tests::paint -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate zero_crossing_snap -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate selection_resize_while_playing_does_not_restart_each_drag_update -- --test-threads=1 --nocapture`

## Known limitations

- I did not complete a manual live-app smoke in this pass.
- Broader exploratory commands surfaced two unrelated local failures outside this change's scope:
  - `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate playmark -- --test-threads=1 --nocapture` failed in `native_app::tests::waveform_playback::playmark_selection_change_marks_harvest_file_touched` with `harvest file should exist`.
  - `CARGO_TARGET_DIR=/tmp/wavecrate-opt965-target cargo test -p wavecrate native_app::waveform::tests::widget_input -- --test-threads=1 --nocapture` failed in `native_app::waveform::tests::widget_input::playback_cache_backed_waveform_accepts_primary_click` because persisted playback cache unexpectedly had source WAV bytes.

## Review status

User review is required before merge.
