### PR TITLE
OPT-930: Align context menu labels and shortcut hints

### DIFF
--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -8,6 +8,10 @@ use crate::native_app::sample_library::context_menu_target::{
 };
 use wavecrate::sample_sources::SourceRole;
 
+const NEW_FOLDER_HOTKEY_HINT: &str = "N";
+const RENAME_HOTKEY_HINT: &str = "F2 / Cmd-R";
+const DELETE_HOTKEY_HINT: &str = "Delete / Backspace";
+
 pub(in crate::native_app) fn overlay(
     menu: &BrowserContextMenu,
     harvest_active: bool,
@@ -29,6 +33,7 @@ fn context_menu_commands(
                 "Delete Tag",
                 GuiMessage::Metadata(MetadataMessage::DeleteContextMetadataTag),
             )
+            .hotkey_hint(DELETE_HOTKEY_HINT)
             .danger(),
         ];
     }
@@ -53,24 +58,24 @@ fn context_menu_commands(
         menu.kind,
         BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder
     ) {
-        actions.push(ui::MenuCommand::new(
-            "New Folder",
-            GuiMessage::CreateFolderAtContextTarget,
-        ));
+        actions.push(
+            ui::MenuCommand::new("New Folder", GuiMessage::CreateFolderAtContextTarget)
+                .hotkey_hint(NEW_FOLDER_HOTKEY_HINT),
+        );
     }
     if menu.kind == BrowserContextTargetKind::Folder {
-        actions.push(ui::MenuCommand::new(
-            "Rename Folder",
-            GuiMessage::RenameContextFolder,
-        ));
+        actions.push(
+            ui::MenuCommand::new("Rename Folder", GuiMessage::RenameContextFolder)
+                .hotkey_hint(RENAME_HOTKEY_HINT),
+        );
         actions.push(ui::MenuCommand::new(
             folder_lock_command_label(menu),
             GuiMessage::ToggleContextFolderLock,
         ));
-        actions.push(ui::MenuCommand::new(
-            "Delete Folder",
-            GuiMessage::RequestDeleteContextFolder,
-        ));
+        actions.push(
+            ui::MenuCommand::new("Delete Folder", GuiMessage::RequestDeleteContextFolder)
+                .hotkey_hint(DELETE_HOTKEY_HINT),
+        );
     }
     if menu.kind == BrowserContextTargetKind::Sample {
         if menu.sample_keep_locked {
@@ -114,7 +119,9 @@ fn context_menu_commands(
             ));
         }
         actions.push(
-            ui::MenuCommand::new("Move to Trash", GuiMessage::MoveContextTargetToTrash).danger(),
+            ui::MenuCommand::new("Move to Trash", GuiMessage::MoveContextTargetToTrash)
+                .hotkey_hint(DELETE_HOTKEY_HINT)
+                .danger(),
         );
     }
     if menu.kind == BrowserContextTargetKind::Source && menu.source_id.is_some() {

--- a/src/native_app/app_chrome/waveform_context_menu.rs
+++ b/src/native_app/app_chrome/waveform_context_menu.rs
@@ -27,26 +27,33 @@ fn playmark_context_menu_commands(
     extract_to_harvest_destination: bool,
 ) -> Vec<ui::MenuCommand<GuiMessage>> {
     let mut commands = vec![
-        ui::MenuCommand::new("Play Selection", GuiMessage::PlaySelectedSample),
-        ui::MenuCommand::new("Extract Selection", GuiMessage::ExtractPlaymarkedRange),
+        ui::MenuCommand::new("Play Selection", GuiMessage::PlaySelectedSample).hotkey_hint("Space"),
+        ui::MenuCommand::new("Extract Selection", GuiMessage::ExtractPlaymarkedRange)
+            .hotkey_hint("E"),
         ui::MenuCommand::new(
             "Extract and Trim",
             GuiMessage::RequestExtractAndTrimPlaymarkSelection,
-        ),
+        )
+        .hotkey_hint("Cmd-E"),
         ui::MenuCommand::new(
             "Crop to Selection",
             GuiMessage::RequestCropPlaymarkSelection,
         )
+        .hotkey_hint("C")
         .danger(),
-        ui::MenuCommand::new("Trim Selection", GuiMessage::RequestTrimPlaymarkSelection).danger(),
+        ui::MenuCommand::new("Trim Selection", GuiMessage::RequestTrimPlaymarkSelection)
+            .hotkey_hint("D")
+            .danger(),
         ui::MenuCommand::new(
             "Reverse Selection",
             GuiMessage::RequestReversePlaymarkSelection,
-        ),
+        )
+        .hotkey_hint("R"),
         ui::MenuCommand::new(
             "Zoom to Selection",
             GuiMessage::Waveform(WaveformInteraction::ZoomToPlaySelection),
-        ),
+        )
+        .hotkey_hint("Z"),
         ui::MenuCommand::new("Find Similar Sections", GuiMessage::ToggleSimilarSections),
     ];
     if extract_to_harvest_destination {

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -39,6 +39,90 @@ fn folder_context_menu_paints_as_full_width_overlay_panel() {
 }
 
 #[test]
+fn folder_context_menu_paints_registered_shortcut_hints() {
+    let menu = crate::native_app::test_support::context_menu::BrowserContextMenu {
+        kind: crate::native_app::test_support::context_menu::BrowserContextTargetKind::Folder,
+        path: PathBuf::from("Documents"),
+        source_id: None,
+        source_role: wavecrate::sample_sources::SourceRole::Normal,
+        source_removable: false,
+        folder_locked: false,
+        folder_lock_inherited: false,
+        metadata_tag: None,
+        collection: None,
+        sample_missing: false,
+        sample_keep_locked: false,
+        anchor: Point::new(72.0, 142.0),
+        title: String::from("Documents"),
+    };
+    let frame = crate::native_app::test_support::context_menu::browser_context_menu_overlay(&menu)
+        .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
+
+    for (label, hint) in [
+        ("New Folder", "N"),
+        ("Rename Folder", "F2 / Cmd-R"),
+        ("Delete Folder", "Delete / Backspace"),
+    ] {
+        let label_run = frame
+            .paint_plan
+            .first_text_run(label)
+            .unwrap_or_else(|| panic!("{label} should paint"));
+        let hint_run = frame
+            .paint_plan
+            .first_text_run(hint)
+            .unwrap_or_else(|| panic!("{hint} should paint"));
+
+        assert_eq!(label_run.align, PaintTextAlign::Left);
+        assert_eq!(hint_run.align, PaintTextAlign::Right);
+        assert!(
+            label_run.rect.max.x < hint_run.rect.min.x,
+            "{label} and {hint} should not overlap: label={:?}, hint={:?}",
+            label_run.rect,
+            hint_run.rect
+        );
+    }
+}
+
+#[test]
+fn sample_context_menu_paints_move_to_trash_shortcut_hint() {
+    let menu = crate::native_app::test_support::context_menu::BrowserContextMenu {
+        kind: crate::native_app::test_support::context_menu::BrowserContextTargetKind::Sample,
+        path: PathBuf::from("kick.wav"),
+        source_id: None,
+        source_role: wavecrate::sample_sources::SourceRole::Normal,
+        source_removable: false,
+        folder_locked: false,
+        folder_lock_inherited: false,
+        metadata_tag: None,
+        collection: None,
+        sample_missing: false,
+        sample_keep_locked: false,
+        anchor: Point::new(72.0, 142.0),
+        title: String::from("kick.wav"),
+    };
+    let frame = crate::native_app::test_support::context_menu::browser_context_menu_overlay(&menu)
+        .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
+
+    let label = frame
+        .paint_plan
+        .first_text_run("Move to Trash")
+        .expect("trash label should paint");
+    let hint = frame
+        .paint_plan
+        .first_text_run("Delete / Backspace")
+        .expect("trash shortcut hint should paint");
+
+    assert_eq!(label.align, PaintTextAlign::Left);
+    assert_eq!(hint.align, PaintTextAlign::Right);
+    assert!(
+        label.rect.max.x < hint.rect.min.x,
+        "trash label and shortcut should not overlap: label={:?}, hint={:?}",
+        label.rect,
+        hint.rect
+    );
+}
+
+#[test]
 fn folder_context_menu_opens_downward_when_space_allows() {
     let menu = crate::native_app::test_support::context_menu::BrowserContextMenu {
         kind: crate::native_app::test_support::context_menu::BrowserContextTargetKind::Folder,

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -3,7 +3,7 @@ use crate::native_app::sample_library::context_menu_target::{
     BrowserContextPointerAnchor, BrowserContextPointerTarget,
 };
 use crate::native_app::test_support::state::GuiMessage;
-use radiant::runtime::RuntimeUpdateSnapshot;
+use radiant::runtime::{PaintTextAlign, RuntimeUpdateSnapshot};
 
 #[test]
 fn folder_context_menu_paints_as_full_width_overlay_panel() {
@@ -272,6 +272,57 @@ fn playmark_context_menu_paints_selection_actions() {
             "{label} should render in the playmark context menu"
         );
     }
+}
+
+#[test]
+fn playmark_context_menu_paints_shortcut_hints_in_trailing_column() {
+    let menu = crate::native_app::test_support::context_menu::WaveformContextMenu {
+        anchor: Point::new(240.0, 180.0),
+        title: String::from("Playmark Selection"),
+        extract_to_harvest_destination: false,
+    };
+    let frame = crate::native_app::test_support::context_menu::waveform_context_menu_overlay(&menu)
+        .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
+
+    let play_label = frame
+        .paint_plan
+        .first_text_run("Play Selection")
+        .expect("play label should paint");
+    let extract_label = frame
+        .paint_plan
+        .first_text_run("Extract Selection")
+        .expect("extract label should paint");
+    let space_hint = frame
+        .paint_plan
+        .first_text_run("Space")
+        .expect("space shortcut hint should paint");
+    let extract_hint = frame
+        .paint_plan
+        .first_text_run("E")
+        .expect("extract shortcut hint should paint");
+
+    assert_eq!(play_label.align, PaintTextAlign::Left);
+    assert_eq!(extract_label.align, PaintTextAlign::Left);
+    assert_eq!(space_hint.align, PaintTextAlign::Right);
+    assert_eq!(extract_hint.align, PaintTextAlign::Right);
+    assert!(
+        (play_label.rect.min.x - extract_label.rect.min.x).abs() < 0.01,
+        "menu labels should share a left column: play={:?}, extract={:?}",
+        play_label.rect,
+        extract_label.rect
+    );
+    assert!(
+        (space_hint.rect.max.x - extract_hint.rect.max.x).abs() < 0.01,
+        "shortcut hints should share a right column: space={:?}, extract={:?}",
+        space_hint.rect,
+        extract_hint.rect
+    );
+    assert!(
+        play_label.rect.max.x < space_hint.rect.min.x,
+        "label and shortcut hint should be separate columns: label={:?}, hint={:?}",
+        play_label.rect,
+        space_hint.rect
+    );
 }
 
 #[test]


### PR DESCRIPTION
Scope
- Update Wavecrate to the Radiant context-menu row layout with a separate trailing shortcut hint column.
- Add real shortcut hints to playmark context-menu actions backed by registered waveform shortcuts.
- Add regression coverage for playmark menu label/hint column alignment.

Definition of Done
- Context menu labels are consistently left-aligned.
- Shortcut hints render right-aligned in a trailing column.
- Menu width/padding reserves room for labels and hints without overlap.
- Items without shortcuts still share the same label column.

Validation commands
- cargo fmt --check
- cargo fmt --manifest-path vendor/radiant/Cargo.toml --check
- git diff --check
- Attempted: CARGO_INCREMENTAL=0 cargo test -p wavecrate playmark_context_menu_paints_shortcut_hints_in_trailing_column --lib

Known limitations
- Local Rust validation could not complete because rustc repeatedly parked at 0% CPU while compiling Radiant, including before and after retrying with CARGO_INCREMENTAL=0. No compiler diagnostics were emitted before cancellation.
- Depends on Radiant PR: https://github.com/PORTALSURFER/radiant/pull/1386

User review is required before merge.