### PR TITLE
OPT-1049: Migrate sample rows to dense row policy

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -117,20 +117,8 @@ fn sample_file_hit_target_builder(
     content: ui::View<GuiMessage>,
     model: &SampleFileHitTargetModel<'_>,
 ) -> ui::InteractiveRowUnderlayBuilder<GuiMessage> {
-    let visual_state = ui::InteractiveRowVisualStateParts {
-        selected: model.explicitly_selected
-            || model.copy_flash
-            || model.protected_source_error_flash
-            || model.cut_pending
-            || model.missing,
-        ..ui::InteractiveRowVisualStateParts::default()
-    };
     let underlay = ui::interactive_row_underlay(content)
-        .tracked_drag_source(model.drag_active, model.drag_source)
-        .activation_modifiers()
-        .custom_paint_hit_target()
-        .style(SAMPLE_ROW_STYLE)
-        .visual_state(visual_state)
+        .dense_row_policy(sample_file_row_policy(model))
         .leading_marker_if(
             model.explicitly_selected || model.cut_pending || model.missing,
             ui::DenseRowMarkerStyle::new(
@@ -156,15 +144,32 @@ fn sample_file_hit_target_builder(
     }
 }
 
+fn sample_file_row_policy(model: &SampleFileHitTargetModel<'_>) -> ui::DenseRowPolicy {
+    let visual_state = ui::InteractiveRowVisualStateParts {
+        selected: model.explicitly_selected
+            || model.copy_flash
+            || model.protected_source_error_flash
+            || model.cut_pending
+            || model.missing,
+        ..ui::InteractiveRowVisualStateParts::default()
+    };
+    ui::DenseRowPolicy::with_visual_state(visual_state)
+        .tracked_drag_source(model.drag_active, model.drag_source)
+        .drag_session_motion(model.drag_active)
+        .activation_modifiers()
+        .style(SAMPLE_ROW_STYLE)
+}
+
 fn sample_file_row_actions(path: String) -> ui::InteractiveRowActions<GuiMessage> {
     ui::row_actions()
-        .primary_with_modifiers_key(path.clone(), |path, modifiers| {
-            GuiMessage::SelectSampleWithModifiers { path, modifiers }
-        })
-        .double_key(path.clone(), |path| GuiMessage::SelectSampleWithModifiers {
-            path,
-            modifiers: Default::default(),
-        })
+        .primary_with_modifiers_and_double_key(
+            path.clone(),
+            |path, modifiers| GuiMessage::SelectSampleWithModifiers { path, modifiers },
+            |path| GuiMessage::SelectSampleWithModifiers {
+                path,
+                modifiers: Default::default(),
+            },
+        )
         .secondary_key(path.clone(), |path, position| {
             GuiMessage::OpenSampleContextMenu { path, position }
         })


### PR DESCRIPTION
## Scope

- Update `vendor/radiant` to the companion Radiant policy commit from PORTALSURFER/radiant#1397.
- Migrate Wavecrate sample-browser row hit targets onto `DenseRowPolicy`.
- Keep Wavecrate-owned row visuals, markers, focus outlines, palettes, stable row identity, tooltips, and host messages outside Radiant.
- Use the new action helper for modifier-aware primary activation plus double-click selection routing.

## Definition of Done

- At least one real Wavecrate dense row family is migrated to policy-oriented Radiant APIs.
- Sample-row drag, selection, double-click, secondary click, focus, custom paint, tooltip, and marker behavior remain covered by existing tests.
- Low-level Radiant APIs remain available for other custom widgets.
- Radiant companion PR is merged before this parent PR merges so the submodule pointer is reachable from Radiant `main`.

## Validation commands

- `bash scripts/agent.sh request` *(baseline failed on existing Wavecrate facade guardrail violations outside this change)*
- `cargo test --manifest-path vendor/radiant/Cargo.toml --lib interactive_row`
- `cargo test --manifest-path vendor/radiant/Cargo.toml --test application_builder_public_api dense_row_policy_is_available_from_prelude`
- `cargo test --manifest-path vendor/radiant/Cargo.toml dense`
- `cargo test -p wavecrate active_drag`
- `cargo test -p wavecrate sample_browser` *(sample-row policy tests pass; one unrelated starmap copy-flash test fails)*
- `cargo test -p wavecrate copying_sample_selected_from_map_flashes_map_node_and_waveform` *(reproduces the unrelated failure)*
- `cargo test -p wavecrate folder_browser` *(333/334 pass; unrelated root facade export assertion fails)*
- `git diff --check`

## Known limitations

- Depends on PORTALSURFER/radiant#1397 and should not merge before that PR.
- Manual Wavecrate smoke was not run: sample row select/double-click/context-menu/drag, folder row select/rename/context-menu, collection rows, and metadata tag rows still need hands-on confirmation.
- Current local validation has unrelated failures outside the changed files:
  - `native_app::tests::sample_browser::copying_sample_selected_from_map_flashes_map_node_and_waveform`
  - `native_app::sample_library::folder_browser::tests::root_facade_exports_only_stable_entrypoints`
  - baseline `bash scripts/agent.sh request` ends on existing Wavecrate facade guardrail violations.

User review is required before merge.
