### PR TITLE
OPT-982 Publish RC and stable releases to PortalSurfer

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -38,6 +38,8 @@ jobs:
       release_tag: ${{ steps.resolve.outputs.release_tag }}
       build_number: ${{ steps.resolve.outputs.build_number }}
       build_date: ${{ steps.resolve.outputs.build_date }}
+      portal_build_id: ${{ steps.resolve.outputs.portal_build_id }}
+      released_at: ${{ steps.resolve.outputs.released_at }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,12 +82,16 @@ jobs:
           fi
           build_number="$(git rev-list --count "$target_sha")"
           build_date="$(date -u '+%Y-%m-%d')"
+          portal_build_id="wavecrate-${release_version}"
+          released_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
           echo "target_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
           echo "build_date=$build_date" >> "$GITHUB_OUTPUT"
+          echo "portal_build_id=$portal_build_id" >> "$GITHUB_OUTPUT"
+          echo "released_at=$released_at" >> "$GITHUB_OUTPUT"
 
   test:
     name: Run RC validation tests
@@ -248,3 +254,18 @@ jobs:
           prerelease: true
           make_latest: false
           files: dist/release/*
+      - name: Publish PortalSurfer RC release
+        shell: bash
+        env:
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          scripts/internal/release/publish_portalsurfer_release.sh \
+            --channel rc \
+            --build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --release-version "${{ needs.resolve.outputs.release_version }}" \
+            --released-at "${{ needs.resolve.outputs.released_at }}" \
+            --artifact-dir dist/release \
+            --release-log dist/release/release-log.md \
+            --full-changelog-out dist/release/changelog.md

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -34,6 +34,8 @@ jobs:
       build_number: ${{ steps.resolve.outputs.build_number }}
       build_date: ${{ steps.resolve.outputs.build_date }}
       rc_tag: ${{ steps.resolve.outputs.rc_tag }}
+      portal_build_id: ${{ steps.resolve.outputs.portal_build_id }}
+      released_at: ${{ steps.resolve.outputs.released_at }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,12 +84,16 @@ jobs:
           fi
           build_number="$(git rev-list --count "$target_sha")"
           build_date="$(date -u '+%Y-%m-%d')"
+          portal_build_id="wavecrate-${VERSION}"
+          released_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
           echo "target_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
           echo "build_date=$build_date" >> "$GITHUB_OUTPUT"
           echo "rc_tag=$rc_tag" >> "$GITHUB_OUTPUT"
+          echo "portal_build_id=$portal_build_id" >> "$GITHUB_OUTPUT"
+          echo "released_at=$released_at" >> "$GITHUB_OUTPUT"
       - name: Validate promoted RC GitHub release artifacts
         shell: bash
         env:
@@ -259,3 +265,18 @@ jobs:
           prerelease: false
           make_latest: true
           files: dist/release/*
+      - name: Publish PortalSurfer stable release
+        shell: bash
+        env:
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          scripts/internal/release/publish_portalsurfer_release.sh \
+            --channel stable \
+            --build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --release-version "${{ needs.resolve.outputs.target_version }}" \
+            --released-at "${{ needs.resolve.outputs.released_at }}" \
+            --artifact-dir dist/release \
+            --release-log dist/release/release-log.md \
+            --full-changelog-out dist/release/changelog.md

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -105,13 +105,17 @@ under `scripts/internal/release/`:
 - `sign_release_checksums.sh` signs and optionally verifies checksum files.
 - `validate_promoted_rc_release.py` verifies that stable promotion is backed by
   a complete RC GitHub prerelease before stable builds start.
+- `publish_portalsurfer_release.sh` uploads release files and the generated log
+  to PortalSurfer, verifies the public catalog and per-release changelog, then
+  updates and verifies the full Wavecrate changelog.
 - `prune_github_release_assets.sh` removes stale assets from a rolling GitHub
   release before upload.
 
 RC runs require `version`, `rc_number`, and `branch` inputs. The branch must be
 `release/X.Y` for the requested `X.Y.Z` version, and the package manifest must
 already carry that target version. RC releases are published as GitHub
-pre-releases tagged `vX.Y.Z-rc.N`.
+pre-releases tagged `vX.Y.Z-rc.N` and as PortalSurfer catalog entries with build
+ids like `wavecrate-X.Y.Z-rc.N`.
 
 Stable runs require `version` and `branch` inputs. The branch must be
 `release/X.Y`, the package manifest must match `X.Y.Z`, and the latest
@@ -120,7 +124,11 @@ promotion also validates that the promoted RC exists as a GitHub prerelease with
 the expected platform zips from `release_contract.toml`, a checksum file,
 checksum signature, downloadable assets whose hashes match the checksum file,
 and a release-bound `Wavecrate X.Y.Z-rc.N` log body. Stable releases are
-published as normal GitHub releases tagged `vX.Y.Z`.
+published as normal GitHub releases tagged `vX.Y.Z` and as PortalSurfer catalog
+entries with build ids like `wavecrate-X.Y.Z`. RC and stable PortalSurfer
+publication uploads the generated release zips, checksum file, checksum
+signature, and release log, then verifies the catalog entry, per-release
+changelog, and full Wavecrate changelog round trips.
 
 The nightly workflow publishes an immutable nightly version tag named like
 `19.1.0-nightly.20260701+abc1234` for changelog history, updates the rolling GitHub

--- a/scripts/internal/release/publish_portalsurfer_release.sh
+++ b/scripts/internal/release/publish_portalsurfer_release.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR="dist/release"
+RELEASE_LOG="dist/release/release-log.md"
+FULL_CHANGELOG_OUT="dist/release/changelog.md"
+CHANNEL=""
+BUILD_ID=""
+BUILD_NUMBER=""
+RELEASE_VERSION=""
+RELEASED_AT=""
+
+usage() {
+  cat <<'USAGE'
+Usage: publish_portalsurfer_release.sh --channel <nightly|rc|stable> --build-id <id> --build-number <n> --release-version <version> --released-at <iso-time> [--artifact-dir <path>] [--release-log <path>] [--full-changelog-out <path>]
+
+Requires PORTALSURFER_RELEASE_UPLOAD_TOKEN. Uses PORTALSURFER_RELEASE_UPLOAD_URL
+when set, otherwise https://portalsurfer.org/wavecrate/api/v1/release-uploads.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --build-id)
+      BUILD_ID="${2:-}"
+      shift 2
+      ;;
+    --build-number)
+      BUILD_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --release-version)
+      RELEASE_VERSION="${2:-}"
+      shift 2
+      ;;
+    --released-at)
+      RELEASED_AT="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --release-log)
+      RELEASE_LOG="${2:-}"
+      shift 2
+      ;;
+    --full-changelog-out)
+      FULL_CHANGELOG_OUT="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CHANNEL" || -z "$BUILD_ID" || -z "$BUILD_NUMBER" || -z "$RELEASE_VERSION" || -z "$RELEASED_AT" ]]; then
+  usage >&2
+  exit 1
+fi
+case "$CHANNEL" in
+  nightly|rc|stable) ;;
+  *)
+    echo "channel must be nightly, rc, or stable." >&2
+    exit 1
+    ;;
+esac
+if [[ -z "${PORTALSURFER_RELEASE_UPLOAD_TOKEN:-}" ]]; then
+  echo "Missing required secret: PORTALSURFER_RELEASE_UPLOAD_TOKEN" >&2
+  exit 1
+fi
+if [[ ! "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "build-number must be numeric." >&2
+  exit 1
+fi
+if [[ ! -s "$RELEASE_LOG" ]]; then
+  echo "Release log is missing or empty: $RELEASE_LOG" >&2
+  exit 1
+fi
+
+upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+upload_base="${upload_base%/}"
+if [[ "$upload_base" != */release-uploads ]]; then
+  echo "PORTALSURFER_RELEASE_UPLOAD_URL must end with /release-uploads." >&2
+  exit 1
+fi
+
+api_base="${upload_base%/release-uploads}"
+catalog_url="$api_base/releases"
+full_changelog_url="$api_base/changelog"
+response_dir="$(mktemp -d)"
+trap 'rm -rf "$response_dir"' EXIT
+
+shopt -s nullglob
+files=("${ARTIFACT_DIR}"/*.zip "${ARTIFACT_DIR}"/checksums-*.txt "${ARTIFACT_DIR}"/checksums-*.txt.sig)
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No release artifacts found in $ARTIFACT_DIR." >&2
+  exit 1
+fi
+
+uploaded_names=()
+for file in "${files[@]}"; do
+  file_name="$(basename "$file")"
+  if [[ ! -s "$file" ]]; then
+    echo "Release file is empty: $file" >&2
+    exit 1
+  fi
+  content_type="application/octet-stream"
+  if [[ "$file_name" == *.zip ]]; then
+    content_type="application/zip"
+  fi
+  sha256="$(sha256sum "$file" | awk '{ print $1 }')"
+  encoded_name="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$file_name")"
+  response_file="$response_dir/$file_name.json"
+  curl --fail-with-body --retry 3 --retry-delay 2 \
+    --request PUT \
+    --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
+    --header "Content-Type: $content_type" \
+    --header "X-Wavecrate-Build-Number: ${BUILD_NUMBER}" \
+    --header "X-Wavecrate-Release-Channel: $CHANNEL" \
+    --header "X-Wavecrate-Release-Version: $RELEASE_VERSION" \
+    --header "X-Wavecrate-Released-At: $RELEASED_AT" \
+    --header "X-Wavecrate-Sha256: $sha256" \
+    --data-binary "@$file" \
+    "$upload_base/$BUILD_ID/files/$encoded_name" > "$response_file"
+  python3 - "$response_file" "$BUILD_ID" "$BUILD_NUMBER" "$file_name" "$sha256" <<'PY'
+import json
+import sys
+
+response_path, expected_build, expected_build_number, expected_name, expected_sha = sys.argv[1:]
+response = json.loads(open(response_path, encoding="utf-8").read())
+release = response.get("release") or {}
+file = response.get("file") or {}
+if release.get("build_id") != expected_build:
+    raise SystemExit(f"Uploaded release id mismatch: {release.get('build_id')} != {expected_build}")
+if release.get("build_number") != int(expected_build_number):
+    raise SystemExit(f"Uploaded release build number mismatch: {release.get('build_number')} != {expected_build_number}")
+if file.get("name") != expected_name:
+    raise SystemExit(f"Uploaded file name mismatch: {file.get('name')} != {expected_name}")
+if file.get("sha256") != expected_sha:
+    raise SystemExit(f"Uploaded file sha mismatch: {file.get('sha256')} != {expected_sha}")
+if not isinstance(file.get("size_bytes"), int) or file["size_bytes"] <= 0:
+    raise SystemExit("Uploaded file size was not recorded")
+PY
+  uploaded_names+=("$file_name")
+done
+
+changelog_response_file="$response_dir/changelog-upload.json"
+curl --fail-with-body --retry 3 --retry-delay 2 \
+  --request PUT \
+  --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
+  --header "Content-Type: text/markdown; charset=utf-8" \
+  --header "X-Wavecrate-Build-Number: ${BUILD_NUMBER}" \
+  --header "X-Wavecrate-Release-Channel: $CHANNEL" \
+  --header "X-Wavecrate-Release-Version: $RELEASE_VERSION" \
+  --header "X-Wavecrate-Released-At: $RELEASED_AT" \
+  --data-binary "@$RELEASE_LOG" \
+  "$upload_base/$BUILD_ID/changelog" > "$changelog_response_file"
+python3 - "$changelog_response_file" "$BUILD_ID" "$BUILD_NUMBER" <<'PY'
+import json
+import sys
+
+response_path, expected_build, expected_build_number = sys.argv[1:]
+response = json.loads(open(response_path, encoding="utf-8").read())
+release = response.get("release") or {}
+changelog = response.get("changelog") or {}
+if release.get("build_id") != expected_build:
+    raise SystemExit(f"Uploaded changelog release id mismatch: {release.get('build_id')} != {expected_build}")
+if release.get("build_number") != int(expected_build_number):
+    raise SystemExit(f"Uploaded changelog build number mismatch: {release.get('build_number')} != {expected_build_number}")
+if changelog.get("format") != "markdown":
+    raise SystemExit("Uploaded changelog was not recorded as markdown")
+if not changelog.get("url"):
+    raise SystemExit("Uploaded changelog did not expose a public URL")
+PY
+
+catalog_file="$response_dir/releases.json"
+curl --fail-with-body --retry 3 --retry-delay 2 "$catalog_url" > "$catalog_file"
+python3 - "$catalog_file" "$BUILD_ID" "$BUILD_NUMBER" "$RELEASE_VERSION" "$RELEASED_AT" "${uploaded_names[@]}" <<'PY'
+import json
+import sys
+
+catalog_path = sys.argv[1]
+expected_build = sys.argv[2]
+expected_build_number = int(sys.argv[3])
+expected_version = sys.argv[4]
+expected_released_at = sys.argv[5]
+expected_files = set(sys.argv[6:])
+catalog = json.loads(open(catalog_path, encoding="utf-8").read())
+releases = catalog.get("releases") or []
+release = next((item for item in releases if item.get("build_id") == expected_build), None)
+if release is None:
+    raise SystemExit(f"Release catalog does not list {expected_build}")
+if release.get("build_number") != expected_build_number:
+    raise SystemExit(f"Release catalog build number mismatch: {release.get('build_number')} != {expected_build_number}")
+if release.get("version") != expected_version:
+    raise SystemExit(f"Release catalog version mismatch: {release.get('version')} != {expected_version}")
+if release.get("released_at") != expected_released_at:
+    raise SystemExit(f"Release catalog timestamp mismatch: {release.get('released_at')} != {expected_released_at}")
+catalog_files = {item.get("name") for item in release.get("files") or []}
+missing = sorted(expected_files - catalog_files)
+if missing:
+    raise SystemExit(f"Release catalog is missing files: {', '.join(missing)}")
+changelog = release.get("changelog") or {}
+if changelog.get("format") != "markdown" or not changelog.get("url"):
+    raise SystemExit("Release catalog is missing the markdown changelog link")
+print(f"Uploaded {len(expected_files)} Wavecrate release file(s) to {expected_build}")
+PY
+
+changelog_catalog_file="$response_dir/changelog-catalog.json"
+curl --fail-with-body --retry 3 --retry-delay 2 \
+  "$catalog_url/$BUILD_ID/changelog" > "$changelog_catalog_file"
+python3 - "$changelog_catalog_file" "$BUILD_ID" "$RELEASE_LOG" <<'PY'
+import json
+import sys
+
+catalog_path, expected_build, changelog_path = sys.argv[1:]
+response = json.loads(open(catalog_path, encoding="utf-8").read())
+if response.get("build_id") != expected_build:
+    raise SystemExit(f"Fetched changelog id mismatch: {response.get('build_id')} != {expected_build}")
+body = (response.get("changelog") or {}).get("body", "").strip()
+expected_body = open(changelog_path, encoding="utf-8").read().strip()
+if body != expected_body:
+    raise SystemExit("Fetched changelog body does not match generated release log")
+print(f"Uploaded Wavecrate release log to {expected_build}")
+PY
+
+scripts/internal/release/assemble_portal_changelog.py \
+  --catalog-url "$catalog_url" \
+  --current-build-id "$BUILD_ID" \
+  --current-log "$RELEASE_LOG" \
+  --existing-changelog-url "$full_changelog_url" \
+  --generated-at "$RELEASED_AT" \
+  --output "$FULL_CHANGELOG_OUT"
+
+full_changelog_response_file="$response_dir/full-changelog-upload.json"
+curl --fail-with-body --retry 3 --retry-delay 2 \
+  --request PUT \
+  --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
+  --header "Content-Type: text/markdown; charset=utf-8" \
+  --header "X-Wavecrate-Changelog-Title: Wavecrate changelog" \
+  --data-binary "@$FULL_CHANGELOG_OUT" \
+  "$upload_base/changelog" > "$full_changelog_response_file"
+python3 - "$full_changelog_response_file" <<'PY'
+import json
+import sys
+
+response = json.loads(open(sys.argv[1], encoding="utf-8").read())
+changelog = response.get("changelog") or {}
+if changelog.get("format") != "markdown":
+    raise SystemExit("Uploaded full changelog was not recorded as markdown")
+if not changelog.get("url"):
+    raise SystemExit("Uploaded full changelog did not expose a public URL")
+PY
+
+full_changelog_catalog_file="$response_dir/full-changelog-catalog.json"
+curl --fail-with-body --retry 3 --retry-delay 2 \
+  "$full_changelog_url" > "$full_changelog_catalog_file"
+python3 - "$full_changelog_catalog_file" "$FULL_CHANGELOG_OUT" <<'PY'
+import json
+import sys
+
+catalog_path, changelog_path = sys.argv[1:]
+response = json.loads(open(catalog_path, encoding="utf-8").read())
+body = (response.get("changelog") or {}).get("body", "").strip()
+expected_body = open(changelog_path, encoding="utf-8").read().strip()
+if body != expected_body:
+    raise SystemExit("Fetched full changelog body does not match generated changelog")
+print("Uploaded Wavecrate full changelog")
+PY

--- a/src/updater/public_catalog.rs
+++ b/src/updater/public_catalog.rs
@@ -530,8 +530,35 @@ mod tests {
         .expect("nightly");
 
         assert_eq!(stable.version, "19.1.0");
+        assert_eq!(stable.build_id, "wavecrate-19.1.0");
         assert_eq!(rc.version, "19.1.0");
+        assert_eq!(rc.build_id, "wavecrate-19.1.0");
         assert_eq!(nightly.version, "19.1.0-nightly.20260701+abcdef0");
+    }
+
+    #[test]
+    fn public_catalog_exposes_rc_when_no_newer_stable_supersedes_it() {
+        let catalog = catalog(&[release_with_version(
+            251,
+            "wavecrate-19.1.0-rc.1",
+            "19.1.0-rc.1",
+            "wavecrate-19.1.0-rc.1-macos-aarch64.zip",
+            "2026-07-02T20:00:00.000Z",
+        )]);
+
+        let rc = latest_available_public_release(
+            &catalog,
+            1,
+            "unknown",
+            "macos",
+            "aarch64",
+            UpdateChannel::Rc,
+        )
+        .expect("release contract")
+        .expect("rc");
+
+        assert_eq!(rc.build_id, "wavecrate-19.1.0-rc.1");
+        assert_eq!(rc.version, "19.1.0-rc.1");
     }
 
     fn catalog(releases: &[PublicReleaseCatalogRelease]) -> PublicReleaseCatalog {

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -21,6 +21,8 @@ const CHECKOUT_RADIANT_SCRIPT: &str =
 const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
 const RELEASE_LOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/generate_release_log.sh");
+const PUBLISH_PORTALSURFER_SCRIPT: &str =
+    include_str!("../scripts/internal/release/publish_portalsurfer_release.sh");
 const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
 const VALIDATE_PROMOTED_RC_SCRIPT: &str =
@@ -313,6 +315,47 @@ fn rc_and_stable_workflows_use_structured_release_log_generator() {
 }
 
 #[test]
+fn rc_and_stable_workflows_publish_to_portalsurfer_catalog() {
+    for (name, workflow, channel) in [
+        ("RC workflow", RC_WORKFLOW, "rc"),
+        ("stable workflow", STABLE_WORKFLOW, "stable"),
+    ] {
+        assert!(
+            workflow.contains("scripts/internal/release/publish_portalsurfer_release.sh \\"),
+            "{name} must publish release artifacts through the shared PortalSurfer helper"
+        );
+        assert!(
+            workflow.contains(&format!("--channel {channel} \\")),
+            "{name} must pass the explicit PortalSurfer channel"
+        );
+        assert!(
+            workflow.contains("PORTALSURFER_RELEASE_UPLOAD_TOKEN"),
+            "{name} must use the PortalSurfer upload token"
+        );
+        assert!(
+            workflow.contains("--artifact-dir dist/release"),
+            "{name} must publish the same assembled release files used for GitHub"
+        );
+        assert!(
+            workflow.contains("--release-log dist/release/release-log.md"),
+            "{name} must upload the generated release-bound markdown log"
+        );
+        assert!(
+            workflow.contains("--full-changelog-out dist/release/changelog.md"),
+            "{name} must update the full PortalSurfer changelog"
+        );
+    }
+    assert!(
+        RC_WORKFLOW.contains("portal_build_id=\"wavecrate-${release_version}\""),
+        "RC PortalSurfer build ids must include the RC version"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("portal_build_id=\"wavecrate-${VERSION}\""),
+        "stable PortalSurfer build ids must include the stable version"
+    );
+}
+
+#[test]
 fn structured_release_log_generator_declares_required_sections() {
     for section in [
         "## Release Metadata",
@@ -461,6 +504,28 @@ fn shared_release_helpers_keep_policy_visible_and_strict() {
     assert!(
         SIGN_RELEASE_CHECKSUMS_SCRIPT.contains("--verify-public-key"),
         "checksum signing helper must preserve public-key verification support"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("--channel <nightly|rc|stable>"),
+        "PortalSurfer publish helper must keep channel explicit"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("X-Wavecrate-Release-Channel"),
+        "PortalSurfer publish helper must send channel metadata"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("assemble_portal_changelog.py"),
+        "PortalSurfer publish helper must update the full changelog"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("Fetched changelog body does not match generated release log"),
+        "PortalSurfer publish helper must verify per-release changelog round trips"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("Fetched full changelog body does not match generated changelog"),
+        "PortalSurfer publish helper must verify full changelog round trips"
     );
     assert!(
         VALIDATE_PROMOTED_RC_SCRIPT.contains("gh\","),


### PR DESCRIPTION
## Scope
- Add `scripts/internal/release/publish_portalsurfer_release.sh` as the shared PortalSurfer release publication helper.
- Publish RC and stable release zips, checksum files, checksum signatures, and generated release logs to PortalSurfer after the GitHub release is published.
- Use channel-specific PortalSurfer build ids: `wavecrate-X.Y.Z-rc.N` for RC and `wavecrate-X.Y.Z` for stable.
- Verify PortalSurfer upload responses, public catalog entries, per-release changelog round trips, and full Wavecrate changelog round trips.
- Add release workflow contract tests and public catalog tests for RC/stable visibility semantics.
- Document the RC/stable PortalSurfer publication path.

## Definition of Done
- RC and stable workflows publish to PortalSurfer, not just GitHub.
- PortalSurfer catalog entries are validated for build id, build number, version, timestamp, files, and changelog URL.
- The in-app public update check can discover RC entries and stable entries according to selected update channel semantics.
- Full changelog updates include the generated RC/stable release logs through the shared helper.
- Workflow contract tests prevent RC/stable from regressing to GitHub-only publication.

## Validation commands
- `cargo fmt --check`
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh scripts/internal/release/checkout_radiant_submodule.sh scripts/internal/release/build_release_artifact.sh scripts/internal/release/assemble_release_files.sh scripts/internal/release/sign_release_checksums.sh scripts/internal/release/prune_github_release_assets.sh scripts/internal/release/build_release_zip.sh scripts/internal/release/generate_release_log.sh`
- `cargo test --test release_contract --test manual_release_matching`
- `cargo test -p wavecrate updater::public_catalog`
- `bash scripts/check.sh workflow-toolchain`
- `git diff --check`

## Known limitations
- `bash scripts/agent.sh request` was run during preflight and still fails the existing unrelated Radiant source-quality guardrails: `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, and `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`.
- The paused OPT-986 WIP was stashed separately and is not included in this PR.

## User review
User review is required before merge.