### PR TITLE
Wavecrate: show extractions during active playmark drags

### DIFF
--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -171,13 +171,19 @@ fn starmap_items_for_display(
 
 fn waveform_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bool {
     state.waveform.current.active_drag_kind().is_some()
+        && !state
+            .library
+            .folder_browser
+            .visible_sample_window_needs_content_refresh()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native_app::sample_library::folder_browser::FolderBrowserState;
     use crate::native_app::test_support::state::{NativeAppStateFixture, WaveformInteraction};
     use crate::native_app::waveform::WaveformSelectionKind;
+    use std::fs;
 
     #[test]
     fn list_mode_projection_does_not_build_starmap_items() {
@@ -204,6 +210,46 @@ mod tests {
                 visible_ratio: 0.25,
             });
 
+        assert!(waveform_drag_defers_sample_browser_preparation(&state));
+    }
+
+    #[test]
+    fn active_waveform_drag_allows_sample_browser_preparation_after_file_refresh() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let original = source.join("original.wav");
+        let extracted = source.join("original_extraction.wav");
+        fs::write(&original, [0_u8; 8]).expect("write original");
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_root(source.clone()))
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.set_play_selection_range(0.2, 0.4);
+        prepare_sample_browser_view(&mut state);
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+        fs::write(&extracted, [1_u8; 8]).expect("write extraction");
+        assert!(state.library.folder_browser.refresh_file_path(&extracted));
+
+        assert!(!waveform_drag_defers_sample_browser_preparation(&state));
+        prepare_sample_browser_view(&mut state);
+        let projection = SampleBrowserViewProjection::from_prepared_app_state(&state);
+
+        assert!(
+            projection
+                .visible_samples
+                .rows
+                .iter()
+                .any(|row| row.file.id == extracted.to_string_lossy().as_ref()),
+            "extracted row should be visible before the active playmark drag ends"
+        );
         assert!(waveform_drag_defers_sample_browser_preparation(&state));
     }
 

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -432,6 +432,10 @@ impl FolderBrowserState {
         self.sample_list.bump_content_revision();
     }
 
+    pub(in crate::native_app) fn visible_sample_window_needs_content_refresh(&self) -> bool {
+        self.sample_list.prepared_content_revision != self.sample_list.content_revision
+    }
+
     pub(in crate::native_app) fn invalidate_visible_sample_projection_cache(&mut self) {
         self.sample_list.projection_cache.clear();
     }

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -78,6 +78,7 @@ pub(super) struct SampleListState {
     pub(super) view_controller: ui::VirtualListController,
     pub(super) follow_selection: ui::VirtualListFollowState<String>,
     pub(super) prepared_window: ui::VirtualListWindow,
+    pub(super) prepared_content_revision: u64,
     pub(super) content_revision: u64,
     pub(super) missing_collection_files: Vec<FileEntry>,
     pub(super) missing_collection_counts: BTreeMap<u8, usize>,
@@ -103,6 +104,7 @@ impl SampleListState {
             view_controller: ui::VirtualListController::default(),
             follow_selection: ui::VirtualListFollowState::default(),
             prepared_window: ui::VirtualListWindow::default(),
+            prepared_content_revision: 0,
             content_revision: 0,
             missing_collection_files: Vec::new(),
             missing_collection_counts: BTreeMap::new(),
@@ -119,6 +121,7 @@ impl SampleListState {
         self.view_controller = ui::VirtualListController::default();
         self.follow_selection.clear();
         self.prepared_window = ui::VirtualListWindow::default();
+        self.prepared_content_revision = self.content_revision;
         self.refollow_selected_after_content_change = false;
     }
 
@@ -454,12 +457,14 @@ impl FolderBrowserState {
         &mut self,
         policy: VisibleSampleWindowPolicy<'_>,
     ) -> ui::VirtualListWindow {
-        self.follow_selected_file_view_matching_tags(
+        let window = self.follow_selected_file_view_matching_tags(
             policy.viewport_rows,
             policy.overscan_rows,
             policy.guard_rows,
             policy.tags_by_file,
-        )
+        );
+        self.sample_list.prepared_content_revision = self.sample_list.content_revision;
+        window
     }
 
     pub(in crate::native_app) fn visible_samples<'a>(


### PR DESCRIPTION
## Scope

- Track which folder-browser content revision the visible sample window was prepared from.
- Keep the existing active-waveform-drag preparation deferral, but allow a preparation pass when file content changes during the drag.
- Add regression coverage for a playmark move drag where a refreshed extraction file becomes visible before the drag ends.

## Definition of Done

- Extractions registered while a playmark slide is active can refresh the browser/list immediately.
- Ordinary drag frames still defer sample-window preparation once the refreshed content has been prepared, preserving the live slide preview guard.
- Existing extraction completion, protected-source, and Harvest routing behavior remains unchanged.

## Validation commands

- `cargo fmt --check`
- `cargo test active_waveform_drag_allows_sample_browser_preparation_after_file_refresh --bin wavecrate`
- `cargo test playmark_extraction_completion_evicts_reused_output_cache --bin wavecrate`
- `cargo test waveform_drag --bin wavecrate`
- `cargo test playmark_extraction --bin wavecrate`
- `cargo check --bin wavecrate`

## Known limitations

None.

## Review

User review is required before merge.
