### PR TITLE
Verify PortalSurfer release downloads through gate

### DIFF
--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -88,6 +88,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""), help="GitHub repo owner/name")
     parser.add_argument("--portal-catalog-url", help="PortalSurfer releases catalog URL")
     parser.add_argument("--portal-build-id", help="PortalSurfer release build_id to inspect")
+    parser.add_argument(
+        "--portal-download-token",
+        help="Pre-issued PortalSurfer download token for fixture or diagnostic runs",
+    )
     parser.add_argument("--build-number", type=int, help="Expected PortalSurfer build number")
     parser.add_argument(
         "--source",
@@ -411,6 +415,7 @@ class local_asset_dir:
 
     def download_portalsurfer_assets(self, asset_dir: Path) -> None:
         entries = {str(item.get("name")): item for item in release_file_entries(self.release) if item.get("name")}
+        download_token = self.args.portal_download_token or fetch_portalsurfer_download_token(self.args)
         for asset in self.required_assets:
             entry = entries.get(asset)
             if not entry:
@@ -418,7 +423,10 @@ class local_asset_dir:
             url = str(entry.get("url") or entry.get("download_url") or entry.get("href") or "")
             if not url:
                 raise SystemExit(f"PortalSurfer catalog entry for {asset} does not include a download URL")
-            download_url(resolve_portalsurfer_url(self.args, url), asset_dir / asset)
+            download_url(
+                portalsurfer_download_url(resolve_portalsurfer_url(self.args, url), download_token),
+                asset_dir / asset,
+            )
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         if self.temp:
@@ -642,6 +650,32 @@ def download_url(url: str, path: Path) -> None:
 
 def request_for_url(url: str) -> urllib.request.Request:
     return urllib.request.Request(url, headers={"User-Agent": "wavecrate-release-verifier"})
+
+
+def fetch_portalsurfer_download_token(args: argparse.Namespace) -> str:
+    response = fetch_json(portalsurfer_gate_url(args))
+    if response.get("build_id") != args.portal_build_id:
+        raise SystemExit(
+            f"PortalSurfer gate build id mismatch: {response.get('build_id')} != {args.portal_build_id}"
+        )
+    token = response.get("download_token")
+    if not isinstance(token, str) or not token:
+        raise SystemExit("PortalSurfer gate did not return a download token")
+    return token
+
+
+def portalsurfer_gate_url(args: argparse.Namespace) -> str:
+    releases_base = (args.portal_catalog_url or "https://portalsurfer.org/wavecrate/api/v1/releases").rstrip("/")
+    build_id = urllib.parse.quote(str(args.portal_build_id), safe="")
+    return f"{releases_base}/{build_id}/gate?donation_amount=0.00"
+
+
+def portalsurfer_download_url(url: str, download_token: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query = [(key, value) for key, value in query if key != "download_token"]
+    query.append(("download_token", download_token))
+    return urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(query)))
 
 
 def resolve_portalsurfer_url(args: argparse.Namespace, url: str) -> str:

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -429,6 +429,11 @@ fn release_workflows_verify_published_artifacts_after_publication() {
         VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("pkeyutl"),
         "post-publish verifier must verify checksum signatures"
     );
+    assert!(
+        VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("/gate?donation_amount=0.00")
+            && VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("download_token"),
+        "PortalSurfer post-publish downloads must verify through the public download gate"
+    );
 }
 
 #[test]

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -504,6 +504,28 @@ fn portalsurfer_upload_catalog_verifier_rejects_different_timestamps() {
     );
 }
 
+#[test]
+fn published_release_verifier_adds_portalsurfer_download_tokens_to_file_urls() {
+    let script = repo_path("scripts/internal/release/verify_published_release.py");
+    let python = format!(
+        r#"
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location("verify_published_release", {script:?})
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+url = module.portalsurfer_download_url(
+    "https://portalsurfer.org/wavecrate/api/v1/releases/build/files/file.zip/download?existing=1",
+    "token with spaces",
+)
+assert url == "https://portalsurfer.org/wavecrate/api/v1/releases/build/files/file.zip/download?existing=1&download_token=token+with+spaces", url
+"#,
+        script = script.display().to_string(),
+    );
+    run_success(Command::new("python3").arg("-c").arg(python));
+}
+
 fn generate_ed25519_key(path: &Path) -> bool {
     let keygen = Command::new("openssl")
         .arg("genpkey")


### PR DESCRIPTION
## Scope
- Fix PortalSurfer post-publish verification to request a zero-price public download gate token before downloading release files.
- Append the returned `download_token` to catalog file download URLs while preserving existing query parameters.
- Keep checksum, signature, manifest, catalog hash, and metadata validation unchanged.

## Definition of Done
- PortalSurfer verification follows the same public gate flow as the website instead of downloading gated file URLs directly.
- The verifier no longer fails with `HTTP Error 403: Forbidden` for valid public release assets that require `download_token`.
- Tests protect the token-appending behavior and the release contract requires the gate path.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers published_release_verifier_adds_portalsurfer_download_tokens_to_file_urls`
- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`
- `CARGO_INCREMENTAL=0 cargo test --test release_contract`

## Live Failure Context
- Failed run: https://github.com/PORTALSURFER/wavecrate/actions/runs/28585503436
- Failed step: `Verify published PortalSurfer nightly release artifacts`
- Observed error: direct download of `/files/.../download` returned `HTTP Error 403: Forbidden`.
- Live smoke with this branch fetched a PortalSurfer gate token and got past the prior 403. It then stopped locally at checksum signature verification because macOS system LibreSSL cannot load the pinned Ed25519 public key; Ubuntu Actions has already exercised that signature verifier successfully in the preceding GitHub release verification step.

## Known Limitations
- I did not re-run the full GitHub nightly workflow from this branch.

User review is required before merge.