### PR TITLE
[codex] Fix folder rename active tree update

### DIFF
--- a/src/native_app/sample_library/folder_browser/rename_tree.rs
+++ b/src/native_app/sample_library/folder_browser/rename_tree.rs
@@ -10,17 +10,32 @@ impl FolderBrowserState {
     pub(super) fn rewrite_renamed_folder_paths(&mut self, old_path: &Path, new_path: &Path) {
         let old_id = path_id(old_path);
         let new_id = path_id(new_path);
-        let Some(source) = self
+
+        let active_tree_rewritten = if self
+            .tree
+            .folders
+            .iter()
+            .any(|root_folder| root_folder.find(&old_id).is_some())
+        {
+            for root_folder in &mut self.tree.folders {
+                root_folder.rewrite_path_prefix(old_path, new_path);
+            }
+            true
+        } else {
+            false
+        };
+
+        if let Some(root_folder) = self
             .source
             .sources
             .iter_mut()
             .find(|source| source.id == self.source.selected_source)
-        else {
-            return;
-        };
-        if let Some(root_folder) = &mut source.root_folder {
+            .and_then(|source| source.root_folder.as_mut())
+        {
             root_folder.rewrite_path_prefix(old_path, new_path);
-            self.tree.folders = vec![root_folder.clone()];
+            if !active_tree_rewritten {
+                self.tree.folders = vec![root_folder.clone()];
+            }
         }
         self.selection.rewrite_folder_prefix(old_path, new_path);
         self.rewrite_similarity_path_prefix(old_path, new_path);

--- a/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
+++ b/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
@@ -49,6 +49,45 @@ fn folder_rename_updates_filesystem_tree_and_selected_audio_files() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn folder_rename_updates_selected_tree_without_parked_source_cache() {
+    let root = temp_source_root("wavecrate-gui-folder-rename-selected-tree");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create nested folder");
+    fs::write(drums.join("kick.wav"), [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.source.sources[0].root_folder = None;
+
+    browser
+        .begin_rename_selected()
+        .expect("rename can start")
+        .expect("rename input id");
+    let status = submit_rename(&mut browser, "breaks").status;
+
+    let renamed = root.join("breaks");
+    assert_eq!(status, "Renamed folder to breaks");
+    assert!(!drums.exists());
+    assert!(renamed.join("kick.wav").is_file());
+    assert_eq!(browser.selection.selected_folder, path_id(&renamed));
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .any(|folder| folder.id == path_id(&renamed) && folder.name == "breaks")
+    );
+    assert_eq!(
+        browser
+            .selected_audio_files()
+            .iter()
+            .map(|file| file.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![path_id(&renamed.join("kick.wav"))]
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn create_subfolder_starts_pending_rename_row_and_creates_on_submit() {
     let root = temp_source_root("wavecrate-gui-folder-create");


### PR DESCRIPTION
## Scope

- Fix folder rename completion so it rewrites the active selected folder tree before falling back to the parked source cache.
- Keep any parked selected-source cache in sync when it exists.
- Add a regression for renaming a folder while the selected source tree is active and `SourceEntry::root_folder` is empty.

## Definition of Done

- Folder rename updates the visible tree, selected folder, and selected audio file paths after the filesystem rename succeeds.
- The selected-source active tree remains the source of truth when the parked source cache is empty.
- Existing folder create/rename tests remain green.

## Validation commands

- `cargo test -p wavecrate --bin wavecrate folder_rename_updates_selected_tree_without_parked_source_cache`
- `cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::folder_editing`
- `git diff --check`

## Known limitations

None.

User review is required before merge unless the user explicitly signs off.