### PR TITLE
OPT-941 Align updater asset platforms with release contract

### DIFF
--- a/apps/updater-helper/src/main.rs
+++ b/apps/updater-helper/src/main.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use wavecrate::updater::{
     APP_NAME, ApplyPlan, REPO_SLUG, RuntimeIdentity, UpdateChannel, UpdateError, UpdaterRunArgs,
-    apply_update,
+    apply_update, supported_release_target_for_platform_arch,
 };
 
 #[cfg(test)]
@@ -172,55 +172,43 @@ Options:\n\
 }
 
 fn default_target() -> Option<String> {
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    {
-        return Some("x86_64-pc-windows-msvc".to_string());
-    }
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    {
-        return Some("x86_64-unknown-linux-gnu".to_string());
-    }
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    {
-        return Some("aarch64-unknown-linux-gnu".to_string());
-    }
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    {
-        return Some("x86_64-apple-darwin".to_string());
-    }
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
-        return Some("aarch64-apple-darwin".to_string());
-    }
-    #[allow(unreachable_code)]
-    None
+    supported_release_target_for_platform_arch(default_platform_label()?, default_arch_label()?)
+        .map(str::to_string)
 }
 
 fn default_platform() -> Option<String> {
+    let platform = default_platform_label()?;
+    supported_release_target_for_platform_arch(platform, default_arch_label()?)?;
+    Some(platform.to_string())
+}
+
+fn default_arch() -> Option<String> {
+    let arch = default_arch_label()?;
+    supported_release_target_for_platform_arch(default_platform_label()?, arch)?;
+    Some(arch.to_string())
+}
+
+fn default_platform_label() -> Option<&'static str> {
     #[cfg(target_os = "windows")]
     {
-        return Some("windows".to_string());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        return Some("linux".to_string());
+        return Some("windows");
     }
     #[cfg(target_os = "macos")]
     {
-        return Some("macos".to_string());
+        return Some("macos");
     }
     #[allow(unreachable_code)]
     None
 }
 
-fn default_arch() -> Option<String> {
+fn default_arch_label() -> Option<&'static str> {
     #[cfg(target_arch = "x86_64")]
     {
-        return Some("x86_64".to_string());
+        return Some("x86_64");
     }
     #[cfg(target_arch = "aarch64")]
     {
-        return Some("aarch64".to_string());
+        return Some("aarch64");
     }
     #[allow(unreachable_code)]
     None

--- a/src/app/controller/updates.rs
+++ b/src/app/controller/updates.rs
@@ -205,13 +205,8 @@ fn runtime_identity(channel: UpdateChannel) -> RuntimeIdentity {
     let platform = platform_raw;
     let arch_raw = std::env::consts::ARCH;
     let arch = arch_raw;
-    let target = match (platform, arch) {
-        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
-        ("windows", "aarch64") => "aarch64-pc-windows-msvc",
-        ("macos", "x86_64") => "x86_64-apple-darwin",
-        ("macos", "aarch64") => "aarch64-apple-darwin",
-        _ => "unknown",
-    };
+    let target = crate::updater::supported_release_target_for_platform_arch(platform, arch)
+        .unwrap_or("unknown");
     RuntimeIdentity {
         app: crate::updater::APP_NAME.to_string(),
         channel,

--- a/src/updater/asset_names.rs
+++ b/src/updater/asset_names.rs
@@ -3,6 +3,7 @@
 //! These helpers keep the GitHub release contract in one place so the apply and
 //! discovery paths derive identical asset names for the current runtime.
 
+use super::release_contract;
 use super::{APP_NAME, RuntimeIdentity, UpdateChannel, UpdateError};
 
 /// Return the expected zip asset name for a runtime identity.
@@ -10,25 +11,14 @@ pub(crate) fn expected_zip_asset_name(
     identity: &RuntimeIdentity,
     version: Option<&str>,
 ) -> Result<String, UpdateError> {
-    let platform = match identity.platform.as_str() {
-        "windows" | "macos" => identity.platform.as_str(),
-        _ => {
-            return Err(UpdateError::Invalid(format!(
-                "Unsupported platform/arch {}/{}",
-                identity.platform, identity.arch
-            )));
-        }
-    };
-    let arch = match identity.arch.as_str() {
-        "x86_64" => "x86_64",
-        "aarch64" => "aarch64",
-        _ => {
-            return Err(UpdateError::Invalid(format!(
-                "Unsupported platform/arch {}/{}",
-                identity.platform, identity.arch
-            )));
-        }
-    };
+    let platform = identity.platform.as_str();
+    let arch = identity.arch.as_str();
+    if !release_contract::supports_platform_arch(platform, arch)? {
+        return Err(UpdateError::Invalid(format!(
+            "Unsupported platform/arch {}/{}",
+            identity.platform, identity.arch
+        )));
+    }
     match identity.channel {
         UpdateChannel::Stable => {
             let version =
@@ -89,17 +79,69 @@ mod tests {
     use super::*;
 
     #[test]
-    fn expected_zip_asset_name_rejects_linux_runtime_identity() {
-        let identity = RuntimeIdentity {
-            app: APP_NAME.to_string(),
-            channel: UpdateChannel::Stable,
-            target: "x86_64-unknown-linux-gnu".to_string(),
-            platform: "linux".to_string(),
-            arch: "x86_64".to_string(),
-        };
+    fn expected_zip_asset_name_emits_supported_nightly_assets() {
+        assert_eq!(
+            expected_zip_asset_name(&identity(UpdateChannel::Nightly, "windows", "x86_64"), None)
+                .unwrap(),
+            "wavecrate-nightly-windows-x86_64.zip"
+        );
+        assert_eq!(
+            expected_zip_asset_name(&identity(UpdateChannel::Nightly, "macos", "x86_64"), None)
+                .unwrap(),
+            "wavecrate-nightly-macos-x86_64.zip"
+        );
+        assert_eq!(
+            expected_zip_asset_name(&identity(UpdateChannel::Nightly, "macos", "aarch64"), None)
+                .unwrap(),
+            "wavecrate-nightly-macos-aarch64.zip"
+        );
+    }
 
-        let err = expected_zip_asset_name(&identity, Some("1.2.3")).unwrap_err();
+    #[test]
+    fn expected_zip_asset_name_emits_supported_tagged_assets() {
+        assert_eq!(
+            expected_zip_asset_name(
+                &identity(UpdateChannel::Stable, "windows", "x86_64"),
+                Some("19.1.0")
+            )
+            .unwrap(),
+            "wavecrate-19.1.0-windows-x86_64.zip"
+        );
+        assert_eq!(
+            expected_zip_asset_name(
+                &identity(UpdateChannel::Rc, "macos", "aarch64"),
+                Some("19.1.0-rc.2")
+            )
+            .unwrap(),
+            "wavecrate-19.1.0-rc.2-macos-aarch64.zip"
+        );
+    }
+
+    #[test]
+    fn expected_zip_asset_name_rejects_unpublished_release_targets() {
+        assert_unsupported("linux", "x86_64");
+        assert_unsupported("windows", "aarch64");
+        assert_unsupported("macos", "riscv64");
+    }
+
+    fn assert_unsupported(platform: &str, arch: &str) {
+        let err = expected_zip_asset_name(
+            &identity(UpdateChannel::Stable, platform, arch),
+            Some("1.2.3"),
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("Unsupported platform/arch"));
+    }
+
+    fn identity(channel: UpdateChannel, platform: &str, arch: &str) -> RuntimeIdentity {
+        let identity = RuntimeIdentity {
+            app: APP_NAME.to_string(),
+            channel,
+            target: "target".to_string(),
+            platform: platform.to_string(),
+            arch: arch.to_string(),
+        };
+        identity
     }
 }

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -11,6 +11,7 @@ mod fs_ops;
 mod github;
 mod path_guard;
 mod public_catalog;
+mod release_contract;
 
 use std::path::PathBuf;
 
@@ -28,6 +29,7 @@ pub use public_catalog::{
     PUBLIC_RELEASE_CATALOG_URL, PUBLIC_RELEASE_PAGE_URL, PublicReleaseCheckRequest,
     PublicReleaseInfo, check_public_release_catalog,
 };
+pub use release_contract::supported_release_target_for_platform_arch;
 
 /// Canonical app name used by the release contract.
 pub const APP_NAME: &str = "wavecrate";

--- a/src/updater/public_catalog.rs
+++ b/src/updater/public_catalog.rs
@@ -5,17 +5,9 @@ use serde::Deserialize;
 
 use crate::http_client;
 
-use super::{UpdateChannel, UpdateError};
+use super::{UpdateChannel, UpdateError, release_contract};
 
 const MAX_RELEASE_CATALOG_JSON_BYTES: usize = 512 * 1024;
-// Catalogs may retain historical files, but only these active release targets
-// are eligible for current public-download matching.
-const SUPPORTED_PUBLIC_RELEASE_TARGETS: &[(&str, &str)] = &[
-    ("windows", "x86_64"),
-    ("macos", "x86_64"),
-    ("macos", "aarch64"),
-];
-
 /// Public Wavecrate release catalog exposed by portalsurfer.org.
 pub const PUBLIC_RELEASE_CATALOG_URL: &str = "https://portalsurfer.org/wavecrate/api/v1/releases";
 /// Human-facing Wavecrate download page on portalsurfer.org.
@@ -80,14 +72,14 @@ pub fn check_public_release_catalog(
     let bytes = http_client::read_response_bytes(response, MAX_RELEASE_CATALOG_JSON_BYTES)
         .map_err(|err| UpdateError::Http(err.to_string()))?;
     let catalog: PublicReleaseCatalog = serde_json::from_slice(&bytes)?;
-    Ok(latest_available_public_release(
+    latest_available_public_release(
         &catalog,
         request.current_build_number,
         &request.current_build_sha,
         &request.platform,
         &request.arch,
         request.channel,
-    ))
+    )
 }
 
 fn latest_available_public_release(
@@ -97,8 +89,10 @@ fn latest_available_public_release(
     platform: &str,
     arch: &str,
     channel: UpdateChannel,
-) -> Option<PublicReleaseInfo> {
-    let asset_suffix = public_release_asset_suffix(platform, arch)?;
+) -> Result<Option<PublicReleaseInfo>, UpdateError> {
+    let Some(asset_suffix) = public_release_asset_suffix(platform, arch)? else {
+        return Ok(None);
+    };
     let releases = catalog
         .releases
         .iter()
@@ -108,9 +102,12 @@ fn latest_available_public_release(
     let latest = releases
         .iter()
         .copied()
-        .max_by(compare_public_release_recency)?;
+        .max_by(compare_public_release_recency);
+    let Some(latest) = latest else {
+        return Ok(None);
+    };
     if latest.matches_build_sha(current_build_sha) {
-        return None;
+        return Ok(None);
     }
     if let Some(current_release) = releases
         .iter()
@@ -118,13 +115,13 @@ fn latest_available_public_release(
         .filter(|release| release.matches_build_sha(current_build_sha))
         .max_by(compare_public_release_recency)
     {
-        return release_is_newer_than(latest, current_release)
-            .then(|| PublicReleaseInfo::from_catalog_release(latest));
+        return Ok(release_is_newer_than(latest, current_release)
+            .then(|| PublicReleaseInfo::from_catalog_release(latest)));
     }
     if latest.build_number <= current_build_number {
-        return None;
+        return Ok(None);
     }
-    Some(PublicReleaseInfo::from_catalog_release(latest))
+    Ok(Some(PublicReleaseInfo::from_catalog_release(latest)))
 }
 
 fn release_matches_channel(release: &PublicReleaseCatalogRelease, channel: UpdateChannel) -> bool {
@@ -138,16 +135,11 @@ fn release_matches_channel(release: &PublicReleaseCatalogRelease, channel: Updat
     }
 }
 
-fn public_release_asset_suffix(platform: &str, arch: &str) -> Option<String> {
-    if !SUPPORTED_PUBLIC_RELEASE_TARGETS
-        .iter()
-        .any(|(supported_platform, supported_arch)| {
-            platform == *supported_platform && arch == *supported_arch
-        })
-    {
-        return None;
+fn public_release_asset_suffix(platform: &str, arch: &str) -> Result<Option<String>, UpdateError> {
+    if !release_contract::supports_platform_arch(platform, arch)? {
+        return Ok(None);
     }
-    Some(format!("{platform}-{arch}.zip"))
+    Ok(Some(format!("{platform}-{arch}.zip")))
 }
 
 fn map_http_error(err: ureq::Error) -> UpdateError {
@@ -258,6 +250,7 @@ mod tests {
             "aarch64",
             UpdateChannel::Nightly,
         )
+        .expect("release contract")
         .expect("new macos arm release");
 
         assert_eq!(release.build_number, 242);
@@ -277,6 +270,7 @@ mod tests {
                 "aarch64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_none()
         );
     }
@@ -294,6 +288,7 @@ mod tests {
                 "aarch64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_none()
         );
     }
@@ -313,6 +308,7 @@ mod tests {
             "aarch64",
             UpdateChannel::Nightly,
         )
+        .expect("release contract")
         .expect("new macos arm release");
 
         assert_eq!(release.build_number, 242);
@@ -332,6 +328,7 @@ mod tests {
                 "x86_64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_none()
         );
     }
@@ -339,25 +336,43 @@ mod tests {
     #[test]
     fn public_release_asset_suffix_accepts_supported_download_targets() {
         assert_eq!(
-            public_release_asset_suffix("windows", "x86_64").as_deref(),
+            public_release_asset_suffix("windows", "x86_64")
+                .unwrap()
+                .as_deref(),
             Some("windows-x86_64.zip")
         );
         assert_eq!(
-            public_release_asset_suffix("macos", "x86_64").as_deref(),
+            public_release_asset_suffix("macos", "x86_64")
+                .unwrap()
+                .as_deref(),
             Some("macos-x86_64.zip")
         );
         assert_eq!(
-            public_release_asset_suffix("macos", "aarch64").as_deref(),
+            public_release_asset_suffix("macos", "aarch64")
+                .unwrap()
+                .as_deref(),
             Some("macos-aarch64.zip")
         );
     }
 
     #[test]
     fn public_release_asset_suffix_rejects_unsupported_download_targets() {
-        assert!(public_release_asset_suffix("freebsd", "x86_64").is_none());
-        assert!(public_release_asset_suffix("linux", "x86_64").is_none());
-        assert!(public_release_asset_suffix("windows", "aarch64").is_none());
-        assert!(public_release_asset_suffix("macos", "riscv64").is_none());
+        assert_eq!(
+            public_release_asset_suffix("freebsd", "x86_64").unwrap(),
+            None
+        );
+        assert_eq!(
+            public_release_asset_suffix("linux", "x86_64").unwrap(),
+            None
+        );
+        assert_eq!(
+            public_release_asset_suffix("windows", "aarch64").unwrap(),
+            None
+        );
+        assert_eq!(
+            public_release_asset_suffix("macos", "riscv64").unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -385,6 +400,7 @@ mod tests {
             "aarch64",
             UpdateChannel::Nightly,
         )
+        .expect("release contract")
         .expect("newer release by public catalog recency");
 
         assert_eq!(release.build_id, "wavecrate-nightly-b242-4c969d95");
@@ -416,6 +432,7 @@ mod tests {
                 "aarch64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_none()
         );
     }
@@ -438,6 +455,7 @@ mod tests {
                 "aarch64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_none()
         );
         assert!(
@@ -449,6 +467,7 @@ mod tests {
                 "aarch64",
                 UpdateChannel::Nightly
             )
+            .expect("release contract")
             .is_some()
         );
     }
@@ -487,6 +506,7 @@ mod tests {
             "x86_64",
             UpdateChannel::Stable,
         )
+        .expect("release contract")
         .expect("stable");
         let rc = latest_available_public_release(
             &catalog,
@@ -496,6 +516,7 @@ mod tests {
             "x86_64",
             UpdateChannel::Rc,
         )
+        .expect("release contract")
         .expect("rc");
         let nightly = latest_available_public_release(
             &catalog,
@@ -505,6 +526,7 @@ mod tests {
             "x86_64",
             UpdateChannel::Nightly,
         )
+        .expect("release contract")
         .expect("nightly");
 
         assert_eq!(stable.version, "19.1.0");

--- a/src/updater/release_contract.rs
+++ b/src/updater/release_contract.rs
@@ -1,0 +1,115 @@
+//! Runtime access to the active release target matrix.
+//!
+//! `release_contract.toml` is the release-pipeline source of truth. The updater
+//! uses the same target matrix here so asset lookup cannot infer support for
+//! unpublished platform/architecture pairs.
+
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use super::UpdateError;
+
+const RELEASE_CONTRACT: &str = include_str!("../../release_contract.toml");
+
+static ACTIVE_TARGETS: OnceLock<Result<Vec<ReleaseTarget>, String>> = OnceLock::new();
+
+#[derive(Debug, Deserialize)]
+struct ReleaseContract {
+    targets: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReleaseTarget {
+    target: String,
+    platform: String,
+    arch: String,
+}
+
+/// Return whether `platform`/`arch` is an active published release target.
+pub(super) fn supports_platform_arch(platform: &str, arch: &str) -> Result<bool, UpdateError> {
+    Ok(active_targets()?
+        .iter()
+        .any(|target| target.platform == platform && target.arch == arch))
+}
+
+/// Return the active target triple for a published `platform`/`arch` pair.
+pub fn supported_release_target_for_platform_arch(
+    platform: &str,
+    arch: &str,
+) -> Option<&'static str> {
+    active_targets().ok()?.iter().find_map(|target| {
+        (target.platform == platform && target.arch == arch).then_some(target.target.as_str())
+    })
+}
+
+fn active_targets() -> Result<&'static [ReleaseTarget], UpdateError> {
+    match ACTIVE_TARGETS.get_or_init(load_active_targets) {
+        Ok(targets) => Ok(targets.as_slice()),
+        Err(message) => Err(UpdateError::Invalid(format!(
+            "Invalid release contract: {message}"
+        ))),
+    }
+}
+
+fn load_active_targets() -> Result<Vec<ReleaseTarget>, String> {
+    let contract: ReleaseContract = toml::from_str(RELEASE_CONTRACT)
+        .map_err(|err| format!("release_contract.toml does not parse: {err}"))?;
+    let mut targets = Vec::with_capacity(contract.targets.len());
+    for target in contract.targets {
+        targets.push(release_target_from_triple(&target)?);
+    }
+    Ok(targets)
+}
+
+fn release_target_from_triple(target: &str) -> Result<ReleaseTarget, String> {
+    let Some((arch, _)) = target.split_once('-') else {
+        return Err(format!(
+            "target '{target}' is missing an architecture prefix"
+        ));
+    };
+    let platform = if target.contains("-pc-windows-") {
+        "windows"
+    } else if target.ends_with("-apple-darwin") {
+        "macos"
+    } else {
+        return Err(format!(
+            "target '{target}' is not a supported release target"
+        ));
+    };
+    Ok(ReleaseTarget {
+        target: target.to_string(),
+        platform: platform.to_string(),
+        arch: arch.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_contract_supports_current_published_targets() {
+        assert!(supports_platform_arch("windows", "x86_64").unwrap());
+        assert!(supports_platform_arch("macos", "x86_64").unwrap());
+        assert!(supports_platform_arch("macos", "aarch64").unwrap());
+    }
+
+    #[test]
+    fn release_contract_rejects_unpublished_targets() {
+        assert!(!supports_platform_arch("linux", "x86_64").unwrap());
+        assert!(!supports_platform_arch("windows", "aarch64").unwrap());
+    }
+
+    #[test]
+    fn release_contract_resolves_target_triples_for_supported_pairs() {
+        assert_eq!(
+            supported_release_target_for_platform_arch("windows", "x86_64"),
+            Some("x86_64-pc-windows-msvc")
+        );
+        assert_eq!(
+            supported_release_target_for_platform_arch("linux", "x86_64"),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## Scope
- Add an updater release-contract facade backed by `release_contract.toml`.
- Validate updater zip asset-name support against active release platform/arch pairs instead of separate platform and arch allowlists.
- Reuse the same release matrix for public catalog matching, main-app runtime target resolution, and updater-helper detected defaults.
- Keep Windows/macOS current asset names unchanged and reject unpublished Linux plus unsupported Windows ARM64 asset identities.

## Definition of Done
- Linux is not accepted as a normal updater asset platform while unpublished.
- Supported updater platforms are driven by the active release target matrix in `release_contract.toml`.
- Windows/macOS nightly, RC, and stable asset names remain unchanged for active release targets.
- Public catalog matching and runtime/helper default target detection share the same release matrix.

## Validation
- `CARGO_TARGET_DIR=E:\dev\wavecrate\target cargo fmt --check`
- `CARGO_TARGET_DIR=E:\dev\wavecrate\target cargo check -p wavecrate --lib`
- `CARGO_TARGET_DIR=E:\dev\wavecrate\target cargo test --test release_contract`
- `CARGO_TARGET_DIR=E:\dev\wavecrate\target cargo test -p wavecrate-updater-helper --no-run`
- `git diff --check HEAD~1..HEAD`

## Known Limitations
- `cargo test -p wavecrate updater::release_contract --lib` currently fails before running filtered updater tests because unrelated delete-recovery test modules have unused imports under `#![deny(warnings)]`.
- `cargo test -p wavecrate-updater-helper` builds the helper test binary but cannot execute it in this environment because Windows returns `os error 740` / elevation required for the generated updater executable. The compile-only `--no-run` check passed.
- Full local CI was not run because the E: drive had limited free space and the focused change is confined to updater release-contract behavior.

User review is required before merge.