### PR TITLE
OPT-951: document headless ALSA validation tooling

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -318,7 +318,9 @@ When set, ALSA uses the provided config file path instead of system defaults.
 On headless Linux runs, `scripts/ci.sh local` and `scripts/perf.sh guard`
 set this automatically to `scripts/internal/alsa_headless.conf` unless already defined.
 This routes default playback probing to a dummy sink to reduce `ALSA lib`
-warning noise in test/bench logs.
+warning noise in test/bench logs. This is developer validation tooling for
+headless Linux CI/agent/perf hosts only and does not describe shipped Linux app
+support.
 
 ## UI and runtime profiling
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -81,6 +81,18 @@ Windows note:
 - set `WAVECRATE_ENABLE_SCCACHE=1` only when you explicitly want wrapper caching
 - do not run multiple cargo test commands concurrently
 
+Headless Linux audio note:
+
+- `scripts/internal/setup_headless_audio.sh` is retained as developer
+  validation tooling for Bash CI, agent, and perf lanes that may run on
+  headless Linux hosts
+- `scripts/ci.sh local` and `scripts/perf.sh guard` source it to set
+  `ALSA_CONFIG_PATH=scripts/internal/alsa_headless.conf` only when the host is
+  Linux, no display server is present, and the caller has not already set
+  `ALSA_CONFIG_PATH`
+- this dummy ALSA path reduces CPAL/ALSA missing-device warning noise in
+  test/bench logs and does not represent shipped Linux app support
+
 ## Safe feature-change checklist
 
 Before push:

--- a/scripts/internal/alsa_headless.conf
+++ b/scripts/internal/alsa_headless.conf
@@ -1,4 +1,6 @@
-# Dummy ALSA PCM for headless CI/test runs.
+# Dummy ALSA PCM for headless CI/agent/perf validation runs only.
+#
+# This is developer tooling and does not indicate shipped Linux app support.
 #
 # This intentionally routes default playback to ALSA's `null` sink so CPAL
 # probing/open attempts do not emit missing-card warnings on hosts without real

--- a/scripts/internal/ci/ci_local.sh
+++ b/scripts/internal/ci/ci_local.sh
@@ -12,6 +12,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT_DIR"
 # shellcheck source=scripts/internal/setup_headless_audio.sh
 source "$ROOT_DIR/scripts/internal/setup_headless_audio.sh"
+# Tooling-only Linux fallback for headless agent/CI hosts; not product support.
 wavecrate_setup_headless_audio "ci_local"
 # shellcheck source=scripts/internal/use_cargo_cache.sh
 source "$ROOT_DIR/scripts/internal/use_cargo_cache.sh"

--- a/scripts/internal/data/validation_contract.json
+++ b/scripts/internal/data/validation_contract.json
@@ -25,6 +25,7 @@
     ],
     "syntax_bash": [
       "scripts/agent.sh",
+      "scripts/internal/setup_headless_audio.sh",
       "scripts/internal/agent/run_agent_ci_checks.sh",
       "scripts/internal/agent/run_agent_preflight.sh",
       "scripts/ci.sh",

--- a/scripts/internal/perf/run_perf_guard.sh
+++ b/scripts/internal/perf/run_perf_guard.sh
@@ -12,6 +12,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT_DIR"
 # shellcheck source=scripts/internal/setup_headless_audio.sh
 source "$ROOT_DIR/scripts/internal/setup_headless_audio.sh"
+# Tooling-only Linux fallback for headless perf hosts; not product support.
 wavecrate_setup_headless_audio "perf_guard"
 
 RADIANT_RUNTIME_FILE="$ROOT_DIR/vendor/radiant/src/gui_runtime/native_vello.rs"

--- a/scripts/internal/setup_headless_audio.sh
+++ b/scripts/internal/setup_headless_audio.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Configure a dummy ALSA backend for headless Linux runs so CI logs are not
-# flooded with "cannot find card" / "Unknown PCM default" noise.
+# Developer-validation helper only. Wavecrate does not ship Linux app builds.
+# This configures a dummy ALSA backend for headless Linux CI/agent/perf runs so
+# logs are not flooded with "cannot find card" / "Unknown PCM default" noise.
 wavecrate_setup_headless_audio() {
   local log_prefix="${1:-headless_audio}"
 


### PR DESCRIPTION
## Summary
- Keep the headless Linux ALSA helper as developer validation tooling for Bash CI, agent, and perf lanes.
- Clarify that the dummy ALSA config and call sites do not imply shipped Linux app support.
- Add the helper to Bash script syntax guardrails so the retained tooling path is checked.

## Decision
Linux headless ALSA setup remains supported validation tooling only. It is retained because `scripts/ci.sh local` and `scripts/perf.sh guard` source it for headless Bash validation/perf hosts, while README/docs continue to state that shipped app builds are Windows/macOS only.

## Validation
- `bash -n scripts/internal/setup_headless_audio.sh scripts/internal/ci/ci_local.sh scripts/internal/perf/run_perf_guard.sh scripts/ci.sh scripts/perf.sh`
- `bash scripts/check.sh script-guardrails`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 script-guardrails`
- `bash scripts/check.sh docs-index`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1 docs-index`
- `bash scripts/check.sh report-env-vars` (advisory; no used-in-code vars missing from docs)
- `bash -lc 'unset ALSA_CONFIG_PATH; source scripts/internal/setup_headless_audio.sh; wavecrate_setup_headless_audio direct_smoke; test -z "${ALSA_CONFIG_PATH:-}"'`
- `bash scripts/ci.sh smoke --app-only`
- `git diff --check`

Linear: OPT-951