### PR TITLE
Clarify startup perf calibration policy

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -375,7 +375,7 @@ flush boundaries. Accepted values: `1`, `true`, `on`, `yes`
 ## Performance guard benchmark overrides
 
 - `WAVECRATE_PERF_GUARD_OUT`
-Output path used by `scripts/perf.sh guard` for the benchmark JSON report.
+Output path used by `scripts/perf.* guard` for the benchmark JSON report.
 Default: `target/perf/bench.json`.
 
 - `WAVECRATE_PERF_GUARD_GUI_ROWS`
@@ -401,13 +401,22 @@ Default: `16`.
 
 - `WAVECRATE_PERF_GUARD_RUNS`
 Number of full `wavecrate-bench` benchmark CLI runs executed by
-`scripts/perf.sh guard`. When greater than `1`, the guard reports median
+`scripts/perf.* guard`. When greater than `1`, the guard reports median
 percentiles across runs and the p95 spread across runs. Default: `1`.
 
 - `WAVECRATE_PERF_GUARD_STARTUP_PROFILE`
-When set to `1`/`true`/`on`/`yes`, `scripts/perf.sh guard` also captures
+When set to `1`/`true`/`on`/`yes`, `scripts/perf.* guard` also captures
 native startup timing logs by launching `wavecrate` under timeout and parsing
 `RADIANT_NATIVE_STARTUP_PROFILE` output. Default: disabled (`0`).
+For release-risk startup evidence, run this guard on supported app platforms.
+The Bash `scripts/perf.sh calibrate-startup` command is Linux developer-only
+threshold-refresh tooling and is not product Linux support.
+
+- `WAVECRATE_PERF_GUARD_STARTUP_HIDDEN`
+Optional developer-only startup-profile flag. When set to `1`/`true`/`on`/`yes`,
+Wavecrate keeps its native window hidden after surface setup while preserving
+first-present timing diagnostics. Leave this unset for release-risk startup
+evidence because hidden-window captures do not measure user-visible first paint.
 
 - `WAVECRATE_PERF_GUARD_STARTUP_TIMEOUT_SECS`
 Timeout (seconds) used for each startup-profile capture run when startup
@@ -429,12 +438,12 @@ Default: `<WAVECRATE_PERF_GUARD_OUT>.startup_summary.json`.
 
 - `WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_OUT`
 Optional output env file path for startup threshold locking. When set and
-startup profiling succeeds, `scripts/perf.sh guard` writes startup threshold
+startup profiling succeeds, `scripts/perf.* guard` writes startup threshold
 assignments to this file using `scripts/internal/perf/perf_startup_lock_thresholds.py`.
 
 - `WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_IN`
 Optional startup threshold lock-file input path sourced by
-`scripts/perf.sh guard` before threshold parsing. Defaults to the tracked
+`scripts/perf.* guard` before threshold parsing. Defaults to the tracked
 lock file at `scripts/internal/perf/locks/startup_thresholds.env`. Set to an empty value
 to disable auto-loading.
 
@@ -445,7 +454,7 @@ Minimum valid startup-profile run count required before writing
 
 - `WAVECRATE_PERF_GUARD_FRAME_QUALITY_LOCK_ENV_OUT`
 Optional output env file path for frame-quality threshold locking. When set,
-`scripts/perf.sh guard` writes calibrated frame-jank and missed-present
+`scripts/perf.* guard` writes calibrated frame-jank and missed-present
 threshold assignments to this path using
 `scripts/internal/perf/perf_frame_quality_lock_thresholds.py`.
 
@@ -508,7 +517,7 @@ interaction benchmark results. Default: `8000`.
 
 - `WAVECRATE_PERF_WARN_FRAME_JANK_RATIO`
 Warning threshold (ratio `0.0..=1.0`) for per-scenario frame-jank proxy share
-reported by `scripts/perf.sh guard` from benchmark latency samples above
+reported by `scripts/perf.* guard` from benchmark latency samples above
 `frame_budget_us` (`16667us`). Default: `0.10`.
 
 - `WAVECRATE_PERF_FAIL_FRAME_JANK_RATIO`
@@ -517,7 +526,7 @@ proxy share. Unset by default.
 
 - `WAVECRATE_PERF_WARN_MISSED_PRESENT_PROXY_RATIO`
 Warning threshold (ratio `0.0..=1.0`) for per-scenario missed-present proxy
-share reported by `scripts/perf.sh guard` from benchmark latency samples
+share reported by `scripts/perf.* guard` from benchmark latency samples
 above `2 * frame_budget_us` (`33334us`). Default: `0.05`.
 
 - `WAVECRATE_PERF_FAIL_MISSED_PRESENT_PROXY_RATIO`

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -319,6 +319,13 @@ per-launch diagnostics trail.
   - `bash scripts/perf.sh guard`
   - `powershell -ExecutionPolicy Bypass -File scripts/perf.ps1 guard`
 
+Startup threshold calibration is not a release lane by itself. The Bash
+`scripts/perf.sh calibrate-startup` command is optional Linux developer tooling
+for refreshing startup threshold lock files on compositor-backed hosts. Current
+release-risk startup perf evidence should be collected with `scripts/perf.* guard`
+on supported app platforms, using `WAVECRATE_PERF_GUARD_STARTUP_PROFILE=1` when
+first-paint startup timing evidence is required.
+
 ## CI reference
 
 GitHub CI and local wrappers together cover:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,8 +16,10 @@ dispatcher maps. These are the public entrypoints people should run directly:
   entrypoints.
 - `check.{sh,ps1}`: focused guardrails and report helpers.
 - `run.{sh,ps1}`: sandbox, cleanup, log, and bug-bundle helpers.
-- `perf.{sh,ps1}`: performance guard and calibration commands. The startup
-  threshold calibration helper is currently bash-only.
+- `perf.{sh,ps1}`: performance guard commands. `scripts/perf.* guard` is the
+  maintained local/manual or release-risk perf lane. The Bash-only
+  `calibrate-startup` command is optional Linux developer tooling for refreshing
+  startup threshold lock files; it is not shipped Linux product support.
 - `gui.ps1`: Windows GUI validation lanes.
 
 PowerShell compatibility wrappers also remain available for the older

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -62,7 +62,7 @@
     },
     {
       "path": "scripts/perf.sh",
-      "role": "Runtime performance helpers, including bash-only calibration.",
+      "role": "Runtime performance helpers; bash-only startup calibration is Linux developer tooling, not a supported-platform release lane.",
       "windows_supported": false
     },
     {

--- a/scripts/internal/perf/calibrate_startup_thresholds.sh
+++ b/scripts/internal/perf/calibrate_startup_thresholds.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-# Calibrate startup-first-paint perf thresholds on a compositor-backed host and
-# write/update the tracked startup threshold lock file.
+# Optional Linux developer-only startup threshold calibration.
+#
+# Release-risk startup perf evidence is owned by scripts/perf.* guard on
+# supported app platforms. This helper remains for contributor threshold refresh
+# on Linux compositor-backed hosts; it does not imply shipped Linux app support.
 
 set -euo pipefail
 
@@ -12,11 +15,11 @@ LOCK_OUT="${WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_OUT:-$ROOT_DIR/scripts/interna
 RUNS="${WAVECRATE_PERF_GUARD_RUNS:-7}"
 
 if [[ -z "${WAYLAND_DISPLAY:-}" && -z "${DISPLAY:-}" ]]; then
-  echo "[perf_guard] ERROR: startup calibration requires a compositor-backed host (WAYLAND_DISPLAY or DISPLAY)." >&2
+  echo "[perf_guard] ERROR: developer-only startup calibration requires a Linux compositor-backed host (WAYLAND_DISPLAY or DISPLAY)." >&2
   exit 2
 fi
 
-echo "[perf_guard] calibrating startup thresholds (runs=${RUNS})"
+echo "[perf_guard] calibrating startup thresholds with Linux developer tooling (runs=${RUNS})"
 WAVECRATE_PERF_GUARD_RUNS="$RUNS" \
 WAVECRATE_PERF_GUARD_STARTUP_PROFILE=1 \
 WAVECRATE_PERF_GUARD_STARTUP_REQUIRE_VALID_RUNS=1 \

--- a/scripts/internal/perf/locks/startup_thresholds.env
+++ b/scripts/internal/perf/locks/startup_thresholds.env
@@ -1,19 +1,25 @@
 # Startup perf-guard thresholds (tracked lock file).
 #
-# This file is sourced by scripts/internal/perf/run_perf_guard.sh when present.
-# Use default assignment so explicit caller-provided env overrides always win.
+# This file is loaded by scripts/internal/perf/run_perf_guard.sh and
+# scripts/internal/perf/run_perf_guard.ps1 when startup profiling is enabled.
+# Use default assignment syntax so explicit caller-provided env overrides always
+# win.
 #
-# Calibrate on compositor-backed hosts with:
+# Optional Linux developer-only calibration on compositor-backed hosts:
 #   bash scripts/internal/perf/calibrate_startup_thresholds.sh
+#
+# Release-risk startup perf evidence should come from scripts/perf.* guard on
+# supported app platforms. This lock file does not imply shipped Linux app
+# support.
 
-: "${WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_MS:=800}"
+: "${WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_MS:=2970}"
 export WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_MS
 
-: "${WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_MS:=1600}"
+: "${WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_MS:=4752}"
 export WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_MS
 
-: "${WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_SPREAD_MS:=300}"
+: "${WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_SPREAD_MS:=1107}"
 export WAVECRATE_PERF_WARN_STARTUP_FIRST_PRESENT_SPREAD_MS
 
-: "${WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_SPREAD_MS:=600}"
+: "${WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_SPREAD_MS:=1993}"
 export WAVECRATE_PERF_FAIL_STARTUP_FIRST_PRESENT_SPREAD_MS

--- a/scripts/internal/perf/perf_startup_summary.py
+++ b/scripts/internal/perf/perf_startup_summary.py
@@ -41,7 +41,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Parse native startup timing logs emitted by "
-            "WAVECRATE_NATIVE_STARTUP_PROFILE and print a guard summary."
+            "RADIANT_NATIVE_STARTUP_PROFILE and print a guard summary."
         )
     )
     parser.add_argument(

--- a/scripts/internal/perf/run_perf_guard.ps1
+++ b/scripts/internal/perf/run_perf_guard.ps1
@@ -186,8 +186,8 @@ function Invoke-StartupProfileRun {
   $stderrPath = "$OutputPath.stderr.log"
   Remove-Item -LiteralPath $stdoutPath, $stderrPath, $OutputPath -ErrorAction SilentlyContinue
 
-  $previousStartupProfile = $env:WAVECRATE_NATIVE_STARTUP_PROFILE
-  $env:WAVECRATE_NATIVE_STARTUP_PROFILE = "1"
+  $previousStartupProfile = $env:RADIANT_NATIVE_STARTUP_PROFILE
+  $env:RADIANT_NATIVE_STARTUP_PROFILE = "1"
   try {
     $process = Start-Process `
       -FilePath $BinaryPath `
@@ -202,9 +202,9 @@ function Invoke-StartupProfileRun {
     }
   } finally {
     if ($null -eq $previousStartupProfile) {
-      Remove-Item Env:WAVECRATE_NATIVE_STARTUP_PROFILE -ErrorAction SilentlyContinue
+      Remove-Item Env:RADIANT_NATIVE_STARTUP_PROFILE -ErrorAction SilentlyContinue
     } else {
-      $env:WAVECRATE_NATIVE_STARTUP_PROFILE = $previousStartupProfile
+      $env:RADIANT_NATIVE_STARTUP_PROFILE = $previousStartupProfile
     }
   }
 
@@ -226,7 +226,7 @@ $startupProfileEnabled = Get-BoolEnvFlag -Name "WAVECRATE_PERF_GUARD_STARTUP_PRO
 $startupTimeoutSecs = Get-EnvInt -Name "WAVECRATE_PERF_GUARD_STARTUP_TIMEOUT_SECS" -Default 6
 $startupRequireValidRuns = Get-BoolEnvFlag -Name "WAVECRATE_PERF_GUARD_STARTUP_REQUIRE_VALID_RUNS"
 $startupLockEnvOut = [Environment]::GetEnvironmentVariable("WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_OUT")
-$startupLockEnvIn = Get-EnvString -Name "WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_IN" -Default (Join-Path $rootDir "scripts\perf\locks\startup_thresholds.env")
+$startupLockEnvIn = Get-EnvString -Name "WAVECRATE_PERF_GUARD_STARTUP_LOCK_ENV_IN" -Default (Join-Path $rootDir "scripts\internal\perf\locks\startup_thresholds.env")
 $startupLockMinValidRuns = Get-OptionalEnvInt -Name "WAVECRATE_PERF_GUARD_STARTUP_LOCK_MIN_VALID_RUNS"
 
 if ($runs -lt 1) {
@@ -235,13 +235,27 @@ if ($runs -lt 1) {
 
 if ($startupProfileEnabled -and (Test-Path $startupLockEnvIn)) {
   Get-Content $startupLockEnvIn | ForEach-Object {
-    if ($_ -match '^\s*(?:#|$)') {
+    $line = $_.Trim()
+    if ($line -match '^\s*(?:#|$)') {
       return
     }
-    if ($_ -match 'WAVECRATE_PERF_[A-Z0-9_]+=') {
-      $parts = $_ -split '=', 2
-      $name = $parts[0].Trim(' :${}" ')
-      $value = $parts[1].Trim(' "}')
+
+    $name = $null
+    $value = $null
+    $isDefaultAssignment = $false
+    if ($line -match '^:\s*"\$\{(?<name>WAVECRATE_PERF_[A-Z0-9_]+):=(?<value>[^}]*)\}"\s*$') {
+      $name = $Matches["name"]
+      $value = $Matches["value"]
+      $isDefaultAssignment = $true
+    } elseif ($line -match '^(?:export\s+)?(?<name>WAVECRATE_PERF_[A-Z0-9_]+)=(?<value>.*)$') {
+      $name = $Matches["name"]
+      $value = $Matches["value"].Trim(' "')
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($name)) {
+      if ($isDefaultAssignment -and -not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($name))) {
+        return
+      }
       [Environment]::SetEnvironmentVariable($name, $value)
     }
   }

--- a/scripts/internal/perf/run_perf_guard.sh
+++ b/scripts/internal/perf/run_perf_guard.sh
@@ -144,7 +144,7 @@ for run in $(seq 1 "$RUNS"); do
     STARTUP_LOG_PATHS+=("$startup_log")
     echo "[perf_guard] capturing native startup profile (run ${run}/${RUNS})"
     set +e
-    WAVECRATE_NATIVE_STARTUP_PROFILE=1 \
+    RADIANT_NATIVE_STARTUP_PROFILE=1 \
       timeout --signal=TERM --kill-after=1s "${STARTUP_TIMEOUT_SECS}s" \
       "$startup_binary" >"$startup_log" 2>&1
     startup_status=$?

--- a/scripts/perf.sh
+++ b/scripts/perf.sh
@@ -5,6 +5,15 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage: scripts/perf.sh <guard|calibrate-startup|wheel-stability> [args...]
+
+Commands:
+  guard              Run the maintained local/manual perf guard.
+  wheel-stability    Collect wheel-latency stability evidence.
+  calibrate-startup  Linux developer-only startup threshold refresh helper.
+
+`calibrate-startup` requires WAYLAND_DISPLAY or DISPLAY and does not represent
+shipped Linux product support. Use `scripts/perf.* guard` for release-risk
+startup perf evidence on supported app platforms.
 EOF
 }
 

--- a/src/native_app/shell/launch/options.rs
+++ b/src/native_app/shell/launch/options.rs
@@ -7,6 +7,7 @@ use wavecrate::native_runtime::{WAVECRATE_UI_FONT_BYTES, wavecrate_ui_font_path}
 use super::icon::wavecrate_window_icon;
 
 const APP_NAME: &str = "Wavecrate";
+const PERF_GUARD_STARTUP_HIDDEN_ENV: &str = "WAVECRATE_PERF_GUARD_STARTUP_HIDDEN";
 
 pub(in crate::native_app) fn default_window_title() -> String {
     let metadata = wavecrate::release_metadata::CURRENT;
@@ -19,6 +20,13 @@ pub(in crate::native_app) fn default_window_title() -> String {
 }
 
 pub(super) fn native_run_options(debug_layout: bool) -> NativeRunOptions {
+    native_run_options_with_startup_hidden(debug_layout, perf_guard_startup_hidden())
+}
+
+fn native_run_options_with_startup_hidden(
+    debug_layout: bool,
+    startup_hidden: bool,
+) -> NativeRunOptions {
     NativeRunOptions {
         window: NativeWindowOptions {
             title: default_window_title(),
@@ -30,6 +38,7 @@ pub(super) fn native_run_options(debug_layout: bool) -> NativeRunOptions {
             behavior: NativeWindowBehavior {
                 drag_and_drop: true,
                 maximized: true,
+                reveal_after_surface_setup: !startup_hidden,
                 ..NativeWindowBehavior::default()
             },
             icon: wavecrate_window_icon(),
@@ -45,6 +54,15 @@ pub(super) fn native_run_options(debug_layout: bool) -> NativeRunOptions {
         },
         ..NativeRunOptions::default()
     }
+}
+
+fn perf_guard_startup_hidden() -> bool {
+    std::env::var(PERF_GUARD_STARTUP_HIDDEN_ENV).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 #[cfg(test)]
@@ -67,6 +85,14 @@ mod tests {
         assert!(options.frame.debug_layout);
         assert!(options.window.behavior.maximized);
         assert!(options.window.behavior.decorations);
+        assert!(options.window.behavior.reveal_after_surface_setup);
+    }
+
+    #[test]
+    fn perf_guard_startup_hidden_keeps_main_window_unrevealed() {
+        let options = native_run_options_with_startup_hidden(false, true);
+
+        assert!(!options.window.behavior.reveal_after_surface_setup);
     }
 
     #[test]

--- a/tools/bench-cli/src/bench/gui/interactions.rs
+++ b/tools/bench-cli/src/bench/gui/interactions.rs
@@ -5,7 +5,10 @@ pub(super) mod step_patterns;
 
 use super::super::{options::BenchOptions, stats};
 use super::workspace::wait_for_rows;
-use wavecrate::app_core::actions::{NativeAppBridge, NativeMotionModel, NativeUiAction};
+use wavecrate::app_core::actions::{
+    NativeAppBridge, NativeBrowserAction, NativeMotionModel, NativeOptionsAction, NativeUiAction,
+    NativeWaveformAction,
+};
 use wavecrate::app_core::controller::{AppController, AppControllerUiRuntimeExt};
 use wavecrate::app_core::state::{
     MapBounds, MapPoint, MapQueryBounds, SampleBrowserSort, TriageFlagFilter,
@@ -71,7 +74,9 @@ pub(super) fn bench_wheel_latency(
             };
             step = step.saturating_add(1);
             timer.mark_input_done();
-            bridge.reduce_action(NativeUiAction::MoveBrowserFocus { delta });
+            bridge.reduce_action(NativeUiAction::Browser(
+                NativeBrowserAction::MoveBrowserFocus { delta },
+            ));
             timer.mark_apply_done();
             let _ = bridge.project_model();
             timer.mark_pull_done();
@@ -284,9 +289,9 @@ pub(super) fn bench_volume_drag_latency(
         interaction_iters(options),
         |timer| {
             timer.mark_input_done();
-            bridge.reduce_action(NativeUiAction::SetVolume {
+            bridge.reduce_action(NativeUiAction::Options(NativeOptionsAction::SetVolume {
                 value_milli: volume_milli_for_step(step),
-            });
+            }));
             step = step.saturating_add(1);
             timer.mark_apply_done();
             let _ = bridge.project_model();
@@ -307,9 +312,11 @@ pub(super) fn bench_idle_cursor_motion_latency(
         interaction_iters(options),
         |timer| {
             timer.mark_input_done();
-            bridge.reduce_action(NativeUiAction::SetWaveformCursor {
-                position_milli: ((step.saturating_mul(37) % 1000) + 1) as u16,
-            });
+            bridge.reduce_action(NativeUiAction::Waveform(
+                NativeWaveformAction::SetWaveformCursorPrecise {
+                    position_nanos: ((step.saturating_mul(37) % 1000) + 1) as u32 * 1_000_000,
+                },
+            ));
             step = step.saturating_add(1);
             timer.mark_apply_done();
             let _: Option<NativeMotionModel> = bridge.project_motion_model();
@@ -350,7 +357,9 @@ fn interaction_warmup(options: &BenchOptions) -> usize {
 
 /// Prime map cache fields so interaction benchmarks avoid cold-start query cost.
 pub(super) fn prime_map_cache_for_benchmark(controller: &mut AppController) -> Result<(), String> {
-    controller.apply_ui_action(NativeUiAction::SetBrowserTab { map: true });
+    controller.apply_ui_action(NativeUiAction::Browser(
+        NativeBrowserAction::SetBrowserTab { map: true },
+    ));
     let source_id = controller
         .ui
         .sources

--- a/tools/bench-cli/src/bench/gui/interactions/step_patterns.rs
+++ b/tools/bench-cli/src/bench/gui/interactions/step_patterns.rs
@@ -1,52 +1,52 @@
 //! Deterministic interaction-step helpers shared by GUI benchmark scenarios.
 
-use wavecrate::app_core::actions::NativeUiAction;
+use wavecrate::app_core::actions::{NativeUiAction, NativeWaveformAction};
 use wavecrate::app_core::state::{SampleBrowserSort, TriageFlagFilter};
 
 /// Return a deterministic waveform action for a benchmark step index.
 pub(in crate::bench::gui) fn waveform_action_for_step(step: usize) -> NativeUiAction {
     match step % 6 {
-        0 => NativeUiAction::SeekWaveform {
-            position_milli: 320,
-        },
-        1 => NativeUiAction::SetWaveformCursor {
-            position_milli: 480,
-        },
-        2 => NativeUiAction::SetWaveformSelectionRange {
+        0 => NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise {
+            position_nanos: 320_000_000,
+        }),
+        1 => NativeUiAction::Waveform(NativeWaveformAction::SetWaveformCursorPrecise {
+            position_nanos: 480_000_000,
+        }),
+        2 => NativeUiAction::Waveform(NativeWaveformAction::SetWaveformSelectionRange {
             start_micros: 220_000,
             end_micros: 660_000,
             snap_override: false,
             preserve_view_edge: false,
-        },
-        3 => NativeUiAction::ZoomWaveform {
+        }),
+        3 => NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform {
             zoom_in: true,
             steps: 2,
             anchor_ratio_micros: None,
-        },
-        4 => NativeUiAction::ZoomWaveformToSelection,
-        _ => NativeUiAction::ZoomWaveformFull,
+        }),
+        4 => NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveformToSelection),
+        _ => NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveformFull),
     }
 }
 
 /// Return an adjacent pan/zoom waveform action for a benchmark step index.
 pub(in crate::bench::gui) fn adjacent_waveform_action_for_step(step: usize) -> NativeUiAction {
     match step % 4 {
-        0 => NativeUiAction::SeekWaveform {
-            position_milli: 380,
-        },
-        1 => NativeUiAction::SeekWaveform {
-            position_milli: 410,
-        },
-        2 => NativeUiAction::ZoomWaveform {
+        0 => NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise {
+            position_nanos: 380_000_000,
+        }),
+        1 => NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise {
+            position_nanos: 410_000_000,
+        }),
+        2 => NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform {
             zoom_in: true,
             steps: 1,
             anchor_ratio_micros: None,
-        },
-        _ => NativeUiAction::ZoomWaveform {
+        }),
+        _ => NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform {
             zoom_in: false,
             steps: 1,
             anchor_ratio_micros: None,
-        },
+        }),
     }
 }
 

--- a/tools/bench-cli/src/bench/gui/rebuild_probe.rs
+++ b/tools/bench-cli/src/bench/gui/rebuild_probe.rs
@@ -12,7 +12,9 @@ use super::interactions::{
     },
 };
 use super::workspace::wait_for_rows;
-use wavecrate::app_core::actions::NativeUiAction;
+use wavecrate::app_core::actions::{
+    NativeBrowserAction, NativeOptionsAction, NativeUiAction, NativeWaveformAction,
+};
 use wavecrate::app_core::controller::{AppController, AppControllerUiRuntimeExt};
 use wavecrate::app_core::state::{SampleBrowserSort, TriageFlagFilter};
 use wavecrate::app_core::ui_bridge::{
@@ -132,7 +134,9 @@ fn probe_wheel(
                 _ => -2,
             };
             step = step.saturating_add(1);
-            controller.apply_ui_action(NativeUiAction::MoveBrowserFocus { delta });
+            controller.apply_ui_action(NativeUiAction::Browser(
+                NativeBrowserAction::MoveBrowserFocus { delta },
+            ));
         },
     )
 }
@@ -281,9 +285,9 @@ fn probe_volume(
         measure_iters,
         false,
         |controller, step| {
-            controller.apply_ui_action(NativeUiAction::SetVolume {
+            controller.apply_ui_action(NativeUiAction::Options(NativeOptionsAction::SetVolume {
                 value_milli: volume_milli_for_step(step),
-            });
+            }));
         },
     )
 }
@@ -301,9 +305,11 @@ fn probe_idle_cursor_motion(
         measure_iters,
         true,
         |controller, _| {
-            controller.apply_ui_action(NativeUiAction::SetWaveformCursor {
-                position_milli: ((step.saturating_mul(37) % 1000) + 1) as u16,
-            });
+            controller.apply_ui_action(NativeUiAction::Waveform(
+                NativeWaveformAction::SetWaveformCursorPrecise {
+                    position_nanos: ((step.saturating_mul(37) % 1000) + 1) as u32 * 1_000_000,
+                },
+            ));
             step = step.saturating_add(1);
         },
     )

--- a/tools/bench-cli/src/bench/gui/segment_probe.rs
+++ b/tools/bench-cli/src/bench/gui/segment_probe.rs
@@ -4,7 +4,7 @@ use super::super::options::BenchOptions;
 use super::attribution::{GuiInteractionSegmentAttribution, SegmentAttributionSummary};
 use super::interactions::{execute_interaction_step, prime_map_cache_for_benchmark};
 use super::workspace::wait_for_rows;
-use wavecrate::app_core::actions::NativeUiAction;
+use wavecrate::app_core::actions::{NativeBrowserAction, NativeUiAction, NativeWaveformAction};
 use wavecrate::app_core::controller::{AppController, AppControllerUiRuntimeExt};
 use wavecrate::app_core::ui_bridge::{
     ProjectionSegmentLookupCount, ProjectionSegmentProbeMeasurement,
@@ -57,7 +57,9 @@ pub(super) fn collect_interaction_segment_attribution(
                 _ => -2,
             };
             rows_step = rows_step.saturating_add(1);
-            controller.apply_ui_action(NativeUiAction::MoveBrowserFocus { delta });
+            controller.apply_ui_action(NativeUiAction::Browser(
+                NativeBrowserAction::MoveBrowserFocus { delta },
+            ));
         },
     );
 
@@ -84,9 +86,11 @@ pub(super) fn collect_interaction_segment_attribution(
         warmup_iters,
         measure_iters,
         |controller, _| {
-            controller.apply_ui_action(NativeUiAction::SetWaveformCursor {
-                position_milli: ((waveform_step % 1000) + 1) as u16,
-            });
+            controller.apply_ui_action(NativeUiAction::Waveform(
+                NativeWaveformAction::SetWaveformCursorPrecise {
+                    position_nanos: ((waveform_step % 1000) + 1) as u32 * 1_000_000,
+                },
+            ));
             waveform_step = waveform_step.saturating_add(37);
         },
     );


### PR DESCRIPTION
## Summary
- keep Linux startup calibration as optional developer-only tooling while making supported-platform perf guard evidence the release-risk path
- fix startup profiling to use `RADIANT_NATIVE_STARTUP_PROFILE` and update the startup threshold lock from visible Windows runs
- add explicit developer-only hidden startup support without making hidden captures the default release metric
- update bench-cli GUI actions for the grouped native action model so perf guard runs

## Validation
- `cargo test -p radiant window_policy`
- `cargo test -p wavecrate --bin wavecrate native_app::shell::launch::options::tests`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 docs-index`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 markdown-links`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 script-guardrails`
- `bash -n scripts/perf.sh scripts/internal/perf/calibrate_startup_thresholds.sh scripts/internal/perf/run_perf_guard.sh`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/perf.ps1 guard` with `WAVECRATE_PERF_GUARD_STARTUP_PROFILE=1`, 3 visible runs, required valid startup profiles, and tracked startup lock loaded
- startup summary validation against visible verification logs with `runs=3/3`
- Radiant API skill validators

Note: a broad `cargo test -p wavecrate ...` attempt hit unrelated pre-existing unused imports in delete-recovery tests, so the changed launch code was verified through the binary test target.