### PR TITLE
OPT-983 Validate promoted RC release before stable

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -204,7 +204,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
@@ -142,7 +142,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -88,6 +88,16 @@ jobs:
           echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
           echo "build_date=$build_date" >> "$GITHUB_OUTPUT"
           echo "rc_tag=$rc_tag" >> "$GITHUB_OUTPUT"
+      - name: Validate promoted RC GitHub release artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/internal/release/validate_promoted_rc_release.py \
+            --version "${{ steps.resolve.outputs.target_version }}" \
+            --rc-tag "${{ steps.resolve.outputs.rc_tag }}" \
+            --repo "${{ github.repository }}" \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
 
   test:
     name: Run stable validation tests
@@ -104,7 +114,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
@@ -144,7 +154,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
         run: scripts/internal/release/checkout_radiant_submodule.sh
-      - name: Read pinned Rust toolchain
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
         id: rust_toolchain
         shell: bash
         run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -103,6 +103,8 @@ under `scripts/internal/release/`:
 - `assemble_release_files.sh` copies built zips and assembles the channel
   checksum file.
 - `sign_release_checksums.sh` signs and optionally verifies checksum files.
+- `validate_promoted_rc_release.py` verifies that stable promotion is backed by
+  a complete RC GitHub prerelease before stable builds start.
 - `prune_github_release_assets.sh` removes stale assets from a rolling GitHub
   release before upload.
 
@@ -113,8 +115,12 @@ pre-releases tagged `vX.Y.Z-rc.N`.
 
 Stable runs require `version` and `branch` inputs. The branch must be
 `release/X.Y`, the package manifest must match `X.Y.Z`, and the latest
-`vX.Y.Z-rc.N` tag must point at the same commit being promoted. Stable releases
-are published as normal GitHub releases tagged `vX.Y.Z`.
+`vX.Y.Z-rc.N` tag must point at the same commit being promoted. Stable
+promotion also validates that the promoted RC exists as a GitHub prerelease with
+the expected platform zips from `release_contract.toml`, a checksum file,
+checksum signature, downloadable assets whose hashes match the checksum file,
+and a release-bound `Wavecrate X.Y.Z-rc.N` log body. Stable releases are
+published as normal GitHub releases tagged `vX.Y.Z`.
 
 The nightly workflow publishes an immutable nightly version tag named like
 `19.1.0-nightly.20260701+abc1234` for changelog history, updates the rolling GitHub

--- a/scripts/internal/release/validate_promoted_rc_release.py
+++ b/scripts/internal/release/validate_promoted_rc_release.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Validate that a stable promotion is backed by a complete RC release."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+RC_TAG_RE = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-rc\.(?P<number>[0-9]+)$")
+ED25519_SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+
+def main() -> int:
+    args = parse_args()
+    errors: list[str] = []
+
+    if not VERSION_RE.fullmatch(args.version):
+        errors.append("version must be MAJOR.MINOR.PATCH")
+    rc_match = RC_TAG_RE.fullmatch(args.rc_tag)
+    if not rc_match:
+        errors.append("rc-tag must be vMAJOR.MINOR.PATCH-rc.N")
+    elif rc_match.group("version") != args.version:
+        errors.append(f"rc-tag {args.rc_tag} does not belong to version {args.version}")
+
+    if errors:
+        print_errors(errors)
+        return 1
+
+    rc_number = rc_match.group("number") if rc_match else ""
+    rc_version = f"{args.version}-rc.{rc_number}"
+    contract = load_release_contract(args.contract)
+    expected = expected_rc_assets(contract, args.version, rc_number)
+
+    release = load_release(args)
+    errors.extend(validate_release_metadata(release, args.rc_tag, rc_version, expected.required_assets))
+    if errors:
+        print_errors(errors)
+        return 1
+
+    with local_asset_dir(args, expected.required_assets) as asset_dir:
+        errors.extend(validate_downloaded_assets(asset_dir, expected, args.checksum_public_key))
+
+    if errors:
+        print_errors(errors)
+        return 1
+
+    print(f"Promoted RC release {args.rc_tag} is complete.")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Stable version, e.g. 19.1.0")
+    parser.add_argument("--rc-tag", required=True, help="Promoted RC tag, e.g. v19.1.0-rc.2")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""), help="GitHub repo owner/name")
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=REPO_ROOT / "release_contract.toml",
+        help="Release contract TOML path",
+    )
+    parser.add_argument(
+        "--release-json",
+        type=Path,
+        help="Fixture JSON from `gh release view --json tagName,isPrerelease,body,assets`",
+    )
+    parser.add_argument("--asset-dir", type=Path, help="Fixture directory containing downloaded RC assets")
+    parser.add_argument(
+        "--checksum-public-key",
+        help="Optional base64 Ed25519 public key used to verify the checksum signature",
+    )
+    return parser.parse_args()
+
+
+def load_release_contract(path: Path) -> dict[str, Any]:
+    try:
+        import tomllib  # type: ignore[import-not-found]
+
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except ModuleNotFoundError:
+        return parse_minimal_release_contract(path.read_text(encoding="utf-8"))
+
+
+def parse_minimal_release_contract(text: str) -> dict[str, Any]:
+    app_name = require_match(r'^app_name\s*=\s*"([^"]+)"', text, "app_name")
+    targets_match = require_match(r"(?ms)^targets\s*=\s*\[(.*?)\]", text, "targets")
+    targets = re.findall(r'"([^"]+)"', targets_match)
+    templates_match = require_match(r"(?ms)^\[templates\]\s*(.*?)(?:^\[|\Z)", text, "templates")
+    templates = dict(re.findall(r'(?m)^([A-Za-z0-9_]+)\s*=\s*"([^"]+)"', templates_match))
+    return {"app_name": app_name, "targets": targets, "templates": templates}
+
+
+def require_match(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text)
+    if not match:
+        raise SystemExit(f"release contract is missing {label}")
+    return match.group(1)
+
+
+class ExpectedAssets:
+    def __init__(self, zips: list[str], checksum: str, signature: str) -> None:
+        self.zips = zips
+        self.checksum = checksum
+        self.signature = signature
+        self.required_assets = zips + [checksum, signature]
+
+
+def expected_rc_assets(contract: dict[str, Any], version: str, rc_number: str) -> ExpectedAssets:
+    app_name = contract["app_name"]
+    templates = contract["templates"]
+    zips = [
+        apply_template(templates["rc_asset"], app_name, version, rc_number, platform_for_target(target), arch_for_target(target))
+        for target in contract["targets"]
+    ]
+    checksum = apply_template(templates["rc_checksums"], app_name, version, rc_number, "", "")
+    signature = apply_template(templates["rc_checksums_sig"], app_name, version, rc_number, "", "")
+    return ExpectedAssets(sorted(zips), checksum, signature)
+
+
+def apply_template(
+    template: str,
+    app_name: str,
+    version: str,
+    rc_number: str,
+    platform: str,
+    arch: str,
+) -> str:
+    return (
+        template.replace("{APP_NAME}", app_name)
+        .replace("{version}", version)
+        .replace("{rc_number}", rc_number)
+        .replace("{platform}", platform)
+        .replace("{arch}", arch)
+    )
+
+
+def platform_for_target(target: str) -> str:
+    if "-pc-windows-" in target:
+        return "windows"
+    if target.endswith("-apple-darwin"):
+        return "macos"
+    if "-unknown-linux-" in target:
+        return "linux"
+    raise SystemExit(f"unsupported release target triple: {target}")
+
+
+def arch_for_target(target: str) -> str:
+    return target.split("-", 1)[0]
+
+
+def load_release(args: argparse.Namespace) -> dict[str, Any]:
+    if args.release_json:
+        return json.loads(args.release_json.read_text(encoding="utf-8"))
+    if not args.repo:
+        raise SystemExit("Missing --repo or GITHUB_REPOSITORY for live GitHub release validation")
+    output = run(
+        [
+            "gh",
+            "release",
+            "view",
+            args.rc_tag,
+            "--repo",
+            args.repo,
+            "--json",
+            "tagName,isPrerelease,body,assets",
+        ],
+        "view promoted RC GitHub release",
+    )
+    return json.loads(output)
+
+
+def validate_release_metadata(
+    release: dict[str, Any],
+    rc_tag: str,
+    rc_version: str,
+    required_assets: list[str],
+) -> list[str]:
+    errors: list[str] = []
+    tag_name = release.get("tagName")
+    if tag_name and tag_name != rc_tag:
+        errors.append(f"RC release tagName is {tag_name}, expected {rc_tag}")
+    if release.get("isPrerelease") is not True:
+        errors.append(f"RC release {rc_tag} must be marked as a prerelease")
+
+    body = str(release.get("body") or "").strip()
+    if not body:
+        errors.append(f"RC release {rc_tag} must have a non-empty release log body")
+    elif f"Wavecrate {rc_version}" not in body:
+        errors.append(f"RC release body must be release-bound to Wavecrate {rc_version}")
+
+    asset_names = release_asset_names(release)
+    missing = [name for name in required_assets if name not in asset_names]
+    if missing:
+        errors.append("RC release is missing required assets: " + ", ".join(missing))
+    return errors
+
+
+def release_asset_names(release: dict[str, Any]) -> set[str]:
+    assets = release.get("assets") or []
+    if isinstance(assets, dict):
+        assets = assets.get("nodes") or []
+    names = set()
+    for asset in assets:
+        if isinstance(asset, dict) and asset.get("name"):
+            names.add(str(asset["name"]))
+    return names
+
+
+class local_asset_dir:
+    def __init__(self, args: argparse.Namespace, required_assets: list[str]) -> None:
+        self.args = args
+        self.required_assets = required_assets
+        self.temp: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> Path:
+        if self.args.asset_dir:
+            return self.args.asset_dir
+        if not self.args.repo:
+            raise SystemExit("Missing --repo or GITHUB_REPOSITORY for live GitHub asset downloads")
+        self.temp = tempfile.TemporaryDirectory(prefix="wavecrate-promoted-rc-")
+        asset_dir = Path(self.temp.name)
+        patterns = []
+        for asset in self.required_assets:
+            patterns.extend(["--pattern", asset])
+        run(
+            [
+                "gh",
+                "release",
+                "download",
+                self.args.rc_tag,
+                "--repo",
+                self.args.repo,
+                "--dir",
+                str(asset_dir),
+                "--clobber",
+                *patterns,
+            ],
+            "download promoted RC release assets",
+        )
+        return asset_dir
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        if self.temp:
+            self.temp.cleanup()
+
+
+def validate_downloaded_assets(
+    asset_dir: Path,
+    expected: ExpectedAssets,
+    checksum_public_key: str | None,
+) -> list[str]:
+    errors: list[str] = []
+    for asset in expected.required_assets:
+        path = asset_dir / asset
+        if not path.is_file():
+            errors.append(f"Downloaded RC asset is missing: {asset}")
+        elif path.stat().st_size == 0:
+            errors.append(f"Downloaded RC asset is empty: {asset}")
+
+    checksum_path = asset_dir / expected.checksum
+    if checksum_path.is_file():
+        errors.extend(validate_checksum_file(checksum_path, asset_dir, expected.zips))
+
+    signature_path = asset_dir / expected.signature
+    if checksum_public_key and checksum_path.is_file() and signature_path.is_file():
+        errors.extend(verify_checksum_signature(checksum_path, signature_path, checksum_public_key))
+    return errors
+
+
+def validate_checksum_file(checksum_path: Path, asset_dir: Path, expected_zips: list[str]) -> list[str]:
+    errors: list[str] = []
+    entries: dict[str, str] = {}
+    for line_number, line in enumerate(checksum_path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) != 2 or not re.fullmatch(r"[0-9a-fA-F]{64}", parts[0]):
+            errors.append(f"{checksum_path.name}:{line_number} is not a SHA-256 checksum entry")
+            continue
+        entries[parts[1]] = parts[0].lower()
+
+    for zip_name in expected_zips:
+        expected_hash = entries.get(zip_name)
+        if not expected_hash:
+            errors.append(f"Checksum file is missing entry for {zip_name}")
+            continue
+        zip_path = asset_dir / zip_name
+        if not zip_path.is_file():
+            continue
+        actual_hash = sha256(zip_path)
+        if actual_hash != expected_hash:
+            errors.append(
+                f"Checksum mismatch for {zip_name}: checksum file has {expected_hash}, asset hashes to {actual_hash}"
+            )
+    return errors
+
+
+def verify_checksum_signature(checksum_path: Path, signature_path: Path, checksum_public_key: str) -> list[str]:
+    if not shutil.which("openssl"):
+        return ["openssl is required to verify the RC checksum signature"]
+    try:
+        public_key = base64.b64decode(checksum_public_key, validate=True)
+    except ValueError as error:
+        return [f"invalid base64 checksum public key: {error}"]
+    if len(public_key) != 32:
+        return ["checksum public key must decode to a 32-byte Ed25519 public key"]
+
+    with tempfile.TemporaryDirectory(prefix="wavecrate-rc-signature-") as temp:
+        pub_der = Path(temp) / "checksum-public-key.der"
+        sig_bin = Path(temp) / "checksums.sig"
+        pub_der.write_bytes(ED25519_SPKI_PREFIX + public_key)
+        try:
+            sig_bin.write_bytes(base64.b64decode(signature_path.read_text(encoding="utf-8"), validate=True))
+        except ValueError as error:
+            return [f"checksum signature is not valid base64: {error}"]
+        completed = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(pub_der),
+                "-keyform",
+                "DER",
+                "-rawin",
+                "-in",
+                str(checksum_path),
+                "-sigfile",
+                str(sig_bin),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if completed.returncode != 0:
+        return ["RC checksum signature verification failed: " + completed.stderr.strip()]
+    return []
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(command: list[str], label: str) -> str:
+    completed = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(f"Failed to {label}:\n{completed.stderr.strip()}")
+    return completed.stdout
+
+
+def print_errors(errors: list[str]) -> None:
+    print("Promoted RC release validation failed:", file=sys.stderr)
+    for error in errors:
+        print(f" - {error}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -23,6 +23,8 @@ const RELEASE_LOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/generate_release_log.sh");
 const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
+const VALIDATE_PROMOTED_RC_SCRIPT: &str =
+    include_str!("../scripts/internal/release/validate_promoted_rc_release.py");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 
 #[test]
@@ -248,6 +250,36 @@ fn stable_workflow_requires_matching_rc_before_publish() {
 }
 
 #[test]
+fn stable_workflow_validates_promoted_rc_release_before_publish() {
+    assert!(
+        STABLE_WORKFLOW.contains("scripts/internal/release/validate_promoted_rc_release.py \\"),
+        "stable workflow must validate the promoted RC GitHub release"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("--rc-tag \"${{ steps.resolve.outputs.rc_tag }}\""),
+        "stable workflow must validate the exact latest RC tag selected by resolve"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("--repo \"${{ github.repository }}\""),
+        "stable workflow must validate the RC release in the current GitHub repository"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("--checksum-public-key"),
+        "stable workflow must verify the promoted RC checksum signature"
+    );
+    let validate_position = STABLE_WORKFLOW
+        .find("Validate promoted RC GitHub release artifacts")
+        .expect("stable workflow validation step");
+    let test_job_position = STABLE_WORKFLOW
+        .find("name: Run stable validation tests")
+        .expect("stable workflow test job");
+    assert!(
+        validate_position < test_job_position,
+        "stable workflow must validate the promoted RC before stable test/build jobs start"
+    );
+}
+
+#[test]
 fn rc_and_stable_workflows_use_structured_release_log_generator() {
     for (name, workflow) in [
         ("RC workflow", RC_WORKFLOW),
@@ -429,6 +461,22 @@ fn shared_release_helpers_keep_policy_visible_and_strict() {
     assert!(
         SIGN_RELEASE_CHECKSUMS_SCRIPT.contains("--verify-public-key"),
         "checksum signing helper must preserve public-key verification support"
+    );
+    assert!(
+        VALIDATE_PROMOTED_RC_SCRIPT.contains("gh\","),
+        "promoted RC validator must use GitHub CLI for live release validation"
+    );
+    assert!(
+        VALIDATE_PROMOTED_RC_SCRIPT.contains("release_contract.toml"),
+        "promoted RC validator must derive expected assets from the release contract"
+    );
+    assert!(
+        VALIDATE_PROMOTED_RC_SCRIPT.contains("RC release is missing required assets"),
+        "promoted RC validator must fail clearly when release assets are incomplete"
+    );
+    assert!(
+        VALIDATE_PROMOTED_RC_SCRIPT.contains("Checksum mismatch"),
+        "promoted RC validator must compare checksum entries to downloaded zip hashes"
     );
 }
 

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use serde_json::json;
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
 #[test]
@@ -180,6 +182,177 @@ fn build_release_artifact_helper_names_zip_and_checksum_entry() {
     );
 }
 
+#[test]
+fn promoted_rc_validator_accepts_complete_release_fixture() {
+    let temp = tempfile::tempdir().expect("create promoted RC fixture");
+    let (release_json, asset_dir) =
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/validate_promoted_rc_release.py",
+            ))
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--rc-tag")
+            .arg("v19.1.0-rc.2")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir),
+    );
+}
+
+#[test]
+fn promoted_rc_validator_verifies_checksum_signature_when_public_key_is_supplied() {
+    let temp = tempfile::tempdir().expect("create promoted RC fixture");
+    let (release_json, asset_dir) =
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+    let key = temp.path().join("ed25519.pem");
+    let keygen = Command::new("openssl")
+        .arg("genpkey")
+        .arg("-algorithm")
+        .arg("Ed25519")
+        .arg("-out")
+        .arg(&key)
+        .output()
+        .expect("run openssl key generation");
+    if !keygen.status.success() {
+        let stderr = String::from_utf8_lossy(&keygen.stderr);
+        if stderr.contains("Algorithm Ed25519 not found") {
+            eprintln!(
+                "local openssl does not support Ed25519 key generation; skipping validator signature roundtrip"
+            );
+            return;
+        }
+        panic!(
+            "openssl key generation failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&keygen.stdout),
+            stderr
+        );
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let key_pem = fs::read_to_string(&key).expect("read generated key");
+
+    run_success(
+        Command::new("bash")
+            .arg(repo_path(
+                "scripts/internal/release/sign_release_checksums.sh",
+            ))
+            .arg("--checksum-file")
+            .arg(asset_dir.join("checksums-19.1.0-rc.2.txt"))
+            .arg("--signature-file")
+            .arg(asset_dir.join("checksums-19.1.0-rc.2.txt.sig"))
+            .env("CHECKSUMS_SIGNING_KEY", key_pem),
+    );
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/validate_promoted_rc_release.py",
+            ))
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--rc-tag")
+            .arg("v19.1.0-rc.2")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir)
+            .arg("--checksum-public-key")
+            .arg(expected_pubkey.trim()),
+    );
+}
+
+#[test]
+fn promoted_rc_validator_rejects_missing_release_assets() {
+    let temp = tempfile::tempdir().expect("create promoted RC fixture");
+    let missing = "wavecrate-19.1.0-rc.2-macos-aarch64.zip";
+    let (release_json, asset_dir) = write_promoted_rc_fixture(
+        &temp,
+        Some(missing),
+        false,
+        "# Wavecrate 19.1.0-rc.2\n",
+        true,
+    );
+
+    let output = run_failure(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/validate_promoted_rc_release.py",
+            ))
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--rc-tag")
+            .arg("v19.1.0-rc.2")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("RC release is missing required assets"),
+        "missing asset failure should name the release asset problem\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn promoted_rc_validator_rejects_undownloadable_release_assets() {
+    let temp = tempfile::tempdir().expect("create promoted RC fixture");
+    let missing = "wavecrate-19.1.0-rc.2-macos-aarch64.zip";
+    let (release_json, asset_dir) =
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+    fs::remove_file(asset_dir.join(missing)).expect("remove fixture asset");
+
+    let output = run_failure(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/validate_promoted_rc_release.py",
+            ))
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--rc-tag")
+            .arg("v19.1.0-rc.2")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Downloaded RC asset is missing"),
+        "missing asset failure should prove the asset was not downloadable\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn promoted_rc_validator_rejects_checksum_mismatches() {
+    let temp = tempfile::tempdir().expect("create promoted RC fixture");
+    let (release_json, asset_dir) =
+        write_promoted_rc_fixture(&temp, None, true, "# Wavecrate 19.1.0-rc.2\n", true);
+
+    let output = run_failure(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/validate_promoted_rc_release.py",
+            ))
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--rc-tag")
+            .arg("v19.1.0-rc.2")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Checksum mismatch"),
+        "checksum failure should report the mismatched asset\nstderr:\n{stderr}"
+    );
+}
+
 fn expected_public_key(key: &Path, temp: &TempDir) -> String {
     let pub_der = temp.path().join("public.der");
     run_success(
@@ -210,6 +383,59 @@ fn expected_public_key(key: &Path, temp: &TempDir) -> String {
     String::from_utf8(output.stdout).expect("pubkey utf-8")
 }
 
+fn write_promoted_rc_fixture(
+    temp: &TempDir,
+    missing_asset: Option<&str>,
+    corrupt_checksum: bool,
+    body: &str,
+    is_prerelease: bool,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let asset_dir = temp.path().join("assets");
+    fs::create_dir_all(&asset_dir).expect("create asset dir");
+    let zip_assets = [
+        "wavecrate-19.1.0-rc.2-macos-aarch64.zip",
+        "wavecrate-19.1.0-rc.2-macos-x86_64.zip",
+        "wavecrate-19.1.0-rc.2-windows-x86_64.zip",
+    ];
+    let checksum_asset = "checksums-19.1.0-rc.2.txt";
+    let signature_asset = "checksums-19.1.0-rc.2.txt.sig";
+
+    let mut checksum_lines = Vec::new();
+    for zip in zip_assets {
+        let bytes = format!("fixture bytes for {zip}\n");
+        if missing_asset != Some(zip) {
+            fs::write(asset_dir.join(zip), bytes.as_bytes()).expect("write fixture zip");
+        }
+        let mut hash = format!("{:x}", Sha256::digest(bytes.as_bytes()));
+        if corrupt_checksum && zip.ends_with("windows-x86_64.zip") {
+            hash = "0".repeat(64);
+        }
+        checksum_lines.push(format!("{hash}  {zip}\n"));
+    }
+    fs::write(asset_dir.join(checksum_asset), checksum_lines.concat()).expect("write checksum");
+    fs::write(asset_dir.join(signature_asset), "c2lnbmF0dXJl\n").expect("write signature");
+
+    let asset_names = [zip_assets.as_slice(), &[checksum_asset, signature_asset]]
+        .concat()
+        .into_iter()
+        .filter(|asset| missing_asset != Some(*asset))
+        .map(|name| json!({ "name": name }))
+        .collect::<Vec<_>>();
+    let release = json!({
+        "tagName": "v19.1.0-rc.2",
+        "isPrerelease": is_prerelease,
+        "body": body,
+        "assets": asset_names,
+    });
+    let release_json = temp.path().join("release.json");
+    fs::write(
+        &release_json,
+        serde_json::to_string_pretty(&release).expect("serialize release json"),
+    )
+    .expect("write release json");
+    (release_json, asset_dir)
+}
+
 fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
 }
@@ -226,4 +452,15 @@ fn run_success(command: &mut Command) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn run_failure(command: &mut Command) -> std::process::Output {
+    let output = command.output().expect("run command");
+    assert!(
+        !output.status.success(),
+        "command should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
 }


### PR DESCRIPTION
## Scope
- Add `scripts/internal/release/validate_promoted_rc_release.py` to validate that a stable promotion is backed by a complete GitHub RC prerelease, not only a matching tag.
- Wire the stable workflow resolve job to validate the selected latest RC before stable test/build/publish jobs run.
- Derive expected RC zip/checksum/signature names from `release_contract.toml`, download the required assets, compare zip SHA-256 hashes against the checksum file, verify the checksum signature with the public key, and require a release-bound `Wavecrate X.Y.Z-rc.N` body.
- Update release docs and add workflow/script fixture tests for complete, missing, undownloadable, checksum-mismatched, and signature-verified RC releases.
- Keep the existing same-commit RC tag guard intact.

## Definition of Done
- Stable promotion fails when the latest RC tag exists but the GitHub RC release is missing or incomplete.
- Stable promotion fails when expected RC zips, checksum file, signature, release body, downloads, checksum hashes, or checksum signature validation are invalid.
- Stable promotion still requires the latest RC tag to point at the stable target commit.
- Workflow contract and helper tests cover the promoted-RC validation path.
- Release docs state that stable promotion requires a complete RC release, not only a tag.

## Validation commands
- `cargo fmt --check`
- `python3 -m py_compile scripts/internal/release/validate_promoted_rc_release.py`
- `bash -n scripts/internal/release/checkout_radiant_submodule.sh scripts/internal/release/build_release_artifact.sh scripts/internal/release/assemble_release_files.sh scripts/internal/release/sign_release_checksums.sh scripts/internal/release/prune_github_release_assets.sh scripts/internal/release/build_release_zip.sh scripts/internal/release/generate_release_log.sh`
- `cargo test --test release_contract --test release_workflow_helpers`
- `bash scripts/check.sh workflow-toolchain`
- `git diff --check`

## Known limitations
- `bash scripts/agent.sh request` now passes the workflow toolchain-pinning guard, but still fails the existing Radiant source-quality guardrails unrelated to this release-workflow change: `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, and `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`.
- PortalSurfer catalog validation is not included here because the issue scopes that behind the PortalSurfer integration work.

## User review
User review is required before merge.