### PR TITLE
Keep GitHub release body out of release assets

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -246,7 +246,7 @@ jobs:
             --out dist/release/release-log.md
           scripts/internal/release/prepare_github_release_body.py \
             --input dist/release/release-log.md \
-            --output dist/release/github-release-body.md
+            --output dist/github-release-body.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
@@ -262,7 +262,7 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.release_tag }}
           name: Wavecrate ${{ needs.resolve.outputs.release_version }}
           target_commitish: ${{ needs.resolve.outputs.target_sha }}
-          body_path: dist/release/github-release-body.md
+          body_path: dist/github-release-body.md
           prerelease: true
           make_latest: false
           files: dist/release/*

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -257,7 +257,7 @@ jobs:
             --out dist/release/release-log.md
           scripts/internal/release/prepare_github_release_body.py \
             --input dist/release/release-log.md \
-            --output dist/release/github-release-body.md
+            --output dist/github-release-body.md
       - name: Sign release checksums
         env:
           CHECKSUMS_SIGNING_KEY: ${{ secrets.WAVECRATE_CHECKSUMS_ED25519_KEY || secrets.SEMPAL_CHECKSUMS_ED25519_KEY }}
@@ -273,7 +273,7 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.release_tag }}
           name: Wavecrate ${{ needs.resolve.outputs.target_version }}
           target_commitish: ${{ needs.resolve.outputs.target_sha }}
-          body_path: dist/release/github-release-body.md
+          body_path: dist/github-release-body.md
           prerelease: false
           make_latest: true
           files: dist/release/*

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -587,11 +587,11 @@ fn rc_and_stable_workflows_use_structured_release_log_generator() {
             "{name} must prepare the GitHub body from the canonical release log"
         );
         assert!(
-            workflow.contains("--output dist/release/github-release-body.md"),
-            "{name} must write the bounded GitHub body beside the canonical log"
+            workflow.contains("--output dist/github-release-body.md"),
+            "{name} must keep the bounded GitHub body outside the release asset directory"
         );
         assert!(
-            workflow.contains("body_path: dist/release/github-release-body.md"),
+            workflow.contains("body_path: dist/github-release-body.md"),
             "{name} must publish the bounded GitHub release body"
         );
     }


### PR DESCRIPTION
Scope
- Write the bounded RC/stable GitHub release body outside dist/release.
- Keep public release assets limited to zips, checksums, signatures, and canonical release-log.md.
- Guard the workflow path with the release contract test.

Definition of Done
- RC/stable GitHub release body remains bounded without uploading github-release-body.md as an asset.
- Canonical release-log.md remains available as an attached asset and PortalSurfer changelog input.

Validation commands
- git diff --check
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_contract rc_and_stable_workflows_use_structured_release_log_generator -- --nocapture
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_contract

Known limitations
- Existing RC 2 already includes github-release-body.md as an extra asset; future RC/stable runs will not.

User review
- User already approved continuing and merging release-pipeline fixes for this goal.