### PR TITLE
OPT-1074 Preserve static and shared application text

### DIFF
--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -300,7 +300,7 @@ fn sample_passive_badge(label: String) -> ui::View<GuiMessage> {
         .height(14.0)
 }
 
-fn compact_text(text: impl Into<String>) -> ui::View<GuiMessage> {
+fn compact_text(text: impl Into<ui::TextContent>) -> ui::View<GuiMessage> {
     ui::text(text).height(18.0).truncate()
 }
 

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -40,7 +40,7 @@ pub(in crate::native_app) fn bottom_status_bar(model: StatusBarViewModel) -> ui:
     .height(STATUS_BAR_HEIGHT)
 }
 
-fn status_segment(label: String) -> ui::View<GuiMessage> {
+fn status_segment(label: impl Into<ui::TextContent>) -> ui::View<GuiMessage> {
     ui::text(label).truncate().height(STATUS_BAR_SEGMENT_HEIGHT)
 }
 
@@ -123,6 +123,7 @@ fn job_details_popover_from_projection(
 mod tests {
     use super::*;
     use radiant::prelude::IntoView;
+    use std::sync::Arc;
 
     #[test]
     fn bottom_status_bar_paints_missing_source_status_as_warning() {
@@ -139,5 +140,19 @@ mod tests {
             frame.paint_plan.first_text_color("Source missing | Ready"),
             Some(SOURCE_MISSING_STATUS_COLOR)
         );
+    }
+
+    #[test]
+    fn status_segment_accepts_shared_text_content() {
+        let label: Arc<str> = Arc::from("Shared worker status");
+        let frame = status_segment(Arc::clone(&label))
+            .view_frame_at_size_with_default_theme(ui::Vector2::new(240.0, STATUS_BAR_HEIGHT));
+        let run = frame
+            .paint_plan
+            .first_text_run(label.as_ref())
+            .expect("shared status label should paint");
+
+        assert_eq!(run.text.as_str(), label.as_ref());
+        assert!(!run.text.is_static());
     }
 }


### PR DESCRIPTION
## Scope

- Pin `vendor/radiant` to the OPT-1074 implementation in [Radiant PR #1403](https://github.com/PORTALSURFER/radiant/pull/1403).
- Update Wavecrate's compact text helper to accept the canonical `TextContent` payload.
- Update the status-segment helper and add a focused Wavecrate proof that an existing `Arc<str>` reaches paint text through the application builder path.

## Definition of Done

- [x] Wavecrate compiles against the static/shared-aware Radiant application API.
- [x] Existing shared status text can be passed without a `String` round trip.
- [x] Static and owned Wavecrate call sites remain source-compatible.
- [x] The parent gitlink points at the pushed Radiant feature commit.
- [x] Focused Wavecrate and Radiant validation is green.

## Validation commands

- `cargo check -p wavecrate --bin wavecrate -j1` — passed.
- `cargo test -p wavecrate status_segment_accepts_shared_text_content -j1` — passed.
- `rustfmt --edition 2024 --check src/native_app/app_chrome/status_bar.rs src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs` — passed.
- `cargo test --manifest-path vendor/radiant/Cargo.toml --test application_builder_public_api -j1` — 159 passed.
- `cargo test --manifest-path vendor/radiant/Cargo.toml --examples -j1` — all example tests passed.
- `cargo bench --manifest-path vendor/radiant/Cargo.toml --bench perf_harness app_static_text_controls_projection_1k -- --jsonl` — `text_storage_allocation_count: 0`.
- `git diff --check` — passed.

The repository request preflight still stops at the known Wavecrate facade baseline (`app_core` legacy crossings and production `test_support` imports), unrelated to this PR. Radiant's package-wide rustfmt check also reports the pre-existing unmodified `src/widgets/primitives/interactive_row/tests/input.rs` diff.

## Known limitations

- This PR must not merge until Radiant PR #1403 lands so the pinned submodule commit is reachable from Radiant `main`.
- Editable text-input values intentionally remain owned `String` state.

User review is required before merge.