### PR TITLE
[codex] Audit active folder tree mutations

### DIFF
--- a/src/native_app/sample_library/folder_browser.rs
+++ b/src/native_app/sample_library/folder_browser.rs
@@ -106,6 +106,7 @@ pub(in crate::native_app) use state::FolderBrowserState;
 mod tree_state;
 use tree_state::FolderTreeState;
 mod folder_locks;
+mod tree_mutation;
 
 mod delete_types;
 mod tree_view_window;

--- a/src/native_app/sample_library/folder_browser/delete_workflow.rs
+++ b/src/native_app/sample_library/folder_browser/delete_workflow.rs
@@ -139,22 +139,12 @@ impl FolderBrowserState {
             .as_deref()
             .is_some_and(|id| target_ids.contains(id));
         let before_visible_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
-        let Some(source) = self
-            .source
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let changed = root_folder.remove_files_by_ids(&target_ids);
+        let changed = self.mutate_selected_source_trees(|root_folder| {
+            root_folder.remove_files_by_ids(&target_ids)
+        });
         if !changed {
             return false;
         }
-        self.tree.folders = vec![root_folder.clone()];
         self.bump_file_content_revision();
         let after_visible_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
         let fallback_id = focused_removed

--- a/src/native_app/sample_library/folder_browser/drag_drop_move.rs
+++ b/src/native_app/sample_library/folder_browser/drag_drop_move.rs
@@ -260,6 +260,14 @@ impl FolderBrowserState {
             .iter()
             .filter(|source| path.starts_with(&source.root))
             .filter(|source| {
+                if source.id == self.source.selected_source
+                    && self.tree.folders.first().is_some_and(|root| {
+                        root.find_file(file_id)
+                            .is_some_and(super::FileEntry::is_audio)
+                    })
+                {
+                    return true;
+                }
                 source.root_folder.as_ref().is_some_and(|root| {
                     root.find_file(file_id)
                         .is_some_and(super::FileEntry::is_audio)

--- a/src/native_app/sample_library/folder_browser/drag_drop_relocation.rs
+++ b/src/native_app/sample_library/folder_browser/drag_drop_relocation.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::{
-    FolderBrowserState,
+    FolderBrowserState, FolderEntry,
     path_helpers::{path_id, rewrite_path_id},
     scanning::{file_entry_for_source_path, upsert_file, upsert_folder},
 };
@@ -16,39 +16,29 @@ impl FolderBrowserState {
         new_path: &Path,
         target_parent: &Path,
     ) -> Result<(), String> {
-        let old_id = path_id(old_path);
         let target_parent_id = path_id(target_parent);
-        let Some(source) = self
+        let Some(source_index) = self
             .source
             .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
+            .iter()
+            .position(|source| source.id == self.source.selected_source)
         else {
             return Err(String::from(
                 "Folder move failed: selected source is unavailable",
             ));
         };
-        let Some(root_folder) = &mut source.root_folder else {
-            return Err(String::from(
-                "Folder move failed: source tree is unavailable",
-            ));
-        };
-        let Some(mut moved_folder) = root_folder.take_child_by_id(&old_id) else {
-            return Err(String::from(
-                "Folder move failed: source folder is unavailable",
-            ));
-        };
-        moved_folder.rewrite_path_prefix(old_path, new_path);
-        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
-            return Err(String::from(
-                "Folder move failed: target folder is unavailable",
-            ));
-        };
-        upsert_folder(&mut target_folder.children, moved_folder);
+
+        self.try_mutate_selected_source_trees(
+            "Folder move failed: source tree is unavailable",
+            |root_folder| {
+                relocate_moved_folder_in_root(root_folder, old_path, new_path, target_parent)
+            },
+        )?;
+
+        let source = &mut self.source.sources[source_index];
         let removed_old_missing = source.missing_collection_snapshot.remove_prefix(old_path);
         let removed_new_missing = source.missing_collection_snapshot.remove_prefix(new_path);
         let missing_changed = removed_old_missing || removed_new_missing;
-        self.tree.folders = vec![root_folder.clone()];
 
         self.selection.rewrite_folder_prefix(old_path, new_path);
         self.rewrite_similarity_path_prefix(old_path, new_path);
@@ -71,72 +61,39 @@ impl FolderBrowserState {
         moves: &[(PathBuf, PathBuf)],
         target_parent: &Path,
     ) -> Result<(), String> {
-        let Some((source_root, source_database_root)) = self
+        let Some(source_index) = self
             .source
             .sources
             .iter()
-            .find(|source| source.id == self.source.selected_source)
-            .map(|source| (source.root.clone(), source.database_root.clone()))
+            .position(|source| source.id == self.source.selected_source)
         else {
             return Err(String::from(
                 "File move failed: selected source is unavailable",
             ));
         };
-        let old_ids = moves
-            .iter()
-            .map(|(old_path, _)| path_id(old_path))
-            .collect::<HashSet<_>>();
+        let source_root = self.source.sources[source_index].root.clone();
+        let source_database_root = self.source.sources[source_index].database_root.clone();
         let target_parent_id = path_id(target_parent);
-        let Some(source) = self
-            .source
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
-        else {
-            return Err(String::from(
-                "File move failed: selected source is unavailable",
-            ));
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return Err(String::from("File move failed: source tree is unavailable"));
-        };
-        let previous_files = moves
-            .iter()
-            .filter_map(|(old_path, _)| {
-                let old_id = path_id(old_path);
-                root_folder
-                    .find_file(&old_id)
-                    .cloned()
-                    .map(|file| (old_id, file))
-            })
-            .collect::<HashMap<_, _>>();
-        root_folder.remove_files_by_ids(&old_ids);
-        let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
-            return Err(String::from(
-                "File move failed: target folder is unavailable",
-            ));
-        };
-        for (old_path, new_path) in moves {
-            let mut moved_file =
-                file_entry_for_source_path(new_path, &source_root, &source_database_root);
-            let old_id = path_id(old_path);
-            if let Some(previous) = previous_files.get(&old_id)
-                && moved_file.rating.is_neutral()
-                && !previous.rating.is_neutral()
-            {
-                moved_file.rating = previous.rating;
-                moved_file.rating_locked = previous.rating_locked;
-                moved_file.collection = previous.collection;
-                moved_file.collections = previous.collections.clone();
-            }
-            upsert_file(&mut target_folder.files, moved_file);
-        }
+
+        self.try_mutate_selected_source_trees(
+            "File move failed: source tree is unavailable",
+            |root_folder| {
+                relocate_moved_files_in_root(
+                    root_folder,
+                    moves,
+                    target_parent,
+                    &source_root,
+                    &source_database_root,
+                )
+            },
+        )?;
+
+        let source = &mut self.source.sources[source_index];
         let mut missing_changed = false;
         for (old_path, new_path) in moves {
             missing_changed |= source.missing_collection_snapshot.remove_path(old_path);
             missing_changed |= source.missing_collection_snapshot.remove_path(new_path);
         }
-        self.tree.folders = vec![root_folder.clone()];
         let moved_file_ids = moves
             .iter()
             .map(|(old_path, new_path)| (path_id(old_path), path_id(new_path)))
@@ -153,6 +110,97 @@ impl FolderBrowserState {
         }
         Ok(())
     }
+}
+
+fn relocate_moved_folder_in_root(
+    root_folder: &mut FolderEntry,
+    old_path: &Path,
+    new_path: &Path,
+    target_parent: &Path,
+) -> Result<(), String> {
+    let old_id = path_id(old_path);
+    let target_parent_id = path_id(target_parent);
+    if target_parent.starts_with(old_path) {
+        return Err(String::from(
+            "Folder move failed: target folder is unavailable",
+        ));
+    }
+    if root_folder.find(&old_id).is_none() {
+        return Err(String::from(
+            "Folder move failed: source folder is unavailable",
+        ));
+    }
+    if root_folder.find(&target_parent_id).is_none() {
+        return Err(String::from(
+            "Folder move failed: target folder is unavailable",
+        ));
+    }
+    let Some(mut moved_folder) = root_folder.take_child_by_id(&old_id) else {
+        return Err(String::from(
+            "Folder move failed: source folder is unavailable",
+        ));
+    };
+    moved_folder.rewrite_path_prefix(old_path, new_path);
+    let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
+        return Err(String::from(
+            "Folder move failed: target folder is unavailable",
+        ));
+    };
+    upsert_folder(&mut target_folder.children, moved_folder);
+    Ok(())
+}
+
+fn relocate_moved_files_in_root(
+    root_folder: &mut FolderEntry,
+    moves: &[(PathBuf, PathBuf)],
+    target_parent: &Path,
+    source_root: &Path,
+    source_database_root: &Path,
+) -> Result<(), String> {
+    let target_parent_id = path_id(target_parent);
+    if root_folder.find(&target_parent_id).is_none() {
+        return Err(String::from(
+            "File move failed: target folder is unavailable",
+        ));
+    }
+
+    let old_ids = moves
+        .iter()
+        .map(|(old_path, _)| path_id(old_path))
+        .collect::<HashSet<_>>();
+    let previous_files = moves
+        .iter()
+        .filter_map(|(old_path, _)| {
+            let old_id = path_id(old_path);
+            root_folder
+                .find_file(&old_id)
+                .cloned()
+                .map(|file| (old_id, file))
+        })
+        .collect::<HashMap<_, _>>();
+    root_folder.remove_files_by_ids(&old_ids);
+
+    let Some(target_folder) = root_folder.find_mut(&target_parent_id) else {
+        return Err(String::from(
+            "File move failed: target folder is unavailable",
+        ));
+    };
+    for (old_path, new_path) in moves {
+        let mut moved_file =
+            file_entry_for_source_path(new_path, source_root, source_database_root);
+        let old_id = path_id(old_path);
+        if let Some(previous) = previous_files.get(&old_id)
+            && moved_file.rating.is_neutral()
+            && !previous.rating.is_neutral()
+        {
+            moved_file.rating = previous.rating;
+            moved_file.rating_locked = previous.rating_locked;
+            moved_file.collection = previous.collection;
+            moved_file.collections = previous.collections.clone();
+        }
+        upsert_file(&mut target_folder.files, moved_file);
+    }
+    Ok(())
 }
 
 pub(super) fn persist_moved_folders_metadata(

--- a/src/native_app/sample_library/folder_browser/drag_drop_sourced_files.rs
+++ b/src/native_app/sample_library/folder_browser/drag_drop_sourced_files.rs
@@ -60,7 +60,12 @@ impl FolderBrowserState {
             if source_old_ids.is_empty() {
                 continue;
             }
-            if let Some(root_folder) = self.source.sources[source_index].root_folder.as_mut() {
+            if self.source.sources[source_index].id == self.source.selected_source {
+                self.mutate_selected_source_trees(|root_folder| {
+                    root_folder.remove_files_by_ids(&source_old_ids)
+                });
+            } else if let Some(root_folder) = self.source.sources[source_index].root_folder.as_mut()
+            {
                 root_folder.remove_files_by_ids(&source_old_ids);
             }
         }
@@ -160,13 +165,22 @@ impl FolderBrowserState {
         old_ids: &HashSet<String>,
     ) -> HashMap<String, super::FileEntry> {
         let mut previous_files = HashMap::new();
+        if let Some(root_folder) = self.tree.folders.first() {
+            for old_id in old_ids {
+                if let Some(file) = root_folder.find_file(old_id) {
+                    previous_files.insert(old_id.clone(), file.clone());
+                }
+            }
+        }
         for source in &self.source.sources {
             let Some(root_folder) = &source.root_folder else {
                 continue;
             };
             for old_id in old_ids {
                 if let Some(file) = root_folder.find_file(old_id) {
-                    previous_files.insert(old_id.clone(), file.clone());
+                    previous_files
+                        .entry(old_id.clone())
+                        .or_insert_with(|| file.clone());
                 }
             }
         }

--- a/src/native_app/sample_library/folder_browser/rename_tree.rs
+++ b/src/native_app/sample_library/folder_browser/rename_tree.rs
@@ -52,18 +52,9 @@ impl FolderBrowserState {
     }
 
     pub(super) fn rewrite_renamed_file_path(&mut self, old_path: &Path, new_path: &Path) {
-        let Some(source) = self
-            .source
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
-        else {
-            return;
-        };
-        if let Some(root_folder) = &mut source.root_folder {
-            root_folder.rewrite_file_path(old_path, new_path);
-            self.tree.folders = vec![root_folder.clone()];
-        }
+        self.mutate_selected_source_trees(|root_folder| {
+            root_folder.rewrite_file_path(old_path, new_path)
+        });
         self.selection.set_renamed_file(path_id(new_path));
         self.rewrite_similarity_path_prefix(old_path, new_path);
         self.bump_file_content_revision();
@@ -96,58 +87,19 @@ impl FolderBrowserState {
     }
 
     fn remove_folder_by_id(&mut self, folder_id: &str) -> bool {
-        let active_tree_changed = self
-            .tree
-            .folders
-            .first_mut()
-            .is_some_and(|root_folder| root_folder.remove_child_by_id(folder_id));
-        if active_tree_changed {
+        let changed = self
+            .mutate_selected_source_trees(|root_folder| root_folder.remove_child_by_id(folder_id));
+        if changed {
             self.bump_file_content_revision();
         }
-
-        let parked_tree_changed = self
-            .source
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
-            .and_then(|source| source.root_folder.as_mut())
-            .is_some_and(|root_folder| root_folder.remove_child_by_id(folder_id));
-        if parked_tree_changed {
-            self.bump_file_content_revision();
-        }
-
-        active_tree_changed || parked_tree_changed
+        changed
     }
 
     pub(super) fn upsert_child_folder(&mut self, parent_id: &str, folder: FolderEntry) -> bool {
-        if let Some(changed) =
-            self.tree.folders.first_mut().and_then(|root_folder| {
-                upsert_child_in_root(root_folder, parent_id, folder.clone())
-            })
-        {
-            if changed {
-                self.bump_file_content_revision();
-            }
-            return changed;
-        }
-
-        let Some(source) = self
-            .source
-            .sources
-            .iter_mut()
-            .find(|source| source.id == self.source.selected_source)
-        else {
-            return false;
-        };
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
-        };
-        let Some(parent) = root_folder.find_mut(parent_id) else {
-            return false;
-        };
-        let changed = upsert_folder(&mut parent.children, folder);
+        let changed = self.mutate_selected_source_trees(|root_folder| {
+            upsert_child_in_root(root_folder, parent_id, folder.clone()).unwrap_or(false)
+        });
         if changed {
-            self.tree.folders = vec![root_folder.clone()];
             self.bump_file_content_revision();
         }
         changed

--- a/src/native_app/sample_library/folder_browser/tests/delete.rs
+++ b/src/native_app/sample_library/folder_browser/tests/delete.rs
@@ -129,6 +129,43 @@ fn trashed_selected_file_focuses_next_sample_without_clearing_file_selection() {
 }
 
 #[test]
+fn trashed_selected_file_is_removed_from_active_tree_without_parked_source_cache() {
+    let root = temp_source_root("wavecrate-gui-file-trash-active-tree");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let hat = drums.join("hat.wav");
+    let kick = drums.join("kick.wav");
+    let snare = drums.join("snare.wav");
+    for file in [&hat, &kick, &snare] {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&kick));
+    browser.source.sources[0].root_folder = None;
+
+    assert!(browser.discard_trashed_file_paths(std::slice::from_ref(&kick)));
+
+    assert_eq!(browser.selected_file_id(), Some(path_id(&snare).as_str()));
+    assert!(
+        browser
+            .selected_files()
+            .iter()
+            .all(|file| file.id != path_id(&kick)),
+        "trashed file should disappear from the visible active tree immediately"
+    );
+    assert_eq!(
+        browser
+            .selected_audio_files()
+            .iter()
+            .map(|file| file.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["hat.wav", "snare.wav"]
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn trashed_last_selected_file_focuses_previous_sample() {
     let root = temp_source_root("wavecrate-gui-file-trash-focus-previous");
     let drums = root.join("drums");

--- a/src/native_app/sample_library/folder_browser/tests/file_move_drag_drop.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_move_drag_drop.rs
@@ -43,6 +43,7 @@ fn file_drag_drop_moves_selected_files_into_target_folder() {
             ..Default::default()
         },
     );
+    browser.source.sources[0].root_folder = None;
 
     browser.begin_file_drag(path_id(&kick), Point::new(4.0, 8.0));
     let result =
@@ -1044,6 +1045,46 @@ fn file_drag_from_protected_source_copies_to_writable_source_root() {
     assert!(
         copied.is_file(),
         "drop onto source should land at source root"
+    );
+    let _ = fs::remove_dir_all(source_root);
+    let _ = fs::remove_dir_all(target_root);
+}
+
+#[test]
+fn file_drag_between_sources_removes_origin_from_active_tree_without_parked_source_cache() {
+    let source_root = temp_source_root("wavecrate-gui-cross-source-drag-active-tree");
+    let target_root = temp_source_root("wavecrate-gui-cross-source-drag-target");
+    let drums = source_root.join("drums");
+    fs::create_dir_all(&drums).expect("create source folder");
+    fs::create_dir_all(&target_root).expect("create target source root");
+    let kick = drums.join("kick.wav");
+    fs::write(&kick, b"kick").expect("write kick");
+
+    let source = wavecrate::sample_sources::SampleSource::new_with_id(
+        wavecrate::sample_sources::SourceId::from_string("drag-source"),
+        source_root.clone(),
+    );
+    let target = wavecrate::sample_sources::SampleSource::new_with_id(
+        wavecrate::sample_sources::SourceId::from_string("drag-target"),
+        target_root.clone(),
+    );
+    let mut browser = FolderBrowserState::from_sample_sources(&[source.clone(), target.clone()]);
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&kick));
+    browser.source.sources[0].root_folder = None;
+
+    assert!(browser.begin_file_drag(path_id(&kick), Point::new(4.0, 8.0)));
+    let result = submit_source_drop(&mut browser, target.id.as_str())
+        .expect("file drag should move into target source root");
+
+    let moved = target_root.join("kick.wav");
+    assert_eq!(result.moved_paths, vec![(kick.clone(), moved.clone())]);
+    assert!(!kick.exists());
+    assert!(moved.is_file());
+    assert_eq!(browser.selected_source_id(), source.id.as_str());
+    assert!(
+        browser.selected_audio_files().is_empty(),
+        "selected origin tree should drop the moved file even without parked source cache"
     );
     let _ = fs::remove_dir_all(source_root);
     let _ = fs::remove_dir_all(target_root);

--- a/src/native_app/sample_library/folder_browser/tests/file_rename.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_rename.rs
@@ -45,6 +45,47 @@ fn file_rename_hides_and_preserves_extension() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn file_rename_updates_active_tree_without_parked_source_cache() {
+    let root = temp_source_root("wavecrate-gui-file-rename-active-tree");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create nested folder");
+    let kick = drums.join("kick loop.wav");
+    let snare = drums.join("snare loop.wav");
+    fs::write(&kick, [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&kick));
+    browser.source.sources[0].root_folder = None;
+    browser
+        .begin_rename_selected()
+        .expect("rename can start")
+        .expect("rename input id");
+
+    let status = submit_rename(&mut browser, "snare loop").status;
+
+    assert_eq!(status, "Renamed file to snare loop.wav");
+    assert!(!kick.exists());
+    assert!(snare.is_file());
+    assert_eq!(browser.selected_file_id(), Some(path_id(&snare).as_str()));
+    assert!(
+        browser
+            .selected_audio_files()
+            .iter()
+            .all(|file| file.id != path_id(&kick)),
+        "renamed file should disappear from the old active-tree path"
+    );
+    assert!(
+        browser
+            .selected_audio_files()
+            .iter()
+            .any(|file| file.id == path_id(&snare)),
+        "renamed file should appear at the new active-tree path"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn file_rename_submission_cannot_change_extension() {
     let root = temp_source_root("wavecrate-gui-file-rename-extension");

--- a/src/native_app/sample_library/folder_browser/tests/folder_drag_drop.rs
+++ b/src/native_app/sample_library/folder_browser/tests/folder_drag_drop.rs
@@ -13,6 +13,7 @@ fn folder_drag_drop_moves_subtree_into_target_folder() {
     browser.expand_selected_folder();
     browser.activate_folder(path_id(&kicks));
     browser.select_file(path_id(&kick));
+    browser.source.sources[0].root_folder = None;
 
     browser.apply_folder_drag(
         path_id(&kicks),

--- a/src/native_app/sample_library/folder_browser/tree_mutation.rs
+++ b/src/native_app/sample_library/folder_browser/tree_mutation.rs
@@ -1,0 +1,83 @@
+use super::{FolderBrowserState, FolderEntry};
+
+impl FolderBrowserState {
+    pub(super) fn mutate_selected_source_trees(
+        &mut self,
+        mut mutate: impl FnMut(&mut FolderEntry) -> bool,
+    ) -> bool {
+        let active_tree_changed = self
+            .tree
+            .folders
+            .first_mut()
+            .is_some_and(|root_folder| mutate(root_folder));
+
+        let mut parked_tree_snapshot = None;
+        let parked_tree_changed = self
+            .source
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.source.selected_source)
+            .and_then(|source| source.root_folder.as_mut())
+            .is_some_and(|root_folder| {
+                let changed = mutate(root_folder);
+                if changed && !active_tree_changed {
+                    parked_tree_snapshot = Some(root_folder.clone());
+                }
+                changed
+            });
+
+        if let Some(root_folder) = parked_tree_snapshot {
+            self.tree.folders = vec![root_folder];
+        }
+
+        active_tree_changed || parked_tree_changed
+    }
+
+    pub(super) fn try_mutate_selected_source_trees(
+        &mut self,
+        unavailable_error: &str,
+        mut mutate: impl FnMut(&mut FolderEntry) -> Result<(), String>,
+    ) -> Result<(), String> {
+        let mut active_tree_snapshot = None;
+        let mut first_error = None;
+
+        if let Some(root_folder) = self.tree.folders.first_mut() {
+            match mutate(root_folder) {
+                Ok(()) => active_tree_snapshot = Some(root_folder.clone()),
+                Err(error) => first_error = Some(error),
+            }
+        }
+
+        let mut parked_tree_snapshot = None;
+        let parked_tree_mutated = self
+            .source
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.source.selected_source)
+            .and_then(|source| source.root_folder.as_mut())
+            .is_some_and(|root_folder| match mutate(root_folder) {
+                Ok(()) => {
+                    if active_tree_snapshot.is_none() {
+                        parked_tree_snapshot = Some(root_folder.clone());
+                    }
+                    true
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    false
+                }
+            });
+
+        if let Some(root_folder) = parked_tree_snapshot {
+            self.tree.folders = vec![root_folder];
+        }
+
+        if active_tree_snapshot.is_some() || parked_tree_mutated {
+            Ok(())
+        } else {
+            Err(first_error.unwrap_or_else(|| unavailable_error.to_string()))
+        }
+    }
+}


### PR DESCRIPTION
Scope
- Add shared helpers for selected-source mutations that update the visible active tree before falling back to the parked source cache.
- Apply the active-tree-aware mutation path to file rename, file trash removal, folder creation/upsert, same-source folder/file drag relocation, and cross-source file origin removal.
- Make cut/drag source resolution consider the selected active tree when the parked source cache is empty.
- Add regressions for active-tree-only rename, trash, same-source drag/drop, and cross-source drag/drop behavior.

Definition of Done
- Selected-source file/folder mutations no longer rely on source.root_folder being populated when the visible tree is active.
- File rename/trash and drag/drop operations update the visible folder tree immediately.
- Cross-source moves can resolve and remove selected-origin files even when the selected source only exists in self.tree.
- Focused regression coverage protects the active-tree-only paths.

Validation commands
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::folder_editing -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::file_rename -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::delete -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::folder_drag_drop -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::file_move_drag_drop -- --test-threads=1
- git diff --check

Known limitations
- None. This is a scoped audit/fix for selected-source active-tree versus parked-cache mutations, not a broader folder browser architecture rewrite.

User review required before merge unless the user has already signed off.