### PR TITLE
Handle normalized release zip manifest paths

### DIFF
--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -673,12 +673,16 @@ def validate_zip_manifest(
     errors: list[str] = []
     try:
         with zipfile.ZipFile(zip_path) as archive:
-            archive_files = normalized_archive_files(archive)
+            archive_entries = normalized_archive_entries(archive)
+            archive_files = sorted(archive_entries)
             manifest_names = [name for name in archive_files if name.endswith("update-manifest.json")]
             if len(manifest_names) != 1:
                 return [f"{zip_asset.name} must contain exactly one update-manifest.json"]
+            manifest_archive_names = archive_entries[manifest_names[0]]
+            if len(manifest_archive_names) != 1:
+                return [f"{zip_asset.name} must contain exactly one update-manifest.json"]
             errors.extend(validate_archive_layout(zip_asset, archive_layout, archive_files, manifest_names[0]))
-            manifest = json.loads(archive.read(manifest_names[0]).decode("utf-8"))
+            manifest = json.loads(archive.read(manifest_archive_names[0]).decode("utf-8"))
     except zipfile.BadZipFile:
         return [f"{zip_asset.name} is not a valid zip file"]
     except (json.JSONDecodeError, UnicodeDecodeError) as error:
@@ -708,14 +712,14 @@ def validate_zip_manifest(
     return errors
 
 
-def normalized_archive_files(archive: zipfile.ZipFile) -> list[str]:
-    files: list[str] = []
+def normalized_archive_entries(archive: zipfile.ZipFile) -> dict[str, list[str]]:
+    entries: dict[str, list[str]] = {}
     for name in archive.namelist():
         normalized = normalize_archive_relative_path(name)
-        if not normalized or name.endswith("/"):
+        if not normalized or normalized.endswith("/"):
             continue
-        files.append(normalized)
-    return sorted(set(files))
+        entries.setdefault(normalized, []).append(name)
+    return entries
 
 
 def validate_archive_layout(

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -563,6 +563,29 @@ fn published_release_verifier_accepts_portalsurfer_catalog_fixture() {
 }
 
 #[test]
+fn published_release_verifier_accepts_windows_backslash_archive_entries() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) = write_published_release_fixture_with_zip_mutation(
+        &temp,
+        &key,
+        None,
+        Some(PublishedZipMutation::WindowsBackslashes),
+    );
+
+    let mut command =
+        published_release_verifier_command(&release_json, &asset_dir, expected_pubkey.trim());
+    run_success(&mut command);
+}
+
+#[test]
 fn published_release_verifier_rejects_manifest_mismatches() {
     let temp = tempfile::tempdir().expect("create published release fixture");
     let key = temp.path().join("ed25519.pem");
@@ -896,6 +919,7 @@ fn write_published_release_fixture(
 enum PublishedZipMutation {
     FlattenWindows,
     MissingWindowsExecutable,
+    WindowsBackslashes,
 }
 
 fn write_published_release_fixture_with_zip_mutation(
@@ -1066,6 +1090,8 @@ fn write_release_zip(
     for file_name in payload_files {
         let archive_path = if mutation == Some(PublishedZipMutation::FlattenWindows) {
             file_name.to_string()
+        } else if mutation == Some(PublishedZipMutation::WindowsBackslashes) {
+            format!("wavecrate\\{file_name}")
         } else {
             format!("wavecrate/{file_name}")
         };
@@ -1095,6 +1121,9 @@ fn release_zip_payload(
         }
         ("windows", Some(PublishedZipMutation::MissingWindowsExecutable)) => {
             ("wavecrate/update-manifest.json", vec![])
+        }
+        ("windows", Some(PublishedZipMutation::WindowsBackslashes)) => {
+            ("wavecrate\\update-manifest.json", vec!["wavecrate.exe"])
         }
         ("windows", _) => ("wavecrate/update-manifest.json", vec!["wavecrate.exe"]),
         ("macos", _) => (


### PR DESCRIPTION
## Scope
- Fix `verify_published_release.py` so archive layout validation uses normalized ZIP paths while manifest reads use the original ZIP member name.
- Preserve the rooted archive contract for `wavecrate/update-manifest.json` and platform executables.
- Add a regression fixture for Windows-style backslash ZIP entries so the verifier does not crash with `KeyError` after path normalization.

## Definition of Done
- Published release verification no longer crashes when a Windows-created ZIP stores rooted entries with backslash separators.
- The verifier still rejects flattened archives and missing platform executables.
- Regression coverage exercises the exact normalized-path/raw-ZIP-entry mismatch.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- Direct Python fixture with `wavecrate\\update-manifest.json` ZIP entry: passed
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers published_release_verifier_accepts_windows_backslash_archive_entries`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_contract`
- `git diff --check`

## Known Limitations
- The first local Cargo attempts stalled in the `wavecrate` library compile with default incremental settings; rerunning with one build job and incremental disabled completed and all targeted release tests passed.

User review is required before merge unless the user has already signed off.
