### PR TITLE
Plan app-core legacy boundary migration

### DIFF
--- a/src/app_core/app_api.rs
+++ b/src/app_core/app_api.rs
@@ -4,11 +4,22 @@
 //! this file while the migration boundary still depends on the current `app`
 //! implementation.
 //!
-//! Migration inventory:
+//! Current migration inventory:
 //!
-//! | Legacy surface | Active follow-up |
-//! | --- | --- |
-//! | Browser/source/map/audio state DTOs | `OPT-677` |
+//! | Legacy surface | Current owner | Classification | Exit issue | Exit criteria |
+//! | --- | --- | --- | --- | --- |
+//! | `AppController`, startup/test fixture helpers, and WAV edit-support predicate | `src/app::controller` | Intentionally still owned by `src/app` while mature runtime behavior remains there | `OPT-992` | App-core exposes a narrow runtime facade; fixture construction is test-owned; domain helpers no longer require broad controller aliases |
+//! | Browser projection cache, selected-path lookup, preload-window, and auto-rename row state | `src/app::controller` retained projection state | Ready for app-core ownership | `OPT-987` | Browser projection helpers consume app-core-owned cache/row contracts and the matching aliases leave this bridge |
+//! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app::controller` retained projection/query state | Ready for app-core ownership | `OPT-988` | Map projection consumes app-core-owned query/cache contracts or a narrow map runtime adapter |
+//! | Dirty graph node/reason aliases used by frame preparation and invalidation adapters | `src/app::controller::state::runtime` | Ready for app-core invalidation ownership | `OPT-989` | App-core frame preparation and bridge invalidation use app-core invalidation names; legacy conversion is isolated or removed |
+//! | Browser, source, folder, and library-hygiene state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-990` | Browser/source/folder projections and tests use app-core DTOs or focused builders |
+//! | Waveform, prompt, drag/drop, map, audio/options, progress, update, and status state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-991` | Covered projection/action consumers use app-core DTOs or focused builders |
+//!
+//! No current app-api export was classified as ready for direct `native_app`
+//! ownership in the `OPT-949` audit; `native_app` should continue consuming
+//! app-core contracts rather than owning these migration DTOs directly. No
+//! alias was confirmed obsolete/dead in this audit. Remove aliases only after a
+//! scoped follow-up proves the replacement path with focused validation.
 
 pub(crate) mod controller {
     pub(crate) use crate::app::controller::{
@@ -24,7 +35,8 @@ pub(crate) mod controller {
 }
 
 pub(crate) mod state {
-    // Test-only projection fixtures still need these legacy state DTO exports
-    // while OPT-677 replaces legacy state usage behind app-core owned contracts.
+    // Compatibility exports for state DTOs that are being moved in scoped
+    // slices: browser/source/folder through OPT-990 and the remaining
+    // waveform/prompt/drag/map/audio/status groups through OPT-991.
     pub(crate) use crate::app::state::*;
 }

--- a/src/app_core/state.rs
+++ b/src/app_core/state.rs
@@ -4,7 +4,8 @@
 //! instead of reaching into the legacy `app` tree directly. Most entries are
 //! compatibility aliases while the legacy controller still owns the backing UI
 //! state, but this file is the documented boundary for state ownership during
-//! migration.
+//! migration. The active ownership inventory and exit criteria live next to the
+//! single legacy crossing in `app_core::app_api`.
 
 use crate::app_core::actions::NativeBrowserTagTarget;
 use crate::app_core::app_api::state as app_state;


### PR DESCRIPTION
## Summary

- update `app_core::app_api` with the current legacy app-core boundary migration inventory
- classify each remaining bridge group with owner, migration status, live exit issue, and exit criteria
- point `app_core::state` maintainers back to the active ownership inventory
- create Linear follow-ups `OPT-987` through `OPT-992`, with `OPT-992` blocked by the narrower migration slices

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/internal/check/check_migration_boundary.ps1`
- `powershell -ExecutionPolicy Bypass -File scripts/internal/check/check_legacy_app_coupling.ps1`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

`check_wavecrate_facades.ps1` still fails on unrelated pre-existing native-app facade issues: two production imports from `native_app::test_support` and one folder-browser facade module budget violation.