### PR TITLE
OPT-1108 Keep source scans off the UI path

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -32,9 +32,10 @@ use crate::native_app::sample_library::folder_browser::commands::{
     FileMoveConflictCompletion, FileMoveConflictResolutionRequest, FolderMoveCompletion,
 };
 use crate::native_app::sample_library::folder_browser::scan::{
-    FolderScanDiscoveryBatch, FolderScanProgress, FolderScanResult, FolderTreeRefreshResult,
-    FolderVerifyResult,
+    FolderScanDiscoveryBatch, FolderScanProgress, FolderTreeRefreshResult, FolderVerifyResult,
+    PreparedFolderScanResult,
 };
+use crate::native_app::sample_library::folder_scan_actions::FolderScanMaintenanceResult;
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
 use crate::native_app::sample_library::similarity_prep::{
     SimilarityPrepEnqueueResult, SimilarityPrepStatusResult,
@@ -68,7 +69,8 @@ pub(in crate::native_app) enum GuiMessage {
     },
     FolderScanProgress(FolderScanProgress),
     FolderScanDiscoveryBatch(FolderScanDiscoveryBatch),
-    FolderScanFinished(FolderScanResult),
+    FolderScanFinished(PreparedFolderScanResult),
+    FolderScanMaintenanceFinished(FolderScanMaintenanceResult),
     FolderTreeRefreshFinished(ui::TaskCompletion<FolderTreeRefreshResult>),
     SelectedFolderVerifyFinished(ui::TaskCompletion<FolderVerifyResult>),
     SourceFilesystemChanged {

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -2,7 +2,7 @@ use radiant::prelude as ui;
 
 use crate::native_app::sample_library::folder_browser::scan::{
     self, FolderScanDiscovery, FolderScanDiscoveryBatch, FolderScanProgress, FolderScanRequest,
-    FolderScanResult,
+    PreparedFolderScanResult, prepare_folder_scan_cache_update,
 };
 
 const DISCOVERY_BATCH_SIZE: usize = 64;
@@ -15,17 +15,17 @@ pub(in crate::native_app) enum FolderScanWorkerEvent {
 pub(in crate::native_app) fn run_folder_scan_worker(
     request: FolderScanRequest,
     events: ui::BusinessEventSink<FolderScanWorkerEvent>,
-) -> FolderScanResult {
+) -> PreparedFolderScanResult {
     run_folder_scan_worker_with_emit(request, move |event| events.emit(event))
 }
 
 fn run_folder_scan_worker_with_emit(
     request: FolderScanRequest,
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
-) -> FolderScanResult {
+) -> PreparedFolderScanResult {
     let mut discovery_transport =
         FolderScanDiscoveryTransport::new(emit.clone(), request.task_id, request.source_id.clone());
-    let result = scan::scan_source_with_progress(
+    let scan = scan::scan_source_with_progress(
         request,
         |progress| {
             let _ = emit(FolderScanWorkerEvent::Progress(progress));
@@ -35,7 +35,13 @@ fn run_folder_scan_worker_with_emit(
         },
     );
     discovery_transport.flush();
-    result
+    let audio_file_paths = scan.audio_file_paths();
+    let scan_cache_update = prepare_folder_scan_cache_update(&scan);
+    PreparedFolderScanResult {
+        scan,
+        audio_file_paths,
+        scan_cache_update,
+    }
 }
 
 struct FolderScanDiscoveryTransport<Emit> {
@@ -119,7 +125,7 @@ mod tests {
             sender.send(event).is_ok()
         });
 
-        assert_eq!(result.file_count, DISCOVERY_BATCH_SIZE + 2);
+        assert_eq!(result.audio_file_paths.len(), DISCOVERY_BATCH_SIZE + 2);
         let batch_lengths = receiver
             .try_iter()
             .filter_map(|message| match message {
@@ -130,7 +136,34 @@ mod tests {
         assert_eq!(batch_lengths.first().copied(), Some(DISCOVERY_BATCH_SIZE));
         assert_eq!(
             batch_lengths.iter().sum::<usize>(),
-            DISCOVERY_BATCH_SIZE + 3
+            result.scan.file_count,
+            "discovery transport should publish each scanned item once without completed-subtree clones"
         );
+    }
+
+    #[test]
+    fn large_scan_worker_keeps_every_ui_discovery_message_bounded() {
+        let root = temp_source_with_wavs(DISCOVERY_BATCH_SIZE * 16);
+        let (sender, receiver) = mpsc::channel();
+
+        let result = run_folder_scan_worker_with_emit(scan_request(&root), move |event| {
+            sender.send(event).is_ok()
+        });
+
+        let batch_lengths = receiver
+            .try_iter()
+            .filter_map(|message| match message {
+                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events.len()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(batch_lengths.len() > 1);
+        assert!(
+            batch_lengths
+                .iter()
+                .all(|count| *count <= DISCOVERY_BATCH_SIZE)
+        );
+        assert_eq!(batch_lengths.iter().sum::<usize>(), result.scan.file_count);
+        assert_eq!(result.audio_file_paths.len(), DISCOVERY_BATCH_SIZE * 16);
     }
 }

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -89,7 +89,9 @@ where
 mod tests {
     use std::{fs, sync::mpsc};
 
-    use crate::native_app::sample_library::folder_browser::scan::FolderScanRequest;
+    use crate::native_app::sample_library::folder_browser::scan::{
+        FolderScanItem, FolderScanRequest,
+    };
 
     use super::{DISCOVERY_BATCH_SIZE, FolderScanWorkerEvent, run_folder_scan_worker_with_emit};
 
@@ -126,17 +128,22 @@ mod tests {
         });
 
         assert_eq!(result.audio_file_paths.len(), DISCOVERY_BATCH_SIZE + 2);
-        let batch_lengths = receiver
+        let batches = receiver
             .try_iter()
             .filter_map(|message| match message {
-                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events.len()),
+                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events),
                 _ => None,
             })
             .collect::<Vec<_>>();
+        let batch_lengths = batches.iter().map(Vec::len).collect::<Vec<_>>();
+        let published_file_count = batches
+            .iter()
+            .flatten()
+            .filter(|event| matches!(event.item, FolderScanItem::File(_)))
+            .count();
         assert_eq!(batch_lengths.first().copied(), Some(DISCOVERY_BATCH_SIZE));
         assert_eq!(
-            batch_lengths.iter().sum::<usize>(),
-            result.scan.file_count,
+            published_file_count, result.scan.file_count,
             "discovery transport should publish each scanned item once without completed-subtree clones"
         );
     }
@@ -150,20 +157,26 @@ mod tests {
             sender.send(event).is_ok()
         });
 
-        let batch_lengths = receiver
+        let batches = receiver
             .try_iter()
             .filter_map(|message| match message {
-                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events.len()),
+                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events),
                 _ => None,
             })
             .collect::<Vec<_>>();
+        let batch_lengths = batches.iter().map(Vec::len).collect::<Vec<_>>();
+        let published_file_count = batches
+            .iter()
+            .flatten()
+            .filter(|event| matches!(event.item, FolderScanItem::File(_)))
+            .count();
         assert!(batch_lengths.len() > 1);
         assert!(
             batch_lengths
                 .iter()
                 .all(|count| *count <= DISCOVERY_BATCH_SIZE)
         );
-        assert_eq!(batch_lengths.iter().sum::<usize>(), result.scan.file_count);
+        assert_eq!(published_file_count, result.scan.file_count);
         assert_eq!(result.audio_file_paths.len(), DISCOVERY_BATCH_SIZE * 16);
     }
 }

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+pub(in crate::native_app) use super::scan_types::FolderScanItem;
 pub(in crate::native_app) use super::scan_types::{
     FolderScanDiscovery, FolderScanDiscoveryBatch, FolderScanProgress, FolderScanRequest,
     FolderScanResult, FolderTreeRefreshRequest, FolderTreeRefreshResult, FolderVerifyResult,

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -8,4 +8,5 @@ pub(in crate::native_app) use super::scanning::{
 };
 pub(in crate::native_app) use super::source_scan_cache::{
     FolderScanCacheUpdate, apply_folder_scan_cache_update, prepare_folder_scan_cache_update,
+    reserve_source_scan_cache_revision,
 };

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -1,7 +1,11 @@
 pub(in crate::native_app) use super::scan_types::{
     FolderScanDiscovery, FolderScanDiscoveryBatch, FolderScanProgress, FolderScanRequest,
     FolderScanResult, FolderTreeRefreshRequest, FolderTreeRefreshResult, FolderVerifyResult,
+    PreparedFolderScanResult,
 };
 pub(in crate::native_app) use super::scanning::{
     refresh_folder_tree_only, scan_source_with_progress, verify_direct_folder,
+};
+pub(in crate::native_app) use super::source_scan_cache::{
+    FolderScanCacheUpdate, apply_folder_scan_cache_update, prepare_folder_scan_cache_update,
 };

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -33,6 +33,7 @@ pub(in crate::native_app) struct FolderScanProgress {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum FolderScanItem {
+    ResetFolder,
     Folder(FolderEntry),
     File(FileEntry),
 }

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use super::source_scan_cache::FolderScanCacheUpdate;
 use super::{FileEntry, FolderEntry, collections::MissingCollectionSnapshot};
 use wavecrate::sample_sources::config::DEFAULT_RATING_DECAY_WEEKS;
 
@@ -33,7 +34,6 @@ pub(in crate::native_app) struct FolderScanProgress {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum FolderScanItem {
     Folder(FolderEntry),
-    CompletedFolder(FolderEntry),
     File(FileEntry),
 }
 
@@ -74,6 +74,25 @@ impl FolderScanResult {
             .filter(|file| file.is_audio() && !file.is_missing())
             .map(|file| PathBuf::from(&file.id))
             .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct PreparedFolderScanResult {
+    pub(in crate::native_app) scan: FolderScanResult,
+    pub(in crate::native_app) audio_file_paths: Vec<PathBuf>,
+    pub(in crate::native_app) scan_cache_update: FolderScanCacheUpdate,
+}
+
+impl From<FolderScanResult> for PreparedFolderScanResult {
+    fn from(scan: FolderScanResult) -> Self {
+        let audio_file_paths = scan.audio_file_paths();
+        let scan_cache_update = super::source_scan_cache::prepare_folder_scan_cache_update(&scan);
+        Self {
+            scan,
+            audio_file_paths,
+            scan_cache_update,
+        }
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
@@ -7,20 +7,6 @@ pub(in crate::native_app::sample_library::folder_browser) fn merge_scan_discover
     root: &mut FolderEntry,
     event: &FolderScanDiscovery,
 ) -> bool {
-    if let FolderScanItem::CompletedFolder(folder) = &event.item {
-        if root.id == folder.id {
-            if root == folder {
-                return false;
-            }
-            *root = folder.clone();
-            return true;
-        }
-        let Some(parent) = root.find_mut(&event.parent_id) else {
-            return false;
-        };
-        return upsert_folder(&mut parent.children, folder.clone());
-    }
-
     let Some(parent) = root.find_mut(&event.parent_id) else {
         return false;
     };
@@ -28,7 +14,6 @@ pub(in crate::native_app::sample_library::folder_browser) fn merge_scan_discover
         FolderScanItem::Folder(folder) => {
             insert_discovered_folder(&mut parent.children, folder.clone())
         }
-        FolderScanItem::CompletedFolder(_) => unreachable!("completed folders are handled above"),
         FolderScanItem::File(file) => upsert_file(&mut parent.files, file.clone()),
     }
 }

--- a/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
@@ -11,6 +11,12 @@ pub(in crate::native_app::sample_library::folder_browser) fn merge_scan_discover
         return false;
     };
     match &event.item {
+        FolderScanItem::ResetFolder => {
+            let changed = !parent.children.is_empty() || !parent.files.is_empty();
+            parent.children.clear();
+            parent.files.clear();
+            changed
+        }
         FolderScanItem::Folder(folder) => {
             insert_discovered_folder(&mut parent.children, folder.clone())
         }
@@ -74,5 +80,44 @@ pub(in crate::native_app::sample_library::folder_browser) fn upsert_file(
             files.insert(index, file);
             true
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use wavecrate::sample_sources::Rating;
+
+    #[test]
+    fn folder_snapshot_start_prunes_stale_cached_children() {
+        let mut root = FolderEntry {
+            id: String::from("root"),
+            name: String::from("root"),
+            children: vec![FolderEntry {
+                id: String::from("root/stale"),
+                name: String::from("stale"),
+                children: Vec::new(),
+                files: Vec::new(),
+            }],
+            files: vec![FileEntry::missing_collection_member(
+                Path::new("root/stale.wav"),
+                Rating::NEUTRAL,
+                false,
+                Vec::new(),
+                None,
+                None,
+            )],
+        };
+        let event = FolderScanDiscovery {
+            task_id: 1,
+            source_id: String::from("source"),
+            parent_id: String::from("root"),
+            item: FolderScanItem::ResetFolder,
+        };
+
+        assert!(merge_scan_discovery(&mut root, &event));
+        assert!(root.children.is_empty());
+        assert!(root.files.is_empty());
     }
 }

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -54,12 +54,6 @@ pub(in crate::native_app) fn scan_source_with_progress(
         None
     };
     let source_root_available = request.root.is_dir();
-    discovered(FolderScanDiscovery {
-        task_id: request.task_id,
-        source_id: request.source_id.clone(),
-        parent_id: path_id(&request.root),
-        item: FolderScanItem::CompletedFolder(folder.clone()),
-    });
     FolderScanResult {
         task_id: request.task_id,
         source_id: request.source_id,
@@ -166,15 +160,6 @@ where
         });
     }
 
-    fn record_completed_folder(&mut self, parent_id: &str, folder: FolderEntry) {
-        (self.discovered)(FolderScanDiscovery {
-            task_id: self.request.task_id,
-            source_id: self.request.source_id.clone(),
-            parent_id: parent_id.to_string(),
-            item: FolderScanItem::CompletedFolder(folder),
-        });
-    }
-
     fn maybe_report_progress(&mut self, path: &Path) {
         if self.counter.completed == 1 || self.counter.completed.is_multiple_of(64) {
             (self.progress)(FolderScanProgress {
@@ -205,9 +190,7 @@ where
         .filter(|entry| entry.is_dir())
         .filter_map(|entry| {
             scan.record_folder(entry, &parent_id);
-            let child = load_folder_with_progress(entry, scan)?;
-            scan.record_completed_folder(&parent_id, child.clone());
-            Some(child)
+            load_folder_with_progress(entry, scan)
         })
         .collect::<Vec<_>>();
     let files = entries

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -148,6 +148,15 @@ where
         });
     }
 
+    fn record_folder_snapshot_start(&mut self, folder_id: &str) {
+        (self.discovered)(FolderScanDiscovery {
+            task_id: self.request.task_id,
+            source_id: self.request.source_id.clone(),
+            parent_id: folder_id.to_string(),
+            item: FolderScanItem::ResetFolder,
+        });
+    }
+
     fn record_file(&mut self, path: &Path, parent_id: &str, file: FileEntry) {
         self.counter.completed += 1;
         self.counter.files += 1;
@@ -185,6 +194,7 @@ where
 {
     let entries = read_sorted_entries(path)?;
     let parent_id = path_id(path);
+    scan.record_folder_snapshot_start(&parent_id);
     let children = entries
         .iter()
         .filter(|entry| entry.is_dir())

--- a/src/native_app/sample_library/folder_browser/source_scan_cache.rs
+++ b/src/native_app/sample_library/folder_browser/source_scan_cache.rs
@@ -108,17 +108,26 @@ pub(in crate::native_app) fn apply_folder_scan_cache_update(
     update: FolderScanCacheUpdate,
 ) -> Result<(), String> {
     let path = source_scan_cache_path()?;
-    let mut cache = load_source_scan_cache_from_path(&path)?;
+    apply_folder_scan_cache_update_to_path(&path, update)
+}
+
+fn apply_folder_scan_cache_update_to_path(
+    path: &Path,
+    update: FolderScanCacheUpdate,
+) -> Result<(), String> {
+    let Some(source) = update.source else {
+        return Ok(());
+    };
+    let mut cache = load_source_scan_cache_from_path(path).unwrap_or_default();
+    cache.version = SOURCE_SCAN_CACHE_VERSION;
     cache
         .sources
         .retain(|source| source.source_id != update.source_id);
-    if let Some(source) = update.source {
-        cache.sources.push(source);
-    }
+    cache.sources.push(source);
     cache
         .sources
         .sort_by(|left, right| left.source_id.cmp(&right.source_id));
-    save_source_scan_cache_value_to_path(&path, &cache)
+    save_source_scan_cache_value_to_path(path, &cache)
 }
 
 fn source_scan_cache_path() -> Result<PathBuf, String> {
@@ -346,6 +355,81 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["kick.wav"]
         );
+    }
+
+    #[test]
+    fn incremental_update_writes_current_cache_version_for_new_profiles() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(SOURCE_SCAN_CACHE_FILE_NAME);
+        let root = temp.path().join("source");
+
+        apply_folder_scan_cache_update_to_path(
+            &path,
+            FolderScanCacheUpdate {
+                source_id: String::from("source-id"),
+                source: Some(cached_source_for_test("source-id", &root)),
+            },
+        )
+        .expect("apply cache update");
+
+        let cache = load_source_scan_cache_from_path(&path).expect("load updated cache");
+        assert_eq!(cache.version, SOURCE_SCAN_CACHE_VERSION);
+        assert!(cache.folder_for_source("source-id", &root).is_some());
+    }
+
+    #[test]
+    fn incremental_update_preserves_offline_source_snapshot() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(SOURCE_SCAN_CACHE_FILE_NAME);
+        let root = temp.path().join("source");
+        let cache = SourceScanCache::new(vec![cached_source_for_test("source-id", &root)]);
+        save_source_scan_cache_value_to_path(&path, &cache).expect("seed cache");
+        let before = fs::read(&path).expect("read seeded cache");
+
+        apply_folder_scan_cache_update_to_path(
+            &path,
+            FolderScanCacheUpdate {
+                source_id: String::from("source-id"),
+                source: None,
+            },
+        )
+        .expect("preserve offline cache");
+
+        assert_eq!(fs::read(&path).expect("read preserved cache"), before);
+    }
+
+    #[test]
+    fn incremental_update_replaces_corrupt_cache() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(SOURCE_SCAN_CACHE_FILE_NAME);
+        let root = temp.path().join("source");
+        fs::write(&path, b"{not-json").expect("seed corrupt cache");
+
+        apply_folder_scan_cache_update_to_path(
+            &path,
+            FolderScanCacheUpdate {
+                source_id: String::from("source-id"),
+                source: Some(cached_source_for_test("source-id", &root)),
+            },
+        )
+        .expect("repair cache");
+
+        let cache = load_source_scan_cache_from_path(&path).expect("load repaired cache");
+        assert!(cache.folder_for_source("source-id", &root).is_some());
+    }
+
+    fn cached_source_for_test(source_id: &str, root: &Path) -> CachedSourceScan {
+        CachedSourceScan {
+            source_id: source_id.to_owned(),
+            root: root.to_path_buf(),
+            root_folder: FolderEntry {
+                id: root.display().to_string(),
+                name: String::from("source"),
+                children: Vec::new(),
+                files: vec![file_for_cache_test(&root.join("kick.wav"))],
+            },
+            missing_collection_snapshot: MissingCollectionSnapshot::default(),
+        }
     }
 
     fn file_for_cache_test(path: &Path) -> FileEntry {

--- a/src/native_app/sample_library/folder_browser/source_scan_cache.rs
+++ b/src/native_app/sample_library/folder_browser/source_scan_cache.rs
@@ -5,7 +5,9 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{FolderEntry, SourceEntry, collections::MissingCollectionSnapshot};
+use super::{
+    FolderEntry, SourceEntry, collections::MissingCollectionSnapshot, scan::FolderScanResult,
+};
 
 const SOURCE_SCAN_CACHE_FILE_NAME: &str = "source-scan-cache.json";
 const SOURCE_SCAN_CACHE_VERSION: u32 = 2;
@@ -16,7 +18,7 @@ pub(super) struct SourceScanCache {
     sources: Vec<CachedSourceScan>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct CachedSourceScan {
     source_id: String,
     root: PathBuf,
@@ -82,6 +84,43 @@ pub(super) fn save_source_scan_cache(sources: &[SourceEntry]) -> Result<(), Stri
     save_source_scan_cache_to_path(&source_scan_cache_path()?, sources)
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct FolderScanCacheUpdate {
+    source_id: String,
+    source: Option<CachedSourceScan>,
+}
+
+pub(in crate::native_app) fn prepare_folder_scan_cache_update(
+    result: &FolderScanResult,
+) -> FolderScanCacheUpdate {
+    FolderScanCacheUpdate {
+        source_id: result.source_id.clone(),
+        source: result.source_root_available.then(|| CachedSourceScan {
+            source_id: result.source_id.clone(),
+            root: PathBuf::from(&result.folder.id),
+            root_folder: result.folder.clone(),
+            missing_collection_snapshot: result.missing_collection_snapshot.clone(),
+        }),
+    }
+}
+
+pub(in crate::native_app) fn apply_folder_scan_cache_update(
+    update: FolderScanCacheUpdate,
+) -> Result<(), String> {
+    let path = source_scan_cache_path()?;
+    let mut cache = load_source_scan_cache_from_path(&path)?;
+    cache
+        .sources
+        .retain(|source| source.source_id != update.source_id);
+    if let Some(source) = update.source {
+        cache.sources.push(source);
+    }
+    cache
+        .sources
+        .sort_by(|left, right| left.source_id.cmp(&right.source_id));
+    save_source_scan_cache_value_to_path(&path, &cache)
+}
+
 fn source_scan_cache_path() -> Result<PathBuf, String> {
     wavecrate::app_dirs::app_root_dir()
         .map(|root| root.join(SOURCE_SCAN_CACHE_FILE_NAME))
@@ -131,8 +170,15 @@ fn save_source_scan_cache_to_path(path: &Path, sources: &[SourceEntry]) -> Resul
             })
             .collect(),
     );
+    save_source_scan_cache_value_to_path(path, &cache)
+}
+
+fn save_source_scan_cache_value_to_path(
+    path: &Path,
+    cache: &SourceScanCache,
+) -> Result<(), String> {
     let bytes =
-        serde_json::to_vec(&cache).map_err(|err| format!("serialize source scan cache: {err}"))?;
+        serde_json::to_vec(cache).map_err(|err| format!("serialize source scan cache: {err}"))?;
     atomic_write(path, &bytes)
 }
 

--- a/src/native_app/sample_library/folder_browser/source_scan_cache.rs
+++ b/src/native_app/sample_library/folder_browser/source_scan_cache.rs
@@ -1,6 +1,10 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::{
+        LazyLock, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use serde::{Deserialize, Serialize};
@@ -11,6 +15,41 @@ use super::{
 
 const SOURCE_SCAN_CACHE_FILE_NAME: &str = "source-scan-cache.json";
 const SOURCE_SCAN_CACHE_VERSION: u32 = 2;
+
+#[derive(Default)]
+struct CacheSaveRevisionGate {
+    revision: AtomicU64,
+    lock: Mutex<()>,
+}
+
+impl CacheSaveRevisionGate {
+    fn reserve(&self) -> u64 {
+        self.revision.fetch_add(1, Ordering::AcqRel).wrapping_add(1)
+    }
+
+    fn run_if_current(
+        &self,
+        revision: u64,
+        write: impl FnOnce() -> Result<(), String>,
+    ) -> Result<bool, String> {
+        let _guard = self
+            .lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.revision.load(Ordering::Acquire) != revision {
+            return Ok(false);
+        }
+        write()?;
+        Ok(true)
+    }
+}
+
+static CACHE_SAVE_GATE: LazyLock<CacheSaveRevisionGate> =
+    LazyLock::new(CacheSaveRevisionGate::default);
+
+pub(in crate::native_app) fn reserve_source_scan_cache_revision() -> u64 {
+    CACHE_SAVE_GATE.reserve()
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(super) struct SourceScanCache {
@@ -81,7 +120,17 @@ pub(super) fn load_source_scan_cache() -> Result<SourceScanCache, String> {
 }
 
 pub(super) fn save_source_scan_cache(sources: &[SourceEntry]) -> Result<(), String> {
-    save_source_scan_cache_to_path(&source_scan_cache_path()?, sources)
+    let path = source_scan_cache_path()?;
+    let revision = reserve_source_scan_cache_revision();
+    if CACHE_SAVE_GATE
+        .run_if_current(revision, || save_source_scan_cache_to_path(&path, sources))?
+    {
+        Ok(())
+    } else {
+        Err(String::from(
+            "source scan cache save was superseded by a newer snapshot",
+        ))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -106,9 +155,14 @@ pub(in crate::native_app) fn prepare_folder_scan_cache_update(
 
 pub(in crate::native_app) fn apply_folder_scan_cache_update(
     update: FolderScanCacheUpdate,
+    revision: u64,
 ) -> Result<(), String> {
     let path = source_scan_cache_path()?;
-    apply_folder_scan_cache_update_to_path(&path, update)
+    CACHE_SAVE_GATE
+        .run_if_current(revision, || {
+            apply_folder_scan_cache_update_to_path(&path, update)
+        })
+        .map(|_| ())
 }
 
 fn apply_folder_scan_cache_update_to_path(
@@ -243,6 +297,24 @@ fn replace_file(temp_path: &Path, path: &Path) -> Result<(), std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_revision_gate_skips_superseded_maintenance_write() {
+        let gate = CacheSaveRevisionGate::default();
+        let stale = gate.reserve();
+        let _current = gate.reserve();
+        let mut wrote = false;
+
+        let applied = gate
+            .run_if_current(stale, || {
+                wrote = true;
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(!applied);
+        assert!(!wrote);
+    }
     use crate::native_app::sample_library::folder_browser::state_types::SourceAvailability;
     use crate::native_app::sample_library::folder_browser::{FolderEntry, model::FileEntry};
     use wavecrate::sample_sources::{Rating, SampleCollection};

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native_app::sample_library::folder_browser::scan_types::FolderScanItem;
 #[test]
 fn source_scan_installs_finished_tree_after_placeholder_selection() {
     let root = temp_source_root("wavecrate-gui-source-scan");
@@ -327,6 +328,10 @@ fn batched_scan_discoveries_clone_selected_tree_once_per_batch() {
 
     let mut discovery_events = Vec::new();
     let result = scan_source_with_progress(request, |_| {}, |event| discovery_events.push(event));
+    assert!(matches!(
+        discovery_events.first().map(|event| &event.item),
+        Some(FolderScanItem::ResetFolder)
+    ));
     assert!(
         browser.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
             task_id: 88,

--- a/src/native_app/sample_library/folder_scan_actions.rs
+++ b/src/native_app/sample_library/folder_scan_actions.rs
@@ -1,7 +1,10 @@
 mod dialog;
 mod filesystem_refresh;
 mod filesystem_refresh_worker;
+mod maintenance;
 mod progress;
 mod source_commands;
 mod task_ids;
 mod worker;
+
+pub(in crate::native_app) use maintenance::FolderScanMaintenanceResult;

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -17,6 +17,7 @@ pub(super) struct FolderScanMaintenanceRequest {
     pub(super) sources: Vec<SampleSource>,
     pub(super) audio_file_paths: Vec<PathBuf>,
     pub(super) scan_cache_update: FolderScanCacheUpdate,
+    pub(super) scan_cache_revision: u64,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -45,7 +46,9 @@ pub(super) fn persist_folder_scan_maintenance(
     let config_error = save_if_revision_current(&request.config, request.config_revision)
         .err()
         .map(|error| error.to_string());
-    let scan_cache_error = apply_folder_scan_cache_update(request.scan_cache_update).err();
+    let scan_cache_error =
+        apply_folder_scan_cache_update(request.scan_cache_update, request.scan_cache_revision)
+            .err();
     let harvest_errors = request
         .audio_file_paths
         .iter()

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -1,0 +1,82 @@
+use std::path::{Path, PathBuf};
+
+use wavecrate::sample_sources::{
+    HarvestFileIdentity, HarvestFileKey, SampleSource,
+    config::{AppConfig, save},
+    harvest_file_ops, library,
+};
+
+use crate::native_app::sample_library::folder_browser::scan::{
+    FolderScanCacheUpdate, apply_folder_scan_cache_update,
+};
+
+#[derive(Clone)]
+pub(super) struct FolderScanMaintenanceRequest {
+    pub(super) config: AppConfig,
+    pub(super) sources: Vec<SampleSource>,
+    pub(super) audio_file_paths: Vec<PathBuf>,
+    pub(super) scan_cache_update: FolderScanCacheUpdate,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(in crate::native_app) struct FolderScanMaintenanceResult {
+    pub(in crate::native_app) config_error: Option<String>,
+    pub(in crate::native_app) scan_cache_error: Option<String>,
+    pub(in crate::native_app) harvest_errors: Vec<String>,
+}
+
+pub(super) fn persist_folder_scan_maintenance(
+    request: FolderScanMaintenanceRequest,
+) -> FolderScanMaintenanceResult {
+    let config_error = save(&request.config).err().map(|error| error.to_string());
+    let scan_cache_error = apply_folder_scan_cache_update(request.scan_cache_update).err();
+    let harvest_errors = request
+        .audio_file_paths
+        .iter()
+        .filter_map(|path| persist_harvest_discovery(&request.sources, path).err())
+        .collect();
+    FolderScanMaintenanceResult {
+        config_error,
+        scan_cache_error,
+        harvest_errors,
+    }
+}
+
+fn persist_harvest_discovery(sources: &[SampleSource], path: &Path) -> Result<(), String> {
+    let Some((source, relative_path)) = sources
+        .iter()
+        .filter_map(|source| {
+            path.strip_prefix(&source.root)
+                .ok()
+                .map(|relative| (source, relative.to_path_buf()))
+        })
+        .max_by_key(|(source, _)| source.root.components().count())
+    else {
+        return Ok(());
+    };
+    let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(path);
+    let entry = source
+        .open_db()
+        .ok()
+        .and_then(|db| db.entry_for_path(&relative_path).ok().flatten());
+    let identity = HarvestFileIdentity {
+        key: HarvestFileKey::new(source.id.clone(), relative_path),
+        file_size: file_size.or_else(|| entry.as_ref().map(|entry| entry.file_size)),
+        modified_ns: modified_ns.or_else(|| entry.as_ref().map(|entry| entry.modified_ns)),
+        content_hash: entry.and_then(|entry| entry.content_hash),
+    };
+    library::upsert_harvest_file(&identity)
+        .map(|_| ())
+        .map_err(|error| format!("record harvest discovery {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovery_outside_configured_sources_is_a_noop() {
+        let result = persist_harvest_discovery(&[], Path::new("/tmp/outside.wav"));
+        assert_eq!(result, Ok(()));
+    }
+}

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use wavecrate::sample_sources::{
     HarvestFileIdentity, HarvestFileKey, SampleSource,
-    config::{AppConfig, save_if_revision_current},
+    config::{AppConfig, ConfigError, ConfigSaveRevision, save_if_revision_current},
     harvest_file_ops, library,
 };
 
@@ -13,7 +13,7 @@ use crate::native_app::sample_library::folder_browser::scan::{
 #[derive(Clone)]
 pub(super) struct FolderScanMaintenanceRequest {
     pub(super) config: AppConfig,
-    pub(super) config_revision: u64,
+    pub(super) config_revision: Result<ConfigSaveRevision, String>,
     pub(super) sources: Vec<SampleSource>,
     pub(super) audio_file_paths: Vec<PathBuf>,
     pub(super) scan_cache_update: FolderScanCacheUpdate,
@@ -43,9 +43,7 @@ impl FolderScanMaintenanceResult {
 pub(super) fn persist_folder_scan_maintenance(
     request: FolderScanMaintenanceRequest,
 ) -> FolderScanMaintenanceResult {
-    let config_error = save_if_revision_current(&request.config, request.config_revision)
-        .err()
-        .map(|error| error.to_string());
+    let config_error = persist_config_revision(&request.config, &request.config_revision);
     let scan_cache_error =
         apply_folder_scan_cache_update(request.scan_cache_update, request.scan_cache_revision)
             .err();
@@ -58,6 +56,20 @@ pub(super) fn persist_folder_scan_maintenance(
         config_error,
         scan_cache_error,
         harvest_errors,
+    }
+}
+
+fn persist_config_revision(
+    config: &AppConfig,
+    revision: &Result<ConfigSaveRevision, String>,
+) -> Option<String> {
+    match revision {
+        Ok(revision) => match save_if_revision_current(config, revision) {
+            Ok(true) => None,
+            Ok(false) => Some(ConfigError::SaveSuperseded.to_string()),
+            Err(error) => Some(error.to_string()),
+        },
+        Err(error) => Some(error.clone()),
     }
 }
 
@@ -111,5 +123,17 @@ mod tests {
             result.persistence_error().as_deref(),
             Some("source configuration: config denied; source scan cache: cache full")
         );
+    }
+
+    #[test]
+    fn superseded_config_revision_is_reported_as_persistence_error() {
+        let root = tempfile::tempdir().unwrap();
+        let _guard = wavecrate::app_dirs::ConfigBaseGuard::set(root.path().to_path_buf());
+        let stale = wavecrate::sample_sources::config::reserve_save_revision().unwrap();
+        let _current = wavecrate::sample_sources::config::reserve_save_revision().unwrap();
+
+        let error = persist_config_revision(&AppConfig::default(), &Ok(stale));
+
+        assert!(error.is_some_and(|error| error.contains("superseded")));
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use wavecrate::sample_sources::{
     HarvestFileIdentity, HarvestFileKey, SampleSource,
-    config::{AppConfig, save},
+    config::{AppConfig, save_if_revision_current},
     harvest_file_ops, library,
 };
 
@@ -13,6 +13,7 @@ use crate::native_app::sample_library::folder_browser::scan::{
 #[derive(Clone)]
 pub(super) struct FolderScanMaintenanceRequest {
     pub(super) config: AppConfig,
+    pub(super) config_revision: u64,
     pub(super) sources: Vec<SampleSource>,
     pub(super) audio_file_paths: Vec<PathBuf>,
     pub(super) scan_cache_update: FolderScanCacheUpdate,
@@ -25,10 +26,25 @@ pub(in crate::native_app) struct FolderScanMaintenanceResult {
     pub(in crate::native_app) harvest_errors: Vec<String>,
 }
 
+impl FolderScanMaintenanceResult {
+    pub(super) fn persistence_error(&self) -> Option<String> {
+        match (&self.config_error, &self.scan_cache_error) {
+            (Some(config), Some(cache)) => Some(format!(
+                "source configuration: {config}; source scan cache: {cache}"
+            )),
+            (Some(config), None) => Some(format!("source configuration: {config}")),
+            (None, Some(cache)) => Some(format!("source scan cache: {cache}")),
+            (None, None) => None,
+        }
+    }
+}
+
 pub(super) fn persist_folder_scan_maintenance(
     request: FolderScanMaintenanceRequest,
 ) -> FolderScanMaintenanceResult {
-    let config_error = save(&request.config).err().map(|error| error.to_string());
+    let config_error = save_if_revision_current(&request.config, request.config_revision)
+        .err()
+        .map(|error| error.to_string());
     let scan_cache_error = apply_folder_scan_cache_update(request.scan_cache_update).err();
     let harvest_errors = request
         .audio_file_paths
@@ -78,5 +94,19 @@ mod tests {
     fn discovery_outside_configured_sources_is_a_noop() {
         let result = persist_harvest_discovery(&[], Path::new("/tmp/outside.wav"));
         assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn maintenance_result_combines_user_visible_persistence_errors() {
+        let result = FolderScanMaintenanceResult {
+            config_error: Some(String::from("config denied")),
+            scan_cache_error: Some(String::from("cache full")),
+            harvest_errors: Vec::new(),
+        };
+
+        assert_eq!(
+            result.persistence_error().as_deref(),
+            Some("source configuration: config denied; source scan cache: cache full")
+        );
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -7,7 +7,9 @@ use crate::native_app::{
         FolderScanWorkerEvent, GuiMessage, NativeAppState, SourceScanFinish, emit_gui_action,
         run_folder_scan_worker,
     },
-    sample_library::folder_browser::scan::{FolderScanRequest, PreparedFolderScanResult},
+    sample_library::folder_browser::scan::{
+        FolderScanRequest, PreparedFolderScanResult, reserve_source_scan_cache_revision,
+    },
     sample_library::source_prep::SourcePrepTrigger,
 };
 use wavecrate::sample_sources::config::{AppConfig, reserve_save_revision};
@@ -117,6 +119,7 @@ impl NativeAppState {
             sources,
             audio_file_paths,
             scan_cache_update,
+            scan_cache_revision: reserve_source_scan_cache_revision(),
         };
         #[cfg(test)]
         {

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -115,7 +115,7 @@ impl NativeAppState {
                 sources: sources.clone(),
                 core: self.current_settings_core(),
             },
-            config_revision: reserve_save_revision(),
+            config_revision: reserve_save_revision().map_err(|error| error.to_string()),
             sources,
             audio_file_paths,
             scan_cache_update,

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -7,8 +7,13 @@ use crate::native_app::{
         FolderScanWorkerEvent, GuiMessage, NativeAppState, SourceScanFinish, emit_gui_action,
         run_folder_scan_worker,
     },
-    sample_library::folder_browser::scan::{FolderScanRequest, FolderScanResult},
+    sample_library::folder_browser::scan::{FolderScanRequest, PreparedFolderScanResult},
     sample_library::source_prep::SourcePrepTrigger,
+};
+use wavecrate::sample_sources::config::AppConfig;
+
+use super::maintenance::{
+    FolderScanMaintenanceRequest, FolderScanMaintenanceResult, persist_folder_scan_maintenance,
 };
 
 impl NativeAppState {
@@ -48,12 +53,13 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn finish_folder_scan(
         &mut self,
-        result: FolderScanResult,
+        prepared: impl Into<PreparedFolderScanResult>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let prepared = prepared.into();
         let started_at = Instant::now();
-        let discovered_audio_paths = result.audio_file_paths();
-        match self.library.finish_folder_scan(result) {
+        let scan_cache_update = prepared.scan_cache_update;
+        match self.library.finish_folder_scan(prepared.scan) {
             SourceScanFinish::Applied {
                 source_id,
                 label,
@@ -62,9 +68,13 @@ impl NativeAppState {
                 source_db_error,
                 source_root_available,
             } => {
-                if source_root_available {
-                    self.record_harvest_discovered_for_paths(&discovered_audio_paths);
-                }
+                self.queue_folder_scan_maintenance(
+                    source_root_available
+                        .then_some(prepared.audio_file_paths)
+                        .unwrap_or_default(),
+                    scan_cache_update,
+                    context,
+                );
                 self.apply_finished_folder_scan(
                     AppliedFolderScan {
                         source_id,
@@ -91,6 +101,59 @@ impl NativeAppState {
         }
     }
 
+    fn queue_folder_scan_maintenance(
+        &self,
+        audio_file_paths: Vec<std::path::PathBuf>,
+        scan_cache_update: crate::native_app::sample_library::folder_browser::scan::FolderScanCacheUpdate,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let sources = self.library.folder_browser.configured_sample_sources();
+        let request = FolderScanMaintenanceRequest {
+            config: AppConfig {
+                sources: sources.clone(),
+                core: self.current_settings_core(),
+            },
+            sources,
+            audio_file_paths,
+            scan_cache_update,
+        };
+        #[cfg(test)]
+        {
+            let result = persist_folder_scan_maintenance(request.clone());
+            if let Some(error) = result.config_error {
+                tracing::warn!("failed to persist source configuration after scan: {error}");
+            }
+            if let Some(error) = result.scan_cache_error {
+                tracing::warn!("failed to persist source scan cache after scan: {error}");
+            }
+            for error in result.harvest_errors {
+                tracing::warn!("{error}");
+            }
+        }
+        context
+            .business()
+            .background("gui-folder-scan-maintenance")
+            .run(
+                move |_| persist_folder_scan_maintenance(request),
+                GuiMessage::FolderScanMaintenanceFinished,
+            );
+    }
+
+    pub(in crate::native_app) fn finish_folder_scan_maintenance(
+        &mut self,
+        result: FolderScanMaintenanceResult,
+    ) {
+        if let Some(error) = result.config_error {
+            tracing::warn!("failed to persist source configuration after scan: {error}");
+        }
+        if let Some(error) = result.scan_cache_error {
+            tracing::warn!("failed to persist source scan cache after scan: {error}");
+        }
+        for error in result.harvest_errors {
+            tracing::warn!("{error}");
+        }
+    }
+
     fn apply_finished_folder_scan(
         &mut self,
         scan: AppliedFolderScan,
@@ -109,7 +172,6 @@ impl NativeAppState {
                 started_at,
                 Some("source_root_missing"),
             );
-            self.persist_user_configuration("folder_browser.sources.persist", started_at);
             self.sync_source_watcher();
             return;
         }
@@ -151,7 +213,6 @@ impl NativeAppState {
             started_at,
             None,
         );
-        self.persist_user_configuration("folder_browser.sources.persist", started_at);
         self.sync_source_watcher();
         self.open_ready_audio_documents(context, started_at);
     }

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -10,7 +10,7 @@ use crate::native_app::{
     sample_library::folder_browser::scan::{FolderScanRequest, PreparedFolderScanResult},
     sample_library::source_prep::SourcePrepTrigger,
 };
-use wavecrate::sample_sources::config::AppConfig;
+use wavecrate::sample_sources::config::{AppConfig, reserve_save_revision};
 
 use super::maintenance::{
     FolderScanMaintenanceRequest, FolderScanMaintenanceResult, persist_folder_scan_maintenance,
@@ -113,6 +113,7 @@ impl NativeAppState {
                 sources: sources.clone(),
                 core: self.current_settings_core(),
             },
+            config_revision: reserve_save_revision(),
             sources,
             audio_file_paths,
             scan_cache_update,
@@ -143,6 +144,17 @@ impl NativeAppState {
         &mut self,
         result: FolderScanMaintenanceResult,
     ) {
+        if let Some(error) = result.persistence_error() {
+            self.ui.status.sample = format!("Settings not saved: {error}");
+            emit_gui_action(
+                "folder_browser.sources.persist",
+                Some("settings"),
+                None,
+                "persist_error",
+                Instant::now(),
+                Some(&error),
+            );
+        }
         if let Some(error) = result.config_error {
             tracing::warn!("failed to persist source configuration after scan: {error}");
         }

--- a/src/native_app/sample_library/harvest_tracking/persistence.rs
+++ b/src/native_app/sample_library/harvest_tracking/persistence.rs
@@ -56,16 +56,6 @@ impl NativeAppState {
         }
     }
 
-    pub(in crate::native_app) fn record_harvest_discovered_for_paths<I>(&self, paths: I)
-    where
-        I: IntoIterator,
-        I::Item: AsRef<Path>,
-    {
-        for path in paths {
-            self.record_harvest_discovered_for_path(path.as_ref());
-        }
-    }
-
     pub(in crate::native_app) fn record_harvest_extraction_with_source_duration(
         &self,
         source_path: &Path,
@@ -191,15 +181,6 @@ impl NativeAppState {
                 }
             }
             FolderMoveRequest::ExtractedFile { .. } => {}
-        }
-    }
-
-    fn record_harvest_discovered_for_path(&self, path: &Path) {
-        let Some(identity) = self.harvest_identity_for_path(path) else {
-            return;
-        };
-        if let Err(error) = wavecrate::sample_sources::library::upsert_harvest_file(&identity) {
-            tracing::warn!(path = %path.display(), "failed to record discovered harvest file: {error}");
         }
     }
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -79,6 +79,7 @@ impl NativeAppState {
             | GuiMessage::FolderScanProgress(_)
             | GuiMessage::FolderScanDiscoveryBatch(_)
             | GuiMessage::FolderScanFinished(_)
+            | GuiMessage::FolderScanMaintenanceFinished(_)
             | GuiMessage::FolderTreeRefreshFinished(_)
             | GuiMessage::SelectedFolderVerifyFinished(_)
             | GuiMessage::SourceFilesystemChanged { .. }
@@ -312,6 +313,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::FolderScanProgress(_) => "FolderScanProgress",
         GuiMessage::FolderScanDiscoveryBatch(_) => "FolderScanDiscoveryBatch",
         GuiMessage::FolderScanFinished(_) => "FolderScanFinished",
+        GuiMessage::FolderScanMaintenanceFinished(_) => "FolderScanMaintenanceFinished",
         GuiMessage::FolderTreeRefreshFinished(_) => "FolderTreeRefreshFinished",
         GuiMessage::SelectedFolderVerifyFinished(_) => "SelectedFolderVerifyFinished",
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -54,6 +54,9 @@ impl NativeAppState {
                 self.apply_folder_scan_discovery_batch(batch);
             }
             GuiMessage::FolderScanFinished(result) => self.finish_folder_scan(result, context),
+            GuiMessage::FolderScanMaintenanceFinished(result) => {
+                self.finish_folder_scan_maintenance(result)
+            }
             GuiMessage::FolderTreeRefreshFinished(completion) => {
                 self.finish_folder_tree_refresh(completion, context);
             }

--- a/src/sample_sources/config.rs
+++ b/src/sample_sources/config.rs
@@ -6,8 +6,8 @@ mod config_io;
 mod config_types;
 
 pub use config_io::{
-    CONFIG_FILE_NAME, LEGACY_CONFIG_FILE_NAME, config_path, load_or_default, normalize_path,
-    reserve_save_revision, save, save_if_revision_current, save_to_path,
+    CONFIG_FILE_NAME, ConfigSaveRevision, LEGACY_CONFIG_FILE_NAME, config_path, load_or_default,
+    normalize_path, reserve_save_revision, save, save_if_revision_current, save_to_path,
 };
 pub use config_types::{
     AnalysisSettings, AppConfig, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,

--- a/src/sample_sources/config.rs
+++ b/src/sample_sources/config.rs
@@ -6,8 +6,8 @@ mod config_io;
 mod config_types;
 
 pub use config_io::{
-    CONFIG_FILE_NAME, LEGACY_CONFIG_FILE_NAME, config_path, load_or_default, normalize_path, save,
-    save_to_path,
+    CONFIG_FILE_NAME, LEGACY_CONFIG_FILE_NAME, config_path, load_or_default, normalize_path,
+    reserve_save_revision, save, save_if_revision_current, save_to_path,
 };
 pub use config_types::{
     AnalysisSettings, AppConfig, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,

--- a/src/sample_sources/config_io/mod.rs
+++ b/src/sample_sources/config_io/mod.rs
@@ -15,7 +15,7 @@ pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const LEGACY_CONFIG_FILE_NAME: &str = "config.json";
 
 pub use load::{config_path, load_or_default, normalize_path};
-pub use save::{save, save_to_path};
+pub use save::{reserve_save_revision, save, save_if_revision_current, save_to_path};
 
 fn map_app_dir_error(error: app_dirs::AppDirError) -> ConfigError {
     match error {

--- a/src/sample_sources/config_io/mod.rs
+++ b/src/sample_sources/config_io/mod.rs
@@ -15,7 +15,9 @@ pub const CONFIG_FILE_NAME: &str = "config.toml";
 pub const LEGACY_CONFIG_FILE_NAME: &str = "config.json";
 
 pub use load::{config_path, load_or_default, normalize_path};
-pub use save::{reserve_save_revision, save, save_if_revision_current, save_to_path};
+pub use save::{
+    ConfigSaveRevision, reserve_save_revision, save, save_if_revision_current, save_to_path,
+};
 
 fn map_app_dir_error(error: app_dirs::AppDirError) -> ConfigError {
     match error {

--- a/src/sample_sources/config_io/save.rs
+++ b/src/sample_sources/config_io/save.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{
-    LazyLock, Mutex,
+    Arc, LazyLock, Mutex,
     atomic::{AtomicU64, Ordering},
 };
 
@@ -10,11 +11,23 @@ use super::load::config_path;
 
 #[derive(Default)]
 struct SaveRevisionGate {
+    targets: Mutex<HashMap<PathBuf, Arc<TargetSaveRevisionGate>>>,
+}
+
+#[derive(Default)]
+struct TargetSaveRevisionGate {
     revision: AtomicU64,
     lock: Mutex<()>,
 }
 
-impl SaveRevisionGate {
+/// Reserved generation for one concrete configuration target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfigSaveRevision {
+    target: PathBuf,
+    revision: u64,
+}
+
+impl TargetSaveRevisionGate {
     fn reserve(&self) -> u64 {
         self.revision.fetch_add(1, Ordering::AcqRel).wrapping_add(1)
     }
@@ -36,19 +49,47 @@ impl SaveRevisionGate {
     }
 }
 
+impl SaveRevisionGate {
+    fn target(&self, path: &Path) -> Arc<TargetSaveRevisionGate> {
+        let mut targets = self
+            .targets
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Arc::clone(
+            targets
+                .entry(path.to_path_buf())
+                .or_insert_with(|| Arc::new(TargetSaveRevisionGate::default())),
+        )
+    }
+
+    fn reserve(&self, target: PathBuf) -> ConfigSaveRevision {
+        let revision = self.target(&target).reserve();
+        ConfigSaveRevision { target, revision }
+    }
+
+    fn run_if_current<E>(
+        &self,
+        reservation: &ConfigSaveRevision,
+        write: impl FnOnce() -> Result<(), E>,
+    ) -> Result<bool, E> {
+        self.target(&reservation.target)
+            .run_if_current(reservation.revision, write)
+    }
+}
+
 static SAVE_GATE: LazyLock<SaveRevisionGate> = LazyLock::new(SaveRevisionGate::default);
 
 /// Reserve a revision for a configuration snapshot that will be saved later.
-pub fn reserve_save_revision() -> u64 {
-    SAVE_GATE.reserve()
+pub fn reserve_save_revision() -> Result<ConfigSaveRevision, ConfigError> {
+    Ok(SAVE_GATE.reserve(config_path()?))
 }
 
 /// Persist configuration to disk, overwriting any previous contents.
 ///
 /// Settings are written to TOML while sources are stored in SQLite.
 pub fn save(config: &AppConfig) -> Result<(), ConfigError> {
-    let revision = reserve_save_revision();
-    require_current_save(save_if_revision_current(config, revision)?)
+    let revision = reserve_save_revision()?;
+    require_current_save(save_if_revision_current(config, &revision)?)
 }
 
 fn require_current_save(saved: bool) -> Result<(), ConfigError> {
@@ -62,11 +103,11 @@ fn require_current_save(saved: bool) -> Result<(), ConfigError> {
 /// Save a previously captured configuration only when no newer save was requested.
 ///
 /// Returns `false` without writing when `revision` has been superseded.
-pub fn save_if_revision_current(config: &AppConfig, revision: u64) -> Result<bool, ConfigError> {
-    SAVE_GATE.run_if_current(revision, || {
-        let path = config_path()?;
-        save_to_path(config, &path)
-    })
+pub fn save_if_revision_current(
+    config: &AppConfig,
+    revision: &ConfigSaveRevision,
+) -> Result<bool, ConfigError> {
+    SAVE_GATE.run_if_current(revision, || save_to_path(config, &revision.target))
 }
 
 /// Save configuration to a specific path, creating parent directories as needed.
@@ -226,30 +267,48 @@ fn sync_parent_dir(dir: &Path) -> Result<(), ConfigError> {
 #[cfg(test)]
 mod revision_tests {
     use super::{ConfigError, SaveRevisionGate, require_current_save};
-    use std::cell::Cell;
+    use std::{cell::Cell, path::PathBuf};
 
     #[test]
     fn stale_snapshot_is_skipped_after_newer_revision_is_reserved() {
         let gate = SaveRevisionGate::default();
-        let stale = gate.reserve();
-        let current = gate.reserve();
+        let target = PathBuf::from("config.toml");
+        let stale = gate.reserve(target.clone());
+        let current = gate.reserve(target);
         let writes = Cell::new(0);
 
         assert_eq!(
-            gate.run_if_current(stale, || {
+            gate.run_if_current(&stale, || {
                 writes.set(writes.get() + 1);
                 Ok::<(), ()>(())
             }),
             Ok(false)
         );
         assert_eq!(
-            gate.run_if_current(current, || {
+            gate.run_if_current(&current, || {
                 writes.set(writes.get() + 1);
                 Ok::<(), ()>(())
             }),
             Ok(true)
         );
         assert_eq!(writes.get(), 1);
+    }
+
+    #[test]
+    fn revisions_are_scoped_to_the_config_target() {
+        let gate = SaveRevisionGate::default();
+        let first_target = gate.reserve(PathBuf::from("first/config.toml"));
+        let second_target = gate.reserve(PathBuf::from("second/config.toml"));
+        let _newer_first = gate.reserve(PathBuf::from("first/config.toml"));
+
+        assert_eq!(
+            gate.run_if_current(&second_target, || Ok::<(), ()>(())),
+            Ok(true)
+        );
+        assert_eq!(
+            gate.run_if_current(&first_target, || Ok::<(), ()>(())),
+            Ok(false)
+        );
     }
 
     #[test]

--- a/src/sample_sources/config_io/save.rs
+++ b/src/sample_sources/config_io/save.rs
@@ -48,7 +48,15 @@ pub fn reserve_save_revision() -> u64 {
 /// Settings are written to TOML while sources are stored in SQLite.
 pub fn save(config: &AppConfig) -> Result<(), ConfigError> {
     let revision = reserve_save_revision();
-    save_if_revision_current(config, revision).map(|_| ())
+    require_current_save(save_if_revision_current(config, revision)?)
+}
+
+fn require_current_save(saved: bool) -> Result<(), ConfigError> {
+    if saved {
+        Ok(())
+    } else {
+        Err(ConfigError::SaveSuperseded)
+    }
 }
 
 /// Save a previously captured configuration only when no newer save was requested.
@@ -217,7 +225,7 @@ fn sync_parent_dir(dir: &Path) -> Result<(), ConfigError> {
 
 #[cfg(test)]
 mod revision_tests {
-    use super::SaveRevisionGate;
+    use super::{ConfigError, SaveRevisionGate, require_current_save};
     use std::cell::Cell;
 
     #[test]
@@ -242,5 +250,13 @@ mod revision_tests {
             Ok(true)
         );
         assert_eq!(writes.get(), 1);
+    }
+
+    #[test]
+    fn direct_save_reports_superseded_revision() {
+        assert!(matches!(
+            require_current_save(false),
+            Err(ConfigError::SaveSuperseded)
+        ));
     }
 }

--- a/src/sample_sources/config_io/save.rs
+++ b/src/sample_sources/config_io/save.rs
@@ -1,15 +1,64 @@
 use std::io::Write;
 use std::path::Path;
+use std::sync::{
+    LazyLock, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 use super::super::config_types::{AppConfig, AppSettings, ConfigError};
 use super::load::config_path;
+
+#[derive(Default)]
+struct SaveRevisionGate {
+    revision: AtomicU64,
+    lock: Mutex<()>,
+}
+
+impl SaveRevisionGate {
+    fn reserve(&self) -> u64 {
+        self.revision.fetch_add(1, Ordering::AcqRel).wrapping_add(1)
+    }
+
+    fn run_if_current<E>(
+        &self,
+        revision: u64,
+        write: impl FnOnce() -> Result<(), E>,
+    ) -> Result<bool, E> {
+        let _guard = self
+            .lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.revision.load(Ordering::Acquire) != revision {
+            return Ok(false);
+        }
+        write()?;
+        Ok(true)
+    }
+}
+
+static SAVE_GATE: LazyLock<SaveRevisionGate> = LazyLock::new(SaveRevisionGate::default);
+
+/// Reserve a revision for a configuration snapshot that will be saved later.
+pub fn reserve_save_revision() -> u64 {
+    SAVE_GATE.reserve()
+}
 
 /// Persist configuration to disk, overwriting any previous contents.
 ///
 /// Settings are written to TOML while sources are stored in SQLite.
 pub fn save(config: &AppConfig) -> Result<(), ConfigError> {
-    let path = config_path()?;
-    save_to_path(config, &path)
+    let revision = reserve_save_revision();
+    save_if_revision_current(config, revision).map(|_| ())
+}
+
+/// Save a previously captured configuration only when no newer save was requested.
+///
+/// Returns `false` without writing when `revision` has been superseded.
+pub fn save_if_revision_current(config: &AppConfig, revision: u64) -> Result<bool, ConfigError> {
+    SAVE_GATE.run_if_current(revision, || {
+        let path = config_path()?;
+        save_to_path(config, &path)
+    })
 }
 
 /// Save configuration to a specific path, creating parent directories as needed.
@@ -164,4 +213,34 @@ fn sync_parent_dir(dir: &Path) -> Result<(), ConfigError> {
         let _ = dir;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod revision_tests {
+    use super::SaveRevisionGate;
+    use std::cell::Cell;
+
+    #[test]
+    fn stale_snapshot_is_skipped_after_newer_revision_is_reserved() {
+        let gate = SaveRevisionGate::default();
+        let stale = gate.reserve();
+        let current = gate.reserve();
+        let writes = Cell::new(0);
+
+        assert_eq!(
+            gate.run_if_current(stale, || {
+                writes.set(writes.get() + 1);
+                Ok::<(), ()>(())
+            }),
+            Ok(false)
+        );
+        assert_eq!(
+            gate.run_if_current(current, || {
+                writes.set(writes.get() + 1);
+                Ok::<(), ()>(())
+            }),
+            Ok(true)
+        );
+        assert_eq!(writes.get(), 1);
+    }
 }

--- a/src/sample_sources/config_types/errors.rs
+++ b/src/sample_sources/config_types/errors.rs
@@ -80,6 +80,9 @@ pub enum ConfigError {
         /// Rejected profile name.
         profile: String,
     },
+    /// A newer configuration snapshot was reserved before this save could run.
+    #[error("Configuration save was superseded by a newer snapshot")]
+    SaveSuperseded,
     /// Library database error.
     #[error("Library database error: {0}")]
     Library(Box<crate::sample_sources::library::LibraryError>),


### PR DESCRIPTION
## Scope

- Remove recursively cloned completed-folder discovery messages from the UI stream.
- Keep discovery publication ordered and capped at 64 small typed items per message.
- Prepare audio-path and scan-cache updates on the worker.
- Apply scan-cache/config/harvest persistence on a background maintenance task only after the UI accepts the scan generation.
- Version deferred config snapshots so newer user changes supersede stale maintenance writes.
- Preserve offline cache trees, repair corrupt caches, initialize the current cache version, and surface persistence failures in the UI.
- Preserve stale progress/finish rejection and equivalent in-flight scan deduplication.

## Definition of Done

- [x] Traversal, indexing, harvest bookkeeping, config persistence, and scan-cache serialization run off the UI owner.
- [x] Discovery application is bounded and no longer republishes completed subtrees.
- [x] Stale scan results cannot publish cache/config maintenance.
- [x] Stale maintenance snapshots cannot overwrite newer configuration saves.
- [x] Offline, new-profile, and corrupt-cache maintenance cases preserve or repair durable state.
- [x] Persistence failures restore the visible `Settings not saved` status contract.
- [x] A synthetic 1,024-file scan keeps every UI discovery message within 64 items.
- [x] Focused source-scan and non-blocking architecture tests pass.

## Validation commands

- `cargo check -p wavecrate --all-targets`
- `cargo test -p wavecrate source_scan_worker -j1`
- `cargo test -p wavecrate source_scan -j1`
- `cargo test -p wavecrate incremental_update -j1`
- `cargo test -p wavecrate stale_snapshot_is_skipped_after_newer_revision_is_reserved -j1`
- `cargo test -p wavecrate maintenance_result_combines_user_visible_persistence_errors -j1`
- `cargo test -p wavecrate folder_browser::tests::source_scanning -j1`
- `cargo test -p wavecrate --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis -j1`

## Known limitations

- Manual desktop smoke could not be completed because the unattended Mac auto-locked; no unlock bypass was attempted.
- The broad config_sources filter currently also reports three unrelated state-fixture failures in source removal, cached-source switching, and bounded filesystem patching. All 22 source_scan tests and the focused persistence/harvest regressions pass.

User review is required before merge.

Closes OPT-1108