### PR TITLE
Clarify manual usage platform docs

### DIFF
--- a/manual/usage.md
+++ b/manual/usage.md
@@ -10,6 +10,12 @@ description: How to set up Wavecrate, triage samples, edit waveforms, and manage
 * TOC
 {:toc}
 
+## Documentation status
+
+This is the current lightweight GitHub Pages usage guide. The expanded public
+docs live at <https://portalsurfer.org/wavecrate/docs/>; both surfaces document
+the same shipped app platforms: macOS and Windows.
+
 ## Quick start
 - Add a source folder with **+** or by dropping it onto the Sources panel; the first `.wav` row auto-loads and starts playback.
 - Drag on the waveform with the primary mouse button to create a play mark selection, or use the secondary mouse button to create an edit mark selection for destructive in-place edits (crop, trim, reverse, fades, mute, smooth, normalize).


### PR DESCRIPTION
## Summary
- clarify that `manual/usage.md` is the current lightweight GitHub Pages usage guide
- point readers to the expanded public mdBook docs
- make the shared shipped platform matrix explicit: macOS and Windows

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 manual-docs-scope`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 markdown-links`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 docs-index`
- `git diff --check`
- targeted grep confirmed no `XDG_CONFIG_HOME`, `Linux:` path entries, or Linux `.wavecrate` file-location guidance in `manual/usage.md`

Rendered GitHub Pages preview could not run locally because Ruby/Bundler/Jekyll are not installed in this environment.

Linear: OPT-947