### PR TITLE
Rename installer branding to Wavecrate

### DIFF
--- a/apps/installer/src/cleanup.rs
+++ b/apps/installer/src/cleanup.rs
@@ -2,7 +2,9 @@
 use std::{env, fs, io::ErrorKind, path::Path, path::PathBuf};
 
 #[cfg(target_os = "windows")]
-use crate::{UNINSTALL_KEY, paths};
+use crate::paths;
+#[cfg(any(test, target_os = "windows"))]
+use crate::{LEGACY_UNINSTALL_KEYS, UNINSTALL_KEY};
 
 #[cfg(target_os = "windows")]
 use windows::{
@@ -14,14 +16,22 @@ use winreg::RegKey;
 #[cfg(target_os = "windows")]
 use winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
 
+#[cfg(target_os = "windows")]
+#[derive(Debug)]
+struct RegisteredInstall {
+    key_path: &'static str,
+    install_dir: PathBuf,
+}
+
 /// Run uninstall cleanup for the current app installation.
 pub(crate) fn run_uninstall() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        let install_dir = read_install_dir_from_registry()?;
+        let registration = read_install_dir_from_registry()?;
+        let install_dir = registration.install_dir;
         remove_install_payload(&install_dir)?;
         remove_start_menu_shortcut_dir()?;
-        remove_uninstall_registry_key()?;
+        remove_uninstall_registry_keys(registration.key_path, &install_dir)?;
         finalize_install_dir(&install_dir)
     }
     #[cfg(not(target_os = "windows"))]
@@ -31,15 +41,28 @@ pub(crate) fn run_uninstall() -> Result<(), String> {
 }
 
 #[cfg(target_os = "windows")]
-fn read_install_dir_from_registry() -> Result<PathBuf, String> {
+fn read_install_dir_from_registry() -> Result<RegisteredInstall, String> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let uninstall_key = hkcu
-        .open_subkey_with_flags(UNINSTALL_KEY, KEY_READ)
-        .map_err(|err| format!("Failed to open uninstall registry key: {err}"))?;
-    let install_location: String = uninstall_key
-        .get_value("InstallLocation")
-        .map_err(|err| format!("Failed to read InstallLocation: {err}"))?;
-    Ok(PathBuf::from(install_location))
+    let mut errors = Vec::new();
+    for key_path in uninstall_key_candidates() {
+        match hkcu.open_subkey_with_flags(key_path, KEY_READ) {
+            Ok(uninstall_key) => {
+                let install_location: String =
+                    uninstall_key.get_value("InstallLocation").map_err(|err| {
+                        format!("Failed to read InstallLocation from {key_path}: {err}")
+                    })?;
+                return Ok(RegisteredInstall {
+                    key_path,
+                    install_dir: PathBuf::from(install_location),
+                });
+            }
+            Err(err) => errors.push(format!("{key_path}: {err}")),
+        }
+    }
+    Err(format!(
+        "Failed to open Wavecrate or legacy SemPal uninstall registry key: {}",
+        errors.join("; ")
+    ))
 }
 
 #[cfg(target_os = "windows")]
@@ -94,10 +117,63 @@ fn remove_start_menu_shortcut_dir() -> Result<(), String> {
 }
 
 #[cfg(target_os = "windows")]
-fn remove_uninstall_registry_key() -> Result<(), String> {
+fn remove_uninstall_registry_keys(
+    selected_key_path: &'static str,
+    install_dir: &Path,
+) -> Result<(), String> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    hkcu.delete_subkey_all(UNINSTALL_KEY)
-        .map_err(|err| format!("Failed to remove uninstall registry key: {err}"))
+    for key_path in uninstall_key_candidates() {
+        if key_path != selected_key_path
+            && !registry_key_points_to_install_dir(&hkcu, key_path, install_dir)
+        {
+            continue;
+        }
+        match hkcu.delete_subkey_all(key_path) {
+            Ok(()) => {}
+            Err(err) if key_path != selected_key_path => {}
+            Err(err) => {
+                return Err(format!(
+                    "Failed to remove uninstall registry key {key_path}: {err}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn registry_key_points_to_install_dir(hkcu: &RegKey, key_path: &str, install_dir: &Path) -> bool {
+    let Ok(key) = hkcu.open_subkey_with_flags(key_path, KEY_READ) else {
+        return false;
+    };
+    key.get_value::<String, _>("InstallLocation")
+        .ok()
+        .is_some_and(|location| {
+            crate::registry::install_location_matches_install_dir(&location, install_dir)
+        })
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn uninstall_key_candidates() -> impl Iterator<Item = &'static str> {
+    std::iter::once(UNINSTALL_KEY).chain(LEGACY_UNINSTALL_KEYS.iter().copied())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uninstall_key_candidates_prefer_wavecrate_before_legacy_sempal() {
+        let keys = uninstall_key_candidates().collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            vec![
+                "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Wavecrate",
+                "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SemPal",
+            ]
+        );
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/apps/installer/src/main.rs
+++ b/apps/installer/src/main.rs
@@ -13,11 +13,14 @@ mod paths;
 mod registry;
 mod shortcuts;
 
-const APP_NAME: &str = "SemPal";
-#[cfg(target_os = "windows")]
-const APP_PUBLISHER: &str = "SemPal";
-#[cfg(target_os = "windows")]
-const UNINSTALL_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SemPal";
+const APP_NAME: &str = "Wavecrate";
+#[cfg(any(test, target_os = "windows"))]
+const APP_PUBLISHER: &str = "Wavecrate";
+#[cfg(any(test, target_os = "windows"))]
+const UNINSTALL_KEY: &str = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Wavecrate";
+#[cfg(any(test, target_os = "windows"))]
+const LEGACY_UNINSTALL_KEYS: &[&str] =
+    &["Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SemPal"];
 
 fn main() -> ExitCode {
     match run_with_args(
@@ -113,9 +116,26 @@ fn run_headless_install() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::install::{PlanAction, plan_install};
-    use super::{InstallerEntryCommand, run_with_args, select_entry_command};
+    use super::{
+        APP_NAME, APP_PUBLISHER, InstallerEntryCommand, LEGACY_UNINSTALL_KEYS, UNINSTALL_KEY,
+        run_with_args, select_entry_command,
+    };
     use std::cell::Cell;
     use std::fs;
+
+    #[test]
+    fn installer_identity_uses_wavecrate_branding_with_explicit_legacy_uninstall_fallback() {
+        assert_eq!(APP_NAME, "Wavecrate");
+        assert_eq!(APP_PUBLISHER, "Wavecrate");
+        assert_eq!(
+            UNINSTALL_KEY,
+            "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Wavecrate"
+        );
+        assert_eq!(
+            LEGACY_UNINSTALL_KEYS,
+            &["Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SemPal"]
+        );
+    }
 
     #[test]
     fn dry_run_plans_bundle_copies() {

--- a/apps/installer/src/registry.rs
+++ b/apps/installer/src/registry.rs
@@ -4,29 +4,49 @@ use std::path::Path;
 use std::env;
 
 #[cfg(target_os = "windows")]
+use crate::LEGACY_UNINSTALL_KEYS;
+#[cfg(any(test, target_os = "windows"))]
 use crate::{APP_NAME, APP_PUBLISHER, UNINSTALL_KEY};
 
 #[cfg(target_os = "windows")]
 use winreg::RegKey;
 #[cfg(target_os = "windows")]
-use winreg::enums::HKEY_CURRENT_USER;
+use winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
+
+#[cfg(any(test, target_os = "windows"))]
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct UninstallEntryMetadata {
+    pub(crate) key_path: &'static str,
+    pub(crate) display_name: &'static str,
+    pub(crate) publisher: &'static str,
+}
+
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn uninstall_entry_metadata() -> UninstallEntryMetadata {
+    UninstallEntryMetadata {
+        key_path: UNINSTALL_KEY,
+        display_name: APP_NAME,
+        publisher: APP_PUBLISHER,
+    }
+}
 
 pub(crate) fn register_uninstall_entry(install_dir: &Path) -> Result<(), String> {
     #[cfg(not(target_os = "windows"))]
     let _ = install_dir;
     #[cfg(target_os = "windows")]
     {
+        let metadata = uninstall_entry_metadata();
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         let (key, _) = hkcu
-            .create_subkey(UNINSTALL_KEY)
+            .create_subkey(metadata.key_path)
             .map_err(|err| format!("Failed to create uninstall registry key: {err}"))?;
         let exe_path = install_dir.join("wavecrate-installer.exe");
         let uninstall = format!("\"{}\" --uninstall", exe_path.display());
-        key.set_value("DisplayName", &APP_NAME)
+        key.set_value("DisplayName", &metadata.display_name)
             .map_err(|err| format!("Failed to set DisplayName: {err}"))?;
         key.set_value("DisplayVersion", &env!("CARGO_PKG_VERSION"))
             .map_err(|err| format!("Failed to set DisplayVersion: {err}"))?;
-        key.set_value("Publisher", &APP_PUBLISHER)
+        key.set_value("Publisher", &metadata.publisher)
             .map_err(|err| format!("Failed to set Publisher: {err}"))?;
         key.set_value("InstallLocation", &install_dir.display().to_string())
             .map_err(|err| format!("Failed to set InstallLocation: {err}"))?;
@@ -37,8 +57,79 @@ pub(crate) fn register_uninstall_entry(install_dir: &Path) -> Result<(), String>
             &install_dir.join("wavecrate.ico").display().to_string(),
         )
         .map_err(|err| format!("Failed to set DisplayIcon: {err}"))?;
+        remove_legacy_uninstall_entries_for_install_dir(&hkcu, install_dir)?;
         return Ok(());
     }
     #[allow(unreachable_code)]
     Err("Uninstall registry entry is only supported on Windows.".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn remove_legacy_uninstall_entries_for_install_dir(
+    hkcu: &RegKey,
+    install_dir: &Path,
+) -> Result<(), String> {
+    for key_path in LEGACY_UNINSTALL_KEYS {
+        let Ok(key) = hkcu.open_subkey_with_flags(key_path, KEY_READ) else {
+            continue;
+        };
+        let install_location = key.get_value::<String, _>("InstallLocation").ok();
+        drop(key);
+        if install_location
+            .as_deref()
+            .is_some_and(|location| install_location_matches_install_dir(location, install_dir))
+        {
+            hkcu.delete_subkey_all(key_path)
+                .map_err(|err| format!("Failed to remove legacy uninstall registry key: {err}"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(test, target_os = "windows"))]
+pub(crate) fn install_location_matches_install_dir(
+    install_location: &str,
+    install_dir: &Path,
+) -> bool {
+    let lhs = normalize_install_location_text(install_location);
+    let rhs = normalize_install_location_text(&install_dir.display().to_string());
+    lhs.eq_ignore_ascii_case(&rhs)
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn normalize_install_location_text(path: &str) -> String {
+    path.trim().trim_end_matches(['\\', '/']).replace('/', "\\")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uninstall_entry_metadata_registers_wavecrate_not_sempal() {
+        assert_eq!(
+            uninstall_entry_metadata(),
+            UninstallEntryMetadata {
+                key_path: "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Wavecrate",
+                display_name: "Wavecrate",
+                publisher: "Wavecrate",
+            }
+        );
+    }
+
+    #[test]
+    fn install_location_match_handles_case_and_separator_drift() {
+        assert!(install_location_matches_install_dir(
+            r"c:/users/portal/appdata/local/programs/wavecrate/",
+            Path::new(r"C:\Users\portal\AppData\Local\Programs\Wavecrate")
+        ));
+    }
+
+    #[test]
+    fn install_location_match_rejects_separate_legacy_install_dir() {
+        assert!(!install_location_matches_install_dir(
+            r"C:\Users\portal\AppData\Local\Programs\SemPal",
+            Path::new(r"C:\Users\portal\AppData\Local\Programs\Wavecrate")
+        ));
+    }
 }

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -242,6 +242,30 @@ that validation did not leak fixture sources into the real startup profile.
    so the session writes to the dedicated `sandbox` profile instead of the live
    profile.
 
+### Windows installer identity
+
+New Windows installer runs are Wavecrate-branded only. The installer display
+name, publisher value, default install directory, Start Menu folder, and
+uninstall registry key must use `Wavecrate`; new installs must not register a
+`SemPal` uninstall entry.
+
+The SemPal compatibility path is uninstall-only. `wavecrate-installer
+--uninstall` first reads the Wavecrate uninstall key and then falls back to the
+legacy SemPal key so older installs can still be removed with the current
+binary. During install or uninstall, a legacy SemPal uninstall key is removed
+only when its `InstallLocation` points at the same installation being updated or
+removed. A separate old SemPal install is not silently deleted by a Wavecrate
+install.
+
+Focused validation for installer identity changes:
+
+- `cargo test -p wavecrate-installer`
+- `cargo run -p wavecrate-installer -- --dry-run`
+- On Windows, inspect `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Wavecrate`
+  after a real install and confirm `DisplayName=Wavecrate`,
+  `Publisher=Wavecrate`, and `UninstallString` points at
+  `wavecrate-installer.exe --uninstall`.
+
 ### Database migration and compatibility
 
 Use this lane when changing `.wavecrate.db`, `library.db`, source metadata


### PR DESCRIPTION
## Summary
- rename installer-visible identity from SemPal to Wavecrate
- register new installs under the Wavecrate uninstall key with Wavecrate display and publisher metadata
- keep explicit uninstall-only fallback support for legacy SemPal registry entries
- document the installer identity and compatibility contract

Closes OPT-937.

## Validation
- cargo test -p wavecrate-installer
- cargo check -p wavecrate-installer
- cargo run -p wavecrate-installer -- --dry-run with a minimal ignored target/debug/bundle fixture
- cargo fmt --all -- --check
- git diff --check
