### PR TITLE
OPT-1053 Preserve active waveform cache successors

### DIFF
--- a/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     sync::{Arc, Condvar, LazyLock, Mutex},
     thread,
@@ -7,10 +7,10 @@ use std::{
 };
 
 use super::{
-    BACKGROUND_STORE_SHUTDOWN_WAIT,
-    identity::{CacheIdentity, cache_path_for_identity},
+    identity::{cache_path_for_identity, CacheIdentity},
     invalidation::current_path_generation,
     write::store_cached_waveform_file_now,
+    BACKGROUND_STORE_SHUTDOWN_WAIT,
 };
 use crate::native_app::waveform::audio_file::WaveformFile;
 use diagnostics::{log_slow_cache_shutdown_flush, log_store_completion};
@@ -40,13 +40,22 @@ pub(in crate::native_app::waveform::audio_file) fn store_cached_waveform_file_in
     let cache_path = job.cache_path.clone();
     match BACKGROUND_STORE_QUEUE.enqueue(job) {
         StoreEnqueueOutcome::Enqueued => {}
-        StoreEnqueueOutcome::Coalesced => {
+        StoreEnqueueOutcome::ReplacedQueued => {
             tracing::debug!(
                 target: "wavecrate::debug::sample_cache",
-                event = "browser.sample_cache.store_coalesced",
+                event = "browser.sample_cache.store_replaced_queued",
                 path = %path.display(),
                 cache_path = %cache_path.display(),
-                "Coalesced duplicate waveform cache persistence"
+                "Replaced queued waveform cache persistence"
+            );
+        }
+        StoreEnqueueOutcome::DeferredForActive => {
+            tracing::debug!(
+                target: "wavecrate::debug::sample_cache",
+                event = "browser.sample_cache.store_deferred_for_active",
+                path = %path.display(),
+                cache_path = %cache_path.display(),
+                "Deferred waveform cache persistence until active write finishes"
             );
         }
         StoreEnqueueOutcome::QueueFull => {
@@ -79,7 +88,8 @@ pub(in crate::native_app) fn flush_background_waveform_cache_stores_for_shutdown
 #[cfg_attr(test, allow(dead_code))]
 pub(super) enum StoreEnqueueOutcome {
     Enqueued,
-    Coalesced,
+    ReplacedQueued,
+    DeferredForActive,
     QueueFull,
     WorkerUnavailable,
 }
@@ -137,10 +147,11 @@ impl BackgroundStoreQueue {
         }
         if state.queued_paths.contains(&job.cache_path) {
             replace_queued_job(&mut state.queued, job);
-            return StoreEnqueueOutcome::Coalesced;
+            return StoreEnqueueOutcome::ReplacedQueued;
         }
         if state.active_paths.contains(&job.cache_path) {
-            return StoreEnqueueOutcome::Coalesced;
+            state.active_successors.insert(job.cache_path.clone(), job);
+            return StoreEnqueueOutcome::DeferredForActive;
         }
         if state.queued.len() >= self.capacity {
             return StoreEnqueueOutcome::QueueFull;
@@ -179,6 +190,16 @@ impl BackgroundStoreQueue {
     pub(super) fn finish_job(&self, cache_path: &Path) {
         if let Ok(mut state) = self.state.lock() {
             state.active_paths.remove(cache_path);
+            if let Some(successor) = state.active_successors.remove(cache_path) {
+                let successor_cache_path = successor.cache_path.clone();
+                if state.queued_paths.contains(&successor_cache_path) {
+                    replace_queued_job(&mut state.queued, successor);
+                } else {
+                    state.queued_paths.insert(successor_cache_path);
+                    state.queued.push_front(successor);
+                }
+                self.available.notify_one();
+            }
             if state.is_drained() {
                 self.drained.notify_all();
             }
@@ -209,6 +230,7 @@ impl BackgroundStoreQueue {
                 event = "browser.sample_cache.shutdown_flush_timeout",
                 queued = state.queued.len(),
                 active = state.active_paths.len(),
+                active_successors = state.active_successors.len(),
                 elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0,
                 "Timed out waiting for waveform cache persistence during shutdown"
             );
@@ -229,7 +251,7 @@ impl BackgroundStoreQueue {
     #[cfg(test)]
     pub(super) fn pending_for_test(&self) -> usize {
         let state = self.state.lock().expect("waveform cache queue lock");
-        state.queued.len() + state.active_paths.len()
+        state.queued.len() + state.active_paths.len() + state.active_successors.len()
     }
 }
 
@@ -239,11 +261,12 @@ struct StoreQueueState {
     queued: VecDeque<CachedWaveformStoreJob>,
     queued_paths: HashSet<PathBuf>,
     active_paths: HashSet<PathBuf>,
+    active_successors: HashMap<PathBuf, CachedWaveformStoreJob>,
 }
 
 impl StoreQueueState {
     fn is_drained(&self) -> bool {
-        self.queued.is_empty() && self.active_paths.is_empty()
+        self.queued.is_empty() && self.active_paths.is_empty() && self.active_successors.is_empty()
     }
 }
 

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/store_queue_behavior.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/store_queue_behavior.rs
@@ -28,12 +28,76 @@ fn background_store_queue_coalesces_duplicate_cache_paths() {
     );
     assert_eq!(
         queue.enqueue(CachedWaveformStoreJob::new(&replacement).expect("replacement job")),
-        StoreEnqueueOutcome::Coalesced
+        StoreEnqueueOutcome::ReplacedQueued
     );
 
     let queued = queue.pop_next_for_test().expect("queued job");
     assert_eq!(queued.file.sample_rate, 96_000);
     queue.finish_job(&queued.cache_path);
+    assert_eq!(queue.pending_for_test(), 0);
+}
+
+#[test]
+fn background_store_queue_retains_latest_successor_for_active_cache_path() {
+    let _guard = waveform_cache_test_guard();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("active-successor.wav");
+    fs::write(&path, [1_u8, 2, 3, 4]).expect("write sample");
+    let first = waveform_file_from_mono_samples(
+        path.clone(),
+        Arc::from([1_u8, 2, 3, 4]),
+        48_000,
+        1,
+        vec![0.0, 0.25],
+    );
+    let replacement = waveform_file_from_mono_samples(
+        path.clone(),
+        Arc::from([1_u8, 2, 3, 4]),
+        96_000,
+        1,
+        vec![0.0, 0.5],
+    );
+    let latest_replacement = waveform_file_from_mono_samples(
+        path.clone(),
+        Arc::from([1_u8, 2, 3, 4]),
+        192_000,
+        1,
+        vec![0.0, 0.75],
+    );
+    let queue = test_store_queue(4);
+
+    assert_eq!(
+        queue.enqueue(CachedWaveformStoreJob::new(&first).expect("first job")),
+        StoreEnqueueOutcome::Enqueued
+    );
+    let active = queue.pop_next_for_test().expect("active job");
+    invalidate_persisted_waveform_cache_path(&path);
+    assert_eq!(
+        queue.enqueue(CachedWaveformStoreJob::new(&replacement).expect("replacement job")),
+        StoreEnqueueOutcome::DeferredForActive
+    );
+    assert_eq!(
+        queue.enqueue(CachedWaveformStoreJob::new(&latest_replacement).expect("latest job")),
+        StoreEnqueueOutcome::DeferredForActive
+    );
+    assert_eq!(
+        queue.pending_for_test(),
+        2,
+        "active writes retain only the latest successor per cache path"
+    );
+    assert_eq!(
+        store_cached_waveform_file_now(active.clone()),
+        StoreWriteOutcome::StaleInput(Default::default())
+    );
+
+    queue.finish_job(&active.cache_path);
+    let successor = queue.pop_next_for_test().expect("successor job");
+    assert_eq!(successor.file.sample_rate, 192_000);
+    assert!(matches!(
+        store_cached_waveform_file_now(successor.clone()),
+        StoreWriteOutcome::Completed(_)
+    ));
+    queue.finish_job(&successor.cache_path);
     assert_eq!(queue.pending_for_test(), 0);
 }
 


### PR DESCRIPTION
## Scope

- Preserve the latest waveform-cache store job submitted for a cache path that already has an active write.
- Split queue diagnostics/outcomes so queued replacement and active-write deferral are distinguishable.
- Add focused regression coverage for stale active writes followed by retained fresh successors.

## Definition of Done

- Fresh cache writes submitted while an older write for the same cache path is active are retained as bounded latest successors.
- A stale active write can abort without losing the newest retained replacement.
- Duplicate queued writes still coalesce to the latest queued job.
- Queue drain accounting includes active successors.

## Validation commands

- `cargo test -p wavecrate store_queue_behavior -- --test-threads=1`
- `cargo test -p wavecrate waveform_cache -- --test-threads=1`
- `bash scripts/ci.sh smoke`

## Known limitations

None for this change. Note: `bash scripts/agent.sh request` reports a pre-existing native-app boundary guardrail violation in `src/native_app/audio/playback/progress.rs`; the requested smoke lane passed.

## Review status

Status: waiting for user review. User review is required before merge.