### PR TITLE
Fix staged PortalSurfer changelog assembly

### DIFF
--- a/scripts/internal/release/assemble_portal_changelog.py
+++ b/scripts/internal/release/assemble_portal_changelog.py
@@ -30,6 +30,9 @@ def parse_args() -> argparse.Namespace:
     catalog.add_argument("--catalog-file", help="Path to a release catalog JSON file.")
     catalog.add_argument("--catalog-url", help="Public release catalog URL.")
     parser.add_argument("--current-build-id", required=True)
+    parser.add_argument("--current-build-number", type=int, required=True)
+    parser.add_argument("--current-version", required=True)
+    parser.add_argument("--current-released-at", required=True)
     parser.add_argument("--current-log", required=True, help="Markdown log for the current release.")
     parser.add_argument(
         "--existing-changelog-url",
@@ -139,6 +142,19 @@ def release_sort_key(release: dict[str, Any]) -> tuple[str, int]:
     )
 
 
+def current_release_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "build_id": args.current_build_id,
+        "build_number": args.current_build_number,
+        "version": args.current_version,
+        "released_at": args.current_released_at,
+        "changelog": {
+            "title": f"Wavecrate {release_version(args.current_build_id)}",
+            "format": "markdown",
+        },
+    }
+
+
 def load_release_body(
     release: dict[str, Any],
     *,
@@ -213,6 +229,13 @@ def main() -> int:
     if not isinstance(releases, list):
         raise SystemExit("Release catalog does not contain a releases array.")
 
+    current_release = current_release_from_args(args)
+    releases = [
+        release
+        for release in releases
+        if release.get("build_id") != args.current_build_id
+    ]
+    releases.append(current_release)
     sorted_releases = sorted(releases, key=release_sort_key, reverse=True)
     current_release = next(
         (release for release in sorted_releases if release.get("build_id") == args.current_build_id),

--- a/scripts/internal/release/publish_portalsurfer_release.sh
+++ b/scripts/internal/release/publish_portalsurfer_release.sh
@@ -222,6 +222,9 @@ summary_phase="assembling full changelog"
 scripts/internal/release/assemble_portal_changelog.py \
   --catalog-url "$catalog_url" \
   --current-build-id "$BUILD_ID" \
+  --current-build-number "$BUILD_NUMBER" \
+  --current-version "$RELEASE_VERSION" \
+  --current-released-at "$RELEASED_AT" \
   --current-log "$RELEASE_LOG" \
   --existing-changelog-url "$full_changelog_url" \
   --generated-at "$RELEASED_AT" \

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -654,6 +654,12 @@ fn portalsurfer_publish_helper_uses_shared_catalog_verifier() {
         "PortalSurfer publish helper must verify the catalog through the shared upload verifier"
     );
     assert!(
+        PUBLISH_PORTALSURFER_SCRIPT.contains("--current-build-number \"$BUILD_NUMBER\"")
+            && PUBLISH_PORTALSURFER_SCRIPT.contains("--current-version \"$RELEASE_VERSION\"")
+            && PUBLISH_PORTALSURFER_SCRIPT.contains("--current-released-at \"$RELEASED_AT\""),
+        "PortalSurfer publish helper must assemble the full changelog from staged current release metadata before commit"
+    );
+    assert!(
         VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT.contains("parse_released_at"),
         "PortalSurfer upload catalog verifier must normalize release timestamp precision"
     );

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -146,6 +146,68 @@ fn release_summary_helper_writes_public_metadata_without_secret_values() {
 }
 
 #[test]
+fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog() {
+    let temp = tempfile::tempdir().expect("create changelog fixture");
+    let catalog = temp.path().join("catalog.json");
+    let release_log = temp.path().join("release-log.md");
+    let output = temp.path().join("changelog.md");
+    fs::write(
+        &catalog,
+        serde_json::to_string_pretty(&json!({
+            "releases": [
+                {
+                    "build_id": "wavecrate-nightly-b6306-deadbee",
+                    "build_number": 6306,
+                    "version": "19.1.0-nightly.6306+deadbee",
+                    "released_at": "2026-07-03T19:00:00Z",
+                    "changelog": {
+                        "title": "Wavecrate nightly-b6306-deadbee",
+                        "format": "markdown",
+                        "body": "## [nightly-b6306-deadbee]\n\n- Prior nightly\n"
+                    }
+                }
+            ]
+        }))
+        .expect("serialize catalog"),
+    )
+    .expect("write catalog");
+    fs::write(
+        &release_log,
+        "## [nightly-b6307-8f1a7aa2]\n\n- Current staged nightly\n",
+    )
+    .expect("write current log");
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/assemble_portal_changelog.py",
+            ))
+            .arg("--catalog-file")
+            .arg(&catalog)
+            .arg("--current-build-id")
+            .arg("wavecrate-nightly-b6307-8f1a7aa2")
+            .arg("--current-build-number")
+            .arg("6307")
+            .arg("--current-version")
+            .arg("19.1.0-nightly.6307+8f1a7aa2")
+            .arg("--current-released-at")
+            .arg("2026-07-03T20:00:00Z")
+            .arg("--current-log")
+            .arg(&release_log)
+            .arg("--generated-at")
+            .arg("2026-07-03T20:00:00Z")
+            .arg("--output")
+            .arg(&output),
+    );
+
+    let changelog = fs::read_to_string(output).expect("read generated changelog");
+    assert!(changelog.contains("Latest release: wavecrate-nightly-b6307-8f1a7aa2"));
+    assert!(changelog.contains("Latest build: 6307"));
+    assert!(changelog.contains("Current staged nightly"));
+    assert!(changelog.contains("Prior nightly"));
+}
+
+#[test]
 fn checksum_signing_helper_writes_signature_and_verifies_expected_pubkey() {
     let temp = tempfile::tempdir().expect("create signing fixture");
     let key = temp.path().join("ed25519.pem");


### PR DESCRIPTION
## Scope

- Fix nightly/PortalSurfer publish failure where `assemble_portal_changelog.py` required the current staged release to already exist in the public catalog.
- Pass the current staged release build number, version, and release timestamp into the changelog assembler.
- Synthesize the current release during full changelog assembly so files, per-release log, and full changelog can still be committed atomically through `$upload_base/$BUILD_ID/commit`.
- Add focused regression coverage for a public catalog that does not yet list the current staged build id.

## Definition of Done

- PortalSurfer publish can assemble the full changelog before public commit, even when the current build id is only staged.
- The staged upload/commit ordering remains intact.
- Static release contract coverage guards the metadata arguments needed for pre-commit changelog assembly.

## Validation commands

- `cargo fmt`
- `python3 -m py_compile scripts/internal/release/assemble_portal_changelog.py`
- `bash -n scripts/internal/release/publish_portalsurfer_release.sh`
- `cargo test --test release_workflow_helpers portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog`
- `cargo test --test release_contract portalsurfer_publish_helper_uses_shared_catalog_verifier`
- `cargo test --test release_workflow_helpers`
- `cargo test --test release_contract`
- `git diff --check`

## Known limitations

- I did not rerun the GitHub Actions nightly workflow locally; this fix is based on the provided Actions log and local fixture reproduction of the failing pre-commit catalog lookup.

User review is required before merge.
