### PR TITLE
Capture playhead hitch diagnostics from transient overlay frames

### DIFF
--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -52,4 +52,6 @@ pub(in crate::native_app) struct NativeAppState {
     pub(in crate::native_app) audio: AudioAppState,
     pub(in crate::native_app) transactions: TransactionState,
     pub(in crate::native_app) metadata: MetadataAppState,
+    pub(in crate::native_app) playhead_frame_diagnostics:
+        crate::native_app::audio::playback::PlayheadFrameDiagnosticsState,
 }

--- a/src/native_app/audio/playback.rs
+++ b/src/native_app/audio/playback.rs
@@ -16,6 +16,9 @@ use std::time::Duration;
 pub(in crate::native_app) const PLAYBACK_START_ACTIVE_SOURCE_GRACE: Duration =
     Duration::from_millis(120);
 
+pub(in crate::native_app) use diagnostics::{
+    PlayheadFrameDiagnosticsState, playhead_frame_diagnostics_observer_enabled,
+};
 pub(in crate::native_app) use intent::PlaybackIntent;
 pub(in crate::native_app) use planner::{
     ActiveSamplePlaybackPlanState, SamplePlaybackAvailableSources, SamplePlaybackPlan,

--- a/src/native_app/audio/playback/diagnostics.rs
+++ b/src/native_app/audio/playback/diagnostics.rs
@@ -1,4 +1,117 @@
-use std::time::{Duration, Instant};
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+use radiant::prelude as ui;
+
+const PLAYHEAD_FRAME_DIAGNOSTICS_ENV: &str = "WAVECRATE_PLAYHEAD_FRAME_DIAGNOSTICS";
+
+static PLAYHEAD_FRAME_DIAGNOSTICS_ENABLED: OnceLock<bool> = OnceLock::new();
+
+#[derive(Default)]
+pub(in crate::native_app) struct PlayheadFrameDiagnosticsState {
+    latest_overlay: Option<PlayheadOverlayFrameDiagnostics>,
+    latest_frame_message: Option<PlayheadFrameMessageDiagnostics>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app) struct PlayheadOverlayFrameDiagnostics {
+    pub(in crate::native_app) animation_time: Duration,
+    pub(in crate::native_app) progress_ratio: f32,
+    pub(in crate::native_app) visible_ratio: f32,
+    pub(in crate::native_app) cursor_x: f32,
+    pub(in crate::native_app) progress_source: PlayheadProgressSource,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct PlayheadFrameMessageDiagnostics {
+    pub(in crate::native_app) paint_only: bool,
+    pub(in crate::native_app) reason: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum PlayheadProgressSource {
+    InterpolatedVisualProgress,
+    WaveformPlayheadFallback,
+}
+
+impl PlayheadProgressSource {
+    pub(in crate::native_app) fn label(self) -> &'static str {
+        match self {
+            Self::InterpolatedVisualProgress => "interpolated_visual_progress",
+            Self::WaveformPlayheadFallback => "waveform_playhead_fallback",
+        }
+    }
+}
+
+impl PlayheadFrameDiagnosticsState {
+    pub(in crate::native_app) fn record_overlay_frame(
+        &mut self,
+        sample: PlayheadOverlayFrameDiagnostics,
+    ) {
+        if !playhead_frame_diagnostics_enabled() {
+            return;
+        }
+        self.latest_overlay = Some(sample);
+    }
+
+    pub(in crate::native_app) fn record_frame_message(
+        &mut self,
+        sample: PlayheadFrameMessageDiagnostics,
+    ) {
+        if !playhead_frame_diagnostics_enabled() {
+            return;
+        }
+        self.latest_frame_message = Some(sample);
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn latest_overlay_frame(
+        &self,
+    ) -> Option<PlayheadOverlayFrameDiagnostics> {
+        self.latest_overlay
+    }
+
+    pub(in crate::native_app) fn observe_native_frame(
+        &mut self,
+        diagnostics: ui::NativeFrameDiagnostics,
+    ) {
+        if !playhead_frame_diagnostics_enabled() {
+            return;
+        }
+        let Some(overlay) = self.latest_overlay.take() else {
+            return;
+        };
+        let frame_message = self.latest_frame_message.take();
+        tracing::info!(
+            target: "wavecrate::debug::ui_frame",
+            event = "waveform.playhead.frame",
+            since_last_present_ms = duration_ms(diagnostics.timings.since_last_present),
+            animation_time_ms = duration_ms(overlay.animation_time),
+            progress_ratio = overlay.progress_ratio,
+            visible_ratio = overlay.visible_ratio,
+            cursor_x = overlay.cursor_x,
+            progress_source = overlay.progress_source.label(),
+            transient_overlay_paint_ms =
+                duration_ms(diagnostics.timings.transient_overlay.paint),
+            transient_overlay_primitives = diagnostics.timings.transient_overlay.primitives,
+            frame_work = diagnostics.presentation.frame_work_kind,
+            frame_work_reason = diagnostics.presentation.frame_work_reason,
+            native_paint_only = diagnostics.presentation.paint_only,
+            native_scene_rebuild = diagnostics.presentation.scene_rebuild,
+            app_frame_message = frame_message.is_some(),
+            app_frame_message_paint_only = frame_message.is_some_and(|sample| sample.paint_only),
+            app_frame_message_reason = frame_message.map(|sample| sample.reason).unwrap_or("none"),
+            "Waveform playhead frame diagnostics"
+        );
+    }
+}
+
+pub(in crate::native_app) fn playhead_frame_diagnostics_observer_enabled() -> bool {
+    playhead_frame_diagnostics_enabled()
+        && tracing::enabled!(target: "wavecrate::debug::ui_frame", tracing::Level::INFO)
+}
 
 pub(super) fn log_slow_playback_phase(
     event: &'static str,
@@ -18,4 +131,50 @@ pub(super) fn log_slow_playback_phase(
         source_kind,
         "Slow playback UI phase"
     );
+}
+
+fn playhead_frame_diagnostics_enabled() -> bool {
+    *PLAYHEAD_FRAME_DIAGNOSTICS_ENABLED
+        .get_or_init(|| env_var_truthy(PLAYHEAD_FRAME_DIAGNOSTICS_ENV))
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn env_var_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .is_some_and(|value| is_truthy(&value))
+}
+
+fn is_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn playhead_frame_diagnostics_are_disabled_by_default() {
+        assert!(!playhead_frame_diagnostics_observer_enabled());
+    }
+
+    #[test]
+    fn disabled_playhead_frame_diagnostics_do_not_store_overlay_samples() {
+        let mut state = PlayheadFrameDiagnosticsState::default();
+        state.record_overlay_frame(PlayheadOverlayFrameDiagnostics {
+            animation_time: Duration::from_millis(16),
+            progress_ratio: 0.25,
+            visible_ratio: 0.25,
+            cursor_x: 42.0,
+            progress_source: PlayheadProgressSource::InterpolatedVisualProgress,
+        });
+
+        assert_eq!(state.latest_overlay_frame(), None);
+    }
 }

--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use super::{
     PlaybackIntent,
+    diagnostics::PlayheadProgressSource,
     span::{playback_span_matches_selection, retarget_offset_for_selection},
 };
 use crate::native_app::app::{NativeAppState, PendingPlaySelectionRetargetCycle, emit_gui_action};
@@ -10,6 +11,12 @@ use wavecrate::audio::{AudioPlayer, PlaybackRuntimeSpanUpdate};
 const LIVE_LOOP_BOUNDARY_EPSILON: f32 = 0.01;
 const LIVE_LOOP_WRAP_EPSILON: f32 = 0.02;
 const PLAYBACK_PROGRESS_EPSILON: f32 = 0.000_001;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app) struct PlayheadProgressProjection {
+    pub(in crate::native_app) ratio: f32,
+    pub(in crate::native_app) source: PlayheadProgressSource,
+}
 
 impl NativeAppState {
     pub(in crate::native_app) fn toggle_loop_playback(&mut self) {
@@ -86,12 +93,34 @@ impl NativeAppState {
             .or_else(|| self.waveform.current.playhead_ratio())
     }
 
+    #[cfg(test)]
     pub(in crate::native_app) fn current_audio_progress_ratio_for_frame(
         &mut self,
         animation_time: Duration,
     ) -> Option<f32> {
-        self.interpolated_waveform_visual_progress_ratio_for_frame(animation_time)
-            .or_else(|| self.waveform.current.playhead_ratio())
+        self.playhead_progress_projection_for_frame(animation_time)
+            .map(|projection| projection.ratio)
+    }
+
+    pub(in crate::native_app) fn playhead_progress_projection_for_frame(
+        &mut self,
+        animation_time: Duration,
+    ) -> Option<PlayheadProgressProjection> {
+        if let Some(ratio) =
+            self.interpolated_waveform_visual_progress_ratio_for_frame(animation_time)
+        {
+            return Some(PlayheadProgressProjection {
+                ratio,
+                source: PlayheadProgressSource::InterpolatedVisualProgress,
+            });
+        }
+        self.waveform
+            .current
+            .playhead_ratio()
+            .map(|ratio| PlayheadProgressProjection {
+                ratio,
+                source: PlayheadProgressSource::WaveformPlayheadFallback,
+            })
     }
 
     fn interpolated_runtime_waveform_progress_ratio(&self) -> Option<f32> {

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -3,7 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use super::PLAYBACK_START_ACTIVE_SOURCE_GRACE;
+use super::{
+    PLAYBACK_START_ACTIVE_SOURCE_GRACE,
+    diagnostics::{PlayheadFrameMessageDiagnostics, PlayheadOverlayFrameDiagnostics},
+};
 use crate::native_app::app::{
     NativeAppState, SamplePlaybackSession, SamplePlaybackSessionState, emit_gui_action,
     sample_path_label,
@@ -106,11 +109,24 @@ impl NativeAppState {
     }
 
     pub(in crate::native_app) fn frame_can_use_paint_only(
-        &self,
+        &mut self,
         before: FrameRepaintScopeSnapshot,
     ) -> bool {
         let after = FrameRepaintScopeSnapshot::from_state(self);
-        before.same_transient_frame_state(after) && !before.requires_surface_frame()
+        let same_transient_frame_state = before.same_transient_frame_state(after);
+        let requires_surface_frame = before.requires_surface_frame();
+        let paint_only = same_transient_frame_state && !requires_surface_frame;
+        if before.playing || after.playing {
+            self.playhead_frame_diagnostics
+                .record_frame_message(PlayheadFrameMessageDiagnostics {
+                    paint_only,
+                    reason: frame_repaint_reason(
+                        same_transient_frame_state,
+                        requires_surface_frame,
+                    ),
+                });
+        }
+        paint_only
     }
 
     pub(in crate::native_app) fn sync_edit_fade_audio_state(&mut self) {
@@ -417,11 +433,15 @@ impl NativeAppState {
         if self.chrome_overlay_suppresses_waveform_transient_overlay() {
             return;
         }
-        let Some(progress) = self.current_audio_progress_ratio_for_frame(context.animation_time)
+        let Some(projection) = self.playhead_progress_projection_for_frame(context.animation_time)
         else {
             return;
         };
-        let Some(visible_ratio) = self.waveform.current.visible_ratio_for_absolute(progress) else {
+        let Some(visible_ratio) = self
+            .waveform
+            .current
+            .visible_ratio_for_absolute(projection.ratio)
+        else {
             return;
         };
         let Some(bounds) = context
@@ -430,7 +450,17 @@ impl NativeAppState {
         else {
             return;
         };
-        push_playback_cursor(primitives, bounds, visible_ratio);
+        let Some(cursor_x) = push_playback_cursor(primitives, bounds, visible_ratio) else {
+            return;
+        };
+        self.playhead_frame_diagnostics
+            .record_overlay_frame(PlayheadOverlayFrameDiagnostics {
+                animation_time: context.animation_time,
+                progress_ratio: projection.ratio,
+                visible_ratio,
+                cursor_x,
+                progress_source: projection.source,
+            });
     }
 
     pub(in crate::native_app) fn paint_waveform_transient_overlay(
@@ -466,6 +496,14 @@ impl NativeAppState {
                 .sample_playback_session
                 .as_ref()
                 .is_some_and(sample_playback_session_pending_start)
+    }
+
+    pub(in crate::native_app) fn observe_playhead_native_frame_diagnostics(
+        &mut self,
+        diagnostics: radiant::runtime::NativeFrameDiagnostics,
+    ) {
+        self.playhead_frame_diagnostics
+            .observe_native_frame(diagnostics);
     }
 
     fn chrome_overlay_suppresses_waveform_transient_overlay(&self) -> bool {
@@ -749,7 +787,11 @@ impl FrameRepaintScopeSnapshot {
     }
 }
 
-fn push_playback_cursor(primitives: &mut Vec<PaintPrimitive>, bounds: Rect, ratio: f32) {
+fn push_playback_cursor(
+    primitives: &mut Vec<PaintPrimitive>,
+    bounds: Rect,
+    ratio: f32,
+) -> Option<f32> {
     let width = PLAYBACK_CURSOR_WIDTH
         .ceil()
         .clamp(1.0, bounds.width().max(1.0));
@@ -758,7 +800,7 @@ fn push_playback_cursor(primitives: &mut Vec<PaintPrimitive>, bounds: Rect, rati
         (center_x - width * 0.5).clamp(bounds.min.x, (bounds.max.x - width).max(bounds.min.x));
     let right = (left + width).min(bounds.max.x);
     if right <= left {
-        return;
+        return None;
     }
     WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID).push_visible_fill_rect(
         Rect::from_min_max(
@@ -767,6 +809,20 @@ fn push_playback_cursor(primitives: &mut Vec<PaintPrimitive>, bounds: Rect, rati
         ),
         PLAYBACK_CURSOR_COLOR,
     );
+    Some(center_x)
+}
+
+fn frame_repaint_reason(
+    same_transient_frame_state: bool,
+    requires_surface_frame: bool,
+) -> &'static str {
+    if requires_surface_frame {
+        "surface_frame_required"
+    } else if !same_transient_frame_state {
+        "transient_state_changed"
+    } else {
+        "paint_only"
+    }
 }
 
 fn playback_error_indicates_output_unavailable(error: &str) -> bool {

--- a/src/native_app/shell/launch/radiant_runtime.rs
+++ b/src/native_app/shell/launch/radiant_runtime.rs
@@ -4,21 +4,29 @@ use radiant::runtime::NativeRunOptions;
 
 use crate::native_app::app::{NativeAppState, view};
 use crate::native_app::app_chrome::settings;
+use crate::native_app::audio::playback::playhead_frame_diagnostics_observer_enabled;
 
 pub(super) fn run_catching_unwind(
     state: NativeAppState,
     options: NativeRunOptions,
 ) -> Result<Result<(), String>, Box<dyn std::any::Any + Send>> {
     panic::catch_unwind(AssertUnwindSafe(|| {
-        radiant::app(state)
+        let app = radiant::app(state)
             .options(options)
             .view(view)
             .subscriptions(NativeAppState::worker_subscription)
             .auxiliary_windows(settings::auxiliary_windows)
             .on_native_file_open(|state, open, context| {
                 state.open_audio_documents(open.paths, context);
+            });
+        let app = if playhead_frame_diagnostics_observer_enabled() {
+            app.on_native_frame_diagnostics(|state, diagnostics| {
+                state.observe_playhead_native_frame_diagnostics(diagnostics);
             })
-            .on_shutdown(NativeAppState::shutdown)
+        } else {
+            app
+        };
+        app.on_shutdown(NativeAppState::shutdown)
             .handle_message(NativeAppState::handle_message)
             .run()
     }))

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -65,6 +65,7 @@ impl NativeAppState {
             audio,
             transactions: Default::default(),
             metadata: MetadataAppState::from_settings(&config.core),
+            playhead_frame_diagnostics: Default::default(),
         };
         emit_gui_action(
             "runtime.startup.load_default_state",

--- a/src/native_app/test_support/state.rs
+++ b/src/native_app/test_support/state.rs
@@ -78,6 +78,7 @@ impl NativeAppStateFixture {
             audio: AudioAppState::for_tests(),
             transactions: Default::default(),
             metadata: MetadataAppState::from_settings(&self.persisted_settings),
+            playhead_frame_diagnostics: Default::default(),
         }
     }
 }


### PR DESCRIPTION
## Scope
- Add opt-in WaveformView playhead-frame diagnostics behind `WAVECRATE_PLAYHEAD_FRAME_DIAGNOSTICS` and the existing `wavecrate::debug::ui_frame` target.
- Capture transient overlay evidence per emitted playback cursor: `animation_time`, progress ratio/source, visible ratio, cursor x-position, native frame delta, overlay paint timing/primitive count, paint-only vs scene-rebuild status, and app frame-message repaint reason when present.
- Pin `vendor/radiant` to merged Radiant PR #1398 at `f00b804d4dc217671f344861fac4bae1968e9a07`, where native frame diagnostics expose frame-work kind/reason and apps can opt in without paying diagnostics cost by default.

## Definition of Done
- Diagnostics are disabled/no-op by default and the native frame observer is only registered when the env/log target are enabled.
- Enabled diagnostics correlate Wavecrate overlay samples with Radiant native frame presentation metadata.
- Playback overlay behavior remains paint-only in focused frame-overlay tests.
- The committed Wavecrate submodule pointer exactly matches merged Radiant `main` at `f00b804d4dc217671f344861fac4bae1968e9a07`.

## Validation commands
- `bash scripts/agent.sh request` *(non-blocking architecture passed; existing facade guardrail baseline failed in `src/app_core/*` and test-support paths before this change)*
- `git submodule status vendor/radiant`
- `git diff --submodule=log origin/main...HEAD -- vendor/radiant`
- `test "$(git -C vendor/radiant rev-parse HEAD)" = "$(git ls-tree HEAD vendor/radiant | awk '{print $3}')"`
- `cargo test -p wavecrate playhead_frame_diagnostics -- --test-threads=1`
- `cargo test -p wavecrate native_app::tests::toolbar_playback::frame_overlay:: -- --test-threads=1`
- `cargo test -p wavecrate native_app::waveform::tests::paint::playhead_cursor_paints_pixel_stable_rect_when_progress_is_subpixel -- --test-threads=1`
- `cargo test -p wavecrate native_app::audio::playback::loop_control::tests:: -- --test-threads=1`
- `cargo test --manifest-path vendor/radiant/Cargo.toml frame_diagnostics -- --test-threads=1`
- `cargo test --manifest-path vendor/radiant/Cargo.toml route_outcome -- --test-threads=1`
- `git diff --check`
- `git -C vendor/radiant diff --check`
- `rustfmt --edition 2024 --check src/native_app/audio/playback/diagnostics.rs src/native_app/audio/playback/progress.rs src/native_app/shell/launch/radiant_runtime.rs src/native_app/audio/playback/loop_control.rs src/native_app/audio/playback.rs src/native_app/app/state/mod.rs src/native_app/shell/lifecycle.rs src/native_app/test_support/state.rs`
- `rustfmt --edition 2024 --check vendor/radiant/src/application/launch/stateful/lifecycle.rs vendor/radiant/src/application/runtime.rs vendor/radiant/src/application/runtime/bridge.rs vendor/radiant/src/application/runtime/bridge/adapter.rs vendor/radiant/src/gui_runtime/native_vello/generic_runtime/present.rs vendor/radiant/src/gui_runtime/native_vello/generic_runtime/present/diagnostics.rs vendor/radiant/src/gui_runtime/native_vello/generic_runtime/route_outcome.rs vendor/radiant/src/gui_runtime/native_vello/generic_runtime/runner.rs vendor/radiant/src/gui_runtime/native_vello/generic_runtime/runner_state.rs vendor/radiant/src/prelude/runtime/native.rs vendor/radiant/src/runtime/diagnostics.rs vendor/radiant/src/runtime/diagnostics/frame.rs vendor/radiant/src/runtime/mod.rs vendor/radiant/tests/runtime_bridge_public_api/diagnostics.rs`

Final pin validation was rerun after Radiant PR #1398 merged and after Wavecrate committed `f00b804d4dc217671f344861fac4bae1968e9a07`.

## Known limitations
- Manual live playback capture with `WAVECRATE_PLAYHEAD_FRAME_DIAGNOSTICS=1` was not run in this pass; focused tests verify the diagnostic path and overlay/frame behavior.

User review was completed and signed off before merge.
