### PR TITLE
[codex] Keep source re-add preparation off UI thread

### DIFF
--- a/src/app/controller/jobs/dispatch/request_ids.rs
+++ b/src/app/controller/jobs/dispatch/request_ids.rs
@@ -12,6 +12,11 @@ impl ControllerJobs {
         next_request_id(&mut self.request_counters.next_source_hydration_request_id)
     }
 
+    /// Generate a request id for source add preparation jobs.
+    pub(in super::super::super) fn next_source_add_request_id(&mut self) -> u64 {
+        next_request_id(&mut self.request_counters.next_source_add_request_id)
+    }
+
     /// Generate a request id for pane-scoped folder projection jobs.
     pub(in super::super::super) fn next_folder_projection_request_id(&mut self) -> u64 {
         next_request_id(&mut self.request_counters.next_folder_projection_request_id)

--- a/src/app/controller/jobs/messages/mod.rs
+++ b/src/app/controller/jobs/messages/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use self::waveform_types::*;
 #[derive(Debug)]
 pub(crate) enum JobMessage {
     WavLoaded(WavLoadResult),
+    SourceAddPrepared(SourceAddPreparedResult),
     SourceHydrated(SourceHydrationResult),
     BrowserFeatureCacheRefreshed(BrowserFeatureCacheRefreshResult),
     FolderProjected(FolderProjectionResult),

--- a/src/app/controller/jobs/messages/source_lane_types.rs
+++ b/src/app/controller/jobs/messages/source_lane_types.rs
@@ -39,6 +39,28 @@ pub(crate) struct SourceHydrationJob {
     pub(crate) defer_startup_follow_up_work: bool,
 }
 
+/// Background source-add preparation request.
+#[derive(Debug)]
+pub(crate) struct SourceAddJob {
+    /// Monotonic request identifier used to discard stale or duplicate results.
+    pub(crate) request_id: u64,
+    /// Source that will be committed after DB validation succeeds.
+    pub(crate) source: crate::sample_sources::SampleSource,
+}
+
+/// Result of one background source-add preparation request.
+#[derive(Debug)]
+pub(crate) struct SourceAddPreparedResult {
+    /// Request identifier echoed from [`SourceAddJob::request_id`].
+    pub(crate) request_id: u64,
+    /// Source that was prepared.
+    pub(crate) source: crate::sample_sources::SampleSource,
+    /// Worker time spent opening or migrating source state.
+    pub(crate) elapsed: Duration,
+    /// Preparation outcome.
+    pub(crate) result: Result<(), String>,
+}
+
 /// Compact source snapshot prepared off the UI thread for later controller apply.
 #[derive(Debug)]
 pub(crate) struct SourceHydrationSnapshot {

--- a/src/app/controller/jobs/state.rs
+++ b/src/app/controller/jobs/state.rs
@@ -23,6 +23,7 @@ pub(crate) struct PendingSliceBatchExport {
 #[derive(Clone, Copy, Debug)]
 pub(super) struct JobRequestCounters {
     pub(crate) next_source_hydration_request_id: u64,
+    pub(crate) next_source_add_request_id: u64,
     pub(crate) next_feature_cache_request_id: u64,
     pub(crate) next_folder_projection_request_id: u64,
     pub(crate) next_metadata_request_id: u64,
@@ -41,6 +42,7 @@ impl Default for JobRequestCounters {
     fn default() -> Self {
         Self {
             next_source_hydration_request_id: 1,
+            next_source_add_request_id: 1,
             next_feature_cache_request_id: 1,
             next_folder_projection_request_id: 1,
             next_metadata_request_id: 1,

--- a/src/app/controller/library/background_jobs/polling/message_router.rs
+++ b/src/app/controller/library/background_jobs/polling/message_router.rs
@@ -7,6 +7,9 @@ impl AppController {
     pub(super) fn handle_background_job_message(&mut self, message: JobMessage) {
         match message {
             JobMessage::WavLoaded(message) => self.handle_wav_loaded_message(message),
+            JobMessage::SourceAddPrepared(message) => {
+                self.handle_source_add_prepared_message(message)
+            }
             JobMessage::SourceHydrated(message) => self.handle_source_hydrated_message(message),
             JobMessage::BrowserFeatureCacheRefreshed(message) => {
                 self.handle_feature_cache_refreshed_message(message)

--- a/src/app/controller/library/sources.rs
+++ b/src/app/controller/library/sources.rs
@@ -3,3 +3,6 @@ mod hydration_telemetry;
 mod lifecycle;
 mod selection;
 mod status;
+
+#[cfg(test)]
+pub(crate) use lifecycle::with_source_add_async_enabled_for_tests;

--- a/src/app/controller/library/sources/lifecycle.rs
+++ b/src/app/controller/library/sources/lifecycle.rs
@@ -12,6 +12,9 @@ mod remove;
 mod telemetry;
 mod validation;
 
+#[cfg(test)]
+pub(crate) use add::with_source_add_async_enabled_for_tests;
+
 impl AppController {
     pub(crate) fn database_for(
         &mut self,

--- a/src/app/controller/library/sources/lifecycle/add.rs
+++ b/src/app/controller/library/sources/lifecycle/add.rs
@@ -1,6 +1,14 @@
 use super::telemetry::record_source_lifecycle_event;
 use super::validation::{nested_source_conflict_error, source_roots_match};
 use super::*;
+#[cfg(not(test))]
+use crate::app::controller::jobs::JobMessage;
+use crate::app::controller::jobs::{SourceAddJob, SourceAddPreparedResult};
+use crate::app::controller::state::runtime::PendingSourceAdd;
+use crate::app::state::ProgressTaskKind;
+
+#[cfg(test)]
+use std::{cell::Cell, thread_local};
 
 enum AddSourceRoot {
     New(PathBuf),
@@ -46,8 +54,22 @@ impl AppController {
             }
         };
         let source = self.source_for_add_root(&normalized);
-        prepare_database_for_add(&source, &normalized, started_at)?;
-        self.commit_added_source(source, started_at)
+        if let Some(message) = self.pending_source_add_conflict(&normalized) {
+            self.set_status(message, StatusTone::Info);
+            return Ok(());
+        }
+        if source_add_async_enabled() {
+            self.queue_source_add_prepare(source, started_at);
+            return Ok(());
+        }
+        let result = run_source_add_prepare(SourceAddJob {
+            request_id: self.runtime.jobs.next_source_add_request_id(),
+            source,
+        });
+        match result.result {
+            Ok(()) => self.commit_added_source(result.source, started_at),
+            Err(err) => Err(err),
+        }
     }
 
     fn source_for_add_root(&mut self, normalized: &Path) -> SampleSource {
@@ -93,6 +115,116 @@ impl AppController {
         );
         Ok(())
     }
+
+    fn queue_source_add_prepare(&mut self, source: SampleSource, started_at: Instant) {
+        let request_id = self.runtime.jobs.next_source_add_request_id();
+        self.runtime.source_lane.pending_adds.insert(
+            source.root.clone(),
+            PendingSourceAdd {
+                request_id,
+                source: source.clone(),
+                queued_at: started_at,
+            },
+        );
+        self.show_status_progress(ProgressTaskKind::SourceAdd, "Adding source", 1, false);
+        self.update_progress_detail_for_task(
+            ProgressTaskKind::SourceAdd,
+            source.root.display().to_string(),
+        );
+        self.set_status(
+            format!("Adding source {}", source.root.display()),
+            StatusTone::Info,
+        );
+        record_source_lifecycle_event(
+            "sources.add",
+            Some(source.id.as_str()),
+            "prepare_queued",
+            started_at,
+            None,
+        );
+
+        let job = SourceAddJob { request_id, source };
+        #[cfg(not(test))]
+        self.runtime.jobs.spawn_one_shot_job(
+            true,
+            move || run_source_add_prepare(job),
+            JobMessage::SourceAddPrepared,
+        );
+        #[cfg(test)]
+        {
+            let _ = job;
+        }
+    }
+
+    pub(crate) fn handle_source_add_prepared_message(&mut self, message: SourceAddPreparedResult) {
+        let is_current = self
+            .runtime
+            .source_lane
+            .pending_adds
+            .get(&message.source.root)
+            .is_some_and(|pending| {
+                pending.request_id == message.request_id && pending.source.id == message.source.id
+            });
+        if !is_current {
+            return;
+        };
+        let pending = self
+            .runtime
+            .source_lane
+            .pending_adds
+            .remove(&message.source.root)
+            .expect("current source add pending entry");
+        self.clear_progress_task(ProgressTaskKind::SourceAdd);
+        let started_at = pending.queued_at;
+        match message.result {
+            Ok(()) => {
+                if self
+                    .library
+                    .sources
+                    .iter()
+                    .any(|source| source_roots_match(&source.root, &message.source.root))
+                {
+                    record_source_lifecycle_event(
+                        "sources.add",
+                        Some(message.source.id.as_str()),
+                        "short_circuit",
+                        started_at,
+                        Some("already_added_after_prepare"),
+                    );
+                    self.set_status("Source already added", StatusTone::Info);
+                    return;
+                }
+                if let Err(err) = self.commit_added_source(message.source, started_at) {
+                    self.set_status(err, StatusTone::Error);
+                }
+            }
+            Err(err) => {
+                record_source_lifecycle_event(
+                    "sources.add",
+                    Some(message.source.id.as_str()),
+                    "error",
+                    started_at,
+                    Some(err.as_str()),
+                );
+                self.set_status(err, StatusTone::Error);
+            }
+        }
+    }
+
+    fn pending_source_add_conflict(&self, normalized: &PathBuf) -> Option<String> {
+        for pending in self.runtime.source_lane.pending_adds.values() {
+            if source_roots_match(&pending.source.root, normalized) {
+                return Some(String::from("Source add already in progress"));
+            }
+            if let Some(message) = nested_source_conflict_error(&pending.source.root, normalized) {
+                return Some(message);
+            }
+            if let Some(message) = nested_source_conflict_error(normalized, &pending.source.root) {
+                return Some(message);
+            }
+        }
+        None
+    }
 }
 
 struct AddSourceRootError {
@@ -127,21 +259,72 @@ fn validate_add_source_root(
     Ok(AddSourceRoot::New(normalized))
 }
 
-fn prepare_database_for_add(
-    source: &SampleSource,
-    normalized: &PathBuf,
-    started_at: Instant,
-) -> Result<(), String> {
-    if let Err(err) = SourceDatabase::open(normalized) {
-        let error = format!("Failed to create database: {err}");
-        record_source_lifecycle_event(
-            "sources.add",
-            Some(source.id.as_str()),
-            "error",
-            started_at,
-            Some(&error),
-        );
-        return Err(error);
+fn run_source_add_prepare(job: SourceAddJob) -> SourceAddPreparedResult {
+    let started_at = Instant::now();
+    let result = SourceDatabase::open(&job.source.root)
+        .map(|_| ())
+        .map_err(|err| {
+            let error = format!("Failed to create database: {err}");
+            record_source_lifecycle_event(
+                "sources.add",
+                Some(job.source.id.as_str()),
+                "error",
+                started_at,
+                Some(&error),
+            );
+            error
+        });
+    SourceAddPreparedResult {
+        request_id: job.request_id,
+        source: job.source,
+        elapsed: started_at.elapsed(),
+        result,
     }
-    Ok(())
+}
+
+fn source_add_async_enabled() -> bool {
+    #[cfg(test)]
+    {
+        source_add_async_override_for_tests().unwrap_or(false)
+    }
+    #[cfg(not(test))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static SOURCE_ADD_ASYNC_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn source_add_async_override_for_tests() -> Option<bool> {
+    SOURCE_ADD_ASYNC_OVERRIDE.with(|value| value.get())
+}
+
+#[cfg(test)]
+pub(crate) fn with_source_add_async_enabled_for_tests<T>(
+    enabled: bool,
+    run: impl FnOnce() -> T,
+) -> T {
+    struct Reset<'a> {
+        cell: &'a Cell<Option<bool>>,
+        previous: Option<bool>,
+    }
+
+    impl Drop for Reset<'_> {
+        fn drop(&mut self) {
+            self.cell.set(self.previous);
+        }
+    }
+
+    SOURCE_ADD_ASYNC_OVERRIDE.with(|value| {
+        let previous = value.replace(Some(enabled));
+        let _reset = Reset {
+            cell: value,
+            previous,
+        };
+        run()
+    })
 }

--- a/src/app/controller/state/runtime/mod.rs
+++ b/src/app/controller/state/runtime/mod.rs
@@ -54,8 +54,8 @@ pub(crate) use source_lane::ActiveAutoRenameBatchSnapshot;
 pub(crate) use source_lane::{AutoRenameBatchRowSnapshot, AutoRenameBatchRowState};
 pub(crate) use source_lane::{
     BrowserRenameBusyDecision, BrowserRenameIntentKey, MetadataRollback,
-    PendingBrowserAutoRenameIntent, PendingMetadataMutation, PendingSourceHydration,
-    SourceLaneRuntimeState,
+    PendingBrowserAutoRenameIntent, PendingMetadataMutation, PendingSourceAdd,
+    PendingSourceHydration, SourceLaneRuntimeState,
 };
 pub(crate) use source_sync_runtime::SourceSyncRuntimeState;
 pub(crate) use startup_runtime::StartupRuntimeState;

--- a/src/app/controller/state/runtime/source_lane.rs
+++ b/src/app/controller/state/runtime/source_lane.rs
@@ -15,12 +15,25 @@ mod mutations;
 /// Source-lane runtime state grouped by hydration, folder projection, and mutations.
 #[derive(Debug, Default)]
 pub(crate) struct SourceLaneRuntimeState {
+    /// Source roots currently being prepared before they are committed to the library.
+    pub(crate) pending_adds: HashMap<PathBuf, PendingSourceAdd>,
     /// In-flight source hydration requests keyed by selection lane.
     pub(crate) hydration: SourceHydrationRuntime,
     /// Pending pane-scoped folder projection work.
     pub(crate) folder_projection: FolderProjectionRuntime,
     /// Background metadata/file mutation tracking used by optimistic UI state.
     pub(crate) mutations: SourceMutationRuntime,
+}
+
+/// Active controller-side tracking for one source-add preparation request.
+#[derive(Clone, Debug)]
+pub(crate) struct PendingSourceAdd {
+    /// Monotonic request identifier used to discard stale results.
+    pub(crate) request_id: u64,
+    /// Source that should be committed when preparation succeeds.
+    pub(crate) source: crate::sample_sources::SampleSource,
+    /// Time when the preparation request was queued on the controller thread.
+    pub(crate) queued_at: Instant,
 }
 
 /// Runtime tracking for active and inactive source hydration requests.

--- a/src/app/controller/tests/source_async/mod.rs
+++ b/src/app/controller/tests/source_async/mod.rs
@@ -1,9 +1,13 @@
 use super::super::jobs::{
-    JobMessage, MetadataMutationResult, SourceDbMaintenanceOutcome, SourceDbMaintenanceRefresh,
-    SourceDbMaintenanceResult, SourceHydrationKind, SourceHydrationResult, SourceHydrationSnapshot,
+    JobMessage, MetadataMutationResult, SourceAddPreparedResult, SourceDbMaintenanceOutcome,
+    SourceDbMaintenanceRefresh, SourceDbMaintenanceResult, SourceHydrationKind,
+    SourceHydrationResult, SourceHydrationSnapshot,
 };
 use super::super::library::source_folders::with_folder_projection_async_enabled_for_tests;
-use super::super::library::sources::hydration::with_source_hydration_async_enabled_for_tests;
+use super::super::library::sources::{
+    hydration::with_source_hydration_async_enabled_for_tests,
+    with_source_add_async_enabled_for_tests,
+};
 use super::super::library::wavs::with_browser_async_pipeline_enabled_for_tests;
 use super::super::test_support::sample_entry;
 use super::super::*;
@@ -155,4 +159,5 @@ mod file_op_gating;
 mod inactive_projection;
 mod maintenance_reconcile;
 mod passive_status;
+mod source_add;
 mod startup_deferral;

--- a/src/app/controller/tests/source_async/source_add.rs
+++ b/src/app/controller/tests/source_async/source_add.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+#[test]
+fn readding_known_source_prepares_database_off_controller_thread() {
+    let config_root = tempdir().expect("config root");
+    let _guard = crate::app_dirs::ConfigBaseGuard::set(config_root.path().to_path_buf());
+    let source_root = tempdir().expect("source root");
+    let source_path = source_root.path().to_path_buf();
+    let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
+
+    controller
+        .add_source_from_path(source_path.clone())
+        .expect("initial source add");
+    let original_source = controller.library.sources[0].clone();
+    controller.remove_source(0);
+    assert!(controller.library.sources.is_empty());
+
+    crate::sample_sources::db::test_reset_source_db_open_total_count(&source_path);
+    with_source_add_async_enabled_for_tests(true, || {
+        controller
+            .add_source_from_path(source_path.clone())
+            .expect("queue source re-add");
+    });
+
+    assert!(controller.library.sources.is_empty());
+    assert_eq!(
+        crate::sample_sources::db::test_source_db_open_total_count(&source_path),
+        0,
+        "source re-add must not open the source DB on the controller thread"
+    );
+    assert!(
+        controller
+            .ui
+            .progress
+            .has_task(crate::app::state::ProgressTaskKind::SourceAdd)
+    );
+    let pending = controller
+        .runtime
+        .source_lane
+        .pending_adds
+        .get(&source_path)
+        .expect("pending source add");
+    assert_eq!(pending.source.id, original_source.id);
+
+    controller.apply_background_job_message_for_tests(JobMessage::SourceAddPrepared(
+        SourceAddPreparedResult {
+            request_id: pending.request_id,
+            source: pending.source.clone(),
+            elapsed: std::time::Duration::from_millis(3),
+            result: Ok(()),
+        },
+    ));
+
+    assert!(controller.runtime.source_lane.pending_adds.is_empty());
+    assert_eq!(controller.library.sources.len(), 1);
+    assert_eq!(controller.library.sources[0].id, original_source.id);
+    assert_eq!(controller.selected_source_id(), Some(original_source.id));
+    assert!(
+        !controller
+            .ui
+            .progress
+            .has_task(crate::app::state::ProgressTaskKind::SourceAdd)
+    );
+}

--- a/src/app/state/progress/task.rs
+++ b/src/app/state/progress/task.rs
@@ -11,6 +11,8 @@ pub enum ProgressTaskKind {
     WavLoad,
     /// Scanning a sample source.
     Scan,
+    /// Preparing a newly added source.
+    SourceAdd,
     /// Running background analysis jobs.
     Analysis,
     /// Normalizing audio samples.
@@ -66,6 +68,7 @@ pub(super) fn task_priority(task: ProgressTaskKind) -> u8 {
     match task {
         ProgressTaskKind::TrashMove => 100,
         ProgressTaskKind::Scan => 90,
+        ProgressTaskKind::SourceAdd => 85,
         ProgressTaskKind::Analysis => 80,
         ProgressTaskKind::FileOps => 70,
         ProgressTaskKind::Normalization => 60,


### PR DESCRIPTION
## Scope

- Move source add/re-add database preparation out of the controller/UI path in production by queuing a background one-shot job.
- Track pending source-add requests with monotonic request IDs so stale preparation results are ignored.
- Keep user feedback visible with a dedicated source-add progress task/status while the background preparation runs.
- Commit the source, refresh watchers, persist config, and queue follow-up work only after source DB preparation succeeds.
- Add regression coverage for re-adding a previously known source without opening the source DB on the controller thread.

## Definition of Done

- Re-adding a previously indexed source no longer opens or migrates the source DB synchronously on the controller thread.
- The source is only added to the library after the background preparation step succeeds.
- Progress/status remains visible while source-add preparation is pending.
- Existing source async and source lifecycle tests remain green.

## Validation commands

- `cargo test -p wavecrate readding_known_source_prepares_database_off_controller_thread --lib`
- `cargo test -p wavecrate source_async --lib`
- `cargo test -p wavecrate source_lifecycle --lib`
- `git diff --check`

Additional preflight notes from this branch: `bash scripts/check.sh non-blocking-architecture` and `bash scripts/agent.sh request` reached the existing Radiant source-shape guardrail failures (`app_bridge_groups_lifecycle_hooks_and_runtime_flags`, `runtime_controller_context_and_scratch_modules_use_explicit_dependencies`, and `controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules`). The Wavecrate blocking-token/non-blocking portions passed before those baseline failures.

## Known limitations

- Manual desktop smoke with a real large source has not been run in this PR.
- Full architecture/preflight lanes remain blocked by the pre-existing Radiant guardrail failures listed above.
- Repository-wide `cargo fmt --check` was not used as a merge gate because it reports unrelated pre-existing formatting in `tests/release_workflow_helpers.rs`; touched Rust files were kept formatted and `git diff --check` passes.

User review is required before merge unless the user explicitly signs off.