### PR TITLE
Fix nightly PortalSurfer build id

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
           target_version="$(awk -F '"' '/^version =/ { print $2; exit }' Cargo.toml)"
           build_date="$(date -u '+%Y%m%d')"
           nightly_version="${target_version}-nightly.${build_date}+${short_sha}"
-          portal_build_id="wavecrate-${nightly_version}"
+          portal_build_id="wavecrate-nightly-b${build_number}-${short_sha}"
           released_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
           if [[ -z "$build_number" || ! "$build_number" =~ ^[0-9]+$ ]]; then

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -140,12 +140,14 @@ The nightly workflow publishes an immutable nightly version tag named like
 `19.1.0-nightly.20260701+abc1234` for changelog history, updates the rolling GitHub
 `nightly` release for downloads, then uploads the same zips plus the generated
 Markdown release log to the PortalSurfer Wavecrate release-upload API. Each
-PortalSurfer upload uses the matching `wavecrate-<nightly-version>`
+PortalSurfer upload uses a path-safe `wavecrate-nightly-b<build>-<short-sha>`
 build id so the website can show a distinct nightly entry instead of stacking
-every nightly under one changelog group. After the per-release log is visible in
-the public catalog, the workflow verifies that the fetched log body matches the
-generated immutable release log, then prepends that release-bound log to the
-existing site-wide changelog before uploading the maintained full changelog.
+every nightly under one changelog group, while the release log and package
+manifest keep the full SemVer nightly version. After the per-release log is
+visible in the public catalog, the workflow verifies that the fetched log body
+matches the generated immutable release log, then prepends that release-bound
+log to the existing site-wide changelog before uploading the maintained full
+changelog.
 The nightly workflow also verifies the rolling GitHub release assets and the
 PortalSurfer catalog downloads after publication.
 The maintenance step refuses to preserve a full changelog whose historical

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -190,8 +190,17 @@ fn nightly_workflow_publishes_packager_outputs_as_github_assets() {
         "GitHub nightly release must upload the assembled dist/release assets"
     );
     assert!(
-        !NIGHTLY_WORKFLOW.contains("wavecrate-nightly-b"),
+        RELEASE_ZIP_SCRIPT.contains("ZIP_NAME=\"${APP_NAME}-nightly-${PLATFORM}-${ARCH}.zip\""),
         "rolling GitHub nightly workflow must not introduce build-numbered asset names"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW
+            .contains("portal_build_id=\"wavecrate-nightly-b${build_number}-${short_sha}\""),
+        "PortalSurfer nightly build ids must be immutable and URL-path safe"
+    );
+    assert!(
+        !NIGHTLY_WORKFLOW.contains("portal_build_id=\"wavecrate-${nightly_version}\""),
+        "PortalSurfer nightly build ids must not contain SemVer build metadata '+' characters"
     );
 }
 


### PR DESCRIPTION
## Scope
- Fix the nightly PortalSurfer build id generated by `.github/workflows/release-build.yml` so it is safe for the PortalSurfer release-upload URL path.
- Keep the nightly SemVer version with `+<short-sha>` for tags, logs, and package manifests.
- Document the separate PortalSurfer build-id contract and add release-contract coverage.

## Root Cause
The failed nightly run `28580099133` published and verified the GitHub nightly release, then failed on the first PortalSurfer upload with HTTP 400. The upload path used build id `wavecrate-19.1.0-nightly.20260702+1427ce7c`; PortalSurfer's upload parser accepts only `[a-z0-9._-]` in release build ids, so the SemVer `+` made the path invalid.

## Definition of Done
- Nightly PortalSurfer uploads use an immutable URL-safe build id like `wavecrate-nightly-b6240-1427ce7c`.
- GitHub nightly zip asset names remain the unnumbered rolling contract expected by the updater.
- The release log and `update-manifest.json` continue to use the full nightly SemVer version.

## Validation Commands
- `cargo fmt --check`
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --test release_contract`
- Shell check that `wavecrate-nightly-b6240-1427ce7c` matches PortalSurfer's build-id character set.

## Known Limitations
- The failed workflow run needs to be rerun after this PR merges.

User review is required before merge.
