### PR TITLE
OPT-1009 Publish PortalSurfer releases via staged commit

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -109,9 +109,11 @@ under `scripts/internal/release/`:
   assets after publication, verifies checksum signatures and zip hashes, and
   inspects each `update-manifest.json` for the expected channel, version,
   commit, build date, target, platform, and architecture.
-- `publish_portalsurfer_release.sh` uploads release files and the generated log
-  to PortalSurfer, verifies the public catalog and per-release changelog, then
-  updates and verifies the full Wavecrate changelog.
+- `publish_portalsurfer_release.sh` stages release files privately in
+  PortalSurfer, assembles the full Wavecrate changelog, commits the staged
+  files, generated release log, catalog entry, and full changelog in one
+  PortalSurfer request, then verifies the public catalog, per-release
+  changelog, and full changelog.
 - `prune_github_release_assets.sh` removes stale assets from a rolling GitHub
   release during promotion.
 
@@ -130,37 +132,46 @@ checksum signature, downloadable assets whose hashes match the checksum file,
 and a release-bound `Wavecrate X.Y.Z-rc.N` log body. Stable releases are
 published as normal GitHub releases tagged `vX.Y.Z` and as PortalSurfer catalog
 entries with build ids like `wavecrate-X.Y.Z`. RC and stable workflows verify the
-published GitHub release assets, then PortalSurfer publication uploads the
-generated release zips, checksum file, checksum signature, and release log,
-verifies the catalog entry, per-release changelog, and full Wavecrate changelog
-round trips, and finally downloads the public PortalSurfer assets back to verify
-their checksums, signature, and embedded manifests.
+published GitHub release assets, then PortalSurfer publication stages the
+generated release zips, checksum file, and checksum signature, commits those
+files together with the release log and full Wavecrate changelog, verifies the
+catalog entry, per-release changelog, and full changelog round trips, and
+finally downloads the public PortalSurfer assets back to verify their checksums,
+signature, and embedded manifests.
 
-The nightly workflow uploads the generated zips, checksum files, and Markdown
-release log to the PortalSurfer Wavecrate release-upload API before moving the
-rolling GitHub `nightly` identity. Each PortalSurfer upload uses a path-safe
+The nightly workflow stages the generated zips and checksum files through the
+PortalSurfer Wavecrate release-upload API, then commits the complete release
+files, Markdown release log, catalog entry, and full Wavecrate changelog before
+moving the rolling GitHub `nightly` identity. Each PortalSurfer upload uses a path-safe
 `wavecrate-nightly-b<build>-<short-sha>` build id so the website can show a
 distinct nightly entry instead of stacking every nightly under one changelog
 group, while the release log and package manifest keep the full SemVer nightly
-version. After the per-release log is visible in the public catalog, the
-workflow verifies that the fetched log body matches the generated immutable
-release log, then prepends that release-bound log to the existing site-wide
-changelog before uploading the maintained full changelog.
+version. The full changelog is assembled before commit by prepending the
+generated release-bound log to the existing site-wide changelog. After commit,
+the workflow verifies that the public per-release log and full changelog bodies
+match the generated files.
 Only after PortalSurfer publication has been verified does the workflow refresh
 the rolling GitHub `nightly` release assets, publish the immutable nightly
 version tag named like `19.1.0-nightly.20260701+abc1234`, move the rolling
 `nightly` tag, and update the rolling release metadata. Scheduled and manual
 nightly runs do not cancel an in-flight run because tag movement is the final
-public identity transition. If a run fails after PortalSurfer upload begins but
-before GitHub promotion, rerun the workflow for the same `main` commit; the
-same immutable PortalSurfer build id is overwritten and reverified before the
-rolling GitHub identity moves.
+public identity transition. If a run fails before the PortalSurfer commit step,
+only private staged files may remain and public readers keep seeing the previous
+catalog/changelog state. If a run fails after the commit step but before GitHub
+promotion, rerun the workflow for the same `main` commit; the same immutable
+PortalSurfer build id is recommitted idempotently when already-published files
+match by name, size, and SHA-256, then reverified before the rolling GitHub
+identity moves.
 The nightly workflow verifies both the PortalSurfer catalog downloads and the
 rolling GitHub release assets after their respective publication points.
 The maintenance step refuses to preserve a full changelog whose historical
 sections are not already release-bound markdown logs.
 GitHub Actions does not need SSH access or write access to the PortalSurfer
 frontend repository.
+This staged commit flow requires PortalSurfer server support for
+`/wavecrate/api/v1/release-uploads/<build-id>/staging/files/<filename>` and
+`/wavecrate/api/v1/release-uploads/<build-id>/commit`; older servers fail closed
+instead of falling back to direct public mutation.
 
 To rerun the GitHub verifier for a published stable release, use the resolved
 release metadata from the workflow run:

--- a/scripts/internal/release/publish_portalsurfer_release.sh
+++ b/scripts/internal/release/publish_portalsurfer_release.sh
@@ -101,6 +101,8 @@ catalog_url="$api_base/releases"
 full_changelog_url="$api_base/changelog"
 response_dir="$(mktemp -d)"
 trap 'rm -rf "$response_dir"' EXIT
+staged_files_tsv="$response_dir/staged-files.tsv"
+: > "$staged_files_tsv"
 
 shopt -s nullglob
 files=("${ARTIFACT_DIR}"/*.zip "${ARTIFACT_DIR}"/checksums-*.txt "${ARTIFACT_DIR}"/checksums-*.txt.sig)
@@ -121,8 +123,10 @@ for file in "${files[@]}"; do
     content_type="application/zip"
   fi
   sha256="$(sha256sum "$file" | awk '{ print $1 }')"
+  size_bytes="$(wc -c < "$file" | tr -d '[:space:]')"
   encoded_name="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$file_name")"
   response_file="$response_dir/$file_name.json"
+  echo "Staging PortalSurfer release file: $file_name" >&2
   curl --fail-with-body --retry 3 --retry-delay 2 \
     --request PUT \
     --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
@@ -133,41 +137,81 @@ for file in "${files[@]}"; do
     --header "X-Wavecrate-Released-At: $RELEASED_AT" \
     --header "X-Wavecrate-Sha256: $sha256" \
     --data-binary "@$file" \
-    "$upload_base/$BUILD_ID/files/$encoded_name" > "$response_file"
-  python3 - "$response_file" "$BUILD_ID" "$BUILD_NUMBER" "$file_name" "$sha256" <<'PY'
+    "$upload_base/$BUILD_ID/staging/files/$encoded_name" > "$response_file"
+  python3 - "$response_file" "$BUILD_ID" "$file_name" "$sha256" "$size_bytes" <<'PY'
 import json
 import sys
 
-response_path, expected_build, expected_build_number, expected_name, expected_sha = sys.argv[1:]
+response_path, expected_build, expected_name, expected_sha, expected_size = sys.argv[1:]
 response = json.loads(open(response_path, encoding="utf-8").read())
-release = response.get("release") or {}
 file = response.get("file") or {}
-if release.get("build_id") != expected_build:
-    raise SystemExit(f"Uploaded release id mismatch: {release.get('build_id')} != {expected_build}")
-if release.get("build_number") != int(expected_build_number):
-    raise SystemExit(f"Uploaded release build number mismatch: {release.get('build_number')} != {expected_build_number}")
+if response.get("staged") is not True:
+    raise SystemExit("PortalSurfer did not report a staged upload")
+if response.get("build_id") != expected_build:
+    raise SystemExit(f"Staged release id mismatch: {response.get('build_id')} != {expected_build}")
 if file.get("name") != expected_name:
-    raise SystemExit(f"Uploaded file name mismatch: {file.get('name')} != {expected_name}")
+    raise SystemExit(f"Staged file name mismatch: {file.get('name')} != {expected_name}")
 if file.get("sha256") != expected_sha:
-    raise SystemExit(f"Uploaded file sha mismatch: {file.get('sha256')} != {expected_sha}")
-if not isinstance(file.get("size_bytes"), int) or file["size_bytes"] <= 0:
-    raise SystemExit("Uploaded file size was not recorded")
+    raise SystemExit(f"Staged file sha mismatch: {file.get('sha256')} != {expected_sha}")
+if file.get("size_bytes") != int(expected_size):
+    raise SystemExit(f"Staged file size mismatch: {file.get('size_bytes')} != {expected_size}")
 PY
+  printf "%s\t%s\t%s\n" "$file_name" "$sha256" "$size_bytes" >> "$staged_files_tsv"
   uploaded_names+=("$file_name")
 done
 
-changelog_response_file="$response_dir/changelog-upload.json"
+scripts/internal/release/assemble_portal_changelog.py \
+  --catalog-url "$catalog_url" \
+  --current-build-id "$BUILD_ID" \
+  --current-log "$RELEASE_LOG" \
+  --existing-changelog-url "$full_changelog_url" \
+  --generated-at "$RELEASED_AT" \
+  --output "$FULL_CHANGELOG_OUT"
+
+commit_request_file="$response_dir/release-commit.json"
+python3 - "$staged_files_tsv" "$RELEASE_LOG" "$FULL_CHANGELOG_OUT" "$RELEASED_AT" "$commit_request_file" <<'PY'
+import json
+import sys
+
+files_path, release_log_path, full_changelog_path, released_at, out_path = sys.argv[1:]
+files = []
+with open(files_path, encoding="utf-8") as handle:
+    for line in handle:
+        name, sha256, size_bytes = line.rstrip("\n").split("\t")
+        files.append({"name": name, "sha256": sha256, "size_bytes": int(size_bytes)})
+with open(release_log_path, encoding="utf-8") as handle:
+    release_log = handle.read()
+with open(full_changelog_path, encoding="utf-8") as handle:
+    full_changelog = handle.read()
+body = {
+    "files": files,
+    "changelog": {
+        "body": release_log,
+        "generated_at": released_at,
+    },
+    "full_changelog": {
+        "title": "Wavecrate changelog",
+        "body": full_changelog,
+        "generated_at": released_at,
+    },
+}
+with open(out_path, "w", encoding="utf-8") as handle:
+    json.dump(body, handle)
+PY
+
+commit_response_file="$response_dir/release-commit-response.json"
+echo "Committing PortalSurfer release: $BUILD_ID" >&2
 curl --fail-with-body --retry 3 --retry-delay 2 \
   --request PUT \
   --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
-  --header "Content-Type: text/markdown; charset=utf-8" \
+  --header "Content-Type: application/json" \
   --header "X-Wavecrate-Build-Number: ${BUILD_NUMBER}" \
   --header "X-Wavecrate-Release-Channel: $CHANNEL" \
   --header "X-Wavecrate-Release-Version: $RELEASE_VERSION" \
   --header "X-Wavecrate-Released-At: $RELEASED_AT" \
-  --data-binary "@$RELEASE_LOG" \
-  "$upload_base/$BUILD_ID/changelog" > "$changelog_response_file"
-python3 - "$changelog_response_file" "$BUILD_ID" "$BUILD_NUMBER" <<'PY'
+  --data-binary "@$commit_request_file" \
+  "$upload_base/$BUILD_ID/commit" > "$commit_response_file"
+python3 - "$commit_response_file" "$BUILD_ID" "$BUILD_NUMBER" <<'PY'
 import json
 import sys
 
@@ -175,14 +219,17 @@ response_path, expected_build, expected_build_number = sys.argv[1:]
 response = json.loads(open(response_path, encoding="utf-8").read())
 release = response.get("release") or {}
 changelog = response.get("changelog") or {}
+full_changelog = response.get("full_changelog") or {}
+if response.get("committed") is not True:
+    raise SystemExit("PortalSurfer did not report a committed release")
 if release.get("build_id") != expected_build:
-    raise SystemExit(f"Uploaded changelog release id mismatch: {release.get('build_id')} != {expected_build}")
+    raise SystemExit(f"Committed release id mismatch: {release.get('build_id')} != {expected_build}")
 if release.get("build_number") != int(expected_build_number):
-    raise SystemExit(f"Uploaded changelog build number mismatch: {release.get('build_number')} != {expected_build_number}")
-if changelog.get("format") != "markdown":
-    raise SystemExit("Uploaded changelog was not recorded as markdown")
-if not changelog.get("url"):
-    raise SystemExit("Uploaded changelog did not expose a public URL")
+    raise SystemExit(f"Committed release build number mismatch: {release.get('build_number')} != {expected_build_number}")
+if changelog.get("format") != "markdown" or not changelog.get("url"):
+    raise SystemExit("Committed release did not expose a markdown changelog URL")
+if full_changelog.get("format") != "markdown" or not full_changelog.get("url"):
+    raise SystemExit("Committed release did not expose the full changelog URL")
 PY
 
 catalog_file="$response_dir/releases.json"
@@ -215,34 +262,6 @@ expected_body = open(changelog_path, encoding="utf-8").read().strip()
 if body != expected_body:
     raise SystemExit("Fetched changelog body does not match generated release log")
 print(f"Uploaded Wavecrate release log to {expected_build}")
-PY
-
-scripts/internal/release/assemble_portal_changelog.py \
-  --catalog-url "$catalog_url" \
-  --current-build-id "$BUILD_ID" \
-  --current-log "$RELEASE_LOG" \
-  --existing-changelog-url "$full_changelog_url" \
-  --generated-at "$RELEASED_AT" \
-  --output "$FULL_CHANGELOG_OUT"
-
-full_changelog_response_file="$response_dir/full-changelog-upload.json"
-curl --fail-with-body --retry 3 --retry-delay 2 \
-  --request PUT \
-  --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
-  --header "Content-Type: text/markdown; charset=utf-8" \
-  --header "X-Wavecrate-Changelog-Title: Wavecrate changelog" \
-  --data-binary "@$FULL_CHANGELOG_OUT" \
-  "$upload_base/changelog" > "$full_changelog_response_file"
-python3 - "$full_changelog_response_file" <<'PY'
-import json
-import sys
-
-response = json.loads(open(sys.argv[1], encoding="utf-8").read())
-changelog = response.get("changelog") or {}
-if changelog.get("format") != "markdown":
-    raise SystemExit("Uploaded full changelog was not recorded as markdown")
-if not changelog.get("url"):
-    raise SystemExit("Uploaded full changelog did not expose a public URL")
 PY
 
 full_changelog_catalog_file="$response_dir/full-changelog-catalog.json"

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -419,6 +419,26 @@ fn rc_and_stable_workflows_publish_to_portalsurfer_catalog() {
 #[test]
 fn portalsurfer_publish_helper_uses_shared_catalog_verifier() {
     assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("$upload_base/$BUILD_ID/staging/files/$encoded_name"),
+        "PortalSurfer publish helper must stage release files before public catalog commit"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("$upload_base/$BUILD_ID/commit"),
+        "PortalSurfer publish helper must commit staged release files, release log, and full changelog together"
+    );
+    assert!(
+        !PUBLISH_PORTALSURFER_SCRIPT.contains("$upload_base/$BUILD_ID/files/$encoded_name"),
+        "PortalSurfer publish helper must not directly mutate public release files"
+    );
+    assert!(
+        !PUBLISH_PORTALSURFER_SCRIPT.contains("$upload_base/$BUILD_ID/changelog"),
+        "PortalSurfer publish helper must not directly mutate the public per-release changelog"
+    );
+    assert!(
+        !PUBLISH_PORTALSURFER_SCRIPT.contains("$upload_base/changelog"),
+        "PortalSurfer publish helper must not directly mutate the public full changelog"
+    );
+    assert!(
         PUBLISH_PORTALSURFER_SCRIPT
             .contains("scripts/internal/release/verify_portalsurfer_upload_catalog.py"),
         "PortalSurfer publish helper must verify the catalog through the shared upload verifier"
@@ -671,6 +691,14 @@ fn shared_release_helpers_keep_policy_visible_and_strict() {
     assert!(
         PUBLISH_PORTALSURFER_SCRIPT.contains("X-Wavecrate-Release-Channel"),
         "PortalSurfer publish helper must send channel metadata"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("Staging PortalSurfer release file"),
+        "PortalSurfer publish helper must report staged upload progress"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("Committing PortalSurfer release"),
+        "PortalSurfer publish helper must report the public commit step"
     );
     assert!(
         PUBLISH_PORTALSURFER_SCRIPT.contains("assemble_portal_changelog.py"),


### PR DESCRIPTION
## Scope
- Switch `publish_portalsurfer_release.sh` from direct PortalSurfer public mutations to staged artifact upload plus one public commit request.
- Commit release files, per-release changelog, catalog metadata, and full changelog as one PortalSurfer operation, then keep existing public catalog/changelog/download verification.
- Add release contract checks that prevent regression to direct public file, per-release changelog, or full changelog mutation.
- Document the staged commit server dependency and rerun behavior.

## Definition of Done
- Failed PortalSurfer upload before commit leaves only private staged files; public readers keep seeing the previous catalog/changelog state.
- The helper reports staging and committing steps explicitly.
- A successful commit is followed by catalog, per-release changelog, full changelog, and gated download verification.
- Reruns for the same immutable build id are safe when already-published files match by name, size, and SHA-256.

## Validation Commands
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh`
- `cargo fmt --check`
- `cargo test --test release_contract`
- `cargo test --test release_workflow_helpers`
- `git diff --check`
- `PATH="/Users/portalsurfer/.cache/codex-runtimes/codex-primary-runtime/dependencies/native/poppler/poppler/bin:$PATH" python3 scripts/internal/release/verify_published_release.py --surface portalsurfer --channel nightly --version '19.1.0-nightly.20260702+981f180e' --target-version 19.1.0 --commit 981f180e264a6377fa365093969844aa75486572 --build-date 2026-07-02 --portal-catalog-url https://portalsurfer.org/wavecrate/api/v1/releases --portal-build-id wavecrate-nightly-b6257-981f180e --build-number 6257 --source PortalSurfer --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=`
- `bash scripts/agent.sh request` *(baseline failed in unrelated Radiant guardrail tests: `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`)*

## Known Limitations
- Depends on PortalSurfer server PR https://github.com/PORTALSURFER/portalsurfer.org/pull/12 and deployment before this workflow client can publish successfully. Older PortalSurfer servers fail closed because this helper no longer falls back to direct public mutation.
- Existing legacy PortalSurfer direct upload endpoints remain server-side for compatibility, but this helper no longer uses them.

User review is required before merge.
