### PR TITLE
Add release train preparation workflow

### DIFF
--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -1,0 +1,89 @@
+name: Wavecrate release train prep
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable target version, for example 19.1.0
+        required: true
+        type: string
+      source_ref:
+        description: Source commit, branch, or tag used as the release branch base
+        required: true
+        default: main
+        type: string
+      push_branch:
+        description: Push or update release/X.Y after validation
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wavecrate-release-train-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release train
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.source_ref }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
+            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/radiant_submodule_key"
+          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+            git submodule update --init --recursive vendor/radiant
+          rm -f "$key_path"
+      - name: Read pinned Rust toolchain
+        id: rust_toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import pathlib
+          import tomllib
+
+          data = tomllib.loads(pathlib.Path("rust-toolchain.toml").read_text())
+          print(f"channel={data.get('toolchain', {}).get('channel', 'stable')}")
+          PY
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Configure release bot identity
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Prepare release train
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          PUSH_BRANCH: ${{ inputs.push_branch }}
+        run: |
+          set -euo pipefail
+          args=(--version "$VERSION" --source-ref HEAD)
+          if [[ "$PUSH_BRANCH" == "true" ]]; then
+            args+=(--push)
+          else
+            args+=(--dry-run)
+          fi
+          scripts/internal/release/prepare_release_train.py "${args[@]}"

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -52,8 +52,10 @@ and its wrapper probe passes. Default: unset, so repo scripts use direct
 
 ### Release upload secrets
 
-Wavecrate has three public release workflows:
+Wavecrate has four public release workflows:
 
+- `.github/workflows/release-train-prepare.yml`
+  - manual release-train branch/version preparation for `release/X.Y`
 - `.github/workflows/release-build.yml`
   - automatic and manual nightly builds from `main`
 - `.github/workflows/release-rc.yml`
@@ -65,6 +67,29 @@ Nightly runs publish rolling `nightly` builds for Windows x86_64 plus macOS
 x86_64/aarch64 assets from the current `main` commit. The schedule is
 `19:30 UTC` (evening in Europe/Amsterdam), and `workflow_dispatch` provides a
 manual "force a nightly now" button with the same build/upload path.
+
+Before the first RC for a train, run the release-train prep workflow or the
+equivalent local command. The prep lane validates an `X.Y.Z` stable target
+version, derives `release/X.Y`, checks out the requested source commit, updates
+Wavecrate release-package manifests and `Cargo.lock`, rejects stale prerelease
+package versions such as `alpha` or `beta`, and runs focused release contract
+validation. The workflow defaults to dry-run mode; it only pushes or updates the
+`release/X.Y` branch when `push_branch` is explicitly set to `true`.
+
+Local equivalent:
+
+```bash
+scripts/internal/release/prepare_release_train.py \
+  --version 19.1.0 \
+  --source-ref main \
+  --push
+```
+
+Use the workflow dry run first when preparing a new train, then re-run with
+`push_branch=true` once the source commit and version are correct. After prep,
+run the RC workflow against the prepared `release/X.Y` branch. Stable promotion
+then runs against the same release branch after the latest `vX.Y.Z-rc.N` tag has
+passed review.
 
 RC runs require `version`, `rc_number`, and `branch` inputs. The branch must be
 `release/X.Y` for the requested `X.Y.Z` version, and the package manifest must

--- a/scripts/internal/release/prepare_release_train.py
+++ b/scripts/internal/release/prepare_release_train.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Prepare a Wavecrate release train branch and package versions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+PACKAGE_HEADER_RE = re.compile(r"^\[package\]\s*$")
+TABLE_HEADER_RE = re.compile(r"^\[.*\]\s*$")
+VERSION_LINE_RE = re.compile(r'^version\s*=\s*"([^"]+)"\s*$')
+RELEASE_PACKAGE_RE = re.compile(r"^wavecrate($|-)")
+
+
+@dataclass(frozen=True)
+class ReleasePackage:
+    name: str
+    version: str
+    manifest_path: Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare release/X.Y by aligning Wavecrate package versions and Cargo.lock."
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Target release version, for example 19.1.0.",
+    )
+    parser.add_argument(
+        "--source-ref",
+        default="HEAD",
+        help="Commit, branch, or tag used as the release branch base. Defaults to HEAD.",
+    )
+    parser.add_argument(
+        "--branch",
+        help="Release branch to create or update. Defaults to release/X.Y derived from --version.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the current checkout without switching branches, writing files, committing, or pushing.",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push the prepared release branch to origin. This is never implied.",
+    )
+    parser.add_argument(
+        "--skip-release-tests",
+        action="store_true",
+        help="Skip focused release tests. Intended only for script fixture tests.",
+    )
+    args = parser.parse_args()
+
+    repo = repo_root()
+    os.chdir(repo)
+    version = args.version
+    validate_version(version)
+    branch = args.branch or release_branch_for_version(version)
+    validate_branch(branch, version)
+    ensure_clean_worktree()
+    source_commit = git_stdout("rev-parse", "--verify", f"{args.source_ref}^{{commit}}")
+
+    if args.dry_run:
+        print(f"[release-train] dry run for {version} from {source_commit} into {branch}")
+    else:
+        git("switch", "-C", branch, source_commit)
+        print(f"[release-train] preparing {branch} from {source_commit}")
+
+    packages = release_packages(repo)
+    if not packages:
+        raise SystemExit("No Wavecrate release packages were found in the workspace.")
+    reject_prerelease_versions(packages)
+    changed_manifests = update_release_manifests(packages, version, dry_run=args.dry_run)
+
+    if not args.dry_run:
+        refresh_lockfile()
+        validate_release_package_versions(version, release_packages(repo))
+
+    validate_locked_metadata()
+    if args.dry_run:
+        reject_prerelease_lockfile_versions()
+    else:
+        validate_lockfile_versions(version)
+    if not args.skip_release_tests:
+        run_focused_release_tests()
+
+    if not args.dry_run:
+        if changed_manifests or git_has_changes():
+            git(
+                "add",
+                *(str(package.manifest_path.relative_to(repo)) for package in packages),
+                "Cargo.lock",
+            )
+            git("commit", "-m", f"Prepare Wavecrate {version} release train")
+            print(f"[release-train] committed Wavecrate {version} release train prep")
+        else:
+            print("[release-train] no manifest or lockfile changes were needed")
+
+    if args.push:
+        if args.dry_run:
+            raise SystemExit("--push cannot be combined with --dry-run")
+        git("push", "-u", "origin", branch)
+        print(f"[release-train] pushed {branch} to origin")
+    else:
+        print("[release-train] push skipped; pass --push to publish the release branch")
+
+    print(f"[release-train] {branch} is prepared for {version}")
+    return 0
+
+
+def repo_root() -> Path:
+    return Path(git_stdout("rev-parse", "--show-toplevel")).resolve()
+
+
+def git(*args: str) -> None:
+    run(["git", *args])
+
+
+def git_stdout(*args: str) -> str:
+    return run(["git", *args], capture=True).stdout.strip()
+
+
+def cargo(*args: str) -> None:
+    run(["cargo", *args])
+
+
+def cargo_json(*args: str) -> dict:
+    stdout = run(["cargo", *args], capture=True).stdout
+    return json.loads(stdout)
+
+
+def run(argv: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        argv,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    if result.returncode != 0:
+        if capture:
+            sys.stderr.write(result.stdout)
+            sys.stderr.write(result.stderr)
+        raise SystemExit(f"Command failed ({result.returncode}): {' '.join(argv)}")
+    return result
+
+
+def validate_version(version: str) -> None:
+    if not VERSION_RE.fullmatch(version):
+        raise SystemExit(
+            "version must be MAJOR.MINOR.PATCH without alpha, beta, rc, or build metadata"
+        )
+
+
+def release_branch_for_version(version: str) -> str:
+    major, minor, _patch = version.split(".")
+    return f"release/{major}.{minor}"
+
+
+def validate_branch(branch: str, version: str) -> None:
+    expected = release_branch_for_version(version)
+    if branch != expected:
+        raise SystemExit(f"branch must be {expected} for version {version}")
+
+
+def ensure_clean_worktree() -> None:
+    status = git_stdout("status", "--short")
+    if status:
+        raise SystemExit(
+            "release train prep requires a clean working tree before it can switch branches or update manifests"
+        )
+
+
+def release_packages(repo: Path) -> list[ReleasePackage]:
+    metadata = cargo_json("metadata", "--format-version", "1", "--no-deps")
+    workspace_members = set(metadata["workspace_members"])
+    packages: list[ReleasePackage] = []
+    for package in metadata["packages"]:
+        manifest_path = Path(package["manifest_path"]).resolve()
+        if package["id"] not in workspace_members:
+            continue
+        if "vendor" in manifest_path.relative_to(repo).parts:
+            continue
+        if not RELEASE_PACKAGE_RE.match(package["name"]):
+            continue
+        packages.append(
+            ReleasePackage(
+                name=package["name"],
+                version=package["version"],
+                manifest_path=manifest_path,
+            )
+        )
+    return sorted(packages, key=lambda package: str(package.manifest_path))
+
+
+def reject_prerelease_versions(packages: list[ReleasePackage]) -> None:
+    stale = [
+        f"{package.name}={package.version}"
+        for package in packages
+        if not VERSION_RE.fullmatch(package.version)
+    ]
+    if stale:
+        raise SystemExit(
+            "release package versions must be stable MAJOR.MINOR.PATCH before train prep; stale prerelease versions: "
+            + ", ".join(stale)
+        )
+
+
+def update_release_manifests(
+    packages: list[ReleasePackage], version: str, *, dry_run: bool
+) -> list[Path]:
+    changed: list[Path] = []
+    for package in packages:
+        updated = update_manifest_package_version(package.manifest_path, version, dry_run=dry_run)
+        if updated:
+            changed.append(package.manifest_path)
+            verb = "would update" if dry_run else "updated"
+            print(
+                f"[release-train] {verb} {package.manifest_path}: "
+                f"{package.version} -> {version}"
+            )
+    if not changed:
+        print("[release-train] release package manifests already match the requested version")
+    return changed
+
+
+def update_manifest_package_version(manifest_path: Path, version: str, *, dry_run: bool) -> bool:
+    lines = manifest_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    in_package = False
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if PACKAGE_HEADER_RE.fullmatch(stripped):
+            in_package = True
+            continue
+        if in_package and TABLE_HEADER_RE.fullmatch(stripped):
+            break
+        if in_package and (match := VERSION_LINE_RE.fullmatch(stripped)):
+            old_version = match.group(1)
+            if old_version == version:
+                return False
+            line_ending = "\n" if line.endswith("\n") else ""
+            lines[index] = f'version = "{version}"{line_ending}'
+            if not dry_run:
+                manifest_path.write_text("".join(lines), encoding="utf-8")
+            return True
+    raise SystemExit(f"Could not find [package] version in {manifest_path}")
+
+
+def refresh_lockfile() -> None:
+    cargo("generate-lockfile")
+    run(["cargo", "metadata", "--format-version", "1", "--no-deps"], capture=True)
+
+
+def validate_locked_metadata() -> None:
+    run(["cargo", "metadata", "--locked", "--format-version", "1", "--no-deps"], capture=True)
+
+
+def validate_release_package_versions(version: str, packages: list[ReleasePackage]) -> None:
+    mismatches = [
+        f"{package.name}={package.version}"
+        for package in packages
+        if package.version != version
+    ]
+    if mismatches:
+        raise SystemExit(
+            f"Wavecrate release package versions must all be {version}; mismatches: "
+            + ", ".join(mismatches)
+        )
+
+
+def validate_lockfile_versions(version: str) -> None:
+    mismatches: list[str] = []
+    for package in lockfile_packages():
+        name = package.get("name")
+        package_version = package.get("version")
+        if isinstance(name, str) and RELEASE_PACKAGE_RE.match(name) and package_version != version:
+            mismatches.append(f"{name}={package_version}")
+    if mismatches:
+        raise SystemExit(
+            f"Cargo.lock release package versions must all be {version}; mismatches: "
+            + ", ".join(mismatches)
+        )
+
+
+def reject_prerelease_lockfile_versions() -> None:
+    stale: list[str] = []
+    for package in lockfile_packages():
+        name = package.get("name")
+        package_version = package.get("version")
+        if (
+            isinstance(name, str)
+            and RELEASE_PACKAGE_RE.match(name)
+            and isinstance(package_version, str)
+            and not VERSION_RE.fullmatch(package_version)
+        ):
+            stale.append(f"{name}={package_version}")
+    if stale:
+        raise SystemExit(
+            "Cargo.lock release package versions must be stable before train prep; stale prerelease versions: "
+            + ", ".join(stale)
+        )
+
+
+def lockfile_packages() -> list[dict[str, str]]:
+    packages: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for raw_line in Path("Cargo.lock").read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line == "[[package]]":
+            if current is not None:
+                packages.append(current)
+            current = {}
+            continue
+        if current is None or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in {"name", "version"} and value.startswith('"') and value.endswith('"'):
+            current[key] = value[1:-1]
+    if current is not None:
+        packages.append(current)
+    return packages
+
+
+def run_focused_release_tests() -> None:
+    cargo("test", "--test", "release_contract", "--test", "manual_release_matching")
+
+
+def git_has_changes() -> bool:
+    return bool(git_stdout("status", "--short"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -6,8 +6,12 @@ use toml::Value;
 
 const RELEASE_CONTRACT: &str = include_str!("../release_contract.toml");
 const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.yml");
+const RELEASE_TRAIN_PREP_WORKFLOW: &str =
+    include_str!("../.github/workflows/release-train-prepare.yml");
 const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
 const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
+const RELEASE_TRAIN_PREP_SCRIPT: &str =
+    include_str!("../scripts/internal/release/prepare_release_train.py");
 const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
 const RELEASE_LOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/generate_release_log.sh");
@@ -289,6 +293,58 @@ fn structured_release_log_generator_declares_required_sections() {
     assert!(
         RELEASE_LOG_SCRIPT.contains("git log --no-merges --pretty=format:'- %s'"),
         "release log generator must keep a deterministic commit-list fallback"
+    );
+}
+
+#[test]
+fn release_train_prep_workflow_is_manual_and_explicit_about_branch_pushes() {
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("workflow_dispatch:"),
+        "release train prep must be a manual workflow"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("push_branch:"),
+        "release train prep must require an explicit push_branch input"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("default: false"),
+        "release train prep must default to dry-run/no-push"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("scripts/internal/release/prepare_release_train.py"),
+        "release train prep workflow must invoke the shared prep script"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("--dry-run"),
+        "release train prep workflow must support validation without mutation"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW.contains("--push"),
+        "release train prep workflow must only push behind an explicit input"
+    );
+}
+
+#[test]
+fn release_train_prep_script_enforces_version_and_package_scope() {
+    assert!(
+        RELEASE_TRAIN_PREP_SCRIPT.contains("VERSION_RE = re.compile"),
+        "prep script must validate MAJOR.MINOR.PATCH versions"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_SCRIPT.contains("RELEASE_PACKAGE_RE = re.compile"),
+        "prep script must derive release package scope from package names"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_SCRIPT.contains("not VERSION_RE.fullmatch(package.version)"),
+        "prep script must reject stale prerelease package versions"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_SCRIPT.contains("cargo(\"test\", \"--test\", \"release_contract\", \"--test\", \"manual_release_matching\")"),
+        "prep script must run focused release contract validation"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_SCRIPT.contains("validate_lockfile_versions(version)"),
+        "prep script must verify Cargo.lock release package versions"
     );
 }
 

--- a/tests/release_train_prepare.rs
+++ b/tests/release_train_prepare.rs
@@ -1,0 +1,219 @@
+//! Script-level checks for release-train preparation.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn prepare_release_train_updates_wavecrate_packages_and_lockfile() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.git(&["add", "."]);
+    repo.git(&["commit", "-m", "seed workspace"]);
+    let output = repo.run_prepare(&[
+        "--version",
+        "19.2.0",
+        "--source-ref",
+        "HEAD",
+        "--skip-release-tests",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "prepare script failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_stdout(&["branch", "--show-current"]),
+        "release/19.2"
+    );
+    assert!(
+        repo.read("Cargo.toml")
+            .contains("name = \"wavecrate\"\nversion = \"19.2.0\"")
+    );
+    assert!(
+        repo.read("crates/wavecrate-tool/Cargo.toml")
+            .contains("name = \"wavecrate-tool\"\nversion = \"19.2.0\"")
+    );
+    assert!(
+        repo.read("crates/reson/Cargo.toml")
+            .contains("name = \"reson\"\nversion = \"0.1.0\"")
+    );
+    assert!(
+        repo.read("tools/gui-test-cli/Cargo.toml")
+            .contains("name = \"gui-test-cli\"\nversion = \"0.1.0\"")
+    );
+    assert!(
+        repo.read("Cargo.lock")
+            .contains("name = \"wavecrate\"\nversion = \"19.2.0\"")
+    );
+    assert!(
+        repo.read("Cargo.lock")
+            .contains("name = \"wavecrate-tool\"\nversion = \"19.2.0\"")
+    );
+    assert!(
+        repo.git_stdout(&["log", "-1", "--pretty=%s"])
+            .contains("Prepare Wavecrate 19.2.0 release train")
+    );
+}
+
+#[test]
+fn prepare_release_train_rejects_stale_prerelease_package_versions() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0-alpha.1");
+    repo.git(&["add", "."]);
+    repo.git(&["commit", "-m", "seed prerelease workspace"]);
+    let output = repo.run_prepare(&[
+        "--version",
+        "19.1.0",
+        "--source-ref",
+        "HEAD",
+        "--dry-run",
+        "--skip-release-tests",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "prepare script should reject prerelease package versions"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("stale prerelease versions"),
+        "stderr should explain prerelease rejection\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+struct FixtureRepo {
+    temp: TempDir,
+}
+
+impl FixtureRepo {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create release train fixture repo");
+        let repo = Self { temp };
+        repo.git(&["init"]);
+        repo.git(&["config", "user.email", "release-tests@example.invalid"]);
+        repo.git(&["config", "user.name", "Release Tests"]);
+        repo
+    }
+
+    fn path(&self) -> &Path {
+        self.temp.path()
+    }
+
+    fn write_workspace(&self, wavecrate_version: &str) {
+        self.write(
+            "Cargo.toml",
+            &format!(
+                r#"[workspace]
+members = [
+    ".",
+    "crates/wavecrate-tool",
+    "crates/reson",
+    "tools/gui-test-cli",
+]
+resolver = "3"
+
+[package]
+name = "wavecrate"
+version = "{wavecrate_version}"
+edition = "2024"
+
+[dependencies]
+wavecrate-tool = {{ path = "crates/wavecrate-tool" }}
+"#
+            ),
+        );
+        self.write(
+            "crates/wavecrate-tool/Cargo.toml",
+            &format!(
+                r#"[package]
+name = "wavecrate-tool"
+version = "{wavecrate_version}"
+edition = "2024"
+"#
+            ),
+        );
+        self.write(
+            "crates/reson/Cargo.toml",
+            r#"[package]
+name = "reson"
+version = "0.1.0"
+edition = "2024"
+"#,
+        );
+        self.write(
+            "tools/gui-test-cli/Cargo.toml",
+            r#"[package]
+name = "gui-test-cli"
+version = "0.1.0"
+edition = "2024"
+"#,
+        );
+        self.write("src/lib.rs", "");
+        self.write("crates/wavecrate-tool/src/lib.rs", "");
+        self.write("crates/reson/src/lib.rs", "");
+        self.write("tools/gui-test-cli/src/lib.rs", "");
+    }
+
+    fn run_prepare(&self, args: &[&str]) -> std::process::Output {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scripts/internal/release/prepare_release_train.py");
+        Command::new("python3")
+            .arg(script)
+            .args(args)
+            .current_dir(self.path())
+            .output()
+            .expect("run release train prep script")
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.path().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn read(&self, relative: &str) -> String {
+        fs::read_to_string(self.path().join(relative)).expect("read fixture file")
+    }
+
+    fn git(&self, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(self.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdout(&self, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(self.path())
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git stdout utf-8")
+            .trim()
+            .to_string()
+    }
+}


### PR DESCRIPTION
## Scope
- Add a manual `release-train-prepare.yml` workflow for preparing `release/X.Y` before the first RC.
- Add `scripts/internal/release/prepare_release_train.py` to validate `MAJOR.MINOR.PATCH`, derive `release/X.Y`, update Wavecrate release-package manifests, refresh/validate `Cargo.lock`, reject stale prerelease package versions, and run focused release checks.
- Keep workflow branch mutation explicit: default dry-run, push/update `release/X.Y` only when `push_branch=true`.
- Document the release train sequence in `docs/ENV_VARS.md`: prep train, run RC, then promote stable.
- Add contract and fixture tests for workflow wiring, package scope, lockfile updates, and prerelease rejection.

## Definition of Done
- A maintainer can run one documented command/workflow to prepare `release/X.Y` for `X.Y.Z`.
- The prep path updates all intended Wavecrate release-package manifests and matching `Cargo.lock` entries consistently.
- The prep path fails on stale prerelease suffixes such as `alpha`.
- RC/stable workflows can assume their branch/version preconditions were produced by a validated prep lane.
- Release docs explain the sequence from train prep to RC to stable promotion.

## Validation commands
- `bash scripts/agent.sh request` *(baseline failure: unrelated Radiant source-quality guardrails in app bridge/controller modules)*
- `cargo fmt --check`
- `python3 -m py_compile scripts/internal/release/prepare_release_train.py scripts/internal/release/assemble_portal_changelog.py`
- `bash -n scripts/internal/release/build_release_zip.sh && bash -n scripts/internal/release/generate_release_log.sh`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo test --test release_contract --test manual_release_matching --test release_train_prepare`
- `scripts/internal/release/prepare_release_train.py --version 19.1.0 --source-ref HEAD --dry-run`

## Known limitations
- The prep script scopes release package version bumps to workspace package names matching `wavecrate` or `wavecrate-*`; non-release workspace crates like `reson` and `gui-test-cli` keep their independent versions.
- The workflow pushes a release branch only when `push_branch=true`; it does not open a PR against the release branch.

User review is required before merge.
