### PR TITLE
Move starmap and harvest DB reads off native UI paths

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -4,7 +4,8 @@ use radiant::runtime::NativeFileDrop;
 use radiant::widgets::{DragHandleMessage, PointerModifiers};
 use std::{path::PathBuf, time::Instant};
 use wavecrate::sample_sources::{
-    HarvestDerivationOperation, SampleCollection, config::AppSettingsCore,
+    HarvestDerivationOperation, HarvestSeenPersistResult, SampleCollection,
+    StarmapLayoutLoadResult, config::AppSettingsCore,
 };
 use wavecrate::selection::SelectionRange;
 use wavecrate_analysis::aspects::SimilarityAspect;
@@ -31,7 +32,6 @@ use crate::native_app::sample_library::folder_browser::scan::{
     FolderScanDiscoveryBatch, FolderScanProgress, FolderScanResult, FolderTreeRefreshResult,
     FolderVerifyResult,
 };
-use crate::native_app::sample_library::harvest_tracking::HarvestSeenPersistResult;
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
 use crate::native_app::sample_library::similarity_prep::{
     SimilarityPrepEnqueueResult, SimilarityPrepStatusResult,
@@ -150,6 +150,7 @@ pub(in crate::native_app) enum GuiMessage {
         weight: f32,
     },
     SimilaritySettingsPersisted(SimilaritySettingsPersistResult),
+    StarmapLayoutLoaded(StarmapLayoutLoadResult),
     SimilarityPrepStatusResolved(SimilarityPrepStatusResult),
     SimilarityPrepEnqueueFinished(SimilarityPrepEnqueueResult),
     SimilarityScoresResolved(SimilarityScoresResult),

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -4,12 +4,12 @@ use std::path::Path;
 
 use radiant::prelude as ui;
 use radiant::widgets::PointerModifiers;
-use rusqlite::params_from_iter;
-use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceDatabaseConnectionRole};
+use wavecrate::sample_sources::{
+    STARMAP_LAYOUT_UMAP_VERSION, StarmapLayoutLoadRequest, StarmapLayoutLoadResult,
+    StarmapLayoutSample, StarmapSourceLayoutRequest,
+};
 use wavecrate_analysis::aspects::SimilarityAspect;
-use wavecrate_analysis::similarity::SIMILARITY_MODEL_ID;
 
-use crate::native_app::sample_library::similarity_prep::NATIVE_SIMILARITY_UMAP_VERSION;
 use crate::native_app::waveform::should_use_file_backed_wav_decode;
 
 use super::{FileEntry, FolderBrowserState, SimilarityAspectStrengths};
@@ -63,6 +63,8 @@ pub(super) struct StarmapLayoutCache {
     signature: Option<u64>,
     pub(super) points_by_file: HashMap<String, StarmapLayoutPoint>,
     listed_count: usize,
+    pending_load_signature: Option<u64>,
+    loaded_signature: Option<u64>,
     auto_prep_requested_signature: Option<u64>,
 }
 
@@ -70,6 +72,8 @@ impl StarmapLayoutCache {
     fn needs_similarity_prep(&self) -> bool {
         self.signature.is_some()
             && self.listed_count > 0
+            && self.loaded_signature == self.signature
+            && self.pending_load_signature != self.signature
             && self.points_by_file.len() < self.listed_count
             && self.auto_prep_requested_signature != self.signature
     }
@@ -107,17 +111,12 @@ impl FolderBrowserState {
         if self.sample_list.starmap_layout.signature == Some(signature) {
             return;
         }
-        let positions = match load_starmap_layout_positions(self, snapshot.rows()) {
-            Ok(positions) => positions,
-            Err(err) => {
-                tracing::debug!(error = %err, "starmap layout unavailable");
-                HashMap::new()
-            }
-        };
         self.sample_list.starmap_layout = StarmapLayoutCache {
             signature: Some(signature),
             listed_count: snapshot.rows().len(),
-            points_by_file: positions,
+            points_by_file: HashMap::new(),
+            pending_load_signature: None,
+            loaded_signature: None,
             auto_prep_requested_signature: None,
         };
     }
@@ -159,6 +158,69 @@ impl FolderBrowserState {
             }
         }
         source_ids
+    }
+
+    pub(in crate::native_app) fn take_starmap_layout_load_request(
+        &mut self,
+        tags_by_file: &HashMap<String, Vec<String>>,
+    ) -> Option<StarmapLayoutLoadRequest> {
+        let (request, listed_count) = self.starmap_layout_load_request(tags_by_file);
+        let signature = request.signature;
+        if self.sample_list.starmap_layout.signature != Some(signature) {
+            self.sample_list.starmap_layout = StarmapLayoutCache {
+                signature: Some(signature),
+                listed_count,
+                points_by_file: HashMap::new(),
+                pending_load_signature: None,
+                loaded_signature: None,
+                auto_prep_requested_signature: None,
+            };
+        }
+        let cache = &mut self.sample_list.starmap_layout;
+        if cache.pending_load_signature == Some(signature)
+            || cache.loaded_signature == Some(signature)
+            || request.is_empty()
+        {
+            if request.is_empty() {
+                cache.loaded_signature = Some(signature);
+            }
+            return None;
+        }
+        cache.pending_load_signature = Some(signature);
+        Some(request)
+    }
+
+    pub(in crate::native_app) fn apply_starmap_layout_load_result(
+        &mut self,
+        result: StarmapLayoutLoadResult,
+    ) {
+        let cache = &mut self.sample_list.starmap_layout;
+        if cache.signature != Some(result.signature) {
+            return;
+        }
+        cache.pending_load_signature = None;
+        cache.loaded_signature = Some(result.signature);
+        match result.result {
+            Ok(points) => {
+                cache.points_by_file = points
+                    .into_iter()
+                    .map(|(file_id, point)| {
+                        (
+                            file_id,
+                            StarmapLayoutPoint {
+                                x: point.x,
+                                y: point.y,
+                                cluster_id: point.cluster_id,
+                            },
+                        )
+                    })
+                    .collect();
+            }
+            Err(error) => {
+                tracing::debug!(%error, "starmap layout unavailable");
+                cache.points_by_file.clear();
+            }
+        }
     }
 
     pub(in crate::native_app) fn starmap_projection(
@@ -311,125 +373,41 @@ fn instant_audition_ready_for_starmap(
         || instant_audition_sample_paths.contains(&file.id)
 }
 
-fn load_starmap_layout_positions(
-    browser: &FolderBrowserState,
-    files: &[&FileEntry],
-) -> Result<HashMap<String, StarmapLayoutPoint>, String> {
-    let mut by_source: HashMap<String, SourceLayoutRequest> = HashMap::new();
-    for file in files {
-        let path = Path::new(&file.id);
-        let Some((source, relative_path)) = browser.sample_source_for_file_path(path) else {
-            continue;
-        };
-        let sample_id = build_sample_id(source.id.as_str(), &relative_path);
-        by_source
-            .entry(source.id.as_str().to_string())
-            .or_insert_with(|| SourceLayoutRequest {
-                source,
-                samples: Vec::new(),
-            })
-            .samples
-            .push(FileLayoutSample {
-                file_id: file.id.clone(),
-                sample_id,
-            });
-    }
-
-    let mut raw_points = HashMap::new();
-    for request in by_source.values() {
-        load_source_layout_positions(request, &mut raw_points)?;
-    }
-    Ok(normalized_layout_points(raw_points))
-}
-
-#[derive(Clone, Debug)]
-struct SourceLayoutRequest {
-    source: SampleSource,
-    samples: Vec<FileLayoutSample>,
-}
-
-#[derive(Clone, Debug)]
-struct FileLayoutSample {
-    file_id: String,
-    sample_id: String,
-}
-
-fn load_source_layout_positions(
-    request: &SourceLayoutRequest,
-    positions: &mut HashMap<String, RawStarmapLayoutPoint>,
-) -> Result<(), String> {
-    let database_root = request
-        .source
-        .database_root()
-        .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
-    let conn = SourceDatabase::open_connection_with_role_and_database_root(
-        &request.source.root,
-        database_root,
-        SourceDatabaseConnectionRole::UiRead,
-    )
-    .map_err(|err| format!("Open source DB failed: {err}"))?;
-    let file_by_sample_id = request
-        .samples
-        .iter()
-        .map(|sample| (sample.sample_id.as_str(), sample.file_id.as_str()))
-        .collect::<HashMap<_, _>>();
-    for chunk in request.samples.chunks(256) {
-        let mut query = String::from(
-            "SELECT layout_umap.sample_id, layout_umap.x, layout_umap.y, hdbscan_clusters.cluster_id \
-             FROM layout_umap \
-             LEFT JOIN hdbscan_clusters \
-                ON layout_umap.sample_id = hdbscan_clusters.sample_id \
-               AND hdbscan_clusters.model_id = ?1 \
-               AND hdbscan_clusters.method = ?3 \
-               AND hdbscan_clusters.umap_version = ?2 \
-             WHERE layout_umap.model_id = ?1 AND layout_umap.umap_version = ?2 AND layout_umap.sample_id IN (",
-        );
-        query.push_str(
-            &std::iter::repeat_n("?", chunk.len())
-                .collect::<Vec<_>>()
-                .join(","),
-        );
-        query.push(')');
-
-        let mut params = Vec::with_capacity(chunk.len() + 3);
-        params.push(SIMILARITY_MODEL_ID.to_string());
-        params.push(NATIVE_SIMILARITY_UMAP_VERSION.to_string());
-        params.push(String::from("umap"));
-        params.extend(chunk.iter().map(|sample| sample.sample_id.clone()));
-
-        let mut statement = conn
-            .prepare(&query)
-            .map_err(|err| format!("Prepare map layout query failed: {err}"))?;
-        let rows = statement
-            .query_map(params_from_iter(params.iter()), |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, f32>(1)?,
-                    row.get::<_, f32>(2)?,
-                    row.get::<_, Option<i32>>(3)?,
-                ))
-            })
-            .map_err(|err| format!("Query map layout failed: {err}"))?;
-        for row in rows {
-            let (sample_id, x, y, cluster_id) =
-                row.map_err(|err| format!("Decode map layout row failed: {err}"))?;
-            let Some(file_id) = file_by_sample_id.get(sample_id.as_str()) else {
+impl FolderBrowserState {
+    fn starmap_layout_load_request(
+        &self,
+        tags_by_file: &HashMap<String, Vec<String>>,
+    ) -> (StarmapLayoutLoadRequest, usize) {
+        let snapshot = self.browser_listing_snapshot(tags_by_file);
+        let listed_count = snapshot.rows().len();
+        let mut by_source: HashMap<String, StarmapSourceLayoutRequest> = HashMap::new();
+        for file in snapshot.rows() {
+            let path = Path::new(&file.id);
+            let Some((source, relative_path)) = self.sample_source_for_file_path(path) else {
                 continue;
             };
-            positions.insert(
-                (*file_id).to_string(),
-                RawStarmapLayoutPoint { x, y, cluster_id },
-            );
+            let sample_id = build_sample_id(source.id.as_str(), &relative_path);
+            by_source
+                .entry(source.id.as_str().to_string())
+                .or_insert_with(|| StarmapSourceLayoutRequest {
+                    source,
+                    samples: Vec::new(),
+                })
+                .samples
+                .push(StarmapLayoutSample {
+                    file_id: file.id.clone(),
+                    sample_id,
+                });
         }
+        let signature = starmap_layout_signature(self.selected_source_id(), snapshot.rows());
+        (
+            StarmapLayoutLoadRequest {
+                signature,
+                sources: by_source.into_values().collect(),
+            },
+            listed_count,
+        )
     }
-    Ok(())
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct RawStarmapLayoutPoint {
-    x: f32,
-    y: f32,
-    cluster_id: Option<i32>,
 }
 
 fn build_sample_id(source_id: &str, relative_path: &Path) -> String {
@@ -443,53 +421,12 @@ fn build_sample_id(source_id: &str, relative_path: &Path) -> String {
 fn starmap_layout_signature(source_id: &str, files: &[&FileEntry]) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     source_id.hash(&mut hasher);
-    NATIVE_SIMILARITY_UMAP_VERSION.hash(&mut hasher);
+    STARMAP_LAYOUT_UMAP_VERSION.hash(&mut hasher);
     files.len().hash(&mut hasher);
     for file in files {
         file.id.hash(&mut hasher);
     }
     hasher.finish()
-}
-
-fn normalized_layout_points(
-    raw_points: HashMap<String, RawStarmapLayoutPoint>,
-) -> HashMap<String, StarmapLayoutPoint> {
-    if raw_points.is_empty() {
-        return HashMap::new();
-    }
-    let (mut min_x, mut max_x) = (f32::INFINITY, f32::NEG_INFINITY);
-    let (mut min_y, mut max_y) = (f32::INFINITY, f32::NEG_INFINITY);
-    for point in raw_points.values().copied() {
-        min_x = min_x.min(point.x);
-        max_x = max_x.max(point.x);
-        min_y = min_y.min(point.y);
-        max_y = max_y.max(point.y);
-    }
-    raw_points
-        .into_iter()
-        .map(|(file_id, point)| {
-            (
-                file_id,
-                StarmapLayoutPoint {
-                    x: normalize_layout_axis(point.x, min_x, max_x, 0.04, 0.96),
-                    y: normalize_layout_axis(point.y, min_y, max_y, 0.06, 0.94),
-                    cluster_id: point.cluster_id,
-                },
-            )
-        })
-        .collect()
-}
-
-fn normalize_layout_axis(value: f32, min: f32, max: f32, out_min: f32, out_max: f32) -> f32 {
-    if !value.is_finite() || !min.is_finite() || !max.is_finite() {
-        return (out_min + out_max) * 0.5;
-    }
-    let span = max - min;
-    if span.abs() <= f32::EPSILON {
-        return (out_min + out_max) * 0.5;
-    }
-    let unit = ((value - min) / span).clamp(0.0, 1.0);
-    out_min + (out_max - out_min) * unit
 }
 
 fn strongest_enabled_aspect(
@@ -658,6 +595,7 @@ const STARMAP_CLUSTER_PALETTE: [ui::Rgba8; 5] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wavecrate::sample_sources::SampleSource;
 
     #[test]
     fn starmap_position_is_stable_and_bounded() {
@@ -694,45 +632,6 @@ mod tests {
         assert_ne!(fallback, layout);
         assert!((0.0..=1.0).contains(&fallback.0));
         assert!((0.0..=1.0).contains(&fallback.1));
-    }
-
-    #[test]
-    fn normalized_layout_positions_fill_map_domain() {
-        let positions = normalized_layout_points(HashMap::from([
-            (
-                String::from("a.wav"),
-                RawStarmapLayoutPoint {
-                    x: -1.0,
-                    y: 2.0,
-                    cluster_id: Some(3),
-                },
-            ),
-            (
-                String::from("b.wav"),
-                RawStarmapLayoutPoint {
-                    x: 1.0,
-                    y: 6.0,
-                    cluster_id: Some(7),
-                },
-            ),
-        ]));
-
-        assert_eq!(
-            positions.get("a.wav"),
-            Some(&StarmapLayoutPoint {
-                x: 0.04,
-                y: 0.06,
-                cluster_id: Some(3),
-            })
-        );
-        assert_eq!(
-            positions.get("b.wav"),
-            Some(&StarmapLayoutPoint {
-                x: 0.96,
-                y: 0.94,
-                cluster_id: Some(7),
-            })
-        );
     }
 
     #[test]
@@ -1163,6 +1062,8 @@ mod tests {
                     cluster_id: None,
                 },
             )]),
+            pending_load_signature: None,
+            loaded_signature: Some(42),
             auto_prep_requested_signature: None,
         };
 
@@ -1186,12 +1087,16 @@ mod tests {
                     cluster_id: None,
                 },
             )]),
+            pending_load_signature: None,
+            loaded_signature: Some(7),
             auto_prep_requested_signature: None,
         };
         let empty_listing = StarmapLayoutCache {
             signature: Some(8),
             listed_count: 0,
             points_by_file: HashMap::new(),
+            pending_load_signature: None,
+            loaded_signature: Some(8),
             auto_prep_requested_signature: None,
         };
 

--- a/src/native_app/sample_library/harvest_tracking.rs
+++ b/src/native_app/sample_library/harvest_tracking.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use wavecrate::{
     sample_sources::{
         HarvestDerivationOperation, HarvestFileIdentity, HarvestFileKey, HarvestMetadataSnapshot,
-        HarvestSourceRange, HarvestState, NewHarvestDerivation, SampleSource, SourceDatabase,
-        SourceId, WavEntry,
+        HarvestSeenPersistRequest, HarvestSeenPersistResult, HarvestSourceRange, HarvestState,
+        NewHarvestDerivation, SampleSource, WavEntry, persist_harvest_seen,
     },
     selection::SelectionRange,
 };
@@ -33,21 +33,6 @@ pub(in crate::native_app) struct HarvestFamilySummary {
     pub(in crate::native_app) missing_derivative_count: usize,
     pub(in crate::native_app) first_origin_label: Option<String>,
     pub(in crate::native_app) first_derivative_label: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(in crate::native_app) struct HarvestSeenPersistResult {
-    pub(in crate::native_app) file_id: String,
-    pub(in crate::native_app) result: Result<(), String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct HarvestSeenPersistRequest {
-    file_id: String,
-    source_id: SourceId,
-    source_root: PathBuf,
-    source_database_root: PathBuf,
-    relative_path: PathBuf,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1410,34 +1395,6 @@ fn source_db_entry_for_path(source: &SampleSource, relative_path: &Path) -> Opti
         .open_db()
         .ok()
         .and_then(|db| db.entry_for_path(relative_path).ok().flatten())
-}
-
-fn persist_harvest_seen(request: HarvestSeenPersistRequest) -> HarvestSeenPersistResult {
-    let result = persist_harvest_seen_inner(&request);
-    HarvestSeenPersistResult {
-        file_id: request.file_id,
-        result,
-    }
-}
-
-fn persist_harvest_seen_inner(request: &HarvestSeenPersistRequest) -> Result<(), String> {
-    let path = request.source_root.join(&request.relative_path);
-    let (file_size, modified_ns) = file_identity_metadata(&path);
-    let entry = SourceDatabase::open_read_only_with_database_root(
-        &request.source_root,
-        &request.source_database_root,
-    )
-    .ok()
-    .and_then(|db| db.entry_for_path(&request.relative_path).ok().flatten());
-    let identity = HarvestFileIdentity {
-        key: HarvestFileKey::new(request.source_id.clone(), request.relative_path.clone()),
-        file_size: file_size.or_else(|| entry.as_ref().map(|entry| entry.file_size)),
-        modified_ns: modified_ns.or_else(|| entry.as_ref().map(|entry| entry.modified_ns)),
-        content_hash: entry.and_then(|entry| entry.content_hash),
-    };
-    wavecrate::sample_sources::library::mark_harvest_seen(&identity)
-        .map(|_| ())
-        .map_err(|err| err.to_string())
 }
 
 fn file_identity_metadata(path: &Path) -> (Option<u64>, Option<i64>) {

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -1,14 +1,15 @@
 use std::{collections::VecDeque, path::Path};
 
 use radiant::prelude as ui;
-use wavecrate::sample_sources::{SampleSource, SourceId};
+use wavecrate::sample_sources::{
+    SampleSource, SourceId, StarmapLayoutLoadResult, load_starmap_layout,
+};
 
 use crate::native_app::app::{
     GuiMessage, NativeAppState, SampleBrowserDisplayMode, emit_gui_action,
 };
 
 mod worker;
-pub(in crate::native_app) use worker::NATIVE_SIMILARITY_UMAP_VERSION;
 use worker::{
     drain_similarity_prep_jobs, enqueue_similarity_prep_inner, finalize_similarity_prep_if_ready,
     resolve_similarity_prep_status, source_has_active_similarity_prep_jobs,
@@ -83,6 +84,38 @@ impl SimilarityPrepSource {
 }
 
 impl NativeAppState {
+    pub(in crate::native_app) fn maybe_start_starmap_layout_load(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if self.ui.chrome.sample_browser_display != SampleBrowserDisplayMode::Map {
+            return;
+        }
+        let Some(request) = self
+            .library
+            .folder_browser
+            .take_starmap_layout_load_request(&self.metadata.tags_by_file)
+        else {
+            return;
+        };
+        context
+            .business()
+            .background("gui-starmap-layout-load")
+            .run(
+                move |_| load_starmap_layout(request),
+                GuiMessage::StarmapLayoutLoaded,
+            );
+    }
+
+    pub(in crate::native_app) fn finish_starmap_layout_load(
+        &mut self,
+        result: StarmapLayoutLoadResult,
+    ) {
+        self.library
+            .folder_browser
+            .apply_starmap_layout_load_result(result);
+    }
+
     pub(in crate::native_app) fn maybe_prepare_starmap_similarity_layout(
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -22,7 +22,7 @@ mod analysis_enqueue;
 
 use analysis_enqueue::enqueue_analysis_backfill;
 
-pub(in crate::native_app) const NATIVE_SIMILARITY_UMAP_VERSION: &str = "v1";
+pub(in crate::native_app) use wavecrate::sample_sources::STARMAP_LAYOUT_UMAP_VERSION as NATIVE_SIMILARITY_UMAP_VERSION;
 const NATIVE_SIMILARITY_CLUSTER_MIN_SIZE: usize = 10;
 const ANALYZE_SAMPLE_JOB_TYPE: &str = "wav_metadata_v1";
 const EMBEDDING_BACKFILL_JOB_TYPE: &str = "embedding_backfill_v1";

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -40,6 +40,7 @@ impl NativeAppState {
             | GuiMessage::SetSimilarityAspectEnabled { .. }
             | GuiMessage::SetSimilarityAspectWeight { .. }
             | GuiMessage::SimilaritySettingsPersisted(_)
+            | GuiMessage::StarmapLayoutLoaded(_)
             | GuiMessage::SimilarityPrepStatusResolved(_)
             | GuiMessage::SimilarityPrepEnqueueFinished(_)
             | GuiMessage::SimilarityScoresResolved(_)

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -35,6 +35,9 @@ impl NativeAppState {
             GuiMessage::SimilaritySettingsPersisted(result) => {
                 self.finish_similarity_settings_persist(result);
             }
+            GuiMessage::StarmapLayoutLoaded(result) => {
+                self.finish_starmap_layout_load(result);
+            }
             GuiMessage::SimilarityPrepStatusResolved(result) => {
                 self.finish_similarity_prep_status(result);
             }

--- a/src/native_app/shell/message_dispatch/frame.rs
+++ b/src/native_app/shell/message_dispatch/frame.rs
@@ -12,6 +12,7 @@ impl NativeAppState {
         self.maybe_start_release_update_check(context);
         self.maybe_start_waveform_cache_warm(context);
         self.maybe_start_active_folder_cache_warm(context);
+        self.maybe_start_starmap_layout_load(context);
         self.maybe_prepare_starmap_similarity_layout(context);
         self.flush_pending_play_selection_playback_retarget();
         self.advance_frame(context);

--- a/src/sample_sources/harvest_seen.rs
+++ b/src/sample_sources/harvest_seen.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use crate::sample_sources::{
+    HarvestFileIdentity, HarvestFileKey, SourceDatabase, SourceId, harvest_file_ops, library,
+};
+
+/// Result of persisting a harvest file's seen/touched identity in the library database.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HarvestSeenPersistResult {
+    /// Absolute file id/path that the native browser scheduled for persistence.
+    pub file_id: String,
+    /// Persistence outcome with a user-loggable error string on failure.
+    pub result: Result<(), String>,
+}
+
+/// Background request for marking a harvest file as seen.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HarvestSeenPersistRequest {
+    /// Absolute file id/path used to correlate the background result.
+    pub file_id: String,
+    /// Source id that owns the harvest-relative sample path.
+    pub source_id: SourceId,
+    /// Filesystem root of the owning source.
+    pub source_root: PathBuf,
+    /// Metadata database root for the owning source.
+    pub source_database_root: PathBuf,
+    /// Path to the sample relative to the owning source root.
+    pub relative_path: PathBuf,
+}
+
+/// Persist a harvest-seen marker using file metadata and the owning source database.
+pub fn persist_harvest_seen(request: HarvestSeenPersistRequest) -> HarvestSeenPersistResult {
+    let result = persist_harvest_seen_inner(&request);
+    HarvestSeenPersistResult {
+        file_id: request.file_id,
+        result,
+    }
+}
+
+fn persist_harvest_seen_inner(request: &HarvestSeenPersistRequest) -> Result<(), String> {
+    let path = request.source_root.join(&request.relative_path);
+    let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(&path);
+    let entry = SourceDatabase::open_read_only_with_database_root(
+        &request.source_root,
+        &request.source_database_root,
+    )
+    .ok()
+    .and_then(|db| db.entry_for_path(&request.relative_path).ok().flatten());
+    let identity = HarvestFileIdentity {
+        key: HarvestFileKey::new(request.source_id.clone(), request.relative_path.clone()),
+        file_size: file_size.or_else(|| entry.as_ref().map(|entry| entry.file_size)),
+        modified_ns: modified_ns.or_else(|| entry.as_ref().map(|entry| entry.modified_ns)),
+        content_hash: entry.and_then(|entry| entry.content_hash),
+    };
+    library::mark_harvest_seen(&identity)
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -12,6 +12,8 @@ pub mod duplicate_file_ops;
 mod file_move_metadata;
 #[doc(hidden)]
 pub mod harvest_file_ops;
+mod harvest_seen;
+mod starmap_layout;
 /// Scan tracking state to avoid duplicate work.
 pub mod scan_state {
     pub use wavecrate_scan::sample_sources::scan_state::ScanTracker;
@@ -65,6 +67,11 @@ pub use duplicate_file_ops::{
 #[doc(hidden)]
 pub use file_move_metadata::{
     SourcedFileMoveMetadata, persist_copied_file_metadata, persist_sourced_moved_file_metadata,
+};
+pub use harvest_seen::{HarvestSeenPersistRequest, HarvestSeenPersistResult, persist_harvest_seen};
+pub use starmap_layout::{
+    STARMAP_LAYOUT_UMAP_VERSION, StarmapLayoutLoadRequest, StarmapLayoutLoadResult,
+    StarmapLayoutPoint, StarmapLayoutSample, StarmapSourceLayoutRequest, load_starmap_layout,
 };
 pub use wavecrate_library::sample_sources::db::{SampleCollection, SampleSoundType};
 pub(crate) use wavecrate_library::sample_sources::is_supported_audio;

--- a/src/sample_sources/starmap_layout.rs
+++ b/src/sample_sources/starmap_layout.rs
@@ -1,0 +1,245 @@
+use std::collections::HashMap;
+
+use rusqlite::params_from_iter;
+use wavecrate_analysis::similarity::SIMILARITY_MODEL_ID;
+
+use crate::sample_sources::{SampleSource, SourceDatabase, SourceDatabaseConnectionRole};
+
+/// UMAP artifact version used by the native starmap layout.
+pub const STARMAP_LAYOUT_UMAP_VERSION: &str = "v1";
+
+/// Background request for loading starmap layout points from source databases.
+#[derive(Clone, Debug)]
+pub struct StarmapLayoutLoadRequest {
+    /// Native cache signature used to ignore stale background results.
+    pub signature: u64,
+    /// Per-source layout lookups to execute.
+    pub sources: Vec<StarmapSourceLayoutRequest>,
+}
+
+impl StarmapLayoutLoadRequest {
+    /// Return whether this request contains no sample lookups.
+    pub fn is_empty(&self) -> bool {
+        self.sources.iter().all(|source| source.samples.is_empty())
+    }
+}
+
+/// Source-specific starmap layout lookup request.
+#[derive(Clone, Debug)]
+pub struct StarmapSourceLayoutRequest {
+    /// Sample source whose metadata database contains the layout artifacts.
+    pub source: SampleSource,
+    /// Samples to load from this source database.
+    pub samples: Vec<StarmapLayoutSample>,
+}
+
+/// A starmap layout lookup for one file/sample id pair.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StarmapLayoutSample {
+    /// Absolute file id/path used by the native browser.
+    pub file_id: String,
+    /// Stable analysis sample id stored in the source database.
+    pub sample_id: String,
+}
+
+/// Normalized starmap position plus optional cluster id for one browser file.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StarmapLayoutPoint {
+    /// Normalized x coordinate in the starmap domain.
+    pub x: f32,
+    /// Normalized y coordinate in the starmap domain.
+    pub y: f32,
+    /// Optional HDBSCAN cluster id for color grouping.
+    pub cluster_id: Option<i32>,
+}
+
+/// Result of a background starmap layout load.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StarmapLayoutLoadResult {
+    /// Native cache signature used to ignore stale background results.
+    pub signature: u64,
+    /// Loaded layout points keyed by native browser file id.
+    pub result: Result<HashMap<String, StarmapLayoutPoint>, String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RawStarmapLayoutPoint {
+    x: f32,
+    y: f32,
+    cluster_id: Option<i32>,
+}
+
+/// Load and normalize starmap layout points from source metadata databases.
+pub fn load_starmap_layout(request: StarmapLayoutLoadRequest) -> StarmapLayoutLoadResult {
+    let signature = request.signature;
+    StarmapLayoutLoadResult {
+        signature,
+        result: load_starmap_layout_inner(request),
+    }
+}
+
+fn load_starmap_layout_inner(
+    request: StarmapLayoutLoadRequest,
+) -> Result<HashMap<String, StarmapLayoutPoint>, String> {
+    let mut raw_points = HashMap::new();
+    for source in request.sources {
+        load_source_layout_positions(&source, &mut raw_points)?;
+    }
+    Ok(normalized_layout_points(raw_points))
+}
+
+fn load_source_layout_positions(
+    request: &StarmapSourceLayoutRequest,
+    positions: &mut HashMap<String, RawStarmapLayoutPoint>,
+) -> Result<(), String> {
+    let database_root = request
+        .source
+        .database_root()
+        .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
+    let conn = SourceDatabase::open_connection_with_role_and_database_root(
+        &request.source.root,
+        database_root,
+        SourceDatabaseConnectionRole::UiRead,
+    )
+    .map_err(|err| format!("Open source DB failed: {err}"))?;
+    let file_by_sample_id = request
+        .samples
+        .iter()
+        .map(|sample| (sample.sample_id.as_str(), sample.file_id.as_str()))
+        .collect::<HashMap<_, _>>();
+    for chunk in request.samples.chunks(256) {
+        let mut query = String::from(
+            "SELECT layout_umap.sample_id, layout_umap.x, layout_umap.y, hdbscan_clusters.cluster_id \
+             FROM layout_umap \
+             LEFT JOIN hdbscan_clusters \
+                ON layout_umap.sample_id = hdbscan_clusters.sample_id \
+               AND hdbscan_clusters.model_id = ?1 \
+               AND hdbscan_clusters.method = ?3 \
+               AND hdbscan_clusters.umap_version = ?2 \
+             WHERE layout_umap.model_id = ?1 AND layout_umap.umap_version = ?2 AND layout_umap.sample_id IN (",
+        );
+        query.push_str(
+            &std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        query.push(')');
+
+        let mut params = Vec::with_capacity(chunk.len() + 3);
+        params.push(SIMILARITY_MODEL_ID.to_string());
+        params.push(STARMAP_LAYOUT_UMAP_VERSION.to_string());
+        params.push(String::from("umap"));
+        params.extend(chunk.iter().map(|sample| sample.sample_id.clone()));
+
+        let mut statement = conn
+            .prepare(&query)
+            .map_err(|err| format!("Prepare map layout query failed: {err}"))?;
+        let rows = statement
+            .query_map(params_from_iter(params.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, f32>(1)?,
+                    row.get::<_, f32>(2)?,
+                    row.get::<_, Option<i32>>(3)?,
+                ))
+            })
+            .map_err(|err| format!("Query map layout failed: {err}"))?;
+        for row in rows {
+            let (sample_id, x, y, cluster_id) =
+                row.map_err(|err| format!("Decode map layout row failed: {err}"))?;
+            let Some(file_id) = file_by_sample_id.get(sample_id.as_str()) else {
+                continue;
+            };
+            positions.insert(
+                (*file_id).to_string(),
+                RawStarmapLayoutPoint { x, y, cluster_id },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn normalized_layout_points(
+    raw_points: HashMap<String, RawStarmapLayoutPoint>,
+) -> HashMap<String, StarmapLayoutPoint> {
+    if raw_points.is_empty() {
+        return HashMap::new();
+    }
+    let (mut min_x, mut max_x) = (f32::INFINITY, f32::NEG_INFINITY);
+    let (mut min_y, mut max_y) = (f32::INFINITY, f32::NEG_INFINITY);
+    for point in raw_points.values().copied() {
+        min_x = min_x.min(point.x);
+        max_x = max_x.max(point.x);
+        min_y = min_y.min(point.y);
+        max_y = max_y.max(point.y);
+    }
+    raw_points
+        .into_iter()
+        .map(|(file_id, point)| {
+            (
+                file_id,
+                StarmapLayoutPoint {
+                    x: normalize_layout_axis(point.x, min_x, max_x, 0.04, 0.96),
+                    y: normalize_layout_axis(point.y, min_y, max_y, 0.06, 0.94),
+                    cluster_id: point.cluster_id,
+                },
+            )
+        })
+        .collect()
+}
+
+fn normalize_layout_axis(value: f32, min: f32, max: f32, out_min: f32, out_max: f32) -> f32 {
+    if !value.is_finite() || !min.is_finite() || !max.is_finite() {
+        return (out_min + out_max) * 0.5;
+    }
+    let span = max - min;
+    if span.abs() <= f32::EPSILON {
+        return (out_min + out_max) * 0.5;
+    }
+    let unit = ((value - min) / span).clamp(0.0, 1.0);
+    out_min + (out_max - out_min) * unit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized_layout_positions_fill_map_domain() {
+        let positions = normalized_layout_points(HashMap::from([
+            (
+                String::from("a.wav"),
+                RawStarmapLayoutPoint {
+                    x: -1.0,
+                    y: 2.0,
+                    cluster_id: Some(3),
+                },
+            ),
+            (
+                String::from("b.wav"),
+                RawStarmapLayoutPoint {
+                    x: 1.0,
+                    y: 6.0,
+                    cluster_id: Some(7),
+                },
+            ),
+        ]));
+
+        assert_eq!(
+            positions.get("a.wav"),
+            Some(&StarmapLayoutPoint {
+                x: 0.04,
+                y: 0.06,
+                cluster_id: Some(3),
+            })
+        );
+        assert_eq!(
+            positions.get("b.wav"),
+            Some(&StarmapLayoutPoint {
+                x: 0.96,
+                y: 0.94,
+                cluster_id: Some(7),
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Scope
- Move starmap layout source-database open/query/normalization work into `sample_sources::starmap_layout`.
- Change native starmap preparation to cache/signature/request management only, with frame-loop background loading through `context.business()` and stale-result protection.
- Move harvest-seen persistence request/result and DB read/open work into `sample_sources::harvest_seen`, keeping native code responsible for scheduling and applying immutable results.
- Keep the starmap UMAP artifact version shared with the similarity prep worker.

## Definition of Done
- Native starmap view preparation no longer opens source databases synchronously.
- Native harvest-seen persistence no longer contains the cited `SourceDatabase::open...` call.
- `native_app_ui_update_paths_do_not_call_blocking_business_apis` passes without allowlist changes.
- Existing starmap projection/navigation behavior is preserved while persisted layout points load asynchronously.

## Validation Commands
- `cargo fmt --check`
- `cargo check -p wavecrate --no-default-features`
- `cargo test -p wavecrate --no-default-features native_app_ui_update_paths_do_not_call_blocking_business_apis`
- `cargo test -p wavecrate starmap -- --test-threads=1`
- `bash scripts/agent.sh request` (fails after the OPT-971 guardrail passes on unrelated facade guardrails; see Known limitations)
- `cargo test -p wavecrate harvest -- --test-threads=1` (fails in existing harvest touch/seen tests; see Known limitations)

## Known Limitations
- `bash scripts/agent.sh request` reaches and passes the non-blocking architecture guardrail, then fails `Wavecrate facade guardrail` on unrelated existing issues:
  - `src/native_app/app_chrome/view_models/library_sidebar.rs:419` imports test_support in production code.
  - `src/native_app/app_chrome/view_models/sample_browser.rs:179` imports test_support in production code.
  - `src/native_app/sample_library/folder_browser.rs` exceeds its facade public-module budget.
  - `src/native_app/test_support.rs` exceeds its public-module budget.
- `cargo test -p wavecrate harvest -- --test-threads=1` fails in three pre-existing/unrelated harness paths:
  - `native_app::tests::waveform_playback::editmark_selection_change_marks_harvest_file_touched`
  - `native_app::tests::waveform_playback::playmark_selection_change_marks_harvest_file_touched`
  - `native_app::tests::waveform_playback::sample_loading::cache_reuse::sample_load_marks_new_harvest_file_seen`

User review is required before merge.
