### PR TITLE
Fix Ubuntu release validation ALSA deps

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -199,6 +199,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Install Ubuntu audio build dependencies
+        shell: bash
+        run: scripts/internal/release/setup_ubuntu_release_deps.sh
       - name: Run tests
         run: cargo test --workspace --locked
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -117,6 +117,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Install Ubuntu audio build dependencies
+        shell: bash
+        run: scripts/internal/release/setup_ubuntu_release_deps.sh
       - name: Run tests
         run: cargo test --workspace --locked
 

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -129,6 +129,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+      - name: Install Ubuntu audio build dependencies
+        shell: bash
+        run: scripts/internal/release/setup_ubuntu_release_deps.sh
       - name: Run tests
         run: cargo test --workspace --locked
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -69,6 +69,11 @@ The nextest policy is:
   scheduled release lane stays deterministic in GitHub Actions; quarantined,
   GUI/manual, and performance checks remain explicit local or issue-specific
   release-risk evidence.
+- The nightly, RC, and stable Ubuntu release-validation jobs install
+  `pkg-config` and `libasound2-dev` before Cargo builds the workspace.
+  Wavecrate still publishes only the Windows/macOS release targets declared in
+  `release_contract.toml`, but the Linux-hosted validation lane keeps
+  ALSA-backed compilation explicit ahead of planned Linux release support.
 
 The non-blocking app architecture is enforced by
 `scripts/check.* non-blocking-architecture`, and that check is required by

--- a/scripts/internal/release/setup_ubuntu_release_deps.sh
+++ b/scripts/internal/release/setup_ubuntu_release_deps.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "[release_deps] Ubuntu release dependencies are only needed on Linux."
+  exit 0
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "[release_deps] apt-get is required to install Ubuntu release dependencies." >&2
+  exit 1
+fi
+
+apt_get() {
+  if [[ "$(id -u)" == "0" ]]; then
+    DEBIAN_FRONTEND=noninteractive apt-get "$@"
+  else
+    sudo DEBIAN_FRONTEND=noninteractive apt-get "$@"
+  fi
+}
+
+echo "[release_deps] Installing Ubuntu audio build dependencies for release validation."
+apt_get update
+apt_get install -y --no-install-recommends pkg-config libasound2-dev
+
+pkg-config --exists alsa
+echo "[release_deps] ALSA build dependency available: $(pkg-config --modversion alsa)"

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -18,6 +18,8 @@ const BUILD_RELEASE_ARTIFACT_SCRIPT: &str =
     include_str!("../scripts/internal/release/build_release_artifact.sh");
 const CHECKOUT_RADIANT_SCRIPT: &str =
     include_str!("../scripts/internal/release/checkout_radiant_submodule.sh");
+const SETUP_UBUNTU_RELEASE_DEPS_SCRIPT: &str =
+    include_str!("../scripts/internal/release/setup_ubuntu_release_deps.sh");
 const RELEASE_ZIP_SCRIPT: &str = include_str!("../scripts/internal/release/build_release_zip.sh");
 const RELEASE_LOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/generate_release_log.sh");
@@ -124,6 +126,34 @@ fn nightly_workflow_runs_validation_before_build_and_publish() {
             && test_position < publish_frontend_position
             && test_position < publish_github_position,
         "nightly validation job should be declared before build and publish jobs"
+    );
+}
+
+#[test]
+fn release_validation_installs_ubuntu_audio_deps_before_cargo_tests() {
+    for (name, workflow) in [
+        ("nightly workflow", NIGHTLY_WORKFLOW),
+        ("RC workflow", RC_WORKFLOW),
+        ("stable workflow", STABLE_WORKFLOW),
+    ] {
+        let test_job = workflow_job_block(workflow, "test");
+        let deps_position = test_job
+            .find("scripts/internal/release/setup_ubuntu_release_deps.sh")
+            .unwrap_or_else(|| panic!("{name} test job must install Ubuntu release dependencies"));
+        let cargo_test_position = test_job
+            .find("cargo test --workspace --locked")
+            .unwrap_or_else(|| panic!("{name} test job must run the release workspace test lane"));
+        assert!(
+            deps_position < cargo_test_position,
+            "{name} must install Ubuntu release dependencies before Cargo builds workspace tests"
+        );
+    }
+
+    assert!(
+        SETUP_UBUNTU_RELEASE_DEPS_SCRIPT.contains("pkg-config")
+            && SETUP_UBUNTU_RELEASE_DEPS_SCRIPT.contains("libasound2-dev")
+            && SETUP_UBUNTU_RELEASE_DEPS_SCRIPT.contains("pkg-config --exists alsa"),
+        "Ubuntu release dependency helper must install and verify ALSA build dependencies"
     );
 }
 
@@ -793,6 +823,10 @@ fn release_workflows_use_shared_setup_build_and_signing_helpers() {
         assert!(
             workflow.contains("scripts/internal/release/emit_rust_toolchain_channel.py"),
             "{name} must use the shared Rust toolchain channel helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/setup_ubuntu_release_deps.sh"),
+            "{name} must use the shared Ubuntu release dependency helper"
         );
         assert!(
             workflow.contains("scripts/internal/release/setup_windows_asio_sdk.ps1"),


### PR DESCRIPTION
## Scope
- Add a shared Ubuntu release dependency setup helper that installs `pkg-config` and `libasound2-dev` and verifies `pkg-config --exists alsa` before Cargo builds workspace tests.
- Run that helper before the `cargo test --workspace --locked` validation step in nightly, RC, and stable release workflows.
- Document that Ubuntu-hosted release validation now keeps ALSA-backed compilation explicit while shipped release targets remain Windows/macOS.
- Add release contract coverage that guards the helper and its ordering before Cargo tests.

## Definition of Done
- Nightly release validation no longer trips over missing `alsa.pc` on `ubuntu-latest`.
- RC and stable validation receive the same Linux-hosted dependency setup for consistency.
- Linux artifact support remains deferred to the planned release target work; this change only fixes validation dependencies.
- Contract tests fail if the Ubuntu ALSA dependency setup is removed or moved after Cargo tests.

## Validation commands
- `bash -n scripts/internal/release/setup_ubuntu_release_deps.sh`
- `cargo test --test release_contract`
- `cargo fmt --check`
- `cargo test --test release_workflow_helpers`
- `git diff --check`

## Known limitations
- This does not add or publish Linux release artifacts.
- It relies on GitHub Actions `ubuntu-latest` providing `apt-get`/`sudo`, which matches the current runner contract.

User review is required before merge.