### PR TITLE
OPT-1041: Unify sample playback sessions and planner

### DIFF
--- a/src/native_app/app/loading.rs
+++ b/src/native_app/app/loading.rs
@@ -36,13 +36,6 @@ pub(in crate::native_app) struct PreviewAuditionWarmResult {
     pub(in crate::native_app) errors: usize,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(in crate::native_app) enum PendingSamplePlayback {
-    RandomAudition { start_unit: f32, length_unit: f32 },
-    ResumeNormalized { start: f32, end: f32 },
-    ReplayHistory { start: f32, end: f32 },
-}
-
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(in crate::native_app) struct SampleSelectionLoadState {
     pub(in crate::native_app) selected_path: Option<String>,

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -14,8 +14,8 @@ pub(in crate::native_app) use cache::{
 };
 pub(in crate::native_app) use drop::NativeFileDropHover;
 pub(in crate::native_app) use loading::{
-    PendingSamplePlayback, PreviewAuditionResult, PreviewAuditionWarmResult, SampleLoadResult,
-    SampleLoadTaskCompletion, SamplePlaybackReady, SampleSelectionLoadState,
+    PreviewAuditionResult, PreviewAuditionWarmResult, SampleLoadResult, SampleLoadTaskCompletion,
+    SamplePlaybackReady, SampleSelectionLoadState,
 };
 pub(in crate::native_app) use message::{
     GuiMessage, MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult,
@@ -34,18 +34,18 @@ pub(in crate::native_app) use state::DEFAULT_VOLUME;
 pub(in crate::native_app) use state::ReleaseUpdateStatus;
 pub(in crate::native_app) use state::{
     AudioAppState, AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,
-    ChromeUiState, ClipboardHandoffTarget, CutFileClipboard, EarlySamplePlaybackKind,
-    ExtractedFilePlaybackType, FolderScanWorkerEvent, LibraryAppState, MAX_BEAT_GUIDE_COUNT,
-    MIN_BEAT_GUIDE_COUNT, MetadataAppState, NativeAppState, PendingFolderDelete,
-    PendingPlaySelectionRetargetCycle, PendingPlaybackStart, PendingProtectedExtractionAction,
-    PendingProtectedExtractionTargetSource, PendingRuntimePlaybackStart,
-    PendingWaveformDestructiveEdit, SampleBrowserDisplayMode, SamplePlaybackIntent,
-    SamplePlaybackRequest, SamplePlaybackVisibility, SettingsAppState,
-    SourceFilesystemChangePlan, SourceRefreshRequest, SourceScanFinish, StarmapAuditionDragState,
-    StarmapViewport, StarmapViewportChange, StartupState, StatusState, UiAppState,
-    WaveformAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
-    WaveformDestructiveEditTarget, WaveformDestructiveEditUiContext, WaveformEditSelectionSnapshot,
-    WaveformPlaySelectionSnapshot, run_folder_scan_worker,
+    ChromeUiState, ClipboardHandoffTarget, CutFileClipboard, ExtractedFilePlaybackType,
+    FolderScanWorkerEvent, LibraryAppState, MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT,
+    MetadataAppState, NativeAppState, PendingFolderDelete, PendingPlaySelectionRetargetCycle,
+    PendingPlaybackStart, PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,
+    PendingWaveformDestructiveEdit, SampleBrowserDisplayMode, SamplePlaybackHistory,
+    SamplePlaybackIntent, SamplePlaybackNormalization, SamplePlaybackRequest,
+    SamplePlaybackSession, SamplePlaybackSessionState, SamplePlaybackSourceProbe,
+    SamplePlaybackVisibility, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshRequest,
+    SourceScanFinish, StarmapAuditionDragState, StarmapViewport, StarmapViewportChange,
+    StartupState, StatusState, UiAppState, WaveformAppState, WaveformDestructiveEditKind,
+    WaveformDestructiveEditPrompt, WaveformDestructiveEditTarget, WaveformDestructiveEditUiContext,
+    WaveformEditSelectionSnapshot, WaveformPlaySelectionSnapshot, run_folder_scan_worker,
 };
 
 pub(super) use crate::native_app::app_chrome::scene::view;

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -7,9 +7,8 @@ use wavecrate::audio::{
 };
 use wavecrate::sample_sources::config::AppSettingsCore;
 
-use crate::native_app::{
-    app::PendingSamplePlayback,
-    audio::{playback::PlaybackIntent, playback_history::PlaybackNavigationHistory},
+use crate::native_app::audio::{
+    playback::PlaybackIntent, playback_history::PlaybackNavigationHistory,
 };
 
 pub(in crate::native_app) struct AudioAppState {
@@ -30,25 +29,16 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) settings_error: Option<String>,
     pub(in crate::native_app) current_playback_span: Option<(f32, f32)>,
     pub(in crate::native_app) pending_playback_start: Option<PendingPlaybackStart>,
-    pub(in crate::native_app) pending_sample_playback: Option<PendingSamplePlayback>,
+    pub(in crate::native_app) pending_sample_playback: Option<SamplePlaybackRequest>,
     pub(in crate::native_app) playback_history: PlaybackNavigationHistory,
-    pub(in crate::native_app) early_sample_playback_path: Option<String>,
-    pub(in crate::native_app) early_sample_playback_kind: Option<EarlySamplePlaybackKind>,
     pub(in crate::native_app) sample_playback_session: Option<SamplePlaybackSession>,
     pub(in crate::native_app) next_sample_playback_generation: u64,
     pub(in crate::native_app) playback_runtime: Option<PlaybackRuntimeHandle>,
     pub(in crate::native_app) playback_events: Option<Receiver<PlaybackRuntimeEvent>>,
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
-    pub(in crate::native_app) pending_runtime_start: Option<PendingRuntimePlaybackStart>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(in crate::native_app) enum EarlySamplePlaybackKind {
-    PreviewSlice,
-    FullSample,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(dead_code)]
 pub(in crate::native_app) enum SamplePlaybackIntent {
     TransientNavigation,
@@ -58,7 +48,8 @@ pub(in crate::native_app) enum SamplePlaybackIntent {
     StarmapDrag,
     RandomAudition,
     Playmark,
-    Normalized,
+    NormalizedResume,
+    HistoryReplay,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -73,14 +64,142 @@ impl SamplePlaybackVisibility {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) enum SamplePlaybackHistory {
+    Record,
+    Skip,
+}
+
+impl SamplePlaybackHistory {
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn records(self) -> bool {
+        matches!(self, Self::Record)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+pub(in crate::native_app) enum SamplePlaybackLoopMode {
+    FollowApp { offset: Option<f32> },
+    OneShot,
+    Looped { offset: f32 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(in crate::native_app) enum SamplePlaybackNormalization {
+    FollowSetting,
+    Required,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(in crate::native_app) enum SamplePlaybackSourceProbe {
+    LoadedOnly,
+    CachedOnly,
+    AllowFileProbe,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct SamplePlaybackRequest {
     pub(in crate::native_app) path: String,
     pub(in crate::native_app) span: (f32, f32),
     pub(in crate::native_app) intent: SamplePlaybackIntent,
     pub(in crate::native_app) visibility: SamplePlaybackVisibility,
+    pub(in crate::native_app) loop_mode: SamplePlaybackLoopMode,
+    pub(in crate::native_app) history: SamplePlaybackHistory,
+    pub(in crate::native_app) normalization: SamplePlaybackNormalization,
+    pub(in crate::native_app) origin: &'static str,
+    pub(in crate::native_app) source_probe: SamplePlaybackSourceProbe,
+    pub(in crate::native_app) random_units: Option<(f32, f32)>,
     pub(in crate::native_app) stream_policy: PlaybackRuntimeStreamPolicy,
     pub(in crate::native_app) show_start_marker: bool,
+}
+
+impl SamplePlaybackRequest {
+    pub(in crate::native_app) fn transient(
+        path: String,
+        intent: SamplePlaybackIntent,
+        origin: &'static str,
+    ) -> Self {
+        Self {
+            path,
+            span: (0.0, 1.0),
+            intent,
+            visibility: SamplePlaybackVisibility::Transient,
+            loop_mode: SamplePlaybackLoopMode::FollowApp { offset: None },
+            history: SamplePlaybackHistory::Record,
+            normalization: SamplePlaybackNormalization::FollowSetting,
+            origin,
+            source_probe: SamplePlaybackSourceProbe::CachedOnly,
+            random_units: None,
+            stream_policy: PlaybackRuntimeStreamPolicy::transient_navigation(),
+            show_start_marker: false,
+        }
+    }
+
+    pub(in crate::native_app) fn waveform(
+        path: String,
+        span: (f32, f32),
+        intent: SamplePlaybackIntent,
+        origin: &'static str,
+        history: SamplePlaybackHistory,
+    ) -> Self {
+        Self {
+            path,
+            span,
+            intent,
+            visibility: SamplePlaybackVisibility::Waveform,
+            loop_mode: SamplePlaybackLoopMode::FollowApp {
+                offset: Some(span.0),
+            },
+            history,
+            normalization: SamplePlaybackNormalization::FollowSetting,
+            origin,
+            source_probe: SamplePlaybackSourceProbe::LoadedOnly,
+            random_units: None,
+            stream_policy: PlaybackRuntimeStreamPolicy::full(),
+            show_start_marker: true,
+        }
+    }
+
+    pub(in crate::native_app) fn with_start_marker(mut self, show_start_marker: bool) -> Self {
+        self.show_start_marker = show_start_marker;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn with_source_probe(
+        mut self,
+        source_probe: SamplePlaybackSourceProbe,
+    ) -> Self {
+        self.source_probe = source_probe;
+        self
+    }
+
+    pub(in crate::native_app) fn with_random_units(mut self, start: f32, length: f32) -> Self {
+        self.random_units = Some((start, length));
+        self
+    }
+
+    pub(in crate::native_app) fn with_normalization(
+        mut self,
+        normalization: SamplePlaybackNormalization,
+    ) -> Self {
+        self.normalization = normalization;
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[allow(dead_code)]
+pub(in crate::native_app) enum SamplePlaybackSessionState {
+    ResolvingSource,
+    RuntimePending,
+    AudibleTransient,
+    WaveformVisible,
+    Failed(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -90,43 +209,7 @@ pub(in crate::native_app) struct SamplePlaybackSession {
     pub(in crate::native_app) runtime_request_id: Option<PlaybackRequestId>,
     pub(in crate::native_app) source_kind: &'static str,
     pub(in crate::native_app) submitted_at: Instant,
-}
-
-pub(in crate::native_app) struct PendingRuntimePlaybackStart {
-    pub(in crate::native_app) id: PlaybackRequestId,
-    pub(in crate::native_app) session_generation: u64,
-    pub(in crate::native_app) path: String,
-    pub(in crate::native_app) span: (f32, f32),
-    pub(in crate::native_app) show_start_marker: bool,
-    pub(in crate::native_app) visibility: SamplePlaybackVisibility,
-    pub(in crate::native_app) submitted_at: Instant,
-    pub(in crate::native_app) origin: &'static str,
-    pub(in crate::native_app) source_kind: &'static str,
-}
-
-impl PendingRuntimePlaybackStart {
-    pub(in crate::native_app) fn new(
-        id: PlaybackRequestId,
-        session_generation: u64,
-        path: String,
-        span: (f32, f32),
-        show_start_marker: bool,
-        visibility: SamplePlaybackVisibility,
-        origin: &'static str,
-        source_kind: &'static str,
-    ) -> Self {
-        Self {
-            id,
-            session_generation,
-            path,
-            span,
-            show_start_marker,
-            visibility,
-            submitted_at: Instant::now(),
-            origin,
-            source_kind,
-        }
-    }
+    pub(in crate::native_app) state: SamplePlaybackSessionState,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -173,14 +256,11 @@ impl AudioAppState {
             pending_playback_start: None,
             pending_sample_playback: None,
             playback_history: PlaybackNavigationHistory::default(),
-            early_sample_playback_path: None,
-            early_sample_playback_kind: None,
             sample_playback_session: None,
             next_sample_playback_generation: 1,
             playback_runtime: None,
             playback_events: None,
             playback_progress: PlaybackRuntimeProgress::default(),
-            pending_runtime_start: None,
         }
     }
 
@@ -206,6 +286,29 @@ impl AudioAppState {
             runtime_request_id: Some(runtime_request_id),
             source_kind,
             submitted_at: Instant::now(),
+            state: SamplePlaybackSessionState::RuntimePending,
+        });
+        generation
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn start_resolving_sample_playback_session(
+        &mut self,
+        request: SamplePlaybackRequest,
+        source_kind: &'static str,
+    ) -> u64 {
+        let generation = self.next_sample_playback_generation;
+        self.next_sample_playback_generation = self
+            .next_sample_playback_generation
+            .saturating_add(1)
+            .max(1);
+        self.sample_playback_session = Some(SamplePlaybackSession {
+            generation,
+            request,
+            runtime_request_id: None,
+            source_kind,
+            submitted_at: Instant::now(),
+            state: SamplePlaybackSessionState::ResolvingSource,
         });
         generation
     }
@@ -221,13 +324,70 @@ impl AudioAppState {
         let Some(session) = self.sample_playback_session.as_mut() else {
             return false;
         };
-        if session.request.path != path
-            || session.request.visibility == SamplePlaybackVisibility::Waveform
-            || session.source_kind == "preview_samples"
-        {
+        if session.request.path != path || session.source_kind == "preview_samples" {
             return false;
         }
         session.request.visibility = SamplePlaybackVisibility::Waveform;
+        session.state = SamplePlaybackSessionState::WaveformVisible;
         true
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_path(&self) -> Option<&str> {
+        self.sample_playback_session
+            .as_ref()
+            .map(|session| session.request.path.as_str())
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_matches(&self, path: &str) -> bool {
+        self.active_sample_playback_path() == Some(path)
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_is_preview(&self, path: &str) -> bool {
+        self.sample_playback_session
+            .as_ref()
+            .is_some_and(|session| {
+                session.request.path == path && session.source_kind == "preview_samples"
+            })
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_is_streamable(&self, path: &str) -> bool {
+        self.sample_playback_session
+            .as_ref()
+            .is_some_and(|session| {
+                session.request.path == path && session.source_kind != "preview_samples"
+            })
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_updates_waveform(
+        &self,
+        path: &str,
+    ) -> bool {
+        self.sample_playback_session
+            .as_ref()
+            .is_some_and(|session| {
+                session.request.path == path
+                    && session.request.visibility.updates_waveform_playhead()
+            })
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_pending_runtime(&self) -> bool {
+        self.sample_playback_session
+            .as_ref()
+            .is_some_and(|session| {
+                matches!(session.state, SamplePlaybackSessionState::RuntimePending)
+            })
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::native_app) fn active_starmap_audition_path(&self) -> Option<String> {
+        self.sample_playback_session.as_ref().and_then(|session| {
+            (session.request.origin == "starmap_drag").then(|| session.request.path.clone())
+        })
+    }
+
+    pub(in crate::native_app) fn set_active_sample_playback_span(&mut self, span: (f32, f32)) {
+        if let Some(session) = self.sample_playback_session.as_mut() {
+            session.request.span = span;
+        }
     }
 }

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -13,8 +13,9 @@ mod waveform;
 pub(in crate::native_app) const DEFAULT_VOLUME: f32 = 1.0;
 
 pub(in crate::native_app) use audio::{
-    AudioAppState, EarlySamplePlaybackKind, PendingPlaybackStart, PendingRuntimePlaybackStart,
-    SamplePlaybackIntent, SamplePlaybackRequest, SamplePlaybackVisibility,
+    AudioAppState, PendingPlaybackStart, SamplePlaybackHistory, SamplePlaybackIntent,
+    SamplePlaybackNormalization, SamplePlaybackRequest, SamplePlaybackSession,
+    SamplePlaybackSessionState, SamplePlaybackSourceProbe, SamplePlaybackVisibility,
 };
 pub(in crate::native_app) use background::{
     AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,

--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -160,10 +160,10 @@ fn active_starmap_audition_file_id(state: &NativeAppState) -> Option<String> {
         .or_else(|| {
             state
                 .audio
-                .pending_runtime_start
+                .sample_playback_session
                 .as_ref()
-                .filter(|pending| pending.origin == "starmap_drag")
-                .map(|pending| pending.path.clone())
+                .filter(|session| session.request.origin == "starmap_drag")
+                .map(|session| session.request.path.clone())
         })
 }
 

--- a/src/native_app/audio/audio_engine/output_config.rs
+++ b/src/native_app/audio/audio_engine/output_config.rs
@@ -47,7 +47,7 @@ impl NativeAppState {
         self.background.audio_open.cancel();
         self.audio.player = None;
         self.audio.playback_events = None;
-        self.audio.pending_runtime_start = None;
+        self.audio.clear_sample_playback_session();
         self.audio.output_resolved = None;
         self.refresh_audio_options();
 

--- a/src/native_app/audio/playback.rs
+++ b/src/native_app/audio/playback.rs
@@ -5,6 +5,7 @@ mod intent;
 mod loop_control;
 mod metronome;
 mod normalized;
+mod planner;
 mod policy;
 mod progress;
 mod random_audition;
@@ -16,6 +17,10 @@ pub(in crate::native_app) const PLAYBACK_START_ACTIVE_SOURCE_GRACE: Duration =
     Duration::from_millis(120);
 
 pub(in crate::native_app) use intent::PlaybackIntent;
+pub(in crate::native_app) use planner::{
+    ActiveSamplePlaybackPlanState, SamplePlaybackAvailableSources, SamplePlaybackPlan,
+    plan_sample_playback,
+};
 pub(in crate::native_app) use policy::{
     TaggedPlaybackMode, tagged_playback_mode_for_tag, tagged_playback_mode_for_tags,
 };

--- a/src/native_app/audio/playback/commands.rs
+++ b/src/native_app/audio/playback/commands.rs
@@ -7,7 +7,8 @@ use super::random_audition::{
     RandomAuditionSource, RandomAuditionSpan, RandomAuditionUnits, random_audition_span_for_units,
 };
 use crate::native_app::app::{
-    GuiMessage, NativeAppState, PendingSamplePlayback, emit_gui_action, sample_path_label,
+    GuiMessage, NativeAppState, SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest,
+    emit_gui_action, sample_path_label,
 };
 
 impl NativeAppState {
@@ -44,8 +45,15 @@ impl NativeAppState {
             .filter(|selection| selection.width() > 0.0)
             .map(|selection| (selection.start(), selection.end()))
             .unwrap_or((0.0, 1.0));
-        match self.start_playback_current_span(start, end) {
-            Ok(()) => {
+        let request = SamplePlaybackRequest::waveform(
+            self.waveform.current.path().display().to_string(),
+            (start, end),
+            SamplePlaybackIntent::ExplicitPlayback,
+            "transport",
+            SamplePlaybackHistory::Record,
+        );
+        match self.request_sample_playback(request, context) {
+            Ok(_) => {
                 let file_name = self.waveform.current.file_name();
                 self.record_selected_sample_last_played(context);
                 self.ui.status.sample = format!("Playing {file_name}");
@@ -78,8 +86,15 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
-        match self.start_playback_intent(PlaybackIntent::new(start_ratio, 1.0)) {
-            Ok(()) => {
+        let request = SamplePlaybackRequest::waveform(
+            self.waveform.current.path().display().to_string(),
+            (start_ratio, 1.0),
+            SamplePlaybackIntent::WaveformSpan,
+            "waveform",
+            SamplePlaybackHistory::Record,
+        );
+        match self.request_sample_playback(request, context) {
+            Ok(_) => {
                 let file_name = self.waveform.current.file_name();
                 self.record_selected_sample_last_played(context);
                 self.ui.status.sample =
@@ -198,10 +213,16 @@ impl NativeAppState {
                 started_at,
                 None,
             );
-            self.audio.pending_sample_playback = Some(PendingSamplePlayback::RandomAudition {
-                start_unit: units.start,
-                length_unit: units.length,
-            });
+            self.audio.pending_sample_playback = Some(
+                SamplePlaybackRequest::waveform(
+                    path.clone(),
+                    (0.0, 1.0),
+                    SamplePlaybackIntent::RandomAudition,
+                    "random_audition",
+                    SamplePlaybackHistory::Record,
+                )
+                .with_random_units(units.start, units.length),
+            );
             self.load_sample_without_autoplay(path, context);
             return;
         }
@@ -221,19 +242,33 @@ impl NativeAppState {
                 started_at,
                 None,
             );
-            self.audio.pending_sample_playback = Some(PendingSamplePlayback::RandomAudition {
-                start_unit: units.start,
-                length_unit: units.length,
-            });
+            self.audio.pending_sample_playback = Some(
+                SamplePlaybackRequest::waveform(
+                    path.clone(),
+                    (0.0, 1.0),
+                    SamplePlaybackIntent::RandomAudition,
+                    "random_audition",
+                    SamplePlaybackHistory::Record,
+                )
+                .with_random_units(units.start, units.length),
+            );
             self.focus_browser_file_for_playback_navigation(Path::new(&path), context);
             self.load_sample_without_autoplay(path, context);
             return;
         }
         let file_name = self.waveform.current.file_name();
         let span = self.random_audition_span_for_loaded_waveform(units);
+        let request = SamplePlaybackRequest::waveform(
+            self.waveform.current.path().display().to_string(),
+            (span.start, span.end),
+            SamplePlaybackIntent::RandomAudition,
+            "random_audition",
+            SamplePlaybackHistory::Record,
+        )
+        .with_random_units(units.start, units.length);
 
-        match self.start_random_audition_span(span) {
-            Ok(()) => {
+        match self.request_sample_playback(request, context) {
+            Ok(_) => {
                 self.record_selected_sample_last_played(context);
                 self.ui.status.sample = span.status_message(&file_name);
                 emit_gui_action(
@@ -320,7 +355,6 @@ impl NativeAppState {
     pub(in crate::native_app) fn stop_audio_output_playback(&mut self) {
         if let Some(runtime) = self.audio.playback_runtime.as_ref() {
             let _ = runtime.try_stop();
-            self.audio.pending_runtime_start = None;
         } else if let Some(player) = self.audio.player.as_mut() {
             player.stop();
         }

--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -1,11 +1,14 @@
 use super::{
+    ActiveSamplePlaybackPlanState, SamplePlaybackAvailableSources, SamplePlaybackPlan,
     diagnostics::log_slow_playback_phase,
     intent::{PlaybackCommand, PlaybackIntent, PlaybackMode},
+    plan_sample_playback,
 };
 use crate::native_app::app::{
-    NativeAppState, PendingPlaybackStart, PendingRuntimePlaybackStart, SamplePlaybackIntent,
-    SamplePlaybackRequest, SamplePlaybackVisibility,
+    GuiMessage, NativeAppState, PendingPlaybackStart, SamplePlaybackHistory, SamplePlaybackIntent,
+    SamplePlaybackRequest,
 };
+use radiant::prelude as ui;
 use std::time::Instant;
 use wavecrate::audio::{
     PlaybackMetronomeConfig, PlaybackRuntimeMode, PlaybackRuntimeReplacePolicy,
@@ -13,7 +16,111 @@ use wavecrate::audio::{
     edit_fade_range_from_selection,
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) enum SamplePlaybackOutcome {
+    Started,
+    QueuedLoad,
+    Promoted,
+    Unavailable,
+}
+
 impl NativeAppState {
+    pub(in crate::native_app) fn request_sample_playback(
+        &mut self,
+        request: SamplePlaybackRequest,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) -> Result<SamplePlaybackOutcome, String> {
+        let active = self.active_sample_playback_plan_state(request.path.as_str());
+        let sources = self.sample_playback_available_sources(request.path.as_str());
+        match plan_sample_playback(&request, sources, active) {
+            SamplePlaybackPlan::PromoteActiveSession => {
+                if self
+                    .audio
+                    .promote_sample_playback_session_to_waveform(request.path.as_str())
+                {
+                    return Ok(SamplePlaybackOutcome::Promoted);
+                }
+            }
+            SamplePlaybackPlan::Unavailable => return Ok(SamplePlaybackOutcome::Unavailable),
+            SamplePlaybackPlan::QueueLoad | SamplePlaybackPlan::QueuePreviewDecode => {
+                self.audio.pending_sample_playback = Some(request.clone());
+                self.load_sample_without_autoplay(request.path, context);
+                return Ok(SamplePlaybackOutcome::QueuedLoad);
+            }
+            SamplePlaybackPlan::HandOffPreviewToFullSource
+            | SamplePlaybackPlan::SubmitRuntime { .. } => {}
+        }
+
+        if !self.waveform.current.has_loaded_sample()
+            || self.waveform.current.path() != std::path::Path::new(request.path.as_str())
+        {
+            self.audio.pending_sample_playback = Some(request.clone());
+            self.load_sample_without_autoplay(request.path, context);
+            return Ok(SamplePlaybackOutcome::QueuedLoad);
+        }
+
+        match request.intent {
+            SamplePlaybackIntent::RandomAudition => {
+                let Some((start_unit, length_unit)) = request.random_units else {
+                    return Ok(SamplePlaybackOutcome::Unavailable);
+                };
+                let span = self.random_audition_span_for_loaded_waveform(
+                    super::random_audition::RandomAuditionUnits::new(start_unit, length_unit),
+                );
+                self.start_random_audition_span(span)?;
+            }
+            SamplePlaybackIntent::HistoryReplay => {
+                self.start_playback_intent_with_history(
+                    PlaybackIntent::fixed_region(request.span.0, request.span.1),
+                    false,
+                )?;
+            }
+            _ => {
+                self.start_playback_intent_with_history(
+                    PlaybackIntent::new(request.span.0, request.span.1),
+                    request.history.records(),
+                )?;
+            }
+        }
+        Ok(SamplePlaybackOutcome::Started)
+    }
+
+    fn active_sample_playback_plan_state(&self, path: &str) -> ActiveSamplePlaybackPlanState {
+        self.audio
+            .sample_playback_session
+            .as_ref()
+            .map(|session| ActiveSamplePlaybackPlanState {
+                same_path: session.request.path == path,
+                preview_source: session.source_kind == "preview_samples",
+                streamable_source: session.source_kind != "preview_samples",
+                waveform_visible: session.request.visibility.updates_waveform_playhead(),
+            })
+            .unwrap_or_default()
+    }
+
+    fn sample_playback_available_sources(&mut self, path: &str) -> SamplePlaybackAvailableSources {
+        let loaded_current = self.waveform.current.has_loaded_sample()
+            && self.waveform.current.path() == std::path::Path::new(path);
+        SamplePlaybackAvailableSources {
+            loaded_decoded_samples: loaded_current
+                && self.waveform.current.playback_samples().is_some(),
+            loaded_f32_cache: loaded_current
+                && self.waveform.current.playback_cache_file().is_some(),
+            loaded_audio_bytes: loaded_current,
+            persisted_f32_descriptor: self
+                .waveform
+                .cache
+                .instant_audition_descriptors
+                .contains_key(std::path::Path::new(path)),
+            file_backed_audio_descriptor: false,
+            preview_clip: self
+                .waveform
+                .cache
+                .preview_audition_clip(std::path::Path::new(path))
+                .is_some(),
+        }
+    }
+
     pub(in crate::native_app) fn start_playback_current_span(
         &mut self,
         start_ratio: f32,
@@ -22,6 +129,7 @@ impl NativeAppState {
         self.start_playback_intent(PlaybackIntent::new(start_ratio, end_ratio))
     }
 
+    #[allow(dead_code)]
     pub(in crate::native_app) fn start_playback_fixed_span_without_history(
         &mut self,
         start_ratio: f32,
@@ -139,28 +247,21 @@ impl NativeAppState {
         self.audio.playback_progress = Default::default();
         self.audio.current_playback_span =
             Some((command.resolved.start_ratio, command.resolved.end_ratio));
-        let session_request = SamplePlaybackRequest {
-            path: self.waveform.current.path().display().to_string(),
-            span: (command.resolved.start_ratio, command.resolved.end_ratio),
-            intent: SamplePlaybackIntent::WaveformSpan,
-            visibility: SamplePlaybackVisibility::Waveform,
-            stream_policy: PlaybackRuntimeStreamPolicy::full(),
-            show_start_marker: command.intent.show_start_marker,
-        };
-        let source_kind = self.current_waveform_runtime_source_kind();
-        let session_generation =
-            self.audio
-                .start_sample_playback_session(session_request.clone(), request_id, source_kind);
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            command.intent.show_start_marker,
-            SamplePlaybackVisibility::Waveform,
+        let session_request = SamplePlaybackRequest::waveform(
+            self.waveform.current.path().display().to_string(),
+            (command.resolved.start_ratio, command.resolved.end_ratio),
+            SamplePlaybackIntent::WaveformSpan,
             "waveform",
-            source_kind,
-        ));
+            if record_history {
+                SamplePlaybackHistory::Record
+            } else {
+                SamplePlaybackHistory::Skip
+            },
+        )
+        .with_start_marker(command.intent.show_start_marker);
+        let source_kind = self.current_waveform_runtime_source_kind();
+        self.audio
+            .start_sample_playback_session(session_request, request_id, source_kind);
         if record_history {
             self.record_current_playback_history(
                 command.resolved.start_ratio,

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -69,9 +69,7 @@ impl NativeAppState {
                 false,
             )?;
             self.audio.current_playback_span = Some((start, end));
-            if let Some(pending) = self.audio.pending_runtime_start.as_mut() {
-                pending.span = (start, end);
-            }
+            self.audio.set_active_sample_playback_span((start, end));
             Ok(())
         } else {
             self.retarget_active_playback_mode(start, end, current)

--- a/src/native_app/audio/playback/metronome.rs
+++ b/src/native_app/audio/playback/metronome.rs
@@ -57,8 +57,6 @@ impl NativeAppState {
 
     fn restore_active_span_after_metronome_restart(&mut self, start: f32, end: f32) {
         self.audio.current_playback_span = Some((start, end));
-        if let Some(pending) = self.audio.pending_runtime_start.as_mut() {
-            pending.span = (start, end);
-        }
+        self.audio.set_active_sample_playback_span((start, end));
     }
 }

--- a/src/native_app/audio/playback/planner.rs
+++ b/src/native_app/audio/playback/planner.rs
@@ -1,0 +1,219 @@
+use crate::native_app::app::{
+    SamplePlaybackIntent, SamplePlaybackRequest, SamplePlaybackSourceProbe,
+};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::native_app) struct SamplePlaybackAvailableSources {
+    pub(in crate::native_app) loaded_decoded_samples: bool,
+    pub(in crate::native_app) loaded_f32_cache: bool,
+    pub(in crate::native_app) loaded_audio_bytes: bool,
+    pub(in crate::native_app) persisted_f32_descriptor: bool,
+    pub(in crate::native_app) file_backed_audio_descriptor: bool,
+    pub(in crate::native_app) preview_clip: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(in crate::native_app) enum SamplePlaybackPlan {
+    SubmitRuntime { source_kind: &'static str },
+    QueueLoad,
+    QueuePreviewDecode,
+    PromoteActiveSession,
+    HandOffPreviewToFullSource,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(in crate::native_app) struct ActiveSamplePlaybackPlanState {
+    pub(in crate::native_app) same_path: bool,
+    pub(in crate::native_app) preview_source: bool,
+    pub(in crate::native_app) streamable_source: bool,
+    pub(in crate::native_app) waveform_visible: bool,
+}
+
+pub(in crate::native_app) fn plan_sample_playback(
+    request: &SamplePlaybackRequest,
+    sources: SamplePlaybackAvailableSources,
+    active: ActiveSamplePlaybackPlanState,
+) -> SamplePlaybackPlan {
+    if active.same_path
+        && active.streamable_source
+        && request.intent == SamplePlaybackIntent::SettledNavigation
+        && request.visibility.updates_waveform_playhead()
+    {
+        return SamplePlaybackPlan::PromoteActiveSession;
+    }
+    if active.same_path
+        && active.preview_source
+        && !preview_allowed_for_intent(request.intent)
+        && real_source_available(sources)
+    {
+        return SamplePlaybackPlan::HandOffPreviewToFullSource;
+    }
+    if sources.loaded_decoded_samples {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "decoded_samples",
+        };
+    }
+    if sources.loaded_f32_cache {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "interleaved_f32_file",
+        };
+    }
+    if sources.loaded_audio_bytes {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "audio_bytes",
+        };
+    }
+    if sources.persisted_f32_descriptor {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "interleaved_f32_file",
+        };
+    }
+    if sources.file_backed_audio_descriptor
+        && request.source_probe == SamplePlaybackSourceProbe::AllowFileProbe
+    {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "audio_file",
+        };
+    }
+    if sources.preview_clip && preview_allowed_for_intent(request.intent) {
+        return SamplePlaybackPlan::SubmitRuntime {
+            source_kind: "preview_samples",
+        };
+    }
+    if preview_allowed_for_intent(request.intent) {
+        SamplePlaybackPlan::QueuePreviewDecode
+    } else {
+        SamplePlaybackPlan::QueueLoad
+    }
+}
+
+fn preview_allowed_for_intent(intent: SamplePlaybackIntent) -> bool {
+    matches!(
+        intent,
+        SamplePlaybackIntent::TransientNavigation | SamplePlaybackIntent::StarmapDrag
+    )
+}
+
+fn real_source_available(sources: SamplePlaybackAvailableSources) -> bool {
+    sources.loaded_decoded_samples
+        || sources.loaded_f32_cache
+        || sources.loaded_audio_bytes
+        || sources.persisted_f32_descriptor
+        || sources.file_backed_audio_descriptor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::app::{
+        SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest,
+    };
+
+    fn request(intent: SamplePlaybackIntent) -> SamplePlaybackRequest {
+        SamplePlaybackRequest::waveform(
+            String::from("kick.wav"),
+            (0.0, 1.0),
+            intent,
+            "test",
+            SamplePlaybackHistory::Record,
+        )
+    }
+
+    #[test]
+    fn planner_prefers_real_sources_over_preview() {
+        let plan = plan_sample_playback(
+            &request(SamplePlaybackIntent::ExplicitPlayback),
+            SamplePlaybackAvailableSources {
+                persisted_f32_descriptor: true,
+                preview_clip: true,
+                ..Default::default()
+            },
+            ActiveSamplePlaybackPlanState::default(),
+        );
+
+        assert_eq!(
+            plan,
+            SamplePlaybackPlan::SubmitRuntime {
+                source_kind: "interleaved_f32_file"
+            }
+        );
+    }
+
+    #[test]
+    fn transient_navigation_may_use_preview() {
+        let plan = plan_sample_playback(
+            &SamplePlaybackRequest::transient(
+                String::from("hat.wav"),
+                SamplePlaybackIntent::TransientNavigation,
+                "browser",
+            ),
+            SamplePlaybackAvailableSources {
+                preview_clip: true,
+                ..Default::default()
+            },
+            ActiveSamplePlaybackPlanState::default(),
+        );
+
+        assert_eq!(
+            plan,
+            SamplePlaybackPlan::SubmitRuntime {
+                source_kind: "preview_samples"
+            }
+        );
+    }
+
+    #[test]
+    fn normalized_playback_never_uses_preview() {
+        let plan = plan_sample_playback(
+            &request(SamplePlaybackIntent::NormalizedResume),
+            SamplePlaybackAvailableSources {
+                preview_clip: true,
+                ..Default::default()
+            },
+            ActiveSamplePlaybackPlanState::default(),
+        );
+
+        assert_eq!(plan, SamplePlaybackPlan::QueueLoad);
+    }
+
+    #[test]
+    fn settled_streamable_session_promotes_without_restart() {
+        let plan = plan_sample_playback(
+            &request(SamplePlaybackIntent::SettledNavigation),
+            SamplePlaybackAvailableSources::default(),
+            ActiveSamplePlaybackPlanState {
+                same_path: true,
+                streamable_source: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(plan, SamplePlaybackPlan::PromoteActiveSession);
+    }
+
+    #[test]
+    fn explicit_same_path_playback_still_starts_runtime() {
+        let plan = plan_sample_playback(
+            &request(SamplePlaybackIntent::ExplicitPlayback),
+            SamplePlaybackAvailableSources {
+                loaded_decoded_samples: true,
+                ..Default::default()
+            },
+            ActiveSamplePlaybackPlanState {
+                same_path: true,
+                streamable_source: true,
+                waveform_visible: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            plan,
+            SamplePlaybackPlan::SubmitRuntime {
+                source_kind: "decoded_samples"
+            }
+        );
+    }
+}

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -5,7 +5,8 @@ use std::{
 
 use super::PLAYBACK_START_ACTIVE_SOURCE_GRACE;
 use crate::native_app::app::{
-    emit_gui_action, sample_path_label, NativeAppState, PendingRuntimePlaybackStart,
+    NativeAppState, SamplePlaybackSession, SamplePlaybackSessionState, emit_gui_action,
+    sample_path_label,
 };
 use crate::native_app::app_chrome::library_browser::sample_browser_view;
 use crate::native_app::starmap_audition_telemetry::{
@@ -78,7 +79,7 @@ impl NativeAppState {
                 == Some(path)
         {
             "starmap_drag"
-        } else if self.audio.early_sample_playback_path.as_deref() == Some(path) {
+        } else if self.audio.active_sample_playback_matches(path) {
             "instant_audition"
         } else {
             "browser"
@@ -148,40 +149,47 @@ impl NativeAppState {
     }
 
     fn finish_runtime_playback_started(&mut self, started: PlaybackRuntimeStarted) {
-        let Some(pending) = self.audio.pending_runtime_start.take() else {
+        let Some(session) = self.audio.sample_playback_session.as_mut() else {
             return;
         };
-        if pending.id != started.id || !self.runtime_start_matches_active_session(&pending) {
+        if session.runtime_request_id != Some(started.id) {
             log_runtime_playback_event(
                 "runtime.started",
                 "id_mismatch",
                 Some(StarmapAuditionCounter::RuntimeStale),
-                &pending,
+                session,
                 None,
                 None,
             );
-            self.audio.pending_runtime_start = Some(pending);
             return;
         }
-        let submit_elapsed = pending.submitted_at.elapsed();
+        let submit_elapsed = session.submitted_at.elapsed();
         log_runtime_playback_event(
             "runtime.started",
             "started",
             Some(StarmapAuditionCounter::RuntimeStarted),
-            &pending,
+            session,
             Some(submit_elapsed),
             None,
         );
-        let source_updates_waveform = pending.visibility.updates_waveform_playhead();
+        let source_updates_waveform = session.request.visibility.updates_waveform_playhead();
+        session.state = if source_updates_waveform {
+            SamplePlaybackSessionState::WaveformVisible
+        } else {
+            SamplePlaybackSessionState::AudibleTransient
+        };
+        let path = session.request.path.clone();
+        let span = session.request.span;
+        let show_start_marker = session.request.show_start_marker;
         self.audio.output_resolved = Some(started.output);
-        self.audio.current_playback_span = source_updates_waveform.then_some(pending.span);
+        self.audio.current_playback_span = source_updates_waveform.then_some(span);
         self.audio.playback_progress.active = true;
         self.audio.playback_progress.elapsed = Some(Duration::ZERO);
         self.audio.playback_progress.looping = self.audio.loop_playback;
         self.audio.playback_progress.progress = Some(started.playback_start);
         self.audio.playback_progress.error = None;
-        if source_updates_waveform && self.waveform.current.path() == Path::new(&pending.path) {
-            if pending.show_start_marker {
+        if source_updates_waveform && self.waveform.current.path() == Path::new(&path) {
+            if show_start_marker {
                 self.waveform.current.start_playback(started.playback_start);
             } else {
                 self.waveform
@@ -189,7 +197,7 @@ impl NativeAppState {
                     .start_playback_without_marker(started.playback_start);
             }
         }
-        self.ui.status.sample = format!("Playing {}", sample_path_label(&pending.path));
+        self.ui.status.sample = format!("Playing {}", sample_path_label(&path));
     }
 
     fn finish_runtime_playback_failed(
@@ -197,27 +205,26 @@ impl NativeAppState {
         id: wavecrate::audio::PlaybackRequestId,
         error: String,
     ) {
-        let Some(pending) = self.audio.pending_runtime_start.take() else {
+        let Some(session) = self.audio.sample_playback_session.as_mut() else {
             return;
         };
-        if pending.id != id || !self.runtime_start_matches_active_session(&pending) {
+        if session.runtime_request_id != Some(id) {
             log_runtime_playback_event(
                 "runtime.failed",
                 "id_mismatch",
                 Some(StarmapAuditionCounter::RuntimeStale),
-                &pending,
+                session,
                 None,
                 Some(&error),
             );
-            self.audio.pending_runtime_start = Some(pending);
             return;
         }
-        let submit_elapsed = pending.submitted_at.elapsed();
+        let submit_elapsed = session.submitted_at.elapsed();
         log_runtime_playback_event(
             "runtime.failed",
             "failed",
             Some(StarmapAuditionCounter::RuntimeFailed),
-            &pending,
+            session,
             Some(submit_elapsed),
             Some(&error),
         );
@@ -225,26 +232,15 @@ impl NativeAppState {
             self.mark_audio_output_unavailable(error);
             return;
         }
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
+        let path = session.request.path.clone();
+        session.state = SamplePlaybackSessionState::Failed(error.clone());
         self.audio.clear_sample_playback_session();
         self.audio.current_playback_span = None;
         self.waveform.current.stop_playback();
         self.ui.status.sample = format!(
             "Loaded {} | playback unavailable: {error}",
-            sample_path_label(&pending.path)
+            sample_path_label(&path)
         );
-    }
-
-    fn runtime_start_matches_active_session(&self, pending: &PendingRuntimePlaybackStart) -> bool {
-        self.audio
-            .sample_playback_session
-            .as_ref()
-            .is_some_and(|session| {
-                session.generation == pending.session_generation
-                    && session.runtime_request_id == Some(pending.id)
-                    && session.request.path == pending.path
-            })
     }
 
     fn finish_runtime_playback_cancelled(
@@ -252,22 +248,21 @@ impl NativeAppState {
         id: wavecrate::audio::PlaybackRequestId,
         reason: PlaybackRuntimeCancellation,
     ) {
-        let Some(pending) = self.audio.pending_runtime_start.take() else {
+        let Some(session) = self.audio.sample_playback_session.as_ref() else {
             return;
         };
-        if pending.id != id {
+        if session.runtime_request_id != Some(id) {
             log_runtime_playback_event(
                 "runtime.cancelled",
                 "id_mismatch",
                 Some(StarmapAuditionCounter::RuntimeStale),
-                &pending,
+                session,
                 None,
                 None,
             );
-            self.audio.pending_runtime_start = Some(pending);
             return;
         }
-        let submit_elapsed = pending.submitted_at.elapsed();
+        let submit_elapsed = session.submitted_at.elapsed();
         log_runtime_playback_event(
             "runtime.cancelled",
             match reason {
@@ -276,13 +271,12 @@ impl NativeAppState {
                 PlaybackRuntimeCancellation::Shutdown => "shutdown",
             },
             Some(StarmapAuditionCounter::RuntimeCancelled),
-            &pending,
+            session,
             Some(submit_elapsed),
             None,
         );
         if reason != PlaybackRuntimeCancellation::Superseded {
-            self.audio.early_sample_playback_path = None;
-            self.audio.early_sample_playback_kind = None;
+            self.audio.clear_sample_playback_session();
             self.audio.current_playback_span = None;
             self.waveform.current.stop_playback();
         }
@@ -336,9 +330,14 @@ impl NativeAppState {
             self.stop_playback_after_progress_error(error);
             return;
         }
-        if let Some(pending) = self.audio.pending_runtime_start.as_ref() {
+        if self.audio.active_sample_playback_pending_runtime() {
             if let Some(progress) = self.audio.playback_progress.progress {
-                if pending.visibility.updates_waveform_playhead() {
+                if self
+                    .audio
+                    .sample_playback_session
+                    .as_ref()
+                    .is_some_and(|session| session.request.visibility.updates_waveform_playhead())
+                {
                     self.waveform.current.set_playhead_ratio(progress);
                 }
             }
@@ -352,8 +351,14 @@ impl NativeAppState {
         let should_be_looping = self.audio.loop_playback && self.waveform.current.is_playing();
         let within_start_grace =
             elapsed.is_some_and(|elapsed| elapsed <= PLAYBACK_START_ACTIVE_SOURCE_GRACE);
-        if self.audio.early_sample_playback_kind
-            == Some(crate::native_app::app::EarlySamplePlaybackKind::PreviewSlice)
+        if self
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .is_some_and(|session| {
+                session.source_kind == "preview_samples"
+                    && !session.request.visibility.updates_waveform_playhead()
+            })
         {
             return;
         }
@@ -441,8 +446,7 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn playback_visual_activity_active(&self) -> bool {
         self.waveform.current.is_playing()
-            || self.audio.early_sample_playback_path.is_some()
-            || self.audio.pending_runtime_start.is_some()
+            || self.audio.sample_playback_session.is_some()
             || self.audio.playback_progress.active
     }
 
@@ -527,10 +531,10 @@ impl NativeAppState {
                 .as_deref())
             .or_else(|| {
                 self.audio
-                    .pending_runtime_start
+                    .sample_playback_session
                     .as_ref()
-                    .filter(|pending| pending.origin == "starmap_drag")
-                    .map(|pending| pending.path.as_str())
+                    .filter(|session| session.request.origin == "starmap_drag")
+                    .map(|session| session.request.path.as_str())
             })
     }
 
@@ -557,9 +561,6 @@ impl NativeAppState {
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
         self.audio.pending_playback_start = None;
-        self.audio.pending_runtime_start = None;
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
         self.audio.clear_sample_playback_session();
         if let Some(runtime) = self.audio.playback_runtime.take() {
             let _ = runtime.try_shutdown();
@@ -618,8 +619,7 @@ impl NativeAppState {
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
         self.audio.playback_progress = Default::default();
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
+        self.audio.clear_sample_playback_session();
         emit_gui_action(
             "playback.progress",
             Some("transport"),
@@ -635,7 +635,7 @@ fn log_runtime_playback_event(
     stage: &'static str,
     outcome: &'static str,
     starmap_counter: Option<StarmapAuditionCounter>,
-    pending: &PendingRuntimePlaybackStart,
+    session: &SamplePlaybackSession,
     elapsed: Option<Duration>,
     error: Option<&str>,
 ) {
@@ -647,16 +647,16 @@ fn log_runtime_playback_event(
         module = "wavecrate_native_playback",
         stage,
         outcome,
-        origin = pending.origin,
-        source_kind = pending.source_kind,
-        path = %pending.path,
-        start_ratio = pending.span.0,
-        end_ratio = pending.span.1,
+        origin = session.request.origin,
+        source_kind = session.source_kind,
+        path = %session.request.path,
+        start_ratio = session.request.span.0,
+        end_ratio = session.request.span.1,
         elapsed_ms = elapsed.map(duration_ms).unwrap_or(0.0),
         error = error.unwrap_or_default(),
         "Native playback runtime event"
     );
-    if pending.origin != "starmap_drag" {
+    if session.request.origin != "starmap_drag" {
         return;
     }
     if let Some(elapsed) = elapsed {
@@ -666,7 +666,7 @@ fn log_runtime_playback_event(
         starmap_counter,
         stage,
         outcome,
-        Some(pending.path.as_str()),
+        Some(session.request.path.as_str()),
         0,
         0,
         true,
@@ -775,7 +775,7 @@ fn playback_error_indicates_output_unavailable(error: &str) -> bool {
 mod tests {
     use super::*;
     use crate::native_app::{
-        app::EarlySamplePlaybackKind,
+        app::{SamplePlaybackIntent, SamplePlaybackRequest, SamplePlaybackSourceProbe},
         test_support::state::{NativeAppStateFixture, WaveformState},
         waveform::test_decoded_waveform_file_from_mono_samples,
     };
@@ -788,8 +788,15 @@ mod tests {
             test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
         let mut state = NativeAppStateFixture::default().build();
         state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
-        state.audio.early_sample_playback_path = Some(path.display().to_string());
-        state.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::PreviewSlice);
+        let request = SamplePlaybackRequest::transient(
+            path.display().to_string(),
+            SamplePlaybackIntent::TransientNavigation,
+            "browser",
+        )
+        .with_source_probe(SamplePlaybackSourceProbe::CachedOnly);
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "preview_samples");
         state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
             active: true,
             elapsed: Some(Duration::from_millis(80)),

--- a/src/native_app/audio/playback_history.rs
+++ b/src/native_app/audio/playback_history.rs
@@ -142,11 +142,8 @@ impl NativeAppState {
         if self.audio.pending_playback_start.is_some() {
             return Some("pending_playback");
         }
-        if self.audio.early_sample_playback_path.is_some() {
-            return Some("early_playback");
-        }
-        if self.audio.pending_runtime_start.is_some() {
-            return Some("pending_runtime_start");
+        if self.audio.sample_playback_session.is_some() {
+            return Some("sample_playback_session");
         }
         if self.waveform.current.is_playing() {
             return Some("playback");

--- a/src/native_app/audio/playback_history/navigation.rs
+++ b/src/native_app/audio/playback_history/navigation.rs
@@ -3,7 +3,8 @@ use std::{path::Path, time::Instant};
 use radiant::prelude as ui;
 
 use crate::native_app::app::{
-    GuiMessage, NativeAppState, PendingSamplePlayback, emit_gui_action, sample_path_label,
+    GuiMessage, NativeAppState, SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest,
+    emit_gui_action, sample_path_label,
 };
 
 const PLAYBACK_NAVIGATION_HISTORY_LIMIT: usize = 50;
@@ -159,10 +160,13 @@ impl NativeAppState {
             return;
         }
 
-        self.audio.pending_sample_playback = Some(PendingSamplePlayback::ReplayHistory {
-            start: entry.start_ratio,
-            end: entry.end_ratio,
-        });
+        self.audio.pending_sample_playback = Some(SamplePlaybackRequest::waveform(
+            entry.path.clone(),
+            (entry.start_ratio, entry.end_ratio),
+            SamplePlaybackIntent::HistoryReplay,
+            "playback_history",
+            SamplePlaybackHistory::Skip,
+        ));
         self.load_sample_without_autoplay(entry.path, context);
         self.ui.status.sample = format!("Loading {label} from playback history");
         emit_gui_action(
@@ -185,8 +189,15 @@ impl NativeAppState {
     ) {
         let start_ratio = entry.start_ratio;
         let end_ratio = entry.end_ratio;
-        match self.start_playback_fixed_span_without_history(entry.start_ratio, entry.end_ratio) {
-            Ok(()) => {
+        let request = SamplePlaybackRequest::waveform(
+            entry.path.clone(),
+            (entry.start_ratio, entry.end_ratio),
+            SamplePlaybackIntent::HistoryReplay,
+            "playback_history",
+            SamplePlaybackHistory::Skip,
+        );
+        match self.request_sample_playback(request, context) {
+            Ok(_) => {
                 self.waveform
                     .current
                     .restore_play_selection_range_in_focus(start_ratio, end_ratio);

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -9,10 +9,10 @@ use std::{
 
 use crate::native_app::{
     app::{
-        emit_gui_action, sample_path_label, EarlySamplePlaybackKind, GuiMessage, NativeAppState,
-        PendingPlaybackStart, PendingRuntimePlaybackStart, PreviewAuditionResult,
-        PreviewAuditionWarmResult, SampleBrowserDisplayMode, SamplePlaybackIntent,
-        SamplePlaybackRequest, SamplePlaybackVisibility, WaveformState,
+        GuiMessage, NativeAppState, PendingPlaybackStart, PreviewAuditionResult,
+        PreviewAuditionWarmResult, SampleBrowserDisplayMode, SamplePlaybackHistory,
+        SamplePlaybackIntent, SamplePlaybackRequest, SamplePlaybackVisibility, WaveformState,
+        emit_gui_action, sample_path_label,
     },
     audio::{
         playback::PlaybackIntent,
@@ -20,8 +20,8 @@ use crate::native_app::{
     },
     starmap_audition_telemetry as starmap_telemetry,
     waveform::{
-        decode_wav_preview_clip, load_cached_waveform_playback_descriptor_sidecar,
-        PreviewAuditionClip, WaveformPlaybackReady,
+        PreviewAuditionClip, WaveformPlaybackReady, decode_wav_preview_clip,
+        load_cached_waveform_playback_descriptor_sidecar,
     },
     waveform::{file_backed_wav_playback_descriptor, should_use_file_backed_wav_decode},
 };
@@ -755,34 +755,20 @@ impl NativeAppState {
                 return InstantAuditionOutcome::Unavailable;
             }
         };
-        self.audio.early_sample_playback_path = Some(path.to_owned());
-        self.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::FullSample);
         let visibility = fast_audition_session_visibility();
         self.audio.current_playback_span =
             visibility.updates_waveform_playhead().then_some((0.0, 1.0));
-        let session_request = SamplePlaybackRequest {
-            path: path.to_owned(),
-            span: (0.0, 1.0),
-            intent: fast_audition_session_intent_for_origin(origin),
-            visibility,
-            stream_policy: PlaybackRuntimeStreamPolicy::transient_navigation(),
-            show_start_marker: visibility.updates_waveform_playhead(),
-        };
-        let session_generation = self.audio.start_sample_playback_session(
-            session_request.clone(),
+        let session_request = SamplePlaybackRequest::transient(
+            path.to_owned(),
+            fast_audition_session_intent_for_origin(origin),
+            origin,
+        )
+        .with_start_marker(visibility.updates_waveform_playhead());
+        self.audio.start_sample_playback_session(
+            session_request,
             request_id,
             "interleaved_f32_file",
         );
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            session_request.show_start_marker,
-            visibility,
-            origin,
-            "interleaved_f32_file",
-        ));
         self.ui.status.sample = format!("Playing {}", sample_path_label(path));
         if record_history {
             self.record_sample_last_played(path.to_owned(), context);
@@ -879,33 +865,15 @@ impl NativeAppState {
                 return false;
             }
         };
-        self.audio.early_sample_playback_path = Some(path.to_owned());
-        self.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::FullSample);
-        let visibility = SamplePlaybackVisibility::Transient;
         self.audio.current_playback_span = None;
-        let session_request = SamplePlaybackRequest {
-            path: path.to_owned(),
-            span: (0.0, 1.0),
-            intent: SamplePlaybackIntent::TransientNavigation,
-            visibility,
-            stream_policy: PlaybackRuntimeStreamPolicy::transient_navigation(),
-            show_start_marker: false,
-        };
-        let session_generation = self.audio.start_sample_playback_session(
-            session_request.clone(),
-            request_id,
-            "audio_file",
-        );
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            session_request.show_start_marker,
-            visibility,
+        let session_request = SamplePlaybackRequest::transient(
+            path.to_owned(),
+            SamplePlaybackIntent::TransientNavigation,
             origin,
-            "audio_file",
-        ));
+        )
+        .with_start_marker(false);
+        self.audio
+            .start_sample_playback_session(session_request, request_id, "audio_file");
         self.ui.status.sample = format!("Playing {}", sample_path_label(path));
         if record_history {
             self.record_sample_last_played(path.to_owned(), context);
@@ -1015,33 +983,14 @@ impl NativeAppState {
                 return false;
             }
         };
-        self.audio.early_sample_playback_path = Some(path.clone());
-        self.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::PreviewSlice);
         self.audio.current_playback_span = None;
-        let visibility = fast_audition_session_visibility();
-        let session_request = SamplePlaybackRequest {
-            path: path.clone(),
-            span: (0.0, 1.0),
-            intent: fast_audition_session_intent(options),
-            visibility,
-            stream_policy: PlaybackRuntimeStreamPolicy::transient_navigation(),
-            show_start_marker: false,
-        };
-        let session_generation = self.audio.start_sample_playback_session(
-            session_request.clone(),
-            request_id,
-            "preview_samples",
-        );
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            session_request.show_start_marker,
-            visibility,
+        let session_request = SamplePlaybackRequest::transient(
+            path.clone(),
+            fast_audition_session_intent(options),
             options.origin,
-            "preview_samples",
-        ));
+        );
+        self.audio
+            .start_sample_playback_session(session_request, request_id, "preview_samples");
         self.ui.status.sample = format!("Playing {}", sample_path_label(path.as_str()));
         if options.record_history {
             self.record_sample_last_played(path.clone(), context);
@@ -1813,33 +1762,17 @@ impl NativeAppState {
                 return false;
             }
         };
-        self.audio.early_sample_playback_path = Some(path.clone());
-        self.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::FullSample);
         self.audio.current_playback_span = Some((0.0, 1.0));
         let origin = self.runtime_playback_origin_for_path(path.as_str());
-        let session_request = SamplePlaybackRequest {
+        let session_request = SamplePlaybackRequest::waveform(
             path,
-            span: (0.0, 1.0),
-            intent: SamplePlaybackIntent::ExplicitPlayback,
-            visibility: SamplePlaybackVisibility::Waveform,
-            stream_policy: PlaybackRuntimeStreamPolicy::full(),
-            show_start_marker: true,
-        };
-        let session_generation = self.audio.start_sample_playback_session(
-            session_request.clone(),
-            request_id,
-            "decoded_samples",
-        );
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            session_request.show_start_marker,
-            session_request.visibility,
+            (0.0, 1.0),
+            SamplePlaybackIntent::ExplicitPlayback,
             origin,
-            "decoded_samples",
-        ));
+            SamplePlaybackHistory::Record,
+        );
+        self.audio
+            .start_sample_playback_session(session_request, request_id, "decoded_samples");
         self.ui.status.sample = format!("Playing {label}");
         log_sample_load_timing(
             "browser.sample_load.playback_ready.playback_submit",
@@ -1982,10 +1915,6 @@ impl NativeAppState {
         }
         let current_path = self.waveform.current.path().display().to_string();
         let start_ratio = start_ratio.clamp(0.0, 0.999);
-        if self.audio.early_sample_playback_path.as_deref() == Some(current_path.as_str()) {
-            self.audio.early_sample_playback_path = None;
-            self.audio.early_sample_playback_kind = None;
-        }
         self.prepare_playback_mode_for_loaded_sample();
         if self.audio.playback_runtime.is_none() {
             self.audio.pending_playback_start = Some(PendingPlaybackStart::record(
@@ -2074,29 +2003,15 @@ impl NativeAppState {
         self.audio.current_playback_span = Some((0.0, 1.0));
         let origin = self.runtime_playback_origin_for_path(current_path.as_str());
         let source_kind = self.current_waveform_runtime_source_kind();
-        let session_request = SamplePlaybackRequest {
-            path: current_path.clone(),
-            span: (0.0, 1.0),
-            intent: SamplePlaybackIntent::ExplicitPlayback,
-            visibility: SamplePlaybackVisibility::Waveform,
-            stream_policy: PlaybackRuntimeStreamPolicy::full(),
-            show_start_marker: true,
-        };
-        let session_generation = self.audio.start_sample_playback_session(
-            session_request.clone(),
-            request_id,
-            source_kind,
-        );
-        self.audio.pending_runtime_start = Some(PendingRuntimePlaybackStart::new(
-            request_id,
-            session_generation,
-            session_request.path,
-            session_request.span,
-            session_request.show_start_marker,
-            session_request.visibility,
+        let session_request = SamplePlaybackRequest::waveform(
+            current_path.clone(),
+            (0.0, 1.0),
+            SamplePlaybackIntent::ExplicitPlayback,
             origin,
-            source_kind,
-        ));
+            SamplePlaybackHistory::Record,
+        );
+        self.audio
+            .start_sample_playback_session(session_request, request_id, source_kind);
         self.record_current_playback_history(0.0, 1.0);
         Ok(())
     }
@@ -2105,8 +2020,7 @@ impl NativeAppState {
         &self,
         path: &str,
     ) -> Option<f32> {
-        if self.audio.early_sample_playback_path.as_deref() != Some(path)
-            || self.audio.early_sample_playback_kind != Some(EarlySamplePlaybackKind::PreviewSlice)
+        if !self.audio.active_sample_playback_is_preview(path)
             || !self.waveform.current.has_loaded_sample()
             || self.waveform.current.path() != Path::new(path)
         {
@@ -2428,7 +2342,7 @@ mod tests {
             "preview-head decode should be tracked as the active cancellable task"
         );
         assert!(
-            state.audio.pending_runtime_start.is_none(),
+            state.audio.sample_playback_session.is_none(),
             "the long WAV path should not synchronously probe or submit file-backed playback on the UI path"
         );
     }

--- a/src/native_app/audio/sample_load_actions/completion/loaded.rs
+++ b/src/native_app/audio/sample_load_actions/completion/loaded.rs
@@ -1,10 +1,7 @@
 use std::{path::Path, time::Instant};
 
 use crate::native_app::{
-    app::{
-        emit_gui_action, EarlySamplePlaybackKind, GuiMessage, NativeAppState,
-        PendingSamplePlayback, WaveformState,
-    },
+    app::{GuiMessage, NativeAppState, SamplePlaybackIntent, WaveformState, emit_gui_action},
     audio::{playback::RandomAuditionUnits, sample_load_actions::log_slow_sample_load_phase},
 };
 use wavecrate::audio::PlaybackRuntimeReplacePolicy;
@@ -56,10 +53,7 @@ impl NativeAppState {
             replace_started_at,
         );
         self.schedule_harvest_seen_for_path(Path::new(&path), context);
-        if display_after_instant_audition
-            && self.audio.early_sample_playback_path.as_deref() == Some(path.as_str())
-            && self.audio.early_sample_playback_kind == Some(EarlySamplePlaybackKind::PreviewSlice)
-        {
+        if display_after_instant_audition && self.audio.active_sample_playback_is_preview(&path) {
             self.ui.status.sample = format!("Preparing {file_name}");
             emit_gui_action(
                 "browser.sample_load.finish",
@@ -72,7 +66,7 @@ impl NativeAppState {
             return;
         }
         let preview_handoff_start_ratio = self.preview_slice_full_sample_handoff_ratio(&path);
-        if self.continue_early_sample_playback(&path, &file_name, started_at, context) {
+        if self.continue_streamable_sample_playback(&path, &file_name, started_at, context) {
             return;
         }
         if self.start_pending_sample_playback(&path, &file_name, started_at, context) {
@@ -104,27 +98,20 @@ impl NativeAppState {
         );
     }
 
-    fn continue_early_sample_playback(
+    fn continue_streamable_sample_playback(
         &mut self,
         path: &str,
         file_name: &str,
         started_at: Instant,
         context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
     ) -> bool {
-        if self.audio.early_sample_playback_path.as_deref() != Some(path) {
-            return false;
-        }
-        if self.audio.early_sample_playback_kind != Some(EarlySamplePlaybackKind::FullSample) {
-            self.audio.early_sample_playback_path = None;
-            self.audio.early_sample_playback_kind = None;
+        if !self.audio.active_sample_playback_is_streamable(path) {
             return false;
         }
         let progress = self.audio.playback_progress.progress.unwrap_or(0.0);
         self.waveform.current.start_playback(progress);
         self.audio.current_playback_span = Some((0.0, 1.0));
         self.record_current_playback_history(0.0, 1.0);
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
         self.record_sample_last_played(path.to_owned(), context);
         self.ui.status.sample = format!("Playing {file_name}");
         emit_gui_action(
@@ -148,18 +135,21 @@ impl NativeAppState {
         let Some(playback) = self.audio.pending_sample_playback.take() else {
             return false;
         };
+        if playback.path != path {
+            return false;
+        }
         self.maybe_open_audio_player(context);
-        match playback {
-            PendingSamplePlayback::RandomAudition {
-                start_unit,
-                length_unit,
-            } => {
+        match playback.intent {
+            SamplePlaybackIntent::RandomAudition => {
+                let Some((start_unit, length_unit)) = playback.random_units else {
+                    return false;
+                };
                 let span = self.random_audition_span_for_loaded_waveform(RandomAuditionUnits::new(
                     start_unit,
                     length_unit,
                 ));
-                match self.start_random_audition_span(span) {
-                    Ok(()) => {
+                match self.request_sample_playback(playback, context) {
+                    Ok(_) => {
                         self.record_selected_sample_last_played(context);
                         self.ui.status.sample = span.status_message(file_name);
                         emit_gui_action(
@@ -185,9 +175,9 @@ impl NativeAppState {
                 }
                 true
             }
-            PendingSamplePlayback::ResumeNormalized { start, end } => {
-                match self.start_playback_current_span(start, end) {
-                    Ok(()) => {
+            SamplePlaybackIntent::NormalizedResume => {
+                match self.request_sample_playback(playback, context) {
+                    Ok(_) => {
                         self.record_selected_sample_last_played(context);
                         self.ui.status.sample = format!("Playing {file_name}");
                         emit_gui_action(
@@ -214,10 +204,12 @@ impl NativeAppState {
                 }
                 true
             }
-            PendingSamplePlayback::ReplayHistory { start, end } => {
+            SamplePlaybackIntent::HistoryReplay => {
                 self.focus_browser_file_for_playback_navigation(Path::new(path), context);
-                match self.start_playback_fixed_span_without_history(start, end) {
-                    Ok(()) => {
+                let start = playback.span.0;
+                let end = playback.span.1;
+                match self.request_sample_playback(playback, context) {
+                    Ok(_) => {
                         self.waveform
                             .current
                             .restore_play_selection_range_in_focus(start, end);
@@ -247,6 +239,7 @@ impl NativeAppState {
                 }
                 true
             }
+            _ => false,
         }
     }
 }

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -4,10 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::native_app::app::{
-    emit_gui_action, sample_path_label, EarlySamplePlaybackKind, GuiMessage, NativeAppState,
-    SamplePlaybackVisibility,
-};
+use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action, sample_path_label};
 use crate::native_app::starmap_audition_telemetry::{
     self as starmap_telemetry, StarmapAuditionCounter, StarmapAuditionDuration,
 };
@@ -380,8 +377,8 @@ impl NativeAppState {
         if self.start_memory_cached_sample(path.as_str(), true, context, started_at) {
             return;
         }
-        let existing_early_playback = self.early_sample_playback_kind_for_path(path.as_str());
-        let instant_audition_outcome = if existing_early_playback.is_none() {
+        let existing_session_for_path = self.audio.active_sample_playback_matches(path.as_str());
+        let instant_audition_outcome = if !existing_session_for_path {
             self.start_fast_path_audition(
                 path.as_str(),
                 context,
@@ -392,13 +389,13 @@ impl NativeAppState {
             super::cache_start::InstantAuditionOutcome::Unavailable
         };
         if transient_navigation
-            && (existing_early_playback == Some(EarlySamplePlaybackKind::PreviewSlice)
+            && (self.audio.active_sample_playback_is_preview(path.as_str())
                 || self
                     .fast_audition_needs_settled_promotion(path.as_str(), instant_audition_outcome))
         {
             self.schedule_settled_sample_promotion(path.as_str(), context);
         }
-        let instant_audition_started = existing_early_playback.is_some()
+        let instant_audition_started = existing_session_for_path
             || instant_audition_outcome == super::cache_start::InstantAuditionOutcome::Started
             || (transient_navigation && instant_audition_outcome.uses_ready_source());
         self.start_foreground_sample_load_with_priority(
@@ -503,7 +500,9 @@ impl NativeAppState {
                 && self.waveform.current.path() == Path::new(path.as_str())
             {
                 let progress = self.audio.playback_progress.progress.unwrap_or(0.0);
-                self.waveform.current.start_playback_without_marker(progress);
+                self.waveform
+                    .current
+                    .start_playback_without_marker(progress);
             }
             emit_gui_action(
                 "browser.select_sample.settled_promotion",
@@ -654,11 +653,9 @@ impl NativeAppState {
         }
 
         self.audio.pending_sample_playback = None;
-        if self.audio.early_sample_playback_path.as_deref() == Some(path) {
+        if self.audio.active_sample_playback_matches(path) {
             self.stop_audio_output_playback();
             self.audio.current_playback_span = None;
-            self.audio.early_sample_playback_path = None;
-            self.audio.early_sample_playback_kind = None;
             self.audio.clear_sample_playback_session();
         }
         self.ui.status.sample = format!("Removed missing {}", sample_path_label(path));
@@ -685,12 +682,6 @@ impl NativeAppState {
         true
     }
 
-    fn early_sample_playback_kind_for_path(&self, path: &str) -> Option<EarlySamplePlaybackKind> {
-        (self.audio.early_sample_playback_path.as_deref() == Some(path))
-            .then_some(self.audio.early_sample_playback_kind)
-            .flatten()
-    }
-
     fn fast_audition_needs_settled_promotion(
         &self,
         path: &str,
@@ -698,8 +689,7 @@ impl NativeAppState {
     ) -> bool {
         match outcome {
             super::cache_start::InstantAuditionOutcome::Started => {
-                self.early_sample_playback_kind_for_path(path)
-                    == Some(EarlySamplePlaybackKind::PreviewSlice)
+                self.audio.active_sample_playback_is_preview(path)
             }
             super::cache_start::InstantAuditionOutcome::AudioPending => true,
             super::cache_start::InstantAuditionOutcome::Unavailable => false,
@@ -707,21 +697,7 @@ impl NativeAppState {
     }
 
     fn full_sample_playback_already_promoted_for_path(&self, path: &str) -> bool {
-        if let Some(session) = self.audio.sample_playback_session.as_ref()
-            && session.request.path == path
-        {
-            return session.request.visibility == SamplePlaybackVisibility::Waveform;
-        }
-        if self.audio.early_sample_playback_path.as_deref() == Some(path) {
-            return self.audio.early_sample_playback_kind
-                == Some(EarlySamplePlaybackKind::FullSample);
-        }
-        if self
-            .audio
-            .pending_runtime_start
-            .as_ref()
-            .is_some_and(|pending| pending.path == path && pending.visibility == SamplePlaybackVisibility::Waveform)
-        {
+        if self.audio.active_sample_playback_updates_waveform(path) {
             return true;
         }
         if !self.waveform.current.has_loaded_sample()
@@ -747,15 +723,23 @@ fn log_settled_promotion_timing(path: &str, elapsed: Duration) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::native_app::test_support::state::NativeAppStateFixture;
+    use crate::native_app::{
+        app::{SamplePlaybackIntent, SamplePlaybackRequest},
+        test_support::state::NativeAppStateFixture,
+    };
 
     #[test]
     fn full_sample_fast_audition_does_not_schedule_settled_replay() {
         let mut state = NativeAppStateFixture::default().build();
         let path = "full-ready.wav";
-        state.audio.early_sample_playback_path = Some(path.to_owned());
-        state.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::FullSample);
+        let request = SamplePlaybackRequest::transient(
+            path.to_owned(),
+            SamplePlaybackIntent::TransientNavigation,
+            "browser",
+        );
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "audio_file");
 
         assert!(!state.fast_audition_needs_settled_promotion(
             path,
@@ -767,8 +751,14 @@ mod tests {
     fn preview_fast_audition_schedules_settled_promotion() {
         let mut state = NativeAppStateFixture::default().build();
         let path = "preview-ready.wav";
-        state.audio.early_sample_playback_path = Some(path.to_owned());
-        state.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::PreviewSlice);
+        let request = SamplePlaybackRequest::transient(
+            path.to_owned(),
+            SamplePlaybackIntent::TransientNavigation,
+            "browser",
+        );
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "preview_samples");
 
         assert!(state.fast_audition_needs_settled_promotion(
             path,

--- a/src/native_app/audio/sample_load_actions/plan.rs
+++ b/src/native_app/audio/sample_load_actions/plan.rs
@@ -106,12 +106,10 @@ impl NativeAppState {
         outcome: &'static str,
         started_at: Instant,
     ) {
-        let early_playback_matches_load =
-            self.audio.early_sample_playback_path.as_deref() == Some(path);
+        let early_playback_matches_load = self.audio.active_sample_playback_matches(path);
         let keep_audible_waveform_visible = self.waveform.current.is_playing()
             || self.audio.current_playback_span.is_some()
-            || self.audio.pending_runtime_start.is_some()
-            || self.audio.early_sample_playback_path.is_some();
+            || self.audio.sample_playback_session.is_some();
         if !early_playback_matches_load {
             self.stop_current_sample_playback_for_load();
         }

--- a/src/native_app/audio/sample_load_actions/playback_state.rs
+++ b/src/native_app/audio/sample_load_actions/playback_state.rs
@@ -34,7 +34,7 @@ impl NativeAppState {
     pub(in crate::native_app) fn sample_cache_warm_should_pause_active(&self) -> bool {
         self.waveform_sample_load_active()
             || self.audio.pending_playback_start.is_some()
-            || self.audio.early_sample_playback_path.is_some()
+            || self.audio.sample_playback_session.is_some()
             || self.normalization_work_active()
     }
 
@@ -78,14 +78,12 @@ impl NativeAppState {
     }
 
     pub(super) fn stop_current_sample_playback_for_load(&mut self) {
-        if !self.waveform.current.is_playing() && self.audio.early_sample_playback_path.is_none() {
+        if !self.waveform.current.is_playing() && self.audio.sample_playback_session.is_none() {
             return;
         }
         self.stop_audio_output_playback();
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
         self.audio.clear_sample_playback_session();
     }
 
@@ -105,17 +103,14 @@ impl NativeAppState {
         self.cancel_active_sample_load_worker();
         self.waveform.load.selection.cancel();
         let preserve_early_playback = preserved_early_path
-            .is_some_and(|path| self.audio.early_sample_playback_path.as_deref() == Some(path));
-        if self.audio.early_sample_playback_path.is_some() && !preserve_early_playback {
+            .is_some_and(|path| self.audio.active_sample_playback_matches(path));
+        if self.audio.sample_playback_session.is_some() && !preserve_early_playback {
             self.stop_audio_output_playback();
-            self.audio.pending_runtime_start = None;
             self.audio.current_playback_span = None;
             self.audio.playback_progress = Default::default();
             self.audio.clear_sample_playback_session();
         }
         if !preserve_early_playback {
-            self.audio.early_sample_playback_path = None;
-            self.audio.early_sample_playback_kind = None;
             self.audio.clear_sample_playback_session();
         }
     }

--- a/src/native_app/audio/sample_load_actions/reload.rs
+++ b/src/native_app/audio/sample_load_actions/reload.rs
@@ -3,7 +3,10 @@ use std::time::Instant;
 use radiant::prelude as ui;
 
 use crate::native_app::{
-    app::{GuiMessage, NativeAppState, PendingSamplePlayback},
+    app::{
+        GuiMessage, NativeAppState, SamplePlaybackHistory, SamplePlaybackIntent,
+        SamplePlaybackNormalization, SamplePlaybackRequest,
+    },
     audio::sample_load_actions::{foreground_sample_load_priority, types::SampleLoadStrategy},
 };
 
@@ -18,8 +21,16 @@ impl NativeAppState {
             let (_, previous_end) = playback.span.unwrap_or((0.0, 1.0));
             let start = playback.start_ratio.clamp(0.0, 1.0);
             let end = previous_end.max(start).clamp(start, 1.0);
-            self.audio.pending_sample_playback =
-                Some(PendingSamplePlayback::ResumeNormalized { start, end });
+            self.audio.pending_sample_playback = Some(
+                SamplePlaybackRequest::waveform(
+                    reload.path.display().to_string(),
+                    (start, end),
+                    SamplePlaybackIntent::NormalizedResume,
+                    "normalization",
+                    SamplePlaybackHistory::Record,
+                )
+                .with_normalization(SamplePlaybackNormalization::Required),
+            );
         }
         self.library
             .folder_browser

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -248,14 +248,11 @@ impl NativeAppState {
     }
 
     fn stop_starmap_drag_audio(&mut self, active_target: Option<&str>, reason: &'static str) {
-        let had_pending_runtime = self.audio.pending_runtime_start.is_some();
-        let had_early_playback = self.audio.early_sample_playback_path.is_some();
+        let had_pending_runtime = self.audio.active_sample_playback_pending_runtime();
+        let had_early_playback = self.audio.sample_playback_session.is_some();
         let had_playback_progress = self.audio.playback_progress.active;
         self.stop_audio_output_playback();
         self.waveform.current.stop_playback();
-        self.audio.pending_runtime_start = None;
-        self.audio.early_sample_playback_path = None;
-        self.audio.early_sample_playback_kind = None;
         self.audio.clear_sample_playback_session();
         self.audio.current_playback_span = None;
         self.audio.playback_progress = Default::default();

--- a/src/native_app/test_support/state.rs
+++ b/src/native_app/test_support/state.rs
@@ -2,10 +2,11 @@ pub(in crate::native_app) use crate::native_app::app::{
     ActiveFolderCacheWarmPlanProgress, ActiveFolderCacheWarmProgress, ActiveFolderCacheWarmStage,
     AppSettingsTab, AudioAppState, AudioSettingsDropdown, BackgroundTaskState, ChromeUiState,
     DEFAULT_VOLUME, FileMoveProgress, GuiMessage, LibraryAppState, MetadataAppState,
-    MetadataMessage, NativeAppState, NativeFileDropHover, NormalizationProgress,
-    PendingSamplePlayback, SampleLoadResult, SamplePlaybackReady, SettingsAppState, StartupState,
-    StatusState, UiAppState, WaveformAppState, default_gui_shortcuts, format_sample_rate_label,
-    shortcut_help_bindings, shortcut_help_sections, view,
+    MetadataMessage, NativeAppState, NativeFileDropHover, NormalizationProgress, SampleLoadResult,
+    SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackReady, SamplePlaybackRequest,
+    SettingsAppState, StartupState, StatusState, UiAppState, WaveformAppState,
+    default_gui_shortcuts, format_sample_rate_label, shortcut_help_bindings,
+    shortcut_help_sections, view,
 };
 use crate::native_app::sample_library::folder_browser::view_contract::DEFAULT_FOLDER_WIDTH;
 pub(in crate::native_app) use crate::native_app::sample_library::folder_browser::{
@@ -79,4 +80,16 @@ impl NativeAppStateFixture {
             metadata: MetadataAppState::from_settings(&self.persisted_settings),
         }
     }
+}
+
+pub(in crate::native_app) fn seed_sample_playback_session(
+    state: &mut NativeAppState,
+    path: String,
+    source_kind: &'static str,
+) {
+    let request =
+        SamplePlaybackRequest::transient(path, SamplePlaybackIntent::TransientNavigation, "test");
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, source_kind);
 }

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -474,7 +474,11 @@ fn keyboard_navigation_stops_previous_preview_tail_before_cold_target_is_ready()
         )
         .build();
     state.library.folder_browser.select_file(first_id.clone());
-    state.audio.early_sample_playback_path = Some(first_id);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        first_id,
+        "preview_samples",
+    );
     state.audio.current_playback_span = Some((0.0, 1.0));
     state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
         active: true,
@@ -500,7 +504,7 @@ fn keyboard_navigation_stops_previous_preview_tail_before_cold_target_is_ready()
         "keyboard navigation should update selection immediately"
     );
     assert_eq!(
-        state.audio.early_sample_playback_path, None,
+        state.audio.sample_playback_session, None,
         "rapid keyboard/list navigation should stop the previous preview before the cold target is ready"
     );
     assert_eq!(state.audio.current_playback_span, None);
@@ -624,7 +628,7 @@ fn keyboard_navigation_ignores_stale_preview_audition_decode_after_rapid_navigat
         "stale keyboard preview decode completion must not cache an old target"
     );
     assert_ne!(
-        state.audio.early_sample_playback_path.as_deref(),
+        state.audio.active_sample_playback_path(),
         Some(second_id.as_str()),
         "stale keyboard preview decode completion must not start early playback for the old target"
     );
@@ -1459,7 +1463,11 @@ fn starmap_mode_frame_does_not_warm_preview_audition_heads_while_playback_active
         )
         .build();
     state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
-    state.audio.early_sample_playback_path = Some(sample_id);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_id,
+        "preview_samples",
+    );
     prepare_sample_browser_view(&mut state);
     let mut context = radiant::prelude::UiUpdateContext::default();
 
@@ -1836,7 +1844,11 @@ fn starmap_drag_finish_after_motion_stops_drag_playback_state() {
         },
         &mut context,
     );
-    state.audio.early_sample_playback_path = Some(second_id);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        second_id,
+        "preview_samples",
+    );
     state.audio.current_playback_span = Some((0.0, 1.0));
     state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
         active: true,
@@ -1851,7 +1863,7 @@ fn starmap_drag_finish_after_motion_stops_drag_playback_state() {
         &mut context,
     );
 
-    assert_eq!(state.audio.early_sample_playback_path, None);
+    assert_eq!(state.audio.sample_playback_session, None);
     assert_eq!(state.audio.current_playback_span, None);
     assert_eq!(
         state.audio.playback_progress,
@@ -1887,7 +1899,11 @@ fn starmap_drag_replacement_stops_previous_drag_playback_tail() {
         },
         &mut context,
     );
-    state.audio.early_sample_playback_path = Some(first_id);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        first_id,
+        "preview_samples",
+    );
     state.audio.current_playback_span = Some((0.0, 1.0));
     state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
         active: true,
@@ -1916,7 +1932,7 @@ fn starmap_drag_replacement_stops_previous_drag_playback_tail() {
         Some(second_id.as_str())
     );
     assert_eq!(
-        state.audio.early_sample_playback_path, None,
+        state.audio.sample_playback_session, None,
         "replacing an active drag target should stop the previous preview immediately"
     );
     assert_eq!(state.audio.current_playback_span, None);
@@ -1954,7 +1970,11 @@ fn starmap_click_finish_preserves_started_audition_playback_state() {
         },
         &mut context,
     );
-    state.audio.early_sample_playback_path = Some(sample_id.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_id.clone(),
+        "preview_samples",
+    );
     state.audio.current_playback_span = Some((0.0, 1.0));
     state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
         active: true,
@@ -1970,7 +1990,7 @@ fn starmap_click_finish_preserves_started_audition_playback_state() {
     );
 
     assert_eq!(
-        state.audio.early_sample_playback_path.as_deref(),
+        state.audio.active_sample_playback_path(),
         Some(sample_id.as_str())
     );
     assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -17,7 +17,11 @@ fn playback_frame_uses_paint_only_when_only_playhead_changes() {
 #[test]
 fn early_runtime_playback_handoff_keeps_transient_overlay_active() {
     let mut state = gui_state_for_span_tests();
-    state.audio.early_sample_playback_path = Some(String::from("kick.wav"));
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        String::from("kick.wav"),
+        "audio_file",
+    );
     state.audio.playback_progress.active = true;
     state.audio.playback_progress.progress = Some(0.25);
 
@@ -66,7 +70,11 @@ fn active_starmap_queue_keeps_app_transient_overlay_active_between_pointer_event
 #[test]
 fn early_runtime_playback_handoff_still_uses_paint_only_frames() {
     let mut state = gui_state_for_span_tests();
-    state.audio.early_sample_playback_path = Some(String::from("kick.wav"));
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        String::from("kick.wav"),
+        "audio_file",
+    );
     state.audio.playback_progress.active = true;
     state.audio.playback_progress.progress = Some(0.25);
 

--- a/src/native_app/tests/toolbar_playback/random_audition.rs
+++ b/src/native_app/tests/toolbar_playback/random_audition.rs
@@ -102,9 +102,9 @@ fn random_toolbar_click_queues_random_audition_for_unselected_browser_sample() {
     assert!(
         matches!(
             runtime.bridge().state().audio.pending_sample_playback,
-            Some(
-                crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition { .. }
-            )
+            Some(ref request)
+                if request.intent
+                    == crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition
         ),
         "random toolbar click should preserve random-audition intent while the browser sample loads"
     );
@@ -238,9 +238,9 @@ fn shift_clicking_random_toolbar_button_selects_random_listed_sample_before_audi
     assert!(
         matches!(
             runtime.bridge().state().audio.pending_sample_playback,
-            Some(
-                crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition { .. }
-            )
+            Some(ref request)
+                if request.intent
+                    == crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition
         ),
         "Shift-random should preserve random-audition intent while the listed sample loads"
     );
@@ -324,9 +324,9 @@ fn random_toolbar_click_queues_random_audition_for_selected_unloaded_sample() {
     assert!(
         matches!(
             runtime.bridge().state().audio.pending_sample_playback,
-            Some(
-                crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition { .. }
-            )
+            Some(ref request)
+                if request.intent
+                    == crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition
         ),
         "random toolbar click should preserve random-audition intent while the selected sample loads"
     );

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -608,7 +608,7 @@ fn loop_toggle_after_spacebar_keeps_runtime_looping_past_original_end() {
 }
 
 #[test]
-fn loop_toggle_waits_for_pending_runtime_start_before_recovering() {
+fn loop_toggle_waits_for_pending_session_start_before_recovering() {
     let Some(mut scenario) =
         WaveformPlaybackScenario::loaded_with_player("loop-toggle-pending-start.wav", &[0; 4800])
     else {
@@ -2910,9 +2910,10 @@ fn looped_playback_retarget_restarts_when_playhead_is_already_beyond_new_end() {
 fn pending_runtime_playback_start_id(state: &NativeAppState) -> Option<u64> {
     state
         .audio
-        .pending_runtime_start
+        .sample_playback_session
         .as_ref()
-        .map(|pending| pending.id.get())
+        .and_then(|session| session.runtime_request_id)
+        .map(|id| id.get())
 }
 
 fn assert_playback_span_state(state: &NativeAppState, expected_start: f32, expected_end: f32) {

--- a/src/native_app/tests/waveform_playback/persisted_cache.rs
+++ b/src/native_app/tests/waveform_playback/persisted_cache.rs
@@ -216,15 +216,11 @@ fn playback_ready_persisted_cache_marks_row_without_memory_warm_after_restart() 
     );
     assert!(active_sample_load_ticket(&state).is_some());
     if playback_runtime_installed {
-        assert_eq!(
-            state.audio.early_sample_playback_path.as_deref(),
-            Some(sample_path_string.as_str()),
-            "selection should submit descriptor playback before waveform completion"
+        let session = state.audio.sample_playback_session.as_ref().expect(
+            "selection should create descriptor playback session before waveform completion",
         );
-        assert!(
-            state.audio.pending_runtime_start.is_some(),
-            "descriptor playback should be handed to the runtime immediately"
-        );
+        assert_eq!(session.request.path, sample_path_string);
+        assert_eq!(session.source_kind, "interleaved_f32_file");
     }
     assert_ne!(state.waveform.current.path(), sample_path);
 

--- a/src/native_app/tests/waveform_playback/random_audition.rs
+++ b/src/native_app/tests/waveform_playback/random_audition.rs
@@ -221,14 +221,13 @@ fn random_audition_for_unloaded_selection_resumes_after_sample_load() {
 
     assert!(matches!(
         scenario.state.audio.pending_sample_playback,
-        Some(
-            crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition {
-                start_unit,
-                length_unit,
-            }
-        )
-            if (start_unit - 0.5).abs() < f32::EPSILON
-                && (length_unit - 0.25).abs() < f32::EPSILON
+        Some(ref request)
+            if request.intent
+                == crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition
+                && request.random_units.is_some_and(|(start_unit, length_unit)| {
+                    (start_unit - 0.5).abs() < f32::EPSILON
+                        && (length_unit - 0.25).abs() < f32::EPSILON
+                })
     ));
 
     scenario.start_deferred_load(false);

--- a/src/native_app/tests/waveform_playback/sample_loading/cache_reuse.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/cache_reuse.rs
@@ -471,14 +471,6 @@ fn large_navigation_sample_starts_source_file_audition_before_background_wavefor
             Some(ui::TaskPriority::Background),
             "waveform loading should move behind immediate source-file playback"
         );
-        assert_eq!(
-            state.audio.early_sample_playback_path.as_deref(),
-            Some(sample_path_string.as_str())
-        );
-        assert!(
-            state.audio.pending_runtime_start.is_some(),
-            "source-file playback should be submitted before waveform completion"
-        );
         let session = state
             .audio
             .sample_playback_session
@@ -556,7 +548,7 @@ fn large_navigation_sample_skips_sidecar_lookup_when_source_file_can_play() {
             "visual waveform loading should move behind source-file playback even when a sidecar exists"
         );
         assert_eq!(
-            state.audio.early_sample_playback_path.as_deref(),
+            state.audio.active_sample_playback_path(),
             Some(sample_path_string.as_str())
         );
     } else {

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::native_app::app::EarlySamplePlaybackKind;
 
 #[test]
 fn wav_load_reports_playback_ready_before_waveform_summary_completion() {
@@ -103,12 +102,14 @@ fn playback_ready_message_starts_audio_before_waveform_completion() {
         &mut context,
     );
 
-    assert_eq!(
-        state.audio.early_sample_playback_path.as_deref(),
-        Some(sample_path_string.as_str())
-    );
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_ref()
+        .expect("playback-ready audio should create a session");
+    assert_eq!(session.request.path, sample_path_string);
+    assert_eq!(session.source_kind, "decoded_samples");
     assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));
-    assert!(state.audio.pending_runtime_start.is_some());
     assert!(!state.waveform.current.has_loaded_sample());
     assert!(
         !state.waveform.current.is_playing(),
@@ -130,7 +131,11 @@ fn playback_ready_message_starts_audio_before_waveform_completion() {
         &mut context,
     );
 
-    assert_eq!(state.audio.early_sample_playback_path, None);
+    assert!(
+        state
+            .audio
+            .active_sample_playback_updates_waveform(&sample_path_string)
+    );
     assert!(state.waveform.current.is_playing());
     assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));
 }
@@ -151,8 +156,11 @@ fn display_after_preview_waits_for_settled_full_playback_promotion() {
         .library
         .folder_browser
         .select_file(sample_path_string.clone());
-    state.audio.early_sample_playback_path = Some(sample_path_string.clone());
-    state.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::PreviewSlice);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "preview_samples",
+    );
 
     let mut context = ui::UiUpdateContext::default();
     state.load_navigation_sample_validated(
@@ -177,13 +185,14 @@ fn display_after_preview_waits_for_settled_full_playback_promotion() {
     );
 
     assert_eq!(
-        state.audio.early_sample_playback_path.as_deref(),
+        state.audio.active_sample_playback_path(),
         Some(sample_path_string.as_str()),
         "display-only completion should keep the preview marker for the settle handoff"
     );
-    assert_eq!(
-        state.audio.early_sample_playback_kind,
-        Some(EarlySamplePlaybackKind::PreviewSlice)
+    assert!(
+        state
+            .audio
+            .active_sample_playback_is_preview(&sample_path_string)
     );
     assert!(
         state.ui.status.sample.contains("Preparing"),
@@ -214,8 +223,11 @@ fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
     state.waveform.current =
         crate::native_app::test_support::state::WaveformState::load_path(sample_path.clone())
             .expect("sample loads");
-    state.audio.early_sample_playback_path = Some(sample_path_string.clone());
-    state.audio.early_sample_playback_kind = Some(EarlySamplePlaybackKind::PreviewSlice);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "preview_samples",
+    );
     state.audio.playback_progress.elapsed = Some(std::time::Duration::from_millis(110));
     let ticket = state.background.settled_sample_promotion_task.begin();
     let mut context = ui::UiUpdateContext::default();
@@ -229,8 +241,6 @@ fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
         &mut context,
     );
 
-    assert_eq!(state.audio.early_sample_playback_path, None);
-    assert_eq!(state.audio.early_sample_playback_kind, None);
     assert_eq!(
         state.library.folder_browser.selected_file_id(),
         Some(sample_path_string.as_str())
@@ -239,7 +249,7 @@ fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
     assert!(
         state.waveform.current.is_playing()
             || state.audio.pending_playback_start.is_some()
-            || state.audio.pending_runtime_start.is_some()
+            || state.audio.sample_playback_session.is_some()
             || state.audio.current_playback_span == Some((0.0, 1.0)),
         "settled promotion should hand the current loaded sample to full playback"
     );

--- a/src/native_app/tests/waveform_playback/sample_loading/stale_results.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/stale_results.rs
@@ -52,7 +52,7 @@ fn stale_playback_ready_message_is_ignored_after_selection_changes() {
         &mut context,
     );
 
-    assert_eq!(state.audio.early_sample_playback_path, None);
+    assert_eq!(state.audio.sample_playback_session, None);
     assert_eq!(state.audio.current_playback_span, None);
     assert!(
         !state.ui.status.sample.contains("Playing"),
@@ -177,10 +177,14 @@ fn stale_loaded_sample_result_does_not_clear_newer_pending_playback() {
         "second foreground load should replace the first worker ticket"
     );
     state.audio.pending_sample_playback = Some(
-        crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition {
-            start_unit: 0.25,
-            length_unit: 0.5,
-        },
+        crate::native_app::test_support::state::SamplePlaybackRequest::waveform(
+            second_path_string.clone(),
+            (0.0, 1.0),
+            crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition,
+            "random_audition",
+            crate::native_app::test_support::state::SamplePlaybackHistory::Record,
+        )
+        .with_random_units(0.25, 0.5),
     );
 
     state.apply_message(
@@ -200,10 +204,14 @@ fn stale_loaded_sample_result_does_not_clear_newer_pending_playback() {
     assert_eq!(
         state.audio.pending_sample_playback,
         Some(
-            crate::native_app::test_support::state::PendingSamplePlayback::RandomAudition {
-                start_unit: 0.25,
-                length_unit: 0.5,
-            }
+            crate::native_app::test_support::state::SamplePlaybackRequest::waveform(
+                second_path_string,
+                (0.0, 1.0),
+                crate::native_app::test_support::state::SamplePlaybackIntent::RandomAudition,
+                "random_audition",
+                crate::native_app::test_support::state::SamplePlaybackHistory::Record,
+            )
+            .with_random_units(0.25, 0.5)
         ),
         "stale completion must not cancel playback requested by the newer selection"
     );

--- a/src/native_app/waveform_edits.rs
+++ b/src/native_app/waveform_edits.rs
@@ -640,7 +640,7 @@ impl NativeAppState {
         self.audio.current_playback_span = None;
         self.audio.pending_playback_start = None;
         self.audio.pending_sample_playback = None;
-        self.audio.pending_runtime_start = None;
+        self.audio.clear_sample_playback_session();
 
         let preserved_marks = self.preserved_marks_after_destructive_edit(&request);
         let mut worker_request =


### PR DESCRIPTION
## Scope
- Add `NativeAppState::request_sample_playback(...)` as the unified app-level playback entrypoint and route list navigation, row click/spacebar, waveform span, playmark/selection, random audition, normalized resume, history replay, and starmap drag paths through `SamplePlaybackRequest`.
- Introduce `SamplePlaybackSession` state with explicit generation, source kind, runtime request id, visibility, submitted time, and state-machine status.
- Extract pure `plan_sample_playback(...)` source selection with preview clips treated as a planner-selected source only for transient/starmap intents.
- Remove legacy `EarlySamplePlaybackKind`, `early_sample_playback_path`, `early_sample_playback_kind`, `PendingSamplePlayback`, and `pending_runtime_start` compatibility state.
- Make runtime/progress/sample-load completion handling consult the active session rather than independent early-playback mirrors.

## Definition of Done
- All sample playback callers submit the same request shape through the unified entrypoint or session-start path.
- Transient navigation can remain responsive with preview/cache sources, while settled streamable navigation promotes without a second runtime start.
- Preview-only transient sessions do not own waveform playhead state and can hand off through the same session/request flow.
- Explicit, normalized, playmark, looped, selection, random, and history playback avoid incorrect preview-only semantics.
- Stale runtime/progress/load completions cannot mutate a newer active sample playback session.

## Validation Commands
- `bash scripts/agent.sh request` *(pre-existing guardrail failure on `main`: `src/native_app/audio/playback/progress.rs:10` imports app chrome from a domain module)*
- `cargo check -p wavecrate --bin wavecrate`
- `cargo test -p wavecrate planner -- --test-threads=1`
- `cargo test -p wavecrate fast_audition -- --test-threads=1`
- `cargo test -p wavecrate keyboard_navigation -- --test-threads=1`
- `cargo test -p wavecrate waveform_playback::sample_loading -- --test-threads=1`
- `cargo test -p wavecrate random_audition -- --test-threads=1`
- `cargo test -p wavecrate rapid_navigation_harness --no-default-features -- --test-threads=1`
- `cargo test -p reson runtime_normalization_uses_decoded_samples_without_file_io -- --test-threads=1`
- `cargo test -p wavecrate toolbar_playback -- --test-threads=1`
- `cargo test -p wavecrate tagged_playback -- --test-threads=1`
- `cargo test -p wavecrate normalization -- --test-threads=1`
- `cargo test -p wavecrate play_selected_sample_uses_active_playmark_selection_span -- --test-threads=1`
- `cargo test -p wavecrate looped_waveform_click_resolves_to_playmark_span_when_selected -- --test-threads=1`
- `git diff --check`
- `rg -n "early_sample_playback_|EarlySamplePlaybackKind|PendingSamplePlayback|pending_runtime_start|PendingRuntimePlaybackStart|SamplePlaybackIntent::Normalized\\b" src/native_app -S`

## Known Limitations
- Runtime extend-in-place streaming is intentionally deferred; this PR keeps the existing runtime request model plus transient/full stream policies.
- I did not run a real desktop-app smoke pass in this environment.
- A broad `cargo test -p wavecrate playmark -- --test-threads=1` currently reproduces two non-playback failures in direct playmark/harvest-context tests; the focused playmark/selection playback cases above pass.

## Review
User review is required before merge.
