### PR TITLE
OPT-1109 Make macOS multi-file drag-out immediate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2780,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
 ]
 
 [[package]]
@@ -4084,6 +4122,7 @@ dependencies = [
  "arboard",
  "image",
  "kurbo",
+ "lyon_tessellation",
  "naga",
  "open",
  "pollster",

--- a/src/native_app/sample_library/drag_drop_actions/drag_session.rs
+++ b/src/native_app/sample_library/drag_drop_actions/drag_session.rs
@@ -1,4 +1,5 @@
 use radiant::prelude as ui;
+use std::time::Instant;
 
 use crate::native_app::{
     app::{GuiMessage, NativeAppState},
@@ -25,6 +26,7 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
         add_keep_rating: bool,
     ) {
+        let started_at = Instant::now();
         let drag = self.library.folder_browser.drag_preview().map(|preview| {
             ui::DragRequest::new(
                 ui::DragPreview::text_sized(
@@ -37,9 +39,29 @@ impl NativeAppState {
             )
         });
         let external = self.library.folder_browser.external_drag_request();
+        let path_count = external
+            .as_ref()
+            .map(|request| match &request.payload {
+                ui::ExternalDragPayload::Files(paths) => paths.len(),
+            })
+            .unwrap_or_default();
+        tracing::debug!(
+            target: "wavecrate::external_drag",
+            event = "external_drag.payload_ready",
+            path_count,
+            elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0,
+            "External drag payload ready"
+        );
         self.arm_pending_internal_file_drag_paths(external.as_ref(), add_keep_rating);
 
         context.begin_drag_session(drag, external, GuiMessage::ExternalDragCompleted);
+        tracing::debug!(
+            target: "wavecrate::external_drag",
+            event = "external_drag.armed",
+            path_count,
+            elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0,
+            "External drag armed"
+        );
     }
 
     pub(in crate::native_app) fn cancel_browser_drag_on_sample_list(

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -381,6 +381,14 @@ impl NativeAppState {
         result: Result<ui::ExternalDragOutcome, String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        tracing::debug!(
+            target: "wavecrate::external_drag",
+            event = "external_drag.completed",
+            accepted = result.as_ref().is_ok_and(|outcome| outcome.accepted()),
+            effect = ?result.as_ref().ok().map(|outcome| outcome.effect),
+            error = result.as_ref().err().map(String::as_str).unwrap_or(""),
+            "External drag completed"
+        );
         let handoff_paths = self
             .ui
             .browser_interaction

--- a/src/native_app/sample_library/folder_browser/tests/external_drag.rs
+++ b/src/native_app/sample_library/folder_browser/tests/external_drag.rs
@@ -33,6 +33,40 @@ fn file_drag_external_request_uses_selected_file_paths() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn large_file_drag_external_request_is_sorted_complete_and_duplicate_free() {
+    let root = temp_source_root("wavecrate-gui-large-file-external-drag");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let paths = (0..1_000)
+        .map(|index| drums.join(format!("sample-{index:04}.wav")))
+        .collect::<Vec<_>>();
+    for file in &paths {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&paths[999]));
+    for path in paths.iter().rev().skip(1) {
+        browser.select_file_with_modifiers(
+            path_id(path),
+            PointerModifiers {
+                command: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    browser.begin_file_drag(path_id(&paths[500]), Point::new(4.0, 8.0));
+    let request = browser
+        .external_drag_request()
+        .expect("large file drag should expose external request");
+
+    assert_eq!(request.preview.label, "1000 files");
+    assert_eq!(request.payload, ExternalDragPayload::Files(paths.clone()));
+    let _ = fs::remove_dir_all(root);
+}
 #[test]
 fn extracted_file_drag_external_request_uses_extracted_path() {
     let root = temp_source_root("wavecrate-gui-extracted-file-external-drag");


### PR DESCRIPTION
## Scope

- Snapshot the exact selected file payload once when Wavecrate arms the drag.
- Add payload-ready, armed, completion, pointer-exit, item-build, and native-session timing.
- Update Radiant to use one shared file-type preview icon for multi-file drags instead of one synchronous filesystem icon lookup per path.
- Add deterministic 1,000-file payload coverage.

## Definition of Done

- [x] Multi-file preview preparation no longer performs per-file icon loading.
- [x] Single-file previews retain their file-specific icon.
- [x] The external payload is sorted, complete, and duplicate-free at 1,000 files.
- [x] Cancellation/completion clears existing drag state through the retained session flow.
- [x] Wavecrate and Radiant focused external-drag tests pass.

## Validation commands

- cargo check -p wavecrate --all-targets
- cargo test -p wavecrate --bin wavecrate large_file_drag_external_request_is_sorted_complete_and_duplicate_free -j1
- cargo test -p wavecrate --bin wavecrate native_app::sample_library::folder_browser::tests::external_drag -j1
- cargo test --manifest-path vendor/radiant/Cargo.toml --lib external_drag -j1

## Known limitations

- Final Finder/DAW prompt-release acceptance remains a hands-on review step because performing the actual filesystem drop would create files through the desktop UI.
- Current Radiant main has an unrelated source-shape guardrail failure under the broad external_drag integration filter; all eight external-drag library tests pass.

## Nested dependency

- Radiant PR: https://github.com/PORTALSURFER/radiant/pull/1410
- Radiant commit: 5c6e3777

User review is required before merge.

Closes OPT-1109