### PR TITLE
Rate samples copied to DAWs

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -185,6 +185,7 @@ pub(in crate::native_app) enum GuiMessage {
         result: Result<ContextSampleDoubleResult, String>,
     },
     SelectedFilesCopyFinished {
+        paths: Vec<PathBuf>,
         count: usize,
         started_at: Instant,
         result: Result<(), String>,

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -50,7 +50,9 @@ impl NativeAppState {
             1 => String::from("Copying selected file"),
             count => format!("Copying {count} selected files"),
         };
+        let copied_paths = paths.clone();
         context.copy_file_paths(paths, move |result| GuiMessage::SelectedFilesCopyFinished {
+            paths: copied_paths,
             count,
             started_at,
             result: result.into_completed(),
@@ -59,15 +61,23 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn finish_copy_selected_files(
         &mut self,
+        paths: Vec<PathBuf>,
         count: usize,
         started_at: Instant,
         result: Result<(), String>,
     ) {
         match result {
             Ok(()) => {
-                self.ui.status.sample = match count {
-                    1 => String::from("Copied selected file"),
-                    count => format!("Copied {count} selected files"),
+                let rating_error = self.add_keep_rating_to_handoff_paths(&paths).err();
+                self.ui.status.sample = match (count, rating_error) {
+                    (1, None) => String::from("Copied selected file"),
+                    (count, None) => format!("Copied {count} selected files"),
+                    (1, Some(error)) => {
+                        format!("Copied selected file; rating update failed: {error}")
+                    }
+                    (count, Some(error)) => {
+                        format!("Copied {count} selected files; rating update failed: {error}")
+                    }
                 };
                 emit_gui_action(
                     "browser.copy_selected_files",
@@ -350,14 +360,37 @@ impl NativeAppState {
         result: Result<ui::ExternalDragOutcome, String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let handoff_paths = self
+            .ui
+            .browser_interaction
+            .pending_internal_file_drag_paths
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
         context.end_drag();
         self.library.folder_browser.clear_drag();
         self.clear_pending_internal_file_drag_paths();
         self.ui.status.sample = match result {
             Ok(outcome) if outcome.accepted() => match outcome.effect {
-                ui::ExternalDragEffect::Copy => String::from("Dragged item externally"),
+                ui::ExternalDragEffect::Copy | ui::ExternalDragEffect::Link => {
+                    let rating_error = self.add_keep_rating_to_handoff_paths(&handoff_paths).err();
+                    match (outcome.effect, rating_error) {
+                        (ui::ExternalDragEffect::Copy, None) => {
+                            String::from("Dragged item externally")
+                        }
+                        (ui::ExternalDragEffect::Link, None) => {
+                            String::from("Linked item externally")
+                        }
+                        (ui::ExternalDragEffect::Copy, Some(error)) => {
+                            format!("Dragged item externally; rating update failed: {error}")
+                        }
+                        (ui::ExternalDragEffect::Link, Some(error)) => {
+                            format!("Linked item externally; rating update failed: {error}")
+                        }
+                        _ => unreachable!("only copy/link outcomes are matched"),
+                    }
+                }
                 ui::ExternalDragEffect::Move => String::from("Moved item externally"),
-                ui::ExternalDragEffect::Link => String::from("Linked item externally"),
                 ui::ExternalDragEffect::None => String::from("External drag cancelled"),
             },
             Ok(_) => String::from("External drag cancelled"),

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -50,6 +50,26 @@ impl NativeAppState {
         self.adjust_selected_rating_with_policy(delta, context, false);
     }
 
+    pub(in crate::native_app) fn add_keep_rating_to_handoff_paths(
+        &mut self,
+        paths: &[PathBuf],
+    ) -> Result<usize, String> {
+        let plan = self.rating_adjustment_plan_for_paths(paths, 1);
+        if plan.is_empty() {
+            return Ok(0);
+        }
+        let touched_paths = plan
+            .updates
+            .iter()
+            .map(|update| update.absolute_path.clone())
+            .collect::<Vec<_>>();
+        let applied = self.apply_rating_update_states(&plan.updates, RatingUpdateMode::After)?;
+        if applied > 0 {
+            self.mark_harvest_touched_for_paths(&touched_paths);
+        }
+        Ok(applied)
+    }
+
     fn adjust_selected_rating_with_policy(
         &mut self,
         delta: i8,
@@ -230,6 +250,62 @@ impl NativeAppState {
             .map(str::to_owned)
     }
 
+    fn rating_adjustment_plan_for_paths(
+        &self,
+        paths: &[PathBuf],
+        delta: i8,
+    ) -> RatingAdjustmentPlan {
+        if delta == 0 {
+            return RatingAdjustmentPlan::default();
+        }
+        let mut plan = RatingAdjustmentPlan::default();
+        let mut seen = Vec::new();
+        for path in paths.iter().map(|path| normalized_rating_path(path)) {
+            if seen.iter().any(|existing| existing == &path) {
+                continue;
+            }
+            seen.push(path.clone());
+            let Some((absolute_path, previous_rating, previous_locked)) =
+                self.rating_row_state_for_path(&path)
+            else {
+                continue;
+            };
+            if previous_locked || should_auto_trash_on_rating(previous_rating, delta) {
+                continue;
+            }
+            let Some((root, database_root, relative_path)) = self
+                .library
+                .folder_browser
+                .source_database_relative_file_path(&absolute_path)
+            else {
+                continue;
+            };
+            let Some((rating, locked)) = next_rating_state(previous_rating, delta) else {
+                continue;
+            };
+            plan.updates.push(RatingUpdate {
+                root,
+                database_root,
+                relative_path,
+                absolute_path,
+                previous_rating,
+                previous_locked,
+                rating,
+                locked,
+            });
+        }
+        plan
+    }
+
+    fn rating_row_state_for_path(&self, path: &Path) -> Option<(PathBuf, Rating, bool)> {
+        self.library
+            .folder_browser
+            .loaded_source_audio_files()
+            .into_iter()
+            .find(|file| normalized_rating_path(Path::new(&file.id)) == path)
+            .map(|file| (PathBuf::from(&file.id), file.rating, file.rating_locked))
+    }
+
     fn rating_adjustment_plan_for_selected_files(&self, delta: i8) -> RatingAdjustmentPlan {
         if delta == 0 {
             return RatingAdjustmentPlan::default();
@@ -363,6 +439,10 @@ fn next_rating_state(current: Rating, delta: i8) -> Option<(Rating, bool)> {
 
 fn should_auto_trash_on_rating(current: Rating, delta: i8) -> bool {
     current == Rating::TRASH_3 && delta < 0
+}
+
+fn normalized_rating_path(path: &Path) -> PathBuf {
+    path.components().collect()
 }
 
 impl RatingAdjustmentPlan {

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -63,10 +63,11 @@ impl NativeAppState {
                 result,
             } => self.finish_context_sample_double(source_path, started_at, result, context),
             GuiMessage::SelectedFilesCopyFinished {
+                paths,
                 count,
                 started_at,
                 result,
-            } => self.finish_copy_selected_files(count, started_at, result),
+            } => self.finish_copy_selected_files(paths, count, started_at, result),
             GuiMessage::WaveformSelectionCopyExtracted {
                 completion,
                 playback_type,

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -43,6 +43,40 @@ fn read_test_wav_i16(path: &std::path::Path) -> Vec<i16> {
         .expect("read samples")
 }
 
+fn assert_sample_rating(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    path: &Path,
+    rating: Rating,
+    locked: bool,
+) {
+    let file_id = path.display().to_string();
+    let row = state
+        .library
+        .folder_browser
+        .loaded_source_audio_files()
+        .into_iter()
+        .find(|file| file.id == file_id)
+        .expect("rated file should be loaded");
+    assert_eq!(row.rating, rating);
+    assert_eq!(row.rating_locked, locked);
+
+    let (source_root, source_database_root, relative_path) = state
+        .library
+        .folder_browser
+        .source_database_relative_file_path(path)
+        .expect("rated file should belong to a source");
+    let db = SourceDatabase::open_read_only_with_database_root(source_root, &source_database_root)
+        .expect("source database should open");
+    let persisted = db
+        .list_files()
+        .expect("source database files should list")
+        .into_iter()
+        .find(|entry| entry.relative_path == relative_path)
+        .expect("rated file should be persisted");
+    assert_eq!(persisted.tag, rating);
+    assert_eq!(persisted.locked, locked);
+}
+
 fn assert_short_edge_faded_drag_extraction(path: &std::path::Path) {
     let samples = read_test_wav_i16(path);
     assert_eq!(samples.len(), 4);
@@ -101,6 +135,110 @@ fn file_move_conflict_dialog_renders_resolution_choices() {
     assert!(frame.paint_plan.contains_text("Overwrite"));
     assert!(frame.paint_plan.contains_text("Rename"));
     assert!(frame.paint_plan.contains_text("Skip"));
+}
+
+#[test]
+fn successful_selected_file_copy_adds_keep_rating() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let drums = source_root.path().join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let kick = drums.join("kick.wav");
+    write_test_wav_i16(&kick, &[0, 256, -256, 512]);
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::ActivateFolder(
+            drums.display().to_string(),
+            Default::default(),
+        ));
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+
+    state.finish_copy_selected_files(vec![kick.clone()], 1, std::time::Instant::now(), Ok(()));
+
+    assert_sample_rating(&state, &kick, Rating::KEEP_1, false);
+}
+
+#[test]
+fn successful_selected_file_copy_increments_existing_keep_rating() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let drums = source_root.path().join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let kick = drums.join("kick.wav");
+    write_test_wav_i16(&kick, &[0, 256, -256, 512]);
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::ActivateFolder(
+            drums.display().to_string(),
+            Default::default(),
+        ));
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .set_file_rating_state(&kick, Rating::KEEP_1, false)
+    );
+
+    state.finish_copy_selected_files(vec![kick.clone()], 1, std::time::Instant::now(), Ok(()));
+
+    assert_sample_rating(&state, &kick, Rating::new(2), false);
+}
+
+#[test]
+fn accepted_external_file_drag_adds_keep_rating() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let drums = source_root.path().join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let kick = drums.join("kick.wav");
+    write_test_wav_i16(&kick, &[0, 256, -256, 512]);
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::ActivateFolder(
+            drums.display().to_string(),
+            Default::default(),
+        ));
+    state
+        .library
+        .folder_browser
+        .select_file(kick.display().to_string());
+    state
+        .library
+        .folder_browser
+        .begin_file_drag(kick.display().to_string(), Point::new(4.0, 8.0));
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.arm_browser_drag(&mut context);
+
+    state.external_drag_completed(
+        Ok(ui::ExternalDragOutcome {
+            effect: ui::ExternalDragEffect::Copy,
+        }),
+        &mut context,
+    );
+
+    assert_sample_rating(&state, &kick, Rating::KEEP_1, false);
 }
 
 #[test]


### PR DESCRIPTION
## Scope
- Automatically apply one positive Keep rating step after a successful selected-file clipboard handoff.
- Automatically apply one positive Keep rating step after an accepted external drag Copy/Link handoff.
- Reuse Wavecrate's existing rating ladder and persistence path, including Keep 1 -> Keep 2, Trash 1 -> Keep 1, and Keep 3 lock behavior.
- Preserve existing waveform range extraction metadata behavior; extracted clips already receive default metadata through that workflow.

## Definition of Done
- Copying a selected sample for DAW handoff increments that sample's Keep rating once after the platform copy succeeds.
- Dragging a sample externally into a DAW increments that sample's Keep rating once after the external target accepts the drop.
- Failed/cancelled handoffs do not rate samples.
- Rating changes are reflected in the browser row state and persisted source database metadata.

## Validation Commands
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate successful_selected_file_copy_adds_keep_rating -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate successful_selected_file_copy_increments_existing_keep_rating -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate accepted_external_file_drag_adds_keep_rating -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate whole_file_copy_uses_radiant_platform_clipboard_handoff -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate browser_file_copy_after_playmark_selection_uses_original_file_path -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/tmp/wavecrate-daw-rating-target cargo test -p wavecrate file_drag_external_request_uses_selected_file_paths -- --test-threads=1 --nocapture`

## Known Limitations
None.

## Review Status
User review is required before merge.
