### PR TITLE
OPT-1101 Use typed copy journal initializer

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/entry.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/entry.rs
@@ -130,6 +130,25 @@ pub struct MoveJournalEntryInit {
     pub last_curated_at: Option<i64>,
 }
 
+/// Initialization payload for creating copy journal entries without wide signatures.
+#[derive(Debug, Clone)]
+pub struct CopyJournalEntryInit {
+    /// Final target-relative destination path.
+    pub target_relative: PathBuf,
+    /// Temporary staged path used before finalization.
+    pub staged_relative: PathBuf,
+    /// Stored keep/trash rating that should survive reconciliation.
+    pub tag: Rating,
+    /// Stored loop marker that should survive reconciliation.
+    pub looped: bool,
+    /// Stored lock marker that should survive reconciliation.
+    pub locked: bool,
+    /// Stored playback timestamp that should survive reconciliation.
+    pub last_played_at: Option<i64>,
+    /// Stored curation timestamp that should survive reconciliation.
+    pub last_curated_at: Option<i64>,
+}
+
 impl FileOpJournalEntry {
     /// Build a new journal entry for a move operation.
     pub fn new_move(id: String, init: MoveJournalEntryInit) -> Result<Self, SourceDbError> {
@@ -153,31 +172,22 @@ impl FileOpJournalEntry {
     }
 
     /// Build a new journal entry for a copy operation.
-    pub fn new_copy(
-        id: String,
-        target_relative: PathBuf,
-        staged_relative: PathBuf,
-        tag: Rating,
-        looped: bool,
-        locked: bool,
-        last_played_at: Option<i64>,
-        last_curated_at: Option<i64>,
-    ) -> Result<Self, SourceDbError> {
+    pub fn new_copy(id: String, init: CopyJournalEntryInit) -> Result<Self, SourceDbError> {
         Ok(Self {
             id,
             kind: FileOpKind::Copy,
             stage: FileOpStage::Intent,
             source_root: None,
             source_relative: None,
-            target_relative,
-            staged_relative: Some(staged_relative),
+            target_relative: init.target_relative,
+            staged_relative: Some(init.staged_relative),
             file_size: None,
             modified_ns: None,
-            tag: Some(tag),
-            looped: Some(looped),
-            locked: Some(locked),
-            last_played_at,
-            last_curated_at,
+            tag: Some(init.tag),
+            looped: Some(init.looped),
+            locked: Some(init.locked),
+            last_played_at: init.last_played_at,
+            last_curated_at: init.last_curated_at,
             created_at: now_epoch_seconds()?,
         })
     }

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
@@ -21,7 +21,8 @@ mod store;
 mod tests;
 
 pub use entry::{
-    FileOpJournalEntry, FileOpStage, MoveJournalEntryInit, new_op_id, staged_relative_for_target,
+    CopyJournalEntryInit, FileOpJournalEntry, FileOpStage, MoveJournalEntryInit, new_op_id,
+    staged_relative_for_target,
 };
 /// Summary of the work performed while reconciling pending journal entries.
 pub type FileOpReconcileSummary = reconcile::FileOpReconcileSummary;

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/tests/copy_recovery.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/tests/copy_recovery.rs
@@ -12,13 +12,15 @@ fn reconcile_copy_from_staged_file() {
     let staged_relative = staged_relative_for_target(&target_relative, "copy").unwrap();
     let entry = FileOpJournalEntry::new_copy(
         String::from("copy-test"),
-        target_relative.clone(),
-        staged_relative.clone(),
-        Rating::KEEP_1,
-        true,
-        true,
-        Some(123),
-        Some(456),
+        CopyJournalEntryInit {
+            target_relative: target_relative.clone(),
+            staged_relative: staged_relative.clone(),
+            tag: Rating::KEEP_1,
+            looped: true,
+            locked: true,
+            last_played_at: Some(123),
+            last_curated_at: Some(456),
+        },
     )
     .unwrap();
     insert_entry(&target_db, &entry).unwrap();
@@ -77,13 +79,15 @@ fn reconcile_copy_clears_stale_target_metadata_when_journal_defaults_are_empty()
     let staged_relative = staged_relative_for_target(&target_relative, "copy").unwrap();
     let entry = FileOpJournalEntry::new_copy(
         String::from("copy-test"),
-        target_relative.clone(),
-        staged_relative.clone(),
-        Rating::NEUTRAL,
-        false,
-        false,
-        None,
-        None,
+        CopyJournalEntryInit {
+            target_relative: target_relative.clone(),
+            staged_relative: staged_relative.clone(),
+            tag: Rating::NEUTRAL,
+            looped: false,
+            locked: false,
+            last_played_at: None,
+            last_curated_at: None,
+        },
     )
     .unwrap();
     insert_entry(&target_db, &entry).unwrap();
@@ -123,13 +127,15 @@ fn reconcile_copy_preserves_staged_file_when_target_path_was_reused() {
     let staged_relative = staged_relative_for_target(&target_relative, "copy").unwrap();
     let entry = FileOpJournalEntry::new_copy(
         String::from("copy-test"),
-        target_relative.clone(),
-        staged_relative.clone(),
-        Rating::KEEP_1,
-        true,
-        true,
-        Some(123),
-        Some(456),
+        CopyJournalEntryInit {
+            target_relative: target_relative.clone(),
+            staged_relative: staged_relative.clone(),
+            tag: Rating::KEEP_1,
+            looped: true,
+            locked: true,
+            last_played_at: Some(123),
+            last_curated_at: Some(456),
+        },
     )
     .unwrap();
     insert_entry(&target_db, &entry).unwrap();
@@ -200,13 +206,15 @@ fn reconcile_copy_defers_when_target_exists_and_journal_identity_is_incomplete()
     let staged_relative = staged_relative_for_target(&target_relative, "copy").unwrap();
     let entry = FileOpJournalEntry::new_copy(
         String::from("copy-test"),
-        target_relative.clone(),
-        staged_relative.clone(),
-        Rating::KEEP_1,
-        true,
-        true,
-        Some(123),
-        Some(456),
+        CopyJournalEntryInit {
+            target_relative: target_relative.clone(),
+            staged_relative: staged_relative.clone(),
+            tag: Rating::KEEP_1,
+            looped: true,
+            locked: true,
+            last_played_at: Some(123),
+            last_curated_at: Some(456),
+        },
     )
     .unwrap();
     insert_entry(&target_db, &entry).unwrap();

--- a/crates/wavecrate-library/src/sample_sources/library/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/tests.rs
@@ -1,4 +1,16 @@
 use super::*;
+
+type ReopenedDerivationRow = (
+    String,
+    Option<f64>,
+    Option<f64>,
+    Option<f64>,
+    Option<String>,
+    Option<i64>,
+    String,
+    Option<String>,
+    String,
+);
 use crate::sample_sources::{SourceId, SourceMetadataStorage, SourceRole};
 use rusqlite::{Connection, OptionalExtension};
 use std::collections::HashSet;
@@ -401,17 +413,7 @@ fn harvest_derivation_graph_survives_reopen_and_marks_parent_touched() {
         assert_eq!(reopened_child.0, child.file_size.map(|value| value as i64));
         assert_eq!(reopened_child.1, child.modified_ns);
         assert_eq!(reopened_child.2.as_deref(), child.content_hash.as_deref());
-        let reopened_edge: (
-            String,
-            Option<f64>,
-            Option<f64>,
-            Option<f64>,
-            Option<String>,
-            Option<i64>,
-            String,
-            Option<String>,
-            String,
-        ) = reopened
+        let reopened_edge: ReopenedDerivationRow = reopened
             .query_row(
                 "SELECT operation, source_range_start, source_range_end,
                     output_duration_seconds, destination_folder, inherited_rating,

--- a/src/app/controller/ui/clipboard_paste/source_job/mod.rs
+++ b/src/app/controller/ui/clipboard_paste/source_job/mod.rs
@@ -146,13 +146,15 @@ mod tests {
         write_test_wav(&staged_absolute, &[0.0, 0.2, -0.2]);
         let entry = file_ops_journal::FileOpJournalEntry::new_copy(
             op_id.clone(),
-            relative,
-            staged_relative,
-            Rating::NEUTRAL,
-            false,
-            false,
-            None,
-            None,
+            file_ops_journal::CopyJournalEntryInit {
+                target_relative: relative,
+                staged_relative,
+                tag: Rating::NEUTRAL,
+                looped: false,
+                locked: false,
+                last_played_at: None,
+                last_curated_at: None,
+            },
         )
         .unwrap();
         file_ops_journal::insert_entry(&db, &entry).unwrap();
@@ -189,13 +191,15 @@ mod tests {
         write_test_wav(&staged_absolute, &[0.0, 0.1, -0.1]);
         let entry = file_ops_journal::FileOpJournalEntry::new_copy(
             op_id.clone(),
-            relative.clone(),
-            staged_relative.clone(),
-            Rating::NEUTRAL,
-            false,
-            false,
-            None,
-            None,
+            file_ops_journal::CopyJournalEntryInit {
+                target_relative: relative.clone(),
+                staged_relative: staged_relative.clone(),
+                tag: Rating::NEUTRAL,
+                looped: false,
+                locked: false,
+                last_played_at: None,
+                last_curated_at: None,
+            },
         )
         .unwrap();
         file_ops_journal::insert_entry(&context.db, &entry).unwrap();

--- a/src/app/controller/ui/clipboard_paste/source_job/stage.rs
+++ b/src/app/controller/ui/clipboard_paste/source_job/stage.rs
@@ -17,13 +17,15 @@ pub(super) fn stage_source_copy(
 ) -> Result<StagedSourcePaste, Vec<String>> {
     let journal_entry = match file_ops_journal::FileOpJournalEntry::new_copy(
         prepared.op_id.clone(),
-        prepared.relative.clone(),
-        prepared.staged_relative.clone(),
-        Rating::NEUTRAL,
-        false,
-        false,
-        None,
-        None,
+        file_ops_journal::CopyJournalEntryInit {
+            target_relative: prepared.relative.clone(),
+            staged_relative: prepared.staged_relative.clone(),
+            tag: Rating::NEUTRAL,
+            looped: false,
+            locked: false,
+            last_played_at: None,
+            last_curated_at: None,
+        },
     ) {
         Ok(entry) => entry,
         Err(err) => return Err(vec![format!("Failed to stage copy journal: {err}")]),

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/move_transaction.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/move_transaction.rs
@@ -124,13 +124,15 @@ pub(super) fn prepare_staged_copy(
         .map_err(|err| format!("Failed to build staging path: {err}"))?;
     let journal_entry = file_ops_journal::FileOpJournalEntry::new_copy(
         op_id.clone(),
-        target_relative.to_path_buf(),
-        staged_relative.clone(),
-        metadata.tag,
-        metadata.looped,
-        metadata.locked,
-        metadata.last_played_at,
-        metadata.last_curated_at,
+        file_ops_journal::CopyJournalEntryInit {
+            target_relative: target_relative.to_path_buf(),
+            staged_relative: staged_relative.clone(),
+            tag: metadata.tag,
+            looped: metadata.looped,
+            locked: metadata.locked,
+            last_played_at: metadata.last_played_at,
+            last_curated_at: metadata.last_curated_at,
+        },
     )
     .map_err(|err| format!("Failed to stage copy journal: {err}"))?;
     file_ops_journal::insert_entry(journal_db, &journal_entry)


### PR DESCRIPTION
## Scope

- Add `CopyJournalEntryInit`, mirroring the existing typed move-entry initializer.
- Reduce `FileOpJournalEntry::new_copy` to the journal id plus one named initialization payload.
- Migrate library recovery fixtures, clipboard paste, and drag/drop copy call sites without behavior changes.
- Factor the next strict-Clippy-only journal test row tuple into a named alias so the configured target is fully green.

## Definition of Done

- Copy journal construction no longer triggers `clippy::too_many_arguments`.
- No lint allowance or suppression is added.
- Field intent remains explicit at every call site.
- Focused journal recovery and the full repository agent-safe lane pass.

## Validation commands

- `cargo test -p wavecrate-library file_ops_journal -j1`
- `cargo clippy -p wavecrate-library --all-targets -- -D warnings`
- `bash scripts/ci.sh agent`

## Known limitations

None.

User review is required before merge.

Closes OPT-1101