### PR TITLE
OPT-978 keep beat guides visible while sliding selections

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -235,24 +235,21 @@ impl WaveformWidget {
         }
     }
 
-    fn append_live_playmark_resize_beat_guide_paint(
+    fn append_live_selection_preview_beat_guide_paint(
         &self,
         paint: &mut WidgetPaint<'_>,
         bounds: Rect,
         preview: super::widget::LiveSelectionPreview,
     ) {
-        if preview.kind != WaveformSelectionKind::Play
-            || !matches!(
-                self.active_drag_kind,
-                Some(WaveformActiveDragKind::SelectionResize(
-                    WaveformSelectionKind::Play,
-                    _
-                ))
-            )
-        {
-            return;
+        match self.active_drag_kind {
+            Some(WaveformActiveDragKind::SelectionMove(kind))
+            | Some(WaveformActiveDragKind::SelectionResize(kind, _))
+                if kind == preview.kind =>
+            {
+                self.append_beat_guide_paint(paint, bounds, Some(preview.selection));
+            }
+            _ => {}
         }
-        self.append_beat_guide_paint(paint, bounds, Some(preview.selection));
     }
 
     fn append_beat_guide_paint(
@@ -313,7 +310,7 @@ impl WaveformWidget {
                     Some(preview.selection),
                     style,
                 );
-                self.append_live_playmark_resize_beat_guide_paint(&mut paint, bounds, preview);
+                self.append_live_selection_preview_beat_guide_paint(&mut paint, bounds, preview);
                 self.append_selection_affordance_paint(
                     &mut paint,
                     geometry,
@@ -342,6 +339,7 @@ impl WaveformWidget {
                     Some(preview.selection),
                     style,
                 );
+                self.append_live_selection_preview_beat_guide_paint(&mut paint, bounds, preview);
                 self.append_selection_affordance_paint(
                     &mut paint,
                     geometry,

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -32,6 +32,31 @@ fn fill_index(
         .unwrap_or_else(|| panic!("expected fill for {label}, got {fills:?}"))
 }
 
+fn beat_guide_fills<'a>(fills: &'a [&PaintFillRect]) -> Vec<&'a PaintFillRect> {
+    fills
+        .iter()
+        .copied()
+        .filter(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 214, 188, 170)
+        })
+        .collect()
+}
+
+fn assert_beat_guides_at(fills: &[&PaintFillRect], expected_xs: &[f32]) {
+    let guides = beat_guide_fills(fills);
+    assert_eq!(guides.len(), expected_xs.len(), "got guides {guides:?}");
+    for expected_x in expected_xs {
+        assert!(
+            guides.iter().any(|fill| {
+                (fill.rect.center().x - expected_x).abs() < 0.01
+                    && (fill.rect.min.y - 11.0).abs() < 0.01
+                    && (fill.rect.max.y - 69.0).abs() < 0.01
+            }),
+            "expected beat guide at x={expected_x}, got {guides:?}"
+        );
+    }
+}
+
 #[test]
 fn overlay_paint_projects_play_edit_and_playhead_markers() {
     let mut state = WaveformState::synthetic_for_tests();
@@ -925,6 +950,85 @@ fn beat_guides_do_not_paint_during_live_selection_creation_preview() {
                 && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
         }),
         "the live selection preview should still paint"
+    );
+}
+
+#[test]
+fn beat_guides_paint_from_live_playmark_slide_preview() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state_with_beat_guides(&state, true, 4);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.35, 0.75),
+    });
+
+    let plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    assert_beat_guides_at(&fills, &[90.0, 110.0, 130.0]);
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 70.0).abs() < 0.001
+                && (fill.rect.max.x - 150.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48)
+        }),
+        "the live slid playmark selection should still paint"
+    );
+}
+
+#[test]
+fn beat_guides_paint_from_live_editmark_slide_preview() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.edit_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.edit_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state_with_beat_guides(&state, true, 4);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Edit,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Edit,
+        selection: wavecrate::selection::SelectionRange::new(0.35, 0.75),
+    });
+
+    let plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    assert_beat_guides_at(&fills, &[90.0, 110.0, 130.0]);
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 70.0).abs() < 0.001
+                && (fill.rect.max.x - 150.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (82, 168, 255, 46)
+        }),
+        "the live slid editmark selection should still paint"
+    );
+}
+
+#[test]
+fn beat_guides_remain_hidden_for_live_slide_preview_when_disabled() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state_with_beat_guides(&state, false, 4);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.35, 0.75),
+    });
+
+    let plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    assert!(
+        beat_guide_fills(&fills).is_empty(),
+        "disabled beat guides should not paint during live slide previews"
     );
 }
 


### PR DESCRIPTION
## Scope
- Render beat guides from the live selection preview while playmark and editmark slide gestures are active.
- Keep the existing resize preview beat-guide behavior by sharing the same live-preview guide helper.
- Preserve fresh selection creation behavior and disabled beat-guide behavior.
- Add paint regression coverage for playmark slide, editmark slide, and disabled guide previews.

## Definition of Done
- Beat guides remain visible throughout playmark slide previews when enabled.
- Beat guides remain visible throughout editmark slide previews when enabled.
- Guide positions are derived from the live slid selection bounds.
- Beat guides remain hidden when disabled and during the existing fresh-creation preview path.

## Validation commands
- `cargo fmt --check`
- `cargo test -p wavecrate --bin wavecrate native_app::waveform::tests::paint -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate playmark_move_motion_updates_live_until_release -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate secondary_press_on_edit_top_handle_starts_move -- --test-threads=1`
- `git diff --check`

## Known limitations
- Manual app smoke testing is still recommended for sliding playmarks/editmarks near sample boundaries on the real waveform surface.

User review is required before merge.