### PR TITLE
[codex] Fix context folder creation tree update

### DIFF
--- a/src/native_app/sample_library/folder_browser/rename_tree.rs
+++ b/src/native_app/sample_library/folder_browser/rename_tree.rs
@@ -101,6 +101,17 @@ impl FolderBrowserState {
     }
 
     pub(super) fn upsert_child_folder(&mut self, parent_id: &str, folder: FolderEntry) -> bool {
+        if let Some(changed) =
+            self.tree.folders.first_mut().and_then(|root_folder| {
+                upsert_child_in_root(root_folder, parent_id, folder.clone())
+            })
+        {
+            if changed {
+                self.bump_file_content_revision();
+            }
+            return changed;
+        }
+
         let Some(source) = self
             .source
             .sources
@@ -122,4 +133,13 @@ impl FolderBrowserState {
         }
         changed
     }
+}
+
+fn upsert_child_in_root(
+    root_folder: &mut FolderEntry,
+    parent_id: &str,
+    folder: FolderEntry,
+) -> Option<bool> {
+    let parent = root_folder.find_mut(parent_id)?;
+    Some(upsert_folder(&mut parent.children, folder))
 }

--- a/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
+++ b/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
@@ -96,6 +96,63 @@ fn create_subfolder_starts_pending_rename_row_and_creates_on_submit() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn context_created_folder_updates_selected_tree_without_parked_source_cache() {
+    let root = temp_source_root("wavecrate-gui-context-folder-create-selected");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create nested folder");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.source.sources[0].root_folder = None;
+
+    let loops = drums.join("loops");
+    let input_id = browser
+        .apply_created_folder(path_id(&drums), loops.clone())
+        .expect("context-created folder should update active tree");
+
+    assert_ne!(input_id, 0);
+    assert_eq!(browser.selection.selected_folder, path_id(&loops));
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .any(|folder| folder.id == path_id(&loops)
+                && folder.name == "loops"
+                && folder.rename_draft.as_deref() == Some("loops")
+                && folder.rename_input_id == Some(input_id))
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn context_created_folder_updates_deferred_source_root_placeholder() {
+    let root = temp_source_root("wavecrate-gui-context-folder-create-deferred");
+    let sources = vec![wavecrate::sample_sources::SampleSource::new_with_id(
+        wavecrate::sample_sources::SourceId::from_string(root.to_string_lossy().to_string()),
+        root.clone(),
+    )];
+    let mut browser = FolderBrowserState::from_sample_sources_deferred(&sources);
+    let new_folder = root.join("incoming");
+
+    let input_id = browser
+        .apply_created_folder(path_id(&root), new_folder.clone())
+        .expect("context-created folder should update deferred source root");
+
+    assert_ne!(input_id, 0);
+    assert!(!browser.selected_source_loaded());
+    assert_eq!(browser.selection.selected_folder, path_id(&new_folder));
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .any(|folder| folder.id == path_id(&new_folder)
+                && folder.name == "incoming"
+                && folder.rename_draft.as_deref() == Some("incoming")
+                && folder.rename_input_id == Some(input_id))
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn create_subfolder_cancel_removes_pending_row_without_touching_disk() {
     let root = temp_source_root("wavecrate-gui-folder-create-cancel");


### PR DESCRIPTION
## Scope

- Fix context-menu folder creation so the newly created folder is inserted into the active selected folder tree before falling back to the parked source cache.
- Preserve deferred-source state when creating a folder from a source root whose scan tree has not fully hydrated yet.
- Add regressions for context-created folders on both an active selected tree without parked source cache and a deferred source-root placeholder.

## Definition of Done

- Creating a folder from a source/folder context menu no longer reports `New folder failed: parent folder is unavailable` when the parent exists in the active tree.
- Deferred source-root context creation updates the visible tree without falsely marking the whole source tree loaded.
- Existing inline new-folder and folder rename behavior remains covered.

## Validation commands

- `cargo test -p wavecrate --bin wavecrate context_created_folder_updates`
- `cargo test -p wavecrate --bin wavecrate create_subfolder`
- `cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::folder_editing`
- `git diff --check`

## Known limitations

None.

User review is required before merge unless the user explicitly signs off.