### PR TITLE
OPT-957: Align column drop marker with reorder boundary

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/header.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/header.rs
@@ -160,21 +160,24 @@ fn sample_browser_header(
     let header_cells = columns
         .iter()
         .flat_map(|column| sample_header_cells(column, sort, &similarity_header));
-    let header = ui::row([
+    let details_header = ui::compact_details_header_row(header_cells)
+        .fill_width()
+        .height(24.0);
+    let details_header = match drag_marker_x {
+        Some(marker_x) => ui::stack([details_header, column_drop_marker(marker_x)])
+            .fill_width()
+            .height(24.0),
+        None => details_header,
+    };
+    ui::row([
         ui::spacer()
             .width(SAMPLE_SIMILARITY_TOGGLE_HEADER_WIDTH)
             .height(24.0),
-        ui::compact_details_header_row(header_cells).fill_width(),
+        details_header,
     ])
     .spacing(0.0)
     .fill_width()
-    .height(24.0);
-    let Some(marker_x) = drag_marker_x else {
-        return header;
-    };
-    ui::stack([header, column_drop_marker(marker_x)])
-        .fill_width()
-        .height(24.0)
+    .height(24.0)
 }
 
 fn column_drop_marker(x: f32) -> ui::View<GuiMessage> {

--- a/src/native_app/sample_library/folder_browser/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns.rs
@@ -1,9 +1,12 @@
 pub(in crate::native_app) const MIN_FILE_COLUMN_WIDTH: f32 = 48.0;
 const MAX_FILE_COLUMN_WIDTH: f32 = 420.0;
 pub(in crate::native_app) const FILE_COLUMN_GAP: f32 = 10.0;
-/// Column reorder feedback should paint at the same boundary used for the
-/// eventual insertion target, without shifting toward resize chrome.
-const FILE_COLUMN_DROP_MARKER_HANDLE_OFFSET: f32 = 0.0;
+const FILE_COLUMN_RESIZE_HANDLE_WIDTH: f32 = 4.0;
+const FILE_COLUMN_DROP_MARKER_WIDTH: f32 = 2.0;
+/// Column reorder feedback should paint on the dotted resize divider that marks
+/// the visible insertion boundary, not at the next column label's text origin.
+const FILE_COLUMN_DROP_MARKER_HANDLE_OFFSET: f32 =
+    FILE_COLUMN_GAP + (FILE_COLUMN_RESIZE_HANDLE_WIDTH + FILE_COLUMN_DROP_MARKER_WIDTH) * 0.5;
 
 mod drag;
 mod layout;

--- a/src/native_app/sample_library/folder_browser/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns.rs
@@ -1,9 +1,9 @@
 pub(in crate::native_app) const MIN_FILE_COLUMN_WIDTH: f32 = 48.0;
 const MAX_FILE_COLUMN_WIDTH: f32 = 420.0;
 pub(in crate::native_app) const FILE_COLUMN_GAP: f32 = 10.0;
-const FILE_COLUMN_RESIZE_HANDLE_WIDTH: f32 = 4.0;
-const FILE_COLUMN_DROP_MARKER_HANDLE_OFFSET: f32 =
-    FILE_COLUMN_GAP + FILE_COLUMN_RESIZE_HANDLE_WIDTH * 0.5;
+/// Column reorder feedback should paint at the same boundary used for the
+/// eventual insertion target, without shifting toward resize chrome.
+const FILE_COLUMN_DROP_MARKER_HANDLE_OFFSET: f32 = 0.0;
 
 mod drag;
 mod layout;

--- a/src/native_app/sample_library/folder_browser/tests/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_columns.rs
@@ -643,7 +643,7 @@ fn sample_file_column_drag_reorders_columns() {
         .expect("active column drag should project visual feedback");
     assert_eq!(feedback.label, "Rating");
     assert_eq!(feedback.pointer, Point::new(560.0, 0.0));
-    assert_eq!(feedback.marker_x, 534.0);
+    assert_eq!(feedback.marker_x, 546.0);
 
     browser.apply_message(FolderBrowserMessage::DragFileColumn(
         String::from("rating"),
@@ -668,6 +668,65 @@ fn sample_file_column_drag_reorders_columns() {
         ]
     );
 }
+
+#[test]
+fn sample_file_column_drag_feedback_tracks_resized_and_narrow_boundaries() {
+    let mut browser = FolderBrowserState::load_default();
+
+    browser.apply_message(FolderBrowserMessage::ResizeFileColumn(
+        String::from("name"),
+        radiant::widgets::DragHandleMessage::started(Point::new(0.0, 0.0)),
+    ));
+    browser.apply_message(FolderBrowserMessage::ResizeFileColumn(
+        String::from("name"),
+        radiant::widgets::DragHandleMessage::moved(Point::new(120.0, 0.0)),
+    ));
+    browser.apply_message(FolderBrowserMessage::ResizeFileColumn(
+        String::from("collection"),
+        radiant::widgets::DragHandleMessage::started(Point::new(0.0, 0.0)),
+    ));
+    browser.apply_message(FolderBrowserMessage::ResizeFileColumn(
+        String::from("collection"),
+        radiant::widgets::DragHandleMessage::moved(Point::new(-80.0, 0.0)),
+    ));
+
+    browser.apply_message(FolderBrowserMessage::DragFileColumn(
+        String::from("rating"),
+        radiant::widgets::DragHandleMessage::started(Point::new(404.0, 0.0)),
+    ));
+    browser.apply_message(FolderBrowserMessage::DragFileColumn(
+        String::from("rating"),
+        radiant::widgets::DragHandleMessage::moved(Point::new(660.0, 0.0)),
+    ));
+
+    let feedback = browser
+        .file_column_drag_feedback()
+        .expect("resized column drag should project visual feedback");
+    assert_eq!(feedback.marker_x, 656.0);
+
+    browser.apply_message(FolderBrowserMessage::DragFileColumn(
+        String::from("rating"),
+        radiant::widgets::DragHandleMessage::ended(Point::new(660.0, 0.0)),
+    ));
+
+    assert_eq!(
+        browser
+            .visible_file_columns()
+            .into_iter()
+            .map(|column| column.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "name",
+            "playback_type",
+            "collection",
+            "extension",
+            "rating",
+            "size",
+            "modified"
+        ]
+    );
+}
+
 #[test]
 /// Hiding Harvest preserves the stored width and order for later reactivation.
 fn hidden_harvest_column_preserves_resize_and_order_when_reactivated() {

--- a/src/native_app/sample_library/folder_browser/tests/file_columns.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_columns.rs
@@ -643,7 +643,7 @@ fn sample_file_column_drag_reorders_columns() {
         .expect("active column drag should project visual feedback");
     assert_eq!(feedback.label, "Rating");
     assert_eq!(feedback.pointer, Point::new(560.0, 0.0));
-    assert_eq!(feedback.marker_x, 546.0);
+    assert_eq!(feedback.marker_x, 533.0);
 
     browser.apply_message(FolderBrowserMessage::DragFileColumn(
         String::from("rating"),
@@ -702,7 +702,7 @@ fn sample_file_column_drag_feedback_tracks_resized_and_narrow_boundaries() {
     let feedback = browser
         .file_column_drag_feedback()
         .expect("resized column drag should project visual feedback");
-    assert_eq!(feedback.marker_x, 656.0);
+    assert_eq!(feedback.marker_x, 643.0);
 
     browser.apply_message(FolderBrowserMessage::DragFileColumn(
         String::from("rating"),

--- a/src/native_app/tests/sample_browser/column_reorder.rs
+++ b/src/native_app/tests/sample_browser/column_reorder.rs
@@ -199,7 +199,16 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
     runtime.dispatch_event(Event::pointer_move(hover_size_left));
     runtime.dispatch_event(Event::pointer_move(hover_size_left_update));
     let dragging_frame = runtime.frame_with_default_theme();
-    let marker = dragging_frame
+    let marker = column_drop_marker_rect(&dragging_frame);
+    let boundary_delta = marker.min.x - size_rect.min.x;
+    assert!(
+        boundary_delta.abs() <= 1.0,
+        "drop marker should paint at the size header insertion boundary, marker={marker:?}, size={size_rect:?}, delta={boundary_delta}",
+    );
+}
+
+fn column_drop_marker_rect(frame: &SurfaceFrame) -> Rect {
+    frame
         .paint_plan
         .fill_rects()
         .find(|fill| {
@@ -207,11 +216,6 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
                 && fill.rect.width() <= 2.5
                 && fill.rect.height() >= 20.0
         })
-        .expect("dragging over a later visible header should paint the drop marker");
-    let handle_gap = marker.rect.min.x - size_rect.min.x;
-    assert!(
-        (-120.0..=2.0).contains(&handle_gap),
-        "drop marker should paint in the size header's leading drop region, marker={:?}, size={size_rect:?}, gap={handle_gap}",
-        marker.rect
-    );
+        .map(|fill| fill.rect)
+        .expect("active column drag should paint the drop marker")
 }

--- a/src/native_app/tests/sample_browser/column_reorder.rs
+++ b/src/native_app/tests/sample_browser/column_reorder.rs
@@ -181,6 +181,11 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
             crate::native_app::ui::ids::RETAINED_SAMPLE_HEADER_CELL_ID,
             "size",
         ));
+    let extension_resize_id =
+        radiant::prelude::compact_details_header_resize_id(radiant::widgets::stable_widget_id(
+            crate::native_app::ui::ids::RETAINED_SAMPLE_HEADER_CELL_ID,
+            "extension",
+        ));
     let rating_rect = *runtime
         .layout()
         .rects
@@ -191,6 +196,11 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
         .rects
         .get(&size_header_id)
         .expect("size column header hit target should be laid out");
+    let extension_resize_rect = *runtime
+        .layout()
+        .rects
+        .get(&extension_resize_id)
+        .expect("extension column divider should be laid out");
     let press = rating_rect.center();
     let hover_size_left = Point::new(size_rect.min.x + 12.0, press.y);
     let hover_size_left_update = Point::new(hover_size_left.x + 1.0, hover_size_left.y);
@@ -200,10 +210,10 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
     runtime.dispatch_event(Event::pointer_move(hover_size_left_update));
     let dragging_frame = runtime.frame_with_default_theme();
     let marker = column_drop_marker_rect(&dragging_frame);
-    let boundary_delta = marker.min.x - size_rect.min.x;
+    let divider_delta = marker.center().x - extension_resize_rect.center().x;
     assert!(
-        boundary_delta.abs() <= 1.0,
-        "drop marker should paint at the size header insertion boundary, marker={marker:?}, size={size_rect:?}, delta={boundary_delta}",
+        divider_delta.abs() <= 2.0,
+        "drop marker should paint on the dotted divider before the size header, marker={marker:?}, divider={extension_resize_rect:?}, delta={divider_delta}",
     );
 }
 


### PR DESCRIPTION
## Scope
- Paint the sample-list column drop marker inside the details-header content area so it shares the same local coordinate space as the rendered column cells.
- Remove the Wavecrate-specific resize/gap offset from column reorder feedback so the yellow marker lands on the actual insertion boundary.
- Tighten GUI/state regressions for default, resized, and narrow column layouts.

## Definition of Done
- The yellow column drop-target line aligns with the real insertion boundary used by column reorder logic.
- Dropping a column produces the reorder result indicated by the marker.
- Alignment is covered for default columns plus resized/narrow column layouts.

## Validation commands
- `cargo fmt`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate sample_file_column_drag_feedback_tracks_resized_and_narrow_boundaries`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate full_gui_column_drag_marker_uses_header_local_coordinates`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=target/opt957-validation cargo check --manifest-path vendor/radiant/Cargo.toml`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=target/opt957-validation bash scripts/ci.sh agent` *(failed in non-blocking guardrail on pre-existing `src/native_app/sample_identity_diagnostics.rs` filesystem API findings unrelated to OPT-957 after smoke passed)*

## Known limitations
- Full agent validation currently fails on existing non-blocking guardrail findings in `src/native_app/sample_identity_diagnostics.rs` from prior work; this PR does not modify that file.
- Manual in-app drag verification was not run in this pass.

User review is required before merge.