### PR TITLE
Harden nightly release validation lane

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -202,8 +202,9 @@ jobs:
       - name: Install Ubuntu audio build dependencies
         shell: bash
         run: scripts/internal/release/setup_ubuntu_release_deps.sh
-      - name: Run tests
-        run: cargo test --workspace --locked
+      - name: Run release validation
+        shell: bash
+        run: scripts/internal/release/run_release_validation.sh
 
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} nightly

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -120,8 +120,9 @@ jobs:
       - name: Install Ubuntu audio build dependencies
         shell: bash
         run: scripts/internal/release/setup_ubuntu_release_deps.sh
-      - name: Run tests
-        run: cargo test --workspace --locked
+      - name: Run release validation
+        shell: bash
+        run: scripts/internal/release/run_release_validation.sh
 
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} RC

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -132,8 +132,9 @@ jobs:
       - name: Install Ubuntu audio build dependencies
         shell: bash
         run: scripts/internal/release/setup_ubuntu_release_deps.sh
-      - name: Run tests
-        run: cargo test --workspace --locked
+      - name: Run release validation
+        shell: bash
+        run: scripts/internal/release/run_release_validation.sh
 
   build:
     name: Build ${{ matrix.platform }} ${{ matrix.arch }} stable

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -352,6 +352,7 @@ mod tests {
             locked: false,
             missing: false,
             last_played_at: None,
+            last_curated_at: None,
             user_tag: None,
             tag_named: false,
             normal_tags: Vec::new(),

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -47,9 +47,9 @@ development and release-risk checks:
 | Dead dependency sweep and env-var nudge | none | `scripts/check.* dead-deps --advisory` and `scripts/check.* report-env-vars` | Advisory Linux-only hygiene |
 | GUI semantic contracts | none | `scripts/gui.ps1 contract` or `scripts/gui.ps1 suite` | Local/manual or issue-specific |
 | Perf guard | none | `scripts/perf.* guard` | Local/manual or release-risk validation |
-| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Resolves the exact `main` SHA, runs `cargo test --workspace --locked` on Ubuntu before package builds or publication, builds Windows/macOS nightly assets from that SHA, embeds `X.Y.Z-nightly.DATE+SHA` metadata, verifies the checksum signing key against the pinned public key before public publication, uploads and verifies the immutable PortalSurfer release plus full changelog first, then refreshes the rolling GitHub `nightly` release assets and promotes the immutable and rolling GitHub tags as the final public identity step |
-| RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs workspace tests, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
-| Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs workspace tests, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
+| Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Resolves the exact `main` SHA, runs `scripts/internal/release/run_release_validation.sh` on Ubuntu before package builds or publication, builds Windows/macOS nightly assets from that SHA, embeds `X.Y.Z-nightly.DATE+SHA` metadata, verifies the checksum signing key against the pinned public key before public publication, uploads and verifies the immutable PortalSurfer release plus full changelog first, then refreshes the rolling GitHub `nightly` release assets and promotes the immutable and rolling GitHub tags as the final public identity step |
+| RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
+| Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
 
 The nextest policy is:
 
@@ -63,12 +63,14 @@ The nextest policy is:
 - Local nextest runs remain the primary development evidence. GitHub release
   workflows add deterministic packaging-time checks for nightly, RC, and stable
   artifacts.
-- Nightly uses `cargo test --workspace --locked` on `ubuntu-latest` to match
-  the RC/stable release gate before any package build or public publication.
-  It is intentionally narrower than local `ci-required` nextest coverage so the
-  scheduled release lane stays deterministic in GitHub Actions; quarantined,
-  GUI/manual, and performance checks remain explicit local or issue-specific
-  release-risk evidence.
+- Nightly, RC, and stable use `scripts/internal/release/run_release_validation.sh`
+  on `ubuntu-latest` before any package build or public publication. The helper
+  compiles Wavecrate-owned workspace test targets with `cargo test --workspace
+  --locked --exclude radiant --no-run`, then runs release contract/helper tests
+  and scanner tests. It intentionally avoids running the full native/UI default
+  Cargo test lane in scheduled release workflows; local `ci-required` nextest,
+  quarantined, GUI/manual, and performance checks remain explicit local or
+  issue-specific release-risk evidence.
 - The nightly, RC, and stable Ubuntu release-validation jobs install
   `pkg-config` and `libasound2-dev` before Cargo builds the workspace.
   Wavecrate still publishes only the Windows/macOS release targets declared in

--- a/scripts/internal/release/run_release_validation.sh
+++ b/scripts/internal/release/run_release_validation.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[release_validation] Build Wavecrate workspace test targets."
+cargo test --workspace --locked --exclude radiant --no-run
+
+echo "[release_validation] Run release workflow contract checks."
+cargo test --test release_contract
+cargo test --test release_workflow_helpers
+
+echo "[release_validation] Run scanner tests used by release-time source validation."
+cargo test -p wavecrate-scan --lib
+
+echo "[release_validation] OK"

--- a/src/app_core/controller.rs
+++ b/src/app_core/controller.rs
@@ -22,7 +22,7 @@ mod waveform_actions;
 
 pub(crate) use frame_preparation::UiFramePreparationPlan;
 pub use runtime_facade::AppController;
-pub(crate) use startup::build_ui_app_controller;
+pub use startup::build_ui_app_controller;
 
 use crate::app_core::actions::{NativeAppModel, NativeUiAction};
 #[cfg(test)]

--- a/src/app_core/controller/startup.rs
+++ b/src/app_core/controller/startup.rs
@@ -9,7 +9,7 @@ use super::AppController;
 ///
 /// This centralizes controller creation and config loading so UI hosts need not
 /// depend directly on app-controller initialization details.
-pub(crate) fn build_ui_app_controller(
+pub fn build_ui_app_controller(
     renderer: WaveformRenderer,
     player: Option<Rc<RefCell<AudioPlayer>>>,
 ) -> Result<AppController, String> {

--- a/src/app_core/ui_bridge/mod.rs
+++ b/src/app_core/ui_bridge/mod.rs
@@ -252,7 +252,7 @@ pub fn new_ui_bridge(
 /// GUI test fixtures use this to bypass persisted startup config while still
 /// exercising the same bridge, projection cache, and action-reduction logic as
 /// the real runtime.
-pub(crate) fn new_ui_bridge_with_controller(controller: AppController) -> WavecrateUiBridge {
+pub fn new_ui_bridge_with_controller(controller: AppController) -> WavecrateUiBridge {
     WavecrateUiBridge::from_fixture_controller(controller)
 }
 

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -27,6 +27,8 @@ const PUBLISH_PORTALSURFER_SCRIPT: &str =
     include_str!("../scripts/internal/release/publish_portalsurfer_release.sh");
 const SIGN_RELEASE_CHECKSUMS_SCRIPT: &str =
     include_str!("../scripts/internal/release/sign_release_checksums.sh");
+const RUN_RELEASE_VALIDATION_SCRIPT: &str =
+    include_str!("../scripts/internal/release/run_release_validation.sh");
 const WRITE_RELEASE_SUMMARY_SCRIPT: &str =
     include_str!("../scripts/internal/release/write_release_step_summary.sh");
 const VALIDATE_PROMOTED_RC_SCRIPT: &str =
@@ -91,8 +93,8 @@ fn nightly_workflow_runs_validation_before_build_and_publish() {
         "nightly validation must use the pinned Rust toolchain"
     );
     assert!(
-        NIGHTLY_WORKFLOW.contains("run: cargo test --workspace --locked"),
-        "nightly validation must run the release workspace test lane"
+        NIGHTLY_WORKFLOW.contains("scripts/internal/release/run_release_validation.sh"),
+        "nightly validation must run the shared release validation lane"
     );
     assert!(
         NIGHTLY_WORKFLOW.contains("needs: [resolve-main, test]"),
@@ -140,12 +142,12 @@ fn release_validation_installs_ubuntu_audio_deps_before_cargo_tests() {
         let deps_position = test_job
             .find("scripts/internal/release/setup_ubuntu_release_deps.sh")
             .unwrap_or_else(|| panic!("{name} test job must install Ubuntu release dependencies"));
-        let cargo_test_position = test_job
-            .find("cargo test --workspace --locked")
-            .unwrap_or_else(|| panic!("{name} test job must run the release workspace test lane"));
+        let validation_position = test_job
+            .find("scripts/internal/release/run_release_validation.sh")
+            .unwrap_or_else(|| panic!("{name} test job must run shared release validation"));
         assert!(
-            deps_position < cargo_test_position,
-            "{name} must install Ubuntu release dependencies before Cargo builds workspace tests"
+            deps_position < validation_position,
+            "{name} must install Ubuntu release dependencies before Cargo builds release validation"
         );
     }
 
@@ -154,6 +156,21 @@ fn release_validation_installs_ubuntu_audio_deps_before_cargo_tests() {
             && SETUP_UBUNTU_RELEASE_DEPS_SCRIPT.contains("libasound2-dev")
             && SETUP_UBUNTU_RELEASE_DEPS_SCRIPT.contains("pkg-config --exists alsa"),
         "Ubuntu release dependency helper must install and verify ALSA build dependencies"
+    );
+}
+
+#[test]
+fn release_validation_lane_builds_workspace_and_runs_focused_checks() {
+    assert!(
+        RUN_RELEASE_VALIDATION_SCRIPT
+            .contains("cargo test --workspace --locked --exclude radiant --no-run"),
+        "release validation must compile Wavecrate-owned workspace test targets without running the broad native/UI lane"
+    );
+    assert!(
+        RUN_RELEASE_VALIDATION_SCRIPT.contains("cargo test --test release_contract")
+            && RUN_RELEASE_VALIDATION_SCRIPT.contains("cargo test --test release_workflow_helpers")
+            && RUN_RELEASE_VALIDATION_SCRIPT.contains("cargo test -p wavecrate-scan --lib"),
+        "release validation must run focused release and scanner tests"
     );
 }
 
@@ -827,6 +844,10 @@ fn release_workflows_use_shared_setup_build_and_signing_helpers() {
         assert!(
             workflow.contains("scripts/internal/release/setup_ubuntu_release_deps.sh"),
             "{name} must use the shared Ubuntu release dependency helper"
+        );
+        assert!(
+            workflow.contains("scripts/internal/release/run_release_validation.sh"),
+            "{name} must use the shared release validation helper"
         );
         assert!(
             workflow.contains("scripts/internal/release/setup_windows_asio_sdk.ps1"),

--- a/tools/bench-cli/src/bench/gui/scenario_registry.rs
+++ b/tools/bench-cli/src/bench/gui/scenario_registry.rs
@@ -10,7 +10,9 @@ use super::interactions::{
 use super::{BenchOptions, stats};
 use wavecrate::app_core::actions::{NativeAppBridge, NativeAppModel, NativeMotionModel};
 use wavecrate::app_core::controller::{AppController, AppControllerUiRuntimeExt};
-use wavecrate::app_core::ui_bridge::{WavecrateUiBridge, measure_projection_segment_probe};
+use wavecrate::app_core::ui_bridge::{
+    WavecrateUiBridge, measure_projection_segment_probe, new_ui_bridge_with_controller,
+};
 
 /// Latency summaries collected for every GUI benchmark scenario.
 pub(super) struct GuiScenarioMetrics {
@@ -56,7 +58,7 @@ pub(super) fn collect_gui_scenario_metrics(
     controller: AppController,
     mut execute_interaction_step: impl FnMut(&mut AppController, usize),
 ) -> Result<GuiScenarioMetrics, String> {
-    let mut bridge = WavecrateUiBridge::from_fixture_controller(controller);
+    let mut bridge = new_ui_bridge_with_controller(controller);
     Ok(GuiScenarioMetrics {
         app_model_projection: bench_retained_app_model_projection(options, &mut bridge)?,
         controller_app_model_projection: bench_controller_app_model_projection(

--- a/tools/bench-cli/src/bench/gui_tests.rs
+++ b/tools/bench-cli/src/bench/gui_tests.rs
@@ -5,7 +5,7 @@ use super::interactions::step_patterns::{
 };
 use super::workspace::{build_controller_with_db_rows, wait_for_rows};
 use super::*;
-use wavecrate::app_core::actions::NativeUiAction;
+use wavecrate::app_core::actions::{NativeUiAction, NativeWaveformAction};
 
 /// Panic with context if a GUI benchmark test setup step fails.
 fn must<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
@@ -111,27 +111,27 @@ fn interaction_step_cycles_search_filter_and_sort() {
 fn waveform_action_sequence_covers_expected_native_actions() {
     assert!(matches!(
         waveform_action_for_step(0),
-        NativeUiAction::SeekWaveform { .. }
+        NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise { .. })
     ));
     assert!(matches!(
         waveform_action_for_step(1),
-        NativeUiAction::SetWaveformCursor { .. }
+        NativeUiAction::Waveform(NativeWaveformAction::SetWaveformCursorPrecise { .. })
     ));
     assert!(matches!(
         waveform_action_for_step(2),
-        NativeUiAction::SetWaveformSelectionRange { .. }
+        NativeUiAction::Waveform(NativeWaveformAction::SetWaveformSelectionRange { .. })
     ));
     assert!(matches!(
         waveform_action_for_step(3),
-        NativeUiAction::ZoomWaveform { .. }
+        NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform { .. })
     ));
     assert!(matches!(
         waveform_action_for_step(4),
-        NativeUiAction::ZoomWaveformToSelection
+        NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveformToSelection)
     ));
     assert!(matches!(
         waveform_action_for_step(5),
-        NativeUiAction::ZoomWaveformFull
+        NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveformFull)
     ));
 }
 
@@ -140,31 +140,31 @@ fn waveform_action_sequence_covers_expected_native_actions() {
 fn adjacent_waveform_action_sequence_covers_expected_native_actions() {
     assert!(matches!(
         adjacent_waveform_action_for_step(0),
-        NativeUiAction::SeekWaveform {
-            position_milli: 380
-        }
+        NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise {
+            position_nanos: 380_000_000
+        })
     ));
     assert!(matches!(
         adjacent_waveform_action_for_step(1),
-        NativeUiAction::SeekWaveform {
-            position_milli: 410
-        }
+        NativeUiAction::Waveform(NativeWaveformAction::SeekWaveformPrecise {
+            position_nanos: 410_000_000
+        })
     ));
     assert!(matches!(
         adjacent_waveform_action_for_step(2),
-        NativeUiAction::ZoomWaveform {
+        NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform {
             zoom_in: true,
             steps: 1,
             ..
-        }
+        })
     ));
     assert!(matches!(
         adjacent_waveform_action_for_step(3),
-        NativeUiAction::ZoomWaveform {
+        NativeUiAction::Waveform(NativeWaveformAction::ZoomWaveform {
             zoom_in: false,
             steps: 1,
             ..
-        }
+        })
     ));
 }
 


### PR DESCRIPTION
## Scope
- Fix the reported `wavecrate-scan` test fixture compile failure by initializing `WavEntry::last_curated_at`.
- Add `scripts/internal/release/run_release_validation.sh` and use it from nightly, RC, and stable validation jobs.
- Keep release validation deterministic by compiling Wavecrate-owned workspace test targets with `cargo test --workspace --locked --exclude radiant --no-run`, then running release contract/helper tests and scan crate tests.
- Update app-core facade visibility and bench tool waveform-action assertions so Wavecrate-owned workspace test targets compile under the release validation build step.
- Document the helper-based release lane and guard it with release contract tests.

## Definition of Done
- The reported missing `last_curated_at` compile failure is fixed.
- Nightly/RC/stable release validation uses one shared helper instead of the broad default Cargo test lane.
- The helper still catches workspace compile drift before package builds, while avoiding vendored Radiant example tests and load-sensitive native/UI runtime tests in scheduled releases.
- Contract tests fail if workflows bypass the shared release validation helper or move Ubuntu ALSA dependency setup after validation.

## Validation commands
- `bash -n scripts/internal/release/run_release_validation.sh && bash -n scripts/internal/release/setup_ubuntu_release_deps.sh`
- `cargo fmt --check`
- `git diff --check`
- `scripts/internal/release/run_release_validation.sh`

## Known limitations
- This does not add Linux release artifacts.
- The helper excludes the vendored `radiant` package from direct package test-target builds; Wavecrate still compiles against Radiant as a dependency, and Radiant package/example validation remains owned by the Radiant lane.
- The helper compiles the broad Wavecrate workspace test targets but does not run the full native/UI default Cargo test lane in scheduled release workflows; local nextest, GUI, quarantined, and performance lanes remain the broader validation surfaces.

User review is required before merge.