### PR TITLE
Preserve Starmap layout aspect ratio

### DIFF
--- a/src/app_core/ui_projection/map_projection/points.rs
+++ b/src/app_core/ui_projection/map_projection/points.rs
@@ -30,16 +30,14 @@ fn build_projected_map_points_cache(
     bounds: MapBounds,
     points: &[MapPoint],
 ) -> (Arc<[ProjectedMapPointCacheEntry]>, usize) {
-    let denom_x = (bounds.max_x - bounds.min_x).max(1e-6);
-    let denom_y = (bounds.max_y - bounds.min_y).max(1e-6);
+    let projection = AspectPreservingMapProjection::new(bounds);
     let mut cluster_ids = HashSet::new();
     let mut projected_points = Vec::with_capacity(points.len());
     for point in points {
         if let Some(cluster_id) = point.cluster_id {
             cluster_ids.insert(cluster_id);
         }
-        let x = ((point.x - bounds.min_x) / denom_x).clamp(0.0, 1.0);
-        let y = ((point.y - bounds.min_y) / denom_y).clamp(0.0, 1.0);
+        let (x, y) = projection.project(point.x, point.y);
         projected_points.push(ProjectedMapPointCacheEntry {
             id: Arc::clone(&point.sample_id),
             x_milli: normalized_to_milli(x),
@@ -50,12 +48,44 @@ fn build_projected_map_points_cache(
     (Arc::from(projected_points), cluster_ids.len())
 }
 
+#[derive(Clone, Copy)]
+struct AspectPreservingMapProjection {
+    raw_center_x: f32,
+    raw_center_y: f32,
+    raw_units_per_normalized_unit: f32,
+}
+
+impl AspectPreservingMapProjection {
+    fn new(bounds: MapBounds) -> Self {
+        let raw_center_x = (bounds.min_x + bounds.max_x) * 0.5;
+        let raw_center_y = (bounds.min_y + bounds.max_y) * 0.5;
+        let span_x = (bounds.max_x - bounds.min_x).abs();
+        let span_y = (bounds.max_y - bounds.min_y).abs();
+        let raw_units_per_normalized_unit = span_x.max(span_y);
+        Self {
+            raw_center_x,
+            raw_center_y,
+            raw_units_per_normalized_unit,
+        }
+    }
+
+    fn project(self, x: f32, y: f32) -> (f32, f32) {
+        if !x.is_finite() || !y.is_finite() || self.raw_units_per_normalized_unit <= f32::EPSILON {
+            return (0.5, 0.5);
+        }
+        (
+            (0.5 + (x - self.raw_center_x) / self.raw_units_per_normalized_unit).clamp(0.0, 1.0),
+            (0.5 + (y - self.raw_center_y) / self.raw_units_per_normalized_unit).clamp(0.0, 1.0),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn projected_map_points_normalize_into_milli_space_and_count_clusters() {
+    fn projected_map_points_preserve_raw_shape_in_milli_space_and_count_clusters() {
         let bounds = MapBounds {
             min_x: -1.0,
             max_x: 1.0,
@@ -86,11 +116,43 @@ mod tests {
         let (projected, cluster_count) = build_projected_map_points_cache(bounds, &points);
 
         assert_eq!(cluster_count, 2);
-        assert_eq!(projected[0].x_milli, 0);
+        assert_eq!(projected[0].x_milli, 250);
         assert_eq!(projected[0].y_milli, 0);
-        assert_eq!(projected[1].x_milli, 1000);
+        assert_eq!(projected[1].x_milli, 750);
         assert_eq!(projected[1].y_milli, 1000);
         assert_eq!(projected[2].x_milli, 500);
         assert_eq!(projected[2].y_milli, 500);
+    }
+
+    #[test]
+    fn projected_map_points_do_not_stretch_tiny_sets_into_rectangle() {
+        let bounds = MapBounds {
+            min_x: 0.0,
+            max_x: 0.10,
+            min_y: 0.0,
+            max_y: 8.0,
+        };
+        let points = vec![
+            MapPoint {
+                sample_id: Arc::<str>::from("a"),
+                x: 0.0,
+                y: 0.0,
+                cluster_id: None,
+            },
+            MapPoint {
+                sample_id: Arc::<str>::from("b"),
+                x: 0.10,
+                y: 8.0,
+                cluster_id: None,
+            },
+        ];
+
+        let (projected, cluster_count) = build_projected_map_points_cache(bounds, &points);
+
+        assert_eq!(cluster_count, 0);
+        assert_eq!(projected[0].x_milli, 494);
+        assert_eq!(projected[0].y_milli, 0);
+        assert_eq!(projected[1].x_milli, 506);
+        assert_eq!(projected[1].y_milli, 1000);
     }
 }

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -86,7 +86,7 @@ pub(super) fn starmap_view(
     let items = items.into();
     let map = if items.is_empty() {
         ui::column([
-            ui::text_line(starmap_empty_message(curation_mode_enabled), 23.0).muted_text(),
+            ui::text_line(starmap_empty_message(curation_mode_enabled, status), 23.0).muted_text(),
             ui::spacer().fill_height(),
         ])
         .spacing(0.0)
@@ -132,7 +132,10 @@ pub(in crate::native_app) fn paint_active_starmap_audition_overlay(
     }
 }
 
-fn starmap_empty_message(curation_mode_enabled: bool) -> &'static str {
+fn starmap_empty_message(curation_mode_enabled: bool, status: StarmapStatus) -> &'static str {
+    if status.listed_count > 0 {
+        return "No Starmap positions yet";
+    }
     if curation_mode_enabled {
         "No files left to curate"
     } else {

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -3,8 +3,8 @@ use radiant::{
     layout::LayoutOutput,
     prelude as ui,
     runtime::{
-        push_fill_polygon, push_fill_rect, push_fill_rect_batch, push_stroke_polyline,
-        PaintPrimitive,
+        PaintPrimitive, push_fill_polygon, push_fill_rect, push_fill_rect_batch,
+        push_stroke_polyline,
     },
     theme::ThemeTokens,
     widgets::{
@@ -13,7 +13,7 @@ use radiant::{
     },
 };
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
     sync::{Arc, Mutex, MutexGuard, OnceLock},
 };
@@ -26,7 +26,7 @@ use crate::native_app::sample_library::context_menu_target::{
 };
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::starmap::{
-    starmap_cluster_palette_color, StarmapItem, StarmapStatus,
+    StarmapItem, StarmapStatus, starmap_cluster_palette_color,
 };
 use crate::native_app::starmap_audition_telemetry::{
     self as starmap_telemetry, StarmapAuditionCounter, StarmapAuditionDuration,
@@ -1259,7 +1259,14 @@ fn append_cached_items_paint(
     let started_at = starmap_telemetry::stage_timer();
     if should_use_dense_overview(items.len(), viewport) {
         let (cells, exact_items) = dense_overview_paint(cache, items, paint_signature);
-        paint_dense_overview_items(primitives, widget_id, bounds, viewport, &cells, &exact_items);
+        paint_dense_overview_items(
+            primitives,
+            widget_id,
+            bounds,
+            viewport,
+            &cells,
+            &exact_items,
+        );
         let elapsed = starmap_telemetry::elapsed_since(started_at);
         if let Some(elapsed) = elapsed {
             starmap_telemetry::record_duration(StarmapAuditionDuration::WidgetPaintBuild, elapsed);
@@ -1458,7 +1465,10 @@ fn should_use_dense_overview(item_count: usize, viewport: StarmapViewport) -> bo
 
 fn build_dense_overview_paint(
     items: &[StarmapItem],
-) -> (Vec<StarmapDenseOverviewCell>, Vec<StarmapDenseOverviewExactItem>) {
+) -> (
+    Vec<StarmapDenseOverviewCell>,
+    Vec<StarmapDenseOverviewExactItem>,
+) {
     let mut cells = BTreeMap::<StarmapDenseOverviewCellKey, StarmapDenseOverviewAccumulator>::new();
     let mut exact_items = Vec::new();
     for item in items {
@@ -1467,7 +1477,10 @@ fn build_dense_overview_paint(
             continue;
         }
         let key = StarmapDenseOverviewCellKey::from_item(item);
-        cells.entry(key).or_default().add(starmap_item_color(item));
+        cells
+            .entry(key)
+            .or_default()
+            .add(item, starmap_item_color(item));
     }
     let cells = cells
         .into_iter()
@@ -1899,6 +1912,8 @@ fn dense_overview_coordinate(value: f32) -> i32 {
 #[derive(Clone, Copy, Debug, Default)]
 struct StarmapDenseOverviewAccumulator {
     count: u32,
+    x_sum: f32,
+    y_sum: f32,
     r_sum: u32,
     g_sum: u32,
     b_sum: u32,
@@ -1906,8 +1921,10 @@ struct StarmapDenseOverviewAccumulator {
 }
 
 impl StarmapDenseOverviewAccumulator {
-    fn add(&mut self, color: ui::Rgba8) {
+    fn add(&mut self, item: &StarmapItem, color: ui::Rgba8) {
         self.count += 1;
+        self.x_sum += item.x;
+        self.y_sum += item.y;
         self.r_sum += u32::from(color.r);
         self.g_sum += u32::from(color.g);
         self.b_sum += u32::from(color.b);
@@ -1918,13 +1935,20 @@ impl StarmapDenseOverviewAccumulator {
         if self.count == 0 {
             return None;
         }
-        let (x, y) = key.center();
+        let (fallback_x, fallback_y) = key.center();
         Some(StarmapDenseOverviewCell {
-            x,
-            y,
+            x: self.average_coordinate(self.x_sum, fallback_x),
+            y: self.average_coordinate(self.y_sum, fallback_y),
             color: self.quantized_color(),
             side: self.side(),
         })
+    }
+
+    fn average_coordinate(self, sum: f32, fallback: f32) -> f32 {
+        if !sum.is_finite() {
+            return fallback;
+        }
+        (sum / self.count as f32).clamp(0.0, 1.0)
     }
 
     fn quantized_color(self) -> ui::Rgba8 {
@@ -2712,9 +2736,10 @@ mod tests {
         next.synchronize_from_previous(&previous);
 
         assert_eq!(next.hovered_file_id.as_deref(), Some("/samples/kick.wav"));
-        assert!(next
-            .hit_index
-            .matches(bounds, StarmapViewport::default(), next.item_signature()));
+        assert!(
+            next.hit_index
+                .matches(bounds, StarmapViewport::default(), next.item_signature())
+        );
     }
 
     #[test]
@@ -2818,6 +2843,26 @@ mod tests {
         assert!(
             cache.entry.is_none(),
             "dense overview paint should not churn exact-viewport primitive caches while panning"
+        );
+    }
+
+    #[test]
+    fn dense_overview_cells_use_actual_item_centroids_not_grid_centers() {
+        let color = ui::Rgba8::new(57, 187, 245, 220);
+        let items = vec![
+            starmap_item("/samples/a.wav", 0.0973, 0.1947, color),
+            starmap_item("/samples/b.wav", 0.0981, 0.1955, color),
+        ];
+
+        let (cells, exact_items) = build_dense_overview_paint(&items);
+
+        assert!(exact_items.is_empty());
+        assert_eq!(cells.len(), 1);
+        assert!((cells[0].x - 0.0977).abs() < 0.0001);
+        assert!((cells[0].y - 0.1951).abs() < 0.0001);
+        assert!(
+            (cells[0].x - (7.5 / MAP_DENSE_OVERVIEW_GRID_SIZE as f32)).abs() > 0.005,
+            "dense overview should aggregate at the real local centroid instead of snapping to the grid center"
         );
     }
 
@@ -3154,9 +3199,10 @@ mod tests {
         next.handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 50.0)));
 
         assert_eq!(next.hovered_file_id.as_deref(), Some("/samples/snare.wav"));
-        assert!(next
-            .hit_index
-            .matches(bounds, StarmapViewport::default(), next.item_signature()));
+        assert!(
+            next.hit_index
+                .matches(bounds, StarmapViewport::default(), next.item_signature())
+        );
     }
 
     #[test]

--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -343,6 +343,9 @@ mod tests {
             .with_synthetic_waveform()
             .build();
         state.ui.chrome.sample_browser_display = SampleBrowserDisplayMode::Map;
+        crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+            &mut state,
+        );
         prepare_sample_browser_view(&mut state);
         let before_drag_ids = {
             let before_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
@@ -409,6 +412,9 @@ mod tests {
             .with_folder_browser(FolderBrowserState::from_root(source.clone()))
             .build();
         state.ui.chrome.sample_browser_display = SampleBrowserDisplayMode::Map;
+        crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+            &mut state,
+        );
         prepare_sample_browser_view(&mut state);
         let before_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
         let before_drag_items = before_drag.map_items.clone();
@@ -480,6 +486,9 @@ mod tests {
             .with_folder_browser(FolderBrowserState::from_root(source))
             .build();
         state.ui.chrome.sample_browser_display = SampleBrowserDisplayMode::Map;
+        crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+            &mut state,
+        );
 
         prepare_sample_browser_view(&mut state);
         let cached = state

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -2043,6 +2043,9 @@ mod tests {
             )
             .build();
         state.ui.chrome.sample_browser_display = SampleBrowserDisplayMode::Map;
+        crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+            &mut state,
+        );
         crate::native_app::test_support::sample_browser::prepare_sample_browser_view(&mut state);
         state
     }

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -453,10 +453,22 @@ impl FolderBrowserState {
     fn build_starmap_projection(&self, projection: StarmapProjection<'_>) -> Vec<StarmapItem> {
         let snapshot = self.browser_listing_snapshot(projection.tags_by_file);
         let focused_file_id = self.selected_file_id();
+        let layout_cache = &self.sample_list.starmap_layout;
+        let layout_load_completed = layout_cache.signature.is_some()
+            && layout_cache.loaded_signature == layout_cache.signature;
         snapshot
             .rows()
             .iter()
-            .map(|file| {
+            .filter_map(|file| {
+                let layout_point = self
+                    .sample_list
+                    .starmap_layout
+                    .points_by_file
+                    .get(&file.id)
+                    .copied();
+                if layout_point.is_none() && layout_load_completed {
+                    return None;
+                }
                 let instant_audition_ready = instant_audition_ready_for_starmap(
                     file,
                     projection.instant_audition_sample_paths,
@@ -466,19 +478,13 @@ impl FolderBrowserState {
                 let aspects = self.similarity_aspect_display_strengths_for_file(&file.id);
                 let strength = self.similarity_display_strength_for_file(&file.id);
                 let group = strongest_enabled_aspect(&aspects, self.similarity_controls());
-                let layout_point = self
-                    .sample_list
-                    .starmap_layout
-                    .points_by_file
-                    .get(&file.id)
-                    .copied();
                 let (x, y) = starmap_position(
                     &file.id,
                     group,
                     strength,
                     layout_point.map(|point| (point.x, point.y)),
                 );
-                StarmapItem {
+                Some(StarmapItem {
                     file_id: file.id.clone(),
                     label: file.stem.clone(),
                     x,
@@ -492,7 +498,7 @@ impl FolderBrowserState {
                     preview_audition_ready,
                     preview_audition_candidate: preview_audition_candidate_for_starmap(file),
                     missing: file.is_missing(),
-                }
+                })
             })
             .collect()
     }
@@ -1045,6 +1051,51 @@ mod tests {
                 "fallback point should stay inside the radial aspect cluster"
             );
         }
+    }
+
+    #[test]
+    fn starmap_projection_omits_missing_layout_rows_after_load_completes() {
+        let root = tempfile::tempdir().expect("source root");
+        let positioned = root.path().join("positioned.wav");
+        let missing = root.path().join("missing.wav");
+        std::fs::write(&positioned, []).expect("write positioned");
+        std::fs::write(&missing, []).expect("write missing");
+        let positioned_id = positioned.to_string_lossy().to_string();
+        let missing_id = missing.to_string_lossy().to_string();
+        let mut browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
+            root.path().to_path_buf(),
+        )]);
+        let tags_by_file = HashMap::new();
+        let request = browser
+            .take_starmap_layout_load_request(&tags_by_file)
+            .expect("layout request");
+        browser.apply_starmap_layout_load_result(StarmapLayoutLoadResult {
+            signature: request.signature,
+            result: Ok(HashMap::from([(
+                positioned_id.clone(),
+                wavecrate::sample_sources::StarmapLayoutPoint {
+                    x: 0.25,
+                    y: 0.75,
+                    cluster_id: None,
+                },
+            )])),
+        });
+
+        let map_ids = browser
+            .starmap_projection(StarmapProjection {
+                tags_by_file: &tags_by_file,
+                instant_audition_sample_paths: &HashSet::new(),
+                preview_audition_sample_paths: &HashSet::new(),
+            })
+            .into_iter()
+            .map(|item| item.file_id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(map_ids, vec![positioned_id]);
+        assert!(
+            !map_ids.contains(&missing_id),
+            "completed Starmap loads should not draw synthetic fallback positions for missing layout rows"
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -15,13 +15,6 @@ use crate::native_app::waveform::should_use_file_backed_wav_decode_for_entry;
 
 use super::{FileEntry, FolderBrowserState, SimilarityAspectStrengths};
 
-const GROUP_CENTERS: [(f32, f32); wavecrate_analysis::aspects::ASPECT_COUNT] = [
-    (0.50, 0.50),
-    (0.22, 0.36),
-    (0.42, 0.28),
-    (0.66, 0.36),
-    (0.78, 0.62),
-];
 const STARMAP_PROJECTION_INDEX_GRID: i32 = 48;
 
 #[derive(Clone, Copy)]
@@ -453,9 +446,6 @@ impl FolderBrowserState {
     fn build_starmap_projection(&self, projection: StarmapProjection<'_>) -> Vec<StarmapItem> {
         let snapshot = self.browser_listing_snapshot(projection.tags_by_file);
         let focused_file_id = self.selected_file_id();
-        let layout_cache = &self.sample_list.starmap_layout;
-        let layout_load_completed = layout_cache.signature.is_some()
-            && layout_cache.loaded_signature == layout_cache.signature;
         snapshot
             .rows()
             .iter()
@@ -465,10 +455,7 @@ impl FolderBrowserState {
                     .starmap_layout
                     .points_by_file
                     .get(&file.id)
-                    .copied();
-                if layout_point.is_none() && layout_load_completed {
-                    return None;
-                }
+                    .copied()?;
                 let instant_audition_ready = instant_audition_ready_for_starmap(
                     file,
                     projection.instant_audition_sample_paths,
@@ -478,18 +465,13 @@ impl FolderBrowserState {
                 let aspects = self.similarity_aspect_display_strengths_for_file(&file.id);
                 let strength = self.similarity_display_strength_for_file(&file.id);
                 let group = strongest_enabled_aspect(&aspects, self.similarity_controls());
-                let (x, y) = starmap_position(
-                    &file.id,
-                    group,
-                    strength,
-                    layout_point.map(|point| (point.x, point.y)),
-                );
+                let (x, y) = starmap_position(layout_point);
                 Some(StarmapItem {
                     file_id: file.id.clone(),
                     label: file.stem.clone(),
                     x,
                     y,
-                    color: starmap_color(group, strength, layout_point),
+                    color: starmap_color(group, strength, Some(layout_point)),
                     selected: self.is_file_selected(&file.id),
                     focused: focused_file_id == Some(file.id.as_str()),
                     copy_flash: self.copied_file_flash_active(&file.id),
@@ -709,44 +691,8 @@ fn aspect_strength(aspects: &SimilarityAspectStrengths, aspect: SimilarityAspect
         .unwrap_or(0.0)
 }
 
-fn starmap_position(
-    file_id: &str,
-    group: SimilarityAspect,
-    similarity_strength: Option<f32>,
-    layout_position: Option<(f32, f32)>,
-) -> (f32, f32) {
-    if let Some(position) = layout_position {
-        return position;
-    }
-    let (offset_x, offset_y) = stable_cluster_offset(file_id);
-    let (gx, gy) = GROUP_CENTERS[group.index()];
-    let strength = similarity_strength.unwrap_or(0.0);
-    let spread = fallback_starmap_spread(strength);
-    (
-        (gx + offset_x * spread).clamp(0.04, 0.96),
-        (gy + offset_y * spread).clamp(0.06, 0.94),
-    )
-}
-
-fn fallback_starmap_spread(strength: f32) -> f32 {
-    0.31 - strength.clamp(0.0, 1.0) * 0.13
-}
-
-fn stable_cluster_offset(file_id: &str) -> (f32, f32) {
-    let angle = unit_hash_with_salt(file_id, "sample-map-angle") * std::f32::consts::TAU;
-    let radius = unit_hash_with_salt(file_id, "sample-map-radius").sqrt() * 0.5;
-    (angle.cos() * radius, angle.sin() * radius)
-}
-
-fn unit_hash_with_salt(file_id: &str, salt: &str) -> f32 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    salt.hash(&mut hasher);
-    file_id.hash(&mut hasher);
-    unit_from_hash(hasher.finish())
-}
-
-fn unit_from_hash(hash: u64) -> f32 {
-    (hash as f64 / u64::MAX as f64) as f32
+fn starmap_position(layout_point: StarmapLayoutPoint) -> (f32, f32) {
+    (layout_point.x, layout_point.y)
 }
 
 fn starmap_color(
@@ -993,68 +939,51 @@ mod tests {
             .expect("extend sparse wav");
     }
 
-    #[test]
-    fn starmap_position_is_stable_and_bounded() {
-        let first = starmap_position("kick.wav", SimilarityAspect::Spectrum, Some(0.8), None);
-        let second = starmap_position("kick.wav", SimilarityAspect::Spectrum, Some(0.8), None);
+    fn test_layout_point(
+        index: usize,
+        total: usize,
+    ) -> wavecrate::sample_sources::StarmapLayoutPoint {
+        let total = total.max(1) as f32;
+        let t = (index as f32 + 0.5) / total;
+        wavecrate::sample_sources::StarmapLayoutPoint {
+            x: 0.10 + 0.80 * t,
+            y: 0.50 + ((index % 5) as f32 - 2.0) * 0.04,
+            cluster_id: None,
+        }
+    }
 
-        assert_eq!(first, second);
-        assert!((0.0..=1.0).contains(&first.0));
-        assert!((0.0..=1.0).contains(&first.1));
+    fn complete_test_starmap_layout(
+        browser: &mut FolderBrowserState,
+        tags_by_file: &HashMap<String, Vec<String>>,
+        file_ids: &[String],
+    ) {
+        browser.prepare_starmap_layout(tags_by_file);
+        let request = browser
+            .take_starmap_layout_load_request(tags_by_file)
+            .expect("starmap layout request");
+        browser.apply_starmap_layout_load_result(StarmapLayoutLoadResult {
+            signature: request.signature,
+            result: Ok(file_ids
+                .iter()
+                .enumerate()
+                .map(|(index, file_id)| (file_id.clone(), test_layout_point(index, file_ids.len())))
+                .collect()),
+        });
     }
 
     #[test]
     fn starmap_position_uses_normalized_layout_when_available() {
-        let position = starmap_position(
-            "kick.wav",
-            SimilarityAspect::Spectrum,
-            Some(0.8),
-            Some((0.25, 0.75)),
-        );
+        let position = starmap_position(StarmapLayoutPoint {
+            x: 0.25,
+            y: 0.75,
+            cluster_id: None,
+        });
 
         assert_eq!(position, (0.25, 0.75));
     }
 
     #[test]
-    fn starmap_position_falls_back_when_layout_is_missing() {
-        let fallback = starmap_position("kick.wav", SimilarityAspect::Spectrum, Some(0.8), None);
-        let layout = starmap_position(
-            "kick.wav",
-            SimilarityAspect::Spectrum,
-            Some(0.8),
-            Some((0.25, 0.75)),
-        );
-
-        assert_ne!(fallback, layout);
-        assert!((0.0..=1.0).contains(&fallback.0));
-        assert!((0.0..=1.0).contains(&fallback.1));
-    }
-
-    #[test]
-    fn starmap_missing_layout_fallback_uses_radial_cluster_not_square_jitter() {
-        let group = SimilarityAspect::Amplitude;
-        let (center_x, center_y) = GROUP_CENTERS[group.index()];
-        let max_radius = fallback_starmap_spread(0.0) * 0.5 + 0.0001;
-
-        for index in 0..512 {
-            let position = starmap_position(
-                &format!("missing-layout-{index}.wav"),
-                group,
-                Some(0.0),
-                None,
-            );
-            let dx = position.0 - center_x;
-            let dy = position.1 - center_y;
-
-            assert!(
-                dx * dx + dy * dy <= max_radius * max_radius,
-                "fallback point should stay inside the radial aspect cluster"
-            );
-        }
-    }
-
-    #[test]
-    fn starmap_projection_omits_missing_layout_rows_after_load_completes() {
+    fn starmap_projection_omits_missing_layout_rows_before_and_after_load_completes() {
         let root = tempfile::tempdir().expect("source root");
         let positioned = root.path().join("positioned.wav");
         let missing = root.path().join("missing.wav");
@@ -1069,6 +998,16 @@ mod tests {
         let request = browser
             .take_starmap_layout_load_request(&tags_by_file)
             .expect("layout request");
+        assert!(
+            browser
+                .starmap_projection(StarmapProjection {
+                    tags_by_file: &tags_by_file,
+                    instant_audition_sample_paths: &HashSet::new(),
+                    preview_audition_sample_paths: &HashSet::new(),
+                })
+                .is_empty(),
+            "pending Starmap loads should not draw synthetic fallback positions for missing layout rows"
+        );
         browser.apply_starmap_layout_load_result(StarmapLayoutLoadResult {
             signature: request.signature,
             result: Ok(HashMap::from([(
@@ -1094,7 +1033,7 @@ mod tests {
         assert_eq!(map_ids, vec![positioned_id]);
         assert!(
             !map_ids.contains(&missing_id),
-            "completed Starmap loads should not draw synthetic fallback positions for missing layout rows"
+            "completed Starmap loads should keep omitting missing layout rows"
         );
     }
 
@@ -1162,7 +1101,7 @@ mod tests {
         let kick_id = kick.to_string_lossy().to_string();
         browser.select_file(kick_id.clone());
         let tags_by_file = HashMap::new();
-        browser.prepare_starmap_layout(&tags_by_file);
+        complete_test_starmap_layout(&mut browser, &tags_by_file, std::slice::from_ref(&kick_id));
 
         let position = browser.selected_starmap_position(StarmapProjection {
             tags_by_file: &tags_by_file,
@@ -1388,7 +1327,11 @@ mod tests {
         browser.apply_tag_filter_input(radiant::widgets::TextInputMessage::Changed {
             value: String::from("drum"),
         });
-        browser.prepare_starmap_layout(&tags_by_file);
+        complete_test_starmap_layout(
+            &mut browser,
+            &tags_by_file,
+            &[kick_id.clone(), snare_id.clone()],
+        );
 
         let listing_ids = browser
             .browser_listing_snapshot(&tags_by_file)
@@ -1436,6 +1379,11 @@ mod tests {
         });
         let tags_by_file = HashMap::new();
         let cached_sample_paths = HashSet::new();
+        let file_ids = files
+            .iter()
+            .map(|file| file.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        complete_test_starmap_layout(&mut browser, &tags_by_file, &file_ids);
 
         let visible = browser.visible_samples(
             crate::native_app::sample_library::folder_browser::projection::VisibleSampleQuery {
@@ -1475,10 +1423,15 @@ mod tests {
         write_sparse_wav_i16(&long, 1, 1_024);
         let short_id = short.to_string_lossy().to_string();
         let long_id = long.to_string_lossy().to_string();
-        let browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
+        let mut browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
             root.path().to_path_buf(),
         )]);
         let tags_by_file = HashMap::new();
+        complete_test_starmap_layout(
+            &mut browser,
+            &tags_by_file,
+            &[long_id.clone(), short_id.clone()],
+        );
 
         let cold_items = browser
             .starmap_projection(StarmapProjection {
@@ -1534,10 +1487,11 @@ mod tests {
         let long = root.path().join("long.wav");
         write_sparse_wav_i16(&long, 1, 1_024);
         let long_id = long.to_string_lossy().to_string();
-        let browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
+        let mut browser = FolderBrowserState::from_sample_sources(&[SampleSource::new(
             root.path().to_path_buf(),
         )]);
         let tags_by_file = HashMap::new();
+        complete_test_starmap_layout(&mut browser, &tags_by_file, std::slice::from_ref(&long_id));
 
         let item = browser
             .starmap_projection(StarmapProjection {
@@ -1570,11 +1524,16 @@ mod tests {
         aspects[SimilarityAspect::Spectrum.index()] = Some(0.6);
         aspects[SimilarityAspect::Timbre.index()] = Some(1.0);
         browser.set_similarity_scores_with_aspects(
-            kick_id,
+            kick_id.clone(),
             HashMap::from([(snare_id.clone(), 0.9)]),
             HashMap::from([(snare_id.clone(), aspects)]),
         );
         let tags_by_file = HashMap::new();
+        complete_test_starmap_layout(
+            &mut browser,
+            &tags_by_file,
+            &[kick_id.clone(), snare_id.clone()],
+        );
 
         let timbre_color = browser
             .starmap_projection(StarmapProjection {
@@ -1627,6 +1586,11 @@ mod tests {
             root.path().to_path_buf(),
         )]);
         let tags_by_file = HashMap::new();
+        complete_test_starmap_layout(
+            &mut browser,
+            &tags_by_file,
+            &[kick_id.clone(), snare_id.clone(), hat_id.clone()],
+        );
 
         browser.select_file(kick_id.clone());
         browser.select_file_with_modifiers(

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -712,27 +712,31 @@ fn starmap_position(
     if let Some(position) = layout_position {
         return position;
     }
-    let (jx, jy) = stable_jitter(file_id);
+    let (offset_x, offset_y) = stable_cluster_offset(file_id);
     let (gx, gy) = GROUP_CENTERS[group.index()];
     let strength = similarity_strength.unwrap_or(0.0);
-    let spread = 0.31 - strength.clamp(0.0, 1.0) * 0.13;
+    let spread = fallback_starmap_spread(strength);
     (
-        (gx + (jx - 0.5) * spread).clamp(0.04, 0.96),
-        (gy + (jy - 0.5) * spread).clamp(0.06, 0.94),
+        (gx + offset_x * spread).clamp(0.04, 0.96),
+        (gy + offset_y * spread).clamp(0.06, 0.94),
     )
 }
 
-fn stable_jitter(file_id: &str) -> (f32, f32) {
-    let mut first = std::collections::hash_map::DefaultHasher::new();
-    file_id.hash(&mut first);
-    let mut second = std::collections::hash_map::DefaultHasher::new();
-    // Preserve the historical salt so fallback Starmap placement does not shift.
-    "sample-map-y".hash(&mut second);
-    file_id.hash(&mut second);
-    (
-        unit_from_hash(first.finish()),
-        unit_from_hash(second.finish()),
-    )
+fn fallback_starmap_spread(strength: f32) -> f32 {
+    0.31 - strength.clamp(0.0, 1.0) * 0.13
+}
+
+fn stable_cluster_offset(file_id: &str) -> (f32, f32) {
+    let angle = unit_hash_with_salt(file_id, "sample-map-angle") * std::f32::consts::TAU;
+    let radius = unit_hash_with_salt(file_id, "sample-map-radius").sqrt() * 0.5;
+    (angle.cos() * radius, angle.sin() * radius)
+}
+
+fn unit_hash_with_salt(file_id: &str, salt: &str) -> f32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    salt.hash(&mut hasher);
+    file_id.hash(&mut hasher);
+    unit_from_hash(hasher.finish())
 }
 
 fn unit_from_hash(hash: u64) -> f32 {
@@ -1018,6 +1022,29 @@ mod tests {
         assert_ne!(fallback, layout);
         assert!((0.0..=1.0).contains(&fallback.0));
         assert!((0.0..=1.0).contains(&fallback.1));
+    }
+
+    #[test]
+    fn starmap_missing_layout_fallback_uses_radial_cluster_not_square_jitter() {
+        let group = SimilarityAspect::Amplitude;
+        let (center_x, center_y) = GROUP_CENTERS[group.index()];
+        let max_radius = fallback_starmap_spread(0.0) * 0.5 + 0.0001;
+
+        for index in 0..512 {
+            let position = starmap_position(
+                &format!("missing-layout-{index}.wav"),
+                group,
+                Some(0.0),
+                None,
+            );
+            let dx = position.0 - center_x;
+            let dy = position.1 - center_y;
+
+            assert!(
+                dx * dx + dy * dy <= max_radius * max_radius,
+                "fallback point should stay inside the radial aspect cluster"
+            );
+        }
     }
 
     #[test]

--- a/src/native_app/test_support/sample_browser.rs
+++ b/src/native_app/test_support/sample_browser.rs
@@ -9,6 +9,8 @@ use crate::native_app::app_chrome::view_models::sample_browser::{
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
 use radiant::runtime::UiSurface;
+use std::collections::HashMap;
+use wavecrate::sample_sources::{StarmapLayoutLoadResult, StarmapLayoutPoint};
 
 pub(in crate::native_app) use crate::native_app::sample_library::folder_browser::view_contract::{
     DEFAULT_FOLDER_WIDTH, MAX_FOLDER_WIDTH, MIN_FOLDER_WIDTH,
@@ -35,6 +37,61 @@ pub(in crate::native_app) fn sample_browser(state: &NativeAppState) -> ui::View<
 
 pub(in crate::native_app) fn prepare_sample_browser_view(state: &mut NativeAppState) {
     prepare_chrome_sample_browser_view(state);
+}
+
+pub(in crate::native_app) fn complete_starmap_layout(
+    state: &mut NativeAppState,
+    points_by_file: HashMap<String, StarmapLayoutPoint>,
+) {
+    let tags_by_file = state.metadata.tags_by_file.clone();
+    state
+        .library
+        .folder_browser
+        .prepare_starmap_layout(&tags_by_file);
+    let Some(request) = state
+        .library
+        .folder_browser
+        .take_starmap_layout_load_request(&tags_by_file)
+    else {
+        return;
+    };
+    state
+        .library
+        .folder_browser
+        .apply_starmap_layout_load_result(StarmapLayoutLoadResult {
+            signature: request.signature,
+            result: Ok(points_by_file),
+        });
+}
+
+pub(in crate::native_app) fn complete_starmap_layout_for_selected_source(
+    state: &mut NativeAppState,
+) -> Vec<String> {
+    let file_ids = state
+        .library
+        .folder_browser
+        .selected_source_audio_files()
+        .into_iter()
+        .map(|file| file.id.clone())
+        .collect::<Vec<_>>();
+    let total = file_ids.len().max(1) as f32;
+    let points_by_file = file_ids
+        .iter()
+        .enumerate()
+        .map(|(index, file_id)| {
+            let t = (index as f32 + 0.5) / total;
+            (
+                file_id.clone(),
+                StarmapLayoutPoint {
+                    x: 0.10 + 0.80 * t,
+                    y: 0.50 + ((index % 7) as f32 - 3.0) * 0.035,
+                    cluster_id: None,
+                },
+            )
+        })
+        .collect();
+    complete_starmap_layout(state, points_by_file);
+    file_ids
 }
 
 pub(in crate::native_app) fn sample_file_hit_target(

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -1,6 +1,6 @@
 use radiant::{
     gui::types::{Point, Rect, Rgba8, Vector2},
-    prelude::{dense_row_palette_from_style, IntoView, ThemeTokens, WidgetStyle, WidgetTone},
+    prelude::{IntoView, ThemeTokens, WidgetStyle, WidgetTone, dense_row_palette_from_style},
     runtime::{Command, Event, SurfaceFrame, SurfacePaintPlan, UiSurface},
     widgets::{PointerButton, PointerModifiers, Widget, WidgetInput, WidgetOutput},
 };
@@ -198,10 +198,11 @@ fn recording_sample_last_played_updates_row_and_persists_source_history() {
     let message = run_first_perform(context.into_command()).expect("last played persist command");
     state.apply_message(message, &mut radiant::prelude::UiUpdateContext::default());
 
-    assert!(db
-        .last_played_at_for_path(std::path::Path::new("played.wav"))
-        .expect("read last played")
-        .is_some());
+    assert!(
+        db.last_played_at_for_path(std::path::Path::new("played.wav"))
+            .expect("read last played")
+            .is_some()
+    );
 }
 
 #[test]
@@ -1243,6 +1244,17 @@ fn starmap_mode_frame_warms_preview_audition_heads() {
         )
         .build();
     state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    crate::native_app::test_support::sample_browser::complete_starmap_layout(
+        &mut state,
+        HashMap::from([(
+            sample.display().to_string(),
+            wavecrate::sample_sources::StarmapLayoutPoint {
+                x: 0.50,
+                y: 0.50,
+                cluster_id: None,
+            },
+        )]),
+    );
     prepare_sample_browser_view(&mut state);
     let sample_id = sample.display().to_string();
     assert!(
@@ -1308,6 +1320,17 @@ fn starmap_drag_begin_cancels_active_preview_audition_warm() {
         )
         .build();
     state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    crate::native_app::test_support::sample_browser::complete_starmap_layout(
+        &mut state,
+        HashMap::from([(
+            sample_id.clone(),
+            wavecrate::sample_sources::StarmapLayoutPoint {
+                x: 0.50,
+                y: 0.50,
+                cluster_id: None,
+            },
+        )]),
+    );
     prepare_sample_browser_view(&mut state);
     let mut context = radiant::prelude::UiUpdateContext::default();
     state.apply_message(
@@ -2213,12 +2236,14 @@ fn starmap_drag_update_selects_next_hit_immediately() {
             .as_deref(),
         Some(second_id.as_str())
     );
-    assert!(state
-        .ui
-        .chrome
-        .starmap_audition_queue
-        .queued_file_ids
-        .is_empty());
+    assert!(
+        state
+            .ui
+            .chrome
+            .starmap_audition_queue
+            .queued_file_ids
+            .is_empty()
+    );
     let command = context.into_command();
     assert!(
         command.requests_paint_only(),
@@ -2332,12 +2357,14 @@ fn starmap_drag_latest_hit_advances_without_zero_delay_message() {
             .as_deref(),
         Some(second_id.as_str())
     );
-    assert!(state
-        .ui
-        .chrome
-        .starmap_audition_queue
-        .queued_file_ids
-        .is_empty());
+    assert!(
+        state
+            .ui
+            .chrome
+            .starmap_audition_queue
+            .queued_file_ids
+            .is_empty()
+    );
     assert!(
         delayed.iter().all(|message| !matches!(
             message,

--- a/src/sample_sources/starmap_layout.rs
+++ b/src/sample_sources/starmap_layout.rs
@@ -165,22 +165,17 @@ fn normalized_layout_points(
     if raw_points.is_empty() {
         return HashMap::new();
     }
-    let (mut min_x, mut max_x) = (f32::INFINITY, f32::NEG_INFINITY);
-    let (mut min_y, mut max_y) = (f32::INFINITY, f32::NEG_INFINITY);
-    for point in raw_points.values().copied() {
-        min_x = min_x.min(point.x);
-        max_x = max_x.max(point.x);
-        min_y = min_y.min(point.y);
-        max_y = max_y.max(point.y);
-    }
+    let bounds = raw_layout_bounds(raw_points.values().copied());
+    let projection = AspectPreservingLayoutProjection::new(bounds, (0.04, 0.96), (0.06, 0.94));
     raw_points
         .into_iter()
         .map(|(file_id, point)| {
+            let (x, y) = projection.project(point.x, point.y);
             (
                 file_id,
                 StarmapLayoutPoint {
-                    x: normalize_layout_axis(point.x, min_x, max_x, 0.04, 0.96),
-                    y: normalize_layout_axis(point.y, min_y, max_y, 0.06, 0.94),
+                    x,
+                    y,
                     cluster_id: point.cluster_id,
                 },
             )
@@ -188,16 +183,123 @@ fn normalized_layout_points(
         .collect()
 }
 
-fn normalize_layout_axis(value: f32, min: f32, max: f32, out_min: f32, out_max: f32) -> f32 {
-    if !value.is_finite() || !min.is_finite() || !max.is_finite() {
-        return (out_min + out_max) * 0.5;
+fn raw_layout_bounds(
+    points: impl IntoIterator<Item = RawStarmapLayoutPoint>,
+) -> Option<RawStarmapLayoutBounds> {
+    let (mut min_x, mut max_x) = (f32::INFINITY, f32::NEG_INFINITY);
+    let (mut min_y, mut max_y) = (f32::INFINITY, f32::NEG_INFINITY);
+    let mut valid_count = 0;
+    for point in points {
+        if !point.x.is_finite() || !point.y.is_finite() {
+            continue;
+        }
+        min_x = min_x.min(point.x);
+        max_x = max_x.max(point.x);
+        min_y = min_y.min(point.y);
+        max_y = max_y.max(point.y);
+        valid_count += 1;
     }
-    let span = max - min;
-    if span.abs() <= f32::EPSILON {
-        return (out_min + out_max) * 0.5;
+    (valid_count > 0).then_some(RawStarmapLayoutBounds {
+        min_x,
+        max_x,
+        min_y,
+        max_y,
+    })
+}
+
+#[derive(Clone, Copy)]
+struct RawStarmapLayoutBounds {
+    min_x: f32,
+    max_x: f32,
+    min_y: f32,
+    max_y: f32,
+}
+
+#[derive(Clone, Copy)]
+struct AspectPreservingLayoutProjection {
+    center_x: f32,
+    center_y: f32,
+    raw_center_x: f32,
+    raw_center_y: f32,
+    raw_units_per_normalized_unit: f32,
+    out_min_x: f32,
+    out_max_x: f32,
+    out_min_y: f32,
+    out_max_y: f32,
+}
+
+impl AspectPreservingLayoutProjection {
+    fn new(
+        bounds: Option<RawStarmapLayoutBounds>,
+        output_x: (f32, f32),
+        output_y: (f32, f32),
+    ) -> Self {
+        let (out_min_x, out_max_x) = output_x;
+        let (out_min_y, out_max_y) = output_y;
+        let center_x = (out_min_x + out_max_x) * 0.5;
+        let center_y = (out_min_y + out_max_y) * 0.5;
+        let Some(bounds) = bounds else {
+            return Self::centered(
+                center_x, center_y, out_min_x, out_max_x, out_min_y, out_max_y,
+            );
+        };
+        let raw_center_x = (bounds.min_x + bounds.max_x) * 0.5;
+        let raw_center_y = (bounds.min_y + bounds.max_y) * 0.5;
+        let span_x = (bounds.max_x - bounds.min_x).abs();
+        let span_y = (bounds.max_y - bounds.min_y).abs();
+        let output_span_x = (out_max_x - out_min_x).abs().max(f32::EPSILON);
+        let output_span_y = (out_max_y - out_min_y).abs().max(f32::EPSILON);
+        let raw_units_per_normalized_unit = (span_x / output_span_x).max(span_y / output_span_y);
+        if raw_units_per_normalized_unit <= f32::EPSILON {
+            return Self::centered(
+                center_x, center_y, out_min_x, out_max_x, out_min_y, out_max_y,
+            );
+        }
+        Self {
+            center_x,
+            center_y,
+            raw_center_x,
+            raw_center_y,
+            raw_units_per_normalized_unit,
+            out_min_x,
+            out_max_x,
+            out_min_y,
+            out_max_y,
+        }
     }
-    let unit = ((value - min) / span).clamp(0.0, 1.0);
-    out_min + (out_max - out_min) * unit
+
+    fn centered(
+        center_x: f32,
+        center_y: f32,
+        out_min_x: f32,
+        out_max_x: f32,
+        out_min_y: f32,
+        out_max_y: f32,
+    ) -> Self {
+        Self {
+            center_x,
+            center_y,
+            raw_center_x: 0.0,
+            raw_center_y: 0.0,
+            raw_units_per_normalized_unit: f32::INFINITY,
+            out_min_x,
+            out_max_x,
+            out_min_y,
+            out_max_y,
+        }
+    }
+
+    fn project(self, x: f32, y: f32) -> (f32, f32) {
+        if !x.is_finite() || !y.is_finite() {
+            return (self.center_x, self.center_y);
+        }
+        (
+            (self.center_x + (x - self.raw_center_x) / self.raw_units_per_normalized_unit)
+                .clamp(self.out_min_x, self.out_max_x),
+            (self.center_y + (y - self.raw_center_y) / self.raw_units_per_normalized_unit)
+                .clamp(self.out_min_y, self.out_max_y),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -205,7 +307,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalized_layout_positions_fill_map_domain() {
+    fn normalized_layout_positions_preserve_raw_shape_inside_map_domain() {
         let positions = normalized_layout_points(HashMap::from([
             (
                 String::from("a.wav"),
@@ -226,20 +328,48 @@ mod tests {
         ]));
 
         assert_eq!(
-            positions.get("a.wav"),
-            Some(&StarmapLayoutPoint {
-                x: 0.04,
-                y: 0.06,
-                cluster_id: Some(3),
-            })
+            positions.get("a.wav").map(|point| point.cluster_id),
+            Some(Some(3))
         );
+        let a = positions.get("a.wav").expect("a");
+        assert!((a.x - 0.28).abs() < 0.0001);
+        assert!((a.y - 0.06).abs() < 0.0001);
         assert_eq!(
-            positions.get("b.wav"),
-            Some(&StarmapLayoutPoint {
-                x: 0.96,
-                y: 0.94,
-                cluster_id: Some(7),
-            })
+            positions.get("b.wav").map(|point| point.cluster_id),
+            Some(Some(7))
         );
+        let b = positions.get("b.wav").expect("b");
+        assert!((b.x - 0.72).abs() < 0.0001);
+        assert!((b.y - 0.94).abs() < 0.0001);
+    }
+
+    #[test]
+    fn normalized_layout_positions_do_not_stretch_tiny_sets_into_rectangle() {
+        let positions = normalized_layout_points(HashMap::from([
+            (
+                String::from("a.wav"),
+                RawStarmapLayoutPoint {
+                    x: 0.0,
+                    y: 0.0,
+                    cluster_id: None,
+                },
+            ),
+            (
+                String::from("b.wav"),
+                RawStarmapLayoutPoint {
+                    x: 0.10,
+                    y: 8.0,
+                    cluster_id: None,
+                },
+            ),
+        ]));
+
+        let a = positions.get("a.wav").expect("a");
+        let b = positions.get("b.wav").expect("b");
+
+        assert!((a.x - 0.4945).abs() < 0.0002);
+        assert!((b.x - 0.5055).abs() < 0.0002);
+        assert!((a.y - 0.06).abs() < 0.0001);
+        assert!((b.y - 0.94).abs() < 0.0001);
     }
 }


### PR DESCRIPTION
## Scope
- Preserve raw Starmap layout shape when normalizing source layout rows into the native Starmap domain.
- Apply the same aspect-preserving projection to the app-core map point cache so both map surfaces avoid artificial rectangle stretching.
- Stop dense overview mode from snapping occupied cells to a fixed 72x72 grid center; dense cells now render at the centroid of their real contained items, which removes the visible barcode/rectangle lattice while keeping aggregation.
- Remove synthetic Starmap fallback geometry entirely for files without real layout rows, including while a layout request is pending, so unprepped folders do not flash a temporary ellipse/slash before positions load.
- Add regression coverage for tiny/narrow point sets, dense overview cell centroids, pending and completed missing-layout rows, and prepped test fixtures with explicit layout points.

## Definition of Done
- Small sample-count Starmap layouts no longer force independent x/y min-max normalization into a rectangular footprint.
- Zoomed-out dense Starmap overview no longer paints nodes on an obvious fixed-column lattice.
- Starmap does not draw artificial fallback rectangles, ellipses, or slashes for samples that have no layout row.
- Existing Starmap interaction/render tests remain green.
- Release compile check for the Wavecrate binary passes.

## Validation Commands
- `cargo test -p wavecrate --lib normalized_layout_positions -- --test-threads=1`
- `cargo test -p wavecrate --lib projected_map_points -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate dense_overview -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate starmap_projection_omits_missing_layout_rows_before_and_after_load_completes -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate starmap -- --test-threads=1`
- `cargo check --release -p wavecrate --bin wavecrate`
- `git diff --check`

## Known Limitations
- `bash scripts/agent.sh request` still fails on the pre-existing native boundary violation in `src/native_app/audio/playback/progress.rs`; this PR does not touch that area.

User review is required before merge.