### PR TITLE
OPT-986 Verify published release artifacts

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -327,6 +327,21 @@ jobs:
           prerelease: true
           make_latest: false
           files: dist/release/*
+      - name: Verify published GitHub nightly release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/internal/release/verify_published_release.py \
+            --channel nightly \
+            --version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --target-version "${{ needs.resolve-main.outputs.target_version }}" \
+            --commit "${{ needs.resolve-main.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve-main.outputs.build_date }}" \
+            --tag nightly \
+            --repo "${{ github.repository }}" \
+            --source GitHub \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
 
   publish-frontend:
     name: Upload PortalSurfer nightly downloads
@@ -354,197 +369,46 @@ jobs:
         with:
           name: release-log
           path: dist/release
-      - name: Upload Wavecrate downloads
+      - name: Assemble PortalSurfer nightly release files
+        run: scripts/internal/release/assemble_release_files.sh --checksum-name checksums-nightly.txt
+      - name: Sign PortalSurfer nightly checksums
+        env:
+          CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
+        run: |
+          scripts/internal/release/sign_release_checksums.sh \
+            --checksum-file dist/release/checksums-nightly.txt \
+            --signature-file dist/release/checksums-nightly.txt.sig
+      - name: Publish PortalSurfer nightly release
         shell: bash
         env:
-          UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
-          UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
-          TARGET_SHA: ${{ needs.resolve-main.outputs.target_sha }}
-          BUILD_NUMBER: ${{ needs.resolve-main.outputs.build_number }}
-          RELEASE_VERSION: ${{ needs.resolve-main.outputs.nightly_version }}
-          PORTAL_BUILD_ID: ${{ needs.resolve-main.outputs.portal_build_id }}
-          RELEASED_AT: ${{ needs.resolve-main.outputs.released_at }}
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
         run: |
-          set -euo pipefail
-          shopt -s nullglob
-          files=(dist/artifacts/*.zip)
-          if [[ ${#files[@]} -eq 0 ]]; then
-            echo "No release zip files found in downloaded artifacts." >&2
-            exit 1
-          fi
-
-          version="$RELEASE_VERSION"
-          build_id="$PORTAL_BUILD_ID"
-          released_at="${RELEASED_AT}"
-
-          upload_base="${UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          scripts/internal/release/publish_portalsurfer_release.sh \
+            --channel nightly \
+            --build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve-main.outputs.build_number }}" \
+            --release-version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --released-at "${{ needs.resolve-main.outputs.released_at }}" \
+            --artifact-dir dist/release \
+            --release-log dist/release/release-log.md \
+            --full-changelog-out dist/release/changelog.md
+      - name: Verify published PortalSurfer nightly release artifacts
+        shell: bash
+        env:
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
           upload_base="${upload_base%/}"
-          if [[ "$upload_base" != */release-uploads ]]; then
-            echo "PORTALSURFER_RELEASE_UPLOAD_URL must end with /release-uploads." >&2
-            exit 1
-          fi
-          api_base="${upload_base%/release-uploads}"
-          catalog_url="$api_base/releases"
-          full_changelog_url="$api_base/changelog"
-          response_dir="$(mktemp -d)"
-          changelog_file="dist/release/release-log.md"
-          full_changelog_file="dist/release/changelog.md"
-          uploaded_names=()
-
-          for file in "${files[@]}"; do
-            file_name="$(basename "$file")"
-            if [[ ! -s "$file" ]]; then
-              echo "Release file is empty: $file" >&2
-              exit 1
-            fi
-            sha256="$(sha256sum "$file" | awk '{ print $1 }')"
-            encoded_name="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$file_name")"
-            response_file="$response_dir/$file_name.json"
-            curl --fail-with-body --retry 3 --retry-delay 2 \
-              --request PUT \
-              --header "Authorization: Bearer $UPLOAD_TOKEN" \
-              --header "Content-Type: application/zip" \
-              --header "X-Wavecrate-Build-Number: ${BUILD_NUMBER}" \
-              --header "X-Wavecrate-Release-Version: $version" \
-              --header "X-Wavecrate-Released-At: $released_at" \
-              --header "X-Wavecrate-Sha256: $sha256" \
-              --data-binary "@$file" \
-              "$upload_base/$build_id/files/$encoded_name" > "$response_file"
-            python3 - "$response_file" "$build_id" "$BUILD_NUMBER" "$file_name" "$sha256" <<'PY'
-          import json
-          import sys
-
-          response_path, expected_build, expected_build_number, expected_name, expected_sha = sys.argv[1:]
-          response = json.loads(open(response_path, encoding="utf-8").read())
-          release = response.get("release") or {}
-          file = response.get("file") or {}
-          if release.get("build_id") != expected_build:
-              raise SystemExit(f"Uploaded release id mismatch: {release.get('build_id')} != {expected_build}")
-          if release.get("build_number") != int(expected_build_number):
-              raise SystemExit(f"Uploaded release build number mismatch: {release.get('build_number')} != {expected_build_number}")
-          if file.get("name") != expected_name:
-              raise SystemExit(f"Uploaded file name mismatch: {file.get('name')} != {expected_name}")
-          if file.get("sha256") != expected_sha:
-              raise SystemExit(f"Uploaded file sha mismatch: {file.get('sha256')} != {expected_sha}")
-          if not isinstance(file.get("size_bytes"), int) or file["size_bytes"] <= 0:
-              raise SystemExit("Uploaded file size was not recorded")
-          PY
-            uploaded_names+=("$file_name")
-          done
-
-          changelog_response_file="$response_dir/changelog-upload.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 \
-            --request PUT \
-            --header "Authorization: Bearer $UPLOAD_TOKEN" \
-            --header "Content-Type: text/markdown; charset=utf-8" \
-            --header "X-Wavecrate-Build-Number: ${BUILD_NUMBER}" \
-            --header "X-Wavecrate-Release-Version: $version" \
-            --header "X-Wavecrate-Released-At: $released_at" \
-            --data-binary "@$changelog_file" \
-            "$upload_base/$build_id/changelog" > "$changelog_response_file"
-          python3 - "$changelog_response_file" "$build_id" "$BUILD_NUMBER" <<'PY'
-          import json
-          import sys
-
-          response_path, expected_build, expected_build_number = sys.argv[1:]
-          response = json.loads(open(response_path, encoding="utf-8").read())
-          release = response.get("release") or {}
-          changelog = response.get("changelog") or {}
-          if release.get("build_id") != expected_build:
-              raise SystemExit(f"Uploaded changelog release id mismatch: {release.get('build_id')} != {expected_build}")
-          if release.get("build_number") != int(expected_build_number):
-              raise SystemExit(f"Uploaded changelog build number mismatch: {release.get('build_number')} != {expected_build_number}")
-          if changelog.get("format") != "markdown":
-              raise SystemExit("Uploaded changelog was not recorded as markdown")
-          if not changelog.get("url"):
-              raise SystemExit("Uploaded changelog did not expose a public URL")
-          PY
-
-          catalog_file="$response_dir/releases.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 "$catalog_url" > "$catalog_file"
-          python3 - "$catalog_file" "$build_id" "$BUILD_NUMBER" "${uploaded_names[@]}" <<'PY'
-          import json
-          import sys
-
-          catalog_path = sys.argv[1]
-          expected_build = sys.argv[2]
-          expected_build_number = int(sys.argv[3])
-          expected_files = set(sys.argv[4:])
-          catalog = json.loads(open(catalog_path, encoding="utf-8").read())
-          releases = catalog.get("releases") or []
-          release = next((item for item in releases if item.get("build_id") == expected_build), None)
-          if release is None:
-              raise SystemExit(f"Release catalog does not list {expected_build}")
-          if release.get("build_number") != expected_build_number:
-              raise SystemExit(f"Release catalog build number mismatch: {release.get('build_number')} != {expected_build_number}")
-          catalog_files = {item.get("name") for item in release.get("files") or []}
-          missing = sorted(expected_files - catalog_files)
-          if missing:
-              raise SystemExit(f"Release catalog is missing files: {', '.join(missing)}")
-          changelog = release.get("changelog") or {}
-          if changelog.get("format") != "markdown" or not changelog.get("url"):
-              raise SystemExit("Release catalog is missing the markdown changelog link")
-          print(f"Uploaded {len(expected_files)} Wavecrate release file(s) to {expected_build}")
-          PY
-
-          changelog_catalog_file="$response_dir/changelog-catalog.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 \
-            "$catalog_url/$build_id/changelog" > "$changelog_catalog_file"
-          python3 - "$changelog_catalog_file" "$build_id" "$changelog_file" <<'PY'
-          import json
-          import sys
-
-          catalog_path, expected_build, changelog_path = sys.argv[1:]
-          response = json.loads(open(catalog_path, encoding="utf-8").read())
-          if response.get("build_id") != expected_build:
-              raise SystemExit(f"Fetched changelog id mismatch: {response.get('build_id')} != {expected_build}")
-          body = (response.get("changelog") or {}).get("body", "").strip()
-          expected_body = open(changelog_path, encoding="utf-8").read().strip()
-          if body != expected_body:
-              raise SystemExit("Fetched changelog body does not match generated release log")
-          print(f"Uploaded Wavecrate release log to {expected_build}")
-          PY
-
-          scripts/internal/release/assemble_portal_changelog.py \
-            --catalog-url "$catalog_url" \
-            --current-build-id "$build_id" \
-            --current-log "$changelog_file" \
-            --existing-changelog-url "$full_changelog_url" \
-            --generated-at "$released_at" \
-            --output "$full_changelog_file"
-
-          full_changelog_response_file="$response_dir/full-changelog-upload.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 \
-            --request PUT \
-            --header "Authorization: Bearer $UPLOAD_TOKEN" \
-            --header "Content-Type: text/markdown; charset=utf-8" \
-            --header "X-Wavecrate-Changelog-Title: Wavecrate changelog" \
-            --data-binary "@$full_changelog_file" \
-            "$upload_base/changelog" > "$full_changelog_response_file"
-          python3 - "$full_changelog_response_file" <<'PY'
-          import json
-          import sys
-
-          response = json.loads(open(sys.argv[1], encoding="utf-8").read())
-          changelog = response.get("changelog") or {}
-          if changelog.get("format") != "markdown":
-              raise SystemExit("Uploaded full changelog was not recorded as markdown")
-          if not changelog.get("url"):
-              raise SystemExit("Uploaded full changelog did not expose a public URL")
-          PY
-
-          full_changelog_catalog_file="$response_dir/full-changelog-catalog.json"
-          curl --fail-with-body --retry 3 --retry-delay 2 \
-            "$full_changelog_url" > "$full_changelog_catalog_file"
-          python3 - "$full_changelog_catalog_file" "$full_changelog_file" <<'PY'
-          import json
-          import sys
-
-          catalog_path, changelog_path = sys.argv[1:]
-          response = json.loads(open(catalog_path, encoding="utf-8").read())
-          body = (response.get("changelog") or {}).get("body", "").strip()
-          expected_body = open(changelog_path, encoding="utf-8").read().strip()
-          if body != expected_body:
-              raise SystemExit("Fetched full changelog body does not match generated changelog")
-          print("Uploaded Wavecrate full changelog")
-          PY
+          scripts/internal/release/verify_published_release.py \
+            --surface portalsurfer \
+            --channel nightly \
+            --version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --target-version "${{ needs.resolve-main.outputs.target_version }}" \
+            --commit "${{ needs.resolve-main.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve-main.outputs.build_date }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve-main.outputs.build_number }}" \
+            --source PortalSurfer \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -254,6 +254,21 @@ jobs:
           prerelease: true
           make_latest: false
           files: dist/release/*
+      - name: Verify published GitHub RC release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/internal/release/verify_published_release.py \
+            --channel rc \
+            --version "${{ needs.resolve.outputs.release_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --tag "${{ needs.resolve.outputs.release_tag }}" \
+            --repo "${{ github.repository }}" \
+            --source GitHub \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
       - name: Publish PortalSurfer RC release
         shell: bash
         env:
@@ -269,3 +284,22 @@ jobs:
             --artifact-dir dist/release \
             --release-log dist/release/release-log.md \
             --full-changelog-out dist/release/changelog.md
+      - name: Verify published PortalSurfer RC release artifacts
+        shell: bash
+        env:
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          upload_base="${upload_base%/}"
+          scripts/internal/release/verify_published_release.py \
+            --surface portalsurfer \
+            --channel rc \
+            --version "${{ needs.resolve.outputs.release_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --source PortalSurfer \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -265,6 +265,21 @@ jobs:
           prerelease: false
           make_latest: true
           files: dist/release/*
+      - name: Verify published GitHub stable release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/internal/release/verify_published_release.py \
+            --channel stable \
+            --version "${{ needs.resolve.outputs.target_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --tag "${{ needs.resolve.outputs.release_tag }}" \
+            --repo "${{ github.repository }}" \
+            --source GitHub \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
       - name: Publish PortalSurfer stable release
         shell: bash
         env:
@@ -280,3 +295,22 @@ jobs:
             --artifact-dir dist/release \
             --release-log dist/release/release-log.md \
             --full-changelog-out dist/release/changelog.md
+      - name: Verify published PortalSurfer stable release artifacts
+        shell: bash
+        env:
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          upload_base="${upload_base%/}"
+          scripts/internal/release/verify_published_release.py \
+            --surface portalsurfer \
+            --channel stable \
+            --version "${{ needs.resolve.outputs.target_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-date "${{ needs.resolve.outputs.build_date }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --source PortalSurfer \
+            --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -105,6 +105,10 @@ under `scripts/internal/release/`:
 - `sign_release_checksums.sh` signs and optionally verifies checksum files.
 - `validate_promoted_rc_release.py` verifies that stable promotion is backed by
   a complete RC GitHub prerelease before stable builds start.
+- `verify_published_release.py` downloads public GitHub or PortalSurfer release
+  assets after publication, verifies checksum signatures and zip hashes, and
+  inspects each `update-manifest.json` for the expected channel, version,
+  commit, build date, target, platform, and architecture.
 - `publish_portalsurfer_release.sh` uploads release files and the generated log
   to PortalSurfer, verifies the public catalog and per-release changelog, then
   updates and verifies the full Wavecrate changelog.
@@ -125,10 +129,12 @@ the expected platform zips from `release_contract.toml`, a checksum file,
 checksum signature, downloadable assets whose hashes match the checksum file,
 and a release-bound `Wavecrate X.Y.Z-rc.N` log body. Stable releases are
 published as normal GitHub releases tagged `vX.Y.Z` and as PortalSurfer catalog
-entries with build ids like `wavecrate-X.Y.Z`. RC and stable PortalSurfer
-publication uploads the generated release zips, checksum file, checksum
-signature, and release log, then verifies the catalog entry, per-release
-changelog, and full Wavecrate changelog round trips.
+entries with build ids like `wavecrate-X.Y.Z`. RC and stable workflows verify the
+published GitHub release assets, then PortalSurfer publication uploads the
+generated release zips, checksum file, checksum signature, and release log,
+verifies the catalog entry, per-release changelog, and full Wavecrate changelog
+round trips, and finally downloads the public PortalSurfer assets back to verify
+their checksums, signature, and embedded manifests.
 
 The nightly workflow publishes an immutable nightly version tag named like
 `19.1.0-nightly.20260701+abc1234` for changelog history, updates the rolling GitHub
@@ -140,10 +146,44 @@ every nightly under one changelog group. After the per-release log is visible in
 the public catalog, the workflow verifies that the fetched log body matches the
 generated immutable release log, then prepends that release-bound log to the
 existing site-wide changelog before uploading the maintained full changelog.
+The nightly workflow also verifies the rolling GitHub release assets and the
+PortalSurfer catalog downloads after publication.
 The maintenance step refuses to preserve a full changelog whose historical
 sections are not already release-bound markdown logs.
 GitHub Actions does not need SSH access or write access to the PortalSurfer
 frontend repository.
+
+To rerun the GitHub verifier for a published stable release, use the resolved
+release metadata from the workflow run:
+
+```bash
+scripts/internal/release/verify_published_release.py \
+  --surface github \
+  --channel stable \
+  --version 19.1.0 \
+  --target-version 19.1.0 \
+  --commit <target-sha> \
+  --build-date <yyyy-mm-dd> \
+  --tag v19.1.0 \
+  --repo PORTALSURFER/wavecrate \
+  --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+```
+
+To rerun the PortalSurfer verifier for the same release:
+
+```bash
+scripts/internal/release/verify_published_release.py \
+  --surface portalsurfer \
+  --channel stable \
+  --version 19.1.0 \
+  --target-version 19.1.0 \
+  --commit <target-sha> \
+  --build-date <yyyy-mm-dd> \
+  --portal-catalog-url https://portalsurfer.org/wavecrate/api/v1/releases \
+  --portal-build-id wavecrate-19.1.0 \
+  --build-number <build-number> \
+  --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+```
 
 - `PORTALSURFER_RELEASE_UPLOAD_TOKEN`
 Bearer token sent by the workflow to the PortalSurfer upload endpoint. Store

--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""Verify published Wavecrate release assets after public upload."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ED25519_SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+
+@dataclass(frozen=True)
+class ExpectedZip:
+    name: str
+    target: str
+    platform: str
+    arch: str
+
+
+@dataclass(frozen=True)
+class ExpectedRelease:
+    zips: list[ExpectedZip]
+    checksum: str
+    signature: str
+
+    @property
+    def required_assets(self) -> list[str]:
+        return [zip_asset.name for zip_asset in self.zips] + [self.checksum, self.signature]
+
+
+def main() -> int:
+    args = parse_args()
+    errors = validate_args(args)
+    if errors:
+        print_errors(errors)
+        return 1
+
+    contract = load_release_contract(args.contract)
+    expected = expected_release_assets(contract, args.channel, args.version, args.target_version)
+    release = load_release(args)
+    errors.extend(validate_release_metadata(release, args, expected.required_assets))
+    if errors:
+        print_errors(errors)
+        return 1
+
+    with local_asset_dir(args, release, expected.required_assets) as asset_dir:
+        errors.extend(validate_downloaded_assets(asset_dir, release, expected, args))
+
+    if errors:
+        print_errors(errors)
+        return 1
+
+    print(f"Published {args.channel} release {args.version} verified from {args.source}.")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--surface",
+        default="github",
+        choices=["github", "portalsurfer"],
+        help="Public release surface to verify",
+    )
+    parser.add_argument("--channel", required=True, choices=["nightly", "rc", "stable"])
+    parser.add_argument("--version", required=True, help="Release version embedded in update-manifest.json")
+    parser.add_argument("--target-version", required=True, help="Stable target version, e.g. 19.1.0")
+    parser.add_argument("--commit", required=True, help="Expected release commit SHA")
+    parser.add_argument("--build-date", required=True, help="Expected release build date, YYYY-MM-DD")
+    parser.add_argument("--tag", help="GitHub release tag to inspect")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""), help="GitHub repo owner/name")
+    parser.add_argument("--portal-catalog-url", help="PortalSurfer releases catalog URL")
+    parser.add_argument("--portal-build-id", help="PortalSurfer release build_id to inspect")
+    parser.add_argument("--build-number", type=int, help="Expected PortalSurfer build number")
+    parser.add_argument(
+        "--source",
+        default="",
+        help="Human-readable public surface name for diagnostics",
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=REPO_ROOT / "release_contract.toml",
+        help="Release contract TOML path",
+    )
+    parser.add_argument(
+        "--release-json",
+        type=Path,
+        help="Fixture JSON from `gh release view --json tagName,isPrerelease,targetCommitish,body,assets`",
+    )
+    parser.add_argument("--asset-dir", type=Path, help="Fixture directory containing downloaded release assets")
+    parser.add_argument(
+        "--checksum-public-key",
+        required=True,
+        help="Base64 Ed25519 public key used to verify the checksum signature",
+    )
+    args = parser.parse_args()
+    if not args.source:
+        args.source = "GitHub" if args.surface == "github" else "PortalSurfer"
+    return args
+
+
+def validate_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    if not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", args.build_date):
+        errors.append("build-date must be YYYY-MM-DD")
+    if not re.fullmatch(r"[0-9a-fA-F]{7,40}", args.commit):
+        errors.append("commit must be a 7-40 character hexadecimal SHA")
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.target_version):
+        errors.append("target-version must be MAJOR.MINOR.PATCH")
+    if args.channel == "stable" and args.version != args.target_version:
+        errors.append("stable release version must equal target-version")
+    if args.channel == "rc" and not re.fullmatch(
+        re.escape(args.target_version) + r"-rc\.[0-9]+",
+        args.version,
+    ):
+        errors.append("rc release version must be TARGET_VERSION-rc.N")
+    if args.channel == "nightly" and not args.version.startswith(f"{args.target_version}-nightly."):
+        errors.append("nightly release version must start with TARGET_VERSION-nightly.")
+    if args.surface == "github":
+        if not args.tag:
+            errors.append("github verification requires --tag")
+        if not args.release_json and not args.repo:
+            errors.append("github live verification requires --repo or GITHUB_REPOSITORY")
+    else:
+        if not args.portal_build_id:
+            errors.append("PortalSurfer verification requires --portal-build-id")
+        if args.build_number is None:
+            errors.append("PortalSurfer verification requires --build-number")
+        if not args.release_json and not args.portal_catalog_url:
+            errors.append("PortalSurfer live verification requires --portal-catalog-url")
+    return errors
+
+
+def load_release_contract(path: Path) -> dict[str, Any]:
+    try:
+        import tomllib  # type: ignore[import-not-found]
+
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except ModuleNotFoundError:
+        return parse_minimal_release_contract(path.read_text(encoding="utf-8"))
+
+
+def parse_minimal_release_contract(text: str) -> dict[str, Any]:
+    app_name = require_match(r'^app_name\s*=\s*"([^"]+)"', text, "app_name")
+    targets_match = require_match(r"(?ms)^targets\s*=\s*\[(.*?)\]", text, "targets")
+    targets = re.findall(r'"([^"]+)"', targets_match)
+    templates_match = require_match(r"(?ms)^\[templates\]\s*(.*?)(?:^\[|\Z)", text, "templates")
+    templates = dict(re.findall(r'(?m)^([A-Za-z0-9_]+)\s*=\s*"([^"]+)"', templates_match))
+    return {"app_name": app_name, "targets": targets, "templates": templates}
+
+
+def require_match(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text)
+    if not match:
+        raise SystemExit(f"release contract is missing {label}")
+    return match.group(1)
+
+
+def expected_release_assets(
+    contract: dict[str, Any],
+    channel: str,
+    version: str,
+    target_version: str,
+) -> ExpectedRelease:
+    app_name = contract["app_name"]
+    templates = contract["templates"]
+    targets = [
+        (target, platform_for_target(target), arch_for_target(target))
+        for target in contract["targets"]
+    ]
+    if channel == "nightly":
+        zips = [
+            ExpectedZip(
+                apply_template(templates["nightly_asset"], app_name, version, "", platform, arch),
+                target,
+                platform,
+                arch,
+            )
+            for target, platform, arch in targets
+        ]
+        checksum = templates["nightly_checksums"]
+        signature = templates["nightly_checksums_sig"]
+    elif channel == "rc":
+        rc_number = version.rsplit("-rc.", 1)[1]
+        zips = [
+            ExpectedZip(
+                apply_template(templates["rc_asset"], app_name, target_version, rc_number, platform, arch),
+                target,
+                platform,
+                arch,
+            )
+            for target, platform, arch in targets
+        ]
+        checksum = apply_template(templates["rc_checksums"], app_name, target_version, rc_number, "", "")
+        signature = apply_template(templates["rc_checksums_sig"], app_name, target_version, rc_number, "", "")
+    else:
+        zips = [
+            ExpectedZip(
+                apply_template(templates["stable_asset"], app_name, version, "", platform, arch),
+                target,
+                platform,
+                arch,
+            )
+            for target, platform, arch in targets
+        ]
+        checksum = apply_template(templates["stable_checksums"], app_name, version, "", "", "")
+        signature = apply_template(templates["stable_checksums_sig"], app_name, version, "", "", "")
+    return ExpectedRelease(sorted(zips, key=lambda item: item.name), checksum, signature)
+
+
+def apply_template(
+    template: str,
+    app_name: str,
+    version: str,
+    rc_number: str,
+    platform: str,
+    arch: str,
+) -> str:
+    return (
+        template.replace("{APP_NAME}", app_name)
+        .replace("{version}", version)
+        .replace("{rc_number}", rc_number)
+        .replace("{platform}", platform)
+        .replace("{arch}", arch)
+    )
+
+
+def platform_for_target(target: str) -> str:
+    if "-pc-windows-" in target:
+        return "windows"
+    if target.endswith("-apple-darwin"):
+        return "macos"
+    if "-unknown-linux-" in target:
+        return "linux"
+    raise SystemExit(f"unsupported release target triple: {target}")
+
+
+def arch_for_target(target: str) -> str:
+    return target.split("-", 1)[0]
+
+
+def load_release(args: argparse.Namespace) -> dict[str, Any]:
+    if args.release_json:
+        release = json.loads(args.release_json.read_text(encoding="utf-8"))
+        if args.surface == "portalsurfer":
+            return select_portalsurfer_release(release, args)
+        return release
+    if args.surface == "portalsurfer":
+        catalog = fetch_json(args.portal_catalog_url)
+        return select_portalsurfer_release(catalog, args)
+    output = run(
+        [
+            "gh",
+            "release",
+            "view",
+            str(args.tag),
+            "--repo",
+            args.repo,
+            "--json",
+            "tagName,isPrerelease,targetCommitish,body,assets",
+        ],
+        f"view {args.source} release",
+    )
+    return json.loads(output)
+
+
+def select_portalsurfer_release(catalog_or_release: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    if "releases" not in catalog_or_release:
+        return catalog_or_release
+    releases = catalog_or_release.get("releases") or []
+    release = next(
+        (item for item in releases if isinstance(item, dict) and item.get("build_id") == args.portal_build_id),
+        None,
+    )
+    if release is None:
+        raise SystemExit(f"PortalSurfer catalog does not list {args.portal_build_id}")
+    return release
+
+
+def validate_release_metadata(
+    release: dict[str, Any],
+    args: argparse.Namespace,
+    required_assets: list[str],
+) -> list[str]:
+    errors: list[str] = []
+    if args.surface == "portalsurfer":
+        if release.get("build_id") != args.portal_build_id:
+            errors.append(
+                f"{args.source} release build_id is {release.get('build_id')}, expected {args.portal_build_id}"
+            )
+        if release.get("build_number") != args.build_number:
+            errors.append(
+                f"{args.source} release build_number is {release.get('build_number')}, expected {args.build_number}"
+            )
+        if release.get("version") != args.version:
+            errors.append(f"{args.source} release version is {release.get('version')}, expected {args.version}")
+    else:
+        expected_prerelease = args.channel in {"nightly", "rc"}
+        if release.get("isPrerelease") is not expected_prerelease:
+            errors.append(f"{args.source} {args.channel} release prerelease flag is incorrect")
+
+        target_commitish = str(release.get("targetCommitish") or "").strip()
+        if target_commitish and target_commitish != args.commit:
+            errors.append(
+                f"{args.source} release targetCommitish is {target_commitish}, expected {args.commit}"
+            )
+
+    tag_name = release.get("tagName")
+    if args.tag and tag_name and tag_name != args.tag:
+        errors.append(f"{args.source} release tagName is {tag_name}, expected {args.tag}")
+
+    body = release_body(release, args)
+    if not body:
+        release_label = args.tag or args.portal_build_id or args.version
+        errors.append(f"{args.source} release {release_label} must have a non-empty release log body")
+    elif f"Wavecrate {args.version}" not in body:
+        errors.append(f"{args.source} release body must be release-bound to Wavecrate {args.version}")
+
+    asset_names = release_asset_names(release)
+    missing = [name for name in required_assets if name not in asset_names]
+    if missing:
+        errors.append(f"{args.source} release is missing required assets: " + ", ".join(missing))
+    return errors
+
+
+def release_asset_names(release: dict[str, Any]) -> set[str]:
+    assets = release_file_entries(release)
+    return {
+        str(asset["name"])
+        for asset in assets
+        if isinstance(asset, dict) and asset.get("name")
+    }
+
+
+def release_file_entries(release: dict[str, Any]) -> list[dict[str, Any]]:
+    assets = release.get("assets")
+    if isinstance(assets, dict):
+        assets = assets.get("nodes") or []
+    if not assets:
+        assets = release.get("files") or []
+    return [asset for asset in assets if isinstance(asset, dict)]
+
+
+def release_body(release: dict[str, Any], args: argparse.Namespace) -> str:
+    body = str(release.get("body") or "").strip()
+    if body or args.surface != "portalsurfer":
+        return body
+    changelog = release.get("changelog") or {}
+    body = str(changelog.get("body") or "").strip()
+    if body:
+        return body
+    changelog_url = str(changelog.get("url") or "")
+    if not changelog_url:
+        return ""
+    response = fetch_json(resolve_portalsurfer_url(args, changelog_url))
+    return str((response.get("changelog") or {}).get("body") or "").strip()
+
+
+class local_asset_dir:
+    def __init__(self, args: argparse.Namespace, release: dict[str, Any], required_assets: list[str]) -> None:
+        self.args = args
+        self.release = release
+        self.required_assets = required_assets
+        self.temp: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> Path:
+        if self.args.asset_dir:
+            return self.args.asset_dir
+        self.temp = tempfile.TemporaryDirectory(prefix="wavecrate-published-release-")
+        asset_dir = Path(self.temp.name)
+        if self.args.surface == "portalsurfer":
+            self.download_portalsurfer_assets(asset_dir)
+            return asset_dir
+        patterns = []
+        for asset in self.required_assets:
+            patterns.extend(["--pattern", asset])
+        run(
+            [
+                "gh",
+                "release",
+                "download",
+                str(self.args.tag),
+                "--repo",
+                self.args.repo,
+                "--dir",
+                str(asset_dir),
+                "--clobber",
+                *patterns,
+            ],
+            f"download {self.args.source} release assets",
+        )
+        return asset_dir
+
+    def download_portalsurfer_assets(self, asset_dir: Path) -> None:
+        entries = {str(item.get("name")): item for item in release_file_entries(self.release) if item.get("name")}
+        for asset in self.required_assets:
+            entry = entries.get(asset)
+            if not entry:
+                continue
+            url = str(entry.get("url") or entry.get("download_url") or entry.get("href") or "")
+            if not url:
+                raise SystemExit(f"PortalSurfer catalog entry for {asset} does not include a download URL")
+            download_url(resolve_portalsurfer_url(self.args, url), asset_dir / asset)
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        if self.temp:
+            self.temp.cleanup()
+
+
+def validate_downloaded_assets(
+    asset_dir: Path,
+    release: dict[str, Any],
+    expected: ExpectedRelease,
+    args: argparse.Namespace,
+) -> list[str]:
+    errors: list[str] = []
+    for asset in expected.required_assets:
+        path = asset_dir / asset
+        if not path.is_file():
+            errors.append(f"Downloaded {args.source} asset is missing: {asset}")
+        elif path.stat().st_size == 0:
+            errors.append(f"Downloaded {args.source} asset is empty: {asset}")
+
+    checksum_path = asset_dir / expected.checksum
+    if checksum_path.is_file():
+        errors.extend(validate_checksum_file(checksum_path, asset_dir, expected.zips))
+
+    signature_path = asset_dir / expected.signature
+    if checksum_path.is_file() and signature_path.is_file():
+        errors.extend(verify_checksum_signature(checksum_path, signature_path, args.checksum_public_key))
+
+    if args.surface == "portalsurfer":
+        errors.extend(validate_portalsurfer_catalog_hashes(asset_dir, release, expected.required_assets))
+
+    for zip_asset in expected.zips:
+        zip_path = asset_dir / zip_asset.name
+        if zip_path.is_file():
+            errors.extend(validate_zip_manifest(zip_path, zip_asset, args))
+    return errors
+
+
+def validate_portalsurfer_catalog_hashes(
+    asset_dir: Path,
+    release: dict[str, Any],
+    required_assets: list[str],
+) -> list[str]:
+    errors: list[str] = []
+    entries = {str(item.get("name")): item for item in release_file_entries(release) if item.get("name")}
+    for asset in required_assets:
+        entry = entries.get(asset) or {}
+        expected_hash = str(entry.get("sha256") or "").lower()
+        if not expected_hash:
+            errors.append(f"PortalSurfer catalog entry for {asset} is missing sha256")
+            continue
+        path = asset_dir / asset
+        if path.is_file():
+            actual_hash = sha256(path)
+            if actual_hash != expected_hash:
+                errors.append(
+                    f"PortalSurfer catalog sha256 mismatch for {asset}: catalog has {expected_hash}, asset hashes to {actual_hash}"
+                )
+    return errors
+
+
+def validate_checksum_file(
+    checksum_path: Path,
+    asset_dir: Path,
+    expected_zips: list[ExpectedZip],
+) -> list[str]:
+    errors: list[str] = []
+    entries: dict[str, str] = {}
+    for line_number, line in enumerate(checksum_path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) != 2 or not re.fullmatch(r"[0-9a-fA-F]{64}", parts[0]):
+            errors.append(f"{checksum_path.name}:{line_number} is not a SHA-256 checksum entry")
+            continue
+        entries[parts[1]] = parts[0].lower()
+
+    for zip_asset in expected_zips:
+        expected_hash = entries.get(zip_asset.name)
+        if not expected_hash:
+            errors.append(f"Checksum file is missing entry for {zip_asset.name}")
+            continue
+        zip_path = asset_dir / zip_asset.name
+        if not zip_path.is_file():
+            continue
+        actual_hash = sha256(zip_path)
+        if actual_hash != expected_hash:
+            errors.append(
+                f"Checksum mismatch for {zip_asset.name}: checksum file has {expected_hash}, asset hashes to {actual_hash}"
+            )
+    return errors
+
+
+def verify_checksum_signature(checksum_path: Path, signature_path: Path, checksum_public_key: str) -> list[str]:
+    if not shutil.which("openssl"):
+        return ["openssl is required to verify the checksum signature"]
+    try:
+        public_key = base64.b64decode(checksum_public_key, validate=True)
+    except ValueError as error:
+        return [f"invalid base64 checksum public key: {error}"]
+    if len(public_key) != 32:
+        return ["checksum public key must decode to a 32-byte Ed25519 public key"]
+
+    with tempfile.TemporaryDirectory(prefix="wavecrate-published-signature-") as temp:
+        pub_der = Path(temp) / "checksum-public-key.der"
+        sig_bin = Path(temp) / "checksums.sig"
+        pub_der.write_bytes(ED25519_SPKI_PREFIX + public_key)
+        try:
+            sig_bin.write_bytes(base64.b64decode(signature_path.read_text(encoding="utf-8"), validate=True))
+        except ValueError as error:
+            return [f"checksum signature is not valid base64: {error}"]
+        completed = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(pub_der),
+                "-keyform",
+                "DER",
+                "-rawin",
+                "-in",
+                str(checksum_path),
+                "-sigfile",
+                str(sig_bin),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if completed.returncode != 0:
+        return ["checksum signature verification failed: " + completed.stderr.strip()]
+    return []
+
+
+def validate_zip_manifest(
+    zip_path: Path,
+    zip_asset: ExpectedZip,
+    args: argparse.Namespace,
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        with zipfile.ZipFile(zip_path) as archive:
+            manifest_names = [
+                name
+                for name in archive.namelist()
+                if name == "update-manifest.json" or name.endswith("/update-manifest.json")
+            ]
+            if len(manifest_names) != 1:
+                return [f"{zip_asset.name} must contain exactly one update-manifest.json"]
+            manifest = json.loads(archive.read(manifest_names[0]).decode("utf-8"))
+    except zipfile.BadZipFile:
+        return [f"{zip_asset.name} is not a valid zip file"]
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        return [f"{zip_asset.name} contains an invalid update-manifest.json: {error}"]
+
+    expected = {
+        "app": "wavecrate",
+        "channel": args.channel,
+        "target": zip_asset.target,
+        "platform": zip_asset.platform,
+        "arch": zip_asset.arch,
+        "version": args.version,
+        "target_version": args.target_version,
+        "commit": args.commit,
+        "build_date": args.build_date,
+    }
+    for key, expected_value in expected.items():
+        if manifest.get(key) != expected_value:
+            errors.append(
+                f"{zip_asset.name} manifest {key} is {manifest.get(key)!r}, expected {expected_value!r}"
+            )
+    files = manifest.get("files")
+    if not isinstance(files, list) or "update-manifest.json" not in files:
+        errors.append(f"{zip_asset.name} manifest files must include update-manifest.json")
+    return errors
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(command: list[str], label: str) -> str:
+    completed = subprocess.run(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(f"Failed to {label}:\n{completed.stderr.strip()}")
+    return completed.stdout
+
+
+def fetch_json(url: str | None) -> dict[str, Any]:
+    if not url:
+        raise SystemExit("Missing URL for JSON fetch")
+    try:
+        with urllib.request.urlopen(request_for_url(url), timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise SystemExit(f"Failed to fetch JSON from {url}: {error}") from error
+
+
+def download_url(url: str, path: Path) -> None:
+    try:
+        with urllib.request.urlopen(request_for_url(url), timeout=120) as response:
+            with path.open("wb") as output:
+                shutil.copyfileobj(response, output)
+    except urllib.error.URLError as error:
+        raise SystemExit(f"Failed to download {url}: {error}") from error
+
+
+def request_for_url(url: str) -> urllib.request.Request:
+    return urllib.request.Request(url, headers={"User-Agent": "wavecrate-release-verifier"})
+
+
+def resolve_portalsurfer_url(args: argparse.Namespace, url: str) -> str:
+    if urllib.parse.urlparse(url).scheme:
+        return url
+    base = args.portal_catalog_url or "https://portalsurfer.org/wavecrate/api/v1/releases"
+    return urllib.parse.urljoin(base, url)
+
+
+def print_errors(errors: list[str]) -> None:
+    print("Published release verification failed:", file=sys.stderr)
+    for error in errors:
+        print(f" - {error}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -27,6 +27,8 @@ const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
 const VALIDATE_PROMOTED_RC_SCRIPT: &str =
     include_str!("../scripts/internal/release/validate_promoted_rc_release.py");
+const VERIFY_PUBLISHED_RELEASE_SCRIPT: &str =
+    include_str!("../scripts/internal/release/verify_published_release.py");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 
 #[test]
@@ -352,6 +354,56 @@ fn rc_and_stable_workflows_publish_to_portalsurfer_catalog() {
     assert!(
         STABLE_WORKFLOW.contains("portal_build_id=\"wavecrate-${VERSION}\""),
         "stable PortalSurfer build ids must include the stable version"
+    );
+}
+
+#[test]
+fn release_workflows_verify_published_artifacts_after_publication() {
+    for (name, workflow, channel) in [
+        ("nightly workflow", NIGHTLY_WORKFLOW, "nightly"),
+        ("RC workflow", RC_WORKFLOW, "rc"),
+        ("stable workflow", STABLE_WORKFLOW, "stable"),
+    ] {
+        assert!(
+            workflow.contains("scripts/internal/release/verify_published_release.py \\"),
+            "{name} must invoke the shared post-publish verifier"
+        );
+        assert!(
+            workflow.contains(&format!("--channel {channel} \\")),
+            "{name} must verify the published assets with the matching release channel"
+        );
+        assert!(
+            workflow.contains("--checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4="),
+            "{name} must verify checksum signatures with the pinned public key"
+        );
+        assert!(
+            workflow.contains("--surface portalsurfer"),
+            "{name} must verify PortalSurfer downloads after PortalSurfer publication"
+        );
+    }
+    assert!(
+        NIGHTLY_WORKFLOW.contains("Verify published GitHub nightly release"),
+        "nightly workflow must verify the rolling GitHub nightly release"
+    );
+    assert!(
+        RC_WORKFLOW.contains("Verify published GitHub RC release"),
+        "RC workflow must verify the GitHub RC release"
+    );
+    assert!(
+        STABLE_WORKFLOW.contains("Verify published GitHub stable release"),
+        "stable workflow must verify the GitHub stable release"
+    );
+    assert!(
+        VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("update-manifest.json"),
+        "post-publish verifier must inspect package manifests"
+    );
+    assert!(
+        VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("PortalSurfer catalog sha256 mismatch"),
+        "post-publish verifier must compare public catalog hashes to downloaded bytes"
+    );
+    assert!(
+        VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("pkeyutl"),
+        "post-publish verifier must verify checksum signatures"
     );
 }
 

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -1,12 +1,14 @@
 //! Focused checks for shared release workflow helper scripts.
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+use zip::write::SimpleFileOptions;
 
 #[test]
 fn toolchain_helper_emits_github_output_channel() {
@@ -353,6 +355,121 @@ fn promoted_rc_validator_rejects_checksum_mismatches() {
     );
 }
 
+#[test]
+fn published_release_verifier_accepts_portalsurfer_catalog_fixture() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) = write_published_release_fixture(&temp, &key, None);
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/verify_published_release.py",
+            ))
+            .arg("--surface")
+            .arg("portalsurfer")
+            .arg("--channel")
+            .arg("stable")
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--target-version")
+            .arg("19.1.0")
+            .arg("--commit")
+            .arg("abcdef1")
+            .arg("--build-date")
+            .arg("2026-07-02")
+            .arg("--portal-build-id")
+            .arg("wavecrate-19.1.0")
+            .arg("--build-number")
+            .arg("6200")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir)
+            .arg("--checksum-public-key")
+            .arg(expected_pubkey.trim()),
+    );
+}
+
+#[test]
+fn published_release_verifier_rejects_manifest_mismatches() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) =
+        write_published_release_fixture(&temp, &key, Some(("commit", "deadbee")));
+
+    let output = run_failure(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/verify_published_release.py",
+            ))
+            .arg("--surface")
+            .arg("portalsurfer")
+            .arg("--channel")
+            .arg("stable")
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--target-version")
+            .arg("19.1.0")
+            .arg("--commit")
+            .arg("abcdef1")
+            .arg("--build-date")
+            .arg("2026-07-02")
+            .arg("--portal-build-id")
+            .arg("wavecrate-19.1.0")
+            .arg("--build-number")
+            .arg("6200")
+            .arg("--release-json")
+            .arg(&release_json)
+            .arg("--asset-dir")
+            .arg(&asset_dir)
+            .arg("--checksum-public-key")
+            .arg(expected_pubkey.trim()),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("manifest commit"),
+        "manifest mismatch should report the wrong manifest field\nstderr:\n{stderr}"
+    );
+}
+
+fn generate_ed25519_key(path: &Path) -> bool {
+    let keygen = Command::new("openssl")
+        .arg("genpkey")
+        .arg("-algorithm")
+        .arg("Ed25519")
+        .arg("-out")
+        .arg(path)
+        .output()
+        .expect("run openssl key generation");
+    if keygen.status.success() {
+        return true;
+    }
+    let stderr = String::from_utf8_lossy(&keygen.stderr);
+    if stderr.contains("Algorithm Ed25519 not found") {
+        return false;
+    }
+    panic!(
+        "openssl key generation failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&keygen.stdout),
+        stderr
+    );
+}
+
 fn expected_public_key(key: &Path, temp: &TempDir) -> String {
     let pub_der = temp.path().join("public.der");
     run_success(
@@ -434,6 +551,148 @@ fn write_promoted_rc_fixture(
     )
     .expect("write release json");
     (release_json, asset_dir)
+}
+
+fn write_published_release_fixture(
+    temp: &TempDir,
+    key: &Path,
+    manifest_override: Option<(&str, &str)>,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let asset_dir = temp.path().join("published-assets");
+    fs::create_dir_all(&asset_dir).expect("create asset dir");
+    let zip_assets = [
+        (
+            "wavecrate-19.1.0-macos-aarch64.zip",
+            "aarch64-apple-darwin",
+            "macos",
+            "aarch64",
+        ),
+        (
+            "wavecrate-19.1.0-macos-x86_64.zip",
+            "x86_64-apple-darwin",
+            "macos",
+            "x86_64",
+        ),
+        (
+            "wavecrate-19.1.0-windows-x86_64.zip",
+            "x86_64-pc-windows-msvc",
+            "windows",
+            "x86_64",
+        ),
+    ];
+    let checksum_asset = "checksums-19.1.0.txt";
+    let signature_asset = "checksums-19.1.0.txt.sig";
+
+    let mut checksum_lines = Vec::new();
+    let mut files = Vec::new();
+    for (zip_name, target, platform, arch) in zip_assets {
+        write_release_zip(
+            &asset_dir.join(zip_name),
+            target,
+            platform,
+            arch,
+            manifest_override,
+        );
+        let hash = sha256_file(&asset_dir.join(zip_name));
+        checksum_lines.push(format!("{hash}  {zip_name}\n"));
+        files.push(json!({
+            "name": zip_name,
+            "url": format!("/wavecrate/api/v1/releases/wavecrate-19.1.0/files/{zip_name}/download"),
+            "sha256": hash,
+            "size_bytes": fs::metadata(asset_dir.join(zip_name)).expect("zip metadata").len()
+        }));
+    }
+
+    fs::write(asset_dir.join(checksum_asset), checksum_lines.concat()).expect("write checksum");
+    let key_pem = fs::read_to_string(key).expect("read generated key");
+    run_success(
+        Command::new("bash")
+            .arg(repo_path(
+                "scripts/internal/release/sign_release_checksums.sh",
+            ))
+            .arg("--checksum-file")
+            .arg(asset_dir.join(checksum_asset))
+            .arg("--signature-file")
+            .arg(asset_dir.join(signature_asset))
+            .env("CHECKSUMS_SIGNING_KEY", key_pem),
+    );
+    for file_name in [checksum_asset, signature_asset] {
+        files.push(json!({
+            "name": file_name,
+            "url": format!("/wavecrate/api/v1/releases/wavecrate-19.1.0/files/{file_name}/download"),
+            "sha256": sha256_file(&asset_dir.join(file_name)),
+            "size_bytes": fs::metadata(asset_dir.join(file_name)).expect("asset metadata").len()
+        }));
+    }
+
+    let catalog = json!({
+        "app": "wavecrate",
+        "releases": [{
+            "build_id": "wavecrate-19.1.0",
+            "build_number": 6200,
+            "version": "19.1.0",
+            "released_at": "2026-07-02T09:00:00Z",
+            "changelog": {
+                "title": "Wavecrate 19.1.0",
+                "format": "markdown",
+                "body": "# Wavecrate 19.1.0\n\n## Release Metadata\n",
+                "url": "/wavecrate/api/v1/releases/wavecrate-19.1.0/changelog"
+            },
+            "files": files
+        }]
+    });
+    let release_json = temp.path().join("published-catalog.json");
+    fs::write(
+        &release_json,
+        serde_json::to_string_pretty(&catalog).expect("serialize catalog json"),
+    )
+    .expect("write release json");
+    (release_json, asset_dir)
+}
+
+fn write_release_zip(
+    path: &Path,
+    target: &str,
+    platform: &str,
+    arch: &str,
+    manifest_override: Option<(&str, &str)>,
+) {
+    let file = fs::File::create(path).expect("create zip file");
+    let mut zip = zip::ZipWriter::new(file);
+    zip.start_file(
+        "wavecrate/update-manifest.json",
+        SimpleFileOptions::default(),
+    )
+    .expect("start manifest file");
+    let mut manifest = json!({
+        "app": "wavecrate",
+        "channel": "stable",
+        "target": target,
+        "platform": platform,
+        "arch": arch,
+        "version": "19.1.0",
+        "target_version": "19.1.0",
+        "commit": "abcdef1",
+        "build_date": "2026-07-02",
+        "files": ["wavecrate", "update-manifest.json"]
+    });
+    if let Some((key, value)) = manifest_override {
+        manifest[key] = json!(value);
+    }
+    zip.write_all(
+        serde_json::to_string(&manifest)
+            .expect("serialize manifest")
+            .as_bytes(),
+    )
+    .expect("write manifest");
+    zip.finish().expect("finish zip");
+}
+
+fn sha256_file(path: &Path) -> String {
+    format!(
+        "{:x}",
+        Sha256::digest(fs::read(path).expect("read file for sha256"))
+    )
 }
 
 fn repo_root() -> &'static Path {


### PR DESCRIPTION
## Scope
- Add a shared `verify_published_release.py` post-publish verifier for GitHub and PortalSurfer release surfaces.
- Wire nightly, RC, and stable workflows to verify published GitHub assets after GitHub release publication.
- Wire nightly, RC, and stable workflows to verify public PortalSurfer catalog downloads after PortalSurfer publication.
- Move nightly PortalSurfer publishing onto the shared PortalSurfer helper so nightly also publishes checksum and signature assets.
- Document verifier rerun commands for GitHub and PortalSurfer release surfaces.

## Definition of Done
- Published release checks fail when expected zips, checksum files, signatures, release logs, catalog hashes, or embedded `update-manifest.json` metadata are missing or mismatched.
- Nightly, RC, and stable workflows verify public GitHub and PortalSurfer artifacts with channel-specific metadata.
- PortalSurfer catalog downloads are checked against catalog SHA-256s, signed checksum files, zip checksums, and manifest fields.
- Regression coverage protects workflow wiring and verifier behavior.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh`
- `bash -n scripts/internal/release/assemble_release_files.sh`
- `bash -n scripts/internal/release/sign_release_checksums.sh`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --test release_contract --test release_workflow_helpers --test manual_release_matching`

## Known Limitations
- The live PortalSurfer verifier depends on the catalog exposing downloadable file URLs and SHA-256 fields for every release asset.
- The workflow syntax was validated by contract tests and shell checks; `actionlint` is not installed in this local environment.

User review is required before merge.
