### PR TITLE
OPT-1105 Enforce ImageRgba byte invariants

### DIFF
--- a/src/app_core/ui_bridge/tests/bridge_runtime/projection.rs
+++ b/src/app_core/ui_bridge/tests/bridge_runtime/projection.rs
@@ -56,8 +56,8 @@ fn bridge_reprojects_after_async_waveform_image_arrival() {
         .waveform_image
         .as_ref()
         .expect("async waveform image should be projected");
-    assert_eq!(waveform_image.width, 1);
-    assert_eq!(waveform_image.height, 1);
+    assert_eq!(waveform_image.width(), 1);
+    assert_eq!(waveform_image.height(), 1);
 }
 
 /// Projecting an arrived async image should not immediately schedule another image render.

--- a/src/app_core/ui_projection/tests/waveform.rs
+++ b/src/app_core/ui_projection/tests/waveform.rs
@@ -61,12 +61,9 @@ fn waveform_projection_passes_raster_image_payload() {
         .waveform_image
         .as_ref()
         .expect("waveform image should be projected");
-    assert_eq!(waveform_image.width, 2);
-    assert_eq!(waveform_image.height, 1);
-    assert_eq!(
-        waveform_image.pixels.as_ref(),
-        &[10, 20, 30, 40, 11, 21, 31, 41]
-    );
+    assert_eq!(waveform_image.width(), 2);
+    assert_eq!(waveform_image.height(), 1);
+    assert_eq!(waveform_image.pixels(), &[10, 20, 30, 40, 11, 21, 31, 41]);
 }
 
 #[test]

--- a/src/app_core/ui_projection/waveform_image_translation.rs
+++ b/src/app_core/ui_projection/waveform_image_translation.rs
@@ -44,9 +44,9 @@ mod tests {
 
         let native = waveform_image_to_native_rgba(&image).expect("expected translated image");
 
-        assert_eq!(native.width, 2);
-        assert_eq!(native.height, 1);
-        assert_eq!(native.pixels.as_ref(), &[1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(native.width(), 2);
+        assert_eq!(native.height(), 1);
+        assert_eq!(native.pixels(), &[1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]


### PR DESCRIPTION
## Scope

- Advance the Radiant pointer to [PORTALSURFER/radiant#1413](https://github.com/PORTALSURFER/radiant/pull/1413).
- Migrate Wavecrate to construction-controlled `ImageRgba` fields through read-only accessors.
- Preserve waveform RGBA projection behavior.
- Refresh the lockfile for the current Radiant dependency graph.

## Definition of Done

- Safe public APIs cannot construct an invalid `ImageRgba`.
- Retained-content and upload boundaries reject short, long, or overflowing payloads.
- Wavecrate compiles against the private-field API.
- Existing waveform projection bytes remain unchanged.

## Validation commands

- `cargo test --manifest-path vendor/radiant/Cargo.toml --lib image_rgba -j1`
- `cargo test --manifest-path vendor/radiant/Cargo.toml --lib rgba_atlas -j1`
- `cargo test --manifest-path vendor/radiant/Cargo.toml --lib gpu_atlas_texture_extent -j1`
- `cargo check -p wavecrate --all-targets`
- `cargo test -p wavecrate waveform_image_to_native_rgba -j1`
- `cargo test -p wavecrate waveform_projection_passes_raster_image_payload -j1`

## Known limitations

Radiant broad all-target validation is blocked by pre-existing warnings-as-errors in the unrelated `popup_window` example. Focused Radiant lanes and Wavecrate all-target compatibility pass.

User review is required before merge. The nested Radiant PR must merge first.