### PR TITLE
OPT-938: Rename installer Start Menu shortcut to Wavecrate

### DIFF
--- a/apps/installer/src/shortcuts.rs
+++ b/apps/installer/src/shortcuts.rs
@@ -1,6 +1,7 @@
-#[cfg(target_os = "windows")]
-use std::fs;
 use std::path::Path;
+
+#[cfg(any(test, target_os = "windows"))]
+use std::fs;
 
 #[cfg(target_os = "windows")]
 use crate::paths;
@@ -17,6 +18,11 @@ use windows::{
     core::{HSTRING, Interface, PCWSTR},
 };
 
+#[cfg(any(test, target_os = "windows"))]
+const START_MENU_SHORTCUT_NAME: &str = "Wavecrate.lnk";
+#[cfg(any(test, target_os = "windows"))]
+const LEGACY_START_MENU_SHORTCUT_NAMES: &[&str] = &["SemPal.lnk"];
+
 pub(crate) fn create_start_menu_shortcut(install_dir: &Path) -> Result<(), String> {
     #[cfg(not(target_os = "windows"))]
     let _ = install_dir;
@@ -26,7 +32,7 @@ pub(crate) fn create_start_menu_shortcut(install_dir: &Path) -> Result<(), Strin
         fs::create_dir_all(&start_menu)
             .map_err(|err| format!("Failed to create Start Menu folder: {err}"))?;
 
-        let shortcut_path = start_menu.join("SemPal.lnk");
+        let shortcut_path = start_menu_shortcut_path(&start_menu);
         let target_path = install_dir.join("wavecrate.exe");
         let icon_path = install_dir.join("wavecrate.ico");
 
@@ -60,8 +66,95 @@ pub(crate) fn create_start_menu_shortcut(install_dir: &Path) -> Result<(), Strin
                 .Save(PCWSTR::from_raw(shortcut.as_ptr()), true)
                 .map_err(|err| format!("Failed to save shortcut: {err}"))?;
         }
+        remove_legacy_start_menu_shortcuts(&start_menu)?;
         return Ok(());
     }
     #[allow(unreachable_code)]
     Err("Start Menu shortcut is only supported on Windows.".to_string())
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn start_menu_shortcut_path(start_menu: &Path) -> std::path::PathBuf {
+    start_menu.join(START_MENU_SHORTCUT_NAME)
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn legacy_start_menu_shortcut_paths(
+    start_menu: &Path,
+) -> impl Iterator<Item = std::path::PathBuf> + '_ {
+    LEGACY_START_MENU_SHORTCUT_NAMES
+        .iter()
+        .map(|name| start_menu.join(name))
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn remove_legacy_start_menu_shortcuts(start_menu: &Path) -> Result<usize, String> {
+    let mut removed = 0;
+    for path in legacy_start_menu_shortcut_paths(start_menu) {
+        if !path.exists() {
+            continue;
+        }
+        fs::remove_file(&path)
+            .map_err(|err| format!("Failed to remove legacy shortcut {}: {err}", path.display()))?;
+        removed += 1;
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_menu_shortcut_path_uses_wavecrate_branding() {
+        let start_menu = Path::new(
+            r"C:\Users\portal\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\SemPal",
+        );
+
+        assert_eq!(
+            start_menu_shortcut_path(start_menu),
+            start_menu.join("Wavecrate.lnk")
+        );
+    }
+
+    #[test]
+    fn legacy_start_menu_shortcut_paths_target_only_installer_owned_sempal_link() {
+        let start_menu = Path::new(
+            r"C:\Users\portal\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\SemPal",
+        );
+        let legacy = legacy_start_menu_shortcut_paths(start_menu).collect::<Vec<_>>();
+
+        assert_eq!(legacy, vec![start_menu.join("SemPal.lnk")]);
+        assert!(!legacy.contains(&start_menu.join("Wavecrate.lnk")));
+    }
+
+    #[test]
+    fn remove_legacy_start_menu_shortcuts_removes_only_sempal_link() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let start_menu = temp.path();
+        let legacy = start_menu.join("SemPal.lnk");
+        let current = start_menu.join("Wavecrate.lnk");
+        let custom = start_menu.join("Custom.lnk");
+        fs::write(&legacy, b"legacy").expect("legacy shortcut");
+        fs::write(&current, b"current").expect("current shortcut");
+        fs::write(&custom, b"custom").expect("custom shortcut");
+
+        let removed =
+            remove_legacy_start_menu_shortcuts(start_menu).expect("legacy cleanup succeeds");
+
+        assert_eq!(removed, 1);
+        assert!(!legacy.exists());
+        assert!(current.exists());
+        assert!(custom.exists());
+    }
+
+    #[test]
+    fn remove_legacy_start_menu_shortcuts_ignores_absent_legacy_link() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let removed =
+            remove_legacy_start_menu_shortcuts(temp.path()).expect("legacy cleanup succeeds");
+
+        assert_eq!(removed, 0);
+    }
 }


### PR DESCRIPTION
Addresses OPT-938 / LEG-002.

## Scope
- Change installer-created Start Menu shortcut creation from `SemPal.lnk` to `Wavecrate.lnk`.
- Keep the shortcut target and icon paths pointed at the installed `wavecrate.exe` and `wavecrate.ico` payloads.
- Add a conservative update/install cleanup path that removes only the installer-owned legacy `SemPal.lnk` shortcut in the same Start Menu folder after the new `Wavecrate.lnk` shortcut is saved.
- Leave broader installer app identity, publisher, uninstall registry naming, install directory naming, and Start Menu folder naming to OPT-937.

## Definition of Done
- New shortcut creation uses `Wavecrate.lnk`.
- Stale installer-owned `SemPal.lnk` handling is explicitly implemented: remove that exact legacy link from the installer-owned Start Menu folder after saving the new shortcut.
- Custom or unrelated shortcuts in that folder are not removed by the migration helper.
- Shortcut target and icon setup remain unchanged.
- Installer tests cover the new shortcut name and legacy cleanup behavior.

## Validation Commands
- `bash scripts/agent.sh request` *(fails on pre-existing unrelated `src/native_app/sample_identity_diagnostics.rs` non-blocking guardrail violations at lines 2, 316, and 357)*
- `cargo test -p wavecrate-installer`
- `cargo check -p wavecrate-installer`
- `cargo fmt --check --package wavecrate-installer`
- `git diff --check`
- `rg -n "SemPal\\.lnk|Wavecrate\\.lnk|START_MENU_SHORTCUT_NAME|LEGACY_START_MENU_SHORTCUT" apps/installer/src`

## Known Limitations
- Windows installer dry-run/manual install was not run in this macOS environment. The code path that creates the real `.lnk` remains Windows-only and should be smoked on Windows before final release acceptance.
- The Start Menu folder currently still derives from installer `APP_NAME` (`SemPal`); that broader installer identity work is intentionally left to OPT-937.

## User Review
User review is required before merge.
