### PR TITLE
OPT-1100 Wavecrate ANN: make batch insertion atomic on validation failure

### DIFF
--- a/crates/wavecrate-analysis/src/analysis/ann_index/update.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/update.rs
@@ -3,6 +3,7 @@ use super::state::AnnIndexState;
 use super::storage::{hnsw_dump_paths, upsert_meta};
 use hnsw_rs::api::AnnT;
 use rusqlite::Connection;
+use std::collections::HashSet;
 use std::time::Duration;
 use tempfile::Builder;
 
@@ -45,8 +46,11 @@ pub(crate) fn upsert_embeddings_batch<'a, I>(
 where
     I: IntoIterator<Item = (&'a str, &'a [f32])>,
 {
+    let mut batch_ids = HashSet::new();
+    let mut staged = Vec::new();
+
     for (sample_id, embedding) in items {
-        if state.id_lookup.contains_key(sample_id) {
+        if state.id_lookup.contains_key(sample_id) || !batch_ids.insert(sample_id) {
             continue;
         }
         if embedding.len() != state.params.dim {
@@ -56,6 +60,10 @@ where
                 embedding.len()
             ));
         }
+        staged.push((sample_id, embedding));
+    }
+
+    for (sample_id, embedding) in staged {
         let id = state.id_map.len();
         state.id_map.push(sample_id.to_string());
         state.id_lookup.insert(sample_id.to_string(), id);

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
@@ -47,3 +47,74 @@ fn ann_index_upsert_embeddings_batch_only_appends_new_ids() {
         assert!(state.id_lookup.contains_key("s4"));
     });
 }
+
+#[test]
+fn ann_index_batch_validation_failure_leaves_state_unchanged() {
+    with_ann_test_db(|conn| {
+        let dim = similarity::SIMILARITY_DIM;
+        insert_embeddings(conn, dim, &basic_samples(dim));
+        let params = ann_index::state::default_params();
+        let index_path = ann_storage::default_index_path(conn).expect("ANN index path");
+        let mut state =
+            ann_build::build_index_from_db(conn, params, index_path).expect("ANN in-memory state");
+        state.dirty_inserts = 7;
+
+        let id_map_before = state.id_map.clone();
+        let id_lookup_before = state.id_lookup.clone();
+        let point_count_before = state.hnsw.get_nb_point();
+        let dirty_inserts_before = state.dirty_inserts;
+        let last_flush_before = state.last_flush;
+        let valid = normalize(unit_vec(dim, 4));
+        let invalid = vec![0.0; dim - 1];
+
+        let error = ann_update::upsert_embeddings_batch(
+            conn,
+            &mut state,
+            [
+                ("s1", invalid.as_slice()),
+                ("s4", valid.as_slice()),
+                ("s4", invalid.as_slice()),
+                ("s5", invalid.as_slice()),
+            ],
+        )
+        .expect_err("later invalid dimension must reject the complete batch");
+
+        assert!(error.contains("Embedding dim mismatch"));
+        assert_eq!(state.id_map, id_map_before);
+        assert_eq!(state.id_lookup, id_lookup_before);
+        assert_eq!(state.hnsw.get_nb_point(), point_count_before);
+        assert_eq!(state.dirty_inserts, dirty_inserts_before);
+        assert_eq!(state.last_flush, last_flush_before);
+    });
+}
+
+#[test]
+fn ann_index_batch_preserves_duplicate_handling_with_staged_validation() {
+    with_ann_test_db(|conn| {
+        let dim = similarity::SIMILARITY_DIM;
+        insert_embeddings(conn, dim, &basic_samples(dim));
+        let params = ann_index::state::default_params();
+        let index_path = ann_storage::default_index_path(conn).expect("ANN index path");
+        let mut state =
+            ann_build::build_index_from_db(conn, params, index_path).expect("ANN in-memory state");
+        let fresh = normalize(unit_vec(dim, 4));
+        let invalid_duplicate = vec![0.0; dim - 1];
+
+        ann_update::upsert_embeddings_batch(
+            conn,
+            &mut state,
+            [
+                ("s1", invalid_duplicate.as_slice()),
+                ("s4", fresh.as_slice()),
+                ("s4", invalid_duplicate.as_slice()),
+            ],
+        )
+        .expect("existing and repeated IDs remain skipped");
+
+        assert_eq!(state.id_map.len(), 4);
+        assert_eq!(state.hnsw.get_nb_point(), 4);
+        assert_eq!(state.id_map.iter().filter(|id| *id == "s4").count(), 1);
+        assert_eq!(state.id_lookup.get("s4"), Some(&3));
+        assert_eq!(state.dirty_inserts, 1);
+    });
+}


### PR DESCRIPTION
## Scope\n- prevalidate and stage every non-duplicate ANN batch entry before mutation\n- preserve existing-ID and within-batch duplicate handling\n- add regression coverage for late validation failures and duplicate mixes\n\n## Definition of Done\n- any dimension-validation error leaves HNSW contents, ID maps, dirty state, and flush state unchanged\n- duplicate behavior remains stable\n- focused ANN validation passes\n\n## Validation commands\n- 
running 17 tests
test analysis::ann_index::container::header::tests::ann_container_rejects_inconsistent_graph_offset ... ok
test analysis::ann_index::container::codec::tests::ann_container_rejects_checksum_mismatch ... ok
test analysis::ann_index::container::header::tests::ann_container_rejects_offset_overflow ... ok
test analysis::ann_index::container::header::tests::ann_container_rejects_oversized_id_map_len ... ok
test analysis::ann_index::container::header::tests::ann_container_rejects_oversized_model_id_len ... ok
test analysis::ann_index::container::codec::tests::ann_container_rejects_invalid_utf8_model_id ... ok
test analysis::ann_index::container::header::tests::ann_container_rejects_magic_mismatch ... ok
test analysis::ann_index::container::header::tests::ann_container_rejects_version_mismatch ... ok
test analysis::ann_index_tests::query::ann_index_find_similar_backfills_missing_query_id_from_embeddings_table ... ok
test analysis::ann_index_tests::query::ann_index_incremental_update_matches_full_rebuild ... ok
test analysis::ann_index_tests::storage::ann_index_container_round_trip_loads ... ok
test analysis::ann_index_tests::query::ann_index_matches_bruteforce_neighbors_on_fixture ... ok
test analysis::ann_index_tests::storage::ann_index_legacy_migrates_to_container ... ok
test analysis::ann_index_tests::updates::ann_index_batch_preserves_duplicate_handling_with_staged_validation ... ok
test analysis::ann_index_tests::updates::ann_index_batch_validation_failure_leaves_state_unchanged ... ok
test analysis::ann_index_tests::updates::ann_index_upsert_embedding_skips_existing_ids ... ok
test analysis::ann_index_tests::updates::ann_index_upsert_embeddings_batch_only_appends_new_ids ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 71 filtered out; finished in 0.02s\n- \n- \n\n## Known limitations\nNone.\n\nUser review is required before merge.