### PR TITLE
OPT-1012 Enforce release archive layout

### DIFF
--- a/release_contract.toml
+++ b/release_contract.toml
@@ -30,3 +30,10 @@ stable_checksums_sig = "checksums-{version}.txt.sig"
 root_dir = "{APP_NAME}"
 files = ["{APP_NAME}", "{APP_NAME}.exe"]
 optional_dirs = []
+
+[archive_layout.platform_files]
+windows = ["{APP_NAME}.exe"]
+macos = [
+  "Wavecrate.app/Contents/Info.plist",
+  "Wavecrate.app/Contents/MacOS/{APP_NAME}"
+]

--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -45,6 +45,22 @@ class ExpectedRelease:
         return [zip_asset.name for zip_asset in self.zips] + [self.checksum, self.signature]
 
 
+@dataclass(frozen=True)
+class ArchiveLayout:
+    root_dir: str
+    files: list[str]
+    optional_dirs: list[str]
+    platform_files: dict[str, list[str]]
+
+    def expected_files_for(self, platform: str) -> list[str]:
+        explicit = self.platform_files.get(platform)
+        if explicit is not None:
+            return explicit
+        if platform == "windows":
+            return [path for path in self.files if path.endswith(".exe")]
+        return [path for path in self.files if not path.endswith(".exe")]
+
+
 def main() -> int:
     args = parse_args()
     errors = validate_args(args)
@@ -54,6 +70,7 @@ def main() -> int:
 
     contract = load_release_contract(args.contract)
     expected = expected_release_assets(contract, args.channel, args.version, args.target_version)
+    archive_layout = archive_layout_from_contract(contract)
     release = load_release(args)
     errors.extend(validate_release_metadata(release, args, expected.required_assets))
     if errors:
@@ -61,7 +78,7 @@ def main() -> int:
         return 1
 
     with local_asset_dir(args, release, expected.required_assets) as asset_dir:
-        errors.extend(validate_downloaded_assets(asset_dir, release, expected, args))
+        errors.extend(validate_downloaded_assets(asset_dir, release, expected, archive_layout, args))
 
     if errors:
         print_errors(errors)
@@ -168,7 +185,38 @@ def parse_minimal_release_contract(text: str) -> dict[str, Any]:
     targets = re.findall(r'"([^"]+)"', targets_match)
     templates_match = require_match(r"(?ms)^\[templates\]\s*(.*?)(?:^\[|\Z)", text, "templates")
     templates = dict(re.findall(r'(?m)^([A-Za-z0-9_]+)\s*=\s*"([^"]+)"', templates_match))
-    return {"app_name": app_name, "targets": targets, "templates": templates}
+    archive_match = require_match(r"(?ms)^\[archive_layout\]\s*(.*?)(?:^\[|\Z)", text, "archive_layout")
+    root_dir = require_match(r'(?m)^root_dir\s*=\s*"([^"]+)"', archive_match, "archive_layout.root_dir")
+    files = parse_toml_string_array(archive_match, "files")
+    optional_dirs = parse_toml_string_array(archive_match, "optional_dirs")
+    platform_files_match = re.search(
+        r"(?ms)^\[archive_layout\.platform_files\]\s*(.*?)(?:^\[|\Z)",
+        text,
+    )
+    platform_files: dict[str, list[str]] = {}
+    if platform_files_match:
+        for platform in ("windows", "macos", "linux"):
+            values = parse_toml_string_array(platform_files_match.group(1), platform)
+            if values:
+                platform_files[platform] = values
+    return {
+        "app_name": app_name,
+        "targets": targets,
+        "templates": templates,
+        "archive_layout": {
+            "root_dir": root_dir,
+            "files": files,
+            "optional_dirs": optional_dirs,
+            "platform_files": platform_files,
+        },
+    }
+
+
+def parse_toml_string_array(text: str, key: str) -> list[str]:
+    match = re.search(rf"(?ms)^{re.escape(key)}\s*=\s*\[(.*?)\]", text)
+    if not match:
+        return []
+    return re.findall(r'"([^"]+)"', match.group(1))
 
 
 def require_match(pattern: str, text: str, label: str) -> str:
@@ -228,6 +276,56 @@ def expected_release_assets(
         checksum = apply_template(templates["stable_checksums"], app_name, version, "", "", "")
         signature = apply_template(templates["stable_checksums_sig"], app_name, version, "", "", "")
     return ExpectedRelease(sorted(zips, key=lambda item: item.name), checksum, signature)
+
+
+def archive_layout_from_contract(contract: dict[str, Any]) -> ArchiveLayout:
+    app_name = contract["app_name"]
+    layout = contract.get("archive_layout")
+    if not isinstance(layout, dict):
+        raise SystemExit("release contract is missing [archive_layout]")
+    root_dir = str(layout.get("root_dir") or "").strip()
+    if not root_dir:
+        raise SystemExit("release contract is missing archive_layout.root_dir")
+    files = layout.get("files")
+    if not isinstance(files, list) or not all(isinstance(path, str) and path for path in files):
+        raise SystemExit("release contract archive_layout.files must be a non-empty string array")
+    optional_dirs = layout.get("optional_dirs") or []
+    if not isinstance(optional_dirs, list) or not all(isinstance(path, str) for path in optional_dirs):
+        raise SystemExit("release contract archive_layout.optional_dirs must be a string array")
+    platform_files = layout.get("platform_files") or {}
+    if not isinstance(platform_files, dict):
+        raise SystemExit("release contract archive_layout.platform_files must be a table")
+
+    expanded_platform_files: dict[str, list[str]] = {}
+    for platform, paths in platform_files.items():
+        if not isinstance(paths, list) or not all(isinstance(path, str) and path for path in paths):
+            raise SystemExit(
+                f"release contract archive_layout.platform_files.{platform} must be a non-empty string array"
+            )
+        expanded_platform_files[str(platform)] = [
+            normalize_archive_relative_path(apply_archive_layout_template(path, app_name))
+            for path in paths
+        ]
+    return ArchiveLayout(
+        root_dir=normalize_archive_relative_path(apply_archive_layout_template(root_dir, app_name)),
+        files=[
+            normalize_archive_relative_path(apply_archive_layout_template(path, app_name))
+            for path in files
+        ],
+        optional_dirs=[
+            normalize_archive_relative_path(apply_archive_layout_template(path, app_name))
+            for path in optional_dirs
+        ],
+        platform_files=expanded_platform_files,
+    )
+
+
+def apply_archive_layout_template(template: str, app_name: str) -> str:
+    return template.replace("{APP_NAME}", app_name)
+
+
+def normalize_archive_relative_path(path: str) -> str:
+    return path.replace("\\", "/").strip("/")
 
 
 def apply_template(
@@ -437,6 +535,7 @@ def validate_downloaded_assets(
     asset_dir: Path,
     release: dict[str, Any],
     expected: ExpectedRelease,
+    archive_layout: ArchiveLayout,
     args: argparse.Namespace,
 ) -> list[str]:
     errors: list[str] = []
@@ -461,7 +560,7 @@ def validate_downloaded_assets(
     for zip_asset in expected.zips:
         zip_path = asset_dir / zip_asset.name
         if zip_path.is_file():
-            errors.extend(validate_zip_manifest(zip_path, zip_asset, args))
+            errors.extend(validate_zip_manifest(zip_path, zip_asset, archive_layout, args))
     return errors
 
 
@@ -568,18 +667,17 @@ def verify_checksum_signature(checksum_path: Path, signature_path: Path, checksu
 def validate_zip_manifest(
     zip_path: Path,
     zip_asset: ExpectedZip,
+    archive_layout: ArchiveLayout,
     args: argparse.Namespace,
 ) -> list[str]:
     errors: list[str] = []
     try:
         with zipfile.ZipFile(zip_path) as archive:
-            manifest_names = [
-                name
-                for name in archive.namelist()
-                if name == "update-manifest.json" or name.endswith("/update-manifest.json")
-            ]
+            archive_files = normalized_archive_files(archive)
+            manifest_names = [name for name in archive_files if name.endswith("update-manifest.json")]
             if len(manifest_names) != 1:
                 return [f"{zip_asset.name} must contain exactly one update-manifest.json"]
+            errors.extend(validate_archive_layout(zip_asset, archive_layout, archive_files, manifest_names[0]))
             manifest = json.loads(archive.read(manifest_names[0]).decode("utf-8"))
     except zipfile.BadZipFile:
         return [f"{zip_asset.name} is not a valid zip file"]
@@ -605,6 +703,83 @@ def validate_zip_manifest(
     files = manifest.get("files")
     if not isinstance(files, list) or "update-manifest.json" not in files:
         errors.append(f"{zip_asset.name} manifest files must include update-manifest.json")
+    else:
+        errors.extend(validate_manifest_file_list(zip_asset, archive_layout, archive_files, files))
+    return errors
+
+
+def normalized_archive_files(archive: zipfile.ZipFile) -> list[str]:
+    files: list[str] = []
+    for name in archive.namelist():
+        normalized = normalize_archive_relative_path(name)
+        if not normalized or name.endswith("/"):
+            continue
+        files.append(normalized)
+    return sorted(set(files))
+
+
+def validate_archive_layout(
+    zip_asset: ExpectedZip,
+    archive_layout: ArchiveLayout,
+    archive_files: list[str],
+    manifest_name: str,
+) -> list[str]:
+    errors: list[str] = []
+    root = archive_layout.root_dir
+    root_prefix = f"{root}/"
+    expected_manifest = f"{root_prefix}update-manifest.json"
+    if manifest_name != expected_manifest:
+        errors.append(
+            f"{zip_asset.name} manifest must be at {expected_manifest}, found {manifest_name}"
+        )
+    if not any(name.startswith(root_prefix) for name in archive_files):
+        errors.append(f"{zip_asset.name} must contain expected archive root {root}/")
+
+    allowed_prefixes = [root_prefix] + [f"{path.rstrip('/')}/" for path in archive_layout.optional_dirs]
+    outside_root = [
+        name
+        for name in archive_files
+        if not any(name == prefix.rstrip("/") or name.startswith(prefix) for prefix in allowed_prefixes)
+    ]
+    if outside_root:
+        errors.append(
+            f"{zip_asset.name} contains files outside expected archive root {root}/: "
+            + ", ".join(outside_root[:5])
+        )
+
+    for expected_file in archive_layout.expected_files_for(zip_asset.platform):
+        archive_path = f"{root_prefix}{expected_file}"
+        if archive_path not in archive_files:
+            errors.append(f"{zip_asset.name} is missing required archive file {archive_path}")
+    return errors
+
+
+def validate_manifest_file_list(
+    zip_asset: ExpectedZip,
+    archive_layout: ArchiveLayout,
+    archive_files: list[str],
+    manifest_files: list[Any],
+) -> list[str]:
+    if not all(isinstance(path, str) and path for path in manifest_files):
+        return [f"{zip_asset.name} manifest files must be a string array"]
+    root_prefix = f"{archive_layout.root_dir}/"
+    actual = {
+        name.removeprefix(root_prefix)
+        for name in archive_files
+        if name.startswith(root_prefix)
+    }
+    expected = {normalize_archive_relative_path(path) for path in manifest_files}
+    missing = sorted(actual - expected)
+    extra = sorted(expected - actual)
+    errors: list[str] = []
+    if missing:
+        errors.append(
+            f"{zip_asset.name} manifest files are missing archive entries: " + ", ".join(missing[:5])
+        )
+    if extra:
+        errors.append(
+            f"{zip_asset.name} manifest files lists entries absent from archive: " + ", ".join(extra[:5])
+        )
     return errors
 
 

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -653,6 +653,12 @@ fn release_workflows_verify_published_artifacts_after_publication() {
         "post-publish verifier must inspect package manifests"
     );
     assert!(
+        VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("archive_layout")
+            && VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("platform_files")
+            && VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("expected_files_for"),
+        "post-publish verifier must enforce archive layout from release_contract.toml"
+    );
+    assert!(
         VERIFY_PUBLISHED_RELEASE_SCRIPT.contains("PortalSurfer catalog sha256 mismatch"),
         "post-publish verifier must compare public catalog hashes to downloaded bytes"
     );

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -519,6 +519,66 @@ fn published_release_verifier_rejects_manifest_mismatches() {
 }
 
 #[test]
+fn published_release_verifier_rejects_flattened_archives() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) = write_published_release_fixture_with_zip_mutation(
+        &temp,
+        &key,
+        None,
+        Some(PublishedZipMutation::FlattenWindows),
+    );
+
+    let mut command =
+        published_release_verifier_command(&release_json, &asset_dir, expected_pubkey.trim());
+    let output = run_failure(&mut command);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "wavecrate-19.1.0-windows-x86_64.zip manifest must be at wavecrate/update-manifest.json"
+        ) && stderr.contains("must contain expected archive root wavecrate/"),
+        "flattened archive failure should name the asset and missing root\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn published_release_verifier_rejects_missing_platform_executable() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) = write_published_release_fixture_with_zip_mutation(
+        &temp,
+        &key,
+        None,
+        Some(PublishedZipMutation::MissingWindowsExecutable),
+    );
+
+    let mut command =
+        published_release_verifier_command(&release_json, &asset_dir, expected_pubkey.trim());
+    let output = run_failure(&mut command);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "wavecrate-19.1.0-windows-x86_64.zip is missing required archive file wavecrate/wavecrate.exe"
+        ),
+        "missing executable failure should name the asset and missing executable path\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn portalsurfer_upload_catalog_verifier_accepts_equivalent_timestamp_precision() {
     let temp = tempfile::tempdir().expect("create PortalSurfer catalog fixture");
     let catalog = temp.path().join("catalog.json");
@@ -736,6 +796,21 @@ fn write_published_release_fixture(
     key: &Path,
     manifest_override: Option<(&str, &str)>,
 ) -> (std::path::PathBuf, std::path::PathBuf) {
+    write_published_release_fixture_with_zip_mutation(temp, key, manifest_override, None)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PublishedZipMutation {
+    FlattenWindows,
+    MissingWindowsExecutable,
+}
+
+fn write_published_release_fixture_with_zip_mutation(
+    temp: &TempDir,
+    key: &Path,
+    manifest_override: Option<(&str, &str)>,
+    zip_mutation: Option<PublishedZipMutation>,
+) -> (std::path::PathBuf, std::path::PathBuf) {
     let asset_dir = temp.path().join("published-assets");
     fs::create_dir_all(&asset_dir).expect("create asset dir");
     let zip_assets = [
@@ -764,12 +839,18 @@ fn write_published_release_fixture(
     let mut checksum_lines = Vec::new();
     let mut files = Vec::new();
     for (zip_name, target, platform, arch) in zip_assets {
+        let mutation = if platform == "windows" {
+            zip_mutation
+        } else {
+            None
+        };
         write_release_zip(
             &asset_dir.join(zip_name),
             target,
             platform,
             arch,
             manifest_override,
+            mutation,
         );
         let hash = sha256_file(&asset_dir.join(zip_name));
         checksum_lines.push(format!("{hash}  {zip_name}\n"));
@@ -828,20 +909,52 @@ fn write_published_release_fixture(
     (release_json, asset_dir)
 }
 
+fn published_release_verifier_command(
+    release_json: &Path,
+    asset_dir: &Path,
+    expected_pubkey: &str,
+) -> Command {
+    let mut command = Command::new("python3");
+    command
+        .arg(repo_path(
+            "scripts/internal/release/verify_published_release.py",
+        ))
+        .arg("--surface")
+        .arg("portalsurfer")
+        .arg("--channel")
+        .arg("stable")
+        .arg("--version")
+        .arg("19.1.0")
+        .arg("--target-version")
+        .arg("19.1.0")
+        .arg("--commit")
+        .arg("abcdef1")
+        .arg("--build-date")
+        .arg("2026-07-02")
+        .arg("--portal-build-id")
+        .arg("wavecrate-19.1.0")
+        .arg("--build-number")
+        .arg("6200")
+        .arg("--release-json")
+        .arg(release_json)
+        .arg("--asset-dir")
+        .arg(asset_dir)
+        .arg("--checksum-public-key")
+        .arg(expected_pubkey);
+    command
+}
+
 fn write_release_zip(
     path: &Path,
     target: &str,
     platform: &str,
     arch: &str,
     manifest_override: Option<(&str, &str)>,
+    mutation: Option<PublishedZipMutation>,
 ) {
     let file = fs::File::create(path).expect("create zip file");
     let mut zip = zip::ZipWriter::new(file);
-    zip.start_file(
-        "wavecrate/update-manifest.json",
-        SimpleFileOptions::default(),
-    )
-    .expect("start manifest file");
+    let (manifest_path, payload_files) = release_zip_payload(platform, mutation);
     let mut manifest = json!({
         "app": "wavecrate",
         "channel": "stable",
@@ -852,11 +965,24 @@ fn write_release_zip(
         "target_version": "19.1.0",
         "commit": "abcdef1",
         "build_date": "2026-07-02",
-        "files": ["wavecrate", "update-manifest.json"]
+        "files": payload_files.iter().chain(["update-manifest.json"].iter()).collect::<Vec<_>>()
     });
     if let Some((key, value)) = manifest_override {
         manifest[key] = json!(value);
     }
+    for file_name in payload_files {
+        let archive_path = if mutation == Some(PublishedZipMutation::FlattenWindows) {
+            file_name.to_string()
+        } else {
+            format!("wavecrate/{file_name}")
+        };
+        zip.start_file(archive_path, SimpleFileOptions::default())
+            .expect("start payload file");
+        zip.write_all(format!("fixture payload for {file_name}\n").as_bytes())
+            .expect("write payload file");
+    }
+    zip.start_file(manifest_path, SimpleFileOptions::default())
+        .expect("start manifest file");
     zip.write_all(
         serde_json::to_string(&manifest)
             .expect("serialize manifest")
@@ -864,6 +990,29 @@ fn write_release_zip(
     )
     .expect("write manifest");
     zip.finish().expect("finish zip");
+}
+
+fn release_zip_payload(
+    platform: &str,
+    mutation: Option<PublishedZipMutation>,
+) -> (&'static str, Vec<&'static str>) {
+    match (platform, mutation) {
+        ("windows", Some(PublishedZipMutation::FlattenWindows)) => {
+            ("update-manifest.json", vec!["wavecrate.exe"])
+        }
+        ("windows", Some(PublishedZipMutation::MissingWindowsExecutable)) => {
+            ("wavecrate/update-manifest.json", vec![])
+        }
+        ("windows", _) => ("wavecrate/update-manifest.json", vec!["wavecrate.exe"]),
+        ("macos", _) => (
+            "wavecrate/update-manifest.json",
+            vec![
+                "Wavecrate.app/Contents/Info.plist",
+                "Wavecrate.app/Contents/MacOS/wavecrate",
+            ],
+        ),
+        _ => ("wavecrate/update-manifest.json", vec!["wavecrate"]),
+    }
 }
 
 fn sha256_file(path: &Path) -> String {


### PR DESCRIPTION
## Scope
- Load `[archive_layout]` from `release_contract.toml` in `verify_published_release.py`.
- Enforce the expected archive root, manifest location, platform executable payload, and manifest `files` list against actual ZIP contents.
- Extend the release contract with platform-specific payload paths for Windows and macOS archives.
- Add verifier fixtures for a valid published release, a flattened ZIP, and a missing Windows executable while preserving checksum/signature/catalog validation.

## Definition of Done
- Published-release verification fails for flattened archives and missing platform executables.
- The archive layout source of truth remains `release_contract.toml`.
- Existing checksum, signature, PortalSurfer catalog hash, and update-manifest metadata checks remain active.
- Fixture coverage exercises valid layout, flattened layout, missing executable, manifest mismatch, and PortalSurfer download-token behavior.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- `cargo test --test release_workflow_helpers`
- `cargo test --test release_contract`
- `cargo test --test release_workflow_helpers published_release_verifier -- --test-threads=1`
- `cargo fmt --check`
- `git diff --check`

## Known Limitations
- None.

User review is required before merge.
