### PR TITLE
OPT-1070: Add patch bump support to release wrapper

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -85,12 +85,14 @@ behind explicit operator intent:
 ```bash
 scripts/release.sh prepare --bump minor --source-ref main --dry-run
 scripts/release.sh prepare --bump minor --source-ref main --push
+scripts/release.sh prepare --bump patch --source-ref release/19.1 --dry-run
 scripts/release.sh rc --version 19.2.0 --rc-number 1 --branch release/19.2 --dispatch
 scripts/release.sh stable --version 19.2.0 --branch release/19.2 --dispatch
 ```
 
 `prepare --bump major` bumps `X.Y.Z` to `(X+1).0.0`; `prepare --bump minor`
-bumps to `X.(Y+1).0`. Without `--dispatch`, `rc` and `stable` validate inputs
+bumps to `X.(Y+1).0`; `prepare --bump patch` bumps to `X.Y.(Z+1)` on the same
+`release/X.Y` train. Without `--dispatch`, `rc` and `stable` validate inputs
 and print the exact `gh workflow run ...` command instead of publishing. With
 `--dispatch`, the script requires an authenticated GitHub CLI (`gh`) and invokes
 the existing workflows with their native input names. When `origin` is a GitHub

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -52,8 +52,8 @@ development and release-risk checks:
 | Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
 
 Use `scripts/release.sh` from a clean repo root for macOS/Linux release
-orchestration. It derives major/minor target versions from the package version
-at the resolved source ref, delegates release-train prep to
+orchestration. It derives major, minor, and patch target versions from the
+package version at the resolved source ref, delegates release-train prep to
 `scripts/internal/release/prepare_release_train.py`, and dispatches the RC and
 stable GitHub workflows only when `--dispatch` is passed. Prepare dispatch uses
 `--workflow-ref` (default `main`) for the workflow file ref and sends the

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,9 +21,9 @@ dispatcher maps. These are the public entrypoints people should run directly:
   `calibrate-startup` command is optional Linux developer tooling for refreshing
   startup threshold lock files; it is not shipped Linux product support.
 - `release.sh`: Bash release orchestration for release-train prep and explicit
-  RC/stable GitHub workflow dispatch. It derives major/minor trains from the
-  current release package version and delegates packaging/publication to the
-  existing release workflows.
+  RC/stable GitHub workflow dispatch. It derives major, minor, and patch targets
+  from the resolved source release package version and delegates
+  packaging/publication to the existing release workflows.
 - `gui.ps1`: Windows GUI validation lanes.
 
 PowerShell compatibility wrappers also remain available for the older

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@ repo_slug="${WAVECRATE_GITHUB_REPO:-PORTALSURFER/wavecrate}"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/release.sh prepare --bump <major|minor> [--source-ref <ref>] [--workflow-ref <branch-or-tag>] [--dry-run|--push] [--dispatch]
+  scripts/release.sh prepare --bump <major|minor|patch> [--source-ref <ref>] [--workflow-ref <branch-or-tag>] [--dry-run|--push] [--dispatch]
   scripts/release.sh rc --version <X.Y.Z> --rc-number <N> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
   scripts/release.sh stable --version <X.Y.Z> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
 
@@ -102,7 +102,8 @@ validate_version() {
 
 validate_bump() {
   local bump="$1"
-  [[ "$bump" == "major" || "$bump" == "minor" ]] || die "bump must be major or minor"
+  [[ "$bump" == "major" || "$bump" == "minor" || "$bump" == "patch" ]] \
+    || die "bump must be major, minor, or patch"
 }
 
 package_version_from_stdin() {
@@ -131,10 +132,11 @@ bump_version() {
   local bump="$2"
   validate_version "$version"
   validate_bump "$bump"
-  IFS=. read -r major minor _patch <<<"$version"
+  IFS=. read -r major minor patch <<<"$version"
   case "$bump" in
     major) printf '%s.0.0\n' "$((major + 1))" ;;
     minor) printf '%s.%s.0\n' "$major" "$((minor + 1))" ;;
+    patch) printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))" ;;
   esac
 }
 
@@ -294,7 +296,7 @@ prepare() {
       *) die "unknown prepare argument: $1" ;;
     esac
   done
-  [[ -n "$bump" ]] || die "prepare requires --bump <major|minor>"
+  [[ -n "$bump" ]] || die "prepare requires --bump <major|minor|patch>"
   validate_bump "$bump"
   [[ -n "$workflow_ref" ]] || die "--workflow-ref must not be empty"
   (( push == 0 || explicit_dry_run == 0 )) || die "--dry-run and --push cannot be combined"

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -48,6 +48,35 @@ fn prepare_major_bump_derives_next_major_train() {
 }
 
 #[test]
+fn prepare_patch_bump_derives_next_patch_on_existing_release_train() {
+    let repo = FixtureRepo::new();
+    repo.write_workspace("19.1.3");
+    repo.commit_all("seed release train workspace");
+    repo.create_release_branch("release/19.1");
+    let release_sha = repo.git_stdout(&["rev-parse", "origin/release/19.1"]);
+    repo.write_workspace("20.5.0");
+    repo.commit_all("advance local checkout after release branch");
+    repo.push_branch("main");
+
+    let output = repo.run_release(&[
+        "prepare",
+        "--bump",
+        "patch",
+        "--source-ref",
+        "release/19.1",
+        "--dry-run",
+    ]);
+
+    assert_success(&output);
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Resolved version: 19.1.4"));
+    assert!(stdout.contains("Release branch: release/19.1"));
+    assert!(stdout.contains(&format!("Target SHA: {release_sha}")));
+    assert!(stdout.contains("prepare-helper [--version] [19.1.4]"));
+    assert!(stdout.contains("[cwd-version=19.1.3]"));
+}
+
+#[test]
 fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.1.0");
@@ -160,10 +189,10 @@ fn prepare_rejects_invalid_bump_argument() {
     repo.commit_all("seed workspace");
     repo.push_branch("main");
 
-    let output = repo.run_release(&["prepare", "--bump", "patch", "--dry-run"]);
+    let output = repo.run_release(&["prepare", "--bump", "micro", "--dry-run"]);
 
     assert_failure(&output);
-    assert!(stderr(&output).contains("bump must be major or minor"));
+    assert!(stderr(&output).contains("bump must be major, minor, or patch"));
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Add `scripts/release.sh prepare --bump patch` support.
- Derive patch targets from the resolved `--source-ref` package version and keep patch bumps on the same `release/X.Y` train.
- Update release wrapper help/docs and focused release-orchestration coverage.

## Definition of Done

- `scripts/release.sh prepare --bump patch` resolves `X.Y.(Z+1)` from the requested source ref.
- The resolved branch remains `release/X.Y`.
- Unsupported bump values are still rejected with updated messaging.
- Public release docs and script usage mention `patch` with `major` and `minor`.
- Focused release-orchestration tests pass.

## Validation Commands

- `bash -n scripts/release.sh`
- `git diff --check`
- `cargo test -p wavecrate --test release_orchestration -- --test-threads=1`
- `scripts/release.sh prepare --bump patch --source-ref release/19.1 --dry-run`

Additional preflight attempted:

- `bash scripts/agent.sh request` reached release/non-blocking validation successfully, then failed on unrelated existing facade guardrail violations in `src/app_core/*` and `src/native_app/*`.

## Known Limitations

- No release-wrapper limitations known. The broad agent preflight currently has unrelated existing facade guardrail failures outside this PR scope.

## Review

User review is required before merge.

Linear: OPT-1070
