### PR TITLE
Use Radiant anchored popover primitive

### DIFF
--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -72,7 +72,7 @@ pub(in crate::native_app) fn overlay(
     menu: &BrowserContextMenu,
     harvest_active: bool,
 ) -> ui::View<GuiMessage> {
-    ui::message_context_menu_overlay_auto_width(
+    ui::anchored_message_menu_overlay_auto_width(
         menu.anchor,
         menu.title.clone(),
         context_menu_commands(menu, harvest_active),

--- a/src/native_app/app_chrome/settings/window/dropdowns.rs
+++ b/src/native_app/app_chrome/settings/window/dropdowns.rs
@@ -46,13 +46,22 @@ pub(super) fn audio_settings_dropdown_overlay(
     let Some((row_index, options)) = audio_settings_open_dropdown_options(snapshot) else {
         return ui::empty().fill_width();
     };
-    ui::dropdown_menu_overlay_below_stacked_labeled_control(
+    let cursor = audio_settings_dropdown_cursor(snapshot, row_index);
+    let trigger_y =
+        AUDIO_SETTINGS_PANEL_PADDING + cursor.offset() + ui::labeled_control_control_offset();
+    let anchor = ui::AnchoredPopoverAnchor::trigger(
         SETTINGS_CONTENT_X,
-        AUDIO_SETTINGS_PANEL_PADDING,
-        audio_settings_dropdown_cursor(snapshot, row_index),
-        AUDIO_SETTINGS_DROPDOWN_GAP,
-        Some(SETTINGS_CONTENT_WIDTH),
-        options,
+        trigger_y,
+        SETTINGS_CONTENT_WIDTH,
+        ui::dropdown_trigger_height(),
+    );
+    let size = ui::Vector2::new(
+        SETTINGS_CONTENT_WIDTH,
+        ui::dropdown_menu_height(options.len()),
+    );
+    ui::anchored_popover_from_parts(
+        ui::AnchoredPopoverParts::below(ui::dropdown_menu(options), anchor, size)
+            .gap(AUDIO_SETTINGS_DROPDOWN_GAP),
     )
 }
 


### PR DESCRIPTION
## Scope

- Update Wavecrate to the Radiant anchored popover/menu primitive merged via PORTALSURFER/radiant#1389.
- Migrate the browser context-menu overlay to `anchored_message_menu_overlay_auto_width`.
- Migrate the audio settings dropdown overlay to a generic `AnchoredPopoverParts` + `dropdown_menu` composition.
- Update the Radiant submodule pointer to merged Radiant `main` at `86f38c90`.

## Definition of Done

- Radiant exposes one anchored popover/menu primitive suitable for dropdowns and context menus.
- At least one real Wavecrate context-menu path and one real Wavecrate dropdown path use the shared primitive.
- Existing context-menu labels, shortcut hints, danger styling, row hit surfaces, flip behavior, and outside-click dismissal are preserved by focused tests.
- Public Radiant docs/examples show the preferred anchored menu path.

## Validation Commands

- `CARGO_INCREMENTAL=0 cargo test --manifest-path vendor/radiant/Cargo.toml dropdown -j1`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path vendor/radiant/Cargo.toml menu -j1`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path vendor/radiant/Cargo.toml floating -j1`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path vendor/radiant/Cargo.toml popover -j1`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate audio_settings_dropdown -j1`
- `CARGO_INCREMENTAL=0 cargo test -p wavecrate browser_context_menu -j1` (50 passed, 1 failed; see known limitations)
- `git diff --check`
- `git -C vendor/radiant diff --check`

## Known Limitations

- `CARGO_INCREMENTAL=0 cargo test -p wavecrate browser_context_menu -j1` fails deterministically in `native_app::tests::browser_context_menu::sample_context_menu_open_harvest_destination_requires_primary_source`: actual status is `Opening .../_Harvests/...`, expected `Set a Primary source before using a harvest destination`. The failure is outside the overlay call-site diff; the other 50 browser-context tests pass.
- Manual Wavecrate smoke for bottom-edge context menus, sidebar/settings dropdowns, keyboard dismissal, and outside-click dismissal has not been run in the desktop app in this pass.

## Review

User has signed off for merge.
