### PR TITLE
OPT-1010 Add nightly validation gate before publish

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -174,10 +174,35 @@ jobs:
           path: dist/release/release-log.md
           if-no-files-found: error
 
+  test:
+    name: Run nightly validation tests
+    runs-on: ubuntu-latest
+    needs: resolve-main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+          ref: ${{ needs.resolve-main.outputs.target_sha }}
+      - name: Checkout Radiant submodule
+        shell: bash
+        env:
+          RADIANT_SUBMODULE_DEPLOY_KEY: ${{ secrets.RADIANT_SUBMODULE_DEPLOY_KEY }}
+        run: scripts/internal/release/checkout_radiant_submodule.sh
+      - name: Read pinned Rust toolchain from rust-toolchain.toml
+        id: rust_toolchain
+        shell: bash
+        run: scripts/internal/release/emit_rust_toolchain_channel.py >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Run tests
+        run: cargo test --workspace --locked
+
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} nightly
     runs-on: ${{ matrix.os }}
-    needs: resolve-main
+    needs: [resolve-main, test]
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +273,7 @@ jobs:
   publish-github:
     name: Promote GitHub nightly
     runs-on: ubuntu-latest
-    needs: [resolve-main, release-log, build, publish-frontend]
+    needs: [resolve-main, test, release-log, build, publish-frontend]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -365,7 +390,7 @@ jobs:
   publish-frontend:
     name: Upload PortalSurfer nightly downloads
     runs-on: ubuntu-latest
-    needs: [resolve-main, release-log, build]
+    needs: [resolve-main, test, release-log, build]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -32,8 +32,9 @@ Use the lightest lane that still gives trustworthy coverage for the change.
 
 ## Validation and release lane contract
 
-GitHub Actions currently owns only nightly packaging and upload. Local wrappers
-remain the validation contract for development and release-risk checks:
+GitHub Actions owns release packaging, upload, and the release workflow
+validation gates. Local wrappers remain the primary validation contract for
+development and release-risk checks:
 
 | Lane | GitHub job | Local command | Policy |
 | --- | --- | --- | --- |
@@ -46,7 +47,7 @@ remain the validation contract for development and release-risk checks:
 | Dead dependency sweep and env-var nudge | none | `scripts/check.* dead-deps --advisory` and `scripts/check.* report-env-vars` | Advisory Linux-only hygiene |
 | GUI semantic contracts | none | `scripts/gui.ps1 contract` or `scripts/gui.ps1 suite` | Local/manual or issue-specific |
 | Perf guard | none | `scripts/perf.* guard` | Local/manual or release-risk validation |
-| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Builds Windows/macOS nightly assets from `main`, embeds `X.Y.Z-nightly.DATE+SHA` metadata, verifies the checksum signing key against the pinned public key before public publication, uploads and verifies the immutable PortalSurfer release plus full changelog first, then refreshes the rolling GitHub `nightly` release assets and promotes the immutable and rolling GitHub tags as the final public identity step |
+| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Resolves the exact `main` SHA, runs `cargo test --workspace --locked` on Ubuntu before package builds or publication, builds Windows/macOS nightly assets from that SHA, embeds `X.Y.Z-nightly.DATE+SHA` metadata, verifies the checksum signing key against the pinned public key before public publication, uploads and verifies the immutable PortalSurfer release plus full changelog first, then refreshes the rolling GitHub `nightly` release assets and promotes the immutable and rolling GitHub tags as the final public identity step |
 | RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs workspace tests, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
 | Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs workspace tests, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
 
@@ -60,7 +61,14 @@ The nextest policy is:
 - The default nextest profile stays unfiltered for maintainers who want the
   complete suite and are prepared to triage environment-specific failures.
 - Local nextest runs remain the primary development evidence. GitHub release
-  workflows add packaging-time checks for nightly, RC, and stable artifacts.
+  workflows add deterministic packaging-time checks for nightly, RC, and stable
+  artifacts.
+- Nightly uses `cargo test --workspace --locked` on `ubuntu-latest` to match
+  the RC/stable release gate before any package build or public publication.
+  It is intentionally narrower than local `ci-required` nextest coverage so the
+  scheduled release lane stays deterministic in GitHub Actions; quarantined,
+  GUI/manual, and performance checks remain explicit local or issue-specific
+  release-risk evidence.
 
 The non-blocking app architecture is enforced by
 `scripts/check.* non-blocking-architecture`, and that check is required by

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -65,6 +65,67 @@ fn release_contract_targets_match_nightly_workflow_matrix() {
 }
 
 #[test]
+fn nightly_workflow_runs_validation_before_build_and_publish() {
+    assert!(
+        NIGHTLY_WORKFLOW.contains("test:\n    name: Run nightly validation tests"),
+        "nightly workflow must define a dedicated validation job"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("ref: ${{ needs.resolve-main.outputs.target_sha }}"),
+        "nightly validation must run against the exact resolved main SHA"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("fetch-depth: 0"),
+        "nightly validation must have enough history for workspace tests that inspect git state"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/checkout_radiant_submodule.sh"),
+        "nightly validation must check out the Radiant submodule like RC/stable validation"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/emit_rust_toolchain_channel.py"),
+        "nightly validation must use the pinned Rust toolchain"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("run: cargo test --workspace --locked"),
+        "nightly validation must run the release workspace test lane"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("needs: [resolve-main, test]"),
+        "nightly package builds must wait for validation"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW.contains("needs: [resolve-main, test, release-log, build]"),
+        "PortalSurfer nightly publication must wait for validation"
+    );
+    assert!(
+        NIGHTLY_WORKFLOW
+            .contains("needs: [resolve-main, test, release-log, build, publish-frontend]"),
+        "GitHub nightly promotion must wait for validation and PortalSurfer publication"
+    );
+
+    let test_position = NIGHTLY_WORKFLOW
+        .find("name: Run nightly validation tests")
+        .expect("nightly validation job");
+    let build_position = NIGHTLY_WORKFLOW
+        .find("nightly\n    runs-on: ${{ matrix.os }}")
+        .expect("nightly build job");
+    let publish_frontend_position = NIGHTLY_WORKFLOW
+        .find("name: Upload PortalSurfer nightly downloads")
+        .expect("PortalSurfer nightly publish job");
+    let publish_github_position = NIGHTLY_WORKFLOW
+        .find("name: Promote GitHub nightly")
+        .expect("GitHub nightly publish job");
+
+    assert!(
+        test_position < build_position
+            && test_position < publish_frontend_position
+            && test_position < publish_github_position,
+        "nightly validation job should be declared before build and publish jobs"
+    );
+}
+
+#[test]
 fn release_contract_targets_match_manual_release_workflow_matrices() {
     let contract = parse_contract();
     let targets = contract_targets(&contract);
@@ -219,12 +280,13 @@ fn nightly_workflow_promotes_public_identity_after_public_surfaces_are_ready() {
         "nightly runs must not use cancellation-prone public promotion"
     );
     assert!(
-        NIGHTLY_WORKFLOW.contains("needs: [resolve-main, release-log, build, publish-frontend]"),
-        "GitHub nightly promotion must wait for the PortalSurfer upload and verifier job"
+        NIGHTLY_WORKFLOW
+            .contains("needs: [resolve-main, test, release-log, build, publish-frontend]"),
+        "GitHub nightly promotion must wait for validation plus the PortalSurfer upload and verifier job"
     );
     assert!(
-        NIGHTLY_WORKFLOW.contains("needs: [resolve-main, release-log, build]"),
-        "PortalSurfer upload must be able to complete before GitHub nightly identity promotion"
+        NIGHTLY_WORKFLOW.contains("needs: [resolve-main, test, release-log, build]"),
+        "PortalSurfer upload must wait for validation and be able to complete before GitHub nightly identity promotion"
     );
     assert!(
         !NIGHTLY_WORKFLOW.contains("needs: [resolve-main, publish-github]"),


### PR DESCRIPTION
## Scope

- Add a dedicated nightly `test` job that checks out the resolved `main` SHA, prepares the Radiant submodule and pinned Rust toolchain, and runs `cargo test --workspace --locked`.
- Make nightly package builds, PortalSurfer publication, and GitHub nightly promotion depend on that validation job.
- Update release contract coverage and docs so the nightly validation requirement and tradeoff are visible.

## Definition of Done

- Nightly public publication is blocked by deterministic pre-publish validation.
- `publish-frontend` and `publish-github` explicitly depend on the nightly validation job.
- Windows/macOS package builds still check out `needs.resolve-main.outputs.target_sha`.
- Contract tests fail if the nightly validation job or dependency edges are removed.

## Validation Commands

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "#{ARGV.fetch(0)}: ok"' .github/workflows/release-build.yml`\n- `cargo fmt --check`\n- `CARGO_INCREMENTAL=0 cargo test --test release_contract`\n- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`\n- `git diff --check`\n\n## Known Limitations\n\n- Nightly uses the same `cargo test --workspace --locked` release gate as RC/stable on `ubuntu-latest`; quarantined, GUI/manual, local nextest-profile, and performance checks remain explicit issue-specific release-risk evidence as documented in `docs/TEST.md`.\n\nUser review is required before merge.