### PR TITLE
OPT-1076 Make application view projection immutable

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2362,6 +2362,8 @@ Large import lists are not formatting problems. In short: large import lists are
 
 Normal Wavecrate view-construction modules should prefer `use radiant::prelude as ui;` and then call `ui::...` builders/types. Low-level custom widget modules may import explicit Radiant subsystem contracts such as widget input/output, paint primitives, layout output, and theme tokens, but a long cross-subsystem list should trigger a boundary review: keep Wavecrate-specific paint/domain mapping app-side, move reusable interaction, layout, focus, invalidation, or rendering behavior into Radiant, and avoid creating Wavecrate-local GUI preludes to hide the dependency shape.
 
+Normal Radiant `.view(...)` projections and Wavecrate view-model construction must borrow host state immutably. Wavecrate should prepare derived sample-browser windows, starmap projections, and similar host-owned caches before initial launch and after the update messages that invalidate them; view construction must not hide durable state transitions or cache mutation.
+
 Cross-crate public facades must make ownership explicit. Prefer named `pub use`
 lists when Wavecrate owns the compatibility surface. Wildcard-style re-exports
 are allowed only for audited compatibility shims whose module docs name the

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -1,7 +1,6 @@
 use crate::native_app::app::{GuiMessage, NativeAppState, default_gui_shortcuts};
 use crate::native_app::app_chrome::layout;
 use crate::native_app::app_chrome::library_browser::sample_browser_view;
-use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
 use crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID;
 use radiant::{
     prelude as ui,
@@ -11,8 +10,7 @@ use radiant::{
 const APP_TRANSIENT_OVERLAY_KEY: u64 = 0x6170_705f_6f76_726c;
 const APP_FRAME_CLOCK_FPS: u32 = 60;
 
-pub(in crate::native_app) fn view(state: &mut NativeAppState) -> ui::View<GuiMessage> {
-    prepare_sample_browser_view(state);
+pub(in crate::native_app) fn view(state: &NativeAppState) -> ui::View<GuiMessage> {
     scene(state).into_view().fill()
 }
 

--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -59,6 +59,35 @@ pub(in crate::native_app) struct SampleBrowserViewProjection<'a> {
     help_tooltips_enabled: bool,
 }
 
+#[derive(Clone, Copy)]
+pub(in crate::native_app) struct SampleBrowserFramePreparationState {
+    copy_flash_active: bool,
+    startup_auto_load_pending: bool,
+}
+
+impl SampleBrowserFramePreparationState {
+    pub(in crate::native_app) fn capture(state: &NativeAppState) -> Self {
+        Self {
+            copy_flash_active: state.library.folder_browser.copy_flash_active(),
+            startup_auto_load_pending: state.ui.startup.auto_load_pending,
+        }
+    }
+
+    pub(in crate::native_app) fn requires_preparation(self, state: &NativeAppState) -> bool {
+        if live_drag_defers_sample_browser_preparation(state) {
+            return false;
+        }
+        state
+            .library
+            .folder_browser
+            .visible_sample_window_needs_content_refresh()
+            || self.copy_flash_active != state.library.folder_browser.copy_flash_active()
+            || self.startup_auto_load_pending != state.ui.startup.auto_load_pending
+            || (state.ui.chrome.sample_browser_display == SampleBrowserDisplayMode::Map
+                && !state.library.folder_browser.starmap_projection_prepared())
+    }
+}
+
 impl<'a> SampleBrowserViewProjection<'a> {
     pub(in crate::native_app) fn from_prepared_app_state(state: &'a NativeAppState) -> Self {
         let file_drag_active = state.library.folder_browser.file_drag_active();

--- a/src/native_app/sample_library/folder_browser/starmap.rs
+++ b/src/native_app/sample_library/folder_browser/starmap.rs
@@ -406,6 +406,10 @@ impl FolderBrowserState {
         self.sample_list.starmap_layout.projection_items.clone()
     }
 
+    pub(in crate::native_app) fn starmap_projection_prepared(&self) -> bool {
+        self.sample_list.starmap_layout.projection_items.is_some()
+    }
+
     pub(in crate::native_app) fn cached_starmap_projection_len(&self) -> usize {
         self.sample_list
             .starmap_layout

--- a/src/native_app/shell/launch/radiant_runtime.rs
+++ b/src/native_app/shell/launch/radiant_runtime.rs
@@ -4,13 +4,15 @@ use radiant::runtime::NativeRunOptions;
 
 use crate::native_app::app::{NativeAppState, view};
 use crate::native_app::app_chrome::settings;
+use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
 use crate::native_app::audio::playback::playhead_frame_diagnostics_observer_enabled;
 
 pub(super) fn run_catching_unwind(
-    state: NativeAppState,
+    mut state: NativeAppState,
     options: NativeRunOptions,
 ) -> Result<Result<(), String>, Box<dyn std::any::Any + Send>> {
     panic::catch_unwind(AssertUnwindSafe(|| {
+        prepare_sample_browser_view(&mut state);
         let app = radiant::app(state)
             .options(options)
             .view(view)

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -15,6 +15,7 @@ use radiant::prelude as ui;
 use std::time::{Duration, Instant};
 
 use crate::native_app::app::{GuiMessage, NativeAppState, WaveformInteraction, sample_path_label};
+use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 
 const FRAME_MESSAGE_PROFILE_LABEL: &str = "Frame";
@@ -28,6 +29,7 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         self.apply_message(message, context);
+        prepare_sample_browser_view(self);
     }
 
     pub(in crate::native_app) fn apply_message(

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -15,7 +15,9 @@ use radiant::prelude as ui;
 use std::time::{Duration, Instant};
 
 use crate::native_app::app::{GuiMessage, NativeAppState, WaveformInteraction, sample_path_label};
-use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
+use crate::native_app::app_chrome::view_models::sample_browser::{
+    SampleBrowserFramePreparationState, prepare_sample_browser_view,
+};
 use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
 
 const FRAME_MESSAGE_PROFILE_LABEL: &str = "Frame";
@@ -28,8 +30,15 @@ impl NativeAppState {
         message: GuiMessage,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let frame_preparation_state = matches!(message, GuiMessage::Frame)
+            .then(|| SampleBrowserFramePreparationState::capture(self));
         self.apply_message(message, context);
-        prepare_sample_browser_view(self);
+        if frame_preparation_state
+            .map(|state| state.requires_preparation(self))
+            .unwrap_or(true)
+        {
+            prepare_sample_browser_view(self);
+        }
     }
 
     pub(in crate::native_app) fn apply_message(

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::native_app::app::MetadataMessage;
-use std::time::Duration;
+use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
+use crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source;
+use crate::native_app::test_support::state::{FolderBrowserState, NativeAppStateFixture};
+use std::{fs, sync::Arc, time::Duration};
 
 #[test]
 fn root_dispatch_routes_metadata_messages_to_metadata_owner() {
@@ -24,4 +27,75 @@ fn frame_messages_use_frame_budget_slow_threshold() {
         slow_ui_message_threshold("NavigateBrowser"),
         Duration::from_millis(4)
     );
+}
+
+#[test]
+fn idle_map_frame_reuses_prepared_sample_browser_projection() {
+    let (_root, mut state, _sample_id) = prepared_map_state("idle-map-frame.wav");
+    let prepared = state
+        .library
+        .folder_browser
+        .cached_starmap_projection()
+        .expect("prepared starmap projection");
+
+    state.handle_message(GuiMessage::Frame, &mut ui::UiUpdateContext::default());
+
+    let after_frame = state
+        .library
+        .folder_browser
+        .cached_starmap_projection()
+        .expect("starmap projection remains prepared");
+    assert!(
+        Arc::ptr_eq(&prepared, &after_frame),
+        "paint-only frame traffic must not rebuild an unchanged starmap projection"
+    );
+}
+
+#[test]
+fn map_frame_rebuilds_projection_when_copy_flash_expires() {
+    let (_root, mut state, sample_id) = prepared_map_state("copy-flash-map-frame.wav");
+    state
+        .library
+        .folder_browser
+        .flash_copied_file_paths([sample_id.as_str()]);
+    prepare_sample_browser_view(&mut state);
+    let flashed = state
+        .library
+        .folder_browser
+        .cached_starmap_projection()
+        .expect("prepared flashed starmap projection");
+    assert!(flashed[0].copy_flash);
+
+    while state.library.folder_browser.copy_flash_frames() > 1 {
+        state.handle_message(GuiMessage::Frame, &mut ui::UiUpdateContext::default());
+        let during_flash = state
+            .library
+            .folder_browser
+            .cached_starmap_projection()
+            .expect("starmap projection remains prepared during flash");
+        assert!(Arc::ptr_eq(&flashed, &during_flash));
+    }
+    state.handle_message(GuiMessage::Frame, &mut ui::UiUpdateContext::default());
+
+    let after_flash = state
+        .library
+        .folder_browser
+        .cached_starmap_projection()
+        .expect("starmap projection refreshed after flash");
+    assert!(!Arc::ptr_eq(&flashed, &after_flash));
+    assert!(!after_flash[0].copy_flash);
+}
+
+fn prepared_map_state(file_name: &str) -> (tempfile::TempDir, NativeAppState, String) {
+    let root = tempfile::tempdir().expect("source root");
+    let sample = root.path().join(file_name);
+    fs::write(&sample, [0_u8; 8]).expect("write sample");
+    let sample_id = sample.to_string_lossy().into_owned();
+    let mut state = NativeAppStateFixture::default()
+        .with_folder_browser(FolderBrowserState::from_root(root.path().to_path_buf()))
+        .build();
+    state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    complete_starmap_layout_for_selected_source(&mut state);
+    prepare_sample_browser_view(&mut state);
+    (root, state, sample_id)
 }

--- a/src/native_app/tests.rs
+++ b/src/native_app/tests.rs
@@ -71,7 +71,8 @@ type NativeRuntimeForTests = SurfaceRuntime<
     super::test_support::state::GuiMessage,
 >;
 
-fn native_runtime_for_tests(state: NativeAppState, viewport: Vector2) -> NativeRuntimeForTests {
+fn native_runtime_for_tests(mut state: NativeAppState, viewport: Vector2) -> NativeRuntimeForTests {
+    super::test_support::sample_browser::prepare_sample_browser_view(&mut state);
     let mut runtime = radiant::runtime::SurfaceRuntime::new(
         radiant::runtime::declarative_owned_command_runtime_bridge(
             state,
@@ -101,7 +102,7 @@ where
 fn project_gui_surface_for_tests(
     state: &mut NativeAppState,
 ) -> UiSurface<super::test_support::state::GuiMessage> {
-    super::test_support::state::view(state).into_surface()
+    super::test_support::state::view(&*state).into_surface()
 }
 
 fn reduce_gui_message_for_tests(
@@ -109,7 +110,7 @@ fn reduce_gui_message_for_tests(
     message: super::test_support::state::GuiMessage,
 ) -> Command<super::test_support::state::GuiMessage> {
     let mut context = ui::UiUpdateContext::default();
-    state.apply_message(message, &mut context);
+    state.handle_message(message, &mut context);
     context.into_command()
 }
 

--- a/src/native_app/tests/metadata_tag_tests/chips.rs
+++ b/src/native_app/tests/metadata_tag_tests/chips.rs
@@ -48,8 +48,7 @@ fn metadata_tag_library_toggle_exposes_state_aware_help_tooltip() {
         native_app_state_with_temp_sample("tag-target.wav");
     closed_state.ui.chrome.help_tooltips_enabled = true;
     closed_state.metadata.tag_library_open = false;
-    let closed_surface =
-        crate::native_app::test_support::state::view(&mut closed_state).into_surface();
+    let closed_surface = crate::native_app::test_support::state::view(&closed_state).into_surface();
     let closed_tooltip = closed_surface
         .find_widget(
             crate::native_app::test_support::metadata_sidebar::METADATA_TAG_LIBRARY_TOGGLE_ID,
@@ -62,7 +61,7 @@ fn metadata_tag_library_toggle_exposes_state_aware_help_tooltip() {
         native_app_state_with_temp_sample("tag-target.wav");
     open_state.ui.chrome.help_tooltips_enabled = true;
     open_state.metadata.tag_library_open = true;
-    let open_surface = crate::native_app::test_support::state::view(&mut open_state).into_surface();
+    let open_surface = crate::native_app::test_support::state::view(&open_state).into_surface();
     let open_tooltip = open_surface
         .find_widget(
             crate::native_app::test_support::metadata_sidebar::METADATA_TAG_LIBRARY_TOGGLE_ID,
@@ -173,7 +172,7 @@ fn metadata_tag_chips_display_playback_tags_first() {
         ],
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
 
     let loop_rect = frame
@@ -237,7 +236,7 @@ fn metadata_tag_chips_show_mixed_tags_for_multi_selection() {
         radiant::widgets::WidgetState::default(),
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size(Vector2::new(900.0, 620.0), &theme);
     let bass_rect = frame
         .paint_plan

--- a/src/native_app/tests/metadata_tag_tests/input/rendering.rs
+++ b/src/native_app/tests/metadata_tag_tests/input/rendering.rs
@@ -60,9 +60,9 @@ fn folder_browser_metadata_tag_field_renders_completion_suffix_without_overlay_o
 
 #[test]
 fn folder_browser_metadata_category_completion_renders_above_tag_input() {
-    let (mut baseline_state, _baseline_source_root, _baseline_selected_file) =
+    let (baseline_state, _baseline_source_root, _baseline_selected_file) =
         native_app_state_with_temp_sample("baseline-tag-target.wav");
-    let baseline_frame = crate::native_app::test_support::state::view(&mut baseline_state)
+    let baseline_frame = crate::native_app::test_support::state::view(&baseline_state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
     let baseline_tag_input =
         metadata_tag_text_input(&baseline_frame).expect("baseline tag input should paint");
@@ -75,7 +75,7 @@ fn folder_browser_metadata_category_completion_renders_above_tag_input() {
         };
     state.metadata.tag_draft.clear();
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
 
     let tag_input = metadata_tag_text_input(&frame).expect("tag input should paint");

--- a/src/native_app/tests/metadata_tag_tests/layout.rs
+++ b/src/native_app/tests/metadata_tag_tests/layout.rs
@@ -40,7 +40,7 @@ fn metadata_section_sits_flush_against_bottom_status_bar() {
         .tags_by_file
         .insert(selected_file, vec![String::from("kick")]);
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
     let metadata_rect = frame
         .paint_plan
@@ -201,7 +201,7 @@ fn metadata_section_collapses_to_header_only_height() {
         ),
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
     let metadata_rect = frame
         .paint_plan

--- a/src/native_app/tests/metadata_tag_tests/library/categories.rs
+++ b/src/native_app/tests/metadata_tag_tests/library/categories.rs
@@ -15,7 +15,7 @@ fn default_gui_tag_library_category_headers_collapse_groups() {
         &mut ui::UiUpdateContext::default(),
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
 
     assert!(frame.paint_plan.contains_text("Sound Type (1)"));

--- a/src/native_app/tests/metadata_tag_tests/library/rendering.rs
+++ b/src/native_app/tests/metadata_tag_tests/library/rendering.rs
@@ -14,7 +14,7 @@ fn default_gui_tag_library_opens_beside_library_sidebar() {
     );
     state.metadata.tag_library_open = true;
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
 
     assert!(frame.paint_plan.contains_text("Tag Editor"));
@@ -42,7 +42,7 @@ fn default_gui_tag_library_paints_inactive_playback_tags_as_neutral_pills() {
         radiant::widgets::WidgetState::default(),
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size(Vector2::new(900.0, 620.0), &theme);
 
     assert_eq!(
@@ -77,7 +77,7 @@ fn default_gui_tag_library_paints_applied_playback_tags_as_active_pills() {
         },
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size(Vector2::new(900.0, 620.0), &theme);
 
     assert_eq!(
@@ -126,7 +126,7 @@ fn tag_library_paints_opposite_playback_type_as_inactive_after_replacement() {
         },
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size(Vector2::new(900.0, 620.0), &theme);
     let one_shot_rect = frame
         .paint_plan
@@ -191,7 +191,7 @@ fn default_gui_tag_library_paints_mixed_tags_as_partial_pills() {
         radiant::widgets::WidgetState::default(),
     );
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size(Vector2::new(900.0, 620.0), &theme);
     let bass_rect = frame
         .paint_plan
@@ -222,7 +222,7 @@ fn default_gui_tag_library_uses_custom_dictionary_categories() {
         .insert(String::from("deep-kick"), String::from("sound-type"));
     state.metadata.tag_library_open = true;
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(900.0, 620.0));
 
     assert!(frame.paint_plan.contains_text("Sound Type (1)"));

--- a/src/native_app/tests/sample_browser.rs
+++ b/src/native_app/tests/sample_browser.rs
@@ -889,8 +889,39 @@ fn copying_sample_selected_from_map_flashes_map_node_and_waveform() {
             ]),
         )
         .build();
-    state.library.folder_browser.select_file(first_id);
+    state.library.folder_browser.select_file(first_id.clone());
     state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    prepare_sample_browser_view(&mut state);
+    let layout_request = state
+        .library
+        .folder_browser
+        .take_starmap_layout_load_request(&state.metadata.tags_by_file)
+        .expect("starmap layout request");
+    state
+        .library
+        .folder_browser
+        .apply_starmap_layout_load_result(wavecrate::sample_sources::StarmapLayoutLoadResult {
+            signature: layout_request.signature,
+            result: Ok(HashMap::from([
+                (
+                    first_id,
+                    wavecrate::sample_sources::StarmapLayoutPoint {
+                        x: 0.35,
+                        y: 0.50,
+                        cluster_id: None,
+                    },
+                ),
+                (
+                    second_id.clone(),
+                    wavecrate::sample_sources::StarmapLayoutPoint {
+                        x: 0.65,
+                        y: 0.50,
+                        cluster_id: None,
+                    },
+                ),
+            ])),
+        });
+    prepare_sample_browser_view(&mut state);
 
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::BeginStarmapAuditionDrag {
@@ -900,7 +931,12 @@ fn copying_sample_selected_from_map_flashes_map_node_and_waveform() {
         },
         &mut radiant::prelude::UiUpdateContext::default(),
     );
+    assert_eq!(
+        state.library.folder_browser.selected_file_paths(),
+        [std::path::PathBuf::from(&second_id)]
+    );
     state.copy_selected_files(&mut radiant::prelude::UiUpdateContext::default());
+    assert!(state.library.folder_browser.copy_flash_active());
 
     assert_eq!(
         state.library.folder_browser.selected_file_id(),
@@ -918,10 +954,21 @@ fn copying_sample_selected_from_map_flashes_map_node_and_waveform() {
             preview_audition_sample_paths: state.waveform.cache.preview_audition_sample_paths(),
         },
     );
+    let copied = items
+        .iter()
+        .find(|item| item.file_id == second_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "map-selected sample should remain projected: {:?}",
+                items
+                    .iter()
+                    .map(|item| item.file_id.as_str())
+                    .collect::<Vec<_>>()
+            )
+        });
+    assert!(copied.selected, "copied map node should remain selected");
     assert!(
-        items
-            .iter()
-            .any(|item| item.file_id == second_id && item.selected && item.copy_flash),
+        copied.copy_flash,
         "copying the map-selected sample should flash the selected map node"
     );
 }

--- a/src/native_app/tests/sample_browser/rows.rs
+++ b/src/native_app/tests/sample_browser/rows.rs
@@ -259,7 +259,8 @@ fn full_gui_frame_places_sample_browser_text_inside_visible_area() {
         .into_iter()
         .map(|file| file.stem.clone())
         .collect::<Vec<_>>();
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    prepare_sample_browser_view(&mut state);
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(1517.0, 758.0));
     let sample_texts = frame
         .paint_plan

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -555,7 +555,7 @@ fn apply_gui_message_for_presentation_test(
     context: &mut ui::UiUpdateContext<GuiMessage>,
 ) {
     let frame_message = matches!(message, GuiMessage::Frame);
-    state.apply_message(message, context);
+    state.handle_message(message, context);
     if !frame_message {
         context.request_repaint();
     }

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -468,7 +468,7 @@ fn transaction_list_modal_renders_registered_transactions() {
     state.begin_transaction("Open batch");
     state.register_transaction_action("First action", |_| Ok(()), |_| Ok(()));
 
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(960.0, 540.0));
 
     assert!(frame.paint_plan.contains_text("Transactions"));

--- a/src/native_app/tests/waveform_playback/keyboard_navigation.rs
+++ b/src/native_app/tests/waveform_playback/keyboard_navigation.rs
@@ -26,11 +26,11 @@ fn rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow() {
     let state_for_update = std::rc::Rc::clone(&state);
     let bridge = ui::app(())
         .view(move |()| {
-            let mut state = lock_navigation_harness_state(&state_for_view);
-            crate::native_app::test_support::state::view(&mut state)
+            let state = lock_navigation_harness_state(&state_for_view);
+            crate::native_app::test_support::state::view(&state)
         })
         .handle_message(move |(), message, context| {
-            lock_navigation_harness_state(&state_for_update).apply_message(message, context);
+            lock_navigation_harness_state(&state_for_update).handle_message(message, context);
         })
         .into_bridge();
     let mut runtime = radiant::runtime::SurfaceRuntime::new(bridge, ui::Vector2::new(900.0, 620.0));

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -410,7 +410,7 @@ fn uncached_sample_load_clears_previous_waveform_until_current_waveform_finishes
     );
     assert_eq!(state.waveform.load.label.as_deref(), Some("selected.wav"));
     assert!(state.waveform_input_blocked_by_sample_load());
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(900.0, 620.0));
     assert!(
         frame.paint_plan.contains_text("Loading selected.wav"),
@@ -468,7 +468,7 @@ fn uncached_sample_load_keeps_playing_waveform_visible_until_replacement_is_read
     );
     assert_eq!(state.audio.current_playback_span, None);
     assert_eq!(state.waveform.load.label.as_deref(), Some("selected.wav"));
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(900.0, 620.0));
     assert!(
         frame.paint_plan.contains_text("Loading selected.wav"),

--- a/src/native_app/tests/window_chrome/app_bridge.rs
+++ b/src/native_app/tests/window_chrome/app_bridge.rs
@@ -9,7 +9,7 @@ fn app_bridge_scene_routes_primary_waveform_selection_drag() {
         .view(crate::native_app::test_support::state::view)
         .handle_message(move |state, message, context| {
             captured_messages.borrow_mut().push(message.clone());
-            state.apply_message(message, context);
+            state.handle_message(message, context);
         })
         .into_bridge();
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
@@ -90,7 +90,7 @@ fn app_bridge_scene_routes_native_file_drop_to_waveform_view() {
         .view(crate::native_app::test_support::state::view)
         .handle_message(move |state, message, context| {
             captured_messages.borrow_mut().push(message.clone());
-            state.apply_message(message, context);
+            state.handle_message(message, context);
             *captured_waveform_loading_label.borrow_mut() = state.waveform.load.label.clone();
         })
         .into_bridge();
@@ -144,7 +144,7 @@ fn app_bridge_scene_routes_targetless_native_file_drop_to_single_waveform_target
     let bridge = radiant::app(state)
         .view(crate::native_app::test_support::state::view)
         .handle_message(move |state, message, context| {
-            state.apply_message(message, context);
+            state.handle_message(message, context);
             *captured_waveform_loading_label.borrow_mut() = state.waveform.load.label.clone();
         })
         .into_bridge();
@@ -171,7 +171,7 @@ fn app_bridge_scene_preserves_waveform_drag_during_playback_frame_refresh() {
         .view(crate::native_app::test_support::state::view)
         .handle_message(move |state, message, context| {
             captured_messages.borrow_mut().push(message.clone());
-            state.apply_message(message, context);
+            state.handle_message(message, context);
         })
         .into_bridge();
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));

--- a/src/native_app/tests/window_chrome/audio_settings.rs
+++ b/src/native_app/tests/window_chrome/audio_settings.rs
@@ -44,7 +44,7 @@ fn audio_settings_popover_opens_as_centered_floating_window() {
 fn audio_settings_window_does_not_add_full_height_panel_chrome() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.ui.settings.ui.audio_settings_open = true;
-    let frame = crate::native_app::test_support::state::view(&mut state)
+    let frame = crate::native_app::test_support::state::view(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(960.0, 540.0));
     let audio_panel_fills = frame
         .paint_plan


### PR DESCRIPTION
## Scope

- Pin Radiant commit `35ba27be` from [PORTALSURFER/radiant#1401](https://github.com/PORTALSURFER/radiant/pull/1401), changing the normal `.view(...)` projection contract to `&State`.
- Make Wavecrate's root native-app view read-only.
- Prepare sample-browser windows and starmap view models explicitly before launch and after GUI-message updates.
- Keep paint-only `Frame` traffic on the prepared sample-browser projection unless frame-owned state invalidates it.
- Migrate Wavecrate call sites and test harnesses to immutable view construction.
- Update the Wavecrate/Radiant architecture contract and preserve selection-follow, viewport, drag-deferral, map/list, and copy-feedback behavior.

## Definition of Done

- [x] Normal Radiant `.view(...)` accepts immutable host state.
- [x] Wavecrate root view and sample-browser view-model construction are read-only.
- [x] Initial and post-message preparation own derived host-state mutation.
- [x] Idle map frames reuse the prepared projection; invalidating frame transitions still rebuild it.
- [x] Virtual-list viewport/follow behavior remains covered.
- [x] Sample-browser selection visibility and starmap behavior remain covered.
- [x] Docs and public API tests make immutable projection canonical.

## Validation commands

- `cargo test --manifest-path vendor/radiant/Cargo.toml --test application_builder_public_api`
  - 152 passed
- `cargo test --manifest-path vendor/radiant/Cargo.toml --examples`
  - all maintained examples passed, including the new repeated-projection regression
- `cargo test -p wavecrate --bin wavecrate sample_browser -- --nocapture`
  - 222 passed
- focused frame-preparation regressions
  - idle map frames preserve the cached projection identity
  - copy-flash expiry triggers exactly the required projection refresh
- `bash scripts/ci.sh agent`
  - smoke and compile checks passed
  - non-blocking architecture and strict responsiveness guardrails passed
  - 1,563 Radiant library tests passed
  - 47 Radiant app-runtime tests passed
  - 1,830 Wavecrate library tests passed, 20 ignored by policy

## Known limitations

None in the implementation. `bash scripts/ci.sh quick` could not complete locally because `cargo-nextest` hung while enumerating integration-test binaries, even after installing it through `scripts/bootstrap.sh`; the focused suites and stronger non-nextest agent lane passed.

Radiant PR #1401 merged first; Wavecrate now pins its reachable squash commit `35ba27be`.

User review is required before merge.