### PR TITLE
OPT-1052: Remove app_chrome import from playback progress

### DIFF
--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -1,7 +1,12 @@
 use crate::native_app::app::{GuiMessage, NativeAppState, default_gui_shortcuts};
 use crate::native_app::app_chrome::layout;
+use crate::native_app::app_chrome::library_browser::sample_browser_view;
 use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
-use radiant::prelude as ui;
+use crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID;
+use radiant::{
+    prelude as ui,
+    runtime::{PaintPrimitive, TransientOverlayContext},
+};
 
 const APP_TRANSIENT_OVERLAY_KEY: u64 = 0x6170_705f_6f76_726c;
 const APP_FRAME_CLOCK_FPS: u32 = 60;
@@ -33,5 +38,40 @@ fn app_transient_overlay() -> ui::TransientOverlay<NativeAppState> {
     ui::TransientOverlay::new(APP_TRANSIENT_OVERLAY_KEY)
         .paint_only()
         .when(|state: &mut NativeAppState| state.should_paint_app_transient_overlay())
-        .paint(NativeAppState::paint_app_transient_overlay)
+        .paint(paint_app_transient_overlay)
+}
+
+fn paint_app_transient_overlay(
+    state: &mut NativeAppState,
+    context: TransientOverlayContext<'_>,
+    primitives: &mut Vec<PaintPrimitive>,
+) {
+    state.paint_waveform_transient_overlay(context, primitives);
+    paint_starmap_active_audition_overlay(state, context, primitives);
+}
+
+fn paint_starmap_active_audition_overlay(
+    state: &mut NativeAppState,
+    context: TransientOverlayContext<'_>,
+    primitives: &mut Vec<PaintPrimitive>,
+) {
+    let Some(active_file_id) = state.active_starmap_audition_file_id() else {
+        return;
+    };
+    let Some(bounds) = context
+        .plan
+        .first_widget_rect_by_priority([SAMPLE_BROWSER_MAP_ID])
+    else {
+        return;
+    };
+    let Some(items) = state.library.folder_browser.cached_starmap_projection() else {
+        return;
+    };
+    sample_browser_view::paint_active_starmap_audition_overlay(
+        primitives,
+        bounds,
+        &items,
+        state.ui.chrome.starmap_viewport,
+        active_file_id,
+    );
 }

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -8,11 +8,9 @@ use crate::native_app::app::{
     NativeAppState, SamplePlaybackSession, SamplePlaybackSessionState, emit_gui_action,
     sample_path_label,
 };
-use crate::native_app::app_chrome::library_browser::sample_browser_view;
 use crate::native_app::starmap_audition_telemetry::{
     self as starmap_telemetry, StarmapAuditionCounter, StarmapAuditionDuration,
 };
-use crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID;
 use crate::native_app::waveform::{WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID};
 use radiant::{
     gui::types::{Point, Rect, Rgba8},
@@ -435,7 +433,6 @@ impl NativeAppState {
         push_playback_cursor(primitives, bounds, visible_ratio);
     }
 
-    #[cfg(test)]
     pub(in crate::native_app) fn paint_waveform_transient_overlay(
         &mut self,
         context: TransientOverlayContext<'_>,
@@ -446,19 +443,6 @@ impl NativeAppState {
         }
         self.paint_loading_overlay(context, primitives);
         self.paint_playback_overlay(context, primitives);
-    }
-
-    pub(in crate::native_app) fn paint_app_transient_overlay(
-        &mut self,
-        context: TransientOverlayContext<'_>,
-        primitives: &mut Vec<PaintPrimitive>,
-    ) {
-        if self.chrome_overlay_suppresses_waveform_transient_overlay() {
-            return;
-        }
-        self.paint_loading_overlay(context, primitives);
-        self.paint_playback_overlay(context, primitives);
-        self.paint_starmap_active_audition_overlay(context, primitives);
     }
 
     pub(in crate::native_app) fn should_paint_app_transient_overlay(&self) -> bool {
@@ -525,33 +509,7 @@ impl NativeAppState {
         );
     }
 
-    fn paint_starmap_active_audition_overlay(
-        &mut self,
-        context: TransientOverlayContext<'_>,
-        primitives: &mut Vec<PaintPrimitive>,
-    ) {
-        let Some(active_file_id) = self.active_starmap_audition_file_id() else {
-            return;
-        };
-        let Some(bounds) = context
-            .plan
-            .first_widget_rect_by_priority([SAMPLE_BROWSER_MAP_ID])
-        else {
-            return;
-        };
-        let Some(items) = self.library.folder_browser.cached_starmap_projection() else {
-            return;
-        };
-        sample_browser_view::paint_active_starmap_audition_overlay(
-            primitives,
-            bounds,
-            &items,
-            self.ui.chrome.starmap_viewport,
-            active_file_id,
-        );
-    }
-
-    fn active_starmap_audition_file_id(&self) -> Option<&str> {
+    pub(in crate::native_app) fn active_starmap_audition_file_id(&self) -> Option<&str> {
         self.ui
             .chrome
             .starmap_audition_drag

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -397,6 +397,45 @@ fn scene_installs_playback_cursor_transient_overlay() {
 }
 
 #[test]
+fn scene_installs_starmap_active_audition_transient_overlay() {
+    let (mut state, _source_root, selected_file) = native_app_state_with_temp_sample("kick.wav");
+    state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+        &mut state,
+    );
+    state.ui.chrome.starmap_audition_queue.active_file_id = Some(selected_file);
+    let theme = radiant::theme::ThemeTokens::default();
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(apply_gui_message_for_presentation_test)
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+    let frame = runtime.frame(&theme);
+    let mut primitives = Vec::new();
+
+    runtime.bridge_mut().paint_transient_overlay(
+        TransientOverlayContext::new(
+            &frame.paint_plan,
+            Vector2::new(900.0, 620.0),
+            Duration::ZERO,
+        ),
+        &mut primitives,
+    );
+
+    assert!(
+        primitives.iter().any(|primitive| matches!(
+            primitive,
+            radiant::runtime::PaintPrimitive::FillPolygon(fill)
+                if fill.widget_id == crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID
+                    && fill.color.a == 255
+                    && fill.points.len() == 4
+        )),
+        "root scene should paint the active Starmap audition overlay from app chrome"
+    );
+}
+
+#[test]
 fn shortcut_help_modal_suppresses_waveform_transient_overlay() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -761,6 +761,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "audio file worker",
         ),
         (
+            "src/native_app/sample_identity_diagnostics.rs",
+            "explicit opt-in sample identity diagnostics boundary",
+        ),
+        (
             "src/native_app/sample_library/drag_drop_actions/external/clipboard_clip.rs",
             "waveform clipboard clip staging worker",
         ),


### PR DESCRIPTION
## Scope

- Remove the app_chrome dependency from src/native_app/audio/playback/progress.rs.
- Move app-level transient Starmap audition overlay composition into app_chrome::scene while keeping waveform/loading progress painting in audio playback progress.
- Add focused scene coverage for the active Starmap audition transient overlay.
- Keep validation guardrails moving by updating the Radiant runtime-work test layout and allowing the explicitly opt-in sample identity diagnostics boundary in the Wavecrate non-blocking guardrail.

## Definition of Done

- src/native_app/audio/playback/progress.rs no longer imports crate::native_app::app_chrome.
- Native-app boundary guardrail passes.
- Production rg check for crate::native_app::app_chrome in native-app domain roots has no matches.
- Focused overlay and runtime-progress tests cover the moved playback/Starmap transient overlay path.
- User review is required before merge.

## Validation commands

- bash scripts/internal/check/check_native_app_boundary.sh
- rg -n "crate::native_app::app_chrome" src/native_app/audio src/native_app/metadata src/native_app/sample_library src/native_app/waveform src/native_app/workflows --glob '*.rs'  # no matches
- cargo test -p wavecrate frame_overlay -- --test-threads=1
- cargo test -p wavecrate runtime_progress -- --test-threads=1
- cargo test -p wavecrate playback_progress -- --test-threads=1  # command passes; filter currently matches 0 tests
- cargo test --manifest-path vendor/radiant/Cargo.toml --test generic_surface_guardrails app_facing_runtime_paths_do_not_introduce_obvious_blocking_calls -- --test-threads=1
- cargo test -p wavecrate --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis -- --test-threads=1
- rustfmt --edition 2024 --check src/native_app/app_chrome/scene.rs src/native_app/audio/playback/progress.rs src/native_app/tests/toolbar_playback/frame_overlay.rs tests/gui_boundary.rs && rustfmt --edition 2021 --check vendor/radiant/src/application/runtime/bridge/adapter/runtime_work.rs vendor/radiant/src/application/runtime/tests/runtime_work.rs
- git diff --check

## Known limitations

- bash scripts/agent.sh request now passes the native-app boundary, Radiant non-blocking guardrails, and Wavecrate non-blocking guardrail stages, but still fails later on an unrelated existing Wavecrate facade guardrail baseline involving app_core legacy crossings, production test_support imports, and facade module budget entries. This PR does not attempt that broad cleanup.

## Review

User review is required before merge.