### PR TITLE
OPT-985 Factor shared release workflow helpers

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -203,56 +203,18 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          channel="$(python3 - <<'PY'
-          import tomllib
-          from pathlib import Path
-
-          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
-          print(data.get("toolchain", {}).get("channel", "stable"))
-          PY
-          )"
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
       - name: Fetch ASIO SDK (Windows)
         if: ${{ matrix.platform == 'windows' }}
         shell: pwsh
-        run: |
-          git lfs install --local
-          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
-          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
-          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
-          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
-          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
-          if (-not $asioHeader) {
-            throw "ASIO header not found under $asioRoot"
-          }
-          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
-          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
-            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
-          }
-          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+        run: ./scripts/internal/release/setup_windows_asio_sdk.ps1
       - name: Build nightly zip
         shell: bash
         env:
@@ -266,7 +228,7 @@ jobs:
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
           APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         run: |
-          scripts/internal/release/build_release_zip.sh \
+          scripts/internal/release/build_release_artifact.sh \
             --target "${{ matrix.target }}" \
             --platform "${{ matrix.platform }}" \
             --arch "${{ matrix.arch }}" \
@@ -277,11 +239,6 @@ jobs:
             --git-sha "$TARGET_SHA" \
             --build-date "${{ needs.resolve-main.outputs.build_date }}" \
             --out-dir dist/release
-      - name: Uniquify checksums entry
-        shell: bash
-        run: |
-          mv dist/release/checksums-entry.txt \
-            "dist/release/checksums-entry-${{ matrix.platform }}-${{ matrix.arch }}.txt"
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.platform }}-${{ matrix.arch }}
@@ -307,59 +264,15 @@ jobs:
           path: dist/release
       - name: Assemble release files
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p dist/release
-          cp dist/artifacts/*.zip dist/release/
-          shopt -s nullglob
-          entries=(dist/artifacts/checksums-entry-*.txt)
-          if [[ ${#entries[@]} -eq 0 ]]; then
-            echo "No checksums entry files found." >&2
-            exit 1
-          fi
-          cat "${entries[@]}" > dist/release/checksums-nightly.txt
+        run: scripts/internal/release/assemble_release_files.sh --checksum-name checksums-nightly.txt
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
         run: |
-          set -euo pipefail
-          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
-            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
-            exit 1
-          fi
-          key_path="dist/release/checksums-signing-key.pem"
-          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
-          openssl pkeyutl -sign -inkey "$key_path" -rawin \
-            -in dist/release/checksums-nightly.txt \
-            -out dist/release/checksums-nightly.txt.sig.bin
-          base64 -w 0 dist/release/checksums-nightly.txt.sig.bin \
-            > dist/release/checksums-nightly.txt.sig
-          rm -f "$key_path"
-      - name: Verify release checksum signature
-        env:
-          CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
-            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
-            exit 1
-          fi
-          key_path="dist/release/checksums-signing-key.pem"
-          pub_der="dist/release/checksums-signing-key.pub.der"
-          sig_bin="dist/release/checksums-nightly.txt.sig.bin"
-          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
-          openssl pkey -in "$key_path" -pubout -outform DER -out "$pub_der"
-          tail -c 32 "$pub_der" | base64 -w 0 > dist/release/checksums-pubkey.txt
-          openssl pkeyutl -verify -pubin -inkey "$pub_der" -rawin \
-            -in dist/release/checksums-nightly.txt \
-            -sigfile "$sig_bin"
-          expected_pubkey="8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4="
-          actual_pubkey="$(cat dist/release/checksums-pubkey.txt)"
-          if [[ "$actual_pubkey" != "$expected_pubkey" ]]; then
-            echo "Public key mismatch: $actual_pubkey" >&2
-            exit 1
-          fi
-          rm -f "$key_path" "$pub_der" dist/release/checksums-pubkey.txt "$sig_bin"
+          scripts/internal/release/sign_release_checksums.sh \
+            --checksum-file dist/release/checksums-nightly.txt \
+            --signature-file dist/release/checksums-nightly.txt.sig \
+            --verify-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
       - name: Publish nightly tags
         env:
           GH_TOKEN: ${{ github.token }}
@@ -400,24 +313,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          set -euo pipefail
-          current_assets="$(mktemp)"
-          for asset_path in dist/release/*; do
-            basename "$asset_path"
-          done | sort > "$current_assets"
-          if ! gh release view nightly --repo "$REPOSITORY" --json assets --jq '.assets[].name' >/tmp/nightly-assets.txt 2>/dev/null; then
-            rm -f "$current_assets"
-            exit 0
-          fi
-          while IFS= read -r asset_name; do
-            if [[ -z "$asset_name" ]]; then
-              continue
-            fi
-            if ! grep -Fxq "$asset_name" "$current_assets"; then
-              gh release delete-asset nightly "$asset_name" --repo "$REPOSITORY" --yes
-            fi
-          done </tmp/nightly-assets.txt
-          rm -f "$current_assets" /tmp/nightly-assets.txt
+          scripts/internal/release/prune_github_release_assets.sh \
+            --tag nightly \
+            --repo "$REPOSITORY" \
+            --release-dir dist/release
       - name: Upload nightly release assets
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -101,34 +101,11 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          channel="$(python3 - <<'PY'
-          import tomllib
-          from pathlib import Path
-          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
-          print(data.get("toolchain", {}).get("channel", "stable"))
-          PY
-          )"
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
@@ -164,53 +141,18 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          channel="$(python3 - <<'PY'
-          import tomllib
-          from pathlib import Path
-          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
-          print(data.get("toolchain", {}).get("channel", "stable"))
-          PY
-          )"
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
       - name: Fetch ASIO SDK (Windows)
         if: ${{ matrix.platform == 'windows' }}
         shell: pwsh
-        run: |
-          git lfs install --local
-          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
-          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
-          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
-          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
-          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
-          if (-not $asioHeader) { throw "ASIO header not found under $asioRoot" }
-          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
-          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
-            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
-          }
-          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+        run: ./scripts/internal/release/setup_windows_asio_sdk.ps1
       - name: Build RC zip
         shell: bash
         env:
@@ -224,7 +166,7 @@ jobs:
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
           APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         run: |
-          scripts/internal/release/build_release_zip.sh \
+          scripts/internal/release/build_release_artifact.sh \
             --target "${{ matrix.target }}" \
             --platform "${{ matrix.platform }}" \
             --arch "${{ matrix.arch }}" \
@@ -235,8 +177,6 @@ jobs:
             --git-sha "$TARGET_SHA" \
             --build-date "${{ needs.resolve.outputs.build_date }}" \
             --out-dir dist/release
-          mv dist/release/checksums-entry.txt \
-            "dist/release/checksums-entry-${{ matrix.platform }}-${{ matrix.arch }}.txt"
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.platform }}-${{ matrix.arch }}
@@ -273,11 +213,10 @@ jobs:
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
-          mkdir -p dist/release
-          cp dist/artifacts/*.zip dist/release/
           checksum_name="checksums-${RELEASE_VERSION}.txt"
           checksum_sig_name="${checksum_name}.sig"
-          cat dist/artifacts/checksums-entry-*.txt > "dist/release/${checksum_name}"
+          scripts/internal/release/assemble_release_files.sh \
+            --checksum-name "$checksum_name"
           scripts/internal/release/generate_release_log.sh \
             --channel rc \
             --version "$RELEASE_VERSION" \
@@ -296,19 +235,9 @@ jobs:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
           RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
         run: |
-          set -euo pipefail
-          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
-            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
-            exit 1
-          fi
-          key_path="dist/release/checksums-signing-key.pem"
-          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
-          openssl pkeyutl -sign -inkey "$key_path" -rawin \
-            -in "dist/release/checksums-${RELEASE_VERSION}.txt" \
-            -out "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin"
-          base64 -w 0 "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin" \
-            > "dist/release/checksums-${RELEASE_VERSION}.txt.sig"
-          rm -f "$key_path" "dist/release/checksums-${RELEASE_VERSION}.txt.sig.bin"
+          scripts/internal/release/sign_release_checksums.sh \
+            --checksum-file "dist/release/checksums-${RELEASE_VERSION}.txt" \
+            --signature-file "dist/release/checksums-${RELEASE_VERSION}.txt.sig"
       - name: Publish RC release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -103,34 +103,11 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          channel="$(python3 - <<'PY'
-          import tomllib
-          from pathlib import Path
-          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
-          print(data.get("toolchain", {}).get("channel", "stable"))
-          PY
-          )"
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
@@ -166,53 +143,18 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          channel="$(python3 - <<'PY'
-          import tomllib
-          from pathlib import Path
-          data = tomllib.loads(Path("rust-toolchain.toml").read_text(encoding="utf-8"))
-          print(data.get("toolchain", {}).get("channel", "stable"))
-          PY
-          )"
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
       - name: Fetch ASIO SDK (Windows)
         if: ${{ matrix.platform == 'windows' }}
         shell: pwsh
-        run: |
-          git lfs install --local
-          git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
-          git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
-          git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
-          $asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
-          $asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
-          if (-not $asioHeader) { throw "ASIO header not found under $asioRoot" }
-          $sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
-          if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
-            throw "ASIO SDK directory not found for $($asioHeader.FullName)"
-          }
-          "CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV
+        run: ./scripts/internal/release/setup_windows_asio_sdk.ps1
       - name: Build stable zip
         shell: bash
         env:
@@ -226,7 +168,7 @@ jobs:
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
           APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         run: |
-          scripts/internal/release/build_release_zip.sh \
+          scripts/internal/release/build_release_artifact.sh \
             --target "${{ matrix.target }}" \
             --platform "${{ matrix.platform }}" \
             --arch "${{ matrix.arch }}" \
@@ -237,8 +179,6 @@ jobs:
             --git-sha "$TARGET_SHA" \
             --build-date "${{ needs.resolve.outputs.build_date }}" \
             --out-dir dist/release
-          mv dist/release/checksums-entry.txt \
-            "dist/release/checksums-entry-${{ matrix.platform }}-${{ matrix.arch }}.txt"
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.platform }}-${{ matrix.arch }}
@@ -275,11 +215,10 @@ jobs:
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
           set -euo pipefail
-          mkdir -p dist/release
-          cp dist/artifacts/*.zip dist/release/
           checksum_name="checksums-${VERSION}.txt"
           checksum_sig_name="${checksum_name}.sig"
-          cat dist/artifacts/checksums-entry-*.txt > "dist/release/${checksum_name}"
+          scripts/internal/release/assemble_release_files.sh \
+            --checksum-name "$checksum_name"
           scripts/internal/release/generate_release_log.sh \
             --channel stable \
             --version "$VERSION" \
@@ -297,19 +236,9 @@ jobs:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
           VERSION: ${{ needs.resolve.outputs.target_version }}
         run: |
-          set -euo pipefail
-          if [[ -z "${CHECKSUMS_SIGNING_KEY}" ]]; then
-            echo "Missing WAVECRATE_CHECKSUMS_ED25519_KEY or SEMPAL_CHECKSUMS_ED25519_KEY secret." >&2
-            exit 1
-          fi
-          key_path="dist/release/checksums-signing-key.pem"
-          printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
-          openssl pkeyutl -sign -inkey "$key_path" -rawin \
-            -in "dist/release/checksums-${VERSION}.txt" \
-            -out "dist/release/checksums-${VERSION}.txt.sig.bin"
-          base64 -w 0 "dist/release/checksums-${VERSION}.txt.sig.bin" \
-            > "dist/release/checksums-${VERSION}.txt.sig"
-          rm -f "$key_path" "dist/release/checksums-${VERSION}.txt.sig.bin"
+          scripts/internal/release/sign_release_checksums.sh \
+            --checksum-file "dist/release/checksums-${VERSION}.txt" \
+            --signature-file "dist/release/checksums-${VERSION}.txt.sig"
       - name: Publish stable release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -38,33 +38,11 @@ jobs:
         shell: bash
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
-        run: |
-          set -euo pipefail
-          if [[ -z "$RADIANT_SUBMODULE_DEPLOY_KEY" ]]; then
-            echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          key_path="$HOME/.ssh/radiant_submodule_key"
-          printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
-          GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
-            git submodule update --init --recursive vendor/radiant
-          rm -f "$key_path"
+        run: scripts/internal/release/checkout_radiant_submodule.sh
       - name: Read pinned Rust toolchain
         id: rust_toolchain
         shell: bash
-        run: |
-          set -euo pipefail
-          python - <<'PY' >> "$GITHUB_OUTPUT"
-          import pathlib
-          import tomllib
-
-          data = tomllib.loads(pathlib.Path("rust-toolchain.toml").read_text())
-          print(f"channel={data.get('toolchain', {}).get('channel', 'stable')}")
-          PY
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -91,6 +91,21 @@ run the RC workflow against the prepared `release/X.Y` branch. Stable promotion
 then runs against the same release branch after the latest `vX.Y.Z-rc.N` tag has
 passed review.
 
+The release workflows keep channel policy in YAML but share operational helpers
+under `scripts/internal/release/`:
+
+- `checkout_radiant_submodule.sh` configures the private Radiant submodule.
+- `emit_rust_toolchain_channel.py` emits the pinned Rust toolchain channel for
+  `dtolnay/rust-toolchain`.
+- `setup_windows_asio_sdk.ps1` prepares the Windows ASIO SDK path.
+- `build_release_artifact.sh` wraps package creation and per-platform checksum
+  entry naming.
+- `assemble_release_files.sh` copies built zips and assembles the channel
+  checksum file.
+- `sign_release_checksums.sh` signs and optionally verifies checksum files.
+- `prune_github_release_assets.sh` removes stale assets from a rolling GitHub
+  release before upload.
+
 RC runs require `version`, `rc_number`, and `branch` inputs. The branch must be
 `release/X.Y` for the requested `X.Y.Z` version, and the package manifest must
 already carry that target version. RC releases are published as GitHub

--- a/scripts/internal/release/assemble_release_files.sh
+++ b/scripts/internal/release/assemble_release_files.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR="dist/artifacts"
+OUT_DIR="dist/release"
+CHECKSUM_NAME=""
+
+usage() {
+  cat <<'USAGE'
+Usage: assemble_release_files.sh --checksum-name <name> [--artifact-dir <path>] [--out-dir <path>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --checksum-name)
+      CHECKSUM_NAME="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CHECKSUM_NAME" ]]; then
+  echo "Missing --checksum-name" >&2
+  usage >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+shopt -s nullglob
+zips=("${ARTIFACT_DIR}"/*.zip)
+entries=("${ARTIFACT_DIR}"/checksums-entry-*.txt)
+if [[ ${#zips[@]} -eq 0 ]]; then
+  echo "No release zip files found in $ARTIFACT_DIR." >&2
+  exit 1
+fi
+if [[ ${#entries[@]} -eq 0 ]]; then
+  echo "No checksums entry files found in $ARTIFACT_DIR." >&2
+  exit 1
+fi
+
+cp "${zips[@]}" "$OUT_DIR/"
+cat "${entries[@]}" > "${OUT_DIR}/${CHECKSUM_NAME}"

--- a/scripts/internal/release/build_release_artifact.sh
+++ b/scripts/internal/release/build_release_artifact.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET=""
+PLATFORM=""
+ARCH=""
+CHANNEL=""
+VERSION=""
+TARGET_VERSION=""
+BUILD_NUMBER=""
+GIT_SHA=""
+BUILD_DATE=""
+OUT_DIR="dist/release"
+
+usage() {
+  cat <<'USAGE'
+Usage: build_release_artifact.sh --target <triple> --platform <label> --arch <label> --channel <nightly|rc|stable> --version <semver> --target-version <x.y.z> --build-number <n> --git-sha <sha> --build-date <YYYY-MM-DD> [--out-dir <path>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="${2:-}"
+      shift 2
+      ;;
+    --platform)
+      PLATFORM="${2:-}"
+      shift 2
+      ;;
+    --arch)
+      ARCH="${2:-}"
+      shift 2
+      ;;
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --target-version)
+      TARGET_VERSION="${2:-}"
+      shift 2
+      ;;
+    --build-number)
+      BUILD_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --git-sha)
+      GIT_SHA="${2:-}"
+      shift 2
+      ;;
+    --build-date)
+      BUILD_DATE="${2:-}"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for required in TARGET PLATFORM ARCH CHANNEL VERSION TARGET_VERSION BUILD_NUMBER GIT_SHA BUILD_DATE; do
+  if [[ -z "${!required}" ]]; then
+    echo "Missing required argument for $required" >&2
+    usage >&2
+    exit 1
+  fi
+done
+
+scripts/internal/release/build_release_zip.sh \
+  --target "$TARGET" \
+  --platform "$PLATFORM" \
+  --arch "$ARCH" \
+  --channel "$CHANNEL" \
+  --version "$VERSION" \
+  --target-version "$TARGET_VERSION" \
+  --build-number "$BUILD_NUMBER" \
+  --git-sha "$GIT_SHA" \
+  --build-date "$BUILD_DATE" \
+  --out-dir "$OUT_DIR"
+
+mv "${OUT_DIR}/checksums-entry.txt" \
+  "${OUT_DIR}/checksums-entry-${PLATFORM}-${ARCH}.txt"

--- a/scripts/internal/release/checkout_radiant_submodule.sh
+++ b/scripts/internal/release/checkout_radiant_submodule.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${RADIANT_SUBMODULE_DEPLOY_KEY:-}" ]]; then
+  echo "Missing RADIANT_SUBMODULE_DEPLOY_KEY secret." >&2
+  exit 1
+fi
+
+mkdir -p ~/.ssh
+key_path="$HOME/.ssh/radiant_submodule_key"
+cleanup() {
+  rm -f "$key_path"
+}
+trap cleanup EXIT
+
+printf '%s\n' "$RADIANT_SUBMODULE_DEPLOY_KEY" > "$key_path"
+chmod 600 "$key_path"
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+git config submodule.vendor/radiant.url git@github.com:PORTALSURFER/radiant.git
+GIT_SSH_COMMAND="ssh -i $key_path -o IdentitiesOnly=yes" \
+  git submodule update --init --recursive vendor/radiant

--- a/scripts/internal/release/emit_rust_toolchain_channel.py
+++ b/scripts/internal/release/emit_rust_toolchain_channel.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Emit the pinned Rust toolchain channel for GitHub Actions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    text = Path("rust-toolchain.toml").read_text(encoding="utf-8")
+    channel = "stable"
+    in_toolchain = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line == "[toolchain]":
+            in_toolchain = True
+            continue
+        if in_toolchain and line.startswith("["):
+            break
+        if in_toolchain and (match := re.fullmatch(r'channel\s*=\s*"([^"]+)"', line)):
+            channel = match.group(1)
+            break
+    print(f"channel={channel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/internal/release/prune_github_release_assets.sh
+++ b/scripts/internal/release/prune_github_release_assets.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG_NAME=""
+REPOSITORY=""
+RELEASE_DIR="dist/release"
+
+usage() {
+  cat <<'USAGE'
+Usage: prune_github_release_assets.sh --tag <tag> --repo <owner/name> [--release-dir <path>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      TAG_NAME="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPOSITORY="${2:-}"
+      shift 2
+      ;;
+    --release-dir)
+      RELEASE_DIR="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG_NAME" || -z "$REPOSITORY" ]]; then
+  echo "Missing --tag or --repo" >&2
+  usage >&2
+  exit 1
+fi
+
+current_assets="$(mktemp)"
+remote_assets="$(mktemp)"
+cleanup() {
+  rm -f "$current_assets" "$remote_assets"
+}
+trap cleanup EXIT
+
+for asset_path in "$RELEASE_DIR"/*; do
+  [[ -f "$asset_path" ]] || continue
+  basename "$asset_path"
+done | sort > "$current_assets"
+
+if ! gh release view "$TAG_NAME" --repo "$REPOSITORY" --json assets --jq '.assets[].name' >"$remote_assets" 2>/dev/null; then
+  exit 0
+fi
+
+while IFS= read -r asset_name; do
+  if [[ -z "$asset_name" ]]; then
+    continue
+  fi
+  if ! grep -Fxq "$asset_name" "$current_assets"; then
+    gh release delete-asset "$TAG_NAME" "$asset_name" --repo "$REPOSITORY" --yes
+  fi
+done <"$remote_assets"

--- a/scripts/internal/release/setup_windows_asio_sdk.ps1
+++ b/scripts/internal/release/setup_windows_asio_sdk.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+
+git lfs install --local
+git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/audiosdk/asio "$env:GITHUB_WORKSPACE/asio"
+git -C "$env:GITHUB_WORKSPACE/asio" submodule update --init --recursive
+git -C "$env:GITHUB_WORKSPACE/asio" lfs pull
+
+$asioRoot = Join-Path $env:GITHUB_WORKSPACE "asio"
+$asioHeader = Get-ChildItem -Path $asioRoot -Recurse -Filter "asiodrivers.h" -File | Select-Object -First 1
+if (-not $asioHeader) {
+  throw "ASIO header not found under $asioRoot"
+}
+
+$sdkDir = Split-Path -Parent (Split-Path -Parent $asioHeader.FullName)
+if (-not (Test-Path (Join-Path $sdkDir "host")) -or -not (Test-Path (Join-Path $sdkDir "common"))) {
+  throw "ASIO SDK directory not found for $($asioHeader.FullName)"
+}
+
+"CPAL_ASIO_DIR=$sdkDir" >> $env:GITHUB_ENV

--- a/scripts/internal/release/sign_release_checksums.sh
+++ b/scripts/internal/release/sign_release_checksums.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHECKSUM_FILE=""
+SIGNATURE_FILE=""
+EXPECTED_PUBKEY=""
+
+usage() {
+  cat <<'USAGE'
+Usage: sign_release_checksums.sh --checksum-file <path> --signature-file <path> [--verify-public-key <base64-ed25519-pubkey>]
+
+Requires CHECKSUMS_SIGNING_KEY to contain the Ed25519 private key PEM.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --checksum-file)
+      CHECKSUM_FILE="${2:-}"
+      shift 2
+      ;;
+    --signature-file)
+      SIGNATURE_FILE="${2:-}"
+      shift 2
+      ;;
+    --verify-public-key)
+      EXPECTED_PUBKEY="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CHECKSUM_FILE" || -z "$SIGNATURE_FILE" ]]; then
+  echo "Missing --checksum-file or --signature-file" >&2
+  usage >&2
+  exit 1
+fi
+if [[ -z "${CHECKSUMS_SIGNING_KEY:-}" ]]; then
+  echo "Missing CHECKSUMS_SIGNING_KEY." >&2
+  exit 1
+fi
+if [[ ! -s "$CHECKSUM_FILE" ]]; then
+  echo "Checksum file is missing or empty: $CHECKSUM_FILE" >&2
+  exit 1
+fi
+
+work_dir="$(dirname "$SIGNATURE_FILE")"
+mkdir -p "$work_dir"
+key_path="$(mktemp "${work_dir}/checksums-signing-key.XXXXXX.pem")"
+sig_bin="$(mktemp "${work_dir}/checksums-signature.XXXXXX.bin")"
+pub_der="$(mktemp "${work_dir}/checksums-signing-key.XXXXXX.pub.der")"
+cleanup() {
+  rm -f "$key_path" "$sig_bin" "$pub_der"
+}
+trap cleanup EXIT
+
+printf "%s" "$CHECKSUMS_SIGNING_KEY" > "$key_path"
+openssl pkeyutl -sign -inkey "$key_path" -rawin \
+  -in "$CHECKSUM_FILE" \
+  -out "$sig_bin"
+openssl base64 -A -in "$sig_bin" -out "$SIGNATURE_FILE"
+
+if [[ -n "$EXPECTED_PUBKEY" ]]; then
+  openssl pkey -in "$key_path" -pubout -outform DER -out "$pub_der"
+  actual_pubkey="$(tail -c 32 "$pub_der" | openssl base64 -A)"
+  if [[ "$actual_pubkey" != "$EXPECTED_PUBKEY" ]]; then
+    echo "Public key mismatch: $actual_pubkey" >&2
+    exit 1
+  fi
+  openssl pkeyutl -verify -pubin -inkey "$pub_der" -rawin \
+    -in "$CHECKSUM_FILE" \
+    -sigfile "$sig_bin"
+fi

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -12,9 +12,17 @@ const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
 const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
 const RELEASE_TRAIN_PREP_SCRIPT: &str =
     include_str!("../scripts/internal/release/prepare_release_train.py");
+const ASSEMBLE_RELEASE_FILES_SCRIPT: &str =
+    include_str!("../scripts/internal/release/assemble_release_files.sh");
+const BUILD_RELEASE_ARTIFACT_SCRIPT: &str =
+    include_str!("../scripts/internal/release/build_release_artifact.sh");
+const CHECKOUT_RADIANT_SCRIPT: &str =
+    include_str!("../scripts/internal/release/checkout_radiant_submodule.sh");
 const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
 const RELEASE_LOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/generate_release_log.sh");
+const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
+    include_str!("../scripts/internal/release/sign_release_checksums.sh");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 
 #[test]
@@ -156,19 +164,19 @@ fn release_packager_uses_contract_nightly_asset_name_without_build_number() {
 #[test]
 fn nightly_workflow_publishes_packager_outputs_as_github_assets() {
     assert!(
-        NIGHTLY_WORKFLOW.contains("scripts/internal/release/build_release_zip.sh \\"),
-        "nightly workflow must use the shared release zip packager"
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/build_release_artifact.sh \\"),
+        "nightly workflow must use the shared release artifact builder"
     );
     assert!(
         NIGHTLY_WORKFLOW.contains("--channel nightly \\"),
         "nightly workflow must call the packager in nightly mode"
     );
     assert!(
-        NIGHTLY_WORKFLOW.contains("cp dist/artifacts/*.zip dist/release/"),
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/assemble_release_files.sh"),
         "GitHub nightly release must publish the zip filenames emitted by the packager"
     );
     assert!(
-        NIGHTLY_WORKFLOW.contains("cat \"${entries[@]}\" > dist/release/checksums-nightly.txt"),
+        NIGHTLY_WORKFLOW.contains("--checksum-name checksums-nightly.txt"),
         "GitHub nightly checksums must be assembled from packager checksum entries"
     );
     assert!(
@@ -345,6 +353,82 @@ fn release_train_prep_script_enforces_version_and_package_scope() {
     assert!(
         RELEASE_TRAIN_PREP_SCRIPT.contains("validate_lockfile_versions(version)"),
         "prep script must verify Cargo.lock release package versions"
+    );
+}
+
+#[test]
+fn release_workflows_use_shared_setup_build_and_signing_helpers() {
+    for (name, workflow) in [
+        ("nightly workflow", NIGHTLY_WORKFLOW),
+        ("RC workflow", RC_WORKFLOW),
+        ("stable workflow", STABLE_WORKFLOW),
+    ] {
+        assert!(
+            workflow.contains("scripts/internal/release/checkout_radiant_submodule.sh"),
+            "{name} must use the shared Radiant checkout helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/emit_rust_toolchain_channel.py"),
+            "{name} must use the shared Rust toolchain channel helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/setup_windows_asio_sdk.ps1"),
+            "{name} must use the shared Windows ASIO setup helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/build_release_artifact.sh"),
+            "{name} must use the shared release artifact build helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/assemble_release_files.sh"),
+            "{name} must use the shared release assembly helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/sign_release_checksums.sh"),
+            "{name} must use the shared checksum signing helper"
+        );
+    }
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW
+            .contains("scripts/internal/release/checkout_radiant_submodule.sh"),
+        "release train prep must use the shared Radiant checkout helper"
+    );
+    assert!(
+        RELEASE_TRAIN_PREP_WORKFLOW
+            .contains("scripts/internal/release/emit_rust_toolchain_channel.py"),
+        "release train prep must use the shared Rust toolchain channel helper"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/prune_github_release_assets.sh"),
+        "nightly workflow must use the shared rolling-release asset pruning helper"
+    );
+}
+
+#[test]
+fn shared_release_helpers_keep_policy_visible_and_strict() {
+    assert!(
+        CHECKOUT_RADIANT_SCRIPT.contains("Missing RADIANT_SUBMODULE_DEPLOY_KEY"),
+        "Radiant checkout helper must fail clearly when the deploy key is missing"
+    );
+    assert!(
+        BUILD_RELEASE_ARTIFACT_SCRIPT.contains("--channel <nightly|rc|stable>"),
+        "artifact build helper must keep release channel explicit"
+    );
+    assert!(
+        BUILD_RELEASE_ARTIFACT_SCRIPT.contains("build_release_zip.sh"),
+        "artifact build helper must delegate to the canonical zip packager"
+    );
+    assert!(
+        ASSEMBLE_RELEASE_FILES_SCRIPT.contains("No checksums entry files found"),
+        "release assembly helper must fail when checksum entries are missing"
+    );
+    assert!(
+        SIGN_RELEASE_CHECKSUMS_SCRIPT.contains("Missing CHECKSUMS_SIGNING_KEY"),
+        "checksum signing helper must fail clearly when the signing key is missing"
+    );
+    assert!(
+        SIGN_RELEASE_CHECKSUMS_SCRIPT.contains("--verify-public-key"),
+        "checksum signing helper must preserve public-key verification support"
     );
 }
 

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -1,0 +1,229 @@
+//! Focused checks for shared release workflow helper scripts.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn toolchain_helper_emits_github_output_channel() {
+    let output = Command::new("python3")
+        .arg(repo_path(
+            "scripts/internal/release/emit_rust_toolchain_channel.py",
+        ))
+        .current_dir(repo_root())
+        .output()
+        .expect("run toolchain helper");
+
+    assert!(
+        output.status.success(),
+        "toolchain helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("toolchain output utf-8");
+    assert!(
+        stdout.trim().starts_with("channel="),
+        "toolchain helper must emit a GitHub output assignment"
+    );
+}
+
+#[test]
+fn assemble_release_files_copies_zips_and_combines_checksum_entries() {
+    let temp = tempfile::tempdir().expect("create helper fixture");
+    let artifacts = temp.path().join("artifacts");
+    let release = temp.path().join("release");
+    fs::create_dir_all(&artifacts).expect("create artifacts dir");
+    fs::write(
+        artifacts.join("wavecrate-nightly-windows-x86_64.zip"),
+        "zip",
+    )
+    .expect("write zip");
+    fs::write(
+        artifacts.join("checksums-entry-windows-x86_64.txt"),
+        "abc  wavecrate-nightly-windows-x86_64.zip\n",
+    )
+    .expect("write checksum entry");
+
+    run_success(
+        Command::new("bash")
+            .arg(repo_path(
+                "scripts/internal/release/assemble_release_files.sh",
+            ))
+            .arg("--artifact-dir")
+            .arg(&artifacts)
+            .arg("--out-dir")
+            .arg(&release)
+            .arg("--checksum-name")
+            .arg("checksums-nightly.txt"),
+    );
+
+    assert!(
+        release
+            .join("wavecrate-nightly-windows-x86_64.zip")
+            .is_file()
+    );
+    assert_eq!(
+        fs::read_to_string(release.join("checksums-nightly.txt")).expect("read checksums"),
+        "abc  wavecrate-nightly-windows-x86_64.zip\n"
+    );
+}
+
+#[test]
+fn checksum_signing_helper_writes_signature_and_verifies_expected_pubkey() {
+    let temp = tempfile::tempdir().expect("create signing fixture");
+    let key = temp.path().join("ed25519.pem");
+    let checksum = temp.path().join("checksums.txt");
+    let signature = temp.path().join("checksums.txt.sig");
+    fs::write(&checksum, "abc  wavecrate.zip\n").expect("write checksum");
+    let keygen = Command::new("openssl")
+        .arg("genpkey")
+        .arg("-algorithm")
+        .arg("Ed25519")
+        .arg("-out")
+        .arg(&key)
+        .output()
+        .expect("run openssl key generation");
+    if !keygen.status.success() {
+        let stderr = String::from_utf8_lossy(&keygen.stderr);
+        if stderr.contains("Algorithm Ed25519 not found") {
+            eprintln!(
+                "local openssl does not support Ed25519 key generation; skipping signing roundtrip"
+            );
+            return;
+        }
+        panic!(
+            "openssl key generation failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&keygen.stdout),
+            stderr
+        );
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let key_pem = fs::read_to_string(&key).expect("read generated key");
+
+    run_success(
+        Command::new("bash")
+            .arg(repo_path(
+                "scripts/internal/release/sign_release_checksums.sh",
+            ))
+            .arg("--checksum-file")
+            .arg(&checksum)
+            .arg("--signature-file")
+            .arg(&signature)
+            .arg("--verify-public-key")
+            .arg(expected_pubkey.trim())
+            .env("CHECKSUMS_SIGNING_KEY", key_pem),
+    );
+
+    assert!(signature.is_file(), "signature file should be written");
+    assert!(
+        !fs::read_to_string(signature)
+            .expect("read signature")
+            .trim()
+            .is_empty(),
+        "signature should not be empty"
+    );
+}
+
+#[test]
+fn build_release_artifact_helper_names_zip_and_checksum_entry() {
+    let temp = tempfile::tempdir().expect("create artifact fixture");
+    let dummy = repo_root().join("target/x86_64-pc-windows-msvc/release/wavecrate.exe");
+    fs::create_dir_all(dummy.parent().expect("dummy binary parent")).expect("create dummy parent");
+    fs::write(&dummy, "dry-run wavecrate exe\n").expect("write dummy binary");
+    let output = Command::new("bash")
+        .arg(repo_path(
+            "scripts/internal/release/build_release_artifact.sh",
+        ))
+        .arg("--target")
+        .arg("x86_64-pc-windows-msvc")
+        .arg("--platform")
+        .arg("windows")
+        .arg("--arch")
+        .arg("x86_64")
+        .arg("--channel")
+        .arg("nightly")
+        .arg("--version")
+        .arg("19.1.0-nightly.20260702+abcdef0")
+        .arg("--target-version")
+        .arg("19.1.0")
+        .arg("--build-number")
+        .arg("123")
+        .arg("--git-sha")
+        .arg("abcdef1")
+        .arg("--build-date")
+        .arg("2026-07-02")
+        .arg("--out-dir")
+        .arg(temp.path())
+        .env("WAVECRATE_SKIP_BUILD", "1")
+        .current_dir(repo_root())
+        .output()
+        .expect("run artifact helper");
+    let _ = fs::remove_file(dummy);
+    assert!(
+        output.status.success(),
+        "artifact helper failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        temp.path()
+            .join("wavecrate-nightly-windows-x86_64.zip")
+            .is_file()
+    );
+    assert!(
+        temp.path()
+            .join("checksums-entry-windows-x86_64.txt")
+            .is_file()
+    );
+}
+
+fn expected_public_key(key: &Path, temp: &TempDir) -> String {
+    let pub_der = temp.path().join("public.der");
+    run_success(
+        Command::new("openssl")
+            .arg("pkey")
+            .arg("-in")
+            .arg(key)
+            .arg("-pubout")
+            .arg("-outform")
+            .arg("DER")
+            .arg("-out")
+            .arg(&pub_der),
+    );
+    let output = Command::new("bash")
+        .arg("-lc")
+        .arg(format!(
+            "tail -c 32 '{}' | openssl base64 -A",
+            pub_der.display()
+        ))
+        .output()
+        .expect("derive expected pubkey");
+    assert!(
+        output.status.success(),
+        "derive expected pubkey failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("pubkey utf-8")
+}
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn repo_path(relative: &str) -> std::path::PathBuf {
+    repo_root().join(relative)
+}
+
+fn run_success(command: &mut Command) {
+    let output = command.output().expect("run command");
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Scope
- Extract shared release workflow operations for Radiant checkout, Rust toolchain channel emission, Windows ASIO setup, build artifact invocation, release file assembly, checksum signing, and stale nightly asset pruning.
- Update nightly, RC, stable, and release-train preparation workflows to call those helpers while keeping channel-specific release policy visible in YAML.
- Add focused helper/contract tests and maintainer docs for the new release helper seams.

## Definition of Done
- Nightly, RC, and stable workflows share common release setup/build/publish helpers instead of duplicating large inline blocks.
- Channel-specific differences remain explicit and tested.
- Checksum signing, artifact assembly, and GitHub release asset pruning can be maintained through shared scripts.
- Release docs identify the helper scripts maintainers should inspect while debugging release workflows.

## Validation commands
- `cargo fmt --check`
- `bash -n scripts/internal/release/checkout_radiant_submodule.sh scripts/internal/release/build_release_artifact.sh scripts/internal/release/assemble_release_files.sh scripts/internal/release/sign_release_checksums.sh scripts/internal/release/prune_github_release_assets.sh scripts/internal/release/build_release_zip.sh scripts/internal/release/generate_release_log.sh`
- `python3 -m py_compile scripts/internal/release/emit_rust_toolchain_channel.py scripts/internal/release/prepare_release_train.py scripts/internal/release/assemble_portal_changelog.py`
- `cargo test --test release_contract --test manual_release_matching --test release_workflow_helpers --test release_log_generator --test release_train_prepare`
- `git diff --check`

## Known limitations
- Local PowerShell parse validation was skipped because `pwsh` is not installed in this environment.
- PortalSurfer RC/stable upload/catalog/changelog helper extraction is intentionally deferred because OPT-982 is still blocking this part of the release path.
- The Ed25519 signing fixture tolerates local OpenSSL builds without Ed25519 key generation support; the signing script itself is syntax-checked and exercised where OpenSSL supports the algorithm.

## User review
User review is required before merge.