### PR TITLE
Generate structured RC and stable release logs

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -250,7 +250,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
       - uses: actions/download-artifact@v4
         with:
           path: dist/artifacts
@@ -262,24 +267,30 @@ jobs:
           RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
           TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          TARGET_BRANCH: ${{ inputs.branch }}
+          BUILD_DATE: ${{ needs.resolve.outputs.build_date }}
+          RC_NUMBER: ${{ inputs.rc_number }}
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
           mkdir -p dist/release
           cp dist/artifacts/*.zip dist/release/
-          cat dist/artifacts/checksums-entry-*.txt > "dist/release/checksums-${RELEASE_VERSION}.txt"
-          {
-            echo "# Wavecrate ${RELEASE_VERSION}"
-            echo
-            echo "- Channel: Release Candidate"
-            echo "- Commit: ${TARGET_SHA}"
-            echo
-            if [[ -n "$RELEASE_NOTES" ]]; then
-              printf '%s\n' "$RELEASE_NOTES"
-            else
-              echo "Release candidate for final validation."
-            fi
-          } > dist/release/release-log.md
+          checksum_name="checksums-${RELEASE_VERSION}.txt"
+          checksum_sig_name="${checksum_name}.sig"
+          cat dist/artifacts/checksums-entry-*.txt > "dist/release/${checksum_name}"
+          scripts/internal/release/generate_release_log.sh \
+            --channel rc \
+            --version "$RELEASE_VERSION" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --target-sha "$TARGET_SHA" \
+            --target-branch "$TARGET_BRANCH" \
+            --build-date "$BUILD_DATE" \
+            --artifact-dir dist/release \
+            --checksum-name "$checksum_name" \
+            --checksum-sig-name "$checksum_sig_name" \
+            --rc-number "$RC_NUMBER" \
+            --release-tag "$RELEASE_TAG" \
+            --out dist/release/release-log.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -252,7 +252,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: ${{ needs.resolve.outputs.target_sha }}
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
       - uses: actions/download-artifact@v4
         with:
           path: dist/artifacts
@@ -264,25 +269,29 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.target_version }}
           TARGET_SHA: ${{ needs.resolve.outputs.target_sha }}
           RC_TAG: ${{ needs.resolve.outputs.rc_tag }}
+          TARGET_BRANCH: ${{ inputs.branch }}
+          BUILD_DATE: ${{ needs.resolve.outputs.build_date }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
           mkdir -p dist/release
           cp dist/artifacts/*.zip dist/release/
-          cat dist/artifacts/checksums-entry-*.txt > "dist/release/checksums-${VERSION}.txt"
-          {
-            echo "# Wavecrate ${VERSION}"
-            echo
-            echo "- Channel: Stable"
-            echo "- Commit: ${TARGET_SHA}"
-            echo "- Promoted from: ${RC_TAG}"
-            echo
-            if [[ -n "$RELEASE_NOTES" ]]; then
-              printf '%s\n' "$RELEASE_NOTES"
-            else
-              echo "Stable release promoted from ${RC_TAG}."
-            fi
-          } > dist/release/release-log.md
+          checksum_name="checksums-${VERSION}.txt"
+          checksum_sig_name="${checksum_name}.sig"
+          cat dist/artifacts/checksums-entry-*.txt > "dist/release/${checksum_name}"
+          scripts/internal/release/generate_release_log.sh \
+            --channel stable \
+            --version "$VERSION" \
+            --target-sha "$TARGET_SHA" \
+            --target-branch "$TARGET_BRANCH" \
+            --build-date "$BUILD_DATE" \
+            --artifact-dir dist/release \
+            --checksum-name "$checksum_name" \
+            --checksum-sig-name "$checksum_sig_name" \
+            --promoted-rc-tag "$RC_TAG" \
+            --release-tag "$RELEASE_TAG" \
+            --out dist/release/release-log.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}

--- a/scripts/internal/release/generate_release_log.sh
+++ b/scripts/internal/release/generate_release_log.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHANNEL=""
+VERSION=""
+TARGET_VERSION=""
+TARGET_SHA=""
+TARGET_BRANCH=""
+BUILD_DATE=""
+ARTIFACT_DIR=""
+CHECKSUM_NAME=""
+CHECKSUM_SIG_NAME=""
+OUT_FILE=""
+RC_NUMBER=""
+PROMOTED_RC_TAG=""
+RELEASE_TAG=""
+CLIFF_CONFIG="cliff.toml"
+
+usage() {
+  cat <<'USAGE'
+Usage: generate_release_log.sh --channel <rc|stable> --version <version> --target-sha <sha> --target-branch <branch> --build-date <YYYY-MM-DD> --artifact-dir <path> --checksum-name <name> --checksum-sig-name <name> --out <path> [options]
+
+Options:
+  --target-version <x.y.z>       Stable target version for RC logs.
+  --rc-number <n>                RC number for RC logs.
+  --promoted-rc-tag <tag>        Promoted RC tag for stable logs.
+  --release-tag <tag>            Git tag for the release being generated.
+  --cliff-config <path>          git-cliff config path. Defaults to cliff.toml.
+
+Manual notes can be supplied with RELEASE_NOTES.
+Set WAVECRATE_RELEASE_LOG_DISABLE_GIT_CLIFF=1 to force the deterministic git-log fallback.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --target-version)
+      TARGET_VERSION="${2:-}"
+      shift 2
+      ;;
+    --target-sha)
+      TARGET_SHA="${2:-}"
+      shift 2
+      ;;
+    --target-branch)
+      TARGET_BRANCH="${2:-}"
+      shift 2
+      ;;
+    --build-date)
+      BUILD_DATE="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --checksum-name)
+      CHECKSUM_NAME="${2:-}"
+      shift 2
+      ;;
+    --checksum-sig-name)
+      CHECKSUM_SIG_NAME="${2:-}"
+      shift 2
+      ;;
+    --out)
+      OUT_FILE="${2:-}"
+      shift 2
+      ;;
+    --rc-number)
+      RC_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --promoted-rc-tag)
+      PROMOTED_RC_TAG="${2:-}"
+      shift 2
+      ;;
+    --release-tag)
+      RELEASE_TAG="${2:-}"
+      shift 2
+      ;;
+    --cliff-config)
+      CLIFF_CONFIG="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_arg() {
+  local value="$1"
+  local name="$2"
+  if [[ -z "$value" ]]; then
+    echo "Missing required argument: $name" >&2
+    exit 1
+  fi
+}
+
+require_arg "$CHANNEL" "--channel"
+require_arg "$VERSION" "--version"
+require_arg "$TARGET_SHA" "--target-sha"
+require_arg "$TARGET_BRANCH" "--target-branch"
+require_arg "$BUILD_DATE" "--build-date"
+require_arg "$ARTIFACT_DIR" "--artifact-dir"
+require_arg "$CHECKSUM_NAME" "--checksum-name"
+require_arg "$CHECKSUM_SIG_NAME" "--checksum-sig-name"
+require_arg "$OUT_FILE" "--out"
+
+if [[ "$CHANNEL" != "rc" && "$CHANNEL" != "stable" ]]; then
+  echo "channel must be rc or stable" >&2
+  exit 1
+fi
+if [[ ! "$BUILD_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "build date must be YYYY-MM-DD" >&2
+  exit 1
+fi
+if [[ "$CHANNEL" == "rc" ]]; then
+  require_arg "$TARGET_VERSION" "--target-version"
+  require_arg "$RC_NUMBER" "--rc-number"
+  if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+    echo "rc number must be a positive integer" >&2
+    exit 1
+  fi
+fi
+if [[ "$CHANNEL" == "stable" ]]; then
+  require_arg "$PROMOTED_RC_TAG" "--promoted-rc-tag"
+fi
+if [[ ! -f "${ARTIFACT_DIR}/${CHECKSUM_NAME}" ]]; then
+  echo "Checksum file not found: ${ARTIFACT_DIR}/${CHECKSUM_NAME}" >&2
+  exit 1
+fi
+
+if ! target_commit="$(git rev-parse -q --verify "${TARGET_SHA}^{commit}" 2>/dev/null)"; then
+  echo "Target commit does not resolve: $TARGET_SHA" >&2
+  exit 1
+fi
+TARGET_SHA="$target_commit"
+
+mkdir -p "$(dirname "$OUT_FILE")"
+git fetch --tags --force >/dev/null 2>&1 || true
+
+find_previous_stable_tag() {
+  local exclude_tag="$1"
+  local target="$2"
+  local tag commit
+  while IFS= read -r tag; do
+    if [[ "$tag" == "$exclude_tag" || ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      continue
+    fi
+    if ! commit="$(git rev-list -n 1 "$tag" 2>/dev/null)"; then
+      continue
+    fi
+    if [[ "$commit" == "$target" ]]; then
+      continue
+    fi
+    if git merge-base --is-ancestor "$commit" "$target"; then
+      printf '%s\n' "$tag"
+      return 0
+    fi
+  done < <(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname)
+}
+
+find_previous_rc_tag() {
+  local target_version="$1"
+  local rc_number="$2"
+  local target="$3"
+  local tag suffix best_tag="" best_number=0 commit
+  while IFS= read -r tag; do
+    suffix="${tag##*.}"
+    if [[ ! "$suffix" =~ ^[0-9]+$ ]]; then
+      continue
+    fi
+    if (( suffix >= rc_number || suffix <= best_number )); then
+      continue
+    fi
+    if ! commit="$(git rev-list -n 1 "$tag" 2>/dev/null)"; then
+      continue
+    fi
+    if ! git merge-base --is-ancestor "$commit" "$target"; then
+      continue
+    fi
+    best_tag="$tag"
+    best_number="$suffix"
+  done < <(git tag -l "v${target_version}-rc.*")
+  if [[ -n "$best_tag" ]]; then
+    printf '%s\n' "$best_tag"
+  fi
+}
+
+bounded_range_for_target() {
+  local target="$1"
+  local first_in_window parent
+  first_in_window="$(git rev-list --max-count=80 "$target" | tail -n 1)"
+  if parent="$(git rev-parse "${first_in_window}^" 2>/dev/null)"; then
+    printf '%s..%s\n' "$parent" "$target"
+  else
+    printf '%s\n' "$target"
+  fi
+}
+
+previous_ref=""
+previous_label=""
+case "$CHANNEL" in
+  rc)
+    previous_ref="$(find_previous_rc_tag "$TARGET_VERSION" "$RC_NUMBER" "$TARGET_SHA" || true)"
+    if [[ -n "$previous_ref" ]]; then
+      previous_label="$previous_ref"
+    else
+      previous_ref="$(find_previous_stable_tag "" "$TARGET_SHA" || true)"
+      if [[ -n "$previous_ref" ]]; then
+        previous_label="$previous_ref"
+      fi
+    fi
+    ;;
+  stable)
+    previous_ref="$(find_previous_stable_tag "$RELEASE_TAG" "$TARGET_SHA" || true)"
+    if [[ -n "$previous_ref" ]]; then
+      previous_label="$previous_ref"
+    fi
+    ;;
+esac
+
+range=""
+if [[ -n "$previous_ref" ]]; then
+  previous_commit="$(git rev-list -n 1 "$previous_ref")"
+  if [[ "$previous_commit" == "$TARGET_SHA" ]]; then
+    range=""
+  else
+    range="${previous_commit}..${TARGET_SHA}"
+  fi
+else
+  range="$(bounded_range_for_target "$TARGET_SHA")"
+  previous_label="bounded commit window"
+fi
+
+changes_file="$(mktemp)"
+artifacts_file="$(mktemp)"
+cleanup() {
+  rm -f "$changes_file" "$artifacts_file"
+}
+trap cleanup EXIT
+
+zip_files=()
+while IFS= read -r zip_name; do
+  zip_files+=("$zip_name")
+done < <(find "$ARTIFACT_DIR" -maxdepth 1 -type f -name '*.zip' -exec basename {} \; | sort)
+if [[ ${#zip_files[@]} -eq 0 ]]; then
+  echo "No release zip artifacts found in $ARTIFACT_DIR" >&2
+  exit 1
+fi
+for zip_name in "${zip_files[@]}"; do
+  stem="${zip_name%.zip}"
+  arch="${stem##*-}"
+  platform_part="${stem%-*}"
+  platform="${platform_part##*-}"
+  printf -- '- %s / %s: `%s`\n' "$platform" "$arch" "$zip_name" >> "$artifacts_file"
+done
+
+if [[ -z "$range" ]]; then
+  echo "- No code changes since the previous release boundary; this run refreshed release artifacts from the same target commit." > "$changes_file"
+elif [[ "${WAVECRATE_RELEASE_LOG_DISABLE_GIT_CLIFF:-0}" != "1" && -f "$CLIFF_CONFIG" && "$(command -v git-cliff || true)" ]]; then
+  if ! git cliff --config "$CLIFF_CONFIG" --tag "$VERSION" "$range" > "$changes_file"; then
+    git log --no-merges --pretty=format:'- %s' "$range" > "$changes_file"
+  fi
+else
+  git log --no-merges --pretty=format:'- %s' "$range" > "$changes_file"
+fi
+if ! grep -Eq '^[[:space:]]*-' "$changes_file"; then
+  git log --no-merges --pretty=format:'- %s' "$range" > "$changes_file" || true
+fi
+if [[ ! -s "$changes_file" ]]; then
+  echo "- No commit messages were found for this release range." > "$changes_file"
+fi
+
+manual_notes="${RELEASE_NOTES:-}"
+channel_label="Stable"
+if [[ "$CHANNEL" == "rc" ]]; then
+  channel_label="Release Candidate"
+fi
+
+{
+  echo "# Wavecrate ${VERSION}"
+  echo
+  echo "## Release Metadata"
+  echo
+  echo "- Channel: ${channel_label}"
+  echo "- Version: ${VERSION}"
+  echo "- Target branch: ${TARGET_BRANCH}"
+  echo "- Commit: ${TARGET_SHA}"
+  echo "- Build date: ${BUILD_DATE}"
+  if [[ "$CHANNEL" == "rc" ]]; then
+    echo "- RC number: ${RC_NUMBER}"
+  fi
+  if [[ "$CHANNEL" == "stable" ]]; then
+    echo "- Promoted from: ${PROMOTED_RC_TAG}"
+  fi
+  echo "- Previous release boundary: ${previous_label}"
+  echo
+  echo "## Artifacts"
+  echo
+  cat "$artifacts_file"
+  echo
+  echo "## Checksums"
+  echo
+  echo "- Checksums: \`${CHECKSUM_NAME}\`"
+  echo "- Signature: \`${CHECKSUM_SIG_NAME}\`"
+  echo
+  if [[ -n "$manual_notes" ]]; then
+    echo "## Manual Notes"
+    echo
+    printf '%s\n' "$manual_notes"
+    echo
+  fi
+  echo "## Generated Changes"
+  echo
+  cat "$changes_file"
+} > "$OUT_FILE"
+
+if [[ ! -s "$OUT_FILE" ]]; then
+  echo "Generated release log is empty." >&2
+  exit 1
+fi

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -9,6 +9,8 @@ const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.
 const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
 const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
 const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
+const RELEASE_LOG_SCRIPT: &str =
+    include_str!("../scripts/internal/release/generate_release_log.sh");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 
 #[test]
@@ -230,6 +232,63 @@ fn stable_workflow_requires_matching_rc_before_publish() {
     assert!(
         STABLE_WORKFLOW.contains("Latest RC ${rc_tag} points at"),
         "stable workflow must require the latest RC tag to point at the stable target commit"
+    );
+}
+
+#[test]
+fn rc_and_stable_workflows_use_structured_release_log_generator() {
+    for (name, workflow) in [
+        ("RC workflow", RC_WORKFLOW),
+        ("stable workflow", STABLE_WORKFLOW),
+    ] {
+        assert!(
+            workflow.contains("fetch-depth: 0"),
+            "{name} must fetch full history so release log ranges can be generated"
+        );
+        assert!(
+            workflow.contains("tool: git-cliff"),
+            "{name} must install git-cliff for generated release logs"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/generate_release_log.sh \\"),
+            "{name} must invoke the shared structured release-log generator"
+        );
+        assert!(
+            workflow.contains("body_path: dist/release/release-log.md"),
+            "{name} must publish the generated release log as the GitHub release body"
+        );
+    }
+    assert!(
+        !RC_WORKFLOW.contains("Release candidate for final validation."),
+        "RC workflow must not fall back to a manual-only minimal release body"
+    );
+    assert!(
+        !STABLE_WORKFLOW.contains("Stable release promoted from ${RC_TAG}."),
+        "stable workflow must not fall back to a manual-only minimal release body"
+    );
+}
+
+#[test]
+fn structured_release_log_generator_declares_required_sections() {
+    for section in [
+        "## Release Metadata",
+        "## Artifacts",
+        "## Checksums",
+        "## Manual Notes",
+        "## Generated Changes",
+    ] {
+        assert!(
+            RELEASE_LOG_SCRIPT.contains(section),
+            "release log generator must declare {section}"
+        );
+    }
+    assert!(
+        RELEASE_LOG_SCRIPT.contains("git cliff"),
+        "release log generator must try git-cliff before using the fallback"
+    );
+    assert!(
+        RELEASE_LOG_SCRIPT.contains("git log --no-merges --pretty=format:'- %s'"),
+        "release log generator must keep a deterministic commit-list fallback"
     );
 }
 

--- a/tests/release_log_generator.rs
+++ b/tests/release_log_generator.rs
@@ -1,0 +1,275 @@
+//! Script-level checks for structured RC and stable release logs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn rc_first_release_log_uses_previous_stable_boundary_and_manual_notes() {
+    let repo = FixtureRepo::new();
+    repo.commit("initial stable");
+    repo.tag("v19.0.0");
+    let target_sha = repo.commit("add sampler polishing");
+    let release_dir = repo.release_dir();
+    write_release_files(
+        &release_dir,
+        "wavecrate-19.1.0-rc.1-windows-x86_64.zip",
+        "checksums-19.1.0-rc.1.txt",
+    );
+
+    let out = release_dir.join("release-log.md");
+    run_generator(
+        &repo,
+        &[
+            "--channel",
+            "rc",
+            "--version",
+            "19.1.0-rc.1",
+            "--target-version",
+            "19.1.0",
+            "--target-sha",
+            &target_sha,
+            "--target-branch",
+            "release/19.1",
+            "--build-date",
+            "2026-07-02",
+            "--artifact-dir",
+            release_dir.to_str().expect("release dir utf-8"),
+            "--checksum-name",
+            "checksums-19.1.0-rc.1.txt",
+            "--checksum-sig-name",
+            "checksums-19.1.0-rc.1.txt.sig",
+            "--rc-number",
+            "1",
+            "--release-tag",
+            "v19.1.0-rc.1",
+            "--out",
+            out.to_str().expect("output path utf-8"),
+        ],
+        Some("Manual review note."),
+    );
+
+    let log = fs::read_to_string(out).expect("read generated log");
+    assert!(log.contains("# Wavecrate 19.1.0-rc.1"));
+    assert!(log.contains("- Channel: Release Candidate"));
+    assert!(log.contains("- Target branch: release/19.1"));
+    assert!(log.contains("- RC number: 1"));
+    assert!(log.contains("- Previous release boundary: v19.0.0"));
+    assert!(log.contains("- windows / x86_64: `wavecrate-19.1.0-rc.1-windows-x86_64.zip`"));
+    assert!(log.contains("- Checksums: `checksums-19.1.0-rc.1.txt`"));
+    assert!(log.contains("- Signature: `checksums-19.1.0-rc.1.txt.sig`"));
+    assert!(log.contains("## Manual Notes"));
+    assert!(log.contains("Manual review note."));
+    assert!(log.contains("## Generated Changes"));
+    assert!(log.contains("- add sampler polishing"));
+}
+
+#[test]
+fn later_rc_release_log_uses_previous_rc_boundary() {
+    let repo = FixtureRepo::new();
+    repo.commit("initial stable");
+    repo.tag("v19.0.0");
+    repo.commit("prepare rc one");
+    repo.tag("v19.1.0-rc.1");
+    let target_sha = repo.commit("fix rc two blocker");
+    let release_dir = repo.release_dir();
+    write_release_files(
+        &release_dir,
+        "wavecrate-19.1.0-rc.2-macos-aarch64.zip",
+        "checksums-19.1.0-rc.2.txt",
+    );
+
+    let out = release_dir.join("release-log.md");
+    run_generator(
+        &repo,
+        &[
+            "--channel",
+            "rc",
+            "--version",
+            "19.1.0-rc.2",
+            "--target-version",
+            "19.1.0",
+            "--target-sha",
+            &target_sha,
+            "--target-branch",
+            "release/19.1",
+            "--build-date",
+            "2026-07-02",
+            "--artifact-dir",
+            release_dir.to_str().expect("release dir utf-8"),
+            "--checksum-name",
+            "checksums-19.1.0-rc.2.txt",
+            "--checksum-sig-name",
+            "checksums-19.1.0-rc.2.txt.sig",
+            "--rc-number",
+            "2",
+            "--release-tag",
+            "v19.1.0-rc.2",
+            "--out",
+            out.to_str().expect("output path utf-8"),
+        ],
+        None,
+    );
+
+    let log = fs::read_to_string(out).expect("read generated log");
+    assert!(log.contains("- Previous release boundary: v19.1.0-rc.1"));
+    assert!(log.contains("- fix rc two blocker"));
+    assert!(!log.contains("- prepare rc one"));
+}
+
+#[test]
+fn stable_release_log_records_promoted_rc_and_previous_stable_boundary() {
+    let repo = FixtureRepo::new();
+    repo.commit("initial stable");
+    repo.tag("v19.0.0");
+    repo.commit("prepare final train");
+    let target_sha = repo.commit("final release polish");
+    repo.tag("v19.1.0-rc.2");
+    let release_dir = repo.release_dir();
+    write_release_files(
+        &release_dir,
+        "wavecrate-19.1.0-macos-x86_64.zip",
+        "checksums-19.1.0.txt",
+    );
+
+    let out = release_dir.join("release-log.md");
+    run_generator(
+        &repo,
+        &[
+            "--channel",
+            "stable",
+            "--version",
+            "19.1.0",
+            "--target-sha",
+            &target_sha,
+            "--target-branch",
+            "release/19.1",
+            "--build-date",
+            "2026-07-02",
+            "--artifact-dir",
+            release_dir.to_str().expect("release dir utf-8"),
+            "--checksum-name",
+            "checksums-19.1.0.txt",
+            "--checksum-sig-name",
+            "checksums-19.1.0.txt.sig",
+            "--promoted-rc-tag",
+            "v19.1.0-rc.2",
+            "--release-tag",
+            "v19.1.0",
+            "--out",
+            out.to_str().expect("output path utf-8"),
+        ],
+        None,
+    );
+
+    let log = fs::read_to_string(out).expect("read generated log");
+    assert!(log.contains("# Wavecrate 19.1.0"));
+    assert!(log.contains("- Channel: Stable"));
+    assert!(log.contains("- Promoted from: v19.1.0-rc.2"));
+    assert!(log.contains("- Previous release boundary: v19.0.0"));
+    assert!(log.contains("- macos / x86_64: `wavecrate-19.1.0-macos-x86_64.zip`"));
+    assert!(log.contains("- prepare final train"));
+    assert!(log.contains("- final release polish"));
+}
+
+fn run_generator(repo: &FixtureRepo, args: &[&str], release_notes: Option<&str>) {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts/internal/release/generate_release_log.sh");
+    let mut command = Command::new("bash");
+    command
+        .arg(script)
+        .args(args)
+        .current_dir(repo.path())
+        .env("WAVECRATE_RELEASE_LOG_DISABLE_GIT_CLIFF", "1");
+    if let Some(notes) = release_notes {
+        command.env("RELEASE_NOTES", notes);
+    }
+    let output = command.output().expect("run release log generator");
+    assert!(
+        output.status.success(),
+        "release log generator failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_release_files(release_dir: &Path, zip_name: &str, checksum_name: &str) {
+    fs::create_dir_all(release_dir).expect("create release dir");
+    fs::write(release_dir.join(zip_name), "zip fixture").expect("write zip fixture");
+    fs::write(
+        release_dir.join(checksum_name),
+        format!("abc123  {zip_name}\n"),
+    )
+    .expect("write checksum fixture");
+}
+
+struct FixtureRepo {
+    temp: TempDir,
+}
+
+impl FixtureRepo {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create fixture repo");
+        let repo = Self { temp };
+        repo.git(&["init"]);
+        repo.git(&["config", "user.email", "release-tests@example.invalid"]);
+        repo.git(&["config", "user.name", "Release Tests"]);
+        repo
+    }
+
+    fn path(&self) -> &Path {
+        self.temp.path()
+    }
+
+    fn release_dir(&self) -> PathBuf {
+        self.path().join("dist/release")
+    }
+
+    fn commit(&self, message: &str) -> String {
+        let file_name = format!("{}.txt", message.replace(' ', "-"));
+        fs::write(self.path().join(file_name), message).expect("write commit fixture");
+        self.git(&["add", "."]);
+        self.git(&["commit", "-m", message]);
+        self.git_stdout(&["rev-parse", "HEAD"])
+    }
+
+    fn tag(&self, tag: &str) {
+        self.git(&["tag", tag]);
+    }
+
+    fn git(&self, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(self.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(&self, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(self.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git stdout utf-8")
+            .trim()
+            .to_string()
+    }
+}


### PR DESCRIPTION
## Scope
- Add a shared `scripts/internal/release/generate_release_log.sh` generator for RC and stable release bodies.
- Generate release-bound markdown with release metadata, target branch/commit, build date, artifact matrix, checksum/signature names, optional manual notes, and generated changes.
- Use previous RC tags for later RC ranges, previous stable tags for first RC/stable ranges, and a bounded deterministic fallback when no release boundary exists.
- Wire RC and stable publish workflows to install `git-cliff`, fetch full history, assemble release artifacts/checksums, and publish the generated `dist/release/release-log.md` as the GitHub release body.
- Add release contract and script-level fixture coverage for RC first-release, later RC, and stable promotion logs.

## Definition of Done
- RC releases generate a release-bound markdown log without requiring manual notes.
- Stable releases generate a release-bound markdown log that records the promoted RC and final release metadata.
- Logs include release version, channel, commit, build date, artifact/checksum summary, and generated changes.
- The same generated log is used as the GitHub release body and remains compatible with PortalSurfer changelog header binding.
- Tests fail if RC/stable workflows regress to minimal manual-only logs or stop invoking the shared generator.

## Validation commands
- `bash scripts/agent.sh request` *(baseline failure: unrelated Radiant source-quality guardrails in app bridge/controller modules)*
- `cargo fmt --check`
- `bash -n scripts/internal/release/generate_release_log.sh && bash -n scripts/internal/release/build_release_zip.sh`
- `cargo test --test release_contract --test release_log_generator`
- `cargo test --test manual_release_matching`

## Known limitations
- The generator is currently wired for RC and stable workflows only; nightly keeps its existing inline generator.
- `git-cliff` is preferred when installed, with deterministic `git log --no-merges` fallback when unavailable or empty.

User review is required before merge.
