### PR TITLE
OPT-1021 Reduce protected playmark copy stalls

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -21,7 +21,9 @@ use crate::native_app::app::{
 use crate::native_app::audio::playback_history::{
     LastPlayedPersistRequest, LastPlayedPersistResult,
 };
-use crate::native_app::metadata::{MetadataTagLoadResult, MetadataTagPersistResult};
+use crate::native_app::metadata::{
+    MetadataRatingPersistResult, MetadataTagLoadResult, MetadataTagPersistResult,
+};
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextPointerAnchor, BrowserContextTargetKind,
 };
@@ -414,6 +416,7 @@ pub(in crate::native_app) enum MetadataMessage {
     },
     DeleteContextMetadataTag,
     DeleteSelectedMetadataTag,
+    MetadataRatingPersisted(MetadataRatingPersistResult),
     MetadataTagsPersisted(MetadataTagPersistResult),
     MetadataTagsLoaded(MetadataTagLoadResult),
     ToggleSampleNameViewMode,

--- a/src/native_app/metadata/assignment.rs
+++ b/src/native_app/metadata/assignment.rs
@@ -1,11 +1,14 @@
 use super::persistence::{
-    persist_file_rating_assignment, persist_metadata_tag_assignment,
+    persist_metadata_rating_assignment, persist_metadata_tag_assignment,
     persist_metadata_tag_assignments,
 };
 use super::playback_type_tags::{
     playback_type_replacement_present, replace_other_playback_type_tags,
 };
-use super::types::{MetadataTagPersistRequest, MetadataTagPersistResult};
+use super::types::{
+    MetadataRatingPersistRequest, MetadataRatingPersistResult, MetadataTagPersistRequest,
+    MetadataTagPersistResult,
+};
 use super::{GuiMessage, MetadataMessage, NativeAppState};
 use crate::native_app::app::ExtractedFilePlaybackType;
 use radiant::prelude as ui;
@@ -55,21 +58,22 @@ impl NativeAppState {
                 "extracted file is not inside a configured source",
             ));
         };
-        let rating_result = persist_file_rating_assignment(
+        self.library.folder_browser.set_file_rating_state(
             absolute_path,
-            &source_root,
-            &source_database_root,
-            &relative_path,
             EXTRACTED_FILE_RATING,
             EXTRACTED_FILE_LOCKED,
         );
-        if rating_result.is_ok() {
-            self.library.folder_browser.set_file_rating_state(
-                absolute_path,
-                EXTRACTED_FILE_RATING,
-                EXTRACTED_FILE_LOCKED,
-            );
-        }
+        enqueue_metadata_rating_persist_request(
+            MetadataRatingPersistRequest {
+                absolute_path: absolute_path.to_path_buf(),
+                source_root: source_root.clone(),
+                source_database_root: source_database_root.clone(),
+                relative_path: relative_path.clone(),
+                rating: EXTRACTED_FILE_RATING,
+                locked: EXTRACTED_FILE_LOCKED,
+            },
+            context,
+        );
 
         self.assign_extracted_file_playback_type(
             absolute_path,
@@ -80,7 +84,7 @@ impl NativeAppState {
             context,
         );
 
-        rating_result.map_err(|error| format!("rating not saved: {error}"))
+        Ok(())
     }
 
     fn assign_extracted_file_playback_type(
@@ -406,6 +410,16 @@ impl NativeAppState {
         }
     }
 
+    pub(in crate::native_app) fn finish_metadata_rating_persist(
+        &mut self,
+        result: MetadataRatingPersistResult,
+    ) {
+        if let Err(error) = result.result {
+            let label = crate::native_app::app::sample_path_label(&result.absolute_path);
+            self.ui.status.sample = format!("Rating for {label} not saved: {error}");
+        }
+    }
+
     fn selected_metadata_tag_targets(
         &self,
         action: &'static str,
@@ -531,4 +545,17 @@ fn enqueue_metadata_tag_persist_requests(
                 |result| GuiMessage::Metadata(MetadataMessage::MetadataTagsPersisted(result)),
             );
     }
+}
+
+fn enqueue_metadata_rating_persist_request(
+    request: MetadataRatingPersistRequest,
+    context: &mut ui::UiUpdateContext<GuiMessage>,
+) {
+    context
+        .business()
+        .background("gui-metadata-rating-persist")
+        .run(
+            move |_| persist_metadata_rating_assignment(request),
+            |result| GuiMessage::Metadata(MetadataMessage::MetadataRatingPersisted(result)),
+        );
 }

--- a/src/native_app/metadata/mod.rs
+++ b/src/native_app/metadata/mod.rs
@@ -15,9 +15,9 @@ pub(in crate::native_app) use style::{
 #[cfg(test)]
 pub(super) use types::MetadataTagCommit;
 pub(super) use types::{
-    MetadataTagCategoryGroup, MetadataTagCompletionOption, MetadataTagDisplayCategory,
-    MetadataTagInputMode, MetadataTagLoadResult, MetadataTagPersistResult,
-    MetadataTagSelectionState,
+    MetadataRatingPersistResult, MetadataTagCategoryGroup, MetadataTagCompletionOption,
+    MetadataTagDisplayCategory, MetadataTagInputMode, MetadataTagLoadResult,
+    MetadataTagPersistResult, MetadataTagSelectionState,
 };
 pub(super) use vocabulary::{
     commit_metadata_tag_text, inferred_metadata_tag_category_id_for_name,

--- a/src/native_app/metadata/persistence.rs
+++ b/src/native_app/metadata/persistence.rs
@@ -1,12 +1,15 @@
 use super::playback_type_tags::sanitize_playback_type_tags;
-use super::types::{MetadataTagPersistRequest, MetadataTagPersistResult};
+use super::types::{
+    MetadataRatingPersistRequest, MetadataRatingPersistResult, MetadataTagPersistRequest,
+    MetadataTagPersistResult,
+};
 use crate::native_app::audio::playback::tagged_playback_mode_for_tag;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     time::SystemTime,
 };
-use wavecrate::sample_sources::{Rating, SourceDatabase, SourceDbError, db::SourceWriteBatch};
+use wavecrate::sample_sources::{SourceDatabase, SourceDbError, db::SourceWriteBatch};
 
 pub(super) fn persist_metadata_tag_assignment(
     request: MetadataTagPersistRequest,
@@ -46,6 +49,16 @@ pub(super) fn persist_metadata_tag_deletions(
     MetadataTagPersistResult {
         tags,
         assigned: false,
+        result,
+    }
+}
+
+pub(super) fn persist_metadata_rating_assignment(
+    request: MetadataRatingPersistRequest,
+) -> MetadataRatingPersistResult {
+    let result = persist_file_rating_assignment_inner(&request);
+    MetadataRatingPersistResult {
+        absolute_path: request.absolute_path,
         result,
     }
 }
@@ -92,29 +105,24 @@ fn persist_metadata_tag_assignment_inner(
     batch.commit().map_err(|err| err.to_string())
 }
 
-pub(super) fn persist_file_rating_assignment(
-    absolute_path: &Path,
-    source_root: &Path,
-    source_database_root: &Path,
-    relative_path: &Path,
-    rating: Rating,
-    locked: bool,
+fn persist_file_rating_assignment_inner(
+    request: &MetadataRatingPersistRequest,
 ) -> Result<(), String> {
-    let (file_size, modified_ns) = file_metadata(absolute_path)?;
+    let (file_size, modified_ns) = file_metadata(&request.absolute_path)?;
     let db = SourceDatabase::open_for_user_metadata_write_with_database_root(
-        source_root,
-        source_database_root,
+        &request.source_root,
+        &request.source_database_root,
     )
     .map_err(|err| err.to_string())?;
     let mut batch = db.write_batch().map_err(|err| err.to_string())?;
     batch
-        .upsert_file(relative_path, file_size, modified_ns)
+        .upsert_file(&request.relative_path, file_size, modified_ns)
         .map_err(|err| err.to_string())?;
     batch
-        .set_tag(relative_path, rating)
+        .set_tag(&request.relative_path, request.rating)
         .map_err(|err| err.to_string())?;
     batch
-        .set_locked(relative_path, locked)
+        .set_locked(&request.relative_path, request.locked)
         .map_err(|err| err.to_string())?;
     batch.commit().map_err(|err| err.to_string())
 }

--- a/src/native_app/metadata/types.rs
+++ b/src/native_app/metadata/types.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
+use wavecrate::sample_sources::Rating;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct MetadataTagCommit {
     pub(in crate::native_app) tags: Vec<String>,
@@ -10,6 +12,12 @@ pub(in crate::native_app) struct MetadataTagCommit {
 pub(in crate::native_app) struct MetadataTagPersistResult {
     pub(in crate::native_app) tags: Vec<String>,
     pub(in crate::native_app) assigned: bool,
+    pub(in crate::native_app) result: Result<(), String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct MetadataRatingPersistResult {
+    pub(in crate::native_app) absolute_path: PathBuf,
     pub(in crate::native_app) result: Result<(), String>,
 }
 
@@ -28,6 +36,16 @@ pub(in crate::native_app) struct MetadataTagPersistRequest {
     pub(in crate::native_app) relative_path: PathBuf,
     pub(in crate::native_app) tags: Vec<String>,
     pub(in crate::native_app) assigned: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::native_app) struct MetadataRatingPersistRequest {
+    pub(in crate::native_app) absolute_path: PathBuf,
+    pub(in crate::native_app) source_root: PathBuf,
+    pub(in crate::native_app) source_database_root: PathBuf,
+    pub(in crate::native_app) relative_path: PathBuf,
+    pub(in crate::native_app) rating: Rating,
+    pub(in crate::native_app) locked: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -332,11 +332,12 @@ impl NativeAppState {
         source_duration_seconds: f64,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) -> Option<String> {
-        if self
+        let started_at = Instant::now();
+        let protected_origin = self
             .library
             .folder_browser
-            .path_is_in_protected_source(source_path)
-        {
+            .path_is_in_protected_source(source_path);
+        if protected_origin {
             self.library
                 .folder_browser
                 .refresh_file_path_across_sources(copied_path);
@@ -353,6 +354,25 @@ impl NativeAppState {
             source_duration_seconds,
             HarvestDerivationOperation::Export,
         );
+        let elapsed = started_at.elapsed();
+        tracing::debug!(
+            target: "wavecrate::waveform_copy",
+            source = %source_path.display(),
+            copied = %copied_path.display(),
+            protected_origin,
+            elapsed_ms = elapsed.as_millis(),
+            "scheduled waveform selection copy bookkeeping"
+        );
+        if elapsed >= std::time::Duration::from_millis(16) {
+            tracing::warn!(
+                target: "wavecrate::waveform_copy",
+                source = %source_path.display(),
+                copied = %copied_path.display(),
+                protected_origin,
+                elapsed_ms = elapsed.as_millis(),
+                "slow waveform selection copy bookkeeping"
+            );
+        }
         metadata_error
     }
 

--- a/src/native_app/sample_library/drag_drop_actions/waveform_drag.rs
+++ b/src/native_app/sample_library/drag_drop_actions/waveform_drag.rs
@@ -11,6 +11,8 @@ use crate::native_app::app::{
 };
 use crate::native_app::waveform::{WaveformSelectionKind, execute_waveform_extraction};
 
+const WAVEFORM_SELECTION_DRAG_TASK_NAME: &str = "gui-waveform-selection-drag-extract";
+
 impl NativeAppState {
     pub(in crate::native_app) fn drag_loaded_waveform_sample(
         &mut self,
@@ -210,16 +212,20 @@ impl NativeAppState {
                 self.ui.status.sample = String::from("Extracting dragged range");
                 let playback_type =
                     ExtractedFilePlaybackType::from_loop_active(self.audio.loop_playback);
-                let completion = execute_waveform_extraction(request);
-                self.finish_play_selection_extraction(
-                    completion,
-                    Some(position),
-                    playback_type,
-                    HarvestDerivationOperation::Extract,
-                    false,
-                    started_at,
-                    context,
-                );
+                context
+                    .business()
+                    .interactive(WAVEFORM_SELECTION_DRAG_TASK_NAME)
+                    .run(
+                        move |_| execute_waveform_extraction(request),
+                        move |completion| GuiMessage::PlaySelectionExtractionFinished {
+                            completion,
+                            drag_position: Some(position),
+                            playback_type,
+                            harvest_operation: HarvestDerivationOperation::Extract,
+                            focus_derivative: false,
+                            started_at,
+                        },
+                    );
                 true
             }
             Err(error) => {

--- a/src/native_app/shell/message_dispatch/metadata.rs
+++ b/src/native_app/shell/message_dispatch/metadata.rs
@@ -63,6 +63,9 @@ impl NativeAppState {
             MetadataMessage::DeleteSelectedMetadataTag => {
                 self.remove_selected_metadata_tag(context);
             }
+            MetadataMessage::MetadataRatingPersisted(result) => {
+                self.finish_metadata_rating_persist(result);
+            }
             MetadataMessage::MetadataTagsPersisted(result) => {
                 self.finish_metadata_tag_persist(result);
             }

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -381,6 +381,21 @@ fn external_drag_file_paths(
     }
 }
 
+fn run_named_perform(
+    command: radiant::runtime::Command<crate::native_app::test_support::state::GuiMessage>,
+    target_name: &'static str,
+) -> Option<crate::native_app::test_support::state::GuiMessage> {
+    match command {
+        radiant::runtime::Command::Perform { name, work, .. } if name == target_name => {
+            Some(work())
+        }
+        radiant::runtime::Command::Batch(commands) => commands
+            .into_iter()
+            .find_map(|command| run_named_perform(command, target_name)),
+        _ => None,
+    }
+}
+
 fn sample_load_completion(
     ticket: ui::TaskTicket,
     path: String,
@@ -748,7 +763,15 @@ fn playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff
         Ok(()),
         &mut copy_finished_context,
     );
+    let metadata_command = copy_finished_context.into_command();
+    assert_eq!(
+        metadata_command.business_task_priority("gui-metadata-rating-persist"),
+        Some(ui::TaskPriority::Background),
+        "extracted rating persistence should not block clipboard completion"
+    );
     assert_extracted_file_metadata(&scenario.state, &extracted, &["one-shot"]);
+    run_command_for_tests(&mut scenario.state, metadata_command);
+    assert_persisted_extracted_file_keep_1_rating(&scenario.state, &extracted);
     assert_source_file_not_keep_rated(&scenario.state, &source_path);
     let parent = wavecrate::sample_sources::library::harvest_file(&harvest_key)
         .expect("load harvest parent")
@@ -2050,7 +2073,12 @@ fn assert_extracted_file_keep_1_rating(
         .expect("extracted file should be visible in the browser");
     assert_eq!(row.rating, wavecrate::sample_sources::Rating::KEEP_1);
     assert!(!row.rating_locked);
+}
 
+fn assert_persisted_extracted_file_keep_1_rating(
+    state: &crate::native_app::test_support::state::NativeAppState,
+    extracted: &std::path::Path,
+) {
     let (source_root, source_database_root, relative_path) = state
         .library
         .folder_browser
@@ -2220,11 +2248,28 @@ fn playmark_selection_drag_extracts_before_external_handoff() {
     ));
 
     assert!(
+        !extracted_path.is_file(),
+        "drag start should schedule extraction instead of decoding/writing on the UI thread"
+    );
+    let command = context.into_command();
+    assert_eq!(
+        command.business_task_priority("gui-waveform-selection-drag-extract"),
+        Some(ui::TaskPriority::Interactive),
+        "drag extraction should be user-interactive but asynchronous"
+    );
+    let completion = run_named_perform(command, "gui-waveform-selection-drag-extract")
+        .expect("drag extraction worker command");
+    let mut finish_context = ui::UiUpdateContext::default();
+    scenario
+        .state
+        .apply_message(completion, &mut finish_context);
+
+    assert!(
         extracted_path.is_file(),
-        "dragging a playmark handle should create a durable file before native drag-out"
+        "drag worker should create a durable file before native drag-out starts"
     );
     assert_eq!(
-        external_drag_file_paths(context.into_command()),
+        external_drag_file_paths(finish_context.into_command()),
         Some(vec![extracted_path.clone()]),
         "DAWs need the extracted file path as the native drag payload"
     );


### PR DESCRIPTION
## Scope
- Move extracted-file keep-rating persistence out of the playmark copy/extraction completion handler and into a background metadata task while keeping the browser row updated immediately.
- Keep playback-type tag assignment on the existing async persistence path and add a rating persistence completion message for failure reporting.
- Move waveform play-selection drag extraction off the UI handler and onto an interactive business worker before starting the external drag handoff.
- Add timing logs around waveform-selection copy bookkeeping so protected-origin refresh/metadata scheduling shows up clearly in logs.
- Update waveform playback regressions to require non-blocking rating persistence and async drag extraction.

## Definition of Done
- Protected-source playmark copy/extraction no longer performs extracted keep-rating SQLite persistence synchronously on the UI completion path.
- Dragging a playmark selection no longer decodes/writes the extracted file inside the drag-start UI handler.
- The copied/extracted file still becomes visible with immediate in-memory keep-rating/playback-type state, and persistence failures are reported asynchronously.
- Protected-source target routing and prompt behavior remain covered by existing focused tests.

## Validation commands
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p wavecrate`
- `cargo test -p wavecrate playmark_selection_copy_extracts_into_current_folder_before_clipboard_handoff -- --test-threads=1`
- `cargo test -p wavecrate playmark_selection_drag_extracts_before_external_handoff -- --test-threads=1`
- `cargo test -p wavecrate protected_playmark_extraction -- --test-threads=1`
- `cargo test -p wavecrate playmark_extraction_marks_new_file_one_shot_and_keep_1_by_default -- --test-threads=1`

## Known limitations
- `cargo test -p wavecrate waveform_playback -- --test-threads=1` currently fails two harvest-touch tests (`playmark_selection_change_marks_harvest_file_touched`, `editmark_selection_change_marks_harvest_file_touched`) because the expected harvest record is missing. The same pair also fails when run directly with `cargo test -p wavecrate harvest_file_touched -- --test-threads=1`, independent of this change.
- Manual real-app timing validation against a protected source is still recommended before merge, because this PR removes identified UI-thread work but does not benchmark every possible disk/decode path on a real library.

User review is required before merge.
