### PR TITLE
Fix Windows release archive root layout

### DIFF
--- a/scripts/internal/release/build_release_zip.sh
+++ b/scripts/internal/release/build_release_zip.sh
@@ -283,7 +283,7 @@ create_zip() {
       POWERSHELL_WORK_DIR=$(powershell.exe -NoProfile -Command "[System.IO.Path]::GetFullPath('$WORK_DIR')")
     fi
     POWERSHELL_ZIP_PATH="$POWERSHELL_OUT_DIR\\${ZIP_NAME}"
-    powershell.exe -NoProfile -Command "Compress-Archive -Path \"$POWERSHELL_WORK_DIR\\$APP_NAME\\*\" -DestinationPath \"$POWERSHELL_ZIP_PATH\" -Force"
+    powershell.exe -NoProfile -Command "Compress-Archive -LiteralPath \"$POWERSHELL_WORK_DIR\\$APP_NAME\" -DestinationPath \"$POWERSHELL_ZIP_PATH\" -Force"
   else
     echo "No zip tool found (zip, ditto, or powershell Compress-Archive required)." >&2
     exit 1

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -377,6 +377,14 @@ fn release_packager_uses_contract_nightly_asset_name_without_build_number() {
         RELEASE_ZIP_SCRIPT.contains(r#"printf "%s  %s\n" "$SHA" "$ZIP_NAME""#),
         "checksums-entry.txt must list the exact zip filename selected by the packager"
     );
+    assert!(
+        RELEASE_ZIP_SCRIPT.contains("Compress-Archive -LiteralPath"),
+        "PowerShell zip fallback must archive the app root directory as a literal path"
+    );
+    assert!(
+        !RELEASE_ZIP_SCRIPT.contains(r#"$POWERSHELL_WORK_DIR\\$APP_NAME\\*"#),
+        "PowerShell zip fallback must not flatten the archive root with a wildcard"
+    );
 }
 
 #[test]

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -310,6 +310,37 @@ fn build_release_artifact_helper_names_zip_and_checksum_entry() {
             .join("wavecrate-nightly-windows-x86_64.zip")
             .is_file()
     );
+    let zip_path = temp.path().join("wavecrate-nightly-windows-x86_64.zip");
+    let zip_file = fs::File::open(&zip_path).expect("open release zip");
+    let mut archive = zip::ZipArchive::new(zip_file).expect("read release zip");
+    let mut archive_names = Vec::new();
+    for index in 0..archive.len() {
+        archive_names.push(
+            archive
+                .by_index(index)
+                .expect("read release zip entry")
+                .name()
+                .to_owned(),
+        );
+    }
+    assert!(
+        archive_names
+            .iter()
+            .any(|name| name == "wavecrate/update-manifest.json"),
+        "release zip must keep update manifest under the wavecrate root: {archive_names:?}"
+    );
+    assert!(
+        archive_names
+            .iter()
+            .any(|name| name == "wavecrate/wavecrate.exe"),
+        "release zip must keep the executable under the wavecrate root: {archive_names:?}"
+    );
+    assert!(
+        !archive_names
+            .iter()
+            .any(|name| name == "update-manifest.json" || name == "wavecrate.exe"),
+        "release zip must not flatten archive entries at the root: {archive_names:?}"
+    );
     assert!(
         temp.path()
             .join("checksums-entry-windows-x86_64.txt")


### PR DESCRIPTION
## Scope
- Fix the Windows PowerShell fallback in `build_release_zip.sh` so it archives the `wavecrate` root directory instead of flattening its contents.
- Add a release contract guard that forbids the old wildcard `Compress-Archive` path.
- Extend the release helper test to inspect the generated Windows nightly zip layout and require `wavecrate/update-manifest.json` plus `wavecrate/wavecrate.exe`.

## Definition of Done
- Windows nightly release archives preserve the expected `wavecrate/` root directory.
- The published-release verifier no longer rejects Windows nightly zips as flattened when the PowerShell fallback is used.
- Tests guard both the script contract and generated archive layout.

## Validation Commands
- `bash -n scripts/internal/release/build_release_zip.sh`
- `cargo test --test release_contract release_packager_uses_contract_nightly_asset_name_without_build_number`
- `cargo test --test release_workflow_helpers build_release_artifact_helper_names_zip_and_checksum_entry`
- `cargo test --test release_contract`
- `cargo test --test release_workflow_helpers`
- `git diff --check`

## Known Limitations
- The actual PowerShell fallback path was not executed locally on macOS; the PR adds a static contract check for that command and a local generated-zip layout check for the shared helper output.

User review is required before merge unless the user has already signed off.
