### PR TITLE
[codex] Align release docs after installer removal

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -269,29 +269,29 @@ that validation did not leak fixture sources into the real startup profile.
    so the session writes to the dedicated `sandbox` profile instead of the live
    profile.
 
-### Windows installer identity
+### Windows ZIP Distribution Lifecycle
 
-New Windows installer runs are Wavecrate-branded only. The installer display
-name, publisher value, default install directory, Start Menu folder, and
-uninstall registry key must use `Wavecrate`; new installs must not register a
-`SemPal` uninstall entry.
+Windows releases are distributed as downloadable ZIP artifacts. A supported
+Windows release package contains the `wavecrate/` archive root, the
+`wavecrate/wavecrate.exe` runtime binary, and `wavecrate/update-manifest.json`.
+Wavecrate does not currently provide OS-managed app registration or automatic
+system cleanup for the supported release path.
 
-The SemPal compatibility path is uninstall-only. `wavecrate-installer
---uninstall` first reads the Wavecrate uninstall key and then falls back to the
-legacy SemPal key so older installs can still be removed with the current
-binary. During install or uninstall, a legacy SemPal uninstall key is removed
-only when its `InstallLocation` points at the same installation being updated or
-removed. A separate old SemPal install is not silently deleted by a Wavecrate
-install.
+Windows users install Wavecrate by extracting the ZIP to a folder they manage.
+To update a manual install, close Wavecrate, download a newer ZIP, and replace
+the extracted `wavecrate/` folder or its files with the newer release contents.
+To remove Wavecrate, delete the extracted folder. App settings, source metadata,
+logs, and rebuildable caches live under the user's `.wavecrate` app data paths
+and can be removed separately when the user deliberately wants to clear local
+Wavecrate state.
 
-Focused validation for installer identity changes:
+Focused validation for Windows release distribution changes:
 
-- `cargo test -p wavecrate-installer`
-- `cargo run -p wavecrate-installer -- --dry-run`
-- On Windows, inspect `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\Wavecrate`
-  after a real install and confirm `DisplayName=Wavecrate`,
-  `Publisher=Wavecrate`, and `UninstallString` points at
-  `wavecrate-installer.exe --uninstall`.
+- `cargo test --test release_contract`
+- `python3 -m py_compile scripts/internal/release/verify_published_release.py`
+  when archive verification behavior changes
+- Inspect the release ZIP and confirm it preserves the archive root and required
+  runtime files declared by `release_contract.toml`
 
 ### Database migration and compatibility
 

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -12,6 +12,13 @@ Wavecrate works with ordinary local folders. It does not upload your samples or 
 
 Wavecrate app builds currently support macOS and Windows. Linux is not currently supported for app installs.
 
+On Windows, Wavecrate is a manual ZIP install. Extract the `wavecrate/` folder to
+a location you manage and run `wavecrate.exe` from that folder. To update, close
+Wavecrate and replace the extracted folder with the newer ZIP contents. To
+remove Wavecrate, delete the extracted folder; app settings, logs, source
+metadata, and caches remain in the `.wavecrate` app data folder until you remove
+that state deliberately.
+
 > Safety warning: Wavecrate includes destructive actions that can modify, rename, move, or delete files when you choose those commands. Keep backups for important sample folders.
 
 ## Add Your First Source

--- a/manual/usage.md
+++ b/manual/usage.md
@@ -37,7 +37,7 @@ the same shipped app platforms: macOS and Windows.
 - App settings live in `config.toml`; sources are stored in `library.db` in the same folder. Legacy `config.json` files migrate automatically.
 - You can override the app data root by setting `app_data_dir` in `config.toml` (absolute path to the `.wavecrate` folder). This controls where models, logs, and the library DB live.
 - Each source keeps `.wavecrate_samples.db` beside the audio. Logs live under `.wavecrate/logs`.
-- Portable bundles may include ML assets under `models/`; the Windows installer copies them into the app data directory if present.
+- Downloaded bundles may include ML assets under `models/`; keep those assets with the extracted app bundle unless a release note says they should be moved into app data.
 - Model assets (when present) live in `.wavecrate/models` (Windows: `%APPDATA%\\.wavecrate\\models\\`, macOS: `~/Library/Application Support/.wavecrate/models/`).
 - Tip: Use **Options → Open config folder** to jump to the right place on disk.
 

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -37,6 +37,10 @@ const VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/verify_portalsurfer_upload_catalog.py");
 const VERIFY_PUBLISHED_RELEASE_SCRIPT: &str =
     include_str!("../scripts/internal/release/verify_published_release.py");
+const TEST_DOCS: &str = include_str!("../docs/TEST.md");
+const TARGET_DOCS: &str = include_str!("../docs/TARGET.md");
+const GETTING_STARTED_DOCS: &str = include_str!("../docs/book/src/getting-started.md");
+const MANUAL_USAGE_DOCS: &str = include_str!("../manual/usage.md");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 const CHECKSUMS_PUBLIC_KEY: &str = "8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=";
 
@@ -341,6 +345,35 @@ fn release_contract_template_emits_supported_nightly_asset_names() {
 }
 
 #[test]
+fn release_surfaces_describe_supported_artifacts_without_setup_contracts() {
+    assert!(
+        TEST_DOCS.contains("### Windows ZIP Distribution Lifecycle"),
+        "docs/TEST.md must describe the supported manual Windows release lifecycle"
+    );
+    assert!(
+        GETTING_STARTED_DOCS.contains("On Windows, Wavecrate is a manual ZIP install"),
+        "user docs must explain the supported Windows ZIP install path"
+    );
+    assert!(
+        TARGET_DOCS.contains("Windows release installs are manual by design"),
+        "target contract must keep the manual Windows install policy explicit"
+    );
+    assert!(
+        MANUAL_USAGE_DOCS.contains("Downloaded bundles may include ML assets"),
+        "manual usage docs must avoid setup-managed asset-copy promises"
+    );
+
+    for (surface, contents) in release_distribution_surfaces() {
+        for forbidden in unsupported_setup_contract_terms() {
+            assert!(
+                !contents.contains(&forbidden),
+                "{surface} must not advertise unsupported OS-managed release behavior: {forbidden}"
+            );
+        }
+    }
+}
+
+#[test]
 fn release_packager_uses_contract_nightly_asset_name_without_build_number() {
     let contract = parse_contract();
     let nightly_template = contract
@@ -385,6 +418,33 @@ fn release_packager_uses_contract_nightly_asset_name_without_build_number() {
         !RELEASE_ZIP_SCRIPT.contains(r#"$POWERSHELL_WORK_DIR\\$APP_NAME\\*"#),
         "PowerShell zip fallback must not flatten the archive root with a wildcard"
     );
+}
+
+fn release_distribution_surfaces() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("release_contract.toml", RELEASE_CONTRACT),
+        ("nightly release workflow", NIGHTLY_WORKFLOW),
+        ("RC release workflow", RC_WORKFLOW),
+        ("stable release workflow", STABLE_WORKFLOW),
+        ("release artifact builder", BUILD_RELEASE_ARTIFACT_SCRIPT),
+        ("release ZIP builder", RELEASE_ZIP_SCRIPT),
+        ("release assembly helper", ASSEMBLE_RELEASE_FILES_SCRIPT),
+        ("post-publish verifier", VERIFY_PUBLISHED_RELEASE_SCRIPT),
+        ("docs/TEST.md", TEST_DOCS),
+        ("docs/book/src/getting-started.md", GETTING_STARTED_DOCS),
+        ("manual/usage.md", MANUAL_USAGE_DOCS),
+    ]
+}
+
+fn unsupported_setup_contract_terms() -> Vec<String> {
+    let old_binary_suffix = ["instal", "ler"].concat();
+    vec![
+        ["wavecrate", old_binary_suffix.as_str()].join("-"),
+        ["Start", "Menu"].join(" "),
+        ["uninstall", "registry"].join(" "),
+        ["Add/Remove", "Programs"].join(" "),
+        ["Programs", "and", "Features"].join(" "),
+    ]
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Replace active Windows installer validation docs with the supported Windows ZIP distribution lifecycle.
- Clarify user-facing Windows install, update, remove, and bundled asset behavior in the public docs/manual.
- Add a release contract guard so release-facing workflows, helpers, contracts, and docs do not advertise the removed installer-managed distribution path.

## Definition of Done

- Supported release/docs surfaces no longer describe an installer-managed Wavecrate distribution.
- Release contract checks cover the post-installer artifact story for active release surfaces.
- Windows install/update/remove instructions describe the manual ZIP flow clearly.

## Validation Commands

- `cargo test --test release_contract`
- `bash scripts/check.sh mdbook`
- `git diff --check`
- `rg "installer|wavecrate-installer|Start Menu|uninstall registry|Add/Remove Programs|Programs and Features" docs README.md manual .github scripts tests release_contract.toml -g '!target'`

## Known Limitations

- OPT-1035 has not landed yet, so the installer crate and its CODEOWNERS entry remain intentionally untouched. The remaining broad audit matches are unrelated bootstrap hook-installation wording and the out-of-scope `apps/installer/` ownership entry.

User review is required before merge.