### PR TITLE
Add playmark drag ghost preview

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -43,6 +43,7 @@ const PLAY_START_MARKER_COLOR: Rgba8 = Rgba8::new(204, 255, 255, 245);
 const PLAYHEAD_COLOR: Rgba8 = Rgba8::new(71, 220, 255, 245);
 const HOVER_CURSOR_COLOR: Rgba8 = Rgba8::new(255, 255, 255, 210);
 const PLAY_HANDLE_ACTION_HOVER_COLOR: Rgba8 = Rgba8::new(255, 202, 112, 255);
+const PLAY_HANDLE_DRAG_GHOST_ALPHA: u8 = 178;
 const HANDLE_HOVER_ALPHA: u8 = 255;
 const EDIT_RESIZE_HANDLE_ALPHA: u8 = 190;
 const EDIT_GAIN_HANDLE_ALPHA: u8 = 225;
@@ -366,6 +367,49 @@ impl WaveformWidget {
                     ),
                 );
             }
+        }
+    }
+
+    pub(super) fn append_playmark_drag_ghost_paint(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+    ) {
+        let Some(preview) = self.live_selection_preview_for_kind(WaveformSelectionKind::Play)
+        else {
+            return;
+        };
+        let Some(role) = self.active_playmark_drag_ghost_role() else {
+            return;
+        };
+        let Some(geometry) = self.selection_geometry(bounds, Some(preview.selection)) else {
+            return;
+        };
+        let edge_bounds = match role {
+            DragHandleRole::Start | DragHandleRole::End => {
+                bounds.top_edge_strip(SELECTION_RESIZE_HANDLE_STRIP_HEIGHT)
+            }
+            _ => bounds,
+        };
+        let mut paint = WidgetPaint::new(primitives, self.common.id);
+        self.append_hover_selection_handle_fill(
+            &mut paint,
+            geometry,
+            edge_bounds,
+            role,
+            PLAY_HANDLE_ACTION_HOVER_COLOR.with_alpha(PLAY_HANDLE_DRAG_GHOST_ALPHA),
+        );
+    }
+
+    fn active_playmark_drag_ghost_role(&self) -> Option<DragHandleRole> {
+        match self.active_drag_kind {
+            Some(WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, edge)) => {
+                Some(waveform_selection_edge_role(edge))
+            }
+            Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play)) => {
+                Some(DragHandleRole::Body)
+            }
+            _ => None,
         }
     }
 

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -899,6 +899,73 @@ fn resize_selection_paints_once_from_base_layer_when_preview_is_live() {
 }
 
 #[test]
+fn playmark_resize_drag_ghost_paints_active_handle_without_double_painting_selection() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.8));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state(&state);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionResize(
+        WaveformSelectionKind::Play,
+        WaveformSelectionEdge::End,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.2, 0.8),
+    });
+
+    let runtime_plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let runtime_fills = fill_rects(&runtime_plan);
+
+    assert!(
+        runtime_fills.iter().any(|fill| {
+            (fill.rect.min.x - 156.5).abs() < 0.001
+                && (fill.rect.max.x - 163.5).abs() < 0.001
+                && (fill.rect.min.y - 0.0).abs() < 0.001
+                && (fill.rect.max.y - 22.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 202, 112, 178)
+        }),
+        "active resize handle should paint a drag ghost"
+    );
+    assert!(
+        runtime_fills.iter().all(|fill| {
+            !((fill.rect.min.x - 40.0).abs() < 0.001
+                && (fill.rect.max.x - 160.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 48))
+        }),
+        "drag ghost must not reintroduce runtime double-painting of the playmark range"
+    );
+}
+
+#[test]
+fn playmark_move_drag_ghost_paints_body_handle_on_live_preview() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let mut widget = waveform_widget_for_state(&state);
+    widget.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.25, 0.65),
+    });
+
+    let plan = runtime_overlay_plan(&widget, Rect::from_size(200.0, 80.0));
+    let fills = fill_rects(&plan);
+
+    assert!(
+        fills.iter().any(|fill| {
+            (fill.rect.min.x - 59.0).abs() < 0.001
+                && (fill.rect.max.x - 121.0).abs() < 0.001
+                && (fill.rect.min.y - 0.0).abs() < 0.001
+                && (fill.rect.max.y - 7.0).abs() < 0.001
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 202, 112, 178)
+        }),
+        "active move handle should paint a drag ghost over the live preview"
+    );
+}
+
+#[test]
 fn committed_selection_paints_as_resize_fallback_until_preview_is_live() {
     let mut state = WaveformState::synthetic_for_tests();
     state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -437,6 +437,7 @@ impl Widget for WaveformWidget {
         _theme: &ThemeTokens,
     ) {
         self.append_live_selection_preview_paint(primitives, bounds);
+        self.append_playmark_drag_ghost_paint(primitives, bounds);
         self.append_sample_slide_preview_paint(primitives, bounds);
         self.append_hover_edit_fade_handle_paint(primitives, bounds);
         self.append_hover_edit_fade_outer_gain_handle_paint(primitives, bounds);


### PR DESCRIPTION
## Scope
- Add a lightweight runtime-overlay drag ghost for playmark resize and move drags.
- Reuse the existing playmark action-hover color at lower alpha so active dragging has visible feedback without painting another full selection range.
- Cover resize and move drag ghost paint behavior with focused waveform paint tests.

## Definition of Done
- Playmark resize drags paint a visible ghost on the active resize handle while dragging.
- Playmark move drags paint a visible ghost on the live preview body handle while dragging.
- Runtime resize overlay still does not double-paint the translucent playmark selection range.
- Focused paint and input regression tests pass.

## Validation commands
- cargo fmt --check
- git diff --check
- cargo test -p wavecrate --bin wavecrate native_app::waveform::tests::paint -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate resized_playmark_preview_survives_widget_rebuild_after_press -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate zoomed_playmark_resize_preview_matches_committed_transform -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate playmark_resize_motion_updates_live_until_release -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate playmark_move_motion_updates_live_until_release -- --test-threads=1

## Known limitations
None

User review is required before merge.