### PR TITLE
Keep collection color markers inside their column

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -28,6 +28,8 @@ const SAMPLE_NAME_BADGE_LIMIT: usize = 4;
 pub(super) const RATING_MARKER_SIDE: u8 = 5;
 pub(super) const LOCKED_KEEP_RATING_MARKER_SIDE: u8 = 7;
 pub(super) const LOCKED_KEEP_RATING_COLOR: ui::Rgba8 = ui::Rgba8::new(232, 188, 56, 245);
+/// Keeps right-aligned collection markers left of the header resize-divider gutter.
+pub(super) const COLLECTION_MARKER_RIGHT_INSET: u8 = 14;
 const SIMILARITY_ANCHOR_ICON_TINTS: ui::SvgIconTintPalette = ui::SvgIconTintPalette::new(
     ui::Rgba8::new(238, 238, 238, 220),
     ui::Rgba8::new(255, 160, 82, 255),
@@ -125,7 +127,11 @@ fn sample_rename_cell(rename: FileRenameView, width: f32) -> ui::View<GuiMessage
 /// Render the passive collection-membership marker cell.
 pub(super) fn sample_collection_cell(colors: Vec<ui::Rgba8>, width: f32) -> ui::View<GuiMessage> {
     ui::compact_details_cell(
-        ui::marker_run_colors(colors).side(6).gap(4).inset(4).view(),
+        ui::marker_run_colors(colors)
+            .side(6)
+            .gap(4)
+            .inset(COLLECTION_MARKER_RIGHT_INSET)
+            .view(),
         Some(width),
     )
 }

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -188,6 +188,46 @@ fn collection_cell_paints_each_collection_membership_color() {
 }
 
 #[test]
+/// Verifies collection markers remain clipped to their own column cell.
+fn collection_cell_keeps_markers_inside_narrow_column_bounds() {
+    let collections = [
+        SampleCollection::new(0).expect("collection"),
+        SampleCollection::new(1).expect("collection"),
+        SampleCollection::new(2).expect("collection"),
+    ];
+    let theme = ThemeTokens::default();
+    let folder_browser = FolderBrowserState::load_default();
+    let collection_colors = collections
+        .into_iter()
+        .filter_map(|collection| folder_browser.collection_color(collection))
+        .collect::<Vec<_>>();
+    let column_width = 24.0;
+    let frame = sample_collection_cell(collection_colors.clone(), column_width)
+        .view_frame_at_size(Vector2::new(column_width, 20.0), &theme);
+
+    let marker_rects = frame
+        .paint_plan
+        .fill_rects()
+        .filter(|fill| collection_colors.contains(&fill.color))
+        .map(|fill| fill.rect)
+        .collect::<Vec<_>>();
+
+    assert!(
+        !marker_rects.is_empty(),
+        "collection cell should paint visible collection markers"
+    );
+    assert!(
+        marker_rects.iter().all(|rect| {
+            rect.min.x >= 0.0
+                && rect.max.x <= column_width
+                && rect.min.y >= 0.0
+                && rect.max.y <= 20.0
+        }),
+        "collection markers should stay inside the collection column bounds: {marker_rects:?}"
+    );
+}
+
+#[test]
 /// Verifies playback-type cells paint compact type labels.
 fn playback_type_cell_paints_loop_label() {
     let theme = ThemeTokens::default();

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -1,8 +1,8 @@
 use super::super::cells::{
-    LOCKED_KEEP_RATING_COLOR, LOCKED_KEEP_RATING_MARKER_SIDE, RATING_MARKER_SIDE,
-    SIMILARITY_ASPECT_DISABLED_TRACK, SIMILARITY_SCORE_FILL, muted_sample_file_cell,
-    sample_collection_cell, sample_file_cell, sample_playback_type_cell, sample_rating_cell,
-    sample_similarity_cell,
+    COLLECTION_MARKER_RIGHT_INSET, LOCKED_KEEP_RATING_COLOR, LOCKED_KEEP_RATING_MARKER_SIDE,
+    RATING_MARKER_SIDE, SIMILARITY_ASPECT_DISABLED_TRACK, SIMILARITY_SCORE_FILL,
+    muted_sample_file_cell, sample_collection_cell, sample_file_cell, sample_playback_type_cell,
+    sample_rating_cell, sample_similarity_cell,
 };
 use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
@@ -224,6 +224,38 @@ fn collection_cell_keeps_markers_inside_narrow_column_bounds() {
                 && rect.max.y <= 20.0
         }),
         "collection markers should stay inside the collection column bounds: {marker_rects:?}"
+    );
+}
+
+#[test]
+/// Verifies collection markers reserve the header divider gutter.
+fn collection_cell_keeps_markers_left_of_header_divider_gutter() {
+    let collections = [
+        SampleCollection::new(0).expect("collection"),
+        SampleCollection::new(1).expect("collection"),
+        SampleCollection::new(2).expect("collection"),
+    ];
+    let theme = ThemeTokens::default();
+    let folder_browser = FolderBrowserState::load_default();
+    let collection_colors = collections
+        .into_iter()
+        .filter_map(|collection| folder_browser.collection_color(collection))
+        .collect::<Vec<_>>();
+    let column_width = 58.0;
+    let frame = sample_collection_cell(collection_colors.clone(), column_width)
+        .view_frame_at_size(Vector2::new(column_width, 20.0), &theme);
+
+    let max_marker_x = frame
+        .paint_plan
+        .fill_rects()
+        .filter(|fill| collection_colors.contains(&fill.color))
+        .map(|fill| fill.rect.max.x)
+        .max_by(f32::total_cmp)
+        .expect("collection cell should paint visible collection markers");
+
+    assert!(
+        max_marker_x <= column_width - COLLECTION_MARKER_RIGHT_INSET as f32,
+        "collection markers should end left of the header divider gutter: max_marker_x={max_marker_x}"
     );
 }
 


### PR DESCRIPTION
Scope
- Update Wavecrate to a Radiant marker-run fix that clips marker fill rects to their assigned widget bounds.
- Add a collection-cell regression proving collection marker fill rects stay inside a narrow collection column.
- Preserve existing marker colors, marker sizing, collection membership semantics, and adjacent column behavior.

Definition of Done
- Collection color rectangles paint fully inside the collection column.
- Markers no longer cross into adjacent/new columns when the collection column is narrow.
- The geometry path is protected by focused Wavecrate and Radiant tests.

Validation commands
- cargo fmt --manifest-path vendor/radiant/Cargo.toml
- cargo fmt
- cargo test --manifest-path vendor/radiant/Cargo.toml marker_run
- CARGO_INCREMENTAL=0 cargo test -p wavecrate collection_cell
- git diff --check

Known limitations
- Manual app smoke testing is still recommended for resized/reordered columns before merge.
- Depends on Radiant support PR: https://github.com/PORTALSURFER/radiant/pull/1384

User review is required before merge unless the user has already signed off.