### PR TITLE
Remove stale drag position refresh path

### DIFF
--- a/src/app/controller/ui/drag_drop_controller/actions.rs
+++ b/src/app/controller/ui/drag_drop_controller/actions.rs
@@ -40,7 +40,6 @@ pub(crate) trait DragDropActions {
         shift_down: bool,
         alt_down: bool,
     );
-    fn refresh_drag_position(&mut self, pos: UiPoint, shift_down: bool, alt_down: bool);
     fn finish_active_drag(&mut self);
 }
 
@@ -141,24 +140,6 @@ impl DragDropActions for DragDropController<'_> {
         {
             let _ = shift_down;
             *keep_source_focused = true;
-        }
-    }
-
-    fn refresh_drag_position(&mut self, pos: UiPoint, shift_down: bool, alt_down: bool) {
-        if self.ui.drag.payload.is_some() {
-            if self.ui.drag.pointer_left_window {
-                return;
-            }
-            self.ui.drag.position = Some(pos);
-            self.ui.drag.copy_on_drop = alt_down;
-            if let Some(DragPayload::Selection {
-                keep_source_focused,
-                ..
-            }) = self.ui.drag.payload.as_mut()
-            {
-                let _ = shift_down;
-                *keep_source_focused = true;
-            }
         }
     }
 

--- a/src/app/controller/ui/drag_drop_controller/delegates.rs
+++ b/src/app/controller/ui/drag_drop_controller/delegates.rs
@@ -77,12 +77,6 @@ impl AppController {
             .update_active_drag(pos, source, target, shift_down, alt_down);
     }
 
-    /// Update the stored drag pointer position (used when egui pointer positions are missing).
-    pub fn refresh_drag_position(&mut self, pos: UiPoint, shift_down: bool, alt_down: bool) {
-        self.drag_drop()
-            .refresh_drag_position(pos, shift_down, alt_down);
-    }
-
     /// Finish the active drag gesture and apply any resulting action.
     pub fn finish_active_drag(&mut self) {
         self.drag_drop().finish_active_drag();


### PR DESCRIPTION
## Summary
- remove the unused drag-position refresh compatibility entrypoint from the legacy drag/drop controller
- remove the stale egui-specific comment instead of preserving a dead wrapper
- leave the active Radiant/native typed drag update path unchanged

Closes OPT-948.

## Validation
- cargo check -p wavecrate --lib
- cargo fmt --all -- --check
- git diff --check
- rg -n "egui|refresh_drag_position" src/app/controller/ui/drag_drop_controller src/app_core/controller src/native_app/sample_library src/native_app/shell

## Notes
- `cargo test -p wavecrate drag_drop --lib` is currently blocked before running drag/drop tests by unrelated pre-existing unused imports in `src/app/controller/library/source_folders/delete_recovery/recovery/tests/*` under `#![deny(warnings)]`.
