### PR TITLE
OPT-959 Align W context menus to pointer anchors

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -22,7 +22,9 @@ use crate::native_app::audio::playback_history::{
     LastPlayedPersistRequest, LastPlayedPersistResult,
 };
 use crate::native_app::metadata::MetadataTagPersistResult;
-use crate::native_app::sample_library::context_menu_target::BrowserContextTargetKind;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextTargetKind,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::commands::RenameCommitCompletion;
 use crate::native_app::sample_library::folder_browser::commands::{
@@ -84,6 +86,7 @@ pub(in crate::native_app) enum GuiMessage {
         path: String,
         position: Point,
     },
+    RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor),
     DragSampleFile {
         path: String,
         drag: DragHandleMessage,

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -11,7 +11,9 @@ use wavecrate::sample_sources::config::AppSettingsCore;
 use wavecrate::selection::SelectionRange;
 
 use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, NativeFileDropHover};
-use crate::native_app::sample_library::context_menu_target::BrowserContextMenu;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextMenu, BrowserContextPointerAnchor,
+};
 use crate::native_app::waveform::WaveformContextMenu;
 
 pub(in crate::native_app) const DEFAULT_BEAT_GUIDE_COUNT: u8 = 4;
@@ -313,6 +315,7 @@ pub(in crate::native_app) enum ReleaseUpdateStatus {
 pub(in crate::native_app) struct BrowserInteractionState {
     pub(in crate::native_app) context_menu: Option<BrowserContextMenu>,
     pub(in crate::native_app) waveform_context_menu: Option<WaveformContextMenu>,
+    pub(in crate::native_app) context_menu_pointer_anchor: Option<BrowserContextPointerAnchor>,
     pub(in crate::native_app) clipboard_handoff_target: ClipboardHandoffTarget,
     pub(in crate::native_app) pending_folder_delete: Option<PendingFolderDelete>,
     pub(in crate::native_app) pending_waveform_destructive_edit:

--- a/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/rows.rs
@@ -7,6 +7,9 @@ use super::identity::{
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::sidebar_row_underlay;
 use crate::native_app::app_chrome::view_models::library_sidebar::CollectionRowViewModel;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::view_contract::{
     COLLECTION_ROW_HEIGHT, SampleCollectionView,
@@ -62,6 +65,12 @@ fn collection_row_actions(
     collection_id: SampleCollection,
 ) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
+        .hover_key(collection_id, |collection_id, position| {
+            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+                target: BrowserContextPointerTarget::Collection(collection_id),
+                position,
+            })
+        })
         .drop_target_key(
             collection_id,
             |collection_id| {

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
@@ -3,6 +3,9 @@ use radiant::prelude as ui;
 use super::identity::{RETAINED_FOLDER_TREE_ROW_INPUT_SCOPE, retained_folder_row_key};
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::SIDEBAR_ROW_STYLE;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::model::VisibleFolder;
 use crate::native_app::sample_library::folder_browser::view_contract::{
@@ -130,6 +133,12 @@ fn standard_folder_row(folder: &VisibleFolder, id: String) -> ui::View<GuiMessag
 
 fn folder_row_actions(id: String) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
+        .hover_key(id.clone(), |id, position| {
+            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+                target: BrowserContextPointerTarget::Folder(id),
+                position,
+            })
+        })
         .primary_with_modifiers_key(id.clone(), |id, modifiers| {
             GuiMessage::FolderBrowser(FolderBrowserMessage::ActivateFolder(id, modifiers))
         })

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -7,6 +7,9 @@ use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::sidebar_row_underlay;
 use crate::native_app::app_chrome::toolbar::toolbar_icon_color;
 use crate::native_app::app_chrome::view_models::library_sidebar::SourceRowViewModel;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use wavecrate::sample_sources::SourceRole;
 
@@ -44,15 +47,28 @@ pub(super) fn source_row(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
         )
         .selected(source.selected)
         .outline(source_row_outline())
-        .actions(ui::row_actions().primary_secondary_key(
-            source.id.clone(),
-            |source_id| GuiMessage::FolderBrowser(FolderBrowserMessage::SelectSource(source_id)),
-            |source_id, position| {
-                GuiMessage::FolderBrowser(FolderBrowserMessage::OpenSourceContextMenu(
-                    source_id, position,
-                ))
-            },
-        ))
+        .actions(
+            ui::row_actions()
+                .hover_key(source.id.clone(), |source_id, position| {
+                    GuiMessage::RememberBrowserContextMenuPointerAnchor(
+                        BrowserContextPointerAnchor {
+                            target: BrowserContextPointerTarget::Source(source_id),
+                            position,
+                        },
+                    )
+                })
+                .primary_secondary_key(
+                    source.id.clone(),
+                    |source_id| {
+                        GuiMessage::FolderBrowser(FolderBrowserMessage::SelectSource(source_id))
+                    },
+                    |source_id, position| {
+                        GuiMessage::FolderBrowser(FolderBrowserMessage::OpenSourceContextMenu(
+                            source_id, position,
+                        ))
+                    },
+                ),
+        )
         .fill_width()
         .height(SOURCE_ROW_HEIGHT)
 }

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -4,6 +4,9 @@ use radiant::theme::ThemeTokens;
 
 use super::identity;
 use crate::native_app::app::GuiMessage;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 
 const SAMPLE_ROW_STYLE: ui::WidgetStyle = ui::WidgetStyle::subtle(ui::WidgetTone::Accent);
 const COPY_FLASH_FILL: ui::Rgba8 = ui::Rgba8 {
@@ -144,6 +147,12 @@ fn sample_file_hit_target_builder(
 
 fn sample_file_row_actions(path: String) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
+        .hover_key(path.clone(), |path, position| {
+            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+                target: BrowserContextPointerTarget::Sample(path),
+                position,
+            })
+        })
         .primary_with_modifiers_key(path.clone(), |path, modifiers| {
             GuiMessage::SelectSampleWithModifiers { path, modifiers }
         })

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -20,6 +20,9 @@ use std::{
 use crate::native_app::app::{
     GuiMessage, StarmapAuditionDragState, StarmapViewport, StarmapViewportChange,
 };
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::starmap::{
     StarmapItem, StarmapStatus, starmap_cluster_palette_color,
@@ -452,6 +455,17 @@ impl StarmapWidget {
         self.hovered_file_id = self.hit_file_id(bounds, point);
     }
 
+    fn remember_hovered_context_menu_anchor(&self, point: Point) -> Option<WidgetOutput> {
+        self.hovered_file_id.as_ref().map(|file_id| {
+            WidgetOutput::typed(GuiMessage::RememberBrowserContextMenuPointerAnchor(
+                BrowserContextPointerAnchor {
+                    target: BrowserContextPointerTarget::Sample(file_id.clone()),
+                    position: point,
+                },
+            ))
+        })
+    }
+
     fn hovered_item(&self) -> Option<&StarmapItem> {
         let hovered_file_id = self.hovered_file_id.as_deref()?;
         self.items
@@ -647,7 +661,7 @@ impl Widget for StarmapWidget {
                 ),
             CanvasGestureEvent::Hover(pointer) => {
                 self.set_hovered_file_at(bounds, pointer.position);
-                None
+                self.remember_hovered_context_menu_anchor(pointer.position)
             }
             CanvasGestureEvent::Press {
                 pointer,
@@ -1400,10 +1414,16 @@ mod tests {
         item.label = String::from("Kick Tight 01");
         let mut widget = StarmapWidget::new(vec![item], StarmapViewport::default(), None);
 
-        assert!(
+        assert_eq!(
             widget
                 .handle_input(bounds, WidgetInput::pointer_move(Point::new(50.0, 50.0)))
-                .is_none()
+                .and_then(|output| output.typed_cloned::<GuiMessage>()),
+            Some(GuiMessage::RememberBrowserContextMenuPointerAnchor(
+                BrowserContextPointerAnchor {
+                    target: BrowserContextPointerTarget::Sample(String::from("/samples/kick.wav")),
+                    position: Point::new(50.0, 50.0),
+                }
+            ))
         );
         let mut primitives = Vec::new();
         widget.append_runtime_overlay_paint(
@@ -1532,11 +1552,17 @@ mod tests {
             StarmapViewport::default(),
             None,
         );
-        assert!(
+        assert_eq!(
             previous
                 .handle_input(bounds, WidgetInput::pointer_move(Point::new(50.0, 50.0)))
-                .is_none(),
-            "hover should update local runtime state only"
+                .and_then(|output| output.typed_cloned::<GuiMessage>()),
+            Some(GuiMessage::RememberBrowserContextMenuPointerAnchor(
+                BrowserContextPointerAnchor {
+                    target: BrowserContextPointerTarget::Sample(String::from("/samples/kick.wav")),
+                    position: Point::new(50.0, 50.0),
+                }
+            )),
+            "hover should remember a pointer anchor while updating local runtime state"
         );
         previous.ensure_hit_index(bounds);
 

--- a/src/native_app/sample_library/context_menu_target.rs
+++ b/src/native_app/sample_library/context_menu_target.rs
@@ -30,6 +30,29 @@ pub(in crate::native_app) struct BrowserContextMenu {
     pub(in crate::native_app) title: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct BrowserContextPointerAnchor {
+    pub(in crate::native_app) target: BrowserContextPointerTarget,
+    pub(in crate::native_app) position: Point,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum BrowserContextPointerTarget {
+    Source(String),
+    Folder(String),
+    Collection(SampleCollection),
+    Sample(String),
+}
+
+impl BrowserContextPointerAnchor {
+    pub(in crate::native_app) fn new(
+        target: BrowserContextPointerTarget,
+        position: Point,
+    ) -> Option<Self> {
+        (position.x.is_finite() && position.y.is_finite()).then_some(Self { target, position })
+    }
+}
+
 pub(in crate::native_app) fn target_label(path: &Path) -> String {
     path.file_name()
         .map(|name| name.to_string_lossy().to_string())

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -55,6 +55,7 @@ impl NativeAppState {
             | GuiMessage::NormalizationFinished(_)
             | GuiMessage::SelectSampleWithModifiers { .. }
             | GuiMessage::OpenSampleContextMenu { .. }
+            | GuiMessage::RememberBrowserContextMenuPointerAnchor(_)
             | GuiMessage::DragSampleFile { .. }
             | GuiMessage::ExternalDragCompleted(_) => self.apply_browser_dispatch(message, context),
             GuiMessage::DeferredSampleLoad { .. }

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -85,6 +85,9 @@ impl NativeAppState {
                     ClipboardHandoffTarget::BrowserFiles;
                 self.open_sample_context_menu(path, position);
             }
+            GuiMessage::RememberBrowserContextMenuPointerAnchor(anchor) => {
+                self.ui.browser_interaction.context_menu_pointer_anchor = Some(anchor);
+            }
             GuiMessage::DragSampleFile { path, drag } => {
                 self.ui.browser_interaction.clipboard_handoff_target =
                     ClipboardHandoffTarget::BrowserFiles;

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -130,7 +130,7 @@ impl NativeAppState {
                 self.request_apply_edit_selection_effects(context);
             }
             GuiMessage::OpenContextMenu => {
-                self.open_context_menu_from_shortcut();
+                self.open_context_menu_from_shortcut(context);
             }
             GuiMessage::ConfirmPendingWaveformDestructiveEdit => {
                 self.confirm_pending_waveform_destructive_edit(context);

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -202,8 +202,14 @@ impl NativeAppState {
         );
     }
 
-    pub(in crate::native_app) fn open_play_selection_context_menu_from_shortcut(&mut self) {
-        let Some(position) = self.waveform.current.play_selection_context_menu_anchor() else {
+    pub(in crate::native_app) fn open_play_selection_context_menu_from_shortcut(
+        &mut self,
+        current_pointer_position: Option<ui::Point>,
+    ) {
+        let Some(position) = current_pointer_position
+            .filter(|position| position.x.is_finite() && position.y.is_finite())
+            .or_else(|| self.waveform.current.play_selection_context_menu_anchor())
+        else {
             self.ui.status.sample = String::from("Set a playmark selection first");
             return;
         };

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -37,7 +37,7 @@ pub(in crate::native_app) fn default_gui_shortcuts(
         .layer_when(
             state.ui.browser_interaction.context_menu.is_some()
                 || state.ui.browser_interaction.waveform_context_menu.is_some(),
-            ui::ShortcutLayer::modal_escape(GuiMessage::CloseContextMenu),
+            context_menu_modal_shortcuts(),
         )
         .layer_when(
             state
@@ -135,6 +135,18 @@ fn collection_focus_shortcuts() -> ui::ShortcutLayer<GuiMessage> {
         ui::KeyPress::new(ui::KeyCode::Escape),
         GuiMessage::FolderBrowser(FolderBrowserMessage::ExitCollectionFocus),
     )
+}
+
+fn context_menu_modal_shortcuts() -> ui::ShortcutLayer<GuiMessage> {
+    ui::ShortcutLayer::modal()
+        .bind(
+            ui::KeyPress::new(ui::KeyCode::Escape),
+            GuiMessage::CloseContextMenu,
+        )
+        .bind(
+            ui::KeyPress::new(ui::KeyCode::W),
+            GuiMessage::CloseContextMenu,
+        )
 }
 
 fn pending_destructive_edit_shortcuts() -> ui::ShortcutLayer<GuiMessage> {

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -432,6 +432,35 @@ fn global_context_menu_uses_live_pointer_position_over_stale_sample_anchor() {
 }
 
 #[test]
+fn w_command_toggles_open_browser_context_menu_closed() {
+    let mut state = gui_state_for_span_tests();
+    state.ui.browser_interaction.context_menu = Some(
+        crate::native_app::test_support::context_menu::BrowserContextMenu {
+            kind: crate::native_app::test_support::context_menu::BrowserContextTargetKind::Folder,
+            path: PathBuf::from("Documents"),
+            source_id: None,
+            source_role: wavecrate::sample_sources::SourceRole::Normal,
+            source_removable: false,
+            folder_locked: false,
+            folder_lock_inherited: false,
+            metadata_tag: None,
+            collection: None,
+            sample_missing: false,
+            sample_keep_locked: false,
+            anchor: Point::new(72.0, 142.0),
+            title: String::from("Documents"),
+        },
+    );
+
+    state.apply_message(
+        GuiMessage::OpenContextMenu,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(state.ui.browser_interaction.context_menu, None);
+}
+
+#[test]
 fn global_context_menu_opens_selected_folder_menu_at_matching_pointer_anchor() {
     let root = tempfile::tempdir().expect("source root");
     let mut state = gui_state_for_span_tests();
@@ -578,6 +607,25 @@ fn w_command_opens_playmark_context_menu_at_live_pointer_over_stale_waveform_anc
         .waveform_context_menu
         .expect("playmark context menu opens");
     assert_eq!(menu.anchor, live_pointer);
+}
+
+#[test]
+fn w_command_toggles_open_playmark_context_menu_closed() {
+    let mut state = gui_state_for_span_tests();
+    state.ui.browser_interaction.waveform_context_menu = Some(
+        crate::native_app::test_support::context_menu::WaveformContextMenu {
+            anchor: Point::new(12.0, 24.0),
+            title: String::from("Playmark Selection"),
+            extract_to_harvest_destination: false,
+        },
+    );
+
+    state.apply_message(
+        GuiMessage::OpenContextMenu,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(state.ui.browser_interaction.waveform_context_menu, None);
 }
 
 #[test]

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -3,6 +3,7 @@ use crate::native_app::sample_library::context_menu_target::{
     BrowserContextPointerAnchor, BrowserContextPointerTarget,
 };
 use crate::native_app::test_support::state::GuiMessage;
+use radiant::runtime::RuntimeUpdateSnapshot;
 
 #[test]
 fn folder_context_menu_paints_as_full_width_overlay_panel() {
@@ -389,6 +390,45 @@ fn global_context_menu_ignores_stale_sample_pointer_anchor_after_focus_changes()
         .expect("sample context menu opens");
     assert_eq!(menu.path, snare);
     assert_eq!(menu.anchor, Point::new(720.0, 520.0));
+}
+
+#[test]
+fn global_context_menu_uses_live_pointer_position_over_stale_sample_anchor() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    fs::write(&snare, [0_u8; 8]).expect("write snare");
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(root.path().to_path_buf()),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(snare.display().to_string());
+    state.apply_message(
+        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+            target: BrowserContextPointerTarget::Sample(kick.display().to_string()),
+            position: Point::new(333.0, 222.0),
+        }),
+        &mut ui::UiUpdateContext::default(),
+    );
+    let live_pointer = Point::new(610.0, 388.0);
+    let mut context = ui::UiUpdateContext::from_runtime_snapshot(
+        RuntimeUpdateSnapshot::with_current_pointer_position(Some(live_pointer)),
+    );
+
+    state.apply_message(GuiMessage::OpenContextMenu, &mut context);
+
+    let menu = state
+        .ui
+        .browser_interaction
+        .context_menu
+        .expect("sample context menu opens");
+    assert_eq!(menu.path, snare);
+    assert_eq!(menu.anchor, live_pointer);
 }
 
 #[test]

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::native_app::sample_library::context_menu_target::{
+    BrowserContextPointerAnchor, BrowserContextPointerTarget,
+};
 use crate::native_app::test_support::state::GuiMessage;
 
 #[test]
@@ -323,6 +326,14 @@ fn global_context_menu_opens_selected_sample_menu_without_playmark() {
         .library
         .folder_browser
         .select_file(sample.display().to_string());
+    let pointer_anchor = Point::new(333.0, 222.0);
+    state.apply_message(
+        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+            target: BrowserContextPointerTarget::Sample(sample.display().to_string()),
+            position: pointer_anchor,
+        }),
+        &mut ui::UiUpdateContext::default(),
+    );
 
     state.apply_message(
         GuiMessage::OpenContextMenu,
@@ -339,7 +350,85 @@ fn global_context_menu_opens_selected_sample_menu_without_playmark() {
         crate::native_app::test_support::context_menu::BrowserContextTargetKind::Sample
     );
     assert_eq!(menu.path, sample);
+    assert_eq!(menu.anchor, pointer_anchor);
+}
+
+#[test]
+fn global_context_menu_ignores_stale_sample_pointer_anchor_after_focus_changes() {
+    let root = tempfile::tempdir().expect("source root");
+    let kick = root.path().join("kick.wav");
+    let snare = root.path().join("snare.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write kick");
+    fs::write(&snare, [0_u8; 8]).expect("write snare");
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(root.path().to_path_buf()),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(snare.display().to_string());
+    state.apply_message(
+        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+            target: BrowserContextPointerTarget::Sample(kick.display().to_string()),
+            position: Point::new(333.0, 222.0),
+        }),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    state.apply_message(
+        GuiMessage::OpenContextMenu,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let menu = state
+        .ui
+        .browser_interaction
+        .context_menu
+        .expect("sample context menu opens");
+    assert_eq!(menu.path, snare);
     assert_eq!(menu.anchor, Point::new(720.0, 520.0));
+}
+
+#[test]
+fn global_context_menu_opens_selected_folder_menu_at_matching_pointer_anchor() {
+    let root = tempfile::tempdir().expect("source root");
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(root.path().to_path_buf()),
+        ]);
+    let folder_id = state
+        .library
+        .folder_browser
+        .selected_folder_id()
+        .expect("folder selected")
+        .to_owned();
+    let pointer_anchor = Point::new(88.0, 144.0);
+    state.apply_message(
+        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
+            target: BrowserContextPointerTarget::Folder(folder_id),
+            position: pointer_anchor,
+        }),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    state.apply_message(
+        GuiMessage::OpenContextMenu,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    let menu = state
+        .ui
+        .browser_interaction
+        .context_menu
+        .expect("folder context menu opens");
+    assert_eq!(
+        menu.kind,
+        crate::native_app::test_support::context_menu::BrowserContextTargetKind::Folder
+    );
+    assert_eq!(menu.anchor, pointer_anchor);
 }
 
 #[test]

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -556,6 +556,31 @@ fn w_command_opens_playmark_context_menu_at_remembered_mouse_location() {
 }
 
 #[test]
+fn w_command_opens_playmark_context_menu_at_live_pointer_over_stale_waveform_anchor() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.2, 0.6);
+    state
+        .waveform
+        .current
+        .apply_interaction(WaveformInteraction::RememberPointerLocation {
+            position: Point::new(333.0, 222.0),
+        });
+    let live_pointer = Point::new(760.0, 512.0);
+    let mut context = ui::UiUpdateContext::from_runtime_snapshot(
+        RuntimeUpdateSnapshot::with_current_pointer_position(Some(live_pointer)),
+    );
+
+    state.apply_message(GuiMessage::OpenContextMenu, &mut context);
+
+    let menu = state
+        .ui
+        .browser_interaction
+        .waveform_context_menu
+        .expect("playmark context menu opens");
+    assert_eq!(menu.anchor, live_pointer);
+}
+
+#[test]
 fn waveform_interaction_marks_context_menu_harvest_destination_route() {
     let protected_root = tempfile::tempdir().expect("protected source root");
     let primary_root = tempfile::tempdir().expect("primary source root");

--- a/src/native_app/tests/shortcuts_context/context_menu.rs
+++ b/src/native_app/tests/shortcuts_context/context_menu.rs
@@ -38,6 +38,17 @@ fn context_menu_escape_shortcut_closes_context_menu() {
 }
 
 #[test]
+fn context_menu_w_shortcut_closes_context_menu() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.browser_interaction.context_menu = Some(sample_context_menu("C:\\samples\\kick.wav"));
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::W));
+
+    assert_eq!(resolution.action, Some(GuiMessage::CloseContextMenu));
+    assert!(resolution.handled);
+}
+
+#[test]
 fn waveform_context_menu_escape_shortcut_closes_context_menu() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.ui.browser_interaction.waveform_context_menu = Some(WaveformContextMenu {
@@ -47,6 +58,21 @@ fn waveform_context_menu_escape_shortcut_closes_context_menu() {
     });
 
     let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Escape));
+
+    assert_eq!(resolution.action, Some(GuiMessage::CloseContextMenu));
+    assert!(resolution.handled);
+}
+
+#[test]
+fn waveform_context_menu_w_shortcut_closes_context_menu() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.browser_interaction.waveform_context_menu = Some(WaveformContextMenu {
+        anchor: Point::new(12.0, 24.0),
+        title: String::from("Playmark Selection"),
+        extract_to_harvest_destination: false,
+    });
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::W));
 
     assert_eq!(resolution.action, Some(GuiMessage::CloseContextMenu));
     assert!(resolution.handled);

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -29,7 +29,7 @@ impl NativeAppState {
             .play_selection_context_menu_anchor()
             .is_some()
         {
-            self.open_play_selection_context_menu_from_shortcut();
+            self.open_play_selection_context_menu_from_shortcut(context.current_pointer_position());
             return;
         }
         if let Some(file_id) = self

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -2,7 +2,7 @@ use radiant::gui::types::Point;
 use std::path::Path;
 use std::time::Instant;
 
-use crate::native_app::app::{NativeAppState, emit_gui_action};
+use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::context_menu_target as context_menu;
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextMenu, BrowserContextPointerAnchor, BrowserContextPointerTarget,
@@ -19,7 +19,10 @@ const FOLDER_CONTEXT_SHORTCUT_ANCHOR: Point = Point { x: 96.0, y: 240.0 };
 const SOURCE_CONTEXT_SHORTCUT_ANCHOR: Point = Point { x: 96.0, y: 120.0 };
 
 impl NativeAppState {
-    pub(in crate::native_app) fn open_context_menu_from_shortcut(&mut self) {
+    pub(in crate::native_app) fn open_context_menu_from_shortcut(
+        &mut self,
+        context: &radiant::prelude::UiUpdateContext<GuiMessage>,
+    ) {
         if self
             .waveform
             .current
@@ -36,15 +39,21 @@ impl NativeAppState {
             .map(str::to_owned)
         {
             let target = BrowserContextPointerTarget::Sample(file_id.clone());
-            let anchor =
-                self.context_menu_pointer_position_for(&target, SAMPLE_CONTEXT_SHORTCUT_ANCHOR);
+            let anchor = self.context_menu_pointer_position_for(
+                &target,
+                SAMPLE_CONTEXT_SHORTCUT_ANCHOR,
+                context.current_pointer_position(),
+            );
             self.open_sample_context_menu(file_id, anchor);
             return;
         }
         if let Some(collection) = self.library.folder_browser.selected_collection() {
             let target = BrowserContextPointerTarget::Collection(collection);
-            let anchor =
-                self.context_menu_pointer_position_for(&target, COLLECTION_CONTEXT_SHORTCUT_ANCHOR);
+            let anchor = self.context_menu_pointer_position_for(
+                &target,
+                COLLECTION_CONTEXT_SHORTCUT_ANCHOR,
+                context.current_pointer_position(),
+            );
             self.open_collection_context_menu(collection, anchor);
             return;
         }
@@ -55,15 +64,21 @@ impl NativeAppState {
             .map(str::to_owned)
         {
             let target = BrowserContextPointerTarget::Folder(folder_id.clone());
-            let anchor =
-                self.context_menu_pointer_position_for(&target, FOLDER_CONTEXT_SHORTCUT_ANCHOR);
+            let anchor = self.context_menu_pointer_position_for(
+                &target,
+                FOLDER_CONTEXT_SHORTCUT_ANCHOR,
+                context.current_pointer_position(),
+            );
             self.open_folder_context_menu(folder_id, anchor);
             return;
         }
         let source_id = self.library.folder_browser.selected_source_id().to_owned();
         let target = BrowserContextPointerTarget::Source(source_id.clone());
-        let anchor =
-            self.context_menu_pointer_position_for(&target, SOURCE_CONTEXT_SHORTCUT_ANCHOR);
+        let anchor = self.context_menu_pointer_position_for(
+            &target,
+            SOURCE_CONTEXT_SHORTCUT_ANCHOR,
+            context.current_pointer_position(),
+        );
         self.open_source_context_menu(source_id, anchor);
     }
 
@@ -312,13 +327,18 @@ impl NativeAppState {
         &self,
         target: &BrowserContextPointerTarget,
         fallback: Point,
+        current_pointer_position: Option<Point>,
     ) -> Point {
-        self.ui
-            .browser_interaction
-            .context_menu_pointer_anchor
-            .as_ref()
-            .filter(|anchor| &anchor.target == target)
-            .map(|anchor| anchor.position)
+        current_pointer_position
+            .filter(|position| position.x.is_finite() && position.y.is_finite())
+            .or_else(|| {
+                self.ui
+                    .browser_interaction
+                    .context_menu_pointer_anchor
+                    .as_ref()
+                    .filter(|anchor| &anchor.target == target)
+                    .map(|anchor| anchor.position)
+            })
             .unwrap_or(fallback)
     }
 }

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -23,6 +23,9 @@ impl NativeAppState {
         &mut self,
         context: &radiant::prelude::UiUpdateContext<GuiMessage>,
     ) {
+        if self.close_open_context_menu() {
+            return;
+        }
         if self
             .waveform
             .current
@@ -80,6 +83,16 @@ impl NativeAppState {
             context.current_pointer_position(),
         );
         self.open_source_context_menu(source_id, anchor);
+    }
+
+    fn close_open_context_menu(&mut self) -> bool {
+        let open = self.ui.browser_interaction.context_menu.is_some()
+            || self.ui.browser_interaction.waveform_context_menu.is_some();
+        if open {
+            self.ui.browser_interaction.context_menu = None;
+            self.ui.browser_interaction.waveform_context_menu = None;
+        }
+        open
     }
 
     pub(in crate::native_app) fn open_source_context_menu(

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 use crate::native_app::app::{NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::context_menu_target as context_menu;
 use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextMenu, BrowserContextTargetKind,
+    BrowserContextMenu, BrowserContextPointerAnchor, BrowserContextPointerTarget,
+    BrowserContextTargetKind,
 };
 use crate::native_app::sample_library::file_actions::sample_path_label;
 use crate::native_app::sample_library::folder_browser::view_contract::collection_hotkey;
@@ -34,11 +35,17 @@ impl NativeAppState {
             .selected_file_id()
             .map(str::to_owned)
         {
-            self.open_sample_context_menu(file_id, SAMPLE_CONTEXT_SHORTCUT_ANCHOR);
+            let target = BrowserContextPointerTarget::Sample(file_id.clone());
+            let anchor =
+                self.context_menu_pointer_position_for(&target, SAMPLE_CONTEXT_SHORTCUT_ANCHOR);
+            self.open_sample_context_menu(file_id, anchor);
             return;
         }
         if let Some(collection) = self.library.folder_browser.selected_collection() {
-            self.open_collection_context_menu(collection, COLLECTION_CONTEXT_SHORTCUT_ANCHOR);
+            let target = BrowserContextPointerTarget::Collection(collection);
+            let anchor =
+                self.context_menu_pointer_position_for(&target, COLLECTION_CONTEXT_SHORTCUT_ANCHOR);
+            self.open_collection_context_menu(collection, anchor);
             return;
         }
         if let Some(folder_id) = self
@@ -47,11 +54,17 @@ impl NativeAppState {
             .selected_folder_id()
             .map(str::to_owned)
         {
-            self.open_folder_context_menu(folder_id, FOLDER_CONTEXT_SHORTCUT_ANCHOR);
+            let target = BrowserContextPointerTarget::Folder(folder_id.clone());
+            let anchor =
+                self.context_menu_pointer_position_for(&target, FOLDER_CONTEXT_SHORTCUT_ANCHOR);
+            self.open_folder_context_menu(folder_id, anchor);
             return;
         }
         let source_id = self.library.folder_browser.selected_source_id().to_owned();
-        self.open_source_context_menu(source_id, SOURCE_CONTEXT_SHORTCUT_ANCHOR);
+        let target = BrowserContextPointerTarget::Source(source_id.clone());
+        let anchor =
+            self.context_menu_pointer_position_for(&target, SOURCE_CONTEXT_SHORTCUT_ANCHOR);
+        self.open_source_context_menu(source_id, anchor);
     }
 
     pub(in crate::native_app) fn open_source_context_menu(
@@ -59,6 +72,10 @@ impl NativeAppState {
         source_id: String,
         position: Point,
     ) {
+        self.remember_context_menu_pointer_anchor(
+            BrowserContextPointerTarget::Source(source_id.clone()),
+            position,
+        );
         let started_at = Instant::now();
         let Some(path) = self.library.folder_browser.source_root_path(&source_id) else {
             self.ui.status.sample = String::from("Source is unavailable");
@@ -101,6 +118,10 @@ impl NativeAppState {
         folder_id: String,
         position: Point,
     ) {
+        self.remember_context_menu_pointer_anchor(
+            BrowserContextPointerTarget::Folder(folder_id.clone()),
+            position,
+        );
         let started_at = Instant::now();
         let Some(path) = self.library.folder_browser.folder_path(&folder_id) else {
             self.ui.status.sample = String::from("Folder is unavailable");
@@ -154,6 +175,10 @@ impl NativeAppState {
         collection: SampleCollection,
         position: Point,
     ) {
+        self.remember_context_menu_pointer_anchor(
+            BrowserContextPointerTarget::Collection(collection),
+            position,
+        );
         let title = self
             .library
             .folder_browser
@@ -184,6 +209,10 @@ impl NativeAppState {
         path: String,
         position: Point,
     ) {
+        self.remember_context_menu_pointer_anchor(
+            BrowserContextPointerTarget::Sample(path.clone()),
+            position,
+        );
         let started_at = Instant::now();
         if !self
             .library
@@ -265,6 +294,32 @@ impl NativeAppState {
             anchor: position,
             title: tag,
         });
+    }
+}
+
+impl NativeAppState {
+    pub(in crate::native_app) fn remember_context_menu_pointer_anchor(
+        &mut self,
+        target: BrowserContextPointerTarget,
+        position: Point,
+    ) {
+        if let Some(anchor) = BrowserContextPointerAnchor::new(target, position) {
+            self.ui.browser_interaction.context_menu_pointer_anchor = Some(anchor);
+        }
+    }
+
+    fn context_menu_pointer_position_for(
+        &self,
+        target: &BrowserContextPointerTarget,
+        fallback: Point,
+    ) -> Point {
+        self.ui
+            .browser_interaction
+            .context_menu_pointer_anchor
+            .as_ref()
+            .filter(|anchor| &anchor.target == target)
+            .map(|anchor| anchor.position)
+            .unwrap_or(fallback)
     }
 }
 


### PR DESCRIPTION
## Scope

- Add a shared browser context-menu pointer anchor that records both target identity and surface-space pointer position.
- Use target-matched pointer anchors for `W`-opened sample, collection, folder, source, and starmap context menus, with existing deterministic fallback anchors when no valid matching pointer exists.
- Wire item-list/sidebar row hover and starmap hover into the shared anchor contract.
- Update focused regression coverage for pointer-aligned sample/folder shortcut menus, stale pointer anchors, and starmap hover anchoring.
- Update the Radiant submodule to PORTALSURFER/radiant#1385 for opt-in interactive-row hover anchor support.

## Definition of Done

- `W`-opened context menus use the current matching pointer anchor when one exists.
- Stale pointer anchors from a different selected/focused target are ignored.
- Keyboard-only invocation still uses deterministic fallback anchors.
- Item-list/sidebar row surfaces and starmap use one target-aware anchor contract.

## Validation commands

- `cargo fmt`
- `(cd vendor/radiant && cargo fmt)`
- `(cd vendor/radiant && CARGO_INCREMENTAL=0 cargo test -p radiant interactive_row)`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate global_context_menu_opens_selected_sample_menu_without_playmark`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate global_context_menu_ignores_stale_sample_pointer_anchor_after_focus_changes`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate global_context_menu_opens_selected_folder_menu_at_matching_pointer_anchor`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate hovering_starmap_node_paints_lightweight_runtime_highlight_without_label`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate starmap_widget_synchronizes_hover_and_hit_index_from_previous_instance`
- `git diff --check`
- `(cd vendor/radiant && git diff --check)`

## Known limitations

- `bash scripts/agent.sh request` still fails on the existing unrelated `native_app_ui_update_paths_do_not_call_blocking_business_apis` guardrail in `src/native_app/sample_identity_diagnostics.rs` at lines 2, 316, and 357.
- Manual app smoke verification of W menus near window edges was not performed in this Codex session.

User review is required before merge.