### PR TITLE
Clarify public docs supported storage paths

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -36,7 +36,7 @@ After a source is added:
 
 ## Where Wavecrate Stores Settings
 
-Wavecrate keeps app data in a `.wavecrate` folder inside your supported operating system config directory.
+On supported app platforms, Wavecrate keeps app data in a `.wavecrate` folder inside the operating system config directory.
 
 - macOS: `~/Library/Application Support/.wavecrate/`
 - Windows: `%APPDATA%\\.wavecrate\\`

--- a/docs/book/src/troubleshooting.md
+++ b/docs/book/src/troubleshooting.md
@@ -4,7 +4,9 @@
 
 Use **Options -> Open config folder** and look under `.wavecrate/logs`.
 
-Wavecrate app builds currently support macOS and Windows. On a normal supported install, the config folder is:
+Wavecrate app builds currently support macOS and Windows. Linux is not currently supported for app installs.
+
+On supported app platforms, the config folder is:
 
 - macOS: `~/Library/Application Support/.wavecrate/`
 - Windows: `%APPDATA%\\.wavecrate\\`


### PR DESCRIPTION
## Summary
- align public mdBook storage/log path wording with current macOS/Windows app support
- keep public config/log path lists limited to macOS and Windows
- explicitly state Linux app installs are not currently supported in troubleshooting

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 markdown-links`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 docs-index`
- `powershell -ExecutionPolicy Bypass -File scripts\check.ps1 mdbook`
- `bash -lc 'PATH="$HOME/.cargo/bin:$PATH"; scripts/check.sh mdbook'`
- `git diff --check`