### PR TITLE
Keep compact column decorations inside item-list cells

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -28,8 +28,8 @@ const SAMPLE_NAME_BADGE_LIMIT: usize = 4;
 pub(super) const RATING_MARKER_SIDE: u8 = 5;
 pub(super) const LOCKED_KEEP_RATING_MARKER_SIDE: u8 = 7;
 pub(super) const LOCKED_KEEP_RATING_COLOR: ui::Rgba8 = ui::Rgba8::new(232, 188, 56, 245);
-/// Keeps right-aligned collection markers left of the header resize-divider gutter.
-pub(super) const COLLECTION_MARKER_RIGHT_INSET: u8 = 14;
+/// Keeps compact column decorations left of the header resize-divider gutter.
+pub(super) const COMPACT_COLUMN_DECORATION_TRAILING_GUTTER: f32 = 14.0;
 const SIMILARITY_ANCHOR_ICON_TINTS: ui::SvgIconTintPalette = ui::SvgIconTintPalette::new(
     ui::Rgba8::new(238, 238, 238, 220),
     ui::Rgba8::new(255, 160, 82, 255),
@@ -126,13 +126,9 @@ fn sample_rename_cell(rename: FileRenameView, width: f32) -> ui::View<GuiMessage
 
 /// Render the passive collection-membership marker cell.
 pub(super) fn sample_collection_cell(colors: Vec<ui::Rgba8>, width: f32) -> ui::View<GuiMessage> {
-    ui::compact_details_cell(
-        ui::marker_run_colors(colors)
-            .side(6)
-            .gap(4)
-            .inset(COLLECTION_MARKER_RIGHT_INSET)
-            .view(),
-        Some(width),
+    compact_column_decoration_cell(
+        ui::marker_run_colors(colors).side(6).gap(4).inset(0).view(),
+        width,
     )
 }
 
@@ -219,23 +215,23 @@ pub(super) fn muted_sample_file_cell(value: String, width: f32) -> ui::View<GuiM
 /// Render a projected passive rating cell.
 fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<GuiMessage> {
     if projection == RatingCellProjection::LockedKeepMarker {
-        return ui::compact_details_cell(
+        return compact_column_decoration_cell(
             ui::marker_run(Some(LOCKED_KEEP_RATING_COLOR), 1)
                 .side(LOCKED_KEEP_RATING_MARKER_SIDE)
                 .gap(4)
-                .inset(4)
+                .inset(0)
                 .view(),
-            Some(width),
+            width,
         );
     }
 
-    ui::compact_details_cell(
+    compact_column_decoration_cell(
         ui::marker_run(projection.marker_color(), projection.marker_count())
             .side(RATING_MARKER_SIDE)
             .gap(4)
-            .inset(4)
+            .inset(0)
             .view(),
-        Some(width),
+        width,
     )
 }
 
@@ -271,11 +267,11 @@ fn sample_badge_run_cell(badges: Vec<String>, muted: bool, width: f32) -> ui::Vi
     if badges.is_empty() {
         return sample_file_cell_with_tone(String::new(), width, muted);
     }
-    ui::compact_details_cell(
+    compact_column_decoration_cell(
         ui::row(sample_badge_views(badges))
             .spacing(4.0)
             .fill_width(),
-        Some(width),
+        width,
     )
 }
 
@@ -299,6 +295,24 @@ fn sample_passive_badge(label: String) -> ui::View<GuiMessage> {
     ui::passive_badge(label)
         .style(ui::WidgetStyle::subtle(ui::WidgetTone::Neutral))
         .height(14.0)
+}
+
+fn compact_column_decoration_cell(
+    content: ui::View<GuiMessage>,
+    width: f32,
+) -> ui::View<GuiMessage> {
+    let content_width = (width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER).max(0.0);
+    ui::compact_details_cell(
+        ui::row([content.width(content_width).height(20.0)])
+            .spacing(0.0)
+            .height(20.0),
+        Some(width),
+    )
+}
+
+#[cfg(test)]
+pub(super) fn sample_harvest_badge_cell(badges: Vec<String>, width: f32) -> ui::View<GuiMessage> {
+    sample_badge_run_cell(badges, false, width)
 }
 
 static SIMILARITY_ANCHOR_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -28,8 +28,8 @@ const SAMPLE_NAME_BADGE_LIMIT: usize = 4;
 pub(super) const RATING_MARKER_SIDE: u8 = 5;
 pub(super) const LOCKED_KEEP_RATING_MARKER_SIDE: u8 = 7;
 pub(super) const LOCKED_KEEP_RATING_COLOR: ui::Rgba8 = ui::Rgba8::new(232, 188, 56, 245);
-/// Keeps compact column decorations left of the header resize-divider gutter.
-pub(super) const COMPACT_COLUMN_DECORATION_TRAILING_GUTTER: f32 = 14.0;
+/// Keeps compact column content left of the header resize-divider gutter.
+pub(super) const COMPACT_COLUMN_CONTENT_TRAILING_GUTTER: f32 = 14.0;
 const SIMILARITY_ANCHOR_ICON_TINTS: ui::SvgIconTintPalette = ui::SvgIconTintPalette::new(
     ui::Rgba8::new(238, 238, 238, 220),
     ui::Rgba8::new(255, 160, 82, 255),
@@ -107,9 +107,9 @@ pub(super) fn sample_playback_type_cell(
 
 /// Render the passive playback-type cell.
 fn render_playback_type_cell(label: String, available: bool, width: f32) -> ui::View<GuiMessage> {
-    let text = ui::text(label).height(18.0).fill_width();
+    let text = compact_text(label);
     let text = if available { text } else { text.muted_text() };
-    ui::compact_details_cell(text, Some(width))
+    compact_column_content_cell(text, width)
 }
 
 fn sample_rename_cell(rename: FileRenameView, width: f32) -> ui::View<GuiMessage> {
@@ -126,7 +126,7 @@ fn sample_rename_cell(rename: FileRenameView, width: f32) -> ui::View<GuiMessage
 
 /// Render the passive collection-membership marker cell.
 pub(super) fn sample_collection_cell(colors: Vec<ui::Rgba8>, width: f32) -> ui::View<GuiMessage> {
-    compact_column_decoration_cell(
+    compact_column_content_cell(
         ui::marker_run_colors(colors).side(6).gap(4).inset(0).view(),
         width,
     )
@@ -215,7 +215,7 @@ pub(super) fn muted_sample_file_cell(value: String, width: f32) -> ui::View<GuiM
 /// Render a projected passive rating cell.
 fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<GuiMessage> {
     if projection == RatingCellProjection::LockedKeepMarker {
-        return compact_column_decoration_cell(
+        return compact_column_content_cell(
             ui::marker_run(Some(LOCKED_KEEP_RATING_COLOR), 1)
                 .side(LOCKED_KEEP_RATING_MARKER_SIDE)
                 .gap(4)
@@ -225,7 +225,7 @@ fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<
         );
     }
 
-    compact_column_decoration_cell(
+    compact_column_content_cell(
         ui::marker_run(projection.marker_color(), projection.marker_count())
             .side(RATING_MARKER_SIDE)
             .gap(4)
@@ -242,9 +242,9 @@ pub(super) fn sample_file_cell(value: String, width: f32) -> ui::View<GuiMessage
 }
 
 fn sample_file_cell_with_tone(value: String, width: f32, muted: bool) -> ui::View<GuiMessage> {
-    let text = ui::text(value);
+    let text = compact_text(value);
     let text = if muted { text.muted_text() } else { text };
-    ui::compact_details_cell(text, Some(width))
+    compact_column_content_cell(text, width)
 }
 
 fn sample_name_cell(
@@ -257,17 +257,17 @@ fn sample_name_cell(
         return sample_file_cell_with_tone(text, width, muted);
     }
     let mut cells = Vec::with_capacity(badges.len() + 1);
-    let name = ui::text(text).height(18.0).fill_width();
+    let name = compact_text(text).fill_width();
     cells.push(if muted { name.muted_text() } else { name });
     cells.extend(sample_badge_views(badges));
-    ui::compact_details_cell(ui::row(cells).spacing(4.0).fill_width(), Some(width))
+    compact_column_content_cell(ui::row(cells).spacing(4.0).fill_width(), width)
 }
 
 fn sample_badge_run_cell(badges: Vec<String>, muted: bool, width: f32) -> ui::View<GuiMessage> {
     if badges.is_empty() {
         return sample_file_cell_with_tone(String::new(), width, muted);
     }
-    compact_column_decoration_cell(
+    compact_column_content_cell(
         ui::row(sample_badge_views(badges))
             .spacing(4.0)
             .fill_width(),
@@ -297,11 +297,12 @@ fn sample_passive_badge(label: String) -> ui::View<GuiMessage> {
         .height(14.0)
 }
 
-fn compact_column_decoration_cell(
-    content: ui::View<GuiMessage>,
-    width: f32,
-) -> ui::View<GuiMessage> {
-    let content_width = (width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER).max(0.0);
+fn compact_text(text: impl Into<String>) -> ui::View<GuiMessage> {
+    ui::text(text).height(18.0).truncate()
+}
+
+fn compact_column_content_cell(content: ui::View<GuiMessage>, width: f32) -> ui::View<GuiMessage> {
+    let content_width = (width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER).max(0.0);
     ui::compact_details_cell(
         ui::row([content.width(content_width).height(20.0)])
             .spacing(0.0)

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -1,14 +1,20 @@
 use super::super::cells::{
-    COLLECTION_MARKER_RIGHT_INSET, LOCKED_KEEP_RATING_COLOR, LOCKED_KEEP_RATING_MARKER_SIDE,
-    RATING_MARKER_SIDE, SIMILARITY_ASPECT_DISABLED_TRACK, SIMILARITY_SCORE_FILL,
-    muted_sample_file_cell, sample_collection_cell, sample_file_cell, sample_playback_type_cell,
-    sample_rating_cell, sample_similarity_cell,
+    COMPACT_COLUMN_DECORATION_TRAILING_GUTTER, LOCKED_KEEP_RATING_COLOR,
+    LOCKED_KEEP_RATING_MARKER_SIDE, RATING_MARKER_SIDE, SIMILARITY_ASPECT_DISABLED_TRACK,
+    SIMILARITY_SCORE_FILL, muted_sample_file_cell, sample_collection_cell, sample_file_cell,
+    sample_harvest_badge_cell, sample_playback_type_cell, sample_rating_cell,
+    sample_similarity_cell,
 };
 use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
 use super::*;
 use crate::native_app::sample_library::folder_browser::{FolderBrowserState, model::FileEntry};
-use radiant::{layout::Vector2, prelude::IntoView, theme::ThemeTokens};
+use radiant::{
+    layout::Vector2,
+    prelude::{self as ui, IntoView},
+    runtime::PaintPrimitive,
+    theme::ThemeTokens,
+};
 use wavecrate::sample_sources::{Rating, SampleCollection};
 
 /// Builds a representative file entry for row rendering tests.
@@ -29,6 +35,29 @@ fn file_entry() -> FileEntry {
         collection: None,
         collections: Vec::new(),
     }
+}
+
+fn fill_rects_with_colors(
+    frame: &radiant::runtime::SurfaceFrame,
+) -> Vec<(radiant::prelude::Rect, radiant::prelude::Rgba8)> {
+    let mut rects = frame
+        .paint_plan
+        .fill_rects()
+        .map(|fill| (fill.rect, fill.color))
+        .collect::<Vec<_>>();
+    for primitive in &frame.paint_plan.primitives {
+        if let PaintPrimitive::FillRectBatch(batch) = primitive {
+            rects.extend(batch.rects.iter().copied().map(|rect| (rect, batch.color)));
+        }
+    }
+    rects
+}
+
+fn fill_rects(frame: &radiant::runtime::SurfaceFrame) -> Vec<radiant::prelude::Rect> {
+    fill_rects_with_colors(frame)
+        .into_iter()
+        .map(|(rect, _)| rect)
+        .collect()
 }
 
 #[test]
@@ -254,8 +283,142 @@ fn collection_cell_keeps_markers_left_of_header_divider_gutter() {
         .expect("collection cell should paint visible collection markers");
 
     assert!(
-        max_marker_x <= column_width - COLLECTION_MARKER_RIGHT_INSET as f32,
+        max_marker_x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER,
         "collection markers should end left of the header divider gutter: max_marker_x={max_marker_x}"
+    );
+}
+
+#[test]
+/// Verifies rating markers reserve the same divider gutter as collection markers.
+fn rating_cell_keeps_markers_left_of_header_divider_gutter() {
+    let theme = ThemeTokens::default();
+    let column_width = 68.0;
+    let frame = sample_rating_cell(RatingIndicator::new(Rating::KEEP_3, false), column_width)
+        .view_frame_at_size(Vector2::new(column_width, 20.0), &theme);
+
+    let marker_rects = fill_rects(&frame);
+
+    assert!(
+        !marker_rects.is_empty(),
+        "rating cell should paint visible rating markers"
+    );
+    assert!(
+        marker_rects.iter().all(|rect| {
+            rect.min.x >= 0.0
+                && rect.max.x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER
+                && rect.min.y >= 0.0
+                && rect.max.y <= 20.0
+        }),
+        "rating markers should stay inside the rating column decoration bounds: {marker_rects:?}"
+    );
+}
+
+#[test]
+/// Verifies Harvest badges reserve the shared divider gutter.
+fn harvest_cell_keeps_badges_left_of_header_divider_gutter() {
+    let theme = ThemeTokens::default();
+    let column_width = 74.0;
+    let frame = sample_harvest_badge_cell(
+        vec![String::from("touch"), String::from("D3")],
+        column_width,
+    )
+    .view_frame_at_size(Vector2::new(column_width, 20.0), &theme);
+
+    let text_rects = frame
+        .paint_plan
+        .text_runs()
+        .filter(|run| run.text == "touch" || run.text == "D3")
+        .map(|run| run.rect)
+        .collect::<Vec<_>>();
+
+    assert!(
+        !text_rects.is_empty(),
+        "harvest cell should paint visible Harvest badge text"
+    );
+    assert!(
+        text_rects.iter().all(|rect| {
+            rect.min.x >= 0.0
+                && rect.max.x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER
+                && rect.min.y >= 0.0
+                && rect.max.y <= 20.0
+        }),
+        "Harvest badge text should stay inside the Harvest column decoration bounds: {text_rects:?}"
+    );
+}
+
+#[test]
+/// Verifies compact decorations do not bleed across neighboring columns.
+fn compact_decorations_stay_inside_adjacent_column_boundaries() {
+    let theme = ThemeTokens::default();
+    let folder_browser = FolderBrowserState::load_default();
+    let collection = SampleCollection::new(0).expect("collection");
+    let collection_color = folder_browser
+        .collection_color(collection)
+        .expect("collection color");
+    let rating = RatingIndicator::new(Rating::KEEP_3, false);
+    let rating_color = rating.color().expect("rating marker color");
+
+    let rating_width = 68.0;
+    let harvest_width = 74.0;
+    let collection_width = 58.0;
+    let row_padding = 8.0;
+    let column_spacing = 10.0;
+    let rating_start = row_padding;
+    let harvest_start = rating_start + rating_width + column_spacing;
+    let collection_start = harvest_start + harvest_width + column_spacing;
+    let row_width = collection_start + collection_width + row_padding;
+    let frame = ui::compact_details_row([
+        sample_rating_cell(rating, rating_width),
+        sample_harvest_badge_cell(
+            vec![String::from("touch"), String::from("D3")],
+            harvest_width,
+        ),
+        sample_collection_cell(vec![collection_color], collection_width),
+    ])
+    .view_frame_at_size(Vector2::new(row_width, 22.0), &theme);
+
+    let fills = fill_rects_with_colors(&frame);
+    let rating_rects = fills
+        .iter()
+        .filter_map(|(rect, color)| (*color == rating_color).then_some(*rect))
+        .collect::<Vec<_>>();
+    let collection_rects = fills
+        .iter()
+        .filter_map(|(rect, color)| (*color == collection_color).then_some(*rect))
+        .collect::<Vec<_>>();
+    let harvest_text_rects = frame
+        .paint_plan
+        .text_runs()
+        .filter(|run| run.text == "touch" || run.text == "D3")
+        .map(|run| run.rect)
+        .collect::<Vec<_>>();
+
+    assert!(
+        !rating_rects.is_empty(),
+        "adjacent row should paint rating markers"
+    );
+    assert!(
+        !harvest_text_rects.is_empty(),
+        "adjacent row should paint Harvest badge text"
+    );
+    assert!(
+        !collection_rects.is_empty(),
+        "adjacent row should paint collection markers"
+    );
+    assert!(
+        rating_rects.iter().all(|rect| rect.max.x
+            <= rating_start + rating_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+        "rating markers should not bleed into the Harvest column: {rating_rects:?}"
+    );
+    assert!(
+        harvest_text_rects.iter().all(|rect| rect.max.x
+            <= harvest_start + harvest_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+        "Harvest badges should not bleed into the collection column: {harvest_text_rects:?}"
+    );
+    assert!(
+        collection_rects.iter().all(|rect| rect.max.x
+            <= collection_start + collection_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+        "collection markers should not bleed past their column: {collection_rects:?}"
     );
 }
 

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -1,5 +1,5 @@
 use super::super::cells::{
-    COMPACT_COLUMN_DECORATION_TRAILING_GUTTER, LOCKED_KEEP_RATING_COLOR,
+    COMPACT_COLUMN_CONTENT_TRAILING_GUTTER, LOCKED_KEEP_RATING_COLOR,
     LOCKED_KEEP_RATING_MARKER_SIDE, RATING_MARKER_SIDE, SIMILARITY_ASPECT_DISABLED_TRACK,
     SIMILARITY_SCORE_FILL, muted_sample_file_cell, sample_collection_cell, sample_file_cell,
     sample_harvest_badge_cell, sample_playback_type_cell, sample_rating_cell,
@@ -120,6 +120,30 @@ fn sample_text_uses_primary_theme_color() {
             .text_runs()
             .any(|run| run.text == "kick_deep" && run.color == theme.text_primary),
         "sample rows should not express loaded/cache state through text color"
+    );
+}
+
+#[test]
+/// Verifies long sample names end before the header divider gutter.
+fn sample_text_keeps_long_label_left_of_header_divider_gutter() {
+    let theme = ThemeTokens::default();
+    let column_width = 240.0;
+    let frame = sample_file_cell(
+        String::from("KAB1_0_AmenBreak_Original_FullStem"),
+        column_width,
+    )
+    .view_frame_at_size(Vector2::new(column_width, 20.0), &theme);
+
+    let text = frame
+        .paint_plan
+        .text_runs()
+        .find(|run| run.text == "KAB1_0_AmenBreak_Original_FullStem")
+        .expect("sample name text should paint");
+
+    assert!(
+        text.rect.max.x <= column_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER,
+        "sample name text should end left of the header divider gutter: rect={:?}",
+        text.rect
     );
 }
 
@@ -283,7 +307,7 @@ fn collection_cell_keeps_markers_left_of_header_divider_gutter() {
         .expect("collection cell should paint visible collection markers");
 
     assert!(
-        max_marker_x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER,
+        max_marker_x <= column_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER,
         "collection markers should end left of the header divider gutter: max_marker_x={max_marker_x}"
     );
 }
@@ -305,11 +329,11 @@ fn rating_cell_keeps_markers_left_of_header_divider_gutter() {
     assert!(
         marker_rects.iter().all(|rect| {
             rect.min.x >= 0.0
-                && rect.max.x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER
+                && rect.max.x <= column_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER
                 && rect.min.y >= 0.0
                 && rect.max.y <= 20.0
         }),
-        "rating markers should stay inside the rating column decoration bounds: {marker_rects:?}"
+        "rating markers should stay inside the rating column content bounds: {marker_rects:?}"
     );
 }
 
@@ -338,17 +362,17 @@ fn harvest_cell_keeps_badges_left_of_header_divider_gutter() {
     assert!(
         text_rects.iter().all(|rect| {
             rect.min.x >= 0.0
-                && rect.max.x <= column_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER
+                && rect.max.x <= column_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER
                 && rect.min.y >= 0.0
                 && rect.max.y <= 20.0
         }),
-        "Harvest badge text should stay inside the Harvest column decoration bounds: {text_rects:?}"
+        "Harvest badge text should stay inside the Harvest column content bounds: {text_rects:?}"
     );
 }
 
 #[test]
-/// Verifies compact decorations do not bleed across neighboring columns.
-fn compact_decorations_stay_inside_adjacent_column_boundaries() {
+/// Verifies compact content does not bleed across neighboring columns.
+fn compact_column_content_stays_inside_adjacent_column_boundaries() {
     let theme = ThemeTokens::default();
     let folder_browser = FolderBrowserState::load_default();
     let collection = SampleCollection::new(0).expect("collection");
@@ -358,16 +382,22 @@ fn compact_decorations_stay_inside_adjacent_column_boundaries() {
     let rating = RatingIndicator::new(Rating::KEEP_3, false);
     let rating_color = rating.color().expect("rating marker color");
 
+    let name_width = 240.0;
     let rating_width = 68.0;
     let harvest_width = 74.0;
     let collection_width = 58.0;
     let row_padding = 8.0;
     let column_spacing = 10.0;
-    let rating_start = row_padding;
+    let name_start = row_padding;
+    let rating_start = name_start + name_width + column_spacing;
     let harvest_start = rating_start + rating_width + column_spacing;
     let collection_start = harvest_start + harvest_width + column_spacing;
     let row_width = collection_start + collection_width + row_padding;
     let frame = ui::compact_details_row([
+        sample_file_cell(
+            String::from("KAB1_0_AmenBreak_Original_FullStem"),
+            name_width,
+        ),
         sample_rating_cell(rating, rating_width),
         sample_harvest_badge_cell(
             vec![String::from("touch"), String::from("D3")],
@@ -392,7 +422,17 @@ fn compact_decorations_stay_inside_adjacent_column_boundaries() {
         .filter(|run| run.text == "touch" || run.text == "D3")
         .map(|run| run.rect)
         .collect::<Vec<_>>();
+    let name_text_rects = frame
+        .paint_plan
+        .text_runs()
+        .filter(|run| run.text == "KAB1_0_AmenBreak_Original_FullStem")
+        .map(|run| run.rect)
+        .collect::<Vec<_>>();
 
+    assert!(
+        !name_text_rects.is_empty(),
+        "adjacent row should paint sample name text"
+    );
     assert!(
         !rating_rects.is_empty(),
         "adjacent row should paint rating markers"
@@ -406,18 +446,25 @@ fn compact_decorations_stay_inside_adjacent_column_boundaries() {
         "adjacent row should paint collection markers"
     );
     assert!(
+        name_text_rects
+            .iter()
+            .all(|rect| rect.max.x
+                <= name_start + name_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER),
+        "sample name text should not bleed into the rating column: {name_text_rects:?}"
+    );
+    assert!(
         rating_rects.iter().all(|rect| rect.max.x
-            <= rating_start + rating_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+            <= rating_start + rating_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER),
         "rating markers should not bleed into the Harvest column: {rating_rects:?}"
     );
     assert!(
         harvest_text_rects.iter().all(|rect| rect.max.x
-            <= harvest_start + harvest_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+            <= harvest_start + harvest_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER),
         "Harvest badges should not bleed into the collection column: {harvest_text_rects:?}"
     );
     assert!(
         collection_rects.iter().all(|rect| rect.max.x
-            <= collection_start + collection_width - COMPACT_COLUMN_DECORATION_TRAILING_GUTTER),
+            <= collection_start + collection_width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER),
         "collection markers should not bleed past their column: {collection_rects:?}"
     );
 }


### PR DESCRIPTION
Scope
- Add a shared compact column content lane that reserves the header resize-divider gutter.
- Route sample-label text, playback-type text, collection markers, rating markers, and Harvest/Curation badge runs through the same bounded cell contract.
- Keep marker sizes, badge rendering, and column data semantics unchanged while preventing rightward bleed into neighboring columns.
- Add focused paint-plan regressions for sample labels, collection, rating, Harvest, and a side-by-side adjacent-column row.

Definition of Done
- Main sample labels clip before the Name column divider gutter.
- Rating rectangles paint inside the rating column content bounds.
- Harvest badges paint inside the Harvest column content bounds.
- Collection markers use the same corrected content-cell contract.
- Compact row content does not bleed into adjacent columns in a representative compact details row.

Validation commands
- cargo fmt
- git diff --check
- CARGO_INCREMENTAL=0 cargo test -p wavecrate cell_keeps
- CARGO_INCREMENTAL=0 cargo test -p wavecrate sample_text_keeps_long_label_left_of_header_divider_gutter
- CARGO_INCREMENTAL=0 cargo test -p wavecrate compact_column_content_stays_inside_adjacent_column_boundaries
- CARGO_INCREMENTAL=0 cargo test -p wavecrate native_app::app_chrome::library_browser::sample_browser_view::rows::tests

Known limitations
- Manual app smoke testing is still recommended for resized/reordered and horizontally scrolled layouts.
- bash scripts/ci.sh quick could not run because cargo-nextest is not installed in this shell.
- Fallback CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib --tests was run and failed in unrelated broader baseline areas: source_scan_worker batching, folder_browser filesystem refresh/root facade tests, browser context menu harvest-destination source requirement, folder layout x-toggle focus, native file drop/import, config source removal, harvest/waveform playback persistence, window chrome native drop/hit target masking, and playback-cache-backed waveform input. The OPT-914 row/cell tests above passed.

User review is required before merge unless the user has already signed off.