### PR TITLE
OPT-992: shrink app-core controller bridge

### DIFF
--- a/scripts/internal/check/allowlists/legacy_app_coupling_allowlist.txt
+++ b/scripts/internal/check/allowlists/legacy_app_coupling_allowlist.txt
@@ -5,5 +5,8 @@
 
 src/app_core/app_api.rs
 src/app_core/browser_source_state.rs
+src/app_core/controller/runtime_facade.rs
+src/app_core/gui_fixtures.rs
 src/app_core/invalidation_contracts.rs
 src/app_core/projection_state.rs
+src/app_core/wav_edit_support.rs

--- a/scripts/internal/check/check_migration_boundary.ps1
+++ b/scripts/internal/check/check_migration_boundary.ps1
@@ -21,8 +21,11 @@ try {
   $allowedFile = Join-Path $appCoreDir "app_api.rs"
   $allowedTransitionalFiles = @(
     (Join-Path $appCoreDir "browser_source_state.rs")
+    (Join-Path $appCoreDir "controller/runtime_facade.rs")
+    (Join-Path $appCoreDir "gui_fixtures.rs")
     (Join-Path $appCoreDir "invalidation_contracts.rs")
     (Join-Path $appCoreDir "projection_state.rs")
+    (Join-Path $appCoreDir "wav_edit_support.rs")
   )
 
   if (-not (Test-Path -LiteralPath $appCoreDir)) {

--- a/scripts/internal/check/check_migration_boundary.sh
+++ b/scripts/internal/check/check_migration_boundary.sh
@@ -7,8 +7,11 @@ APP_CORE_DIR="$ROOT_DIR/src/app_core"
 ALLOWED_FILE="$APP_CORE_DIR/app_api.rs"
 ALLOWED_TRANSITIONAL_FILES=(
   "$APP_CORE_DIR/browser_source_state.rs"
+  "$APP_CORE_DIR/controller/runtime_facade.rs"
+  "$APP_CORE_DIR/gui_fixtures.rs"
   "$APP_CORE_DIR/invalidation_contracts.rs"
   "$APP_CORE_DIR/projection_state.rs"
+  "$APP_CORE_DIR/wav_edit_support.rs"
 )
 
 matches=()

--- a/src/app/controller/ui/hotkeys_controller/tests/similarity.rs
+++ b/src/app/controller/ui/hotkeys_controller/tests/similarity.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app_core::controller::build_named_gui_fixture_controller;
+use crate::app_core::gui_fixtures::build_named_gui_fixture_controller;
 use crate::waveform::WaveformRenderer;
 
 #[test]

--- a/src/app_core/app_api.rs
+++ b/src/app_core/app_api.rs
@@ -8,21 +8,15 @@
 //!
 //! | Legacy surface | Current owner | Classification | Exit issue | Exit criteria |
 //! | --- | --- | --- | --- | --- |
-//! | `AppController`, startup/test fixture helpers, and WAV edit-support predicate | `src/app::controller` | Intentionally still owned by `src/app` while mature runtime behavior remains there | `OPT-992` | App-core exposes a narrow runtime facade; fixture construction is test-owned; domain helpers no longer require broad controller aliases |
+//! | App-controller runtime backend | `src/app_core::controller::runtime_facade` | App-core owned facade as of `OPT-992`; the retained legacy controller remains the backend implementation behind the facade | Done | Remaining work should add explicit facade methods instead of reintroducing `AppController` aliases through `app_api` |
+//! | GUI fixture construction | `src/app_core::gui_fixtures` | App-core owned fixture adapter as of `OPT-992`; deterministic seeding still delegates to retained legacy fixture builders | Done | Remaining work should keep fixture construction out of production controller exports |
+//! | WAV edit-support predicate | `src/app_core::wav_edit_support` | App-core owned projection/domain helper as of `OPT-992`; predicate implementation still delegates to retained legacy WAV library support | Done | Remaining work should move the implementation to a product-domain module when destructive-edit IO leaves the retained controller |
 //! | Browser projection cache, selected-path lookup, preload-window, and auto-rename row state | `src/app_core::browser_projection_cache` | App-core owned as of `OPT-987` | Done | Remaining work should keep new browser projection contracts in app-core and avoid reintroducing bridge aliases |
 //! | Map projection cache key, projected map-point entry, and UMAP point query payload | `src/app_core::map_projection_contracts` | App-core owned as of `OPT-988` | Done | Remaining work should keep new map projection contracts in app-core and avoid reintroducing bridge aliases |
 //! | Dirty graph node/reason contracts used by frame preparation and invalidation adapters | `src/app_core::invalidation_contracts` | App-core owned as of `OPT-989`; conversion to the retained controller dirty graph is isolated in the contract adapter | Done | Remaining work should keep app-core invalidation names at frame-prep/bridge call sites and avoid reintroducing bridge aliases |
 //! | Browser, source, folder, and library-hygiene state DTOs | `src/app_core::browser_source_state` | App-core owned as of `OPT-990`; representation aliases remain while the legacy controller stores the backing UI state | Done | Remaining work should keep browser/source/folder state imports on app-core contracts and avoid reintroducing wildcard state bridge aliases |
 //! | Waveform, prompt, drag/drop, map, audio/options, progress, update, and status state DTOs | `src/app_core::projection_state` | App-core owned as of `OPT-991`; representation aliases remain while the legacy controller stores the backing UI state | Done | Remaining work should keep projection/action state imports on app-core contracts and avoid reintroducing wildcard state bridge aliases |
 //!
-//! No current app-api export was classified as ready for direct `native_app`
-//! ownership in the `OPT-949` audit; `native_app` should continue consuming
-//! app-core contracts rather than owning these migration DTOs directly. No
-//! alias was confirmed obsolete/dead in this audit. Remove aliases only after a
-//! scoped follow-up proves the replacement path with focused validation.
-
-pub(crate) mod controller {
-    pub(crate) use crate::app::controller::{
-        AppController, build_named_gui_fixture_controller, supports_wav_destructive_edits,
-    };
-}
+//! No current app-api export remains after `OPT-992`; `native_app` should
+//! continue consuming app-core contracts rather than owning migration DTOs
+//! directly. Reintroduce aliases here only with a scoped owner and exit issue.

--- a/src/app_core/controller.rs
+++ b/src/app_core/controller.rs
@@ -1,8 +1,7 @@
-//! Backend-neutral controller aliases for migration consumers.
+//! Backend-neutral controller facade for migration consumers.
 //!
-//! These aliases keep UI runtime entrypoints stable while the runtime-agnostic
-//! controller API remains sourced from the current `app` implementation during
-//! migration.
+//! The facade keeps UI runtime entrypoints stable while the current legacy
+//! controller remains the backend implementation during migration.
 
 /// UI runtime action dispatch orchestration and telemetry helpers.
 mod action_dispatch;
@@ -14,20 +13,16 @@ mod frame_preparation;
 mod map_actions;
 /// Prompt, progress, and update UI action dispatch helpers.
 mod prompt_update_actions;
+/// App-core-owned runtime facade over the retained legacy controller backend.
+mod runtime_facade;
 /// UI-runtime controller startup helpers.
 mod startup;
 /// Focused waveform-UI action dispatch extracted from the main controller shim.
 mod waveform_actions;
 
-use crate::app_core::app_api::controller as current_controller;
-use current_controller::AppController as CurrentAppController;
-pub(crate) use current_controller::{
-    build_named_gui_fixture_controller, supports_wav_destructive_edits,
-};
 pub(crate) use frame_preparation::UiFramePreparationPlan;
-pub use startup::build_ui_app_controller;
-/// Runtime-facing app controller type used by migration hosts.
-pub type AppController = CurrentAppController;
+pub use runtime_facade::AppController;
+pub(crate) use startup::build_ui_app_controller;
 
 use crate::app_core::actions::{NativeAppModel, NativeUiAction};
 #[cfg(test)]
@@ -38,7 +33,7 @@ use map_actions::apply_map_ui_action;
 use prompt_update_actions::apply_prompt_and_update_ui_action;
 use waveform_actions::apply_waveform_ui_action;
 
-/// Backend-neutral UI-runtime orchestration helpers.
+/// Backend-neutral UI-runtime orchestration helpers exposed by the facade.
 pub trait AppControllerUiRuntimeExt {
     /// Apply per-frame controller maintenance before projecting the UI model.
     ///

--- a/src/app_core/controller/runtime_facade.rs
+++ b/src/app_core/controller/runtime_facade.rs
@@ -1,0 +1,8 @@
+//! App-core-owned runtime facade over the retained legacy controller backend.
+//!
+//! The mature controller implementation still lives in `src/app`. This module
+//! is the only app-core production adapter that names that backend while
+//! migration slices continue moving behavior behind narrower app-core methods.
+
+/// Runtime-facing controller type owned by the app-core facade module.
+pub type AppController = crate::app::controller::AppController;

--- a/src/app_core/controller/startup.rs
+++ b/src/app_core/controller/startup.rs
@@ -9,7 +9,7 @@ use super::AppController;
 ///
 /// This centralizes controller creation and config loading so UI hosts need not
 /// depend directly on app-controller initialization details.
-pub fn build_ui_app_controller(
+pub(crate) fn build_ui_app_controller(
     renderer: WaveformRenderer,
     player: Option<Rc<RefCell<AudioPlayer>>>,
 ) -> Result<AppController, String> {

--- a/src/app_core/controller/tests/contextual_actions.rs
+++ b/src/app_core/controller/tests/contextual_actions.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app_core::controller::build_named_gui_fixture_controller;
+use crate::app_core::gui_fixtures::build_named_gui_fixture_controller;
 use std::path::Path;
 
 fn with_fixture_controller(tag: &str, run: impl FnOnce(&mut AppController)) {

--- a/src/app_core/controller/tests/waveform/mod.rs
+++ b/src/app_core/controller/tests/waveform/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::app_core::controller::build_named_gui_fixture_controller;
+use crate::app_core::gui_fixtures::build_named_gui_fixture_controller;
 use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
 use std::path::Path;
 

--- a/src/app_core/gui_fixtures.rs
+++ b/src/app_core/gui_fixtures.rs
@@ -1,0 +1,29 @@
+//! App-core fixture builders for deterministic GUI/runtime scenarios.
+//!
+//! Fixture seeding still uses the retained legacy controller implementation, but
+//! callers receive the app-core runtime facade so fixture construction does not
+//! leak the broad legacy controller type through `app_api`.
+
+use tempfile::TempDir;
+
+use crate::{app_core::controller::AppController, waveform::WaveformRenderer};
+
+/// One app-core controller fixture and the temporary resources it keeps alive.
+pub(crate) struct GuiFixtureControllerBundle {
+    /// Seeded controller facade ready for GUI scenario execution.
+    pub(crate) controller: AppController,
+    /// Temporary directories that back seeded files and databases.
+    pub(crate) sandbox_guards: Vec<TempDir>,
+}
+
+/// Build a deterministic app-core controller fixture for the requested GUI tag.
+pub(crate) fn build_named_gui_fixture_controller(
+    renderer: WaveformRenderer,
+    fixture_tag: &str,
+) -> Result<GuiFixtureControllerBundle, String> {
+    let bundle = crate::app::controller::build_named_gui_fixture_controller(renderer, fixture_tag)?;
+    Ok(GuiFixtureControllerBundle {
+        controller: bundle.controller,
+        sandbox_guards: bundle.sandbox_guards,
+    })
+}

--- a/src/app_core/mod.rs
+++ b/src/app_core/mod.rs
@@ -13,8 +13,14 @@ pub(crate) mod browser_source_state;
 /// Retained map projection query/cache contracts owned by app-core.
 pub(crate) mod map_projection_contracts;
 
+/// Deterministic GUI fixture builders that return app-core runtime facades.
+pub(crate) mod gui_fixtures;
+
 /// Projection, prompt, drag/drop, map, audio, status, and waveform state contracts.
 pub(crate) mod projection_state;
+
+/// WAV destructive-edit support checks owned by app-core projection helpers.
+pub(crate) mod wav_edit_support;
 
 /// Retained UI invalidation contracts owned by app-core.
 pub(crate) mod invalidation_contracts;

--- a/src/app_core/ui_bridge/mod.rs
+++ b/src/app_core/ui_bridge/mod.rs
@@ -101,7 +101,7 @@ impl WavecrateUiBridge {
     /// Benchmark and fixture harnesses use this to drive the retained native
     /// bridge over a known controller snapshot without loading persisted app
     /// configuration a second time.
-    pub fn from_fixture_controller(controller: AppController) -> Self {
+    pub(crate) fn from_fixture_controller(controller: AppController) -> Self {
         Self {
             controller,
             projection_cache: projection_cache::UiProjectionCache::default(),

--- a/src/app_core/ui_bridge/tests/bridge_runtime/projection.rs
+++ b/src/app_core/ui_bridge/tests/bridge_runtime/projection.rs
@@ -64,7 +64,7 @@ fn bridge_reprojects_after_async_waveform_image_arrival() {
 #[test]
 #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn async_waveform_image_arrival_is_projection_only_dirty_work() {
-    let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
+    let bundle = crate::app_core::gui_fixtures::build_named_gui_fixture_controller(
         WaveformRenderer::new(32, 16),
         "waveform",
     )
@@ -173,7 +173,7 @@ fn random_navigation_toggle_updates_projected_browser_actions_immediately() {
 #[test]
 #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn duplicate_cleanup_projects_active_browser_state_and_row_badges() {
-    let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
+    let bundle = crate::app_core::gui_fixtures::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
         "waveform",
     )
@@ -232,7 +232,7 @@ fn duplicate_cleanup_projects_active_browser_state_and_row_badges() {
 #[test]
 #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn toggle_loop_playback_refreshes_loaded_sample_loop_badge_immediately() {
-    let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
+    let bundle = crate::app_core::gui_fixtures::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
         "waveform",
     )
@@ -273,7 +273,7 @@ fn toggle_loop_playback_refreshes_loaded_sample_loop_badge_immediately() {
 #[test]
 #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn toggle_loop_playback_refreshes_loaded_sample_bpm_and_loop_badges_immediately() {
-    let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
+    let bundle = crate::app_core::gui_fixtures::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
         "waveform",
     )

--- a/src/app_core/ui_bridge/tests/bridge_runtime/pull_prep.rs
+++ b/src/app_core/ui_bridge/tests/bridge_runtime/pull_prep.rs
@@ -159,7 +159,7 @@ fn startup_work_uses_startup_retained_pull_plan() {
 #[test]
 #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed bridge runtime coverage is too expensive for the default lib test lane"]
 fn metadata_work_uses_metadata_retained_pull_plan() {
-    let bundle = crate::app_core::controller::build_named_gui_fixture_controller(
+    let bundle = crate::app_core::gui_fixtures::build_named_gui_fixture_controller(
         WaveformRenderer::new(16, 16),
         "waveform",
     )

--- a/src/app_core/ui_projection.rs
+++ b/src/app_core/ui_projection.rs
@@ -10,7 +10,6 @@ use crate::app_core::actions::{
     NativeDragOverlayModel as DragOverlayModel, NativeFocusContextModel as FocusContextModel,
     NativeProgressOverlayModel as ProgressOverlayModel,
 };
-use crate::app_core::controller::supports_wav_destructive_edits;
 #[cfg(test)]
 use crate::app_core::state::{
     BrowserDuplicateCleanupState, CompareAnchorState, DestructiveEditPrompt,
@@ -22,6 +21,7 @@ use crate::app_core::state::{
     DragPayload, DragTarget, FocusContext, SampleBrowserTab, TriageFlagColumn, UiPoint, UiState,
 };
 use crate::app_core::ui::MAX_RENDERED_BROWSER_ROWS;
+use crate::app_core::wav_edit_support::supports_wav_destructive_edits;
 use std::sync::atomic::AtomicU64;
 
 #[cfg(test)]

--- a/src/app_core/wav_edit_support.rs
+++ b/src/app_core/wav_edit_support.rs
@@ -1,0 +1,11 @@
+//! Product-domain helper for destructive WAV edit capability checks.
+//!
+//! The file-format predicate remains implemented by the retained controller
+//! library while app-core owns the projection-facing helper surface.
+
+use std::path::Path;
+
+/// Return whether the file path can be handled by destructive WAV edit actions.
+pub(crate) fn supports_wav_destructive_edits(path: &Path) -> bool {
+    crate::app::controller::supports_wav_destructive_edits(path)
+}

--- a/src/gui_test/fixtures.rs
+++ b/src/gui_test/fixtures.rs
@@ -6,7 +6,7 @@ use crate::{
             NativeAppBridge, NativeDirtySegments, NativeFrameBuildResult, NativeMotionModel,
             NativeSegmentRevisions, NativeUiAction,
         },
-        controller::build_named_gui_fixture_controller,
+        gui_fixtures::build_named_gui_fixture_controller,
         ui_bridge::{WavecrateUiBridge, new_ui_bridge, new_ui_bridge_with_controller},
     },
     app_dirs::PersistenceProfileGuard,


### PR DESCRIPTION
## Scope
- Retire the `app_core::app_api::controller` export for `AppController`, GUI fixture construction, and WAV destructive-edit support.
- Add focused app-core owners for the remaining retained-controller seams:
  - `app_core::controller::runtime_facade` for the runtime-facing controller backend surface.
  - `app_core::gui_fixtures` for deterministic GUI fixture construction.
  - `app_core::wav_edit_support` for projection-facing WAV destructive-edit capability checks.
- Update fixture/test callers and GUI fixture bridge code to use the app-core fixture adapter instead of the controller bridge.
- Update migration inventory and guardrail allowlists so future legacy crossings stay localized to named adapter files.

## Definition of Done
- App-core no longer exposes `AppController` through `app_core::app_api::controller`.
- Fixture construction is isolated behind app-core fixture helpers.
- WAV destructive-edit support no longer requires a broad controller bridge export.
- Legacy controller backend access is documented as a retained implementation detail behind the app-core runtime facade adapter.
- Migration boundary checks pass with the new adapter locations.

## Validation Commands
- `cargo fmt --check`
- `cargo test -p wavecrate --lib app_core::controller`
- `cargo test -p wavecrate --lib app_core::ui_projection`
- `cargo test -p wavecrate --lib app_core::ui_bridge`
- `bash scripts/internal/check/check_migration_boundary.sh`
- `bash scripts/internal/check/check_legacy_app_coupling.sh`
- `bash scripts/ci.sh agent` *(Wavecrate smoke portion passed; failed later in existing Radiant non-blocking architecture guardrail tests, with no `vendor/radiant` changes in this PR.)*

## Known Limitations
- The retained legacy controller remains the backend implementation behind `app_core::controller::runtime_facade`; this PR removes the `app_api` alias and localizes the seam, but does not rewrite the mature controller.
- Local PowerShell is unavailable in this shell, so I ran the bash equivalents for the migration checks and agent validation.
- `scripts/ci.sh agent` currently fails in unrelated Radiant guardrail tests: `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`, and `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`.

User review is required before merge.
