### PR TITLE
Ignore release zip directory entries in verifier

### DIFF
--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -716,7 +716,7 @@ def normalized_archive_entries(archive: zipfile.ZipFile) -> dict[str, list[str]]
     entries: dict[str, list[str]] = {}
     for name in archive.namelist():
         normalized = normalize_archive_relative_path(name)
-        if not normalized or normalized.endswith("/"):
+        if not normalized or name.endswith("/"):
             continue
         entries.setdefault(normalized, []).append(name)
     return entries

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -586,6 +586,29 @@ fn published_release_verifier_accepts_windows_backslash_archive_entries() {
 }
 
 #[test]
+fn published_release_verifier_ignores_macos_directory_entries() {
+    let temp = tempfile::tempdir().expect("create published release fixture");
+    let key = temp.path().join("ed25519.pem");
+    if !generate_ed25519_key(&key) {
+        eprintln!(
+            "local openssl does not support Ed25519 key generation; skipping verifier roundtrip"
+        );
+        return;
+    }
+    let expected_pubkey = expected_public_key(&key, &temp);
+    let (release_json, asset_dir) = write_published_release_fixture_with_zip_mutation(
+        &temp,
+        &key,
+        None,
+        Some(PublishedZipMutation::MacosDirectoryEntries),
+    );
+
+    let mut command =
+        published_release_verifier_command(&release_json, &asset_dir, expected_pubkey.trim());
+    run_success(&mut command);
+}
+
+#[test]
 fn published_release_verifier_rejects_manifest_mismatches() {
     let temp = tempfile::tempdir().expect("create published release fixture");
     let key = temp.path().join("ed25519.pem");
@@ -918,6 +941,7 @@ fn write_published_release_fixture(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PublishedZipMutation {
     FlattenWindows,
+    MacosDirectoryEntries,
     MissingWindowsExecutable,
     WindowsBackslashes,
 }
@@ -956,10 +980,11 @@ fn write_published_release_fixture_with_zip_mutation(
     let mut checksum_lines = Vec::new();
     let mut files = Vec::new();
     for (zip_name, target, platform, arch) in zip_assets {
-        let mutation = if platform == "windows" {
-            zip_mutation
-        } else {
-            None
+        let mutation = match (platform, zip_mutation) {
+            ("windows", Some(PublishedZipMutation::MacosDirectoryEntries)) => None,
+            ("macos", Some(PublishedZipMutation::MacosDirectoryEntries)) => zip_mutation,
+            ("windows", _) => zip_mutation,
+            _ => None,
         };
         write_release_zip(
             &asset_dir.join(zip_name),
@@ -1086,6 +1111,18 @@ fn write_release_zip(
     });
     if let Some((key, value)) = manifest_override {
         manifest[key] = json!(value);
+    }
+    if mutation == Some(PublishedZipMutation::MacosDirectoryEntries) {
+        for directory in [
+            "wavecrate/Wavecrate.app/",
+            "wavecrate/Wavecrate.app/Contents/",
+            "wavecrate/Wavecrate.app/Contents/MacOS/",
+            "wavecrate/Wavecrate.app/Contents/Resources/",
+            "wavecrate/Wavecrate.app/Contents/_CodeSignature/",
+        ] {
+            zip.add_directory(directory, SimpleFileOptions::default())
+                .expect("add app bundle directory");
+        }
     }
     for file_name in payload_files {
         let archive_path = if mutation == Some(PublishedZipMutation::FlattenWindows) {


### PR DESCRIPTION
## Scope
- Fix `verify_published_release.py` so raw ZIP directory members are ignored before normalized archive-file comparison.
- Add a regression fixture for macOS `.app` bundle directory entries such as `Wavecrate.app/Contents/` and `_CodeSignature/`.
- Preserve the existing archive-root, executable, checksum, signature, and manifest metadata validation.

## Definition of Done
- Nightly macOS zips with app-bundle directory entries do not fail manifest file-list comparison.
- Directory entries are not treated as required manifest file entries after path normalization.
- Existing flattened archive, missing executable, and Windows backslash-entry checks still pass.

## Validation Commands
- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers published_release_verifier_ignores_macos_directory_entries`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_contract`
- `git diff --check`

## Known Limitations
- None.

User review is required before merge unless the user has already signed off.
