### PR TITLE
Keep last starmap audition loaded on release

### DIFF
--- a/crates/reson/src/player/runtime.rs
+++ b/crates/reson/src/player/runtime.rs
@@ -336,6 +336,17 @@ impl PlaybackRuntimeHandle {
             .map_err(map_send_error)
     }
 
+    /// Cancel queued playback without stopping the currently audible source.
+    pub fn try_cancel_pending_playback(
+        &self,
+    ) -> Result<PlaybackRequestId, PlaybackRuntimeSubmitError> {
+        let id = self.next_request_id();
+        self.commands
+            .send(PlaybackRuntimeCommand::CancelPendingPlayback)
+            .map(|()| id)
+            .map_err(map_send_error)
+    }
+
     /// Submit a playback-progress snapshot request without waiting for the runtime thread.
     pub fn try_poll_progress(&self) -> Result<PlaybackRequestId, PlaybackRuntimeSubmitError> {
         let id = self.next_request_id();
@@ -419,6 +430,7 @@ enum PlaybackRuntimeCommand {
     Stop {
         id: PlaybackRequestId,
     },
+    CancelPendingPlayback,
     RetargetSpan {
         id: PlaybackRequestId,
         update: PlaybackRuntimeSpanUpdate,
@@ -597,6 +609,7 @@ fn run_playback_runtime(
                 };
                 let _ = events.send(event);
             }
+            CoalescedCommand::CancelPendingPlayback => {}
             CoalescedCommand::RetargetSpan { id, update } => {
                 let event = match executor.retarget_span(update) {
                     Ok(_) => PlaybackRuntimeEvent::Progress {
@@ -642,6 +655,7 @@ enum CoalescedCommand {
     Stop {
         id: PlaybackRequestId,
     },
+    CancelPendingPlayback,
     RetargetSpan {
         id: PlaybackRequestId,
         update: PlaybackRuntimeSpanUpdate,
@@ -705,6 +719,10 @@ fn coalesce_pending_command(
             cancel_pending_commands(pending, PlaybackRuntimeCancellation::Shutdown, events);
             PlaybackRuntimeCommand::Shutdown
         }
+        current @ PlaybackRuntimeCommand::CancelPendingPlayback => {
+            cancel_pending_play_commands(pending, events);
+            current
+        }
         // Stop is an ordering barrier: dropping it lets an old loop keep running
         // while the host app is still loading the replacement sample.
         current @ PlaybackRuntimeCommand::Stop { .. } => current,
@@ -727,6 +745,13 @@ fn coalesce_play_command(
                 let stop = pending.pop_front().expect("pending stop command");
                 cancel_command(current, PlaybackRuntimeCancellation::Stopped, events);
                 return stop;
+            }
+            Some(PlaybackRuntimeCommand::CancelPendingPlayback) => {
+                let cancel = pending
+                    .pop_front()
+                    .expect("pending cancel-playback command");
+                cancel_command(current, PlaybackRuntimeCancellation::Stopped, events);
+                return cancel;
             }
             Some(PlaybackRuntimeCommand::Shutdown) => {
                 let shutdown = pending.pop_front().expect("pending shutdown command");
@@ -759,6 +784,11 @@ fn coalesce_span_retarget_command(
             }
             Some(PlaybackRuntimeCommand::Stop { .. }) => {
                 return pending.pop_front().expect("pending stop command");
+            }
+            Some(PlaybackRuntimeCommand::CancelPendingPlayback) => {
+                return pending
+                    .pop_front()
+                    .expect("pending cancel-playback command");
             }
             Some(PlaybackRuntimeCommand::Shutdown) => {
                 return pending.pop_front().expect("pending shutdown command");
@@ -815,6 +845,7 @@ fn command_to_coalesced(command: PlaybackRuntimeCommand) -> CoalescedCommand {
     match command {
         PlaybackRuntimeCommand::Play { id, request } => CoalescedCommand::Play { id, request },
         PlaybackRuntimeCommand::Stop { id } => CoalescedCommand::Stop { id },
+        PlaybackRuntimeCommand::CancelPendingPlayback => CoalescedCommand::CancelPendingPlayback,
         PlaybackRuntimeCommand::RetargetSpan { id, update } => {
             CoalescedCommand::RetargetSpan { id, update }
         }
@@ -849,6 +880,22 @@ fn cancel_pending_commands(
     while let Some(command) = pending.pop_front() {
         cancel_command(command, reason, events);
     }
+}
+
+fn cancel_pending_play_commands(
+    pending: &mut VecDeque<PlaybackRuntimeCommand>,
+    events: &mpsc::Sender<PlaybackRuntimeEvent>,
+) {
+    let mut retained = VecDeque::new();
+    while let Some(command) = pending.pop_front() {
+        match command {
+            PlaybackRuntimeCommand::Play { id, .. } => {
+                send_cancelled(id, PlaybackRuntimeCancellation::Stopped, events);
+            }
+            other => retained.push_back(other),
+        }
+    }
+    *pending = retained;
 }
 
 fn send_cancelled(
@@ -1243,6 +1290,23 @@ mod tests {
             events.as_slice(),
             [PlaybackRuntimeEvent::Cancelled { id, reason }]
                 if *id == first_play && *reason == PlaybackRuntimeCancellation::Stopped
+        ));
+    }
+
+    #[test]
+    fn coalescing_play_then_cancel_pending_drops_play_without_stop() {
+        let play_id = PlaybackRequestId(1);
+        let (coalesced, pending, events) = coalesce_for_test(
+            play_command(play_id, 0.25),
+            vec![PlaybackRuntimeCommand::CancelPendingPlayback],
+        );
+
+        assert!(matches!(coalesced, CoalescedCommand::CancelPendingPlayback));
+        assert!(pending.is_empty());
+        assert!(matches!(
+            events.as_slice(),
+            [PlaybackRuntimeEvent::Cancelled { id, reason }]
+                if *id == play_id && *reason == PlaybackRuntimeCancellation::Stopped
         ));
     }
 

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -10,7 +10,9 @@ use wavecrate::sample_sources::SampleSource;
 use wavecrate::sample_sources::config::AppSettingsCore;
 use wavecrate::selection::SelectionRange;
 
-use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, NativeFileDropHover};
+use crate::native_app::app::{
+    AppSettingsTab, AudioSettingsDropdown, NativeFileDropHover, SamplePlaybackSession,
+};
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextMenu, BrowserContextPointerAnchor,
 };
@@ -78,9 +80,11 @@ pub(in crate::native_app) struct StarmapAuditionDragState {
     pub(in crate::native_app) modifiers: PointerModifiers,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(in crate::native_app) struct StarmapAuditionQueueState {
     pub(in crate::native_app) active_file_id: Option<String>,
+    pub(in crate::native_app) last_played_file_id: Option<String>,
+    pub(in crate::native_app) last_played_session: Option<SamplePlaybackSession>,
     pub(in crate::native_app) queued_file_ids: VecDeque<String>,
     pub(in crate::native_app) modifiers: PointerModifiers,
     pub(in crate::native_app) gesture_moved: bool,

--- a/src/native_app/app/state/waveform.rs
+++ b/src/native_app/app/state/waveform.rs
@@ -18,6 +18,7 @@ use wavecrate::selection::SelectionRange;
 pub(in crate::native_app) struct WaveformAppState {
     pub(in crate::native_app) current: WaveformState,
     pub(in crate::native_app) display: WaveformDisplayState,
+    pub(in crate::native_app) starmap_drag_restore: Option<WaveformState>,
     pub(in crate::native_app) load: WaveformLoadState,
     pub(in crate::native_app) cache: WaveformCacheState,
     pub(in crate::native_app) pending_play_selection_transaction:
@@ -35,6 +36,7 @@ impl WaveformAppState {
         Self {
             current,
             display: WaveformDisplayState::Authoritative,
+            starmap_drag_restore: None,
             load: WaveformLoadState::default(),
             cache: WaveformCacheState::default(),
             pending_play_selection_transaction: None,
@@ -47,6 +49,30 @@ impl WaveformAppState {
 
     pub(in crate::native_app) fn mark_current_authoritative(&mut self) {
         self.display = WaveformDisplayState::Authoritative;
+        self.starmap_drag_restore = None;
+    }
+
+    pub(in crate::native_app) fn capture_starmap_drag_restore(&mut self) {
+        if self.starmap_drag_restore.is_some()
+            || self.instant_preview_active()
+            || !self.current.has_loaded_sample()
+        {
+            return;
+        }
+        let mut snapshot = self.current.clone();
+        snapshot.stop_playback();
+        self.starmap_drag_restore = Some(snapshot);
+    }
+
+    pub(in crate::native_app) fn restore_starmap_drag_snapshot(&mut self) -> Option<WaveformState> {
+        let Some(snapshot) = self.starmap_drag_restore.take() else {
+            return None;
+        };
+        if !self.instant_preview_active() {
+            return None;
+        }
+        self.display = WaveformDisplayState::Authoritative;
+        Some(std::mem::replace(&mut self.current, snapshot))
     }
 
     pub(in crate::native_app) fn replace_current_with_instant_waveform_preview(

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -36,6 +36,16 @@ struct CachedPlaybackOutcomes {
     error: &'static str,
 }
 
+#[derive(Clone, Copy)]
+struct FullSamplePlaybackOptions {
+    start_ratio: f32,
+    replace_policy: PlaybackRuntimeReplacePolicy,
+    origin: &'static str,
+    history: SamplePlaybackHistory,
+    show_start_marker: bool,
+    record_history: bool,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum InstantAuditionOutcome {
     Started,
@@ -392,6 +402,16 @@ fn record_preview_audition_warm_phase_profile(
 }
 
 impl NativeAppState {
+    pub(in crate::native_app) fn remember_starmap_last_played_sample(&mut self, path: &str) {
+        self.ui.chrome.starmap_audition_queue.last_played_file_id = Some(path.to_owned());
+        self.ui.chrome.starmap_audition_queue.last_played_session = self
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .filter(|session| session.request.path == path)
+            .cloned();
+    }
+
     pub(super) fn start_fast_path_audition(
         &mut self,
         path: &str,
@@ -1020,6 +1040,7 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if origin == "starmap_drag" {
+            self.remember_starmap_last_played_sample(path);
             self.schedule_starmap_audition_promotion(path.to_owned(), context);
         }
     }
@@ -1926,16 +1947,35 @@ impl NativeAppState {
         start_ratio: f32,
         replace_policy: PlaybackRuntimeReplacePolicy,
     ) -> Result<(), String> {
+        let current_path = self.waveform.current.path().display().to_string();
+        let origin = self.runtime_playback_origin_for_path(current_path.as_str());
+        self.submit_current_full_sample_runtime_playback(FullSamplePlaybackOptions {
+            start_ratio,
+            replace_policy,
+            origin,
+            history: SamplePlaybackHistory::Record,
+            show_start_marker: true,
+            record_history: true,
+        })
+    }
+
+    fn submit_current_full_sample_runtime_playback(
+        &mut self,
+        options: FullSamplePlaybackOptions,
+    ) -> Result<(), String> {
         if !self.waveform.current.has_loaded_sample() {
             return Err(String::from("Select a sample to load"));
         }
         let current_path = self.waveform.current.path().display().to_string();
-        let start_ratio = start_ratio.clamp(0.0, 0.999);
+        let start_ratio = options.start_ratio.clamp(0.0, 0.999);
         self.prepare_playback_mode_for_loaded_sample();
         if self.audio.playback_runtime.is_none() {
-            self.audio.pending_playback_start = Some(PendingPlaybackStart::record(
-                PlaybackIntent::new(start_ratio, 1.0),
-            ));
+            let intent = PlaybackIntent::new(start_ratio, 1.0);
+            self.audio.pending_playback_start = Some(if options.record_history {
+                PendingPlaybackStart::record(intent)
+            } else {
+                PendingPlaybackStart::skip_history(intent)
+            });
             if self.background.audio_open.active().is_some() {
                 return Ok(());
             }
@@ -1993,7 +2033,7 @@ impl NativeAppState {
             volume: self.audio.volume,
             playback_gain,
             playback_gain_normalization,
-            replace_policy,
+            replace_policy: options.replace_policy,
             edit_fade: None,
             metronome: self.playback_metronome_config_for_span(0.0, 1.0, start_ratio),
         };
@@ -2015,20 +2055,28 @@ impl NativeAppState {
         let request_id = runtime
             .try_play(request)
             .map_err(|err| format!("submit playback request: {err:?}"))?;
-        self.waveform.current.start_playback(start_ratio);
+        if options.show_start_marker {
+            self.waveform.current.start_playback(start_ratio);
+        } else {
+            self.waveform
+                .current
+                .start_playback_without_marker(start_ratio);
+        }
         self.audio.current_playback_span = Some((0.0, 1.0));
-        let origin = self.runtime_playback_origin_for_path(current_path.as_str());
         let source_kind = self.current_waveform_runtime_source_kind();
         let session_request = SamplePlaybackRequest::waveform(
             current_path.clone(),
             (0.0, 1.0),
             SamplePlaybackIntent::ExplicitPlayback,
-            origin,
-            SamplePlaybackHistory::Record,
-        );
+            options.origin,
+            options.history,
+        )
+        .with_start_marker(options.show_start_marker);
         self.audio
             .start_sample_playback_session(session_request, request_id, source_kind);
-        self.record_current_playback_history(0.0, 1.0);
+        if options.record_history {
+            self.record_current_playback_history(0.0, 1.0);
+        }
         Ok(())
     }
 

--- a/src/native_app/audio/sample_load_actions/completion/playback_ready.rs
+++ b/src/native_app/audio/sample_load_actions/completion/playback_ready.rs
@@ -131,6 +131,9 @@ impl NativeAppState {
             {
                 self.schedule_next_starmap_audition_hit(context);
             }
+            if outcome == "playback_ready_playing" {
+                self.remember_starmap_last_played_sample(ready.path.as_str());
+            }
         }
         emit_gui_action(
             "browser.sample_load.playback_ready",

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -159,6 +159,7 @@ impl NativeAppState {
         }
         self.audio.pending_sample_playback = None;
         if self.start_loaded_navigation_sample(path.as_str(), context, started_at) {
+            self.remember_starmap_last_played_sample(path.as_str());
             starmap_telemetry::record_event(
                 Some(StarmapAuditionCounter::LoadedCurrent),
                 "sample_start.loaded_current",
@@ -195,6 +196,9 @@ impl NativeAppState {
             super::cache_start::FastAuditionOptions::starmap_drag(),
         );
         self.start_starmap_waveform_preview(path.as_str());
+        if ready_outcome == super::cache_start::InstantAuditionOutcome::Started {
+            self.remember_starmap_last_played_sample(path.as_str());
+        }
         let ready_elapsed = starmap_telemetry::elapsed_since(ready_started_at);
         if let Some(elapsed) = ready_elapsed {
             starmap_telemetry::record_duration(StarmapAuditionDuration::ReadySource, elapsed);

--- a/src/native_app/audio/sample_load_actions/visual_preview.rs
+++ b/src/native_app/audio/sample_load_actions/visual_preview.rs
@@ -15,6 +15,7 @@ impl NativeAppState {
         {
             return;
         }
+        self.waveform.capture_starmap_drag_restore();
         if let Some(preview) = self
             .waveform
             .cache
@@ -34,6 +35,12 @@ impl NativeAppState {
         self.waveform.load.label = Some(sample_path_label(path));
         self.waveform.load.progress = 0.0;
         self.waveform.load.target_progress = 0.0;
+    }
+
+    pub(in crate::native_app) fn restore_starmap_waveform_preview_after_drag(&mut self) {
+        if let Some(previous) = self.waveform.restore_starmap_drag_snapshot() {
+            defer_large_drop(previous);
+        }
     }
 
     fn replace_current_with_instant_waveform_preview(&mut self, preview: InstantWaveformPreview) {

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -199,8 +199,15 @@ impl NativeAppState {
             .ui
             .chrome
             .starmap_audition_queue
-            .active_file_id
+            .last_played_file_id
             .as_deref()
+            .or_else(|| {
+                self.ui
+                    .chrome
+                    .starmap_audition_queue
+                    .active_file_id
+                    .as_deref()
+            })
             .or_else(|| {
                 self.ui
                     .chrome
@@ -209,9 +216,12 @@ impl NativeAppState {
                     .and_then(|drag| drag.last_hit_file_id.as_deref())
             })
             .map(str::to_owned);
+        let active_target_for_log = active_target.clone();
+        let active_target = active_target_for_log.as_deref();
         self.background.starmap_audition_advance_task.cancel();
         if gesture_moved {
             self.background.starmap_audition_promotion_task.cancel();
+            self.background.settled_sample_promotion_task.cancel();
             self.background.preview_audition_task.cancel();
             self.background.sample_load_validation_task.cancel();
             self.background.deferred_sample_load_task.cancel();
@@ -226,7 +236,18 @@ impl NativeAppState {
             self.waveform.load.target_progress = 0.0;
             self.waveform.load.selection.cancel();
             self.audio.pending_sample_playback = None;
-            self.stop_starmap_drag_audio(active_target.as_deref(), "finish_after_motion");
+            self.restore_starmap_waveform_preview_after_drag();
+            let loaded_path = self
+                .waveform
+                .current
+                .has_loaded_sample()
+                .then(|| self.waveform.current.path().display().to_string());
+            if let Some(loaded_path) = loaded_path.as_deref() {
+                self.library
+                    .folder_browser
+                    .select_known_starmap_file_for_audition(loaded_path.to_owned());
+            }
+            self.keep_starmap_drag_audio_after_release(loaded_path.as_deref(), active_target);
         }
         self.ui.chrome.starmap_audition_drag = None;
         self.ui.chrome.starmap_audition_queue = Default::default();
@@ -239,11 +260,66 @@ impl NativeAppState {
             } else {
                 "cleared_click"
             },
-            None,
+            active_target,
             0,
             0,
             false,
             starmap_telemetry::elapsed_since(started_at),
+        );
+    }
+
+    fn keep_starmap_drag_audio_after_release(
+        &mut self,
+        loaded_path: Option<&str>,
+        active_target: Option<&str>,
+    ) {
+        let active_playback_path = self.audio.active_sample_playback_path().map(str::to_owned);
+        let playback_progress = self.audio.playback_progress.progress.unwrap_or(0.0);
+        let mut playback_span = (0.0, 1.0);
+        let last_played_session = self
+            .ui
+            .chrome
+            .starmap_audition_queue
+            .last_played_session
+            .clone();
+        if let Some(session) = self.audio.sample_playback_session.as_mut() {
+            playback_span = session.request.span;
+            session.request.origin = "starmap_release";
+        }
+        if loaded_path.is_some_and(|path| active_playback_path.as_deref() == Some(path)) {
+            self.waveform
+                .current
+                .start_playback_without_marker(playback_progress);
+            self.audio.current_playback_span = Some(playback_span);
+        } else if loaded_path.is_some_and(|path| active_playback_path.as_deref() != Some(path))
+            && active_playback_path.is_some()
+            && self.waveform.current.has_loaded_sample()
+        {
+            if let Some(runtime) = self.audio.playback_runtime.as_ref() {
+                let _ = runtime.try_cancel_pending_playback();
+            }
+            self.audio.clear_sample_playback_session();
+            if let Some(mut session) = last_played_session.filter(|session| {
+                loaded_path.is_some_and(|path| session.request.path.as_str() == path)
+            }) {
+                playback_span = session.request.span;
+                session.request.origin = "starmap_release";
+                self.audio.sample_playback_session = Some(session);
+            }
+            self.waveform
+                .current
+                .start_playback_without_marker(playback_progress);
+            self.audio.current_playback_span = Some(playback_span);
+        }
+        starmap_telemetry::record_event(
+            None,
+            "controller.drag_audio_keep",
+            "release",
+            active_playback_path.as_deref().or(active_target),
+            0,
+            0,
+            self.audio.playback_progress.active,
+            None,
         );
     }
 

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -1811,7 +1811,7 @@ fn starmap_drag_finish_clears_active_drag_audition_state() {
 }
 
 #[test]
-fn starmap_drag_finish_after_motion_stops_drag_playback_state() {
+fn starmap_drag_finish_after_motion_keeps_drag_playback_state() {
     let source_root = tempfile::tempdir().expect("source root");
     let first = source_root.path().join("a.wav");
     let second = source_root.path().join("b.wav");
@@ -1863,12 +1863,259 @@ fn starmap_drag_finish_after_motion_stops_drag_playback_state() {
         &mut context,
     );
 
-    assert_eq!(state.audio.sample_playback_session, None);
-    assert_eq!(state.audio.current_playback_span, None);
+    assert!(state.audio.sample_playback_session.is_some());
+    assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));
     assert_eq!(
         state.audio.playback_progress,
-        wavecrate::audio::PlaybackRuntimeProgress::default(),
-        "drag release after motion should not leave preview playback visually active"
+        wavecrate::audio::PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(std::time::Duration::from_millis(90)),
+            looping: false,
+            progress: Some(0.25),
+            error: None,
+        },
+        "drag release after motion should keep active playback running"
+    );
+    assert_ne!(
+        state
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .map(|session| session.request.origin),
+        Some("starmap_drag"),
+        "release should not leave kept playback tagged as an active starmap drag"
+    );
+    assert_eq!(state.ui.chrome.starmap_audition_queue, Default::default());
+}
+
+#[test]
+fn starmap_drag_release_preserves_loaded_last_played_sample_not_latest_hit() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let first = source_root.path().join("a.wav");
+    let second = source_root.path().join("b.wav");
+    let third = source_root.path().join("c.wav");
+    write_test_wav_i16(&first, &[0, 100, -100]);
+    write_test_wav_i16(&second, &[0, 120, -120, 60]);
+    write_test_wav_i16(&third, &[0, 140, -140]);
+    let first_id = first.display().to_string();
+    let second_id = second.display().to_string();
+    let third_id = third.display().to_string();
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(
+            crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+                wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+            ]),
+        )
+        .build();
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(second.clone())
+            .expect("second sample loads");
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::BeginStarmapAuditionDrag {
+            path: Some(first_id),
+            position: Point::new(10.0, 10.0),
+            modifiers: PointerModifiers::default(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::UpdateStarmapAuditionDrag {
+            paths: vec![third_id.clone()],
+            position: Point::new(90.0, 10.0),
+            modifiers: PointerModifiers::default(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    state.ui.chrome.starmap_audition_queue.last_played_file_id = Some(second_id.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        second_id,
+        "preview_samples",
+    );
+    state.audio.current_playback_span = Some((0.0, 1.0));
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(std::time::Duration::from_millis(90)),
+        looping: false,
+        progress: Some(0.25),
+        error: None,
+    };
+    assert!(
+        !state.waveform.current.has_loaded_sample(),
+        "test setup should reproduce the blank waveform preview-loading state"
+    );
+    assert_eq!(
+        state
+            .ui
+            .chrome
+            .starmap_audition_queue
+            .active_file_id
+            .as_deref(),
+        Some(third_id.as_str()),
+        "test setup keeps the latest drag hit different from the audible sample"
+    );
+    let stale_settled_ticket = state.background.settled_sample_promotion_task.begin();
+
+    let mut release_context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::FinishStarmapAuditionDrag,
+        &mut release_context,
+    );
+    let (delayed, perform_count) =
+        collect_after_commands_and_perform_count(release_context.into_command());
+
+    assert_eq!(state.waveform.current.path(), second.as_path());
+    assert!(state.waveform.current.has_loaded_sample());
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(second.to_string_lossy().as_ref()),
+        "release should keep keyboard playback aligned with the restored loaded sample"
+    );
+    assert!(
+        !state.waveform.instant_preview_active(),
+        "release should restore the authoritative waveform display"
+    );
+    assert!(
+        state.waveform.current.is_playing(),
+        "release should keep the loaded starmap sample playing"
+    );
+    assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));
+    assert!(
+        state.audio.sample_playback_session.is_some(),
+        "release should preserve the matching playback session"
+    );
+    assert_ne!(
+        state
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .map(|session| session.request.origin),
+        Some("starmap_drag"),
+        "release should not leave kept playback tagged as an active starmap drag"
+    );
+    assert_ne!(
+        state.waveform.current.path(),
+        third.as_path(),
+        "release should not retarget to the latest dense-node hit"
+    );
+    assert_eq!(
+        delayed,
+        Vec::new(),
+        "release should not schedule a delayed load for the last played sample"
+    );
+    assert_eq!(
+        perform_count, 0,
+        "release should not run a foreground sample load"
+    );
+    assert!(
+        state
+            .background
+            .settled_sample_promotion_task
+            .active()
+            .is_none(),
+        "release should cancel settled promotions that could retarget after mouse-up"
+    );
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SettledSamplePromotion {
+            ticket: stale_settled_ticket,
+            path: third_id.clone(),
+            scheduled_at: std::time::Instant::now(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    assert_eq!(
+        state.waveform.current.path(),
+        second.as_path(),
+        "stale settled promotion after release must not load the latest hit"
+    );
+    assert_eq!(state.ui.chrome.starmap_audition_queue, Default::default());
+}
+
+#[test]
+fn starmap_drag_release_replaces_mismatched_audio_target_with_restored_sample() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let first = source_root.path().join("a.wav");
+    let second = source_root.path().join("b.wav");
+    let third = source_root.path().join("c.wav");
+    write_test_wav_i16(&first, &[0, 100, -100]);
+    write_test_wav_i16(&second, &[0, 120, -120, 60]);
+    write_test_wav_i16(&third, &[0, 140, -140]);
+    let first_id = first.display().to_string();
+    let second_id = second.display().to_string();
+    let third_id = third.display().to_string();
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(
+            crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+                wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+            ]),
+        )
+        .build();
+    state.waveform.current =
+        crate::native_app::test_support::state::WaveformState::load_path(second.clone())
+            .expect("second sample loads");
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::BeginStarmapAuditionDrag {
+            path: Some(first_id),
+            position: Point::new(10.0, 10.0),
+            modifiers: PointerModifiers::default(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::UpdateStarmapAuditionDrag {
+            paths: vec![third_id.clone()],
+            position: Point::new(90.0, 10.0),
+            modifiers: PointerModifiers::default(),
+        },
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+    state.ui.chrome.starmap_audition_queue.last_played_file_id = Some(second_id.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        second_id.clone(),
+        "preview_samples",
+    );
+    state.ui.chrome.starmap_audition_queue.last_played_session =
+        state.audio.sample_playback_session.clone();
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        third_id.clone(),
+        "preview_samples",
+    );
+    state.audio.current_playback_span = Some((0.0, 1.0));
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(std::time::Duration::from_millis(90)),
+        looping: false,
+        progress: Some(0.25),
+        error: None,
+    };
+
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::FinishStarmapAuditionDrag,
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+
+    assert_eq!(state.waveform.current.path(), second.as_path());
+    assert!(state.waveform.current.has_loaded_sample());
+    assert!(
+        state.waveform.current.is_playing(),
+        "release should keep the restored loaded sample visually playing"
+    );
+    assert_ne!(
+        state.audio.active_sample_playback_path(),
+        Some(third_id.as_str()),
+        "release must not leave a stale dense-node hit as the active audio target"
+    );
+    assert_eq!(
+        state.audio.active_sample_playback_path(),
+        Some(second_id.as_str()),
+        "release should restore the previous active session instead of restarting playback"
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(second.to_string_lossy().as_ref()),
+        "keyboard playback should remain aligned with the restored sample"
     );
     assert_eq!(state.ui.chrome.starmap_audition_queue, Default::default());
 }


### PR DESCRIPTION
## Scope
- Track the starmap drag sample that actually starts playback separately from the latest pointer hit.
- Preserve the playback session for the last actually-started starmap audition, not just its path.
- Capture the authoritative loaded waveform before starmap drag preview/loading replaces it, then restore that snapshot on moved drag release if the display is still in transient preview state.
- Preserve active starmap drag playback on mouse release instead of stopping or replaying the audio runtime; release retags the kept session away from active starmap drag state.
- If mouse-up finds a stale dense-node audio target queued after restoring the correct waveform, cancel that pending play without stopping the currently audible source, then restore the last-played session bookkeeping.
- Re-align browser selection to the restored loaded waveform on release, so Space keeps playing the restored sample instead of loading the latest starmap hit.
- Cancel both starmap-specific promotion and generic settled-sample promotion on moved drag release, so stale post-release timers cannot load the latest hit.
- Add regressions for dense-node release where the latest hit differs from the loaded/audible sample, including blank preview-loading state, preserved playback/progress, selection alignment, stale settled-promotion delivery, stale active-audio-target mismatch, and no replay/restart on release.

## Definition of Done
- Starmap drag playback records the last file and playback session that actually started playback across loaded/current, fast-audition, and playback-ready paths.
- Releasing a moved starmap drag does not initiate a sample change, foreground load, audio stop, or audio replay.
- If drag preview left the waveform blank/loading, release restores the previously loaded sample waveform and clears preview mode.
- Active playback continues across release and is no longer tagged as an active starmap drag.
- A stale queued audio target from the latest dense-node hit cannot remain active after release when the restored waveform is a different sample.
- Post-release Space playback remains aligned with the restored loaded sample.
- Post-release promotion timers from drag audition cannot retarget the waveform to the latest dense-node hit.
- Existing starmap click behavior remains unchanged.

## Validation Commands
- `cargo test -p wavecrate --bin wavecrate starmap_drag -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate fast_audition -- --test-threads=1`
- `cargo test -p wavecrate --bin wavecrate starmap -- --test-threads=1`
- `cargo test -p reson`
- `cargo check --release -p wavecrate --bin wavecrate`
- `git diff --check`

## Known Limitations
- `cargo fmt --check` currently reports unrelated formatting diffs outside this PR.
- `bash scripts/agent.sh request` currently fails on a pre-existing native-app boundary violation in `src/native_app/audio/playback/progress.rs`, which this PR does not touch.

User review is required before merge.
