### PR TITLE
Align nightly release asset names

### DIFF
--- a/scripts/internal/release/build_release_zip.sh
+++ b/scripts/internal/release/build_release_zip.sh
@@ -106,14 +106,12 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|nightly)\.[0-9A-Za-z.-]+)?(\+
   exit 1
 fi
 
-BUILD_LABEL=""
 if [[ -n "$BUILD_NUMBER" ]]; then
   BUILD_NUMBER="${BUILD_NUMBER#b}"
   if [[ -z "$BUILD_NUMBER" || ! "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
     echo "Build number must be numeric." >&2
     exit 1
   fi
-  BUILD_LABEL="-b${BUILD_NUMBER}"
 fi
 if [[ -n "$GIT_SHA" ]]; then
   GIT_SHA="$(printf '%s' "$GIT_SHA" | tr -d '[:space:]')"
@@ -146,7 +144,7 @@ case "$CHANNEL" in
     ZIP_NAME="${APP_NAME}-${VERSION}-${PLATFORM}-${ARCH}.zip"
     ;;
   nightly)
-    ZIP_NAME="${APP_NAME}-nightly${BUILD_LABEL}-${PLATFORM}-${ARCH}.zip"
+    ZIP_NAME="${APP_NAME}-nightly-${PLATFORM}-${ARCH}.zip"
     ;;
   *)
     echo "Unknown channel: $CHANNEL" >&2

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -8,6 +8,8 @@ const RELEASE_CONTRACT: &str = include_str!("../release_contract.toml");
 const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.yml");
 const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
 const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
+const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
+const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 
 #[test]
 fn platform_labels_are_active_release_labels_only() {
@@ -103,6 +105,73 @@ fn release_contract_template_emits_supported_nightly_asset_names() {
     assert!(
         asset_names.iter().all(|name| !name.contains("linux")),
         "nightly assets generated from the release contract must not include Linux"
+    );
+}
+
+#[test]
+fn release_packager_uses_contract_nightly_asset_name_without_build_number() {
+    let contract = parse_contract();
+    let nightly_template = contract
+        .get("templates")
+        .and_then(Value::as_table)
+        .and_then(|templates| templates.get("nightly_asset"))
+        .and_then(Value::as_str)
+        .expect("nightly_asset template");
+    let expected_assignment = format!(
+        r#"ZIP_NAME="{}""#,
+        nightly_template
+            .replace("{APP_NAME}", "${APP_NAME}")
+            .replace("{platform}", "${PLATFORM}")
+            .replace("{arch}", "${ARCH}")
+    );
+    let expected_updater_format = nightly_template
+        .replace("{APP_NAME}", "{APP_NAME}")
+        .replace("{platform}", "{platform}")
+        .replace("{arch}", "{arch}");
+
+    assert!(
+        RELEASE_ZIP_SCRIPT.contains(&expected_assignment),
+        "nightly packager ZIP_NAME must match release_contract.toml: {expected_assignment}"
+    );
+    assert!(
+        UPDATER_ASSET_NAMES.contains(&expected_updater_format),
+        "GitHub updater nightly asset lookup must match release_contract.toml: {expected_updater_format}"
+    );
+    assert!(
+        !RELEASE_ZIP_SCRIPT.contains("nightly${BUILD_LABEL}"),
+        "rolling GitHub nightly assets must not include build-number labels"
+    );
+    assert!(
+        RELEASE_ZIP_SCRIPT.contains(r#"printf "%s  %s\n" "$SHA" "$ZIP_NAME""#),
+        "checksums-entry.txt must list the exact zip filename selected by the packager"
+    );
+}
+
+#[test]
+fn nightly_workflow_publishes_packager_outputs_as_github_assets() {
+    assert!(
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/build_release_zip.sh \\"),
+        "nightly workflow must use the shared release zip packager"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("--channel nightly \\"),
+        "nightly workflow must call the packager in nightly mode"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("cp dist/artifacts/*.zip dist/release/"),
+        "GitHub nightly release must publish the zip filenames emitted by the packager"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("cat \"${entries[@]}\" > dist/release/checksums-nightly.txt"),
+        "GitHub nightly checksums must be assembled from packager checksum entries"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("files: dist/release/*"),
+        "GitHub nightly release must upload the assembled dist/release assets"
+    );
+    assert!(
+        !NIGHTLY_WORKFLOW.contains("wavecrate-nightly-b"),
+        "rolling GitHub nightly workflow must not introduce build-numbered asset names"
     );
 }
 


### PR DESCRIPTION
## Scope
- Align rolling nightly GitHub zip names with the updater's expected stable asset contract: `wavecrate-nightly-<platform>-<arch>.zip`.
- Keep nightly build numbers accepted and available for metadata/versioning, but remove them from the rolling GitHub zip filename.
- Add release contract coverage tying together `release_contract.toml`, the packager script, updater asset lookup, workflow publishing, and checksum entry generation.

## Definition of Done
- Nightly GitHub release zips use the same unnumbered names the updater expects.
- `release_contract.toml`, `src/updater/asset_names.rs`, `scripts/internal/release/build_release_zip.sh`, and `.github/workflows/release-build.yml` agree on the nightly asset naming contract.
- Checksum entries list the exact zip filename emitted by the packager.
- Focused release contract tests fail if the packager, updater, or workflow drift apart again.

## Validation commands
- `cargo fmt --check`
- `bash -n scripts/internal/release/build_release_zip.sh`
- `cargo test --test release_contract --test manual_release_matching`
- Dry packaging probe with `WAVECRATE_SKIP_BUILD=1`, `--channel nightly`, and `--build-number 123`; verified output `wavecrate-nightly-windows-x86_64.zip` and checksum entry for that same filename.

## Known limitations
- None.

User review is required before merge.
