### PR TITLE
OPT-987 move browser projection cache contracts

### DIFF
--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -40,6 +40,9 @@ pub(crate) mod undo;
 mod undo_jobs;
 pub(crate) mod updates;
 
+use crate::app_core::browser_projection_cache::{
+    ProjectedBrowserPreloadWindow, ProjectedBrowserRowCacheEntry, ProjectedSelectedPathsLookup,
+};
 pub(crate) use crate::app_core::state::StatusTone;
 use crate::{
     app::state::UiState,
@@ -90,50 +93,6 @@ pub(crate) const FOCUS_HISTORY_LIMIT: usize = 100;
 pub(crate) const UNDO_LIMIT: usize = 20;
 pub(crate) const STATUS_LOG_LIMIT: usize = 200;
 
-/// Retained browser-row projection fields keyed by absolute entry index.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ProjectedBrowserRowCacheEntry {
-    /// Stable row-identity hash derived from the live entry relative path.
-    pub row_identity_hash: u64,
-    /// Relative sample path used for metadata preloads and label fallback.
-    pub relative_path: PathBuf,
-    /// Stable rendered row label for the browser list.
-    pub row_label: String,
-    /// Triage column index (`0..=2`) for this row.
-    pub column_index: usize,
-    /// Signed keep/trash rating level for this row (`-3..=3`).
-    pub rating_level: i8,
-    /// Playback-age bucket projected for row-aging visuals.
-    pub playback_age_bucket: crate::app::state::PlaybackAgeBucket,
-    /// Stable rendered inline metadata label for the browser list row.
-    pub bucket_label: String,
-    /// Whether the backing sample file is currently marked missing.
-    pub missing: bool,
-    /// Whether the backing sample is marked looped.
-    pub looped: bool,
-    /// Whether the backing sample is marked as a confirmed keep lock.
-    pub locked: bool,
-    /// Cached BPM bits used to detect metadata changes without rebuilding label text.
-    pub bpm_value_bits: Option<u32>,
-    /// Whether the backing sample currently carries the long-sample marker.
-    pub long_sample_mark: bool,
-    /// Monotonic usage tick used for bounded least-recently-used eviction.
-    pub last_used_tick: u64,
-}
-
-/// Visible browser window metadata retained for incremental BPM preloads.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ProjectedBrowserPreloadWindow {
-    /// Selected source associated with the last preload window.
-    pub source_id: Option<SourceId>,
-    /// Visible-row revision associated with the last preload window.
-    pub visible_rows_revision: u64,
-    /// First visible row index covered by the last preload window.
-    pub window_start: usize,
-    /// Number of rows covered by the last preload window.
-    pub window_len: usize,
-}
-
 /// Cache key for retained map-point projection payloads.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ProjectedMapPointsCacheKey {
@@ -155,15 +114,6 @@ pub(crate) struct ProjectedMapPointsCacheKey {
 
 /// Retained immutable map-point payload reused across native map projections.
 pub(crate) type ProjectedMapPointCacheEntry = crate::app_core::actions::NativeMapPointModel;
-
-/// Retained selected-row lookup representation for browser projections.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ProjectedSelectedPathsLookup {
-    /// Fast path for the common single-selection case.
-    Single(usize),
-    /// Dense lookup used for larger multi-selections.
-    Dense(Vec<bool>),
-}
 
 /// Maintains app state and bridges core logic to the active GUI runtime.
 pub struct AppController {

--- a/src/app/controller/state/runtime/source_lane.rs
+++ b/src/app/controller/state/runtime/source_lane.rs
@@ -1,5 +1,6 @@
 use crate::app::controller::jobs::{SampleAutoRenameProgress, SourceHydrationKind};
 use crate::app::state::FolderPaneId;
+pub(crate) use crate::app_core::browser_projection_cache::AutoRenameBatchRowState;
 use crate::sample_sources::Rating;
 use crate::sample_sources::SourceId;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -68,16 +69,6 @@ pub(crate) struct SourceMutationRuntime {
     queued_browser_auto_rename_intent: Option<PendingBrowserAutoRenameIntent>,
     /// Active source-scoped browser auto-rename batch row state.
     active_auto_rename_batch: Option<ActiveAutoRenameBatchState>,
-}
-
-/// UI row state for one requested path in an active auto-rename batch.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AutoRenameBatchRowState {
-    Queued,
-    Active,
-    Completed,
-    Skipped,
-    Failed,
 }
 
 /// Source-scoped snapshot exposed to controller/UI projection code.

--- a/src/app_core/app_api.rs
+++ b/src/app_core/app_api.rs
@@ -9,7 +9,7 @@
 //! | Legacy surface | Current owner | Classification | Exit issue | Exit criteria |
 //! | --- | --- | --- | --- | --- |
 //! | `AppController`, startup/test fixture helpers, and WAV edit-support predicate | `src/app::controller` | Intentionally still owned by `src/app` while mature runtime behavior remains there | `OPT-992` | App-core exposes a narrow runtime facade; fixture construction is test-owned; domain helpers no longer require broad controller aliases |
-//! | Browser projection cache, selected-path lookup, preload-window, and auto-rename row state | `src/app::controller` retained projection state | Ready for app-core ownership | `OPT-987` | Browser projection helpers consume app-core-owned cache/row contracts and the matching aliases leave this bridge |
+//! | Browser projection cache, selected-path lookup, preload-window, and auto-rename row state | `src/app_core::browser_projection_cache` | App-core owned as of `OPT-987` | Done | Remaining work should keep new browser projection contracts in app-core and avoid reintroducing bridge aliases |
 //! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app::controller` retained projection/query state | Ready for app-core ownership | `OPT-988` | Map projection consumes app-core-owned query/cache contracts or a narrow map runtime adapter |
 //! | Dirty graph node/reason aliases used by frame preparation and invalidation adapters | `src/app::controller::state::runtime` | Ready for app-core invalidation ownership | `OPT-989` | App-core frame preparation and bridge invalidation use app-core invalidation names; legacy conversion is isolated or removed |
 //! | Browser, source, folder, and library-hygiene state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-990` | Browser/source/folder projections and tests use app-core DTOs or focused builders |
@@ -23,13 +23,10 @@
 
 pub(crate) mod controller {
     pub(crate) use crate::app::controller::{
-        AppController, ProjectedBrowserPreloadWindow, ProjectedBrowserRowCacheEntry,
-        ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey, ProjectedSelectedPathsLookup,
-        UmapPointQuery, build_named_gui_fixture_controller, supports_wav_destructive_edits,
+        AppController, ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey, UmapPointQuery,
+        build_named_gui_fixture_controller, supports_wav_destructive_edits,
     };
 
-    pub(crate) type AutoRenameBatchRowState =
-        crate::app::controller::state::runtime::AutoRenameBatchRowState;
     pub(crate) type DerivedNodeId = crate::app::controller::state::runtime::DerivedNodeId;
     pub(crate) type DirtyReason = crate::app::controller::state::runtime::DirtyReason;
 }

--- a/src/app_core/browser_projection_cache.rs
+++ b/src/app_core/browser_projection_cache.rs
@@ -1,0 +1,68 @@
+//! Browser projection cache contracts owned by app-core.
+
+use crate::app_core::state::PlaybackAgeBucket;
+use crate::sample_sources::SourceId;
+use std::path::PathBuf;
+
+/// Retained browser-row projection fields keyed by absolute entry index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectedBrowserRowCacheEntry {
+    /// Stable row-identity hash derived from the live entry relative path.
+    pub row_identity_hash: u64,
+    /// Relative sample path used for metadata preloads and label fallback.
+    pub relative_path: PathBuf,
+    /// Stable rendered row label for the browser list.
+    pub row_label: String,
+    /// Triage column index (`0..=2`) for this row.
+    pub column_index: usize,
+    /// Signed keep/trash rating level for this row (`-3..=3`).
+    pub rating_level: i8,
+    /// Playback-age bucket projected for row-aging visuals.
+    pub playback_age_bucket: PlaybackAgeBucket,
+    /// Stable rendered inline metadata label for the browser list row.
+    pub bucket_label: String,
+    /// Whether the backing sample file is currently marked missing.
+    pub missing: bool,
+    /// Whether the backing sample is marked looped.
+    pub looped: bool,
+    /// Whether the backing sample is marked as a confirmed keep lock.
+    pub locked: bool,
+    /// Cached BPM bits used to detect metadata changes without rebuilding label text.
+    pub bpm_value_bits: Option<u32>,
+    /// Whether the backing sample currently carries the long-sample marker.
+    pub long_sample_mark: bool,
+    /// Monotonic usage tick used for bounded least-recently-used eviction.
+    pub last_used_tick: u64,
+}
+
+/// Visible browser window metadata retained for incremental BPM preloads.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectedBrowserPreloadWindow {
+    /// Selected source associated with the last preload window.
+    pub source_id: Option<SourceId>,
+    /// Visible-row revision associated with the last preload window.
+    pub visible_rows_revision: u64,
+    /// First visible row index covered by the last preload window.
+    pub window_start: usize,
+    /// Number of rows covered by the last preload window.
+    pub window_len: usize,
+}
+
+/// Retained selected-row lookup representation for browser projections.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ProjectedSelectedPathsLookup {
+    /// Fast path for the common single-selection case.
+    Single(usize),
+    /// Dense lookup used for larger multi-selections.
+    Dense(Vec<bool>),
+}
+
+/// UI row state for one requested path in an active auto-rename batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AutoRenameBatchRowState {
+    Queued,
+    Active,
+    Completed,
+    Skipped,
+    Failed,
+}

--- a/src/app_core/controller.rs
+++ b/src/app_core/controller.rs
@@ -28,20 +28,12 @@ pub(crate) use frame_preparation::UiFramePreparationPlan;
 pub use startup::build_ui_app_controller;
 /// Runtime-facing app controller type used by migration hosts.
 pub type AppController = CurrentAppController;
-/// Retained browser preload-window cache type used by ui-projection helpers.
-pub(crate) type ProjectedBrowserPreloadWindow = current_controller::ProjectedBrowserPreloadWindow;
-/// Retained browser-row cache entry used by ui-projection helpers.
-pub(crate) type ProjectedBrowserRowCacheEntry = current_controller::ProjectedBrowserRowCacheEntry;
 /// Retained map-point cache key used by ui-projection helpers.
 pub(crate) type ProjectedMapPointsCacheKey = current_controller::ProjectedMapPointsCacheKey;
 /// Retained normalized map-point cache entry used by ui-projection helpers.
 pub(crate) type ProjectedMapPointCacheEntry = current_controller::ProjectedMapPointCacheEntry;
-/// Retained selected-path lookup cache entry used by ui-projection helpers.
-pub(crate) type ProjectedSelectedPathsLookup = current_controller::ProjectedSelectedPathsLookup;
 /// Map-point query payload alias used by ui-projection map projection.
 pub(crate) type UmapPointQuery<'a> = current_controller::UmapPointQuery<'a>;
-/// Active browser auto-rename row state used by ui-projection.
-pub(crate) type AutoRenameBatchRowState = current_controller::AutoRenameBatchRowState;
 /// Retained controller dirty graph node identifiers used by frame preparation and bridge adapters.
 pub(crate) type DerivedNodeId = current_controller::DerivedNodeId;
 /// Retained controller dirty graph reason identifiers used by bridge adapters.

--- a/src/app_core/mod.rs
+++ b/src/app_core/mod.rs
@@ -4,6 +4,9 @@
 
 mod app_api;
 
+/// Retained browser projection cache contracts owned by app-core.
+pub(crate) mod browser_projection_cache;
+
 /// Controller aliases and helpers used by migration-facing runtimes.
 pub mod controller;
 

--- a/src/app_core/ui_bridge/projection_cache/projection_key/browser.rs
+++ b/src/app_core/ui_bridge/projection_cache/projection_key/browser.rs
@@ -4,6 +4,7 @@ use super::super::{
     BrowserRowsStateProjectionCacheKey, BrowserTagSidebarProjectionCacheKey,
 };
 use super::shared::hash_string_for_projection_key;
+use crate::app_core::browser_projection_cache::AutoRenameBatchRowState;
 use crate::app_core::controller::AppController;
 use std::hash::{Hash, Hasher};
 
@@ -94,11 +95,11 @@ fn browser_auto_rename_rows_hash(controller: &AppController) -> u64 {
     for row in snapshot.rows {
         row.current_path.hash(&mut hasher);
         match row.state {
-            crate::app_core::controller::AutoRenameBatchRowState::Queued => 1_u8,
-            crate::app_core::controller::AutoRenameBatchRowState::Active => 2,
-            crate::app_core::controller::AutoRenameBatchRowState::Completed => 3,
-            crate::app_core::controller::AutoRenameBatchRowState::Skipped => 4,
-            crate::app_core::controller::AutoRenameBatchRowState::Failed => 5,
+            AutoRenameBatchRowState::Queued => 1_u8,
+            AutoRenameBatchRowState::Active => 2,
+            AutoRenameBatchRowState::Completed => 3,
+            AutoRenameBatchRowState::Skipped => 4,
+            AutoRenameBatchRowState::Failed => 5,
         }
         .hash(&mut hasher);
     }

--- a/src/app_core/ui_projection.rs
+++ b/src/app_core/ui_projection.rs
@@ -25,9 +25,11 @@ use crate::app_core::ui::MAX_RENDERED_BROWSER_ROWS;
 use std::sync::atomic::AtomicU64;
 
 #[cfg(test)]
-use super::controller::{
-    AppController, ProjectedBrowserPreloadWindow, ProjectedBrowserRowCacheEntry,
+use super::browser_projection_cache::{
+    ProjectedBrowserPreloadWindow, ProjectedBrowserRowCacheEntry,
 };
+#[cfg(test)]
+use super::controller::AppController;
 #[cfg(test)]
 use crate::app_core::actions::{
     NativeBrowserTagState as BrowserTagState, NativeConfirmPromptKind as ConfirmPromptKind,

--- a/src/app_core/ui_projection/browser_projection/cache.rs
+++ b/src/app_core/ui_projection/browser_projection/cache.rs
@@ -1,9 +1,10 @@
 //! Retained browser-row and selected-path projection cache helpers.
 
 use super::super::{MAX_RETAINED_BROWSER_ROW_PROJECTION_CACHE, trace_browser_row_cache_lookup};
-use crate::app_core::controller::{
-    AppController, ProjectedBrowserRowCacheEntry, ProjectedSelectedPathsLookup,
+use crate::app_core::browser_projection_cache::{
+    ProjectedBrowserRowCacheEntry, ProjectedSelectedPathsLookup,
 };
+use crate::app_core::controller::AppController;
 use crate::app_core::state::PlaybackAgeBucket;
 use crate::app_core::view_model;
 use std::hash::{Hash, Hasher};

--- a/src/app_core/ui_projection/browser_projection/preload.rs
+++ b/src/app_core/ui_projection/browser_projection/preload.rs
@@ -1,4 +1,5 @@
-use crate::app_core::controller::{AppController, ProjectedBrowserPreloadWindow};
+use crate::app_core::browser_projection_cache::ProjectedBrowserPreloadWindow;
+use crate::app_core::controller::AppController;
 use crate::sample_sources::SourceId;
 
 /// Preload BPM metadata for the current visible browser window in one batch query.

--- a/src/app_core/ui_projection/browser_projection/row_window.rs
+++ b/src/app_core/ui_projection/browser_projection/row_window.rs
@@ -7,8 +7,8 @@ use crate::app_core::actions::NativeBrowserRowProcessingState as BrowserRowProce
 use crate::app_core::actions::{
     NativeBrowserRowModel as BrowserRowModel, NativeRetainedVec as RetainedVec,
 };
+use crate::app_core::browser_projection_cache::AutoRenameBatchRowState;
 use crate::app_core::controller::AppController;
-use crate::app_core::controller::AutoRenameBatchRowState;
 use crate::app_core::state::{PlaybackAgeBucket, SampleBrowserTab};
 use crate::app_core::ui::MAX_RENDERED_BROWSER_ROWS;
 use std::collections::HashMap;

--- a/src/app_core/ui_projection/tests/browser_cache/lifecycle.rs
+++ b/src/app_core/ui_projection/tests/browser_cache/lifecycle.rs
@@ -104,7 +104,7 @@ fn selected_path_lookup_refreshes_for_same_len_path_changes() {
     refresh_projected_selected_paths_lookup(&mut controller);
     assert!(matches!(
         controller.projected_selected_paths_lookup,
-        Some(crate::app_core::controller::ProjectedSelectedPathsLookup::Single(0))
+        Some(crate::app_core::browser_projection_cache::ProjectedSelectedPathsLookup::Single(0))
     ));
     assert!(selected_index_is_selected(&controller, 0));
     assert!(!selected_index_is_selected(&controller, 1));
@@ -114,7 +114,7 @@ fn selected_path_lookup_refreshes_for_same_len_path_changes() {
     refresh_projected_selected_paths_lookup(&mut controller);
     assert!(matches!(
         controller.projected_selected_paths_lookup,
-        Some(crate::app_core::controller::ProjectedSelectedPathsLookup::Single(1))
+        Some(crate::app_core::browser_projection_cache::ProjectedSelectedPathsLookup::Single(1))
     ));
     assert!(!selected_index_is_selected(&controller, 0));
     assert!(selected_index_is_selected(&controller, 1));


### PR DESCRIPTION
## Scope
- Move browser projection cache contracts into `app_core::browser_projection_cache`.
- Point browser row cache, preload-window, selected-path lookup, and auto-rename row state consumers at the app-core-owned contract module.
- Remove the retired browser projection-cache aliases from `app_core::app_api::controller` and `app_core::controller`.
- Update the close-to-code migration inventory for the completed OPT-987 alias group.

## Definition of Done
- Browser projection-cache and auto-rename row status contracts are owned by app-core.
- Legacy controller storage remains an implementation detail while callers consume the app-core contract.
- Retired bridge aliases are removed and grep-checked.
- User-visible browser row projection behavior is unchanged.

## Validation Commands
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::ui_projection::browser_projection`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::controller`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib browser_cache`
- `bash scripts/internal/check/check_migration_boundary.sh`
- `bash scripts/internal/check/check_legacy_app_coupling.sh`
- `cargo fmt --check`
- `git diff --check`
- `rg -n "app_api::controller::(ProjectedBrowserPreloadWindow|ProjectedBrowserRowCacheEntry|ProjectedSelectedPathsLookup|AutoRenameBatchRowState)|app_core::controller::(ProjectedBrowserPreloadWindow|ProjectedBrowserRowCacheEntry|ProjectedSelectedPathsLookup|AutoRenameBatchRowState)|pub\(crate\) type (ProjectedBrowserPreloadWindow|ProjectedBrowserRowCacheEntry|ProjectedSelectedPathsLookup|AutoRenameBatchRowState)|pub\(crate\) use crate::app::controller::\{[^}]*ProjectedBrowser" src scripts tests` (expected no matches)

## Known Limitations
None.

User review is required before merge.