### PR TITLE
Route protected extraction outputs to Primary

### DIFF
--- a/src/native_app/sample_library/folder_browser/source_management/catalog.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/catalog.rs
@@ -179,6 +179,29 @@ impl FolderBrowserState {
             .map(SourceEntry::as_sample_source)
     }
 
+    pub(in crate::native_app) fn default_writable_extraction_source(
+        &self,
+        error: impl Into<String>,
+    ) -> Result<SampleSource, String> {
+        let error = error.into();
+        if let Some(source) = self.primary_sample_source() {
+            return Ok(source);
+        }
+
+        let mut normal_sources = self.source.sources.iter().filter(|source| {
+            !source.is_default_assets_source()
+                && !source.is_missing()
+                && source.role == SourceRole::Normal
+        });
+        let Some(source) = normal_sources.next() else {
+            return Err(error);
+        };
+        if normal_sources.next().is_some() {
+            return Err(error);
+        }
+        Ok(source.as_sample_source())
+    }
+
     pub(in crate::native_app) fn source_is_removable(&self, source_id: &str) -> bool {
         self.source
             .sources

--- a/src/native_app/sample_library/harvest_tracking.rs
+++ b/src/native_app/sample_library/harvest_tracking.rs
@@ -351,26 +351,6 @@ impl NativeAppState {
         self.harvest_destination_for_source(&origin_source)
     }
 
-    pub(in crate::native_app) fn optional_harvest_destination_for_protected_origin(
-        &self,
-        source_path: &Path,
-    ) -> Option<PathBuf> {
-        let (origin_source, _) = self
-            .library
-            .folder_browser
-            .sample_source_for_file_path(source_path)?;
-        if !origin_source.is_protected() {
-            return None;
-        }
-        let primary_source = self.library.folder_browser.primary_sample_source()?;
-        Some(
-            primary_source
-                .root
-                .join(HARVEST_ROOT_FOLDER)
-                .join(harvest_source_folder_name(&origin_source)),
-        )
-    }
-
     pub(in crate::native_app) fn open_context_sample_harvest_destination(
         &mut self,
         context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
@@ -797,12 +777,13 @@ impl NativeAppState {
     }
 
     fn harvest_destination_for_source(&self, source: &SampleSource) -> Result<PathBuf, String> {
-        let Some(primary_source) = self.library.folder_browser.primary_sample_source() else {
-            return Err(String::from(
+        let target_source = self
+            .library
+            .folder_browser
+            .default_writable_extraction_source(
                 "Set a Primary source before using a harvest destination",
-            ));
-        };
-        Ok(primary_source
+            )?;
+        Ok(target_source
             .root
             .join(HARVEST_ROOT_FOLDER)
             .join(harvest_source_folder_name(source)))

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -379,14 +379,34 @@ impl NativeAppState {
         &self,
         request: WaveformExtractionRequest,
     ) -> Result<WaveformExtractionRequest, String> {
-        if request.has_explicit_target_folder() {
+        if let Some(target_folder) =
+            self.harvest_destination_for_protected_origin(request.source_path())?
+        {
+            wavecrate::sample_sources::harvest_file_ops::ensure_dir(
+                &target_folder,
+                "Could not create harvest destination",
+            )?;
+            return Ok(request.with_target_folder(target_folder));
+        }
+
+        if !request.has_explicit_target_folder() {
             return Ok(request);
         }
-        let Some(target_folder) =
-            self.optional_harvest_destination_for_protected_origin(request.source_path())
-        else {
+        let target_folder = request.target_folder()?;
+        if !self
+            .library
+            .folder_browser
+            .path_is_in_protected_source(target_folder)
+        {
             return Ok(request);
-        };
+        }
+        let target_source = self
+            .library
+            .folder_browser
+            .default_writable_extraction_source(
+                "Set a Primary source before extracting into a protected source",
+            )?;
+        let target_folder = target_source.primary_import_path();
         wavecrate::sample_sources::harvest_file_ops::ensure_dir(
             &target_folder,
             "Could not create harvest destination",

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -1123,7 +1123,7 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
 }
 
 #[test]
-fn protected_playmark_extraction_preserves_explicit_target_folder() {
+fn protected_playmark_extraction_redirects_explicit_protected_target_to_primary() {
     let config_root = tempfile::tempdir().expect("config root");
     let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
     let mut scenario = WaveformPlaybackScenario::with_temp_wav(
@@ -1146,7 +1146,7 @@ fn protected_playmark_extraction_preserves_explicit_target_folder() {
         wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
     scenario.state.library.folder_browser =
         crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
-            protected_source,
+            protected_source.clone(),
             primary_source,
         ]);
     scenario
@@ -1166,9 +1166,339 @@ fn protected_playmark_extraction_preserves_explicit_target_folder() {
     let routed = scenario
         .state
         .route_harvest_extraction_request(request)
-        .expect("explicit target should stay valid");
+        .expect("explicit protected target should redirect to primary");
+    let expected_folder = primary_root.path().join("_Harvests").join(
+        protected_source
+            .root
+            .file_name()
+            .expect("source root folder name"),
+    );
 
-    assert_eq!(routed.target_folder(), Ok(source_root.as_path()));
+    assert_eq!(routed.target_folder(), Ok(expected_folder.as_path()));
+}
+
+#[test]
+fn protected_playmark_extraction_without_writable_destination_reports_error() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-protected-no-primary.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.clone()).protected();
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source,
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(None)
+        .expect("protected extraction request");
+
+    let error = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect_err("protected extraction requires a primary source");
+
+    assert_eq!(
+        error,
+        "Set a Primary source before extracting from a protected source"
+    );
+}
+
+#[test]
+fn protected_playmark_extraction_with_single_normal_source_routes_to_normal_harvest_destination() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-protected-single-normal.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let normal_root = tempfile::tempdir().expect("normal source root");
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.clone()).protected();
+    let normal_source =
+        wavecrate::sample_sources::SampleSource::new(normal_root.path().to_path_buf());
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            normal_source.clone(),
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(None)
+        .expect("protected extraction request");
+
+    let routed = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect("single normal source should be an unambiguous writable destination");
+    let expected_folder = normal_source.root.join("_Harvests").join(
+        protected_source
+            .root
+            .file_name()
+            .expect("source root folder name"),
+    );
+
+    assert_eq!(routed.target_folder(), Ok(expected_folder.as_path()));
+}
+
+#[test]
+fn protected_playmark_extraction_with_multiple_normal_sources_requires_primary() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-protected-many-normal.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let normal_a_root = tempfile::tempdir().expect("normal source root a");
+    let normal_b_root = tempfile::tempdir().expect("normal source root b");
+    let protected_source =
+        wavecrate::sample_sources::SampleSource::new(source_root.clone()).protected();
+    let normal_a = wavecrate::sample_sources::SampleSource::new(normal_a_root.path().to_path_buf());
+    let normal_b = wavecrate::sample_sources::SampleSource::new(normal_b_root.path().to_path_buf());
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source,
+            normal_a,
+            normal_b,
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(None)
+        .expect("protected extraction request");
+
+    let error = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect_err("multiple normal destinations require an explicit primary source");
+
+    assert_eq!(
+        error,
+        "Set a Primary source before extracting from a protected source"
+    );
+}
+
+#[test]
+fn normal_playmark_extraction_redirects_explicit_protected_target_to_primary_import() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-into-protected-target.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let protected_root = tempfile::tempdir().expect("protected target root");
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let source = wavecrate::sample_sources::SampleSource::new(source_root.clone());
+    let protected_target =
+        wavecrate::sample_sources::SampleSource::new(protected_root.path().to_path_buf())
+            .protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            source,
+            protected_target,
+            primary_source.clone(),
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let protected_folder = protected_root.path().join("incoming");
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(Some(protected_folder))
+        .expect("explicit protected target extraction request");
+
+    let routed = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect("protected target should redirect to primary");
+
+    assert_eq!(
+        routed.target_folder(),
+        Ok(primary_source.primary_import_path().as_path())
+    );
+}
+
+#[test]
+fn normal_playmark_extraction_into_protected_target_uses_single_normal_source() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-into-protected-no-primary.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let protected_root = tempfile::tempdir().expect("protected target root");
+    let source = wavecrate::sample_sources::SampleSource::new(source_root.clone());
+    let protected_target =
+        wavecrate::sample_sources::SampleSource::new(protected_root.path().to_path_buf())
+            .protected();
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            source.clone(),
+            protected_target,
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let protected_folder = protected_root.path().join("incoming");
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(Some(protected_folder))
+        .expect("explicit protected target extraction request");
+
+    let routed = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect("single normal source should be an unambiguous writable destination");
+
+    assert_eq!(
+        routed.target_folder(),
+        Ok(source.primary_import_path().as_path())
+    );
+}
+
+#[test]
+fn normal_playmark_extraction_into_protected_target_with_multiple_normal_sources_requires_primary()
+{
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-into-protected-many-normal.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let normal_b_root = tempfile::tempdir().expect("normal source root b");
+    let protected_root = tempfile::tempdir().expect("protected target root");
+    let source = wavecrate::sample_sources::SampleSource::new(source_root.clone());
+    let normal_b = wavecrate::sample_sources::SampleSource::new(normal_b_root.path().to_path_buf());
+    let protected_target =
+        wavecrate::sample_sources::SampleSource::new(protected_root.path().to_path_buf())
+            .protected();
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            source,
+            normal_b,
+            protected_target,
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let protected_folder = protected_root.path().join("incoming");
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(Some(protected_folder))
+        .expect("explicit protected target extraction request");
+
+    let error = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect_err("multiple normal destinations require an explicit primary source");
+
+    assert_eq!(
+        error,
+        "Set a Primary source before extracting into a protected source"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Disallow waveform/playmark extraction outputs from landing in protected sources.
- Resolve the writable extraction destination as:
  1. configured Primary source, when present;
  2. the sole available Normal source, when exactly one exists;
  3. otherwise block and ask the user to assign a Primary source.
- Route protected-origin extractions through that writable destination's harvest folder.
- Route normal-origin extractions that explicitly target a protected source into the writable destination's import folder.
- Return clear user-facing errors when the destination is ambiguous or missing:
  - `Set a Primary source before extracting from a protected source`
  - `Set a Primary source before extracting into a protected source`
- Remove the optional protected-origin destination helper that previously collapsed `not protected` and `protected without Primary` into the same fallback path.

## Definition of Done

- Protected source originals are never used as extraction output destinations.
- Extraction from protected sources writes into Primary when available.
- If no Primary exists and exactly one Normal source is available, protected extraction uses that Normal source as the writable destination.
- If no Primary exists and multiple Normal sources are available, extraction blocks with an actionable status error.
- Extraction into protected target folders redirects into the writable destination when unambiguous, and blocks when ambiguous.
- Normal non-protected extraction behavior remains unchanged.

## Validation Commands

- `cargo test -p wavecrate protected_playmark_extraction`
- `cargo test -p wavecrate normal_playmark_extraction`
- `cargo fmt --check`
- `cargo check -p wavecrate`
- `git diff --check`
- `bash scripts/ci.sh agent` failed on an unrelated pre-existing non-blocking guardrail in `src/native_app/sample_identity_diagnostics.rs` lines 2, 316, and 357. Before that failure, devcheck passed, including `cargo check -p wavecrate --tests --bins`.

## Known Limitations

- This PR changes waveform/playmark extraction routing. It does not change the broader protected-source policy that allows adding ordinary copied files into protected sources in non-extraction workflows.
- Full `bash scripts/ci.sh agent` remains blocked by the unrelated guardrail noted above.

User review is required before merge.
