### PR TITLE
OPT-1068: Use frame-time clock for waveform playhead paint

### DIFF
--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -90,18 +90,16 @@ impl NativeAppState {
         &mut self,
         animation_time: Duration,
     ) -> Option<f32> {
-        if let Some(progress) = self.audio.player.as_ref().and_then(AudioPlayer::progress) {
-            return Some(progress);
-        }
-        self.interpolated_runtime_waveform_progress_ratio_for_frame(animation_time)
+        self.interpolated_waveform_visual_progress_ratio_for_frame(animation_time)
             .or_else(|| self.waveform.current.playhead_ratio())
     }
 
     fn interpolated_runtime_waveform_progress_ratio(&self) -> Option<f32> {
+        self.interpolated_waveform_visual_progress_ratio()
+    }
+
+    fn interpolated_waveform_visual_progress_ratio(&self) -> Option<f32> {
         if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
-            return None;
-        }
-        if !self.audio.playback_progress.active {
             return None;
         }
         let visual_progress = self.audio.playback_visual_progress?;
@@ -124,14 +122,11 @@ impl NativeAppState {
         ))
     }
 
-    fn interpolated_runtime_waveform_progress_ratio_for_frame(
+    fn interpolated_waveform_visual_progress_ratio_for_frame(
         &mut self,
         animation_time: Duration,
     ) -> Option<f32> {
         if !self.waveform.current.is_playing() || self.audio.current_playback_span.is_none() {
-            return None;
-        }
-        if !self.audio.playback_progress.active {
             return None;
         }
         let duration_seconds = self.waveform.current.duration_seconds();
@@ -646,6 +641,45 @@ mod tests {
         assert!(
             first_visible_frame > 0.39 && first_visible_frame < 0.42,
             "first paint after a delayed overlay should advance from the latest runtime snapshot, got {first_visible_frame}"
+        );
+    }
+
+    #[test]
+    fn fallback_player_waveform_progress_for_frame_uses_seeded_visual_clock() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.current.start_playback(0.20);
+        state.audio.current_playback_span = Some((0.0, 1.0));
+        state.audio.reset_playback_visual_progress(0.20, false);
+        assert!(
+            !state.audio.playback_progress.active,
+            "fallback player coverage should not depend on runtime progress snapshots"
+        );
+
+        let base_time = Duration::from_secs(30);
+        let sample_duration = state.waveform.current.duration_seconds();
+        state
+            .audio
+            .playback_visual_progress
+            .as_mut()
+            .expect("visual progress")
+            .anchor_animation_time = Some(base_time);
+
+        let progress = state
+            .current_audio_progress_ratio_for_frame(
+                base_time + Duration::from_secs_f32(sample_duration * 0.10),
+            )
+            .expect("fallback visual progress");
+
+        assert!(
+            progress > 0.29 && progress < 0.31,
+            "fallback/player overlay paint should advance from animation_time, got {progress}"
+        );
+        assert_eq!(
+            state.waveform.current.playhead_ratio(),
+            Some(0.20),
+            "fallback visual interpolation should not mutate the retained static playhead marker"
         );
     }
 

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -698,6 +698,56 @@ fn playback_cursor_overlay_progresses_smoothly_across_timed_frames() {
 }
 
 #[test]
+fn fallback_player_cursor_overlay_uses_seeded_visual_clock() {
+    let base_time = Duration::from_secs(30);
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.start_playback(0.20);
+    state.audio.current_playback_span = Some((0.0, 1.0));
+    state.audio.reset_playback_visual_progress(0.20, false);
+    state
+        .audio
+        .playback_visual_progress
+        .as_mut()
+        .expect("visual progress")
+        .anchor_animation_time = Some(base_time);
+    assert!(
+        !state.audio.playback_progress.active,
+        "fallback/player paint coverage should not rely on runtime progress"
+    );
+    assert_active_playback_frame_is_paint_only(&mut state);
+
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+    let cursor_xs = [
+        playback_cursor_x_for_frame(
+            &mut runtime,
+            &frame.paint_plan,
+            base_time + Duration::from_millis(16),
+        )
+        .expect("fallback cursor paint on first frame"),
+        playback_cursor_x_for_frame(
+            &mut runtime,
+            &frame.paint_plan,
+            base_time + Duration::from_millis(32),
+        )
+        .expect("fallback cursor paint on next frame"),
+        playback_cursor_x_for_frame(
+            &mut runtime,
+            &frame.paint_plan,
+            base_time + Duration::from_millis(48),
+        )
+        .expect("fallback cursor paint on later frame"),
+    ];
+
+    assert!(
+        cursor_xs[0] > waveform_cursor_x_from_ratio(&frame.paint_plan, 0.20),
+        "fallback/player cursor should advance from the seeded visual clock"
+    );
+    assert_cursor_xs_monotonic_and_bounded("fallback/player playback", &cursor_xs, 24.0);
+}
+
+#[test]
 fn looped_playback_cursor_overlay_stays_smooth_inside_span() {
     let base_time = Duration::from_secs(30);
     let mut state = state_with_runtime_playback(0.32, (0.25, 0.75), true);


### PR DESCRIPTION
## Scope

- Remove the raw `AudioPlayer::progress` precedence from WaveformView transient playback-cursor paint.
- Let frame paint derive moving cursor position from the seeded playback visual clock and `TransientOverlayContext.animation_time`.
- Allow seeded visual progress to drive fallback/player playback even when runtime progress snapshots are inactive.
- Add focused runtime/fallback coverage at the state interpolation seam and transient-overlay paint seam.

## Definition of Done

- No active transient-overlay paint path samples raw audio/player progress independently of the display-frame visual clock.
- Runtime and fallback playback cursor movement share the same monotonic frame-time source.
- Tests cover runtime interpolation, fallback/player seeded visual-clock behavior, delayed first paint, and restart anchoring.
- Real-app manual smoke is still needed before merge from a desktop session with sample playback.

## Validation commands

- `git status --short --branch`
- `git fetch --prune`
- `bash scripts/agent.sh request` *(fails on pre-existing facade guardrail violations on `main`, before this branch's changes)*
- `cargo test -p wavecrate native_app::audio::playback::loop_control -- --test-threads=1`
- `cargo test -p wavecrate native_app::tests::toolbar_playback::frame_overlay -- --test-threads=1`
- `git diff --check`

## Known limitations

- Manual real-app smoke was not performed from this Codex session; before merge, play, stop, and retrigger several WaveformView samples in the desktop app and confirm the moving playhead has no visible cadence jitter or backward jump.
- The repo request preflight currently fails on unrelated existing facade guardrail findings, including `src/app_core/*` legacy crossing allowlist violations and production imports of `native_app::test_support`; this branch does not touch those files.

## Review

User review is required before merge.
