### PR TITLE
Bound RC and stable GitHub release bodies

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -244,6 +244,9 @@ jobs:
             --rc-number "$RC_NUMBER" \
             --release-tag "$RELEASE_TAG" \
             --out dist/release/release-log.md
+          scripts/internal/release/prepare_github_release_body.py \
+            --input dist/release/release-log.md \
+            --output dist/release/github-release-body.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
@@ -259,7 +262,7 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.release_tag }}
           name: Wavecrate ${{ needs.resolve.outputs.release_version }}
           target_commitish: ${{ needs.resolve.outputs.target_sha }}
-          body_path: dist/release/release-log.md
+          body_path: dist/release/github-release-body.md
           prerelease: true
           make_latest: false
           files: dist/release/*

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -255,6 +255,9 @@ jobs:
             --promoted-rc-tag "$RC_TAG" \
             --release-tag "$RELEASE_TAG" \
             --out dist/release/release-log.md
+          scripts/internal/release/prepare_github_release_body.py \
+            --input dist/release/release-log.md \
+            --output dist/release/github-release-body.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
@@ -270,7 +273,7 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.release_tag }}
           name: Wavecrate ${{ needs.resolve.outputs.target_version }}
           target_commitish: ${{ needs.resolve.outputs.target_sha }}
-          body_path: dist/release/release-log.md
+          body_path: dist/release/github-release-body.md
           prerelease: false
           make_latest: true
           files: dist/release/*

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -102,6 +102,9 @@ under `scripts/internal/release/`:
   entry naming.
 - `assemble_release_files.sh` copies built zips and assembles the channel
   checksum file.
+- `prepare_github_release_body.py` writes the bounded body used for RC/stable
+  GitHub releases. The canonical `release-log.md` remains attached to the
+  release and is still used for the PortalSurfer per-release and full changelog.
 - `sign_release_checksums.sh` signs and optionally verifies checksum files.
 - `validate_promoted_rc_release.py` verifies that stable promotion is backed by
   a complete RC GitHub prerelease before stable builds start.

--- a/scripts/internal/release/prepare_github_release_body.py
+++ b/scripts/internal/release/prepare_github_release_body.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Prepare a GitHub release body within GitHub's release body limit."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_MAX_CHARS = 120_000
+NOTICE_TEMPLATE = """
+
+## Full Release Log
+
+This generated release log exceeded GitHub's release-body limit and was
+shortened for the GitHub release page. The complete log is attached as
+`release-log.md` and is published in the PortalSurfer release changelog.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write a GitHub-safe release body from a canonical release log."
+    )
+    parser.add_argument("--input", required=True, help="Canonical release-log.md path.")
+    parser.add_argument("--output", required=True, help="GitHub body output path.")
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=DEFAULT_MAX_CHARS,
+        help=f"Maximum output characters. Defaults to {DEFAULT_MAX_CHARS}.",
+    )
+    return parser.parse_args()
+
+
+def shorten_release_log(body: str, max_chars: int) -> str:
+    if max_chars <= 0:
+        raise ValueError("--max-chars must be positive")
+    if len(body) <= max_chars:
+        return body
+
+    notice = NOTICE_TEMPLATE.strip("\n")
+    suffix = "\n\n" + notice + "\n"
+    if len(suffix) >= max_chars:
+        raise ValueError("--max-chars is too small for the truncation notice")
+
+    budget = max_chars - len(suffix)
+    prefix = body[:budget].rstrip()
+    return prefix + suffix
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    body = input_path.read_text(encoding="utf-8")
+    output = shorten_release_log(body, args.max_chars)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(output, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -579,8 +579,20 @@ fn rc_and_stable_workflows_use_structured_release_log_generator() {
             "{name} must invoke the shared structured release-log generator"
         );
         assert!(
-            workflow.contains("body_path: dist/release/release-log.md"),
-            "{name} must publish the generated release log as the GitHub release body"
+            workflow.contains("scripts/internal/release/prepare_github_release_body.py \\"),
+            "{name} must bound the GitHub release body before public publication"
+        );
+        assert!(
+            workflow.contains("--input dist/release/release-log.md"),
+            "{name} must prepare the GitHub body from the canonical release log"
+        );
+        assert!(
+            workflow.contains("--output dist/release/github-release-body.md"),
+            "{name} must write the bounded GitHub body beside the canonical log"
+        );
+        assert!(
+            workflow.contains("body_path: dist/release/github-release-body.md"),
+            "{name} must publish the bounded GitHub release body"
         );
     }
     assert!(

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -146,6 +146,65 @@ fn release_summary_helper_writes_public_metadata_without_secret_values() {
 }
 
 #[test]
+fn github_release_body_helper_leaves_short_logs_unchanged() {
+    let temp = tempfile::tempdir().expect("create GitHub body fixture");
+    let input = temp.path().join("release-log.md");
+    let output = temp.path().join("github-release-body.md");
+    let body = "# Wavecrate 19.1.0-rc.1\n\n- Short release log\n";
+    fs::write(&input, body).expect("write release log");
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/prepare_github_release_body.py",
+            ))
+            .arg("--input")
+            .arg(&input)
+            .arg("--output")
+            .arg(&output)
+            .arg("--max-chars")
+            .arg("1000"),
+    );
+
+    assert_eq!(
+        fs::read_to_string(output).expect("read GitHub release body"),
+        body
+    );
+}
+
+#[test]
+fn github_release_body_helper_caps_oversized_logs_with_full_log_notice() {
+    let temp = tempfile::tempdir().expect("create GitHub body fixture");
+    let input = temp.path().join("release-log.md");
+    let output = temp.path().join("github-release-body.md");
+    let body = format!(
+        "# Wavecrate 19.1.0-rc.1\n\n## Generated Changes\n\n- {}\n",
+        "very long generated change ".repeat(200)
+    );
+    fs::write(&input, body).expect("write release log");
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/prepare_github_release_body.py",
+            ))
+            .arg("--input")
+            .arg(&input)
+            .arg("--output")
+            .arg(&output)
+            .arg("--max-chars")
+            .arg("1000"),
+    );
+
+    let github_body = fs::read_to_string(output).expect("read GitHub release body");
+    assert!(github_body.len() <= 1000);
+    assert!(github_body.starts_with("# Wavecrate 19.1.0-rc.1"));
+    assert!(github_body.contains("## Full Release Log"));
+    assert!(github_body.contains("`release-log.md`"));
+    assert!(github_body.contains("PortalSurfer release changelog"));
+}
+
+#[test]
 fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog() {
     let temp = tempfile::tempdir().expect("create changelog fixture");
     let catalog = temp.path().join("catalog.json");


### PR DESCRIPTION
Scope
- Add a release helper that prepares a GitHub-safe release body from the canonical release log.
- Use the bounded GitHub body for RC/stable GitHub releases while keeping release-log.md as the attached canonical log and PortalSurfer changelog source.
- Guard the workflow contract and helper behavior with tests.
- Document the GitHub-body cap behavior for release operators.

Definition of Done
- RC/stable GitHub release publication cannot fail solely because the generated canonical release log exceeds GitHub body limits.
- Full release logs remain preserved as artifacts and PortalSurfer changelog input.
- Release contract tests require the bounded body path.

Validation commands
- python3 -m py_compile scripts/internal/release/prepare_github_release_body.py
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_contract
- git diff --check

Known limitations
- GitHub release pages may show a shortened generated changes section for very large release ranges; the complete log remains attached as release-log.md and published through PortalSurfer.

User review
- User already approved continuing and merging release-pipeline fixes for this goal.