### PR TITLE
Clarify README Linux tooling scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ Audio sample triage tool built with Rust.
 
 https://portalsurfer.org/wavecrate/  
 https://portalsurfer.org/wavecrate/docs
+
+## Platform support
+
+Wavecrate app builds currently support macOS and Windows. Linux is not
+currently supported for app installs.
+
+Linux, WSL, and headless ALSA references in repository scripts and developer
+docs are for CI, agent, and contributor validation only; they do not describe a
+shipped Linux product platform.
+
+## Storage and logs
+
+Use **Options -> Open config folder** in the app when you need logs, settings,
+or support context.
+
+- macOS: `~/Library/Application Support/.wavecrate/`
+- Windows: `%APPDATA%\\.wavecrate\\`


### PR DESCRIPTION
## Summary
- state that Wavecrate app installs currently support macOS and Windows only
- label Linux, WSL, and headless ALSA references as CI/agent/contributor validation tooling only
- list README storage/log paths only for supported app platforms

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 docs-index`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 markdown-links`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 manual-docs-scope`
- `git diff --check`

`powershell -ExecutionPolicy Bypass -File scripts\check.ps1 mdbook` could not run because `mdbook` is not installed locally (`cargo install mdbook --locked`).

Linear: OPT-946