### PR TITLE
[codex] Remove duplicate new-folder placeholder

### DIFF
--- a/src/native_app/sample_library/folder_browser/rename_tree.rs
+++ b/src/native_app/sample_library/folder_browser/rename_tree.rs
@@ -96,23 +96,27 @@ impl FolderBrowserState {
     }
 
     fn remove_folder_by_id(&mut self, folder_id: &str) -> bool {
-        let Some(source) = self
+        let active_tree_changed = self
+            .tree
+            .folders
+            .first_mut()
+            .is_some_and(|root_folder| root_folder.remove_child_by_id(folder_id));
+        if active_tree_changed {
+            self.bump_file_content_revision();
+        }
+
+        let parked_tree_changed = self
             .source
             .sources
             .iter_mut()
             .find(|source| source.id == self.source.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let changed = root_folder.remove_child_by_id(folder_id);
-        if changed {
-            self.tree.folders = vec![root_folder.clone()];
+            .and_then(|source| source.root_folder.as_mut())
+            .is_some_and(|root_folder| root_folder.remove_child_by_id(folder_id));
+        if parked_tree_changed {
             self.bump_file_content_revision();
         }
-        changed
+
+        active_tree_changed || parked_tree_changed
     }
 
     pub(super) fn upsert_child_folder(&mut self, parent_id: &str, folder: FolderEntry) -> bool {

--- a/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
+++ b/src/native_app/sample_library/folder_browser/tests/folder_editing.rs
@@ -133,6 +133,13 @@ fn create_subfolder_starts_pending_rename_row_and_creates_on_submit() {
                 && folder.name == "loops"
                 && folder.rename_draft.is_none())
     );
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .all(|folder| folder.id != path_id(&pending)),
+        "pending placeholder row must be removed after folder create succeeds"
+    );
     let _ = fs::remove_dir_all(root);
 }
 


### PR DESCRIPTION
## Scope

- Remove pending new-folder placeholders from the active selected folder tree when folder creation completes.
- Keep parked source-cache cleanup intact when a parked tree exists.
- Add a regression assertion that the optimistic `New folder` row is gone after the real created folder is inserted.

## Definition of Done

- Creating a new folder no longer leaves both the final named folder and a stale `New folder` row visible.
- The active selected tree and parked source cache both clean up pending placeholders safely.
- Existing folder create/rename tests remain green.

## Validation commands

- `cargo test -p wavecrate --bin wavecrate create_subfolder_starts_pending_rename_row_and_creates_on_submit`
- `cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::folder_editing`
- `git diff --check`

## Known limitations

None.

User review is required before merge unless the user explicitly signs off.