### PR TITLE
Add macOS external file drag support

### DIFF
--- a/src/app/controller/library/selection_export/completion.rs
+++ b/src/app/controller/library/selection_export/completion.rs
@@ -7,7 +7,7 @@ use crate::sample_sources::{
 };
 use crate::selection::SelectionRange;
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use tracing::{info, warn};
 
 impl AppController {
@@ -150,7 +150,7 @@ impl AppController {
         }
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn finish_external_selection_drag_export(&mut self, success: SelectionClipExportSuccess) {
         let Some(request_id) = self.ui.drag.pending_external_selection_request_id else {
             warn!(
@@ -197,8 +197,18 @@ impl AppController {
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
-    fn finish_external_selection_drag_export(&mut self, _success: SelectionClipExportSuccess) {}
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    fn finish_external_selection_drag_export(&mut self, success: SelectionClipExportSuccess) {
+        self.ui.drag.pending_external_selection_request_id = None;
+        self.drag_drop().reset_drag();
+        self.set_status(
+            format!(
+                "External drag-out is not supported on this platform for {}",
+                success.entry.relative_path.display()
+            ),
+            StatusTone::Error,
+        );
+    }
 
     fn record_selection_clip_export_harvest_derivation(
         &self,

--- a/src/app/controller/ui/drag_drop_controller/actions/external_drag.rs
+++ b/src/app/controller/ui/drag_drop_controller/actions/external_drag.rs
@@ -1,14 +1,14 @@
 use super::*;
-#[cfg(any(target_os = "windows", test))]
+#[cfg(any(target_os = "windows", target_os = "macos", test))]
 use std::time::{Duration, Instant};
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use tracing::{debug, info, warn};
 
 impl DragDropController<'_> {
-    #[cfg(any(target_os = "windows", test))]
+    #[cfg(any(target_os = "windows", target_os = "macos", test))]
     pub(crate) const EXTERNAL_DRAG_ARM_WINDOW: Duration = Duration::from_millis(250);
 
-    #[cfg(any(target_os = "windows", test))]
+    #[cfg(any(target_os = "windows", target_os = "macos", test))]
     pub(crate) fn should_launch_external_drag(
         &mut self,
         pointer_outside: bool,
@@ -37,7 +37,7 @@ impl DragDropController<'_> {
         }
         let Some(armed_at) = self.ui.drag.external_arm_at else {
             self.ui.drag.external_arm_at = Some(now);
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             debug!(
                 pointer_outside,
                 pointer_left,
@@ -48,7 +48,7 @@ impl DragDropController<'_> {
             return false;
         };
         let ready = now.duration_since(armed_at) >= Self::EXTERNAL_DRAG_ARM_WINDOW;
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "macos"))]
         if ready {
             info!(
                 pointer_outside,
@@ -61,7 +61,7 @@ impl DragDropController<'_> {
         ready
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     pub(crate) fn maybe_launch_external_drag(
         &mut self,
         pointer_outside: bool,
@@ -163,7 +163,7 @@ impl DragDropController<'_> {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn drag_payload_kind(payload: &DragPayload) -> &'static str {
     match payload {
         DragPayload::Sample { .. } => "sample",

--- a/src/app/controller/ui/drag_drop_controller/delegates.rs
+++ b/src/app/controller/ui/drag_drop_controller/delegates.rs
@@ -87,8 +87,8 @@ impl AppController {
         self.drag_drop().reset_drag();
     }
 
-    #[cfg(target_os = "windows")]
-    /// Attempt to start an OS-level drag out of the app window (Windows-only).
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    /// Attempt to start an OS-level drag out of the app window.
     pub fn maybe_launch_external_drag(
         &mut self,
         pointer_outside: bool,

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/external_drag.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/external_drag.rs
@@ -1,7 +1,7 @@
 use super::super::DragDropController;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::path::PathBuf;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use tracing::info;
 
 impl DragDropController<'_> {
@@ -20,5 +20,18 @@ impl DragDropController<'_> {
             "drag controller: launching Windows external drag"
         );
         crate::external_drag::start_file_drag(hwnd, paths)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn start_external_drag(&self, paths: &[PathBuf]) -> Result<(), String> {
+        info!(
+            path_count = paths.len(),
+            first_path = %paths
+                .first()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default(),
+            "drag controller: launching macOS external drag"
+        );
+        crate::external_drag::start_file_drag((), paths)
     }
 }

--- a/src/app/controller/ui/drag_drop_controller/path_resolution.rs
+++ b/src/app/controller/ui/drag_drop_controller/path_resolution.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl DragDropController<'_> {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     pub(crate) fn sample_absolute_path(
         &self,
         source_id: &SourceId,

--- a/src/app_core/actions/ui_projection_bridge.rs
+++ b/src/app_core/actions/ui_projection_bridge.rs
@@ -66,7 +66,7 @@ pub trait NativeAppBridge {
     fn set_external_drag_hwnd(&mut self, _hwnd: isize) {}
 
     /// Ask the host to launch an external drag for the current active drag payload.
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn maybe_launch_external_drag(&mut self, _pointer_outside: bool, _pointer_left: bool) -> bool {
         false
     }

--- a/src/app_core/ui_bridge/native_bridge.rs
+++ b/src/app_core/ui_bridge/native_bridge.rs
@@ -59,7 +59,7 @@ impl NativeAppBridge for WavecrateUiBridge {
             )));
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn maybe_launch_external_drag(&mut self, pointer_outside: bool, pointer_left: bool) -> bool {
         let consumed = self
             .controller

--- a/src/external_drag/mod.rs
+++ b/src/external_drag/mod.rs
@@ -1,8 +1,8 @@
 //! Platform helpers for starting external drag-and-drop operations.
 //!
-//! Currently implemented for Windows by emitting a `CF_HDROP` drag with one or
-//! more absolute file paths. Other platforms return an unsupported error to
-//! keep behaviour predictable.
+//! Implemented for Windows by emitting a `CF_HDROP` drag and for macOS by
+//! starting an AppKit file-URL dragging session. Other platforms return an
+//! unsupported error to keep behaviour predictable.
 
 use std::path::PathBuf;
 
@@ -20,23 +20,39 @@ pub fn start_file_drag(
     platform::start_file_drag(hwnd, paths)
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
 /// Start dragging the given file paths to an external target.
 ///
-/// Returns an error because non-Windows platforms are not supported here.
-pub fn start_file_drag(_hwnd: (), _paths: &[PathBuf]) -> Result<(), String> {
-    Err("External drag-out is only supported on Windows in this build".into())
+/// The active AppKit key/main window and content view are used as the native
+/// drag anchor.
+pub fn start_file_drag(_anchor: (), paths: &[PathBuf]) -> Result<(), String> {
+    if paths.is_empty() {
+        return Err("No files to drag".into());
+    }
+    platform::start_file_drag(paths)
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+/// Start dragging the given file paths to an external target.
+///
+/// Returns an error because this platform is not supported here.
+pub fn start_file_drag(_anchor: (), _paths: &[PathBuf]) -> Result<(), String> {
+    Err("External drag-out is only supported on Windows and macOS in this build".into())
 }
 
 #[cfg(target_os = "windows")]
 mod payload;
+
 #[cfg(target_os = "windows")]
+mod platform;
+#[cfg(target_os = "macos")]
+#[path = "platform_macos.rs"]
 mod platform;
 #[cfg(all(test, target_os = "windows"))]
 mod tests;
 
-#[cfg(target_os = "windows")]
-/// Normalize one drag path to an absolute non-verbatim Windows filesystem path.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+/// Normalize one drag path to an absolute filesystem path.
 fn normalize_path(path: &std::path::Path) -> PathBuf {
     let absolute = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let verbatim_prefix = "\\\\?\\";

--- a/src/external_drag/platform_macos.rs
+++ b/src/external_drag/platform_macos.rs
@@ -1,0 +1,529 @@
+//! macOS outgoing file-drag platform implementation.
+
+use super::normalize_path;
+use std::{
+    ffi::{CStr, c_char, c_void},
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
+use tracing::{info, warn};
+
+type Id = *mut c_void;
+type Sel = *mut c_void;
+type ObjcBool = i8;
+
+const YES: ObjcBool = 1;
+const NO: ObjcBool = 0;
+const NS_DRAG_OPERATION_COPY: usize = 1;
+const NS_LEFT_MOUSE_DOWN: usize = 1;
+const NS_LEFT_MOUSE_DRAGGED: usize = 6;
+const NS_UTF8_STRING_ENCODING: usize = 4;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSPoint {
+    x: f64,
+    y: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSSize {
+    width: f64,
+    height: f64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSRect {
+    origin: NSPoint,
+    size: NSSize,
+}
+
+#[link(name = "AppKit", kind = "framework")]
+unsafe extern "C" {}
+
+#[link(name = "Foundation", kind = "framework")]
+unsafe extern "C" {}
+
+#[link(name = "objc")]
+unsafe extern "C" {
+    fn objc_allocateClassPair(superclass: Id, name: *const c_char, extra_bytes: usize) -> Id;
+    fn objc_getClass(name: *const c_char) -> Id;
+    fn objc_msgSend();
+    fn objc_registerClassPair(class: Id);
+    fn class_addMethod(class: Id, name: Sel, imp: *const c_void, types: *const c_char) -> ObjcBool;
+    fn sel_registerName(name: *const c_char) -> Sel;
+}
+
+pub(super) fn start_file_drag(paths: &[PathBuf]) -> Result<(), String> {
+    info!(
+        path_count = paths.len(),
+        first_path = %paths
+            .first()
+            .map(|path| path.display().to_string())
+            .unwrap_or_default(),
+        "external drag: starting macOS file drag"
+    );
+    let _pool = AutoreleasePool::new()?;
+    let absolute = paths
+        .iter()
+        .map(|path| normalize_path(path.as_path()))
+        .collect::<Vec<_>>();
+    let app = unsafe { shared_application()? };
+    let (window, view) = unsafe { key_window_and_content_view(app)? };
+    let event = unsafe { external_drag_event(app, window)? };
+    let items = unsafe { dragging_items(&absolute)? };
+    let source = unsafe { dragging_source()? };
+    let session = unsafe {
+        msg_id_id_id_id(
+            view,
+            selector(c"beginDraggingSessionWithItems:event:source:"),
+            items,
+            event,
+            source,
+        )
+    };
+    if session.is_null() {
+        warn!("external drag: NSView beginDraggingSessionWithItems returned nil");
+        return Err(String::from(
+            "Could not start external drag: native macOS view anchor is unavailable",
+        ));
+    }
+    info!("external drag: macOS file drag session started");
+    Ok(())
+}
+
+struct AutoreleasePool {
+    pool: Id,
+}
+
+impl AutoreleasePool {
+    fn new() -> Result<Self, String> {
+        let pool = unsafe {
+            let class = class(c"NSAutoreleasePool")?;
+            msg_id(class, selector(c"new"))
+        };
+        if pool.is_null() {
+            Err(String::from("Failed to create NSAutoreleasePool"))
+        } else {
+            Ok(Self { pool })
+        }
+    }
+}
+
+impl Drop for AutoreleasePool {
+    fn drop(&mut self) {
+        unsafe {
+            msg_void(self.pool, selector(c"drain"));
+        }
+    }
+}
+
+unsafe fn shared_application() -> Result<Id, String> {
+    let app = unsafe {
+        let class = class(c"NSApplication")?;
+        msg_id(class, selector(c"sharedApplication"))
+    };
+    if app.is_null() {
+        Err(String::from("NSApplication sharedApplication returned nil"))
+    } else {
+        Ok(app)
+    }
+}
+
+unsafe fn external_drag_event(app: Id, window: Id) -> Result<Id, String> {
+    let event = unsafe { current_event(app) };
+    if !event.is_null() && unsafe { is_drag_start_event(event) } {
+        Ok(event)
+    } else {
+        unsafe { synthetic_left_drag_event(window) }
+    }
+}
+
+unsafe fn current_event(app: Id) -> Id {
+    unsafe { msg_id(app, selector(c"currentEvent")) }
+}
+
+unsafe fn is_drag_start_event(event: Id) -> bool {
+    matches!(
+        unsafe { msg_usize(event, selector(c"type")) },
+        NS_LEFT_MOUSE_DOWN | NS_LEFT_MOUSE_DRAGGED
+    )
+}
+
+unsafe fn synthetic_left_drag_event(window: Id) -> Result<Id, String> {
+    let point = unsafe { msg_point(window, selector(c"mouseLocationOutsideOfEventStream")) };
+    let window_number = unsafe { msg_isize(window, selector(c"windowNumber")) };
+    let event_class = unsafe { class(c"NSEvent")? };
+    let event = unsafe {
+        msg_id_usize_point_usize_f64_isize_id_isize_isize_f64(
+            event_class,
+            selector(
+                c"mouseEventWithType:location:modifierFlags:timestamp:windowNumber:context:eventNumber:clickCount:pressure:",
+            ),
+            NS_LEFT_MOUSE_DRAGGED,
+            point,
+            0,
+            0.0,
+            window_number,
+            std::ptr::null_mut(),
+            0,
+            1,
+            1.0,
+        )
+    };
+    if event.is_null() {
+        Err(String::from(
+            "Failed to synthesize NSEvent for external drag",
+        ))
+    } else {
+        Ok(event)
+    }
+}
+
+unsafe fn key_window_and_content_view(app: Id) -> Result<(Id, Id), String> {
+    let mut window = unsafe { msg_id(app, selector(c"keyWindow")) };
+    if window.is_null() {
+        window = unsafe { msg_id(app, selector(c"mainWindow")) };
+    }
+    if window.is_null() {
+        return Err(String::from(
+            "Could not start external drag: NSApplication has no key or main window",
+        ));
+    }
+    let view = unsafe { msg_id(window, selector(c"contentView")) };
+    if view.is_null() {
+        Err(String::from(
+            "Could not start external drag: NSWindow contentView returned nil",
+        ))
+    } else {
+        Ok((window, view))
+    }
+}
+
+unsafe fn dragging_items(paths: &[PathBuf]) -> Result<Id, String> {
+    let items = unsafe { ns_mutable_array(paths.len())? };
+    for path in paths {
+        let url = unsafe { file_url_for_path(path)? };
+        let item = unsafe { ns_dragging_item(url)? };
+        let contents = unsafe { file_icon_for_path(path)? };
+        unsafe {
+            msg_void_rect_id(
+                item,
+                selector(c"setDraggingFrame:contents:"),
+                dragging_frame(),
+                contents,
+            );
+            msg_void_id(items, selector(c"addObject:"), item);
+        }
+    }
+    Ok(items)
+}
+
+unsafe fn ns_mutable_array(capacity: usize) -> Result<Id, String> {
+    let array = unsafe {
+        let class = class(c"NSMutableArray")?;
+        msg_id_usize(class, selector(c"arrayWithCapacity:"), capacity)
+    };
+    if array.is_null() {
+        Err(String::from("Failed to create NSMutableArray"))
+    } else {
+        Ok(array)
+    }
+}
+
+unsafe fn file_url_for_path(path: &Path) -> Result<Id, String> {
+    let path = path_to_string(path)?;
+    let ns_path = unsafe { ns_string(&path)? };
+    let url = unsafe {
+        let class = class(c"NSURL")?;
+        msg_id_id(class, selector(c"fileURLWithPath:"), ns_path)
+    };
+    if url.is_null() {
+        Err(format!("Failed to create file URL for {path}"))
+    } else {
+        Ok(url)
+    }
+}
+
+unsafe fn ns_dragging_item(url: Id) -> Result<Id, String> {
+    let allocated = unsafe {
+        let class = class(c"NSDraggingItem")?;
+        msg_id(class, selector(c"alloc"))
+    };
+    if allocated.is_null() {
+        return Err(String::from("Failed to allocate NSDraggingItem"));
+    }
+    let item = unsafe { msg_id_id(allocated, selector(c"initWithPasteboardWriter:"), url) };
+    if item.is_null() {
+        Err(String::from("Failed to create NSDraggingItem"))
+    } else {
+        Ok(unsafe { msg_id(item, selector(c"autorelease")) })
+    }
+}
+
+unsafe fn file_icon_for_path(path: &Path) -> Result<Id, String> {
+    let path = path_to_string(path)?;
+    let ns_path = unsafe { ns_string(&path)? };
+    let workspace = unsafe {
+        let class = class(c"NSWorkspace")?;
+        msg_id(class, selector(c"sharedWorkspace"))
+    };
+    if workspace.is_null() {
+        return Err(String::from("NSWorkspace sharedWorkspace returned nil"));
+    }
+    let icon = unsafe { msg_id_id(workspace, selector(c"iconForFile:"), ns_path) };
+    if icon.is_null() {
+        Err(format!("NSWorkspace iconForFile returned nil for {path}"))
+    } else {
+        Ok(icon)
+    }
+}
+
+fn dragging_frame() -> NSRect {
+    NSRect {
+        origin: NSPoint { x: 0.0, y: 0.0 },
+        size: NSSize {
+            width: 48.0,
+            height: 48.0,
+        },
+    }
+}
+
+unsafe fn dragging_source() -> Result<Id, String> {
+    static SOURCE: OnceLock<usize> = OnceLock::new();
+    let source = *SOURCE.get_or_init(|| unsafe {
+        match create_dragging_source() {
+            Ok(source) => source as usize,
+            Err(_) => 0,
+        }
+    }) as Id;
+    if source.is_null() {
+        Err(String::from("Failed to create NSDraggingSource"))
+    } else {
+        Ok(source)
+    }
+}
+
+unsafe fn create_dragging_source() -> Result<Id, String> {
+    let superclass = unsafe { class(c"NSObject")? };
+    let class_name = c"WavecrateExternalFileDraggingSource";
+    let mut source_class = unsafe { objc_getClass(class_name.as_ptr()) };
+    if source_class.is_null() {
+        source_class = unsafe { objc_allocateClassPair(superclass, class_name.as_ptr(), 0) };
+        if source_class.is_null() {
+            return Err(String::from("objc_allocateClassPair failed"));
+        }
+        unsafe {
+            add_method(
+                source_class,
+                c"draggingSession:sourceOperationMaskForDraggingContext:",
+                dragging_source_operation_mask as *const c_void,
+                c"Q@:@@q",
+            )?;
+            add_method(
+                source_class,
+                c"ignoreModifierKeysForDraggingSession:",
+                dragging_source_ignores_modifier_keys as *const c_void,
+                c"c@:@",
+            )?;
+            objc_registerClassPair(source_class);
+        }
+    }
+    let source = unsafe { msg_id(source_class, selector(c"new")) };
+    if source.is_null() {
+        Err(String::from("Failed to instantiate NSDraggingSource"))
+    } else {
+        Ok(source)
+    }
+}
+
+unsafe fn add_method(
+    class: Id,
+    name: &'static CStr,
+    imp: *const c_void,
+    types: &'static CStr,
+) -> Result<(), String> {
+    let added = unsafe { class_addMethod(class, selector(name), imp, types.as_ptr()) };
+    if added == NO {
+        Err(format!(
+            "class_addMethod failed for {}",
+            name.to_string_lossy()
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+extern "C" fn dragging_source_operation_mask(_: Id, _: Sel, _: Id, _: isize) -> usize {
+    NS_DRAG_OPERATION_COPY
+}
+
+extern "C" fn dragging_source_ignores_modifier_keys(_: Id, _: Sel, _: Id) -> ObjcBool {
+    YES
+}
+
+unsafe fn ns_string(value: &str) -> Result<Id, String> {
+    let allocated = unsafe {
+        let class = class(c"NSString")?;
+        msg_id(class, selector(c"alloc"))
+    };
+    if allocated.is_null() {
+        return Err(String::from("Failed to allocate NSString"));
+    }
+    let string = unsafe {
+        msg_id_ptr_usize_usize(
+            allocated,
+            selector(c"initWithBytes:length:encoding:"),
+            value.as_ptr().cast(),
+            value.len(),
+            NS_UTF8_STRING_ENCODING,
+        )
+    };
+    if string.is_null() {
+        Err(String::from("Failed to create NSString"))
+    } else {
+        Ok(unsafe { msg_id(string, selector(c"autorelease")) })
+    }
+}
+
+unsafe fn class(name: &'static CStr) -> Result<Id, String> {
+    let class = unsafe { objc_getClass(name.as_ptr()) };
+    if class.is_null() {
+        Err(format!(
+            "Objective-C class {} not found",
+            name.to_string_lossy()
+        ))
+    } else {
+        Ok(class)
+    }
+}
+
+unsafe fn selector(name: &'static CStr) -> Sel {
+    unsafe { sel_registerName(name.as_ptr()) }
+}
+
+unsafe fn msg_id(receiver: Id, selector: Sel) -> Id {
+    let msg: unsafe extern "C" fn(Id, Sel) -> Id =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector) }
+}
+
+unsafe fn msg_id_id(receiver: Id, selector: Sel, arg: Id) -> Id {
+    let msg: unsafe extern "C" fn(Id, Sel, Id) -> Id =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, arg) }
+}
+
+unsafe fn msg_id_id_id_id(receiver: Id, selector: Sel, first: Id, second: Id, third: Id) -> Id {
+    let msg: unsafe extern "C" fn(Id, Sel, Id, Id, Id) -> Id =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, first, second, third) }
+}
+
+unsafe fn msg_id_usize(receiver: Id, selector: Sel, arg: usize) -> Id {
+    let msg: unsafe extern "C" fn(Id, Sel, usize) -> Id =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, arg) }
+}
+
+unsafe fn msg_id_usize_point_usize_f64_isize_id_isize_isize_f64(
+    receiver: Id,
+    selector: Sel,
+    event_type: usize,
+    location: NSPoint,
+    modifier_flags: usize,
+    timestamp: f64,
+    window_number: isize,
+    context: Id,
+    event_number: isize,
+    click_count: isize,
+    pressure: f64,
+) -> Id {
+    let msg: unsafe extern "C" fn(
+        Id,
+        Sel,
+        usize,
+        NSPoint,
+        usize,
+        f64,
+        isize,
+        Id,
+        isize,
+        isize,
+        f64,
+    ) -> Id = unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe {
+        msg(
+            receiver,
+            selector,
+            event_type,
+            location,
+            modifier_flags,
+            timestamp,
+            window_number,
+            context,
+            event_number,
+            click_count,
+            pressure,
+        )
+    }
+}
+
+unsafe fn msg_id_ptr_usize_usize(
+    receiver: Id,
+    selector: Sel,
+    bytes: *const c_void,
+    length: usize,
+    encoding: usize,
+) -> Id {
+    let msg: unsafe extern "C" fn(Id, Sel, *const c_void, usize, usize) -> Id =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, bytes, length, encoding) }
+}
+
+unsafe fn msg_void(receiver: Id, selector: Sel) {
+    let msg: unsafe extern "C" fn(Id, Sel) =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector) }
+}
+
+unsafe fn msg_void_id(receiver: Id, selector: Sel, arg: Id) {
+    let msg: unsafe extern "C" fn(Id, Sel, Id) =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, arg) }
+}
+
+unsafe fn msg_void_rect_id(receiver: Id, selector: Sel, rect: NSRect, arg: Id) {
+    let msg: unsafe extern "C" fn(Id, Sel, NSRect, Id) =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector, rect, arg) }
+}
+
+unsafe fn msg_isize(receiver: Id, selector: Sel) -> isize {
+    let msg: unsafe extern "C" fn(Id, Sel) -> isize =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector) }
+}
+
+unsafe fn msg_point(receiver: Id, selector: Sel) -> NSPoint {
+    let msg: unsafe extern "C" fn(Id, Sel) -> NSPoint =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector) }
+}
+
+unsafe fn msg_usize(receiver: Id, selector: Sel) -> usize {
+    let msg: unsafe extern "C" fn(Id, Sel) -> usize =
+        unsafe { std::mem::transmute(objc_msgSend as *const ()) };
+    unsafe { msg(receiver, selector) }
+}
+
+fn path_to_string(path: &Path) -> Result<String, String> {
+    path.to_str().map(ToOwned::to_owned).ok_or_else(|| {
+        format!(
+            "Cannot drag non-UTF-8 path to external application: {}",
+            path.display()
+        )
+    })
+}

--- a/src/gui_test/fixtures.rs
+++ b/src/gui_test/fixtures.rs
@@ -171,7 +171,7 @@ impl NativeAppBridge for GuiFixtureBridge {
         self.bridge.set_external_drag_hwnd(hwnd);
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     fn maybe_launch_external_drag(&mut self, pointer_outside: bool, pointer_left: bool) -> bool {
         self.bridge
             .maybe_launch_external_drag(pointer_outside, pointer_left)

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -115,6 +115,22 @@ fn assert_sample_not_keep_rated(
     }
 }
 
+fn run_command_collecting_followups(
+    state: &mut crate::native_app::test_support::state::NativeAppState,
+    command: Command<GuiMessage>,
+) -> Vec<Command<GuiMessage>> {
+    let mut followups = Vec::new();
+    command.run_inline_for_tests(|message| {
+        let mut context = ui::UiUpdateContext::default();
+        state.apply_message(message, &mut context);
+        let command = context.into_command();
+        if !command.is_empty() {
+            followups.push(command);
+        }
+    });
+    followups
+}
+
 fn assert_short_edge_faded_drag_extraction(path: &std::path::Path) {
     let samples = read_test_wav_i16(path);
     assert_eq!(samples.len(), 4);
@@ -296,13 +312,19 @@ fn waveform_selection_drag_start_prepares_extraction_for_external_handoff() {
         &mut context,
     ));
     assert!(
+        !extraction.is_file(),
+        "drag start should queue extraction instead of writing on the UI thread"
+    );
+    run_command_for_tests(&mut state, context.into_command());
+    assert!(
         extraction.is_file(),
-        "starting a waveform drag must write the extraction before native drag-out"
+        "running the extraction completion must create the file before native drag-out"
     );
 
+    let mut end_context = ui::UiUpdateContext::default();
     assert!(state.drag_waveform_play_selection(
         DragHandleMessage::ended(Point::new(26.0, 12.0)),
-        &mut context,
+        &mut end_context,
     ));
 
     assert!(
@@ -329,6 +351,10 @@ fn accepted_waveform_selection_external_drag_does_not_add_whole_file_keep_rating
         DragHandleMessage::started(Point::new(20.0, 12.0)),
         &mut drag_context,
     ));
+    let followups = run_command_collecting_followups(&mut state, drag_context.into_command());
+    for command in followups {
+        run_command_for_tests(&mut state, command);
+    }
     assert_sample_rating(&state, &extraction, Rating::KEEP_1, false);
 
     let mut completion_context = ui::UiUpdateContext::default();

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -320,6 +320,81 @@ fn waveform_clipboard_staging_worker_does_not_touch_platform_clipboard() {
 }
 
 #[test]
+fn external_drag_adapter_has_macos_appkit_file_url_session() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let module_path = manifest_dir.join("src/external_drag/mod.rs");
+    let macos_path = manifest_dir.join("src/external_drag/platform_macos.rs");
+    let module = fs::read_to_string(&module_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", module_path.display()));
+    let macos = fs::read_to_string(&macos_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", macos_path.display()));
+
+    assert!(
+        module.contains("#[cfg(target_os = \"macos\")]")
+            && module.contains("#[path = \"platform_macos.rs\"]")
+            && module.contains("platform::start_file_drag(paths)"),
+        "external drag module should route macOS file drags to the AppKit platform adapter"
+    );
+    for required_contract in [
+        "beginDraggingSessionWithItems:event:source:",
+        "fileURLWithPath:",
+        "initWithPasteboardWriter:",
+        "NSApplication has no key or main window",
+        "NSWindow contentView returned nil",
+        "External drag-out is only supported on Windows and macOS",
+    ] {
+        assert!(
+            module.contains(required_contract) || macos.contains(required_contract),
+            "macOS external drag support should keep contract `{required_contract}`"
+        );
+    }
+}
+
+#[test]
+fn legacy_selection_export_completion_launches_external_drag_on_macos() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let completion_path =
+        manifest_dir.join("src/app/controller/library/selection_export/completion.rs");
+    let action_path =
+        manifest_dir.join("src/app/controller/ui/drag_drop_controller/actions/external_drag.rs");
+    let effects_path = manifest_dir
+        .join("src/app/controller/ui/drag_drop_controller/drag_effects/external_drag.rs");
+    let bridge_path = manifest_dir.join("src/app_core/ui_bridge/native_bridge.rs");
+    let completion = fs::read_to_string(&completion_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", completion_path.display()));
+    let actions = fs::read_to_string(&action_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", action_path.display()));
+    let effects = fs::read_to_string(&effects_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", effects_path.display()));
+    let bridge = fs::read_to_string(&bridge_path)
+        .unwrap_or_else(|err| panic!("{} should be readable: {err}", bridge_path.display()));
+
+    let platform_cfg = "#[cfg(any(target_os = \"windows\", target_os = \"macos\"))]";
+    assert!(
+        completion.contains(platform_cfg)
+            && completion.contains("finish_external_selection_drag_export")
+            && !completion.contains(
+                "#[cfg(not(target_os = \"windows\"))]\n    fn finish_external_selection_drag_export(&mut self, _success"
+            ),
+        "selection export completion must launch external drags on macOS instead of no-oping"
+    );
+    assert!(
+        actions.contains(platform_cfg)
+            && actions.contains("pub(crate) fn maybe_launch_external_drag"),
+        "external drag launch polling should be compiled for both Windows and macOS"
+    );
+    assert!(
+        effects.contains("#[cfg(target_os = \"macos\")]")
+            && effects.contains("crate::external_drag::start_file_drag((), paths)"),
+        "drag controller should call the macOS external drag adapter"
+    );
+    assert!(
+        bridge.contains(platform_cfg) && bridge.contains("maybe_launch_external_drag"),
+        "native bridge should forward external drag polling on macOS"
+    );
+}
+
+#[test]
 fn native_app_playback_paths_do_not_start_audio_directly() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let native_app_root = manifest_dir.join("src/native_app");


### PR DESCRIPTION
## Scope
- Add a macOS AppKit external file-drag adapter for Wavecrate file paths using file URL `NSDraggingItem` payloads.
- Compile the legacy controller external-drag launch and selection-export completion paths for macOS as well as Windows.
- Keep Windows HWND/OLE behavior isolated and unchanged.
- Keep unsupported platforms explicit for future Linux work instead of silently no-oping.
- Update native-app external-drag tests to drive async extraction/rating follow-up commands before asserting persisted handoff state.
- Add static GUI boundary checks for the macOS AppKit contract and macOS controller wiring.

## Definition of Done
- macOS builds have a real outgoing external file drag path for exported sample files.
- Selection export completion launches the external drag adapter on macOS instead of no-oping.
- Windows behavior remains behind the existing Windows-specific HWND/OLE implementation.
- Unsupported platforms return a clear unsupported message.
- Focused tests guard the macOS adapter and shared external-drag completion wiring.

## Validation commands
- `cargo check -p wavecrate`
- `cargo test --test gui_boundary external_drag`
- `cargo test -p wavecrate external_drag`
- `cargo test -p wavecrate --bin wavecrate waveform_selection_drag_start_prepares_extraction_for_external_handoff`
- `git diff --check`

## Known limitations
- I did not perform the manual Finder/DAW drag-out smoke test from the running macOS app in this pass.
- `bash scripts/agent.sh request` still reports pre-existing Radiant generic surface guardrail failures unrelated to this PR: `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, `app_bridge_groups_lifecycle_hooks_and_runtime_flags`, and `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`.

User review is required before merge.
