### PR TITLE
OPT-943: Remove unsupported Linux from manual download matching

### DIFF
--- a/manual/index.md
+++ b/manual/index.md
@@ -12,7 +12,7 @@ Wavecrate is a focused sample-library workstation for browsing large folders, au
 [![Wavecrate nightly release](https://github.com/PORTALSURFER/wavecrate/actions/workflows/release-build.yml/badge.svg)](https://github.com/PORTALSURFER/wavecrate/actions/workflows/release-build.yml)
 
 <div class="download-hero">
-  <div class="download-copy">Download the latest portable bundle.</div>
+  <div class="download-copy">Download the latest Windows or macOS portable bundle.</div>
   <a class="download-link" href="https://github.com/portalsurfer/wavecrate/releases/latest" id="release-link">
     View latest releases
   </a>
@@ -164,6 +164,7 @@ Wavecrate is a focused sample-library workstation for browsing large folders, au
           return;
         }
         var match = null;
+        // Current public downloads are Windows/macOS only; historical Linux assets are ignored here.
         var assetPattern =
           /^wavecrate-v\d+\.\d+\.\d+-(windows|macos)-(x86_64|aarch64)\.zip$/i;
         for (var i = 0; i < releases.length; i += 1) {

--- a/tests/manual_release_matching.rs
+++ b/tests/manual_release_matching.rs
@@ -1,0 +1,61 @@
+//! Public manual download-page release asset matching checks.
+
+use regex::{Regex, RegexBuilder};
+
+const MANUAL_INDEX: &str = include_str!("../manual/index.md");
+
+#[test]
+fn manual_release_asset_pattern_accepts_current_supported_platforms() {
+    let pattern = manual_release_asset_pattern();
+
+    for name in [
+        "wavecrate-v1.2.3-windows-x86_64.zip",
+        "wavecrate-v1.2.3-macos-x86_64.zip",
+        "wavecrate-v1.2.3-macos-aarch64.zip",
+    ] {
+        assert!(pattern.is_match(name), "{name} should match");
+    }
+}
+
+#[test]
+fn manual_release_asset_pattern_rejects_unsupported_linux_assets() {
+    let pattern = manual_release_asset_pattern();
+
+    for name in [
+        "wavecrate-v1.2.3-linux-x86_64.zip",
+        "wavecrate-v1.2.3-linux-aarch64.zip",
+    ] {
+        assert!(
+            !pattern.is_match(name),
+            "{name} must not be treated as a current public download"
+        );
+    }
+}
+
+#[test]
+fn manual_download_copy_names_only_current_download_platforms() {
+    let copy = "Download the latest Windows or macOS portable bundle.";
+
+    assert!(MANUAL_INDEX.contains(copy));
+    assert!(
+        !MANUAL_INDEX.contains("Linux portable bundle"),
+        "current download copy must not imply Linux support"
+    );
+}
+
+fn manual_release_asset_pattern() -> Regex {
+    let js_pattern = MANUAL_INDEX
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix('/')
+                .and_then(|rest| rest.strip_suffix("/i;"))
+        })
+        .expect("manual release asset regex literal");
+
+    RegexBuilder::new(js_pattern)
+        .case_insensitive(true)
+        .build()
+        .expect("manual release asset regex compiles as Rust regex")
+}


### PR DESCRIPTION
## Scope

- Fixes OPT-943 / LEG-010.
- Keeps the public manual current-download asset matcher constrained to Windows/macOS stable zip assets.
- Adds a nearby comment making the policy explicit: current public downloads are Windows/macOS only, and historical Linux assets are ignored by this current-download affordance.
- Updates the manual download hero copy to say `Windows or macOS` instead of the platform-neutral `portable bundle` wording.
- Adds `tests/manual_release_matching.rs`, which extracts the actual `assetPattern` regex from `manual/index.md` and verifies representative Windows/macOS assets match while Linux assets do not.

## Definition of Done

- The public manual/download page does not treat Linux assets as current downloadable platforms.
- Windows/macOS matching remains covered for representative stable asset names.
- Historical Linux handling is explicitly ignored by the current-download UI rather than surfaced as supported.
- Page copy agrees with the current supported public download platform matrix.

## Validation Commands

- `cargo test -p wavecrate --test manual_release_matching`
- `bash scripts/check.sh manual-docs-scope`
- `cargo fmt --check`
- `cargo check -p wavecrate`
- `git diff --check`
- `bash scripts/agent.sh request` failed on an unrelated pre-existing non-blocking guardrail in `src/native_app/sample_identity_diagnostics.rs` lines 2, 316, and 357. Earlier preflight checks in that lane passed, including manual docs scope before edits.

## Known Limitations

- The stale issue evidence said `manual/index.md` still matched Linux; current `main` already had a Windows/macOS-only regex. This PR locks that behavior with a focused regression and clarifies the visible page copy.
- This does not add or restore Linux public download support.
- Full `bash scripts/agent.sh request` remains blocked by the unrelated guardrail noted above.

User review is required before merge.
