### PR TITLE
OPT-1011 Add release workflow timeouts and summaries

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,6 +18,7 @@ jobs:
   resolve-main:
     name: Resolve main nightly target
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       target_sha: ${{ steps.target.outputs.target_sha }}
       build_number: ${{ steps.target.outputs.build_number }}
@@ -66,6 +67,7 @@ jobs:
   release-log:
     name: Generate nightly release log
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: resolve-main
     steps:
       - uses: actions/checkout@v4
@@ -177,6 +179,7 @@ jobs:
   test:
     name: Run nightly validation tests
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     needs: resolve-main
     steps:
       - uses: actions/checkout@v4
@@ -202,6 +205,7 @@ jobs:
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} nightly
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     needs: [resolve-main, test]
     strategy:
       fail-fast: false
@@ -273,6 +277,7 @@ jobs:
   publish-github:
     name: Promote GitHub nightly
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [resolve-main, test, release-log, build, publish-frontend]
     steps:
       - uses: actions/checkout@v4
@@ -386,10 +391,33 @@ jobs:
             --repo "${{ github.repository }}" \
             --source GitHub \
             --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+      - name: Summarize GitHub nightly promotion
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SUMMARY_STATUS: ${{ job.status }}
+        run: |
+          scripts/internal/release/write_release_step_summary.sh \
+            --title "GitHub nightly promotion" \
+            --status "$SUMMARY_STATUS" \
+            --channel nightly \
+            --version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --target-version "${{ needs.resolve-main.outputs.target_version }}" \
+            --commit "${{ needs.resolve-main.outputs.target_sha }}" \
+            --build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve-main.outputs.build_number }}" \
+            --github-tag nightly \
+            --github-release-url "https://github.com/${{ github.repository }}/releases/tag/nightly" \
+            --portal-catalog-url "https://portalsurfer.org/wavecrate/api/v1/releases" \
+            --portal-build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --artifact-dir dist/release \
+            --checksum-file dist/release/checksums-nightly.txt \
+            --note "PortalSurfer job result: ${{ needs.publish-frontend.result }}"
 
   publish-frontend:
     name: Upload PortalSurfer nightly downloads
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [resolve-main, test, release-log, build]
     steps:
       - uses: actions/checkout@v4
@@ -456,3 +484,25 @@ jobs:
             --build-number "${{ needs.resolve-main.outputs.build_number }}" \
             --source PortalSurfer \
             --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+      - name: Summarize PortalSurfer nightly verification
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SUMMARY_STATUS: ${{ job.status }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          upload_base="${upload_base%/}"
+          scripts/internal/release/write_release_step_summary.sh \
+            --title "PortalSurfer nightly verification" \
+            --status "$SUMMARY_STATUS" \
+            --channel nightly \
+            --version "${{ needs.resolve-main.outputs.nightly_version }}" \
+            --target-version "${{ needs.resolve-main.outputs.target_version }}" \
+            --commit "${{ needs.resolve-main.outputs.target_sha }}" \
+            --build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve-main.outputs.build_number }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve-main.outputs.portal_build_id }}" \
+            --artifact-dir dist/release \
+            --checksum-file dist/release/checksums-nightly.txt

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -31,6 +31,7 @@ jobs:
   resolve:
     name: Resolve RC target
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
       target_version: ${{ steps.resolve.outputs.target_version }}
@@ -96,6 +97,7 @@ jobs:
   test:
     name: Run RC validation tests
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     needs: resolve
     steps:
       - uses: actions/checkout@v4
@@ -121,6 +123,7 @@ jobs:
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} RC
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     needs: [resolve, test]
     strategy:
       fail-fast: false
@@ -192,6 +195,7 @@ jobs:
   publish:
     name: Publish GitHub RC
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [resolve, build]
     steps:
       - uses: actions/checkout@v4
@@ -304,3 +308,27 @@ jobs:
             --build-number "${{ needs.resolve.outputs.build_number }}" \
             --source PortalSurfer \
             --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+      - name: Summarize RC release publication
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SUMMARY_STATUS: ${{ job.status }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          upload_base="${upload_base%/}"
+          scripts/internal/release/write_release_step_summary.sh \
+            --title "RC release publication" \
+            --status "$SUMMARY_STATUS" \
+            --channel rc \
+            --version "${{ needs.resolve.outputs.release_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --github-tag "${{ needs.resolve.outputs.release_tag }}" \
+            --github-release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --artifact-dir dist/release \
+            --checksum-file "dist/release/checksums-${{ needs.resolve.outputs.release_version }}.txt"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -27,6 +27,7 @@ jobs:
   resolve:
     name: Resolve stable target
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       target_sha: ${{ steps.resolve.outputs.target_sha }}
       target_version: ${{ steps.resolve.outputs.target_version }}
@@ -108,6 +109,7 @@ jobs:
   test:
     name: Run stable validation tests
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     needs: resolve
     steps:
       - uses: actions/checkout@v4
@@ -133,6 +135,7 @@ jobs:
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} stable
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
     needs: [resolve, test]
     strategy:
       fail-fast: false
@@ -204,6 +207,7 @@ jobs:
   publish:
     name: Publish GitHub stable release
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [resolve, build]
     steps:
       - uses: actions/checkout@v4
@@ -315,3 +319,27 @@ jobs:
             --build-number "${{ needs.resolve.outputs.build_number }}" \
             --source PortalSurfer \
             --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
+      - name: Summarize stable release publication
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SUMMARY_STATUS: ${{ job.status }}
+          PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
+        run: |
+          upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
+          upload_base="${upload_base%/}"
+          scripts/internal/release/write_release_step_summary.sh \
+            --title "Stable release publication" \
+            --status "$SUMMARY_STATUS" \
+            --channel stable \
+            --version "${{ needs.resolve.outputs.target_version }}" \
+            --target-version "${{ needs.resolve.outputs.target_version }}" \
+            --commit "${{ needs.resolve.outputs.target_sha }}" \
+            --build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --build-number "${{ needs.resolve.outputs.build_number }}" \
+            --github-tag "${{ needs.resolve.outputs.release_tag }}" \
+            --github-release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}" \
+            --portal-catalog-url "${upload_base%/release-uploads}/releases" \
+            --portal-build-id "${{ needs.resolve.outputs.portal_build_id }}" \
+            --artifact-dir dist/release \
+            --checksum-file "dist/release/checksums-${{ needs.resolve.outputs.target_version }}.txt"

--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -29,6 +29,7 @@ jobs:
   prepare:
     name: Prepare release train
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,3 +66,17 @@ jobs:
             args+=(--dry-run)
           fi
           scripts/internal/release/prepare_release_train.py "${args[@]}"
+      - name: Summarize release train prep
+        if: ${{ always() }}
+        shell: bash
+        env:
+          SUMMARY_STATUS: ${{ job.status }}
+        run: |
+          scripts/internal/release/write_release_step_summary.sh \
+            --title "Release train preparation" \
+            --status "$SUMMARY_STATUS" \
+            --version "${{ inputs.version }}" \
+            --target-version "${{ inputs.version }}" \
+            --commit "$(git rev-parse HEAD)" \
+            --note "Source ref: ${{ inputs.source_ref }}" \
+            --note "Push branch: ${{ inputs.push_branch }}"

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -116,6 +116,9 @@ under `scripts/internal/release/`:
   changelog, and full changelog.
 - `prune_github_release_assets.sh` removes stale assets from a rolling GitHub
   release during promotion.
+- `write_release_step_summary.sh` writes secret-safe GitHub Actions summaries
+  with public release metadata, artifact filenames, file hashes, checksum file
+  names, PortalSurfer catalog/build ids, and verification status.
 
 RC runs require `version`, `rc_number`, and `branch` inputs. The branch must be
 `release/X.Y` for the requested `X.Y.Z` version, and the package manifest must
@@ -172,6 +175,27 @@ This staged commit flow requires PortalSurfer server support for
 `/wavecrate/api/v1/release-uploads/<build-id>/staging/files/<filename>` and
 `/wavecrate/api/v1/release-uploads/<build-id>/commit`; older servers fail closed
 instead of falling back to direct public mutation.
+
+Release jobs use explicit GitHub Actions timeout budgets so stalled tests,
+packaging, upload, verification, or release-train preparation fail with bounded
+operator feedback instead of consuming the platform default timeout. Build jobs
+are intentionally the most generous because macOS signing and notarization can
+be slow; publish jobs are shorter because they should only assemble, upload,
+commit, and verify already-built artifacts. Each publish path appends a
+`GITHUB_STEP_SUMMARY` section with the resolved commit, version, build id,
+GitHub release URL or tag, PortalSurfer catalog URL/build id, artifact names,
+checksums, and final verification status. The summary helper only receives
+public release metadata and local artifact paths; upload tokens, checksum
+signing keys, Apple credentials, and private key material must never be passed
+to it.
+
+PortalSurfer upload and catalog fetches are bounded with curl connection and
+total transfer timeouts. By default,
+`PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS=10` and
+`PORTALSURFER_RELEASE_MAX_TIME_SECONDS=300` apply to each staged file upload,
+commit request, and verification fetch. Override those only for an explicit
+operator recovery run where large artifacts or a known network incident need a
+larger transfer window.
 
 To rerun the GitHub verifier for a published stable release, use the resolved
 release metadata from the workflow run:

--- a/scripts/internal/release/publish_portalsurfer_release.sh
+++ b/scripts/internal/release/publish_portalsurfer_release.sh
@@ -89,6 +89,22 @@ if [[ ! -s "$RELEASE_LOG" ]]; then
   exit 1
 fi
 
+PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS="${PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS:-10}"
+PORTALSURFER_RELEASE_MAX_TIME_SECONDS="${PORTALSURFER_RELEASE_MAX_TIME_SECONDS:-300}"
+for timeout_value in "$PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS" "$PORTALSURFER_RELEASE_MAX_TIME_SECONDS"; do
+  if [[ ! "$timeout_value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "PortalSurfer curl timeout values must be positive integer seconds." >&2
+    exit 1
+  fi
+done
+curl_args=(
+  --fail-with-body
+  --retry 3
+  --retry-delay 2
+  --connect-timeout "$PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS"
+  --max-time "$PORTALSURFER_RELEASE_MAX_TIME_SECONDS"
+)
+
 upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"
 upload_base="${upload_base%/}"
 if [[ "$upload_base" != */release-uploads ]]; then
@@ -100,9 +116,50 @@ api_base="${upload_base%/release-uploads}"
 catalog_url="$api_base/releases"
 full_changelog_url="$api_base/changelog"
 response_dir="$(mktemp -d)"
-trap 'rm -rf "$response_dir"' EXIT
 staged_files_tsv="$response_dir/staged-files.tsv"
 : > "$staged_files_tsv"
+summary_phase="validating release artifacts"
+summary_written=0
+
+write_portalsurfer_summary() {
+  local status_code="$1"
+  if [[ "$summary_written" == "1" ]]; then
+    return 0
+  fi
+  summary_written=1
+  local status_text="success"
+  if [[ "$status_code" != "0" ]]; then
+    status_text="failure during ${summary_phase}"
+  fi
+  local checksum_file=""
+  shopt -s nullglob
+  local checksum_candidates=("${ARTIFACT_DIR}"/checksums-*.txt)
+  shopt -u nullglob
+  if [[ ${#checksum_candidates[@]} -gt 0 ]]; then
+    checksum_file="${checksum_candidates[0]}"
+  fi
+  bash scripts/internal/release/write_release_step_summary.sh \
+    --title "PortalSurfer ${CHANNEL} publication" \
+    --status "$status_text" \
+    --channel "$CHANNEL" \
+    --version "$RELEASE_VERSION" \
+    --commit "${GITHUB_SHA:-}" \
+    --build-id "$BUILD_ID" \
+    --build-number "$BUILD_NUMBER" \
+    --portal-catalog-url "$catalog_url" \
+    --portal-build-id "$BUILD_ID" \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --checksum-file "$checksum_file" \
+    --note "PortalSurfer phase: $summary_phase" || true
+}
+
+cleanup() {
+  local status_code="$?"
+  write_portalsurfer_summary "$status_code"
+  rm -rf "$response_dir"
+  exit "$status_code"
+}
+trap cleanup EXIT
 
 shopt -s nullglob
 files=("${ARTIFACT_DIR}"/*.zip "${ARTIFACT_DIR}"/checksums-*.txt "${ARTIFACT_DIR}"/checksums-*.txt.sig)
@@ -112,6 +169,7 @@ if [[ ${#files[@]} -eq 0 ]]; then
 fi
 
 uploaded_names=()
+summary_phase="staging release files"
 for file in "${files[@]}"; do
   file_name="$(basename "$file")"
   if [[ ! -s "$file" ]]; then
@@ -127,7 +185,7 @@ for file in "${files[@]}"; do
   encoded_name="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$file_name")"
   response_file="$response_dir/$file_name.json"
   echo "Staging PortalSurfer release file: $file_name" >&2
-  curl --fail-with-body --retry 3 --retry-delay 2 \
+  curl "${curl_args[@]}" \
     --request PUT \
     --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
     --header "Content-Type: $content_type" \
@@ -160,6 +218,7 @@ PY
   uploaded_names+=("$file_name")
 done
 
+summary_phase="assembling full changelog"
 scripts/internal/release/assemble_portal_changelog.py \
   --catalog-url "$catalog_url" \
   --current-build-id "$BUILD_ID" \
@@ -201,7 +260,8 @@ PY
 
 commit_response_file="$response_dir/release-commit-response.json"
 echo "Committing PortalSurfer release: $BUILD_ID" >&2
-curl --fail-with-body --retry 3 --retry-delay 2 \
+summary_phase="committing staged release"
+curl "${curl_args[@]}" \
   --request PUT \
   --header "Authorization: Bearer $PORTALSURFER_RELEASE_UPLOAD_TOKEN" \
   --header "Content-Type: application/json" \
@@ -233,7 +293,8 @@ if full_changelog.get("format") != "markdown" or not full_changelog.get("url"):
 PY
 
 catalog_file="$response_dir/releases.json"
-curl --fail-with-body --retry 3 --retry-delay 2 "$catalog_url" > "$catalog_file"
+summary_phase="verifying public catalog"
+curl "${curl_args[@]}" "$catalog_url" > "$catalog_file"
 catalog_args=(
   --catalog-file "$catalog_file"
   --build-id "$BUILD_ID"
@@ -247,7 +308,8 @@ done
 python3 scripts/internal/release/verify_portalsurfer_upload_catalog.py "${catalog_args[@]}"
 
 changelog_catalog_file="$response_dir/changelog-catalog.json"
-curl --fail-with-body --retry 3 --retry-delay 2 \
+summary_phase="verifying per-release changelog"
+curl "${curl_args[@]}" \
   "$catalog_url/$BUILD_ID/changelog" > "$changelog_catalog_file"
 python3 - "$changelog_catalog_file" "$BUILD_ID" "$RELEASE_LOG" <<'PY'
 import json
@@ -265,7 +327,8 @@ print(f"Uploaded Wavecrate release log to {expected_build}")
 PY
 
 full_changelog_catalog_file="$response_dir/full-changelog-catalog.json"
-curl --fail-with-body --retry 3 --retry-delay 2 \
+summary_phase="verifying full changelog"
+curl "${curl_args[@]}" \
   "$full_changelog_url" > "$full_changelog_catalog_file"
 python3 - "$full_changelog_catalog_file" "$FULL_CHANGELOG_OUT" <<'PY'
 import json
@@ -279,3 +342,4 @@ if body != expected_body:
     raise SystemExit("Fetched full changelog body does not match generated changelog")
 print("Uploaded Wavecrate full changelog")
 PY
+summary_phase="complete"

--- a/scripts/internal/release/write_release_step_summary.sh
+++ b/scripts/internal/release/write_release_step_summary.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TITLE="Wavecrate release summary"
+STATUS="unknown"
+CHANNEL=""
+VERSION=""
+TARGET_VERSION=""
+COMMIT=""
+BUILD_ID=""
+BUILD_NUMBER=""
+GITHUB_RELEASE_URL=""
+GITHUB_TAG=""
+PORTAL_CATALOG_URL=""
+PORTAL_BUILD_ID=""
+ARTIFACT_DIR=""
+CHECKSUM_FILE=""
+NOTES=()
+
+usage() {
+  cat <<'USAGE'
+Usage: write_release_step_summary.sh [options]
+
+Appends a secret-safe Markdown release summary to GITHUB_STEP_SUMMARY when that
+environment variable is set. All values must be public release metadata.
+
+Options:
+  --title <text>
+  --status <text>
+  --channel <nightly|rc|stable>
+  --version <version>
+  --target-version <version>
+  --commit <sha>
+  --build-id <id>
+  --build-number <number>
+  --github-release-url <url>
+  --github-tag <tag>
+  --portal-catalog-url <url>
+  --portal-build-id <id>
+  --artifact-dir <path>
+  --checksum-file <path>
+  --note <text>
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)
+      TITLE="${2:-}"
+      shift 2
+      ;;
+    --status)
+      STATUS="${2:-}"
+      shift 2
+      ;;
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --target-version)
+      TARGET_VERSION="${2:-}"
+      shift 2
+      ;;
+    --commit)
+      COMMIT="${2:-}"
+      shift 2
+      ;;
+    --build-id)
+      BUILD_ID="${2:-}"
+      shift 2
+      ;;
+    --build-number)
+      BUILD_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --github-release-url)
+      GITHUB_RELEASE_URL="${2:-}"
+      shift 2
+      ;;
+    --github-tag)
+      GITHUB_TAG="${2:-}"
+      shift 2
+      ;;
+    --portal-catalog-url)
+      PORTAL_CATALOG_URL="${2:-}"
+      shift 2
+      ;;
+    --portal-build-id)
+      PORTAL_BUILD_ID="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --checksum-file)
+      CHECKSUM_FILE="${2:-}"
+      shift 2
+      ;;
+    --note)
+      NOTES+=("${2:-}")
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+summary_file="${GITHUB_STEP_SUMMARY:-}"
+if [[ -z "$summary_file" ]]; then
+  exit 0
+fi
+
+cell() {
+  local value="${1:-}"
+  value="${value//$'\n'/ }"
+  value="${value//$'\r'/ }"
+  value="${value//|/\\|}"
+  if [[ -z "$value" ]]; then
+    value="not available"
+  fi
+  printf "%s" "$value"
+}
+
+row() {
+  local label="$1"
+  local value="$2"
+  printf '| %s | %s |\n' "$(cell "$label")" "$(cell "$value")"
+}
+
+artifact_rows=()
+if [[ -n "$ARTIFACT_DIR" && -d "$ARTIFACT_DIR" ]]; then
+  while IFS= read -r -d '' artifact; do
+    name="$(basename "$artifact")"
+    size_bytes="$(wc -c < "$artifact" | tr -d '[:space:]')"
+    sha256="$(sha256sum "$artifact" | awk '{ print $1 }')"
+    artifact_rows+=("| $(cell "$name") | $(cell "$size_bytes") | $(cell "$sha256") |")
+  done < <(find "$ARTIFACT_DIR" -maxdepth 1 -type f -print0 | sort -z)
+fi
+
+checksum_name=""
+if [[ -n "$CHECKSUM_FILE" ]]; then
+  checksum_name="$(basename "$CHECKSUM_FILE")"
+fi
+
+{
+  echo "## $(cell "$TITLE")"
+  echo
+  echo "| Field | Value |"
+  echo "| --- | --- |"
+  row "Status" "$STATUS"
+  row "Channel" "$CHANNEL"
+  row "Version" "$VERSION"
+  row "Target version" "$TARGET_VERSION"
+  row "Commit" "$COMMIT"
+  row "Build ID" "$BUILD_ID"
+  row "Build number" "$BUILD_NUMBER"
+  row "GitHub tag" "$GITHUB_TAG"
+  row "GitHub release" "$GITHUB_RELEASE_URL"
+  row "PortalSurfer build ID" "$PORTAL_BUILD_ID"
+  row "PortalSurfer catalog" "$PORTAL_CATALOG_URL"
+  row "Checksum file" "$checksum_name"
+  echo
+  if [[ ${#artifact_rows[@]} -gt 0 ]]; then
+    echo "| Artifact | Bytes | SHA-256 |"
+    echo "| --- | ---: | --- |"
+    printf '%s\n' "${artifact_rows[@]}"
+  else
+    echo "_No local release artifacts were available to summarize._"
+  fi
+  if [[ ${#NOTES[@]} -gt 0 ]]; then
+    echo
+    echo "### Notes"
+    for note in "${NOTES[@]}"; do
+      echo "- $(cell "$note")"
+    done
+  fi
+  echo
+} >> "$summary_file"

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -25,6 +25,8 @@ const PUBLISH_PORTALSURFER_SCRIPT: &str =
     include_str!("../scripts/internal/release/publish_portalsurfer_release.sh");
 const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
+const WRITE_RELEASE_SUMMARY_SCRIPT: &str =
+    include_str!("../scripts/internal/release/write_release_step_summary.sh");
 const VALIDATE_PROMOTED_RC_SCRIPT: &str =
     include_str!("../scripts/internal/release/validate_promoted_rc_release.py");
 const VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT: &str =
@@ -122,6 +124,105 @@ fn nightly_workflow_runs_validation_before_build_and_publish() {
             && test_position < publish_frontend_position
             && test_position < publish_github_position,
         "nightly validation job should be declared before build and publish jobs"
+    );
+}
+
+#[test]
+fn release_workflows_define_timeouts_and_step_summaries() {
+    for (workflow_name, workflow, jobs) in [
+        (
+            "nightly workflow",
+            NIGHTLY_WORKFLOW,
+            &[
+                ("resolve-main", "10"),
+                ("release-log", "20"),
+                ("test", "75"),
+                ("build", "120"),
+                ("publish-github", "30"),
+                ("publish-frontend", "45"),
+            ][..],
+        ),
+        (
+            "RC workflow",
+            RC_WORKFLOW,
+            &[
+                ("resolve", "15"),
+                ("test", "75"),
+                ("build", "120"),
+                ("publish", "45"),
+            ][..],
+        ),
+        (
+            "stable workflow",
+            STABLE_WORKFLOW,
+            &[
+                ("resolve", "30"),
+                ("test", "75"),
+                ("build", "120"),
+                ("publish", "45"),
+            ][..],
+        ),
+        (
+            "release train prep workflow",
+            RELEASE_TRAIN_PREP_WORKFLOW,
+            &[("prepare", "60")][..],
+        ),
+    ] {
+        for (job, minutes) in jobs {
+            assert_job_timeout(workflow_name, workflow, job, minutes);
+        }
+        assert!(
+            workflow.contains("if: ${{ always() }}"),
+            "{workflow_name} must write release summaries from always() steps"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/write_release_step_summary.sh \\"),
+            "{workflow_name} must use the shared release summary helper"
+        );
+    }
+}
+
+#[test]
+fn portalsurfer_publish_helper_bounds_http_and_summarizes_state() {
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS=\"${PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS:-10}\""),
+        "PortalSurfer helper must default to a bounded connect timeout"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("PORTALSURFER_RELEASE_MAX_TIME_SECONDS=\"${PORTALSURFER_RELEASE_MAX_TIME_SECONDS:-300}\""),
+        "PortalSurfer helper must default to a bounded per-request transfer timeout"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .contains("--connect-timeout \"$PORTALSURFER_RELEASE_CONNECT_TIMEOUT_SECONDS\"")
+            && PUBLISH_PORTALSURFER_SCRIPT
+                .contains("--max-time \"$PORTALSURFER_RELEASE_MAX_TIME_SECONDS\""),
+        "PortalSurfer curl calls must include connection and total transfer bounds"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT
+            .matches("curl \"${curl_args[@]}\"")
+            .count()
+            >= 5,
+        "PortalSurfer upload, commit, and verification fetches must use the bounded curl policy"
+    );
+    assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("write_portalsurfer_summary \"$status_code\""),
+        "PortalSurfer helper must summarize success or the failed upload phase"
+    );
+    assert!(
+        WRITE_RELEASE_SUMMARY_SCRIPT.contains("GITHUB_STEP_SUMMARY")
+            && WRITE_RELEASE_SUMMARY_SCRIPT.contains("SHA-256")
+            && WRITE_RELEASE_SUMMARY_SCRIPT.contains("PortalSurfer catalog"),
+        "release summary helper must write structured public release metadata"
+    );
+    assert!(
+        !WRITE_RELEASE_SUMMARY_SCRIPT.contains("UPLOAD_TOKEN")
+            && !WRITE_RELEASE_SUMMARY_SCRIPT.contains("SIGNING_KEY")
+            && !WRITE_RELEASE_SUMMARY_SCRIPT.contains("APPLE_"),
+        "release summary helper must not read or print release secrets"
     );
 }
 
@@ -911,6 +1012,35 @@ fn workflow_release_targets(workflow: &str) -> BTreeSet<ReleaseTarget> {
     insert_workflow_entry(&mut targets, &mut entry);
 
     targets
+}
+
+fn assert_job_timeout(workflow_name: &str, workflow: &str, job: &str, minutes: &str) {
+    let block = workflow_job_block(workflow, job);
+    assert!(
+        block.contains(&format!("timeout-minutes: {minutes}")),
+        "{workflow_name} job {job} must declare timeout-minutes: {minutes}"
+    );
+}
+
+fn workflow_job_block(workflow: &str, job: &str) -> String {
+    let marker = format!("  {job}:");
+    let mut found = false;
+    let mut block = Vec::new();
+    for line in workflow.lines() {
+        if line == marker {
+            found = true;
+            block.push(line);
+            continue;
+        }
+        if found && line.starts_with("  ") && !line.starts_with("    ") && line.ends_with(':') {
+            break;
+        }
+        if found {
+            block.push(line);
+        }
+    }
+    assert!(found, "workflow job {job} must exist");
+    block.join("\n")
 }
 
 fn insert_workflow_entry(

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -75,6 +75,77 @@ fn assemble_release_files_copies_zips_and_combines_checksum_entries() {
 }
 
 #[test]
+fn release_summary_helper_writes_public_metadata_without_secret_values() {
+    let temp = tempfile::tempdir().expect("create summary fixture");
+    let artifact_dir = temp.path().join("release");
+    let summary_file = temp.path().join("summary.md");
+    fs::create_dir_all(&artifact_dir).expect("create release dir");
+    fs::write(
+        artifact_dir.join("wavecrate-19.1.0-windows-x86_64.zip"),
+        "not a real zip but enough for summary hashing\n",
+    )
+    .expect("write artifact");
+    fs::write(
+        artifact_dir.join("checksums-19.1.0.txt"),
+        "abc  wavecrate-19.1.0-windows-x86_64.zip\n",
+    )
+    .expect("write checksum");
+
+    run_success(
+        Command::new("bash")
+            .arg(repo_path(
+                "scripts/internal/release/write_release_step_summary.sh",
+            ))
+            .arg("--title")
+            .arg("Stable release publication")
+            .arg("--status")
+            .arg("success")
+            .arg("--channel")
+            .arg("stable")
+            .arg("--version")
+            .arg("19.1.0")
+            .arg("--target-version")
+            .arg("19.1.0")
+            .arg("--commit")
+            .arg("abcdef123456")
+            .arg("--build-id")
+            .arg("wavecrate-19.1.0")
+            .arg("--build-number")
+            .arg("6258")
+            .arg("--github-release-url")
+            .arg("https://github.com/PORTALSURFER/wavecrate/releases/tag/v19.1.0")
+            .arg("--portal-catalog-url")
+            .arg("https://portalsurfer.org/wavecrate/api/v1/releases")
+            .arg("--portal-build-id")
+            .arg("wavecrate-19.1.0")
+            .arg("--artifact-dir")
+            .arg(&artifact_dir)
+            .arg("--checksum-file")
+            .arg(artifact_dir.join("checksums-19.1.0.txt"))
+            .arg("--note")
+            .arg("fixture note")
+            .env("GITHUB_STEP_SUMMARY", &summary_file)
+            .env(
+                "PORTALSURFER_RELEASE_UPLOAD_TOKEN",
+                "super-secret-upload-token",
+            )
+            .env("CHECKSUMS_SIGNING_KEY", "super-secret-signing-key")
+            .env(
+                "APPLE_DEVELOPER_ID_APPLICATION_CERT_BASE64",
+                "super-secret-apple-cert",
+            ),
+    );
+
+    let summary = fs::read_to_string(summary_file).expect("read summary");
+    assert!(summary.contains("## Stable release publication"));
+    assert!(summary.contains("wavecrate-19.1.0-windows-x86_64.zip"));
+    assert!(summary.contains("checksums-19.1.0.txt"));
+    assert!(summary.contains("PortalSurfer catalog"));
+    assert!(summary.contains("SHA-256"));
+    assert!(!summary.contains("super-secret"));
+}
+
+#[test]
 fn checksum_signing_helper_writes_signature_and_verifies_expected_pubkey() {
     let temp = tempfile::tempdir().expect("create signing fixture");
     let key = temp.path().join("ed25519.pem");


### PR DESCRIPTION
## Scope

- Add explicit timeout budgets to release-train prep, nightly, RC, and stable release jobs.
- Add a shared `write_release_step_summary.sh` helper for secret-safe GitHub Actions summaries with public release metadata, artifact names, hashes, checksum file names, GitHub release links, PortalSurfer catalog/build ids, and status.
- Wire `always()` summary steps into publish/prep workflows and add PortalSurfer helper phase summaries for success or failed upload phases.
- Add bounded PortalSurfer curl connection and per-request transfer timeouts.
- Document timeout choices, summary boundaries, and override knobs.

## Definition of Done

- Release jobs have explicit `timeout-minutes` budgets.
- PortalSurfer upload/fetch calls use bounded `--connect-timeout` and `--max-time` curl policy.
- Successful and failed publish paths append concise, secret-safe Actions summaries.
- Contract/helper tests guard workflow timeouts, summary instrumentation, curl timeout policy, and summary secret safety.

## Validation Commands

- `bash -n scripts/internal/release/publish_portalsurfer_release.sh scripts/internal/release/write_release_step_summary.sh`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/release-build.yml .github/workflows/release-rc.yml .github/workflows/release-stable.yml .github/workflows/release-train-prepare.yml`\n- `cargo fmt --check`\n- `CARGO_INCREMENTAL=0 cargo test --test release_contract`\n- `CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`\n- `git diff --check`\n- Dry-run summary fixture rendered and manually inspected for public-only metadata.\n\n## Known Limitations\n\n- A job killed by the GitHub Actions runner at the timeout boundary may not run its final `always()` summary step; the timeout budget still bounds the hang and earlier helper summaries remain available when the shell receives normal failure control.\n- PortalSurfer curl timeouts are per request, not whole release-run deadlines; the job-level timeout remains the overall cap.\n\nUser review is required before merge.