### PR TITLE
OPT-964: Fix normalized audition for long file-backed samples

### DIFF
--- a/src/native_app/audio/audio_engine/volume.rs
+++ b/src/native_app/audio/audio_engine/volume.rs
@@ -58,11 +58,13 @@ impl NativeAppState {
                     .map(|selection| (selection.start(), selection.end()))
             })
             .unwrap_or((0.0, 1.0));
-        let playback_gain_normalization =
-            self.playback_gain_normalization_for_span(current_span.0, current_span.1);
+        let (playback_gain, playback_gain_normalization) =
+            self.runtime_playback_gain_for_span(current_span.0, current_span.1);
         if let Some(runtime) = self.audio.playback_runtime.as_ref() {
-            let _ =
-                runtime.try_set_playback_gain_with_normalization(1.0, playback_gain_normalization);
+            let _ = runtime.try_set_playback_gain_with_normalization(
+                playback_gain,
+                playback_gain_normalization,
+            );
         } else {
             let gain = self.normalized_audition_gain_for_current_span();
             if let Some(player) = self.audio.player.as_mut() {

--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -210,15 +210,16 @@ impl NativeAppState {
                 end: f64::from(command.resolved.end_ratio),
             },
         };
+        let (playback_gain, playback_gain_normalization) = self.runtime_playback_gain_for_span(
+            command.resolved.start_ratio,
+            command.resolved.end_ratio,
+        );
         Ok(PlaybackRuntimeRequest {
             source,
             mode,
             volume: self.audio.volume,
-            playback_gain: 1.0,
-            playback_gain_normalization: self.playback_gain_normalization_for_span(
-                command.resolved.start_ratio,
-                command.resolved.end_ratio,
-            ),
+            playback_gain,
+            playback_gain_normalization,
             edit_fade: edit_fade_range_from_selection(waveform.edit_selection()),
             metronome: self.playback_metronome_config_for_span(
                 command.resolved.start_ratio,
@@ -278,6 +279,70 @@ fn selection_contains_span(
 ) -> bool {
     const EPSILON: f32 = 0.000_1;
     start + EPSILON >= selection.start() && end <= selection.end() + EPSILON
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::{
+        test_support::state::{NativeAppStateFixture, WaveformState},
+        waveform::{
+            test_decoded_waveform_file_from_mono_samples,
+            test_file_backed_waveform_file_from_mono_samples,
+        },
+    };
+    use std::{path::PathBuf, sync::Arc};
+
+    #[test]
+    fn runtime_request_uses_summary_gain_for_file_backed_normalized_audition() {
+        let file = test_file_backed_waveform_file_from_mono_samples(
+            PathBuf::from("normalized-runtime-summary.wav"),
+            vec![0.1, 0.1, 0.25, 0.5, 0.1, 0.1, 0.8, 0.8],
+        );
+        let mut state = NativeAppStateFixture::default().build();
+        state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+        state.audio.normalized_audition_enabled = true;
+
+        let command = state.playback_command_for_intent(PlaybackIntent::fixed_region(0.25, 0.5));
+        let request = state
+            .playback_runtime_request(command)
+            .expect("runtime request");
+
+        assert!(matches!(
+            request.source,
+            PlaybackRuntimeSource::AudioFile { .. }
+        ));
+        assert!((request.playback_gain - 2.0).abs() < f32::EPSILON);
+        assert_eq!(request.playback_gain_normalization, None);
+    }
+
+    #[test]
+    fn runtime_request_keeps_runtime_normalization_for_decoded_samples() {
+        let file = test_decoded_waveform_file_from_mono_samples(
+            PathBuf::from("normalized-runtime-decoded.wav"),
+            vec![0.1, 0.1, 0.25, 0.5],
+        );
+        let mut state = NativeAppStateFixture::default().build();
+        state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+        state.audio.normalized_audition_enabled = true;
+
+        let command = state.playback_command_for_intent(PlaybackIntent::fixed_region(0.25, 0.5));
+        let request = state
+            .playback_runtime_request(command)
+            .expect("runtime request");
+
+        assert!(matches!(
+            request.source,
+            PlaybackRuntimeSource::DecodedSamples { .. }
+        ));
+        assert!((request.playback_gain - 1.0).abs() < f32::EPSILON);
+        assert_eq!(
+            request.playback_gain_normalization,
+            Some(wavecrate::audio::PlaybackRuntimeGainNormalization::new(
+                0.25, 0.5
+            ))
+        );
+    }
 }
 
 fn ratio_to_frame(ratio: f32, total_frames: u64) -> u64 {

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -305,7 +305,8 @@ impl NativeAppState {
         looped: bool,
     ) -> Result<(), String> {
         let metronome = self.playback_metronome_config_for_span(start, end, offset);
-        let playback_gain_normalization = self.playback_gain_normalization_for_span(start, end);
+        let (playback_gain, playback_gain_normalization) =
+            self.runtime_playback_gain_for_span(start, end);
         if let Some(runtime) = self.audio.playback_runtime.as_ref() {
             runtime
                 .try_retarget_span(PlaybackRuntimeSpanUpdate {
@@ -314,7 +315,7 @@ impl NativeAppState {
                     offset: f64::from(offset),
                     seek_to_offset,
                     looped,
-                    playback_gain: 1.0,
+                    playback_gain,
                     playback_gain_normalization,
                     metronome,
                 })

--- a/src/native_app/audio/playback/normalized.rs
+++ b/src/native_app/audio/playback/normalized.rs
@@ -29,13 +29,24 @@ impl NativeAppState {
             .normalized_audition_gain_for_span(start, end)
     }
 
-    pub(in crate::native_app) fn playback_gain_normalization_for_span(
+    pub(in crate::native_app) fn runtime_playback_gain_for_span(
         &self,
         start: f32,
         end: f32,
-    ) -> Option<PlaybackRuntimeGainNormalization> {
-        self.audio
-            .normalized_audition_enabled
-            .then_some(PlaybackRuntimeGainNormalization::new(start, end))
+    ) -> (f32, Option<PlaybackRuntimeGainNormalization>) {
+        if !self.audio.normalized_audition_enabled {
+            return (1.0, None);
+        }
+        if self.waveform.current.playback_samples().is_some()
+            || self.waveform.current.playback_cache_file().is_some()
+        {
+            return (1.0, Some(PlaybackRuntimeGainNormalization::new(start, end)));
+        }
+        (
+            self.waveform
+                .current
+                .normalized_audition_gain_for_span(start, end),
+            None,
+        )
     }
 }

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -303,6 +303,8 @@ impl NativeAppState {
                 channels: self.waveform.current.channels(),
             }
         };
+        let (playback_gain, playback_gain_normalization) =
+            self.runtime_playback_gain_for_span(0.0, 1.0);
         let request = PlaybackRuntimeRequest {
             source,
             mode: if self.audio.loop_playback {
@@ -318,8 +320,8 @@ impl NativeAppState {
                 }
             },
             volume: self.audio.volume,
-            playback_gain: 1.0,
-            playback_gain_normalization: self.playback_gain_normalization_for_span(0.0, 1.0),
+            playback_gain,
+            playback_gain_normalization,
             edit_fade: None,
             metronome: self.playback_metronome_config_for_span(0.0, 1.0, 0.0),
         };

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -58,14 +58,17 @@ pub(in crate::native_app) use audio_file::cached_waveform_file_playback_ready_ex
 pub(super) use audio_file::store_cached_waveform_file_for_tests;
 #[cfg(test)]
 pub(super) use audio_file::store_summary_only_cached_waveform_file_for_tests;
-#[cfg(test)]
-pub(super) use audio_file::test_waveform_file_from_mono_samples;
 pub(in crate::native_app) use audio_file::{
     WaveformPlaybackReady, cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
     flush_background_waveform_cache_stores_for_shutdown, invalidate_persisted_waveform_cache_path,
     invalidate_persisted_waveform_cache_paths, load_cached_waveform_file_for_playback,
     mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
     should_use_file_backed_wav_decode,
+};
+#[cfg(test)]
+pub(super) use audio_file::{
+    test_decoded_waveform_file_from_mono_samples, test_file_backed_waveform_file_from_mono_samples,
+    test_waveform_file_from_mono_samples,
 };
 
 mod similar_sections;

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -33,12 +33,15 @@ pub(in crate::native_app) use cache_facade::{
 #[cfg(test)]
 pub(super) use construction::synthetic_waveform_file;
 #[cfg(test)]
-pub(in crate::native_app) use construction::test_waveform_file_from_mono_samples;
-#[cfg(test)]
 pub(super) use construction::waveform_file_from_mono_samples;
 pub(super) use construction::{
     content_revision_for_audio_bytes, empty_waveform_file, gain_preview_for_range_with_gain,
     gain_preview_for_selection, waveform_file_from_mono_samples_with_progress_and_cancel,
+};
+#[cfg(test)]
+pub(in crate::native_app) use construction::{
+    test_decoded_waveform_file_from_mono_samples, test_file_backed_waveform_file_from_mono_samples,
+    test_waveform_file_from_mono_samples,
 };
 #[cfg(test)]
 pub(super) use downmix::downmix_to_mono;

--- a/src/native_app/waveform/audio_file/construction.rs
+++ b/src/native_app/waveform/audio_file/construction.rs
@@ -23,6 +23,29 @@ pub(in crate::native_app) fn test_waveform_file_from_mono_samples(
 }
 
 #[cfg(test)]
+pub(in crate::native_app) fn test_file_backed_waveform_file_from_mono_samples(
+    path: PathBuf,
+    samples: Vec<f32>,
+) -> WaveformFile {
+    let mut file = waveform_file_from_mono_samples(path, Arc::from([]), 48_000, 1, samples);
+    file.playback_samples = None;
+    file.playback_cache_file = None;
+    file
+}
+
+#[cfg(test)]
+pub(in crate::native_app) fn test_decoded_waveform_file_from_mono_samples(
+    path: PathBuf,
+    samples: Vec<f32>,
+) -> WaveformFile {
+    let mut file =
+        waveform_file_from_mono_samples(path, Arc::from([1_u8]), 48_000, 1, samples.clone());
+    file.playback_samples = Some(Arc::from(samples));
+    file.playback_cache_file = None;
+    file
+}
+
+#[cfg(test)]
 pub(in crate::native_app::waveform) fn synthetic_waveform_file() -> WaveformFile {
     let frames = SYNTHETIC_SAMPLE_RATE as usize * SYNTHETIC_SECONDS;
     let samples = (0..frames)

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -57,8 +57,19 @@ pub(in crate::native_app::waveform) struct NormalizedAuditionGainCacheKey {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app::waveform) enum NormalizedAuditionGainSourceKey {
-    Samples { ptr: usize, sample_count: usize },
-    CacheFile { path: PathBuf, sample_count: u64 },
+    Samples {
+        ptr: usize,
+        sample_count: usize,
+    },
+    CacheFile {
+        path: PathBuf,
+        sample_count: u64,
+    },
+    Summary {
+        path: PathBuf,
+        content_revision: u64,
+        frames: usize,
+    },
 }
 
 impl NormalizedAuditionGainCache {

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -37,11 +37,16 @@ impl WaveformState {
                 ptr: samples.as_ptr() as usize,
                 sample_count: samples.len(),
             }
-        } else {
-            let cache_file = self.file.playback_cache_file.as_ref()?;
+        } else if let Some(cache_file) = self.file.playback_cache_file.as_ref() {
             NormalizedAuditionGainSourceKey::CacheFile {
                 path: cache_file.path.clone(),
                 sample_count: cache_file.sample_count,
+            }
+        } else {
+            NormalizedAuditionGainSourceKey::Summary {
+                path: self.file.path.clone(),
+                content_revision: self.file.content_revision,
+                frames: self.file.frames,
             }
         };
         Some(NormalizedAuditionGainCacheKey {
@@ -62,7 +67,48 @@ impl WaveformState {
             )
             .map(wavecrate::audio::normalized_gain_from_peak);
         }
-        None
+        self.normalized_audition_summary_peak_for_span(start, end)
+            .map(wavecrate::audio::normalized_gain_from_peak)
+    }
+
+    fn normalized_audition_summary_peak_for_span(&self, start: f32, end: f32) -> Option<f32> {
+        const RAW_BAND: usize = 3;
+
+        let summary = self.file.gpu_signal_summary.as_ref();
+        if summary.frames == 0 || summary.band_count <= RAW_BAND {
+            return None;
+        }
+        let level = summary.levels.first()?;
+        let bucket_count = level.buckets.len() / summary.band_count;
+        if bucket_count == 0 {
+            return None;
+        }
+        let (start, end) = if start <= end {
+            (start, end)
+        } else {
+            (end, start)
+        };
+        let start_frame = (start.clamp(0.0, 1.0) * summary.frames as f32).floor() as usize;
+        let mut end_frame = (end.clamp(0.0, 1.0) * summary.frames as f32).ceil() as usize;
+        if end_frame <= start_frame {
+            end_frame = (start_frame + 1).min(summary.frames);
+        }
+        let bucket_frames = level.bucket_frames.max(1);
+        let first_bucket = start_frame / bucket_frames;
+        let last_bucket = end_frame
+            .saturating_sub(1)
+            .checked_div(bucket_frames)?
+            .min(bucket_count.saturating_sub(1));
+        let mut peak = 0.0_f32;
+        for bucket in first_bucket..=last_bucket {
+            let raw = level.buckets.get(
+                bucket
+                    .saturating_mul(summary.band_count)
+                    .saturating_add(RAW_BAND),
+            )?;
+            peak = peak.max(raw.min.abs()).max(raw.max.abs());
+        }
+        peak.is_finite().then_some(peak)
     }
 
     pub(in crate::native_app) fn is_playing(&self) -> bool {

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -222,7 +222,7 @@ fn normalized_audition_signal_preview_uses_active_playmark_peak() {
 }
 
 #[test]
-fn normalized_audition_signal_preview_does_not_read_persisted_playback_cache() {
+fn normalized_audition_signal_preview_uses_summary_when_samples_are_file_backed() {
     let root = tempfile::tempdir().expect("temp root");
     let cache_path = root.path().join("normalized-playback-cache.pcm");
     write_interleaved_f32_file(
@@ -246,10 +246,32 @@ fn normalized_audition_signal_preview_does_not_read_persisted_playback_cache() {
     let playback_gain = state.normalized_audition_gain_for_span(0.25, 0.5);
     let preview = signal_gain_preview_for_state(&state, true).expect("normalized cache preview");
 
-    assert!((playback_gain - 1.0).abs() < f32::EPSILON);
+    assert!((playback_gain - 4.0).abs() < f32::EPSILON);
     assert_eq!(preview.start, 0.25);
     assert_eq!(preview.end, 0.5);
-    assert!((preview.gain - 1.0).abs() < f32::EPSILON);
+    assert!((preview.gain - playback_gain).abs() < f32::EPSILON);
+}
+
+#[test]
+fn normalized_audition_signal_preview_uses_playmark_summary_peak_for_long_files() {
+    let mut file = waveform_file_from_mono_samples(
+        "normalized-long-summary.wav".into(),
+        Arc::from([]),
+        48_000,
+        1,
+        vec![0.1, 0.1, 0.25, 0.5, 0.1, 0.1, 0.8, 0.8],
+    );
+    file.playback_samples = None;
+    let mut state = WaveformState::from_file(Arc::new(file));
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.25, 0.5));
+
+    let playback_gain = state.normalized_audition_gain_for_span(0.25, 0.5);
+    let preview = signal_gain_preview_for_state(&state, true).expect("normalized long preview");
+
+    assert!((playback_gain - 2.0).abs() < f32::EPSILON);
+    assert_eq!(preview.start, 0.25);
+    assert_eq!(preview.end, 0.5);
+    assert!((preview.gain - playback_gain).abs() < f32::EPSILON);
 }
 
 #[test]


### PR DESCRIPTION
## Scope
- Fix normalized audition for long/file-backed samples that do not keep decoded playback samples resident.
- Use waveform summary raw peak data as the normalized-audition gain fallback for summary-only/file-backed waveform states.
- Keep decoded samples and persisted playback-cache sources on the runtime-owned exact normalization path.
- Apply the same gain contract to initial playback, full-sample playback, live span retargeting, and normalized-audition toggle updates.
- Remove Radiant's GPU signal-preview `4x` gain cap so high normalized gains render at full visual scale instead of only getting somewhat larger.
- Add regression coverage for file-backed normalized playback requests, long-file normalized waveform preview, and uncapped shader gain preview.

## Definition of Done
- Long/file-backed samples can enter normalized audition without silently falling back to no visual gain preview.
- Audio playback requests for summary-only `AudioFile` sources carry an immediate summary-derived scalar gain instead of an unusable runtime normalization request.
- Decoded/cache-backed sources continue using runtime-owned exact normalization.
- Normalized visual previews are not artificially capped below the requested normalized gain.
- Extraction/edit gain paths continue to use the same waveform-state normalized gain calculation.
- User review is required before merge.

## Validation Commands
- `cargo fmt --check`
- `cargo check --bin wavecrate`
- `cargo test runtime_request_ --bin wavecrate`
- `cargo test normalized_audition_signal_preview --bin wavecrate`
- `cargo test normalized_gain --lib`
- `cargo test large_foreground_sample_load_reuses_file_backed_summary_cache --bin wavecrate`
- `cargo test playmark_extraction --bin wavecrate`
- `cargo test -p radiant gpu_signal_shader_does_not_cap_gain_preview --lib`
- `cargo test -p radiant gpu_signal_shader_parses_as_wgsl --lib`
- `git diff --check`
- `bash scripts/agent.sh request` *(fails on pre-existing unrelated `src/native_app/sample_identity_diagnostics.rs` non-blocking guardrail violations at lines 2, 316, and 357)*

## Known Limitations
- `bash scripts/agent.sh request` is currently blocked by an unrelated pre-existing guardrail failure in `src/native_app/sample_identity_diagnostics.rs`; this PR does not touch that file.
- Summary-only normalized gain is based on the raw waveform summary buckets, so it is an immediate bounded approximation for file-backed long sources rather than a fresh full-file decode/scan on the playback start path.

Addresses OPT-964.
