### PR TITLE
OPT-963: Redact issue gateway error bodies

### DIFF
--- a/src/app/controller/library/background_jobs/updates.rs
+++ b/src/app/controller/library/background_jobs/updates.rs
@@ -158,3 +158,46 @@ pub(crate) fn handle_issue_token_deleted(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::controller::jobs::IssueGatewayCreateResult;
+    use crate::issue_gateway::api::CreateIssueError;
+
+    #[test]
+    fn issue_gateway_error_status_and_log_do_not_include_raw_response_body() {
+        let (mut controller, _source) = crate::app::controller::test_support::dummy_controller();
+        controller.ui.feedback_issue.submitting = true;
+        let body = r#"{
+            "error": "Authorization: Bearer secret-token-12345678901234567890",
+            "message": "Issue body: private production note from /Users/portal/secret.wav",
+            "request_id": "req_public_42"
+        }"#;
+
+        handle_issue_gateway_created(
+            &mut controller,
+            IssueGatewayCreateResult {
+                result: Err(CreateIssueError::status_for_tests(400, body)),
+            },
+        );
+
+        let last_error = controller
+            .ui
+            .feedback_issue
+            .last_error
+            .as_deref()
+            .expect("last error");
+        let status_text = controller.ui.status.text.as_str();
+        let status_log = controller.ui.status.log.join("\n");
+        for sink in [last_error, status_text, status_log.as_str()] {
+            assert!(!sink.contains("secret-token"));
+            assert!(!sink.contains("Bearer secret"));
+            assert!(!sink.contains("private production note"));
+            assert!(!sink.contains("/Users/portal"));
+            assert!(sink.contains("HTTP 400"));
+            assert!(sink.contains("req_public_42"));
+        }
+        assert!(!controller.ui.feedback_issue.submitting);
+    }
+}

--- a/src/issue_gateway/api/auth.rs
+++ b/src/issue_gateway/api/auth.rs
@@ -1,7 +1,7 @@
 //! Token authorization flow for the issue gateway.
 
 use super::transport;
-use super::wire::{self, IssueAuthError};
+use super::wire::{self, IssueAuthError, map_auth_status_error, redact_issue_gateway_text};
 
 pub(super) fn fetch_issue_token(auth_start_url: &str) -> Result<String, IssueAuthError> {
     let response = match transport::get_with_retry(auth_start_url) {
@@ -9,15 +9,18 @@ pub(super) fn fetch_issue_token(auth_start_url: &str) -> Result<String, IssueAut
         Err(ureq::Error::Status(code, response)) => {
             let body =
                 transport::read_auth_response_text(response).unwrap_or_else(|err| err.to_string());
-            return Err(IssueAuthError::ServerError(format!("HTTP {code}: {body}")));
+            return Err(map_auth_status_error(code, body));
         }
         Err(ureq::Error::Transport(err)) => {
-            return Err(IssueAuthError::Transport(err.to_string()));
+            return Err(IssueAuthError::Transport(redact_issue_gateway_text(
+                &err.to_string(),
+            )));
         }
     };
 
-    let body = transport::read_auth_response_text(response)
-        .map_err(|err| IssueAuthError::InvalidResponse(err.to_string()))?;
+    let body = transport::read_auth_response_text(response).map_err(|err| {
+        IssueAuthError::InvalidResponse(redact_issue_gateway_text(&err.to_string()))
+    })?;
     wire::parse_issue_token(&body)
 }
 
@@ -35,15 +38,18 @@ pub(super) fn poll_issue_token(
         Err(ureq::Error::Status(code, response)) => {
             let body =
                 transport::read_auth_response_text(response).unwrap_or_else(|err| err.to_string());
-            return Err(IssueAuthError::ServerError(format!("HTTP {code}: {body}")));
+            return Err(map_auth_status_error(code, body));
         }
         Err(ureq::Error::Transport(err)) => {
-            return Err(IssueAuthError::Transport(err.to_string()));
+            return Err(IssueAuthError::Transport(redact_issue_gateway_text(
+                &err.to_string(),
+            )));
         }
     };
 
-    let body = transport::read_auth_response_text(response)
-        .map_err(|err| IssueAuthError::InvalidResponse(err.to_string()))?;
+    let body = transport::read_auth_response_text(response).map_err(|err| {
+        IssueAuthError::InvalidResponse(redact_issue_gateway_text(&err.to_string()))
+    })?;
     wire::parse_poll_issue_token_response(&body)
 }
 

--- a/src/issue_gateway/api/issue.rs
+++ b/src/issue_gateway/api/issue.rs
@@ -3,7 +3,7 @@
 use super::transport;
 use super::wire::{
     CreateIssueError, CreateIssueRequest, CreateIssueResponse, map_status_error,
-    parse_create_issue_response,
+    parse_create_issue_response, redact_issue_gateway_text,
 };
 use uuid::Uuid;
 
@@ -22,11 +22,13 @@ pub(super) fn create_issue(
             return Err(map_status_error(code, body));
         }
         Err(ureq::Error::Transport(err)) => {
-            return Err(CreateIssueError::Transport(err.to_string()));
+            return Err(CreateIssueError::Transport(redact_issue_gateway_text(
+                &err.to_string(),
+            )));
         }
     };
 
     let body = transport::read_issue_response_text(response)
-        .map_err(|err| CreateIssueError::Json(err.to_string()))?;
+        .map_err(|err| CreateIssueError::Json(redact_issue_gateway_text(&err.to_string())))?;
     parse_create_issue_response(&body)
 }

--- a/src/issue_gateway/api/wire.rs
+++ b/src/issue_gateway/api/wire.rs
@@ -1,6 +1,24 @@
 //! Wire DTOs, response parsing, and status mapping for the issue gateway.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::sync::LazyLock;
+
+const REDACTED_TEXT_LIMIT: usize = 240;
+
+static BEARER_TOKEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+").expect("bearer regex"));
+static SECRET_KEY_VALUE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(authorization|token|secret|api[_-]?key|password)\s*[:=]\s*\S+")
+        .expect("secret key/value regex")
+});
+static LOCAL_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)(?:[A-Z]:\\[^\s"'<>]+|/(?:Users|Volumes|private|var|tmp|home)/[^\s"'<>]+)"#)
+        .expect("local path regex")
+});
+static TOKEN_LIKE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Za-z0-9_-]{32,}\b").expect("token-like string regex"));
 
 /// Payload sent to the issue gateway when creating a GitHub issue.
 #[derive(Clone, Debug, Serialize)]
@@ -31,19 +49,64 @@ pub enum CreateIssueError {
     Unauthorized,
     /// Request payload was invalid.
     #[error("Invalid input: {0}")]
-    BadRequest(String),
+    BadRequest(GatewayErrorContext),
     /// Gateway rate limit was hit.
     #[error("Rate limited; try again later")]
     RateLimited,
     /// Gateway returned a server error.
     #[error("Server error: {0}")]
-    ServerError(String),
+    ServerError(GatewayErrorContext),
+    /// Gateway returned an unrecognized HTTP status.
+    #[error("Unexpected gateway status: {0}")]
+    UnexpectedStatus(GatewayErrorContext),
     /// Transport error when calling the gateway.
     #[error("HTTP error: {0}")]
     Transport(String),
     /// JSON parsing/serialization error.
     #[error("JSON error: {0}")]
     Json(String),
+}
+
+/// Safe, bounded metadata extracted from an issue-gateway error response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GatewayErrorContext {
+    status_code: u16,
+    class: Option<String>,
+    request_id: Option<String>,
+}
+
+impl GatewayErrorContext {
+    fn from_body(status_code: u16, body: &str) -> Self {
+        let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+        Self {
+            status_code,
+            class: parsed
+                .as_ref()
+                .and_then(gateway_error_class)
+                .or_else(|| Some(default_gateway_error_class(status_code).to_string())),
+            request_id: parsed.as_ref().and_then(gateway_request_id),
+        }
+    }
+}
+
+impl CreateIssueError {
+    #[cfg(test)]
+    pub(crate) fn status_for_tests(code: u16, body: impl Into<String>) -> Self {
+        map_status_error(code, body.into())
+    }
+}
+
+impl fmt::Display for GatewayErrorContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "HTTP {}", self.status_code)?;
+        if let Some(class) = self.class.as_deref() {
+            write!(formatter, " ({class})")?;
+        }
+        if let Some(request_id) = self.request_id.as_deref() {
+            write!(formatter, ", request id {request_id}")?;
+        }
+        Ok(())
+    }
 }
 
 /// Error states surfaced when fetching or polling auth tokens.
@@ -86,13 +149,19 @@ struct PollResponseWire {
 }
 
 pub(super) fn map_status_error(code: u16, body: String) -> CreateIssueError {
+    let context = GatewayErrorContext::from_body(code, &body);
     match code {
-        400 => CreateIssueError::BadRequest(body),
+        400 => CreateIssueError::BadRequest(context),
         401 => CreateIssueError::Unauthorized,
         429 => CreateIssueError::RateLimited,
-        500..=599 => CreateIssueError::ServerError(body),
-        _ => CreateIssueError::Transport(format!("HTTP {code}: {body}")),
+        500..=599 => CreateIssueError::ServerError(context),
+        _ => CreateIssueError::UnexpectedStatus(context),
     }
+}
+
+pub(super) fn map_auth_status_error(code: u16, body: String) -> IssueAuthError {
+    let context = GatewayErrorContext::from_body(code, &body);
+    IssueAuthError::ServerError(context.to_string())
 }
 
 pub(super) fn parse_create_issue_response(
@@ -103,7 +172,7 @@ pub(super) fn parse_create_issue_response(
         return Err(CreateIssueError::Json("Empty response body".to_string()));
     }
     let parsed: CreateIssueResponseWire = serde_json::from_str(trimmed)
-        .map_err(|err| CreateIssueError::Json(format!("{err}: {trimmed}")))?;
+        .map_err(|err| CreateIssueError::Json(redact_issue_gateway_text(&err.to_string())))?;
 
     let ok = parsed.ok;
     if let (Some(issue_url), Some(number)) = (parsed.issue_url, parsed.number) {
@@ -120,7 +189,9 @@ pub(super) fn parse_create_issue_response(
     if is_session_expired_message(&message) {
         return Err(CreateIssueError::Unauthorized);
     }
-    Err(CreateIssueError::Json(message))
+    Err(CreateIssueError::Json(safe_create_issue_response_error(
+        &message,
+    )))
 }
 
 pub(super) fn parse_poll_issue_token_response(
@@ -136,7 +207,7 @@ pub(super) fn parse_poll_issue_token_response(
     }
 
     if let Some(err) = parsed.error {
-        return Err(IssueAuthError::ServerError(err));
+        return Err(IssueAuthError::ServerError(safe_auth_response_error(&err)));
     }
 
     Ok(None)
@@ -192,6 +263,75 @@ fn is_session_expired_message(message: &str) -> bool {
     lowered.contains("session") && lowered.contains("expired")
 }
 
+fn safe_create_issue_response_error(_message: &str) -> String {
+    "Gateway response was missing issue details".to_string()
+}
+
+fn safe_auth_response_error(_message: &str) -> String {
+    "Gateway auth failed".to_string()
+}
+
+pub(crate) fn redact_issue_gateway_text(input: &str) -> String {
+    let body = input.replace(['\r', '\n', '\t'], " ");
+    let body = BEARER_TOKEN_RE.replace_all(&body, "Bearer [redacted]");
+    let body = SECRET_KEY_VALUE_RE.replace_all(&body, "$1=[redacted]");
+    let body = LOCAL_PATH_RE.replace_all(&body, "[local-path]");
+    let body = TOKEN_LIKE_RE.replace_all(&body, "[redacted-token]");
+    bound_redacted_text(body.trim())
+}
+
+fn bound_redacted_text(input: &str) -> String {
+    let mut output = String::new();
+    for ch in input.chars() {
+        if output.len() >= REDACTED_TEXT_LIMIT {
+            output.push_str("...");
+            break;
+        }
+        output.push(ch);
+    }
+    output
+}
+
+fn gateway_error_class(value: &serde_json::Value) -> Option<String> {
+    ["error_class", "errorClass", "code", "type"]
+        .into_iter()
+        .filter_map(|key| value.get(key).and_then(|value| value.as_str()))
+        .find_map(safe_metadata_token)
+}
+
+fn gateway_request_id(value: &serde_json::Value) -> Option<String> {
+    ["request_id", "requestId", "trace_id", "traceId"]
+        .into_iter()
+        .filter_map(|key| value.get(key).and_then(|value| value.as_str()))
+        .find_map(safe_metadata_token)
+}
+
+fn safe_metadata_token(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > 96 {
+        return None;
+    }
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':'))
+    {
+        return None;
+    }
+    let redacted = redact_issue_gateway_text(trimmed);
+    if redacted.contains("[redacted") || redacted.contains("[local-path]") {
+        return None;
+    }
+    Some(redacted)
+}
+
+fn default_gateway_error_class(status_code: u16) -> &'static str {
+    match status_code {
+        400 => "bad_request",
+        500..=599 => "server_error",
+        _ => "unexpected_status",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,9 +345,12 @@ mod tests {
     }
 
     #[test]
-    fn reports_error_field() {
+    fn reports_error_field_without_echoing_gateway_body() {
         let err = parse_create_issue_response(r#"{ "error": "nope" }"#).unwrap_err();
-        assert!(err.to_string().contains("nope"));
+        assert_eq!(
+            err.to_string(),
+            "JSON error: Gateway response was missing issue details"
+        );
     }
 
     #[test]
@@ -231,6 +374,87 @@ mod tests {
             map_status_error(503, String::from("unavailable")),
             CreateIssueError::ServerError(_)
         ));
+        assert!(matches!(
+            map_status_error(418, String::from("teapot")),
+            CreateIssueError::UnexpectedStatus(_)
+        ));
+    }
+
+    #[test]
+    fn status_errors_do_not_display_raw_gateway_bodies() {
+        let body = r#"{
+            "error": "Authorization: Bearer secret-token-12345678901234567890",
+            "message": "Issue body: private production note from /Users/portal/secret.wav",
+            "request_id": "req_public_42"
+        }"#;
+
+        for status in [400, 500, 599, 418] {
+            let message = map_status_error(status, body.to_string()).to_string();
+            assert!(!message.contains("secret-token"));
+            assert!(!message.contains("Bearer secret"));
+            assert!(!message.contains("private production note"));
+            assert!(!message.contains("/Users/portal"));
+            assert!(message.contains(&format!("HTTP {status}")));
+            assert!(message.contains("req_public_42"));
+        }
+    }
+
+    #[test]
+    fn auth_status_errors_do_not_display_raw_gateway_bodies() {
+        let body = r#"{
+            "error": "Authorization: Bearer secret-token-12345678901234567890",
+            "message": "Issue body: private production note from /Users/portal/secret.wav",
+            "request_id": "req_public_42"
+        }"#;
+
+        let message = map_auth_status_error(503, body.to_string()).to_string();
+
+        assert!(!message.contains("secret-token"));
+        assert!(!message.contains("Bearer secret"));
+        assert!(!message.contains("private production note"));
+        assert!(!message.contains("/Users/portal"));
+        assert!(message.contains("HTTP 503"));
+        assert!(message.contains("req_public_42"));
+    }
+
+    #[test]
+    fn poll_response_error_does_not_display_raw_gateway_body_field() {
+        let message = parse_poll_issue_token_response(
+            r#"{ "error": "Authorization: Bearer secret-token-12345678901234567890 /Users/portal/private.wav" }"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(!message.contains("secret-token"));
+        assert!(!message.contains("/Users/portal"));
+        assert_eq!(message, "Server error: Gateway auth failed");
+    }
+
+    #[test]
+    fn malformed_create_issue_response_does_not_display_raw_body() {
+        let body = r#"not json Authorization: Bearer secret-token-12345678901234567890 /Users/portal/private.wav"#;
+
+        let message = parse_create_issue_response(body).unwrap_err().to_string();
+
+        assert!(!message.contains("secret-token"));
+        assert!(!message.contains("/Users/portal"));
+        assert!(!message.contains("not json"));
+        assert!(message.contains("JSON error:"));
+    }
+
+    #[test]
+    fn redacts_gateway_text_defensively() {
+        let redacted = redact_issue_gateway_text(
+            "Authorization: Bearer secret-token-12345678901234567890 token=abcDEF1234567890abcDEF1234567890abc /Users/portal/private.wav C:\\Users\\portal\\private.wav",
+        );
+
+        assert!(!redacted.contains("secret-token"));
+        assert!(!redacted.contains("abcDEF1234567890abc"));
+        assert!(!redacted.contains("/Users/portal"));
+        assert!(!redacted.contains("C:\\Users"));
+        assert!(redacted.contains("Authorization=[redacted]"));
+        assert!(redacted.contains("token=[redacted]"));
+        assert!(redacted.contains("[local-path]"));
     }
 
     #[test]


### PR DESCRIPTION
## Scope

- Fixes OPT-963 and security scan candidate `WC-CAND-006-001`.
- Adds an issue-gateway error sanitization boundary so non-success gateway response bodies no longer flow into `CreateIssueError`, displayed issue errors, UI status text, tracing status output, or diagnostic log paths.
- Replaces raw body-bearing status errors with `GatewayErrorContext`, retaining only safe metadata: HTTP status, a bounded safe gateway error class, and a bounded safe request/trace id.
- Keeps user-facing recovery categories distinguishable for bad request, auth expired, rate limited, server error, unexpected status, transport failure, and invalid gateway responses.
- Adds defense-in-depth redaction for gateway-supplied strings that still reach public error text, including bearer tokens, common secret key/value patterns, local paths, and long token-like strings.
- Covers adjacent issue auth gateway status/error parsing so the same response-body invariant applies consistently.
- Adds controller-level regression coverage proving issue gateway failures do not write raw body text into status state or the status log.

## Definition of Done

- Raw gateway response bodies are not preserved in issue-gateway status errors or displayed/logged issue creation failures.
- 400, 401, 429, 5xx, and unknown statuses remain distinguishable and actionable.
- Synthetic tests prove bodies containing `Authorization: Bearer ...`, local paths, and private issue text are removed before status/log sinks.
- Focused issue-gateway tests cover status mapping, response parsing, malformed responses, auth polling errors, and defensive redaction.
- No live gateway calls or real tokens are used in tests.

## Validation Commands

- `bash scripts/agent.sh request` failed before implementation on an unrelated pre-existing guardrail in `src/native_app/sample_identity_diagnostics.rs` lines 2, 316, and 357.
- `cargo test -p wavecrate --lib issue_gateway`
- `cargo test -p wavecrate --lib issue_gateway_error_status_and_log_do_not_include_raw_response_body`
- `cargo fmt --check`
- `cargo check -p wavecrate`
- `git diff --check`
- `rg -n "HTTP \\{code\\}:|\\{trimmed\\}|CreateIssueError::(BadRequest|ServerError|Transport|Json|UnexpectedStatus)|IssueAuthError::(ServerError|Transport|InvalidResponse)|read_(issue|auth)_response_text" src/issue_gateway src/app/controller/library/background_jobs src/app/controller/ui/status.rs`

## Known Limitations

- The original scan report path from the Linear issue no longer exists under `/private/var/...`; implementation used the Linear evidence anchors and current source paths instead.
- `bash scripts/agent.sh request` remains blocked by the unrelated `sample_identity_diagnostics.rs` guardrail noted above.
- No live gateway validation was run; coverage uses synthetic gateway responses without real secrets.

User review is required before merge.
