### PR TITLE
OPT-1020 Preserve higher bit-depth WAV extraction

### DIFF
--- a/src/native_app/waveform/audio_file/extraction.rs
+++ b/src/native_app/waveform/audio_file/extraction.rs
@@ -174,15 +174,16 @@ pub(super) fn extract_wav_reader_range_to_folder<R: Read + Seek>(
     gain: f32,
 ) -> Result<PathBuf, String> {
     let output_path = next_extraction_path(source_path, target_folder)?;
-    if (gain - 1.0).abs() <= f32::EPSILON
-        && raw_wav::copy_selection_to_file(
-            &mut reader,
-            loaded_frames,
-            selection,
-            &output_path,
-            DEFAULT_SHORT_EDGE_FADE,
-        )?
-    {
+    // Prefer the raw WAV path so extraction preserves the source bit depth/sample format
+    // while applying the same edge fade and gain policy.
+    if raw_wav::copy_selection_to_file(
+        &mut reader,
+        loaded_frames,
+        selection,
+        &output_path,
+        gain,
+        DEFAULT_SHORT_EDGE_FADE,
+    )? {
         return Ok(output_path);
     }
     reader
@@ -334,6 +335,7 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             sample_count,
             channels,
             spec.sample_rate,
+            spec.bits_per_sample,
             gain,
         )?,
         hound::SampleFormat::Int if spec.bits_per_sample <= 16 => write_samples::<_, i16>(
@@ -342,6 +344,7 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             sample_count,
             channels,
             spec.sample_rate,
+            spec.bits_per_sample,
             gain,
         )?,
         hound::SampleFormat::Int => write_samples::<_, i32>(
@@ -350,6 +353,7 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             sample_count,
             channels,
             spec.sample_rate,
+            spec.bits_per_sample,
             gain,
         )?,
     }
@@ -365,6 +369,7 @@ fn write_samples<R, S>(
     sample_count: usize,
     channels: usize,
     sample_rate: u32,
+    bits_per_sample: u16,
     gain: f32,
 ) -> Result<(), String>
 where
@@ -381,7 +386,7 @@ where
             .write_sample(
                 sample
                     .map_err(|err| format!("failed to read sample: {err}"))?
-                    .with_gain(gain),
+                    .with_gain(gain, bits_per_sample),
             )
             .map_err(|err| format!("failed to write extraction: {err}"))?;
     }
@@ -389,27 +394,35 @@ where
 }
 
 trait FadedSample {
-    fn with_gain(self, gain: f32) -> Self;
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self;
 }
 
 impl FadedSample for f32 {
-    fn with_gain(self, gain: f32) -> Self {
+    fn with_gain(self, gain: f32, _bits_per_sample: u16) -> Self {
         (self * gain).clamp(-1.0, 1.0)
     }
 }
 
 impl FadedSample for i16 {
-    fn with_gain(self, gain: f32) -> Self {
-        (f32::from(self) * gain)
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
+        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(16));
+        (f64::from(self) * f64::from(gain))
             .round()
-            .clamp(i16::MIN as f32, i16::MAX as f32) as i16
+            .clamp(min as f64, max as f64) as i16
     }
 }
 
 impl FadedSample for i32 {
-    fn with_gain(self, gain: f32) -> Self {
-        (self as f32 * gain)
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
+        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(32));
+        (f64::from(self) * f64::from(gain))
             .round()
-            .clamp(i32::MIN as f32, i32::MAX as f32) as i32
+            .clamp(min as f64, max as f64) as i32
     }
+}
+
+fn signed_integer_sample_bounds(bits_per_sample: u16) -> (i64, i64) {
+    let bits = u32::from(bits_per_sample.clamp(1, 32));
+    let max = (1_i64 << (bits - 1)) - 1;
+    (-1_i64 << (bits - 1), max)
 }

--- a/src/native_app/waveform/audio_file/extraction/raw_wav.rs
+++ b/src/native_app/waveform/audio_file/extraction/raw_wav.rs
@@ -28,6 +28,7 @@ pub(super) fn copy_selection_to_file<R: Read + Seek>(
     loaded_frames: usize,
     selection: SelectionRange,
     output_path: &Path,
+    gain: f32,
     fade_duration: Duration,
 ) -> Result<bool, String> {
     if selection.has_edit_effects() {
@@ -42,7 +43,7 @@ pub(super) fn copy_selection_to_file<R: Read + Seek>(
     }
     let frame_range = selection.frame_bounds(total_frames);
     let byte_span = layout.byte_span(frame_range.start_frame, frame_range.end_frame)?;
-    write_raw_slice(reader, &layout, byte_span, output_path, fade_duration)?;
+    write_raw_slice(reader, &layout, byte_span, output_path, gain, fade_duration)?;
     Ok(true)
 }
 
@@ -282,6 +283,7 @@ fn write_raw_slice<R: Read + Seek>(
     layout: &RawWavLayout,
     span: RawByteSpan,
     output_path: &Path,
+    gain: f32,
     fade_duration: Duration,
 ) -> Result<(), String> {
     let data_len = u32::try_from(span.byte_len)
@@ -305,10 +307,10 @@ fn write_raw_slice<R: Read + Seek>(
     let frame_count = span.byte_len / u64::from(layout.block_align);
     let fade_frames =
         short_edge_fade_frame_count(layout.sample_rate, frame_count as usize, fade_duration);
-    if fade_frames == 0 {
+    if fade_frames == 0 && (gain - 1.0).abs() <= f32::EPSILON {
         copy_exact_data(reader, &mut writer, span.byte_len)?;
     } else {
-        fade::write_faded_data(reader, &mut writer, layout, frame_count, fade_frames)?;
+        fade::write_faded_data(reader, &mut writer, layout, frame_count, fade_frames, gain)?;
     }
     if span.byte_len % 2 == 1 {
         writer

--- a/src/native_app/waveform/audio_file/extraction/raw_wav/fade.rs
+++ b/src/native_app/waveform/audio_file/extraction/raw_wav/fade.rs
@@ -10,13 +10,17 @@ pub(super) fn write_faded_data<R: Read, W: Write>(
     layout: &RawWavLayout,
     frame_count: u64,
     fade_frames: usize,
+    gain: f32,
 ) -> Result<(), String> {
     let fade_frames = fade_frames as u64;
     let block_align = usize::from(layout.block_align);
     let mut frame_bytes = vec![0_u8; block_align];
     let mut frame = 0_u64;
     while frame < frame_count {
-        if frame >= fade_frames && frame_count.saturating_sub(frame) > fade_frames {
+        if (gain - 1.0).abs() <= f32::EPSILON
+            && frame >= fade_frames
+            && frame_count.saturating_sub(frame) > fade_frames
+        {
             let middle_frames = frame_count
                 .saturating_sub(fade_frames)
                 .saturating_sub(frame);
@@ -32,7 +36,8 @@ pub(super) fn write_faded_data<R: Read, W: Write>(
         reader
             .read_exact(&mut frame_bytes)
             .map_err(|err| format!("failed to read WAV selection frame: {err}"))?;
-        let gain = short_edge_fade_gain(frame as usize, frame_count as usize, fade_frames as usize);
+        let gain =
+            gain * short_edge_fade_gain(frame as usize, frame_count as usize, fade_frames as usize);
         scale_frame_samples(&mut frame_bytes, layout, gain)?;
         writer
             .write_all(&frame_bytes)

--- a/src/native_app/waveform/audio_file/extraction_tests.rs
+++ b/src/native_app/waveform/audio_file/extraction_tests.rs
@@ -127,6 +127,69 @@ fn wav_range_extraction_applies_forced_normalized_gain() {
 }
 
 #[test]
+fn wav_range_extraction_preserves_i24_source_format_with_gain() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source-24.wav");
+    let mut samples = vec![0_i32; 768];
+    samples[384] = 5_000_000;
+    samples[448] = -5_000_000;
+    write_i24_wav(&source, &samples);
+    let bytes = std::fs::read(&source).expect("read source wav");
+    let selection = SelectionRange::new_precise(128.0 / 768.0, 640.0 / 768.0);
+
+    let output = extract_wav_reader_range_to_folder(
+        &source,
+        root.path(),
+        Cursor::new(bytes),
+        768,
+        selection,
+        2.0,
+    )
+    .expect("extract 24-bit wav range with gain");
+
+    let mut reader = hound::WavReader::open(&output).expect("open extracted 24-bit wav");
+    let spec = reader.spec();
+    assert_eq!(spec.bits_per_sample, 24);
+    assert_eq!(spec.sample_format, hound::SampleFormat::Int);
+    let extracted = reader
+        .samples::<i32>()
+        .map(|sample| sample.expect("read 24-bit sample"))
+        .collect::<Vec<_>>();
+    assert_eq!(extracted.len(), 512);
+    assert_eq!(extracted[0], 0);
+    assert_eq!(extracted[256], 8_388_607);
+    assert_eq!(extracted[320], -8_388_608);
+    assert_eq!(extracted[511], 0);
+}
+
+#[test]
+fn decoded_wav_range_writer_clamps_i24_samples_to_destination_depth() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("decoded-source-24.wav");
+    let output = root.path().join("decoded-output-24.wav");
+    let mut samples = vec![0_i32; 256];
+    samples[128] = 5_000_000;
+    samples[160] = -5_000_000;
+    write_i24_wav(&source, &samples);
+    let reader = hound::WavReader::open(&source).expect("open 24-bit wav");
+    let spec = reader.spec();
+
+    write_wav_frame_range(reader, spec, 1, 0, 256, &output, 2.0)
+        .expect("write decoded 24-bit range with gain");
+
+    let mut reader = hound::WavReader::open(&output).expect("open decoded 24-bit output");
+    let spec = reader.spec();
+    assert_eq!(spec.bits_per_sample, 24);
+    assert_eq!(spec.sample_format, hound::SampleFormat::Int);
+    let extracted = reader
+        .samples::<i32>()
+        .map(|sample| sample.expect("read 24-bit sample"))
+        .collect::<Vec<_>>();
+    assert_eq!(extracted[128], 8_388_607);
+    assert_eq!(extracted[160], -8_388_608);
+}
+
+#[test]
 fn wav_range_extraction_handles_metadata_chunk_before_data() {
     let root = tempfile::tempdir().expect("temp root");
     let source = root.path().join("source.wav");
@@ -162,6 +225,20 @@ fn write_i16_wav(path: &std::path::Path, frames: i16) {
         writer.write_sample(sample).expect("write sample");
     }
     writer.finalize().expect("finalize wav");
+}
+
+fn write_i24_wav(path: &std::path::Path, samples: &[i32]) {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 44_100,
+        bits_per_sample: 24,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).expect("create 24-bit wav");
+    for sample in samples {
+        writer.write_sample(*sample).expect("write 24-bit sample");
+    }
+    writer.finalize().expect("finalize 24-bit wav");
 }
 
 fn read_i16_wav(path: &std::path::Path) -> Vec<i16> {


### PR DESCRIPTION
## Scope
- Fix WAV range extraction/copy for valid higher-bit-depth PCM sources that previously could surface hound's obscure `the sample has more bits than the destination type` error.
- Prefer the raw WAV extraction path for supported PCM/float WAVs even when extraction gain is applied, preserving source bit depth/sample format while applying edge fades and gain in-place.
- Harden the decoded hound fallback so integer samples are clamped to the destination WAV bit depth before writing.
- Add regression coverage for 24-bit PCM extraction with gain and for the decoded fallback clamp path, while keeping existing 16-bit extraction coverage green.

## Definition of Done
- Valid 24-bit PCM WAV extraction with gain succeeds and preserves 24-bit integer output.
- Decoded fallback writing clamps to destination bit depth instead of emitting hound's low-level bit-depth error.
- Existing lower-bit-depth extraction behavior still works.
- Protected-source routing semantics are unchanged and covered by focused tests.

## Validation commands
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo check -p wavecrate`
- `cargo test -p wavecrate waveform::audio_file::extraction_tests -- --test-threads=1`
- `cargo test -p wavecrate protected_playmark_extraction -- --test-threads=1`

## Known limitations
- Manual verification with the originally failing sample was not run in this environment. The new regression uses a synthetic 24-bit PCM WAV that reproduces the higher-bit-depth conversion/clamp class.
- This does not add new codec/container support beyond the existing supported WAV formats.

User review is required before merge.
