### PR TITLE
OPT-1038 Keep playmark selection responsive in starmap

### DIFF
--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -68,6 +68,7 @@ impl<'a> SampleBrowserViewProjection<'a> {
             .is_some();
         let drag_feedback = state.library.folder_browser.file_column_drag_feedback();
         let display_mode = state.ui.chrome.sample_browser_display;
+        let waveform_drag_active = state.waveform.current.active_drag_kind().is_some();
         let visible_samples = state
             .library
             .folder_browser
@@ -75,7 +76,7 @@ impl<'a> SampleBrowserViewProjection<'a> {
                 tags_by_file: &state.metadata.tags_by_file,
                 cached_sample_paths: &state.waveform.cache.cached_sample_paths,
             });
-        let map_items = starmap_items_for_display(state, display_mode);
+        let map_items = starmap_items_for_display(state, display_mode, waveform_drag_active);
 
         Self {
             visible_samples,
@@ -150,14 +151,29 @@ pub(in crate::native_app) fn prepare_sample_browser_view(state: &mut NativeAppSt
             .library
             .folder_browser
             .prepare_starmap_layout(&state.metadata.tags_by_file);
+        state
+            .library
+            .folder_browser
+            .prepare_starmap_projection(StarmapProjection {
+                tags_by_file: &state.metadata.tags_by_file,
+                instant_audition_sample_paths: &state.waveform.cache.instant_audition_sample_paths,
+            });
     }
 }
 
 fn starmap_items_for_display(
     state: &NativeAppState,
     display_mode: SampleBrowserDisplayMode,
+    waveform_drag_active: bool,
 ) -> Vec<StarmapItem> {
     if display_mode != SampleBrowserDisplayMode::Map {
+        return Vec::new();
+    }
+    let cached = state.library.folder_browser.cached_starmap_projection();
+    if let Some(cached) = cached {
+        return cached.to_vec();
+    }
+    if waveform_drag_active {
         return Vec::new();
     }
     state
@@ -180,9 +196,12 @@ fn waveform_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::native_app::sample_library::folder_browser::FolderBrowserState;
     use crate::native_app::test_support::state::{NativeAppStateFixture, WaveformInteraction};
     use crate::native_app::waveform::WaveformSelectionKind;
+    use crate::native_app::{
+        app::SampleBrowserDisplayMode, sample_library::folder_browser::FolderBrowserState,
+    };
+    use radiant::widgets::TextInputMessage;
     use std::fs;
 
     #[test]
@@ -251,6 +270,72 @@ mod tests {
             "extracted row should be visible before the active playmark drag ends"
         );
         assert!(waveform_drag_defers_sample_browser_preparation(&state));
+    }
+
+    #[test]
+    fn active_waveform_drag_reuses_cached_starmap_projection() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let kick = source.join("kick.wav");
+        let snare = source.join("snare.wav");
+        fs::write(&kick, [0_u8; 8]).expect("write kick");
+        fs::write(&snare, [1_u8; 8]).expect("write snare");
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_root(source.clone()))
+            .with_synthetic_waveform()
+            .build();
+        state.ui.chrome.sample_browser_display = SampleBrowserDisplayMode::Map;
+        prepare_sample_browser_view(&mut state);
+        let before_drag_ids = {
+            let before_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
+            assert_eq!(before_drag.map_items.len(), 2);
+            before_drag
+                .map_items
+                .iter()
+                .map(|item| item.file_id.clone())
+                .collect::<Vec<_>>()
+        };
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelection {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+        state
+            .library
+            .folder_browser
+            .apply_name_filter_input(TextInputMessage::Changed {
+                value: String::from("does-not-match"),
+            });
+        assert!(waveform_drag_defers_sample_browser_preparation(&state));
+        prepare_sample_browser_view(&mut state);
+        let during_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
+
+        assert_eq!(
+            during_drag
+                .map_items
+                .iter()
+                .map(|item| item.file_id.clone())
+                .collect::<Vec<_>>(),
+            before_drag_ids,
+            "live playmark drags should reuse the prepared starmap projection instead of rebuilding it"
+        );
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::FinishSelection {
+                visible_ratio: 0.45,
+            });
+        prepare_sample_browser_view(&mut state);
+        let after_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
+        assert!(
+            after_drag.map_items.is_empty(),
+            "starmap projection should refresh normally after the live playmark drag ends"
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -62,6 +62,8 @@ impl StarmapStatus {
 pub(super) struct StarmapLayoutCache {
     signature: Option<u64>,
     pub(super) points_by_file: HashMap<String, StarmapLayoutPoint>,
+    pub(super) projection_items: Vec<StarmapItem>,
+    projection_prepared: bool,
     listed_count: usize,
     pending_load_signature: Option<u64>,
     loaded_signature: Option<u64>,
@@ -103,6 +105,8 @@ impl FolderBrowserState {
             signature: Some(signature),
             listed_count: snapshot.rows().len(),
             points_by_file: HashMap::new(),
+            projection_items: Vec::new(),
+            projection_prepared: false,
             pending_load_signature: None,
             loaded_signature: None,
         };
@@ -116,6 +120,9 @@ impl FolderBrowserState {
         &mut self,
         tags_by_file: &HashMap<String, Vec<String>>,
     ) -> Option<StarmapLayoutLoadRequest> {
+        if !self.starmap_layout_load_may_need_request() {
+            return None;
+        }
         let (request, listed_count) = self.starmap_layout_load_request(tags_by_file);
         let signature = request.signature;
         if self.sample_list.starmap_layout.signature != Some(signature) {
@@ -123,6 +130,8 @@ impl FolderBrowserState {
                 signature: Some(signature),
                 listed_count,
                 points_by_file: HashMap::new(),
+                projection_items: Vec::new(),
+                projection_prepared: false,
                 pending_load_signature: None,
                 loaded_signature: None,
             };
@@ -139,6 +148,14 @@ impl FolderBrowserState {
         }
         cache.pending_load_signature = Some(signature);
         Some(request)
+    }
+
+    pub(in crate::native_app) fn starmap_layout_load_may_need_request(&self) -> bool {
+        let cache = &self.sample_list.starmap_layout;
+        let Some(signature) = cache.signature else {
+            return true;
+        };
+        cache.pending_load_signature != Some(signature) && cache.loaded_signature != Some(signature)
     }
 
     pub(in crate::native_app) fn apply_starmap_layout_load_result(
@@ -178,6 +195,26 @@ impl FolderBrowserState {
         &self,
         projection: StarmapProjection<'_>,
     ) -> Vec<StarmapItem> {
+        self.build_starmap_projection(projection)
+    }
+
+    pub(in crate::native_app) fn prepare_starmap_projection(
+        &mut self,
+        projection: StarmapProjection<'_>,
+    ) {
+        let items = self.build_starmap_projection(projection);
+        self.sample_list.starmap_layout.projection_items = items;
+        self.sample_list.starmap_layout.projection_prepared = true;
+    }
+
+    pub(in crate::native_app) fn cached_starmap_projection(&self) -> Option<&[StarmapItem]> {
+        self.sample_list
+            .starmap_layout
+            .projection_prepared
+            .then_some(self.sample_list.starmap_layout.projection_items.as_slice())
+    }
+
+    fn build_starmap_projection(&self, projection: StarmapProjection<'_>) -> Vec<StarmapItem> {
         let snapshot = self.browser_listing_snapshot(projection.tags_by_file);
         let focused_file_id = self.selected_file_id();
         snapshot
@@ -667,6 +704,45 @@ mod tests {
             .expect("selected map item");
         assert_eq!(position, Some((selected.x, selected.y)));
         assert!(selected.focused);
+    }
+
+    #[test]
+    fn starmap_layout_request_is_needed_only_until_pending_or_loaded() {
+        let root = tempfile::tempdir().expect("source root");
+        let kick = root.path().join("kick.wav");
+        std::fs::write(&kick, []).expect("write sample");
+        let mut browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
+            root.path().to_path_buf(),
+        )]);
+        let tags_by_file = HashMap::new();
+        browser.prepare_starmap_layout(&tags_by_file);
+
+        assert!(browser.starmap_layout_load_may_need_request());
+        let request = browser
+            .take_starmap_layout_load_request(&tags_by_file)
+            .expect("first map layout request");
+
+        assert!(
+            !browser.starmap_layout_load_may_need_request(),
+            "pending layout loads should not ask the frame loop to rebuild map requests"
+        );
+        assert!(
+            browser
+                .take_starmap_layout_load_request(&tags_by_file)
+                .is_none(),
+            "duplicate layout requests should stay suppressed while one is pending"
+        );
+        browser.apply_starmap_layout_load_result(StarmapLayoutLoadResult {
+            signature: request.signature,
+            result: Ok(HashMap::new()),
+        });
+        assert!(
+            !browser.starmap_layout_load_may_need_request(),
+            "loaded layouts should stay quiet until the starmap layout is invalidated"
+        );
+
+        browser.invalidate_starmap_layout();
+        assert!(browser.starmap_layout_load_may_need_request());
     }
 
     #[test]


### PR DESCRIPTION
## Scope
- Cache prepared starmap projection items so live waveform/playmark drags reuse the last prepared map view instead of rebuilding the full starmap projection on each UI pass.
- Suppress duplicate starmap layout-load request construction once a layout request is pending or loaded.
- Preserve normal starmap projection refresh after the waveform drag finishes or when the browser view is allowed to refresh.

## Definition of Done
- Playmark creation, resize, and move interactions avoid starmap projection/layout request rebuild work during live drags.
- Starmap projection refreshes normally after the drag ends.
- Existing playmark playback retarget behavior remains covered: fresh playmark creation retargets on release, existing playmark edits keep live retargeting.
- Starmap drag/audition behavior remains covered.

## Validation commands
- `git diff --check`
- `cargo test -p wavecrate --bin wavecrate app_chrome::view_models::sample_browser::tests::active_waveform_drag_reuses_cached_starmap_projection -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate sample_library::folder_browser::starmap::tests::starmap_layout_request_is_needed_only_until_pending_or_loaded -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate shell::message_dispatch::waveform::tests -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate waveform::tests::widget_input::playmark -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate native_app::tests::sample_browser::starmap -- --test-threads=1`

## Known limitations
- Manual desktop smoke with a populated real starmap was not run in this agent session.
- `bash scripts/agent.sh request` was run before implementation and hit the existing Radiant guardrail baseline failures; focused validation above passed.

User review is required before merge.