### PR TITLE
Clarify updater apply test platform fixtures

### DIFF
--- a/src/app/controller/library/source_folders/delete_recovery/recovery/tests/mod.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/tests/mod.rs
@@ -9,8 +9,11 @@ use super::*;
 use crate::app::controller::library::source_folders::delete_recovery::restore_merge::restore_retained_folder_with_merge_with_stamp;
 use crate::app::controller::library::source_folders::delete_recovery::{
     DeleteRecoveryAction, DeleteRecoveryStatus, mark_delete_restore_pending_db,
-    mark_delete_retained, purge_deleted_folder, restore_deleted_folder, rollback_staged_folder,
-    stage_folder_for_delete,
+    mark_delete_retained, stage_folder_for_delete,
+};
+#[cfg(unix)]
+use crate::app::controller::library::source_folders::delete_recovery::{
+    purge_deleted_folder, restore_deleted_folder, rollback_staged_folder,
 };
 use crate::sample_sources::SampleSource;
 use std::fs;

--- a/src/app/controller/library/source_folders/delete_recovery/recovery/tests/path_containment.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/recovery/tests/path_containment.rs
@@ -1,6 +1,9 @@
 use super::*;
+#[cfg(unix)]
 use crate::app::controller::library::source_folders::delete_recovery::DeleteStagingInfo;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 
 #[test]
 fn recover_rejects_parent_dir_original_without_restoring_outside_source() {

--- a/src/updater/apply/relaunch.rs
+++ b/src/updater/apply/relaunch.rs
@@ -39,25 +39,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn app_executable_name_prefers_manifest_exe_when_present() {
-        let manifest = manifest_with_files(vec!["wavecrate.exe"]);
+    fn app_executable_name_prefers_windows_manifest_exe_when_present() {
+        let manifest = windows_manifest_with_files(vec!["wavecrate.exe"]);
 
         assert_eq!(app_executable_name("wavecrate", &manifest), "wavecrate.exe");
     }
 
     #[test]
-    fn app_executable_name_uses_app_name_without_exe_manifest_entry() {
-        let manifest = manifest_with_files(vec!["wavecrate"]);
+    fn app_executable_name_uses_macos_binary_name_without_exe_manifest_entry() {
+        let manifest = macos_manifest_with_files(vec!["wavecrate"]);
 
         assert_eq!(app_executable_name("wavecrate", &manifest), "wavecrate");
     }
 
-    fn manifest_with_files(files: Vec<&str>) -> UpdateManifest {
+    fn windows_manifest_with_files(files: Vec<&str>) -> UpdateManifest {
+        supported_platform_manifest_with_files("x86_64-pc-windows-msvc", "windows", files)
+    }
+
+    fn macos_manifest_with_files(files: Vec<&str>) -> UpdateManifest {
+        supported_platform_manifest_with_files("x86_64-apple-darwin", "macos", files)
+    }
+
+    fn supported_platform_manifest_with_files(
+        target: &str,
+        platform: &str,
+        files: Vec<&str>,
+    ) -> UpdateManifest {
         UpdateManifest {
             app: "wavecrate".to_string(),
             channel: "stable".to_string(),
-            target: "target".to_string(),
-            platform: "macos".to_string(),
+            target: target.to_string(),
+            platform: platform.to_string(),
             arch: "x86_64".to_string(),
             files: files.into_iter().map(String::from).collect(),
         }

--- a/src/updater/apply/tests.rs
+++ b/src/updater/apply/tests.rs
@@ -5,13 +5,17 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use tempfile::tempdir;
 
+const MACOS_TARGET: &str = "x86_64-apple-darwin";
+const MACOS_PLATFORM: &str = "macos";
+const X86_64_ARCH: &str = "x86_64";
+
 fn identity(channel: UpdateChannel) -> RuntimeIdentity {
     RuntimeIdentity {
         app: "wavecrate".to_string(),
         channel,
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
     }
 }
 
@@ -19,9 +23,9 @@ fn manifest(channel: &str) -> UpdateManifest {
     UpdateManifest {
         app: "wavecrate".to_string(),
         channel: channel.to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: vec!["update-manifest.json".to_string()],
     }
 }
@@ -48,9 +52,9 @@ fn relaunch_app_errors_when_executable_missing() {
     let manifest = UpdateManifest {
         app: "wavecrate".to_string(),
         channel: "stable".to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: Vec::new(),
     };
     let err = relaunch_app(tmp.path(), "wavecrate", &manifest).unwrap_err();
@@ -80,9 +84,9 @@ fn apply_files_and_dirs_keeps_running_executable_on_stage_failure() {
     let manifest = UpdateManifest {
         app: "wavecrate".to_string(),
         channel: "stable".to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: vec![running_name.clone()],
     };
 
@@ -106,7 +110,7 @@ fn apply_files_and_dirs_removes_stale_files_from_prior_manifest() {
     let installed_manifest_json = r#"{
   "app": "wavecrate",
   "channel": "stable",
-  "target": "target",
+  "target": "x86_64-apple-darwin",
   "platform": "macos",
   "arch": "x86_64",
   "files": ["update-manifest.json", "current.txt", "old.txt"]
@@ -123,9 +127,9 @@ fn apply_files_and_dirs_removes_stale_files_from_prior_manifest() {
     let next_manifest = UpdateManifest {
         app: "wavecrate".to_string(),
         channel: "stable".to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: vec![
             "update-manifest.json".to_string(),
             "current.txt".to_string(),
@@ -157,7 +161,7 @@ fn apply_files_and_dirs_removes_stale_resources_dir() {
     let installed_manifest_json = r#"{
   "app": "wavecrate",
   "channel": "stable",
-  "target": "target",
+  "target": "x86_64-apple-darwin",
   "platform": "macos",
   "arch": "x86_64",
   "files": ["update-manifest.json", "current.txt"]
@@ -177,9 +181,9 @@ fn apply_files_and_dirs_removes_stale_resources_dir() {
     let next_manifest = UpdateManifest {
         app: "wavecrate".to_string(),
         channel: "stable".to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: vec![
             "update-manifest.json".to_string(),
             "current.txt".to_string(),
@@ -219,7 +223,7 @@ fn apply_files_and_dirs_reports_stale_removal_failures() {
     let installed_manifest_json = r#"{
   "app": "wavecrate",
   "channel": "stable",
-  "target": "target",
+  "target": "x86_64-apple-darwin",
   "platform": "macos",
   "arch": "x86_64",
   "files": ["update-manifest.json", "current.txt", "stale/stale.txt"]
@@ -235,9 +239,9 @@ fn apply_files_and_dirs_reports_stale_removal_failures() {
     let next_manifest = UpdateManifest {
         app: "wavecrate".to_string(),
         channel: "stable".to_string(),
-        target: "target".to_string(),
-        platform: "macos".to_string(),
-        arch: "x86_64".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
         files: vec![
             "update-manifest.json".to_string(),
             "current.txt".to_string(),


### PR DESCRIPTION
## Summary
- replace generic updater apply fixture identifiers with supported macOS release identities
- split relaunch fixture helpers into explicit Windows `.exe` and macOS non-`.exe` cases
- gate Unix-only delete-recovery test imports so Windows updater validation compiles cleanly

## Notes
- `src/updater/apply/**` no longer contains Linux-labeled fixtures.
- Remaining Linux references under `src/updater` are explicit unsupported/historical release-contract tests in asset-name and public-catalog coverage.

## Validation
- `cargo test -p wavecrate updater::apply --lib -- --nocapture`
- `cargo test -p wavecrate updater:: --lib -- --nocapture`
- `cargo test -p wavecrate delete_recovery::recovery::tests --lib -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "linux|x86_64-unknown-linux|linux-x86_64" src\updater\apply src\updater\apply.rs`