### PR TITLE
OPT-940: disable unsupported Linux update identities

### DIFF
--- a/src/app/controller/updates.rs
+++ b/src/app/controller/updates.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::updater::{
     RuntimeIdentity, UpdateChannel, UpdateCheckOutcome, UpdateCheckRequest, check_for_updates,
 };
-use std::path::Path;
+use std::{fmt, path::Path};
 
 impl AppController {
     pub(super) fn maybe_check_for_updates_on_startup(&mut self) {
@@ -147,12 +147,17 @@ impl AppController {
             Ok(v) => v,
             Err(_) => semver::Version::new(0, 0, 0),
         };
-        let request = UpdateCheckRequest {
-            repo: crate::updater::REPO_SLUG.to_string(),
-            channel: map_channel(self.settings.updates.channel),
-            identity: runtime_identity(map_channel(self.settings.updates.channel)),
+        let channel = map_channel(self.settings.updates.channel);
+        let request = match update_check_request(
+            channel,
             current_version,
-            last_seen_nightly_published_at: self.ui.update.last_seen_nightly_published_at.clone(),
+            self.ui.update.last_seen_nightly_published_at.clone(),
+        ) {
+            Ok(request) => request,
+            Err(err) => {
+                self.apply_unsupported_update_platform(err);
+                return;
+            }
         };
         let update_changed = self.ui.update.status != crate::app::state::UpdateStatus::Checking
             || self.ui.update.last_error.is_some();
@@ -162,6 +167,25 @@ impl AppController {
             self.mark_update_projection_revision_dirty();
         }
         self.runtime.jobs.begin_update_check(request);
+    }
+
+    fn apply_unsupported_update_platform(&mut self, err: UnsupportedUpdatePlatform) {
+        let message = err.to_string();
+        tracing::info!("{message}");
+        let update_changed = self.ui.update.status != crate::app::state::UpdateStatus::Idle
+            || self.ui.update.last_error.as_deref() != Some(message.as_str())
+            || self.ui.update.available_tag.is_some()
+            || self.ui.update.available_url.is_some()
+            || self.ui.update.available_published_at.is_some();
+        self.ui.update.status = crate::app::state::UpdateStatus::Idle;
+        self.ui.update.last_error = Some(message.clone());
+        self.ui.update.available_tag = None;
+        self.ui.update.available_url = None;
+        self.ui.update.available_published_at = None;
+        if update_changed {
+            self.mark_update_projection_revision_dirty();
+        }
+        self.set_status(message, StatusTone::Info);
     }
 }
 
@@ -200,20 +224,80 @@ pub(crate) fn run_update_check(request: UpdateCheckRequest) -> Result<UpdateChec
     check_for_updates(request).map_err(|err| err.to_string())
 }
 
-fn runtime_identity(channel: UpdateChannel) -> RuntimeIdentity {
-    let platform_raw = std::env::consts::OS;
-    let platform = platform_raw;
-    let arch_raw = std::env::consts::ARCH;
-    let arch = arch_raw;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnsupportedUpdatePlatform {
+    platform: String,
+    arch: String,
+}
+
+impl fmt::Display for UnsupportedUpdatePlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Wavecrate update checks are unavailable on {}/{} because release assets are published only for Windows x86_64 and macOS x86_64/aarch64.",
+            self.platform, self.arch
+        )
+    }
+}
+
+fn update_check_request(
+    channel: UpdateChannel,
+    current_version: semver::Version,
+    last_seen_nightly_published_at: Option<String>,
+) -> Result<UpdateCheckRequest, UnsupportedUpdatePlatform> {
+    let identity = runtime_identity(channel)?;
+    Ok(UpdateCheckRequest {
+        repo: crate::updater::REPO_SLUG.to_string(),
+        channel,
+        identity,
+        current_version,
+        last_seen_nightly_published_at,
+    })
+}
+
+#[cfg(test)]
+fn update_check_request_for_platform_arch(
+    channel: UpdateChannel,
+    current_version: semver::Version,
+    last_seen_nightly_published_at: Option<String>,
+    platform: &str,
+    arch: &str,
+) -> Result<UpdateCheckRequest, UnsupportedUpdatePlatform> {
+    let identity = runtime_identity_for_platform_arch(channel, platform, arch)?;
+    Ok(UpdateCheckRequest {
+        repo: crate::updater::REPO_SLUG.to_string(),
+        channel,
+        identity,
+        current_version,
+        last_seen_nightly_published_at,
+    })
+}
+
+fn runtime_identity_for_platform_arch(
+    channel: UpdateChannel,
+    platform: &str,
+    arch: &str,
+) -> Result<RuntimeIdentity, UnsupportedUpdatePlatform> {
     let target = crate::updater::supported_release_target_for_platform_arch(platform, arch)
-        .unwrap_or("unknown");
-    RuntimeIdentity {
+        .ok_or_else(|| UnsupportedUpdatePlatform {
+            platform: platform.to_string(),
+            arch: arch.to_string(),
+        })?;
+    Ok(RuntimeIdentity {
         app: crate::updater::APP_NAME.to_string(),
         channel,
         target: target.to_string(),
         platform: platform.to_string(),
         arch: arch.to_string(),
-    }
+    })
+}
+
+fn runtime_identity(channel: UpdateChannel) -> Result<RuntimeIdentity, UnsupportedUpdatePlatform> {
+    let platform_raw = std::env::consts::OS;
+    let platform = platform_raw;
+    let arch_raw = std::env::consts::ARCH;
+    let arch = arch_raw;
+    runtime_identity_for_platform_arch(channel, platform, arch)
 }
 
 #[cfg(test)]
@@ -257,5 +341,90 @@ mod tests {
                 .join("target-release")
                 .join("wavecrate")
         ));
+    }
+
+    #[test]
+    fn runtime_identity_keeps_supported_release_targets() {
+        let windows =
+            runtime_identity_for_platform_arch(UpdateChannel::Stable, "windows", "x86_64")
+                .expect("windows x86_64 release target");
+        assert_eq!(windows.app, crate::updater::APP_NAME);
+        assert_eq!(windows.channel, UpdateChannel::Stable);
+        assert_eq!(windows.target, "x86_64-pc-windows-msvc");
+        assert_eq!(windows.platform, "windows");
+        assert_eq!(windows.arch, "x86_64");
+
+        let macos_intel = runtime_identity_for_platform_arch(UpdateChannel::Rc, "macos", "x86_64")
+            .expect("macos x86_64 release target");
+        assert_eq!(macos_intel.channel, UpdateChannel::Rc);
+        assert_eq!(macos_intel.target, "x86_64-apple-darwin");
+        assert_eq!(macos_intel.platform, "macos");
+        assert_eq!(macos_intel.arch, "x86_64");
+
+        let macos_arm =
+            runtime_identity_for_platform_arch(UpdateChannel::Nightly, "macos", "aarch64")
+                .expect("macos aarch64 release target");
+        assert_eq!(macos_arm.channel, UpdateChannel::Nightly);
+        assert_eq!(macos_arm.target, "aarch64-apple-darwin");
+        assert_eq!(macos_arm.platform, "macos");
+        assert_eq!(macos_arm.arch, "aarch64");
+    }
+
+    #[test]
+    fn runtime_identity_rejects_unsupported_release_platforms() {
+        for (platform, arch) in [
+            ("linux", "x86_64"),
+            ("linux", "aarch64"),
+            ("windows", "aarch64"),
+            ("macos", "riscv64"),
+        ] {
+            let err = runtime_identity_for_platform_arch(UpdateChannel::Stable, platform, arch)
+                .expect_err("unsupported runtime identity should be rejected");
+            assert_eq!(err.platform, platform);
+            assert_eq!(err.arch, arch);
+            let message = err.to_string();
+            assert!(message.contains(platform));
+            assert!(message.contains(arch));
+            assert!(message.contains("Windows x86_64 and macOS x86_64/aarch64"));
+        }
+    }
+
+    #[test]
+    fn update_check_request_rejects_linux_before_asset_lookup() {
+        let err = update_check_request_for_platform_arch(
+            UpdateChannel::Nightly,
+            semver::Version::new(19, 1, 0),
+            Some("2026-07-01T00:00:00Z".to_string()),
+            "linux",
+            "x86_64",
+        )
+        .expect_err("linux should not create an update-check request");
+
+        assert_eq!(err.platform, "linux");
+        assert_eq!(err.arch, "x86_64");
+    }
+
+    #[test]
+    fn update_check_request_preserves_supported_identity_and_channel() {
+        let request = update_check_request_for_platform_arch(
+            UpdateChannel::Rc,
+            semver::Version::new(19, 1, 0),
+            Some("2026-07-01T00:00:00Z".to_string()),
+            "macos",
+            "aarch64",
+        )
+        .expect("supported macos request");
+
+        assert_eq!(request.repo, crate::updater::REPO_SLUG);
+        assert_eq!(request.channel, UpdateChannel::Rc);
+        assert_eq!(request.identity.channel, UpdateChannel::Rc);
+        assert_eq!(request.identity.platform, "macos");
+        assert_eq!(request.identity.arch, "aarch64");
+        assert_eq!(request.identity.target, "aarch64-apple-darwin");
+        assert_eq!(request.current_version, semver::Version::new(19, 1, 0));
+        assert_eq!(
+            request.last_seen_nightly_published_at.as_deref(),
+            Some("2026-07-01T00:00:00Z")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Reject unsupported runtime platform/arch pairs before the main app starts an update-check job.
- Preserve the current Windows x86_64 and macOS x86_64/aarch64 release identities through the existing release-contract helper.
- Add focused tests proving Linux and other unpublished identities do not create update-check requests.

## Validation
- cargo fmt --all -- --check
- cargo test updates --lib
- cargo test updater::release_contract --lib
- cargo check --lib
- git diff --check

Linear: OPT-940