### PR TITLE
Keep rating hotkeys on current sample

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -158,7 +158,7 @@ pub(in crate::native_app) enum GuiMessage {
     Settings(SettingsMessage),
     Metadata(MetadataMessage),
     FocusLoadedFile,
-    AdjustSelectedRating(i8),
+    AdjustSelectedRatingWithoutAdvance(i8),
     AssignSelectedCollection(SampleCollection),
     RemoveContextSampleFromCollection,
     CleanMissingContextSampleFromCollection,

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -33,13 +33,31 @@ struct RatingAdjustmentPlan {
 }
 
 impl NativeAppState {
+    #[cfg(test)]
     pub(in crate::native_app) fn adjust_selected_rating(
         &mut self,
         delta: i8,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.adjust_selected_rating_with_policy(delta, context, true);
+    }
+
+    pub(in crate::native_app) fn adjust_selected_rating_without_advance(
+        &mut self,
+        delta: i8,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.adjust_selected_rating_with_policy(delta, context, false);
+    }
+
+    fn adjust_selected_rating_with_policy(
+        &mut self,
+        delta: i8,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+        allow_advance: bool,
+    ) {
         let started_at = Instant::now();
-        let advance_visible_ids = self.rating_advance_visible_ids_before_adjustment();
+        let advance_visible_ids = self.rating_advance_visible_ids_before_adjustment(allow_advance);
         let advance_previous_index = advance_visible_ids.as_ref().and_then(|_| {
             self.library
                 .folder_browser
@@ -106,7 +124,8 @@ impl NativeAppState {
             return;
         }
 
-        if applied > 0 && self.ui.settings.persisted.controls.advance_after_rating {
+        if applied > 0 && allow_advance && self.ui.settings.persisted.controls.advance_after_rating
+        {
             if let Some(visible_ids) = advance_visible_ids {
                 self.advance_after_rating_in_visible_order(
                     &visible_ids,
@@ -124,8 +143,12 @@ impl NativeAppState {
         }
     }
 
-    fn rating_advance_visible_ids_before_adjustment(&self) -> Option<Vec<String>> {
-        if !self.ui.settings.persisted.controls.advance_after_rating
+    fn rating_advance_visible_ids_before_adjustment(
+        &self,
+        allow_advance: bool,
+    ) -> Option<Vec<String>> {
+        if !allow_advance
+            || !self.ui.settings.persisted.controls.advance_after_rating
             || self.library.folder_browser.random_navigation_enabled()
         {
             return None;

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -87,7 +87,7 @@ impl NativeAppState {
             GuiMessage::Settings(message) => self.apply_settings_message(message, context),
             GuiMessage::Metadata(message) => self.apply_metadata_message(message, context),
             GuiMessage::FocusLoadedFile
-            | GuiMessage::AdjustSelectedRating(_)
+            | GuiMessage::AdjustSelectedRatingWithoutAdvance(_)
             | GuiMessage::AssignSelectedCollection(_)
             | GuiMessage::RemoveContextSampleFromCollection
             | GuiMessage::CleanMissingContextSampleFromCollection

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -10,7 +10,9 @@ impl NativeAppState {
     ) {
         match message {
             GuiMessage::FocusLoadedFile => self.focus_loaded_file(context),
-            GuiMessage::AdjustSelectedRating(delta) => self.adjust_selected_rating(delta, context),
+            GuiMessage::AdjustSelectedRatingWithoutAdvance(delta) => {
+                self.adjust_selected_rating_without_advance(delta, context)
+            }
             GuiMessage::AssignSelectedCollection(collection) => {
                 self.assign_selected_collection(collection, context)
             }

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -214,11 +214,11 @@ fn default_shortcuts(state: &NativeAppState) -> ui::ShortcutLayer<GuiMessage> {
         .bind(ui::KeyPress::new(ui::KeyCode::N), new_item_action(state))
         .bind(
             ui::KeyPress::new(ui::KeyCode::OpenBracket),
-            GuiMessage::AdjustSelectedRating(-1),
+            GuiMessage::AdjustSelectedRatingWithoutAdvance(-1),
         )
         .bind(
             ui::KeyPress::new(ui::KeyCode::CloseBracket),
-            GuiMessage::AdjustSelectedRating(1),
+            GuiMessage::AdjustSelectedRatingWithoutAdvance(1),
         )
         .bind(
             ui::KeyPress::new(ui::KeyCode::Space),

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -1956,6 +1956,43 @@ fn rating_advance_uses_pre_rating_sorted_order_when_rating_sort_changes() {
 }
 
 #[test]
+fn rating_hotkey_adjustment_does_not_advance_when_auto_advance_is_enabled() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let current = source_root.path().join("a-current.wav");
+    let next = source_root.path().join("b-next.wav");
+    write_test_wav_i16(&current, &[0, 256, -256, 512]);
+    write_test_wav_i16(&next, &[0, 1024, -2048, 4096]);
+    let current_id = current.display().to_string();
+    state.ui.settings.persisted.controls.advance_after_rating = true;
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state.library.folder_browser.select_file(current_id.clone());
+
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.adjust_selected_rating_without_advance(1, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(current_id.as_str())
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_paths(),
+        vec![current.clone()]
+    );
+    assert_eq!(state.waveform.load.label.as_deref(), None);
+    let rows = state.library.folder_browser.selected_audio_files();
+    let current_row = rows
+        .iter()
+        .find(|file| file.id == current_id)
+        .expect("current row remains visible");
+    assert_eq!(current_row.rating, Rating::KEEP_1);
+}
+
+#[test]
 fn rating_advance_moves_to_next_recursive_root_sample() {
     let mut state = gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");

--- a/src/native_app/tests/shortcuts_context/transactions.rs
+++ b/src/native_app/tests/shortcuts_context/transactions.rs
@@ -60,8 +60,14 @@ fn bracket_shortcuts_route_to_rating_adjustments() {
     let down = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::OpenBracket));
     let up = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::CloseBracket));
 
-    assert_eq!(down.action, Some(GuiMessage::AdjustSelectedRating(-1)));
-    assert_eq!(up.action, Some(GuiMessage::AdjustSelectedRating(1)));
+    assert_eq!(
+        down.action,
+        Some(GuiMessage::AdjustSelectedRatingWithoutAdvance(-1))
+    );
+    assert_eq!(
+        up.action,
+        Some(GuiMessage::AdjustSelectedRatingWithoutAdvance(1))
+    );
     assert!(down.handled);
     assert!(up.handled);
 }


### PR DESCRIPTION
## Scope
- Route `[` and `]` rating shortcuts through a no-advance rating action.
- Keep explicit rating auto-advance behavior available for existing internal/test paths.
- Add regression coverage for rating via the hotkey path while `advance_after_rating` is enabled.

## Definition of Done
- Pressing `[` or `]` updates the selected sample rating without navigating to another file.
- The selected sample stays selected and no waveform load is queued by the hotkey rating action.
- Existing explicit auto-advance behavior remains covered and unchanged.

## Validation Commands
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-rating-hotkeys-target cargo test -p wavecrate bracket_shortcuts_route_to_rating_adjustments -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-rating-hotkeys-target cargo test -p wavecrate rating_hotkey_adjustment_does_not_advance_when_auto_advance_is_enabled -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-rating-hotkeys-target cargo test -p wavecrate rating_advance_moves_to_next_recursive_root_sample -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-rating-hotkeys-target cargo test -p wavecrate rating_advance_uses_pre_rating_sorted_order_when_rating_sort_changes -- --test-threads=1 --nocapture`
- `git diff --check`

## Known Limitations
None.

## Review Status
User review is required before merge.
