### PR TITLE
OPT-1102 Own ANN loader backing with loaded indexes

### DIFF
--- a/crates/wavecrate-analysis/src/analysis/ann_index/build.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/build.rs
@@ -1,12 +1,12 @@
 use super::container;
 use super::state::{
-    AnnIndexMetaRow, AnnIndexParams, AnnIndexState, build_id_lookup, default_params,
+    AnnHnsw, AnnIndexMetaRow, AnnIndexParams, AnnIndexState, LoadedAnnHnsw, build_id_lookup,
+    default_params,
 };
 use super::storage::{
     default_index_path, hnsw_dump_paths, legacy_id_map_path_for, load_legacy_id_map, read_meta,
 };
 use crate::analysis::decode_f32_le_blob;
-use hnsw_rs::hnswio::HnswIo;
 use hnsw_rs::prelude::*;
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
@@ -47,7 +47,12 @@ pub(crate) fn build_index_from_db(
     let mut hnsw = build_hnsw(&params, count);
     let mut id_map = Vec::with_capacity(count.max(0) as usize);
     insert_embeddings(conn, &params, &mut hnsw, &mut id_map)?;
-    Ok(build_state(params, hnsw, id_map, index_path))
+    Ok(build_state(
+        params,
+        AnnHnsw::Built(hnsw),
+        id_map,
+        index_path,
+    ))
 }
 
 /// Attempt to load an ANN index from disk using stored metadata.
@@ -115,7 +120,7 @@ fn insert_embeddings(
 
 fn build_state(
     params: AnnIndexParams,
-    hnsw: Hnsw<'static, f32, DistCosine>,
+    hnsw: AnnHnsw,
     id_map: Vec<String>,
     index_path: PathBuf,
 ) -> AnnIndexState {
@@ -194,18 +199,11 @@ fn load_legacy_index(
     build_loaded_state(hnsw, id_map, params, index_path.to_path_buf())
 }
 
-fn load_hnsw(
-    dir: &std::path::Path,
-    basename: &str,
-) -> Result<Hnsw<'static, f32, DistCosine>, String> {
-    let hnsw_io = Box::new(HnswIo::new(dir, basename));
-    let hnsw_io = Box::leak(hnsw_io);
-    hnsw_io
-        .load_hnsw::<f32, DistCosine>()
-        .map_err(|_| "Failed to read ANN index".to_string())
+fn load_hnsw(dir: &std::path::Path, basename: &str) -> Result<AnnHnsw, String> {
+    LoadedAnnHnsw::load(dir, basename).map(AnnHnsw::Loaded)
 }
 
-fn load_hnsw_from_path(index_path: &Path) -> Result<Hnsw<'static, f32, DistCosine>, String> {
+fn load_hnsw_from_path(index_path: &Path) -> Result<AnnHnsw, String> {
     let basename = index_path
         .file_name()
         .and_then(|name| name.to_str())
@@ -270,7 +268,7 @@ fn update_index_path(mut state: AnnIndexState, index_path: &Path, force: bool) -
 }
 
 fn build_loaded_state(
-    hnsw: Hnsw<'static, f32, DistCosine>,
+    hnsw: AnnHnsw,
     id_map: Vec<String>,
     params: &AnnIndexParams,
     index_path: PathBuf,

--- a/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
@@ -1,9 +1,20 @@
 use crate::analysis::{similarity, version};
+use hnsw_rs::hnswio::HnswIo;
 use hnsw_rs::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    mem::ManuallyDrop,
+    ops::Deref,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+#[cfg(test)]
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 /// Configuration parameters for ANN index building/loading.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -20,13 +31,108 @@ pub(crate) struct AnnIndexParams {
 
 /// In-memory ANN index state with metadata for persistence.
 pub(crate) struct AnnIndexState {
-    pub(crate) hnsw: Hnsw<'static, f32, DistCosine>,
+    pub(crate) hnsw: AnnHnsw,
     pub(crate) id_map: Vec<String>,
     pub(crate) id_lookup: HashMap<String, usize>,
     pub(crate) params: AnnIndexParams,
     pub(crate) index_path: PathBuf,
     pub(crate) last_flush: Instant,
     pub(crate) dirty_inserts: usize,
+}
+
+/// HNSW storage that either owns all point data directly or keeps its disk
+/// loader alive for as long as a loaded graph can reference mmap-backed data.
+pub(crate) enum AnnHnsw {
+    Built(Hnsw<'static, f32, DistCosine>),
+    Loaded(LoadedAnnHnsw),
+}
+
+impl Deref for AnnHnsw {
+    type Target = Hnsw<'static, f32, DistCosine>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Built(hnsw) => hnsw,
+            Self::Loaded(hnsw) => hnsw,
+        }
+    }
+}
+
+/// Self-referential disk-loaded HNSW owner.
+///
+/// `HnswIo::load_hnsw` ties the graph lifetime to the loader because points may
+/// borrow its mmap. The loader lives at a stable boxed address, and `Drop`
+/// destroys the graph before Rust drops that loader.
+pub(crate) struct LoadedAnnHnsw {
+    hnsw: ManuallyDrop<Hnsw<'static, f32, DistCosine>>,
+    _loader: Box<HnswIo>,
+    #[cfg(test)]
+    live_probe: Option<Arc<AtomicUsize>>,
+}
+
+impl LoadedAnnHnsw {
+    pub(crate) fn load(dir: &Path, basename: &str) -> Result<Self, String> {
+        Self::load_inner(dir, basename, None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn load_with_live_probe(
+        dir: &Path,
+        basename: &str,
+        live_probe: Arc<AtomicUsize>,
+    ) -> Result<Self, String> {
+        Self::load_inner(dir, basename, Some(live_probe))
+    }
+
+    fn load_inner(
+        dir: &Path,
+        basename: &str,
+        #[cfg(test)] live_probe: Option<Arc<AtomicUsize>>,
+        #[cfg(not(test))] _live_probe: Option<()>,
+    ) -> Result<Self, String> {
+        let mut loader = Box::new(HnswIo::new(dir, basename));
+        let hnsw = loader
+            .load_hnsw::<f32, DistCosine>()
+            .map_err(|_| "Failed to read ANN index".to_string())?;
+        // SAFETY: `Hnsw` may borrow only from the boxed `HnswIo`. Moving this
+        // wrapper never moves the loader allocation, the graph is not exposed
+        // by value, and our Drop implementation destroys the graph first.
+        let hnsw = unsafe {
+            std::mem::transmute::<Hnsw<'_, f32, DistCosine>, Hnsw<'static, f32, DistCosine>>(hnsw)
+        };
+        #[cfg(test)]
+        if let Some(probe) = &live_probe {
+            probe.fetch_add(1, Ordering::AcqRel);
+        }
+        Ok(Self {
+            hnsw: ManuallyDrop::new(hnsw),
+            _loader: loader,
+            #[cfg(test)]
+            live_probe,
+        })
+    }
+}
+
+impl Deref for LoadedAnnHnsw {
+    type Target = Hnsw<'static, f32, DistCosine>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.hnsw
+    }
+}
+
+impl Drop for LoadedAnnHnsw {
+    fn drop(&mut self) {
+        // SAFETY: `hnsw` is initialized exactly once and this is its only
+        // explicit drop. `_loader` remains alive until after this method.
+        unsafe {
+            ManuallyDrop::drop(&mut self.hnsw);
+        }
+        #[cfg(test)]
+        if let Some(probe) = &self.live_probe {
+            probe.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
 }
 
 /// Metadata persisted in the source database for ANN indexes.

--- a/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
@@ -47,29 +47,32 @@ pub(crate) enum AnnHnsw {
 }
 
 impl AnnHnsw {
-    fn graph(&self) -> &Hnsw<'static, f32, DistCosine> {
+    pub(crate) fn insert(&self, embedding_with_id: (&[f32], usize)) {
         match self {
-            Self::Built(hnsw) => hnsw,
-            Self::Loaded(hnsw) => hnsw.graph(),
+            Self::Built(hnsw) => hnsw.insert(embedding_with_id),
+            Self::Loaded(hnsw) => hnsw.insert(embedding_with_id),
         }
     }
 
-    pub(crate) fn insert(&self, embedding_with_id: (&[f32], usize)) {
-        self.graph().insert(embedding_with_id);
-    }
-
     pub(crate) fn search(&self, embedding: &[f32], requested: usize, ef: usize) -> Vec<Neighbour> {
-        self.graph().search(embedding, requested, ef)
+        match self {
+            Self::Built(hnsw) => hnsw.search(embedding, requested, ef),
+            Self::Loaded(hnsw) => hnsw.search(embedding, requested, ef),
+        }
     }
 
     pub(crate) fn file_dump(&self, dir: &Path, basename: &str) -> Result<String, String> {
-        self.graph()
-            .file_dump(dir, basename)
-            .map_err(|err| err.to_string())
+        match self {
+            Self::Built(hnsw) => hnsw.file_dump(dir, basename).map_err(|err| err.to_string()),
+            Self::Loaded(hnsw) => hnsw.file_dump(dir, basename),
+        }
     }
 
     pub(crate) fn get_nb_point(&self) -> usize {
-        self.graph().get_nb_point()
+        match self {
+            Self::Built(hnsw) => hnsw.get_nb_point(),
+            Self::Loaded(hnsw) => hnsw.get_nb_point(),
+        }
     }
 }
 
@@ -128,13 +131,22 @@ impl LoadedAnnHnsw {
         })
     }
 
-    fn graph(&self) -> &Hnsw<'static, f32, DistCosine> {
-        &self.hnsw
+    fn insert(&self, embedding_with_id: (&[f32], usize)) {
+        self.hnsw.insert(embedding_with_id);
     }
 
-    #[cfg(test)]
+    fn search(&self, embedding: &[f32], requested: usize, ef: usize) -> Vec<Neighbour> {
+        self.hnsw.search(embedding, requested, ef)
+    }
+
+    fn file_dump(&self, dir: &Path, basename: &str) -> Result<String, String> {
+        self.hnsw
+            .file_dump(dir, basename)
+            .map_err(|err| err.to_string())
+    }
+
     pub(crate) fn get_nb_point(&self) -> usize {
-        self.graph().get_nb_point()
+        self.hnsw.get_nb_point()
     }
 }
 

--- a/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/state.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     mem::ManuallyDrop,
-    ops::Deref,
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -47,14 +46,30 @@ pub(crate) enum AnnHnsw {
     Loaded(LoadedAnnHnsw),
 }
 
-impl Deref for AnnHnsw {
-    type Target = Hnsw<'static, f32, DistCosine>;
-
-    fn deref(&self) -> &Self::Target {
+impl AnnHnsw {
+    fn graph(&self) -> &Hnsw<'static, f32, DistCosine> {
         match self {
             Self::Built(hnsw) => hnsw,
-            Self::Loaded(hnsw) => hnsw,
+            Self::Loaded(hnsw) => hnsw.graph(),
         }
+    }
+
+    pub(crate) fn insert(&self, embedding_with_id: (&[f32], usize)) {
+        self.graph().insert(embedding_with_id);
+    }
+
+    pub(crate) fn search(&self, embedding: &[f32], requested: usize, ef: usize) -> Vec<Neighbour> {
+        self.graph().search(embedding, requested, ef)
+    }
+
+    pub(crate) fn file_dump(&self, dir: &Path, basename: &str) -> Result<String, String> {
+        self.graph()
+            .file_dump(dir, basename)
+            .map_err(|err| err.to_string())
+    }
+
+    pub(crate) fn get_nb_point(&self) -> usize {
+        self.graph().get_nb_point()
     }
 }
 
@@ -95,8 +110,9 @@ impl LoadedAnnHnsw {
             .load_hnsw::<f32, DistCosine>()
             .map_err(|_| "Failed to read ANN index".to_string())?;
         // SAFETY: `Hnsw` may borrow only from the boxed `HnswIo`. Moving this
-        // wrapper never moves the loader allocation, the graph is not exposed
-        // by value, and our Drop implementation destroys the graph first.
+        // wrapper never moves the loader allocation, callers can use the graph
+        // only through scoped operations that return no borrowed point data,
+        // and our Drop implementation destroys the graph first.
         let hnsw = unsafe {
             std::mem::transmute::<Hnsw<'_, f32, DistCosine>, Hnsw<'static, f32, DistCosine>>(hnsw)
         };
@@ -111,13 +127,14 @@ impl LoadedAnnHnsw {
             live_probe,
         })
     }
-}
 
-impl Deref for LoadedAnnHnsw {
-    type Target = Hnsw<'static, f32, DistCosine>;
-
-    fn deref(&self) -> &Self::Target {
+    fn graph(&self) -> &Hnsw<'static, f32, DistCosine> {
         &self.hnsw
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_nb_point(&self) -> usize {
+        self.graph().get_nb_point()
     }
 }
 

--- a/crates/wavecrate-analysis/src/analysis/ann_index/update.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/update.rs
@@ -1,7 +1,6 @@
 use super::container;
 use super::state::AnnIndexState;
 use super::storage::{hnsw_dump_paths, upsert_meta};
-use hnsw_rs::api::AnnT;
 use rusqlite::Connection;
 use std::collections::HashSet;
 use std::time::Duration;

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/mod.rs
@@ -4,7 +4,6 @@ use crate::analysis::ann_index::{
 use crate::analysis::vector::encode_f32_le_blob;
 use crate::analysis::{ann_index, similarity};
 use crate::app_dirs::ConfigBaseGuard;
-use hnsw_rs::api::AnnT;
 use rusqlite::{Connection, params};
 use std::sync::{LazyLock, Mutex};
 use tempfile::tempdir;

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/storage.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/storage.rs
@@ -1,4 +1,11 @@
 use super::*;
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+};
 
 #[test]
 fn ann_index_container_round_trip_loads() {
@@ -48,4 +55,81 @@ fn ann_index_legacy_migrates_to_container() {
         let container_path = ann_storage::default_index_path(conn).unwrap();
         assert!(container_path.is_file());
     });
+}
+
+#[test]
+fn repeated_disk_loads_release_loader_backing_on_drop() {
+    with_ann_test_db(|conn| {
+        let path = write_loader_backing_fixture(conn);
+        let dir = path.parent().expect("index parent");
+        let basename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("index basename");
+        let live = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..8 {
+            let loaded = crate::analysis::ann_index::state::LoadedAnnHnsw::load_with_live_probe(
+                dir,
+                basename,
+                Arc::clone(&live),
+            )
+            .expect("load index");
+            assert_eq!(live.load(Ordering::Acquire), 1);
+            assert_eq!(loaded.get_nb_point(), 3);
+            drop(loaded);
+            assert_eq!(live.load(Ordering::Acquire), 0);
+        }
+    });
+}
+
+#[test]
+fn concurrent_cache_population_keeps_only_winner_loader_backing() {
+    with_ann_test_db(|conn| {
+        let path = write_loader_backing_fixture(conn);
+        let dir = path.parent().expect("index parent").to_path_buf();
+        let basename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("index basename")
+            .to_owned();
+        let live = Arc::new(AtomicUsize::new(0));
+        let winner = Arc::new(Mutex::new(None));
+        let threads = (0..8)
+            .map(|_| {
+                let dir = dir.clone();
+                let basename = basename.clone();
+                let live = Arc::clone(&live);
+                let winner = Arc::clone(&winner);
+                thread::spawn(move || {
+                    let loaded =
+                        crate::analysis::ann_index::state::LoadedAnnHnsw::load_with_live_probe(
+                            &dir, &basename, live,
+                        )
+                        .expect("load racing index");
+                    let mut winner = winner.lock().expect("winner lock");
+                    if winner.is_none() {
+                        *winner = Some(loaded);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in threads {
+            handle.join().expect("loader thread");
+        }
+        assert_eq!(live.load(Ordering::Acquire), 1);
+        drop(winner.lock().expect("winner lock").take());
+        assert_eq!(live.load(Ordering::Acquire), 0);
+    });
+}
+
+fn write_loader_backing_fixture(conn: &Connection) -> std::path::PathBuf {
+    let dim = similarity::SIMILARITY_DIM;
+    insert_embeddings(conn, dim, &basic_samples(dim));
+    let params = crate::analysis::ann_index::state::default_params();
+    let path = ann_storage::legacy_index_path(conn).expect("legacy path");
+    let state = ann_build::build_index_from_db(conn, params, path.clone()).expect("build index");
+    write_legacy_ann_files(&state, &path);
+    path
 }


### PR DESCRIPTION
## Scope

- Replace the permanent `Box::leak(HnswIo)` disk-load path with explicit loaded-index ownership.
- Keep each loader at a stable boxed address for any mmap-backed point borrows.
- Encapsulate the HNSW lifetime extension inside a non-extractable owner that drops the graph before its loader.
- Preserve the existing built-index path, search behavior, mutations, and disk format.
- Add repeated load/drop and eight-way racing cache-population backing-lifetime tests.

## Definition of Done

- Every successful disk load owns exactly one loader backing allocation.
- Dropping a loaded state releases that backing.
- Racing loads release all losing states and retain at most the selected winner.
- ANN search, update, container, and legacy migration behavior remains unchanged.

## Validation commands

- `cargo check -p wavecrate-analysis --all-targets`
- `cargo test -p wavecrate-analysis loader_backing -j1`
- `cargo test -p wavecrate-analysis ann_index -j1`
- `cargo test -p wavecrate-analysis -j1`
- `cargo check -p wavecrate --all-targets`

## Known limitations

The HNSW dependency exposes a lifetime tied to `HnswIo` for optional mmap data but no owning loaded type. This PR contains one documented unsafe lifetime extension inside `LoadedAnnHnsw`; its stable boxed loader and explicit graph-before-loader drop order are the enforced safety invariant.

User review is required before merge.

Closes OPT-1102