### PR TITLE
OPT-1055: Coalesce high-volume runtime progress streams

### DIFF
--- a/src/native_app/audio/normalization_actions.rs
+++ b/src/native_app/audio/normalization_actions.rs
@@ -202,7 +202,7 @@ impl NativeAppState {
         context
             .business()
             .priority("gui-normalize-selected-samples", priority)
-            .stream(
+            .stream_latest(
                 move |_context, events| run_normalization_worker(request, events),
                 GuiMessage::NormalizationProgress,
                 GuiMessage::NormalizationFinished,

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -78,7 +78,7 @@ impl NativeAppState {
             .blocking_io("gui-active-folder-cache-warm-plan")
             .cancellable()
             .latest(&mut self.waveform.cache.active_folder_warm_plan_task)
-            .stream(
+            .stream_latest(
                 move |worker_context: BusinessWorkContext,
                       events: BusinessEventSink<ActiveFolderCacheWarmPlanProgress>| {
                     let progress_events = events.clone();
@@ -245,7 +245,7 @@ impl NativeAppState {
             return;
         };
         self.waveform.cache.active_folder_warm_key = Some(key);
-        self.waveform.cache.active_folder_warm_cancel = Some(warm.stream(
+        self.waveform.cache.active_folder_warm_cancel = Some(warm.stream_latest(
             move |worker_context: BusinessWorkContext,
                   events: BusinessEventSink<ActiveFolderCacheWarmProgress>| {
                 let progress_events = events.clone();

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -245,7 +245,10 @@ impl NativeAppState {
             return;
         };
         self.waveform.cache.active_folder_warm_key = Some(key);
-        self.waveform.cache.active_folder_warm_cancel = Some(warm.stream_latest(
+        // Keep this stream fully ordered: `cached` progress events mark each
+        // hydrated file playback-ready, including when a later cancelled result
+        // is intentionally ignored after playback starts.
+        self.waveform.cache.active_folder_warm_cancel = Some(warm.stream(
             move |worker_context: BusinessWorkContext,
                   events: BusinessEventSink<ActiveFolderCacheWarmProgress>| {
                 let progress_events = events.clone();

--- a/src/native_app/audio/sample_load_actions/plan.rs
+++ b/src/native_app/audio/sample_load_actions/plan.rs
@@ -201,6 +201,8 @@ impl NativeAppState {
             .priority("gui-sample-load", request.priority())
             .cancellable()
             .latest_for_resource(&mut self.background.sample_load_tasks, key);
+        // Keep this stream fully ordered: progress and playback-ready are
+        // distinct state transitions.
         self.background.sample_load_cancel = Some(load.stream(
             move |worker_context, events| {
                 SampleLoadWorker::new(request).run(worker_context, events)

--- a/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
+++ b/src/native_app/sample_library/drag_drop_actions/folder_moves.rs
@@ -121,7 +121,7 @@ impl NativeAppState {
         context
             .business()
             .background("gui-folder-browser-move")
-            .stream(
+            .stream_latest(
                 move |_context, events| {
                     execute_folder_move_request_with_progress(request, task_id, move |progress| {
                         events.emit(progress)
@@ -209,7 +209,7 @@ impl NativeAppState {
         context
             .business()
             .background("gui-file-move-conflict")
-            .stream(
+            .stream_latest(
                 move |_context, events| {
                     execute_file_move_conflict_request_with_progress(
                         batch,

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -37,6 +37,8 @@ impl NativeAppState {
             started_at,
             None,
         );
+        // Keep this stream fully ordered: discovery batches must not be
+        // replaced by progress.
         context.business().background("gui-folder-scan").stream(
             move |_context, events| run_folder_scan_worker(request, events),
             folder_scan_worker_event_message,

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -345,6 +345,52 @@ fn active_folder_cache_warm_tracks_worker_progress() {
 }
 
 #[test]
+fn active_folder_cache_warm_uses_ordered_stream_for_cache_ready_progress() {
+    let config_base = tempfile::tempdir().expect("config base");
+    let (_config_lock, _base_guard) =
+        set_waveform_test_config_base(config_base.path().to_path_buf());
+    let source_root = tempfile::tempdir().expect("source root");
+    let first = source_root.path().join("first.wav");
+    let second = source_root.path().join("second.wav");
+    write_test_wav_i16(&first, &[0, 1024, -2048, 4096]);
+    write_test_wav_i16(&second, &[0, 512, -512, 1024]);
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let mut context = ui::UiUpdateContext::default();
+    state.schedule_active_folder_cache_warm(&mut context);
+    finish_active_folder_cache_warm_plan(
+        &mut state,
+        &mut context,
+        source_root.path().display().to_string(),
+        Vec::new(),
+        vec![first, second],
+    );
+
+    let warm_ticket = state
+        .waveform
+        .cache
+        .active_folder_warm_delay_task
+        .active()
+        .expect("source warm delay");
+    let mut start_context = ui::UiUpdateContext::default();
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::ActiveFolderCacheWarmReady(warm_ticket),
+        &mut start_context,
+    );
+    let command = start_context.into_command();
+
+    assert_eq!(
+        active_folder_cache_warm_stream_kind(&command),
+        Some("ordered"),
+        "cache-ready progress events must not be coalesced away"
+    );
+}
+
+#[test]
 fn active_folder_cache_warm_progress_updates_statusbar_realtime() {
     let config_base = tempfile::tempdir().expect("config base");
     let (_config_lock, _base_guard) =
@@ -1844,4 +1890,23 @@ fn normal_sample_load_persists_bright_cache_indicator_before_restart() {
             .contains(&sample_path),
         "freshly loaded cache indicator should survive immediate restart"
     );
+}
+
+fn active_folder_cache_warm_stream_kind(
+    command: &radiant::runtime::Command<crate::native_app::test_support::state::GuiMessage>,
+) -> Option<&'static str> {
+    use radiant::runtime::Command;
+
+    match command {
+        Command::PerformStream { name, .. } if *name == "gui-active-folder-cache-warm" => {
+            Some("ordered")
+        }
+        Command::PerformStreamLatest { name, .. } if *name == "gui-active-folder-cache-warm" => {
+            Some("latest")
+        }
+        Command::Batch(commands) => commands
+            .iter()
+            .find_map(active_folder_cache_warm_stream_kind),
+        _ => None,
+    }
 }


### PR DESCRIPTION
## Scope
- Pull in Radiant runtime latest-stream coalescing from PORTALSURFER/radiant#1392.
- Migrate high-volume Wavecrate progress-only worker streams to stream_latest:
  - normalization progress
  - active-folder cache warm planning/progress
  - file move and conflict progress
- Leave mixed streams fully ordered with comments where intermediate events are not replaceable:
  - sample load progress plus playback-ready
  - folder scan progress plus discovery batches

## Definition of Done
- Radiant exposes an explicit latest-stream API for high-frequency worker progress without unbounded normal-message growth.
- Runtime queue diagnostics expose pending depth, pending stream slots, coalesced events, stale stream events, and dropped stream events.
- Wavecrate's highest-volume progress-only producers use the latest-stream policy.
- Non-idempotent/mixed streams retain ordered delivery semantics.

## Validation commands
- bash scripts/agent.sh request *(fails on existing unrelated native_app boundary violation in src/native_app/audio/playback/progress.rs)*
- cargo test --manifest-path vendor/radiant/Cargo.toml application::runtime::queue -- --nocapture
- cargo test --manifest-path vendor/radiant/Cargo.toml stream_latest -- --nocapture
- cargo test --manifest-path vendor/radiant/Cargo.toml runtime -- --nocapture *(fails 11 unrelated generic runtime scroll/pointer expectation tests; new queue/business tests passed in that run)*
- cargo test -p wavecrate active_folder_cache_warm_progress_updates_statusbar_realtime -- --nocapture
- cargo test -p wavecrate normalization_progress_does_not_advance_activity_tick_on_frame -- --nocapture
- cargo test -p wavecrate status_bar_view_model_reports_file_move_progress -- --nocapture
- git diff --check

## Known limitations
- The broader Radiant runtime filter currently includes unrelated generic runtime scroll/pointer expectation failures.
- Repo request preflight still reports the pre-existing native_app boundary violation in src/native_app/audio/playback/progress.rs.
- Requires Radiant PR #1392 before merge so the submodule commit is reachable from Radiant main.

User review is required before merge.