### PR TITLE
Fix release changelog binding

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -162,37 +162,10 @@ jobs:
             exit 1
           fi
 
-          if ! git cliff --config cliff.toml > /tmp/wavecrate-full-changelog-body.md; then
-            git log --no-merges --reverse --pretty=format:'- %s' "$TARGET_SHA" > /tmp/wavecrate-full-changelog-body.md
-          fi
-          if ! grep -Eq '^[[:space:]]*-' /tmp/wavecrate-full-changelog-body.md; then
-            git log --no-merges --reverse --pretty=format:'- %s' "$TARGET_SHA" > /tmp/wavecrate-full-changelog-body.md
-          fi
-          if [[ ! -s /tmp/wavecrate-full-changelog-body.md ]]; then
-            echo "- No commit messages were found for this repository." > /tmp/wavecrate-full-changelog-body.md
-          fi
-
-          {
-            echo "# Wavecrate Changelog"
-            echo
-            echo "- Latest build: ${BUILD_NUMBER}"
-            echo "- Latest version: ${NIGHTLY_VERSION}"
-            echo "- Latest commit: ${TARGET_SHA}"
-            echo "- Generated: ${RELEASED_AT}"
-            echo
-            cat /tmp/wavecrate-full-changelog-body.md
-          } > dist/release/changelog.md
-
-          if [[ ! -s dist/release/changelog.md ]]; then
-            echo "Generated full changelog is empty." >&2
-            exit 1
-          fi
       - uses: actions/upload-artifact@v4
         with:
           name: release-log
-          path: |
-            dist/release/release-log.md
-            dist/release/changelog.md
+          path: dist/release/release-log.md
           if-no-files-found: error
 
   build:
@@ -452,6 +425,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-main, publish-github]
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-main.outputs.target_sha }}
       - name: Verify PortalSurfer upload secret
         env:
           UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
@@ -575,26 +551,6 @@ jobs:
               raise SystemExit("Uploaded changelog did not expose a public URL")
           PY
 
-          full_changelog_response_file="$response_dir/full-changelog-upload.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 \
-            --request PUT \
-            --header "Authorization: Bearer $UPLOAD_TOKEN" \
-            --header "Content-Type: text/markdown; charset=utf-8" \
-            --header "X-Wavecrate-Changelog-Title: Wavecrate changelog" \
-            --data-binary "@$full_changelog_file" \
-            "$upload_base/changelog" > "$full_changelog_response_file"
-          python3 - "$full_changelog_response_file" <<'PY'
-          import json
-          import sys
-
-          response = json.loads(open(sys.argv[1], encoding="utf-8").read())
-          changelog = response.get("changelog") or {}
-          if changelog.get("format") != "markdown":
-              raise SystemExit("Uploaded full changelog was not recorded as markdown")
-          if not changelog.get("url"):
-              raise SystemExit("Uploaded full changelog did not expose a public URL")
-          PY
-
           catalog_file="$response_dir/releases.json"
           curl --fail-with-body --retry 3 --retry-delay 2 "$catalog_url" > "$catalog_file"
           python3 - "$catalog_file" "$build_id" "$BUILD_NUMBER" "${uploaded_names[@]}" <<'PY'
@@ -619,9 +575,6 @@ jobs:
           changelog = release.get("changelog") or {}
           if changelog.get("format") != "markdown" or not changelog.get("url"):
               raise SystemExit("Release catalog is missing the markdown changelog link")
-          full_changelog = catalog.get("changelog") or {}
-          if full_changelog.get("format") != "markdown" or not full_changelog.get("url"):
-              raise SystemExit("Release catalog is missing the full changelog link")
           print(f"Uploaded {len(expected_files)} Wavecrate release file(s) to {expected_build}")
           PY
 
@@ -641,6 +594,34 @@ jobs:
           if body != expected_body:
               raise SystemExit("Fetched changelog body does not match generated release log")
           print(f"Uploaded Wavecrate release log to {expected_build}")
+          PY
+
+          scripts/internal/release/assemble_portal_changelog.py \
+            --catalog-url "$catalog_url" \
+            --current-build-id "$build_id" \
+            --current-log "$changelog_file" \
+            --existing-changelog-url "$full_changelog_url" \
+            --generated-at "$released_at" \
+            --output "$full_changelog_file"
+
+          full_changelog_response_file="$response_dir/full-changelog-upload.json"
+          curl --fail-with-body --retry 3 --retry-delay 2 \
+            --request PUT \
+            --header "Authorization: Bearer $UPLOAD_TOKEN" \
+            --header "Content-Type: text/markdown; charset=utf-8" \
+            --header "X-Wavecrate-Changelog-Title: Wavecrate changelog" \
+            --data-binary "@$full_changelog_file" \
+            "$upload_base/changelog" > "$full_changelog_response_file"
+          python3 - "$full_changelog_response_file" <<'PY'
+          import json
+          import sys
+
+          response = json.loads(open(sys.argv[1], encoding="utf-8").read())
+          changelog = response.get("changelog") or {}
+          if changelog.get("format") != "markdown":
+              raise SystemExit("Uploaded full changelog was not recorded as markdown")
+          if not changelog.get("url"):
+              raise SystemExit("Uploaded full changelog did not expose a public URL")
           PY
 
           full_changelog_catalog_file="$response_dir/full-changelog-catalog.json"

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -48,12 +48,17 @@ manual "force a nightly now" button with the same build/upload path.
 The workflow publishes an immutable nightly version tag named
 `nightly-b<build>-<short-sha>` for changelog history, updates the rolling GitHub
 `nightly` release for downloads, then uploads the same zips plus the generated
-Markdown release log and full changelog to the PortalSurfer Wavecrate
-release-upload API. Each PortalSurfer upload uses the matching
-`wavecrate-nightly-b<build>-<short-sha>` build id so the website can show a
-distinct nightly entry instead of stacking every nightly under one changelog
-group. GitHub Actions does not need SSH access or write access to the
-PortalSurfer frontend repository.
+Markdown release log to the PortalSurfer Wavecrate release-upload API. Each
+PortalSurfer upload uses the matching `wavecrate-nightly-b<build>-<short-sha>`
+build id so the website can show a distinct nightly entry instead of stacking
+every nightly under one changelog group. After the per-release log is visible in
+the public catalog, the workflow verifies that the fetched log body matches the
+generated immutable release log, then prepends that release-bound log to the
+existing site-wide changelog before uploading the maintained full changelog.
+The maintenance step refuses to preserve a full changelog whose historical
+sections are not already release-bound markdown logs.
+GitHub Actions does not need SSH access or write access to the PortalSurfer
+frontend repository.
 
 - `PORTALSURFER_RELEASE_UPLOAD_TOKEN`
 Bearer token sent by the workflow to the PortalSurfer upload endpoint. Store

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -46,7 +46,7 @@ remain the validation contract for development and release-risk checks:
 | Dead dependency sweep and env-var nudge | none | `scripts/check.* dead-deps --advisory` and `scripts/check.* report-env-vars` | Advisory Linux-only hygiene |
 | GUI semantic contracts | none | `scripts/gui.ps1 contract` or `scripts/gui.ps1 suite` | Local/manual or issue-specific |
 | Perf guard | none | `scripts/perf.* guard` | Local/manual or release-risk validation |
-| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Builds Windows/macOS nightly assets from `main`, updates the rolling GitHub `nightly` release, and uploads downloads plus release log and full changelog to PortalSurfer |
+| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Builds Windows/macOS nightly assets from `main`, updates the rolling GitHub `nightly` release, uploads the immutable release log to PortalSurfer, then maintains the full changelog from release-bound logs |
 
 The nextest policy is:
 

--- a/scripts/internal/release/assemble_portal_changelog.py
+++ b/scripts/internal/release/assemble_portal_changelog.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Assemble the PortalSurfer full changelog from per-release logs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from urllib.error import HTTPError
+from pathlib import Path
+from typing import Any
+
+
+USER_AGENT = "wavecrate-release-changelog-assembler"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a site-wide Wavecrate changelog by concatenating the "
+            "markdown logs bound to each PortalSurfer release."
+        )
+    )
+    catalog = parser.add_mutually_exclusive_group(required=True)
+    catalog.add_argument("--catalog-file", help="Path to a release catalog JSON file.")
+    catalog.add_argument("--catalog-url", help="Public release catalog URL.")
+    parser.add_argument("--current-build-id", required=True)
+    parser.add_argument("--current-log", required=True, help="Markdown log for the current release.")
+    parser.add_argument(
+        "--existing-changelog-url",
+        help="Existing site-wide changelog endpoint used to preserve prior release logs.",
+    )
+    parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--generated-at",
+        help="ISO-8601 timestamp to write in the changelog metadata. Defaults to now.",
+    )
+    parser.add_argument(
+        "--request-delay-seconds",
+        type=float,
+        default=0.25,
+        help="Delay between public changelog fetches. Defaults to 0.25 seconds.",
+    )
+    return parser.parse_args()
+
+
+def read_url(url: str, *, request_delay_seconds: float = 0.0) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    for attempt in range(5):
+        if request_delay_seconds > 0:
+            time.sleep(request_delay_seconds)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return response.read().decode("utf-8")
+        except HTTPError as error:
+            if error.code != 429 or attempt == 4:
+                raise
+            retry_after = error.headers.get("Retry-After")
+            if retry_after is not None and retry_after.isdigit():
+                delay = float(retry_after)
+            else:
+                delay = 2.0 * (attempt + 1)
+            time.sleep(delay)
+    raise RuntimeError(f"Unable to read {url}")
+
+
+def load_json(source: str, *, request_delay_seconds: float = 0.0) -> dict[str, Any]:
+    if source.startswith(("http://", "https://")):
+        return json.loads(read_url(source, request_delay_seconds=request_delay_seconds))
+    return json.loads(Path(source).read_text(encoding="utf-8"))
+
+
+def changelog_url(catalog_url: str | None, release: dict[str, Any]) -> str | None:
+    changelog = release.get("changelog") or {}
+    url = changelog.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    if url.startswith(("http://", "https://")):
+        return url
+    if catalog_url is None:
+        return None
+    return urllib.parse.urljoin(catalog_url, url)
+
+
+def release_version(build_id: str) -> str:
+    prefix = "wavecrate-"
+    return build_id[len(prefix) :] if build_id.startswith(prefix) else build_id
+
+
+def release_header_versions(release: dict[str, Any]) -> list[str]:
+    build_id = release.get("build_id")
+    if not isinstance(build_id, str) or not build_id:
+        return []
+    versions = {release_version(build_id)}
+    changelog = release.get("changelog") or {}
+    title = changelog.get("title")
+    if isinstance(title, str) and title.startswith("Wavecrate "):
+        versions.add(title.removeprefix("Wavecrate ").strip())
+    build_number = release.get("build_number")
+    suffix = build_id.rsplit("-", 1)[-1]
+    if (
+        isinstance(build_number, int)
+        and re.fullmatch(r"[0-9a-fA-F]{7,40}", suffix)
+        and not release_version(build_id).startswith(f"nightly-b{build_number}-")
+    ):
+        versions.add(f"nightly-b{build_number}-{suffix}")
+    return sorted(version for version in versions if version)
+
+
+def assert_bound_header(build_id: str, body: str, versions: list[str]) -> None:
+    patterns = []
+    for version in versions:
+        escaped = re.escape(version)
+        patterns.extend(
+            [
+                rf"(?m)^#{{1,6}}\s+Wavecrate\s+{escaped}\s*$",
+                rf"(?m)^#{{1,6}}\s+\[{escaped}\](?:\s+-\s+.*)?$",
+            ]
+        )
+    if any(re.search(pattern, body) for pattern in patterns):
+        return
+    raise SystemExit(
+        f"Release log for {build_id} does not contain a markdown header "
+        f"bound to one of: {', '.join(versions)}."
+    )
+
+
+def release_sort_key(release: dict[str, Any]) -> tuple[str, int]:
+    released_at = release.get("released_at")
+    build_number = release.get("build_number")
+    return (
+        released_at if isinstance(released_at, str) else "",
+        build_number if isinstance(build_number, int) else -1,
+    )
+
+
+def load_release_body(
+    release: dict[str, Any],
+    *,
+    current_build_id: str,
+    current_body: str,
+    catalog_url: str | None,
+    request_delay_seconds: float,
+) -> str | None:
+    build_id = release.get("build_id")
+    if build_id == current_build_id:
+        return current_body
+    changelog = release.get("changelog") or {}
+    body = changelog.get("body")
+    if isinstance(body, str) and body.strip():
+        return body
+    url = changelog_url(catalog_url, release)
+    if url is None:
+        return None
+    response = load_json(url, request_delay_seconds=request_delay_seconds)
+    body = (response.get("changelog") or {}).get("body")
+    return body if isinstance(body, str) and body.strip() else None
+
+
+def existing_changelog_body(url: str, *, request_delay_seconds: float) -> str:
+    response = load_json(url, request_delay_seconds=request_delay_seconds)
+    body = (response.get("changelog") or {}).get("body")
+    return body if isinstance(body, str) else ""
+
+
+def release_heading_pattern() -> re.Pattern[str]:
+    return re.compile(
+        r"(?m)^(?=(?:#\s+Wavecrate\s+(?!Changelog\b)|##\s+\[nightly-))"
+    )
+
+
+def strip_global_changelog_header(body: str) -> str:
+    body = body.strip()
+    if not body.startswith("# Wavecrate Changelog"):
+        return body
+    match = release_heading_pattern().search(body)
+    if match is None:
+        return ""
+    return body[match.start() :].strip()
+
+
+def remove_release_sections(body: str, versions: list[str]) -> str:
+    body = strip_global_changelog_header(body)
+    if not body:
+        return ""
+    sections = [
+        section.strip()
+        for section in release_heading_pattern().split(body)
+        if section.strip()
+    ]
+    kept = []
+    for section in sections:
+        first_line = section.splitlines()[0] if section.splitlines() else ""
+        if any(version in first_line for version in versions):
+            continue
+        kept.append(section)
+    return "\n\n".join(kept).strip()
+
+
+def main() -> int:
+    args = parse_args()
+    catalog_url = args.catalog_url
+    catalog = load_json(
+        args.catalog_url or args.catalog_file,
+        request_delay_seconds=args.request_delay_seconds,
+    )
+    releases = catalog.get("releases")
+    if not isinstance(releases, list):
+        raise SystemExit("Release catalog does not contain a releases array.")
+
+    sorted_releases = sorted(releases, key=release_sort_key, reverse=True)
+    current_release = next(
+        (release for release in sorted_releases if release.get("build_id") == args.current_build_id),
+        None,
+    )
+    if current_release is None:
+        raise SystemExit(f"Release catalog does not list {args.current_build_id}.")
+    current_body = Path(args.current_log).read_text(encoding="utf-8").strip()
+    if not current_body:
+        raise SystemExit("Current release log is empty.")
+    assert_bound_header(
+        args.current_build_id,
+        current_body,
+        release_header_versions(current_release),
+    )
+
+    generated_at = args.generated_at
+    if generated_at is None:
+        generated_at = (
+            dt.datetime.now(dt.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+
+    output: list[str] = [
+        "# Wavecrate Changelog",
+        "",
+        f"- Latest release: {args.current_build_id}",
+        f"- Latest build: {current_release.get('build_number')}",
+        f"- Latest version: {current_release.get('version')}",
+        f"- Generated: {generated_at}",
+        "",
+    ]
+
+    current_versions = release_header_versions(current_release)
+    if args.existing_changelog_url:
+        existing_body = existing_changelog_body(
+            args.existing_changelog_url,
+            request_delay_seconds=args.request_delay_seconds,
+        )
+        previous_body = remove_release_sections(existing_body, current_versions)
+        if previous_body and not previous_body.startswith("# Wavecrate "):
+            raise SystemExit(
+                "Existing full changelog is not release-bound. Repair it so "
+                "each historical log starts with '# Wavecrate ...' "
+                "before the nightly workflow maintains it."
+            )
+        output.append(current_body)
+        if previous_body:
+            output.extend(["", previous_body])
+        Path(args.output).write_text("\n".join(output).rstrip() + "\n", encoding="utf-8")
+        print(f"Assembled current Wavecrate release log into {args.output}")
+        return 0
+
+    written = 0
+    for release in sorted_releases:
+        build_id = release.get("build_id")
+        if not isinstance(build_id, str) or not build_id:
+            continue
+        body = load_release_body(
+            release,
+            current_build_id=args.current_build_id,
+            current_body=current_body,
+            catalog_url=catalog_url,
+            request_delay_seconds=args.request_delay_seconds,
+        )
+        if body is None:
+            output.extend(
+                [
+                    f"## Wavecrate {release_version(build_id)}",
+                    "",
+                    "Release log unavailable.",
+                    "",
+                ]
+            )
+            written += 1
+            continue
+        body = body.strip()
+        assert_bound_header(build_id, body, release_header_versions(release))
+        output.extend([body, ""])
+        written += 1
+
+    if written == 0:
+        raise SystemExit("No release logs were written to the full changelog.")
+
+    Path(args.output).write_text("\n".join(output).rstrip() + "\n", encoding="utf-8")
+    print(f"Assembled {written} Wavecrate release log(s) into {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope
- Stop generating the PortalSurfer full changelog directly from `git-cliff` in the nightly release-log job, because incomplete historical nightly tags can bind old history to the wrong release header.
- Add `scripts/internal/release/assemble_portal_changelog.py` to maintain the site-wide changelog from verified release-bound markdown logs.
- Update the nightly upload job so it uploads and verifies the immutable per-release log first, then prepends that verified log to the existing release-bound full changelog and uploads the maintained full changelog.
- Document the release-log maintenance invariant in `docs/ENV_VARS.md` and `docs/TEST.md`.

## Definition of Done
- Each nightly still publishes an immutable `wavecrate-nightly-b<build>-<short-sha>` release log.
- The full changelog is no longer regenerated from incomplete Git tag history.
- The maintenance step refuses to preserve a full changelog that is not already composed of release-bound `# Wavecrate ...` sections.
- The live PortalSurfer catalog has been repaired so the existing baseline satisfies that invariant.

## Validation commands
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-build.yml"); puts "workflow yaml ok"'`
- `python3 -m py_compile scripts/internal/release/assemble_portal_changelog.py`
- `bash scripts/check.sh script-guardrails`
- `bash scripts/check.sh workflow-toolchain`
- `git diff --check`
- Helper fixture: assembled a release-bound existing changelog and verified current/previous release sections are preserved once each.
- Live API helper check: assembled from `https://portalsurfer.org/wavecrate/api/v1/releases`, current `wavecrate-nightly-b6176-02cd47eb`, and `https://portalsurfer.org/wavecrate/api/v1/changelog`; verified one current header, 78 top-level release headers, and no old swallowed-history marker.
- Production repair verification: `https://portalsurfer.org/wavecrate/api/v1/changelog` now reports 78 top-level release headers; `wavecrate-nightly-b6176-02cd47eb` per-release changelog contains only that release; Caddy remained healthy and only the Wavecrate service was restarted.

## Known limitations
- The full changelog maintenance path depends on the existing live full changelog already being release-bound. If production data regresses into loose `## [nightly-...]` sections again, the workflow fails instead of preserving the bad shape.
- `bash scripts/agent.sh request` still fails on pre-existing native-app non-blocking guardrail violations unrelated to this release workflow change.

User review is required before merge.
