### PR TITLE
Preserve legacy nightly changelog sections

### DIFF
--- a/scripts/internal/release/assemble_portal_changelog.py
+++ b/scripts/internal/release/assemble_portal_changelog.py
@@ -221,6 +221,10 @@ def remove_release_sections(body: str, versions: list[str]) -> str:
     return "\n\n".join(kept).strip()
 
 
+def starts_with_release_bound_section(body: str) -> bool:
+    return body.startswith("# Wavecrate ") or body.startswith("## [nightly-")
+
+
 def main() -> int:
     args = parse_args()
     catalog_url = args.catalog_url
@@ -281,7 +285,7 @@ def main() -> int:
             request_delay_seconds=args.request_delay_seconds,
         )
         previous_body = remove_release_sections(existing_body, current_versions)
-        if previous_body and not previous_body.startswith("# Wavecrate "):
+        if previous_body and not starts_with_release_bound_section(previous_body):
             raise SystemExit(
                 "Existing full changelog is not release-bound. Repair it so "
                 "each historical log starts with '# Wavecrate ...' "

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -267,6 +267,79 @@ fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog(
 }
 
 #[test]
+fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_stable() {
+    let temp = tempfile::tempdir().expect("create changelog fixture");
+    let catalog = temp.path().join("catalog.json");
+    let existing_changelog = temp.path().join("existing-changelog.json");
+    let release_log = temp.path().join("release-log.md");
+    let output = temp.path().join("changelog.md");
+    fs::write(
+        &catalog,
+        serde_json::to_string_pretty(&json!({
+            "releases": [
+                {
+                    "build_id": "wavecrate-19.1.0",
+                    "build_number": 6315,
+                    "version": "19.1.0",
+                    "released_at": "2026-07-04T10:00:00Z",
+                    "changelog": {
+                        "title": "Wavecrate 19.1.0",
+                        "format": "markdown",
+                        "body": "# Wavecrate 19.1.0\n\n- Current stable\n"
+                    }
+                }
+            ]
+        }))
+        .expect("serialize catalog"),
+    )
+    .expect("write catalog");
+    fs::write(
+        &existing_changelog,
+        serde_json::to_string_pretty(&json!({
+            "changelog": {
+                "title": "Wavecrate changelog",
+                "format": "markdown",
+                "body": "# Wavecrate Changelog\n\n- Latest release: wavecrate-19.1.0\n\n# Wavecrate 19.1.0\n\n- Old stable body\n\n## [nightly-b6307-8f1a7aa2]\n\n- Legacy nightly\n"
+            }
+        }))
+        .expect("serialize existing changelog"),
+    )
+    .expect("write existing changelog");
+    fs::write(&release_log, "# Wavecrate 19.1.0\n\n- Repaired stable body\n")
+        .expect("write current log");
+
+    run_success(
+        Command::new("python3")
+            .arg(repo_path(
+                "scripts/internal/release/assemble_portal_changelog.py",
+            ))
+            .arg("--catalog-file")
+            .arg(&catalog)
+            .arg("--current-build-id")
+            .arg("wavecrate-19.1.0")
+            .arg("--current-build-number")
+            .arg("6315")
+            .arg("--current-version")
+            .arg("19.1.0")
+            .arg("--current-released-at")
+            .arg("2026-07-04T10:00:00Z")
+            .arg("--current-log")
+            .arg(&release_log)
+            .arg("--existing-changelog-url")
+            .arg(&existing_changelog)
+            .arg("--generated-at")
+            .arg("2026-07-04T10:00:00Z")
+            .arg("--output")
+            .arg(&output),
+    );
+
+    let changelog = fs::read_to_string(output).expect("read generated changelog");
+    assert!(changelog.contains("Repaired stable body"));
+    assert!(changelog.contains("Legacy nightly"));
+    assert!(!changelog.contains("Old stable body"));
+}
+
+#[test]
 fn checksum_signing_helper_writes_signature_and_verifies_expected_pubkey() {
     let temp = tempfile::tempdir().expect("create signing fixture");
     let key = temp.path().join("ed25519.pem");


### PR DESCRIPTION
Scope
- Allow the PortalSurfer changelog assembler to preserve legacy release-bound nightly sections starting with ## [nightly-...].
- Add regression coverage for repairing/recommitting a current stable section while preserving legacy nightly history.

Definition of Done
- Stable reruns can repair the current stable changelog without rejecting older legacy nightly sections in the full changelog.
- The assembler still rejects unbound historical content.

Validation commands
- python3 -m py_compile scripts/internal/release/assemble_portal_changelog.py
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers portal_changelog_assembler -- --nocapture
- CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo test --test release_workflow_helpers
- git diff --check

Known limitations
- release/19.1 must be fast-forwarded to this helper fix, then a new RC must be published before stable promotion can target the fixed commit.

User review
- User already approved continuing and merging release-pipeline fixes for this goal.