### PR TITLE
OPT-961: contain delete recovery journal paths

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2599,6 +2599,9 @@ Contract:
 * startup recovery restores incomplete deletes conservatively
 * fully committed deletes remain recoverable until explicit restore or purge
 * explicit restore merges carefully and keeps both copies when content differs
+* recovery journal paths are untrusted and must be validated as relative,
+  symlink-free, and contained under the source or delete-staging root before
+  restore, restage, rollback, retained restore, or purge filesystem effects
 
 ### Updater Policy
 

--- a/src/app/controller/library/source_folders/delete_recovery/journal/staging.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/journal/staging.rs
@@ -2,6 +2,7 @@ use super::load_journal;
 use super::remove_entry;
 use super::store::{insert_entry, update_entry, update_journal_stage};
 use super::{DeleteJournal, DeleteJournalEntry, DeleteJournalStage, DeleteStagingInfo};
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use crate::sample_sources::WavEntry;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -14,8 +15,19 @@ pub(crate) fn stage_folder_for_delete(
     relative: &Path,
     deleted_entries: &[WavEntry],
 ) -> Result<DeleteStagingInfo, String> {
+    let source_root = path_policy::source_root_for_staging_root(staging_root)?;
+    let relative = path_policy::validate_relative_path(relative, "original_relative")?;
+    let expected_absolute =
+        path_policy::contained_child(&source_root, &relative, "original_relative")?;
+    if absolute != expected_absolute {
+        return Err(format!(
+            "Folder delete path does not match source-relative path: {}",
+            relative.display()
+        ));
+    }
+    path_policy::ensure_existing_dir_under(&source_root, absolute, "Folder delete source")?;
     let journal = load_journal(staging_root)?;
-    let staged_relative = unique_staging_relative(staging_root, &journal, relative);
+    let staged_relative = unique_staging_relative(staging_root, &journal, &relative);
     let staged_absolute = staging_root.join(&staged_relative);
     ensure_staging_parent(&staged_absolute, staging_root)?;
     let id = new_delete_op_id();
@@ -75,7 +87,13 @@ pub(crate) fn purge_deleted_folder(
     info: &DeleteStagingInfo,
     staging_root: &Path,
 ) -> Result<(), String> {
-    if info.staged_absolute.exists() {
+    validate_staging_info(info, staging_root)?;
+    if path_policy::path_exists_no_follow(&info.staged_absolute)? {
+        path_policy::ensure_existing_dir_under(
+            staging_root,
+            &info.staged_absolute,
+            "Retained delete staged folder",
+        )?;
         fs::remove_dir_all(&info.staged_absolute).map_err(|err| {
             format!(
                 "Failed to purge deleted folder {}: {err}",
@@ -94,6 +112,14 @@ pub(crate) fn restore_deleted_folder(
     absolute: &Path,
     staging_root: &Path,
 ) -> Result<(), String> {
+    let source_root = path_policy::source_root_for_staging_root(staging_root)?;
+    validate_staging_info(info, staging_root)?;
+    path_policy::ensure_existing_dir_under(
+        staging_root,
+        &info.staged_absolute,
+        "Retained delete staged folder",
+    )?;
+    path_policy::ensure_creatable_path_under(&source_root, absolute, "Restore destination")?;
     if let Some(parent) = absolute.parent() {
         fs::create_dir_all(parent).map_err(|err| {
             format!(
@@ -120,6 +146,9 @@ pub(crate) fn restage_deleted_folder(
     info: &DeleteStagingInfo,
     deleted_entries: &[WavEntry],
 ) -> Result<(), String> {
+    let source_root = path_policy::source_root_for_staging_root(staging_root)?;
+    validate_staging_info(info, staging_root)?;
+    path_policy::ensure_existing_dir_under(&source_root, absolute, "Restored folder")?;
     let entry = DeleteJournalEntry {
         id: info.id.clone(),
         original_relative: info.original_relative.to_string_lossy().to_string(),
@@ -156,6 +185,14 @@ pub(crate) fn rollback_staged_folder(
     staging_root: &Path,
     err: &str,
 ) -> Result<(), String> {
+    let source_root = path_policy::source_root_for_staging_root(staging_root)?;
+    validate_staging_info(info, staging_root)?;
+    path_policy::ensure_existing_dir_under(
+        staging_root,
+        &info.staged_absolute,
+        "Rollback staged folder",
+    )?;
+    path_policy::ensure_creatable_path_under(&source_root, absolute, "Rollback destination")?;
     let rollback_context = format!(
         " (original: {}, staged: {})",
         info.original_relative.display(),
@@ -218,6 +255,20 @@ fn staging_relative_is_available(
 }
 
 fn ensure_staging_parent(staged: &Path, staging_root: &Path) -> Result<(), String> {
+    let source_root = path_policy::source_root_for_staging_root(staging_root)?;
+    if path_policy::path_exists_no_follow(staging_root)? {
+        path_policy::ensure_staging_root(&source_root, staging_root)?;
+    } else {
+        path_policy::ensure_creatable_path_under(
+            &source_root,
+            staging_root,
+            "Delete staging root",
+        )?;
+        fs::create_dir_all(staging_root)
+            .map_err(|err| format!("Failed to prepare folder delete staging: {err}"))?;
+        mark_staging_root_hidden(staging_root);
+    }
+    path_policy::ensure_creatable_path_under(staging_root, staged, "Delete staging path")?;
     if let Some(parent) = staged.parent() {
         fs::create_dir_all(parent)
             .map_err(|err| format!("Failed to prepare folder delete staging: {err}"))?;
@@ -262,4 +313,31 @@ fn now_epoch_seconds() -> Result<i64, String> {
         .duration_since(UNIX_EPOCH)
         .map_err(|err| format!("System time error: {err}"))?;
     Ok(now.as_secs() as i64)
+}
+
+fn validate_staging_info(info: &DeleteStagingInfo, staging_root: &Path) -> Result<(), String> {
+    let original_relative =
+        path_policy::validate_relative_path(&info.original_relative, "original_relative")?;
+    let staged_relative =
+        path_policy::validate_relative_path(&info.staged_relative, "staged_relative")?;
+    if original_relative != info.original_relative {
+        return Err(format!(
+            "Invalid retained delete original path: {}",
+            info.original_relative.display()
+        ));
+    }
+    if staged_relative != info.staged_relative {
+        return Err(format!(
+            "Invalid retained delete staged path: {}",
+            info.staged_relative.display()
+        ));
+    }
+    let expected_staged = staging_root.join(&staged_relative);
+    if expected_staged != info.staged_absolute {
+        return Err(format!(
+            "Retained delete staged path does not match staging root: {}",
+            info.staged_absolute.display()
+        ));
+    }
+    Ok(())
 }

--- a/src/app/controller/library/source_folders/delete_recovery/mod.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/mod.rs
@@ -9,6 +9,7 @@
 
 mod controller_apply;
 mod journal;
+mod path_policy;
 mod recovery;
 mod restore_merge;
 mod retained_resolution;

--- a/src/app/controller/library/source_folders/delete_recovery/path_policy.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/path_policy.rs
@@ -1,0 +1,154 @@
+//! Path validation for source-local delete recovery state.
+
+use crate::sample_sources::normalize_relative_path;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+pub(super) fn validate_relative_path(path: &Path, field: &str) -> Result<PathBuf, String> {
+    normalize_relative_path(path)
+        .map(PathBuf::from)
+        .map_err(|err| format!("Invalid delete recovery {field} {}: {err}", path.display()))
+}
+
+pub(super) fn validate_journal_relative(raw: &str, field: &str) -> Result<PathBuf, String> {
+    validate_relative_path(Path::new(raw), field)
+}
+
+pub(super) fn source_root_for_staging_root(staging_root: &Path) -> Result<PathBuf, String> {
+    staging_root.parent().map(Path::to_path_buf).ok_or_else(|| {
+        format!(
+            "Delete staging root has no source parent: {}",
+            staging_root.display()
+        )
+    })
+}
+
+pub(super) fn contained_child(
+    root: &Path,
+    relative: &Path,
+    field: &str,
+) -> Result<PathBuf, String> {
+    Ok(root.join(validate_relative_path(relative, field)?))
+}
+
+pub(super) fn path_exists_no_follow(path: &Path) -> Result<bool, String> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(format!(
+            "Failed to inspect delete recovery path {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+pub(super) fn ensure_existing_dir_under(
+    root: &Path,
+    path: &Path,
+    context: &str,
+) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|err| format!("Failed to inspect {context} {}: {err}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "{context} must not be a symlink: {}",
+            path.display()
+        ));
+    }
+    if !metadata.file_type().is_dir() {
+        return Err(format!("{context} is not a directory: {}", path.display()));
+    }
+    ensure_existing_path_under(root, path, context)
+}
+
+pub(super) fn ensure_existing_path_under(
+    root: &Path,
+    path: &Path,
+    context: &str,
+) -> Result<(), String> {
+    let canonical_root = canonicalize_root(root, context)?;
+    let canonical_path = fs::canonicalize(path)
+        .map_err(|err| format!("Failed to resolve {context} {}: {err}", path.display()))?;
+    ensure_canonical_under(&canonical_root, &canonical_path, context, path)
+}
+
+pub(super) fn ensure_creatable_path_under(
+    root: &Path,
+    path: &Path,
+    context: &str,
+) -> Result<(), String> {
+    let canonical_root = canonicalize_root(root, context)?;
+    if path_exists_no_follow(path)? {
+        reject_symlink(path, context)?;
+        let canonical_path = fs::canonicalize(path)
+            .map_err(|err| format!("Failed to resolve {context} {}: {err}", path.display()))?;
+        return ensure_canonical_under(&canonical_root, &canonical_path, context, path);
+    }
+    let ancestor = nearest_existing_ancestor(path)?;
+    reject_symlink(&ancestor, context)?;
+    let canonical_ancestor = fs::canonicalize(&ancestor)
+        .map_err(|err| format!("Failed to resolve {context} {}: {err}", ancestor.display()))?;
+    ensure_canonical_under(&canonical_root, &canonical_ancestor, context, path)
+}
+
+pub(super) fn ensure_staging_root(source_root: &Path, staging_root: &Path) -> Result<(), String> {
+    ensure_existing_dir_under(source_root, staging_root, "Delete staging root")
+}
+
+pub(super) fn reject_symlink(path: &Path, context: &str) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|err| format!("Failed to inspect {context} {}: {err}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "{context} must not be a symlink: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn canonicalize_root(root: &Path, context: &str) -> Result<PathBuf, String> {
+    reject_symlink(root, context)?;
+    fs::canonicalize(root)
+        .map_err(|err| format!("Failed to resolve {context} root {}: {err}", root.display()))
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, String> {
+    let mut current = path.parent().unwrap_or_else(|| Path::new("."));
+    loop {
+        match fs::symlink_metadata(current) {
+            Ok(_) => return Ok(current.to_path_buf()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                current = current.parent().ok_or_else(|| {
+                    format!(
+                        "No existing parent found for delete recovery path {}",
+                        path.display()
+                    )
+                })?;
+            }
+            Err(err) => {
+                return Err(format!(
+                    "Failed to inspect delete recovery parent {}: {err}",
+                    current.display()
+                ));
+            }
+        }
+    }
+}
+
+fn ensure_canonical_under(
+    canonical_root: &Path,
+    canonical_path: &Path,
+    context: &str,
+    original: &Path,
+) -> Result<(), String> {
+    if canonical_path.starts_with(canonical_root) {
+        return Ok(());
+    }
+    Err(format!(
+        "{context} escapes delete recovery root: {}",
+        original.display()
+    ))
+}

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/actions.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/actions.rs
@@ -1,4 +1,5 @@
 use super::{DeleteRecoveryAction, DeleteRecoveryEntry, DeleteRecoveryStatus, SampleSource};
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -29,11 +30,15 @@ pub(super) fn recovery_entry(
 pub(super) fn restore_staged_folder(
     staged: &Path,
     original: &Path,
+    staging_root: &Path,
+    source_root: &Path,
 ) -> Result<Option<String>, String> {
-    if !staged.exists() {
+    if !path_policy::path_exists_no_follow(staged)? {
         return Err("Staged folder missing".into());
     }
+    path_policy::ensure_existing_dir_under(staging_root, staged, "Staged delete folder")?;
     let (target, detail) = unique_restore_path(original);
+    path_policy::ensure_creatable_path_under(source_root, &target, "Delete restore destination")?;
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent).map_err(|err| format!("Failed to restore folder: {err}"))?;
     }

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/journaled.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/journaled.rs
@@ -2,6 +2,7 @@ use super::{
     DeleteJournalEntry, DeleteJournalStage, DeleteRecoveryAction, DeleteRecoveryEntry,
     RetainedDeleteEntry, SampleSource, recovery_entry, restore_staged_folder, retained,
 };
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use std::path::{Path, PathBuf};
 
 pub(super) struct JournaledRecovery {
@@ -24,14 +25,31 @@ pub(super) fn recover_journaled_entry(
     staging_root: &Path,
     entry: &DeleteJournalEntry,
 ) -> Option<JournaledRecoveryOutcome> {
-    let original_relative = PathBuf::from(entry.original_relative.clone());
-    let staged = staging_root.join(&entry.staged_relative);
+    let original_relative =
+        match path_policy::validate_journal_relative(&entry.original_relative, "original_relative")
+        {
+            Ok(path) => path,
+            Err(err) => {
+                return Some(invalid_journal_entry(
+                    source,
+                    PathBuf::from(&entry.original_relative),
+                    err,
+                ));
+            }
+        };
+    let staged_relative =
+        match path_policy::validate_journal_relative(&entry.staged_relative, "staged_relative") {
+            Ok(path) => path,
+            Err(err) => return Some(invalid_journal_entry(source, original_relative, err)),
+        };
+    let staged = staging_root.join(&staged_relative);
     let original = source.root.join(&original_relative);
     let (action, outcome) = match entry.stage {
         DeleteJournalStage::Deleted => {
             return retained::recover_retained_delete(
                 source,
                 &original_relative,
+                &staged_relative,
                 &staged,
                 &original,
                 entry,
@@ -42,16 +60,24 @@ pub(super) fn recover_journaled_entry(
                 source,
                 staging_root,
                 &original_relative,
+                &staged_relative,
                 &staged,
                 &original,
                 entry,
             ));
         }
         DeleteJournalStage::Intent | DeleteJournalStage::Staged => {
-            let outcome = if !staged.exists() && original.exists() {
-                Ok(Some("Already restored".into()))
+            let outcome = if !path_policy::path_exists_no_follow(&staged).unwrap_or(false)
+                && path_policy::path_exists_no_follow(&original).unwrap_or(false)
+            {
+                path_policy::ensure_existing_path_under(
+                    &source.root,
+                    &original,
+                    "Restored delete folder",
+                )
+                .map(|_| Some("Already restored".into()))
             } else {
-                restore_staged_folder(&staged, &original)
+                restore_staged_folder(&staged, &original, staging_root, &source.root)
             };
             (DeleteRecoveryAction::Restore, outcome)
         }
@@ -62,4 +88,21 @@ pub(super) fn recover_journaled_entry(
         remove_from_journal,
         needs_hard_sync: false,
     }))
+}
+
+fn invalid_journal_entry(
+    source: &SampleSource,
+    original_relative: PathBuf,
+    err: String,
+) -> JournaledRecoveryOutcome {
+    JournaledRecoveryOutcome::Completed(JournaledRecovery {
+        report_entry: recovery_entry(
+            source,
+            original_relative,
+            DeleteRecoveryAction::Restore,
+            Err(format!("Invalid delete journal entry: {err}")),
+        ),
+        remove_from_journal: false,
+        needs_hard_sync: false,
+    })
 }

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/orchestration.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/orchestration.rs
@@ -3,6 +3,7 @@ use super::{
     SampleSource, SourceId, journaled::recover_journaled_entry, load_journal, remove_entry,
     unjournaled,
 };
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use std::path::Path;
 
 pub(super) fn recover_staged_deletes(sources: &[SampleSource]) -> DeleteRecoveryReport {
@@ -18,7 +19,14 @@ fn recover_source(source: &SampleSource, report: &mut DeleteRecoveryReport) {
         return;
     }
     let staging_root = source.root.join(DELETE_STAGING_DIR);
-    if !staging_root.is_dir() {
+    if !path_policy::path_exists_no_follow(&staging_root).unwrap_or(false) {
+        return;
+    }
+    if let Err(err) = path_policy::ensure_staging_root(&source.root, &staging_root) {
+        report.errors.push(format!(
+            "Invalid delete staging root for {}: {err}",
+            source.root.display()
+        ));
         return;
     }
     let journal = match load_journal(&staging_root) {

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/retained.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/retained.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 
 fn completed_recovery(
     source: &SampleSource,
@@ -18,30 +19,73 @@ fn completed_recovery(
 pub(super) fn recover_retained_delete(
     source: &SampleSource,
     original_relative: &Path,
+    staged_relative: &Path,
     staged: &Path,
     original: &Path,
     entry: &DeleteJournalEntry,
 ) -> Option<JournaledRecoveryOutcome> {
-    if staged.exists() {
-        return Some(JournaledRecoveryOutcome::Retained(RetainedRecovery {
-            retained_entry: RetainedDeleteEntry {
-                id: entry.id.clone(),
-                source_id: source.id.clone(),
-                source_root: source.root.clone(),
-                original_relative: original_relative.to_path_buf(),
-                staged_relative: PathBuf::from(entry.staged_relative.clone()),
-                deleted_entries: entry.deleted_entries.clone(),
-            },
-        }));
+    match path_policy::path_exists_no_follow(staged) {
+        Ok(true) => {
+            if let Err(err) = path_policy::ensure_existing_dir_under(
+                &source.root.join(DELETE_STAGING_DIR),
+                staged,
+                "Retained staged folder",
+            ) {
+                return Some(completed_recovery(
+                    source,
+                    original_relative.to_path_buf(),
+                    DeleteRecoveryAction::Restore,
+                    Err(err),
+                    false,
+                ));
+            }
+            return Some(JournaledRecoveryOutcome::Retained(RetainedRecovery {
+                retained_entry: RetainedDeleteEntry {
+                    id: entry.id.clone(),
+                    source_id: source.id.clone(),
+                    source_root: source.root.clone(),
+                    original_relative: original_relative.to_path_buf(),
+                    staged_relative: staged_relative.to_path_buf(),
+                    deleted_entries: entry.deleted_entries.clone(),
+                },
+            }));
+        }
+        Ok(false) => {}
+        Err(err) => {
+            return Some(completed_recovery(
+                source,
+                original_relative.to_path_buf(),
+                DeleteRecoveryAction::Restore,
+                Err(err),
+                false,
+            ));
+        }
     }
-    if original.exists() {
-        return Some(completed_recovery(
-            source,
-            original_relative.to_path_buf(),
-            DeleteRecoveryAction::Restore,
-            Ok(Some("Already restored".into())),
-            false,
-        ));
+    match path_policy::path_exists_no_follow(original) {
+        Ok(true) => {
+            return Some(completed_recovery(
+                source,
+                original_relative.to_path_buf(),
+                DeleteRecoveryAction::Restore,
+                path_policy::ensure_existing_path_under(
+                    &source.root,
+                    original,
+                    "Restored retained folder",
+                )
+                .map(|_| Some("Already restored".into())),
+                false,
+            ));
+        }
+        Ok(false) => {}
+        Err(err) => {
+            return Some(completed_recovery(
+                source,
+                original_relative.to_path_buf(),
+                DeleteRecoveryAction::Restore,
+                Err(err),
+                false,
+            ));
+        }
     }
     Some(completed_recovery(
         source,
@@ -56,6 +100,7 @@ pub(super) fn recover_pending_retained_restore(
     source: &SampleSource,
     staging_root: &Path,
     original_relative: &Path,
+    staged_relative: &Path,
     staged: &Path,
     original: &Path,
     entry: &DeleteJournalEntry,
@@ -66,11 +111,21 @@ pub(super) fn recover_pending_retained_restore(
             .as_deref()
             .ok_or_else(|| "Retained restore stamp missing".to_string())?;
         let existing_entries = snapshot_existing_restore_entries(source, &entry.deleted_entries)?;
-        if staged.exists() {
+        if path_policy::path_exists_no_follow(staged)? {
+            path_policy::ensure_existing_dir_under(
+                staging_root,
+                staged,
+                "Pending retained staged folder",
+            )?;
+            path_policy::ensure_creatable_path_under(
+                &source.root,
+                original,
+                "Pending retained restore destination",
+            )?;
             let staged_info = DeleteStagingInfo {
                 id: entry.id.clone(),
                 original_relative: original_relative.to_path_buf(),
-                staged_relative: PathBuf::from(entry.staged_relative.clone()),
+                staged_relative: staged_relative.to_path_buf(),
                 staged_absolute: staged.to_path_buf(),
             };
             restore_retained_folder_with_merge_with_stamp(

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/scan.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/scan.rs
@@ -1,10 +1,13 @@
 use super::*;
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 
 pub(super) fn journaled_staged_roots(journal: &DeleteJournal) -> Vec<PathBuf> {
     journal
         .entries
         .iter()
-        .map(|entry| PathBuf::from(&entry.staged_relative))
+        .filter_map(|entry| {
+            path_policy::validate_journal_relative(&entry.staged_relative, "staged_relative").ok()
+        })
         .collect()
 }
 
@@ -25,7 +28,10 @@ pub(super) fn find_unjournaled_staged_roots(
                 continue;
             }
             let path = entry.path();
-            if !path.is_dir() {
+            let Ok(metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
                 continue;
             }
             let child_relative = relative.join(entry.file_name());

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/tests/mod.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/tests/mod.rs
@@ -1,5 +1,6 @@
 mod journal_handling;
 mod metadata_replay;
+mod path_containment;
 mod restore_paths;
 mod retained_cleanup;
 mod staged_state;
@@ -8,7 +9,8 @@ use super::*;
 use crate::app::controller::library::source_folders::delete_recovery::restore_merge::restore_retained_folder_with_merge_with_stamp;
 use crate::app::controller::library::source_folders::delete_recovery::{
     DeleteRecoveryAction, DeleteRecoveryStatus, mark_delete_restore_pending_db,
-    mark_delete_retained, stage_folder_for_delete,
+    mark_delete_retained, purge_deleted_folder, restore_deleted_folder, rollback_staged_folder,
+    stage_folder_for_delete,
 };
 use crate::sample_sources::SampleSource;
 use std::fs;

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/tests/path_containment.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/tests/path_containment.rs
@@ -1,0 +1,215 @@
+use super::*;
+use crate::app::controller::library::source_folders::delete_recovery::DeleteStagingInfo;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn recover_rejects_parent_dir_original_without_restoring_outside_source() {
+    let (temp, source) = sample_source();
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&outside).unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    fs::create_dir_all(staging_root.join("gone")).unwrap();
+    write_journal(
+        &staging_root,
+        "evil-original",
+        "../outside",
+        "gone",
+        "staged",
+    );
+
+    let report = recover_staged_deletes(std::slice::from_ref(&source));
+
+    assert_eq!(report.entries.len(), 1);
+    assert_recovery(
+        &report.entries[0],
+        DeleteRecoveryAction::Restore,
+        DeleteRecoveryStatus::Failed,
+    );
+    assert!(
+        report.entries[0]
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("Invalid delete journal entry"))
+    );
+    assert!(outside.is_dir());
+    assert!(staging_root.join("gone").is_dir());
+}
+
+#[test]
+fn recover_rejects_windows_prefixed_journal_path_without_restoring() {
+    let (_temp, source) = sample_source();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    fs::create_dir_all(staging_root.join("gone")).unwrap();
+    write_journal(
+        &staging_root,
+        "evil-windows",
+        "C:/outside",
+        "gone",
+        "staged",
+    );
+
+    let report = recover_staged_deletes(std::slice::from_ref(&source));
+
+    assert_eq!(report.entries.len(), 1);
+    assert_recovery(
+        &report.entries[0],
+        DeleteRecoveryAction::Restore,
+        DeleteRecoveryStatus::Failed,
+    );
+    assert!(staging_root.join("gone").is_dir());
+}
+
+#[test]
+fn recover_rejects_parent_dir_staged_path_without_touching_outside_staging() {
+    let (temp, source) = sample_source();
+    let outside_staged = temp.path().join("outside-staged");
+    fs::create_dir_all(&outside_staged).unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    fs::create_dir_all(&staging_root).unwrap();
+    write_journal(
+        &staging_root,
+        "evil-staged",
+        "gone",
+        "../outside-staged",
+        "staged",
+    );
+
+    let report = recover_staged_deletes(std::slice::from_ref(&source));
+
+    assert_eq!(report.entries.len(), 1);
+    assert_recovery(
+        &report.entries[0],
+        DeleteRecoveryAction::Restore,
+        DeleteRecoveryStatus::Failed,
+    );
+    assert!(outside_staged.is_dir());
+    assert!(!source.root.join("gone").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn recover_rejects_symlinked_staged_folder_without_moving_target() {
+    let (temp, source) = sample_source();
+    let outside = temp.path().join("outside-target");
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("keep.txt"), b"outside").unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    fs::create_dir_all(&staging_root).unwrap();
+    std::os::unix::fs::symlink(&outside, staging_root.join("gone")).unwrap();
+    write_journal(&staging_root, "evil-link", "gone", "gone", "staged");
+
+    let report = recover_staged_deletes(std::slice::from_ref(&source));
+
+    assert_eq!(report.entries.len(), 1);
+    assert_recovery(
+        &report.entries[0],
+        DeleteRecoveryAction::Restore,
+        DeleteRecoveryStatus::Failed,
+    );
+    assert_eq!(fs::read(outside.join("keep.txt")).unwrap(), b"outside");
+    assert!(!source.root.join("gone").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn purge_deleted_folder_rejects_symlinked_staged_folder_without_deleting_target() {
+    let (temp, source) = sample_source();
+    let outside = temp.path().join("outside-purge");
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("keep.txt"), b"outside").unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    fs::create_dir_all(&staging_root).unwrap();
+    let staged_link = staging_root.join("gone");
+    std::os::unix::fs::symlink(&outside, &staged_link).unwrap();
+    let info = DeleteStagingInfo {
+        id: "evil-purge".into(),
+        original_relative: PathBuf::from("gone"),
+        staged_relative: PathBuf::from("gone"),
+        staged_absolute: staged_link,
+    };
+
+    let err = purge_deleted_folder(&info, &staging_root).unwrap_err();
+
+    assert!(err.contains("symlink"));
+    assert_eq!(fs::read(outside.join("keep.txt")).unwrap(), b"outside");
+}
+
+#[cfg(unix)]
+#[test]
+fn restore_deleted_folder_rejects_symlinked_source_parent_without_moving_staged_folder() {
+    let (temp, source) = sample_source();
+    let outside = temp.path().join("outside-restore");
+    fs::create_dir_all(&outside).unwrap();
+    std::os::unix::fs::symlink(&outside, source.root.join("link-parent")).unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    let staged_absolute = staging_root.join("gone");
+    fs::create_dir_all(&staged_absolute).unwrap();
+    let info = DeleteStagingInfo {
+        id: "evil-restore".into(),
+        original_relative: PathBuf::from("link-parent/gone"),
+        staged_relative: PathBuf::from("gone"),
+        staged_absolute: staged_absolute.clone(),
+    };
+
+    let err = restore_deleted_folder(&info, &source.root.join("link-parent/gone"), &staging_root)
+        .unwrap_err();
+
+    assert!(err.contains("symlink") || err.contains("escapes"));
+    assert!(staged_absolute.is_dir());
+    assert!(!outside.join("gone").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn rollback_staged_folder_rejects_symlinked_source_parent_without_moving_staged_folder() {
+    let (temp, source) = sample_source();
+    let outside = temp.path().join("outside-rollback");
+    fs::create_dir_all(&outside).unwrap();
+    std::os::unix::fs::symlink(&outside, source.root.join("link-parent")).unwrap();
+    let staging_root = source.root.join(DELETE_STAGING_DIR);
+    let staged_absolute = staging_root.join("gone");
+    fs::create_dir_all(&staged_absolute).unwrap();
+    let info = DeleteStagingInfo {
+        id: "evil-rollback".into(),
+        original_relative: PathBuf::from("link-parent/gone"),
+        staged_relative: PathBuf::from("gone"),
+        staged_absolute: staged_absolute.clone(),
+    };
+
+    let err = rollback_staged_folder(
+        &info,
+        &source.root.join("link-parent/gone"),
+        &staging_root,
+        "rollback",
+    )
+    .unwrap_err();
+
+    assert!(err.contains("symlink") || err.contains("escapes"));
+    assert!(staged_absolute.is_dir());
+    assert!(!outside.join("gone").exists());
+}
+
+fn write_journal(
+    staging_root: &Path,
+    id: &str,
+    original_relative: &str,
+    staged_relative: &str,
+    stage: &str,
+) {
+    fs::create_dir_all(staging_root).unwrap();
+    let json = format!(
+        r#"{{
+  "entries": [
+    {{
+      "id": "{id}",
+      "original_relative": "{original_relative}",
+      "staged_relative": "{staged_relative}",
+      "deleted_entries": [],
+      "stage": "{stage}",
+      "created_at": 1
+    }}
+  ]
+}}"#
+    );
+    fs::write(staging_root.join("delete_journal.json"), json).unwrap();
+}

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/unjournaled.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/unjournaled.rs
@@ -2,6 +2,7 @@ use super::{
     DeleteRecoveryAction, DeleteRecoveryReport, SampleSource, find_unjournaled_staged_roots,
     recovery_entry, restore_staged_folder,
 };
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use std::path::{Path, PathBuf};
 
 pub(super) fn recover_unjournaled_entries(
@@ -13,11 +14,13 @@ pub(super) fn recover_unjournaled_entries(
     for relative in find_unjournaled_staged_roots(staging_root, &source.root, journaled_roots) {
         let staged = staging_root.join(&relative);
         let original = source.root.join(&relative);
+        let outcome = path_policy::validate_relative_path(&relative, "staged_relative")
+            .and_then(|_| restore_staged_folder(&staged, &original, staging_root, &source.root));
         report.entries.push(recovery_entry(
             source,
             relative,
             DeleteRecoveryAction::Restore,
-            restore_staged_folder(&staged, &original),
+            outcome,
         ));
     }
 }

--- a/src/app/controller/library/source_folders/delete_recovery/restore_merge.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/restore_merge.rs
@@ -5,6 +5,7 @@
 //! tree file-by-file, reuses exact matches, and preserves both copies when contents differ.
 
 use super::DeleteStagingInfo;
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
 use std::path::{Path, PathBuf};
 
 #[path = "restore_merge/filesystem.rs"]
@@ -94,6 +95,14 @@ pub(crate) fn restore_retained_folder_with_merge_with_stamp(
     staging_root: &Path,
     stamp: &str,
 ) -> Result<RetainedRestoreMergeReport, String> {
+    path_policy::validate_relative_path(&info.original_relative, "original_relative")?;
+    path_policy::validate_relative_path(&info.staged_relative, "staged_relative")?;
+    path_policy::ensure_existing_dir_under(
+        staging_root,
+        &info.staged_absolute,
+        "Retained staged folder",
+    )?;
+    path_policy::ensure_creatable_path_under(source_root, absolute, "Retained restore target")?;
     if !info.staged_absolute.is_dir() {
         return Err(format!(
             "Retained staged folder missing: {}",

--- a/src/app/controller/library/source_folders/delete_recovery/restore_merge/ops.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/restore_merge/ops.rs
@@ -5,6 +5,8 @@ use super::util::{
     timestamped_conflict_path,
 };
 use super::{RestoredFileDisposition, RetainedRestoreMergeReport, filesystem, reporting};
+use crate::app::controller::library::source_folders::delete_recovery::path_policy;
+use std::fs;
 use std::path::Path;
 use time::{OffsetDateTime, format_description::FormatItem, macros::format_description};
 
@@ -16,7 +18,8 @@ pub(super) fn merge_directory(
     stamp: &str,
     report: &mut RetainedRestoreMergeReport,
 ) -> Result<(), String> {
-    if !target_dir.exists() {
+    path_policy::ensure_existing_dir_under(source_root, staged_dir, "Retained staged folder")?;
+    if !path_policy::path_exists_no_follow(target_dir)? {
         return move_whole_directory(
             staged_dir,
             target_dir,
@@ -27,7 +30,11 @@ pub(super) fn merge_directory(
             report,
         );
     }
-    if !target_dir.is_dir() {
+    path_policy::reject_symlink(target_dir, "Retained restore target")?;
+    path_policy::ensure_existing_path_under(source_root, target_dir, "Retained restore target")?;
+    let target_metadata = fs::symlink_metadata(target_dir)
+        .map_err(|err| format!("Failed to inspect retained restore target: {err}"))?;
+    if !target_metadata.file_type().is_dir() {
         report.had_conflicts = true;
         let fallback = timestamped_conflict_path(target_dir, "recovered", stamp);
         let final_relative = source_relative(source_root, &fallback)?;
@@ -47,7 +54,15 @@ pub(super) fn merge_directory(
             .ok_or_else(|| format!("Staged path missing file name: {}", staged_child.display()))?;
         let target_child = target_dir.join(name);
         let child_relative = source_relative(source_root, &target_child)?;
-        if staged_child.is_dir() {
+        let staged_metadata = fs::symlink_metadata(&staged_child)
+            .map_err(|err| format!("Failed to inspect retained staged entry: {err}"))?;
+        if staged_metadata.file_type().is_symlink() {
+            return Err(format!(
+                "Retained staged entry must not be a symlink: {}",
+                staged_child.display()
+            ));
+        }
+        if staged_metadata.file_type().is_dir() {
             merge_directory(
                 &staged_child,
                 &target_child,
@@ -56,7 +71,7 @@ pub(super) fn merge_directory(
                 stamp,
                 report,
             )?;
-        } else if staged_child.is_file() {
+        } else if staged_metadata.file_type().is_file() {
             merge_file(
                 &staged_child,
                 &target_child,
@@ -108,7 +123,7 @@ fn merge_file(
     stamp: &str,
     report: &mut RetainedRestoreMergeReport,
 ) -> Result<(), String> {
-    if !target_file.exists() {
+    if !path_policy::path_exists_no_follow(target_file)? {
         move_file_to_path(
             staged_file,
             target_file,
@@ -119,7 +134,15 @@ fn merge_file(
         )?;
         return Ok(());
     }
-    if !target_file.is_file() {
+    path_policy::reject_symlink(target_file, "Retained restore target file")?;
+    path_policy::ensure_existing_path_under(
+        source_root,
+        target_file,
+        "Retained restore target file",
+    )?;
+    let target_metadata = fs::symlink_metadata(target_file)
+        .map_err(|err| format!("Failed to inspect retained restore target file: {err}"))?;
+    if !target_metadata.file_type().is_file() {
         report.had_conflicts = true;
         let fallback = timestamped_conflict_path(target_file, "recovered", stamp);
         let final_relative = source_relative(source_root, &fallback)?;

--- a/src/app/controller/library/source_folders/delete_recovery/retained_resolution.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/retained_resolution.rs
@@ -9,8 +9,8 @@ use super::retained_restore_reconcile::{
     apply_retained_restore_db_entries, snapshot_existing_restore_entries,
 };
 use super::{
-    DELETE_STAGING_DIR, DeleteStagingInfo, mark_delete_restore_pending_db, purge_deleted_folder,
-    recover_staged_deletes, remove_delete_entry,
+    DELETE_STAGING_DIR, DeleteStagingInfo, mark_delete_restore_pending_db, path_policy,
+    purge_deleted_folder, recover_staged_deletes, remove_delete_entry,
 };
 use crate::app::controller::jobs::{
     FileOpMessage, RetainedDeleteResolutionEntry, RetainedDeleteResolutionRequest,
@@ -89,13 +89,23 @@ fn restore_retained_entry(
 ) -> Result<EntryResolutionOutcome, String> {
     let source = SampleSource::new_with_id(entry.source_id.clone(), entry.source_root.clone());
     let staging_root = source.root.join(DELETE_STAGING_DIR);
-    let absolute = source.root.join(&entry.relative_path);
+    path_policy::ensure_staging_root(&source.root, &staging_root)?;
+    let relative_path = path_policy::validate_relative_path(&entry.relative_path, "relative_path")?;
+    let staged_relative =
+        path_policy::validate_relative_path(&entry.staged_relative, "staged_relative")?;
+    let absolute = path_policy::contained_child(&source.root, &relative_path, "relative_path")?;
     let staged = DeleteStagingInfo {
         id: entry.id.clone(),
-        original_relative: entry.relative_path.clone(),
-        staged_relative: entry.staged_relative.clone(),
-        staged_absolute: staging_root.join(&entry.staged_relative),
+        original_relative: relative_path.clone(),
+        staged_relative: staged_relative.clone(),
+        staged_absolute: staging_root.join(&staged_relative),
     };
+    path_policy::ensure_existing_dir_under(
+        &staging_root,
+        &staged.staged_absolute,
+        "Retained staged folder",
+    )?;
+    path_policy::ensure_creatable_path_under(&source.root, &absolute, "Retained restore target")?;
     let existing_entries = snapshot_existing_restore_entries(&source, &entry.deleted_entries)?;
     let stamp = new_restore_stamp()?;
     mark_delete_restore_pending_db(&staging_root, &staged.id, &stamp)?;
@@ -119,11 +129,15 @@ fn purge_retained_entry(
 ) -> Result<EntryResolutionOutcome, String> {
     let source = SampleSource::new_with_id(entry.source_id.clone(), entry.source_root.clone());
     let staging_root = source.root.join(DELETE_STAGING_DIR);
+    path_policy::ensure_staging_root(&source.root, &staging_root)?;
+    let relative_path = path_policy::validate_relative_path(&entry.relative_path, "relative_path")?;
+    let staged_relative =
+        path_policy::validate_relative_path(&entry.staged_relative, "staged_relative")?;
     let staged = DeleteStagingInfo {
         id: entry.id.clone(),
-        original_relative: entry.relative_path.clone(),
-        staged_relative: entry.staged_relative.clone(),
-        staged_absolute: staging_root.join(&entry.staged_relative),
+        original_relative: relative_path,
+        staged_relative: staged_relative.clone(),
+        staged_absolute: staging_root.join(&staged_relative),
     };
     purge_deleted_folder(&staged, &staging_root)?;
     Ok(EntryResolutionOutcome {


### PR DESCRIPTION
Scope
- Fixes OPT-961 / security scan candidate WC-CAND-DELETE-JOURNAL-PATH-TRUST-001.
- Adds a shared delete-recovery path policy for journal-relative paths, staging roots, source roots, symlink rejection, and canonical containment checks.
- Applies the policy before folder-delete restore, purge, rollback, redo restage, retained restore, startup journal recovery, unjournaled staging recovery, and retained merge operations.
- Documents the delete-recovery containment invariant in docs/TARGET.md.

Definition of Done
- Journal original/staged paths are treated as untrusted and rejected when absolute, parent-traversing, Windows-prefixed, symlinked, or outside the expected source/delete-staging root.
- Restore, retained restore, purge, rollback, redo restage, and merge paths validate containment before filesystem mutation.
- Symlinked staged folders and symlinked source parents are rejected without moving or deleting external targets.
- Normal folder delete, undo, redo, retained recovery, and valid staged recovery behavior remains intact.

Validation commands
- cargo fmt --check
- cargo check -p wavecrate --tests --bins
- cargo test -p wavecrate deleting_folder_supports_undo_and_redo --lib
- cargo test -p wavecrate source_folders::delete_recovery --lib
- cargo test -p wavecrate browser_focus_transition_commit_keeps_browser_and_waveform_targets_aligned --lib
- cargo test -p wavecrate --lib (passed on rerun: 1807 passed, 0 failed, 20 ignored)
- git diff --check
- bash scripts/ci.sh agent (blocked by pre-existing non-blocking architecture guardrail in src/native_app/sample_identity_diagnostics.rs lines 2, 316, and 357)

Known limitations
- Full agent validation is still blocked by the existing native_app/sample_identity_diagnostics.rs guardrail, unrelated to this delete-recovery path hardening. The touched Rust checks, focused security regressions, and full lib suite pass.

User review
- User review is required before merge.
