### PR TITLE
Accept nightly SemVer release log headers

### DIFF
--- a/scripts/internal/release/assemble_portal_changelog.py
+++ b/scripts/internal/release/assemble_portal_changelog.py
@@ -100,6 +100,9 @@ def release_header_versions(release: dict[str, Any]) -> list[str]:
     if not isinstance(build_id, str) or not build_id:
         return []
     versions = {release_version(build_id)}
+    version = release.get("version")
+    if isinstance(version, str) and version.strip():
+        versions.add(version.strip())
     changelog = release.get("changelog") or {}
     title = changelog.get("title")
     if isinstance(title, str) and title.startswith("Wavecrate "):

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -173,7 +173,7 @@ fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog(
     .expect("write catalog");
     fs::write(
         &release_log,
-        "## [nightly-b6307-8f1a7aa2]\n\n- Current staged nightly\n",
+        "# Wavecrate 19.1.0-nightly.6307+8f1a7aa2\n\n- Current staged nightly\n",
     )
     .expect("write current log");
 


### PR DESCRIPTION
## Scope
- Fix PortalSurfer full changelog assembly for staged nightly publishes whose release log header uses the generated SemVer nightly version.
- Keep the strict release-log binding check, but include the catalog/workflow `version` field as an accepted identity alongside the path-safe PortalSurfer build id.
- Update the staged-current-release fixture to use the same `# Wavecrate <nightly semver>` header shape emitted by `.github/workflows/release-build.yml`.

## Definition of Done
- Nightly PortalSurfer publishing no longer rejects a valid release log headed by `# Wavecrate 19.1.0-nightly.DATE+SHA`.
- The full changelog assembler still rejects logs that are not bound to the current release id/title/version metadata.
- Release helper coverage guards the staged-current-release path before public commit.

## Validation commands
- `python3 -m py_compile scripts/internal/release/assemble_portal_changelog.py`
- `cargo test --test release_workflow_helpers portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog`
- `cargo test --test release_workflow_helpers`
- `cargo test --test release_contract`
- `git diff --check`

## Known limitations
- I did not rerun the live GitHub Actions nightly workflow from this branch. The fixture now matches the generated nightly release-log header shape that failed in the provided log.

User review is required before merge.
