### PR TITLE
OPT-933: Stop X selection toggle from advancing sample-list focus

### DIFF
--- a/docs/book/src/advanced-waveform.md
+++ b/docs/book/src/advanced-waveform.md
@@ -9,7 +9,7 @@ The waveform toolbar contains controls for tighter edits, loop checking, and ana
 - `Shift-X` zooms out with a silence margin.
 - Use the waveform drag handle to drag the loaded sample out when drag-out is supported.
 
-The same `X` key can mark a sample and advance when the waveform is already fully zoomed out and the browser is in that browsing context.
+The same `X` key can toggle the focused sample selection when the waveform is already fully zoomed out and the browser is in that browsing context.
 
 ## Editmark Effects
 

--- a/docs/book/src/shortcuts.md
+++ b/docs/book/src/shortcuts.md
@@ -33,7 +33,7 @@ Press `Command-/` in the app to open the current context-aware shortcut overlay.
 | `Command-E` | Extract and trim the selection |
 | `W` | Open the waveform context menu |
 | `Z` | Zoom to the play selection |
-| `X` | Zoom out when the waveform is zoomed, or mark and advance in browser context |
+| `X` | Zoom out when the waveform is zoomed, or toggle the focused sample in browser context |
 | `Shift-X` | Zoom out with a silence margin |
 | `C` | Crop to the selection |
 | `D` | Trim the selection out |

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -71,7 +71,7 @@ const CACHED_MARKER: ui::Rgba8 = ui::Rgba8 {
 
 pub(in crate::native_app) struct SampleFileHitTargetModel<'a> {
     pub(in crate::native_app) file_id: &'a str,
-    pub(in crate::native_app) selected: bool,
+    pub(in crate::native_app) explicitly_selected: bool,
     pub(in crate::native_app) focused: bool,
     pub(in crate::native_app) copy_flash: bool,
     pub(in crate::native_app) cut_pending: bool,
@@ -105,7 +105,10 @@ fn sample_file_hit_target_builder(
     model: &SampleFileHitTargetModel<'_>,
 ) -> ui::InteractiveRowUnderlayBuilder<GuiMessage> {
     let visual_state = ui::InteractiveRowVisualStateParts {
-        selected: model.selected || model.copy_flash || model.cut_pending || model.missing,
+        selected: model.explicitly_selected
+            || model.copy_flash
+            || model.cut_pending
+            || model.missing,
         ..ui::InteractiveRowVisualStateParts::default()
     };
     let underlay = ui::interactive_row_underlay(content)
@@ -115,7 +118,7 @@ fn sample_file_hit_target_builder(
         .style(SAMPLE_ROW_STYLE)
         .visual_state(visual_state)
         .leading_marker_if(
-            model.selected || model.cut_pending || model.missing,
+            model.explicitly_selected || model.cut_pending || model.missing,
             ui::DenseRowMarkerStyle::new(
                 ui::DenseRowMarkerParts::leading(3.0).vertical_inset(4.0),
                 if model.missing {
@@ -128,7 +131,7 @@ fn sample_file_hit_target_builder(
             ),
         )
         .trailing_marker_if(
-            model.cached && !model.selected && !model.copy_flash && !model.cut_pending,
+            model.cached && !model.explicitly_selected && !model.copy_flash && !model.cut_pending,
             ui::DenseRowMarkerStyle::new(ui::DenseRowMarkerParts::trailing(2.0), CACHED_MARKER),
         )
         .outline_if(model.focused, sample_file_focus_outline());

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target_tests.rs
@@ -23,7 +23,7 @@ fn sample_hit_target(
 ) -> UiSurface<GuiMessage> {
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
-        selected,
+        explicitly_selected: selected,
         focused: false,
         copy_flash: false,
         cut_pending: false,
@@ -41,9 +41,17 @@ fn sample_hit_target_with_focus(
     focused: bool,
     cached: bool,
 ) -> UiSurface<GuiMessage> {
+    sample_hit_target_with_focus_and_explicit_selection(selected, focused, cached)
+}
+
+fn sample_hit_target_with_focus_and_explicit_selection(
+    explicitly_selected: bool,
+    focused: bool,
+    cached: bool,
+) -> UiSurface<GuiMessage> {
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
-        selected,
+        explicitly_selected,
         focused,
         copy_flash: false,
         cut_pending: false,
@@ -59,7 +67,7 @@ fn sample_hit_target_with_focus(
 fn sample_hit_target_with_copy_flash(selected: bool, cached: bool) -> UiSurface<GuiMessage> {
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
-        selected,
+        explicitly_selected: selected,
         focused: false,
         copy_flash: true,
         cut_pending: false,
@@ -75,7 +83,7 @@ fn sample_hit_target_with_copy_flash(selected: bool, cached: bool) -> UiSurface<
 fn sample_hit_target_with_cut_pending(selected: bool, cached: bool) -> UiSurface<GuiMessage> {
     sample_hit_target_with_model(SampleFileHitTargetModel {
         file_id: "sample.wav",
-        selected,
+        explicitly_selected: selected,
         focused: false,
         copy_flash: false,
         cut_pending: true,
@@ -143,7 +151,7 @@ fn production_hit_target_derives_stable_input_identity_from_sample_row_key() {
         ui::empty(),
         SampleFileHitTargetModel {
             file_id: "sample.wav",
-            selected: false,
+            explicitly_selected: false,
             focused: false,
             copy_flash: false,
             cut_pending: false,
@@ -240,6 +248,27 @@ fn selected_rows_paint_selection_fill_and_marker_without_focus_outline() {
     assert!(
         !paints_focus_outline(&plan),
         "selection alone should not paint the focused-row outline"
+    );
+}
+
+#[test]
+/// Verifies the ordinary current row does not hide the explicit X-selection affordance.
+fn implicit_focused_selection_does_not_paint_explicit_selection_chrome() {
+    let bounds = ui::Rect::from_xy_size(10.0, 20.0, 120.0, 22.0);
+    let target = sample_hit_target_with_focus_and_explicit_selection(false, true, false);
+    let plan = sample_widget_plan(&target, bounds);
+
+    assert!(
+        paints_focus_outline(&plan),
+        "the current sample should keep the focused-row outline"
+    );
+    assert!(
+        !plan.fill_rects().any(|fill| fill.color == selected_fill()),
+        "implicit current-row selection should not already paint the marked-selection fill"
+    );
+    assert!(
+        !paints_selection_marker(&plan, bounds),
+        "implicit current-row selection should not already paint the marked-selection marker"
     );
 }
 

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection.rs
@@ -14,7 +14,7 @@ use crate::native_app::sample_library::folder_browser::view_contract::collection
 
 pub(super) struct SampleRowDisplay<'a> {
     pub(super) file_id: &'a str,
-    pub(super) selected: bool,
+    pub(super) explicitly_selected: bool,
     pub(super) focused: bool,
     pub(super) copy_flash: bool,
     pub(super) cut_pending: bool,
@@ -74,7 +74,7 @@ pub(super) fn sample_row_display<'a>(
     let file = row.file;
     SampleRowDisplay {
         file_id: file.id.as_str(),
-        selected: row.selected,
+        explicitly_selected: row.explicitly_selected,
         focused: row.focused,
         copy_flash: row.copy_flash,
         cut_pending: cut_file_ids.is_some_and(|ids| ids.iter().any(|id| id == &file.id)),

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/row_projection/tests.rs
@@ -25,7 +25,7 @@ fn file_entry() -> FileEntry {
 fn visible_row(file: &FileEntry) -> VisibleSampleRow<'_> {
     VisibleSampleRow {
         file,
-        selected: false,
+        explicitly_selected: false,
         focused: false,
         copy_flash: false,
         drag_active: false,
@@ -45,10 +45,10 @@ fn visible_row(file: &FileEntry) -> VisibleSampleRow<'_> {
 }
 
 #[test]
-fn sample_row_display_preserves_selection_and_focus_separately() {
+fn sample_row_display_preserves_explicit_selection_and_focus_separately() {
     let file = file_entry();
     let mut row = visible_row(&file);
-    row.selected = true;
+    row.explicitly_selected = true;
     row.focused = false;
     let column = FileColumn::for_tests("name", "Name", 160.0);
 
@@ -61,10 +61,10 @@ fn sample_row_display_preserves_selection_and_focus_separately() {
         &HashMap::new(),
         None,
     );
-    let selected_only_selected = selected_only.selected;
+    let selected_only_explicitly_selected = selected_only.explicitly_selected;
     let selected_only_focused = selected_only.focused;
 
-    row.selected = false;
+    row.explicitly_selected = false;
     row.focused = true;
     let focused_only = sample_row_display(
         &row,
@@ -75,12 +75,12 @@ fn sample_row_display_preserves_selection_and_focus_separately() {
         &HashMap::new(),
         None,
     );
-    let focused_only_selected = focused_only.selected;
+    let focused_only_explicitly_selected = focused_only.explicitly_selected;
     let focused_only_focused = focused_only.focused;
 
-    assert!(selected_only_selected);
+    assert!(selected_only_explicitly_selected);
     assert!(!selected_only_focused);
-    assert!(!focused_only_selected);
+    assert!(!focused_only_explicitly_selected);
     assert!(focused_only_focused);
 }
 

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -84,7 +84,7 @@ fn sample_browser_row(
         row_content,
         SampleFileHitTargetModel {
             file_id: row.file_id,
-            selected: row.selected,
+            explicitly_selected: row.explicitly_selected,
             focused: row.focused,
             copy_flash: row.copy_flash,
             cut_pending: row.cut_pending,

--- a/src/native_app/sample_library/folder_browser/file_selection.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection.rs
@@ -7,7 +7,7 @@ mod navigation;
 mod selection_mutation;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(in crate::native_app) struct ToggleSelectedSampleAdvanceResult {
+pub(in crate::native_app) struct ToggleSelectedSampleResult {
     pub(in crate::native_app) toggled_id: String,
     pub(in crate::native_app) toggled_selected: bool,
     pub(in crate::native_app) focused_id: String,

--- a/src/native_app/sample_library/folder_browser/file_selection/selection_mutation.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/selection_mutation.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use radiant::widgets::PointerModifiers;
 
 use super::super::FolderBrowserState;
-use super::ToggleSelectedSampleAdvanceResult;
+use super::ToggleSelectedSampleResult;
 
 impl FolderBrowserState {
     pub(in crate::native_app) fn select_file(&mut self, id: String) {
@@ -80,10 +80,10 @@ impl FolderBrowserState {
         self.select_audio_file_ids(ids)
     }
 
-    pub(in crate::native_app) fn toggle_focused_sample_selection_and_advance(
+    pub(in crate::native_app) fn toggle_focused_sample_selection(
         &mut self,
         tags_by_file: &HashMap<String, Vec<String>>,
-    ) -> Option<ToggleSelectedSampleAdvanceResult> {
+    ) -> Option<ToggleSelectedSampleResult> {
         if self.rename_active() {
             return None;
         }
@@ -94,8 +94,8 @@ impl FolderBrowserState {
             self.focus_first_active_collection_file_matching_tags(tags_by_file)?;
         }
         let file_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
-        let outcome = self.selection.toggle_focused_file_and_advance(&file_ids)?;
-        Some(ToggleSelectedSampleAdvanceResult {
+        let outcome = self.selection.toggle_focused_file(&file_ids)?;
+        Some(ToggleSelectedSampleResult {
             toggled_id: outcome.toggled_id,
             toggled_selected: outcome.toggled_selected,
             focused_id: outcome.focused_id,

--- a/src/native_app/sample_library/folder_browser/file_selection_model.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection_model.rs
@@ -10,7 +10,7 @@ pub(super) struct FileSelectionModel {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct SelectionToggleAdvanceOutcome {
+pub(super) struct SelectionToggleOutcome {
     pub(super) toggled_id: String,
     pub(super) toggled_selected: bool,
     pub(super) focused_id: String,
@@ -142,12 +142,14 @@ impl FileSelectionModel {
         Some(target)
     }
 
-    pub(super) fn toggle_focused_and_advance(
+    pub(super) fn toggle_focused(
         &mut self,
         visible_ids: &[String],
-    ) -> Option<SelectionToggleAdvanceOutcome> {
+    ) -> Option<SelectionToggleOutcome> {
         let focused = self.focused_id.as_ref()?;
-        let current_index = visible_ids.iter().position(|id| id == focused)?;
+        if !visible_ids.iter().any(|id| id == focused) {
+            return None;
+        }
         let toggled_id = focused.clone();
         let already_marked = self.explicit && self.selected_ids.contains(&toggled_id);
         let toggled_selected = if already_marked {
@@ -158,10 +160,9 @@ impl FileSelectionModel {
             true
         };
         self.explicit = true;
-        let focused_id =
-            visible_ids[current_index.saturating_add(1).min(visible_ids.len() - 1)].clone();
+        let focused_id = toggled_id.clone();
         self.focused_id = Some(focused_id.clone());
-        Some(SelectionToggleAdvanceOutcome {
+        Some(SelectionToggleOutcome {
             toggled_id,
             toggled_selected,
             focused_id,
@@ -319,19 +320,41 @@ mod tests {
     }
 
     #[test]
-    fn toggle_focused_file_advances_within_visible_ids() {
+    fn toggle_focused_file_keeps_focus_within_visible_ids() {
         let visible_ids = ids(&["kick", "snare", "hat"]);
         let mut selection =
             FileSelectionModel::new(Some(String::from("kick")), HashSet::new(), false);
 
         let outcome = selection
-            .toggle_focused_and_advance(&visible_ids)
+            .toggle_focused(&visible_ids)
             .expect("focused file should toggle");
 
         assert_eq!(outcome.toggled_id, "kick");
         assert!(outcome.toggled_selected);
-        assert_eq!(outcome.focused_id, "snare");
-        assert_eq!(selection.focused_id(), Some("snare"));
+        assert_eq!(outcome.focused_id, "kick");
+        assert_eq!(selection.focused_id(), Some("kick"));
         assert_eq!(selection.active_ids(), set(&["kick"]));
+    }
+
+    #[test]
+    fn repeated_toggle_focused_file_selects_and_deselects_same_id() {
+        let visible_ids = ids(&["kick", "snare", "hat"]);
+        let mut selection =
+            FileSelectionModel::new(Some(String::from("snare")), HashSet::new(), false);
+
+        let first = selection
+            .toggle_focused(&visible_ids)
+            .expect("focused file should select");
+        let second = selection
+            .toggle_focused(&visible_ids)
+            .expect("focused file should deselect");
+
+        assert_eq!(first.toggled_id, "snare");
+        assert!(first.toggled_selected);
+        assert_eq!(second.toggled_id, "snare");
+        assert!(!second.toggled_selected);
+        assert_eq!(selection.focused_id(), Some("snare"));
+        assert!(selection.selected_ids().is_empty());
+        assert!(selection.explicit());
     }
 }

--- a/src/native_app/sample_library/folder_browser/selection_state/files.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state/files.rs
@@ -1,6 +1,6 @@
 use super::{BrowserSelectionSnapshot, BrowserSelectionState};
 use crate::native_app::sample_library::folder_browser::file_selection_model::{
-    FileSelectionModel, SelectionToggleAdvanceOutcome,
+    FileSelectionModel, SelectionToggleOutcome,
 };
 use radiant::widgets::PointerModifiers;
 use std::collections::HashSet;
@@ -158,12 +158,12 @@ impl BrowserSelectionState {
         Some(target)
     }
 
-    pub(in crate::native_app::sample_library::folder_browser) fn toggle_focused_file_and_advance(
+    pub(in crate::native_app::sample_library::folder_browser) fn toggle_focused_file(
         &mut self,
         visible_ids: &[String],
-    ) -> Option<SelectionToggleAdvanceOutcome> {
+    ) -> Option<SelectionToggleOutcome> {
         let mut selection = self.file_selection_model();
-        let outcome = selection.toggle_focused_and_advance(visible_ids)?;
+        let outcome = selection.toggle_focused(visible_ids)?;
         self.apply_file_selection_model(selection);
         Some(outcome)
     }

--- a/src/native_app/sample_library/folder_browser/tests/file_keyboard_selection.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_keyboard_selection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native_app::sample_library::folder_browser::projection::VisibleSampleQuery;
 
 #[test]
 fn file_keyboard_navigation_moves_audio_selection_without_leaving_folder() {
@@ -53,8 +54,8 @@ fn file_keyboard_navigation_can_extend_audio_selection() {
     let _ = fs::remove_dir_all(root);
 }
 #[test]
-fn toggle_focused_sample_selection_marks_and_advances() {
-    let root = temp_source_root("wavecrate-gui-toggle-mark-advance");
+fn toggle_focused_sample_selection_marks_without_advancing() {
+    let root = temp_source_root("wavecrate-gui-toggle-mark-stationary");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
     let hat = drums.join("hat.wav");
@@ -68,16 +69,111 @@ fn toggle_focused_sample_selection_marks_and_advances() {
     browser.select_file(path_id(&hat));
 
     let result = browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("toggle focused sample");
 
     assert_eq!(result.toggled_id, path_id(&hat));
     assert!(result.toggled_selected);
-    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
+    assert_eq!(result.focused_id, path_id(&hat));
+    assert_eq!(browser.selected_file_id(), Some(path_id(&hat).as_str()));
     assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn toggle_focused_sample_selection_marks_visible_row_as_explicit_selection() {
+    let root = temp_source_root("wavecrate-gui-toggle-mark-visible-explicit");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let hat = drums.join("hat.wav");
+    let kick = drums.join("kick.wav");
+    for file in [&hat, &kick] {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let tags_by_file = std::collections::HashMap::new();
+    let cached_sample_paths = std::collections::HashSet::new();
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.apply_file_view_window_change(radiant::prelude::VirtualListWindowChange {
+        offset_y: 0.0,
+        row_height: 22.0,
+        window: radiant::prelude::VirtualListWindow {
+            total_items: 2,
+            viewport_start: 0,
+            viewport_end: 2,
+            window_start: 0,
+            window_end: 2,
+        },
+    });
+    browser.select_file(path_id(&hat));
+
+    let before = browser.visible_samples(VisibleSampleQuery {
+        tags_by_file: &tags_by_file,
+        cached_sample_paths: &cached_sample_paths,
+    });
+    let focused_before = before
+        .rows
+        .iter()
+        .find(|row| row.file.id == path_id(&hat))
+        .expect("focused row before toggle");
+
+    assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
+    assert!(focused_before.focused);
+    assert!(!focused_before.explicitly_selected);
+
+    browser
+        .toggle_focused_sample_selection(&Default::default())
+        .expect("toggle focused sample");
+
+    let after = browser.visible_samples(VisibleSampleQuery {
+        tags_by_file: &tags_by_file,
+        cached_sample_paths: &cached_sample_paths,
+    });
+    let focused_after = after
+        .rows
+        .iter()
+        .find(|row| row.file.id == path_id(&hat))
+        .expect("focused row after toggle");
+
+    assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
+    assert!(focused_after.focused);
+    assert!(focused_after.explicitly_selected);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn repeated_toggle_focused_sample_selection_toggles_same_row() {
+    let root = temp_source_root("wavecrate-gui-toggle-repeat-stationary");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let hat = drums.join("hat.wav");
+    let kick = drums.join("kick.wav");
+    for file in [&hat, &kick] {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&hat));
+
+    let first = browser
+        .toggle_focused_sample_selection(&Default::default())
+        .expect("select focused sample");
+    let second = browser
+        .toggle_focused_sample_selection(&Default::default())
+        .expect("deselect focused sample");
+
+    assert_eq!(first.toggled_id, path_id(&hat));
+    assert!(first.toggled_selected);
+    assert_eq!(second.toggled_id, path_id(&hat));
+    assert!(!second.toggled_selected);
+    assert_eq!(browser.selected_file_id(), Some(path_id(&hat).as_str()));
+    assert!(browser.selected_file_paths().is_empty());
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn file_keyboard_navigation_preserves_toggle_marked_samples() {
     let root = temp_source_root("wavecrate-gui-toggle-mark-arrow-preserve");
@@ -95,22 +191,29 @@ fn file_keyboard_navigation_preserves_toggle_marked_samples() {
     browser.select_file(path_id(&hat));
 
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("mark first sample");
-    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
+    assert_eq!(browser.selected_file_id(), Some(path_id(&hat).as_str()));
 
-    assert_eq!(browser.navigate_vertical(1, false), Some(path_id(&snare)));
+    assert_eq!(browser.navigate_vertical(1, false), Some(path_id(&kick)));
     assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
 
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
-        .expect("mark third sample");
+        .toggle_focused_sample_selection(&Default::default())
+        .expect("mark second sample");
 
     assert_eq!(
         browser.selected_file_paths(),
-        vec![hat.clone(), snare.clone()]
+        vec![hat.clone(), kick.clone()]
     );
-    assert_eq!(browser.selected_file_id(), Some(path_id(&tom).as_str()));
+    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
+
+    assert_eq!(browser.navigate_vertical(1, false), Some(path_id(&snare)));
+    assert_eq!(
+        browser.selected_file_paths(),
+        vec![hat.clone(), kick.clone()]
+    );
+    assert_eq!(browser.selected_file_id(), Some(path_id(&snare).as_str()));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -157,8 +260,8 @@ fn collection_keyboard_navigation_reuses_cached_id_projection() {
 }
 
 #[test]
-fn toggle_focused_sample_selection_unmarks_and_advances() {
-    let root = temp_source_root("wavecrate-gui-toggle-unmark-advance");
+fn toggle_focused_sample_selection_unmarks_without_advancing() {
+    let root = temp_source_root("wavecrate-gui-toggle-unmark-stationary");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
     let hat = drums.join("hat.wav");
@@ -171,7 +274,7 @@ fn toggle_focused_sample_selection_unmarks_and_advances() {
     browser.activate_folder(path_id(&drums));
     browser.select_file(path_id(&hat));
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("mark first sample");
     browser.select_file_with_modifiers(
         path_id(&kick),
@@ -182,12 +285,13 @@ fn toggle_focused_sample_selection_unmarks_and_advances() {
     );
 
     let result = browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("toggle focused sample");
 
     assert_eq!(result.toggled_id, path_id(&kick));
     assert!(!result.toggled_selected);
-    assert_eq!(browser.selected_file_id(), Some(path_id(&snare).as_str()));
+    assert_eq!(result.focused_id, path_id(&kick));
+    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
     assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
 
     let _ = fs::remove_dir_all(root);
@@ -207,7 +311,7 @@ fn toggle_focused_sample_selection_stays_on_last_visible_sample() {
     browser.select_file(path_id(&kick));
 
     let result = browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("toggle focused sample");
 
     assert_eq!(result.toggled_id, path_id(&kick));
@@ -218,8 +322,8 @@ fn toggle_focused_sample_selection_stays_on_last_visible_sample() {
     let _ = fs::remove_dir_all(root);
 }
 #[test]
-fn toggle_focused_sample_selection_advances_through_tag_filtered_rows() {
-    let root = temp_source_root("wavecrate-gui-toggle-mark-filtered");
+fn toggle_focused_sample_selection_stays_put_through_tag_filtered_rows() {
+    let root = temp_source_root("wavecrate-gui-toggle-mark-filtered-stationary");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
     let hat = drums.join("hat.wav");
@@ -243,12 +347,12 @@ fn toggle_focused_sample_selection_advances_through_tag_filtered_rows() {
     browser.select_file(path_id(&hat));
 
     let result = browser
-        .toggle_focused_sample_selection_and_advance(&tags_by_file)
+        .toggle_focused_sample_selection(&tags_by_file)
         .expect("toggle focused sample");
 
     assert_eq!(result.toggled_id, path_id(&hat));
-    assert_eq!(result.focused_id, path_id(&snare));
-    assert_eq!(browser.selected_file_id(), Some(path_id(&snare).as_str()));
+    assert_eq!(result.focused_id, path_id(&hat));
+    assert_eq!(browser.selected_file_id(), Some(path_id(&hat).as_str()));
     assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
 
     let _ = fs::remove_dir_all(root);

--- a/src/native_app/sample_library/folder_browser/tests/file_mouse_selection.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_mouse_selection.rs
@@ -15,7 +15,7 @@ fn file_mouse_replace_selection_clears_toggle_marked_samples() {
     browser.activate_folder(path_id(&drums));
     browser.select_file(path_id(&hat));
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("mark first sample");
 
     browser.select_file(path_id(&snare));

--- a/src/native_app/sample_library/folder_browser/tests/file_move_drag_drop.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_move_drag_drop.rs
@@ -558,8 +558,8 @@ fn file_drag_drop_moves_shift_selected_offscreen_range() {
 }
 
 #[test]
-fn file_drag_drop_moves_explicit_selection_when_focus_has_advanced() {
-    let root = temp_source_root("wavecrate-gui-file-drag-explicit-focus-advanced");
+fn file_drag_drop_moves_explicit_selection_after_keyboard_focus_navigation() {
+    let root = temp_source_root("wavecrate-gui-file-drag-explicit-focus-navigation");
     let drums = root.join("drums");
     let loops = root.join("loops");
     fs::create_dir_all(&drums).expect("create drums folder");
@@ -575,12 +575,14 @@ fn file_drag_drop_moves_explicit_selection_when_focus_has_advanced() {
     browser.activate_folder(path_id(&drums));
     browser.select_file(path_id(&hat));
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("mark first file");
     browser.navigate_vertical(1, false);
+    browser.navigate_vertical(1, false);
     browser
-        .toggle_focused_sample_selection_and_advance(&Default::default())
+        .toggle_focused_sample_selection(&Default::default())
         .expect("mark third file");
+    browser.navigate_vertical(1, false);
     assert_eq!(browser.selected_file_id(), Some(path_id(&tom).as_str()));
     assert_eq!(
         browser.selected_file_paths(),

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -47,7 +47,7 @@ pub(super) struct VisibleSampleWindowFiles<'a> {
 
 pub(in crate::native_app) struct VisibleSampleRow<'a> {
     pub(in crate::native_app) file: &'a FileEntry,
-    pub(in crate::native_app) selected: bool,
+    pub(in crate::native_app) explicitly_selected: bool,
     pub(in crate::native_app) focused: bool,
     pub(in crate::native_app) copy_flash: bool,
     pub(in crate::native_app) drag_active: bool,
@@ -530,9 +530,10 @@ impl FolderBrowserState {
         show_new_harvest_badges: bool,
     ) -> VisibleSampleRow<'a> {
         let harvest_facts = harvest_lookup.facts_for_file(self, file);
+        let selected = self.is_file_selected(&file.id);
         VisibleSampleRow {
             file,
-            selected: self.is_file_selected(&file.id),
+            explicitly_selected: selected && self.selection.selected_file_ids_explicit(),
             focused: self.selected_file_id() == Some(file.id.as_str()),
             copy_flash: self.copied_file_flash_active(&file.id),
             drag_active: self.file_drag_active(),

--- a/src/native_app/sample_library/folder_browser_actions/navigation.rs
+++ b/src/native_app/sample_library/folder_browser_actions/navigation.rs
@@ -272,7 +272,7 @@ impl NativeAppState {
         }
     }
 
-    pub(in crate::native_app) fn toggle_selected_sample_and_advance(
+    pub(in crate::native_app) fn toggle_focused_browser_selection(
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
@@ -289,11 +289,11 @@ impl NativeAppState {
         let Some(result) = self
             .library
             .folder_browser
-            .toggle_focused_sample_selection_and_advance(&self.metadata.tags_by_file)
+            .toggle_focused_sample_selection(&self.metadata.tags_by_file)
         else {
             self.ui.status.sample = String::from("Select a sample to mark");
             emit_gui_action(
-                "browser.toggle_sample_selection_and_advance",
+                "browser.toggle_sample_selection",
                 Some("browser"),
                 None,
                 "short_circuit",
@@ -334,7 +334,7 @@ impl NativeAppState {
             sample_path_label(&result.toggled_id)
         );
         emit_gui_action(
-            "browser.toggle_sample_selection_and_advance",
+            "browser.toggle_sample_selection",
             Some("browser"),
             Some(&sample_path_label(&result.toggled_id)),
             "success",

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -34,7 +34,7 @@ impl NativeAppState {
             GuiMessage::ToggleSelectedSampleAndAdvance => {
                 self.ui.browser_interaction.clipboard_handoff_target =
                     ClipboardHandoffTarget::BrowserFiles;
-                self.toggle_selected_sample_and_advance(context);
+                self.toggle_focused_browser_selection(context);
             }
             GuiMessage::SelectAllSamples => {
                 self.ui.browser_interaction.clipboard_handoff_target =

--- a/src/native_app/shell/shortcuts/help.rs
+++ b/src/native_app/shell/shortcuts/help.rs
@@ -210,7 +210,7 @@ fn x_help_label(state: &NativeAppState) -> &'static str {
     if super::waveform_zoom_out_shortcut_active(state) {
         "Zoom out"
     } else {
-        "Mark sample and advance"
+        "Toggle focused sample selection"
     }
 }
 

--- a/src/native_app/test_support/sample_browser.rs
+++ b/src/native_app/test_support/sample_browser.rs
@@ -48,7 +48,7 @@ pub(in crate::native_app) fn sample_file_hit_target(
         ui::empty(),
         SampleFileHitTargetModel {
             file_id: "sample.wav",
-            selected,
+            explicitly_selected: selected,
             focused: false,
             copy_flash: false,
             cut_pending: false,

--- a/src/native_app/tests/shortcuts_context/help.rs
+++ b/src/native_app/tests/shortcuts_context/help.rs
@@ -184,3 +184,22 @@ fn shortcut_help_space_label_reflects_sticky_random_playback() {
             .any(|item| item.keys == "Space" && item.action == "Play random sample section")
     );
 }
+
+#[test]
+fn shortcut_help_x_label_reflects_browser_selection_toggle() {
+    let state = NativeAppState::load_default().expect("default state loads");
+    let sections = shortcut_help_sections(&state);
+
+    assert!(
+        sections
+            .iter()
+            .flat_map(|section| &section.items)
+            .any(|item| { item.keys == "X" && item.action == "Toggle focused sample selection" })
+    );
+    assert!(
+        !sections
+            .iter()
+            .flat_map(|section| &section.items)
+            .any(|item| item.keys == "X" && item.action == "Mark sample and advance")
+    );
+}

--- a/src/native_app/tests/shortcuts_context/transport.rs
+++ b/src/native_app/tests/shortcuts_context/transport.rs
@@ -207,7 +207,7 @@ fn command_right_shortcut_routes_to_next_playback_history() {
 }
 
 #[test]
-fn x_shortcut_routes_to_toggle_selected_sample_and_advance() {
+fn x_shortcut_routes_to_toggle_focused_browser_selection() {
     let state = NativeAppState::load_default().expect("default state loads");
     let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::X));
 


### PR DESCRIPTION
Addresses OPT-933.

## Scope
- Change sample-list `X` handling so it toggles the focused sample selection in place instead of advancing focus.
- Keep selected-set behavior intact for repeated toggles, multi-selection, filtered rows, and keyboard navigation.
- Preserve folder-tree fallback behavior when no sample file focus exists.
- Thread explicit sample selection into the visible row projection so `X`-marked rows paint distinct selected chrome even when the row is also focused.
- Update shortcut/help documentation that described the old select-and-advance behavior.

## Definition of Done
- Pressing `X` in the sample list toggles selection for the focused sample and leaves focus on that same sample.
- Repeated `X` presses toggle the same item without advancing.
- A single focused sample visibly changes when it becomes explicitly selected with `X`.
- Multi-selection and keyboard navigation remain stable.
- Help/shortcut documentation is updated for the stationary toggle behavior.
- Automated validation covers stationary toggle behavior, repeated toggles, filtered rows, multi-selection, explicit selected-row styling, shortcut routing, rename shielding, docs, formatting, and compile checks.

## Validation Commands
- `cargo test file_keyboard_selection --bin wavecrate`
- `cargo test file_selection_model --bin wavecrate`
- `cargo test toggle_focused_sample_selection_marks_visible_row_as_explicit_selection --bin wavecrate`
- `cargo test implicit_focused_selection_does_not_paint_explicit_selection_chrome --bin wavecrate`
- `cargo test selected_focused_rows_paint_selection_and_focus_together --bin wavecrate`
- `cargo test selected_sample_browser_row_paints_strong_fill_and_left_marker --bin wavecrate`
- `cargo test sample_row_display_preserves_explicit_selection_and_focus_separately --bin wavecrate`
- `cargo test x_shortcut_routes_to_toggle_focused_browser_selection --bin wavecrate`
- `cargo test x_shortcut_is_consumed_while_renaming --bin wavecrate`
- `cargo test shortcut_help_x_label_reflects_browser_selection_toggle --bin wavecrate`
- `cargo test file_drag_drop_moves_explicit_selection_after_keyboard_focus_navigation --bin wavecrate`
- `bash scripts/check.sh mdbook`
- `cargo fmt --check`
- `cargo check --bin wavecrate`
- `git diff --check`

## Known Limitations
- `bash scripts/agent.sh request` currently fails on a pre-existing unrelated guardrail in `src/native_app/sample_identity_diagnostics.rs` at lines 2, 316, and 357.
- A broad local filter run, `cargo test hit_target --bin wavecrate`, also picked up unrelated window-chrome hit-target tests that failed outside the sample-row path; the exact sample-row hit-target regressions listed above pass.

## User Review
User review is required before merge.
