### PR TITLE
OPT-988 move map projection contracts

### DIFF
--- a/src/app/controller.rs
+++ b/src/app/controller.rs
@@ -43,6 +43,9 @@ pub(crate) mod updates;
 use crate::app_core::browser_projection_cache::{
     ProjectedBrowserPreloadWindow, ProjectedBrowserRowCacheEntry, ProjectedSelectedPathsLookup,
 };
+use crate::app_core::map_projection_contracts::{
+    ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey,
+};
 pub(crate) use crate::app_core::state::StatusTone;
 use crate::{
     app::state::UiState,
@@ -80,7 +83,6 @@ use tracing::info;
 
 #[cfg(test)]
 pub(crate) use ui::loading::ApplyWavEntriesParams;
-pub(crate) use ui::starmap_view::UmapPointQuery;
 pub(crate) use ui::status_message::StatusMessage;
 
 pub(crate) const MIN_SELECTION_WIDTH: f32 = 0.001;
@@ -92,28 +94,6 @@ pub(crate) const RANDOM_HISTORY_LIMIT: usize = 20;
 pub(crate) const FOCUS_HISTORY_LIMIT: usize = 100;
 pub(crate) const UNDO_LIMIT: usize = 20;
 pub(crate) const STATUS_LOG_LIMIT: usize = 200;
-
-/// Cache key for retained map-point projection payloads.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ProjectedMapPointsCacheKey {
-    /// Stable hash of the active source identifier.
-    pub source_id_hash: u64,
-    /// Stable hash of the active UMAP version.
-    pub umap_version_hash: u64,
-    /// Monotonic revision for cached map points.
-    pub points_revision: u64,
-    /// Bitwise query minimum X bound.
-    pub query_min_x_bits: u32,
-    /// Bitwise query maximum X bound.
-    pub query_max_x_bits: u32,
-    /// Bitwise query minimum Y bound.
-    pub query_min_y_bits: u32,
-    /// Bitwise query maximum Y bound.
-    pub query_max_y_bits: u32,
-}
-
-/// Retained immutable map-point payload reused across native map projections.
-pub(crate) type ProjectedMapPointCacheEntry = crate::app_core::actions::NativeMapPointModel;
 
 /// Maintains app state and bridges core logic to the active GUI runtime.
 pub struct AppController {

--- a/src/app/controller/ui/starmap_view/controller.rs
+++ b/src/app/controller/ui/starmap_view/controller.rs
@@ -2,6 +2,7 @@
 
 use crate::app::controller::library::analysis_jobs;
 use crate::app::state::SampleBrowserTab;
+use crate::app_core::map_projection_contracts::UmapPointQuery;
 use std::collections::HashMap;
 
 use super::connections::open_cached_source_db;

--- a/src/app/controller/ui/starmap_view/mod.rs
+++ b/src/app/controller/ui/starmap_view/mod.rs
@@ -7,4 +7,4 @@ mod models;
 mod repository;
 
 pub(crate) use jobs::{run_umap_build, run_umap_cluster_build};
-pub(crate) use models::{UmapBounds, UmapPoint, UmapPointQuery};
+pub(crate) use models::{UmapBounds, UmapPoint};

--- a/src/app/controller/ui/starmap_view/models.rs
+++ b/src/app/controller/ui/starmap_view/models.rs
@@ -1,7 +1,5 @@
 //! Shared starmap data models used by the UI controller and repository loaders.
 
-use crate::sample_sources::SourceId;
-
 /// Aggregate starmap bounds for the current layout.
 pub(crate) struct UmapBounds {
     pub min_x: f32,
@@ -16,15 +14,4 @@ pub(crate) struct UmapPoint {
     pub x: f32,
     pub y: f32,
     pub cluster_id: Option<i32>,
-}
-
-/// Query payload for loading visible starmap points and optional cluster metadata.
-pub(crate) struct UmapPointQuery<'a> {
-    pub model_id: &'a str,
-    pub umap_version: &'a str,
-    pub cluster_method: &'a str,
-    pub cluster_umap_version: &'a str,
-    pub source_id: Option<&'a SourceId>,
-    pub bounds: crate::app::state::MapQueryBounds,
-    pub limit: usize,
 }

--- a/src/app/controller/ui/starmap_view/repository/points.rs
+++ b/src/app/controller/ui/starmap_view/repository/points.rs
@@ -1,4 +1,5 @@
-use super::super::{UmapPoint, UmapPointQuery};
+use super::super::UmapPoint;
+use crate::app_core::map_projection_contracts::UmapPointQuery;
 use rusqlite::types::Value;
 use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 

--- a/src/app/controller/ui/starmap_view/repository/tests.rs
+++ b/src/app/controller/ui/starmap_view/repository/tests.rs
@@ -1,8 +1,8 @@
-use super::super::super::super::super::state::MapQueryBounds;
-use super::super::UmapPointQuery;
 use super::{
     bounds::load_umap_bounds, clusters::load_umap_cluster_centroids, points::load_umap_points,
 };
+use crate::app_core::map_projection_contracts::UmapPointQuery;
+use crate::app_core::state::MapQueryBounds;
 use crate::sample_sources::SourceId;
 use rusqlite::Connection;
 

--- a/src/app_core/app_api.rs
+++ b/src/app_core/app_api.rs
@@ -10,7 +10,7 @@
 //! | --- | --- | --- | --- | --- |
 //! | `AppController`, startup/test fixture helpers, and WAV edit-support predicate | `src/app::controller` | Intentionally still owned by `src/app` while mature runtime behavior remains there | `OPT-992` | App-core exposes a narrow runtime facade; fixture construction is test-owned; domain helpers no longer require broad controller aliases |
 //! | Browser projection cache, selected-path lookup, preload-window, and auto-rename row state | `src/app_core::browser_projection_cache` | App-core owned as of `OPT-987` | Done | Remaining work should keep new browser projection contracts in app-core and avoid reintroducing bridge aliases |
-//! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app::controller` retained projection/query state | Ready for app-core ownership | `OPT-988` | Map projection consumes app-core-owned query/cache contracts or a narrow map runtime adapter |
+//! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app_core::map_projection_contracts` | App-core owned as of `OPT-988` | Done | Remaining work should keep new map projection contracts in app-core and avoid reintroducing bridge aliases |
 //! | Dirty graph node/reason aliases used by frame preparation and invalidation adapters | `src/app::controller::state::runtime` | Ready for app-core invalidation ownership | `OPT-989` | App-core frame preparation and bridge invalidation use app-core invalidation names; legacy conversion is isolated or removed |
 //! | Browser, source, folder, and library-hygiene state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-990` | Browser/source/folder projections and tests use app-core DTOs or focused builders |
 //! | Waveform, prompt, drag/drop, map, audio/options, progress, update, and status state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-991` | Covered projection/action consumers use app-core DTOs or focused builders |
@@ -23,8 +23,7 @@
 
 pub(crate) mod controller {
     pub(crate) use crate::app::controller::{
-        AppController, ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey, UmapPointQuery,
-        build_named_gui_fixture_controller, supports_wav_destructive_edits,
+        AppController, build_named_gui_fixture_controller, supports_wav_destructive_edits,
     };
 
     pub(crate) type DerivedNodeId = crate::app::controller::state::runtime::DerivedNodeId;

--- a/src/app_core/controller.rs
+++ b/src/app_core/controller.rs
@@ -28,12 +28,6 @@ pub(crate) use frame_preparation::UiFramePreparationPlan;
 pub use startup::build_ui_app_controller;
 /// Runtime-facing app controller type used by migration hosts.
 pub type AppController = CurrentAppController;
-/// Retained map-point cache key used by ui-projection helpers.
-pub(crate) type ProjectedMapPointsCacheKey = current_controller::ProjectedMapPointsCacheKey;
-/// Retained normalized map-point cache entry used by ui-projection helpers.
-pub(crate) type ProjectedMapPointCacheEntry = current_controller::ProjectedMapPointCacheEntry;
-/// Map-point query payload alias used by ui-projection map projection.
-pub(crate) type UmapPointQuery<'a> = current_controller::UmapPointQuery<'a>;
 /// Retained controller dirty graph node identifiers used by frame preparation and bridge adapters.
 pub(crate) type DerivedNodeId = current_controller::DerivedNodeId;
 /// Retained controller dirty graph reason identifiers used by bridge adapters.

--- a/src/app_core/map_projection_contracts.rs
+++ b/src/app_core/map_projection_contracts.rs
@@ -1,0 +1,37 @@
+//! Map projection query and retained-cache contracts owned by app-core.
+
+use crate::app_core::state::MapQueryBounds;
+use crate::sample_sources::SourceId;
+
+/// Cache key for retained map-point projection payloads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ProjectedMapPointsCacheKey {
+    /// Stable hash of the active source identifier.
+    pub source_id_hash: u64,
+    /// Stable hash of the active UMAP version.
+    pub umap_version_hash: u64,
+    /// Monotonic revision for cached map points.
+    pub points_revision: u64,
+    /// Bitwise query minimum X bound.
+    pub query_min_x_bits: u32,
+    /// Bitwise query maximum X bound.
+    pub query_max_x_bits: u32,
+    /// Bitwise query minimum Y bound.
+    pub query_min_y_bits: u32,
+    /// Bitwise query maximum Y bound.
+    pub query_max_y_bits: u32,
+}
+
+/// Retained immutable map-point payload reused across native map projections.
+pub(crate) type ProjectedMapPointCacheEntry = crate::app_core::actions::NativeMapPointModel;
+
+/// Query payload for loading visible starmap points and optional cluster metadata.
+pub(crate) struct UmapPointQuery<'a> {
+    pub model_id: &'a str,
+    pub umap_version: &'a str,
+    pub cluster_method: &'a str,
+    pub cluster_umap_version: &'a str,
+    pub source_id: Option<&'a SourceId>,
+    pub bounds: MapQueryBounds,
+    pub limit: usize,
+}

--- a/src/app_core/mod.rs
+++ b/src/app_core/mod.rs
@@ -7,6 +7,9 @@ mod app_api;
 /// Retained browser projection cache contracts owned by app-core.
 pub(crate) mod browser_projection_cache;
 
+/// Retained map projection query/cache contracts owned by app-core.
+pub(crate) mod map_projection_contracts;
+
 /// Controller aliases and helpers used by migration-facing runtimes.
 pub mod controller;
 

--- a/src/app_core/ui_projection/map_projection/cache.rs
+++ b/src/app_core/ui_projection/map_projection/cache.rs
@@ -1,4 +1,5 @@
-use crate::app_core::controller::{AppController, ProjectedMapPointsCacheKey, UmapPointQuery};
+use crate::app_core::controller::AppController;
+use crate::app_core::map_projection_contracts::{ProjectedMapPointsCacheKey, UmapPointQuery};
 use crate::app_core::state::{MapBounds, MapPoint, MapQueryBounds};
 use crate::app_core::ui::MAX_RENDERED_MAP_POINTS;
 use crate::sample_sources::SourceId;

--- a/src/app_core/ui_projection/map_projection/points.rs
+++ b/src/app_core/ui_projection/map_projection/points.rs
@@ -1,6 +1,7 @@
 use super::super::waveform_projection::normalized_to_milli;
-use crate::app_core::controller::{
-    AppController, ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey,
+use crate::app_core::controller::AppController;
+use crate::app_core::map_projection_contracts::{
+    ProjectedMapPointCacheEntry, ProjectedMapPointsCacheKey,
 };
 use crate::app_core::state::{MapBounds, MapPoint};
 use std::collections::HashSet;


### PR DESCRIPTION
## Scope
- Add app-core-owned map projection query/cache contracts in `app_core::map_projection_contracts`.
- Move `ProjectedMapPointsCacheKey`, `ProjectedMapPointCacheEntry`, and `UmapPointQuery` callers off the `app_api::controller` / `app_core::controller` bridge aliases.
- Keep the legacy starmap repository/controller as the implementation detail while app-core owns the projection-facing contract.
- Update the migration inventory to mark the OPT-988 alias group done.

## Definition of Done
- Map projection query/cache contracts are owned by app-core.
- Retired map aliases are removed from `app_core::app_api::controller` and `app_core::controller`.
- Existing map projection and starmap repository behavior remains unchanged.
- Grep checks prevent lingering old bridge paths for this alias group.

## Validation Commands
- `bash scripts/agent.sh request`
  - Passed branch, migration boundary, script, legacy coupling, native boundary, and non-blocking fixture checks before stopping on the known Radiant generic guardrail trio.
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::ui_projection::map_projection`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib starmap_view::repository`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::controller`
- `bash scripts/internal/check/check_migration_boundary.sh`
- `bash scripts/internal/check/check_legacy_app_coupling.sh`
- `cargo fmt --check`
- `git diff --check`
- `rg -n "app_api::controller::(ProjectedMapPointCacheEntry|ProjectedMapPointsCacheKey|UmapPointQuery)|app_core::controller::(ProjectedMapPointCacheEntry|ProjectedMapPointsCacheKey|UmapPointQuery)|current_controller::(ProjectedMapPointCacheEntry|ProjectedMapPointsCacheKey|UmapPointQuery)" src tests scripts` (expected no matches)

## Known Limitations
- `bash scripts/agent.sh request` still stops on the existing Radiant generic guardrail trio unrelated to this change: `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, and `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`.

User review is required before merge.