### PR TITLE
OPT-1045 Add release orchestration script

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -93,11 +93,13 @@ scripts/release.sh stable --version 19.2.0 --branch release/19.2 --dispatch
 bumps to `X.(Y+1).0`. Without `--dispatch`, `rc` and `stable` validate inputs
 and print the exact `gh workflow run ...` command instead of publishing. With
 `--dispatch`, the script requires an authenticated GitHub CLI (`gh`) and invokes
-the existing workflows with their native input names. `prepare --dispatch`
-dispatches the workflow file from `--workflow-ref` (default `main`) while passing
-the resolved source commit SHA as the workflow `source_ref` input. Stable
-dispatch also preflights the safety invariant locally: the latest `vX.Y.Z-rc.N`
-tag must point at the same commit as the release branch.
+the existing workflows with their native input names. When `origin` is a GitHub
+remote, it must match `WAVECRATE_GITHUB_REPO` so local ref resolution and
+workflow dispatch target the same repository. `prepare --dispatch` dispatches
+the workflow file from `--workflow-ref` (default `main`) while passing the
+resolved source commit SHA as the workflow `source_ref` input. Stable dispatch
+also preflights the safety invariant locally: the latest `vX.Y.Z-rc.N` tag must
+point at the same commit as the release branch.
 
 Local equivalent:
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -79,8 +79,8 @@ validation. The workflow defaults to dry-run mode; it only pushes or updates the
 The repo-root Bash orchestrator is the preferred operator entrypoint on
 macOS/Linux. It must be run from a clean Wavecrate repo root, fetches/prunes
 release refs before resolving commits, derives the target stable version from
-the current release package version, and keeps public publishing behind explicit
-operator intent:
+the package version at the resolved source ref, and keeps public publishing
+behind explicit operator intent:
 
 ```bash
 scripts/release.sh prepare --bump minor --source-ref main --dry-run
@@ -93,9 +93,11 @@ scripts/release.sh stable --version 19.2.0 --branch release/19.2 --dispatch
 bumps to `X.(Y+1).0`. Without `--dispatch`, `rc` and `stable` validate inputs
 and print the exact `gh workflow run ...` command instead of publishing. With
 `--dispatch`, the script requires an authenticated GitHub CLI (`gh`) and invokes
-the existing workflows with their native input names. Stable dispatch also
-preflights the safety invariant locally: the latest `vX.Y.Z-rc.N` tag must point
-at the same commit as the release branch.
+the existing workflows with their native input names. `prepare --dispatch`
+dispatches the workflow file from `--workflow-ref` (default `main`) while passing
+the resolved source commit SHA as the workflow `source_ref` input. Stable
+dispatch also preflights the safety invariant locally: the latest `vX.Y.Z-rc.N`
+tag must point at the same commit as the release branch.
 
 Local equivalent:
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -76,6 +76,27 @@ package versions such as `alpha` or `beta`, and runs focused release contract
 validation. The workflow defaults to dry-run mode; it only pushes or updates the
 `release/X.Y` branch when `push_branch` is explicitly set to `true`.
 
+The repo-root Bash orchestrator is the preferred operator entrypoint on
+macOS/Linux. It must be run from a clean Wavecrate repo root, fetches/prunes
+release refs before resolving commits, derives the target stable version from
+the current release package version, and keeps public publishing behind explicit
+operator intent:
+
+```bash
+scripts/release.sh prepare --bump minor --source-ref main --dry-run
+scripts/release.sh prepare --bump minor --source-ref main --push
+scripts/release.sh rc --version 19.2.0 --rc-number 1 --branch release/19.2 --dispatch
+scripts/release.sh stable --version 19.2.0 --branch release/19.2 --dispatch
+```
+
+`prepare --bump major` bumps `X.Y.Z` to `(X+1).0.0`; `prepare --bump minor`
+bumps to `X.(Y+1).0`. Without `--dispatch`, `rc` and `stable` validate inputs
+and print the exact `gh workflow run ...` command instead of publishing. With
+`--dispatch`, the script requires an authenticated GitHub CLI (`gh`) and invokes
+the existing workflows with their native input names. Stable dispatch also
+preflights the safety invariant locally: the latest `vX.Y.Z-rc.N` tag must point
+at the same commit as the release branch.
+
 Local equivalent:
 
 ```bash

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -58,8 +58,10 @@ at the resolved source ref, delegates release-train prep to
 stable GitHub workflows only when `--dispatch` is passed. Prepare dispatch uses
 `--workflow-ref` (default `main`) for the workflow file ref and sends the
 resolved source commit SHA through the `source_ref` workflow input. The script
-requires `gh` only for explicit workflow dispatch; dry RC/stable runs print the
-exact workflow command and follow-up run-list command without publishing.
+requires `gh` only for explicit workflow dispatch. When `origin` is a GitHub
+remote, it must match `WAVECRATE_GITHUB_REPO` before release refs are fetched or
+resolved. Dry RC/stable runs print the exact workflow command and follow-up
+run-list command without publishing.
 
 The nextest policy is:
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -52,12 +52,14 @@ development and release-risk checks:
 | Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
 
 Use `scripts/release.sh` from a clean repo root for macOS/Linux release
-orchestration. It derives major/minor target versions from the current release
-package version, delegates release-train prep to
+orchestration. It derives major/minor target versions from the package version
+at the resolved source ref, delegates release-train prep to
 `scripts/internal/release/prepare_release_train.py`, and dispatches the RC and
-stable GitHub workflows only when `--dispatch` is passed. The script requires
-`gh` only for explicit workflow dispatch; dry RC/stable runs print the exact
-workflow command and follow-up run-list command without publishing.
+stable GitHub workflows only when `--dispatch` is passed. Prepare dispatch uses
+`--workflow-ref` (default `main`) for the workflow file ref and sends the
+resolved source commit SHA through the `source_ref` workflow input. The script
+requires `gh` only for explicit workflow dispatch; dry RC/stable runs print the
+exact workflow command and follow-up run-list command without publishing.
 
 The nextest policy is:
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -51,6 +51,14 @@ development and release-risk checks:
 | RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
 | Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
 
+Use `scripts/release.sh` from a clean repo root for macOS/Linux release
+orchestration. It derives major/minor target versions from the current release
+package version, delegates release-train prep to
+`scripts/internal/release/prepare_release_train.py`, and dispatches the RC and
+stable GitHub workflows only when `--dispatch` is passed. The script requires
+`gh` only for explicit workflow dispatch; dry RC/stable runs print the exact
+workflow command and follow-up run-list command without publishing.
+
 The nextest policy is:
 
 - `ci-required` is the merge-blocking test subset and excludes known timing,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,10 @@ dispatcher maps. These are the public entrypoints people should run directly:
   maintained local/manual or release-risk perf lane. The Bash-only
   `calibrate-startup` command is optional Linux developer tooling for refreshing
   startup threshold lock files; it is not shipped Linux product support.
+- `release.sh`: Bash release orchestration for release-train prep and explicit
+  RC/stable GitHub workflow dispatch. It derives major/minor trains from the
+  current release package version and delegates packaging/publication to the
+  existing release workflows.
 - `gui.ps1`: Windows GUI validation lanes.
 
 PowerShell compatibility wrappers also remain available for the older

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -66,6 +66,11 @@
       "windows_supported": false
     },
     {
+      "path": "scripts/release.sh",
+      "role": "Repo-root release orchestration for release-train prep plus RC/stable workflow dispatch.",
+      "windows_supported": false
+    },
+    {
       "path": "scripts/run.ps1",
       "role": "Sandbox, cleanup, log, and bug-bundle helpers.",
       "windows_supported": true

--- a/scripts/internal/data/validation_contract.json
+++ b/scripts/internal/data/validation_contract.json
@@ -42,6 +42,7 @@
       "scripts/internal/perf/run_perf_guard.sh",
       "scripts/internal/perf/calibrate_startup_thresholds.sh",
       "scripts/internal/perf/run_perf_wheel_stability.sh",
+      "scripts/release.sh",
       "scripts/run.sh"
     ],
     "required_fragments": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,6 +30,12 @@ run() {
   "$@"
 }
 
+print_dry_gh_command() {
+  printf 'Dry command:'
+  printf ' %q' gh "$@"
+  printf '\n'
+}
+
 repo_root() {
   git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
 }
@@ -259,14 +265,16 @@ rc() {
   print_resolved "$version" "$branch" "$target_sha"
   echo "RC tag: v${version}-rc.${rc_number}"
 
+  local args
+  args=(workflow run release-rc.yml --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")
+  [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
+
   if (( dispatch )); then
-    local gh_bin args
+    local gh_bin
     gh_bin="$(require_gh)"
-    args=(workflow run release-rc.yml --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")
-    [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
     run "$gh_bin" "${args[@]}"
   else
-    echo "Dry command: gh workflow run release-rc.yml --ref $branch -f version=$version -f rc_number=$rc_number -f branch=$branch"
+    print_dry_gh_command "${args[@]}"
   fi
   print_followups "release-rc.yml" "$branch"
 }
@@ -306,14 +314,16 @@ stable() {
   print_resolved "$version" "$branch" "$target_sha"
   echo "Promoted RC tag: $latest_rc_tag"
 
+  local args
+  args=(workflow run release-stable.yml --ref "$branch" -f "version=$version" -f "branch=$branch")
+  [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
+
   if (( dispatch )); then
-    local gh_bin args
+    local gh_bin
     gh_bin="$(require_gh)"
-    args=(workflow run release-stable.yml --ref "$branch" -f "version=$version" -f "branch=$branch")
-    [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
     run "$gh_bin" "${args[@]}"
   else
-    echo "Dry command: gh workflow run release-stable.yml --ref $branch -f version=$version -f branch=$branch"
+    print_dry_gh_command "${args[@]}"
   fi
   print_followups "release-stable.yml" "$branch"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -170,6 +170,15 @@ validate_rc_tag_available() {
     || die "RC tag $tag already points at $existing, not $target_sha"
 }
 
+validate_stable_tag_available() {
+  local tag="$1"
+  local target_sha="$2"
+  local existing
+  existing="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
+  [[ -z "$existing" || "$existing" == "$target_sha" ]] \
+    || die "stable tag $tag already points at $existing, not $target_sha"
+}
+
 resolve_ref_sha() {
   local ref="$1"
   local candidate="$ref"
@@ -417,6 +426,7 @@ stable() {
 
   print_resolved "$version" "$branch" "$target_sha"
   echo "Promoted RC tag: $latest_rc_tag"
+  validate_stable_tag_available "v${version}" "$target_sha"
 
   local args
   args=(workflow run release-stable.yml --repo "$repo_slug" --ref "$branch" -f "version=$version" -f "branch=$branch")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,8 +88,8 @@ ensure_origin_matches_repo_slug() {
 fetch_release_refs() {
   git remote get-url origin >/dev/null 2>&1 || die "git remote 'origin' is required"
   ensure_origin_matches_repo_slug
-  run git fetch --prune origin
-  run git fetch --prune --prune-tags --tags --force origin
+  run git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'
+  run git fetch --prune --prune-tags --force origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
 }
 
 stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -220,6 +220,13 @@ run_prepare_train_dry_run_at_ref() {
 
   if (( status == 0 )); then
     set +e
+    run git -C "$worktree" submodule update --init --recursive
+    status=$?
+    set -e
+  fi
+
+  if (( status == 0 )); then
+    set +e
     (cd "$worktree" && run scripts/internal/release/prepare_release_train.py "$@")
     status=$?
     set -e

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -191,12 +191,12 @@ prepare() {
   ensure_clean_worktree
   fetch_release_refs
 
-  local current_version target_version branch target_sha
-  current_version="$(current_package_version)"
-  validate_version "$current_version"
-  target_version="$(bump_version "$current_version" "$bump")"
-  branch="$(release_branch_for_version "$target_version")"
+  local source_version target_version branch target_sha
   target_sha="$(resolve_ref_sha "$source_ref")"
+  source_version="$(package_version_at_ref "$target_sha")"
+  validate_version "$source_version"
+  target_version="$(bump_version "$source_version" "$bump")"
+  branch="$(release_branch_for_version "$target_version")"
   print_resolved "$target_version" "$branch" "$target_sha"
 
   if (( dispatch )); then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_slug="${WAVECRATE_GITHUB_REPO:-PORTALSURFER/wavecrate}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/release.sh prepare --bump <major|minor> [--source-ref <ref>] [--dry-run|--push] [--dispatch]
+  scripts/release.sh rc --version <X.Y.Z> --rc-number <N> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
+  scripts/release.sh stable --version <X.Y.Z> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
+
+Prepare derives the target version from the current Cargo.toml package version.
+Without --dispatch, prepare runs scripts/internal/release/prepare_release_train.py locally.
+Without --dispatch, rc/stable validate inputs and print the exact gh workflow command.
+Public publishing workflow dispatch requires --dispatch.
+EOF
+}
+
+die() {
+  echo "release: $*" >&2
+  exit 2
+}
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
+}
+
+ensure_repo_root() {
+  local root
+  root="$(repo_root)"
+  [[ "$PWD" == "$root" ]] || die "run from the Wavecrate repo root: $root"
+  [[ -f Cargo.toml && -d scripts/internal/release && -d .github/workflows ]] \
+    || die "current directory does not look like the Wavecrate repo root"
+}
+
+ensure_clean_worktree() {
+  local status
+  status="$(git status --short)"
+  [[ -z "$status" ]] || die "release orchestration requires a clean working tree"
+}
+
+fetch_release_refs() {
+  git remote get-url origin >/dev/null 2>&1 || die "git remote 'origin' is required"
+  run git fetch --prune origin
+  run git fetch --tags --force origin
+}
+
+stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+rc_number_re='^[1-9][0-9]*$'
+
+validate_version() {
+  local version="$1"
+  [[ "$version" =~ $stable_version_re ]] || die "version must be MAJOR.MINOR.PATCH"
+}
+
+validate_bump() {
+  local bump="$1"
+  [[ "$bump" == "major" || "$bump" == "minor" ]] || die "bump must be major or minor"
+}
+
+package_version_from_stdin() {
+  awk '
+    /^\[package\][[:space:]]*$/ { in_package = 1; next }
+    in_package && /^\[/ { exit }
+    in_package && /^[[:space:]]*version[[:space:]]*=/ {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  '
+}
+
+current_package_version() {
+  package_version_from_stdin < Cargo.toml
+}
+
+package_version_at_ref() {
+  local sha="$1"
+  git show "${sha}:Cargo.toml" 2>/dev/null | package_version_from_stdin
+}
+
+bump_version() {
+  local version="$1"
+  local bump="$2"
+  validate_version "$version"
+  validate_bump "$bump"
+  IFS=. read -r major minor _patch <<<"$version"
+  case "$bump" in
+    major) printf '%s.0.0\n' "$((major + 1))" ;;
+    minor) printf '%s.%s.0\n' "$major" "$((minor + 1))" ;;
+  esac
+}
+
+release_branch_for_version() {
+  local version="$1"
+  validate_version "$version"
+  IFS=. read -r major minor _patch <<<"$version"
+  printf 'release/%s.%s\n' "$major" "$minor"
+}
+
+validate_branch_for_version() {
+  local branch="$1"
+  local version="$2"
+  local expected
+  expected="$(release_branch_for_version "$version")"
+  [[ "$branch" == "$expected" ]] || die "branch must be $expected for version $version"
+}
+
+validate_manifest_version_at_ref() {
+  local sha="$1"
+  local version="$2"
+  local actual
+  actual="$(package_version_at_ref "$sha")"
+  [[ "$actual" == "$version" ]] || die "Cargo.toml version $actual at $sha does not match $version"
+}
+
+resolve_ref_sha() {
+  local ref="$1"
+  local candidate="$ref"
+  if git rev-parse --verify --quiet "origin/${ref}^{commit}" >/dev/null; then
+    candidate="origin/${ref}"
+  fi
+  git rev-parse --verify "${candidate}^{commit}" 2>/dev/null \
+    || die "could not resolve source ref '$ref' to a commit"
+}
+
+workflow_url() {
+  local workflow="$1"
+  printf 'https://github.com/%s/actions/workflows/%s\n' "$repo_slug" "$workflow"
+}
+
+require_gh() {
+  local gh_bin="${WAVECRATE_RELEASE_GH_BIN:-gh}"
+  if [[ "$gh_bin" == */* ]]; then
+    [[ -x "$gh_bin" ]] || die "gh CLI not found or not executable: $gh_bin"
+  else
+    command -v "$gh_bin" >/dev/null 2>&1 || die "gh CLI not found; install gh or set WAVECRATE_RELEASE_GH_BIN"
+  fi
+  "$gh_bin" auth status >/dev/null 2>&1 || die "gh CLI is not authenticated; run gh auth login"
+  printf '%s\n' "$gh_bin"
+}
+
+print_resolved() {
+  local version="$1"
+  local branch="$2"
+  local sha="$3"
+  echo "Resolved version: $version"
+  echo "Release branch: $branch"
+  echo "Target SHA: $sha"
+}
+
+print_followups() {
+  local workflow="$1"
+  local branch="$2"
+  echo "Workflow: $(workflow_url "$workflow")"
+  echo "Run lookup: gh run list --workflow $workflow --branch $branch --limit 5"
+}
+
+prepare() {
+  local bump=""
+  local source_ref="main"
+  local dry_run=1
+  local explicit_dry_run=0
+  local push=0
+  local dispatch=0
+  while (( $# > 0 )); do
+    case "$1" in
+      --bump) bump="${2:-}"; shift 2 ;;
+      --source-ref) source_ref="${2:-}"; shift 2 ;;
+      --dry-run) explicit_dry_run=1; dry_run=1; shift ;;
+      --push) push=1; dry_run=0; shift ;;
+      --dispatch) dispatch=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown prepare argument: $1" ;;
+    esac
+  done
+  [[ -n "$bump" ]] || die "prepare requires --bump <major|minor>"
+  validate_bump "$bump"
+  (( push == 0 || explicit_dry_run == 0 )) || die "--dry-run and --push cannot be combined"
+
+  ensure_repo_root
+  ensure_clean_worktree
+  fetch_release_refs
+
+  local current_version target_version branch target_sha
+  current_version="$(current_package_version)"
+  validate_version "$current_version"
+  target_version="$(bump_version "$current_version" "$bump")"
+  branch="$(release_branch_for_version "$target_version")"
+  target_sha="$(resolve_ref_sha "$source_ref")"
+  print_resolved "$target_version" "$branch" "$target_sha"
+
+  if (( dispatch )); then
+    local gh_bin push_branch
+    gh_bin="$(require_gh)"
+    push_branch=false
+    (( push )) && push_branch=true
+    run "$gh_bin" workflow run release-train-prepare.yml \
+      --ref "$source_ref" \
+      -f "version=$target_version" \
+      -f "source_ref=$target_sha" \
+      -f "push_branch=$push_branch"
+    print_followups "release-train-prepare.yml" "$branch"
+    return 0
+  fi
+
+  local args=(--version "$target_version" --source-ref "$target_sha")
+  if (( push )); then
+    args+=(--push)
+  else
+    args+=(--dry-run)
+  fi
+  run scripts/internal/release/prepare_release_train.py "${args[@]}"
+  print_followups "release-train-prepare.yml" "$branch"
+}
+
+rc() {
+  local version=""
+  local rc_number=""
+  local branch=""
+  local release_notes=""
+  local dispatch=0
+  while (( $# > 0 )); do
+    case "$1" in
+      --version) version="${2:-}"; shift 2 ;;
+      --rc-number) rc_number="${2:-}"; shift 2 ;;
+      --branch) branch="${2:-}"; shift 2 ;;
+      --release-notes) release_notes="${2:-}"; shift 2 ;;
+      --dispatch) dispatch=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown rc argument: $1" ;;
+    esac
+  done
+  [[ -n "$version" && -n "$rc_number" && -n "$branch" ]] \
+    || die "rc requires --version, --rc-number, and --branch"
+  validate_version "$version"
+  [[ "$rc_number" =~ $rc_number_re ]] || die "rc_number must be a positive integer"
+  validate_branch_for_version "$branch" "$version"
+
+  ensure_repo_root
+  ensure_clean_worktree
+  fetch_release_refs
+
+  local target_sha
+  target_sha="$(resolve_ref_sha "$branch")"
+  validate_manifest_version_at_ref "$target_sha" "$version"
+  print_resolved "$version" "$branch" "$target_sha"
+  echo "RC tag: v${version}-rc.${rc_number}"
+
+  if (( dispatch )); then
+    local gh_bin args
+    gh_bin="$(require_gh)"
+    args=(workflow run release-rc.yml --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")
+    [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
+    run "$gh_bin" "${args[@]}"
+  else
+    echo "Dry command: gh workflow run release-rc.yml --ref $branch -f version=$version -f rc_number=$rc_number -f branch=$branch"
+  fi
+  print_followups "release-rc.yml" "$branch"
+}
+
+stable() {
+  local version=""
+  local branch=""
+  local release_notes=""
+  local dispatch=0
+  while (( $# > 0 )); do
+    case "$1" in
+      --version) version="${2:-}"; shift 2 ;;
+      --branch) branch="${2:-}"; shift 2 ;;
+      --release-notes) release_notes="${2:-}"; shift 2 ;;
+      --dispatch) dispatch=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown stable argument: $1" ;;
+    esac
+  done
+  [[ -n "$version" && -n "$branch" ]] || die "stable requires --version and --branch"
+  validate_version "$version"
+  validate_branch_for_version "$branch" "$version"
+
+  ensure_repo_root
+  ensure_clean_worktree
+  fetch_release_refs
+
+  local target_sha latest_rc_tag rc_sha
+  target_sha="$(resolve_ref_sha "$branch")"
+  validate_manifest_version_at_ref "$target_sha" "$version"
+  latest_rc_tag="$(git tag -l "v${version}-rc.*" --sort=-v:refname | head -n 1)"
+  [[ -n "$latest_rc_tag" ]] || die "stable release $version requires at least one RC tag v${version}-rc.N"
+  rc_sha="$(git rev-list -n 1 "$latest_rc_tag")"
+  [[ "$rc_sha" == "$target_sha" ]] \
+    || die "latest RC $latest_rc_tag points at $rc_sha; stable target is $target_sha"
+
+  print_resolved "$version" "$branch" "$target_sha"
+  echo "Promoted RC tag: $latest_rc_tag"
+
+  if (( dispatch )); then
+    local gh_bin args
+    gh_bin="$(require_gh)"
+    args=(workflow run release-stable.yml --ref "$branch" -f "version=$version" -f "branch=$branch")
+    [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
+    run "$gh_bin" "${args[@]}"
+  else
+    echo "Dry command: gh workflow run release-stable.yml --ref $branch -f version=$version -f branch=$branch"
+  fi
+  print_followups "release-stable.yml" "$branch"
+}
+
+main() {
+  if (( $# == 0 )); then
+    usage
+    exit 0
+  fi
+  local command="$1"
+  shift
+  case "$command" in
+    prepare) prepare "$@" ;;
+    rc) rc "$@" ;;
+    stable) stable "$@" ;;
+    -h|--help) usage ;;
+    *) die "unknown release command: $command" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -171,6 +171,25 @@ resolve_ref_sha() {
     || die "could not resolve source ref '$ref' to a commit"
 }
 
+commit_reachable_from_origin() {
+  local sha="$1"
+  git branch -r --contains "$sha" --format='%(refname:short)' | grep -q '^origin/' \
+    || git tag --contains "$sha" | grep -q .
+}
+
+ensure_ref_dispatchable_from_origin() {
+  local ref="$1"
+  local sha="$2"
+  commit_reachable_from_origin "$sha" \
+    || die "source ref '$ref' resolves to local-only commit $sha; push it to origin or use a ref from $repo_slug before workflow dispatch"
+}
+
+ensure_origin_branch_for_workflow() {
+  local branch="$1"
+  git rev-parse --verify --quiet "origin/${branch}^{commit}" >/dev/null \
+    || die "release branch '$branch' is not present on origin; push it before dispatching or copying workflow commands"
+}
+
 workflow_url() {
   local workflow="$1"
   printf 'https://github.com/%s/actions/workflows/%s\n' "$repo_slug" "$workflow"
@@ -276,6 +295,7 @@ prepare() {
 
   if (( dispatch )); then
     local gh_bin push_branch
+    ensure_ref_dispatchable_from_origin "$source_ref" "$target_sha"
     gh_bin="$(require_gh)"
     push_branch=false
     (( push )) && push_branch=true
@@ -332,6 +352,7 @@ rc() {
 
   local target_sha
   target_sha="$(resolve_ref_sha "$branch")"
+  ensure_origin_branch_for_workflow "$branch"
   validate_manifest_version_at_ref "$target_sha" "$version"
   print_resolved "$version" "$branch" "$target_sha"
   echo "RC tag: v${version}-rc.${rc_number}"
@@ -375,6 +396,7 @@ stable() {
 
   local target_sha latest_rc_tag rc_sha
   target_sha="$(resolve_ref_sha "$branch")"
+  ensure_origin_branch_for_workflow "$branch"
   validate_manifest_version_at_ref "$target_sha" "$version"
   latest_rc_tag="$(git tag -l "v${version}-rc.*" --sort=-v:refname | head -n 1)"
   [[ -n "$latest_rc_tag" ]] || die "stable release $version requires at least one RC tag v${version}-rc.N"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,11 +7,11 @@ repo_slug="${WAVECRATE_GITHUB_REPO:-PORTALSURFER/wavecrate}"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/release.sh prepare --bump <major|minor> [--source-ref <ref>] [--dry-run|--push] [--dispatch]
+  scripts/release.sh prepare --bump <major|minor> [--source-ref <ref>] [--workflow-ref <branch-or-tag>] [--dry-run|--push] [--dispatch]
   scripts/release.sh rc --version <X.Y.Z> --rc-number <N> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
   scripts/release.sh stable --version <X.Y.Z> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
 
-Prepare derives the target version from the current Cargo.toml package version.
+Prepare derives the target version from Cargo.toml at the resolved source ref.
 Without --dispatch, prepare runs scripts/internal/release/prepare_release_train.py locally.
 Without --dispatch, rc/stable validate inputs and print the exact gh workflow command.
 Public publishing workflow dispatch requires --dispatch.
@@ -168,6 +168,7 @@ print_followups() {
 prepare() {
   local bump=""
   local source_ref="main"
+  local workflow_ref="${WAVECRATE_RELEASE_WORKFLOW_REF:-main}"
   local dry_run=1
   local explicit_dry_run=0
   local push=0
@@ -176,6 +177,7 @@ prepare() {
     case "$1" in
       --bump) bump="${2:-}"; shift 2 ;;
       --source-ref) source_ref="${2:-}"; shift 2 ;;
+      --workflow-ref) workflow_ref="${2:-}"; shift 2 ;;
       --dry-run) explicit_dry_run=1; dry_run=1; shift ;;
       --push) push=1; dry_run=0; shift ;;
       --dispatch) dispatch=1; shift ;;
@@ -185,6 +187,7 @@ prepare() {
   done
   [[ -n "$bump" ]] || die "prepare requires --bump <major|minor>"
   validate_bump "$bump"
+  [[ -n "$workflow_ref" ]] || die "--workflow-ref must not be empty"
   (( push == 0 || explicit_dry_run == 0 )) || die "--dry-run and --push cannot be combined"
 
   ensure_repo_root
@@ -205,7 +208,7 @@ prepare() {
     push_branch=false
     (( push )) && push_branch=true
     run "$gh_bin" workflow run release-train-prepare.yml \
-      --ref "$source_ref" \
+      --ref "$workflow_ref" \
       -f "version=$target_version" \
       -f "source_ref=$target_sha" \
       -f "push_branch=$push_branch"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -423,10 +423,10 @@ stable() {
   rc_sha="$(git rev-list -n 1 "$latest_rc_tag")"
   [[ "$rc_sha" == "$target_sha" ]] \
     || die "latest RC $latest_rc_tag points at $rc_sha; stable target is $target_sha"
+  validate_stable_tag_available "v${version}" "$target_sha"
 
   print_resolved "$version" "$branch" "$target_sha"
   echo "Promoted RC tag: $latest_rc_tag"
-  validate_stable_tag_available "v${version}" "$target_sha"
 
   local args
   args=(workflow run release-stable.yml --repo "$repo_slug" --ref "$branch" -f "version=$version" -f "branch=$branch")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -54,8 +54,40 @@ ensure_clean_worktree() {
   [[ -z "$status" ]] || die "release orchestration requires a clean working tree"
 }
 
+normalize_repo_slug() {
+  local slug="$1"
+  slug="${slug%/}"
+  slug="${slug%.git}"
+  [[ "$slug" == */* ]] || return 1
+  printf '%s\n' "$slug" | tr '[:upper:]' '[:lower:]'
+}
+
+origin_github_repo_slug() {
+  local url slug
+  url="$(git remote get-url origin)"
+  case "$url" in
+    https://github.com/*) slug="${url#https://github.com/}" ;;
+    http://github.com/*) slug="${url#http://github.com/}" ;;
+    git@github.com:*) slug="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) slug="${url#ssh://git@github.com/}" ;;
+    *) return 1 ;;
+  esac
+  normalize_repo_slug "$slug"
+}
+
+ensure_origin_matches_repo_slug() {
+  local target_slug origin_slug
+  target_slug="$(normalize_repo_slug "$repo_slug")" \
+    || die "WAVECRATE_GITHUB_REPO must be an owner/repo slug"
+  if origin_slug="$(origin_github_repo_slug)"; then
+    [[ "$origin_slug" == "$target_slug" ]] \
+      || die "origin remote resolves release refs from $origin_slug, but workflows target $target_slug; set WAVECRATE_GITHUB_REPO to $origin_slug or update origin before release orchestration"
+  fi
+}
+
 fetch_release_refs() {
   git remote get-url origin >/dev/null 2>&1 || die "git remote 'origin' is required"
+  ensure_origin_matches_repo_slug
   run git fetch --prune origin
   run git fetch --prune --prune-tags --tags --force origin
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -161,6 +161,15 @@ validate_manifest_version_at_ref() {
   [[ "$actual" == "$version" ]] || die "Cargo.toml version $actual at $sha does not match $version"
 }
 
+validate_rc_tag_available() {
+  local tag="$1"
+  local target_sha="$2"
+  local existing
+  existing="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
+  [[ -z "$existing" || "$existing" == "$target_sha" ]] \
+    || die "RC tag $tag already points at $existing, not $target_sha"
+}
+
 resolve_ref_sha() {
   local ref="$1"
   local candidate="$ref"
@@ -355,7 +364,9 @@ rc() {
   ensure_origin_branch_for_workflow "$branch"
   validate_manifest_version_at_ref "$target_sha" "$version"
   print_resolved "$version" "$branch" "$target_sha"
-  echo "RC tag: v${version}-rc.${rc_number}"
+  local rc_tag="v${version}-rc.${rc_number}"
+  validate_rc_tag_available "$rc_tag" "$target_sha"
+  echo "RC tag: $rc_tag"
 
   local args
   args=(workflow run release-rc.yml --repo "$repo_slug" --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -168,7 +168,9 @@ print_followups() {
   local workflow="$1"
   local branch="$2"
   echo "Workflow: $(workflow_url "$workflow")"
-  echo "Run lookup: gh run list --workflow $workflow --branch $branch --limit 5"
+  printf 'Run lookup:'
+  printf ' %q' gh run list --repo "$repo_slug" --workflow "$workflow" --branch "$branch" --limit 5
+  printf '\n'
 }
 
 prepare() {
@@ -214,6 +216,7 @@ prepare() {
     push_branch=false
     (( push )) && push_branch=true
     run "$gh_bin" workflow run release-train-prepare.yml \
+      --repo "$repo_slug" \
       --ref "$workflow_ref" \
       -f "version=$target_version" \
       -f "source_ref=$target_sha" \
@@ -266,7 +269,7 @@ rc() {
   echo "RC tag: v${version}-rc.${rc_number}"
 
   local args
-  args=(workflow run release-rc.yml --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")
+  args=(workflow run release-rc.yml --repo "$repo_slug" --ref "$branch" -f "version=$version" -f "rc_number=$rc_number" -f "branch=$branch")
   [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
 
   if (( dispatch )); then
@@ -315,7 +318,7 @@ stable() {
   echo "Promoted RC tag: $latest_rc_tag"
 
   local args
-  args=(workflow run release-stable.yml --ref "$branch" -f "version=$version" -f "branch=$branch")
+  args=(workflow run release-stable.yml --repo "$repo_slug" --ref "$branch" -f "version=$version" -f "branch=$branch")
   [[ -z "$release_notes" ]] || args+=(-f "release_notes=$release_notes")
 
   if (( dispatch )); then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -173,6 +173,31 @@ print_followups() {
   printf '\n'
 }
 
+run_prepare_train_dry_run_at_ref() {
+  local target_sha="$1"
+  shift
+  local temp_root worktree status
+  temp_root="$(mktemp -d "${TMPDIR:-/tmp}/wavecrate-release-dry-run.XXXXXX")" \
+    || die "failed to create temporary dry-run worktree"
+  worktree="$temp_root/source"
+
+  set +e
+  run git worktree add --detach "$worktree" "$target_sha"
+  status=$?
+  set -e
+
+  if (( status == 0 )); then
+    set +e
+    (cd "$worktree" && run scripts/internal/release/prepare_release_train.py "$@")
+    status=$?
+    set -e
+  fi
+
+  git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  rm -rf "$temp_root"
+  return "$status"
+}
+
 prepare() {
   local bump=""
   local source_ref="main"
@@ -231,7 +256,11 @@ prepare() {
   else
     args+=(--dry-run)
   fi
-  run scripts/internal/release/prepare_release_train.py "${args[@]}"
+  if (( dry_run )); then
+    run_prepare_train_dry_run_at_ref "$target_sha" "${args[@]}"
+  else
+    run scripts/internal/release/prepare_release_train.py "${args[@]}"
+  fi
   print_followups "release-train-prepare.yml" "$branch"
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,7 +57,7 @@ ensure_clean_worktree() {
 fetch_release_refs() {
   git remote get-url origin >/dev/null 2>&1 || die "git remote 'origin' is required"
   run git fetch --prune origin
-  run git fetch --tags --force origin
+  run git fetch --prune --prune-tags --tags --force origin
 }
 
 stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -47,6 +47,39 @@ fn prepare_major_bump_derives_next_major_train() {
 }
 
 #[test]
+fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+    repo.git(&["switch", "-c", "stale-local"]);
+    repo.git(&["switch", "main"]);
+    repo.write_workspace("20.5.0");
+    repo.commit_all("advance main release version");
+    repo.push_branch("main");
+    repo.git(&["switch", "stale-local"]);
+    assert!(
+        repo.read("Cargo.toml").contains("version = \"19.1.0\""),
+        "fixture checkout should stay on the stale package version"
+    );
+
+    let output = repo.run_release(&[
+        "prepare",
+        "--bump",
+        "minor",
+        "--source-ref",
+        "main",
+        "--dry-run",
+    ]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Resolved version: 20.6.0"));
+    assert!(stdout.contains("Release branch: release/20.6"));
+    assert!(stdout.contains("prepare-helper [--version] [20.6.0]"));
+}
+
+#[test]
 fn prepare_rejects_invalid_bump_argument() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
@@ -279,6 +312,10 @@ edition = "2024"
             fs::create_dir_all(parent).expect("create fixture parent");
         }
         fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn read(&self, relative: &str) -> String {
+        fs::read_to_string(self.path().join(relative)).expect("read fixture file")
     }
 
     fn git(&self, args: &[&str]) {

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -250,6 +250,37 @@ fn rc_rejects_local_only_release_branch_before_printing_workflow_command() {
 }
 
 #[test]
+fn rc_rejects_existing_tag_that_points_at_different_commit() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    let release_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    repo.create_release_branch("release/19.2");
+    repo.write("src/lib.rs", "// later commit with reused rc tag\n");
+    repo.commit_all("advance main after release branch");
+    let tag_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    repo.git(&["tag", "v19.2.0-rc.1"]);
+    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
+    assert_ne!(release_sha, tag_sha);
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.2",
+    ]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains(&format!(
+        "RC tag v19.2.0-rc.1 already points at {tag_sha}, not {release_sha}"
+    )));
+    assert!(!stdout(&output).contains("Dry command: gh workflow run"));
+}
+
+#[test]
 fn rc_dispatch_requires_gh_cli_before_workflow_run() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -425,6 +425,7 @@ fn stable_rejects_existing_tag_that_points_at_different_commit() {
     assert!(stderr(&output).contains(&format!(
         "stable tag v19.2.0 already points at {tag_sha}, not {release_sha}"
     )));
+    assert!(!stdout(&output).contains("Promoted RC tag: v19.2.0-rc.1"));
     assert!(!stdout(&output).contains("Dry command: gh workflow run"));
 }
 

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -123,6 +123,37 @@ fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
 }
 
 #[test]
+fn prepare_dispatch_rejects_local_only_source_ref() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+    repo.write_workspace("19.2.0");
+    repo.commit_all("local release source only");
+    let local_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    let fake_gh = repo.write_fake_gh();
+
+    let output = repo
+        .release_command(&[
+            "prepare",
+            "--bump",
+            "minor",
+            "--source-ref",
+            "HEAD",
+            "--dispatch",
+        ])
+        .env("WAVECRATE_RELEASE_GH_BIN", fake_gh)
+        .output()
+        .expect("run release wrapper");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains(&format!(
+        "source ref 'HEAD' resolves to local-only commit {local_sha}"
+    )));
+    assert!(!stdout(&output).contains("fake-gh [workflow] [run]"));
+}
+
+#[test]
 fn prepare_rejects_invalid_bump_argument() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
@@ -193,6 +224,29 @@ fn rc_rejects_wrong_branch_for_version() {
 
     assert_failure(&output);
     assert!(stderr(&output).contains("branch must be release/19.2"));
+}
+
+#[test]
+fn rc_rejects_local_only_release_branch_before_printing_workflow_command() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.git(&["switch", "-c", "release/19.2"]);
+    repo.git(&["switch", "main"]);
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.2",
+    ]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("release branch 'release/19.2' is not present on origin"));
+    assert!(!stdout(&output).contains("Dry command: gh workflow run"));
 }
 
 #[test]

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -248,6 +248,37 @@ fn stable_requires_latest_rc_tag_to_match_release_branch_commit() {
 }
 
 #[test]
+fn stable_prunes_stale_local_rc_tags_before_selecting_promoted_rc() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+    repo.git(&["tag", "v19.2.0-rc.1"]);
+    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
+    repo.write("src/lib.rs", "// stale local rc tag only\n");
+    repo.commit_all("advance main after remote rc");
+    repo.git(&["tag", "v19.2.0-rc.2"]);
+    assert_eq!(
+        repo.git_stdout(&["tag", "-l", "v19.2.0-rc.*", "--sort=-v:refname"])
+            .lines()
+            .next(),
+        Some("v19.2.0-rc.2"),
+        "stale local rc tag should sort ahead before the wrapper fetches"
+    );
+
+    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
+    assert!(
+        !repo
+            .git_stdout(&["tag", "-l", "v19.2.0-rc.2"])
+            .contains("v19.2.0-rc.2")
+    );
+}
+
+#[test]
 fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -80,6 +80,35 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
 }
 
 #[test]
+fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+    let source_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    let fake_gh = repo.write_fake_gh();
+
+    let output = repo
+        .release_command(&[
+            "prepare",
+            "--bump",
+            "minor",
+            "--source-ref",
+            &source_sha,
+            "--dispatch",
+        ])
+        .env("WAVECRATE_RELEASE_GH_BIN", fake_gh)
+        .output()
+        .expect("run release wrapper");
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("fake-gh [workflow] [run] [release-train-prepare.yml] [--ref] [main]"));
+    assert!(stdout.contains(&format!("[-f] [source_ref={source_sha}]")));
+    assert!(!stdout.contains(&format!("[--ref] [{source_sha}]")));
+}
+
+#[test]
 fn prepare_rejects_invalid_bump_argument() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
@@ -316,6 +345,21 @@ edition = "2024"
 
     fn read(&self, relative: &str) -> String {
         fs::read_to_string(self.path().join(relative)).expect("read fixture file")
+    }
+
+    fn write_fake_gh(&self) -> PathBuf {
+        let path = self
+            .path()
+            .parent()
+            .expect("fixture temp dir")
+            .join("fake-gh");
+        fs::write(
+            &path,
+            "#!/usr/bin/env bash\nif [[ \"$1\" == \"auth\" && \"$2\" == \"status\" ]]; then exit 0; fi\nprintf 'fake-gh'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf '\\n'\n",
+        )
+        .expect("write fake gh");
+        make_executable(path.clone());
+        path
     }
 
     fn git(&self, args: &[&str]) {

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -50,6 +50,7 @@ fn prepare_major_bump_derives_next_major_train() {
 fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
+    repo.add_radiant_submodule();
     repo.commit_all("seed workspace");
     repo.push_branch("main");
     repo.git(&["switch", "-c", "stale-local"]);
@@ -63,14 +64,18 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
         "fixture checkout should stay on the stale package version"
     );
 
-    let output = repo.run_release(&[
-        "prepare",
-        "--bump",
-        "minor",
-        "--source-ref",
-        "main",
-        "--dry-run",
-    ]);
+    let output = repo
+        .release_command(&[
+            "prepare",
+            "--bump",
+            "minor",
+            "--source-ref",
+            "main",
+            "--dry-run",
+        ])
+        .env("GIT_ALLOW_PROTOCOL", "file")
+        .output()
+        .expect("run release wrapper");
 
     assert_success(&output);
     let stdout = stdout(&output);
@@ -78,6 +83,7 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     assert!(stdout.contains("Release branch: release/20.6"));
     assert!(stdout.contains("prepare-helper [--version] [20.6.0]"));
     assert!(stdout.contains("[cwd-version=20.5.0]"));
+    assert!(stdout.contains("[radiant-submodule=present]"));
 }
 
 #[test]
@@ -398,12 +404,48 @@ edition = "2024"
         self.write(".github/workflows/release-stable.yml", "");
         self.write(
             "scripts/internal/release/prepare_release_train.py",
-            "#!/usr/bin/env bash\nversion=\"$(awk '/^\\[package\\]$/ { in_package = 1; next } in_package && /^\\[/ { exit } in_package && /^[[:space:]]*version[[:space:]]*=/ { gsub(/\\\"/, \"\", $3); print $3; exit }' Cargo.toml)\"\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf ' [cwd-version=%s]\\n' \"$version\"\n",
+            "#!/usr/bin/env bash\nversion=\"$(awk '/^\\[package\\]$/ { in_package = 1; next } in_package && /^\\[/ { exit } in_package && /^[[:space:]]*version[[:space:]]*=/ { gsub(/\\\"/, \"\", $3); print $3; exit }' Cargo.toml)\"\nradiant_status=\"\"\nif [[ -f .gitmodules ]]; then\n  if [[ ! -f vendor/radiant/radiant.marker ]]; then\n    echo 'missing vendor/radiant submodule contents' >&2\n    exit 42\n  fi\n  radiant_status=' [radiant-submodule=present]'\nfi\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf ' [cwd-version=%s]%s\\n' \"$version\" \"$radiant_status\"\n",
         );
         make_executable(
             self.path()
                 .join("scripts/internal/release/prepare_release_train.py"),
         );
+    }
+
+    fn add_radiant_submodule(&self) {
+        let submodule_path = self
+            .path()
+            .parent()
+            .expect("fixture temp dir")
+            .join("radiant-src");
+        fs::create_dir_all(&submodule_path).expect("create radiant fixture repo");
+        assert_success(&run_git(Some(&submodule_path), &["init", "-b", "main"]));
+        assert_success(&run_git(
+            Some(&submodule_path),
+            &["config", "user.email", "release-tests@example.invalid"],
+        ));
+        assert_success(&run_git(
+            Some(&submodule_path),
+            &["config", "user.name", "Release Tests"],
+        ));
+        fs::write(
+            submodule_path.join("radiant.marker"),
+            "fixture radiant submodule\n",
+        )
+        .expect("write radiant marker");
+        assert_success(&run_git(Some(&submodule_path), &["add", "."]));
+        assert_success(&run_git(
+            Some(&submodule_path),
+            &["commit", "-m", "seed radiant fixture"],
+        ));
+        self.git(&[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            submodule_path.to_str().expect("radiant fixture path"),
+            "vendor/radiant",
+        ]);
     }
 
     fn create_release_branch(&self, branch: &str) {

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -85,6 +85,7 @@ fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
     repo.write_workspace("19.1.0");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
+    let configured_repo = "PORTALSURFER/wavecrate-fork";
     let source_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
     let fake_gh = repo.write_fake_gh();
 
@@ -98,14 +99,19 @@ fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
             "--dispatch",
         ])
         .env("WAVECRATE_RELEASE_GH_BIN", fake_gh)
+        .env("WAVECRATE_GITHUB_REPO", configured_repo)
         .output()
         .expect("run release wrapper");
 
     assert_success(&output);
     let stdout = stdout(&output);
-    assert!(stdout.contains("fake-gh [workflow] [run] [release-train-prepare.yml] [--ref] [main]"));
+    assert!(stdout.contains(
+        "fake-gh [workflow] [run] [release-train-prepare.yml] [--repo] [PORTALSURFER/wavecrate-fork] [--ref] [main]"
+    ));
     assert!(stdout.contains(&format!("[-f] [source_ref={source_sha}]")));
     assert!(!stdout.contains(&format!("[--ref] [{source_sha}]")));
+    assert!(stdout.contains("Workflow: https://github.com/PORTALSURFER/wavecrate-fork/actions/workflows/release-train-prepare.yml"));
+    assert!(stdout.contains("Run lookup: gh run list --repo PORTALSURFER/wavecrate-fork"));
 }
 
 #[test]
@@ -204,6 +210,7 @@ fn rc_dry_run_preserves_release_notes_input() {
     assert_success(&output);
     let stdout = stdout(&output);
     assert!(stdout.contains("Dry command: gh workflow run release-rc.yml"));
+    assert!(stdout.contains("--repo PORTALSURFER/wavecrate"));
     assert!(stdout.contains("-f release_notes=RC\\ notes\\ with\\ spaces"));
 }
 
@@ -301,6 +308,7 @@ fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
     let stdout = stdout(&output);
     assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
     assert!(stdout.contains("Dry command: gh workflow run release-stable.yml"));
+    assert!(stdout.contains("--repo PORTALSURFER/wavecrate"));
     assert!(stdout.contains("-f release_notes=Stable\\ notes\\ with\\ spaces"));
     assert!(stdout.contains("release-stable.yml"));
 }

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -1,0 +1,342 @@
+//! Checks for the repo-root release orchestration wrapper.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+#[test]
+fn prepare_minor_bump_derives_target_version_branch_and_runs_prep_helper() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+
+    let output = repo.run_release(&[
+        "prepare",
+        "--bump",
+        "minor",
+        "--source-ref",
+        "main",
+        "--dry-run",
+    ]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Resolved version: 19.2.0"));
+    assert!(stdout.contains("Release branch: release/19.2"));
+    assert!(stdout.contains("prepare-helper [--version] [19.2.0]"));
+    assert!(stdout.contains("[--dry-run]"));
+    assert!(stdout.contains("release-train-prepare.yml"));
+}
+
+#[test]
+fn prepare_major_bump_derives_next_major_train() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.4.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+
+    let output = repo.run_release(&["prepare", "--bump", "major", "--source-ref", "main"]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Resolved version: 20.0.0"));
+    assert!(stdout.contains("Release branch: release/20.0"));
+}
+
+#[test]
+fn prepare_rejects_invalid_bump_argument() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+
+    let output = repo.run_release(&["prepare", "--bump", "patch", "--dry-run"]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("bump must be major or minor"));
+}
+
+#[test]
+fn release_wrapper_rejects_dirty_worktree_before_release_actions() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+    repo.write("dirty.txt", "not committed\n");
+
+    let output = repo.run_release(&["prepare", "--bump", "minor", "--dry-run"]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("clean working tree"));
+}
+
+#[test]
+fn rc_rejects_wrong_branch_for_version() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.3",
+    ]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("branch must be release/19.2"));
+}
+
+#[test]
+fn rc_dispatch_requires_gh_cli_before_workflow_run() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+
+    let output = repo
+        .release_command(&[
+            "rc",
+            "--version",
+            "19.2.0",
+            "--rc-number",
+            "1",
+            "--branch",
+            "release/19.2",
+            "--dispatch",
+        ])
+        .env("WAVECRATE_RELEASE_GH_BIN", repo.path().join("missing-gh"))
+        .output()
+        .expect("run release wrapper");
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("gh CLI not found"));
+}
+
+#[test]
+fn rc_rejects_release_branch_with_mismatched_manifest_version() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.2",
+    ]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("Cargo.toml version 19.1.0"));
+}
+
+#[test]
+fn stable_requires_latest_rc_tag_to_match_release_branch_commit() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    let release_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    repo.create_release_branch("release/19.2");
+    repo.write("src/lib.rs", "// changed after release branch\n");
+    repo.commit_all("advance main");
+    repo.git(&["tag", "v19.2.0-rc.1"]);
+    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
+    assert_ne!(repo.git_stdout(&["rev-parse", "HEAD"]), release_sha);
+
+    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains("stable target is"));
+}
+
+#[test]
+fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+    repo.git(&["tag", "v19.2.0-rc.1"]);
+    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
+
+    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
+    assert!(stdout.contains("Dry command: gh workflow run release-stable.yml"));
+    assert!(stdout.contains("release-stable.yml"));
+}
+
+struct FixtureRepo {
+    _temp: TempDir,
+    worktree: PathBuf,
+    origin: PathBuf,
+}
+
+impl FixtureRepo {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create release wrapper fixture repo");
+        let worktree = temp.path().join("worktree");
+        let origin = temp.path().join("origin.git");
+        fs::create_dir_all(&worktree).expect("create fixture worktree");
+        assert_success(&run_git(
+            None,
+            &["init", "--bare", origin.to_str().expect("origin path")],
+        ));
+        let repo = Self {
+            _temp: temp,
+            worktree,
+            origin,
+        };
+        repo.git(&["init", "-b", "main"]);
+        repo.git(&["config", "user.email", "release-tests@example.invalid"]);
+        repo.git(&["config", "user.name", "Release Tests"]);
+        repo.git(&[
+            "remote",
+            "add",
+            "origin",
+            repo.origin.to_str().expect("origin path"),
+        ]);
+        repo
+    }
+
+    fn path(&self) -> &Path {
+        &self.worktree
+    }
+
+    fn write_workspace(&self, wavecrate_version: &str) {
+        self.write(
+            "Cargo.toml",
+            &format!(
+                r#"[workspace]
+members = ["."]
+resolver = "3"
+
+[package]
+name = "wavecrate"
+version = "{wavecrate_version}"
+edition = "2024"
+"#
+            ),
+        );
+        self.write("Cargo.lock", "# fixture lockfile\n");
+        self.write("src/lib.rs", "");
+        self.write(".github/workflows/release-train-prepare.yml", "");
+        self.write(".github/workflows/release-rc.yml", "");
+        self.write(".github/workflows/release-stable.yml", "");
+        self.write(
+            "scripts/internal/release/prepare_release_train.py",
+            "#!/usr/bin/env bash\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf '\\n'\n",
+        );
+        make_executable(
+            self.path()
+                .join("scripts/internal/release/prepare_release_train.py"),
+        );
+    }
+
+    fn create_release_branch(&self, branch: &str) {
+        self.git(&["switch", "-c", branch]);
+        self.push_branch(branch);
+        self.git(&["switch", "main"]);
+    }
+
+    fn push_branch(&self, branch: &str) {
+        self.git(&["push", "-u", "origin", branch]);
+    }
+
+    fn commit_all(&self, message: &str) {
+        self.git(&["add", "."]);
+        self.git(&["commit", "-m", message]);
+    }
+
+    fn run_release(&self, args: &[&str]) -> Output {
+        self.release_command(args)
+            .output()
+            .expect("run release wrapper")
+    }
+
+    fn release_command(&self, args: &[&str]) -> Command {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/release.sh");
+        let mut command = Command::new("bash");
+        command.arg(script).args(args).current_dir(self.path());
+        command
+    }
+
+    fn write(&self, relative: &str, contents: &str) {
+        let path = self.path().join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn git(&self, args: &[&str]) {
+        let output = run_git(Some(self.path()), args);
+        assert_success(&output);
+    }
+
+    fn git_stdout(&self, args: &[&str]) -> String {
+        let output = run_git(Some(self.path()), args);
+        assert_success(&output);
+        stdout(&output).trim().to_string()
+    }
+}
+
+fn run_git(cwd: Option<&Path>, args: &[&str]) -> Output {
+    let mut command = Command::new("git");
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    command.output().expect("run git")
+}
+
+#[cfg(unix)]
+fn make_executable(path: PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = fs::metadata(&path).expect("helper metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod helper");
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: PathBuf) {
+    // The Bash release wrapper and its fixture helper are supported on macOS/Linux.
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "command should have failed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -1,4 +1,5 @@
 //! Checks for the repo-root release orchestration wrapper.
+#![cfg(unix)]
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -143,6 +143,31 @@ fn release_wrapper_rejects_dirty_worktree_before_release_actions() {
 }
 
 #[test]
+fn release_wrapper_rejects_github_origin_that_differs_from_target_repo() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.0");
+    repo.commit_all("seed workspace");
+    repo.push_branch("main");
+    repo.git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://github.com/PORTALSURFER/wavecrate.git",
+    ]);
+
+    let output = repo
+        .release_command(&["prepare", "--bump", "minor", "--source-ref", "main"])
+        .env("WAVECRATE_GITHUB_REPO", "PORTALSURFER/wavecrate-fork")
+        .output()
+        .expect("run release wrapper");
+
+    assert_failure(&output);
+    let stderr = stderr(&output);
+    assert!(stderr.contains("origin remote resolves release refs from portalsurfer/wavecrate"));
+    assert!(stderr.contains("workflows target portalsurfer/wavecrate-fork"));
+}
+
+#[test]
 fn rc_rejects_wrong_branch_for_version() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -404,6 +404,31 @@ fn stable_prunes_stale_local_rc_tags_before_selecting_promoted_rc() {
 }
 
 #[test]
+fn stable_rejects_existing_tag_that_points_at_different_commit() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    let release_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    repo.create_release_branch("release/19.2");
+    repo.git(&["tag", "v19.2.0-rc.1"]);
+    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
+    repo.write("src/lib.rs", "// later commit with reused stable tag\n");
+    repo.commit_all("advance main after release branch");
+    let tag_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
+    repo.git(&["tag", "v19.2.0"]);
+    repo.git(&["push", "origin", "v19.2.0"]);
+    assert_ne!(release_sha, tag_sha);
+
+    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
+
+    assert_failure(&output);
+    assert!(stderr(&output).contains(&format!(
+        "stable tag v19.2.0 already points at {tag_sha}, not {release_sha}"
+    )));
+    assert!(!stdout(&output).contains("Dry command: gh workflow run"));
+}
+
+#[test]
 fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -250,6 +250,37 @@ fn rc_rejects_local_only_release_branch_before_printing_workflow_command() {
 }
 
 #[test]
+fn rc_fetches_release_branch_even_when_origin_refspec_only_tracks_main() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+    repo.git(&["config", "--unset-all", "remote.origin.fetch"]);
+    repo.git(&[
+        "config",
+        "--add",
+        "remote.origin.fetch",
+        "+refs/heads/main:refs/remotes/origin/main",
+    ]);
+    repo.git(&["update-ref", "-d", "refs/remotes/origin/release/19.2"]);
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.2",
+    ]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("RC tag: v19.2.0-rc.1"));
+    assert!(stdout.contains("Dry command: gh workflow run release-rc.yml"));
+}
+
+#[test]
 fn rc_rejects_existing_tag_that_points_at_different_commit() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -183,6 +183,31 @@ fn rc_dispatch_requires_gh_cli_before_workflow_run() {
 }
 
 #[test]
+fn rc_dry_run_preserves_release_notes_input() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.2.0");
+    repo.commit_all("seed workspace");
+    repo.create_release_branch("release/19.2");
+
+    let output = repo.run_release(&[
+        "rc",
+        "--version",
+        "19.2.0",
+        "--rc-number",
+        "1",
+        "--branch",
+        "release/19.2",
+        "--release-notes",
+        "RC notes with spaces",
+    ]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Dry command: gh workflow run release-rc.yml"));
+    assert!(stdout.contains("-f release_notes=RC\\ notes\\ with\\ spaces"));
+}
+
+#[test]
 fn rc_rejects_release_branch_with_mismatched_manifest_version() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
@@ -231,12 +256,21 @@ fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
     repo.git(&["tag", "v19.2.0-rc.1"]);
     repo.git(&["push", "origin", "v19.2.0-rc.1"]);
 
-    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
+    let output = repo.run_release(&[
+        "stable",
+        "--version",
+        "19.2.0",
+        "--branch",
+        "release/19.2",
+        "--release-notes",
+        "Stable notes with spaces",
+    ]);
 
     assert_success(&output);
     let stdout = stdout(&output);
     assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
     assert!(stdout.contains("Dry command: gh workflow run release-stable.yml"));
+    assert!(stdout.contains("-f release_notes=Stable\\ notes\\ with\\ spaces"));
     assert!(stdout.contains("release-stable.yml"));
 }
 

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -77,6 +77,7 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     assert!(stdout.contains("Resolved version: 20.6.0"));
     assert!(stdout.contains("Release branch: release/20.6"));
     assert!(stdout.contains("prepare-helper [--version] [20.6.0]"));
+    assert!(stdout.contains("[cwd-version=20.5.0]"));
 }
 
 #[test]
@@ -372,7 +373,7 @@ edition = "2024"
         self.write(".github/workflows/release-stable.yml", "");
         self.write(
             "scripts/internal/release/prepare_release_train.py",
-            "#!/usr/bin/env bash\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf '\\n'\n",
+            "#!/usr/bin/env bash\nversion=\"$(awk '/^\\[package\\]$/ { in_package = 1; next } in_package && /^\\[/ { exit } in_package && /^[[:space:]]*version[[:space:]]*=/ { gsub(/\\\"/, \"\", $3); print $3; exit }' Cargo.toml)\"\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf ' [cwd-version=%s]\\n' \"$version\"\n",
         );
         make_executable(
             self.path()


### PR DESCRIPTION
## Scope

- Add `scripts/release.sh` as a repo-root Bash release orchestrator for Wavecrate release trains.
- Support `prepare --bump major|minor`, deriving the target stable version and `release/X.Y` branch from the current package version.
- Delegate release-train preparation to `scripts/internal/release/prepare_release_train.py` and RC/stable publication to the existing GitHub Actions workflows.
- Add local safety checks for clean repo root, fetched/pruned refs, branch/version alignment, release-branch manifest version, `gh` availability for explicit dispatch, and stable RC tag alignment.
- Document the operator workflow in `docs/ENV_VARS.md`, `docs/TEST.md`, and `scripts/README.md`; register the script in the public command inventory and script guardrail contract.

## Definition of Done

- `scripts/release.sh prepare --bump minor --source-ref main --dry-run` resolves `19.2.0`, `release/19.2`, and the target `main` SHA without publishing.
- Major/minor bump derivation is covered by tests.
- Invalid bump args, dirty worktrees, wrong branch/version pairs, missing `gh` for dispatch, mismatched release branch manifests, and stable RC tag mismatches fail clearly.
- RC/stable dispatch remains explicit via `--dispatch`; dry RC/stable commands print the exact `gh workflow run ...` command and follow-up run-list command.
- Existing release train, release contract, and workflow helper tests continue to pass.

## Validation Commands

- `bash -n scripts/release.sh`
- `cargo test --test release_orchestration`
- `cargo test --test release_train_prepare --test release_workflow_helpers --test release_contract`
- `bash scripts/check.sh script-guardrails`
- `cargo test --test manual_release_matching`
- `cargo check --release`
- `scripts/release.sh prepare --bump minor --source-ref main --dry-run`
- `git diff --check`

## Known Limitations

- No patch bump support; this intentionally matches OPT-1045 scope.
- `scripts/release.sh` is a Bash/macOS/Linux operator entrypoint. There is no PowerShell release wrapper in this PR.
- Actual RC/stable publication still requires explicit `--dispatch` and an authenticated `gh` CLI with workflow permission.
- Agent request preflight currently fails on an existing native-app boundary violation in `src/native_app/audio/playback/progress.rs`, unrelated to this release tooling change.

## Review Gate

User review is required before merge.

Refs OPT-1045.
