### PR TITLE
[codex] Use platform-native file manager labels

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -801,7 +801,7 @@ Undo/redo should cover:
 - move/copy/export/trash operations
 - folder operations where practical
 
-Transport play/stop/restart, momentary playback position, ordinary seek state, browser focus, row selection, source/folder navigation, browser position, waveform scroll/zoom position, cursor movement, ordinary view switching, Open/Reveal in Explorer actions, and Copy Path actions should not be undoable by default. Opening or revealing a file, folder, or source in the platform file manager and copying a path string to the clipboard are external non-mutating utility actions, not Wavecrate state. Undo should restore metadata, file, rating, collection, edit, workflow-flag, and play/edit selection context, but it should not behave like a transport, browsing history, external-app launch, or clipboard utility history.
+Transport play/stop/restart, momentary playback position, ordinary seek state, browser focus, row selection, source/folder navigation, browser position, waveform scroll/zoom position, cursor movement, ordinary view switching, Open/Reveal in Finder/Explorer/File Manager actions, and Copy Path actions should not be undoable by default. Opening or revealing a file, folder, or source in the platform file manager and copying a path string to the clipboard are external non-mutating utility actions, not Wavecrate state. Undo should restore metadata, file, rating, collection, edit, workflow-flag, and play/edit selection context, but it should not behave like a transport, browsing history, external-app launch, or clipboard utility history.
 
 Undo/redo should be transaction-based. A user action should either complete as a coherent operation or fail in a recoverable way. Partial failures should be logged and reported clearly.
 
@@ -934,7 +934,7 @@ Region handoff behavior should be:
 
 When an explicit export writes a new audio file inside an indexed source folder, Wavecrate should register and index the exported file if registration succeeds. When an export writes outside indexed sources, the result should remain an external file and should not become Wavecrate library state unless the user later adds/imports that location as a source.
 
-If an explicit export successfully writes a file but registration or indexing fails, Wavecrate should leave the exported file on disk and show a clear recoverable warning. The warning should explain that the file was created but is not yet indexed, and should offer retry registration, rescan/reconcile, reveal in Explorer, or diagnostics where practical.
+If an explicit export successfully writes a file but registration or indexing fails, Wavecrate should leave the exported file on disk and show a clear recoverable warning. The warning should explain that the file was created but is not yet indexed, and should offer retry registration, rescan/reconcile, reveal in the platform file manager, or diagnostics where practical.
 
 Explicit exports outside indexed sources should not be undoable in Wavecrate because they create user-directed external files outside Wavecrate-managed library state. Explicit exports that are successfully registered into an indexed source should be undoable as library file-creation transactions, using the same recovery and file-removal safety expectations as other Wavecrate-created source files.
 
@@ -1127,13 +1127,13 @@ When a source-add request is rejected because it is nested with an existing sour
 
 Removing a source from Wavecrate should remove it from the indexed source list but should not delete audio files from disk. Source removal should be available from the source's context menu as `Remove Source` and should act as the explicit cancel/remove path for a source that was just added. It should stop file watching, stop or cancel in-progress scan/indexing/background jobs for that source, and ignore stale completions from those jobs. Source removal can happen immediately without confirmation because it only removes Wavecrate's active index reference and does not delete files. The result status should make that boundary clear, such as by saying the source was removed from Wavecrate and files were left on disk. If the user has no configured sources, the source list should be empty; Wavecrate should not show a bundled, hardcoded, or otherwise non-removable placeholder source in the normal source list.
 
-Source items should have a context menu with an "Open in Explorer" action on Windows. This should open the source root folder in Explorer so users can inspect files, manually back up `.wavecrate.db`, or manage the folder outside Wavecrate. Future platforms should provide the equivalent reveal/open-in-file-manager action.
+Source items should have a context menu with a platform-native file-manager action. The visible label should be "Open in Explorer" on Windows, "Open in Finder" on macOS, and "Open in File Manager" on fallback platforms. This should open the source root folder in the platform file manager so users can inspect files, manually back up `.wavecrate.db`, or manage the folder outside Wavecrate.
 
-Sample rows should have a context menu with a "Reveal in Explorer" action on Windows. This should open Explorer at the containing folder and select the specific audio file where the platform supports file selection. If the file is missing or unavailable, Wavecrate should show the missing-file state and offer source reconciliation or cleanup actions instead of opening an invalid path.
+Sample rows should have a context menu with a platform-native reveal action. The visible label should be "Reveal in Explorer" on Windows, "Reveal in Finder" on macOS, and "Reveal in File Manager" on fallback platforms. This should open the containing folder and select the specific audio file where the platform supports file selection. If the file is missing or unavailable, Wavecrate should show the missing-file state and offer source reconciliation or cleanup actions instead of opening an invalid path.
 
-Folder rows in the folder tree should also have an "Open in Explorer" context-menu action on Windows. This should open the actual folder path in Explorer. If the folder is missing or unavailable, Wavecrate should show the missing-folder/source state and offer reconciliation, relink, rescan, or cleanup actions instead of opening an invalid path.
+Folder rows in the folder tree should also have the same platform-native open action as source rows. This should open the actual folder path in the platform file manager. If the folder is missing or unavailable, Wavecrate should show the missing-folder/source state and offer reconciliation, relink, rescan, or cleanup actions instead of opening an invalid path.
 
-The context-menu labels should be standardized: sources and folders use "Open in Explorer"; sample files use "Reveal in Explorer". When multiple rows are selected, these Explorer actions should operate on only one item: the focused row if it is part of the relevant selection, otherwise the first selected row in visible order. They should not open multiple Explorer windows in the current target.
+The context-menu labels should be standardized by platform: sources and folders use the platform's open label; sample files use the platform's reveal label. When multiple rows are selected, these file-manager actions should operate on only one item: the focused row if it is part of the relevant selection, otherwise the first selected row in visible order. They should not open multiple file-manager windows in the current target.
 
 Source items, folder rows, and sample rows should also have a shared "Copy Path" context-menu action for path copying. This should copy the real absolute filesystem path as text to the normal text clipboard only. Copied paths should use forward slashes as separators, including on Windows. If the copied path contains spaces, Wavecrate should wrap the copied path in standard double quotes, for example `"C:/sample folder/kick.wav"`. Paths without spaces should be copied unquoted. For sample rows it should copy the selected file path; for folder rows it should copy the folder path; for source rows it should copy the source root path. It should not copy source-relative paths in the current target. This is distinct from clipboard audio/file handoff, which places files on the system clipboard for DAWs or Explorer.
 
@@ -1358,12 +1358,12 @@ Dragging a waveform selection outside Wavecrate should create a new audio file f
 Wavecrate should also support workflows such as:
 
 - copy a file path
-- reveal a sample file in Explorer
+- reveal a sample file in the platform file manager
 - export or copy a prepared sample file to a chosen folder
 - extract a region and immediately drag/copy/export the new file
 - hand off the exact audio the user auditioned, including baked audition-time warp when extraction/export requires it
 
-Initial implementation should prioritize drag-and-drop into DAWs such as Ableton Live and Bitwig where practical, plus reveal-in-Explorer and copy-file-path.
+Initial implementation should prioritize drag-and-drop into DAWs such as Ableton Live and Bitwig where practical, plus reveal-in-platform-file-manager and copy-file-path.
 
 Handoff should be fast and predictable. It should not require users to understand Wavecrate internals.
 
@@ -1865,7 +1865,7 @@ Wavecrate should support:
 * applying generated display names to disk filenames
 * exporting extracted or edited files to chosen folders
 * moving rejected files to the configured trash folder
-* revealing files in Explorer
+* revealing files in the platform file manager
 
 Moving or renaming a folder inside a source should happen immediately without confirmation, even when the folder contains files hidden by the current visibility mode, as long as the folder is not the configured source root itself. It should be undoable during the current session, preserve Wavecrate metadata for affected files, update source/folder/browser state, and use the shared destination-folder collision-numbering policy when the destination already contains a folder with the same name.
 

--- a/docs/book/src/sample-files-sources.md
+++ b/docs/book/src/sample-files-sources.md
@@ -6,7 +6,7 @@ Wavecrate keeps source browsing, file moves, and source maintenance close to the
 
 Right-click a sample row to open the sample context menu.
 
-- **Reveal in Explorer:** open the selected sample in the system file browser.
+- **Reveal in Finder/Explorer/File Manager:** open the selected sample in the system file browser.
 - **Copy Path:** copy the sample path.
 - **Duplicate Same:** create a duplicate at the same playback length.
 - **Duplicate Double:** create a duplicate with doubled playback length.
@@ -34,7 +34,7 @@ Wavecrate preserves source safety rules during moves. If a target source is prot
 
 Right-click a source in the Sources list to open source actions.
 
-- **Open in Explorer:** open the source folder in the system file browser.
+- **Open in Finder/Explorer/File Manager:** open the source folder in the system file browser.
 - **Copy Path:** copy the source root path.
 - **New Folder:** create a folder under the source root.
 - **Protect Source** or **Unprotect Source:** change whether Wavecrate treats the source as protected original material.
@@ -47,7 +47,7 @@ Right-click a source in the Sources list to open source actions.
 
 Right-click a folder in the sidebar to open folder actions.
 
-- **Open in Explorer:** open the folder in the system file browser.
+- **Open in Finder/Explorer/File Manager:** open the folder in the system file browser.
 - **Copy Path:** copy the folder path.
 - **New Folder:** create a child folder.
 - **Rename Folder:** rename the folder.

--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -12,6 +12,62 @@ const NEW_FOLDER_HOTKEY_HINT: &str = "N";
 const RENAME_HOTKEY_HINT: &str = "F2 / Cmd-R";
 const DELETE_HOTKEY_HINT: &str = "Delete / Backspace";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) enum FileManagerLabelPlatform {
+    Windows,
+    Macos,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) struct FileManagerContextLabels {
+    open: &'static str,
+    reveal: &'static str,
+}
+
+impl FileManagerContextLabels {
+    pub(in crate::native_app) fn open(self) -> &'static str {
+        self.open
+    }
+
+    pub(in crate::native_app) fn reveal(self) -> &'static str {
+        self.reveal
+    }
+}
+
+pub(in crate::native_app) fn file_manager_context_labels() -> FileManagerContextLabels {
+    file_manager_context_labels_for_platform(current_file_manager_label_platform())
+}
+
+pub(in crate::native_app) fn file_manager_context_labels_for_platform(
+    platform: FileManagerLabelPlatform,
+) -> FileManagerContextLabels {
+    match platform {
+        FileManagerLabelPlatform::Windows => FileManagerContextLabels {
+            open: "Open in Explorer",
+            reveal: "Reveal in Explorer",
+        },
+        FileManagerLabelPlatform::Macos => FileManagerContextLabels {
+            open: "Open in Finder",
+            reveal: "Reveal in Finder",
+        },
+        FileManagerLabelPlatform::Other => FileManagerContextLabels {
+            open: "Open in File Manager",
+            reveal: "Reveal in File Manager",
+        },
+    }
+}
+
+fn current_file_manager_label_platform() -> FileManagerLabelPlatform {
+    if cfg!(target_os = "windows") {
+        FileManagerLabelPlatform::Windows
+    } else if cfg!(target_os = "macos") {
+        FileManagerLabelPlatform::Macos
+    } else {
+        FileManagerLabelPlatform::Other
+    }
+}
+
 pub(in crate::native_app) fn overlay(
     menu: &BrowserContextMenu,
     harvest_active: bool,
@@ -41,10 +97,13 @@ fn context_menu_commands(
         return collection_context_menu_commands(menu);
     }
 
+    let file_manager_labels = file_manager_context_labels();
     let action_label = match menu.kind {
-        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => "Open in Explorer",
+        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => {
+            file_manager_labels.open()
+        }
         BrowserContextTargetKind::Collection => unreachable!("handled above"),
-        BrowserContextTargetKind::Sample => "Reveal in Explorer",
+        BrowserContextTargetKind::Sample => file_manager_labels.reveal(),
         BrowserContextTargetKind::MetadataTag => unreachable!("handled above"),
     };
     if menu.kind == BrowserContextTargetKind::Sample && menu.sample_missing {

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -1,9 +1,35 @@
 use super::*;
+use crate::native_app::app_chrome::browser_context_menu::{
+    FileManagerLabelPlatform, file_manager_context_labels, file_manager_context_labels_for_platform,
+};
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextPointerAnchor, BrowserContextPointerTarget,
 };
 use crate::native_app::test_support::state::GuiMessage;
 use radiant::runtime::{PaintTextAlign, RuntimeUpdateSnapshot};
+
+fn open_file_manager_label() -> &'static str {
+    file_manager_context_labels().open()
+}
+
+fn reveal_file_manager_label() -> &'static str {
+    file_manager_context_labels().reveal()
+}
+
+#[test]
+fn file_manager_context_labels_are_platform_native() {
+    let windows = file_manager_context_labels_for_platform(FileManagerLabelPlatform::Windows);
+    assert_eq!(windows.open(), "Open in Explorer");
+    assert_eq!(windows.reveal(), "Reveal in Explorer");
+
+    let macos = file_manager_context_labels_for_platform(FileManagerLabelPlatform::Macos);
+    assert_eq!(macos.open(), "Open in Finder");
+    assert_eq!(macos.reveal(), "Reveal in Finder");
+
+    let fallback = file_manager_context_labels_for_platform(FileManagerLabelPlatform::Other);
+    assert_eq!(fallback.open(), "Open in File Manager");
+    assert_eq!(fallback.reveal(), "Reveal in File Manager");
+}
 
 #[test]
 fn folder_context_menu_paints_as_full_width_overlay_panel() {
@@ -27,7 +53,7 @@ fn folder_context_menu_paints_as_full_width_overlay_panel() {
 
     let action_text_rect = frame
         .paint_plan
-        .first_text_run("Open in Explorer")
+        .first_text_run(open_file_manager_label())
         .map(|text| text.rect)
         .expect("folder context menu action text should render");
 
@@ -144,7 +170,7 @@ fn folder_context_menu_opens_downward_when_space_allows() {
 
     let action_text_rect = frame
         .paint_plan
-        .first_text_run("Open in Explorer")
+        .first_text_run(open_file_manager_label())
         .map(|text| text.rect)
         .expect("folder context menu action text should render");
 
@@ -177,7 +203,7 @@ fn folder_context_menu_flips_upward_near_bottom_edge() {
 
     let first_action = frame
         .paint_plan
-        .first_text_run("Open in Explorer")
+        .first_text_run(open_file_manager_label())
         .map(|text| text.rect)
         .expect("folder context menu action text should render");
     let final_action = frame
@@ -222,7 +248,7 @@ fn harvest_sample_context_menu_flips_using_dynamic_height() {
 
     let first_action = frame
         .paint_plan
-        .first_text_run("Reveal in Explorer")
+        .first_text_run(reveal_file_manager_label())
         .map(|text| text.rect)
         .expect("sample context menu action text should render");
     let final_action = frame
@@ -863,6 +889,7 @@ fn source_context_menu_paints_remove_source_action_for_user_sources() {
     let frame = crate::native_app::test_support::context_menu::browser_context_menu_overlay(&menu)
         .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
 
+    assert!(frame.paint_plan.contains_text(open_file_manager_label()));
     assert!(frame.paint_plan.contains_text("Refresh Source"));
     assert!(frame.paint_plan.contains_text("Process Source"));
     assert!(frame.paint_plan.contains_text("New Folder"));
@@ -1016,7 +1043,7 @@ fn folder_context_menu_commands_share_neutral_style() {
         .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
 
     let command_labels = [
-        "Open in Explorer",
+        open_file_manager_label(),
         "Copy Path",
         "New Folder",
         "Rename Folder",
@@ -1109,6 +1136,7 @@ fn sample_context_menu_paints_remove_from_collection_action_in_collection_view()
     let frame = crate::native_app::test_support::context_menu::browser_context_menu_overlay(&menu)
         .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
 
+    assert!(frame.paint_plan.contains_text(reveal_file_manager_label()));
     assert!(frame.paint_plan.contains_text("Remove from collection"));
     assert!(!frame.paint_plan.contains_text("New Folder"));
     assert!(!frame.paint_plan.contains_text("Delete Folder"));
@@ -2193,7 +2221,7 @@ fn missing_sample_context_menu_paints_cleanup_actions_without_file_actions() {
             .paint_plan
             .contains_text("Clean all missing in collection")
     );
-    assert!(!frame.paint_plan.contains_text("Reveal in Explorer"));
+    assert!(!frame.paint_plan.contains_text(reveal_file_manager_label()));
     assert!(!frame.paint_plan.contains_text("Move to Trash"));
 }
 


### PR DESCRIPTION
Scope
- Centralize file-manager context-menu labels behind a platform-aware label helper.
- Render source/folder actions as Open in Explorer on Windows, Open in Finder on macOS, and Open in File Manager on fallback platforms.
- Render sample actions as Reveal in Explorer on Windows, Reveal in Finder on macOS, and Reveal in File Manager on fallback platforms.
- Keep command IDs, hotkeys, hit testing, and backend open/reveal behavior unchanged.
- Update user/developer docs to describe platform-native file-manager labels.

Definition of Done
- File-manager context actions use platform-native visible labels.
- macOS no longer shows Explorer wording for Finder-backed actions.
- Windows Explorer wording remains unchanged.
- Docs and tests reflect the platform-aware label contract.
- Backend open/reveal behavior is unchanged.

Validation commands
- bash scripts/agent.sh request (fails in existing vendored Radiant generic_surface_guardrails checks: runtime_controller_context_and_scratch_modules_use_explicit_dependencies, app_bridge_groups_lifecycle_hooks_and_runtime_flags, controller_commands_keep_outcome_drain_and_dispatch_in_focused_modules)
- cargo test -p wavecrate --lib native_app::tests::browser_context_menu -- --test-threads=1 (compiles, but matches 0 tests in current repo layout)
- cargo test -p wavecrate --bin wavecrate native_app::tests::browser_context_menu::file_manager_context_labels_are_platform_native -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::tests::browser_context_menu::source_context_menu_paints_remove_source_action_for_user_sources -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::tests::browser_context_menu::folder_context_menu_paints_as_full_width_overlay_panel -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::tests::browser_context_menu::sample_context_menu_paints_remove_from_collection_action_in_collection_view -- --test-threads=1
- cargo test -p wavecrate --bin wavecrate native_app::tests::browser_context_menu -- --test-threads=1 (50 passed, 2 unrelated current failures: sample_context_menu_open_harvest_destination_requires_primary_source, w_command_opens_playmark_context_menu_and_clears_browser_menu)
- bash scripts/check.sh mdbook
- git diff --check

Known limitations
- Full browser_context_menu binary-module validation currently has two unrelated failures outside this label change; focused label contract and source/folder/sample rendering tests pass.

User review required before merge unless the user has already signed off.