### PR TITLE
OPT-991 own projection state contracts in app core

### DIFF
--- a/scripts/internal/check/allowlists/legacy_app_coupling_allowlist.txt
+++ b/scripts/internal/check/allowlists/legacy_app_coupling_allowlist.txt
@@ -6,3 +6,4 @@
 src/app_core/app_api.rs
 src/app_core/browser_source_state.rs
 src/app_core/invalidation_contracts.rs
+src/app_core/projection_state.rs

--- a/scripts/internal/check/check_migration_boundary.ps1
+++ b/scripts/internal/check/check_migration_boundary.ps1
@@ -22,6 +22,7 @@ try {
   $allowedTransitionalFiles = @(
     (Join-Path $appCoreDir "browser_source_state.rs")
     (Join-Path $appCoreDir "invalidation_contracts.rs")
+    (Join-Path $appCoreDir "projection_state.rs")
   )
 
   if (-not (Test-Path -LiteralPath $appCoreDir)) {

--- a/scripts/internal/check/check_migration_boundary.sh
+++ b/scripts/internal/check/check_migration_boundary.sh
@@ -8,6 +8,7 @@ ALLOWED_FILE="$APP_CORE_DIR/app_api.rs"
 ALLOWED_TRANSITIONAL_FILES=(
   "$APP_CORE_DIR/browser_source_state.rs"
   "$APP_CORE_DIR/invalidation_contracts.rs"
+  "$APP_CORE_DIR/projection_state.rs"
 )
 
 matches=()

--- a/src/app_core/app_api.rs
+++ b/src/app_core/app_api.rs
@@ -13,7 +13,7 @@
 //! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app_core::map_projection_contracts` | App-core owned as of `OPT-988` | Done | Remaining work should keep new map projection contracts in app-core and avoid reintroducing bridge aliases |
 //! | Dirty graph node/reason contracts used by frame preparation and invalidation adapters | `src/app_core::invalidation_contracts` | App-core owned as of `OPT-989`; conversion to the retained controller dirty graph is isolated in the contract adapter | Done | Remaining work should keep app-core invalidation names at frame-prep/bridge call sites and avoid reintroducing bridge aliases |
 //! | Browser, source, folder, and library-hygiene state DTOs | `src/app_core::browser_source_state` | App-core owned as of `OPT-990`; representation aliases remain while the legacy controller stores the backing UI state | Done | Remaining work should keep browser/source/folder state imports on app-core contracts and avoid reintroducing wildcard state bridge aliases |
-//! | Waveform, prompt, drag/drop, map, audio/options, progress, update, and status state DTOs exposed through the wildcard state bridge | `src/app::state` | Ready for app-core state ownership | `OPT-991` | Covered projection/action consumers use app-core DTOs or focused builders |
+//! | Waveform, prompt, drag/drop, map, audio/options, progress, update, and status state DTOs | `src/app_core::projection_state` | App-core owned as of `OPT-991`; representation aliases remain while the legacy controller stores the backing UI state | Done | Remaining work should keep projection/action state imports on app-core contracts and avoid reintroducing wildcard state bridge aliases |
 //!
 //! No current app-api export was classified as ready for direct `native_app`
 //! ownership in the `OPT-949` audit; `native_app` should continue consuming
@@ -25,11 +25,4 @@ pub(crate) mod controller {
     pub(crate) use crate::app::controller::{
         AppController, build_named_gui_fixture_controller, supports_wav_destructive_edits,
     };
-}
-
-pub(crate) mod state {
-    // Compatibility exports for state DTOs that are being moved in scoped
-    // slices: browser/source/folder through OPT-990 and the remaining
-    // waveform/prompt/drag/map/audio/status groups through OPT-991.
-    pub(crate) use crate::app::state::*;
 }

--- a/src/app_core/browser_source_state.rs
+++ b/src/app_core/browser_source_state.rs
@@ -3,7 +3,7 @@
 //! The legacy controller still stores the backing UI state during migration, so
 //! these contracts remain representation aliases for now. Keeping the aliases
 //! grouped here gives browser/source/folder projections one explicit app-core
-//! ownership point instead of depending on the broad `app_api::state` bridge.
+//! ownership point instead of depending on a broad legacy state bridge.
 
 use crate::app_core::actions::NativeBrowserTagTarget;
 

--- a/src/app_core/mod.rs
+++ b/src/app_core/mod.rs
@@ -13,6 +13,9 @@ pub(crate) mod browser_source_state;
 /// Retained map projection query/cache contracts owned by app-core.
 pub(crate) mod map_projection_contracts;
 
+/// Projection, prompt, drag/drop, map, audio, status, and waveform state contracts.
+pub(crate) mod projection_state;
+
 /// Retained UI invalidation contracts owned by app-core.
 pub(crate) mod invalidation_contracts;
 

--- a/src/app_core/projection_state.rs
+++ b/src/app_core/projection_state.rs
@@ -1,0 +1,111 @@
+//! Projection, prompt, drag/drop, map, audio, status, and waveform state contracts owned by app-core.
+//!
+//! The legacy controller still stores these backing state values during the
+//! runtime-facade migration. This module keeps the remaining projection-facing
+//! aliases grouped behind a focused app-core ownership point instead of the
+//! broad legacy state bridge.
+
+// Map projection state.
+
+/// Normalized map query bounds shared with map projection helpers.
+pub type MapQueryBounds = crate::app::state::MapQueryBounds;
+
+/// Cached map bounds used by migration-facing map projections.
+pub type MapBounds = crate::app::state::MapBounds;
+
+/// Cached projected map point payload used by migration-facing map projections.
+pub type MapPoint = crate::app::state::MapPoint;
+
+/// Map similarity-preparation status surfaced by map projections.
+pub type MapSimilarityPrepStatus = crate::app::state::MapSimilarityPrepStatus;
+
+/// Map rendering mode exposed by migration-facing projections.
+pub type MapRenderMode = crate::app::state::MapRenderMode;
+
+// Options/audio status state.
+
+/// Active audio-picker target shown in options flows.
+pub type AudioPickerTarget = crate::app::state::AudioPickerTarget;
+
+/// Active audio output description.
+#[cfg(test)]
+pub(crate) type ActiveAudioOutput = crate::app::state::ActiveAudioOutput;
+
+/// Audio host option description.
+#[cfg(test)]
+pub(crate) type AudioHostView = crate::app::state::AudioHostView;
+
+/// Audio device option description.
+#[cfg(test)]
+pub(crate) type AudioDeviceView = crate::app::state::AudioDeviceView;
+
+/// Update status exposed by migration-facing projections.
+pub type UpdateStatus = crate::app::state::UpdateStatus;
+
+/// UI status tone used for app-level status messages.
+pub type StatusTone = crate::app::state::StatusTone;
+
+/// Progress task kind used by progress overlays.
+#[cfg(test)]
+pub(crate) type ProgressTaskKind = crate::app::state::ProgressTaskKind;
+
+/// Progress overlay state used by controller action tests.
+#[cfg(test)]
+pub(crate) type ProgressOverlayState = crate::app::state::ProgressOverlayState;
+
+/// Issue-token status used by controller action tests.
+#[cfg(test)]
+pub(crate) type IssueTokenStatus = crate::app::state::IssueTokenStatus;
+
+// Prompt, drag/drop, and waveform state.
+
+/// Pending modal folder action prompt.
+pub type FolderActionPrompt = crate::app::state::FolderActionPrompt;
+
+/// Pending options-panel confirmation prompt.
+pub type OptionsPanelPrompt = crate::app::state::OptionsPanelPrompt;
+
+/// Destructive edit action exposed by prompt surfaces.
+pub type DestructiveSelectionEdit = crate::app::state::DestructiveSelectionEdit;
+
+/// Prompt model for destructive edits.
+pub type DestructiveEditPrompt = crate::app::state::DestructiveEditPrompt;
+
+/// Unified drag target used by migration-facing drag/drop projections.
+pub type DragTarget = crate::app::state::DragTarget;
+
+/// Active drag payload.
+pub type DragPayload = crate::app::state::DragPayload;
+
+/// Drag source used by waveform and browser actions.
+pub type DragSource = crate::app::state::DragSource;
+
+/// Focus context shared by controller action routing.
+pub type FocusContext = crate::app::state::FocusContext;
+
+/// UI-space point for drag/drop and waveform interactions.
+pub type UiPoint = crate::app::state::UiPoint;
+
+/// Waveform comparison-anchor state.
+#[cfg(test)]
+pub(crate) type CompareAnchorState = crate::app::state::CompareAnchorState;
+
+/// Waveform view state projected through migration-facing APIs.
+#[cfg(test)]
+pub(crate) type WaveformView = crate::app::state::WaveformView;
+
+/// Waveform slice batch profile used by waveform projection and options tests.
+pub type WaveformSliceBatchProfile = crate::app::state::WaveformSliceBatchProfile;
+
+/// Waveform slice-review state used by options tests.
+#[cfg(test)]
+pub(crate) type WaveformSliceReviewState = crate::app::state::WaveformSliceReviewState;
+
+/// Waveform duplicate-cleanup state used by options tests.
+#[cfg(test)]
+pub(crate) type WaveformDuplicateCleanupState = crate::app::state::WaveformDuplicateCleanupState;
+
+/// Waveform duplicate-cleanup preview used by options tests.
+#[cfg(test)]
+pub(crate) type WaveformDuplicateCleanupPreview =
+    crate::app::state::WaveformDuplicateCleanupPreview;

--- a/src/app_core/state.rs
+++ b/src/app_core/state.rs
@@ -3,11 +3,10 @@
 //! App-core projections and tests should import state DTOs from this module
 //! instead of reaching into the legacy `app` tree directly. Most entries are
 //! compatibility aliases while the legacy controller still owns the backing UI
-//! state, but this file is the documented boundary for state ownership during
-//! migration. The active ownership inventory and exit criteria live next to the
-//! single legacy crossing in `app_core::app_api`.
+//! state, but this file is the documented app-core re-export boundary for state
+//! ownership during migration. The active ownership inventory and exit criteria
+//! live in `app_core::app_api`.
 
-use crate::app_core::app_api::state as app_state;
 pub use crate::app_core::browser_source_state::{
     BrowserBpmFacet, BrowserDuplicateCleanupState, BrowserSidebarFilterFacet,
     BrowserSidebarFilterOption, BrowserSidebarFilterState, BrowserTagTarget, FolderBrowserUiState,
@@ -19,107 +18,15 @@ pub use crate::app_core::browser_source_state::{
 };
 #[cfg(test)]
 pub(crate) use crate::app_core::browser_source_state::{SampleBrowserIndex, SimilarQuery};
-
-// Map projection state.
-
-/// Normalized map query bounds shared with map projection helpers.
-pub type MapQueryBounds = app_state::MapQueryBounds;
-
-/// Cached map bounds used by migration-facing map projections.
-pub type MapBounds = app_state::MapBounds;
-
-/// Cached projected map point payload used by migration-facing map projections.
-pub type MapPoint = app_state::MapPoint;
-
-/// Map similarity-preparation status surfaced by map projections.
-pub type MapSimilarityPrepStatus = app_state::MapSimilarityPrepStatus;
-
-/// Map rendering mode exposed by migration-facing projections.
-pub type MapRenderMode = app_state::MapRenderMode;
-
-// Options/audio status state.
-
-/// Active audio-picker target shown in options flows.
-pub type AudioPickerTarget = app_state::AudioPickerTarget;
-
-/// Active audio output description.
 #[cfg(test)]
-pub(crate) type ActiveAudioOutput = app_state::ActiveAudioOutput;
-
-/// Audio host option description.
-#[cfg(test)]
-pub(crate) type AudioHostView = app_state::AudioHostView;
-
-/// Audio device option description.
-#[cfg(test)]
-pub(crate) type AudioDeviceView = app_state::AudioDeviceView;
-
-/// Update status exposed by migration-facing projections.
-pub type UpdateStatus = app_state::UpdateStatus;
-
-/// UI status tone used for app-level status messages.
-pub type StatusTone = app_state::StatusTone;
-
-/// Progress task kind used by progress overlays.
-#[cfg(test)]
-pub(crate) type ProgressTaskKind = app_state::ProgressTaskKind;
-
-/// Progress overlay state used by controller action tests.
-#[cfg(test)]
-pub(crate) type ProgressOverlayState = app_state::ProgressOverlayState;
-
-/// Issue-token status used by controller action tests.
-#[cfg(test)]
-pub(crate) type IssueTokenStatus = app_state::IssueTokenStatus;
-
-// Prompt, drag/drop, and waveform state.
-
-/// Pending modal folder action prompt.
-pub type FolderActionPrompt = app_state::FolderActionPrompt;
-
-/// Pending options-panel confirmation prompt.
-pub type OptionsPanelPrompt = app_state::OptionsPanelPrompt;
-
-/// Destructive edit action exposed by prompt surfaces.
-pub type DestructiveSelectionEdit = app_state::DestructiveSelectionEdit;
-
-/// Prompt model for destructive edits.
-pub type DestructiveEditPrompt = app_state::DestructiveEditPrompt;
-
-/// Unified drag target used by migration-facing drag/drop projections.
-pub type DragTarget = app_state::DragTarget;
-
-/// Active drag payload.
-pub type DragPayload = app_state::DragPayload;
-
-/// Drag source used by waveform and browser actions.
-pub type DragSource = app_state::DragSource;
-
-/// Focus context shared by controller action routing.
-pub type FocusContext = app_state::FocusContext;
-
-/// UI-space point for drag/drop and waveform interactions.
-pub type UiPoint = app_state::UiPoint;
-
-/// Waveform comparison-anchor state.
-#[cfg(test)]
-pub(crate) type CompareAnchorState = app_state::CompareAnchorState;
-
-/// Waveform view state projected through migration-facing APIs.
-#[cfg(test)]
-pub(crate) type WaveformView = app_state::WaveformView;
-
-/// Waveform slice batch profile used by waveform projection and options tests.
-pub type WaveformSliceBatchProfile = app_state::WaveformSliceBatchProfile;
-
-/// Waveform slice-review state used by options tests.
-#[cfg(test)]
-pub(crate) type WaveformSliceReviewState = app_state::WaveformSliceReviewState;
-
-/// Waveform duplicate-cleanup state used by options tests.
-#[cfg(test)]
-pub(crate) type WaveformDuplicateCleanupState = app_state::WaveformDuplicateCleanupState;
-
-/// Waveform duplicate-cleanup preview used by options tests.
-#[cfg(test)]
-pub(crate) type WaveformDuplicateCleanupPreview = app_state::WaveformDuplicateCleanupPreview;
+pub(crate) use crate::app_core::projection_state::{
+    ActiveAudioOutput, AudioDeviceView, AudioHostView, CompareAnchorState, IssueTokenStatus,
+    ProgressOverlayState, ProgressTaskKind, WaveformDuplicateCleanupPreview,
+    WaveformDuplicateCleanupState, WaveformSliceReviewState, WaveformView,
+};
+pub use crate::app_core::projection_state::{
+    AudioPickerTarget, DestructiveEditPrompt, DestructiveSelectionEdit, DragPayload, DragSource,
+    DragTarget, FocusContext, FolderActionPrompt, MapBounds, MapPoint, MapQueryBounds,
+    MapRenderMode, MapSimilarityPrepStatus, OptionsPanelPrompt, StatusTone, UiPoint, UpdateStatus,
+    WaveformSliceBatchProfile,
+};


### PR DESCRIPTION
## Scope
- Add `app_core::projection_state` as the explicit app-core ownership point for map, audio/options/status, prompt, drag/drop/focus, and waveform state DTOs.
- Re-export those contracts through `app_core::state`, removing the remaining broad `app_state::...` aliases from `state.rs`.
- Remove the wildcard `app_core::app_api::state` bridge now that OPT-990 and OPT-991 state groups have focused app-core contract modules.
- Update the migration inventory and guard allowlists for the focused transitional adapter.

## Definition of Done
- Waveform, prompt, drag/drop, map, audio/options, progress, and status state ownership is explicit in `app_core::projection_state`.
- Covered app-core consumers no longer depend on the broad wildcard legacy state bridge for migrated DTOs.
- User-visible projection/action behavior is unchanged and covered by focused tests.
- Remaining state ownership is documented through the app-core contract modules rather than wildcard app-api aliases.

## Validation Commands
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::ui_projection`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::controller::waveform_actions` (passes; current filter matches 0 tests)
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::ui_bridge`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate --lib app_core::controller`
- `bash scripts/internal/check/check_migration_boundary.sh`
- `bash scripts/internal/check/check_legacy_app_coupling.sh`
- `rg -n "app_api::state|app_core::app_api::state|use crate::app_core::app_api::state|pub\\(crate\\) mod state|app_state::" src/app_core src/native_app`
- `rg -n "crate::app::state::" src/app_core/ui_projection src/app_core/controller/waveform_actions src/app_core/ui_bridge src/app_core/test_fixtures.rs src/app_core/state.rs`
- `cargo fmt --check`
- `git diff --cached --check`

## Known Limitations
- PowerShell guard parity was updated but not executed locally because neither `pwsh` nor `powershell` is available in this environment.
- These state contracts remain representation aliases while the legacy controller stores the backing UI state; OPT-992 owns replacing the broad controller runtime facade.

User review is required before merge.
