### PR TITLE
OPT-1002 Preserve list focus across filtered samples

### DIFF
--- a/src/native_app/metadata/assignment.rs
+++ b/src/native_app/metadata/assignment.rs
@@ -169,6 +169,10 @@ impl NativeAppState {
         targets: Vec<MetadataTagTarget>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         let mut requests = Vec::new();
         let mut changed_files = Vec::new();
         for target in targets {
@@ -231,7 +235,7 @@ impl NativeAppState {
         }
         let touched_paths = changed_files.iter().map(PathBuf::from).collect::<Vec<_>>();
         self.mark_harvest_touched_for_paths(&touched_paths);
-        self.finish_metadata_tag_curation_change(&changed_files);
+        self.finish_metadata_tag_curation_change(&changed_files, previous_visible_ids);
         let status_tags = added_metadata_tag_status_tags(&requests, &tags);
         self.ui.status.sample = metadata_tag_added_status(&status_tags, changed_files.len());
         enqueue_metadata_tag_persist_requests(requests, context);
@@ -312,6 +316,10 @@ impl NativeAppState {
         targets: Vec<MetadataTagTarget>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         let mut requests = Vec::new();
         let mut changed_files = Vec::new();
         for target in targets {
@@ -345,7 +353,7 @@ impl NativeAppState {
         }
         let touched_paths = changed_files.iter().map(PathBuf::from).collect::<Vec<_>>();
         self.mark_harvest_touched_for_paths(&touched_paths);
-        self.finish_metadata_tag_curation_change(&changed_files);
+        self.finish_metadata_tag_curation_change(&changed_files, previous_visible_ids);
         self.ui.status.sample = metadata_tag_removed_status(&tag, changed_files.len());
         if requests.len() == 1 {
             let request = requests.remove(0);
@@ -367,10 +375,14 @@ impl NativeAppState {
         }
     }
 
-    fn finish_metadata_tag_curation_change(&mut self, file_ids: &[String]) {
+    fn finish_metadata_tag_curation_change(
+        &mut self,
+        file_ids: &[String],
+        previous_visible_ids: Vec<String>,
+    ) {
         self.library.folder_browser.clear_curation_focus_override();
         self.mark_file_ids_curated(file_ids);
-        self.retain_visible_file_selection_after_metadata_tag_change();
+        self.retain_visible_file_selection_after_metadata_tag_change(previous_visible_ids);
     }
 
     fn mark_file_ids_curated(&mut self, file_ids: &[String]) {

--- a/src/native_app/metadata/library.rs
+++ b/src/native_app/metadata/library.rs
@@ -134,6 +134,10 @@ impl NativeAppState {
         if self.metadata.selected_tag.as_deref() == Some(tag.as_str()) {
             self.metadata.selected_tag = None;
         }
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
 
         let mut removed_count = 0usize;
         let mut requests = Vec::new();
@@ -178,7 +182,7 @@ impl NativeAppState {
             }
         }
 
-        self.retain_visible_file_selection_after_metadata_tag_change();
+        self.retain_visible_file_selection_after_metadata_tag_change(previous_visible_ids);
         self.persist_user_configuration("metadata.tags.dictionary.delete", Instant::now());
         self.ui.status.sample = if removed_count == 0 {
             format!("Deleted tag {tag}")

--- a/src/native_app/metadata/mod.rs
+++ b/src/native_app/metadata/mod.rs
@@ -109,13 +109,19 @@ impl NativeAppState {
         }
     }
 
-    pub(super) fn retain_visible_file_selection_after_metadata_tag_change(&mut self) {
+    pub(super) fn retain_visible_file_selection_after_metadata_tag_change(
+        &mut self,
+        previous_visible_ids: Vec<String>,
+    ) {
         self.library
             .folder_browser
             .invalidate_visible_sample_projection_cache();
         self.library
             .folder_browser
-            .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+            .reconcile_visible_file_selection_after_tag_filter(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
     }
 
     pub(in crate::native_app) fn metadata_tag_selection_state(

--- a/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
@@ -146,7 +146,7 @@ impl FolderBrowserState {
             .collect()
     }
 
-    pub(in crate::native_app::sample_library::folder_browser) fn selected_audio_file_ids_matching_tags(
+    pub(in crate::native_app) fn selected_audio_file_ids_matching_tags(
         &self,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> Vec<String> {

--- a/src/native_app/sample_library/folder_browser/file_selection_model.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection_model.rs
@@ -169,15 +169,45 @@ impl FileSelectionModel {
         })
     }
 
-    pub(super) fn retain_visible(&mut self, visible_ids: &HashSet<String>) {
-        self.selected_ids.retain(|id| visible_ids.contains(id));
-        if self
-            .focused_id
+    pub(super) fn reconcile_visible(
+        &mut self,
+        previous_visible_ids: &[String],
+        visible_ids: &[String],
+    ) {
+        let visible_id_set = visible_ids.iter().cloned().collect::<HashSet<_>>();
+        let previous_focused_id = self.focused_id.clone();
+        self.selected_ids.retain(|id| visible_id_set.contains(id));
+
+        if previous_focused_id
             .as_ref()
-            .is_some_and(|id| !visible_ids.contains(id))
+            .is_some_and(|id| visible_id_set.contains(id))
         {
-            self.focused_id = None;
+            return;
         }
+
+        self.focused_id = previous_focused_id
+            .as_ref()
+            .and_then(|id| {
+                previous_visible_ids
+                    .iter()
+                    .position(|candidate| candidate == id)
+            })
+            .and_then(|previous_index| {
+                if visible_ids.is_empty() {
+                    None
+                } else {
+                    visible_ids.get(previous_index.min(visible_ids.len() - 1))
+                }
+            })
+            .cloned();
+
+        if !self.explicit {
+            self.selected_ids.clear();
+            if let Some(focused_id) = self.focused_id.clone() {
+                self.selected_ids.insert(focused_id);
+            }
+        }
+
         if self.focused_id.is_none() && self.selected_ids.is_empty() {
             self.explicit = false;
         }
@@ -308,15 +338,42 @@ mod tests {
     }
 
     #[test]
-    fn retain_visible_removes_hidden_focus_and_selected_ids() {
+    fn reconcile_visible_moves_hidden_focus_to_next_row() {
         let mut selection =
             FileSelectionModel::new(Some(String::from("kick")), set(&["kick", "hat"]), true);
 
-        selection.retain_visible(&set(&["hat"]));
+        selection.reconcile_visible(&ids(&["kick", "hat"]), &ids(&["hat"]));
 
-        assert_eq!(selection.focused_id(), None);
+        assert_eq!(selection.focused_id(), Some("hat"));
         assert!(selection.explicit());
         assert_eq!(selection.active_ids(), set(&["hat"]));
+    }
+
+    #[test]
+    fn reconcile_visible_moves_hidden_focus_to_previous_row_at_end() {
+        let mut selection = FileSelectionModel::new(
+            Some(String::from("hat")),
+            set(&["kick", "snare", "hat"]),
+            false,
+        );
+
+        selection.reconcile_visible(&ids(&["kick", "snare", "hat"]), &ids(&["kick"]));
+
+        assert_eq!(selection.focused_id(), Some("kick"));
+        assert!(!selection.explicit());
+        assert_eq!(selection.active_ids(), set(&["kick"]));
+    }
+
+    #[test]
+    fn reconcile_visible_clears_focus_when_no_rows_remain() {
+        let mut selection =
+            FileSelectionModel::new(Some(String::from("kick")), set(&["kick"]), false);
+
+        selection.reconcile_visible(&ids(&["kick"]), &[]);
+
+        assert_eq!(selection.focused_id(), None);
+        assert!(!selection.explicit());
+        assert!(selection.active_ids().is_empty());
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_browser/panel_state.rs
+++ b/src/native_app/sample_library/folder_browser/panel_state.rs
@@ -1,5 +1,5 @@
 use radiant::{prelude as ui, widgets::TextInputMessageKind};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 use super::{
     DEFAULT_COLLECTIONS_PANEL_HEIGHT, FolderBrowserState,
@@ -163,10 +163,11 @@ impl FolderBrowserState {
         if self.filters.name_filter == value {
             return;
         }
+        let previous_visible_ids = self.selected_audio_file_ids();
         self.filters.name_filter = value;
         self.filters.name_enabled = !self.filters.name_filter.trim().is_empty();
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
         self.reset_file_view();
     }
 
@@ -192,6 +193,7 @@ impl FolderBrowserState {
         family: FilterFamily,
         enabled: bool,
     ) {
+        let previous_visible_ids = self.selected_audio_file_ids();
         let changed = match family {
             FilterFamily::Name => set_bool(&mut self.filters.name_enabled, enabled),
             FilterFamily::Tags => set_bool(&mut self.filters.tags_enabled, enabled),
@@ -211,7 +213,7 @@ impl FolderBrowserState {
             return;
         }
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
         self.reset_file_view();
     }
 
@@ -219,6 +221,7 @@ impl FolderBrowserState {
         if !RATING_FILTER_LEVELS.contains(&level) {
             return;
         }
+        let previous_visible_ids = self.selected_audio_file_ids();
         let changed = if enabled {
             self.filters.rating_filter.insert(level)
         } else {
@@ -229,7 +232,7 @@ impl FolderBrowserState {
         }
         self.filters.rating_enabled = !self.filters.rating_filter.is_empty();
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
         self.reset_file_view();
     }
 
@@ -241,6 +244,7 @@ impl FolderBrowserState {
         if !PLAYBACK_TYPE_FILTERS.contains(&filter) {
             return;
         }
+        let previous_visible_ids = self.selected_audio_file_ids();
         let changed = if enabled {
             self.filters.playback_type_filter.insert(filter)
         } else {
@@ -249,6 +253,7 @@ impl FolderBrowserState {
         if changed {
             self.filters.playback_type_enabled = !self.filters.playback_type_filter.is_empty();
             self.clear_listing_reveals();
+            self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
             self.reset_file_view();
         }
     }
@@ -262,10 +267,11 @@ impl FolderBrowserState {
         if self.filters.curation.enabled == next_enabled && self.filters.curation.scope == scope {
             return;
         }
+        let previous_visible_ids = self.selected_audio_file_ids();
         self.filters.curation.enabled = next_enabled;
         self.filters.curation.scope = scope;
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
         self.reset_file_view();
     }
 
@@ -280,39 +286,39 @@ impl FolderBrowserState {
         if self.filters.harvest == Some(filter) && self.filters.harvest_enabled == enabled {
             return;
         }
+        let previous_visible_ids = self.selected_audio_file_ids();
         self.filters.harvest = Some(filter);
         self.filters.harvest_enabled = enabled;
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_filter(previous_visible_ids);
         self.reset_file_view();
     }
 
-    pub(in crate::native_app) fn refresh_after_harvest_state_change(&mut self) {
+    pub(in crate::native_app) fn refresh_after_harvest_state_change_matching_tags(
+        &mut self,
+        previous_visible_ids: Vec<String>,
+        tags_by_file: &HashMap<String, Vec<String>>,
+    ) {
         self.clear_listing_reveals();
-        self.retain_visible_file_selection_after_filter();
+        self.reconcile_visible_file_selection_after_tag_filter(previous_visible_ids, tags_by_file);
         self.reset_file_view();
         self.bump_file_content_revision();
     }
 
-    pub(in crate::native_app) fn retain_visible_file_selection_after_tag_filter(
+    pub(in crate::native_app) fn reconcile_visible_file_selection_after_tag_filter(
         &mut self,
+        previous_visible_ids: Vec<String>,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) {
-        let visible_ids = self
-            .selected_audio_files_matching_tags(tags_by_file)
-            .into_iter()
-            .map(|file| file.id.clone())
-            .collect::<HashSet<_>>();
-        self.selection.retain_visible_files(&visible_ids);
+        let visible_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
+        self.selection
+            .reconcile_visible_files(&previous_visible_ids, &visible_ids);
     }
 
-    fn retain_visible_file_selection_after_filter(&mut self) {
-        let visible_ids = self
-            .selected_audio_files()
-            .into_iter()
-            .map(|file| file.id.clone())
-            .collect::<HashSet<_>>();
-        self.selection.retain_visible_files(&visible_ids);
+    fn reconcile_visible_file_selection_after_filter(&mut self, previous_visible_ids: Vec<String>) {
+        let visible_ids = self.selected_audio_file_ids();
+        self.selection
+            .reconcile_visible_files(&previous_visible_ids, &visible_ids);
     }
 
     pub(in crate::native_app) fn metadata_panel_height(&self) -> f32 {

--- a/src/native_app/sample_library/folder_browser/selection_state/files.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state/files.rs
@@ -168,13 +168,31 @@ impl BrowserSelectionState {
         Some(outcome)
     }
 
+    pub(in crate::native_app::sample_library::folder_browser) fn reconcile_visible_files(
+        &mut self,
+        previous_visible_ids: &[String],
+        visible_ids: &[String],
+    ) {
+        let mut selection = self.file_selection_model();
+        selection.reconcile_visible(previous_visible_ids, visible_ids);
+        self.apply_file_selection_model(selection);
+    }
+
     pub(in crate::native_app::sample_library::folder_browser) fn retain_visible_files(
         &mut self,
         visible_ids: &HashSet<String>,
     ) {
-        let mut selection = self.file_selection_model();
-        selection.retain_visible(visible_ids);
-        self.apply_file_selection_model(selection);
+        self.selected_file_ids.retain(|id| visible_ids.contains(id));
+        if self
+            .selected_file
+            .as_ref()
+            .is_some_and(|id| !visible_ids.contains(id))
+        {
+            self.selected_file = None;
+        }
+        if self.selected_file_ids.is_empty() {
+            self.selected_file_ids_explicit = false;
+        }
     }
 
     pub(in crate::native_app::sample_library::folder_browser) fn set_focus_file_set(

--- a/src/native_app/sample_library/folder_browser/tests/file_filters.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_filters.rs
@@ -615,7 +615,7 @@ fn copied_file_flash_projects_to_visible_rows_and_clears() {
 }
 
 #[test]
-fn name_filter_limits_selected_audio_files_and_clears_hidden_selection() {
+fn name_filter_moves_hidden_focus_to_remaining_visible_file() {
     let root = temp_source_root("wavecrate-gui-name-filter");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
@@ -643,7 +643,7 @@ fn name_filter_limits_selected_audio_files_and_clears_hidden_selection() {
             .collect::<Vec<_>>(),
         vec!["Deep Kick.wav"]
     );
-    assert_eq!(browser.selected_file_id(), None);
+    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
 
     browser.apply_message(FolderBrowserMessage::NameFilterInput(
         TextInputMessage::Changed {
@@ -820,6 +820,55 @@ fn harvest_filter_family_reactivation_preserves_each_selected_mode() {
 }
 
 #[test]
+fn harvest_filter_state_change_moves_hidden_focus_to_next_visible_file() {
+    let root = temp_source_root("wavecrate-gui-harvest-filter-focus");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let first = drums.join("001.wav");
+    let focused = drums.join("002.wav");
+    let next = drums.join("003.wav");
+    for file in [&first, &focused, &next] {
+        fs::write(file, []).expect("write sample file");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.apply_message(FolderBrowserMessage::SetHarvestFilter(
+        HarvestFilter::New,
+        true,
+    ));
+    browser.select_file(path_id(&focused));
+    let previous_visible_ids = browser.selected_audio_file_ids();
+    let focused_key = wavecrate::sample_sources::HarvestFileKey::new(
+        wavecrate::sample_sources::SourceId::from_string(path_id(&root)),
+        focused
+            .strip_prefix(&root)
+            .expect("focused file should be under root")
+            .to_path_buf(),
+    );
+    let focused_identity = wavecrate::sample_sources::HarvestFileIdentity::new(focused_key);
+    wavecrate::sample_sources::library::upsert_harvest_file(&focused_identity)
+        .expect("upsert harvest file");
+    wavecrate::sample_sources::library::set_harvest_state(
+        &focused_identity.key,
+        wavecrate::sample_sources::HarvestState::Done,
+    )
+    .expect("set harvest state");
+
+    browser.refresh_after_harvest_state_change_matching_tags(previous_visible_ids, &HashMap::new());
+
+    assert_eq!(browser.selected_file_id(), Some(path_id(&next).as_str()));
+    assert_eq!(
+        browser
+            .selected_audio_files()
+            .into_iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["001.wav", "003.wav"]
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn rating_filter_limits_visible_samples_and_can_combine_levels() {
     let root = temp_source_root("wavecrate-gui-rating-filter");
     let drums = root.join("drums");
@@ -898,7 +947,7 @@ fn rating_filter_can_show_unrated_samples() {
 }
 
 #[test]
-fn rating_filter_clears_selection_hidden_by_filter() {
+fn rating_filter_moves_hidden_focus_to_remaining_visible_file() {
     let root = temp_source_root("wavecrate-gui-rating-filter-selection");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
@@ -914,7 +963,7 @@ fn rating_filter_clears_selection_hidden_by_filter() {
 
     browser.apply_message(FolderBrowserMessage::ToggleRatingFilter(1, true));
 
-    assert_eq!(browser.selected_file_id(), None);
+    assert_eq!(browser.selected_file_id(), Some(path_id(&keep).as_str()));
     assert_eq!(
         browser
             .selected_audio_files()
@@ -945,12 +994,13 @@ fn playback_type_filter_limits_visible_samples_and_combines_modes() {
         (path_id(&shot), vec![String::from("one-shot")]),
     ]);
     let cached_sample_paths = HashSet::new();
+    let previous_visible_ids = browser.selected_audio_file_ids_matching_tags(&tags_by_file);
 
     browser.apply_message(FolderBrowserMessage::TogglePlaybackTypeFilter(
         PlaybackTypeFilter::Loop,
         true,
     ));
-    browser.retain_visible_file_selection_after_tag_filter(&tags_by_file);
+    browser.reconcile_visible_file_selection_after_tag_filter(previous_visible_ids, &tags_by_file);
 
     let visible = browser.visible_samples(VisibleSampleQuery {
         tags_by_file: &tags_by_file,
@@ -965,7 +1015,10 @@ fn playback_type_filter_limits_visible_samples_and_combines_modes() {
             .collect::<Vec<_>>(),
         vec!["loop.wav"]
     );
-    assert_eq!(browser.selected_file_id(), None);
+    assert_eq!(
+        browser.selected_file_id(),
+        Some(path_id(&loop_file).as_str())
+    );
 
     browser.apply_message(FolderBrowserMessage::TogglePlaybackTypeFilter(
         PlaybackTypeFilter::OneShot,
@@ -1226,7 +1279,7 @@ fn disabling_folder_subtree_listing_drops_hidden_nested_file_selection() {
 }
 
 #[test]
-fn tag_filter_limits_selected_audio_files_and_clears_hidden_selection() {
+fn tag_filter_moves_hidden_focus_to_remaining_visible_file() {
     let root = temp_source_root("wavecrate-gui-tag-filter");
     let drums = root.join("drums");
     fs::create_dir_all(&drums).expect("create drums folder");
@@ -1247,13 +1300,14 @@ fn tag_filter_limits_selected_audio_files_and_clears_hidden_selection() {
         (path_id(&snare), vec![String::from("Drum")]),
         (path_id(&hat), vec![String::from("Metal")]),
     ]);
+    let previous_visible_ids = browser.selected_audio_file_ids_matching_tags(&tags_by_file);
 
     browser.apply_message(FolderBrowserMessage::TagFilterInput(
         TextInputMessage::Changed {
             value: String::from("drum, warm"),
         },
     ));
-    browser.retain_visible_file_selection_after_tag_filter(&tags_by_file);
+    browser.reconcile_visible_file_selection_after_tag_filter(previous_visible_ids, &tags_by_file);
 
     assert_eq!(
         browser
@@ -1263,7 +1317,7 @@ fn tag_filter_limits_selected_audio_files_and_clears_hidden_selection() {
             .collect::<Vec<_>>(),
         vec!["Deep Kick.wav"]
     );
-    assert_eq!(browser.selected_file_id(), None);
+    assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
 
     browser.apply_message(FolderBrowserMessage::TagFilterInput(
         TextInputMessage::Changed {

--- a/src/native_app/sample_library/folder_browser_actions.rs
+++ b/src/native_app/sample_library/folder_browser_actions.rs
@@ -43,12 +43,19 @@ impl NativeAppState {
                 self.toggle_folder_browser_playback_type_filter(filter, enabled);
             }
             FolderBrowserMessage::SetCurationScope(scope, enabled) => {
+                let previous_visible_ids = self
+                    .library
+                    .folder_browser
+                    .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
                 self.library
                     .folder_browser
                     .set_curation_scope(scope, enabled);
                 self.library
                     .folder_browser
-                    .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+                    .reconcile_visible_file_selection_after_tag_filter(
+                        previous_visible_ids,
+                        &self.metadata.tags_by_file,
+                    );
                 self.focus_visible_browser_file_after_filter_change(context);
             }
             FolderBrowserMessage::DropOnFolder(folder_id) => {

--- a/src/native_app/sample_library/folder_browser_actions/navigation.rs
+++ b/src/native_app/sample_library/folder_browser_actions/navigation.rs
@@ -25,12 +25,19 @@ impl NativeAppState {
         &mut self,
         message: radiant::widgets::TextInputMessage,
     ) {
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         self.library
             .folder_browser
             .apply_message(FolderBrowserMessage::TagFilterInput(message));
         self.library
             .folder_browser
-            .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+            .reconcile_visible_file_selection_after_tag_filter(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
     }
 
     pub(super) fn toggle_folder_browser_playback_type_filter(
@@ -38,6 +45,10 @@ impl NativeAppState {
         filter: PlaybackTypeFilter,
         enabled: bool,
     ) {
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         self.library
             .folder_browser
             .apply_message(FolderBrowserMessage::TogglePlaybackTypeFilter(
@@ -45,7 +56,10 @@ impl NativeAppState {
             ));
         self.library
             .folder_browser
-            .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+            .reconcile_visible_file_selection_after_tag_filter(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
     }
 
     pub(super) fn toggle_similarity_anchor(

--- a/src/native_app/sample_library/harvest_tracking.rs
+++ b/src/native_app/sample_library/harvest_tracking.rs
@@ -419,6 +419,10 @@ impl NativeAppState {
         else {
             return;
         };
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         let target_state = if targets
             .iter()
             .all(|target| target.state == HarvestState::Done)
@@ -435,6 +439,7 @@ impl NativeAppState {
                 self.finish_toggle_selected_harvest_done_error(
                     &targets,
                     applied_any,
+                    &previous_visible_ids,
                     started_at,
                     error.to_string(),
                 );
@@ -447,6 +452,7 @@ impl NativeAppState {
                 self.finish_toggle_selected_harvest_done_error(
                     &targets,
                     applied_any,
+                    &previous_visible_ids,
                     started_at,
                     error.to_string(),
                 );
@@ -457,7 +463,10 @@ impl NativeAppState {
 
         self.library
             .folder_browser
-            .refresh_after_harvest_state_change();
+            .refresh_after_harvest_state_change_matching_tags(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
         let target_label = harvest_state_targets_label(&targets);
         self.ui.status.sample = harvest_state_toggle_status(target_state, &targets);
         emit_gui_action(
@@ -960,6 +969,10 @@ impl NativeAppState {
         ) else {
             return;
         };
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
 
         let mut changed = false;
         for target in &targets {
@@ -969,7 +982,10 @@ impl NativeAppState {
                 if changed {
                     self.library
                         .folder_browser
-                        .refresh_after_harvest_state_change();
+                        .refresh_after_harvest_state_change_matching_tags(
+                            previous_visible_ids.clone(),
+                            &self.metadata.tags_by_file,
+                        );
                 }
                 self.ui.status.sample = format!("Update harvest state failed: {error}");
                 emit_gui_action(
@@ -991,7 +1007,10 @@ impl NativeAppState {
                     if changed {
                         self.library
                             .folder_browser
-                            .refresh_after_harvest_state_change();
+                            .refresh_after_harvest_state_change_matching_tags(
+                                previous_visible_ids.clone(),
+                                &self.metadata.tags_by_file,
+                            );
                     }
                     self.ui.status.sample = format!("Update harvest state failed: {error}");
                     emit_gui_action(
@@ -1009,7 +1028,10 @@ impl NativeAppState {
 
         self.library
             .folder_browser
-            .refresh_after_harvest_state_change();
+            .refresh_after_harvest_state_change_matching_tags(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
         let target_label = harvest_state_targets_label(&targets);
         self.ui.status.sample = format!("{status_prefix} {target_label}");
         emit_gui_action(
@@ -1211,13 +1233,17 @@ impl NativeAppState {
         &mut self,
         targets: &[HarvestStateTarget],
         applied_any: bool,
+        previous_visible_ids: &[String],
         started_at: std::time::Instant,
         error: String,
     ) {
         if applied_any {
             self.library
                 .folder_browser
-                .refresh_after_harvest_state_change();
+                .refresh_after_harvest_state_change_matching_tags(
+                    previous_visible_ids.to_vec(),
+                    &self.metadata.tags_by_file,
+                );
         }
         let target_label = harvest_state_targets_label(targets);
         self.ui.status.sample = format!("Update harvest state failed: {error}");

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -130,6 +130,10 @@ impl NativeAppState {
             rating: previous_rating,
             locked: false,
         };
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         let applied = match self
             .apply_rating_update_states(std::slice::from_ref(&update), RatingUpdateMode::After)
         {
@@ -164,7 +168,10 @@ impl NativeAppState {
         self.register_rating_transaction_with_label("Unlock sample", vec![update]);
         self.library
             .folder_browser
-            .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+            .reconcile_visible_file_selection_after_tag_filter(
+                previous_visible_ids,
+                &self.metadata.tags_by_file,
+            );
         emit_gui_action(
             "browser.context_menu.sample.unlock",
             Some("browser"),
@@ -183,6 +190,10 @@ impl NativeAppState {
     ) {
         let started_at = Instant::now();
         let advance_visible_ids = self.rating_advance_visible_ids_before_adjustment(allow_advance);
+        let previous_visible_ids = self
+            .library
+            .folder_browser
+            .selected_audio_file_ids_matching_tags(&self.metadata.tags_by_file);
         let advance_previous_index = advance_visible_ids.as_ref().and_then(|_| {
             self.library
                 .folder_browser
@@ -264,7 +275,10 @@ impl NativeAppState {
         if applied > 0 {
             self.library
                 .folder_browser
-                .retain_visible_file_selection_after_tag_filter(&self.metadata.tags_by_file);
+                .reconcile_visible_file_selection_after_tag_filter(
+                    previous_visible_ids,
+                    &self.metadata.tags_by_file,
+                );
         }
     }
 


### PR DESCRIPTION
## Scope
- Preserve native folder-browser sample focus when the focused row is removed by a filter-affecting change.
- Reconcile focus from the previous visible order to the next visible row at the old index, then the previous remaining row, and clear focus only when no visible rows remain.
- Apply the policy across name, rating, harvest, curation, playback type, metadata tag, and tag-backed refresh paths while keeping existing non-filter retain behavior for filesystem/source refreshes.
- Add regression coverage for the Harvest `New` filter repro and update filter tests to guard the new focus successor behavior.

## Definition of Done
- Pressing `H` on a focused sample under the Harvest `New` filter moves focus to the next visible file instead of dropping list focus.
- Filter-affecting metadata/rating/tag changes reconcile focus from the pre-change visible order.
- Empty filtered lists still clear focus.
- Focus policy is covered by model tests and native folder-browser filter tests.

## Validation Commands
- `bash scripts/agent.sh request` *(baseline failed before implementation in unrelated Radiant guardrail tests: `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`)*
- `cargo fmt --check`
- `cargo test -p wavecrate file_selection_model -- --test-threads=1`
- `cargo test -p wavecrate file_filters -- --test-threads=1`

## Known Limitations
- None.

User review is required before merge.
