### PR TITLE
Set up Wavecrate 19.1 release pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,9 +22,11 @@ jobs:
       target_sha: ${{ steps.target.outputs.target_sha }}
       build_number: ${{ steps.target.outputs.build_number }}
       nightly_version: ${{ steps.target.outputs.nightly_version }}
+      target_version: ${{ steps.target.outputs.target_version }}
       portal_build_id: ${{ steps.target.outputs.portal_build_id }}
       previous_nightly_sha: ${{ steps.target.outputs.previous_nightly_sha }}
       released_at: ${{ steps.target.outputs.released_at }}
+      build_date: ${{ steps.target.outputs.build_date }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +43,9 @@ jobs:
           previous_nightly_sha="$(scripts/internal/release/github_ref_sha.sh --allow-missing "$REPOSITORY" tags/nightly)"
           build_number="$(git rev-list --count "$target_sha")"
           short_sha="${target_sha::8}"
-          nightly_version="nightly-b${build_number}-${short_sha}"
+          target_version="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
+          build_date="$(date -u '+%Y%m%d')"
+          nightly_version="${target_version}-nightly.${build_date}+${short_sha}"
           portal_build_id="wavecrate-${nightly_version}"
           released_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
@@ -53,9 +57,11 @@ jobs:
           echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
           echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
           echo "nightly_version=$nightly_version" >> "$GITHUB_OUTPUT"
+          echo "target_version=$target_version" >> "$GITHUB_OUTPUT"
           echo "portal_build_id=$portal_build_id" >> "$GITHUB_OUTPUT"
           echo "previous_nightly_sha=$previous_nightly_sha" >> "$GITHUB_OUTPUT"
           echo "released_at=$released_at" >> "$GITHUB_OUTPUT"
+          echo "build_date=${build_date:0:4}-${build_date:4:2}-${build_date:6:2}" >> "$GITHUB_OUTPUT"
 
   release-log:
     name: Generate nightly release log
@@ -265,8 +271,11 @@ jobs:
             --platform "${{ matrix.platform }}" \
             --arch "${{ matrix.arch }}" \
             --channel nightly \
+            --version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --target-version "${{ needs.resolve-main.outputs.target_version }}" \
             --build-number "$BUILD_NUMBER" \
             --git-sha "$TARGET_SHA" \
+            --build-date "${{ needs.resolve-main.outputs.build_date }}" \
             --out-dir dist/release
       - name: Uniquify checksums entry
         shell: bash
@@ -453,6 +462,7 @@ jobs:
           UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
           TARGET_SHA: ${{ needs.resolve-main.outputs.target_sha }}
           BUILD_NUMBER: ${{ needs.resolve-main.outputs.build_number }}
+          RELEASE_VERSION: ${{ needs.resolve-main.outputs.nightly_version }}
           PORTAL_BUILD_ID: ${{ needs.resolve-main.outputs.portal_build_id }}
           RELEASED_AT: ${{ needs.resolve-main.outputs.released_at }}
         run: |
@@ -464,7 +474,7 @@ jobs:
             exit 1
           fi
 
-          version="nightly"
+          version="$RELEASE_VERSION"
           build_id="$PORTAL_BUILD_ID"
           released_at="${RELEASED_AT}"
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -1,0 +1,310 @@
+name: Wavecrate RC release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable target version, for example 19.1.0
+        required: true
+        type: string
+      rc_number:
+        description: RC number, for example 1
+        required: true
+        type: string
+      branch:
+        description: Release branch, for example release/19.1
+        required: true
+        type: string
+      release_notes:
+        description: Optional release notes
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wavecrate-rc-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve RC target
+    runs-on: ubuntu-latest
+    outputs:
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+      target_version: ${{ steps.resolve.outputs.target_version }}
+      release_version: ${{ steps.resolve.outputs.release_version }}
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      build_number: ${{ steps.resolve.outputs.build_number }}
+      build_date: ${{ steps.resolve.outputs.build_date }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+      - name: Validate RC inputs
+        id: resolve
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          RC_NUMBER: ${{ inputs.rc_number }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must be MAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "rc_number must be a positive integer" >&2
+            exit 1
+          fi
+          minor_branch="$(awk -F. '{ print $1 "." $2 }' <<<"$VERSION")"
+          if [[ "$BRANCH" != "release/${minor_branch}" ]]; then
+            echo "branch must be release/${minor_branch} for version ${VERSION}" >&2
+            exit 1
+          fi
+          manifest_version="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
+          if [[ "$manifest_version" != "$VERSION" ]]; then
+            echo "Cargo.toml version ${manifest_version} does not match ${VERSION}" >&2
+            exit 1
+          fi
+          target_sha="$(git rev-parse HEAD)"
+          release_version="${VERSION}-rc.${RC_NUMBER}"
+          release_tag="v${release_version}"
+          existing="$(git rev-parse -q --verify "refs/tags/${release_tag}^{commit}" 2>/dev/null || true)"
+          if [[ -n "$existing" && "$existing" != "$target_sha" ]]; then
+            echo "Tag ${release_tag} already points at ${existing}, not ${target_sha}" >&2
+            exit 1
+          fi
+          build_number="$(git rev-list --count "$target_sha")"
+          build_date="$(date -u '+%Y-%m-%d')"
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+          echo "target_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
+          echo "build_date=$build_date" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Run RC validation tests
+    runs-on: ubuntu-latest
+    needs: resolve
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
+            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/radiant_submodule_key"
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+            git submodule update --init --recursive vendor/radiant
+          rm -f "$key_path"
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Run tests
+        run: cargo test --workspace --locked
+
+  build:
+    name: Build ${{ matrix.platform }} ${{ matrix.arch }} RC
+    runs-on: ${{ matrix.os }}
+    needs: [resolve, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: windows
+            arch: x86_64
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            platform: macos
+            arch: x86_64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            platform: macos
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
+            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/radiant_submodule_key"
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+            git submodule update --init --recursive vendor/radiant
+          rm -f "$key_path"
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Fetch ASIO SDK (Windows)
+        if: ${{ matrix.platform == 'windows' }}
+        shell: pwsh
+        run: |
+          git lfs install --local
+          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
+          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
+          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
+          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
+          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
+          if (-not $asioHeader) { throw "ASIO header not found under $asioRoot" }
+          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
+          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
+            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
+          }
+          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+      - name: Build RC zip
+        shell: bash
+        env:
+          BUILD_NUMBER: ${{ needs.resolve.outputs.build_number }}
+          TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
+          WAVECRATE_MACOS_SIGNING: ${{ matrix.platform == 'macos' && '1' || '0' }}
+          APPLE_DEVELOPER_ID_APPLICATION_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD }}
+          APPLE_NOTARY_KEY_BASE64: ${{ secrets.APPLE_NOTARY_KEY_BASE64 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+        run: |
+          scripts/internal/release/build_release_zip.sh \
+            --target "${{ matrix.target }}" \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --channel rc \
+            --version "${{ needs.resolve.outputs.release_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --build-number "$BUILD_NUMBER" \
+            --git-sha "$TARGET_SHA" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --out-dir dist/release
+          mv dist/release/checksums-entry.txt \
+            "dist/release/checksums-entry-${{ matrix.platform }}-${{ matrix.arch }}.txt"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/release
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub RC
+    runs-on: ubuntu-latest
+    needs: [resolve, build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/artifacts
+          pattern: release-*
+          merge-multiple: true
+      - name: Assemble RC release files
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          cp dist/artifacts/*.zip dist/release/
+          cat dist/artifacts/checksums-entry-*.txt > "dist/release/checksums-${RELEASE_VERSION}.txt"
+          {
+            echo "# Wavecrate ${RELEASE_VERSION}"
+            echo
+            echo "- Channel: Release Candidate"
+            echo "- Commit: ${TARGET_SHA}"
+            echo
+            if [[ -n "$RELEASE_NOTES" ]]; then
+              printf '%s\n' "$RELEASE_NOTES"
+            else
+              echo "Release candidate for final validation."
+            fi
+          } > dist/release/release-log.md
+      - name: Sign release checksums
+        env:
+          CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
+            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
+            exit 1
+          fi
+          key_path="dist/release/checksums-signing-key.pem"
+          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
+          openssl pkeyutl -sign -inkey "$key_path" -rawin \
+            -in "dist/release/checksums-${RELEASE_VERSION}.txt" \
+            -out "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin"
+          base64 -w 0 "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin" \
+            > "dist/release/checksums-${RELEASE_VERSION}.txt.sig"
+          rm -f "$key_path" "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin"
+      - name: Publish RC release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.resolve.outputs.release_tag }}
+          name: Wavecrate ${{ needs.resolve.outputs.release_version }}
+          target_commitish: ${{ needs.resolve.outputs.target_sha }}
+          body_path: dist/release/release-log.md
+          prerelease: true
+          make_latest: false
+          files: dist/release/*

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,0 +1,313 @@
+name: Wavecrate stable release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version, for example 19.1.0
+        required: true
+        type: string
+      branch:
+        description: Release branch, for example release/19.1
+        required: true
+        type: string
+      release_notes:
+        description: Optional release notes
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wavecrate-stable-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve stable target
+    runs-on: ubuntu-latest
+    outputs:
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+      target_version: ${{ steps.resolve.outputs.target_version }}
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      build_number: ${{ steps.resolve.outputs.build_number }}
+      build_date: ${{ steps.resolve.outputs.build_date }}
+      rc_tag: ${{ steps.resolve.outputs.rc_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch }}
+      - name: Validate stable inputs
+        id: resolve
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version must be MAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+          minor_branch="$(awk -F. '{ print $1 "." $2 }' <<<"$VERSION")"
+          if [[ "$BRANCH" != "release/${minor_branch}" ]]; then
+            echo "branch must be release/${minor_branch} for version ${VERSION}" >&2
+            exit 1
+          fi
+          manifest_version="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
+          if [[ "$manifest_version" != "$VERSION" ]]; then
+            echo "Cargo.toml version ${manifest_version} does not match ${VERSION}" >&2
+            exit 1
+          fi
+          target_sha="$(git rev-parse HEAD)"
+          mapfile -t rc_tags < <(git tag -l "v${VERSION}-rc.*" --sort=-v:refname)
+          if [[ ${#rc_tags[@]} -eq 0 ]]; then
+            echo "Stable release ${VERSION} requires at least one RC tag v${VERSION}-rc.N" >&2
+            exit 1
+          fi
+          rc_tag="${rc_tags[0]}"
+          rc_sha="$(git rev-list -n 1 "$rc_tag")"
+          if [[ "$rc_sha" != "$target_sha" ]]; then
+            echo "Latest RC ${rc_tag} points at ${rc_sha}; stable target is ${target_sha}" >&2
+            exit 1
+          fi
+          release_tag="v${VERSION}"
+          existing="$(git rev-parse -q --verify "refs/tags/${release_tag}^{commit}" 2>/dev/null || true)"
+          if [[ -n "$existing" && "$existing" != "$target_sha" ]]; then
+            echo "Tag ${release_tag} already points at ${existing}, not ${target_sha}" >&2
+            exit 1
+          fi
+          build_number="$(git rev-list --count "$target_sha")"
+          build_date="$(date -u '+%Y-%m-%d')"
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+          echo "target_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
+          echo "build_date=$build_date" >> "$GITHUB_OUTPUT"
+          echo "rc_tag=$rc_tag" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Run stable validation tests
+    runs-on: ubuntu-latest
+    needs: resolve
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
+            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/radiant_submodule_key"
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+            git submodule update --init --recursive vendor/radiant
+          rm -f "$key_path"
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Run tests
+        run: cargo test --workspace --locked
+
+  build:
+    name: Build ${{ matrix.platform }} ${{ matrix.arch }} stable
+    runs-on: ${{ matrix.os }}
+    needs: [resolve, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform: windows
+            arch: x86_64
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            platform: macos
+            arch: x86_64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            platform: macos
+            arch: aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
+            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/radiant_submodule_key"
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+            git submodule update --init --recursive vendor/radiant
+          rm -f "$key_path"
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
+          print(data.get("toolchain", {}).get("channel", "stable"))
+          PY
+          )"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Fetch ASIO SDK (Windows)
+        if: ${{ matrix.platform == 'windows' }}
+        shell: pwsh
+        run: |
+          git lfs install --local
+          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
+          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
+          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
+          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
+          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
+          if (-not $asioHeader) { throw "ASIO header not found under $asioRoot" }
+          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
+          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
+            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
+          }
+          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+      - name: Build stable zip
+        shell: bash
+        env:
+          BUILD_NUMBER: ${{ needs.resolve.outputs.build_number }}
+          TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
+          WAVECRATE_MACOS_SIGNING: ${{ matrix.platform == 'macos' && '1' || '0' }}
+          APPLE_DEVELOPER_ID_APPLICATION_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD }}
+          APPLE_NOTARY_KEY_BASE64: ${{ secrets.APPLE_NOTARY_KEY_BASE64 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+        run: |
+          scripts/internal/release/build_release_zip.sh \
+            --target "${{ matrix.target }}" \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --channel stable \
+            --version "${{ needs.resolve.outputs.target_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --build-number "$BUILD_NUMBER" \
+            --git-sha "$TARGET_SHA" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --out-dir dist/release
+          mv dist/release/checksums-entry.txt \
+            "dist/release/checksums-entry-${{ matrix.platform }}-${{ matrix.arch }}.txt"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/release
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub stable release
+    runs-on: ubuntu-latest
+    needs: [resolve, build]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.target_sha }}
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/artifacts
+          pattern: release-*
+          merge-multiple: true
+      - name: Assemble stable release files
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve.outputs.target_version }}
+          TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
+          RC_TAG: ${{ needs.resolve.outputs.rc_tag }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          cp dist/artifacts/*.zip dist/release/
+          cat dist/artifacts/checksums-entry-*.txt > "dist/release/checksums-${VERSION}.txt"
+          {
+            echo "# Wavecrate ${VERSION}"
+            echo
+            echo "- Channel: Stable"
+            echo "- Commit: ${TARGET_SHA}"
+            echo "- Promoted from: ${RC_TAG}"
+            echo
+            if [[ -n "$RELEASE_NOTES" ]]; then
+              printf '%s\n' "$RELEASE_NOTES"
+            else
+              echo "Stable release promoted from ${RC_TAG}."
+            fi
+          } > dist/release/release-log.md
+      - name: Sign release checksums
+        env:
+          CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
+          VERSION: ${{ needs.resolve.outputs.target_version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
+            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
+            exit 1
+          fi
+          key_path="dist/release/checksums-signing-key.pem"
+          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
+          openssl pkeyutl -sign -inkey "$key_path" -rawin \
+            -in "dist/release/checksums-${VERSION}.txt" \
+            -out "dist/release/checksums-${VERSION}.txt.sig.bin"
+          base64 -w 0 "dist/release/checksums-${VERSION}.txt.sig.bin" \
+            > "dist/release/checksums-${VERSION}.txt.sig"
+          rm -f "$key_path" "dist/release/checksums-${VERSION}.txt.sig.bin"
+      - name: Publish stable release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.resolve.outputs.release_tag }}
+          name: Wavecrate ${{ needs.resolve.outputs.target_version }}
+          target_commitish: ${{ needs.resolve.outputs.target_sha }}
+          body_path: dist/release/release-log.md
+          prerelease: false
+          make_latest: true
+          files: dist/release/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "arboard",
  "base64",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-analysis"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "blake3",
  "directories",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-analysis-admin"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "hdbscan",
  "rusqlite",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-bench-cli"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "hound",
  "rand 0.9.2",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-installer"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "embed-resource",
  "image",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-library"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "directories",
  "libc",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-scan"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "blake3",
  "libc",
@@ -5992,14 +5992,14 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-similarity-prep"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "wavecrate",
 ]
 
 [[package]]
 name = "wavecrate-updater-helper"
-version = "19.0.2"
+version = "19.1.0"
 dependencies = [
  "wavecrate",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 
 [package]
 name = "wavecrate"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 default-run = "wavecrate"
 autobins = false

--- a/apps/installer/Cargo.toml
+++ b/apps/installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-installer"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [[bin]]

--- a/apps/updater-helper/Cargo.toml
+++ b/apps/updater-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-updater-helper"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [[bin]]

--- a/apps/updater-helper/src/main.rs
+++ b/apps/updater-helper/src/main.rs
@@ -93,6 +93,7 @@ impl ArgState {
                 let value = next_value(args, i, "--channel")?;
                 self.channel = match value.as_str() {
                     "stable" => UpdateChannel::Stable,
+                    "rc" => UpdateChannel::Rc,
                     "nightly" => UpdateChannel::Nightly,
                     other => return Err(format!("Unknown channel '{other}'")),
                 };
@@ -158,7 +159,7 @@ fn help_text() -> String {
     format!(
         "Usage: {APP_NAME}-updater --install-dir <dir> [options]\n\n\
 Options:\n\
-  --channel <stable|nightly>   Update channel (default: stable)\n\
+  --channel <stable|rc|nightly> Update channel (default: stable)\n\
   --repo <OWNER/REPO>          GitHub repository (default: {REPO_SLUG})\n\
   --target <TRIPLE>            Target triple (default: detected)\n\
   --platform <LABEL>           Platform label (default: detected)\n\

--- a/apps/updater-helper/src/tests.rs
+++ b/apps/updater-helper/src/tests.rs
@@ -121,6 +121,19 @@ fn parse_args_rejects_unknown_channel() {
 }
 
 #[test]
+fn parse_args_accepts_rc_channel() {
+    let (args, _headless) = parse_args(vec![
+        "--channel".to_string(),
+        "rc".to_string(),
+        "--install-dir".to_string(),
+        sample_install_dir().display().to_string(),
+    ])
+    .expect("parse args");
+
+    assert_eq!(args.identity.channel, UpdateChannel::Rc);
+}
+
+#[test]
 fn parse_args_rejects_unknown_argument_with_help_text() {
     let err = parse_args(vec![
         "--install-dir".to_string(),

--- a/build.rs
+++ b/build.rs
@@ -13,10 +13,15 @@ fn main() {
     println!("cargo:rerun-if-changed=assets/logo3.ico");
     println!("cargo:rerun-if-env-changed=WAVECRATE_GIT_SHA");
     println!("cargo:rerun-if-env-changed=WAVECRATE_BUILD_NUMBER");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_RELEASE_VERSION");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_RELEASE_CHANNEL");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_RELEASE_TARGET_VERSION");
+    println!("cargo:rerun-if-env-changed=WAVECRATE_RELEASE_BUILD_DATE");
 
     emit_git_rerun_hints();
     emit_git_sha();
     emit_build_number();
+    emit_release_metadata();
 
     if compiling_for_windows_target()
         && let Err(error) = compile_windows_resources()
@@ -67,6 +72,32 @@ fn emit_build_number() {
     println!("cargo:rustc-env=WAVECRATE_BUILD_NUMBER={build_number}");
 }
 
+fn emit_release_metadata() {
+    let package_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| String::from("0.0.0"));
+    let release_version = env::var("WAVECRATE_RELEASE_VERSION")
+        .ok()
+        .and_then(trim_nonempty)
+        .unwrap_or_else(|| package_version.clone());
+    let release_channel = env::var("WAVECRATE_RELEASE_CHANNEL")
+        .ok()
+        .and_then(trim_nonempty)
+        .unwrap_or_else(|| String::from("stable"));
+    let target_version = env::var("WAVECRATE_RELEASE_TARGET_VERSION")
+        .ok()
+        .and_then(trim_nonempty)
+        .unwrap_or(package_version);
+    let build_date = env::var("WAVECRATE_RELEASE_BUILD_DATE")
+        .ok()
+        .and_then(valid_build_date)
+        .or_else(current_utc_date)
+        .unwrap_or_else(|| String::from("1970-01-01"));
+
+    println!("cargo:rustc-env=WAVECRATE_RELEASE_VERSION={release_version}");
+    println!("cargo:rustc-env=WAVECRATE_RELEASE_CHANNEL={release_channel}");
+    println!("cargo:rustc-env=WAVECRATE_RELEASE_TARGET_VERSION={target_version}");
+    println!("cargo:rustc-env=WAVECRATE_RELEASE_BUILD_DATE={build_date}");
+}
+
 fn resolve_head_reference_path(head_path: &Path) -> Option<PathBuf> {
     let head_contents = fs::read_to_string(head_path).ok()?;
     let reference = head_contents.trim().strip_prefix("ref: ")?;
@@ -112,6 +143,29 @@ fn resolve_git_commit_count() -> Option<String> {
     }
     let count = String::from_utf8(output.stdout).ok()?;
     valid_build_number(count)
+}
+
+fn current_utc_date() -> Option<String> {
+    let output = Command::new("git")
+        .args(["show", "-s", "--format=%cs", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    valid_build_date(String::from_utf8(output.stdout).ok()?)
+}
+
+fn valid_build_date(value: impl AsRef<str>) -> Option<String> {
+    let trimmed = value.as_ref().trim();
+    let bytes = trimmed.as_bytes();
+    let valid = bytes.len() == 10
+        && bytes[0..4].iter().all(|byte| byte.is_ascii_digit())
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(|byte| byte.is_ascii_digit())
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(|byte| byte.is_ascii_digit());
+    valid.then(|| trimmed.to_string())
 }
 
 fn valid_build_number(value: impl AsRef<str>) -> Option<String> {

--- a/crates/wavecrate-analysis/Cargo.toml
+++ b/crates/wavecrate-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-analysis"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [lints.rust]

--- a/crates/wavecrate-library/Cargo.toml
+++ b/crates/wavecrate-library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-library"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [lints.rust]

--- a/crates/wavecrate-scan/Cargo.toml
+++ b/crates/wavecrate-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-scan"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [lints.rust]

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -21,10 +21,23 @@ Overrides the build tool used by `scripts/internal/release/build_release_zip.sh`
 `cargo`).
 
 - `WAVECRATE_CHECKSUMS_ED25519_KEY`
-CI secret used by `.github/workflows/release-build.yml` to sign release checksum
-files. This is expected to be an Ed25519 private key in PEM form that OpenSSL
-can use for `pkeyutl -sign`. The release workflow also accepts the legacy
+CI secret used by the release workflows to sign release checksum files. This is
+expected to be an Ed25519 private key in PEM form that OpenSSL can use for
+`pkeyutl -sign`. The release workflows also accept the legacy
 `SEMPAL_CHECKSUMS_ED25519_KEY` secret name as a compatibility fallback.
+
+- `WAVECRATE_RELEASE_VERSION`
+Full semver release identity embedded into a packaged binary. Examples:
+`19.1.0-nightly.20260701+abc1234`, `19.1.0-rc.1`, `19.1.0`.
+
+- `WAVECRATE_RELEASE_CHANNEL`
+Embedded release channel: `nightly`, `rc`, or `stable`.
+
+- `WAVECRATE_RELEASE_TARGET_VERSION`
+Stable target version for the release train, such as `19.1.0`.
+
+- `WAVECRATE_RELEASE_BUILD_DATE`
+UTC build date embedded into the binary in `YYYY-MM-DD` form.
 
 - `WAVECRATE_DISABLE_SCCACHE`
 When set to `1`, repo Cargo helper scripts force direct `rustc` and clear any
@@ -39,17 +52,35 @@ and its wrapper probe passes. Default: unset, so repo scripts use direct
 
 ### Release upload secrets
 
-The `release-build.yml` workflow is the only GitHub Actions workflow in this
-repo. It publishes rolling `nightly` builds only: Windows x86_64 plus macOS
+Wavecrate has three public release workflows:
+
+- `.github/workflows/release-build.yml`
+  - automatic and manual nightly builds from `main`
+- `.github/workflows/release-rc.yml`
+  - manual release-candidate builds from `release/X.Y`
+- `.github/workflows/release-stable.yml`
+  - manual stable releases from `release/X.Y`
+
+Nightly runs publish rolling `nightly` builds for Windows x86_64 plus macOS
 x86_64/aarch64 assets from the current `main` commit. The schedule is
 `19:30 UTC` (evening in Europe/Amsterdam), and `workflow_dispatch` provides a
 manual "force a nightly now" button with the same build/upload path.
 
-The workflow publishes an immutable nightly version tag named
-`nightly-b<build>-<short-sha>` for changelog history, updates the rolling GitHub
+RC runs require `version`, `rc_number`, and `branch` inputs. The branch must be
+`release/X.Y` for the requested `X.Y.Z` version, and the package manifest must
+already carry that target version. RC releases are published as GitHub
+pre-releases tagged `vX.Y.Z-rc.N`.
+
+Stable runs require `version` and `branch` inputs. The branch must be
+`release/X.Y`, the package manifest must match `X.Y.Z`, and the latest
+`vX.Y.Z-rc.N` tag must point at the same commit being promoted. Stable releases
+are published as normal GitHub releases tagged `vX.Y.Z`.
+
+The nightly workflow publishes an immutable nightly version tag named like
+`19.1.0-nightly.20260701+abc1234` for changelog history, updates the rolling GitHub
 `nightly` release for downloads, then uploads the same zips plus the generated
 Markdown release log to the PortalSurfer Wavecrate release-upload API. Each
-PortalSurfer upload uses the matching `wavecrate-nightly-b<build>-<short-sha>`
+PortalSurfer upload uses the matching `wavecrate-<nightly-version>`
 build id so the website can show a distinct nightly entry instead of stacking
 every nightly under one changelog group. After the per-release log is visible in
 the public catalog, the workflow verifies that the fetched log body matches the
@@ -70,10 +101,10 @@ Optional upload endpoint. Defaults to
 `https://portalsurfer.org/wavecrate/api/v1/release-uploads` and must end with
 `/release-uploads`.
 
-### macOS nightly signing secrets
+### macOS release signing secrets
 
-Nightly macOS zips are packaged as `Wavecrate.app` bundles. On GitHub Actions,
-the release workflow signs them with Developer ID, submits them to Apple
+macOS zips are packaged as `Wavecrate.app` bundles. On GitHub Actions, the
+release workflows sign them with Developer ID, submit them to Apple
 notarization, staples the ticket, and only then uploads the zip to GitHub and
 PortalSurfer.
 

--- a/docs/MACOS_RELEASE_SIGNING.md
+++ b/docs/MACOS_RELEASE_SIGNING.md
@@ -51,8 +51,11 @@ scripts/internal/release/build_release_zip.sh \
   --platform macos \
   --arch aarch64 \
   --channel nightly \
+  --version "19.1.0-nightly.$(date -u +%Y%m%d)+$(git rev-parse --short=8 HEAD)" \
+  --target-version 19.1.0 \
   --build-number 1 \
-  --git-sha "$(git rev-parse HEAD)"
+  --git-sha "$(git rev-parse HEAD)" \
+  --build-date "$(date -u +%Y-%m-%d)"
 ```
 
 Set `WAVECRATE_MACOS_SIGNING=1` only when intentionally testing the full

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -46,7 +46,9 @@ remain the validation contract for development and release-risk checks:
 | Dead dependency sweep and env-var nudge | none | `scripts/check.* dead-deps --advisory` and `scripts/check.* report-env-vars` | Advisory Linux-only hygiene |
 | GUI semantic contracts | none | `scripts/gui.ps1 contract` or `scripts/gui.ps1 suite` | Local/manual or issue-specific |
 | Perf guard | none | `scripts/perf.* guard` | Local/manual or release-risk validation |
-| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Builds Windows/macOS nightly assets from `main`, updates the rolling GitHub `nightly` release, uploads the immutable release log to PortalSurfer, then maintains the full changelog from release-bound logs |
+| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Builds Windows/macOS nightly assets from `main`, embeds `X.Y.Z-nightly.DATE+SHA` metadata, updates the rolling GitHub `nightly` release, uploads the immutable release log to PortalSurfer, then maintains the full changelog from release-bound logs |
+| RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs workspace tests, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
+| Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs workspace tests, and publishes `vX.Y.Z` as the normal GitHub release |
 
 The nextest policy is:
 
@@ -57,8 +59,8 @@ The nextest policy is:
   stale-removal behavior.
 - The default nextest profile stays unfiltered for maintainers who want the
   complete suite and are prepared to triage environment-specific failures.
-- Local nextest runs are the source of test evidence while GitHub Actions is
-  narrowed to the nightly release workflow.
+- Local nextest runs remain the primary development evidence. GitHub release
+  workflows add packaging-time checks for nightly, RC, and stable artifacts.
 
 The non-blocking app architecture is enforced by
 `scripts/check.* non-blocking-architecture`, and that check is required by

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -3,16 +3,16 @@
 ## Install
 
 1. Open the Wavecrate download page.
-2. Download the latest macOS or Windows alpha bundle.
+2. Download the latest macOS or Windows stable, RC, or nightly bundle.
 3. Unzip the bundle.
 4. Launch Wavecrate.
 5. Add a sample folder from the Sources panel.
 
 Wavecrate works with ordinary local folders. It does not upload your samples or require a cloud library.
 
-Wavecrate alpha app builds currently support macOS and Windows. Linux is not currently supported for app installs.
+Wavecrate app builds currently support macOS and Windows. Linux is not currently supported for app installs.
 
-> Alpha warning: Wavecrate includes destructive actions that can modify, rename, move, or delete files when you choose those commands. Keep backups for important sample folders.
+> Safety warning: Wavecrate includes destructive actions that can modify, rename, move, or delete files when you choose those commands. Keep backups for important sample folders.
 
 ## Add Your First Source
 

--- a/docs/book/src/troubleshooting.md
+++ b/docs/book/src/troubleshooting.md
@@ -4,7 +4,7 @@
 
 Use **Options -> Open config folder** and look under `.wavecrate/logs`.
 
-Wavecrate alpha app builds currently support macOS and Windows. On a normal supported install, the config folder is:
+Wavecrate app builds currently support macOS and Windows. On a normal supported install, the config folder is:
 
 - macOS: `~/Library/Application Support/.wavecrate/`
 - Windows: `%APPDATA%\\.wavecrate\\`

--- a/manual/_layouts/default.html
+++ b/manual/_layouts/default.html
@@ -26,7 +26,7 @@
       <a href="{{ '/' | relative_url }}">Overview</a>
       <a href="{{ '/usage' | relative_url }}">Usage</a>
     </nav>
-    <div class="status-chip" role="status">Alpha channel</div>
+    <div class="status-chip" role="status">Nightly / RC / Stable</div>
   </header>
 
   <main class="content-shell">

--- a/manual/index.md
+++ b/manual/index.md
@@ -166,7 +166,7 @@ Wavecrate is a focused sample-library workstation for browsing large folders, au
         var match = null;
         // Current public downloads are Windows/macOS only; historical Linux assets are ignored here.
         var assetPattern =
-          /^wavecrate-v\d+\.\d+\.\d+-(windows|macos)-(x86_64|aarch64)\.zip$/i;
+          /^wavecrate-\d+\.\d+\.\d+-(windows|macos)-(x86_64|aarch64)\.zip$/i;
         for (var i = 0; i < releases.length; i += 1) {
           var release = releases[i];
           if (!release || release.draft) {

--- a/manual/usage.md
+++ b/manual/usage.md
@@ -24,7 +24,7 @@ description: How to set up Wavecrate, triage samples, edit waveforms, and manage
 - **Resizable sidebar:** Drag the divider to resize Sources and the main view.
 
 ## Configuration and storage
-- Wavecrate alpha app builds currently support macOS and Windows. Linux is not currently supported for app installs.
+- Wavecrate app builds currently support macOS and Windows. Linux is not currently supported for app installs.
 - App files live in a single `.wavecrate` folder inside your supported OS config directory. You can override the base dir with `WAVECRATE_CONFIG_HOME`.
   - Windows: `%APPDATA%\\.wavecrate\\`
   - macOS: `~/Library/Application Support/.wavecrate/`

--- a/release_contract.toml
+++ b/release_contract.toml
@@ -1,6 +1,6 @@
 app_name = "wavecrate"
 repo_slug = "PORTALSURFER/wavecrate"
-channels = ["nightly"]
+channels = ["nightly", "rc", "stable"]
 targets = [
   "x86_64-pc-windows-msvc",
   "x86_64-apple-darwin",
@@ -17,8 +17,14 @@ aarch64 = "aarch64"
 
 [templates]
 nightly_asset = "{APP_NAME}-nightly-{platform}-{arch}.zip"
+rc_asset = "{APP_NAME}-{version}-rc.{rc_number}-{platform}-{arch}.zip"
+stable_asset = "{APP_NAME}-{version}-{platform}-{arch}.zip"
 nightly_checksums = "checksums-nightly.txt"
 nightly_checksums_sig = "checksums-nightly.txt.sig"
+rc_checksums = "checksums-{version}-rc.{rc_number}.txt"
+rc_checksums_sig = "checksums-{version}-rc.{rc_number}.txt.sig"
+stable_checksums = "checksums-{version}.txt"
+stable_checksums_sig = "checksums-{version}.txt.sig"
 
 [archive_layout]
 root_dir = "{APP_NAME}"

--- a/scripts/internal/release/build_release_zip.sh
+++ b/scripts/internal/release/build_release_zip.sh
@@ -15,8 +15,10 @@ PLATFORM=""
 ARCH=""
 CHANNEL=""
 VERSION=""
+TARGET_VERSION=""
 BUILD_NUMBER=""
 GIT_SHA=""
+BUILD_DATE=""
 
 is_truthy() {
   local value
@@ -29,7 +31,7 @@ is_truthy() {
 
 usage() {
   cat <<'EOF'
-Usage: build_release_zip.sh --target <triple> --platform <label> --arch <label> --channel <stable|nightly> [--version <x.y.z>] [--build-number <n>] [--git-sha <sha>] [--out-dir <path>]
+Usage: build_release_zip.sh --target <triple> --platform <label> --arch <label> --channel <stable|rc|nightly> --version <semver> [--target-version <x.y.z>] [--build-number <n>] [--git-sha <sha>] [--build-date <YYYY-MM-DD>] [--out-dir <path>]
 EOF
 }
 
@@ -55,12 +57,20 @@ while [[ $# -gt 0 ]]; do
       VERSION="$2"
       shift 2
       ;;
+    --target-version)
+      TARGET_VERSION="$2"
+      shift 2
+      ;;
     --build-number)
       BUILD_NUMBER="$2"
       shift 2
       ;;
     --git-sha)
       GIT_SHA="$2"
+      shift 2
+      ;;
+    --build-date)
+      BUILD_DATE="$2"
       shift 2
       ;;
     --out-dir)
@@ -79,8 +89,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$TARGET" || -z "$PLATFORM" || -z "$ARCH" || -z "$CHANNEL" ]]; then
+if [[ -z "$TARGET" || -z "$PLATFORM" || -z "$ARCH" || -z "$CHANNEL" || -z "$VERSION" ]]; then
   usage >&2
+  exit 1
+fi
+
+if [[ -z "$TARGET_VERSION" ]]; then
+  TARGET_VERSION="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
+fi
+if [[ -z "$TARGET_VERSION" || ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Target version must be MAJOR.MINOR.PATCH." >&2
+  exit 1
+fi
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|nightly)\.[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  echo "Version must be stable, rc, or nightly semver." >&2
   exit 1
 fi
 
@@ -100,14 +122,28 @@ if [[ -n "$GIT_SHA" ]]; then
     exit 1
   fi
 fi
+if [[ -z "$BUILD_DATE" ]]; then
+  BUILD_DATE="$(date -u '+%Y-%m-%d')"
+fi
+if [[ ! "$BUILD_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "Build date must be YYYY-MM-DD." >&2
+  exit 1
+fi
 
 case "$CHANNEL" in
   stable)
-    if [[ -z "$VERSION" ]]; then
-      echo "Stable releases require --version." >&2
+    if [[ "$VERSION" != "$TARGET_VERSION" ]]; then
+      echo "Stable release version must equal target version." >&2
       exit 1
     fi
-    ZIP_NAME="${APP_NAME}-v${VERSION}${BUILD_LABEL}-${PLATFORM}-${ARCH}.zip"
+    ZIP_NAME="${APP_NAME}-${VERSION}-${PLATFORM}-${ARCH}.zip"
+    ;;
+  rc)
+    if [[ ! "$VERSION" =~ ^${TARGET_VERSION//./\\.}-rc\.[0-9]+$ ]]; then
+      echo "RC release version must be ${TARGET_VERSION}-rc.N." >&2
+      exit 1
+    fi
+    ZIP_NAME="${APP_NAME}-${VERSION}-${PLATFORM}-${ARCH}.zip"
     ;;
   nightly)
     ZIP_NAME="${APP_NAME}-nightly${BUILD_LABEL}-${PLATFORM}-${ARCH}.zip"
@@ -126,6 +162,10 @@ if ! is_truthy "$SKIP_BUILD"; then
   if [[ -n "$GIT_SHA" ]]; then
     env_args+=("WAVECRATE_GIT_SHA=$GIT_SHA")
   fi
+  env_args+=("WAVECRATE_RELEASE_VERSION=$VERSION")
+  env_args+=("WAVECRATE_RELEASE_CHANNEL=$CHANNEL")
+  env_args+=("WAVECRATE_RELEASE_TARGET_VERSION=$TARGET_VERSION")
+  env_args+=("WAVECRATE_RELEASE_BUILD_DATE=$BUILD_DATE")
   env "${env_args[@]}" "$BUILD_CARGO_BIN" build --release -p "$APP_NAME" --bin "$APP_NAME" --target "$TARGET"
 fi
 
@@ -141,12 +181,12 @@ ROOT_DIR="${WORK_DIR}/${APP_NAME}"
 mkdir -p "$ROOT_DIR"
 
 write_update_manifest() {
-  python3 - "$ROOT_DIR" "$APP_NAME" "$CHANNEL" "$TARGET" "$PLATFORM" "$ARCH" <<'PY'
+  python3 - "$ROOT_DIR" "$APP_NAME" "$CHANNEL" "$TARGET" "$PLATFORM" "$ARCH" "$VERSION" "$TARGET_VERSION" "$GIT_SHA" "$BUILD_DATE" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-root, app, channel, target, platform, arch = sys.argv[1:]
+root, app, channel, target, platform, arch, version, target_version, commit, build_date = sys.argv[1:]
 root_path = Path(root)
 files = sorted(
     path.relative_to(root_path).as_posix()
@@ -160,6 +200,10 @@ manifest = {
     "target": target,
     "platform": platform,
     "arch": arch,
+    "version": version,
+    "target_version": target_version,
+    "commit": commit,
+    "build_date": build_date,
     "files": files,
 }
 (root_path / "update-manifest.json").write_text(
@@ -181,7 +225,7 @@ create_macos_app_bundle() {
 
   icon_name="$(basename "$APP_ICON_SOURCE")"
   bundle_version="${BUILD_NUMBER:-0}"
-  short_version="${VERSION:-$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)}"
+  short_version="${TARGET_VERSION}"
 
   mkdir -p "$macos_dir" "$resources_dir"
   cp "$executable_source" "${macos_dir}/${APP_NAME}"

--- a/src/app/controller/updates.rs
+++ b/src/app/controller/updates.rs
@@ -142,7 +142,8 @@ impl AppController {
         if self.runtime.jobs.update_check_in_progress() {
             return;
         }
-        let current_version = match semver::Version::parse(env!("CARGO_PKG_VERSION")) {
+        let current_version = match semver::Version::parse(crate::release_metadata::CURRENT.version)
+        {
             Ok(v) => v,
             Err(_) => semver::Version::new(0, 0, 0),
         };
@@ -190,6 +191,7 @@ fn startup_update_check_should_skip_for_exe(exe: &Path) -> bool {
 fn map_channel(channel: crate::sample_sources::config::UpdateChannel) -> UpdateChannel {
     match channel {
         crate::sample_sources::config::UpdateChannel::Stable => UpdateChannel::Stable,
+        crate::sample_sources::config::UpdateChannel::Rc => UpdateChannel::Rc,
         crate::sample_sources::config::UpdateChannel::Nightly => UpdateChannel::Nightly,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod logging;
 /// events; it does not define UI widgets, input handling policies, or layout
 /// logic.
 pub mod native_runtime;
+/// Build-time release metadata.
+pub mod release_metadata;
 /// Sample source management.
 pub mod sample_sources;
 /// Selection math utilities.

--- a/src/native_app/release_update.rs
+++ b/src/native_app/release_update.rs
@@ -22,6 +22,7 @@ impl NativeAppState {
 
         let ticket = self.background.release_update_check_task.begin();
         let current_build_number = current_build_number();
+        let channel = release_update_channel(self.ui.settings.persisted.updates.channel);
         self.ui.release_update.begin_check();
         context
             .business()
@@ -29,7 +30,7 @@ impl NativeAppState {
             .run(
                 move |_| ui::TaskCompletion {
                     ticket,
-                    output: run_release_update_check(current_build_number),
+                    output: run_release_update_check(current_build_number, channel),
                 },
                 GuiMessage::ReleaseUpdateCheckFinished,
             );
@@ -66,11 +67,30 @@ impl NativeAppState {
     }
 }
 
-fn run_release_update_check(current_build_number: u64) -> ReleaseUpdateCheckResult {
+fn run_release_update_check(
+    current_build_number: u64,
+    channel: wavecrate::updater::UpdateChannel,
+) -> ReleaseUpdateCheckResult {
     wavecrate::updater::check_public_release_catalog(
-        wavecrate::updater::PublicReleaseCheckRequest::current(current_build_number),
+        wavecrate::updater::PublicReleaseCheckRequest::current(current_build_number, channel),
     )
     .map_err(|err| err.to_string())
+}
+
+fn release_update_channel(
+    channel: wavecrate::sample_sources::config::UpdateChannel,
+) -> wavecrate::updater::UpdateChannel {
+    match channel {
+        wavecrate::sample_sources::config::UpdateChannel::Stable => {
+            wavecrate::updater::UpdateChannel::Stable
+        }
+        wavecrate::sample_sources::config::UpdateChannel::Rc => {
+            wavecrate::updater::UpdateChannel::Rc
+        }
+        wavecrate::sample_sources::config::UpdateChannel::Nightly => {
+            wavecrate::updater::UpdateChannel::Nightly
+        }
+    }
 }
 
 fn current_build_number() -> u64 {

--- a/src/native_app/shell/launch/options.rs
+++ b/src/native_app/shell/launch/options.rs
@@ -7,13 +7,14 @@ use wavecrate::native_runtime::{WAVECRATE_UI_FONT_BYTES, wavecrate_ui_font_path}
 use super::icon::wavecrate_window_icon;
 
 const APP_NAME: &str = "Wavecrate";
-const RELEASE_CHANNEL: &str = "Alpha";
 
 pub(in crate::native_app) fn default_window_title() -> String {
+    let metadata = wavecrate::release_metadata::CURRENT;
     format!(
-        "{APP_NAME} {} b{} - {RELEASE_CHANNEL}",
-        env!("CARGO_PKG_VERSION"),
-        env!("WAVECRATE_BUILD_NUMBER")
+        "{APP_NAME} {} b{} - {}",
+        metadata.version,
+        metadata.build_number,
+        metadata.release_channel().display_label()
     )
 }
 

--- a/src/native_app/tests/window_chrome/audio_settings.rs
+++ b/src/native_app/tests/window_chrome/audio_settings.rs
@@ -1,11 +1,13 @@
 use super::*;
 
 #[test]
-fn default_window_title_marks_versioned_alpha_build() {
+fn default_window_title_marks_versioned_release_channel() {
+    let metadata = wavecrate::release_metadata::CURRENT;
     let expected = format!(
-        "Wavecrate {} b{} - Alpha",
-        env!("CARGO_PKG_VERSION"),
-        env!("WAVECRATE_BUILD_NUMBER")
+        "Wavecrate {} b{} - {}",
+        metadata.version,
+        metadata.build_number,
+        metadata.release_channel().display_label()
     );
 
     assert_eq!(

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,0 +1,70 @@
+//! Build-time release metadata embedded into Wavecrate binaries.
+
+/// Release channel embedded into the current binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseChannel {
+    /// Stable public release.
+    Stable,
+    /// Release candidate build.
+    Rc,
+    /// Nightly development build.
+    Nightly,
+    /// Unknown or locally supplied channel.
+    Other,
+}
+
+impl ReleaseChannel {
+    /// Parse the canonical build-time channel label.
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "stable" => Self::Stable,
+            "rc" => Self::Rc,
+            "nightly" => Self::Nightly,
+            _ => Self::Other,
+        }
+    }
+
+    /// User-facing channel label.
+    pub fn display_label(self) -> &'static str {
+        match self {
+            Self::Stable => "Stable",
+            Self::Rc => "Release Candidate",
+            Self::Nightly => "Nightly",
+            Self::Other => "Custom",
+        }
+    }
+}
+
+/// Release metadata compiled into the binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReleaseMetadata {
+    /// Full release version, including prerelease/build metadata when present.
+    pub version: &'static str,
+    /// Canonical channel string: `stable`, `rc`, or `nightly`.
+    pub channel: &'static str,
+    /// Git commit SHA or `<unknown>`.
+    pub commit: &'static str,
+    /// UTC build date in `YYYY-MM-DD` form.
+    pub build_date: &'static str,
+    /// Stable target version this build belongs to.
+    pub target_version: &'static str,
+    /// Numeric build counter.
+    pub build_number: &'static str,
+}
+
+impl ReleaseMetadata {
+    /// Parsed release channel.
+    pub fn release_channel(self) -> ReleaseChannel {
+        ReleaseChannel::parse(self.channel)
+    }
+}
+
+/// Metadata for the current binary.
+pub const CURRENT: ReleaseMetadata = ReleaseMetadata {
+    version: env!("WAVECRATE_RELEASE_VERSION"),
+    channel: env!("WAVECRATE_RELEASE_CHANNEL"),
+    commit: env!("WAVECRATE_BUILD_GIT_SHA"),
+    build_date: env!("WAVECRATE_RELEASE_BUILD_DATE"),
+    target_version: env!("WAVECRATE_RELEASE_TARGET_VERSION"),
+    build_number: env!("WAVECRATE_BUILD_NUMBER"),
+};

--- a/src/sample_sources/config_types/updates.rs
+++ b/src/sample_sources/config_types/updates.rs
@@ -7,7 +7,7 @@ use super::super::config_defaults::default_true;
 /// Config keys: `channel`, `check_on_startup`, `last_seen_nightly_published_at`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateSettings {
-    /// Selected update channel (stable or nightly).
+    /// Selected update channel.
     #[serde(default)]
     pub channel: UpdateChannel,
     /// Whether to check for updates on startup.
@@ -36,6 +36,8 @@ pub enum UpdateChannel {
     /// Receive stable releases only.
     #[default]
     Stable,
+    /// Receive release candidates and stable releases.
+    Rc,
     /// Receive nightly/pre-release builds.
     Nightly,
 }

--- a/src/updater/apply.rs
+++ b/src/updater/apply.rs
@@ -35,7 +35,7 @@ mod tests;
 pub struct UpdateManifest {
     /// Application name.
     pub app: String,
-    /// Channel label (stable/nightly).
+    /// Channel label (stable/rc/nightly).
     pub channel: String,
     /// Target identifier.
     pub target: String,
@@ -56,7 +56,7 @@ impl UpdateManifest {
                 expected.app, self.app
             )));
         }
-        if self.channel != channel_label(expected.channel) {
+        if !manifest_channel_allowed(&self.channel, expected.channel) {
             return Err(UpdateError::Invalid(format!(
                 "Manifest channel mismatch: expected {}, got {}",
                 channel_label(expected.channel),
@@ -145,6 +145,13 @@ where
     };
     let version = match args.identity.channel {
         UpdateChannel::Stable => Some(
+            release
+                .tag_name
+                .strip_prefix('v')
+                .ok_or_else(|| UpdateError::Invalid(format!("Invalid tag {}", release.tag_name)))?
+                .to_string(),
+        ),
+        UpdateChannel::Rc => Some(
             release
                 .tag_name
                 .strip_prefix('v')
@@ -268,6 +275,14 @@ fn apply_files_and_dirs(
 fn channel_label(channel: UpdateChannel) -> &'static str {
     match channel {
         UpdateChannel::Stable => "stable",
+        UpdateChannel::Rc => "rc",
         UpdateChannel::Nightly => "nightly",
+    }
+}
+
+fn manifest_channel_allowed(manifest_channel: &str, expected_channel: UpdateChannel) -> bool {
+    match expected_channel {
+        UpdateChannel::Rc => manifest_channel == "rc" || manifest_channel == "stable",
+        channel => manifest_channel == channel_label(channel),
     }
 }

--- a/src/updater/apply/tests.rs
+++ b/src/updater/apply/tests.rs
@@ -1,8 +1,46 @@
+use super::super::RuntimeIdentity;
 use super::*;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use tempfile::tempdir;
+
+fn identity(channel: UpdateChannel) -> RuntimeIdentity {
+    RuntimeIdentity {
+        app: "wavecrate".to_string(),
+        channel,
+        target: "target".to_string(),
+        platform: "macos".to_string(),
+        arch: "x86_64".to_string(),
+    }
+}
+
+fn manifest(channel: &str) -> UpdateManifest {
+    UpdateManifest {
+        app: "wavecrate".to_string(),
+        channel: channel.to_string(),
+        target: "target".to_string(),
+        platform: "macos".to_string(),
+        arch: "x86_64".to_string(),
+        files: vec!["update-manifest.json".to_string()],
+    }
+}
+
+#[test]
+fn rc_identity_accepts_stable_manifest() {
+    manifest("stable")
+        .validate(&identity(UpdateChannel::Rc))
+        .unwrap();
+}
+
+#[test]
+fn stable_identity_rejects_rc_manifest() {
+    let err = manifest("rc")
+        .validate(&identity(UpdateChannel::Stable))
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Manifest channel mismatch"));
+}
 
 #[test]
 fn relaunch_app_errors_when_executable_missing() {

--- a/src/updater/asset_names.rs
+++ b/src/updater/asset_names.rs
@@ -33,7 +33,12 @@ pub(crate) fn expected_zip_asset_name(
         UpdateChannel::Stable => {
             let version =
                 version.ok_or_else(|| UpdateError::Invalid("Missing stable version".into()))?;
-            Ok(format!("{APP_NAME}-v{version}-{platform}-{arch}.zip"))
+            Ok(format!("{APP_NAME}-{version}-{platform}-{arch}.zip"))
+        }
+        UpdateChannel::Rc => {
+            let version =
+                version.ok_or_else(|| UpdateError::Invalid("Missing RC version".into()))?;
+            Ok(format!("{APP_NAME}-{version}-{platform}-{arch}.zip"))
         }
         UpdateChannel::Nightly => Ok(format!("{APP_NAME}-nightly-{platform}-{arch}.zip")),
     }
@@ -48,7 +53,12 @@ pub(crate) fn expected_checksums_name(
         UpdateChannel::Stable => {
             let version =
                 version.ok_or_else(|| UpdateError::Invalid("Missing stable version".into()))?;
-            Ok(format!("checksums-v{version}.txt"))
+            Ok(format!("checksums-{version}.txt"))
+        }
+        UpdateChannel::Rc => {
+            let version =
+                version.ok_or_else(|| UpdateError::Invalid("Missing RC version".into()))?;
+            Ok(format!("checksums-{version}.txt"))
         }
         UpdateChannel::Nightly => Ok("checksums-nightly.txt".to_string()),
     }
@@ -63,7 +73,12 @@ pub(crate) fn expected_checksums_signature_name(
         UpdateChannel::Stable => {
             let version =
                 version.ok_or_else(|| UpdateError::Invalid("Missing stable version".into()))?;
-            Ok(format!("checksums-v{version}.txt.sig"))
+            Ok(format!("checksums-{version}.txt.sig"))
+        }
+        UpdateChannel::Rc => {
+            let version =
+                version.ok_or_else(|| UpdateError::Invalid("Missing RC version".into()))?;
+            Ok(format!("checksums-{version}.txt.sig"))
         }
         UpdateChannel::Nightly => Ok("checksums-nightly.txt.sig".to_string()),
     }

--- a/src/updater/check.rs
+++ b/src/updater/check.rs
@@ -56,6 +56,7 @@ pub(super) fn check_for_updates(
 
     match request.channel {
         UpdateChannel::Stable => stable_outcome(&request.current_version, release),
+        UpdateChannel::Rc => rc_outcome(&request.current_version, release),
         UpdateChannel::Nightly => nightly_outcome(&request.last_seen_nightly_published_at, release),
     }
 }
@@ -72,6 +73,30 @@ fn stable_outcome(
     };
     let latest = Version::parse(version_text).map_err(|err| {
         UpdateError::Invalid(format!("Invalid stable version '{version_text}': {err}"))
+    })?;
+    if &latest > current {
+        Ok(UpdateCheckOutcome::UpdateAvailable {
+            tag,
+            html_url: release.html_url,
+            published_at: release.published_at,
+        })
+    } else {
+        Ok(UpdateCheckOutcome::UpToDate)
+    }
+}
+
+fn rc_outcome(
+    current: &Version,
+    release: github::Release,
+) -> Result<UpdateCheckOutcome, UpdateError> {
+    let tag = release.tag_name.trim().to_string();
+    let Some(version_text) = tag.strip_prefix('v') else {
+        return Err(UpdateError::Invalid(format!(
+            "RC release tag must be 'v{{VERSION}}' or 'v{{VERSION}}-rc.N', got '{tag}'"
+        )));
+    };
+    let latest = Version::parse(version_text).map_err(|err| {
+        UpdateError::Invalid(format!("Invalid RC version '{version_text}': {err}"))
     })?;
     if &latest > current {
         Ok(UpdateCheckOutcome::UpdateAvailable {

--- a/src/updater/github/asset_validation.rs
+++ b/src/updater/github/asset_validation.rs
@@ -25,6 +25,15 @@ pub(super) fn nightly_release_has_assets(
     Ok(has_assets(release, &required))
 }
 
+pub(super) fn rc_release_has_assets(
+    release: &Release,
+    version_text: &str,
+    identity: &RuntimeIdentity,
+) -> Result<bool, UpdateError> {
+    let required = rc_required_assets(identity, version_text)?;
+    Ok(has_assets(release, &required))
+}
+
 pub(super) fn validate_tagged_release_assets(
     release: &Release,
     tag: &str,
@@ -51,6 +60,12 @@ fn required_assets_for_tag(
                 UpdateError::Invalid(format!("Stable tag must start with 'v', got '{tag}'"))
             })?;
             stable_required_assets(identity, version_text)
+        }
+        UpdateChannel::Rc => {
+            let version_text = tag.strip_prefix('v').ok_or_else(|| {
+                UpdateError::Invalid(format!("RC tag must start with 'v', got '{tag}'"))
+            })?;
+            rc_required_assets(identity, version_text)
         }
         UpdateChannel::Nightly => {
             if tag != "nightly" {
@@ -82,6 +97,17 @@ fn nightly_required_assets(identity: &RuntimeIdentity) -> Result<[String; 3], Up
     ])
 }
 
+fn rc_required_assets(
+    identity: &RuntimeIdentity,
+    version_text: &str,
+) -> Result<[String; 3], UpdateError> {
+    Ok([
+        expected_zip_asset_name(identity, Some(version_text))?,
+        expected_checksums_name(identity, Some(version_text))?,
+        expected_checksums_signature_name(identity, Some(version_text))?,
+    ])
+}
+
 fn has_assets(release: &Release, required: &[String; 3]) -> bool {
     required
         .iter()
@@ -99,9 +125,9 @@ mod tests {
             "v1.2.3",
             false,
             &[
-                "wavecrate-v1.2.3-windows-x86_64.zip",
-                "checksums-v1.2.3.txt",
-                "checksums-v1.2.3.txt.sig",
+                "wavecrate-1.2.3-windows-x86_64.zip",
+                "checksums-1.2.3.txt",
+                "checksums-1.2.3.txt.sig",
             ],
         );
 
@@ -114,10 +140,7 @@ mod tests {
         let release = release_with_assets(
             "v1.2.3",
             false,
-            &[
-                "wavecrate-v1.2.3-windows-x86_64.zip",
-                "checksums-v1.2.3.txt",
-            ],
+            &["wavecrate-1.2.3-windows-x86_64.zip", "checksums-1.2.3.txt"],
         );
 
         assert!(!stable_release_has_assets(&release, "1.2.3", &identity).unwrap());
@@ -137,6 +160,22 @@ mod tests {
         );
 
         assert!(nightly_release_has_assets(&release, &identity).unwrap());
+    }
+
+    #[test]
+    fn rc_asset_validation_requires_rc_zip_checksums_and_signature() {
+        let identity = identity(UpdateChannel::Rc);
+        let release = release_with_assets(
+            "v1.2.3-rc.2",
+            true,
+            &[
+                "wavecrate-1.2.3-rc.2-windows-x86_64.zip",
+                "checksums-1.2.3-rc.2.txt",
+                "checksums-1.2.3-rc.2.txt.sig",
+            ],
+        );
+
+        assert!(rc_release_has_assets(&release, "1.2.3-rc.2", &identity).unwrap());
     }
 
     fn identity(channel: UpdateChannel) -> RuntimeIdentity {

--- a/src/updater/github/release_selection.rs
+++ b/src/updater/github/release_selection.rs
@@ -51,6 +51,18 @@ fn release_has_required_assets(
             };
             asset_validation::stable_release_has_assets(release, version_text, identity)
         }
+        UpdateChannel::Rc => {
+            let Some(version_text) = release.tag_name.strip_prefix('v') else {
+                return Ok(false);
+            };
+            if release.prerelease {
+                if !version_text.contains("-rc.") {
+                    return Ok(false);
+                }
+                return asset_validation::rc_release_has_assets(release, version_text, identity);
+            }
+            asset_validation::stable_release_has_assets(release, version_text, identity)
+        }
         UpdateChannel::Nightly => {
             if release.tag_name != "nightly" {
                 return Ok(false);
@@ -74,7 +86,7 @@ mod tests {
                 release(
                     "v1.2.2",
                     false,
-                    &["wavecrate-v1.2.2-windows-x86_64.zip".to_string()],
+                    &["wavecrate-1.2.2-windows-x86_64.zip".to_string()],
                 ),
                 release("v1.2.3", false, &stable_assets("1.2.3")),
             ],
@@ -108,6 +120,24 @@ mod tests {
     }
 
     #[test]
+    fn rc_selection_accepts_rc_prereleases_and_stable_releases() {
+        let identity = identity(UpdateChannel::Rc);
+        let selected = select_release_with_assets(
+            vec![
+                release("nightly", true, &nightly_assets()),
+                release("v1.2.3-beta.1", true, &rc_assets("1.2.3-beta.1")),
+                release("v1.2.3-rc.2", true, &rc_assets("1.2.3-rc.2")),
+                release("v1.2.3", false, &stable_assets("1.2.3")),
+            ],
+            UpdateChannel::Rc,
+            &identity,
+        )
+        .expect("rc release");
+
+        assert_eq!(selected.tag_name, "v1.2.3-rc.2");
+    }
+
+    #[test]
     fn summary_listing_preserves_matching_release_order_and_limit() {
         let identity = identity(UpdateChannel::Stable);
         let summaries = list_releases_with_assets(
@@ -137,10 +167,14 @@ mod tests {
 
     fn stable_assets(version: &str) -> Vec<String> {
         vec![
-            format!("wavecrate-v{version}-windows-x86_64.zip"),
-            format!("checksums-v{version}.txt"),
-            format!("checksums-v{version}.txt.sig"),
+            format!("wavecrate-{version}-windows-x86_64.zip"),
+            format!("checksums-{version}.txt"),
+            format!("checksums-{version}.txt.sig"),
         ]
+    }
+
+    fn rc_assets(version: &str) -> Vec<String> {
+        stable_assets(version)
     }
 
     fn nightly_assets() -> Vec<String> {

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -43,6 +43,8 @@ pub enum UpdateChannel {
     /// Stable release channel.
     #[default]
     Stable,
+    /// Release candidate channel.
+    Rc,
     /// Nightly/pre-release channel.
     Nightly,
 }

--- a/src/updater/public_catalog.rs
+++ b/src/updater/public_catalog.rs
@@ -1,10 +1,11 @@
 //! Public PortalSurfer release-catalog checks.
 
+use semver::Version;
 use serde::Deserialize;
 
 use crate::http_client;
 
-use super::UpdateError;
+use super::{UpdateChannel, UpdateError};
 
 const MAX_RELEASE_CATALOG_JSON_BYTES: usize = 512 * 1024;
 // Catalogs may retain historical files, but only these active release targets
@@ -33,17 +34,20 @@ pub struct PublicReleaseCheckRequest {
     pub platform: String,
     /// Runtime architecture label used in release file names.
     pub arch: String,
+    /// Update channel to select from the public catalog.
+    pub channel: UpdateChannel,
 }
 
 impl PublicReleaseCheckRequest {
     /// Build a request for the current binary and target.
-    pub fn current(current_build_number: u64) -> Self {
+    pub fn current(current_build_number: u64, channel: UpdateChannel) -> Self {
         Self {
             catalog_url: PUBLIC_RELEASE_CATALOG_URL.to_string(),
             current_build_number,
             current_build_sha: env!("WAVECRATE_BUILD_GIT_SHA").to_string(),
             platform: std::env::consts::OS.to_string(),
             arch: std::env::consts::ARCH.to_string(),
+            channel,
         }
     }
 }
@@ -82,6 +86,7 @@ pub fn check_public_release_catalog(
         &request.current_build_sha,
         &request.platform,
         &request.arch,
+        request.channel,
     ))
 }
 
@@ -91,11 +96,13 @@ fn latest_available_public_release(
     current_build_sha: &str,
     platform: &str,
     arch: &str,
+    channel: UpdateChannel,
 ) -> Option<PublicReleaseInfo> {
     let asset_suffix = public_release_asset_suffix(platform, arch)?;
     let releases = catalog
         .releases
         .iter()
+        .filter(|release| release_matches_channel(release, channel))
         .filter(|release| release.has_download_for(&asset_suffix))
         .collect::<Vec<_>>();
     let latest = releases
@@ -118,6 +125,17 @@ fn latest_available_public_release(
         return None;
     }
     Some(PublicReleaseInfo::from_catalog_release(latest))
+}
+
+fn release_matches_channel(release: &PublicReleaseCatalogRelease, channel: UpdateChannel) -> bool {
+    let Ok(version) = Version::parse(&release.version) else {
+        return channel == UpdateChannel::Nightly && release.version == "nightly";
+    };
+    match channel {
+        UpdateChannel::Stable => version.pre.is_empty(),
+        UpdateChannel::Rc => version.pre.is_empty() || version.pre.as_str().starts_with("rc."),
+        UpdateChannel::Nightly => version.pre.as_str().starts_with("nightly."),
+    }
 }
 
 fn public_release_asset_suffix(platform: &str, arch: &str) -> Option<String> {
@@ -232,8 +250,15 @@ mod tests {
             release(243, "wavecrate-nightly-b243-macos-x86_64.zip"),
         ]);
 
-        let release = latest_available_public_release(&catalog, 241, "unknown", "macos", "aarch64")
-            .expect("new macos arm release");
+        let release = latest_available_public_release(
+            &catalog,
+            241,
+            "unknown",
+            "macos",
+            "aarch64",
+            UpdateChannel::Nightly,
+        )
+        .expect("new macos arm release");
 
         assert_eq!(release.build_number, 242);
         assert_eq!(release.build_id, "wavecrate-nightly-b242");
@@ -244,7 +269,15 @@ mod tests {
         let catalog = catalog(&[release(241, "wavecrate-nightly-b241-macos-aarch64.zip")]);
 
         assert!(
-            latest_available_public_release(&catalog, 241, "unknown", "macos", "aarch64").is_none()
+            latest_available_public_release(
+                &catalog,
+                241,
+                "unknown",
+                "macos",
+                "aarch64",
+                UpdateChannel::Nightly
+            )
+            .is_none()
         );
     }
 
@@ -253,7 +286,15 @@ mod tests {
         let catalog = catalog(&[release(242, "wavecrate-nightly-b242-windows-x86_64.zip")]);
 
         assert!(
-            latest_available_public_release(&catalog, 241, "unknown", "macos", "aarch64").is_none()
+            latest_available_public_release(
+                &catalog,
+                241,
+                "unknown",
+                "macos",
+                "aarch64",
+                UpdateChannel::Nightly
+            )
+            .is_none()
         );
     }
 
@@ -264,8 +305,15 @@ mod tests {
             release(999, "wavecrate-nightly-b999-linux-x86_64.zip"),
         ]);
 
-        let release = latest_available_public_release(&catalog, 241, "unknown", "macos", "aarch64")
-            .expect("new macos arm release");
+        let release = latest_available_public_release(
+            &catalog,
+            241,
+            "unknown",
+            "macos",
+            "aarch64",
+            UpdateChannel::Nightly,
+        )
+        .expect("new macos arm release");
 
         assert_eq!(release.build_number, 242);
         assert_eq!(release.build_id, "wavecrate-nightly-b242");
@@ -276,7 +324,15 @@ mod tests {
         let catalog = catalog(&[release(999, "wavecrate-nightly-b999-linux-x86_64.zip")]);
 
         assert!(
-            latest_available_public_release(&catalog, 241, "unknown", "linux", "x86_64").is_none()
+            latest_available_public_release(
+                &catalog,
+                241,
+                "unknown",
+                "linux",
+                "x86_64",
+                UpdateChannel::Nightly
+            )
+            .is_none()
         );
     }
 
@@ -327,6 +383,7 @@ mod tests {
             "d7fd3205abcdef00",
             "macos",
             "aarch64",
+            UpdateChannel::Nightly,
         )
         .expect("newer release by public catalog recency");
 
@@ -356,7 +413,8 @@ mod tests {
                 5_975,
                 "4c969d95abcdef00",
                 "macos",
-                "aarch64"
+                "aarch64",
+                UpdateChannel::Nightly
             )
             .is_none()
         );
@@ -372,13 +430,86 @@ mod tests {
         )]);
 
         assert!(
-            latest_available_public_release(&catalog, 5_975, "<unknown>", "macos", "aarch64")
-                .is_none()
+            latest_available_public_release(
+                &catalog,
+                5_975,
+                "<unknown>",
+                "macos",
+                "aarch64",
+                UpdateChannel::Nightly
+            )
+            .is_none()
         );
         assert!(
-            latest_available_public_release(&catalog, 241, "<unknown>", "macos", "aarch64")
-                .is_some()
+            latest_available_public_release(
+                &catalog,
+                241,
+                "<unknown>",
+                "macos",
+                "aarch64",
+                UpdateChannel::Nightly
+            )
+            .is_some()
         );
+    }
+
+    #[test]
+    fn public_catalog_filters_stable_rc_and_nightly_channels() {
+        let catalog = catalog(&[
+            release_with_version(
+                250,
+                "wavecrate-19.1.0-nightly.20260701+abcdef0",
+                "19.1.0-nightly.20260701+abcdef0",
+                "wavecrate-19.1.0-nightly.20260701+abcdef0-windows-x86_64.zip",
+                "2026-07-01T20:00:00.000Z",
+            ),
+            release_with_version(
+                251,
+                "wavecrate-19.1.0-rc.1",
+                "19.1.0-rc.1",
+                "wavecrate-19.1.0-rc.1-windows-x86_64.zip",
+                "2026-07-02T20:00:00.000Z",
+            ),
+            release_with_version(
+                252,
+                "wavecrate-19.1.0",
+                "19.1.0",
+                "wavecrate-19.1.0-windows-x86_64.zip",
+                "2026-07-03T20:00:00.000Z",
+            ),
+        ]);
+
+        let stable = latest_available_public_release(
+            &catalog,
+            1,
+            "unknown",
+            "windows",
+            "x86_64",
+            UpdateChannel::Stable,
+        )
+        .expect("stable");
+        let rc = latest_available_public_release(
+            &catalog,
+            1,
+            "unknown",
+            "windows",
+            "x86_64",
+            UpdateChannel::Rc,
+        )
+        .expect("rc");
+        let nightly = latest_available_public_release(
+            &catalog,
+            1,
+            "unknown",
+            "windows",
+            "x86_64",
+            UpdateChannel::Nightly,
+        )
+        .expect("nightly");
+
+        assert_eq!(stable.version, "19.1.0");
+        assert_eq!(rc.version, "19.1.0");
+        assert_eq!(nightly.version, "19.1.0-nightly.20260701+abcdef0");
     }
 
     fn catalog(releases: &[PublicReleaseCatalogRelease]) -> PublicReleaseCatalog {
@@ -406,6 +537,24 @@ mod tests {
             build_id: build_id.to_string(),
             build_number,
             version: "nightly".to_string(),
+            released_at: released_at.to_string(),
+            files: vec![PublicReleaseCatalogFile {
+                name: file_name.to_string(),
+            }],
+        }
+    }
+
+    fn release_with_version(
+        build_number: u64,
+        build_id: &str,
+        version: &str,
+        file_name: &str,
+        released_at: &str,
+    ) -> PublicReleaseCatalogRelease {
+        PublicReleaseCatalogRelease {
+            build_id: build_id.to_string(),
+            build_number,
+            version: version.to_string(),
             released_at: released_at.to_string(),
             files: vec![PublicReleaseCatalogFile {
                 name: file_name.to_string(),

--- a/tests/manual_release_matching.rs
+++ b/tests/manual_release_matching.rs
@@ -9,9 +9,9 @@ fn manual_release_asset_pattern_accepts_current_supported_platforms() {
     let pattern = manual_release_asset_pattern();
 
     for name in [
-        "wavecrate-v1.2.3-windows-x86_64.zip",
-        "wavecrate-v1.2.3-macos-x86_64.zip",
-        "wavecrate-v1.2.3-macos-aarch64.zip",
+        "wavecrate-1.2.3-windows-x86_64.zip",
+        "wavecrate-1.2.3-macos-x86_64.zip",
+        "wavecrate-1.2.3-macos-aarch64.zip",
     ] {
         assert!(pattern.is_match(name), "{name} should match");
     }
@@ -24,6 +24,10 @@ fn manual_release_asset_pattern_rejects_unsupported_linux_assets() {
     for name in [
         "wavecrate-v1.2.3-linux-x86_64.zip",
         "wavecrate-v1.2.3-linux-aarch64.zip",
+        "wavecrate-1.2.3-linux-x86_64.zip",
+        "wavecrate-1.2.3-linux-aarch64.zip",
+        "wavecrate-1.2.3-rc.1-windows-x86_64.zip",
+        "wavecrate-1.2.3-nightly.20260701+abcdef0-windows-x86_64.zip",
     ] {
         assert!(
             !pattern.is_match(name),

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -1,11 +1,13 @@
-//! Release contract checks for active targets and nightly asset labels.
+//! Release contract checks for active targets and release asset labels.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use toml::Value;
 
 const RELEASE_CONTRACT: &str = include_str!("../release_contract.toml");
-const RELEASE_WORKFLOW: &str = include_str!("../.github/workflows/release-build.yml");
+const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.yml");
+const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
+const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
 
 #[test]
 fn platform_labels_are_active_release_labels_only() {
@@ -28,13 +30,45 @@ fn platform_labels_are_active_release_labels_only() {
 fn release_contract_targets_match_nightly_workflow_matrix() {
     let contract = parse_contract();
     let targets = contract_targets(&contract);
-    let workflow_targets = workflow_release_targets();
+    let workflow_targets = workflow_release_targets(NIGHTLY_WORKFLOW);
 
     assert_eq!(
         workflow_targets,
         active_target_matrix(&targets),
         "release_contract.toml targets must match the nightly release workflow matrix"
     );
+}
+
+#[test]
+fn release_contract_targets_match_manual_release_workflow_matrices() {
+    let contract = parse_contract();
+    let targets = contract_targets(&contract);
+    let active = active_target_matrix(&targets);
+
+    assert_eq!(
+        workflow_release_targets(RC_WORKFLOW),
+        active,
+        "RC workflow matrix must match release_contract.toml targets"
+    );
+    assert_eq!(
+        workflow_release_targets(STABLE_WORKFLOW),
+        active,
+        "stable workflow matrix must match release_contract.toml targets"
+    );
+}
+
+#[test]
+fn release_contract_declares_required_channels() {
+    let contract = parse_contract();
+    let channels: BTreeSet<_> = contract
+        .get("channels")
+        .and_then(Value::as_array)
+        .expect("channels")
+        .iter()
+        .map(|channel| channel.as_str().expect("channel string"))
+        .collect();
+
+    assert_eq!(channels, BTreeSet::from(["nightly", "rc", "stable"]));
 }
 
 #[test]
@@ -69,6 +103,64 @@ fn release_contract_template_emits_supported_nightly_asset_names() {
     assert!(
         asset_names.iter().all(|name| !name.contains("linux")),
         "nightly assets generated from the release contract must not include Linux"
+    );
+}
+
+#[test]
+fn release_contract_templates_emit_supported_rc_and_stable_asset_names() {
+    let contract = parse_contract();
+    let targets = contract_targets(&contract);
+    let templates = contract
+        .get("templates")
+        .and_then(Value::as_table)
+        .expect("templates");
+    let rc_template = templates
+        .get("rc_asset")
+        .and_then(Value::as_str)
+        .expect("rc_asset template");
+    let stable_template = templates
+        .get("stable_asset")
+        .and_then(Value::as_str)
+        .expect("stable_asset template");
+
+    let rc_names: BTreeSet<String> = active_target_matrix(&targets)
+        .iter()
+        .map(|target| apply_asset_template(rc_template, app_name(&contract), target, "19.1.0", "2"))
+        .collect();
+    let stable_names: BTreeSet<String> = active_target_matrix(&targets)
+        .iter()
+        .map(|target| {
+            apply_asset_template(stable_template, app_name(&contract), target, "19.1.0", "2")
+        })
+        .collect();
+
+    assert_eq!(
+        rc_names,
+        BTreeSet::from([
+            "wavecrate-19.1.0-rc.2-macos-aarch64.zip".to_string(),
+            "wavecrate-19.1.0-rc.2-macos-x86_64.zip".to_string(),
+            "wavecrate-19.1.0-rc.2-windows-x86_64.zip".to_string(),
+        ])
+    );
+    assert_eq!(
+        stable_names,
+        BTreeSet::from([
+            "wavecrate-19.1.0-macos-aarch64.zip".to_string(),
+            "wavecrate-19.1.0-macos-x86_64.zip".to_string(),
+            "wavecrate-19.1.0-windows-x86_64.zip".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn stable_workflow_requires_matching_rc_before_publish() {
+    assert!(
+        STABLE_WORKFLOW.contains("requires at least one RC tag"),
+        "stable workflow must fail when no RC exists"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("Latest RC ${rc_tag} points at"),
+        "stable workflow must require the latest RC tag to point at the stable target commit"
     );
 }
 
@@ -143,12 +235,27 @@ fn arch_for_target(target: &str) -> String {
         .expect("target arch")
 }
 
-fn workflow_release_targets() -> BTreeSet<ReleaseTarget> {
+fn apply_asset_template(
+    template: &str,
+    app_name: &str,
+    target: &ReleaseTarget,
+    version: &str,
+    rc_number: &str,
+) -> String {
+    template
+        .replace("{APP_NAME}", app_name)
+        .replace("{version}", version)
+        .replace("{rc_number}", rc_number)
+        .replace("{platform}", &target.platform)
+        .replace("{arch}", &target.arch)
+}
+
+fn workflow_release_targets(workflow: &str) -> BTreeSet<ReleaseTarget> {
     let mut targets = BTreeSet::new();
     let mut entry = BTreeMap::new();
     let mut in_matrix_include = false;
 
-    for line in RELEASE_WORKFLOW.lines() {
+    for line in workflow.lines() {
         let trimmed = line.trim();
         if trimmed == "include:" {
             in_matrix_include = true;

--- a/tools/analysis-admin/Cargo.toml
+++ b/tools/analysis-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-analysis-admin"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [dependencies]

--- a/tools/bench-cli/Cargo.toml
+++ b/tools/bench-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-bench-cli"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [lints.rust]

--- a/tools/similarity-prep/Cargo.toml
+++ b/tools/similarity-prep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-similarity-prep"
-version = "19.0.2"
+version = "19.1.0"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- bump Wavecrate packages to 19.1.0 and remove alpha-era release labeling
- add release metadata embedding and stable/rc/nightly updater channel handling
- keep automatic nightlies and add manual RC/stable release workflows with version, branch, and promotion gates
- update release contracts, tests, and release docs for the full release path

## Validation
- cargo check -p wavecrate -p wavecrate-updater-helper -p wavecrate-installer --locked
- cargo test --test release_contract --test manual_release_matching
- bash -n scripts/internal/release/build_release_zip.sh
- powershell -ExecutionPolicy Bypass -File scripts/check.ps1 workflow-toolchain
- git diff --check
