### PR TITLE
Use runtime pointer snapshot for menu anchors

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -25,9 +25,7 @@ use crate::native_app::audio::playback_history::{
 use crate::native_app::metadata::{
     MetadataRatingPersistResult, MetadataTagLoadResult, MetadataTagPersistResult,
 };
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextTargetKind,
-};
+use crate::native_app::sample_library::context_menu_target::BrowserContextTargetKind;
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::commands::RenameCommitCompletion;
 use crate::native_app::sample_library::folder_browser::commands::{
@@ -89,7 +87,6 @@ pub(in crate::native_app) enum GuiMessage {
         path: String,
         position: Point,
     },
-    RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor),
     DragSampleFile {
         path: String,
         drag: DragHandleMessage,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/collections_section/rows.rs
@@ -7,9 +7,6 @@ use super::identity::{
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::sidebar_row_underlay;
 use crate::native_app::app_chrome::view_models::library_sidebar::CollectionRowViewModel;
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::view_contract::{
     COLLECTION_ROW_HEIGHT, SampleCollectionView,
@@ -65,12 +62,6 @@ fn collection_row_actions(
     collection_id: SampleCollection,
 ) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
-        .hover_key(collection_id, |collection_id, position| {
-            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-                target: BrowserContextPointerTarget::Collection(collection_id),
-                position,
-            })
-        })
         .drop_target_key(
             collection_id,
             |collection_id| {

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
@@ -3,9 +3,6 @@ use radiant::prelude as ui;
 use super::identity::{RETAINED_FOLDER_TREE_ROW_INPUT_SCOPE, retained_folder_row_key};
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::SIDEBAR_ROW_STYLE;
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::model::VisibleFolder;
 use crate::native_app::sample_library::folder_browser::view_contract::{
@@ -133,12 +130,6 @@ fn standard_folder_row(folder: &VisibleFolder, id: String) -> ui::View<GuiMessag
 
 fn folder_row_actions(id: String) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
-        .hover_key(id.clone(), |id, position| {
-            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-                target: BrowserContextPointerTarget::Folder(id),
-                position,
-            })
-        })
         .primary_with_modifiers_key(id.clone(), |id, modifiers| {
             GuiMessage::FolderBrowser(FolderBrowserMessage::ActivateFolder(id, modifiers))
         })

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -7,9 +7,6 @@ use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::library_browser::library_sidebar::sidebar_row::sidebar_row_underlay;
 use crate::native_app::app_chrome::toolbar::toolbar_icon_color;
 use crate::native_app::app_chrome::view_models::library_sidebar::SourceRowViewModel;
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use wavecrate::sample_sources::SourceRole;
 
@@ -63,12 +60,6 @@ pub(super) fn source_row(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
     };
     row.actions(
         ui::row_actions()
-            .hover_key(source.id.clone(), |source_id, position| {
-                GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-                    target: BrowserContextPointerTarget::Source(source_id),
-                    position,
-                })
-            })
             .primary_secondary_key(
                 source.id.clone(),
                 |source_id| {

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -4,9 +4,6 @@ use radiant::theme::ThemeTokens;
 
 use super::identity;
 use crate::native_app::app::GuiMessage;
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
 
 const SAMPLE_ROW_STYLE: ui::WidgetStyle = ui::WidgetStyle::subtle(ui::WidgetTone::Accent);
 const COPY_FLASH_FILL: ui::Rgba8 = ui::Rgba8 {
@@ -161,12 +158,6 @@ fn sample_file_hit_target_builder(
 
 fn sample_file_row_actions(path: String) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
-        .hover_key(path.clone(), |path, position| {
-            GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-                target: BrowserContextPointerTarget::Sample(path),
-                position,
-            })
-        })
         .primary_with_modifiers_key(path.clone(), |path, modifiers| {
             GuiMessage::SelectSampleWithModifiers { path, modifiers }
         })

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/starmap_view.rs
@@ -21,9 +21,6 @@ use std::{
 use crate::native_app::app::{
     GuiMessage, StarmapAuditionDragState, StarmapViewport, StarmapViewportChange,
 };
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 use crate::native_app::sample_library::folder_browser::starmap::{
     StarmapItem, StarmapStatus, starmap_cluster_palette_color,
@@ -593,17 +590,6 @@ impl StarmapWidget {
         self.hovered_file_id = index.map(|index| self.items[index].file_id.clone());
     }
 
-    fn remember_hovered_context_menu_anchor(&self, point: Point) -> Option<WidgetOutput> {
-        self.hovered_file_id.as_ref().map(|file_id| {
-            WidgetOutput::typed(GuiMessage::RememberBrowserContextMenuPointerAnchor(
-                BrowserContextPointerAnchor {
-                    target: BrowserContextPointerTarget::Sample(file_id.clone()),
-                    position: point,
-                },
-            ))
-        })
-    }
-
     fn hovered_item(&self) -> Option<&StarmapItem> {
         let hovered_file_id = self.hovered_file_id.as_deref()?;
         self.item_for_cached_index(self.hovered_item_index, hovered_file_id)
@@ -1072,7 +1058,7 @@ impl Widget for StarmapWidget {
                 ),
             CanvasGestureEvent::Hover(pointer) => {
                 self.set_hovered_file_at(bounds, pointer.position);
-                self.remember_hovered_context_menu_anchor(pointer.position)
+                None
             }
             CanvasGestureEvent::Press {
                 pointer,
@@ -2372,12 +2358,8 @@ mod tests {
             widget
                 .handle_input(bounds, WidgetInput::pointer_move(Point::new(50.0, 50.0)))
                 .and_then(|output| output.typed_cloned::<GuiMessage>()),
-            Some(GuiMessage::RememberBrowserContextMenuPointerAnchor(
-                BrowserContextPointerAnchor {
-                    target: BrowserContextPointerTarget::Sample(String::from("/samples/kick.wav")),
-                    position: Point::new(50.0, 50.0),
-                }
-            ))
+            None,
+            "ordinary starmap hover should update widget-local paint state without host output"
         );
         let mut primitives = Vec::new();
         widget.append_runtime_overlay_paint(
@@ -2721,13 +2703,8 @@ mod tests {
             previous
                 .handle_input(bounds, WidgetInput::pointer_move(Point::new(50.0, 50.0)))
                 .and_then(|output| output.typed_cloned::<GuiMessage>()),
-            Some(GuiMessage::RememberBrowserContextMenuPointerAnchor(
-                BrowserContextPointerAnchor {
-                    target: BrowserContextPointerTarget::Sample(String::from("/samples/kick.wav")),
-                    position: Point::new(50.0, 50.0),
-                }
-            )),
-            "hover should remember a pointer anchor while updating local runtime state"
+            None,
+            "hover should update local runtime state without host output"
         );
         previous.ensure_hit_index(bounds);
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -76,7 +76,6 @@ impl NativeAppState {
             | GuiMessage::NormalizationFinished(_)
             | GuiMessage::SelectSampleWithModifiers { .. }
             | GuiMessage::OpenSampleContextMenu { .. }
-            | GuiMessage::RememberBrowserContextMenuPointerAnchor(_)
             | GuiMessage::DragSampleFile { .. }
             | GuiMessage::ExternalDragCompleted(_) => self.apply_browser_dispatch(message, context),
             GuiMessage::DeferredSampleLoad { .. }

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -85,9 +85,6 @@ impl NativeAppState {
                     ClipboardHandoffTarget::BrowserFiles;
                 self.open_sample_context_menu(path, position);
             }
-            GuiMessage::RememberBrowserContextMenuPointerAnchor(anchor) => {
-                self.ui.browser_interaction.context_menu_pointer_anchor = Some(anchor);
-            }
             GuiMessage::DragSampleFile { path, drag } => {
                 self.ui.browser_interaction.clipboard_handoff_target =
                     ClipboardHandoffTarget::BrowserFiles;

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -2,9 +2,7 @@ use super::*;
 use crate::native_app::app_chrome::browser_context_menu::{
     FileManagerLabelPlatform, file_manager_context_labels, file_manager_context_labels_for_platform,
 };
-use crate::native_app::sample_library::context_menu_target::{
-    BrowserContextPointerAnchor, BrowserContextPointerTarget,
-};
+use crate::native_app::sample_library::context_menu_target::BrowserContextPointerTarget;
 use crate::native_app::test_support::state::GuiMessage;
 use radiant::runtime::{PaintTextAlign, RuntimeUpdateSnapshot};
 
@@ -489,12 +487,9 @@ fn global_context_menu_opens_selected_sample_menu_without_playmark() {
         .folder_browser
         .select_file(sample.display().to_string());
     let pointer_anchor = Point::new(333.0, 222.0);
-    state.apply_message(
-        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-            target: BrowserContextPointerTarget::Sample(sample.display().to_string()),
-            position: pointer_anchor,
-        }),
-        &mut ui::UiUpdateContext::default(),
+    state.remember_context_menu_pointer_anchor(
+        BrowserContextPointerTarget::Sample(sample.display().to_string()),
+        pointer_anchor,
     );
 
     state.apply_message(
@@ -531,12 +526,9 @@ fn global_context_menu_ignores_stale_sample_pointer_anchor_after_focus_changes()
         .library
         .folder_browser
         .select_file(snare.display().to_string());
-    state.apply_message(
-        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-            target: BrowserContextPointerTarget::Sample(kick.display().to_string()),
-            position: Point::new(333.0, 222.0),
-        }),
-        &mut ui::UiUpdateContext::default(),
+    state.remember_context_menu_pointer_anchor(
+        BrowserContextPointerTarget::Sample(kick.display().to_string()),
+        Point::new(333.0, 222.0),
     );
 
     state.apply_message(
@@ -569,12 +561,9 @@ fn global_context_menu_uses_live_pointer_position_over_stale_sample_anchor() {
         .library
         .folder_browser
         .select_file(snare.display().to_string());
-    state.apply_message(
-        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-            target: BrowserContextPointerTarget::Sample(kick.display().to_string()),
-            position: Point::new(333.0, 222.0),
-        }),
-        &mut ui::UiUpdateContext::default(),
+    state.remember_context_menu_pointer_anchor(
+        BrowserContextPointerTarget::Sample(kick.display().to_string()),
+        Point::new(333.0, 222.0),
     );
     let live_pointer = Point::new(610.0, 388.0);
     let mut context = ui::UiUpdateContext::from_runtime_snapshot(
@@ -636,12 +625,9 @@ fn global_context_menu_opens_selected_folder_menu_at_matching_pointer_anchor() {
         .expect("folder selected")
         .to_owned();
     let pointer_anchor = Point::new(88.0, 144.0);
-    state.apply_message(
-        GuiMessage::RememberBrowserContextMenuPointerAnchor(BrowserContextPointerAnchor {
-            target: BrowserContextPointerTarget::Folder(folder_id),
-            position: pointer_anchor,
-        }),
-        &mut ui::UiUpdateContext::default(),
+    state.remember_context_menu_pointer_anchor(
+        BrowserContextPointerTarget::Folder(folder_id),
+        pointer_anchor,
     );
 
     state.apply_message(

--- a/src/native_app/tests/sample_browser/rows.rs
+++ b/src/native_app/tests/sample_browser/rows.rs
@@ -168,12 +168,16 @@ fn sample_browser_row_hover_paints_bright_background_without_marker() {
     let bounds = Rect::from_size(180.0, 22.0);
     let mut hit_target = sample_hit_target(false, false, false, false);
 
-    let _ = sample_hit_target_input(
+    let output = sample_hit_target_input(
         &mut hit_target,
         bounds,
         WidgetInput::pointer_move(Point::new(20.0, 10.0)),
     );
 
+    assert!(
+        output.is_none(),
+        "ordinary sample-row hover should not emit a host message"
+    );
     let plan = sample_hit_target_plan(&hit_target, bounds);
     let fills = plan.fill_rects().collect::<Vec<_>>();
     let hover_fill = shared_dense_row_palette()


### PR DESCRIPTION
## Scope

- Update `vendor/radiant` to the OPT-1047 row pointer-routing commit from PORTALSURFER/radiant#1396.
- Remove Wavecrate row and starmap hover messages that only remembered browser context-menu pointer anchors.
- Remove the now-dead `RememberBrowserContextMenuPointerAnchor` app message and dispatch path.
- Keep keyboard-open context menus preferring `UiUpdateContext::current_pointer_position()` with direct fallback anchors only when no live pointer exists.

## Definition of Done

- Context-menu anchor plumbing no longer requires routine hover widget output.
- Sample, source, folder, collection, and starmap hover paths do not emit anchor-only host messages.
- Sample-row and starmap regressions cover hover state without host output.
- Wavecrate menu-open tests continue to cover live pointer preference and fallback anchors.

## Validation commands

- `bash scripts/agent.sh request` *(fails on existing Wavecrate facade guardrail violations on main; non-blocking architecture and earlier checks passed before the facade gate)*
- `cargo test --manifest-path vendor/radiant/Cargo.toml pointer_motion`
- `cargo test --manifest-path vendor/radiant/Cargo.toml native_pointer`
- `cargo test -p wavecrate browser_context_menu` *(50/51 passed; existing deterministic failure: `sample_context_menu_open_harvest_destination_requires_primary_source` expects no Primary source, but fixture opens a harvest destination)*
- `cargo test -p wavecrate sample_context_menu_open_harvest_destination_requires_primary_source` *(same existing failure reproduced alone)*
- `cargo test -p wavecrate waveform::tests::widget_input`
- `cargo test -p wavecrate sample_browser_row_hover_paints_bright_background_without_marker`
- `cargo test -p wavecrate starmap`

## Known limitations

- Manual Wavecrate smoke was not run in this headless pass.
- The broad `browser_context_menu` filter is blocked by the unrelated harvest destination fixture failure noted above.
- `bash scripts/agent.sh request` is blocked by existing facade guardrail violations on `main`.

User review is required before merge.