### PR TITLE
Fix PortalSurfer release timestamp verification

### DIFF
--- a/scripts/internal/release/publish_portalsurfer_release.sh
+++ b/scripts/internal/release/publish_portalsurfer_release.sh
@@ -187,36 +187,17 @@ PY
 
 catalog_file="$response_dir/releases.json"
 curl --fail-with-body --retry 3 --retry-delay 2 "$catalog_url" > "$catalog_file"
-python3 - "$catalog_file" "$BUILD_ID" "$BUILD_NUMBER" "$RELEASE_VERSION" "$RELEASED_AT" "${uploaded_names[@]}" <<'PY'
-import json
-import sys
-
-catalog_path = sys.argv[1]
-expected_build = sys.argv[2]
-expected_build_number = int(sys.argv[3])
-expected_version = sys.argv[4]
-expected_released_at = sys.argv[5]
-expected_files = set(sys.argv[6:])
-catalog = json.loads(open(catalog_path, encoding="utf-8").read())
-releases = catalog.get("releases") or []
-release = next((item for item in releases if item.get("build_id") == expected_build), None)
-if release is None:
-    raise SystemExit(f"Release catalog does not list {expected_build}")
-if release.get("build_number") != expected_build_number:
-    raise SystemExit(f"Release catalog build number mismatch: {release.get('build_number')} != {expected_build_number}")
-if release.get("version") != expected_version:
-    raise SystemExit(f"Release catalog version mismatch: {release.get('version')} != {expected_version}")
-if release.get("released_at") != expected_released_at:
-    raise SystemExit(f"Release catalog timestamp mismatch: {release.get('released_at')} != {expected_released_at}")
-catalog_files = {item.get("name") for item in release.get("files") or []}
-missing = sorted(expected_files - catalog_files)
-if missing:
-    raise SystemExit(f"Release catalog is missing files: {', '.join(missing)}")
-changelog = release.get("changelog") or {}
-if changelog.get("format") != "markdown" or not changelog.get("url"):
-    raise SystemExit("Release catalog is missing the markdown changelog link")
-print(f"Uploaded {len(expected_files)} Wavecrate release file(s) to {expected_build}")
-PY
+catalog_args=(
+  --catalog-file "$catalog_file"
+  --build-id "$BUILD_ID"
+  --build-number "$BUILD_NUMBER"
+  --release-version "$RELEASE_VERSION"
+  --released-at "$RELEASED_AT"
+)
+for uploaded_name in "${uploaded_names[@]}"; do
+  catalog_args+=(--expected-file "$uploaded_name")
+done
+python3 scripts/internal/release/verify_portalsurfer_upload_catalog.py "${catalog_args[@]}"
 
 changelog_catalog_file="$response_dir/changelog-catalog.json"
 curl --fail-with-body --retry 3 --retry-delay 2 \

--- a/scripts/internal/release/verify_portalsurfer_upload_catalog.py
+++ b/scripts/internal/release/verify_portalsurfer_upload_catalog.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Verify a PortalSurfer release-upload catalog round trip."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that a PortalSurfer catalog lists an uploaded release.",
+    )
+    parser.add_argument("--catalog-file", required=True, type=Path)
+    parser.add_argument("--build-id", required=True)
+    parser.add_argument("--build-number", required=True, type=int)
+    parser.add_argument("--release-version", required=True)
+    parser.add_argument("--released-at", required=True)
+    parser.add_argument("--expected-file", action="append", default=[])
+    return parser.parse_args()
+
+
+def parse_released_at(value: Any, label: str) -> dt.datetime:
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"{label} is missing or not a string")
+    normalized = value
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise SystemExit(f"{label} is not a valid ISO-8601 timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise SystemExit(f"{label} must include a timezone: {value}")
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def main() -> int:
+    args = parse_args()
+    catalog = json.loads(args.catalog_file.read_text(encoding="utf-8"))
+    releases = catalog.get("releases") or []
+    release = next((item for item in releases if item.get("build_id") == args.build_id), None)
+    if release is None:
+        raise SystemExit(f"Release catalog does not list {args.build_id}")
+    if release.get("build_number") != args.build_number:
+        raise SystemExit(
+            f"Release catalog build number mismatch: "
+            f"{release.get('build_number')} != {args.build_number}"
+        )
+    if release.get("version") != args.release_version:
+        raise SystemExit(
+            f"Release catalog version mismatch: "
+            f"{release.get('version')} != {args.release_version}"
+        )
+    actual_released_at = parse_released_at(release.get("released_at"), "Release catalog timestamp")
+    expected_released_at = parse_released_at(args.released_at, "Expected release timestamp")
+    if actual_released_at != expected_released_at:
+        raise SystemExit(
+            f"Release catalog timestamp mismatch: "
+            f"{release.get('released_at')} != {args.released_at}"
+        )
+    expected_files = set(args.expected_file)
+    catalog_files = {item.get("name") for item in release.get("files") or []}
+    missing = sorted(expected_files - catalog_files)
+    if missing:
+        raise SystemExit(f"Release catalog is missing files: {', '.join(missing)}")
+    changelog = release.get("changelog") or {}
+    if changelog.get("format") != "markdown" or not changelog.get("url"):
+        raise SystemExit("Release catalog is missing the markdown changelog link")
+    print(f"Uploaded {len(expected_files)} Wavecrate release file(s) to {args.build_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/app/controller/state/runtime/mod.rs
+++ b/src/app/controller/state/runtime/mod.rs
@@ -49,9 +49,9 @@ pub(crate) use projection_runtime::{ProjectionRevisionDirtyMask, ProjectionRunti
 pub(crate) use similarity_runtime::{
     SimilarityPrepStage, SimilarityPrepState, SimilarityRuntimeState,
 };
+pub(crate) use source_lane::ActiveAutoRenameBatchSnapshot;
 #[cfg(test)]
-pub(crate) use source_lane::AutoRenameBatchRowSnapshot;
-pub(crate) use source_lane::{ActiveAutoRenameBatchSnapshot, AutoRenameBatchRowState};
+pub(crate) use source_lane::{AutoRenameBatchRowSnapshot, AutoRenameBatchRowState};
 pub(crate) use source_lane::{
     BrowserRenameBusyDecision, BrowserRenameIntentKey, MetadataRollback,
     PendingBrowserAutoRenameIntent, PendingMetadataMutation, PendingSourceHydration,

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -27,6 +27,8 @@ const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
 const VALIDATE_PROMOTED_RC_SCRIPT: &str =
     include_str!("../scripts/internal/release/validate_promoted_rc_release.py");
+const VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT: &str =
+    include_str!("../scripts/internal/release/verify_portalsurfer_upload_catalog.py");
 const VERIFY_PUBLISHED_RELEASE_SCRIPT: &str =
     include_str!("../scripts/internal/release/verify_published_release.py");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
@@ -363,6 +365,19 @@ fn rc_and_stable_workflows_publish_to_portalsurfer_catalog() {
     assert!(
         STABLE_WORKFLOW.contains("portal_build_id=\"wavecrate-${VERSION}\""),
         "stable PortalSurfer build ids must include the stable version"
+    );
+}
+
+#[test]
+fn portalsurfer_publish_helper_uses_shared_catalog_verifier() {
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("scripts/internal/release/verify_portalsurfer_upload_catalog.py"),
+        "PortalSurfer publish helper must verify the catalog through the shared upload verifier"
+    );
+    assert!(
+        VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT.contains("parse_released_at"),
+        "PortalSurfer upload catalog verifier must normalize release timestamp precision"
     );
 }
 

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -447,6 +447,63 @@ fn published_release_verifier_rejects_manifest_mismatches() {
     );
 }
 
+#[test]
+fn portalsurfer_upload_catalog_verifier_accepts_equivalent_timestamp_precision() {
+    let temp = tempfile::tempdir().expect("create PortalSurfer catalog fixture");
+    let catalog = temp.path().join("catalog.json");
+    write_portalsurfer_upload_catalog(&catalog, "2026-07-02T10:10:24.000Z");
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/verify_portalsurfer_upload_catalog.py",
+            ))
+            .arg("--catalog-file")
+            .arg(&catalog)
+            .arg("--build-id")
+            .arg("wavecrate-nightly-b6242-5e5f4198")
+            .arg("--build-number")
+            .arg("6242")
+            .arg("--release-version")
+            .arg("19.1.0-nightly.20260702+5e5f4198")
+            .arg("--released-at")
+            .arg("2026-07-02T10:10:24Z")
+            .arg("--expected-file")
+            .arg("wavecrate-nightly-macos-aarch64.zip"),
+    );
+}
+
+#[test]
+fn portalsurfer_upload_catalog_verifier_rejects_different_timestamps() {
+    let temp = tempfile::tempdir().expect("create PortalSurfer catalog fixture");
+    let catalog = temp.path().join("catalog.json");
+    write_portalsurfer_upload_catalog(&catalog, "2026-07-02T10:10:25.000Z");
+
+    let output = run_failure(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/verify_portalsurfer_upload_catalog.py",
+            ))
+            .arg("--catalog-file")
+            .arg(&catalog)
+            .arg("--build-id")
+            .arg("wavecrate-nightly-b6242-5e5f4198")
+            .arg("--build-number")
+            .arg("6242")
+            .arg("--release-version")
+            .arg("19.1.0-nightly.20260702+5e5f4198")
+            .arg("--released-at")
+            .arg("2026-07-02T10:10:24Z")
+            .arg("--expected-file")
+            .arg("wavecrate-nightly-macos-aarch64.zip"),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Release catalog timestamp mismatch"),
+        "timestamp mismatch should still fail for a different instant\nstderr:\n{stderr}"
+    );
+}
+
 fn generate_ed25519_key(path: &Path) -> bool {
     let keygen = Command::new("openssl")
         .arg("genpkey")
@@ -468,6 +525,34 @@ fn generate_ed25519_key(path: &Path) -> bool {
         String::from_utf8_lossy(&keygen.stdout),
         stderr
     );
+}
+
+fn write_portalsurfer_upload_catalog(path: &Path, released_at: &str) {
+    let catalog = json!({
+        "app": "wavecrate",
+        "releases": [{
+            "build_id": "wavecrate-nightly-b6242-5e5f4198",
+            "build_number": 6242,
+            "version": "19.1.0-nightly.20260702+5e5f4198",
+            "released_at": released_at,
+            "changelog": {
+                "title": "Wavecrate nightly",
+                "format": "markdown",
+                "url": "/wavecrate/api/v1/releases/wavecrate-nightly-b6242-5e5f4198/changelog"
+            },
+            "files": [{
+                "name": "wavecrate-nightly-macos-aarch64.zip",
+                "url": "/wavecrate/api/v1/releases/wavecrate-nightly-b6242-5e5f4198/files/wavecrate-nightly-macos-aarch64.zip/download",
+                "sha256": "0".repeat(64),
+                "size_bytes": 123
+            }]
+        }]
+    });
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&catalog).expect("serialize PortalSurfer catalog"),
+    )
+    .expect("write PortalSurfer catalog fixture");
 }
 
 fn expected_public_key(key: &Path, temp: &TempDir) -> String {


### PR DESCRIPTION
## Scope
- Fix the PortalSurfer release upload catalog verifier so equivalent RFC3339 timestamps compare as the same instant.
- Keep build id, build number, version, expected files, and markdown changelog checks strict.
- Route `publish_portalsurfer_release.sh` through a focused catalog verifier helper instead of inline timestamp string comparison.
- Make the OPT-987 auto-rename row-state re-export test-only so integration-test builds do not fail on `deny(warnings)`.

## Definition of Done
- Nightly PortalSurfer publish no longer fails when the catalog returns `released_at` with millisecond precision, e.g. `.000Z` instead of `Z`.
- True timestamp mismatches still fail.
- Release helper tests cover both equivalent precision and different-instant cases.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_portalsurfer_upload_catalog.py`
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers portalsurfer_upload_catalog_verifier`
- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`
- `CARGO_INCREMENTAL=0 cargo test --test release_contract`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::controller`

## Known Limitations
- I did not re-run the live nightly workflow from this branch. The fix is based on the failed run log from https://github.com/PORTALSURFER/wavecrate/actions/runs/28582238683, where the only failing assertion was `2026-07-02T10:10:24.000Z != 2026-07-02T10:10:24Z`.

User review is required before merge.