### PR TITLE
Add configurable rating decay

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -422,6 +422,7 @@ pub(in crate::native_app) enum SettingsMessage {
     SetAudioOutputHost(Option<String>),
     SetAudioOutputDevice(Option<String>),
     SetAudioOutputSampleRate(Option<u32>),
+    SetRatingDecayWeeks(u16),
     PickTrashFolder,
     ClearTrashFolder,
     ClearRebuildableCaches,

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -106,6 +106,7 @@ mod tests {
             label: String::from("Source"),
             root: root.path().to_path_buf(),
             database_root: root.path().to_path_buf(),
+            rating_decay_weeks: FolderScanRequest::default_rating_decay_weeks(),
         }
     }
 

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -54,6 +54,7 @@ fn stale_finish_keeps_active_scan_owner() {
             label: request.label.clone(),
             root: request.root.clone(),
             database_root: request.database_root.clone(),
+            rating_decay_weeks: request.rating_decay_weeks,
         },
         |_| {},
         |_| {},

--- a/src/native_app/app_chrome/settings/window/panels.rs
+++ b/src/native_app/app_chrome/settings/window/panels.rs
@@ -3,13 +3,13 @@ use radiant::prelude as ui;
 mod projection;
 
 use self::projection::{
-    CacheMaintenanceProjection, SettingsActionProjection, SettingsPanelRowProjection,
-    TrashFolderProjection, settings_panel_projection,
+    CacheMaintenanceProjection, RatingDecayProjection, SettingsActionProjection,
+    SettingsPanelRowProjection, TrashFolderProjection, settings_panel_projection,
 };
 use super::AUDIO_SETTINGS_LABELED_ROW_HEIGHT;
 use super::AUDIO_SETTINGS_ROW_SPACING;
 use super::dropdowns::{audio_host_dropdown, audio_output_dropdown, audio_sample_rate_dropdown};
-use crate::native_app::app::{AudioSettingsDropdown, GuiMessage};
+use crate::native_app::app::{AudioSettingsDropdown, GuiMessage, SettingsMessage};
 use crate::native_app::app_chrome::view_models::settings::AudioSettingsSnapshot;
 
 pub(super) fn settings_content(snapshot: &AudioSettingsSnapshot) -> ui::View<GuiMessage> {
@@ -33,6 +33,7 @@ fn settings_panel_row(
             audio_settings_dropdown_row(label, dropdown, snapshot)
         }
         SettingsPanelRowProjection::TrashFolder(projection) => trash_folder_section(projection),
+        SettingsPanelRowProjection::RatingDecay(projection) => rating_decay_section(projection),
         SettingsPanelRowProjection::CacheMaintenance(projection) => {
             cache_maintenance_section(projection)
         }
@@ -70,6 +71,22 @@ fn cache_maintenance_section(projection: CacheMaintenanceProjection) -> ui::View
         settings_action_button(projection.clear_action).fill_width(),
         AUDIO_SETTINGS_LABELED_ROW_HEIGHT,
     )
+}
+
+fn rating_decay_section(projection: RatingDecayProjection) -> ui::View<GuiMessage> {
+    let value_label = ui::text_line(projection.value_label, 18.0).width(92.0);
+    let slider = ui::slider(projection.slider_value)
+        .message(|value| {
+            GuiMessage::Settings(SettingsMessage::SetRatingDecayWeeks(
+                RatingDecayProjection::weeks_from_slider_value(value),
+            ))
+        })
+        .fill_width();
+    let control = ui::row([slider, value_label])
+        .spacing(8.0)
+        .fill_width()
+        .height(24.0);
+    ui::labeled_control(projection.label, control, AUDIO_SETTINGS_LABELED_ROW_HEIGHT)
 }
 
 fn settings_action_button(action: SettingsActionProjection) -> ui::View<GuiMessage> {

--- a/src/native_app/app_chrome/settings/window/panels/projection.rs
+++ b/src/native_app/app_chrome/settings/window/panels/projection.rs
@@ -1,5 +1,8 @@
 use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, SettingsMessage};
 use crate::native_app::app_chrome::view_models::settings::AudioSettingsSnapshot;
+use wavecrate::sample_sources::config::{
+    MAX_RATING_DECAY_WEEKS, MIN_RATING_DECAY_WEEKS, clamp_rating_decay_weeks,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum SettingsPanelProjection {
@@ -35,6 +38,7 @@ pub(super) enum SettingsPanelRowProjection {
         dropdown: AudioSettingsDropdown,
     },
     TrashFolder(TrashFolderProjection),
+    RatingDecay(RatingDecayProjection),
     CacheMaintenance(CacheMaintenanceProjection),
 }
 
@@ -50,6 +54,22 @@ pub(super) struct TrashFolderProjection {
 pub(super) struct CacheMaintenanceProjection {
     pub(super) label: &'static str,
     pub(super) clear_action: SettingsActionProjection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct RatingDecayProjection {
+    pub(super) label: &'static str,
+    pub(super) weeks: u16,
+    pub(super) slider_value: f32,
+    pub(super) value_label: String,
+}
+
+impl RatingDecayProjection {
+    pub(super) fn weeks_from_slider_value(value: f32) -> u16 {
+        let span = f32::from(MAX_RATING_DECAY_WEEKS - MIN_RATING_DECAY_WEEKS);
+        let weeks = f32::from(MIN_RATING_DECAY_WEEKS) + value.clamp(0.0, 1.0) * span;
+        clamp_rating_decay_weeks(weeks.round() as u16)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -102,6 +122,12 @@ fn general_settings_panel_rows(
 ) -> Vec<SettingsPanelRowProjection> {
     vec![
         SettingsPanelRowProjection::Title { label: "General" },
+        SettingsPanelRowProjection::RatingDecay(RatingDecayProjection {
+            label: "Rating Decay",
+            weeks: clamp_rating_decay_weeks(snapshot.rating_decay_weeks),
+            slider_value: rating_decay_slider_value(snapshot.rating_decay_weeks),
+            value_label: rating_decay_value_label(snapshot.rating_decay_weeks),
+        }),
         SettingsPanelRowProjection::TrashFolder(TrashFolderProjection {
             label: "Trash Folder",
             value: snapshot
@@ -126,6 +152,24 @@ fn general_settings_panel_rows(
             },
         }),
     ]
+}
+
+fn rating_decay_slider_value(weeks: u16) -> f32 {
+    let weeks = clamp_rating_decay_weeks(weeks);
+    let span = f32::from(MAX_RATING_DECAY_WEEKS - MIN_RATING_DECAY_WEEKS);
+    if span <= 0.0 {
+        return 0.0;
+    }
+    f32::from(weeks - MIN_RATING_DECAY_WEEKS) / span
+}
+
+fn rating_decay_value_label(weeks: u16) -> String {
+    let weeks = clamp_rating_decay_weeks(weeks);
+    if weeks == 1 {
+        "1 week".to_string()
+    } else {
+        format!("{weeks} weeks")
+    }
 }
 
 #[cfg(test)]
@@ -189,12 +233,23 @@ mod tests {
             panic!("expected general panel");
         };
 
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 4);
         assert_eq!(
             rows[0],
             SettingsPanelRowProjection::Title { label: "General" }
         );
-        let SettingsPanelRowProjection::TrashFolder(trash_folder) = &rows[1] else {
+        let SettingsPanelRowProjection::RatingDecay(rating_decay) = &rows[1] else {
+            panic!("expected rating decay row");
+        };
+        assert_eq!(rating_decay.label, "Rating Decay");
+        assert_eq!(rating_decay.weeks, snapshot.rating_decay_weeks);
+        assert_eq!(rating_decay.value_label, "4 weeks");
+        assert_eq!(
+            RatingDecayProjection::weeks_from_slider_value(rating_decay.slider_value),
+            snapshot.rating_decay_weeks
+        );
+
+        let SettingsPanelRowProjection::TrashFolder(trash_folder) = &rows[2] else {
             panic!("expected trash folder row");
         };
         assert_eq!(trash_folder.label, "Trash Folder");
@@ -210,7 +265,7 @@ mod tests {
             SettingsMessage::ClearTrashFolder
         );
 
-        let SettingsPanelRowProjection::CacheMaintenance(maintenance) = &rows[2] else {
+        let SettingsPanelRowProjection::CacheMaintenance(maintenance) = &rows[3] else {
             panic!("expected cache maintenance row");
         };
         assert_eq!(maintenance.label, "Maintenance");
@@ -231,10 +286,32 @@ mod tests {
         let SettingsPanelProjection::General { rows } = settings_panel_projection(&snapshot) else {
             panic!("expected general panel");
         };
-        let SettingsPanelRowProjection::TrashFolder(trash_folder) = &rows[1] else {
+        let SettingsPanelRowProjection::TrashFolder(trash_folder) = &rows[2] else {
             panic!("expected trash folder row");
         };
 
         assert_eq!(trash_folder.value, "wavecrate-trash");
+    }
+
+    #[test]
+    fn rating_decay_projection_clamps_and_formats_weeks() {
+        let snapshot = snapshot(|snapshot| {
+            snapshot.tab = AppSettingsTab::General;
+            snapshot.rating_decay_weeks = 12;
+        });
+
+        let SettingsPanelProjection::General { rows } = settings_panel_projection(&snapshot) else {
+            panic!("expected general panel");
+        };
+        let SettingsPanelRowProjection::RatingDecay(rating_decay) = &rows[1] else {
+            panic!("expected rating decay row");
+        };
+
+        assert_eq!(rating_decay.weeks, 12);
+        assert_eq!(rating_decay.value_label, "12 weeks");
+        assert_eq!(
+            RatingDecayProjection::weeks_from_slider_value(rating_decay.slider_value),
+            12
+        );
     }
 }

--- a/src/native_app/app_chrome/view_models/settings.rs
+++ b/src/native_app/app_chrome/view_models/settings.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 use wavecrate::audio::{AudioDeviceSummary, AudioHostSummary, AudioOutputConfig};
+#[cfg(test)]
+use wavecrate::sample_sources::config::DEFAULT_RATING_DECAY_WEEKS;
 
 use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, NativeAppState};
 
@@ -7,6 +9,7 @@ use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, NativeAppSta
 pub(in crate::native_app) struct AudioSettingsSnapshot {
     pub(in crate::native_app) tab: AppSettingsTab,
     pub(in crate::native_app) trash_folder: Option<PathBuf>,
+    pub(in crate::native_app) rating_decay_weeks: u16,
     pub(in crate::native_app) detail_label: String,
     pub(in crate::native_app) error: Option<String>,
     pub(in crate::native_app) audio_output_config: AudioOutputConfig,
@@ -21,6 +24,7 @@ impl AudioSettingsSnapshot {
         Self {
             tab: state.ui.settings.ui.app_settings_tab,
             trash_folder: state.ui.settings.persisted.trash_folder.clone(),
+            rating_decay_weeks: state.ui.settings.persisted.controls.rating_decay_weeks,
             detail_label: state.audio_engine_detail_label(),
             error: state.audio.settings_error.clone(),
             audio_output_config: state.audio.output_config.clone(),
@@ -50,6 +54,7 @@ impl AudioSettingsSnapshot {
         Self {
             tab: AppSettingsTab::AudioEngine,
             trash_folder: None,
+            rating_decay_weeks: DEFAULT_RATING_DECAY_WEEKS,
             detail_label: "no audio".to_string(),
             error: None,
             audio_output_config: AudioOutputConfig::default(),

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use super::{FileEntry, FolderEntry, collections::MissingCollectionSnapshot};
+use wavecrate::sample_sources::config::DEFAULT_RATING_DECAY_WEEKS;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct FolderScanRequest {
@@ -9,6 +10,13 @@ pub(in crate::native_app) struct FolderScanRequest {
     pub(in crate::native_app) label: String,
     pub(in crate::native_app) root: PathBuf,
     pub(in crate::native_app) database_root: PathBuf,
+    pub(in crate::native_app) rating_decay_weeks: u16,
+}
+
+impl FolderScanRequest {
+    pub(in crate::native_app) fn default_rating_decay_weeks() -> u16 {
+        DEFAULT_RATING_DECAY_WEEKS
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -1,11 +1,16 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use super::super::FileEntry;
 use super::file_entry_metadata::file_entry_with_metadata;
-use wavecrate::sample_sources::{Rating, SampleCollection, SourceDatabase};
+use wavecrate::sample_sources::{
+    Rating, SampleCollection, SourceDatabase, config::clamp_rating_decay_weeks,
+};
+
+const SECONDS_PER_WEEK: i64 = 7 * 24 * 60 * 60;
 
 pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap = HashMap<
     PathBuf,
@@ -45,6 +50,126 @@ pub(super) fn source_rating_map(root: &Path, database_root: &Path) -> SourceMeta
         .collect()
 }
 
+pub(super) fn source_rating_map_with_rating_decay(
+    root: &Path,
+    database_root: &Path,
+    rating_decay_weeks: u16,
+) -> SourceMetadataMap {
+    source_rating_map_with_rating_decay_at(
+        root,
+        database_root,
+        rating_decay_weeks,
+        current_epoch_seconds(),
+    )
+}
+
+fn source_rating_map_with_rating_decay_at(
+    root: &Path,
+    database_root: &Path,
+    rating_decay_weeks: u16,
+    now_epoch_seconds: i64,
+) -> SourceMetadataMap {
+    let Ok(db) =
+        SourceDatabase::open_for_user_metadata_write_with_database_root(root, database_root)
+    else {
+        return source_rating_map(root, database_root);
+    };
+    let Ok(mut entries) = db.list_files() else {
+        return HashMap::new();
+    };
+    let mut updates = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        if let Some(decayed) = decayed_keep_rating(
+            entry.tag,
+            entry.locked,
+            entry.last_curated_at,
+            rating_decay_weeks,
+            now_epoch_seconds,
+        ) {
+            updates.push((index, decayed.rating, decayed.last_curated_at));
+        }
+    }
+    if !updates.is_empty() {
+        let result = (|| {
+            let mut batch = db.write_batch()?;
+            for (index, rating, last_curated_at) in &updates {
+                let relative_path = entries[*index].relative_path.as_path();
+                batch.set_tag(relative_path, *rating)?;
+                batch.set_last_curated_at(relative_path, *last_curated_at)?;
+            }
+            batch.commit()
+        })();
+        if result.is_ok() {
+            for (index, rating, last_curated_at) in updates {
+                entries[index].tag = rating;
+                entries[index].last_curated_at = Some(last_curated_at);
+            }
+        }
+    }
+    entries
+        .into_iter()
+        .map(|entry| {
+            let collections = db
+                .collections_for_path(&entry.relative_path)
+                .unwrap_or_default();
+            (
+                entry.relative_path,
+                (
+                    entry.tag,
+                    entry.locked,
+                    collections,
+                    entry.last_played_at,
+                    entry.last_curated_at,
+                ),
+            )
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DecayedRating {
+    rating: Rating,
+    last_curated_at: i64,
+}
+
+fn decayed_keep_rating(
+    rating: Rating,
+    locked: bool,
+    last_curated_at: Option<i64>,
+    rating_decay_weeks: u16,
+    now_epoch_seconds: i64,
+) -> Option<DecayedRating> {
+    if locked || !rating.is_keep() {
+        return None;
+    }
+    let last_curated_at = last_curated_at?;
+    let elapsed_seconds = now_epoch_seconds.checked_sub(last_curated_at)?;
+    if elapsed_seconds <= 0 {
+        return None;
+    }
+    let period_seconds = i64::from(clamp_rating_decay_weeks(rating_decay_weeks)) * SECONDS_PER_WEEK;
+    let elapsed_periods = elapsed_seconds / period_seconds;
+    if elapsed_periods <= 0 {
+        return None;
+    }
+    let applied_periods = elapsed_periods.min(i64::from(rating.val()));
+    let next_rating = Rating::new(rating.val() - applied_periods as i8);
+    if next_rating == rating {
+        return None;
+    }
+    Some(DecayedRating {
+        rating: next_rating,
+        last_curated_at: last_curated_at.saturating_add(applied_periods * period_seconds),
+    })
+}
+
+fn current_epoch_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or_default()
+}
+
 pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_source_path(
     path: &PathBuf,
     source_root: &Path,
@@ -60,6 +185,78 @@ pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_sour
     file_entry_with_metadata(
         path, metadata.0, metadata.1, metadata.2, metadata.3, metadata.4,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decays_keep_rating_by_elapsed_intervals() {
+        let decayed = decayed_keep_rating(
+            Rating::KEEP_3,
+            false,
+            Some(1_000),
+            4,
+            1_000 + 9 * SECONDS_PER_WEEK,
+        )
+        .expect("rating should decay");
+
+        assert_eq!(decayed.rating, Rating::KEEP_1);
+        assert_eq!(decayed.last_curated_at, 1_000 + 8 * SECONDS_PER_WEEK);
+    }
+
+    #[test]
+    fn keeps_locked_keep_rating_unchanged() {
+        assert_eq!(
+            decayed_keep_rating(
+                Rating::KEEP_3,
+                true,
+                Some(1_000),
+                4,
+                1_000 + 12 * SECONDS_PER_WEEK
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn leaves_neutral_and_trash_ratings_unchanged() {
+        assert_eq!(
+            decayed_keep_rating(
+                Rating::NEUTRAL,
+                false,
+                Some(1_000),
+                4,
+                1_000 + 12 * SECONDS_PER_WEEK
+            ),
+            None
+        );
+        assert_eq!(
+            decayed_keep_rating(
+                Rating::TRASH_3,
+                false,
+                Some(1_000),
+                4,
+                1_000 + 12 * SECONDS_PER_WEEK
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn waits_until_full_interval_elapsed() {
+        assert_eq!(
+            decayed_keep_rating(
+                Rating::KEEP_1,
+                false,
+                Some(1_000),
+                4,
+                1_000 + 3 * SECONDS_PER_WEEK
+            ),
+            None
+        );
+    }
 }
 
 pub(in crate::native_app::sample_library::folder_browser) fn refreshed_file_entries_for_paths(

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -10,7 +10,7 @@ use super::{
             FolderScanResult,
         },
     },
-    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map},
+    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map_with_rating_decay},
     traversal::{placeholder_folder, read_sorted_entries},
 };
 use wavecrate::sample_sources::{SourceDatabase, scanner};
@@ -21,7 +21,11 @@ pub(in crate::native_app) fn scan_source_with_progress(
     mut discovered: impl FnMut(FolderScanDiscovery),
 ) -> FolderScanResult {
     let ratings = if request.root.is_dir() {
-        source_rating_map(&request.root, &request.database_root)
+        source_rating_map_with_rating_decay(
+            &request.root,
+            &request.database_root,
+            request.rating_decay_weeks,
+        )
     } else {
         SourceMetadataMap::new()
     };

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -39,6 +39,7 @@ impl FolderBrowserState {
             label,
             root,
             database_root,
+            rating_decay_weeks: FolderScanRequest::default_rating_decay_weeks(),
         })
     }
 
@@ -80,6 +81,7 @@ impl FolderBrowserState {
             label: source.label,
             root: source.root,
             database_root: source.database_root,
+            rating_decay_weeks: FolderScanRequest::default_rating_decay_weeks(),
         })
     }
 
@@ -118,6 +120,7 @@ impl FolderBrowserState {
             label: source.label,
             root: source.root,
             database_root: source.database_root,
+            rating_decay_weeks: FolderScanRequest::default_rating_decay_weeks(),
         })
     }
 

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -52,6 +52,79 @@ fn source_scan_installs_finished_tree_after_placeholder_selection() {
     assert!(!discovery_events.is_empty());
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
+    let root = temp_source_root("wavecrate-gui-rating-decay");
+    fs::write(root.join("unlocked.wav"), [0_u8; 8]).expect("write wav");
+    fs::write(root.join("locked.wav"), [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::load_default();
+    let initial_request = browser
+        .begin_add_source_path(root.clone(), 42)
+        .expect("new source should request scan");
+    assert!(browser.apply_scan_finished(scan_source_with_progress(
+        initial_request,
+        |_| {},
+        |_| {}
+    )));
+
+    let stale_curated_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs()
+        .saturating_sub(8 * 7 * 24 * 60 * 60 + 1) as i64;
+    let unlocked_relative = std::path::Path::new("unlocked.wav");
+    let locked_relative = std::path::Path::new("locked.wav");
+    let db = SourceDatabase::open(&root).expect("source db");
+    db.set_tag(unlocked_relative, Rating::KEEP_3)
+        .expect("seed unlocked rating");
+    db.set_last_curated_at(unlocked_relative, stale_curated_at)
+        .expect("seed unlocked curation time");
+    db.set_tag(locked_relative, Rating::KEEP_3)
+        .expect("seed locked rating");
+    db.set_locked(locked_relative, true)
+        .expect("seed locked flag");
+    db.set_last_curated_at(locked_relative, stale_curated_at)
+        .expect("seed locked curation time");
+
+    let mut decay_request = browser
+        .begin_selected_source_scan(43)
+        .expect("selected source refresh should queue");
+    decay_request.rating_decay_weeks = 4;
+    let result = scan_source_with_progress(decay_request, |_| {}, |_| {});
+    let unlocked_file = result
+        .folder
+        .all_files()
+        .into_iter()
+        .find(|file| file.name == "unlocked.wav")
+        .expect("unlocked file");
+    let locked_file = result
+        .folder
+        .all_files()
+        .into_iter()
+        .find(|file| file.name == "locked.wav")
+        .expect("locked file");
+
+    assert_eq!(unlocked_file.rating, Rating::KEEP_1);
+    assert_eq!(locked_file.rating, Rating::KEEP_3);
+    let rows = db.list_files().expect("decayed source db files");
+    assert_eq!(
+        rows.iter()
+            .find(|entry| entry.relative_path == unlocked_relative)
+            .expect("unlocked row")
+            .tag,
+        Rating::KEEP_1
+    );
+    assert_eq!(
+        rows.iter()
+            .find(|entry| entry.relative_path == locked_relative)
+            .expect("locked row")
+            .tag,
+        Rating::KEEP_3
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn non_wav_audio_looking_files_are_visible_but_not_supported_audio() {
     let root = temp_source_root("wavecrate-gui-unsupported-audio");

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -14,9 +14,10 @@ use crate::native_app::{
 impl NativeAppState {
     pub(in crate::native_app) fn launch_folder_scan(
         &mut self,
-        request: FolderScanRequest,
+        mut request: FolderScanRequest,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        request.rating_decay_weeks = self.ui.settings.persisted.controls.rating_decay_weeks;
         let started_at = Instant::now();
         let label = request.label.clone();
         let root = request.root.display().to_string();

--- a/src/native_app/shell/message_dispatch/settings.rs
+++ b/src/native_app/shell/message_dispatch/settings.rs
@@ -1,6 +1,10 @@
 use radiant::prelude as ui;
+use std::time::Instant;
+use wavecrate::sample_sources::config::clamp_rating_decay_weeks;
 
-use crate::native_app::app::{AudioSettingsDropdown, GuiMessage, NativeAppState, SettingsMessage};
+use crate::native_app::app::{
+    AudioSettingsDropdown, GuiMessage, NativeAppState, SettingsMessage, emit_gui_action,
+};
 
 impl NativeAppState {
     pub(super) fn apply_settings_message(
@@ -29,6 +33,7 @@ impl NativeAppState {
             SettingsMessage::SetAudioOutputSampleRate(sample_rate) => {
                 self.set_audio_output_sample_rate(sample_rate);
             }
+            SettingsMessage::SetRatingDecayWeeks(weeks) => self.set_rating_decay_weeks(weeks),
             SettingsMessage::PickTrashFolder => self.pick_trash_folder(context),
             SettingsMessage::ClearTrashFolder => self.clear_trash_folder(),
             SettingsMessage::ClearRebuildableCaches => self.clear_rebuildable_caches(),
@@ -49,5 +54,23 @@ impl NativeAppState {
 
     fn toggle_audio_sample_rate_dropdown(&mut self) {
         self.toggle_audio_settings_dropdown(AudioSettingsDropdown::SampleRate);
+    }
+
+    fn set_rating_decay_weeks(&mut self, weeks: u16) {
+        let started_at = Instant::now();
+        let weeks = clamp_rating_decay_weeks(weeks);
+        if self.ui.settings.persisted.controls.rating_decay_weeks == weeks {
+            return;
+        }
+        self.ui.settings.persisted.controls.rating_decay_weeks = weeks;
+        self.persist_user_configuration("settings.rating_decay_weeks.persist", started_at);
+        emit_gui_action(
+            "settings.rating_decay_weeks",
+            Some("settings"),
+            Some(&weeks.to_string()),
+            "changed",
+            started_at,
+            None,
+        );
     }
 }

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -56,6 +56,7 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
                 label: String::from("source"),
                 root: source_root.path().to_path_buf(),
                 database_root: source_root.path().to_path_buf(),
+                rating_decay_weeks: crate::native_app::sample_library::folder_browser::scan::FolderScanRequest::default_rating_decay_weeks(),
             },
             |_| {},
             |_| {},

--- a/src/native_app/tests/native_file_open.rs
+++ b/src/native_app/tests/native_file_open.rs
@@ -59,6 +59,7 @@ fn native_file_open_adds_parent_source_before_loading_external_audio_file() {
             label: progress.label,
             root: external_root.path().to_path_buf(),
             database_root: external_root.path().to_path_buf(),
+            rating_decay_weeks: crate::native_app::sample_library::folder_browser::scan::FolderScanRequest::default_rating_decay_weeks(),
         },
         |_| {},
         |_| {},

--- a/src/sample_sources/config.rs
+++ b/src/sample_sources/config.rs
@@ -12,6 +12,7 @@ pub use config_io::{
 pub use config_types::{
     AnalysisSettings, AppConfig, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,
     AudioWriteFormatConfig, AudioWriteSampleFormat, AudioWriteSampleRate, ConfigError,
-    DropTargetColor, DropTargetConfig, FeatureFlags, InteractionOptions, SimilarityAspectControl,
-    SimilarityAspectSettings, TooltipMode, UpdateChannel, UpdateSettings,
+    DEFAULT_RATING_DECAY_WEEKS, DropTargetColor, DropTargetConfig, FeatureFlags,
+    InteractionOptions, MAX_RATING_DECAY_WEEKS, MIN_RATING_DECAY_WEEKS, SimilarityAspectControl,
+    SimilarityAspectSettings, TooltipMode, UpdateChannel, UpdateSettings, clamp_rating_decay_weeks,
 };

--- a/src/sample_sources/config_io/tests/save/round_trip/interaction.rs
+++ b/src/sample_sources/config_io/tests/save/round_trip/interaction.rs
@@ -89,6 +89,10 @@ fn save_interaction_and_waveform_controls_round_trip() {
         fixture.expected.core.controls.advance_after_rating
     );
     assert_eq!(
+        fixture.actual.core.controls.rating_decay_weeks,
+        fixture.expected.core.controls.rating_decay_weeks
+    );
+    assert_eq!(
         fixture.actual.core.controls.tooltip_mode,
         fixture.expected.core.controls.tooltip_mode
     );

--- a/src/sample_sources/config_io/tests/save/round_trip/mod.rs
+++ b/src/sample_sources/config_io/tests/save/round_trip/mod.rs
@@ -97,6 +97,7 @@ fn settings_round_trip_fixture() -> SettingsRoundTripFixture {
                 input_monitoring_enabled: false,
                 normalized_audition_enabled: true,
                 advance_after_rating: true,
+                rating_decay_weeks: 8,
                 tooltip_mode: TooltipMode::Regular,
                 loop_lock_enabled: true,
             },

--- a/src/sample_sources/config_types/interaction.rs
+++ b/src/sample_sources/config_types/interaction.rs
@@ -102,6 +102,9 @@ pub struct InteractionOptions {
     /// Advance selection after rating a sample.
     #[serde(default = "default_true")]
     pub advance_after_rating: bool,
+    /// Number of weeks before Keep ratings decay by one point.
+    #[serde(default = "default_rating_decay_weeks")]
+    pub rating_decay_weeks: u16,
     /// Tooltip detail level.
     #[serde(default = "default_tooltip_mode")]
     pub tooltip_mode: TooltipMode,
@@ -132,8 +135,26 @@ impl Default for InteractionOptions {
             input_monitoring_enabled: default_true(),
             normalized_audition_enabled: default_false(),
             advance_after_rating: true,
+            rating_decay_weeks: DEFAULT_RATING_DECAY_WEEKS,
             tooltip_mode: default_tooltip_mode(),
             loop_lock_enabled: default_false(),
         }
     }
+}
+
+/// Default number of weeks before a Keep rating decays by one point.
+pub const DEFAULT_RATING_DECAY_WEEKS: u16 = 4;
+/// Shortest supported Keep rating decay interval in weeks.
+pub const MIN_RATING_DECAY_WEEKS: u16 = 1;
+/// Longest supported Keep rating decay interval in weeks.
+pub const MAX_RATING_DECAY_WEEKS: u16 = 52;
+
+/// Serde default for `InteractionOptions::rating_decay_weeks`.
+pub fn default_rating_decay_weeks() -> u16 {
+    DEFAULT_RATING_DECAY_WEEKS
+}
+
+/// Clamp a Keep rating decay interval into the supported settings range.
+pub fn clamp_rating_decay_weeks(weeks: u16) -> u16 {
+    weeks.clamp(MIN_RATING_DECAY_WEEKS, MAX_RATING_DECAY_WEEKS)
 }

--- a/src/sample_sources/config_types/mod.rs
+++ b/src/sample_sources/config_types/mod.rs
@@ -14,6 +14,9 @@ pub use audio_write::{
     AudioWriteSampleRate,
 };
 pub use errors::ConfigError;
-pub use interaction::{InteractionOptions, TooltipMode};
+pub use interaction::{
+    DEFAULT_RATING_DECAY_WEEKS, InteractionOptions, MAX_RATING_DECAY_WEEKS, MIN_RATING_DECAY_WEEKS,
+    TooltipMode, clamp_rating_decay_weeks,
+};
 pub use similarity::{SimilarityAspectControl, SimilarityAspectSettings};
 pub use updates::{UpdateChannel, UpdateSettings};


### PR DESCRIPTION
## Scope
- Add a persisted `rating_decay_weeks` interaction setting with a default of 4 weeks and a 1-52 week clamp.
- Add a General settings slider for Rating Decay that stores the interval in weeks.
- Apply rating decay during source scan metadata hydration so unlocked Keep ratings lose one point per elapsed interval and the source DB is updated durably.
- Preserve locked Keep samples and leave neutral/trash ratings unchanged.
- Thread the decay interval through folder scan requests launched by the native app.

## Definition of Done
- Unlocked Keep ratings decay by one point per configured interval during source scans.
- Locked Keep samples are not affected by decay.
- Rating decay interval is configurable from the application settings panel in weeks.
- Decayed ratings are reflected in scan results and persisted source metadata.
- Config save/load coverage includes the new setting.

## Validation commands
- `cargo check`
- `cargo test rating_decay`
- `cargo test native_app::sample_library::folder_browser::scanning::metadata::tests`
- `cargo test general_panel_projection`
- `cargo test save_interaction_and_waveform_controls_round_trip`
- `bash scripts/ci.sh agent` (smoke/devcheck passed; failed later in pre-existing non-blocking architecture guardrail violations outside this PR scope)

## Known limitations
- `bash scripts/ci.sh agent` currently fails in `native_app_ui_update_paths_do_not_call_blocking_business_apis` for unrelated pre-existing guardrail hits in files such as `drag_drop_move.rs`, `starmap.rs`, `harvest_tracking.rs`, `selected_file_actions.rs`, `duplicate.rs`, `state_playback.rs`, and `library_sidebar.rs`.

## Review
User review is required before merge.
