### PR TITLE
Route waveform playback gain normalization through runtime

### DIFF
--- a/crates/reson/src/lib.rs
+++ b/crates/reson/src/lib.rs
@@ -35,11 +35,11 @@ pub use output::{
 pub use player::{
     AudioPlayer, EditFadeRange, FadeParams, PlaybackChannelLayout, PlaybackMetronomeConfig,
     PlaybackRequestId, PlaybackRuntime, PlaybackRuntimeCancellation, PlaybackRuntimeConfig,
-    PlaybackRuntimeEvent, PlaybackRuntimeHandle, PlaybackRuntimeMode, PlaybackRuntimeProgress,
-    PlaybackRuntimeRequest, PlaybackRuntimeSource, PlaybackRuntimeSpanUpdate,
-    PlaybackRuntimeStarted, PlaybackRuntimeSubmitError, PlaybackSeekBehavior,
-    PlaybackSourceIdentity, PlaybackSourceKind, PlaybackSpanPlan, PlaybackSpanPlanError,
-    PlaybackSpanRequest,
+    PlaybackRuntimeEvent, PlaybackRuntimeGainNormalization, PlaybackRuntimeHandle,
+    PlaybackRuntimeMode, PlaybackRuntimeProgress, PlaybackRuntimeRequest, PlaybackRuntimeSource,
+    PlaybackRuntimeSpanUpdate, PlaybackRuntimeStarted, PlaybackRuntimeSubmitError,
+    PlaybackSeekBehavior, PlaybackSourceIdentity, PlaybackSourceKind, PlaybackSpanPlan,
+    PlaybackSpanPlanError, PlaybackSpanRequest,
 };
 pub use recording::{AudioRecorder, InputMonitor, RecordingOutcome};
 pub use time_stretch::Wsola;

--- a/crates/reson/src/player/mod.rs
+++ b/crates/reson/src/player/mod.rs
@@ -24,9 +24,9 @@ pub use playback_span_plan::{
 };
 pub use runtime::{
     PlaybackRequestId, PlaybackRuntime, PlaybackRuntimeCancellation, PlaybackRuntimeConfig,
-    PlaybackRuntimeEvent, PlaybackRuntimeHandle, PlaybackRuntimeMode, PlaybackRuntimeProgress,
-    PlaybackRuntimeRequest, PlaybackRuntimeSource, PlaybackRuntimeSpanUpdate,
-    PlaybackRuntimeStarted, PlaybackRuntimeSubmitError,
+    PlaybackRuntimeEvent, PlaybackRuntimeGainNormalization, PlaybackRuntimeHandle,
+    PlaybackRuntimeMode, PlaybackRuntimeProgress, PlaybackRuntimeRequest, PlaybackRuntimeSource,
+    PlaybackRuntimeSpanUpdate, PlaybackRuntimeStarted, PlaybackRuntimeSubmitError,
 };
 
 #[derive(Clone)]

--- a/crates/reson/src/player/runtime.rs
+++ b/crates/reson/src/player/runtime.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::VecDeque,
-    path::PathBuf,
+    fs::File,
+    io::{BufReader, Read, Seek, SeekFrom},
+    ops::Range,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -14,6 +17,8 @@ use super::{AudioPlayer, EditFadeRange, PlaybackMetronomeConfig};
 use crate::output::ResolvedOutput;
 
 const DEFAULT_PLAYBACK_COMMAND_QUEUE: usize = 8;
+const F32_SAMPLE_BYTES: usize = std::mem::size_of::<f32>();
+const NORMALIZED_GAIN_READ_SAMPLES: usize = 4096;
 
 /// Monotonic id assigned to playback runtime commands.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -158,7 +163,21 @@ pub struct PlaybackRuntimeSpanUpdate {
     pub seek_to_offset: bool,
     pub looped: bool,
     pub playback_gain: f32,
+    pub playback_gain_normalization: Option<PlaybackRuntimeGainNormalization>,
     pub metronome: Option<PlaybackMetronomeConfig>,
+}
+
+/// Runtime-owned gain normalization for one normalized playback span.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlaybackRuntimeGainNormalization {
+    pub start: f32,
+    pub end: f32,
+}
+
+impl PlaybackRuntimeGainNormalization {
+    pub fn new(start: f32, end: f32) -> Self {
+        Self { start, end }
+    }
 }
 
 /// Complete neutral playback-start request.
@@ -168,6 +187,7 @@ pub struct PlaybackRuntimeRequest {
     pub mode: PlaybackRuntimeMode,
     pub volume: f32,
     pub playback_gain: f32,
+    pub playback_gain_normalization: Option<PlaybackRuntimeGainNormalization>,
     pub edit_fade: Option<EditFadeRange>,
     pub metronome: Option<PlaybackMetronomeConfig>,
 }
@@ -276,8 +296,20 @@ impl PlaybackRuntimeHandle {
 
     /// Submit a non-blocking playback-gain update for current and future playback.
     pub fn try_set_playback_gain(&self, gain: f32) -> Result<(), PlaybackRuntimeSubmitError> {
+        self.try_set_playback_gain_with_normalization(gain, None)
+    }
+
+    /// Submit a non-blocking playback-gain update with runtime-owned normalization.
+    pub fn try_set_playback_gain_with_normalization(
+        &self,
+        gain: f32,
+        normalization: Option<PlaybackRuntimeGainNormalization>,
+    ) -> Result<(), PlaybackRuntimeSubmitError> {
         self.commands
-            .try_send(PlaybackRuntimeCommand::SetPlaybackGain { gain })
+            .try_send(PlaybackRuntimeCommand::SetPlaybackGain {
+                gain,
+                normalization,
+            })
             .map_err(map_try_send_error)
     }
 
@@ -341,6 +373,7 @@ enum PlaybackRuntimeCommand {
     },
     SetPlaybackGain {
         gain: f32,
+        normalization: Option<PlaybackRuntimeGainNormalization>,
     },
     Shutdown,
 }
@@ -353,7 +386,11 @@ trait PlaybackRuntimeExecutor: Send + 'static {
     fn stop(&mut self) -> Result<(), String>;
     fn retarget_span(&mut self, update: PlaybackRuntimeSpanUpdate) -> Result<f32, String>;
     fn set_volume(&mut self, volume: f32);
-    fn set_playback_gain(&mut self, gain: f32);
+    fn set_playback_gain(
+        &mut self,
+        gain: f32,
+        normalization: Option<PlaybackRuntimeGainNormalization>,
+    );
     fn progress(&mut self) -> PlaybackRuntimeProgress;
 }
 
@@ -372,7 +409,12 @@ impl PlaybackRuntimeExecutor for AudioPlayerPlaybackExecutor {
         request: PlaybackRuntimeRequest,
     ) -> Result<PlaybackRuntimeStartedData, String> {
         self.player.set_volume(request.volume);
-        self.player.set_playback_gain(request.playback_gain);
+        self.player
+            .set_playback_gain(runtime_playback_gain_for_source(
+                request.playback_gain,
+                request.playback_gain_normalization,
+                &request.source,
+            ));
         let output = self.player.output_details().clone();
         request.source.apply_to_player(&mut self.player);
         self.player.set_edit_fade_state(request.edit_fade);
@@ -391,7 +433,12 @@ impl PlaybackRuntimeExecutor for AudioPlayerPlaybackExecutor {
     }
 
     fn retarget_span(&mut self, update: PlaybackRuntimeSpanUpdate) -> Result<f32, String> {
-        self.player.set_playback_gain(update.playback_gain);
+        self.player
+            .set_playback_gain(runtime_playback_gain_for_player(
+                update.playback_gain,
+                update.playback_gain_normalization,
+                &self.player,
+            ));
         if update.looped {
             self.player.retarget_looped_range_with_metronome(
                 update.start,
@@ -419,8 +466,17 @@ impl PlaybackRuntimeExecutor for AudioPlayerPlaybackExecutor {
         self.player.set_volume(volume);
     }
 
-    fn set_playback_gain(&mut self, gain: f32) {
-        self.player.set_playback_gain(gain);
+    fn set_playback_gain(
+        &mut self,
+        gain: f32,
+        normalization: Option<PlaybackRuntimeGainNormalization>,
+    ) {
+        self.player
+            .set_playback_gain(runtime_playback_gain_for_player(
+                gain,
+                normalization,
+                &self.player,
+            ));
     }
 
     fn progress(&mut self) -> PlaybackRuntimeProgress {
@@ -499,8 +555,11 @@ fn run_playback_runtime(
             CoalescedCommand::SetVolume { volume } => {
                 executor.set_volume(volume);
             }
-            CoalescedCommand::SetPlaybackGain { gain } => {
-                executor.set_playback_gain(gain);
+            CoalescedCommand::SetPlaybackGain {
+                gain,
+                normalization,
+            } => {
+                executor.set_playback_gain(gain, normalization);
             }
             CoalescedCommand::Shutdown => return,
         }
@@ -534,6 +593,7 @@ enum CoalescedCommand {
     },
     SetPlaybackGain {
         gain: f32,
+        normalization: Option<PlaybackRuntimeGainNormalization>,
     },
     Shutdown,
 }
@@ -699,9 +759,13 @@ fn command_to_coalesced(command: PlaybackRuntimeCommand) -> CoalescedCommand {
         }
         PlaybackRuntimeCommand::PollProgress { id } => CoalescedCommand::PollProgress { id },
         PlaybackRuntimeCommand::SetVolume { volume } => CoalescedCommand::SetVolume { volume },
-        PlaybackRuntimeCommand::SetPlaybackGain { gain } => {
-            CoalescedCommand::SetPlaybackGain { gain }
-        }
+        PlaybackRuntimeCommand::SetPlaybackGain {
+            gain,
+            normalization,
+        } => CoalescedCommand::SetPlaybackGain {
+            gain,
+            normalization,
+        },
         PlaybackRuntimeCommand::Shutdown => CoalescedCommand::Shutdown,
     }
 }
@@ -741,9 +805,175 @@ fn map_try_send_error(error: TrySendError<PlaybackRuntimeCommand>) -> PlaybackRu
     }
 }
 
+fn runtime_playback_gain_for_source(
+    base_gain: f32,
+    normalization: Option<PlaybackRuntimeGainNormalization>,
+    source: &PlaybackRuntimeSource,
+) -> f32 {
+    let Some(normalization) = normalization else {
+        return sanitize_playback_gain(base_gain);
+    };
+    let normalized = normalized_gain_for_runtime_source(source, normalization).unwrap_or(1.0);
+    sanitize_playback_gain(base_gain * normalized)
+}
+
+fn runtime_playback_gain_for_player(
+    base_gain: f32,
+    normalization: Option<PlaybackRuntimeGainNormalization>,
+    player: &AudioPlayer,
+) -> f32 {
+    let Some(normalization) = normalization else {
+        return sanitize_playback_gain(base_gain);
+    };
+    let normalized = normalized_gain_for_player(player, normalization).unwrap_or(1.0);
+    sanitize_playback_gain(base_gain * normalized)
+}
+
+fn sanitize_playback_gain(gain: f32) -> f32 {
+    if gain.is_finite() && gain > 0.0 {
+        gain
+    } else {
+        1.0
+    }
+}
+
+fn normalized_gain_for_runtime_source(
+    source: &PlaybackRuntimeSource,
+    normalization: PlaybackRuntimeGainNormalization,
+) -> Option<f32> {
+    match source {
+        PlaybackRuntimeSource::DecodedSamples {
+            samples, channels, ..
+        } => normalized_gain_for_interleaved_span(
+            samples,
+            *channels,
+            normalization.start,
+            normalization.end,
+        ),
+        PlaybackRuntimeSource::InterleavedF32File {
+            path,
+            sample_count,
+            channels,
+            ..
+        } => normalized_gain_for_interleaved_f32_file_span(
+            path,
+            (*sample_count).try_into().ok()?,
+            *channels,
+            normalization.start,
+            normalization.end,
+        ),
+        PlaybackRuntimeSource::AudioBytes { .. } | PlaybackRuntimeSource::AudioFile { .. } => None,
+    }
+}
+
+fn normalized_gain_for_player(
+    player: &AudioPlayer,
+    normalization: PlaybackRuntimeGainNormalization,
+) -> Option<f32> {
+    let channels = usize::from(player.track_channels.unwrap_or(1)).max(1);
+    if let Some(samples) = player.playback_samples.as_ref() {
+        return normalized_gain_for_interleaved_span(
+            samples,
+            channels,
+            normalization.start,
+            normalization.end,
+        );
+    }
+    match player.current_audio.as_ref()? {
+        super::AudioPlaybackSource::InterleavedF32File { path, sample_count } => {
+            normalized_gain_for_interleaved_f32_file_span(
+                path,
+                (*sample_count).try_into().ok()?,
+                channels,
+                normalization.start,
+                normalization.end,
+            )
+        }
+        super::AudioPlaybackSource::Bytes(_) | super::AudioPlaybackSource::File(_) => None,
+    }
+}
+
+fn normalized_gain_for_interleaved_span(
+    samples: &[f32],
+    channels: usize,
+    start: f32,
+    end: f32,
+) -> Option<f32> {
+    let bounds = interleaved_span_sample_bounds(samples.len(), channels, start, end)?;
+    let peak = samples[bounds]
+        .iter()
+        .fold(0.0_f32, |peak, sample| peak.max(sample.abs()));
+    Some(normalized_gain_from_peak(peak))
+}
+
+fn normalized_gain_for_interleaved_f32_file_span(
+    path: &Path,
+    sample_count: usize,
+    channels: usize,
+    start: f32,
+    end: f32,
+) -> Option<f32> {
+    let bounds = interleaved_span_sample_bounds(sample_count, channels, start, end)?;
+    let mut reader = BufReader::new(File::open(path).ok()?);
+    let byte_offset = bounds.start.checked_mul(F32_SAMPLE_BYTES)? as u64;
+    reader.seek(SeekFrom::Start(byte_offset)).ok()?;
+
+    let mut remaining = bounds.end.saturating_sub(bounds.start);
+    let mut bytes = vec![0_u8; NORMALIZED_GAIN_READ_SAMPLES * F32_SAMPLE_BYTES];
+    let mut peak = 0.0_f32;
+    while remaining > 0 {
+        let samples_to_read = remaining.min(NORMALIZED_GAIN_READ_SAMPLES);
+        let byte_len = samples_to_read * F32_SAMPLE_BYTES;
+        reader.read_exact(&mut bytes[..byte_len]).ok()?;
+        for sample in bytes[..byte_len].chunks_exact(F32_SAMPLE_BYTES) {
+            peak = peak.max(f32::from_le_bytes(sample.try_into().ok()?).abs());
+        }
+        remaining -= samples_to_read;
+    }
+    Some(normalized_gain_from_peak(peak))
+}
+
+fn interleaved_span_sample_bounds(
+    sample_count: usize,
+    channels: usize,
+    start: f32,
+    end: f32,
+) -> Option<Range<usize>> {
+    if sample_count == 0 || !start.is_finite() || !end.is_finite() {
+        return None;
+    }
+    let channels = channels.max(1);
+    let total_frames = sample_count / channels;
+    if total_frames == 0 {
+        return None;
+    }
+    let (start, end) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    let start_frame = (start.clamp(0.0, 1.0) * total_frames as f32).floor() as usize;
+    let mut end_frame = (end.clamp(0.0, 1.0) * total_frames as f32).ceil() as usize;
+    if end_frame <= start_frame {
+        end_frame = (start_frame + 1).min(total_frames);
+    }
+    let start_idx = start_frame.saturating_mul(channels);
+    let end_idx = end_frame.saturating_mul(channels).min(sample_count);
+    (start_idx < end_idx).then_some(start_idx..end_idx)
+}
+
+fn normalized_gain_from_peak(peak: f32) -> f32 {
+    if peak.is_finite() && peak > f32::EPSILON {
+        1.0 / peak
+    } else {
+        1.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone)]
@@ -808,7 +1038,12 @@ mod tests {
 
         fn set_volume(&mut self, _volume: f32) {}
 
-        fn set_playback_gain(&mut self, _gain: f32) {}
+        fn set_playback_gain(
+            &mut self,
+            _gain: f32,
+            _normalization: Option<PlaybackRuntimeGainNormalization>,
+        ) {
+        }
 
         fn progress(&mut self) -> PlaybackRuntimeProgress {
             PlaybackRuntimeProgress {
@@ -1011,6 +1246,52 @@ mod tests {
         assert_eq!(retargeted.lock().expect("retargeted").as_slice(), &[update]);
     }
 
+    #[test]
+    fn runtime_normalization_reads_interleaved_f32_file_span() {
+        let root = tempfile::tempdir().expect("temp root");
+        let path = root.path().join("normalized-runtime.pcm");
+        let mut file = File::create(&path).expect("create f32 cache");
+        for sample in [
+            0.1_f32, 0.1, 0.1, 0.1, 0.25, 0.5, 0.2, 0.2, 0.9, 0.9, 0.9, 0.9, 0.1, 0.1, 0.1, 0.1,
+        ] {
+            file.write_all(&sample.to_le_bytes()).expect("write sample");
+        }
+        let source = PlaybackRuntimeSource::InterleavedF32File {
+            path,
+            sample_count: 16,
+            duration: 1.0,
+            sample_rate: 48_000,
+            channels: 1,
+        };
+
+        let gain = runtime_playback_gain_for_source(
+            1.0,
+            Some(PlaybackRuntimeGainNormalization::new(0.25, 0.5)),
+            &source,
+        );
+
+        assert!((gain - 2.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn runtime_normalization_uses_decoded_samples_without_file_io() {
+        let source = PlaybackRuntimeSource::DecodedSamples {
+            audio_bytes: Arc::from([]),
+            samples: Arc::from([0.1_f32, -0.25, 0.5, -0.2]),
+            duration: 1.0,
+            sample_rate: 48_000,
+            channels: 1,
+        };
+
+        let gain = runtime_playback_gain_for_source(
+            1.0,
+            Some(PlaybackRuntimeGainNormalization::new(0.0, 1.0)),
+            &source,
+        );
+
+        assert!((gain - 2.0).abs() < f32::EPSILON);
+    }
+
     fn test_request(start: f64) -> PlaybackRuntimeRequest {
         PlaybackRuntimeRequest {
             source: PlaybackRuntimeSource::AudioBytes {
@@ -1022,6 +1303,7 @@ mod tests {
             mode: PlaybackRuntimeMode::OneShot { start, end: 1.0 },
             volume: 1.0,
             playback_gain: 1.0,
+            playback_gain_normalization: None,
             edit_fade: None,
             metronome: None,
         }
@@ -1049,6 +1331,7 @@ mod tests {
             seek_to_offset: true,
             looped,
             playback_gain: 1.0,
+            playback_gain_normalization: None,
             metronome: None,
         }
     }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -12,14 +12,14 @@ pub use reson::{
     AudioDeviceSummary, AudioHostSummary, AudioInputConfig, AudioInputError, AudioOutputConfig,
     AudioOutputError, AudioPlayer, AudioRecorder, EditFadeRange, FadeParams, InputMonitor,
     PlaybackMetronomeConfig, PlaybackRequestId, PlaybackRuntime, PlaybackRuntimeCancellation,
-    PlaybackRuntimeConfig, PlaybackRuntimeEvent, PlaybackRuntimeHandle, PlaybackRuntimeMode,
-    PlaybackRuntimeProgress, PlaybackRuntimeRequest, PlaybackRuntimeSource,
-    PlaybackRuntimeSpanUpdate, PlaybackRuntimeStarted, PlaybackRuntimeSubmitError,
-    RecordingOutcome, ResolvedInput, ResolvedInputConfig, ResolvedOutput, SamplesBuffer, Source,
-    Wsola, available_devices, available_hosts, available_input_channel_count,
-    available_input_devices, available_input_hosts, decoder, input, open_output_stream, output,
-    recording, resolve_input_stream_config, supported_input_sample_rates, supported_sample_rates,
-    wav_sanitize,
+    PlaybackRuntimeConfig, PlaybackRuntimeEvent, PlaybackRuntimeGainNormalization,
+    PlaybackRuntimeHandle, PlaybackRuntimeMode, PlaybackRuntimeProgress, PlaybackRuntimeRequest,
+    PlaybackRuntimeSource, PlaybackRuntimeSpanUpdate, PlaybackRuntimeStarted,
+    PlaybackRuntimeSubmitError, RecordingOutcome, ResolvedInput, ResolvedInputConfig,
+    ResolvedOutput, SamplesBuffer, Source, Wsola, available_devices, available_hosts,
+    available_input_channel_count, available_input_devices, available_input_hosts, decoder, input,
+    open_output_stream, output, recording, resolve_input_stream_config,
+    supported_input_sample_rates, supported_sample_rates, wav_sanitize,
 };
 
 pub use normalized::{

--- a/src/native_app/audio/audio_engine/volume.rs
+++ b/src/native_app/audio/audio_engine/volume.rs
@@ -47,11 +47,27 @@ impl NativeAppState {
             .persisted
             .controls
             .normalized_audition_enabled = enabled;
-        let gain = self.normalized_audition_gain_for_current_span();
+        let current_span = self
+            .audio
+            .current_playback_span
+            .or_else(|| {
+                self.waveform
+                    .current
+                    .play_selection()
+                    .filter(|selection| selection.width() > 0.0)
+                    .map(|selection| (selection.start(), selection.end()))
+            })
+            .unwrap_or((0.0, 1.0));
+        let playback_gain_normalization =
+            self.playback_gain_normalization_for_span(current_span.0, current_span.1);
         if let Some(runtime) = self.audio.playback_runtime.as_ref() {
-            let _ = runtime.try_set_playback_gain(gain);
-        } else if let Some(player) = self.audio.player.as_mut() {
-            player.set_playback_gain(gain);
+            let _ =
+                runtime.try_set_playback_gain_with_normalization(1.0, playback_gain_normalization);
+        } else {
+            let gain = self.normalized_audition_gain_for_current_span();
+            if let Some(player) = self.audio.player.as_mut() {
+                player.set_playback_gain(gain);
+            }
         }
         self.persist_top_bar_audio_settings(context);
     }

--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -205,7 +205,8 @@ impl NativeAppState {
             source,
             mode,
             volume: self.audio.volume,
-            playback_gain: self.normalized_audition_gain_for_span(
+            playback_gain: 1.0,
+            playback_gain_normalization: self.playback_gain_normalization_for_span(
                 command.resolved.start_ratio,
                 command.resolved.end_ratio,
             ),

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -305,7 +305,7 @@ impl NativeAppState {
         looped: bool,
     ) -> Result<(), String> {
         let metronome = self.playback_metronome_config_for_span(start, end, offset);
-        let playback_gain = self.normalized_audition_gain_for_span(start, end);
+        let playback_gain_normalization = self.playback_gain_normalization_for_span(start, end);
         if let Some(runtime) = self.audio.playback_runtime.as_ref() {
             runtime
                 .try_retarget_span(PlaybackRuntimeSpanUpdate {
@@ -314,31 +314,35 @@ impl NativeAppState {
                     offset: f64::from(offset),
                     seek_to_offset,
                     looped,
-                    playback_gain,
+                    playback_gain: 1.0,
+                    playback_gain_normalization,
                     metronome,
                 })
                 .map_err(|err| format!("submit playback retarget request: {err:?}"))?;
-        } else if let Some(player) = self.audio.player.as_mut() {
-            player.set_playback_gain(playback_gain);
-            if looped {
-                player.retarget_looped_range_with_metronome(
-                    f64::from(start),
-                    f64::from(end),
-                    f64::from(offset),
-                    seek_to_offset,
-                    metronome,
-                )?;
-            } else {
-                player.retarget_one_shot_range_with_metronome(
-                    f64::from(start),
-                    f64::from(end),
-                    f64::from(offset),
-                    seek_to_offset,
-                    metronome,
-                )?;
-            }
         } else {
-            return Err(String::from("audio player did not initialize"));
+            let playback_gain = self.normalized_audition_gain_for_span(start, end);
+            if let Some(player) = self.audio.player.as_mut() {
+                player.set_playback_gain(playback_gain);
+                if looped {
+                    player.retarget_looped_range_with_metronome(
+                        f64::from(start),
+                        f64::from(end),
+                        f64::from(offset),
+                        seek_to_offset,
+                        metronome,
+                    )?;
+                } else {
+                    player.retarget_one_shot_range_with_metronome(
+                        f64::from(start),
+                        f64::from(end),
+                        f64::from(offset),
+                        seek_to_offset,
+                        metronome,
+                    )?;
+                }
+            } else {
+                return Err(String::from("audio player did not initialize"));
+            }
         }
 
         self.audio.current_playback_span = Some((start, end));

--- a/src/native_app/audio/playback/normalized.rs
+++ b/src/native_app/audio/playback/normalized.rs
@@ -1,4 +1,5 @@
 use crate::native_app::app::NativeAppState;
+use wavecrate::audio::PlaybackRuntimeGainNormalization;
 
 impl NativeAppState {
     pub(in crate::native_app) fn normalized_audition_gain_for_current_span(&self) -> f32 {
@@ -26,5 +27,15 @@ impl NativeAppState {
         self.waveform
             .current
             .normalized_audition_gain_for_span(start, end)
+    }
+
+    pub(in crate::native_app) fn playback_gain_normalization_for_span(
+        &self,
+        start: f32,
+        end: f32,
+    ) -> Option<PlaybackRuntimeGainNormalization> {
+        self.audio
+            .normalized_audition_enabled
+            .then_some(PlaybackRuntimeGainNormalization::new(start, end))
     }
 }

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -304,7 +304,8 @@ impl NativeAppState {
                 }
             },
             volume: self.audio.volume,
-            playback_gain: self.normalized_audition_gain_for_span(0.0, 1.0),
+            playback_gain: 1.0,
+            playback_gain_normalization: self.playback_gain_normalization_for_span(0.0, 1.0),
             edit_fade: None,
             metronome: self.playback_metronome_config_for_span(0.0, 1.0, 0.0),
         };

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -1,5 +1,3 @@
-use std::{fs::File, io::BufReader};
-
 use super::{
     WaveformState,
     state::{NormalizedAuditionGainCacheKey, NormalizedAuditionGainSourceKey},
@@ -64,18 +62,7 @@ impl WaveformState {
             )
             .map(wavecrate::audio::normalized_gain_from_peak);
         }
-        let cache_file = self.file.playback_cache_file.as_ref()?;
-        let sample_count = usize::try_from(cache_file.sample_count).ok()?;
-        let file = File::open(&cache_file.path).ok()?;
-        let mut reader = BufReader::new(file);
-        wavecrate::audio::peak_for_interleaved_f32_reader_span(
-            &mut reader,
-            sample_count,
-            self.file.channels,
-            start,
-            end,
-        )
-        .map(wavecrate::audio::normalized_gain_from_peak)
+        None
     }
 
     pub(in crate::native_app) fn is_playing(&self) -> bool {

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -222,7 +222,7 @@ fn normalized_audition_signal_preview_uses_active_playmark_peak() {
 }
 
 #[test]
-fn normalized_audition_signal_preview_uses_persisted_playback_cache_peak() {
+fn normalized_audition_signal_preview_does_not_read_persisted_playback_cache() {
     let root = tempfile::tempdir().expect("temp root");
     let cache_path = root.path().join("normalized-playback-cache.pcm");
     write_interleaved_f32_file(
@@ -246,10 +246,10 @@ fn normalized_audition_signal_preview_uses_persisted_playback_cache_peak() {
     let playback_gain = state.normalized_audition_gain_for_span(0.25, 0.5);
     let preview = signal_gain_preview_for_state(&state, true).expect("normalized cache preview");
 
-    assert!((playback_gain - 2.0).abs() < f32::EPSILON);
+    assert!((playback_gain - 1.0).abs() < f32::EPSILON);
     assert_eq!(preview.start, 0.25);
     assert_eq!(preview.end, 0.5);
-    assert!((preview.gain - 2.0).abs() < f32::EPSILON);
+    assert!((preview.gain - 1.0).abs() < f32::EPSILON);
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Route normalized audition playback gain resolution through the playback runtime request boundary.
- Let the runtime thread resolve decoded-sample and interleaved-f32 cache peaks for playback starts, retargets, and normalized-audition gain updates.
- Remove direct filesystem opening/reading from `src/native_app/waveform/state_playback.rs`; native waveform state now keeps only lightweight in-memory gain lookup and playback state.

## Definition of Done

- `state_playback.rs` no longer imports or directly uses filesystem APIs from native UI/update state.
- File-backed playback cache gain normalization is resolved by the playback runtime instead of the native update path.
- Existing playback request, retarget, and normalized-audition toggle paths preserve normalized playback behavior through a typed runtime payload.
- User review is required before merge.

## Validation Commands

- `cargo fmt`
- `cargo test -p reson runtime_normalization --lib`
- `cargo test -p wavecrate normalized_audition_applies_to_plain_playback_without_cached_waveform_decode`
- `cargo test -p wavecrate --no-default-features native_app_ui_update_paths_do_not_call_blocking_business_apis` (expected failure from pre-existing guardrail clusters in `starmap.rs`, `harvest_tracking.rs`, `selected_file_actions.rs`, and `duplicate.rs`; `state_playback.rs` is no longer reported)
- `git diff --check`
- `rg -n "fs::|File::open|BufReader|std::fs" src/native_app/waveform/state_playback.rs`

## Known Limitations

- The broader native app blocking guardrail still fails on unrelated pre-existing violations outside this PR scope.
- Manual smoke was not run in the desktop app during this pass.