### PR TITLE
[codex] Remove trashed folders from active tree

### DIFF
--- a/src/native_app/sample_library/folder_browser/delete_workflow.rs
+++ b/src/native_app/sample_library/folder_browser/delete_workflow.rs
@@ -83,22 +83,22 @@ impl FolderBrowserState {
     pub(in crate::native_app) fn discard_trashed_folder_path(&mut self, path: &Path) -> bool {
         let folder_id = path_id(path);
         let parent_id = path.parent().map(path_id);
-        let Some(source) = self
+        let active_tree_changed = self
+            .tree
+            .folders
+            .first_mut()
+            .is_some_and(|root_folder| root_folder.remove_child_by_id(&folder_id));
+        let parked_tree_changed = self
             .source
             .sources
             .iter_mut()
             .find(|source| source.id == self.source.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let changed = root_folder.remove_child_by_id(&folder_id);
+            .and_then(|source| source.root_folder.as_mut())
+            .is_some_and(|root_folder| root_folder.remove_child_by_id(&folder_id));
+        let changed = active_tree_changed || parked_tree_changed;
         if !changed {
             return false;
         }
-        self.tree.folders = vec![root_folder.clone()];
         let fallback_folder = parent_id
             .filter(|id| self.find_folder(id).is_some())
             .unwrap_or_else(|| {
@@ -110,7 +110,9 @@ impl FolderBrowserState {
             });
         self.selection.discard_folder(&folder_id, fallback_folder);
         self.selection.clear_file_selection();
-        self.tree.expanded_folders.retain(|id| id != &folder_id);
+        self.tree
+            .expanded_folders
+            .retain(|id| id != &folder_id && !Path::new(id).starts_with(path));
         self.bump_file_content_revision();
         true
     }

--- a/src/native_app/sample_library/folder_browser/tests/delete.rs
+++ b/src/native_app/sample_library/folder_browser/tests/delete.rs
@@ -32,6 +32,37 @@ fn folder_delete_blocks_hard_delete_and_keeps_selected_folder() {
 }
 
 #[test]
+fn trashed_selected_folder_is_removed_from_active_tree_without_parked_source_cache() {
+    let root = temp_source_root("wavecrate-gui-folder-trash-active-tree");
+    let drums = root.join("drums");
+    let kicks = drums.join("kicks");
+    fs::create_dir_all(&kicks).expect("create nested folder");
+    fs::write(kicks.join("kick.wav"), [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.expand_selected_folder();
+    browser.activate_folder(path_id(&kicks));
+    browser.source.sources[0].root_folder = None;
+
+    assert!(browser.discard_trashed_folder_path(&kicks));
+
+    assert_eq!(browser.selection.selected_folder, path_id(&drums));
+    assert!(browser.find_folder(&path_id(&kicks)).is_none());
+    assert!(
+        browser
+            .visible_folders()
+            .into_iter()
+            .all(|folder| folder.id != path_id(&kicks)),
+        "trashed folder should disappear from the visible folder tree immediately"
+    );
+    assert!(
+        !browser.tree.expanded_folders.contains(&path_id(&kicks)),
+        "trashed folder expansion state should be discarded"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn file_delete_blocks_hard_delete_and_keeps_selection() {
     let root = temp_source_root("wavecrate-gui-file-delete");
     let drums = root.join("drums");


### PR DESCRIPTION
## Scope

- Remove trashed folders from the active selected folder tree, not only the parked selected-source cache.
- Keep parked source-cache cleanup intact when it exists.
- Discard expansion state for the trashed folder and its descendants.
- Add a regression for trashing a selected folder when the selected tree is active and `SourceEntry::root_folder` is empty.

## Definition of Done

- Moving a folder to trash removes it from the visible folder tree immediately after the trash operation succeeds.
- Selection falls back to the deleted folder's parent when available.
- Existing folder and file delete focus behavior remains green.

## Validation commands

- `cargo test -p wavecrate --bin wavecrate trashed_selected_folder_is_removed_from_active_tree_without_parked_source_cache`
- `cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::delete`
- `git diff --check`

## Known limitations

None.

User review is required before merge unless the user explicitly signs off.