### PR TITLE
OPT-962 Reject symlinked source database paths

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/error.rs
@@ -37,6 +37,30 @@ pub enum SourceDbError {
     /// Read-only mode requires an existing database file.
     #[error("Read-only source DB mode requires an existing database file: {0}")]
     ReadOnlyDatabaseMissing(PathBuf),
+    /// Source database path policy rejected an unsafe local database path.
+    #[error("Unsafe source database path {path}: {reason}")]
+    UnsafeSourceDatabasePath {
+        /// Path rejected by the source DB path policy.
+        path: PathBuf,
+        /// Stable reason suitable for user-facing status and diagnostics.
+        reason: &'static str,
+    },
+    /// Failed to inspect a source database path before trusting it.
+    #[error("Could not inspect source database path {path}: {source}")]
+    InspectSourceDatabasePath {
+        /// Path that could not be inspected.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
+    /// Failed to resolve a source database path before trusting it.
+    #[error("Could not resolve source database path {path}: {source}")]
+    ResolveSourceDatabasePath {
+        /// Path that could not be resolved.
+        path: PathBuf,
+        /// Underlying IO error.
+        source: std::io::Error,
+    },
     /// Failed to resolve the app-owned metadata folder for a protected source.
     #[error("Could not resolve external metadata storage for {path}: {source}")]
     ExternalMetadataRoot {

--- a/crates/wavecrate-library/src/sample_sources/db/open/paths.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open/paths.rs
@@ -1,33 +1,46 @@
 use std::{
     ffi::OsString,
-    fs,
+    fs, io,
     path::{Path, PathBuf},
 };
 
 use super::super::{DB_FILE_NAME, LEGACY_DB_FILE_NAME, SourceDbError};
 
-pub(super) fn read_only_db_path(database_root: &Path) -> PathBuf {
+const SYMLINK_REASON: &str = "source database files and sidecars must not be symlinks";
+const OUTSIDE_ROOT_REASON: &str = "source database path resolves outside the database root";
+const NOT_FILE_REASON: &str = "source database paths must be regular files";
+
+pub(super) fn read_only_db_path(database_root: &Path) -> Result<Option<PathBuf>, SourceDbError> {
+    let Some(policy) = SourceDbPathPolicy::for_read_only(database_root)? else {
+        return Ok(None);
+    };
     let db_path = database_root.join(DB_FILE_NAME);
-    if db_path.is_file() {
-        return db_path;
+    if policy.regular_file_status(&db_path)? == PathStatus::RegularFile {
+        policy.validate_sidecars(&db_path)?;
+        return Ok(Some(db_path));
     }
     let legacy_path = database_root.join(LEGACY_DB_FILE_NAME);
-    if legacy_path.is_file() {
-        legacy_path
-    } else {
-        db_path
+    if policy.regular_file_status(&legacy_path)? == PathStatus::RegularFile {
+        policy.validate_sidecars(&legacy_path)?;
+        return Ok(Some(legacy_path));
     }
+    Ok(None)
 }
 
 pub(super) fn prepare_writable_db_path(database_root: &Path) -> Result<PathBuf, SourceDbError> {
+    let policy = SourceDbPathPolicy::for_writable(database_root)?;
     let db_path = database_root.join(DB_FILE_NAME);
-    if db_path.exists() {
+    if policy.regular_file_status(&db_path)? == PathStatus::RegularFile {
+        policy.validate_sidecars(&db_path)?;
         return Ok(db_path);
     }
     let legacy_path = database_root.join(LEGACY_DB_FILE_NAME);
-    if legacy_path.exists() {
+    if policy.regular_file_status(&legacy_path)? == PathStatus::RegularFile {
+        policy.validate_legacy_migration_paths(&legacy_path, &db_path)?;
         migrate_legacy_source_db(&legacy_path, &db_path)?;
     }
+    policy.validate_creatable_path(&db_path)?;
+    policy.validate_sidecars(&db_path)?;
     Ok(db_path)
 }
 
@@ -39,7 +52,7 @@ fn migrate_legacy_source_db(from: &Path, to: &Path) -> Result<(), SourceDbError>
     })?;
     for suffix in ["-wal", "-shm"] {
         let legacy_sidecar = sqlite_sidecar_path(from, suffix);
-        if legacy_sidecar.exists() {
+        if path_exists_without_following(&legacy_sidecar)? {
             let current_sidecar = sqlite_sidecar_path(to, suffix);
             fs::rename(&legacy_sidecar, &current_sidecar).map_err(|source| {
                 SourceDbError::RenameLegacyDatabase {
@@ -57,4 +70,139 @@ fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
     let mut name = OsString::from(path.as_os_str());
     name.push(suffix);
     PathBuf::from(name)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PathStatus {
+    Missing,
+    RegularFile,
+}
+
+struct SourceDbPathPolicy {
+    canonical_root: PathBuf,
+}
+
+impl SourceDbPathPolicy {
+    fn for_read_only(database_root: &Path) -> Result<Option<Self>, SourceDbError> {
+        if !path_exists_without_following(database_root)? {
+            return Ok(None);
+        }
+        Ok(Some(Self::from_existing_root(database_root)?))
+    }
+
+    fn for_writable(database_root: &Path) -> Result<Self, SourceDbError> {
+        fs::create_dir_all(database_root).map_err(|source| SourceDbError::CreateDir {
+            path: database_root.to_path_buf(),
+            source,
+        })?;
+        Self::from_existing_root(database_root)
+    }
+
+    fn from_existing_root(database_root: &Path) -> Result<Self, SourceDbError> {
+        let canonical_root = fs::canonicalize(database_root).map_err(|source| {
+            SourceDbError::ResolveSourceDatabasePath {
+                path: database_root.to_path_buf(),
+                source,
+            }
+        })?;
+        Ok(Self { canonical_root })
+    }
+
+    fn regular_file_status(&self, path: &Path) -> Result<PathStatus, SourceDbError> {
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => {
+                return Ok(PathStatus::Missing);
+            }
+            Err(source) => {
+                return Err(SourceDbError::InspectSourceDatabasePath {
+                    path: path.to_path_buf(),
+                    source,
+                });
+            }
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return Err(SourceDbError::UnsafeSourceDatabasePath {
+                path: path.to_path_buf(),
+                reason: SYMLINK_REASON,
+            });
+        }
+        if !file_type.is_file() {
+            return Err(SourceDbError::UnsafeSourceDatabasePath {
+                path: path.to_path_buf(),
+                reason: NOT_FILE_REASON,
+            });
+        }
+        self.validate_existing_path_contained(path)?;
+        Ok(PathStatus::RegularFile)
+    }
+
+    fn validate_legacy_migration_paths(
+        &self,
+        legacy_path: &Path,
+        current_path: &Path,
+    ) -> Result<(), SourceDbError> {
+        self.validate_existing_path_contained(legacy_path)?;
+        self.validate_creatable_path(current_path)?;
+        self.validate_sidecars(legacy_path)?;
+        self.validate_sidecars(current_path)?;
+        Ok(())
+    }
+
+    fn validate_sidecars(&self, db_path: &Path) -> Result<(), SourceDbError> {
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = sqlite_sidecar_path(db_path, suffix);
+            self.regular_file_status(&sidecar)?;
+        }
+        Ok(())
+    }
+
+    fn validate_creatable_path(&self, path: &Path) -> Result<(), SourceDbError> {
+        if self.regular_file_status(path)? == PathStatus::RegularFile {
+            return Ok(());
+        }
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let canonical_parent = fs::canonicalize(parent).map_err(|source| {
+            SourceDbError::ResolveSourceDatabasePath {
+                path: parent.to_path_buf(),
+                source,
+            }
+        })?;
+        self.ensure_contained(path, &canonical_parent)
+    }
+
+    fn validate_existing_path_contained(&self, path: &Path) -> Result<(), SourceDbError> {
+        let canonical_path =
+            fs::canonicalize(path).map_err(|source| SourceDbError::ResolveSourceDatabasePath {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        self.ensure_contained(path, &canonical_path)
+    }
+
+    fn ensure_contained(
+        &self,
+        original_path: &Path,
+        canonical_path: &Path,
+    ) -> Result<(), SourceDbError> {
+        if canonical_path.starts_with(&self.canonical_root) {
+            return Ok(());
+        }
+        Err(SourceDbError::UnsafeSourceDatabasePath {
+            path: original_path.to_path_buf(),
+            reason: OUTSIDE_ROOT_REASON,
+        })
+    }
+}
+
+fn path_exists_without_following(path: &Path) -> Result<bool, SourceDbError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(SourceDbError::InspectSourceDatabasePath {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/open/read_only.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open/read_only.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 
 use super::paths;
 use crate::sample_sources::db::{
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, telemetry,
+    DB_FILE_NAME, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, telemetry,
 };
 
 pub(super) fn open_read_only_source_database(
@@ -17,10 +17,8 @@ pub(super) fn open_read_only_source_database(
         return Err(SourceDbError::InvalidRoot(root.to_path_buf()));
     }
 
-    let db_path = paths::read_only_db_path(database_root);
-    if !db_path.is_file() {
-        return Err(SourceDbError::ReadOnlyDatabaseMissing(db_path));
-    }
+    let db_path = paths::read_only_db_path(database_root)?
+        .ok_or_else(|| SourceDbError::ReadOnlyDatabaseMissing(database_root.join(DB_FILE_NAME)))?;
 
     let connect_started = std::time::Instant::now();
     let connection = match Connection::open_with_flags(&db_path, role.open_flags()) {

--- a/crates/wavecrate-library/src/sqlite_wal.rs
+++ b/crates/wavecrate-library/src/sqlite_wal.rs
@@ -134,6 +134,9 @@ fn claim_checkpoint_window(db_path: &Path, now: Instant) -> bool {
 }
 
 fn open_checkpoint_connection(db_path: &Path) -> rusqlite::Result<Connection> {
+    if path_is_symlink(db_path).unwrap_or(false) {
+        return Err(rusqlite::Error::InvalidPath(db_path.to_path_buf()));
+    }
     let connection = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
     connection.busy_timeout(CHECKPOINT_BUSY_TIMEOUT)?;
     Ok(connection)
@@ -150,8 +153,17 @@ fn run_passive_checkpoint(connection: Connection) -> rusqlite::Result<PassiveChe
 }
 
 fn wal_file_size(wal_path: &Path) -> Option<u64> {
-    match std::fs::metadata(wal_path) {
-        Ok(metadata) => Some(metadata.len()),
+    match std::fs::symlink_metadata(wal_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            tracing::warn!(
+                target: "perf::source_db",
+                wal_path = %wal_path.display(),
+                "Skipping WAL checkpoint because the WAL sidecar is a symlink"
+            );
+            None
+        }
+        Ok(metadata) if metadata.file_type().is_file() => Some(metadata.len()),
+        Ok(_) => None,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
         Err(err) => {
             tracing::debug!(
@@ -169,4 +181,27 @@ fn wal_path_for(db_path: &Path) -> PathBuf {
     let mut wal_name = OsString::from(db_path.as_os_str());
     wal_name.push("-wal");
     PathBuf::from(wal_name)
+}
+
+fn path_is_symlink(path: &Path) -> std::io::Result<bool> {
+    std::fs::symlink_metadata(path).map(|metadata| metadata.file_type().is_symlink())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn wal_file_size_ignores_symlinked_wal_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_wal = outside.path().join("outside-wal");
+        std::fs::write(&outside_wal, b"outside").unwrap();
+        let db_path = dir.path().join(".wavecrate.db");
+        let wal_path = wal_path_for(&db_path);
+        std::os::unix::fs::symlink(&outside_wal, &wal_path).unwrap();
+
+        assert_eq!(wal_file_size(&wal_path), None);
+    }
 }

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -15,6 +15,15 @@ the old data can be interpreted safely.
   `library.db`. It owns configured source references and global analysis/cache
   state that is not source-local.
 
+## Source Database Path Policy
+
+Source-local database writes must stay inside the configured source/database
+root. Writable opens, read-only opens, legacy filename migration, and SQLite
+WAL/SHM sidecar handling must reject symlinked `.wavecrate.db`,
+`.wavecrate_samples.db`, and related sidecar paths before handing the path to
+SQLite or filesystem rename operations. Existing regular DB files and newly
+created DB parents must resolve under the canonical database root.
+
 ## Required Change Pattern
 
 Every schema change must update these pieces together:

--- a/tests/unit/source_db_mod_tests/opening/filenames.rs
+++ b/tests/unit/source_db_mod_tests/opening/filenames.rs
@@ -65,3 +65,141 @@ fn read_only_open_keeps_legacy_source_database_filename() {
     assert!(dir.path().join(LEGACY_DB_FILE_NAME).is_file());
     assert!(!dir.path().join(DB_FILE_NAME).exists());
 }
+
+#[cfg(unix)]
+#[test]
+fn writable_open_rejects_symlinked_current_source_database_before_sqlite_open() {
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let outside_db = outside.path().join("outside.db");
+    Connection::open(&outside_db).unwrap();
+    let db_path = dir.path().join(DB_FILE_NAME);
+    std::os::unix::fs::symlink(&outside_db, &db_path).unwrap();
+
+    expect_unsafe_source_db_path(SourceDatabase::open(dir.path()), &db_path);
+
+    assert!(
+        !sqlite_table_exists(&outside_db, "metadata"),
+        "outside database must not receive Wavecrate schema"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn read_only_open_rejects_symlinked_current_source_database_explicitly() {
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let outside_db = outside.path().join("outside.db");
+    Connection::open(&outside_db).unwrap();
+    let db_path = dir.path().join(DB_FILE_NAME);
+    std::os::unix::fs::symlink(&outside_db, &db_path).unwrap();
+
+    expect_unsafe_source_db_path(SourceDatabase::open_read_only(dir.path()), &db_path);
+}
+
+#[cfg(unix)]
+#[test]
+fn writable_open_rejects_symlinked_legacy_source_database_before_migration() {
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let outside_db = outside.path().join("outside.db");
+    Connection::open(&outside_db).unwrap();
+    let legacy_db = dir.path().join(LEGACY_DB_FILE_NAME);
+    std::os::unix::fs::symlink(&outside_db, &legacy_db).unwrap();
+
+    expect_unsafe_source_db_path(SourceDatabase::open(dir.path()), &legacy_db);
+
+    assert!(!dir.path().join(DB_FILE_NAME).exists());
+    assert!(
+        !sqlite_table_exists(&outside_db, "metadata"),
+        "outside database must not receive Wavecrate schema"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn writable_open_rejects_symlinked_current_wal_and_shm_sidecars_before_sqlite_open() {
+    for suffix in ["-wal", "-shm"] {
+        let dir = tempdir().unwrap();
+        SourceDatabase::open(dir.path()).unwrap();
+        let sidecar = sqlite_sidecar_path(&dir.path().join(DB_FILE_NAME), suffix);
+        let outside = tempdir().unwrap();
+        let outside_sidecar = outside.path().join("outside-sidecar");
+        std::fs::write(&outside_sidecar, b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside_sidecar, &sidecar).unwrap();
+
+        expect_unsafe_source_db_path(SourceDatabase::open(dir.path()), &sidecar);
+
+        assert_eq!(std::fs::read(&outside_sidecar).unwrap(), b"outside");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn writable_open_rejects_symlinked_legacy_wal_and_shm_sidecars_before_rename() {
+    for suffix in ["-wal", "-shm"] {
+        let dir = tempdir().unwrap();
+        let legacy_db = dir.path().join(LEGACY_DB_FILE_NAME);
+        {
+            let conn = Connection::open(&legacy_db).unwrap();
+            conn.execute(
+                "CREATE TABLE wav_files (
+                    path TEXT PRIMARY KEY,
+                    file_size INTEGER NOT NULL,
+                    modified_ns INTEGER NOT NULL
+                )",
+                [],
+            )
+            .unwrap();
+        }
+        let sidecar = sqlite_sidecar_path(&legacy_db, suffix);
+        let outside = tempdir().unwrap();
+        let outside_sidecar = outside.path().join("outside-sidecar");
+        std::fs::write(&outside_sidecar, b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside_sidecar, &sidecar).unwrap();
+
+        expect_unsafe_source_db_path(SourceDatabase::open(dir.path()), &sidecar);
+
+        assert!(
+            legacy_db.exists(),
+            "legacy DB should not be renamed after sidecar rejection"
+        );
+        assert!(!dir.path().join(DB_FILE_NAME).exists());
+        assert_eq!(std::fs::read(&outside_sidecar).unwrap(), b"outside");
+    }
+}
+
+#[cfg(unix)]
+fn expect_unsafe_source_db_path(result: Result<SourceDatabase, SourceDbError>, expected: &Path) {
+    match result {
+        Err(SourceDbError::UnsafeSourceDatabasePath { path, reason }) => {
+            assert_eq!(path, expected);
+            assert!(
+                reason.contains("symlink"),
+                "unexpected unsafe-path reason: {reason}"
+            );
+        }
+        Err(err) => panic!("expected unsafe source DB path error for {expected:?}, got {err}"),
+        Ok(_) => panic!("expected unsafe source DB path error for {expected:?}"),
+    }
+}
+
+#[cfg(unix)]
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = std::ffi::OsString::from(path.as_os_str());
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+#[cfg(unix)]
+fn sqlite_table_exists(db_path: &Path, table: &str) -> bool {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |_| Ok(()),
+    )
+    .optional()
+    .unwrap()
+    .is_some()
+}


### PR DESCRIPTION
## Scope

- Fixes OPT-962 / security scan candidate `WC-COV-001-source-db-symlink`.
- Adds a shared source DB path policy for writable opens, read-only opens, legacy filename migration, and SQLite WAL/SHM sidecar handling.
- Rejects symlinked `.wavecrate.db`, `.wavecrate_samples.db`, and current/legacy `-wal` / `-shm` sidecars before SQLite open or filesystem rename.
- Canonicalizes the database root and selected DB target or parent and requires the resolved path to stay under the canonical database root.
- Hardens passive WAL checkpoint maintenance so symlinked DB/WAL paths are not followed through that side path.
- Documents the source DB path policy in `docs/DATABASE_MIGRATIONS.md`.

## Definition of Done

- Writable source DB open fails before SQLite connection when `.wavecrate.db` is a symlink to an external target.
- Legacy DB migration fails safely when the legacy DB or sidecars are symlinks, without mutating outside files.
- Current DB WAL/SHM sidecar symlinks are rejected before SQLite opens the DB.
- Regular in-root DB creation/open and valid legacy migration continue to work.
- Read-only normal DB opens remain compatible, while unsafe symlinked DBs are surfaced as typed `UnsafeSourceDatabasePath` errors.
- Regression tests cover current DB symlink, legacy DB symlink, current sidecar symlinks, legacy sidecar symlinks, valid creation, valid legacy migration, and no-schema mutation of outside DB targets.

## Validation Commands

- `cargo fmt --check` - passed
- `cargo test -p wavecrate-library source_db_mod_tests::opening::filenames` - passed
- `cargo test -p wavecrate-library source_db_mod_tests::opening` - passed
- `cargo test -p wavecrate-library source_db_migration_tests` - passed
- `cargo test -p wavecrate-library sample_sources::db::read` - passed
- `cargo test -p wavecrate-library sample_sources::library` - passed
- `cargo test -p wavecrate-library sqlite_wal::tests` - passed
- `cargo check -p wavecrate-library` - passed
- `cargo test -p wavecrate-library` - passed, 142 tests
- `git diff --check` - passed
- `bash scripts/agent.sh request` - failed on pre-existing unrelated non-blocking guardrail in `src/native_app/sample_identity_diagnostics.rs` lines 2, 316, and 357
- `bash scripts/ci.sh agent` - failed on the same pre-existing unrelated non-blocking guardrail in `src/native_app/sample_identity_diagnostics.rs` lines 2, 316, and 357

## Known Limitations

- The broad agent lane is still blocked by the existing unrelated `sample_identity_diagnostics.rs` non-blocking architecture violation present before this branch. Focused storage/security validation is green.
- The symlink regression tests are Unix-specific because they use Unix symlink APIs. The production checks use Rust `symlink_metadata` and canonicalization paths that also apply to supported platforms.

## Security Boundary

Source-local metadata writes must not follow source-local DB or sidecar symlinks outside the configured database root. The new boundary rejects unsafe path shapes before SQLite can apply pragmas, schema, migrations, or WAL checkpointing.

## Review

User review is required before merge.