### PR TITLE
[codex] Refresh folder tree when showing empty folders

### DIFF
--- a/src/native_app/sample_library/folder_browser_actions.rs
+++ b/src/native_app/sample_library/folder_browser_actions.rs
@@ -11,6 +11,9 @@ use radiant::prelude as ui;
 
 use crate::native_app::app::{GuiMessage, NativeAppState};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
+use crate::native_app::sample_library::folder_browser::view_contract::{
+    FOLDER_TREE_EDGE_CONTEXT_ROWS, FOLDER_TREE_OVERSCAN_ROWS, FOLDER_TREE_PROJECTED_VIEWPORT_ROWS,
+};
 
 impl NativeAppState {
     pub(in crate::native_app) fn apply_folder_browser_message(
@@ -93,6 +96,21 @@ impl NativeAppState {
             }
             FolderBrowserMessage::ToggleSimilarityAnchor(file_id) => {
                 self.toggle_similarity_anchor(file_id, context);
+            }
+            FolderBrowserMessage::ToggleEmptyFolderVisibility => {
+                let enabled = self.library.folder_browser.toggle_empty_folder_visibility();
+                self.library.folder_browser.sync_tree_view_to_selection(
+                    FOLDER_TREE_PROJECTED_VIEWPORT_ROWS,
+                    FOLDER_TREE_OVERSCAN_ROWS,
+                    FOLDER_TREE_EDGE_CONTEXT_ROWS,
+                );
+                if enabled {
+                    self.queue_selected_source_folder_tree_refresh(
+                        context,
+                        "folder_browser.show_empty_folders_refresh",
+                        "gui-show-empty-folder-tree-refresh",
+                    );
+                }
             }
             message => self.library.folder_browser.apply_message(message),
         }

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -63,6 +63,46 @@ fn context_source_refresh_queues_scan_without_clearing_loaded_tree() {
 }
 
 #[test]
+fn enabling_empty_folders_queues_tree_refresh_for_disk_only_folders() {
+    let source_root = tempfile::tempdir().expect("source root");
+    write_test_wav_i16(&source_root.path().join("kick.wav"), &[0, 512, -512]);
+    let folder_browser = crate::native_app::test_support::state::FolderBrowserState::from_root(
+        source_root.path().to_path_buf(),
+    );
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(folder_browser)
+        .with_sample_status("Ready")
+        .build();
+    let disk_only_empty = source_root.path().join("new-empty-folder");
+    fs::create_dir_all(&disk_only_empty).expect("create empty folder after source load");
+    assert!(
+        state
+            .library
+            .folder_browser
+            .folder_path(&disk_only_empty.to_string_lossy())
+            .is_none(),
+        "test setup should leave the empty folder outside the loaded tree"
+    );
+
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_folder_browser_message(
+        crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage::ToggleEmptyFolderVisibility,
+        &mut context,
+    );
+
+    assert!(
+        state
+            .library
+            .folder_browser
+            .empty_folder_visibility_enabled()
+    );
+    assert!(
+        state.background.folder_tree_refresh_task.active().is_some(),
+        "show-empty toggle should immediately queue a selected-source tree refresh"
+    );
+}
+
+#[test]
 fn selecting_missing_source_reports_missing_status_without_scan() {
     let temp = tempfile::tempdir().expect("tempdir");
     let missing_root = temp.path().join("missing-source");


### PR DESCRIPTION
## Scope

- Queue a selected-source folder-tree refresh when `Show folders with no audio files` is enabled.
- Keep disabling the empty-folder view as a local filter-only operation.
- Add a native regression proving an empty folder created on disk after the source tree was loaded causes the toggle to queue a refresh.

## Definition of Done

- Turning on empty-folder visibility reconciles disk-only empty folders instead of relying on stale in-memory folder trees.
- Existing empty-folder projection behavior still shows loaded empty folders correctly.
- The refresh is tree-only/latest-task based, so repeated toggles do not queue a full source scan storm.

## Validation commands

- `cargo test -p wavecrate --bin wavecrate enabling_empty_folders_queues_tree_refresh_for_disk_only_folders -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate visible_folders_mark_branches_without_audio_as_empty -- --test-threads=1`
- `git diff --check`

Additional note: `cargo test -p wavecrate --bin wavecrate native_app::tests::config_sources::refresh -- --test-threads=1` currently has two failures that also reproduce individually on this branch and are not touched by this change: `selecting_loaded_cached_source_does_not_queue_folder_tree_refresh` and `source_filesystem_change_syncs_removed_file_to_source_database`.

## Known limitations

- The toggle queues the tree refresh asynchronously; disk-only empty folders appear after the background tree refresh applies rather than via synchronous UI-thread filesystem walking.
- The two existing config-source refresh test failures listed above remain unresolved in this PR.

User review is required before merge unless the user explicitly signs off.