### PR TITLE
Wavecrate: only bump keep ratings for whole-file handoffs

### DIFF
--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -321,6 +321,7 @@ pub(in crate::native_app) struct BrowserInteractionState {
     pub(in crate::native_app) cut_file_paste_task_id: Option<u64>,
     pub(in crate::native_app) native_file_drop_hover: Option<NativeFileDropHover>,
     pub(in crate::native_app) pending_internal_file_drag_paths: HashSet<PathBuf>,
+    pub(in crate::native_app) pending_internal_file_drag_adds_keep_rating: bool,
     pub(in crate::native_app) file_move_conflict_apply_to_remaining: bool,
 }
 

--- a/src/native_app/sample_library/drag_drop_actions/drag_session.rs
+++ b/src/native_app/sample_library/drag_drop_actions/drag_session.rs
@@ -10,6 +10,21 @@ impl NativeAppState {
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.arm_browser_drag_with_handoff_rating(context, true);
+    }
+
+    pub(in crate::native_app) fn arm_browser_drag_without_handoff_rating(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.arm_browser_drag_with_handoff_rating(context, false);
+    }
+
+    fn arm_browser_drag_with_handoff_rating(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+        add_keep_rating: bool,
+    ) {
         let drag = self.library.folder_browser.drag_preview().map(|preview| {
             ui::DragRequest::new(
                 ui::DragPreview::text_sized(
@@ -22,7 +37,7 @@ impl NativeAppState {
             )
         });
         let external = self.library.folder_browser.external_drag_request();
-        self.arm_pending_internal_file_drag_paths(external.as_ref());
+        self.arm_pending_internal_file_drag_paths(external.as_ref(), add_keep_rating);
 
         context.begin_drag_session(drag, external, GuiMessage::ExternalDragCompleted);
     }

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -368,13 +368,21 @@ impl NativeAppState {
             .iter()
             .cloned()
             .collect::<Vec<_>>();
+        let handoff_adds_keep_rating = self
+            .ui
+            .browser_interaction
+            .pending_internal_file_drag_adds_keep_rating;
         context.end_drag();
         self.library.folder_browser.clear_drag();
         self.clear_pending_internal_file_drag_paths();
         self.ui.status.sample = match result {
             Ok(outcome) if outcome.accepted() => match outcome.effect {
                 ui::ExternalDragEffect::Copy | ui::ExternalDragEffect::Link => {
-                    let rating_error = self.add_keep_rating_to_handoff_paths(&handoff_paths).err();
+                    let rating_error = if handoff_adds_keep_rating {
+                        self.add_keep_rating_to_handoff_paths(&handoff_paths).err()
+                    } else {
+                        None
+                    };
                     match (outcome.effect, rating_error) {
                         (ui::ExternalDragEffect::Copy, None) => {
                             String::from("Dragged item externally")

--- a/src/native_app/sample_library/drag_drop_actions/pending_paths.rs
+++ b/src/native_app/sample_library/drag_drop_actions/pending_paths.rs
@@ -8,11 +8,15 @@ impl NativeAppState {
     pub(in crate::native_app) fn arm_pending_internal_file_drag_paths(
         &mut self,
         request: Option<&ui::ExternalDragRequest>,
+        add_keep_rating: bool,
     ) {
         self.ui
             .browser_interaction
             .pending_internal_file_drag_paths
             .clear();
+        self.ui
+            .browser_interaction
+            .pending_internal_file_drag_adds_keep_rating = false;
         let Some(ui::ExternalDragPayload::Files(paths)) = request.map(|request| &request.payload)
         else {
             return;
@@ -21,6 +25,9 @@ impl NativeAppState {
             .browser_interaction
             .pending_internal_file_drag_paths
             .extend(paths.iter().map(|path| normalized_drag_path(path)));
+        self.ui
+            .browser_interaction
+            .pending_internal_file_drag_adds_keep_rating = add_keep_rating;
     }
 
     pub(in crate::native_app) fn clear_pending_internal_file_drag_paths(&mut self) {
@@ -28,6 +35,9 @@ impl NativeAppState {
             .browser_interaction
             .pending_internal_file_drag_paths
             .clear();
+        self.ui
+            .browser_interaction
+            .pending_internal_file_drag_adds_keep_rating = false;
     }
 
     pub(in crate::native_app) fn is_pending_internal_file_drag_path(&self, path: &Path) -> bool {

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -484,7 +484,7 @@ impl NativeAppState {
                     self.library
                         .folder_browser
                         .begin_extracted_file_drag(path.clone(), position);
-                    self.arm_browser_drag(context);
+                    self.arm_browser_drag_without_handoff_rating(context);
                     let label = sample_path_label(&path);
                     self.ui.status.sample = match metadata_error {
                         Some(error) => {

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -77,6 +77,44 @@ fn assert_sample_rating(
     assert_eq!(persisted.locked, locked);
 }
 
+fn assert_sample_not_keep_rated(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    path: &Path,
+) {
+    let file_id = path.display().to_string();
+    let row = state
+        .library
+        .folder_browser
+        .loaded_source_audio_files()
+        .into_iter()
+        .find(|file| file.id == file_id)
+        .expect("source file should be loaded");
+    assert_eq!(row.rating, Rating::NEUTRAL);
+    assert!(!row.rating_locked);
+
+    let Some((source_root, source_database_root, relative_path)) = state
+        .library
+        .folder_browser
+        .source_database_relative_file_path(path)
+    else {
+        return;
+    };
+    let Ok(db) =
+        SourceDatabase::open_read_only_with_database_root(source_root, &source_database_root)
+    else {
+        return;
+    };
+    if let Some(persisted) = db
+        .list_files()
+        .expect("source database files should list")
+        .into_iter()
+        .find(|entry| entry.relative_path == relative_path)
+    {
+        assert_eq!(persisted.tag, Rating::NEUTRAL);
+        assert!(!persisted.locked);
+    }
+}
+
 fn assert_short_edge_faded_drag_extraction(path: &std::path::Path) {
     let samples = read_test_wav_i16(path);
     assert_eq!(samples.len(), 4);
@@ -272,6 +310,37 @@ fn waveform_selection_drag_start_prepares_extraction_for_external_handoff() {
         "cancelling the drag keeps the durable extraction that was offered externally"
     );
     assert!(!state.library.folder_browser.drag_active());
+}
+
+#[test]
+fn accepted_waveform_selection_external_drag_does_not_add_whole_file_keep_rating() {
+    let (mut state, _source_root, selected_file) =
+        native_app_state_with_temp_sample("drag-partial-rating.wav");
+    let source = std::path::PathBuf::from(&selected_file);
+    write_test_wav_i16(&source, &[0, 256, -256, 512]);
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(source.clone())
+            .expect("load waveform");
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    let extraction = source.with_file_name("drag-partial-rating_extraction.wav");
+    let mut drag_context = ui::UiUpdateContext::default();
+
+    assert!(state.drag_waveform_play_selection(
+        DragHandleMessage::started(Point::new(20.0, 12.0)),
+        &mut drag_context,
+    ));
+    assert_sample_rating(&state, &extraction, Rating::KEEP_1, false);
+
+    let mut completion_context = ui::UiUpdateContext::default();
+    state.external_drag_completed(
+        Ok(ui::ExternalDragOutcome {
+            effect: ui::ExternalDragEffect::Copy,
+        }),
+        &mut completion_context,
+    );
+
+    assert_sample_rating(&state, &extraction, Rating::KEEP_1, false);
+    assert_sample_not_keep_rated(&state, &source);
 }
 
 #[test]

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -729,7 +729,7 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
     );
     let mut copy_finished_context = ui::UiUpdateContext::default();
     scenario.state.finish_waveform_selection_copy(
-        source_path,
+        source_path.clone(),
         selection,
         extracted.clone(),
         crate::native_app::app::ExtractedFilePlaybackType::OneShot,
@@ -739,6 +739,7 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
         &mut copy_finished_context,
     );
     assert_extracted_file_metadata(&scenario.state, &extracted, &["one-shot"]);
+    assert_source_file_not_keep_rated(&scenario.state, &source_path);
     let parent = wavecrate::sample_sources::library::harvest_file(&harvest_key)
         .expect("load harvest parent")
         .expect("harvest parent");
@@ -1536,6 +1537,45 @@ fn assert_extracted_file_keep_1_rating(
         .expect("extracted file should be persisted in the source database");
     assert_eq!(persisted.tag, wavecrate::sample_sources::Rating::KEEP_1);
     assert!(!persisted.locked);
+}
+
+fn assert_source_file_not_keep_rated(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    source: &std::path::Path,
+) {
+    let file_id = source.to_string_lossy().to_string();
+    let row = state
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == file_id)
+        .expect("source file should remain visible in the browser");
+    assert_eq!(row.rating, wavecrate::sample_sources::Rating::NEUTRAL);
+    assert!(!row.rating_locked);
+
+    let Some((source_root, source_database_root, relative_path)) = state
+        .library
+        .folder_browser
+        .source_database_relative_file_path(source)
+    else {
+        return;
+    };
+    let Ok(db) = wavecrate::sample_sources::SourceDatabase::open_read_only_with_database_root(
+        source_root,
+        &source_database_root,
+    ) else {
+        return;
+    };
+    if let Some(persisted) = db
+        .list_files()
+        .expect("source database files should list")
+        .into_iter()
+        .find(|entry| entry.relative_path == relative_path)
+    {
+        assert_eq!(persisted.tag, wavecrate::sample_sources::Rating::NEUTRAL);
+        assert!(!persisted.locked);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Add explicit internal-drag handoff policy for whether an accepted native copy/link should apply the whole-file keep-rating increment.
- Preserve the existing keep-rating behavior for explicit whole-file copy and selected-file external drag handoffs.
- Opt playmark-derived external drag exports out of the extra handoff keep bump because extracted-file metadata already registers the derivative as `KEEP_1`.
- Add regression coverage for partial playmark clipboard copy and accepted playmark external drag handoff.

## Definition of Done

- Partial-region copy/export creates and rates the extracted derivative without adding a keep rating to the source/original.
- Partial-region external drag handoff does not increment the extracted derivative beyond its extracted-file metadata rating.
- Explicit selected-file copy and selected-file external drag still add/increment keep ratings according to the existing whole-file curation rule.
- Existing derivation and extracted-region bookkeeping remains intact.

## Validation commands

- `cargo fmt --check`
- `cargo test accepted_waveform_selection_external_drag_does_not_add_whole_file_keep_rating --bin wavecrate`
- `cargo test playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff --bin wavecrate`
- `cargo test selected_file_copy --bin wavecrate`
- `cargo test external_file_drag --bin wavecrate`
- `cargo test playmark_selection_copy --bin wavecrate`
- `cargo test playmark_extraction --bin wavecrate`
- `cargo test waveform_selection_drag --bin wavecrate`
- `cargo check --bin wavecrate`
- `git diff --check`

## Known limitations

- `bash scripts/agent.sh request` currently fails in the pre-existing Wavecrate app-facing blocking guardrail on `src/native_app/sample_identity_diagnostics.rs` filesystem API findings. This branch does not touch that file or introduce those findings.

## Review

User review is required before merge.

Addresses OPT-968.
