### PR TITLE
Fix bracket rating hotkeys

### DIFF
--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -36,7 +36,15 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) playback_runtime: Option<PlaybackRuntimeHandle>,
     pub(in crate::native_app) playback_events: Option<Receiver<PlaybackRuntimeEvent>>,
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
-    pub(in crate::native_app) playback_progress_updated_at: Option<Instant>,
+    pub(in crate::native_app) playback_visual_progress: Option<PlaybackVisualProgress>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app) struct PlaybackVisualProgress {
+    pub(in crate::native_app) anchor_ratio: f32,
+    pub(in crate::native_app) anchor_at: Instant,
+    pub(in crate::native_app) span: Option<(f32, f32)>,
+    pub(in crate::native_app) looping: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -262,7 +270,7 @@ impl AudioAppState {
             playback_runtime: None,
             playback_events: None,
             playback_progress: PlaybackRuntimeProgress::default(),
-            playback_progress_updated_at: None,
+            playback_visual_progress: None,
         }
     }
 
@@ -324,12 +332,43 @@ impl AudioAppState {
         progress: PlaybackRuntimeProgress,
     ) {
         self.playback_progress = progress;
-        self.playback_progress_updated_at = Some(Instant::now());
+        self.sync_playback_visual_progress(false);
     }
 
     pub(in crate::native_app) fn clear_playback_progress(&mut self) {
         self.playback_progress = PlaybackRuntimeProgress::default();
-        self.playback_progress_updated_at = None;
+        self.playback_visual_progress = None;
+    }
+
+    pub(in crate::native_app) fn reset_playback_visual_progress(
+        &mut self,
+        anchor_ratio: f32,
+        looping: bool,
+    ) {
+        self.playback_visual_progress = Some(PlaybackVisualProgress {
+            anchor_ratio: anchor_ratio.clamp(0.0, 1.0),
+            anchor_at: Instant::now(),
+            span: self.current_playback_span,
+            looping,
+        });
+    }
+
+    fn sync_playback_visual_progress(&mut self, force: bool) {
+        if !self.playback_progress.active {
+            self.playback_visual_progress = None;
+            return;
+        }
+        let Some(progress) = self.playback_progress.progress else {
+            return;
+        };
+        let span = self.current_playback_span;
+        let looping = self.playback_progress.looping;
+        let clock_mismatch = self
+            .playback_visual_progress
+            .is_some_and(|clock| clock.span != span || clock.looping != looping);
+        if force || self.playback_visual_progress.is_none() || clock_mismatch {
+            self.reset_playback_visual_progress(progress, looping);
+        }
     }
 
     pub(in crate::native_app) fn promote_sample_playback_session_to_waveform(

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -1,4 +1,7 @@
-use std::{sync::mpsc::Receiver, time::Instant};
+use std::{
+    sync::mpsc::Receiver,
+    time::{Duration, Instant},
+};
 
 use wavecrate::audio::{
     AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, AudioPlayer, PlaybackRequestId,
@@ -43,6 +46,7 @@ pub(in crate::native_app) struct AudioAppState {
 pub(in crate::native_app) struct PlaybackVisualProgress {
     pub(in crate::native_app) anchor_ratio: f32,
     pub(in crate::native_app) anchor_at: Instant,
+    pub(in crate::native_app) anchor_animation_time: Option<Duration>,
     pub(in crate::native_app) span: Option<(f32, f32)>,
     pub(in crate::native_app) looping: bool,
 }
@@ -348,6 +352,7 @@ impl AudioAppState {
         self.playback_visual_progress = Some(PlaybackVisualProgress {
             anchor_ratio: anchor_ratio.clamp(0.0, 1.0),
             anchor_at: Instant::now(),
+            anchor_animation_time: None,
             span: self.current_playback_span,
             looping,
         });

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -15,6 +15,8 @@ use crate::native_app::audio::{
     playback_history::{LastPlayedPersistRequest, PlaybackNavigationHistory},
 };
 
+const PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE: Duration = Duration::from_millis(8);
+
 pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) player: Option<AudioPlayer>,
     pub(in crate::native_app) loop_playback: bool,
@@ -342,6 +344,14 @@ impl AudioAppState {
         self.sync_playback_visual_progress(false);
     }
 
+    pub(in crate::native_app) fn set_started_playback_progress(
+        &mut self,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        self.playback_progress = progress;
+        self.sync_playback_visual_progress(true);
+    }
+
     pub(in crate::native_app) fn clear_playback_progress(&mut self) {
         self.playback_progress = PlaybackRuntimeProgress::default();
         self.playback_visual_progress = None;
@@ -374,9 +384,28 @@ impl AudioAppState {
         let clock_mismatch = self
             .playback_visual_progress
             .is_some_and(|clock| clock.span != span || clock.looping != looping);
-        if force || self.playback_visual_progress.is_none() || clock_mismatch {
+        let delayed_unpainted_anchor = self.delayed_unpainted_playback_anchor_needs_refresh();
+        if force
+            || self.playback_visual_progress.is_none()
+            || clock_mismatch
+            || delayed_unpainted_anchor
+        {
             self.reset_playback_visual_progress(progress, looping);
         }
+    }
+
+    fn delayed_unpainted_playback_anchor_needs_refresh(&self) -> bool {
+        let Some(clock) = self.playback_visual_progress else {
+            return false;
+        };
+        if clock.anchor_animation_time.is_some() {
+            return false;
+        }
+        let Some(runtime_elapsed) = self.playback_progress.elapsed else {
+            return false;
+        };
+        runtime_elapsed.saturating_add(PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE)
+            >= clock.anchor_at.elapsed()
     }
 
     pub(in crate::native_app) fn promote_sample_playback_session_to_waveform(

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -36,6 +36,7 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) playback_runtime: Option<PlaybackRuntimeHandle>,
     pub(in crate::native_app) playback_events: Option<Receiver<PlaybackRuntimeEvent>>,
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
+    pub(in crate::native_app) playback_progress_updated_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -261,6 +262,7 @@ impl AudioAppState {
             playback_runtime: None,
             playback_events: None,
             playback_progress: PlaybackRuntimeProgress::default(),
+            playback_progress_updated_at: None,
         }
     }
 
@@ -315,6 +317,19 @@ impl AudioAppState {
 
     pub(in crate::native_app) fn clear_sample_playback_session(&mut self) {
         self.sample_playback_session = None;
+    }
+
+    pub(in crate::native_app) fn set_playback_progress(
+        &mut self,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        self.playback_progress = progress;
+        self.playback_progress_updated_at = Some(Instant::now());
+    }
+
+    pub(in crate::native_app) fn clear_playback_progress(&mut self) {
+        self.playback_progress = PlaybackRuntimeProgress::default();
+        self.playback_progress_updated_at = None;
     }
 
     pub(in crate::native_app) fn promote_sample_playback_session_to_waveform(

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -11,7 +11,8 @@ use wavecrate::audio::{
 use wavecrate::sample_sources::config::AppSettingsCore;
 
 use crate::native_app::audio::{
-    playback::PlaybackIntent, playback_history::PlaybackNavigationHistory,
+    playback::PlaybackIntent,
+    playback_history::{LastPlayedPersistRequest, PlaybackNavigationHistory},
 };
 
 pub(in crate::native_app) struct AudioAppState {
@@ -24,6 +25,7 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) volume_persist_deadline: Option<Instant>,
     pub(in crate::native_app) volume_persist_inflight: bool,
     pub(in crate::native_app) last_played_persist_task: radiant::prelude::LatestTask,
+    pub(in crate::native_app) pending_last_played_persist: Option<LastPlayedPersistRequest>,
     pub(in crate::native_app) output_config: AudioOutputConfig,
     pub(in crate::native_app) output_resolved: Option<ResolvedOutput>,
     pub(in crate::native_app) hosts: Vec<AudioHostSummary>,
@@ -259,6 +261,7 @@ impl AudioAppState {
             volume_persist_deadline: None,
             volume_persist_inflight: false,
             last_played_persist_task: radiant::prelude::LatestTask::new(),
+            pending_last_played_persist: None,
             output_config: settings.audio_output.clone(),
             output_resolved: None,
             hosts: Vec::new(),

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -214,6 +214,7 @@ pub(super) fn muted_sample_file_cell(value: String, width: f32) -> ui::View<GuiM
 
 /// Render a projected passive rating cell.
 fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<GuiMessage> {
+    let visual_key = projection.retained_visual_key();
     if projection == RatingCellProjection::LockedKeepMarker {
         return compact_column_content_cell(
             ui::marker_run(Some(LOCKED_KEEP_RATING_COLOR), 1)
@@ -222,7 +223,8 @@ fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<
                 .inset(0)
                 .view(),
             width,
-        );
+        )
+        .key(visual_key);
     }
 
     compact_column_content_cell(
@@ -233,6 +235,7 @@ fn render_rating_cell(projection: RatingCellProjection, width: f32) -> ui::View<
             .view(),
         width,
     )
+    .key(visual_key)
 }
 
 /// Render a passive text cell for a sample file column.

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells/projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells/projection.rs
@@ -123,6 +123,22 @@ impl SampleCellProjection {
 }
 
 impl RatingCellProjection {
+    pub(super) fn retained_visual_key(&self) -> String {
+        match self {
+            Self::LockedKeepMarker => String::from("sample-rating-locked-keep"),
+            Self::MarkerRun {
+                color: Some(color),
+                count,
+            } => format!(
+                "sample-rating-marker-{count}-{}-{}-{}-{}",
+                color.r, color.g, color.b, color.a
+            ),
+            Self::MarkerRun { color: None, count } => {
+                format!("sample-rating-marker-{count}-none")
+            }
+        }
+    }
+
     pub(super) fn from_indicator(indicator: RatingIndicator) -> Self {
         if indicator.shows_locked_keep_marker() {
             Self::LockedKeepMarker
@@ -211,6 +227,19 @@ mod tests {
                 color: Some(_)
             }
         ));
+    }
+
+    #[test]
+    fn rating_projection_visual_key_tracks_marker_state() {
+        let neutral =
+            RatingCellProjection::from_indicator(RatingIndicator::new(Rating::NEUTRAL, false));
+        let keep =
+            RatingCellProjection::from_indicator(RatingIndicator::new(Rating::KEEP_1, false));
+        let locked =
+            RatingCellProjection::from_indicator(RatingIndicator::new(Rating::KEEP_3, true));
+
+        assert_ne!(neutral.retained_visual_key(), keep.retained_visual_key());
+        assert_ne!(keep.retained_visual_key(), locked.retained_visual_key());
     }
 
     #[test]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
@@ -58,6 +58,11 @@ pub(super) fn retained_sample_row_key(file_id: &str) -> String {
     format!("sample-row-{file_id}")
 }
 
+/// Retained visual key for one sample row projection.
+pub(super) fn retained_sample_row_visual_key(file_id: &str, visual_signature: &str) -> String {
+    format!("{}-{visual_signature}", retained_sample_row_key(file_id))
+}
+
 fn similarity_aspect_control_key(aspect: SimilarityAspect) -> &'static str {
     match aspect {
         SimilarityAspect::Overall => "overall",

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
@@ -58,11 +58,6 @@ pub(super) fn retained_sample_row_key(file_id: &str) -> String {
     format!("sample-row-{file_id}")
 }
 
-/// Retained visual key for one sample row projection.
-pub(super) fn retained_sample_row_visual_key(file_id: &str, visual_signature: &str) -> String {
-    format!("{}-{visual_signature}", retained_sample_row_key(file_id))
-}
-
 fn similarity_aspect_control_key(aspect: SimilarityAspect) -> &'static str {
     match aspect {
         SimilarityAspect::Overall => "overall",

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use super::cells::{sample_column_cell, similarity_anchor_toggle};
 use super::hit_target::{SampleFileHitTargetModel, sample_file_hit_target};
 use super::identity;
-use super::row_projection::{SampleColumnContent, SampleRowDisplay, sample_row_display};
+use super::row_projection::{SampleRowDisplay, sample_row_display};
 use crate::native_app::app::{GuiMessage, SampleNameViewMode};
 use crate::native_app::sample_library::folder_browser::projection::VisibleSampleList;
 use crate::native_app::sample_library::sample_list::{
@@ -69,7 +69,6 @@ fn sample_browser_row(
 ) -> ui::View<GuiMessage> {
     let file_id = row.file_id.to_string();
     let file_id_for_toggle = row.file_id.to_string();
-    let visual_key = retained_sample_row_visual_key(&row);
     let row_content = ui::row([
         similarity_anchor_toggle(
             file_id_for_toggle,
@@ -101,25 +100,7 @@ fn sample_browser_row(
     )
     .fill_width()
     .height(SAMPLE_BROWSER_ROW_HEIGHT);
-    row.style(ui::WidgetStyle::default()).key(visual_key)
-}
-
-fn retained_sample_row_visual_key(row: &SampleRowDisplay<'_>) -> String {
-    let rating_signature = row.columns.iter().find_map(|column| {
-        let SampleColumnContent::Rating(indicator) = &column.content else {
-            return None;
-        };
-        Some(format!(
-            "rating-{}-{:?}-{}",
-            indicator.count(),
-            indicator.color(),
-            indicator.shows_locked_keep_marker()
-        ))
-    });
-    identity::retained_sample_row_visual_key(
-        row.file_id,
-        rating_signature.as_deref().unwrap_or("rating-none"),
-    )
+    row.style(ui::WidgetStyle::default())
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 
 use super::cells::{sample_column_cell, similarity_anchor_toggle};
 use super::hit_target::{SampleFileHitTargetModel, sample_file_hit_target};
-use super::identity;
 use super::row_projection::{SampleRowDisplay, sample_row_display};
 use crate::native_app::app::{GuiMessage, SampleNameViewMode};
 use crate::native_app::sample_library::folder_browser::projection::VisibleSampleList;

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 
 use super::cells::{sample_column_cell, similarity_anchor_toggle};
 use super::hit_target::{SampleFileHitTargetModel, sample_file_hit_target};
-use super::row_projection::{SampleRowDisplay, sample_row_display};
+use super::identity;
+use super::row_projection::{SampleColumnContent, SampleRowDisplay, sample_row_display};
 use crate::native_app::app::{GuiMessage, SampleNameViewMode};
 use crate::native_app::sample_library::folder_browser::projection::VisibleSampleList;
 use crate::native_app::sample_library::sample_list::{
@@ -68,6 +69,7 @@ fn sample_browser_row(
 ) -> ui::View<GuiMessage> {
     let file_id = row.file_id.to_string();
     let file_id_for_toggle = row.file_id.to_string();
+    let visual_key = retained_sample_row_visual_key(&row);
     let row_content = ui::row([
         similarity_anchor_toggle(
             file_id_for_toggle,
@@ -99,7 +101,25 @@ fn sample_browser_row(
     )
     .fill_width()
     .height(SAMPLE_BROWSER_ROW_HEIGHT);
-    row.style(ui::WidgetStyle::default())
+    row.style(ui::WidgetStyle::default()).key(visual_key)
+}
+
+fn retained_sample_row_visual_key(row: &SampleRowDisplay<'_>) -> String {
+    let rating_signature = row.columns.iter().find_map(|column| {
+        let SampleColumnContent::Rating(indicator) = &column.content else {
+            return None;
+        };
+        Some(format!(
+            "rating-{}-{:?}-{}",
+            indicator.count(),
+            indicator.color(),
+            indicator.shows_locked_keep_marker()
+        ))
+    });
+    identity::retained_sample_row_visual_key(
+        row.file_id,
+        rating_signature.as_deref().unwrap_or("rating-none"),
+    )
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -5,6 +5,7 @@ use super::super::cells::{
     sample_harvest_badge_cell, sample_playback_type_cell, sample_rating_cell,
     sample_similarity_cell,
 };
+use super::super::row_projection::{SampleColumnDisplay, SampleRowDisplay};
 use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
 use super::*;
@@ -60,6 +61,27 @@ fn fill_rects(frame: &radiant::runtime::SurfaceFrame) -> Vec<radiant::prelude::R
         .collect()
 }
 
+fn row_display_with_rating(rating: Rating, locked: bool) -> SampleRowDisplay<'static> {
+    SampleRowDisplay {
+        file_id: "sample.wav",
+        explicitly_selected: false,
+        focused: false,
+        copy_flash: false,
+        protected_source_error_flash: false,
+        cut_pending: false,
+        drag_active: false,
+        drag_source: false,
+        cached: false,
+        missing: false,
+        similarity_anchor: false,
+        similarity_strength: None,
+        columns: vec![SampleColumnDisplay {
+            width: 68.0,
+            content: SampleColumnContent::Rating(RatingIndicator::new(rating, locked)),
+        }],
+    }
+}
+
 #[test]
 /// Verifies rating strength maps to the visible indicator count.
 fn rating_indicator_count_reflects_rating_strength() {
@@ -68,6 +90,23 @@ fn rating_indicator_count_reflects_rating_strength() {
     assert_eq!(RatingIndicator::new(Rating::new(2), false).count(), 2);
     assert_eq!(RatingIndicator::new(Rating::TRASH_3, false).count(), 3);
     assert_eq!(RatingIndicator::new(Rating::KEEP_3, true).count(), 3);
+}
+
+#[test]
+/// Verifies rating changes invalidate the retained row visual subtree.
+fn rating_state_changes_retained_sample_row_visual_key() {
+    let neutral = row_display_with_rating(Rating::NEUTRAL, false);
+    let keep = row_display_with_rating(Rating::KEEP_1, false);
+    let locked = row_display_with_rating(Rating::KEEP_3, true);
+
+    assert_ne!(
+        retained_sample_row_visual_key(&neutral),
+        retained_sample_row_visual_key(&keep)
+    );
+    assert_ne!(
+        retained_sample_row_visual_key(&keep),
+        retained_sample_row_visual_key(&locked)
+    );
 }
 
 #[test]

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -5,7 +5,6 @@ use super::super::cells::{
     sample_harvest_badge_cell, sample_playback_type_cell, sample_rating_cell,
     sample_similarity_cell,
 };
-use super::super::row_projection::SampleColumnDisplay;
 use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
 use super::*;

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -5,7 +5,7 @@ use super::super::cells::{
     sample_harvest_badge_cell, sample_playback_type_cell, sample_rating_cell,
     sample_similarity_cell,
 };
-use super::super::row_projection::{SampleColumnDisplay, SampleRowDisplay};
+use super::super::row_projection::SampleColumnDisplay;
 use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
 use super::*;
@@ -61,27 +61,6 @@ fn fill_rects(frame: &radiant::runtime::SurfaceFrame) -> Vec<radiant::prelude::R
         .collect()
 }
 
-fn row_display_with_rating(rating: Rating, locked: bool) -> SampleRowDisplay<'static> {
-    SampleRowDisplay {
-        file_id: "sample.wav",
-        explicitly_selected: false,
-        focused: false,
-        copy_flash: false,
-        protected_source_error_flash: false,
-        cut_pending: false,
-        drag_active: false,
-        drag_source: false,
-        cached: false,
-        missing: false,
-        similarity_anchor: false,
-        similarity_strength: None,
-        columns: vec![SampleColumnDisplay {
-            width: 68.0,
-            content: SampleColumnContent::Rating(RatingIndicator::new(rating, locked)),
-        }],
-    }
-}
-
 #[test]
 /// Verifies rating strength maps to the visible indicator count.
 fn rating_indicator_count_reflects_rating_strength() {
@@ -90,23 +69,6 @@ fn rating_indicator_count_reflects_rating_strength() {
     assert_eq!(RatingIndicator::new(Rating::new(2), false).count(), 2);
     assert_eq!(RatingIndicator::new(Rating::TRASH_3, false).count(), 3);
     assert_eq!(RatingIndicator::new(Rating::KEEP_3, true).count(), 3);
-}
-
-#[test]
-/// Verifies rating changes invalidate the retained row visual subtree.
-fn rating_state_changes_retained_sample_row_visual_key() {
-    let neutral = row_display_with_rating(Rating::NEUTRAL, false);
-    let keep = row_display_with_rating(Rating::KEEP_1, false);
-    let locked = row_display_with_rating(Rating::KEEP_3, true);
-
-    assert_ne!(
-        retained_sample_row_visual_key(&neutral),
-        retained_sample_row_visual_key(&keep)
-    );
-    assert_ne!(
-        retained_sample_row_visual_key(&keep),
-        retained_sample_row_visual_key(&locked)
-    );
 }
 
 #[test]

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -20,7 +20,9 @@ fn scene(state: &NativeAppState) -> ui::Scene<GuiMessage> {
 
 fn frame_clock() -> ui::FrameClock<NativeAppState, GuiMessage> {
     ui::FrameClock::message(GuiMessage::Frame)
-        .fps(APP_FRAME_CLOCK_FPS)
+        .fps_with(|state: &mut NativeAppState| {
+            (!state.playback_visual_activity_active()).then_some(APP_FRAME_CLOCK_FPS)
+        })
         .repaint_scope(
             |state: &mut NativeAppState| state.frame_repaint_scope_before_update(),
             |state, scope| state.frame_can_use_paint_only(scope),

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -4,7 +4,6 @@ use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_b
 use radiant::prelude as ui;
 
 const APP_TRANSIENT_OVERLAY_KEY: u64 = 0x6170_705f_6f76_726c;
-const APP_TRANSIENT_OVERLAY_FPS: u32 = 60;
 const APP_FRAME_CLOCK_FPS: u32 = 60;
 
 pub(in crate::native_app) fn view(state: &mut NativeAppState) -> ui::View<GuiMessage> {
@@ -32,6 +31,5 @@ fn app_transient_overlay() -> ui::TransientOverlay<NativeAppState> {
     ui::TransientOverlay::new(APP_TRANSIENT_OVERLAY_KEY)
         .paint_only()
         .when(|state: &mut NativeAppState| state.should_paint_app_transient_overlay())
-        .fps(APP_TRANSIENT_OVERLAY_FPS)
         .paint(NativeAppState::paint_app_transient_overlay)
 }

--- a/src/native_app/audio/playback/commands.rs
+++ b/src/native_app/audio/playback/commands.rs
@@ -340,6 +340,9 @@ impl NativeAppState {
         self.stop_audio_output_playback();
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
+        self.audio.pending_playback_start = None;
+        self.audio.clear_sample_playback_session();
+        self.audio.clear_playback_progress();
         let file_name = self.waveform.current.file_name();
         self.ui.status.sample = format!("Stopped {file_name}");
         emit_gui_action(

--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -244,7 +244,7 @@ impl NativeAppState {
                 .current
                 .start_playback_without_marker(playback_start);
         }
-        self.audio.playback_progress = Default::default();
+        self.audio.clear_playback_progress();
         self.audio.current_playback_span =
             Some((command.resolved.start_ratio, command.resolved.end_ratio));
         let session_request = SamplePlaybackRequest::waveform(

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -142,8 +142,11 @@ impl NativeAppState {
         let anchor_animation_time = match visual_progress.anchor_animation_time {
             Some(anchor_animation_time) => anchor_animation_time,
             None => {
-                visual_progress.anchor_animation_time = Some(animation_time);
-                animation_time
+                let anchor_animation_time = animation_time
+                    .checked_sub(visual_progress.anchor_at.elapsed())
+                    .unwrap_or(animation_time);
+                visual_progress.anchor_animation_time = Some(anchor_animation_time);
+                anchor_animation_time
             }
         };
         let elapsed_seconds = animation_time
@@ -520,7 +523,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_waveform_progress_for_frame_starts_at_anchor_frame_time() {
+    fn runtime_waveform_progress_for_frame_accounts_for_unpainted_elapsed_time() {
         let mut state = NativeAppStateFixture::default()
             .with_synthetic_waveform()
             .build();
@@ -550,12 +553,12 @@ mod tests {
             )
             .expect("later frame progress");
 
-        assert_eq!(
-            first_frame, 0.25,
-            "first paint after a restart should begin at the playback anchor, not include wall-clock setup delay"
+        assert!(
+            first_frame > 0.43 && first_frame < 0.48,
+            "first paint after a delayed overlay should include unpainted elapsed time, got {first_frame}"
         );
         assert!(
-            later_frame > 0.33 && later_frame < 0.38,
+            later_frame > 0.53 && later_frame < 0.58,
             "subsequent paint frames should advance from the frame-time anchor, got {later_frame}"
         );
     }
@@ -595,9 +598,9 @@ mod tests {
         let progress = state
             .current_audio_progress_ratio_for_frame(Duration::from_secs(30))
             .expect("restarted progress");
-        assert_eq!(
-            progress, 0.0,
-            "a new runtime start for the same span should re-anchor the cursor at the restart"
+        assert!(
+            progress >= 0.0 && progress < 0.001,
+            "a new runtime start for the same span should re-anchor the cursor at the restart, got {progress}"
         );
     }
 
@@ -630,13 +633,19 @@ mod tests {
             progress: Some(0.32),
             error: None,
         });
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("latest visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.08);
 
         let first_visible_frame = state
             .current_audio_progress_ratio_for_frame(Duration::from_secs(30))
             .expect("first visible frame progress");
         assert!(
-            first_visible_frame > 0.31 && first_visible_frame < 0.33,
-            "first paint after a delayed overlay should start from the latest runtime snapshot, got {first_visible_frame}"
+            first_visible_frame > 0.39 && first_visible_frame < 0.42,
+            "first paint after a delayed overlay should advance from the latest runtime snapshot, got {first_visible_frame}"
         );
     }
 

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -561,6 +561,86 @@ mod tests {
     }
 
     #[test]
+    fn runtime_waveform_progress_restart_snapshot_resets_visual_clock() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.0);
+        state.audio.current_playback_span = Some((0.0, 1.0));
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: false,
+            progress: Some(0.0),
+            error: None,
+        });
+        let sample_duration = state.waveform.current.duration_seconds();
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.5);
+
+        state
+            .audio
+            .set_started_playback_progress(PlaybackRuntimeProgress {
+                active: true,
+                elapsed: Some(Duration::ZERO),
+                looping: false,
+                progress: Some(0.0),
+                error: None,
+            });
+
+        let progress = state
+            .current_audio_progress_ratio_for_frame(Duration::from_secs(30))
+            .expect("restarted progress");
+        assert_eq!(
+            progress, 0.0,
+            "a new runtime start for the same span should re-anchor the cursor at the restart"
+        );
+    }
+
+    #[test]
+    fn delayed_first_paint_uses_latest_runtime_progress_anchor() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.0);
+        state.audio.current_playback_span = Some((0.0, 1.0));
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: false,
+            progress: Some(0.0),
+            error: None,
+        });
+        let sample_duration = state.waveform.current.duration_seconds();
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.30);
+
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_secs_f32(sample_duration * 0.32)),
+            looping: false,
+            progress: Some(0.32),
+            error: None,
+        });
+
+        let first_visible_frame = state
+            .current_audio_progress_ratio_for_frame(Duration::from_secs(30))
+            .expect("first visible frame progress");
+        assert!(
+            first_visible_frame > 0.31 && first_visible_frame < 0.33,
+            "first paint after a delayed overlay should start from the latest runtime snapshot, got {first_visible_frame}"
+        );
+    }
+
+    #[test]
     fn runtime_waveform_progress_wraps_inside_loop_span() {
         let mut state = NativeAppStateFixture::default()
             .with_synthetic_waveform()

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use super::{
     PlaybackIntent,
@@ -86,6 +86,17 @@ impl NativeAppState {
             .or_else(|| self.waveform.current.playhead_ratio())
     }
 
+    pub(in crate::native_app) fn current_audio_progress_ratio_for_frame(
+        &mut self,
+        animation_time: Duration,
+    ) -> Option<f32> {
+        if let Some(progress) = self.audio.player.as_ref().and_then(AudioPlayer::progress) {
+            return Some(progress);
+        }
+        self.interpolated_runtime_waveform_progress_ratio_for_frame(animation_time)
+            .or_else(|| self.waveform.current.playhead_ratio())
+    }
+
     fn interpolated_runtime_waveform_progress_ratio(&self) -> Option<f32> {
         if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
             return None;
@@ -99,6 +110,46 @@ impl NativeAppState {
             return None;
         }
         let elapsed_seconds = visual_progress.anchor_at.elapsed().as_secs_f32();
+        if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
+            return Some(visual_progress.anchor_ratio.clamp(0.0, 1.0));
+        }
+        let delta_ratio = elapsed_seconds / duration_seconds;
+        let (start, end) = normalized_playback_progress_span(visual_progress.span)?;
+        Some(interpolate_runtime_progress_ratio(
+            visual_progress.anchor_ratio,
+            delta_ratio,
+            start,
+            end,
+            visual_progress.looping,
+        ))
+    }
+
+    fn interpolated_runtime_waveform_progress_ratio_for_frame(
+        &mut self,
+        animation_time: Duration,
+    ) -> Option<f32> {
+        if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
+            return None;
+        }
+        if !self.audio.playback_progress.active {
+            return None;
+        }
+        let duration_seconds = self.waveform.current.duration_seconds();
+        if !duration_seconds.is_finite() || duration_seconds <= 0.0 {
+            return None;
+        }
+        let visual_progress = self.audio.playback_visual_progress.as_mut()?;
+        let anchor_animation_time = match visual_progress.anchor_animation_time {
+            Some(anchor_animation_time) => anchor_animation_time,
+            None => {
+                visual_progress.anchor_animation_time = Some(animation_time);
+                animation_time
+            }
+        };
+        let elapsed_seconds = animation_time
+            .checked_sub(anchor_animation_time)
+            .unwrap_or_default()
+            .as_secs_f32();
         if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
             return Some(visual_progress.anchor_ratio.clamp(0.0, 1.0));
         }
@@ -465,6 +516,47 @@ mod tests {
             state.waveform.current.playhead_ratio(),
             Some(0.25),
             "interpolation should not require mutating the retained waveform playhead"
+        );
+    }
+
+    #[test]
+    fn runtime_waveform_progress_for_frame_starts_at_anchor_frame_time() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.25);
+        state.audio.current_playback_span = Some((0.25, 0.75));
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: false,
+            progress: Some(0.25),
+            error: None,
+        });
+        let sample_duration = state.waveform.current.duration_seconds();
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.2);
+
+        let first_frame = state
+            .current_audio_progress_ratio_for_frame(Duration::from_secs(30))
+            .expect("first frame progress");
+        let later_frame = state
+            .current_audio_progress_ratio_for_frame(
+                Duration::from_secs(30) + Duration::from_secs_f32(sample_duration * 0.1),
+            )
+            .expect("later frame progress");
+
+        assert_eq!(
+            first_frame, 0.25,
+            "first paint after a restart should begin at the playback anchor, not include wall-clock setup delay"
+        );
+        assert!(
+            later_frame > 0.33 && later_frame < 0.38,
+            "subsequent paint frames should advance from the frame-time anchor, got {later_frame}"
         );
     }
 

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -9,6 +9,7 @@ use wavecrate::audio::{AudioPlayer, PlaybackRuntimeSpanUpdate};
 
 const LIVE_LOOP_BOUNDARY_EPSILON: f32 = 0.01;
 const LIVE_LOOP_WRAP_EPSILON: f32 = 0.02;
+const PLAYBACK_PROGRESS_EPSILON: f32 = 0.000_001;
 
 impl NativeAppState {
     pub(in crate::native_app) fn toggle_loop_playback(&mut self) {
@@ -81,7 +82,37 @@ impl NativeAppState {
             .player
             .as_ref()
             .and_then(AudioPlayer::progress)
+            .or_else(|| self.interpolated_runtime_waveform_progress_ratio())
             .or_else(|| self.waveform.current.playhead_ratio())
+    }
+
+    fn interpolated_runtime_waveform_progress_ratio(&self) -> Option<f32> {
+        if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
+            return None;
+        }
+        let progress = &self.audio.playback_progress;
+        if !progress.active {
+            return None;
+        }
+        let anchor = progress.progress?;
+        let updated_at = self.audio.playback_progress_updated_at?;
+        let duration_seconds = self.waveform.current.duration_seconds();
+        if !duration_seconds.is_finite() || duration_seconds <= 0.0 {
+            return None;
+        }
+        let elapsed_seconds = updated_at.elapsed().as_secs_f32();
+        if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
+            return Some(anchor.clamp(0.0, 1.0));
+        }
+        let delta_ratio = elapsed_seconds / duration_seconds;
+        let (start, end) = normalized_playback_progress_span(self.audio.current_playback_span)?;
+        Some(interpolate_runtime_progress_ratio(
+            anchor,
+            delta_ratio,
+            start,
+            end,
+            progress.looping,
+        ))
     }
 
     pub(super) fn recover_loop_playback(&mut self, reason: &'static str) -> Result<(), String> {
@@ -349,5 +380,109 @@ impl NativeAppState {
             self.waveform.current.start_playback(offset);
         }
         Ok(())
+    }
+}
+
+fn normalized_playback_progress_span(span: Option<(f32, f32)>) -> Option<(f32, f32)> {
+    let (start, end) = span.unwrap_or((0.0, 1.0));
+    let start = start.clamp(0.0, 1.0);
+    let end = end.clamp(0.0, 1.0);
+    if !start.is_finite() || !end.is_finite() {
+        return None;
+    }
+    let (start, end) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    (end - start > PLAYBACK_PROGRESS_EPSILON).then_some((start, end))
+}
+
+fn interpolate_runtime_progress_ratio(
+    anchor: f32,
+    delta_ratio: f32,
+    start: f32,
+    end: f32,
+    looping: bool,
+) -> f32 {
+    let anchor = anchor.clamp(start, end);
+    if !delta_ratio.is_finite() || delta_ratio <= 0.0 {
+        return anchor;
+    }
+    if !looping {
+        return (anchor + delta_ratio).clamp(start, end);
+    }
+    let width = end - start;
+    if width <= PLAYBACK_PROGRESS_EPSILON {
+        return start;
+    }
+    start + ((anchor - start + delta_ratio).rem_euclid(width))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::native_app::test_support::state::NativeAppStateFixture;
+    use std::time::{Duration, Instant};
+    use wavecrate::audio::PlaybackRuntimeProgress;
+
+    #[test]
+    fn runtime_waveform_progress_interpolates_between_snapshots() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.25);
+        state.audio.current_playback_span = Some((0.25, 0.75));
+        state.audio.playback_progress = PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: false,
+            progress: Some(0.25),
+            error: None,
+        };
+        let sample_duration = state.waveform.current.duration_seconds();
+        state.audio.playback_progress_updated_at =
+            Some(Instant::now() - Duration::from_secs_f32(sample_duration * 0.1));
+
+        let progress = state
+            .current_audio_progress_ratio()
+            .expect("interpolated runtime progress");
+
+        assert!(
+            progress > 0.33 && progress < 0.38,
+            "runtime waveform progress should advance smoothly between snapshots, got {progress}"
+        );
+        assert_eq!(
+            state.waveform.current.playhead_ratio(),
+            Some(0.25),
+            "interpolation should not require mutating the retained waveform playhead"
+        );
+    }
+
+    #[test]
+    fn runtime_waveform_progress_wraps_inside_loop_span() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.72);
+        state.audio.current_playback_span = Some((0.25, 0.75));
+        state.audio.playback_progress = PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: true,
+            progress: Some(0.72),
+            error: None,
+        };
+        let sample_duration = state.waveform.current.duration_seconds();
+        state.audio.playback_progress_updated_at =
+            Some(Instant::now() - Duration::from_secs_f32(sample_duration * 0.08));
+
+        let progress = state
+            .current_audio_progress_ratio()
+            .expect("looping runtime progress");
+
+        assert!(
+            progress > 0.28 && progress < 0.33,
+            "looping runtime progress should wrap within the active span, got {progress}"
+        );
     }
 }

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -90,28 +90,26 @@ impl NativeAppState {
         if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
             return None;
         }
-        let progress = &self.audio.playback_progress;
-        if !progress.active {
+        if !self.audio.playback_progress.active {
             return None;
         }
-        let anchor = progress.progress?;
-        let updated_at = self.audio.playback_progress_updated_at?;
+        let visual_progress = self.audio.playback_visual_progress?;
         let duration_seconds = self.waveform.current.duration_seconds();
         if !duration_seconds.is_finite() || duration_seconds <= 0.0 {
             return None;
         }
-        let elapsed_seconds = updated_at.elapsed().as_secs_f32();
+        let elapsed_seconds = visual_progress.anchor_at.elapsed().as_secs_f32();
         if !elapsed_seconds.is_finite() || elapsed_seconds <= 0.0 {
-            return Some(anchor.clamp(0.0, 1.0));
+            return Some(visual_progress.anchor_ratio.clamp(0.0, 1.0));
         }
         let delta_ratio = elapsed_seconds / duration_seconds;
-        let (start, end) = normalized_playback_progress_span(self.audio.current_playback_span)?;
+        let (start, end) = normalized_playback_progress_span(visual_progress.span)?;
         Some(interpolate_runtime_progress_ratio(
-            anchor,
+            visual_progress.anchor_ratio,
             delta_ratio,
             start,
             end,
-            progress.looping,
+            visual_progress.looping,
         ))
     }
 
@@ -333,6 +331,11 @@ impl NativeAppState {
         seek_to_offset: bool,
         looped: bool,
     ) -> Result<(), String> {
+        let visual_anchor = if seek_to_offset {
+            offset
+        } else {
+            self.current_audio_progress_ratio().unwrap_or(offset)
+        };
         let metronome = self.playback_metronome_config_for_span(start, end, offset);
         let (playback_gain, playback_gain_normalization) =
             self.runtime_playback_gain_for_span(start, end);
@@ -376,6 +379,8 @@ impl NativeAppState {
         }
 
         self.audio.current_playback_span = Some((start, end));
+        self.audio
+            .reset_playback_visual_progress(visual_anchor, looped);
         if seek_to_offset {
             self.waveform.current.start_playback(offset);
         }
@@ -440,8 +445,13 @@ mod tests {
             error: None,
         };
         let sample_duration = state.waveform.current.duration_seconds();
-        state.audio.playback_progress_updated_at =
-            Some(Instant::now() - Duration::from_secs_f32(sample_duration * 0.1));
+        state.audio.reset_playback_visual_progress(0.25, false);
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.1);
 
         let progress = state
             .current_audio_progress_ratio()
@@ -473,8 +483,13 @@ mod tests {
             error: None,
         };
         let sample_duration = state.waveform.current.duration_seconds();
-        state.audio.playback_progress_updated_at =
-            Some(Instant::now() - Duration::from_secs_f32(sample_duration * 0.08));
+        state.audio.reset_playback_visual_progress(0.72, true);
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.08);
 
         let progress = state
             .current_audio_progress_ratio()
@@ -483,6 +498,48 @@ mod tests {
         assert!(
             progress > 0.28 && progress < 0.33,
             "looping runtime progress should wrap within the active span, got {progress}"
+        );
+    }
+
+    #[test]
+    fn runtime_waveform_progress_ignores_smaller_queued_snapshots() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.25);
+        state.audio.current_playback_span = Some((0.25, 0.75));
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::ZERO),
+            looping: false,
+            progress: Some(0.25),
+            error: None,
+        });
+        let sample_duration = state.waveform.current.duration_seconds();
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_at = Instant::now() - Duration::from_secs_f32(sample_duration * 0.12);
+        let before_snapshot = state
+            .current_audio_progress_ratio()
+            .expect("visual progress before queued snapshot");
+
+        state.audio.set_playback_progress(PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_millis(40)),
+            looping: false,
+            progress: Some(0.26),
+            error: None,
+        });
+        let after_snapshot = state
+            .current_audio_progress_ratio()
+            .expect("visual progress after queued snapshot");
+
+        assert!(
+            after_snapshot >= before_snapshot,
+            "stale runtime snapshots should not pull the visual cursor backward: {before_snapshot} -> {after_snapshot}"
         );
     }
 }

--- a/src/native_app/audio/playback/metronome.rs
+++ b/src/native_app/audio/playback/metronome.rs
@@ -56,7 +56,10 @@ impl NativeAppState {
     }
 
     fn restore_active_span_after_metronome_restart(&mut self, start: f32, end: f32) {
+        let current = self.current_audio_progress_ratio().unwrap_or(start);
         self.audio.current_playback_span = Some((start, end));
         self.audio.set_active_sample_playback_span((start, end));
+        self.audio
+            .reset_playback_visual_progress(current, self.audio.loop_playback);
     }
 }

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -18,7 +18,10 @@ use radiant::{
     gui::types::{Point, Rect, Rgba8},
     runtime::{PaintPrimitive, TransientOverlayContext, WidgetPaint},
 };
-use wavecrate::audio::{PlaybackRuntimeCancellation, PlaybackRuntimeEvent, PlaybackRuntimeStarted};
+use wavecrate::audio::{
+    PlaybackRuntimeCancellation, PlaybackRuntimeEvent, PlaybackRuntimeProgress,
+    PlaybackRuntimeStarted,
+};
 
 const PLAYBACK_CURSOR_COLOR: Rgba8 = Rgba8 {
     r: 71,
@@ -143,9 +146,16 @@ impl NativeAppState {
             }
             PlaybackRuntimeEvent::Stopped { .. } => {}
             PlaybackRuntimeEvent::Progress { progress, .. } => {
-                self.audio.set_playback_progress(progress)
+                self.apply_runtime_playback_progress(progress)
             }
         }
+    }
+
+    fn apply_runtime_playback_progress(&mut self, progress: PlaybackRuntimeProgress) {
+        if self.audio.active_sample_playback_pending_runtime() {
+            return;
+        }
+        self.audio.set_playback_progress(progress);
     }
 
     fn finish_runtime_playback_started(&mut self, started: PlaybackRuntimeStarted) {
@@ -334,16 +344,6 @@ impl NativeAppState {
             return;
         }
         if self.audio.active_sample_playback_pending_runtime() {
-            if let Some(progress) = self.audio.playback_progress.progress {
-                if self
-                    .audio
-                    .sample_playback_session
-                    .as_ref()
-                    .is_some_and(|session| session.request.visibility.updates_waveform_playhead())
-                {
-                    self.waveform.current.set_playhead_ratio(progress);
-                }
-            }
             return;
         }
 
@@ -393,7 +393,8 @@ impl NativeAppState {
         if self.chrome_overlay_suppresses_waveform_transient_overlay() {
             return;
         }
-        let Some(progress) = self.current_audio_progress_ratio() else {
+        let Some(progress) = self.current_audio_progress_ratio_for_frame(context.animation_time)
+        else {
             return;
         };
         let Some(visible_ratio) = self.waveform.current.visible_ratio_for_absolute(progress) else {
@@ -789,7 +790,10 @@ fn playback_error_indicates_output_unavailable(error: &str) -> bool {
 mod tests {
     use super::*;
     use crate::native_app::{
-        app::{SamplePlaybackIntent, SamplePlaybackRequest, SamplePlaybackSourceProbe},
+        app::{
+            SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest,
+            SamplePlaybackSessionState, SamplePlaybackSourceProbe,
+        },
         test_support::state::{NativeAppStateFixture, WaveformState},
         waveform::test_decoded_waveform_file_from_mono_samples,
     };
@@ -832,5 +836,68 @@ mod tests {
         );
         assert_eq!(state.audio.current_playback_span, None);
         assert_eq!(state.audio.playback_progress.progress, Some(0.5));
+    }
+
+    #[test]
+    fn pending_runtime_restart_ignores_progress_until_started_event() {
+        let path = PathBuf::from("restart-visual.wav");
+        let file = test_decoded_waveform_file_from_mono_samples(
+            path.clone(),
+            vec![0.0, 0.5, -0.5, 0.0, 0.25, -0.25],
+        );
+        let mut state = NativeAppStateFixture::default().build();
+        state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+        state.waveform.current.start_playback(0.1);
+        state.audio.current_playback_span = Some((0.1, 0.9));
+        let request = SamplePlaybackRequest::waveform(
+            path.display().to_string(),
+            (0.1, 0.9),
+            SamplePlaybackIntent::WaveformSpan,
+            "waveform",
+            SamplePlaybackHistory::Record,
+        );
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "decoded_samples");
+        state
+            .audio
+            .sample_playback_session
+            .as_mut()
+            .expect("sample playback session")
+            .state = SamplePlaybackSessionState::RuntimePending;
+
+        state.apply_runtime_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_millis(90)),
+            looping: false,
+            progress: Some(0.7),
+            error: None,
+        });
+
+        assert_eq!(
+            state.waveform.current.playhead_ratio(),
+            Some(0.1),
+            "a pending restart should keep the visual cursor at the requested start"
+        );
+        assert!(
+            !state.audio.playback_progress.active,
+            "stale runtime progress should not become the active visual clock while the new start is pending"
+        );
+        assert_eq!(state.audio.playback_visual_progress, None);
+
+        state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_millis(90)),
+            looping: false,
+            progress: Some(0.7),
+            error: None,
+        };
+        state.refresh_runtime_playback_progress();
+
+        assert_eq!(
+            state.waveform.current.playhead_ratio(),
+            Some(0.1),
+            "frame refresh should also ignore progress snapshots until the runtime confirms the new start"
+        );
     }
 }

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -15,7 +15,7 @@ use crate::native_app::starmap_audition_telemetry::{
 use crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID;
 use crate::native_app::waveform::{WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID};
 use radiant::{
-    gui::types::{Rect, Rgba8},
+    gui::types::{Point, Rect, Rgba8},
     runtime::{PaintPrimitive, TransientOverlayContext, WidgetPaint},
 };
 use wavecrate::audio::{PlaybackRuntimeCancellation, PlaybackRuntimeEvent, PlaybackRuntimeStarted};
@@ -761,10 +761,21 @@ impl FrameRepaintScopeSnapshot {
 }
 
 fn push_playback_cursor(primitives: &mut Vec<PaintPrimitive>, bounds: Rect, ratio: f32) {
-    WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID).push_horizontal_value_cursor_fill(
-        bounds,
-        ratio,
-        PLAYBACK_CURSOR_WIDTH,
+    let width = PLAYBACK_CURSOR_WIDTH
+        .ceil()
+        .clamp(1.0, bounds.width().max(1.0));
+    let center_x = bounds.x_for_ratio(ratio.clamp(0.0, 1.0));
+    let left =
+        (center_x - width * 0.5).clamp(bounds.min.x, (bounds.max.x - width).max(bounds.min.x));
+    let right = (left + width).min(bounds.max.x);
+    if right <= left {
+        return;
+    }
+    WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID).push_visible_fill_rect(
+        Rect::from_min_max(
+            Point::new(left, bounds.min.y),
+            Point::new(right, bounds.max.y),
+        ),
         PLAYBACK_CURSOR_COLOR,
     );
 }

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -194,7 +194,7 @@ impl NativeAppState {
         self.audio.output_resolved = Some(started.output);
         self.audio.current_playback_span = source_updates_waveform.then_some(span);
         self.audio
-            .set_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
+            .set_started_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
                 active: true,
                 elapsed: Some(Duration::ZERO),
                 looping: self.audio.loop_playback,

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -143,7 +143,7 @@ impl NativeAppState {
             }
             PlaybackRuntimeEvent::Stopped { .. } => {}
             PlaybackRuntimeEvent::Progress { progress, .. } => {
-                self.audio.playback_progress = progress;
+                self.audio.set_playback_progress(progress)
             }
         }
     }
@@ -183,11 +183,14 @@ impl NativeAppState {
         let show_start_marker = session.request.show_start_marker;
         self.audio.output_resolved = Some(started.output);
         self.audio.current_playback_span = source_updates_waveform.then_some(span);
-        self.audio.playback_progress.active = true;
-        self.audio.playback_progress.elapsed = Some(Duration::ZERO);
-        self.audio.playback_progress.looping = self.audio.loop_playback;
-        self.audio.playback_progress.progress = Some(started.playback_start);
-        self.audio.playback_progress.error = None;
+        self.audio
+            .set_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
+                active: true,
+                elapsed: Some(Duration::ZERO),
+                looping: self.audio.loop_playback,
+                progress: Some(started.playback_start),
+                error: None,
+            });
         if source_updates_waveform && self.waveform.current.path() == Path::new(&path) {
             if show_start_marker {
                 self.waveform.current.start_playback(started.playback_start);
@@ -567,7 +570,7 @@ impl NativeAppState {
         }
         self.audio.player = None;
         self.audio.playback_events = None;
-        self.audio.playback_progress = Default::default();
+        self.audio.clear_playback_progress();
         self.audio.output_resolved = None;
         self.audio.settings_error = Some(error.clone());
         self.ui.status.sample = format!("Audio output OFF: {error}");
@@ -618,7 +621,7 @@ impl NativeAppState {
         let started_at = Instant::now();
         self.waveform.current.stop_playback();
         self.audio.current_playback_span = None;
-        self.audio.playback_progress = Default::default();
+        self.audio.clear_playback_progress();
         self.audio.clear_sample_playback_session();
         emit_gui_action(
             "playback.progress",

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -354,6 +354,9 @@ impl NativeAppState {
         let should_be_looping = self.audio.loop_playback && self.waveform.current.is_playing();
         let within_start_grace =
             elapsed.is_some_and(|elapsed| elapsed <= PLAYBACK_START_ACTIVE_SOURCE_GRACE);
+        if self.finish_inactive_transient_sample_playback(active, within_start_grace) {
+            return;
+        }
         if self
             .audio
             .sample_playback_session
@@ -383,6 +386,29 @@ impl NativeAppState {
         } else if self.waveform.current.is_playing() {
             self.finish_playback_progress();
         }
+    }
+
+    fn finish_inactive_transient_sample_playback(
+        &mut self,
+        active: bool,
+        within_start_grace: bool,
+    ) -> bool {
+        if active || within_start_grace {
+            return false;
+        }
+        let Some(session) = self.audio.sample_playback_session.as_ref() else {
+            return false;
+        };
+        if session.request.visibility.updates_waveform_playhead() {
+            return false;
+        }
+        if !matches!(session.state, SamplePlaybackSessionState::AudibleTransient) {
+            return false;
+        }
+        self.audio.clear_sample_playback_session();
+        self.audio.current_playback_span = None;
+        self.audio.clear_playback_progress();
+        true
     }
 
     pub(in crate::native_app) fn paint_playback_overlay(
@@ -450,8 +476,12 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn playback_visual_activity_active(&self) -> bool {
         self.waveform.current.is_playing()
-            || self.audio.sample_playback_session.is_some()
             || self.audio.playback_progress.active
+            || self
+                .audio
+                .sample_playback_session
+                .as_ref()
+                .is_some_and(sample_playback_session_pending_start)
     }
 
     fn chrome_overlay_suppresses_waveform_transient_overlay(&self) -> bool {
@@ -786,6 +816,13 @@ fn playback_error_indicates_output_unavailable(error: &str) -> bool {
         || error.contains(AUDIO_OUTPUT_UNAVAILABLE_ERROR)
 }
 
+fn sample_playback_session_pending_start(session: &SamplePlaybackSession) -> bool {
+    matches!(
+        session.state,
+        SamplePlaybackSessionState::ResolvingSource | SamplePlaybackSessionState::RuntimePending
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -836,6 +873,82 @@ mod tests {
         );
         assert_eq!(state.audio.current_playback_span, None);
         assert_eq!(state.audio.playback_progress.progress, Some(0.5));
+    }
+
+    #[test]
+    fn active_transient_runtime_progress_counts_as_visual_activity() {
+        let mut state = NativeAppStateFixture::default().build();
+        let request = SamplePlaybackRequest::transient(
+            String::from("active-transient.wav"),
+            SamplePlaybackIntent::TransientNavigation,
+            "browser",
+        );
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "preview_samples");
+        state
+            .audio
+            .sample_playback_session
+            .as_mut()
+            .expect("sample playback session")
+            .state = SamplePlaybackSessionState::AudibleTransient;
+        state.audio.playback_progress = PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_millis(90)),
+            looping: false,
+            progress: Some(0.5),
+            error: None,
+        };
+
+        assert!(
+            state.playback_visual_activity_active(),
+            "active transient runtime progress should keep paint-only playback frames active"
+        );
+    }
+
+    #[test]
+    fn ended_transient_runtime_progress_clears_visual_activity() {
+        let mut state = NativeAppStateFixture::default().build();
+        let request = SamplePlaybackRequest::transient(
+            String::from("ended-transient.wav"),
+            SamplePlaybackIntent::TransientNavigation,
+            "browser",
+        );
+        state
+            .audio
+            .start_resolving_sample_playback_session(request, "preview_samples");
+        state
+            .audio
+            .sample_playback_session
+            .as_mut()
+            .expect("sample playback session")
+            .state = SamplePlaybackSessionState::AudibleTransient;
+        state.audio.current_playback_span = Some((0.0, 1.0));
+        state.audio.playback_progress = PlaybackRuntimeProgress {
+            active: false,
+            elapsed: Some(Duration::from_millis(500)),
+            looping: false,
+            progress: Some(1.0),
+            error: None,
+        };
+
+        assert!(
+            !state.playback_visual_activity_active(),
+            "an inactive transient session should not keep frame work suppressed before cleanup"
+        );
+
+        state.refresh_runtime_playback_progress();
+
+        assert_eq!(
+            state.audio.sample_playback_session, None,
+            "inactive transient sessions should be cleared once runtime progress reports completion"
+        );
+        assert_eq!(state.audio.current_playback_span, None);
+        assert_eq!(
+            state.audio.playback_progress,
+            PlaybackRuntimeProgress::default()
+        );
+        assert!(!state.playback_visual_activity_active());
     }
 
     #[test]

--- a/src/native_app/audio/playback_history.rs
+++ b/src/native_app/audio/playback_history.rs
@@ -12,7 +12,6 @@ mod worker;
 use worker::persist_last_played;
 
 const LAST_PLAYED_PERSIST_DEBOUNCE: Duration = Duration::from_millis(350);
-const LAST_PLAYED_PERSIST_ACTIVE_RETRY: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct LastPlayedPersistResult {
@@ -72,6 +71,7 @@ impl NativeAppState {
         delay: Duration,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.audio.pending_last_played_persist = None;
         context.after_latest(&mut self.audio.last_played_persist_task, delay, |ticket| {
             GuiMessage::LastPlayedPersistReady { ticket, request }
         });
@@ -92,12 +92,33 @@ impl NativeAppState {
                 event = "playback.last_played.persist_deferred",
                 reason,
                 source = request.file_id.as_str(),
-                retry_delay_ms = LAST_PLAYED_PERSIST_ACTIVE_RETRY.as_secs_f64() * 1000.0,
                 "Deferred last-played persistence while playback/navigation is active"
             );
-            self.schedule_last_played_persist(request, LAST_PLAYED_PERSIST_ACTIVE_RETRY, context);
+            self.audio.pending_last_played_persist = Some(request);
             return;
         }
+        self.queue_last_played_persist(request, context);
+    }
+
+    pub(in crate::native_app) fn flush_deferred_last_played_persist_if_idle(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if self.audio.pending_last_played_persist.is_none()
+            || self.last_played_persist_wait_reason().is_some()
+        {
+            return;
+        }
+        if let Some(request) = self.audio.pending_last_played_persist.take() {
+            self.queue_last_played_persist(request, context);
+        }
+    }
+
+    fn queue_last_played_persist(
+        &mut self,
+        request: LastPlayedPersistRequest,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         context
             .business()
             .priority("gui-last-played-persist", ui::TaskPriority::Idle)

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -330,13 +330,13 @@ impl NativeAppState {
         if let Some(token) = self.waveform.cache.active_folder_warm_cancel.take() {
             token.cancel();
         }
+        self.waveform.cache.clear_active_folder_warm_job();
         if running {
             return;
         }
         if let Some(key) = self.waveform.cache.active_folder_warm_key.take() {
             self.waveform.cache.active_folder_warm_tasks.cancel(&key);
         }
-        self.waveform.cache.clear_active_folder_warm_job();
     }
 
     fn reschedule_active_folder_cache_warm_delay(

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -184,6 +184,9 @@ impl NativeAppState {
         {
             return;
         }
+        if self.playback_visual_activity_active() {
+            return;
+        }
         self.maybe_start_active_folder_cache_warm(context);
     }
 
@@ -311,6 +314,26 @@ impl NativeAppState {
         );
     }
 
+    pub(in crate::native_app) fn pause_active_folder_cache_warm_for_playback(&mut self) {
+        self.waveform.cache.active_folder_warm_delay_task.cancel();
+        let running = self
+            .waveform
+            .cache
+            .active_folder_warm_key
+            .as_ref()
+            .and_then(|key| self.waveform.cache.active_folder_warm_tasks.active(key))
+            .is_some();
+        if let Some(token) = self.waveform.cache.active_folder_warm_cancel.take() {
+            token.cancel();
+        }
+        if running {
+            return;
+        }
+        if let Some(key) = self.waveform.cache.active_folder_warm_key.take() {
+            self.waveform.cache.active_folder_warm_tasks.cancel(&key);
+        }
+    }
+
     fn reschedule_active_folder_cache_warm_delay(
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,
@@ -374,6 +397,8 @@ impl NativeAppState {
         if result.cancelled {
             if self.waveform.cache.active_folder_warm_pending.is_empty() {
                 self.waveform.cache.clear_active_folder_warm_job();
+            } else if self.playback_visual_activity_active() {
+                return;
             } else {
                 self.reschedule_active_folder_cache_warm_delay(
                     context,
@@ -389,6 +414,8 @@ impl NativeAppState {
         );
         if self.waveform.cache.active_folder_warm_pending.is_empty() {
             self.waveform.cache.clear_active_folder_warm_job();
+        } else if self.playback_visual_activity_active() {
+            return;
         } else {
             let delay = if result.decoded_source {
                 ACTIVE_FOLDER_CACHE_WARM_CONTINUATION_DELAY

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -315,6 +315,10 @@ impl NativeAppState {
     }
 
     pub(in crate::native_app) fn pause_active_folder_cache_warm_for_playback(&mut self) {
+        self.waveform.cache.active_folder_warm_plan_task.cancel();
+        if let Some(token) = self.waveform.cache.active_folder_warm_plan_cancel.take() {
+            token.cancel();
+        }
         self.waveform.cache.active_folder_warm_delay_task.cancel();
         let running = self
             .waveform
@@ -332,6 +336,7 @@ impl NativeAppState {
         if let Some(key) = self.waveform.cache.active_folder_warm_key.take() {
             self.waveform.cache.active_folder_warm_tasks.cancel(&key);
         }
+        self.waveform.cache.clear_active_folder_warm_job();
     }
 
     fn reschedule_active_folder_cache_warm_delay(

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -1271,6 +1271,11 @@ impl NativeAppState {
         );
     }
 
+    pub(in crate::native_app) fn cancel_preview_audition_warm_for_playback(&mut self) {
+        self.background.preview_audition_warm_task.cancel();
+        self.waveform.cache.cancel_preview_audition_warm_schedule();
+    }
+
     fn preview_audition_warm_should_yield(&self) -> bool {
         self.ui.chrome.starmap_audition_drag.is_some()
             || self.sample_cache_warm_should_pause_active()

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -71,6 +71,7 @@ impl NativeAppState {
             self.cancel_metadata_tag_entry();
             self.metadata.selected_tag = None;
         }
+        context.clear_focus();
         self.audio.pending_sample_playback = None;
         self.queue_sample_load_path_validation(
             path,
@@ -103,6 +104,7 @@ impl NativeAppState {
             self.cancel_metadata_tag_entry();
             self.metadata.selected_tag = None;
         }
+        context.clear_focus();
         self.audio.pending_sample_playback = None;
         self.queue_sample_load_path_validation(
             path,

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -68,9 +68,9 @@ impl NativeAppState {
                 &self.metadata.tags_by_file,
             );
         if self.library.folder_browser.selected_file_id() != previous_selection.as_deref() {
-            self.cancel_metadata_tag_entry();
             self.metadata.selected_tag = None;
         }
+        self.cancel_metadata_tag_entry();
         context.clear_focus();
         self.audio.pending_sample_playback = None;
         self.queue_sample_load_path_validation(
@@ -101,9 +101,9 @@ impl NativeAppState {
                 &self.metadata.tags_by_file,
             );
         if self.library.folder_browser.selected_file_id() != previous_selection.as_deref() {
-            self.cancel_metadata_tag_entry();
             self.metadata.selected_tag = None;
         }
+        self.cancel_metadata_tag_entry();
         context.clear_focus();
         self.audio.pending_sample_playback = None;
         self.queue_sample_load_path_validation(

--- a/src/native_app/audio/sample_load_actions/playback_state.rs
+++ b/src/native_app/audio/sample_load_actions/playback_state.rs
@@ -107,7 +107,7 @@ impl NativeAppState {
         if self.audio.sample_playback_session.is_some() && !preserve_early_playback {
             self.stop_audio_output_playback();
             self.audio.current_playback_span = None;
-            self.audio.playback_progress = Default::default();
+            self.audio.clear_playback_progress();
             self.audio.clear_sample_playback_session();
         }
         if !preserve_early_playback {

--- a/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
@@ -439,20 +439,21 @@ impl FolderBrowserState {
             return false;
         };
         let file_id = path_id(path);
-        let changed = self.source.sources[source_index]
+        let source_changed = self.source.sources[source_index]
             .root_folder
             .as_mut()
             .is_some_and(|root| root.set_file_rating(&file_id, rating, locked));
-        if !changed {
+        let visible_changed =
+            self.update_visible_tree_file_rating(&file_id, source_index, rating, locked);
+        if !(source_changed || visible_changed) {
             return false;
         }
-        self.update_visible_tree_file_rating(&file_id, source_index, rating, locked);
         let curated_at = super::curation::now_epoch_seconds();
         let _ = self.source.sources[source_index]
             .root_folder
             .as_mut()
             .is_some_and(|root| root.set_file_last_curated_at(&file_id, curated_at));
-        self.update_visible_tree_file_last_curated_at(&file_id, source_index, curated_at);
+        let _ = self.update_visible_tree_file_last_curated_at(&file_id, source_index, curated_at);
         self.bump_file_content_revision();
         true
     }
@@ -559,15 +560,16 @@ impl FolderBrowserState {
         source_index: usize,
         rating: Rating,
         locked: bool,
-    ) {
+    ) -> bool {
         if !self.source_is_visible(source_index) {
-            return;
+            return false;
         }
         for root in &mut self.tree.folders {
             if root.set_file_rating(file_id, rating, locked) {
-                break;
+                return true;
             }
         }
+        false
     }
 
     fn update_visible_tree_file_last_played_at(
@@ -596,15 +598,16 @@ impl FolderBrowserState {
         file_id: &str,
         source_index: usize,
         last_curated_at: i64,
-    ) {
+    ) -> bool {
         if !self.source_is_visible(source_index) {
-            return;
+            return false;
         }
         for root in &mut self.tree.folders {
             if root.set_file_last_curated_at(file_id, last_curated_at) {
-                break;
+                return true;
             }
         }
+        false
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -130,6 +130,20 @@ impl FolderBrowserState {
         self.selection.selected_file_id()
     }
 
+    #[cfg(test)]
+    pub(in crate::native_app) fn remove_loaded_source_folder_for_tests(
+        &mut self,
+        folder_id: &str,
+    ) -> bool {
+        self.source
+            .sources
+            .iter_mut()
+            .find(|source| source.id == self.source.selected_source)
+            .and_then(|source| source.root_folder.as_mut())
+            .and_then(|root| root.take_child_by_id(folder_id))
+            .is_some()
+    }
+
     pub(in crate::native_app) fn toggle_focused_folder_selection(
         &mut self,
     ) -> Option<FolderSelectionToggleResult> {

--- a/src/native_app/sample_library/sample_ratings.rs
+++ b/src/native_app/sample_library/sample_ratings.rs
@@ -230,6 +230,19 @@ impl NativeAppState {
             }
         };
 
+        if applied == 0 && plan.auto_trash_paths.is_empty() {
+            self.ui.status.sample = String::from("Rating did not change");
+            emit_gui_action(
+                "browser.rating.adjust",
+                Some("browser"),
+                Some(direction_label(delta)),
+                "blocked",
+                started_at,
+                Some("no_rows_updated"),
+            );
+            return;
+        }
+
         if applied > 0 {
             self.ui.status.sample = format!(
                 "Rated {applied} sample{}",
@@ -509,16 +522,30 @@ impl NativeAppState {
         ) {
             persist_rating_updates(&root, &database_root, &source_updates)?;
             for update in source_updates {
-                if self.library.folder_browser.set_file_rating_state(
-                    &update.absolute_path,
-                    update.rating,
-                    update.locked,
-                ) {
+                if self.apply_rating_update_to_loaded_browser_row(&update) {
                     applied += 1;
                 }
             }
         }
         Ok(applied)
+    }
+
+    fn apply_rating_update_to_loaded_browser_row(&mut self, update: &RatingUpdate) -> bool {
+        if self.library.folder_browser.set_file_rating_state(
+            &update.absolute_path,
+            update.rating,
+            update.locked,
+        ) {
+            return true;
+        }
+        self.library
+            .folder_browser
+            .refresh_file_path_across_sources(&update.absolute_path)
+            && self.library.folder_browser.set_file_rating_state(
+                &update.absolute_path,
+                update.rating,
+                update.locked,
+            )
     }
 }
 

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -137,6 +137,7 @@ impl NativeAppState {
                 .advance_drag_hover_folder_auto_expand();
             self.drain_playback_runtime_events();
             self.refresh_playback_progress();
+            self.flush_deferred_last_played_persist_if_idle(context);
             if self.library.folder_scan_active()
                 || self.background.file_move_progress.is_some()
                 || self.waveform.cache.active_folder_warm_folder_id.is_some()
@@ -175,6 +176,7 @@ impl NativeAppState {
         );
         let playback_started_at = Instant::now();
         self.refresh_playback_progress();
+        self.flush_deferred_last_played_persist_if_idle(context);
         log_slow_frame_phase("ui.frame.update.playback_progress", playback_started_at);
         if self.library.folder_scan_active()
             || self.background.file_move_progress.is_some()

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -151,9 +151,7 @@ impl NativeAppState {
                 }
             }
             self.flush_pending_volume_persist(context);
-            if !self.playback_visual_activity_active() {
-                self.flush_pending_similarity_settings_persist(context);
-            }
+            self.flush_pending_similarity_settings_persist(context);
             return;
         }
         let frame_update_started_at = Instant::now();
@@ -194,9 +192,7 @@ impl NativeAppState {
         }
         let persist_started_at = Instant::now();
         self.flush_pending_volume_persist(context);
-        if !self.playback_visual_activity_active() {
-            self.flush_pending_similarity_settings_persist(context);
-        }
+        self.flush_pending_similarity_settings_persist(context);
         log_slow_frame_phase("ui.frame.update.persist_settings", persist_started_at);
         log_slow_frame_phase("ui.frame.update.total", frame_update_started_at);
     }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -15,7 +15,7 @@ use wavecrate::sample_sources::config::{AppConfig, AppSettingsCore};
 const UI_FRAME_TARGET_FPS: u32 = 60;
 const UI_FRAME_TARGET: Duration = Duration::from_micros(16_667);
 const UI_FRAME_CADENCE: ui::FrameCadenceConfig =
-    ui::FrameCadenceConfig::new(Duration::from_millis(25), Duration::from_millis(100), 60);
+    ui::FrameCadenceConfig::new(Duration::from_millis(25), Duration::from_millis(100), 0);
 
 impl NativeAppState {
     pub(in crate::native_app) fn load_default() -> Result<Self, String> {
@@ -177,6 +177,12 @@ impl NativeAppState {
             );
             return;
         };
+        if !matches!(
+            report.kind,
+            ui::FrameCadenceKind::ErrorSpike | ui::FrameCadenceKind::WarnSpike
+        ) {
+            return;
+        }
         let delta_ms = duration_ms(delta);
         let max_delta_ms = duration_ms(report.max_delta);
         let sample_loading = self.active_sample_load_task().is_some();
@@ -208,52 +214,26 @@ impl NativeAppState {
             .map(sample_path_label)
             .unwrap_or_default();
 
-        match report.kind {
-            ui::FrameCadenceKind::ErrorSpike | ui::FrameCadenceKind::WarnSpike => {
-                tracing::warn!(
-                    target: "wavecrate::debug::ui_frame",
-                    event = "ui.frame.deviation",
-                    severity = report.kind.severity().unwrap_or("warn"),
-                    frame = report.frame_index,
-                    target_fps = UI_FRAME_TARGET_FPS,
-                    target_ms = duration_ms(UI_FRAME_TARGET),
-                    delta_ms,
-                    max_delta_ms,
-                    sample_loading,
-                    audio_opening,
-                    folder_scanning,
-                    normalizing,
-                    waveform_loading,
-                    playing,
-                    pending_playback,
-                    cadence_context,
-                    selected = selected.as_str(),
-                    "UI frame cadence deviated from 60Hz target"
-                );
-            }
-            ui::FrameCadenceKind::Periodic => {
-                tracing::debug!(
-                    target: "wavecrate::debug::ui_frame",
-                    event = "ui.frame",
-                    frame = report.frame_index,
-                    target_fps = UI_FRAME_TARGET_FPS,
-                    target_ms = duration_ms(UI_FRAME_TARGET),
-                    delta_ms,
-                    max_delta_ms,
-                    sample_loading,
-                    audio_opening,
-                    folder_scanning,
-                    normalizing,
-                    waveform_loading,
-                    playing,
-                    pending_playback,
-                    cadence_context,
-                    selected = selected.as_str(),
-                    "UI frame timing"
-                );
-            }
-            ui::FrameCadenceKind::Started | ui::FrameCadenceKind::Normal => {}
-        }
+        tracing::warn!(
+            target: "wavecrate::debug::ui_frame",
+            event = "ui.frame.deviation",
+            severity = report.kind.severity().unwrap_or("warn"),
+            frame = report.frame_index,
+            target_fps = UI_FRAME_TARGET_FPS,
+            target_ms = duration_ms(UI_FRAME_TARGET),
+            delta_ms,
+            max_delta_ms,
+            sample_loading,
+            audio_opening,
+            folder_scanning,
+            normalizing,
+            waveform_loading,
+            playing,
+            pending_playback,
+            cadence_context,
+            selected = selected.as_str(),
+            "UI frame cadence deviated from 60Hz target"
+        );
     }
 
     pub(in crate::native_app) fn maybe_auto_load_startup_sample(

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -124,6 +124,35 @@ impl NativeAppState {
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        if !ui_frame_diagnostics_enabled() {
+            self.waveform
+                .current
+                .apply_interaction(WaveformInteraction::Frame);
+            self.library.folder_browser.advance_copy_flash_frame();
+            self.library
+                .folder_browser
+                .advance_protected_source_error_flash_frame();
+            self.library
+                .folder_browser
+                .advance_drag_hover_folder_auto_expand();
+            self.drain_playback_runtime_events();
+            self.refresh_playback_progress();
+            if self.library.folder_scan_active()
+                || self.background.file_move_progress.is_some()
+                || self.waveform.cache.active_folder_warm_folder_id.is_some()
+            {
+                self.background.progress_tick = (self.background.progress_tick + 0.035) % 1.0;
+            }
+            if self.waveform.load.label.is_some() {
+                let remaining = self.waveform.load.target_progress - self.waveform.load.progress;
+                if remaining > 0.0 {
+                    self.waveform.load.progress += remaining.min(0.03);
+                }
+            }
+            self.flush_pending_volume_persist(context);
+            self.flush_pending_similarity_settings_persist(context);
+            return;
+        }
         let frame_update_started_at = Instant::now();
         self.record_frame_timing();
         let waveform_started_at = Instant::now();
@@ -316,4 +345,8 @@ fn log_slow_frame_phase(event: &'static str, started_at: Instant) {
         elapsed_ms = duration_ms(elapsed),
         "Slow UI frame update phase"
     );
+}
+
+fn ui_frame_diagnostics_enabled() -> bool {
+    cfg!(debug_assertions)
 }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -150,8 +150,8 @@ impl NativeAppState {
                     self.waveform.load.progress += remaining.min(0.03);
                 }
             }
+            self.flush_pending_volume_persist(context);
             if !self.playback_visual_activity_active() {
-                self.flush_pending_volume_persist(context);
                 self.flush_pending_similarity_settings_persist(context);
             }
             return;
@@ -193,8 +193,8 @@ impl NativeAppState {
             }
         }
         let persist_started_at = Instant::now();
+        self.flush_pending_volume_persist(context);
         if !self.playback_visual_activity_active() {
-            self.flush_pending_volume_persist(context);
             self.flush_pending_similarity_settings_persist(context);
         }
         log_slow_frame_phase("ui.frame.update.persist_settings", persist_started_at);

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -150,8 +150,10 @@ impl NativeAppState {
                     self.waveform.load.progress += remaining.min(0.03);
                 }
             }
-            self.flush_pending_volume_persist(context);
-            self.flush_pending_similarity_settings_persist(context);
+            if !self.playback_visual_activity_active() {
+                self.flush_pending_volume_persist(context);
+                self.flush_pending_similarity_settings_persist(context);
+            }
             return;
         }
         let frame_update_started_at = Instant::now();
@@ -191,8 +193,10 @@ impl NativeAppState {
             }
         }
         let persist_started_at = Instant::now();
-        self.flush_pending_volume_persist(context);
-        self.flush_pending_similarity_settings_persist(context);
+        if !self.playback_visual_activity_active() {
+            self.flush_pending_volume_persist(context);
+            self.flush_pending_similarity_settings_persist(context);
+        }
         log_slow_frame_phase("ui.frame.update.persist_settings", persist_started_at);
         log_slow_frame_phase("ui.frame.update.total", frame_update_started_at);
     }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -35,6 +35,10 @@ impl NativeAppState {
         message: GuiMessage,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        if !ui_message_diagnostics_enabled() {
+            self.apply_message_inner(message, context);
+            return;
+        }
         let started_at = Instant::now();
         let message_label = gui_message_profile_label(&message);
         self.apply_message_inner(message, context);
@@ -326,6 +330,10 @@ fn slow_ui_message_threshold(message_label: &'static str) -> Duration {
     } else {
         SLOW_UI_INTERACTION_MESSAGE_THRESHOLD
     }
+}
+
+fn ui_message_diagnostics_enabled() -> bool {
+    cfg!(debug_assertions)
 }
 
 fn folder_browser_profile_label(message: &FolderBrowserMessage) -> &'static str {

--- a/src/native_app/shell/message_dispatch/frame.rs
+++ b/src/native_app/shell/message_dispatch/frame.rs
@@ -23,6 +23,12 @@ struct FrameDispatchProfile {
 
 impl NativeAppState {
     pub(super) fn apply_frame_message(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        if self.playback_visual_activity_active() {
+            self.pause_background_work_for_playback_frame();
+            self.flush_pending_play_selection_playback_retarget();
+            self.advance_frame(context);
+            return;
+        }
         if !super::ui_message_diagnostics_enabled() {
             self.maybe_install_application_icon();
             self.maybe_open_audio_player(context);
@@ -105,6 +111,12 @@ impl NativeAppState {
             selected = selected.as_str(),
             "Slow UI frame dispatch profile"
         );
+    }
+
+    fn pause_background_work_for_playback_frame(&mut self) {
+        self.cancel_waveform_cache_warm();
+        self.pause_active_folder_cache_warm_for_playback();
+        self.cancel_preview_audition_warm_for_playback();
     }
 }
 

--- a/src/native_app/shell/message_dispatch/frame.rs
+++ b/src/native_app/shell/message_dispatch/frame.rs
@@ -23,6 +23,21 @@ struct FrameDispatchProfile {
 
 impl NativeAppState {
     pub(super) fn apply_frame_message(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        if !super::ui_message_diagnostics_enabled() {
+            self.maybe_install_application_icon();
+            self.maybe_open_audio_player(context);
+            self.maybe_startup_source_scan(context);
+            self.maybe_run_pending_source_refresh(context);
+            self.maybe_auto_load_startup_sample(context);
+            self.maybe_start_release_update_check(context);
+            self.maybe_start_waveform_cache_warm(context);
+            self.maybe_start_active_folder_cache_warm(context);
+            self.maybe_start_starmap_layout_load(context);
+            self.maybe_start_preview_audition_warm(context);
+            self.flush_pending_play_selection_playback_retarget();
+            self.advance_frame(context);
+            return;
+        }
         let total_started_at = Instant::now();
         let mut profile = FrameDispatchProfile::default();
         profile.app_icon_ms = measure_frame_phase(|| self.maybe_install_application_icon());

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -331,7 +331,7 @@ impl NativeAppState {
         self.waveform.current.stop_playback();
         self.audio.clear_sample_playback_session();
         self.audio.current_playback_span = None;
-        self.audio.playback_progress = Default::default();
+        self.audio.clear_playback_progress();
         starmap_telemetry::record_event(
             None,
             "controller.drag_audio_stop",

--- a/src/native_app/shell/message_dispatch/playback.rs
+++ b/src/native_app/shell/message_dispatch/playback.rs
@@ -32,7 +32,10 @@ impl NativeAppState {
             GuiMessage::VolumeSettingsPersisted(result) => {
                 self.finish_volume_settings_persist(result)
             }
-            GuiMessage::StopPlayback => self.stop_playback(),
+            GuiMessage::StopPlayback => {
+                self.stop_playback();
+                self.flush_deferred_last_played_persist_if_idle(context);
+            }
             GuiMessage::ToggleLoopPlayback => self.toggle_loop_playback(),
             GuiMessage::ToggleMetronome => self.toggle_metronome(),
             _ => unreachable!("playback dispatcher received a non-playback message"),

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -464,7 +464,6 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::ZoomToPlaySelection => Some("waveform.zoom_to_play_selection"),
         WaveformInteraction::SlidePlaySelection { .. } => Some("waveform.playmark.slide"),
         WaveformInteraction::ZoomFull => Some("waveform.zoom_full"),
-        WaveformInteraction::RememberPointerLocation { .. } => None,
         WaveformInteraction::ScrollTo { .. } => Some("waveform.scroll"),
         WaveformInteraction::BeginSelection { .. } => Some("waveform.selection.begin"),
         WaveformInteraction::BeginEditFade { .. } => Some("waveform.edit_fade.begin"),

--- a/src/native_app/tests/audio_settings_controls/volume.rs
+++ b/src/native_app/tests/audio_settings_controls/volume.rs
@@ -69,3 +69,36 @@ fn default_gui_volume_drag_defers_config_persistence_until_debounce() {
     assert!(state.audio.volume_persist_deadline.is_none());
     assert!(!state.audio.volume_persist_inflight);
 }
+
+#[test]
+fn volume_drag_persists_after_debounce_while_playback_is_active() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let mut state = super::gui_state_for_span_tests();
+    state.persist_user_configuration("test.seed", Instant::now());
+    state.waveform.current.start_playback(0.1);
+
+    state.set_volume(0.35);
+    state.audio.volume_persist_deadline = Some(Instant::now() - Duration::from_millis(1));
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.advance_frame(&mut context);
+
+    assert!(
+        state.playback_visual_activity_active(),
+        "test setup should keep playback visually active during the persist frame"
+    );
+    assert!(state.audio.volume_persist_deadline.is_none());
+    assert!(state.audio.volume_persist_inflight);
+
+    let command = context.into_command();
+    let radiant::runtime::Command::Perform { priority, work, .. } = command else {
+        panic!("expected volume settings persist background command during playback");
+    };
+    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
+    let message = work();
+    state.apply_message(message, &mut radiant::prelude::UiUpdateContext::default());
+
+    let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
+    assert!((loaded.core.volume - 0.35).abs() < f32::EPSILON);
+    assert!(!state.audio.volume_persist_inflight);
+}

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -722,39 +722,9 @@ fn w_command_opens_playmark_context_menu_from_current_selection() {
 }
 
 #[test]
-fn w_command_opens_playmark_context_menu_at_remembered_mouse_location() {
+fn w_command_opens_playmark_context_menu_at_live_pointer() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.set_play_selection_range(0.2, 0.6);
-    state
-        .waveform
-        .current
-        .apply_interaction(WaveformInteraction::RememberPointerLocation {
-            position: Point::new(333.0, 222.0),
-        });
-
-    state.apply_message(
-        GuiMessage::OpenContextMenu,
-        &mut ui::UiUpdateContext::default(),
-    );
-
-    let menu = state
-        .ui
-        .browser_interaction
-        .waveform_context_menu
-        .expect("playmark context menu opens");
-    assert_eq!(menu.anchor, Point::new(333.0, 222.0));
-}
-
-#[test]
-fn w_command_opens_playmark_context_menu_at_live_pointer_over_stale_waveform_anchor() {
-    let mut state = gui_state_for_span_tests();
-    state.waveform.current.set_play_selection_range(0.2, 0.6);
-    state
-        .waveform
-        .current
-        .apply_interaction(WaveformInteraction::RememberPointerLocation {
-            position: Point::new(333.0, 222.0),
-        });
     let live_pointer = Point::new(760.0, 512.0);
     let mut context = ui::UiUpdateContext::from_runtime_snapshot(
         RuntimeUpdateSnapshot::with_current_pointer_position(Some(live_pointer)),

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -2258,6 +2258,51 @@ fn rating_hotkey_adjustment_does_not_advance_when_auto_advance_is_enabled() {
 }
 
 #[test]
+fn rating_hotkey_updates_visible_row_when_loaded_source_tree_is_stale() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let drums = source_root.path().join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let current = drums.join("a-current.wav");
+    write_test_wav_i16(&current, &[0, 256, -256, 512]);
+    let drums_id = drums.display().to_string();
+    let current_id = current.display().to_string();
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .apply_message(FolderBrowserMessage::ActivateFolder(
+            drums_id.clone(),
+            Default::default(),
+        ));
+    state.library.folder_browser.select_file(current_id.clone());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .remove_loaded_source_folder_for_tests(&drums_id),
+        "test setup should leave the visible tree with a selected row while making the loaded source tree unable to refresh the sample"
+    );
+
+    let mut context = radiant::prelude::UiUpdateContext::default();
+    state.adjust_selected_rating_without_advance(1, &mut context);
+    run_command_for_tests(&mut state, context.into_command());
+
+    assert!(state.ui.status.sample.contains("Rated 1 sample"));
+    let current_row = state
+        .library
+        .folder_browser
+        .selected_audio_files()
+        .into_iter()
+        .find(|file| file.id == current_id)
+        .expect("current row remains visible");
+    assert_eq!(current_row.rating, Rating::KEEP_1);
+}
+
+#[test]
 fn rating_advance_moves_to_next_recursive_root_sample() {
     let mut state = gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -2850,6 +2850,74 @@ fn active_playback_defers_last_played_disk_persist_until_idle() {
     ));
 }
 
+#[test]
+fn stop_playback_flushes_deferred_last_played_after_clearing_runtime_state() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join("sample.wav");
+    fs::write(&sample_path, [1_u8, 2, 3, 4]).expect("write sample");
+    let sample_path_string = sample_path.display().to_string();
+
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(
+            crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+                wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+            ]),
+        )
+        .build();
+    let mut context = radiant::prelude::UiUpdateContext::default();
+
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path_string.clone());
+    state.record_sample_last_played(sample_path_string.clone(), &mut context);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "audio_file",
+    );
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(std::time::Duration::from_millis(90)),
+        looping: false,
+        progress: Some(0.25),
+        error: None,
+    };
+
+    let delayed = run_first_after(context.into_command()).expect("last played delayed command");
+    let mut active_context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(delayed, &mut active_context);
+    assert!(
+        matches!(active_context.into_command(), Command::None),
+        "active runtime state should defer last-played persistence"
+    );
+    assert!(
+        state.audio.pending_last_played_persist.is_some(),
+        "deferred last-played request should remain pending while playback is active"
+    );
+
+    let mut stop_context = radiant::prelude::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::StopPlayback,
+        &mut stop_context,
+    );
+
+    assert!(state.audio.sample_playback_session.is_none());
+    assert!(!state.audio.playback_progress.active);
+    assert!(
+        state.audio.pending_last_played_persist.is_none(),
+        "stopping playback should flush deferred last-played persistence immediately"
+    );
+    let message = run_first_perform(stop_context.into_command())
+        .expect("stop should queue idle last-played persist");
+
+    assert!(matches!(
+        message,
+        crate::native_app::test_support::state::GuiMessage::LastPlayedPersisted(result)
+            if result.file_id == sample_path_string
+    ));
+}
+
 fn run_first_after(
     command: Command<crate::native_app::test_support::state::GuiMessage>,
 ) -> Option<crate::native_app::test_support::state::GuiMessage> {

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -1,14 +1,14 @@
 use radiant::{
     gui::types::{Point, Rect, Rgba8, Vector2},
     prelude::{IntoView, ThemeTokens, WidgetStyle, WidgetTone, dense_row_palette_from_style},
-    runtime::{Command, Event, SurfaceFrame, SurfacePaintPlan, UiSurface},
+    runtime::{Command, Event, PaintPrimitive, SurfaceFrame, SurfacePaintPlan, UiSurface},
     widgets::{PointerButton, PointerModifiers, Widget, WidgetInput, WidgetOutput},
 };
 use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 
 use super::{
-    native_app_state_with_temp_sample, native_runtime_for_tests, run_command_for_tests,
-    write_sparse_test_wav_i16, write_test_wav_i16,
+    focus_metadata_tag_input, native_app_state_with_temp_sample, native_runtime_for_tests,
+    run_command_for_tests, write_sparse_test_wav_i16, write_test_wav_i16,
 };
 
 fn sample_hit_target(
@@ -89,6 +89,22 @@ fn sync_sample_hit_target_from_previous(
         .expect("current sample hit-target widget")
         .widget_mut();
     current.synchronize_from_previous(previous);
+}
+
+fn fill_rects_with_color(frame: &SurfaceFrame, color: Rgba8) -> Vec<Rect> {
+    let mut rects = frame
+        .paint_plan
+        .fill_rects()
+        .filter_map(|fill| (fill.color == color).then_some(fill.rect))
+        .collect::<Vec<_>>();
+    for primitive in &frame.paint_plan.primitives {
+        if let PaintPrimitive::FillRectBatch(batch) = primitive
+            && batch.color == color
+        {
+            rects.extend(batch.rects.iter().copied());
+        }
+    }
+    rects
 }
 
 fn folder_drop_target_fill() -> Rgba8 {

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -2833,17 +2833,13 @@ fn active_playback_defers_last_played_disk_persist_until_idle() {
     );
     assert_eq!(
         retry_messages.len(),
-        1,
-        "active playback should reschedule last-played persistence"
+        0,
+        "active playback should not schedule recurring last-played retry messages"
     );
 
     state.waveform.current.stop_playback();
-    let retry = retry_messages
-        .into_iter()
-        .next()
-        .expect("retry last played persist");
     let mut idle_context = radiant::prelude::UiUpdateContext::default();
-    state.apply_message(retry, &mut idle_context);
+    state.advance_frame(&mut idle_context);
     let message = run_first_perform(idle_context.into_command())
         .expect("idle last played should persist to disk");
 

--- a/src/native_app/tests/sample_browser/rows.rs
+++ b/src/native_app/tests/sample_browser/rows.rs
@@ -437,6 +437,93 @@ fn full_gui_starmap_to_list_switch_paints_rows_before_scroll_input() {
 }
 
 #[test]
+fn full_gui_selecting_sample_clears_stale_metadata_text_focus() {
+    let mut state = crate::native_app::test_support::state::NativeAppState::load_default()
+        .expect("default state loads");
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample = source_root.path().join("focused_rating_sample.wav");
+    write_test_wav_i16(&sample, &[0, 256, -256, 512]);
+    let sample_id = sample.display().to_string();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    state.library.folder_browser.select_file(sample_id.clone());
+
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    runtime.dispatch_message(focus_metadata_tag_input());
+    assert_eq!(
+        runtime.focused_widget(),
+        Some(crate::native_app::ui::ids::METADATA_TAG_INPUT_ID),
+        "metadata tag input should own keyboard focus before selecting the sample"
+    );
+
+    runtime.dispatch_message(
+        crate::native_app::test_support::state::GuiMessage::SelectSampleWithModifiers {
+            path: sample_id,
+            modifiers: PointerModifiers::default(),
+        },
+    );
+
+    assert_eq!(
+        runtime.focused_widget(),
+        None,
+        "selecting even the already-selected sample should release stale text focus"
+    );
+}
+
+#[test]
+fn full_gui_rating_hotkey_adjustment_paints_updated_rating_marker() {
+    let mut state = crate::native_app::test_support::state::NativeAppState::load_default()
+        .expect("default state loads");
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample = source_root.path().join("painted_rating_sample.wav");
+    write_test_wav_i16(&sample, &[0, 256, -256, 512]);
+    let sample_id = sample.display().to_string();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    state.library.folder_browser.select_file(sample_id);
+
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let list_rect = runtime
+        .layout()
+        .rects
+        .get(&crate::native_app::ui::ids::SAMPLE_BROWSER_LIST_ID)
+        .copied()
+        .expect("sample browser list should be laid out");
+    let keep_rating_color = Rgba8 {
+        r: 122,
+        g: 226,
+        b: 96,
+        a: 235,
+    };
+    let before = runtime.frame_with_default_theme();
+    assert!(
+        fill_rects_with_color(&before, keep_rating_color)
+            .into_iter()
+            .all(|rect| !list_rect.contains(Point::new(rect.center().x, rect.center().y))),
+        "neutral sample should not paint a keep marker in the list before rating"
+    );
+
+    runtime.dispatch_message(
+        crate::native_app::test_support::state::GuiMessage::AdjustSelectedRatingWithoutAdvance(1),
+    );
+
+    let after = runtime.frame_with_default_theme();
+    let keep_markers = fill_rects_with_color(&after, keep_rating_color)
+        .into_iter()
+        .filter(|rect| list_rect.contains(Point::new(rect.center().x, rect.center().y)))
+        .collect::<Vec<_>>();
+    assert!(
+        !keep_markers.is_empty(),
+        "rating hotkey update should paint visible keep markers before any further input; painted labels were {:?}",
+        after.paint_plan.text_label_strings()
+    );
+}
+
+#[test]
 fn full_gui_random_navigation_to_row_above_keeps_recursive_rows_rendered() {
     let mut state = crate::native_app::test_support::state::NativeAppState::load_default()
         .expect("default state loads");

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -331,6 +331,54 @@ fn sample_browser_similarity_controls_persist_after_debounce() {
 }
 
 #[test]
+fn sample_browser_similarity_controls_persist_after_debounce_while_playback_is_active() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let mut state = crate::native_app::tests::gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.2);
+    let mut context = radiant::prelude::UiUpdateContext::default();
+
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SetSimilarityAspectEnabled {
+            aspect: SimilarityAspect::Spectrum,
+            enabled: false,
+        },
+        &mut context,
+    );
+
+    let loaded = wavecrate::sample_sources::config::load_or_default().expect("load config");
+    assert!(
+        loaded
+            .core
+            .similarity
+            .aspect_enabled(SimilarityAspect::Spectrum)
+    );
+    assert!(state.ui.settings.similarity_persist_deadline.is_some());
+
+    state.ui.settings.similarity_persist_deadline = Some(Instant::now() - Duration::from_millis(1));
+    state.advance_frame(&mut context);
+
+    assert!(
+        state.playback_visual_activity_active(),
+        "test setup should keep playback visually active during the persist frame"
+    );
+    let radiant::runtime::Command::Perform { priority, work, .. } = context.into_command() else {
+        panic!("expected similarity settings persist background command during playback");
+    };
+    assert_eq!(priority, radiant::prelude::TaskPriority::BlockingIo);
+    state.apply_message(work(), &mut radiant::prelude::UiUpdateContext::default());
+
+    let loaded = wavecrate::sample_sources::config::load_or_default().expect("reload config");
+    assert!(
+        !loaded
+            .core
+            .similarity
+            .aspect_enabled(SimilarityAspect::Spectrum)
+    );
+    assert!(!state.ui.settings.similarity_persist_inflight);
+}
+
+#[test]
 fn sample_browser_similarity_anchor_resolves_production_scores() {
     let (mut state, _source_root, anchor_id, near_id, far_id, missing_id) =
         similarity_state_with_embeddings();

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -511,6 +511,40 @@ fn playback_cursor_paints_as_transient_overlay() {
 }
 
 #[test]
+fn playback_cursor_transient_overlay_keeps_subpixel_position() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.12345);
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+    let mut primitives = Vec::new();
+
+    runtime.bridge_mut().state_mut().paint_playback_overlay(
+        TransientOverlayContext::new(
+            &frame.paint_plan,
+            Vector2::new(900.0, 620.0),
+            Duration::ZERO,
+        ),
+        &mut primitives,
+    );
+
+    let cursor = primitives
+        .iter()
+        .filter_map(|primitive| primitive.fill_rect())
+        .find(|fill| {
+            fill.widget_id == crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID
+                && fill.color.r == 71
+                && fill.color.g == 220
+                && fill.color.b == 255
+        })
+        .expect("paint-only playback overlay should append the live cursor");
+    assert!(
+        cursor.rect.min.x.fract().abs() > 0.001,
+        "live playback cursor should keep subpixel positioning instead of snapping to whole pixels"
+    );
+}
+
+#[test]
 fn loading_progress_paints_as_transient_overlay() {
     let mut state = gui_state_for_span_tests();
     state.waveform.load.label = Some(String::from("kick.wav"));

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -253,7 +253,7 @@ fn scene_frame_clock_runs_at_60hz_even_when_idle() {
 }
 
 #[test]
-fn scene_playback_overlay_paints_uncapped_while_frame_messages_stay_60hz() {
+fn scene_playback_overlay_and_frame_messages_share_native_cadence() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
     let bridge = radiant::app(state)
@@ -273,8 +273,8 @@ fn scene_playback_overlay_paints_uncapped_while_frame_messages_stay_60hz() {
     );
     assert_eq!(
         activity.frame_message_target_fps(),
-        Some(60),
-        "host frame updates should remain capped while paint-only cursor frames run faster"
+        None,
+        "playback frame updates should align with the native cursor paint cadence"
     );
 }
 

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -165,6 +165,36 @@ fn source_cache_progress_frame_repaints_surface_for_status_bar_animation() {
 }
 
 #[test]
+fn paused_source_cache_progress_does_not_force_playback_surface_frames() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.25);
+    state.waveform.cache.start_active_folder_warm_decode_queue(
+        String::from("source"),
+        vec![std::path::PathBuf::from("kick.wav")],
+    );
+
+    state.pause_active_folder_cache_warm_for_playback();
+
+    assert!(
+        state.waveform.cache.active_folder_warm_folder_id.is_none(),
+        "playback pause should clear dormant source-cache progress"
+    );
+    assert!(
+        state.waveform.cache.active_folder_warm_pending.is_empty(),
+        "playback pause should clear pending source-cache work"
+    );
+    assert_eq!(state.waveform.cache.active_folder_warm_total, 0);
+
+    let before = state.frame_repaint_scope_before_update();
+    state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
+
+    assert!(
+        state.frame_can_use_paint_only(before),
+        "paused source-cache progress should not force full surface frames during playback"
+    );
+}
+
+#[test]
 fn copy_flash_frame_repaints_surface_while_countdown_changes() {
     let (mut state, _source_root, selected_file) =
         native_app_state_with_temp_sample("copy-flash.wav");

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -253,6 +253,32 @@ fn scene_frame_clock_runs_at_60hz_even_when_idle() {
 }
 
 #[test]
+fn scene_playback_overlay_paints_uncapped_while_frame_messages_stay_60hz() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.25);
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(apply_gui_message_for_presentation_test)
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+
+    let activity = runtime.bridge_mut().animation_activity();
+
+    assert!(activity.needs_frame_message());
+    assert_eq!(
+        activity.target_fps(),
+        None,
+        "playback overlay paint should use the native window cadence"
+    );
+    assert_eq!(
+        activity.frame_message_target_fps(),
+        Some(60),
+        "host frame updates should remain capped while paint-only cursor frames run faster"
+    );
+}
+
+#[test]
 fn scene_frame_clock_queues_gui_frame_message() {
     let mut state = gui_state_for_span_tests();
     state.ui.startup.source_scan_pending = true;

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -505,6 +505,53 @@ fn selecting_another_sample_cancels_metadata_tag_entry() {
 }
 
 #[test]
+fn selecting_same_sample_cancels_metadata_tag_entry_when_focus_clears() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join("same.wav");
+    fs::write(&sample_path, []).expect("sample");
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let file = sample_path.display().to_string();
+    state.library.folder_browser.select_file(file.clone());
+    state.metadata.tag_draft = String::from("sound");
+    state.metadata.tag_tokens = vec![String::from("warm")];
+    state.metadata.tag_input_mode =
+        crate::native_app::test_support::waveform::MetadataTagInputMode::Category {
+            pending_tag: String::from("new-tag"),
+        };
+    state.metadata.tag_completion_cycle.select("sound", 0, 4);
+    assert!(
+        state.metadata_tag_completion_active(),
+        "test setup should activate metadata completion shortcuts"
+    );
+
+    state.select_sample_with_modifiers(
+        file.clone(),
+        PointerModifiers::default(),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(file.as_str())
+    );
+    assert!(state.metadata.tag_draft.is_empty());
+    assert!(state.metadata.tag_tokens.is_empty());
+    assert_eq!(
+        state.metadata.tag_input_mode,
+        crate::native_app::test_support::waveform::MetadataTagInputMode::Tag
+    );
+    assert_eq!(state.metadata.tag_completion_cycle.query_key(), None);
+    assert_eq!(state.metadata.tag_completion_cycle.stored_index(), 0);
+    assert_eq!(state.pending_metadata_tag_category_tag(), None);
+    assert!(!state.metadata_tag_completion_active());
+}
+
+#[test]
 fn play_selected_sample_uses_active_playmark_selection_span() {
     let Some(mut scenario) = WaveformPlaybackScenario::default_loaded_with_player() else {
         return;

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -935,6 +935,98 @@ fn active_folder_cache_warm_does_not_chain_batches_while_playing() {
 }
 
 #[test]
+fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediately() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let folder = source_root.path().join("large-folder");
+    fs::create_dir_all(&folder).expect("create folder");
+    let first = folder.join("first.wav");
+    let second = folder.join("second.wav");
+    write_test_wav_i16(&first, &[0, 1024, -2048, 4096]);
+    write_test_wav_i16(&second, &[0, 512, -512, 1024]);
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::FolderBrowser(
+            crate::native_app::test_support::state::FolderBrowserMessage::ActivateFolder(
+                folder.display().to_string(),
+                Default::default(),
+            ),
+        ),
+        &mut context,
+    );
+    assert!(state.schedule_active_folder_cache_warm(&mut context));
+    finish_active_folder_cache_warm_plan(
+        &mut state,
+        &mut context,
+        source_root.path().display().to_string(),
+        Vec::new(),
+        vec![first, second.clone()],
+    );
+    let warm_ticket = state
+        .waveform
+        .cache
+        .active_folder_warm_delay_task
+        .active()
+        .expect("folder warm delay");
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmReady(warm_ticket),
+        &mut context,
+    );
+    let running_ticket = active_folder_cache_warm_ticket(&state).expect("folder warm task");
+
+    state.waveform.current.start_playback(0.0);
+    state.pause_active_folder_cache_warm_for_playback();
+
+    assert!(
+        active_folder_cache_warm_ticket(&state).is_some(),
+        "running warm task should stay tracked until its cancellation completion arrives"
+    );
+    assert!(
+        state.waveform.cache.active_folder_warm_folder_id.is_none(),
+        "playback pause should clear source-cache progress immediately"
+    );
+    assert!(
+        state.waveform.cache.active_folder_warm_pending.is_empty(),
+        "playback pause should abandon deferred source-cache work immediately"
+    );
+
+    let before = state.frame_repaint_scope_before_update();
+    state.advance_frame(&mut ui::UiUpdateContext::default());
+    assert!(
+        state.frame_can_use_paint_only(before),
+        "a cancelled running source-cache warm must not force playback surface frames"
+    );
+
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmFinished(
+            active_folder_cache_warm_completion_with_deferred(
+                running_ticket,
+                source_root.path().display().to_string(),
+                Vec::new(),
+                vec![second],
+                1,
+                true,
+                true,
+            ),
+        ),
+        &mut context,
+    );
+    assert!(
+        active_folder_cache_warm_ticket(&state).is_none(),
+        "cancelled warm completion should retire the tracked running task"
+    );
+    assert!(
+        state.waveform.cache.active_folder_warm_pending.is_empty(),
+        "cancelled warm completion should not repopulate abandoned playback-time work"
+    );
+}
+
+#[test]
 fn active_folder_cache_warm_delay_does_not_retry_while_playing() {
     let source_root = tempfile::tempdir().expect("source root");
     let folder = source_root.path().join("large-folder");

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -913,13 +913,98 @@ fn active_folder_cache_warm_does_not_chain_batches_while_playing() {
             .cache
             .active_folder_warm_delay_task
             .active()
-            .is_some(),
-        "active folder cache warm should wait until playback is idle before resuming"
+            .is_none(),
+        "active folder cache warm should not schedule retry pulses during playback"
     );
     assert_eq!(
         state.waveform.cache.active_folder_warm_pending.len(),
         1,
         "only the already-started single-file batch may be drained"
+    );
+
+    state.waveform.current.stop_playback();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::Frame,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(
+        active_folder_cache_warm_ticket(&state).is_some(),
+        "active folder cache warm should resume from the normal idle frame path"
+    );
+}
+
+#[test]
+fn active_folder_cache_warm_delay_does_not_retry_while_playing() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let folder = source_root.path().join("large-folder");
+    fs::create_dir_all(&folder).expect("create folder");
+    let first = folder.join("first.wav");
+    let second = folder.join("second.wav");
+    write_test_wav_i16(&first, &[0, 1024, -2048, 4096]);
+    write_test_wav_i16(&second, &[0, 512, -512, 1024]);
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let mut context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::FolderBrowser(
+            crate::native_app::test_support::state::FolderBrowserMessage::ActivateFolder(
+                folder.display().to_string(),
+                Default::default(),
+            ),
+        ),
+        &mut context,
+    );
+    assert!(state.schedule_active_folder_cache_warm(&mut context));
+    finish_active_folder_cache_warm_plan(
+        &mut state,
+        &mut context,
+        source_root.path().display().to_string(),
+        Vec::new(),
+        vec![first, second],
+    );
+    let warm_ticket = state
+        .waveform
+        .cache
+        .active_folder_warm_delay_task
+        .active()
+        .expect("folder warm delay");
+
+    state.waveform.current.start_playback(0.0);
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmReady(warm_ticket),
+        &mut context,
+    );
+
+    assert!(active_folder_cache_warm_ticket(&state).is_none());
+    assert!(
+        state
+            .waveform
+            .cache
+            .active_folder_warm_delay_task
+            .active()
+            .is_none(),
+        "a warm delay that fires during playback should not schedule another playback-time wakeup"
+    );
+    assert_eq!(
+        state.waveform.cache.active_folder_warm_pending.len(),
+        2,
+        "playback-time warm delay should not drain cache candidates"
+    );
+
+    state.waveform.current.stop_playback();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::Frame,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(
+        active_folder_cache_warm_ticket(&state).is_some(),
+        "idle frames should resume deferred active-folder cache warm work"
     );
 }
 

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -32,8 +32,6 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) active_drag: Option<WaveformDrag>,
     pub(in crate::native_app::waveform) pending_playback_start: Option<f32>,
     pub(in crate::native_app::waveform) pending_sample_slide_frame_offset: Option<i64>,
-    pub(in crate::native_app::waveform) context_menu_pointer_position:
-        Option<radiant::gui::types::Point>,
     pub(in crate::native_app::waveform) normalized_audition_gain_cache: NormalizedAuditionGainCache,
 }
 

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -35,13 +35,6 @@ impl WaveformState {
             WaveformInteraction::ZoomFull => {
                 self.zoom_full();
             }
-            WaveformInteraction::RememberPointerLocation { position } => {
-                self.context_menu_pointer_position = position
-                    .x
-                    .is_finite()
-                    .then_some(position)
-                    .filter(|position| position.y.is_finite());
-            }
             WaveformInteraction::ScrollTo { offset_fraction } => {
                 self.set_offset_fraction(offset_fraction);
             }

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -151,7 +151,6 @@ impl WaveformState {
             active_drag: None::<WaveformDrag>,
             pending_playback_start: None,
             pending_sample_slide_frame_offset: None,
-            context_menu_pointer_position: None,
             normalized_audition_gain_cache: Default::default(),
         }
     }

--- a/src/native_app/waveform/state_viewport_access.rs
+++ b/src/native_app/waveform/state_viewport_access.rs
@@ -29,9 +29,6 @@ impl WaveformState {
         let selection = self
             .play_selection()
             .filter(|selection| selection.width() > 0.0)?;
-        if let Some(position) = self.context_menu_pointer_position {
-            return Some(position);
-        }
         let visible_ratio = self
             .visible_ratio_for_absolute(selection.start())
             .or_else(|| self.visible_ratio_for_absolute(selection.end()))

--- a/src/native_app/waveform/tests/mod.rs
+++ b/src/native_app/waveform/tests/mod.rs
@@ -12,7 +12,7 @@ use radiant::{
     prelude::IntoView,
     runtime::{GpuSurfaceContent, PaintFillRect, PaintStrokePolyline, SurfacePaintPlan},
     theme::ThemeTokens,
-    widgets::{PointerButton, PointerModifiers, Widget, WidgetInput, WidgetOutput},
+    widgets::{PointerButton, PointerModifiers, Widget, WidgetInput},
 };
 use std::{fs, sync::Arc};
 
@@ -45,13 +45,6 @@ fn fill_rects(plan: &SurfacePaintPlan) -> Vec<&PaintFillRect> {
 
 fn stroke_polylines(plan: &SurfacePaintPlan) -> Vec<&PaintStrokePolyline> {
     plan.stroke_polylines().collect()
-}
-
-fn assert_pointer_location_output(output: Option<WidgetOutput>) {
-    assert!(matches!(
-        output.and_then(|output| output.typed_copied::<WaveformInteraction>()),
-        Some(WaveformInteraction::RememberPointerLocation { .. })
-    ));
 }
 
 fn gpu_surface_revision_for_file(file: Arc<super::WaveformFile>) -> u64 {

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -164,7 +164,7 @@ fn hover_cursor_paints_thin_white_overlay_line() {
     let mut widget = waveform_widget_for_state(&state);
     let bounds = Rect::from_size(400.0, 80.0);
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(100.0, 40.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
 
     let plan = runtime_overlay_plan(&widget, bounds);
 
@@ -187,7 +187,7 @@ fn playmark_slide_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(60.0, 3.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -213,7 +213,7 @@ fn playmark_resize_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(120.0, 8.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -244,7 +244,7 @@ fn playmark_export_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(118.0, 76.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -278,7 +278,7 @@ fn editmark_slide_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(60.0, 3.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -444,7 +444,7 @@ fn editmark_bottom_resize_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(120.0, 76.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -468,7 +468,7 @@ fn editmark_gain_handle_hover_paints_bright_center_tab() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(80.0, 5.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
     assert!(widget.hovered_edit_gain_handle);
     assert_eq!(widget.hovered_selection_handle, None);
@@ -510,7 +510,7 @@ fn edit_fade_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(60.0, 5.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);
@@ -558,7 +558,7 @@ fn edit_fade_outer_gain_handle_hover_paints_bright_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(20.0, 5.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(
         widget.hovered_edit_fade_outer_gain_handle,
         Some(WaveformEditFadeOuterGainHandle::In)
@@ -1458,7 +1458,7 @@ fn similar_section_hover_paints_brighter_runtime_overlay() {
     let bounds = Rect::from_size(200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(80.0, 40.0)));
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hover_cursor_ratio, None);
 
     let plan = runtime_overlay_plan(&widget, bounds);

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -64,7 +64,14 @@ fn playback_cache_backed_waveform_accepts_primary_click() {
     let sample_path = source_root.path().join("cached-widget-input.wav");
     write_test_wav_i16(&sample_path, &[0, 1024, -2048, 4096, -1024, 512]);
 
-    let full_waveform = WaveformState::load_path(sample_path.clone()).expect("cache sample");
+    let full_waveform = WaveformState::load_path_for_looped_foreground_audition(
+        sample_path.clone(),
+        |_| {},
+        || false,
+        |_| {},
+    )
+    .expect("cache sample");
+    super::super::flush_background_waveform_cache_stores_for_shutdown();
     let file = full_waveform.file();
     super::super::store_cached_waveform_file_for_tests(&file);
     let cached_waveform =
@@ -229,7 +236,7 @@ fn pointer_move_outside_loaded_waveform_clears_hover_cursor() {
 }
 
 #[test]
-fn active_selection_pointer_move_outside_waveform_updates_to_nearest_edge() {
+fn active_selection_pointer_move_outside_waveform_stays_paint_only() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);
     let bounds = Rect::from_xy_size(10.0, 20.0, 200.0, 80.0);
@@ -238,30 +245,20 @@ fn active_selection_pointer_move_outside_waveform_updates_to_nearest_edge() {
     ));
     widget.hover_cursor_ratio = Some(0.25);
 
-    let left_output = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 40.0)))
-        .expect("active drag should continue outside the left edge");
-    let left_interaction = left_output
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-
-    assert_eq!(
-        left_interaction,
-        WaveformInteraction::UpdateSelection { visible_ratio: 0.0 }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 40.0)))
+            .is_none(),
+        "active selection drag motion should repaint locally without reducer output"
     );
     assert_eq!(widget.hover_cursor_ratio, None);
     assert!(!widget.common.is_hovered());
 
-    let right_output = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(240.0, 40.0)))
-        .expect("active drag should continue outside the right edge");
-    let right_interaction = right_output
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-
-    assert_eq!(
-        right_interaction,
-        WaveformInteraction::UpdateSelection { visible_ratio: 1.0 }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(240.0, 40.0)))
+            .is_none(),
+        "active selection drag motion should remain paint-only at the right edge"
     );
     assert!(!widget.common.is_hovered());
 }
@@ -296,39 +293,29 @@ fn captured_selection_drag_outside_waveform_updates_to_nearest_edge() {
         state.apply_interaction(begin_interaction);
         widget.active_drag_kind = state.active_drag_kind();
 
-        let left_update = widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 40.0)))
-            .expect("captured creation drag should update live outside the left edge")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            left_update,
-            WaveformInteraction::UpdateSelection { visible_ratio: 0.0 }
+        assert!(
+            widget
+                .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 40.0)))
+                .is_none(),
+            "captured creation drag should update its local preview without reducer output"
         );
-        state.apply_interaction(left_update);
-        let left_selection = match kind {
-            WaveformSelectionKind::Play => state.play_selection(),
-            WaveformSelectionKind::Edit => state.edit_selection(),
-        }
-        .expect("left-edge live selection");
+        let left_selection = widget
+            .live_selection_preview
+            .expect("left-edge live preview")
+            .selection;
         assert!((left_selection.start() - 0.0).abs() < f32::EPSILON);
         assert!((left_selection.end() - 0.75).abs() < f32::EPSILON);
 
-        let right_update = widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(240.0, 40.0)))
-            .expect("captured creation drag should update live outside the right edge")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            right_update,
-            WaveformInteraction::UpdateSelection { visible_ratio: 1.0 }
+        assert!(
+            widget
+                .handle_input(bounds, WidgetInput::pointer_move(Point::new(240.0, 40.0)))
+                .is_none(),
+            "captured creation drag should keep using local preview at the right edge"
         );
-        state.apply_interaction(right_update);
-        let right_selection = match kind {
-            WaveformSelectionKind::Play => state.play_selection(),
-            WaveformSelectionKind::Edit => state.edit_selection(),
-        }
-        .expect("right-edge live selection");
+        let right_selection = widget
+            .live_selection_preview
+            .expect("right-edge live preview")
+            .selection;
         assert!((right_selection.start() - 0.75).abs() < f32::EPSILON);
         assert!((right_selection.end() - 1.0).abs() < f32::EPSILON);
     }
@@ -528,7 +515,7 @@ fn primary_click_with_tiny_motion_clears_play_selection_without_micro_range() {
 }
 
 #[test]
-fn primary_drag_three_pixels_updates_playmark_selection_live() {
+fn primary_drag_three_pixels_paints_playmark_selection_preview() {
     let mut state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);
     let bounds = Rect::from_size(200.0, 80.0);
@@ -543,20 +530,17 @@ fn primary_drag_three_pixels_updates_playmark_selection_live() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(drag))
-        .expect("creation drag should emit a live selection update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        update,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.215
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(drag))
+            .is_none(),
+        "creation drag should paint a live selection preview"
     );
-    state.apply_interaction(update);
 
-    let live_selection = state.play_selection().expect("live playmark selection");
+    let live_selection = widget
+        .live_selection_preview
+        .expect("live playmark selection preview")
+        .selection;
     assert!((live_selection.start() - 0.2).abs() < f32::EPSILON);
     assert!((live_selection.end() - 0.215).abs() < f32::EPSILON);
 
@@ -599,14 +583,11 @@ fn created_selection_drag_preview_survives_widget_rebuild_after_press() {
 
         let mut current = waveform_widget_for_state(&state);
         Widget::synchronize_from_previous(&mut current, &previous);
-        let update = current
-            .handle_input(bounds, WidgetInput::pointer_move(drag))
-            .expect("rebuilt widget should retain the selection anchor")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            update,
-            WaveformInteraction::UpdateSelection { visible_ratio: 0.4 }
+        assert!(
+            current
+                .handle_input(bounds, WidgetInput::pointer_move(drag))
+                .is_none(),
+            "rebuilt widget should retain the selection anchor without reducer output"
         );
 
         let preview = current
@@ -668,19 +649,16 @@ fn playmark_drag_suppresses_duplicate_live_updates_inside_same_step() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let first_update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(43.0, 40.0)))
-        .expect("first crossed step should emit a live selection update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        first_update,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.215
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(43.0, 40.0)))
+            .is_none(),
+        "first crossed step should paint a local live selection preview"
     );
-    state.apply_interaction(first_update);
-    let first_selection = state.play_selection().expect("first live selection");
+    let first_selection = widget
+        .live_selection_preview
+        .expect("first live selection preview")
+        .selection;
 
     assert!(
         widget
@@ -689,9 +667,11 @@ fn playmark_drag_suppresses_duplicate_live_updates_inside_same_step() {
         "moves that quantize to the same visible step should not churn updates"
     );
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(first_selection),
-        "sub-step motion should not churn live selection geometry"
+        "sub-step motion should not churn live selection preview geometry"
     );
 
     assert!(
@@ -701,21 +681,25 @@ fn playmark_drag_suppresses_duplicate_live_updates_inside_same_step() {
         "same one-pixel preview step should still avoid reducer work"
     );
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(first_selection),
-        "same preview step should not churn live selection geometry"
+        "same preview step should not churn live selection preview geometry"
     );
 
-    let next_update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(44.0, 40.0)))
-        .expect("next crossed pixel should emit a live selection update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    state.apply_interaction(next_update);
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(44.0, 40.0)))
+            .is_none(),
+        "next crossed pixel should still paint locally"
+    );
     assert_ne!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(first_selection),
-        "crossing a preview step should update the live geometry"
+        "crossing a preview step should update the live preview geometry"
     );
 }
 
@@ -777,19 +761,11 @@ fn moved_selection_drag_preview_survives_widget_rebuild_after_press() {
 
         let mut current = waveform_widget_for_state(&state);
         Widget::synchronize_from_previous(&mut current, &previous);
-        let update = current
-            .handle_input(bounds, WidgetInput::pointer_move(drag))
-            .expect("rebuilt widget should retain the move anchor")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            update,
-            WaveformInteraction::UpdateSelection {
-                visible_ratio: match kind {
-                    WaveformSelectionKind::Play => 0.5,
-                    WaveformSelectionKind::Edit => 0.4,
-                }
-            }
+        assert!(
+            current
+                .handle_input(bounds, WidgetInput::pointer_move(drag))
+                .is_none(),
+            "rebuilt widget should retain the move anchor without reducer output"
         );
 
         let preview = current
@@ -848,29 +824,19 @@ fn moved_selection_drag_preview_uses_original_baseline_after_live_update() {
 
         let mut first = waveform_widget_for_state(&state);
         Widget::synchronize_from_previous(&mut first, &initial);
-        let first_update = first
-            .handle_input(bounds, WidgetInput::pointer_move(first_drag))
-            .expect("first drag should emit live update")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            first_update,
-            WaveformInteraction::UpdateSelection { visible_ratio: 0.4 }
+        assert!(
+            first
+                .handle_input(bounds, WidgetInput::pointer_move(first_drag))
+                .is_none(),
+            "first drag should paint the move preview locally"
         );
-        state.apply_interaction(first_update);
 
-        let mut second = waveform_widget_for_state(&state);
-        Widget::synchronize_from_previous(&mut second, &first);
-        let second_update = second
-            .handle_input(bounds, WidgetInput::pointer_move(second_drag))
-            .expect("second drag should emit live update")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            second_update,
-            WaveformInteraction::UpdateSelection {
-                visible_ratio: 0.45
-            }
+        let mut second = first;
+        assert!(
+            second
+                .handle_input(bounds, WidgetInput::pointer_move(second_drag))
+                .is_none(),
+            "second drag should keep the move preview paint-only"
         );
 
         let preview = second
@@ -885,15 +851,6 @@ fn moved_selection_drag_preview_uses_original_baseline_after_live_update() {
             (preview.selection.end() - 0.625).abs() < 0.0001,
             "{kind:?} preview should apply the total drag delta once"
         );
-
-        state.apply_interaction(second_update);
-        let live_selection = match kind {
-            WaveformSelectionKind::Play => state.play_selection(),
-            WaveformSelectionKind::Edit => state.edit_selection(),
-        }
-        .expect("live selection should update");
-        assert!((live_selection.start() - preview.selection.start()).abs() < 0.0001);
-        assert!((live_selection.end() - preview.selection.end()).abs() < 0.0001);
 
         let finish = second
             .handle_input(
@@ -949,21 +906,16 @@ fn three_pixel_drag_starts_play_and_edit_selections_while_zoomed_in() {
         state.apply_interaction(begin);
         widget.active_drag_kind = state.active_drag_kind();
 
-        let update = widget
-            .handle_input(bounds, WidgetInput::pointer_move(drag))
-            .expect("three-pixel creation drag should update the selection live")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert!(matches!(
-            update,
-            WaveformInteraction::UpdateSelection { .. }
-        ));
-        state.apply_interaction(update);
-        let live_selection = match kind {
-            WaveformSelectionKind::Play => state.play_selection(),
-            WaveformSelectionKind::Edit => state.edit_selection(),
-        }
-        .expect("selection should update immediately after click slop");
+        assert!(
+            widget
+                .handle_input(bounds, WidgetInput::pointer_move(drag))
+                .is_none(),
+            "three-pixel creation drag should paint live without reducer output"
+        );
+        let live_selection = widget
+            .live_selection_preview
+            .expect("selection preview should update immediately after click slop")
+            .selection;
         assert!(
             live_selection.width() > 0.0,
             "{kind:?} live selection should have non-zero width"
@@ -1115,20 +1067,18 @@ fn playmark_resize_motion_updates_live_until_release() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
-        .expect("resize motion should emit a live selection update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        update,
-        WaveformInteraction::UpdateSelection { visible_ratio: 0.8 }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
+            .is_none(),
+        "resize motion should paint a live selection preview"
     );
-    state.apply_interaction(update);
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.2, 0.8)),
-        "drag motion should mutate app playmark state live"
+        "drag motion should paint app playmark geometry live"
     );
 
     let finish = widget
@@ -1175,31 +1125,29 @@ fn playmark_right_resize_updates_when_returning_through_original_handle() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let away = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
-        .expect("dragging away should update the right edge")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    state.apply_interaction(away);
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
+            .is_none(),
+        "dragging away should update the right edge preview"
+    );
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.2, 0.8))
     );
 
-    let near_origin = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(121.0, 8.0)))
-        .expect("returning through the original handle must still update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        near_origin,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.605
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(121.0, 8.0)))
+            .is_none(),
+        "returning through the original handle must still update the preview"
     );
-    state.apply_interaction(near_origin);
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.2, 0.605))
     );
 
@@ -1246,31 +1194,29 @@ fn playmark_left_resize_updates_when_returning_through_original_handle() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let away = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 8.0)))
-        .expect("dragging away should update the left edge")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    state.apply_interaction(away);
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 8.0)))
+            .is_none(),
+        "dragging away should update the left edge preview"
+    );
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.0, 0.6))
     );
 
-    let near_origin = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(41.0, 8.0)))
-        .expect("returning through the original handle must still update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        near_origin,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.205
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(41.0, 8.0)))
+            .is_none(),
+        "returning through the original handle must still update the preview"
     );
-    state.apply_interaction(near_origin);
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.205, 0.6))
     );
 
@@ -1333,19 +1279,23 @@ fn playmark_resize_crosses_opposite_edge_without_dead_zone() {
         state.apply_interaction(begin);
         widget.active_drag_kind = state.active_drag_kind();
 
-        let update = widget
-            .handle_input(bounds, WidgetInput::pointer_move(drag))
-            .expect("crossing the opposite edge should emit a live update")
-            .typed_copied::<WaveformInteraction>()
-            .expect("waveform interaction");
-        assert_eq!(
-            update,
-            WaveformInteraction::UpdateSelection {
-                visible_ratio: expected_visible_ratio,
-            }
+        assert!(
+            widget
+                .handle_input(bounds, WidgetInput::pointer_move(drag))
+                .is_none(),
+            "crossing the opposite edge should paint a live preview"
         );
-        state.apply_interaction(update);
-        assert_eq!(state.play_selection(), Some(expected_selection));
+        assert_eq!(
+            expected_visible_ratio,
+            drag.x / bounds.width(),
+            "test expectation should match the pointer ratio"
+        );
+        assert_eq!(
+            widget
+                .live_selection_preview
+                .map(|preview| preview.selection),
+            Some(expected_selection)
+        );
 
         let finish = widget
             .handle_input(
@@ -1387,16 +1337,11 @@ fn zoomed_playmark_resize_preview_matches_committed_transform() {
     let mut current = waveform_widget_for_state(&state);
     Widget::synchronize_from_previous(&mut current, &previous);
 
-    let update = current
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 8.0)))
-        .expect("resize motion should update preview")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        update,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.75
-        }
+    assert!(
+        current
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 8.0)))
+            .is_none(),
+        "resize motion should update preview without reducer output"
     );
     let preview = current
         .live_selection_preview
@@ -1406,7 +1351,6 @@ fn zoomed_playmark_resize_preview_matches_committed_transform() {
         wavecrate::selection::SelectionRange::new(fixed, released)
     );
 
-    state.apply_interaction(update);
     let finish = current
         .handle_input(
             bounds,
@@ -1443,22 +1387,18 @@ fn playmark_move_motion_updates_live_until_release() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(Point::new(110.0, 3.0)))
-        .expect("move motion should emit a live selection update")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        update,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.55
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(Point::new(110.0, 3.0)))
+            .is_none(),
+        "move motion should update the live preview without reducer output"
     );
-    state.apply_interaction(update);
     assert_eq!(
-        state.play_selection(),
+        widget
+            .live_selection_preview
+            .map(|preview| preview.selection),
         Some(wavecrate::selection::SelectionRange::new(0.35, 0.75)),
-        "drag motion should mutate app playmark state live"
+        "drag motion should paint the moved playmark live"
     );
 
     let finish = widget
@@ -1568,20 +1508,17 @@ fn secondary_drag_from_playmark_body_paints_edit_selection() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    let update = widget
-        .handle_input(bounds, WidgetInput::pointer_move(drag))
-        .expect("secondary creation drag should update edit selection live")
-        .typed_copied::<WaveformInteraction>()
-        .expect("waveform interaction");
-    assert_eq!(
-        update,
-        WaveformInteraction::UpdateSelection {
-            visible_ratio: 0.75
-        }
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(drag))
+            .is_none(),
+        "secondary creation drag should update edit selection preview"
     );
-    state.apply_interaction(update);
 
-    let live_selection = state.edit_selection().expect("live edit selection");
+    let live_selection = widget
+        .live_selection_preview
+        .expect("live edit selection preview")
+        .selection;
     assert!((live_selection.start() - 0.4).abs() < f32::EPSILON);
     assert!((live_selection.end() - 0.75).abs() < f32::EPSILON);
 

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -341,6 +341,25 @@ fn pointer_move_updates_hover_cursor_and_remembers_context_menu_position() {
 }
 
 #[test]
+fn hover_cursor_survives_widget_synchronization() {
+    let state = WaveformState::synthetic_for_tests();
+    let mut widget = waveform_widget_for_state(&state);
+    let bounds = Rect::from_xy_size(10.0, 20.0, 200.0, 80.0);
+    widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(60.0, 40.0)));
+    assert_eq!(widget.hover_cursor_ratio, Some(0.25));
+
+    let mut rebuilt = waveform_widget_for_state(&state);
+    rebuilt.synchronize_from_previous(&widget);
+
+    assert!(rebuilt.common.is_hovered());
+    assert_eq!(
+        rebuilt.hover_cursor_ratio,
+        Some(0.25),
+        "paint-only hover cursor state should survive frame-clock widget synchronization"
+    );
+}
+
+#[test]
 fn pointer_move_over_similar_section_uses_region_hover_instead_of_cursor() {
     let mut state = WaveformState::synthetic_for_tests();
     let similar = wavecrate::selection::SelectionRange::new(0.2, 0.6);

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -117,12 +117,7 @@ fn primary_press_emits_playback_ratio_matching_hover_cursor_ratio() {
         .typed_copied::<WaveformInteraction>()
         .expect("waveform interaction");
 
-    assert_eq!(
-        hover.and_then(|output| output.typed_copied::<WaveformInteraction>()),
-        Some(WaveformInteraction::RememberPointerLocation {
-            position: Point::new(60.0, 40.0)
-        })
-    );
+    assert!(hover.is_none());
     assert_eq!(hover_cursor_ratio, Some(0.25));
     assert_eq!(widget.hover_cursor_ratio, None);
     assert_eq!(
@@ -322,19 +317,14 @@ fn captured_selection_drag_outside_waveform_updates_to_nearest_edge() {
 }
 
 #[test]
-fn pointer_move_updates_hover_cursor_and_remembers_context_menu_position() {
+fn pointer_move_updates_hover_cursor_without_emitting_output() {
     let state = WaveformState::synthetic_for_tests();
     let mut widget = waveform_widget_for_state(&state);
     let bounds = Rect::from_xy_size(10.0, 20.0, 200.0, 80.0);
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(60.0, 40.0)));
 
-    assert_eq!(
-        output.and_then(|output| output.typed_copied::<WaveformInteraction>()),
-        Some(WaveformInteraction::RememberPointerLocation {
-            position: Point::new(60.0, 40.0)
-        })
-    );
+    assert!(output.is_none());
     assert!(widget.common.is_hovered());
     assert_eq!(widget.hover_cursor_ratio, Some(0.25));
     assert!(widget.prefers_pointer_move_paint_only());
@@ -370,12 +360,7 @@ fn pointer_move_over_similar_section_uses_region_hover_instead_of_cursor() {
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(80.0, 40.0)));
 
-    assert_eq!(
-        output.and_then(|output| output.typed_copied::<WaveformInteraction>()),
-        Some(WaveformInteraction::RememberPointerLocation {
-            position: Point::new(80.0, 40.0)
-        })
-    );
+    assert!(output.is_none());
     assert!(widget.common.is_hovered());
     assert_eq!(widget.hovered_similar_section, Some(similar));
     assert_eq!(widget.hover_cursor_ratio, None);
@@ -397,7 +382,7 @@ fn pointer_move_hits_clipped_similar_section_in_zoomed_viewport() {
 
     let output = widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(20.0, 40.0)));
 
-    assert_pointer_location_output(output);
+    assert!(output.is_none());
     assert_eq!(widget.hovered_similar_section, Some(similar));
     assert_eq!(widget.hover_cursor_ratio, None);
 }

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -16,6 +16,22 @@ fn set_widget_input_test_config_base(
     (lock, guard)
 }
 
+fn expect_update_selection(
+    output: Option<radiant::widgets::WidgetOutput>,
+    visible_ratio: f32,
+    context: &str,
+) {
+    let interaction = output
+        .unwrap_or_else(|| panic!("{context} should emit a reducer update"))
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        interaction,
+        WaveformInteraction::UpdateSelection { visible_ratio },
+        "{context}"
+    );
+}
+
 #[test]
 fn auxiliary_drag_pans_zoomed_waveform_viewport() {
     let mut state = WaveformState::synthetic_for_tests();
@@ -765,11 +781,13 @@ fn moved_selection_drag_preview_survives_widget_rebuild_after_press() {
 
         let mut current = waveform_widget_for_state(&state);
         Widget::synchronize_from_previous(&mut current, &previous);
-        assert!(
-            current
-                .handle_input(bounds, WidgetInput::pointer_move(drag))
-                .is_none(),
-            "rebuilt widget should retain the move anchor without reducer output"
+        expect_update_selection(
+            current.handle_input(bounds, WidgetInput::pointer_move(drag)),
+            match kind {
+                WaveformSelectionKind::Play => 0.5,
+                WaveformSelectionKind::Edit => 0.4,
+            },
+            "rebuilt widget should retain the move anchor and emit reducer output",
         );
 
         let preview = current
@@ -828,19 +846,17 @@ fn moved_selection_drag_preview_uses_original_baseline_after_live_update() {
 
         let mut first = waveform_widget_for_state(&state);
         Widget::synchronize_from_previous(&mut first, &initial);
-        assert!(
-            first
-                .handle_input(bounds, WidgetInput::pointer_move(first_drag))
-                .is_none(),
-            "first drag should paint the move preview locally"
+        expect_update_selection(
+            first.handle_input(bounds, WidgetInput::pointer_move(first_drag)),
+            0.4,
+            "first drag should paint the move preview locally and emit reducer output",
         );
 
         let mut second = first;
-        assert!(
-            second
-                .handle_input(bounds, WidgetInput::pointer_move(second_drag))
-                .is_none(),
-            "second drag should keep the move preview paint-only"
+        expect_update_selection(
+            second.handle_input(bounds, WidgetInput::pointer_move(second_drag)),
+            0.45,
+            "second drag should keep previewing from the original baseline and emit reducer output",
         );
 
         let preview = second
@@ -1071,11 +1087,10 @@ fn playmark_resize_motion_updates_live_until_release() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
-            .is_none(),
-        "resize motion should paint a live selection preview"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0))),
+        0.8,
+        "resize motion should paint live preview and emit reducer output",
     );
     assert_eq!(
         widget
@@ -1129,11 +1144,10 @@ fn playmark_right_resize_updates_when_returning_through_original_handle() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0)))
-            .is_none(),
-        "dragging away should update the right edge preview"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(160.0, 8.0))),
+        0.8,
+        "dragging away should update the right edge preview and emit reducer output",
     );
     assert_eq!(
         widget
@@ -1142,11 +1156,10 @@ fn playmark_right_resize_updates_when_returning_through_original_handle() {
         Some(wavecrate::selection::SelectionRange::new(0.2, 0.8))
     );
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(121.0, 8.0)))
-            .is_none(),
-        "returning through the original handle must still update the preview"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(121.0, 8.0))),
+        0.605,
+        "returning through the original handle must still update the preview and reducer",
     );
     assert_eq!(
         widget
@@ -1198,11 +1211,10 @@ fn playmark_left_resize_updates_when_returning_through_original_handle() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 8.0)))
-            .is_none(),
-        "dragging away should update the left edge preview"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(0.0, 8.0))),
+        0.0,
+        "dragging away should update the left edge preview and emit reducer output",
     );
     assert_eq!(
         widget
@@ -1211,11 +1223,10 @@ fn playmark_left_resize_updates_when_returning_through_original_handle() {
         Some(wavecrate::selection::SelectionRange::new(0.0, 0.6))
     );
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(41.0, 8.0)))
-            .is_none(),
-        "returning through the original handle must still update the preview"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(41.0, 8.0))),
+        0.205,
+        "returning through the original handle must still update the preview and reducer",
     );
     assert_eq!(
         widget
@@ -1283,11 +1294,10 @@ fn playmark_resize_crosses_opposite_edge_without_dead_zone() {
         state.apply_interaction(begin);
         widget.active_drag_kind = state.active_drag_kind();
 
-        assert!(
-            widget
-                .handle_input(bounds, WidgetInput::pointer_move(drag))
-                .is_none(),
-            "crossing the opposite edge should paint a live preview"
+        expect_update_selection(
+            widget.handle_input(bounds, WidgetInput::pointer_move(drag)),
+            expected_visible_ratio,
+            "crossing the opposite edge should paint a live preview and emit reducer output",
         );
         assert_eq!(
             expected_visible_ratio,
@@ -1341,11 +1351,10 @@ fn zoomed_playmark_resize_preview_matches_committed_transform() {
     let mut current = waveform_widget_for_state(&state);
     Widget::synchronize_from_previous(&mut current, &previous);
 
-    assert!(
-        current
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 8.0)))
-            .is_none(),
-        "resize motion should update preview without reducer output"
+    expect_update_selection(
+        current.handle_input(bounds, WidgetInput::pointer_move(Point::new(150.0, 8.0))),
+        0.75,
+        "resize motion should update preview and emit reducer output",
     );
     let preview = current
         .live_selection_preview
@@ -1391,11 +1400,10 @@ fn playmark_move_motion_updates_live_until_release() {
     state.apply_interaction(begin);
     widget.active_drag_kind = state.active_drag_kind();
 
-    assert!(
-        widget
-            .handle_input(bounds, WidgetInput::pointer_move(Point::new(110.0, 3.0)))
-            .is_none(),
-        "move motion should update the live preview without reducer output"
+    expect_update_selection(
+        widget.handle_input(bounds, WidgetInput::pointer_move(Point::new(110.0, 3.0))),
+        0.55,
+        "move motion should update the live preview and emit reducer output",
     );
     assert_eq!(
         widget

--- a/src/native_app/waveform/types.rs
+++ b/src/native_app/waveform/types.rs
@@ -13,9 +13,6 @@ pub(in crate::native_app) enum WaveformInteraction {
         direction: i8,
     },
     ZoomFull,
-    RememberPointerLocation {
-        position: Point,
-    },
     ScrollTo {
         offset_fraction: f32,
     },

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -389,6 +389,12 @@ impl Widget for WaveformWidget {
         };
         self.common.state = previous.common.state;
         self.gesture = previous.gesture.clone();
+        self.hover_cursor_ratio = previous.hover_cursor_ratio;
+        self.hovered_selection_handle = previous.hovered_selection_handle;
+        self.hovered_edit_fade_handle = previous.hovered_edit_fade_handle;
+        self.hovered_edit_fade_outer_gain_handle = previous.hovered_edit_fade_outer_gain_handle;
+        self.hovered_edit_gain_handle = previous.hovered_edit_gain_handle;
+        self.hovered_similar_section = previous.hovered_similar_section;
         if self.should_preserve_live_selection_preview_from(previous) {
             self.last_live_selection_update_visible_ratio =
                 previous.last_live_selection_update_visible_ratio;

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -269,6 +269,9 @@ impl WaveformWidget {
         }
         self.last_live_selection_update_visible_ratio = Some(visible_ratio);
         self.update_live_selection_preview_for_active_drag(visible_ratio);
+        if self.active_selection_drag_can_paint_live_preview() {
+            return None;
+        }
         Some(WidgetOutput::typed(WaveformInteraction::UpdateSelection {
             visible_ratio,
         }))
@@ -530,6 +533,17 @@ impl WaveformWidget {
         matches!(
             self.active_drag_kind,
             Some(WaveformActiveDragKind::Selection(_))
+        )
+    }
+
+    fn active_selection_drag_can_paint_live_preview(&self) -> bool {
+        matches!(
+            self.active_drag_kind,
+            Some(
+                WaveformActiveDragKind::Selection(_)
+                    | WaveformActiveDragKind::SelectionResize(_, _)
+                    | WaveformActiveDragKind::SelectionMove(_)
+            )
         )
     }
 

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -53,7 +53,7 @@ impl WaveformWidget {
                 self.hovered_edit_gain_handle = false;
                 self.hovered_similar_section = None;
                 self.hover_cursor_ratio = None;
-                return Some(pointer_location_output(pointer));
+                return None;
             }
             self.hovered_edit_fade_handle = self.edit_fade_handle_at(bounds, pointer.position);
             if self.hovered_edit_fade_handle.is_some() {
@@ -62,7 +62,7 @@ impl WaveformWidget {
                 self.hovered_edit_gain_handle = false;
                 self.hovered_similar_section = None;
                 self.hover_cursor_ratio = None;
-                return Some(pointer_location_output(pointer));
+                return None;
             }
             self.hovered_edit_gain_handle = self.edit_gain_handle_at(bounds, pointer.position);
             if self.hovered_edit_gain_handle {
@@ -70,14 +70,14 @@ impl WaveformWidget {
                 self.hovered_selection_handle = None;
                 self.hovered_similar_section = None;
                 self.hover_cursor_ratio = None;
-                return Some(pointer_location_output(pointer));
+                return None;
             }
             self.hovered_selection_handle =
                 self.selection_handle_hover_at(bounds, pointer.position);
             if self.hovered_selection_handle.is_some() {
                 self.hovered_similar_section = None;
                 self.hover_cursor_ratio = None;
-                return Some(pointer_location_output(pointer));
+                return None;
             }
             self.hovered_similar_section = self.similar_section_at(bounds, pointer.position);
             if self.hovered_similar_section.is_some() {
@@ -85,11 +85,11 @@ impl WaveformWidget {
                 self.hovered_edit_fade_handle = None;
                 self.hovered_edit_gain_handle = false;
                 self.hover_cursor_ratio = None;
-                return Some(pointer_location_output(pointer));
+                return None;
             }
             let visible_ratio = pointer.normalized_x();
             self.hover_cursor_ratio = self.absolute_ratio_for_visible(visible_ratio);
-            return Some(pointer_location_output(pointer));
+            return None;
         }
         if let Some((pointer, delta)) = event.wheel_pointer_delta_inside(bounds) {
             let expand_silence_margin =
@@ -742,10 +742,4 @@ fn sample_slide_frame_offset(
         return 0;
     }
     ((visible_ratio - anchor_visible_ratio) * visible_frames.max(1) as f32).round() as i64
-}
-
-fn pointer_location_output(pointer: CanvasPointer) -> WidgetOutput {
-    WidgetOutput::typed(WaveformInteraction::RememberPointerLocation {
-        position: pointer.position,
-    })
 }

--- a/src/native_app/waveform/widget_input.rs
+++ b/src/native_app/waveform/widget_input.rs
@@ -539,11 +539,7 @@ impl WaveformWidget {
     fn active_selection_drag_can_paint_live_preview(&self) -> bool {
         matches!(
             self.active_drag_kind,
-            Some(
-                WaveformActiveDragKind::Selection(_)
-                    | WaveformActiveDragKind::SelectionResize(_, _)
-                    | WaveformActiveDragKind::SelectionMove(_)
-            )
+            Some(WaveformActiveDragKind::Selection(_))
         )
     }
 

--- a/src/native_app/workflows/context_menu_actions/open.rs
+++ b/src/native_app/workflows/context_menu_actions/open.rs
@@ -23,7 +23,13 @@ impl NativeAppState {
         &mut self,
         context: &radiant::prelude::UiUpdateContext<GuiMessage>,
     ) {
-        if self.close_open_context_menu() {
+        if self
+            .ui
+            .browser_interaction
+            .waveform_context_menu
+            .take()
+            .is_some()
+        {
             return;
         }
         if self
@@ -33,6 +39,9 @@ impl NativeAppState {
             .is_some()
         {
             self.open_play_selection_context_menu_from_shortcut(context.current_pointer_position());
+            return;
+        }
+        if self.close_open_context_menu() {
             return;
         }
         if let Some(file_id) = self


### PR DESCRIPTION
Scope
- Update Radiant to include logical bracket shortcut fallback from PORTALSURFER/radiant#1388.
- Restore Wavecrate rating shortcuts so `[` decreases and `]` increases the selected sample rating even when bracket characters are produced through a layout modifier.

Definition of Done
- `[` and `]` rating hotkeys resolve to `AdjustSelectedRatingWithoutAdvance(-1)` and `AdjustSelectedRatingWithoutAdvance(1)`.
- Existing shortcut context behavior remains intact.
- The Wavecrate branch records only the Radiant submodule pointer update.

Validation commands
- `cargo test bracket_shortcuts_route_to_rating_adjustments`
- `cargo test shortcuts_context`
- `bash scripts/ci.sh agent` (fails on pre-existing unrelated guardrail in `src/native_app/sample_identity_diagnostics.rs`: `fs::File`, `std::fs::metadata`, `.metadata()`)

Known limitations
- Agent-safe validation is still blocked by the existing `sample_identity_diagnostics.rs` non-blocking guardrail findings listed above.

User review is required before merge.