### PR TITLE
OPT-1005 render playmark resize handles above boundaries

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -58,23 +58,28 @@ impl WaveformWidget {
         bounds: Rect,
     ) {
         let mut paint = WidgetPaint::new(primitives, self.common.id);
-        if self.extracted_range_overlays_visible() {
-            self.append_extracted_range_paint(&mut paint, bounds);
-        }
-        if self.similar_section_overlays_visible() {
-            self.append_similar_section_paint(&mut paint, bounds);
-        }
-        if self.should_paint_committed_selection(WaveformSelectionKind::Play)
-            && let Some(geometry) = self.selection_geometry(bounds, self.play_selection)
+        let mut handle_primitives = Vec::new();
         {
-            self.append_play_selection_paint(&mut paint, bounds, geometry);
-        }
-        if self.should_paint_committed_selection(WaveformSelectionKind::Edit)
-            && let Some(geometry) = self.selection_geometry(bounds, self.edit_selection)
-        {
-            self.append_edit_selection_paint(&mut paint, bounds, geometry);
+            let mut handle_paint = WidgetPaint::new(&mut handle_primitives, self.common.id);
+            if self.extracted_range_overlays_visible() {
+                self.append_extracted_range_paint(&mut paint, bounds);
+            }
+            if self.similar_section_overlays_visible() {
+                self.append_similar_section_paint(&mut paint, bounds);
+            }
+            if self.should_paint_committed_selection(WaveformSelectionKind::Play)
+                && let Some(geometry) = self.selection_geometry(bounds, self.play_selection)
+            {
+                self.append_play_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
+            }
+            if self.should_paint_committed_selection(WaveformSelectionKind::Edit)
+                && let Some(geometry) = self.selection_geometry(bounds, self.edit_selection)
+            {
+                self.append_edit_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
+            }
         }
         self.append_marker_paint(&mut paint, bounds);
+        paint.primitives_mut().extend(handle_primitives);
     }
 
     fn append_extracted_range_paint(&self, paint: &mut WidgetPaint<'_>, bounds: Rect) {
@@ -162,6 +167,7 @@ impl WaveformWidget {
     fn append_play_selection_paint(
         &self,
         paint: &mut WidgetPaint<'_>,
+        handle_paint: &mut WidgetPaint<'_>,
         bounds: Rect,
         geometry: CanvasSelectionGeometry,
     ) {
@@ -188,7 +194,7 @@ impl WaveformWidget {
         );
         self.append_selection_boundary_cursors(paint, bounds, self.play_selection, style, 1.25);
         self.append_selection_affordance_paint(
-            paint,
+            handle_paint,
             geometry,
             CanvasSelectionAffordanceStyle::new()
                 .with_edge(selection_resize_edge_style())
@@ -385,6 +391,7 @@ impl WaveformWidget {
     fn append_edit_selection_paint(
         &self,
         paint: &mut WidgetPaint<'_>,
+        handle_paint: &mut WidgetPaint<'_>,
         bounds: Rect,
         geometry: CanvasSelectionGeometry,
     ) {
@@ -411,16 +418,21 @@ impl WaveformWidget {
         );
         self.append_selection_boundary_cursors(paint, bounds, self.edit_selection, style, 1.25);
         self.append_selection_affordance_paint(
-            paint,
+            handle_paint,
             geometry,
             CanvasSelectionAffordanceStyle::new().with_body(selection_move_handle_style()),
             style.affordance_paint_parts(bounds),
         );
         if let Some(selection) = self.edit_selection {
-            self.append_edit_selection_resize_handle_paint(paint, bounds, geometry, selection);
+            self.append_edit_selection_resize_handle_paint(
+                handle_paint,
+                bounds,
+                geometry,
+                selection,
+            );
         }
         self.append_edit_gain_handle_for_geometry_paint(
-            paint,
+            handle_paint,
             bounds,
             geometry,
             edit_selection_handle_color(denied_flash_active).with_alpha(

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -21,6 +21,17 @@ fn assert_no_white_hover_border(plan: &SurfacePaintPlan) {
     );
 }
 
+fn fill_index(
+    fills: &[&PaintFillRect],
+    label: &str,
+    predicate: impl Fn(&PaintFillRect) -> bool,
+) -> usize {
+    fills
+        .iter()
+        .position(|fill| predicate(fill))
+        .unwrap_or_else(|| panic!("expected fill for {label}, got {fills:?}"))
+}
+
 #[test]
 fn overlay_paint_projects_play_edit_and_playhead_markers() {
     let mut state = WaveformState::synthetic_for_tests();
@@ -278,6 +289,97 @@ fn editmark_bottom_resize_handles_paint_on_base_edit_selection() {
             && (fill.rect.max.y - 80.0).abs() < 0.001
             && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 190)
     }));
+}
+
+#[test]
+fn playmark_resize_handles_paint_above_boundary_and_play_start_lines() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let widget = waveform_widget_for_state(&state);
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    let left_boundary = fill_index(&fills, "left playmark boundary", |fill| {
+        (fill.rect.center().x - 40.0).abs() < 1.0
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 230)
+    });
+    let right_boundary = fill_index(&fills, "right playmark boundary", |fill| {
+        (fill.rect.center().x - 120.0).abs() < 1.0
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 230)
+    });
+    let play_start_marker = fill_index(&fills, "play-start marker", |fill| {
+        (fill.rect.center().x - 40.0).abs() < 1.0
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (204, 255, 255, 245)
+    });
+    let left_handle = fill_index(&fills, "left playmark resize handle", |fill| {
+        (fill.rect.min.x - 36.5).abs() < 0.001
+            && (fill.rect.max.x - 43.5).abs() < 0.001
+            && (fill.rect.min.y - 0.0).abs() < 0.001
+            && (fill.rect.max.y - 22.0).abs() < 0.001
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 220)
+    });
+    let right_handle = fill_index(&fills, "right playmark resize handle", |fill| {
+        (fill.rect.min.x - 116.5).abs() < 0.001
+            && (fill.rect.max.x - 123.5).abs() < 0.001
+            && (fill.rect.min.y - 0.0).abs() < 0.001
+            && (fill.rect.max.y - 22.0).abs() < 0.001
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 220)
+    });
+
+    assert!(
+        left_boundary < left_handle,
+        "left resize handle should paint above the playmark boundary line"
+    );
+    assert!(
+        right_boundary < right_handle,
+        "right resize handle should paint above the playmark boundary line"
+    );
+    assert!(
+        play_start_marker < left_handle,
+        "left resize handle should paint above the bright play-start marker"
+    );
+}
+
+#[test]
+fn editmark_resize_handles_paint_above_boundary_lines() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.edit_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    let widget = waveform_widget_for_state(&state);
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    let left_boundary = fill_index(&fills, "left editmark boundary", |fill| {
+        (fill.rect.center().x - 40.0).abs() < 1.0
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 230)
+    });
+    let right_boundary = fill_index(&fills, "right editmark boundary", |fill| {
+        (fill.rect.center().x - 120.0).abs() < 1.0
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 230)
+    });
+    let left_handle = fill_index(&fills, "left editmark resize handle", |fill| {
+        (fill.rect.min.x - 36.5).abs() < 0.001
+            && (fill.rect.max.x - 43.5).abs() < 0.001
+            && (fill.rect.min.y - 58.0).abs() < 0.001
+            && (fill.rect.max.y - 80.0).abs() < 0.001
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 190)
+    });
+    let right_handle = fill_index(&fills, "right editmark resize handle", |fill| {
+        (fill.rect.min.x - 116.5).abs() < 0.001
+            && (fill.rect.max.x - 123.5).abs() < 0.001
+            && (fill.rect.min.y - 58.0).abs() < 0.001
+            && (fill.rect.max.y - 80.0).abs() < 0.001
+            && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 190)
+    });
+
+    assert!(
+        left_boundary < left_handle,
+        "left editmark resize handle should paint above the boundary line"
+    );
+    assert!(
+        right_boundary < right_handle,
+        "right editmark resize handle should paint above the boundary line"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope
- Defer waveform selection handle primitives into a final handle layer so playmark resize handles paint above selection boundary lines and the bright play-start marker.
- Apply the same final handle layering to editmark body, resize, and gain handles where they share the committed selection renderer.
- Add paint-order regression coverage for playmark and editmark resize handles.

## Definition of Done
- Playmark resize handles paint on top of playmark boundary/start marker lines.
- Both playmark resize handles remain visible in the committed/base overlay path.
- Editmark resize handles follow the same boundary-over-handle ordering rule.
- Existing resize preview and waveform overlay behavior remains unchanged.

## Validation commands
- `cargo fmt --check`
- `cargo test -p wavecrate native_app::waveform::tests::paint -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate playmark_resize_motion_updates_live_until_release -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate zoomed_playmark_resize_preview_matches_committed_transform -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate resized_playmark_preview_survives_widget_rebuild_after_press -- --test-threads=1`
- `git diff --check`

## Known limitations
- Manual app smoke testing is still recommended for playmark creation, resizing, sliding, and committed states on the real waveform surface.

User review is required before merge.