### PR TITLE
OPT-1099 Wavecrate scan: release DB writer during discovery

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -5,6 +5,7 @@ mod database;
 mod event;
 mod mutation;
 mod paths;
+mod scan_queries;
 mod transaction;
 mod upsert;
 

--- a/crates/wavecrate-library/src/sample_sources/db/write/scan_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/scan_queries.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use rusqlite::params;
+
+use super::super::util::{map_sql_error, parse_relative_path_from_db};
+use super::super::{SourceDbError, SourceWriteBatch};
+
+impl SourceWriteBatch<'_> {
+    /// Fetch current hash-matching paths while holding this writer transaction.
+    pub fn list_paths_with_content_hash(
+        &self,
+        content_hash: &str,
+    ) -> Result<Vec<PathBuf>, SourceDbError> {
+        let mut statement = self
+            .tx
+            .prepare("SELECT path FROM wav_files WHERE content_hash = ?1 ORDER BY path ASC")
+            .map_err(map_sql_error)?;
+        let paths = statement
+            .query_map(params![content_hash], |row| row.get::<_, String>(0))
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        Ok(parse_paths(paths, "hash"))
+    }
+
+    /// Fetch current file-fact-matching paths while holding this writer transaction.
+    pub fn list_paths_with_file_facts(
+        &self,
+        file_size: u64,
+        modified_ns: i64,
+    ) -> Result<Vec<PathBuf>, SourceDbError> {
+        let mut statement = self
+            .tx
+            .prepare(
+                "SELECT path
+                 FROM wav_files
+                 WHERE file_size = ?1 AND modified_ns = ?2
+                 ORDER BY path ASC",
+            )
+            .map_err(map_sql_error)?;
+        let paths = statement
+            .query_map(params![file_size as i64, modified_ns], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        Ok(parse_paths(paths, "file facts"))
+    }
+}
+
+fn parse_paths(paths: Vec<String>, lookup: &str) -> Vec<PathBuf> {
+    paths
+        .into_iter()
+        .filter_map(|path| match parse_relative_path_from_db(&path) {
+            Ok(path) => Some(path),
+            Err(error) => {
+                tracing::warn!(%error, lookup, "Skipping invalid wav path during scan lookup");
+                None
+            }
+        })
+        .collect()
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/scan_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/scan_queries.rs
@@ -11,9 +11,14 @@ impl SourceWriteBatch<'_> {
         &self,
         content_hash: &str,
     ) -> Result<Vec<PathBuf>, SourceDbError> {
+        let filter = crate::sample_sources::supported_audio_where_clause();
         let mut statement = self
             .tx
-            .prepare("SELECT path FROM wav_files WHERE content_hash = ?1 ORDER BY path ASC")
+            .prepare(&format!(
+                "SELECT path FROM wav_files
+                 WHERE {filter} AND content_hash = ?1
+                 ORDER BY path ASC"
+            ))
             .map_err(map_sql_error)?;
         let paths = statement
             .query_map(params![content_hash], |row| row.get::<_, String>(0))
@@ -29,14 +34,16 @@ impl SourceWriteBatch<'_> {
         file_size: u64,
         modified_ns: i64,
     ) -> Result<Vec<PathBuf>, SourceDbError> {
+        let filter = crate::sample_sources::supported_audio_where_clause();
         let mut statement = self
             .tx
-            .prepare(
+            .prepare(&format!(
                 "SELECT path
                  FROM wav_files
-                 WHERE file_size = ?1 AND modified_ns = ?2
-                 ORDER BY path ASC",
-            )
+                 WHERE {filter}
+                   AND file_size = ?1 AND modified_ns = ?2
+                 ORDER BY path ASC"
+            ))
             .map_err(map_sql_error)?;
         let paths = statement
             .query_map(params![file_size as i64, modified_ns], |row| {

--- a/crates/wavecrate-library/src/sample_sources/db/write/tests/upsert.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/tests/upsert.rs
@@ -64,6 +64,27 @@ fn wav_upsert_variants_preserve_hash_tag_and_missing_contracts() {
 }
 
 #[test]
+fn scan_candidate_queries_ignore_unsupported_and_apple_double_rows() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let mut batch = db.write_batch().unwrap();
+    for path in ["one.wav", "legacy.flac", "._sidecar.wav"] {
+        batch
+            .upsert_file_with_hash(Path::new(path), 10, 5, "same-hash")
+            .unwrap();
+    }
+
+    assert_eq!(
+        batch.list_paths_with_content_hash("same-hash").unwrap(),
+        vec![Path::new("one.wav").to_path_buf()]
+    );
+    assert_eq!(
+        batch.list_paths_with_file_facts(10, 5).unwrap(),
+        vec![Path::new("one.wav").to_path_buf()]
+    );
+}
+
+#[test]
 fn collections_can_accumulate_multiple_memberships() {
     let dir = tempdir().unwrap();
     let db = SourceDatabase::open(dir.path()).unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
@@ -8,8 +8,6 @@ use super::{ScanError, ScanMode, ScanStats};
 
 pub(crate) struct ScanContext {
     pub(crate) existing: HashMap<PathBuf, WavEntry>,
-    /// Relative paths observed during filesystem discovery.
-    pub(crate) discovered_paths: HashSet<PathBuf>,
     /// On-demand rename candidate paths keyed by content hash.
     ///
     /// Unlike the previous full in-memory hash index, this cache only stores
@@ -36,7 +34,6 @@ impl ScanContext {
     ) -> Self {
         Self {
             existing,
-            discovered_paths: HashSet::new(),
             rename_candidates_by_hash: HashMap::new(),
             rename_candidates_by_facts: HashMap::new(),
             stats: ScanStats::default(),

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
@@ -8,6 +8,8 @@ use super::{ScanError, ScanMode, ScanStats};
 
 pub(crate) struct ScanContext {
     pub(crate) existing: HashMap<PathBuf, WavEntry>,
+    /// Relative paths observed during filesystem discovery.
+    pub(crate) discovered_paths: HashSet<PathBuf>,
     /// On-demand rename candidate paths keyed by content hash.
     ///
     /// Unlike the previous full in-memory hash index, this cache only stores
@@ -34,6 +36,7 @@ impl ScanContext {
     ) -> Self {
         Self {
             existing,
+            discovered_paths: HashSet::new(),
             rename_candidates_by_hash: HashMap::new(),
             rename_candidates_by_facts: HashMap::new(),
             stats: ScanStats::default(),

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -8,16 +8,6 @@ use super::{ScanError, ScanMode, ScanStats};
 
 pub(crate) struct ScanContext {
     pub(crate) existing: HashMap<PathBuf, WavEntry>,
-    /// On-demand rename candidate paths keyed by content hash.
-    ///
-    /// Unlike the previous full in-memory hash index, this cache only stores
-    /// keys encountered during the current walk.
-    pub(crate) rename_candidates_by_hash: HashMap<String, Vec<PathBuf>>,
-    /// On-demand rename candidate paths keyed by `(file_size, modified_ns)`.
-    ///
-    /// This keeps quick-scan reconciliation incremental and avoids triplicating
-    /// all row mappings in memory.
-    pub(crate) rename_candidates_by_facts: HashMap<(u64, i64), Vec<PathBuf>>,
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
 }
@@ -34,8 +24,6 @@ impl ScanContext {
     ) -> Self {
         Self {
             existing,
-            rename_candidates_by_hash: HashMap::new(),
-            rename_candidates_by_facts: HashMap::new(),
             stats: ScanStats::default(),
             mode,
         }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -8,7 +8,7 @@ use crate::sample_sources::SourceDatabase;
 
 use super::super::scan_db_sync::db_sync_phase;
 use super::super::scan_fs::ensure_root_dir;
-use super::super::scan_walk::{apply_prepared_files, walk_phase};
+use super::super::scan_walk::walk_phase;
 use super::{ScanContext, ScanError, ScanStats};
 
 /// Scan strategy used when walking a source root.
@@ -55,8 +55,7 @@ fn scan(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
-    let prepared = walk_phase(&root, cancel, &mut on_progress, &mut context)?;
-    apply_prepared_files(db, &root, cancel, &mut context, prepared)?;
+    walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
     db_sync_phase(db, &mut context)?;
     Ok(context.stats)
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -8,7 +8,7 @@ use crate::sample_sources::SourceDatabase;
 
 use super::super::scan_db_sync::db_sync_phase;
 use super::super::scan_fs::ensure_root_dir;
-use super::super::scan_walk::walk_phase;
+use super::super::scan_walk::{apply_prepared_files, walk_phase};
 use super::{ScanContext, ScanError, ScanStats};
 
 /// Scan strategy used when walking a source root.
@@ -55,16 +55,9 @@ fn scan(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
-    let mut batch = db.write_batch()?;
-    walk_phase(
-        db,
-        &root,
-        cancel,
-        &mut on_progress,
-        &mut context,
-        &mut batch,
-    )?;
-    db_sync_phase(db, batch, &mut context)?;
+    let prepared = walk_phase(&root, cancel, &mut on_progress, &mut context)?;
+    apply_prepared_files(db, &root, cancel, &mut context, prepared)?;
+    db_sync_phase(db, &mut context)?;
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -221,6 +221,70 @@ fn scan_revalidation_rejects_file_mutation_after_discovery() {
     assert_ne!(db.list_files().unwrap()[0].file_size, before.file_size);
 }
 
+#[test]
+fn scan_refreshes_noop_row_after_concurrent_removal() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"one").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let mut removed = false;
+
+    scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if removed {
+            return;
+        }
+        let writer = SourceDatabase::open(dir.path()).unwrap();
+        let mut batch = writer.write_batch().unwrap();
+        batch.remove_file(Path::new("one.wav")).unwrap();
+        batch.commit().unwrap();
+        removed = true;
+    })
+    .unwrap();
+
+    assert!(removed);
+    assert!(db.entry_for_path(Path::new("one.wav")).unwrap().is_some());
+}
+
+#[test]
+fn missing_stage_keeps_concurrently_restored_live_row() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("restored.wav");
+    std::fs::write(&file_path, b"old").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let stale = db
+        .entry_for_path(Path::new("restored.wav"))
+        .unwrap()
+        .unwrap();
+    std::fs::remove_file(&file_path).unwrap();
+
+    std::fs::write(&file_path, b"new-longer").unwrap();
+    let facts = super::super::super::scan_fs::read_facts(dir.path(), &file_path).unwrap();
+    db.upsert_file(Path::new("restored.wav"), facts.size, facts.modified_ns)
+        .unwrap();
+    let mut stats = ScanStats::default();
+    let mut batch = db.write_batch().unwrap();
+
+    super::super::super::scan_diff::mark_missing(
+        &db,
+        &mut batch,
+        [stale],
+        &mut stats,
+        ScanMode::Quick,
+    )
+    .unwrap();
+    batch.commit().unwrap();
+
+    assert_eq!(stats.missing, 0);
+    let restored = db
+        .entry_for_path(Path::new("restored.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(restored.file_size, facts.size);
+    assert_eq!(restored.modified_ns, facts.modified_ns);
+}
+
 #[cfg(unix)]
 #[test]
 fn scan_hashes_current_bytes_when_facts_are_preserved_after_discovery() {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -163,3 +163,60 @@ fn scan_detects_changed_content_hash() {
     assert_eq!(stats.content_changed, 1);
     assert_eq!(stats.changed_samples.len(), 1);
 }
+
+#[test]
+fn scan_discovery_does_not_hold_the_source_writer() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("one.wav"), b"one").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let mut concurrent_write = None;
+
+    scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if concurrent_write.is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+        let writer = SourceDatabase::open_for_user_metadata_write(dir.path()).unwrap();
+        concurrent_write = Some(writer.set_metadata("scan_contention_probe", "complete"));
+    })
+    .unwrap();
+
+    concurrent_write
+        .expect("progress callback must run")
+        .expect("metadata writer must complete while discovery is active");
+    assert_eq!(
+        db.get_metadata("scan_contention_probe").unwrap().as_deref(),
+        Some("complete")
+    );
+}
+
+#[test]
+fn scan_revalidation_rejects_file_mutation_after_discovery() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"original").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let before = db.list_files().unwrap().remove(0);
+    let mut mutated = false;
+
+    let stale_scan = scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if !mutated {
+            std::fs::write(&file_path, b"replacement-with-different-size").unwrap();
+            mutated = true;
+        }
+    })
+    .unwrap();
+
+    assert!(mutated);
+    assert_eq!(stale_scan.updated, 0);
+    assert_eq!(stale_scan.missing, 0);
+    let after_stale_scan = db.list_files().unwrap().remove(0);
+    assert_eq!(after_stale_scan.file_size, before.file_size);
+    assert_eq!(after_stale_scan.modified_ns, before.modified_ns);
+    assert_eq!(after_stale_scan.content_hash, before.content_hash);
+
+    let fresh_scan = scan_once(&db).unwrap();
+    assert_eq!(fresh_scan.updated, 1);
+    assert_ne!(db.list_files().unwrap()[0].file_size, before.file_size);
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -285,6 +285,93 @@ fn missing_stage_keeps_concurrently_restored_live_row() {
     assert_eq!(restored.modified_ns, facts.modified_ns);
 }
 
+#[test]
+fn missing_stage_prunes_path_replaced_by_directory() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("replaced.wav");
+    std::fs::write(&file_path, b"old").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::remove_file(&file_path).unwrap();
+    std::fs::create_dir(&file_path).unwrap();
+
+    let stats = scan_once(&db).unwrap();
+
+    assert_eq!(stats.missing, 1);
+    assert!(
+        db.entry_for_path(Path::new("replaced.wav"))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn scan_rebases_noop_when_concurrent_writer_clears_hash() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"one").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let row = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    let mut cleared = false;
+
+    let stats = scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if cleared {
+            return;
+        }
+        let writer = SourceDatabase::open(dir.path()).unwrap();
+        let mut batch = writer.write_batch().unwrap();
+        batch
+            .upsert_file_without_hash(Path::new("one.wav"), row.file_size, row.modified_ns)
+            .unwrap();
+        batch.commit().unwrap();
+        cleared = true;
+    })
+    .unwrap();
+
+    assert!(cleared);
+    assert_eq!(stats.hashes_computed, 1);
+    assert!(
+        db.entry_for_path(Path::new("one.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash
+            .is_some()
+    );
+}
+
+#[test]
+fn missing_repair_survives_concurrent_hash_clear() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"one").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let row = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    db.set_missing(Path::new("one.wav"), true).unwrap();
+    let mut cleared = false;
+
+    let stats = scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if cleared {
+            return;
+        }
+        let writer = SourceDatabase::open(dir.path()).unwrap();
+        let mut batch = writer.write_batch().unwrap();
+        batch
+            .upsert_file_without_hash(Path::new("one.wav"), row.file_size, row.modified_ns)
+            .unwrap();
+        batch.commit().unwrap();
+        cleared = true;
+    })
+    .unwrap();
+
+    assert!(cleared);
+    assert_eq!(stats.hashes_computed, 1);
+    let repaired = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    assert!(!repaired.missing);
+    assert!(repaired.content_hash.is_some());
+}
+
 #[cfg(unix)]
 #[test]
 fn scan_hashes_current_bytes_when_facts_are_preserved_after_discovery() {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -107,6 +107,26 @@ fn scan_ignores_non_wav_and_counts_nested() {
 }
 
 #[test]
+fn scan_tracks_dot_prefixed_wav_files_but_not_files_below_hidden_directories() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir(&hidden).unwrap();
+    std::fs::write(dir.path().join(".kick.wav"), b"kick").unwrap();
+    std::fs::write(hidden.join("ignored.wav"), b"ignored").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let stats = scan_once(&db).unwrap();
+
+    assert_eq!(stats.added, 1);
+    assert!(db.entry_for_path(Path::new(".kick.wav")).unwrap().is_some());
+    assert!(
+        db.entry_for_path(Path::new(".hidden/ignored.wav"))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
 fn scan_in_background_finishes() {
     let dir = tempdir().unwrap();
     std::fs::write(dir.path().join("one.wav"), b"one").unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -220,3 +220,112 @@ fn scan_revalidation_rejects_file_mutation_after_discovery() {
     assert_eq!(fresh_scan.updated, 1);
     assert_ne!(db.list_files().unwrap()[0].file_size, before.file_size);
 }
+
+#[cfg(unix)]
+#[test]
+fn scan_hashes_current_bytes_when_facts_are_preserved_after_discovery() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"old!").unwrap();
+    let timestamp = 1_700_000_000;
+    set_file_times(&file_path, timestamp, 0);
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let mut replaced = false;
+
+    scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if !replaced {
+            std::fs::write(&file_path, b"new!").unwrap();
+            set_file_times(&file_path, timestamp, 0);
+            replaced = true;
+        }
+    })
+    .unwrap();
+
+    let row = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    assert_eq!(
+        row.content_hash.as_deref(),
+        Some(blake3::hash(b"new!").to_hex().as_str())
+    );
+}
+
+#[test]
+fn cancellation_after_first_committed_batch_finishes_consistently() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let dir = tempdir().unwrap();
+    for index in 0..70 {
+        std::fs::write(dir.path().join(format!("sample-{index:03}.wav")), b"x").unwrap();
+    }
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let cancel = AtomicBool::new(false);
+
+    let stats = scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |count, _| {
+        if count == 65 {
+            cancel.store(true, Ordering::Relaxed);
+        }
+    })
+    .expect("once a bounded batch commits, the scan must finish consistently");
+
+    assert_eq!(stats.total_files, 70);
+    assert_eq!(db.count_files().unwrap(), 70);
+}
+
+#[test]
+fn unchanged_large_scan_only_commits_completion_metadata() {
+    let dir = tempdir().unwrap();
+    for index in 0..130 {
+        std::fs::write(dir.path().join(format!("sample-{index:03}.wav")), b"x").unwrap();
+    }
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let revision_before = db
+        .get_metadata("revision")
+        .unwrap()
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+
+    let stats = scan_once(&db).unwrap();
+
+    let revision_after = db
+        .get_metadata("revision")
+        .unwrap()
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    assert_eq!(stats.updated, 0);
+    assert_eq!(stats.added, 0);
+    assert_eq!(revision_after, revision_before + 1);
+}
+
+#[test]
+fn skipped_existing_file_is_not_used_as_a_rename_source() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir(&hidden).unwrap();
+    std::fs::write(hidden.join("old.wav"), b"same").unwrap();
+    std::fs::write(dir.path().join("new.wav"), b"same").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let facts =
+        super::super::super::scan_fs::read_facts(dir.path(), &hidden.join("old.wav")).unwrap();
+    let hash = blake3::hash(b"same").to_hex().to_string();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .upsert_file_with_hash(
+            Path::new(".hidden/old.wav"),
+            facts.size,
+            facts.modified_ns,
+            &hash,
+        )
+        .unwrap();
+    batch
+        .set_tag(Path::new(".hidden/old.wav"), Rating::KEEP_1)
+        .unwrap();
+    batch.commit().unwrap();
+
+    let stats = scan_once(&db).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 0);
+    let new_entry = db.entry_for_path(Path::new("new.wav")).unwrap().unwrap();
+    assert_eq!(new_entry.tag, Rating::NEUTRAL);
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -306,6 +306,50 @@ fn missing_stage_prunes_path_replaced_by_directory() {
 }
 
 #[test]
+fn full_scan_prunes_tracked_files_below_hidden_directories() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir(&hidden).unwrap();
+    std::fs::write(hidden.join("one.wav"), b"hidden").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    db.upsert_file(Path::new(".hidden/one.wav"), 6, 1).unwrap();
+
+    let stats = scan_once(&db).unwrap();
+
+    assert_eq!(stats.missing, 1);
+    assert!(
+        db.entry_for_path(Path::new(".hidden/one.wav"))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn unsupported_replacement_after_discovery_remains_eligible_for_pruning() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("one.wav");
+    std::fs::write(&file_path, b"old").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::write(&file_path, b"changed-size").unwrap();
+    let mut replaced = false;
+
+    let stats = scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if replaced {
+            return;
+        }
+        std::fs::remove_file(&file_path).unwrap();
+        std::fs::create_dir(&file_path).unwrap();
+        replaced = true;
+    })
+    .unwrap();
+
+    assert!(replaced);
+    assert_eq!(stats.missing, 1);
+    assert!(db.entry_for_path(Path::new("one.wav")).unwrap().is_none());
+}
+
+#[test]
 fn scan_rebases_noop_when_concurrent_writer_clears_hash() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -50,6 +50,62 @@ fn scan_detects_rename_and_preserves_tag() {
 }
 
 #[test]
+fn rename_apply_refreshes_metadata_changed_during_discovery() {
+    let dir = tempdir().unwrap();
+    let first_path = dir.path().join("one.wav");
+    let second_path = dir.path().join("two.wav");
+    std::fs::write(&first_path, b"one").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::rename(&first_path, &second_path).unwrap();
+    let mut edited = false;
+
+    let stats = scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if !edited {
+            db.set_tag(Path::new("one.wav"), Rating::KEEP_1).unwrap();
+            db.set_user_tag(Path::new("one.wav"), Some("Edited during scan"))
+                .unwrap();
+            edited = true;
+        }
+    })
+    .unwrap();
+
+    assert!(edited);
+    assert_eq!(stats.renames_reconciled, 1);
+    let row = db.entry_for_path(Path::new("two.wav")).unwrap().unwrap();
+    assert_eq!(row.tag, Rating::KEEP_1);
+    assert_eq!(row.user_tag.as_deref(), Some("Edited during scan"));
+}
+
+#[test]
+fn pending_rename_staging_refreshes_metadata_changed_during_discovery() {
+    let dir = tempdir().unwrap();
+    let removed_path = dir.path().join("removed.wav");
+    std::fs::write(&removed_path, b"removed").unwrap();
+    std::fs::write(dir.path().join("live.wav"), b"live").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::remove_file(&removed_path).unwrap();
+    let mut edited = false;
+
+    scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {
+        if !edited {
+            db.set_tag(Path::new("removed.wav"), Rating::KEEP_1)
+                .unwrap();
+            edited = true;
+        }
+    })
+    .unwrap();
+
+    let pending = db.list_pending_renames().unwrap();
+    let removed = pending
+        .iter()
+        .find(|entry| entry.relative_path == Path::new("removed.wav"))
+        .expect("removed path must be staged");
+    assert_eq!(removed.tag, Rating::KEEP_1);
+}
+
+#[test]
 fn quick_scan_defers_hash_for_large_file() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("large.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -77,6 +77,36 @@ fn targeted_sync_adds_new_file_inside_requested_folder() {
 }
 
 #[test]
+fn targeted_sync_does_not_claim_unrelated_missing_rename_source() {
+    let dir = tempdir().unwrap();
+    let unrelated = dir.path().join("unrelated.wav");
+    std::fs::write(&unrelated, b"same").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("unrelated.wav"), Rating::KEEP_1)
+        .unwrap();
+
+    std::fs::remove_file(&unrelated).unwrap();
+    std::fs::write(dir.path().join("requested.wav"), b"same").unwrap();
+    let stats = sync_paths(&db, &[PathBuf::from("requested.wav")]).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 0);
+    assert_eq!(stats.added, 1);
+    assert!(
+        db.entry_for_path(Path::new("unrelated.wav"))
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        db.entry_for_path(Path::new("requested.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+}
+
+#[test]
 fn targeted_sync_ignores_appledouble_sidecars() {
     let dir = tempdir().unwrap();
     let drums = dir.path().join("drums");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -1,20 +1,34 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT;
-use crate::sample_sources::db::SourceWriteBatch;
-
 use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::mark_missing;
+use crate::sample_sources::SourceDatabase;
+use crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT;
+
+const MISSING_BATCH_SIZE: usize = 64;
 
 pub(super) fn db_sync_phase(
-    _db: &SourceDatabase,
-    batch: SourceWriteBatch<'_>,
+    db: &SourceDatabase,
     context: &mut ScanContext,
 ) -> Result<(), ScanError> {
-    let existing = std::mem::take(&mut context.existing);
-    let mut batch = batch;
-    mark_missing(&mut batch, existing, &mut context.stats, context.mode)?;
+    let mut existing = std::mem::take(&mut context.existing)
+        .into_values()
+        .collect::<Vec<_>>()
+        .into_iter();
+    loop {
+        let chunk = existing
+            .by_ref()
+            .take(MISSING_BATCH_SIZE)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        let mut batch = db.write_batch()?;
+        mark_missing(&mut batch, chunk, &mut context.stats, context.mode)?;
+        batch.commit()?;
+    }
+
+    let mut batch = db.write_batch()?;
     if context.mode == ScanMode::Hard {
         batch.clear_all_pending_renames()?;
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -24,7 +24,7 @@ pub(super) fn db_sync_phase(
             break;
         }
         let mut batch = db.write_batch()?;
-        mark_missing(&mut batch, chunk, &mut context.stats, context.mode)?;
+        mark_missing(db, &mut batch, chunk, &mut context.stats, context.mode)?;
         batch.commit()?;
     }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -25,6 +25,7 @@ pub(super) fn apply_diff(
     batch: &mut SourceWriteBatch<'_>,
     prepared: PreparedFile,
     context: &mut ScanContext,
+    root: &Path,
 ) -> Result<(), ScanError> {
     let PreparedFile {
         facts,
@@ -87,7 +88,7 @@ pub(super) fn apply_diff(
         None => {
             if should_hash {
                 let hash = required_prepared_hash(content_hash);
-                if let Some(entry) = take_rename_candidate_by_hash(db, context, &hash)? {
+                if let Some(entry) = take_rename_candidate_by_hash(db, context, root, &hash)? {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename(batch, &path, &facts, &hash, entry, None)?;
                     context.stats.updated += 1;
@@ -129,9 +130,13 @@ pub(super) fn apply_diff(
                     content_hash: hash,
                 });
             } else {
-                if let Some(entry) =
-                    take_rename_candidate_by_facts(db, context, facts.size, facts.modified_ns)?
-                {
+                if let Some(entry) = take_rename_candidate_by_facts(
+                    db,
+                    context,
+                    root,
+                    facts.size,
+                    facts.modified_ns,
+                )? {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename_without_hash(batch, &path, &facts, entry, None)?;
                     context.stats.updated += 1;
@@ -320,11 +325,13 @@ fn apply_rename_without_hash(
 fn take_rename_candidate_by_hash(
     db: &SourceDatabase,
     context: &mut ScanContext,
+    root: &Path,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
     let path = unique_existing_path(
         context.rename_candidates_by_hash.get(hash),
         &context.existing,
+        root,
     );
     let Some(path) = path else {
         return Ok(None);
@@ -336,6 +343,7 @@ fn take_rename_candidate_by_hash(
 fn take_rename_candidate_by_facts(
     db: &SourceDatabase,
     context: &mut ScanContext,
+    root: &Path,
     size: u64,
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
@@ -343,6 +351,7 @@ fn take_rename_candidate_by_facts(
     let path = unique_existing_path(
         context.rename_candidates_by_facts.get(&key),
         &context.existing,
+        root,
     );
     let Some(path) = path else {
         return Ok(None);
@@ -354,11 +363,15 @@ fn take_rename_candidate_by_facts(
 fn unique_existing_path(
     candidates: Option<&Vec<PathBuf>>,
     existing: &HashMap<PathBuf, WavEntry>,
+    root: &Path,
 ) -> Option<PathBuf> {
     let candidates = candidates?;
     let mut match_path: Option<PathBuf> = None;
     for path in candidates {
         if !existing.contains_key(path) {
+            continue;
+        }
+        if root.join(path).exists() {
             continue;
         }
         if match_path.is_some() {
@@ -404,24 +417,39 @@ mod tests {
 
     #[test]
     fn unique_existing_path_returns_single_match() {
+        let root = tempfile::tempdir().unwrap();
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("missing.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing);
+        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
 
         assert_eq!(matched, Some(PathBuf::from("one.wav")));
     }
 
     #[test]
     fn unique_existing_path_rejects_ambiguous_matches() {
+        let root = tempfile::tempdir().unwrap();
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing);
+        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
+
+        assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn unique_existing_path_rejects_candidate_recreated_before_claim() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("one.wav"), b"recreated").unwrap();
+        let mut existing = HashMap::new();
+        existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
+        let candidates = vec![PathBuf::from("one.wav")];
+
+        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
 
         assert_eq!(matched, None);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::atomic::AtomicBool,
 };
 
 use crate::sample_sources::SourceDatabase;
@@ -10,18 +9,25 @@ use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
 use super::scan::{
     ChangedSample, RenamedSample, ScanContext, ScanError, ScanMode, ScanStats, UpdatedSample,
 };
-use super::scan_fs::{FileFacts, compute_content_hash};
+use super::scan_fs::FileFacts;
 
 const QUICK_HASH_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+pub(super) struct PreparedFile {
+    pub(super) facts: FileFacts,
+    pub(super) content_hash: Option<String>,
+}
 
 pub(super) fn apply_diff(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
-    facts: FileFacts,
+    prepared: PreparedFile,
     context: &mut ScanContext,
-    root: &Path,
-    cancel: Option<&AtomicBool>,
 ) -> Result<(), ScanError> {
+    let PreparedFile {
+        facts,
+        content_hash,
+    } = prepared;
     let path = facts.relative.clone();
     let should_hash = should_compute_full_hash(context.mode, facts.size);
     match context.existing.remove(&path) {
@@ -31,8 +37,7 @@ pub(super) fn apply_diff(
             }
             if entry.content_hash.is_none() {
                 if should_hash {
-                    let absolute = root.join(&path);
-                    let hash = compute_content_hash(&absolute, cancel)?;
+                    let hash = required_prepared_hash(content_hash);
                     batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
                     context.stats.hashes_computed += 1;
                 } else {
@@ -41,10 +46,9 @@ pub(super) fn apply_diff(
             }
         }
         Some(entry) => {
-            let absolute = root.join(&path);
             let previous_hash = entry.content_hash.as_deref();
             if should_hash {
-                let hash = compute_content_hash(&absolute, cancel)?;
+                let hash = required_prepared_hash(content_hash);
                 batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
                 context.stats.hashes_computed += 1;
                 context.stats.updated_samples.push(UpdatedSample {
@@ -75,10 +79,9 @@ pub(super) fn apply_diff(
             context.stats.updated += 1;
         }
         None => {
-            let absolute = root.join(&path);
             if should_hash {
-                let hash = compute_content_hash(&absolute, cancel)?;
-                if let Some(entry) = take_rename_candidate_by_hash(db, context, root, &hash)? {
+                let hash = required_prepared_hash(content_hash);
+                if let Some(entry) = take_rename_candidate_by_hash(db, context, &hash)? {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename(batch, &path, &facts, &hash, entry, None)?;
                     context.stats.updated += 1;
@@ -120,13 +123,9 @@ pub(super) fn apply_diff(
                     content_hash: hash,
                 });
             } else {
-                if let Some(entry) = take_rename_candidate_by_facts(
-                    db,
-                    context,
-                    root,
-                    facts.size,
-                    facts.modified_ns,
-                )? {
+                if let Some(entry) =
+                    take_rename_candidate_by_facts(db, context, facts.size, facts.modified_ns)?
+                {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename_without_hash(batch, &path, &facts, entry, None)?;
                     context.stats.updated += 1;
@@ -169,15 +168,19 @@ pub(super) fn apply_diff(
     Ok(())
 }
 
+fn required_prepared_hash(content_hash: Option<String>) -> String {
+    content_hash.expect("hash-required scan entries must be prepared before opening a write batch")
+}
+
 pub(super) fn mark_missing(
     batch: &mut SourceWriteBatch<'_>,
-    existing: HashMap<PathBuf, WavEntry>,
+    existing: impl IntoIterator<Item = WavEntry>,
     stats: &mut ScanStats,
     mode: ScanMode,
 ) -> Result<(), ScanError> {
-    for leftover in existing.values() {
+    for leftover in existing {
         if matches!(mode, ScanMode::Targeted | ScanMode::Quick) {
-            batch.stage_pending_rename(leftover)?;
+            batch.stage_pending_rename(&leftover)?;
         }
         batch.remove_file(&leftover.relative_path)?;
         stats.missing += 1;
@@ -265,7 +268,6 @@ fn apply_rename_without_hash(
 fn take_rename_candidate_by_hash(
     db: &SourceDatabase,
     context: &mut ScanContext,
-    root: &Path,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
     if let std::collections::hash_map::Entry::Vacant(entry) =
@@ -277,7 +279,7 @@ fn take_rename_candidate_by_hash(
     let path = unique_existing_path(
         context.rename_candidates_by_hash.get(hash),
         &context.existing,
-        root,
+        &context.discovered_paths,
     );
     Ok(path.and_then(|path| context.existing.remove(&path)))
 }
@@ -285,7 +287,6 @@ fn take_rename_candidate_by_hash(
 fn take_rename_candidate_by_facts(
     db: &SourceDatabase,
     context: &mut ScanContext,
-    root: &Path,
     size: u64,
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
@@ -299,7 +300,7 @@ fn take_rename_candidate_by_facts(
     let path = unique_existing_path(
         context.rename_candidates_by_facts.get(&key),
         &context.existing,
-        root,
+        &context.discovered_paths,
     );
     Ok(path.and_then(|path| context.existing.remove(&path)))
 }
@@ -307,7 +308,7 @@ fn take_rename_candidate_by_facts(
 fn unique_existing_path(
     candidates: Option<&Vec<PathBuf>>,
     existing: &HashMap<PathBuf, WavEntry>,
-    root: &Path,
+    discovered_paths: &std::collections::HashSet<PathBuf>,
 ) -> Option<PathBuf> {
     let candidates = candidates?;
     let mut match_path: Option<PathBuf> = None;
@@ -315,7 +316,7 @@ fn unique_existing_path(
         if !existing.contains_key(path) {
             continue;
         }
-        if root.join(path).exists() {
+        if discovered_paths.contains(path) {
             continue;
         }
         if match_path.is_some() {
@@ -326,7 +327,7 @@ fn unique_existing_path(
     match_path
 }
 
-fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
+pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
     match mode {
         ScanMode::Targeted | ScanMode::Quick => size <= QUICK_HASH_MAX_BYTES,
         ScanMode::Hard => true,
@@ -337,7 +338,7 @@ fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
 mod tests {
     use super::unique_existing_path;
     use crate::sample_sources::{Rating, WavEntry};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
 
     fn entry(path: &str) -> WavEntry {
@@ -361,26 +362,24 @@ mod tests {
 
     #[test]
     fn unique_existing_path_returns_single_match() {
-        let root = tempfile::tempdir().unwrap();
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("missing.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
+        let matched = unique_existing_path(Some(&candidates), &existing, &HashSet::new());
 
         assert_eq!(matched, Some(PathBuf::from("one.wav")));
     }
 
     #[test]
     fn unique_existing_path_rejects_ambiguous_matches() {
-        let root = tempfile::tempdir().unwrap();
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
+        let matched = unique_existing_path(Some(&candidates), &existing, &HashSet::new());
 
         assert_eq!(matched, None);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -233,6 +233,9 @@ pub(super) fn mark_missing(
     mode: ScanMode,
 ) -> Result<(), ScanError> {
     for stale in existing {
+        if db.root().join(&stale.relative_path).exists() {
+            continue;
+        }
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {
             continue;
         };

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -10,11 +10,13 @@ use super::scan::{
     ChangedSample, RenamedSample, ScanContext, ScanError, ScanMode, ScanStats, UpdatedSample,
 };
 use super::scan_fs::FileFacts;
+use super::scan_fs::is_supported_regular_audio_file;
 
 const QUICK_HASH_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
 pub(super) struct PreparedFile {
     pub(super) facts: FileFacts,
+    pub(super) hash_required: bool,
     pub(super) needs_hash: bool,
     pub(super) requires_apply: bool,
     pub(super) content_hash: Option<String>,
@@ -29,6 +31,7 @@ pub(super) fn apply_diff(
 ) -> Result<(), ScanError> {
     let PreparedFile {
         facts,
+        hash_required: _,
         needs_hash: _,
         requires_apply: _,
         content_hash,
@@ -233,7 +236,7 @@ pub(super) fn mark_missing(
     mode: ScanMode,
 ) -> Result<(), ScanError> {
     for stale in existing {
-        if db.root().join(&stale.relative_path).exists() {
+        if is_supported_regular_audio_file(&db.root().join(&stale.relative_path)) {
             continue;
         }
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -336,8 +336,14 @@ fn take_rename_candidate_by_hash(
     let Some(path) = path else {
         return Ok(None);
     };
+    let Some(entry) = db.entry_for_path(&path)? else {
+        return Ok(None);
+    };
+    if entry.content_hash.as_deref() != Some(hash) {
+        return Ok(None);
+    }
     let _ = context.existing.remove(&path);
-    Ok(db.entry_for_path(&path)?)
+    Ok(Some(entry))
 }
 
 fn take_rename_candidate_by_facts(
@@ -356,8 +362,14 @@ fn take_rename_candidate_by_facts(
     let Some(path) = path else {
         return Ok(None);
     };
+    let Some(entry) = db.entry_for_path(&path)? else {
+        return Ok(None);
+    };
+    if entry.file_size != size || entry.modified_ns != modified_ns {
+        return Ok(None);
+    }
     let _ = context.existing.remove(&path);
-    Ok(db.entry_for_path(&path)?)
+    Ok(Some(entry))
 }
 
 fn unique_existing_path(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -15,6 +15,8 @@ const QUICK_HASH_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
 pub(super) struct PreparedFile {
     pub(super) facts: FileFacts,
+    pub(super) needs_hash: bool,
+    pub(super) requires_apply: bool,
     pub(super) content_hash: Option<String>,
 }
 
@@ -26,11 +28,15 @@ pub(super) fn apply_diff(
 ) -> Result<(), ScanError> {
     let PreparedFile {
         facts,
+        needs_hash: _,
+        requires_apply: _,
         content_hash,
     } = prepared;
     let path = facts.relative.clone();
     let should_hash = should_compute_full_hash(context.mode, facts.size);
-    match context.existing.remove(&path) {
+    let _ = context.existing.remove(&path);
+    let existing = db.entry_for_path(&path)?;
+    match existing {
         Some(entry) if entry.file_size == facts.size && entry.modified_ns == facts.modified_ns => {
             if entry.missing {
                 batch.set_missing(&path, false)?;
@@ -172,13 +178,59 @@ fn required_prepared_hash(content_hash: Option<String>) -> String {
     content_hash.expect("hash-required scan entries must be prepared before opening a write batch")
 }
 
+pub(super) fn preload_rename_candidates(
+    db: &SourceDatabase,
+    root: &Path,
+    context: &mut ScanContext,
+    prepared: &[PreparedFile],
+) -> Result<(), ScanError> {
+    for file in prepared {
+        if context.existing.contains_key(&file.facts.relative) {
+            continue;
+        }
+        if file.needs_hash {
+            let hash = file
+                .content_hash
+                .as_ref()
+                .expect("prepared hash must exist before rename preloading");
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                context.rename_candidates_by_hash.entry(hash.clone())
+            {
+                let paths = db
+                    .list_paths_with_content_hash(hash)?
+                    .into_iter()
+                    .filter(|path| !root.join(path).exists())
+                    .collect();
+                entry.insert(paths);
+            }
+        } else {
+            let key = (file.facts.size, file.facts.modified_ns);
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                context.rename_candidates_by_facts.entry(key)
+            {
+                let paths = db
+                    .list_paths_with_file_facts(file.facts.size, file.facts.modified_ns)?
+                    .into_iter()
+                    .filter(|path| !root.join(path).exists())
+                    .collect();
+                entry.insert(paths);
+            }
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn mark_missing(
+    db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
     existing: impl IntoIterator<Item = WavEntry>,
     stats: &mut ScanStats,
     mode: ScanMode,
 ) -> Result<(), ScanError> {
-    for leftover in existing {
+    for stale in existing {
+        let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {
+            continue;
+        };
         if matches!(mode, ScanMode::Targeted | ScanMode::Quick) {
             batch.stage_pending_rename(&leftover)?;
         }
@@ -270,18 +322,15 @@ fn take_rename_candidate_by_hash(
     context: &mut ScanContext,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
-    if let std::collections::hash_map::Entry::Vacant(entry) =
-        context.rename_candidates_by_hash.entry(hash.to_string())
-    {
-        let paths = db.list_paths_with_content_hash(hash)?;
-        entry.insert(paths);
-    }
     let path = unique_existing_path(
         context.rename_candidates_by_hash.get(hash),
         &context.existing,
-        &context.discovered_paths,
     );
-    Ok(path.and_then(|path| context.existing.remove(&path)))
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let _ = context.existing.remove(&path);
+    Ok(db.entry_for_path(&path)?)
 }
 
 fn take_rename_candidate_by_facts(
@@ -291,32 +340,25 @@ fn take_rename_candidate_by_facts(
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
     let key = (size, modified_ns);
-    if let std::collections::hash_map::Entry::Vacant(entry) =
-        context.rename_candidates_by_facts.entry(key)
-    {
-        let paths = db.list_paths_with_file_facts(size, modified_ns)?;
-        entry.insert(paths);
-    }
     let path = unique_existing_path(
         context.rename_candidates_by_facts.get(&key),
         &context.existing,
-        &context.discovered_paths,
     );
-    Ok(path.and_then(|path| context.existing.remove(&path)))
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let _ = context.existing.remove(&path);
+    Ok(db.entry_for_path(&path)?)
 }
 
 fn unique_existing_path(
     candidates: Option<&Vec<PathBuf>>,
     existing: &HashMap<PathBuf, WavEntry>,
-    discovered_paths: &std::collections::HashSet<PathBuf>,
 ) -> Option<PathBuf> {
     let candidates = candidates?;
     let mut match_path: Option<PathBuf> = None;
     for path in candidates {
         if !existing.contains_key(path) {
-            continue;
-        }
-        if discovered_paths.contains(path) {
             continue;
         }
         if match_path.is_some() {
@@ -338,7 +380,7 @@ pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
 mod tests {
     use super::unique_existing_path;
     use crate::sample_sources::{Rating, WavEntry};
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
     fn entry(path: &str) -> WavEntry {
@@ -367,7 +409,7 @@ mod tests {
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("missing.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, &HashSet::new());
+        let matched = unique_existing_path(Some(&candidates), &existing);
 
         assert_eq!(matched, Some(PathBuf::from("one.wav")));
     }
@@ -379,7 +421,7 @@ mod tests {
         existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, &HashSet::new());
+        let matched = unique_existing_path(Some(&candidates), &existing);
 
         assert_eq!(matched, None);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
@@ -18,9 +21,44 @@ pub(super) struct PreparedFile {
     pub(super) content_hash: Option<String>,
 }
 
+#[derive(Default)]
+pub(super) struct RenameCandidateCache {
+    by_hash: HashMap<String, Vec<PathBuf>>,
+    by_facts: HashMap<(u64, i64), Vec<PathBuf>>,
+}
+
+impl RenameCandidateCache {
+    fn paths_with_hash<'a>(
+        &'a mut self,
+        batch: &SourceWriteBatch<'_>,
+        hash: &str,
+    ) -> Result<&'a [PathBuf], ScanError> {
+        if !self.by_hash.contains_key(hash) {
+            let paths = batch.list_paths_with_content_hash(hash)?;
+            self.by_hash.insert(hash.to_owned(), paths);
+        }
+        Ok(self.by_hash.get(hash).expect("hash cache populated"))
+    }
+
+    fn paths_with_facts<'a>(
+        &'a mut self,
+        batch: &SourceWriteBatch<'_>,
+        size: u64,
+        modified_ns: i64,
+    ) -> Result<&'a [PathBuf], ScanError> {
+        let key = (size, modified_ns);
+        if !self.by_facts.contains_key(&key) {
+            let paths = batch.list_paths_with_file_facts(size, modified_ns)?;
+            self.by_facts.insert(key, paths);
+        }
+        Ok(self.by_facts.get(&key).expect("facts cache populated"))
+    }
+}
+
 pub(super) fn apply_diff(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
+    rename_candidates: &mut RenameCandidateCache,
     prepared: PreparedFile,
     context: &mut ScanContext,
     root: &Path,
@@ -87,8 +125,14 @@ pub(super) fn apply_diff(
         None => {
             if should_hash {
                 let hash = required_prepared_hash(content_hash);
-                if let Some(entry) = take_rename_candidate_by_hash(db, batch, context, root, &hash)?
-                {
+                if let Some(entry) = take_rename_candidate_by_hash(
+                    db,
+                    batch,
+                    rename_candidates,
+                    context,
+                    root,
+                    &hash,
+                )? {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename(batch, &path, &facts, &hash, entry, None)?;
                     context.stats.updated += 1;
@@ -133,6 +177,7 @@ pub(super) fn apply_diff(
                 if let Some(entry) = take_rename_candidate_by_facts(
                     db,
                     batch,
+                    rename_candidates,
                     context,
                     root,
                     facts.size,
@@ -287,13 +332,13 @@ fn apply_rename_without_hash(
 fn take_rename_candidate_by_hash(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
+    rename_candidates: &mut RenameCandidateCache,
     context: &mut ScanContext,
     root: &Path,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates =
-        rename_candidates_in_scope(batch.list_paths_with_content_hash(hash)?, context);
-    let path = unique_missing_path(&current_candidates, root);
+    let current_candidates = rename_candidates.paths_with_hash(batch, hash)?;
+    let path = unique_missing_path_in_scope(current_candidates, context, root);
     let Some(path) = path else {
         return Ok(None);
     };
@@ -310,16 +355,14 @@ fn take_rename_candidate_by_hash(
 fn take_rename_candidate_by_facts(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
+    rename_candidates: &mut RenameCandidateCache,
     context: &mut ScanContext,
     root: &Path,
     size: u64,
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates = rename_candidates_in_scope(
-        batch.list_paths_with_file_facts(size, modified_ns)?,
-        context,
-    );
-    let path = unique_missing_path(&current_candidates, root);
+    let current_candidates = rename_candidates.paths_with_facts(batch, size, modified_ns)?;
+    let path = unique_missing_path_in_scope(current_candidates, context, root);
     let Some(path) = path else {
         return Ok(None);
     };
@@ -333,14 +376,23 @@ fn take_rename_candidate_by_facts(
     Ok(Some(entry))
 }
 
-fn rename_candidates_in_scope(mut candidates: Vec<PathBuf>, context: &ScanContext) -> Vec<PathBuf> {
-    if context.mode == ScanMode::Targeted {
-        candidates.retain(|path| context.existing.contains_key(path));
-    }
-    candidates
+fn unique_missing_path_in_scope(
+    candidates: &[PathBuf],
+    context: &ScanContext,
+    root: &Path,
+) -> Option<PathBuf> {
+    unique_missing_path(
+        candidates.iter().filter(|path| {
+            context.mode != ScanMode::Targeted || context.existing.contains_key(*path)
+        }),
+        root,
+    )
 }
 
-fn unique_missing_path(candidates: &[PathBuf], root: &Path) -> Option<PathBuf> {
+fn unique_missing_path<'a>(
+    candidates: impl IntoIterator<Item = &'a PathBuf>,
+    root: &Path,
+) -> Option<PathBuf> {
     let mut match_path: Option<PathBuf> = None;
     for path in candidates {
         if root.join(path).exists() {
@@ -363,7 +415,9 @@ pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::unique_missing_path;
+    use super::{RenameCandidateCache, unique_missing_path};
+    use crate::sample_sources::SourceDatabase;
+    use std::path::Path;
     use std::path::PathBuf;
 
     #[test]
@@ -396,5 +450,53 @@ mod tests {
         let matched = unique_missing_path(&candidates, root.path());
 
         assert_eq!(matched, None);
+    }
+
+    #[test]
+    fn rename_candidate_cache_reuses_hash_lookup_within_batch() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open(root.path()).unwrap();
+        let mut batch = db.write_batch().unwrap();
+        batch
+            .upsert_file_with_hash(Path::new("one.wav"), 4, 1, "same")
+            .unwrap();
+        let mut cache = RenameCandidateCache::default();
+
+        assert_eq!(
+            cache.paths_with_hash(&batch, "same").unwrap(),
+            &[PathBuf::from("one.wav")]
+        );
+        batch
+            .upsert_file_with_hash(Path::new("two.wav"), 4, 1, "same")
+            .unwrap();
+
+        assert_eq!(
+            cache.paths_with_hash(&batch, "same").unwrap(),
+            &[PathBuf::from("one.wav")]
+        );
+    }
+
+    #[test]
+    fn rename_candidate_cache_reuses_facts_lookup_within_batch() {
+        let root = tempfile::tempdir().unwrap();
+        let db = SourceDatabase::open(root.path()).unwrap();
+        let mut batch = db.write_batch().unwrap();
+        batch
+            .upsert_file_without_hash(Path::new("one.wav"), 4, 1)
+            .unwrap();
+        let mut cache = RenameCandidateCache::default();
+
+        assert_eq!(
+            cache.paths_with_facts(&batch, 4, 1).unwrap(),
+            &[PathBuf::from("one.wav")]
+        );
+        batch
+            .upsert_file_without_hash(Path::new("two.wav"), 4, 1)
+            .unwrap();
+
+        assert_eq!(
+            cache.paths_with_facts(&batch, 4, 1).unwrap(),
+            &[PathBuf::from("one.wav")]
+        );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
@@ -9,8 +6,7 @@ use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
 use super::scan::{
     ChangedSample, RenamedSample, ScanContext, ScanError, ScanMode, ScanStats, UpdatedSample,
 };
-use super::scan_fs::FileFacts;
-use super::scan_fs::is_supported_regular_audio_file;
+use super::scan_fs::{FileFacts, is_supported_scannable_audio_file};
 
 const QUICK_HASH_MAX_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -91,7 +87,8 @@ pub(super) fn apply_diff(
         None => {
             if should_hash {
                 let hash = required_prepared_hash(content_hash);
-                if let Some(entry) = take_rename_candidate_by_hash(db, context, root, &hash)? {
+                if let Some(entry) = take_rename_candidate_by_hash(db, batch, context, root, &hash)?
+                {
                     let old_relative_path = entry.relative_path.clone();
                     apply_rename(batch, &path, &facts, &hash, entry, None)?;
                     context.stats.updated += 1;
@@ -135,6 +132,7 @@ pub(super) fn apply_diff(
             } else {
                 if let Some(entry) = take_rename_candidate_by_facts(
                     db,
+                    batch,
                     context,
                     root,
                     facts.size,
@@ -186,48 +184,6 @@ fn required_prepared_hash(content_hash: Option<String>) -> String {
     content_hash.expect("hash-required scan entries must be prepared before opening a write batch")
 }
 
-pub(super) fn preload_rename_candidates(
-    db: &SourceDatabase,
-    root: &Path,
-    context: &mut ScanContext,
-    prepared: &[PreparedFile],
-) -> Result<(), ScanError> {
-    for file in prepared {
-        if context.existing.contains_key(&file.facts.relative) {
-            continue;
-        }
-        if file.needs_hash {
-            let hash = file
-                .content_hash
-                .as_ref()
-                .expect("prepared hash must exist before rename preloading");
-            if let std::collections::hash_map::Entry::Vacant(entry) =
-                context.rename_candidates_by_hash.entry(hash.clone())
-            {
-                let paths = db
-                    .list_paths_with_content_hash(hash)?
-                    .into_iter()
-                    .filter(|path| !root.join(path).exists())
-                    .collect();
-                entry.insert(paths);
-            }
-        } else {
-            let key = (file.facts.size, file.facts.modified_ns);
-            if let std::collections::hash_map::Entry::Vacant(entry) =
-                context.rename_candidates_by_facts.entry(key)
-            {
-                let paths = db
-                    .list_paths_with_file_facts(file.facts.size, file.facts.modified_ns)?
-                    .into_iter()
-                    .filter(|path| !root.join(path).exists())
-                    .collect();
-                entry.insert(paths);
-            }
-        }
-    }
-    Ok(())
-}
-
 pub(super) fn mark_missing(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
@@ -236,7 +192,7 @@ pub(super) fn mark_missing(
     mode: ScanMode,
 ) -> Result<(), ScanError> {
     for stale in existing {
-        if is_supported_regular_audio_file(&db.root().join(&stale.relative_path)) {
+        if is_supported_scannable_audio_file(db.root(), &stale.relative_path) {
             continue;
         }
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {
@@ -330,15 +286,13 @@ fn apply_rename_without_hash(
 
 fn take_rename_candidate_by_hash(
     db: &SourceDatabase,
+    batch: &mut SourceWriteBatch<'_>,
     context: &mut ScanContext,
     root: &Path,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let path = unique_existing_path(
-        context.rename_candidates_by_hash.get(hash),
-        &context.existing,
-        root,
-    );
+    let current_candidates = batch.list_paths_with_content_hash(hash)?;
+    let path = unique_missing_path(&current_candidates, root);
     let Some(path) = path else {
         return Ok(None);
     };
@@ -354,17 +308,14 @@ fn take_rename_candidate_by_hash(
 
 fn take_rename_candidate_by_facts(
     db: &SourceDatabase,
+    batch: &mut SourceWriteBatch<'_>,
     context: &mut ScanContext,
     root: &Path,
     size: u64,
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let key = (size, modified_ns);
-    let path = unique_existing_path(
-        context.rename_candidates_by_facts.get(&key),
-        &context.existing,
-        root,
-    );
+    let current_candidates = batch.list_paths_with_file_facts(size, modified_ns)?;
+    let path = unique_missing_path(&current_candidates, root);
     let Some(path) = path else {
         return Ok(None);
     };
@@ -378,17 +329,9 @@ fn take_rename_candidate_by_facts(
     Ok(Some(entry))
 }
 
-fn unique_existing_path(
-    candidates: Option<&Vec<PathBuf>>,
-    existing: &HashMap<PathBuf, WavEntry>,
-    root: &Path,
-) -> Option<PathBuf> {
-    let candidates = candidates?;
+fn unique_missing_path(candidates: &[PathBuf], root: &Path) -> Option<PathBuf> {
     let mut match_path: Option<PathBuf> = None;
     for path in candidates {
-        if !existing.contains_key(path) {
-            continue;
-        }
         if root.join(path).exists() {
             continue;
         }
@@ -409,52 +352,26 @@ pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::unique_existing_path;
-    use crate::sample_sources::{Rating, WavEntry};
-    use std::collections::HashMap;
+    use super::unique_missing_path;
     use std::path::PathBuf;
 
-    fn entry(path: &str) -> WavEntry {
-        WavEntry {
-            relative_path: PathBuf::from(path),
-            file_size: 1,
-            modified_ns: 1,
-            content_hash: None,
-            tag: Rating::NEUTRAL,
-            looped: false,
-            sound_type: None,
-            locked: false,
-            missing: false,
-            last_played_at: None,
-            last_curated_at: None,
-            user_tag: None,
-            tag_named: false,
-            normal_tags: Vec::new(),
-        }
+    #[test]
+    fn unique_missing_path_returns_single_match() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("present.wav"), b"present").unwrap();
+        let candidates = vec![PathBuf::from("missing.wav"), PathBuf::from("present.wav")];
+
+        let matched = unique_missing_path(&candidates, root.path());
+
+        assert_eq!(matched, Some(PathBuf::from("missing.wav")));
     }
 
     #[test]
-    fn unique_existing_path_returns_single_match() {
+    fn unique_missing_path_rejects_ambiguous_current_rows() {
         let root = tempfile::tempdir().unwrap();
-        let mut existing = HashMap::new();
-        existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
-        existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
-        let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("missing.wav")];
-
-        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
-
-        assert_eq!(matched, Some(PathBuf::from("one.wav")));
-    }
-
-    #[test]
-    fn unique_existing_path_rejects_ambiguous_matches() {
-        let root = tempfile::tempdir().unwrap();
-        let mut existing = HashMap::new();
-        existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
-        existing.insert(PathBuf::from("two.wav"), entry("two.wav"));
         let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
+        let matched = unique_missing_path(&candidates, root.path());
 
         assert_eq!(matched, None);
     }
@@ -463,11 +380,9 @@ mod tests {
     fn unique_existing_path_rejects_candidate_recreated_before_claim() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("one.wav"), b"recreated").unwrap();
-        let mut existing = HashMap::new();
-        existing.insert(PathBuf::from("one.wav"), entry("one.wav"));
         let candidates = vec![PathBuf::from("one.wav")];
 
-        let matched = unique_existing_path(Some(&candidates), &existing, root.path());
+        let matched = unique_missing_path(&candidates, root.path());
 
         assert_eq!(matched, None);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -291,7 +291,8 @@ fn take_rename_candidate_by_hash(
     root: &Path,
     hash: &str,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates = batch.list_paths_with_content_hash(hash)?;
+    let current_candidates =
+        rename_candidates_in_scope(batch.list_paths_with_content_hash(hash)?, context);
     let path = unique_missing_path(&current_candidates, root);
     let Some(path) = path else {
         return Ok(None);
@@ -314,7 +315,10 @@ fn take_rename_candidate_by_facts(
     size: u64,
     modified_ns: i64,
 ) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates = batch.list_paths_with_file_facts(size, modified_ns)?;
+    let current_candidates = rename_candidates_in_scope(
+        batch.list_paths_with_file_facts(size, modified_ns)?,
+        context,
+    );
     let path = unique_missing_path(&current_candidates, root);
     let Some(path) = path else {
         return Ok(None);
@@ -327,6 +331,13 @@ fn take_rename_candidate_by_facts(
     }
     let _ = context.existing.remove(&path);
     Ok(Some(entry))
+}
+
+fn rename_candidates_in_scope(mut candidates: Vec<PathBuf>, context: &ScanContext) -> Vec<PathBuf> {
+    if context.mode == ScanMode::Targeted {
+        candidates.retain(|path| context.existing.contains_key(path));
+    }
+    candidates
 }
 
 fn unique_missing_path(candidates: &[PathBuf], root: &Path) -> Option<PathBuf> {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -1,23 +1,30 @@
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
-use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::SourceWriteBatch;
-
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff::apply_diff;
-use super::scan_fs::read_facts;
+use super::scan_diff::{PreparedFile, should_compute_full_hash};
+use super::scan_fs::{compute_content_hash, read_facts};
 
-pub(super) fn diff_phase(
-    db: &SourceDatabase,
-    batch: &mut SourceWriteBatch<'_>,
+pub(super) fn prepare_diff(
     root: &Path,
     path: &Path,
-    context: &mut ScanContext,
+    context: &ScanContext,
     cancel: Option<&AtomicBool>,
-) -> Result<(), ScanError> {
+) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
-    apply_diff(db, batch, facts, context, root, cancel)?;
-    context.stats.total_files += 1;
-    Ok(())
+    let needs_hash = should_compute_full_hash(context.mode, facts.size)
+        && context.existing.get(&facts.relative).is_none_or(|entry| {
+            entry.file_size != facts.size
+                || entry.modified_ns != facts.modified_ns
+                || entry.content_hash.is_none()
+        });
+    let content_hash = if needs_hash {
+        Some(compute_content_hash(path, cancel)?)
+    } else {
+        None
+    };
+    Ok(PreparedFile {
+        facts,
+        content_hash,
+    })
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -9,7 +9,8 @@ pub(super) fn prepare_diff(
     context: &ScanContext,
 ) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
-    let needs_hash = should_compute_full_hash(context.mode, facts.size)
+    let hash_required = should_compute_full_hash(context.mode, facts.size);
+    let needs_hash = hash_required
         && context.existing.get(&facts.relative).is_none_or(|entry| {
             entry.file_size != facts.size
                 || entry.modified_ns != facts.modified_ns
@@ -23,6 +24,7 @@ pub(super) fn prepare_diff(
     });
     Ok(PreparedFile {
         facts,
+        hash_required,
         needs_hash,
         requires_apply,
         content_hash: None,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -1,15 +1,12 @@
-use std::path::Path;
-use std::sync::atomic::AtomicBool;
-
 use super::scan::{ScanContext, ScanError};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
-use super::scan_fs::{compute_content_hash, read_facts};
+use super::scan_fs::read_facts;
+use std::path::Path;
 
 pub(super) fn prepare_diff(
     root: &Path,
     path: &Path,
     context: &ScanContext,
-    cancel: Option<&AtomicBool>,
 ) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
     let needs_hash = should_compute_full_hash(context.mode, facts.size)
@@ -18,13 +15,16 @@ pub(super) fn prepare_diff(
                 || entry.modified_ns != facts.modified_ns
                 || entry.content_hash.is_none()
         });
-    let content_hash = if needs_hash {
-        Some(compute_content_hash(path, cancel)?)
-    } else {
-        None
-    };
+    let requires_apply = context.existing.get(&facts.relative).is_none_or(|entry| {
+        entry.file_size != facts.size
+            || entry.modified_ns != facts.modified_ns
+            || entry.missing
+            || (entry.content_hash.is_none() && needs_hash)
+    });
     Ok(PreparedFile {
         facts,
-        content_hash,
+        needs_hash,
+        requires_apply,
+        content_hash: None,
     })
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -28,16 +28,14 @@ pub(super) fn ensure_root_dir(db: &SourceDatabase) -> Result<PathBuf, ScanError>
     }
 }
 
-pub(super) fn visit_dir(
+pub(super) fn visit_dir_with_cancel_check(
     root: &Path,
-    cancel: Option<&AtomicBool>,
+    should_cancel: &mut impl FnMut() -> bool,
     visitor: &mut impl FnMut(&Path) -> Result<(), ScanError>,
 ) -> Result<(), ScanError> {
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        if let Some(cancel) = cancel
-            && cancel.load(Ordering::Relaxed)
-        {
+        if should_cancel() {
             return Err(ScanError::Canceled);
         }
         let entries = match fs::read_dir(&dir) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -120,6 +120,11 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
     })
 }
 
+pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+        && is_supported_audio(path)
+}
+
 /// Hash the entire file contents for change detection, honoring cancellation when requested.
 pub(super) fn compute_content_hash(
     path: &Path,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -125,6 +125,16 @@ pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
         && is_supported_audio(path)
 }
 
+pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
+    let hidden_ancestor = relative_path.components().any(|component| {
+        let std::path::Component::Normal(name) = component else {
+            return false;
+        };
+        name.to_str().is_some_and(|name| name.starts_with('.'))
+    });
+    !hidden_ancestor && is_supported_regular_audio_file(&root.join(relative_path))
+}
+
 /// Hash the entire file contents for change detection, honoring cancellation when requested.
 pub(super) fn compute_content_hash(
     path: &Path,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -12,7 +12,7 @@ use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
 use super::scan::ScanError;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct FileFacts {
     pub(super) relative: PathBuf,
     pub(super) size: u64,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -126,11 +126,13 @@ pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
 }
 
 pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
-    let hidden_ancestor = relative_path.components().any(|component| {
-        let std::path::Component::Normal(name) = component else {
-            return false;
-        };
-        name.to_str().is_some_and(|name| name.starts_with('.'))
+    let hidden_ancestor = relative_path.parent().is_some_and(|parent| {
+        parent.components().any(|component| {
+            let std::path::Component::Normal(name) = component else {
+                return false;
+            };
+            name.to_str().is_some_and(|name| name.starts_with('.'))
+        })
     });
     !hidden_ancestor && is_supported_regular_audio_file(&root.join(relative_path))
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -42,10 +42,7 @@ pub fn sync_paths_with_progress(
             return Err(ScanError::Canceled);
         }
         let absolute = root.join(&relative_path);
-        let prepared_file = prepare_diff(&root, &absolute, &context, cancel)?;
-        context
-            .discovered_paths
-            .insert(prepared_file.facts.relative.clone());
+        let prepared_file = prepare_diff(&root, &absolute, &context)?;
         prepared.push(prepared_file);
         context.stats.total_files += 1;
         on_progress(context.stats.total_files, &absolute);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -46,7 +46,21 @@ pub fn sync_paths_with_progress(
             return Err(ScanError::Canceled);
         }
         let absolute = root.join(&relative_path);
-        let prepared_file = prepare_diff(&root, &absolute, &context)?;
+        let prepared_file = match prepare_diff(&root, &absolute, &context) {
+            Ok(prepared) => prepared,
+            Err(error) if committed => {
+                if absolute.exists() {
+                    context.existing.remove(&relative_path);
+                }
+                tracing::warn!(
+                    path = %absolute.display(),
+                    error = %error,
+                    "Skipping targeted file after an earlier chunk committed"
+                );
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         prepared.push(prepared_file);
         context.stats.total_files += 1;
         on_progress(context.stats.total_files, &absolute);
@@ -59,6 +73,7 @@ pub fn sync_paths_with_progress(
                 cancel.filter(|_| !committed),
                 &mut context,
                 chunk,
+                committed,
             )?;
         }
     }
@@ -69,6 +84,7 @@ pub fn sync_paths_with_progress(
             cancel.filter(|_| !committed),
             &mut context,
             prepared,
+            committed,
         )?;
     }
     db_sync_phase(db, &mut context)?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -12,8 +12,10 @@ use super::{
     scan_db_sync::db_sync_phase,
     scan_diff_phase::prepare_diff,
     scan_fs::ensure_root_dir,
-    scan_walk::apply_prepared_files,
+    scan_walk::apply_prepared_chunk,
 };
+
+const TARGET_PREPARE_BATCH_SIZE: usize = 64;
 
 /// Reconcile a bounded set of changed paths against a source database.
 ///
@@ -34,9 +36,11 @@ pub fn sync_paths_with_progress(
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
-    let mut prepared = Vec::with_capacity(targets.current_files.len());
+    let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
+    let mut committed = false;
     for relative_path in targets.current_files {
-        if let Some(cancel) = cancel
+        if !committed
+            && let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
         {
             return Err(ScanError::Canceled);
@@ -46,8 +50,27 @@ pub fn sync_paths_with_progress(
         prepared.push(prepared_file);
         context.stats.total_files += 1;
         on_progress(context.stats.total_files, &absolute);
+        if prepared.len() == TARGET_PREPARE_BATCH_SIZE {
+            let chunk =
+                std::mem::replace(&mut prepared, Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE));
+            committed |= apply_prepared_chunk(
+                db,
+                &root,
+                cancel.filter(|_| !committed),
+                &mut context,
+                chunk,
+            )?;
+        }
     }
-    apply_prepared_files(db, &root, cancel, &mut context, prepared)?;
+    if !prepared.is_empty() {
+        let _ = apply_prepared_chunk(
+            db,
+            &root,
+            cancel.filter(|_| !committed),
+            &mut context,
+            prepared,
+        )?;
+    }
     db_sync_phase(db, &mut context)?;
     Ok(context.stats)
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -10,8 +10,9 @@ use crate::sample_sources::{SourceDatabase, WavEntry, is_supported_audio};
 use super::{
     scan::{ScanContext, ScanError, ScanMode, ScanStats},
     scan_db_sync::db_sync_phase,
-    scan_diff::apply_diff,
-    scan_fs::{ensure_root_dir, read_facts},
+    scan_diff_phase::prepare_diff,
+    scan_fs::ensure_root_dir,
+    scan_walk::apply_prepared_files,
 };
 
 /// Reconcile a bounded set of changed paths against a source database.
@@ -33,7 +34,7 @@ pub fn sync_paths_with_progress(
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
-    let mut batch = db.write_batch()?;
+    let mut prepared = Vec::with_capacity(targets.current_files.len());
     for relative_path in targets.current_files {
         if let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
@@ -41,12 +42,16 @@ pub fn sync_paths_with_progress(
             return Err(ScanError::Canceled);
         }
         let absolute = root.join(&relative_path);
-        let facts = read_facts(&root, &absolute)?;
-        apply_diff(db, &mut batch, facts, &mut context, &root, cancel)?;
+        let prepared_file = prepare_diff(&root, &absolute, &context, cancel)?;
+        context
+            .discovered_paths
+            .insert(prepared_file.facts.relative.clone());
+        prepared.push(prepared_file);
         context.stats.total_files += 1;
         on_progress(context.stats.total_files, &absolute);
     }
-    db_sync_phase(db, batch, &mut context)?;
+    apply_prepared_files(db, &root, cancel, &mut context, prepared)?;
+    db_sync_phase(db, &mut context)?;
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use std::{
+    cell::Cell,
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -8,37 +9,68 @@ use std::{
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff::{PreparedFile, apply_diff};
+use super::scan_diff::{PreparedFile, apply_diff, preload_rename_candidates};
 use super::scan_diff_phase::prepare_diff;
-use super::scan_fs::{read_facts, visit_dir};
+use super::scan_fs::{compute_content_hash, read_facts, visit_dir_with_cancel_check};
 
 const APPLY_BATCH_SIZE: usize = 64;
 
 pub(super) fn walk_phase(
+    db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
-) -> Result<Vec<PreparedFile>, ScanError> {
-    let mut prepared = Vec::new();
-    visit_dir(root, cancel, &mut |path| {
-        if let Some(cancel) = cancel
-            && cancel.load(Ordering::Relaxed)
-        {
-            return Err(ScanError::Canceled);
-        }
-        let prepared_file = prepare_diff(root, path, context, cancel)?;
-        context
-            .discovered_paths
-            .insert(prepared_file.facts.relative.clone());
-        prepared.push(prepared_file);
-        context.stats.total_files += 1;
-        if let Some(on_progress) = on_progress.as_mut() {
-            on_progress(context.stats.total_files, path);
-        }
-        Ok(())
-    })?;
-    Ok(prepared)
+) -> Result<(), ScanError> {
+    // Before the first commit cancellation is rollback-safe. After a bounded
+    // batch commits, finish the scan so callers never receive `Canceled` for a
+    // partially applied source state.
+    let committed = Cell::new(false);
+    let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
+    visit_dir_with_cancel_check(
+        root,
+        &mut || cancel_requested(cancel, committed.get()),
+        &mut |path| {
+            if cancel_requested(cancel, committed.get()) {
+                return Err(ScanError::Canceled);
+            }
+            let prepared = prepare_diff(root, path, context)?;
+            context.stats.total_files += 1;
+            if let Some(on_progress) = on_progress.as_mut() {
+                on_progress(context.stats.total_files, path);
+            }
+            if !prepared.requires_apply {
+                skip_noop(context, &prepared);
+                return Ok(());
+            }
+            pending.push(prepared);
+            if pending.len() == APPLY_BATCH_SIZE {
+                let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
+                if apply_batch(
+                    db,
+                    root,
+                    cancel.filter(|_| !committed.get()),
+                    context,
+                    files,
+                )? {
+                    committed.set(true);
+                }
+            }
+            Ok(())
+        },
+    )?;
+    if !pending.is_empty()
+        && apply_batch(
+            db,
+            root,
+            cancel.filter(|_| !committed.get()),
+            context,
+            pending,
+        )?
+    {
+        committed.set(true);
+    }
+    Ok(())
 }
 
 pub(super) fn apply_prepared_files(
@@ -48,48 +80,116 @@ pub(super) fn apply_prepared_files(
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
 ) -> Result<(), ScanError> {
+    let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
-    for prepared_file in prepared {
-        check_canceled(cancel)?;
-        if !is_current(root, &prepared_file) {
-            context.existing.remove(&prepared_file.facts.relative);
+    for file in prepared {
+        if cancel_requested(cancel, committed.get()) {
+            return Err(ScanError::Canceled);
+        }
+        if !file.requires_apply {
+            skip_noop(context, &file);
             continue;
         }
-        pending.push(prepared_file);
+        pending.push(file);
         if pending.len() == APPLY_BATCH_SIZE {
-            let batch = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-            apply_batch(db, context, batch)?;
+            let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
+            if apply_batch(
+                db,
+                root,
+                cancel.filter(|_| !committed.get()),
+                context,
+                files,
+            )? {
+                committed.set(true);
+            }
         }
     }
     if !pending.is_empty() {
-        apply_batch(db, context, pending)?;
+        let _ = apply_batch(
+            db,
+            root,
+            cancel.filter(|_| !committed.get()),
+            context,
+            pending,
+        )?;
     }
     Ok(())
+}
+
+pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {
+    if !prepared.needs_hash
+        && context
+            .existing
+            .get(&prepared.facts.relative)
+            .is_some_and(|entry| entry.content_hash.is_none())
+    {
+        context.stats.hashes_pending += 1;
+    }
+    let _ = context.existing.remove(&prepared.facts.relative);
 }
 
 fn apply_batch(
     db: &SourceDatabase,
+    root: &Path,
+    cancel: Option<&AtomicBool>,
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
-) -> Result<(), ScanError> {
-    let mut batch = db.write_batch()?;
-    for prepared_file in prepared {
-        apply_diff(db, &mut batch, prepared_file, context)?;
+) -> Result<bool, ScanError> {
+    let mut ready = Vec::with_capacity(prepared.len());
+    for file in prepared {
+        let relative_path = file.facts.relative.clone();
+        if let Some(file) = prepare_for_apply(root, cancel, file)? {
+            ready.push(file);
+        } else {
+            context.existing.remove(&relative_path);
+        }
     }
-    batch.commit()?;
-    Ok(())
-}
-
-fn is_current(root: &Path, prepared: &PreparedFile) -> bool {
-    let absolute = root.join(&prepared.facts.relative);
-    read_facts(root, &absolute).is_ok_and(|current| {
-        current.size == prepared.facts.size && current.modified_ns == prepared.facts.modified_ns
-    })
-}
-
-fn check_canceled(cancel: Option<&AtomicBool>) -> Result<(), ScanError> {
-    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+    if ready.is_empty() {
+        return Ok(false);
+    }
+    // Candidate DB reads and filesystem existence checks stay outside the
+    // source writer transaction; the selected row itself is refreshed after
+    // the transaction acquires SQLite's writer lock.
+    preload_rename_candidates(db, root, context, &ready)?;
+    if cancel_requested(cancel, false) {
         return Err(ScanError::Canceled);
     }
-    Ok(())
+    let mut batch = db.write_batch()?;
+    for file in ready {
+        apply_diff(db, &mut batch, file, context)?;
+    }
+    batch.commit()?;
+    Ok(true)
+}
+
+fn prepare_for_apply(
+    root: &Path,
+    cancel: Option<&AtomicBool>,
+    mut prepared: PreparedFile,
+) -> Result<Option<PreparedFile>, ScanError> {
+    let absolute = root.join(&prepared.facts.relative);
+    let Ok(before_hash) = read_facts(root, &absolute) else {
+        return Ok(None);
+    };
+    if !facts_match(&prepared, &before_hash) {
+        return Ok(None);
+    }
+    if prepared.needs_hash {
+        prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
+        let Ok(after_hash) = read_facts(root, &absolute) else {
+            return Ok(None);
+        };
+        if !facts_match(&prepared, &after_hash) {
+            return Ok(None);
+        }
+    }
+    Ok(Some(prepared))
+}
+
+fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
+    current.size == prepared.facts.size && current.modified_ns == prepared.facts.modified_ns
+}
+
+fn cancel_requested(cancel: Option<&AtomicBool>, committed: bool) -> bool {
+    !committed && cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -127,11 +127,17 @@ fn refresh_noop_preparation(
 ) -> Result<PreparedFile, ScanError> {
     let relative_path = prepared.facts.relative.clone();
     let current = db.entry_for_path(&relative_path)?;
-    if current.as_ref().is_some_and(|entry| {
-        !entry.missing
-            && entry.file_size == prepared.facts.size
-            && entry.modified_ns == prepared.facts.modified_ns
-    }) {
+    let snapshot = context.existing.get(&relative_path);
+    if current
+        .as_ref()
+        .zip(snapshot)
+        .is_some_and(|(entry, snapshot)| {
+            !entry.missing
+                && entry.file_size == prepared.facts.size
+                && entry.modified_ns == prepared.facts.modified_ns
+                && entry.content_hash == snapshot.content_hash
+        })
+    {
         return Ok(prepared);
     }
     match current {
@@ -244,7 +250,7 @@ fn prepare_for_apply(
     if !facts_match(&prepared, &before_hash) {
         return Ok(PrepareForApply::Skip);
     }
-    if prepared.needs_hash {
+    if prepared.hash_required {
         prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
         let Ok(after_hash) = read_facts(root, &absolute) else {
             return Ok(if absolute.exists() {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -59,7 +59,12 @@ pub(super) fn walk_phase(
                 on_progress(context.stats.total_files, path);
             }
             if !prepared.requires_apply {
-                prepared = refresh_noop_preparation(db, root, context, prepared)?;
+                let Some(refreshed) =
+                    refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
+                else {
+                    return Ok(());
+                };
+                prepared = refreshed;
             }
             if !prepared.requires_apply {
                 skip_noop(context, &prepared);
@@ -108,7 +113,12 @@ pub(super) fn apply_prepared_chunk(
     let mut pending = Vec::with_capacity(prepared.len());
     for mut file in prepared {
         if !file.requires_apply {
-            file = refresh_noop_preparation(db, root, context, file)?;
+            let Some(refreshed) =
+                refresh_noop_preparation_or_skip(db, root, context, file, tolerate_file_errors)?
+            else {
+                continue;
+            };
+            file = refreshed;
         }
         if file.requires_apply {
             pending.push(file);
@@ -120,6 +130,29 @@ pub(super) fn apply_prepared_chunk(
         return Ok(false);
     }
     apply_batch(db, root, cancel, context, pending, tolerate_file_errors)
+}
+
+fn refresh_noop_preparation_or_skip(
+    db: &SourceDatabase,
+    root: &Path,
+    context: &mut ScanContext,
+    prepared: PreparedFile,
+    tolerate_file_errors: bool,
+) -> Result<Option<PreparedFile>, ScanError> {
+    let relative_path = prepared.facts.relative.clone();
+    match refresh_noop_preparation(db, root, context, prepared) {
+        Ok(prepared) => Ok(Some(prepared)),
+        Err(error) if tolerate_file_errors => {
+            skip_changed_or_unavailable(context, root, &relative_path);
+            tracing::warn!(
+                path = %root.join(&relative_path).display(),
+                error = %error,
+                "Skipping no-op refresh failure after an earlier scan batch committed"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn refresh_noop_preparation(
@@ -290,11 +323,13 @@ fn cancel_requested(cancel: Option<&AtomicBool>, committed: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{PrepareForApply, prepare_for_apply};
+    use super::{PrepareForApply, prepare_for_apply, refresh_noop_preparation_or_skip};
     use crate::sample_sources::SourceDatabase;
-    use crate::sample_sources::scanner::scan::scan_once;
+    use crate::sample_sources::scanner::scan::{ScanContext, ScanMode, scan_once};
     use crate::sample_sources::scanner::scan_diff::PreparedFile;
+    use crate::sample_sources::scanner::scan_diff_phase::prepare_diff;
     use crate::sample_sources::scanner::scan_fs::read_facts;
+    use std::collections::HashMap;
     use std::path::Path;
     use tempfile::tempdir;
 
@@ -321,5 +356,32 @@ mod tests {
             panic!("restored missing file should remain ready for apply");
         };
         assert!(prepared.content_hash.is_none());
+    }
+
+    #[test]
+    fn committed_batch_tolerates_noop_refresh_failure() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("one.wav");
+        std::fs::write(&file_path, b"one").unwrap();
+        let db = SourceDatabase::open(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        let entry = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::from([(Path::new("one.wav").to_path_buf(), entry)]),
+            ScanMode::Quick,
+        );
+        let prepared = prepare_diff(dir.path(), &file_path, &context).unwrap();
+        assert!(!prepared.requires_apply);
+
+        std::fs::remove_file(&file_path).unwrap();
+        let mut batch = db.write_batch().unwrap();
+        batch.remove_file(Path::new("one.wav")).unwrap();
+        batch.commit().unwrap();
+
+        let refreshed =
+            refresh_noop_preparation_or_skip(&db, dir.path(), &mut context, prepared, true)
+                .unwrap();
+
+        assert!(refreshed.is_none());
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff::{PreparedFile, apply_diff};
+use super::scan_diff::{PreparedFile, RenameCandidateCache, apply_diff};
 use super::scan_diff_phase::prepare_diff;
 use super::scan_fs::{
     compute_content_hash, is_supported_scannable_audio_file, read_facts,
@@ -205,6 +205,7 @@ fn apply_batch(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    let mut rename_candidates = RenameCandidateCache::default();
     for file in ready {
         let relative_path = file.facts.relative.clone();
         let absolute = root.join(&relative_path);
@@ -215,7 +216,7 @@ fn apply_batch(
                 continue;
             }
         }
-        apply_diff(db, &mut batch, file, context, root)?;
+        apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
     }
     batch.commit()?;
     Ok(true)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -34,7 +34,23 @@ pub(super) fn walk_phase(
             if cancel_requested(cancel, committed.get()) {
                 return Err(ScanError::Canceled);
             }
-            let prepared = prepare_diff(root, path, context)?;
+            let prepared = match prepare_diff(root, path, context) {
+                Ok(prepared) => prepared,
+                Err(error) if committed.get() => {
+                    if let Ok(relative) = path.strip_prefix(root)
+                        && path.exists()
+                    {
+                        context.existing.remove(relative);
+                    }
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "Skipping file that changed after an earlier scan batch committed"
+                    );
+                    return Ok(());
+                }
+                Err(error) => return Err(error),
+            };
             context.stats.total_files += 1;
             if let Some(on_progress) = on_progress.as_mut() {
                 on_progress(context.stats.total_files, path);
@@ -73,47 +89,25 @@ pub(super) fn walk_phase(
     Ok(())
 }
 
-pub(super) fn apply_prepared_files(
+pub(super) fn apply_prepared_chunk(
     db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
-) -> Result<(), ScanError> {
-    let committed = Cell::new(false);
-    let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
+) -> Result<bool, ScanError> {
+    let mut pending = Vec::with_capacity(prepared.len());
     for file in prepared {
-        if cancel_requested(cancel, committed.get()) {
-            return Err(ScanError::Canceled);
-        }
-        if !file.requires_apply {
+        if file.requires_apply {
+            pending.push(file);
+        } else {
             skip_noop(context, &file);
-            continue;
-        }
-        pending.push(file);
-        if pending.len() == APPLY_BATCH_SIZE {
-            let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-            if apply_batch(
-                db,
-                root,
-                cancel.filter(|_| !committed.get()),
-                context,
-                files,
-            )? {
-                committed.set(true);
-            }
         }
     }
-    if !pending.is_empty() {
-        let _ = apply_batch(
-            db,
-            root,
-            cancel.filter(|_| !committed.get()),
-            context,
-            pending,
-        )?;
+    if pending.is_empty() {
+        return Ok(false);
     }
-    Ok(())
+    apply_batch(db, root, cancel, context, pending)
 }
 
 pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {
@@ -138,10 +132,12 @@ fn apply_batch(
     let mut ready = Vec::with_capacity(prepared.len());
     for file in prepared {
         let relative_path = file.facts.relative.clone();
-        if let Some(file) = prepare_for_apply(root, cancel, file)? {
-            ready.push(file);
-        } else {
-            context.existing.remove(&relative_path);
+        match prepare_for_apply(root, cancel, file)? {
+            PrepareForApply::Ready(file) => ready.push(file),
+            PrepareForApply::Gone => {}
+            PrepareForApply::Skip => {
+                context.existing.remove(&relative_path);
+            }
         }
     }
     if ready.is_empty() {
@@ -156,34 +152,48 @@ fn apply_batch(
     }
     let mut batch = db.write_batch()?;
     for file in ready {
-        apply_diff(db, &mut batch, file, context)?;
+        apply_diff(db, &mut batch, file, context, root)?;
     }
     batch.commit()?;
     Ok(true)
+}
+
+enum PrepareForApply {
+    Ready(PreparedFile),
+    Gone,
+    Skip,
 }
 
 fn prepare_for_apply(
     root: &Path,
     cancel: Option<&AtomicBool>,
     mut prepared: PreparedFile,
-) -> Result<Option<PreparedFile>, ScanError> {
+) -> Result<PrepareForApply, ScanError> {
     let absolute = root.join(&prepared.facts.relative);
     let Ok(before_hash) = read_facts(root, &absolute) else {
-        return Ok(None);
+        return Ok(if absolute.exists() {
+            PrepareForApply::Skip
+        } else {
+            PrepareForApply::Gone
+        });
     };
     if !facts_match(&prepared, &before_hash) {
-        return Ok(None);
+        return Ok(PrepareForApply::Skip);
     }
     if prepared.needs_hash {
         prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
         let Ok(after_hash) = read_facts(root, &absolute) else {
-            return Ok(None);
+            return Ok(if absolute.exists() {
+                PrepareForApply::Skip
+            } else {
+                PrepareForApply::Gone
+            });
         };
         if !facts_match(&prepared, &after_hash) {
-            return Ok(None);
+            return Ok(PrepareForApply::Skip);
         }
     }
-    Ok(Some(prepared))
+    Ok(PrepareForApply::Ready(prepared))
 }
 
 fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -6,30 +6,90 @@ use std::{
 };
 
 use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::SourceWriteBatch;
 
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff_phase::diff_phase;
-use super::scan_fs::visit_dir;
+use super::scan_diff::{PreparedFile, apply_diff};
+use super::scan_diff_phase::prepare_diff;
+use super::scan_fs::{read_facts, visit_dir};
+
+const APPLY_BATCH_SIZE: usize = 64;
 
 pub(super) fn walk_phase(
-    db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
-    batch: &mut SourceWriteBatch<'_>,
-) -> Result<(), ScanError> {
+) -> Result<Vec<PreparedFile>, ScanError> {
+    let mut prepared = Vec::new();
     visit_dir(root, cancel, &mut |path| {
         if let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
         {
             return Err(ScanError::Canceled);
         }
-        diff_phase(db, batch, root, path, context, cancel)?;
+        let prepared_file = prepare_diff(root, path, context, cancel)?;
+        context
+            .discovered_paths
+            .insert(prepared_file.facts.relative.clone());
+        prepared.push(prepared_file);
+        context.stats.total_files += 1;
         if let Some(on_progress) = on_progress.as_mut() {
             on_progress(context.stats.total_files, path);
         }
         Ok(())
+    })?;
+    Ok(prepared)
+}
+
+pub(super) fn apply_prepared_files(
+    db: &SourceDatabase,
+    root: &Path,
+    cancel: Option<&AtomicBool>,
+    context: &mut ScanContext,
+    prepared: Vec<PreparedFile>,
+) -> Result<(), ScanError> {
+    let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
+    for prepared_file in prepared {
+        check_canceled(cancel)?;
+        if !is_current(root, &prepared_file) {
+            context.existing.remove(&prepared_file.facts.relative);
+            continue;
+        }
+        pending.push(prepared_file);
+        if pending.len() == APPLY_BATCH_SIZE {
+            let batch = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
+            apply_batch(db, context, batch)?;
+        }
+    }
+    if !pending.is_empty() {
+        apply_batch(db, context, pending)?;
+    }
+    Ok(())
+}
+
+fn apply_batch(
+    db: &SourceDatabase,
+    context: &mut ScanContext,
+    prepared: Vec<PreparedFile>,
+) -> Result<(), ScanError> {
+    let mut batch = db.write_batch()?;
+    for prepared_file in prepared {
+        apply_diff(db, &mut batch, prepared_file, context)?;
+    }
+    batch.commit()?;
+    Ok(())
+}
+
+fn is_current(root: &Path, prepared: &PreparedFile) -> bool {
+    let absolute = root.join(&prepared.facts.relative);
+    read_facts(root, &absolute).is_ok_and(|current| {
+        current.size == prepared.facts.size && current.modified_ns == prepared.facts.modified_ns
     })
+}
+
+fn check_canceled(cancel: Option<&AtomicBool>) -> Result<(), ScanError> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed)) {
+        return Err(ScanError::Canceled);
+    }
+    Ok(())
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -68,6 +68,7 @@ pub(super) fn walk_phase(
                     cancel.filter(|_| !committed.get()),
                     context,
                     files,
+                    committed.get(),
                 )? {
                     committed.set(true);
                 }
@@ -82,6 +83,7 @@ pub(super) fn walk_phase(
             cancel.filter(|_| !committed.get()),
             context,
             pending,
+            committed.get(),
         )?
     {
         committed.set(true);
@@ -95,6 +97,7 @@ pub(super) fn apply_prepared_chunk(
     cancel: Option<&AtomicBool>,
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
+    tolerate_file_errors: bool,
 ) -> Result<bool, ScanError> {
     let mut pending = Vec::with_capacity(prepared.len());
     for file in prepared {
@@ -107,7 +110,7 @@ pub(super) fn apply_prepared_chunk(
     if pending.is_empty() {
         return Ok(false);
     }
-    apply_batch(db, root, cancel, context, pending)
+    apply_batch(db, root, cancel, context, pending, tolerate_file_errors)
 }
 
 pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {
@@ -128,11 +131,25 @@ fn apply_batch(
     cancel: Option<&AtomicBool>,
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
+    tolerate_file_errors: bool,
 ) -> Result<bool, ScanError> {
     let mut ready = Vec::with_capacity(prepared.len());
     for file in prepared {
         let relative_path = file.facts.relative.clone();
-        match prepare_for_apply(root, cancel, file)? {
+        let outcome = match prepare_for_apply(root, cancel, file) {
+            Ok(outcome) => outcome,
+            Err(error) if tolerate_file_errors => {
+                skip_changed_or_unavailable(context, root, &relative_path);
+                tracing::warn!(
+                    path = %root.join(&relative_path).display(),
+                    error = %error,
+                    "Skipping file preparation failure after an earlier scan batch committed"
+                );
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        match outcome {
             PrepareForApply::Ready(file) => ready.push(file),
             PrepareForApply::Gone => {}
             PrepareForApply::Skip => {
@@ -152,10 +169,25 @@ fn apply_batch(
     }
     let mut batch = db.write_batch()?;
     for file in ready {
+        let relative_path = file.facts.relative.clone();
+        let absolute = root.join(&relative_path);
+        match read_facts(root, &absolute) {
+            Ok(current) if facts_match(&file, &current) => {}
+            _ => {
+                skip_changed_or_unavailable(context, root, &relative_path);
+                continue;
+            }
+        }
         apply_diff(db, &mut batch, file, context, root)?;
     }
     batch.commit()?;
     Ok(true)
+}
+
+fn skip_changed_or_unavailable(context: &mut ScanContext, root: &Path, relative_path: &Path) {
+    if root.join(relative_path).exists() {
+        context.existing.remove(relative_path);
+    }
 }
 
 enum PrepareForApply {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -9,9 +9,12 @@ use std::{
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff::{PreparedFile, apply_diff, preload_rename_candidates};
+use super::scan_diff::{PreparedFile, apply_diff};
 use super::scan_diff_phase::prepare_diff;
-use super::scan_fs::{compute_content_hash, read_facts, visit_dir_with_cancel_check};
+use super::scan_fs::{
+    compute_content_hash, is_supported_scannable_audio_file, read_facts,
+    visit_dir_with_cancel_check,
+};
 
 const APPLY_BATCH_SIZE: usize = 64;
 
@@ -38,7 +41,7 @@ pub(super) fn walk_phase(
                 Ok(prepared) => prepared,
                 Err(error) if committed.get() => {
                     if let Ok(relative) = path.strip_prefix(root)
-                        && path.exists()
+                        && is_supported_scannable_audio_file(root, relative)
                     {
                         context.existing.remove(relative);
                     }
@@ -191,17 +194,13 @@ fn apply_batch(
             PrepareForApply::Ready(file) => ready.push(file),
             PrepareForApply::Gone => {}
             PrepareForApply::Skip => {
-                context.existing.remove(&relative_path);
+                skip_changed_or_unavailable(context, root, &relative_path);
             }
         }
     }
     if ready.is_empty() {
         return Ok(false);
     }
-    // Candidate DB reads and filesystem existence checks stay outside the
-    // source writer transaction; the selected row itself is refreshed after
-    // the transaction acquires SQLite's writer lock.
-    preload_rename_candidates(db, root, context, &ready)?;
     if cancel_requested(cancel, false) {
         return Err(ScanError::Canceled);
     }
@@ -223,7 +222,7 @@ fn apply_batch(
 }
 
 fn skip_changed_or_unavailable(context: &mut ScanContext, root: &Path, relative_path: &Path) {
-    if root.join(relative_path).exists() {
+    if is_supported_scannable_audio_file(root, relative_path) {
         context.existing.remove(relative_path);
     }
 }
@@ -240,6 +239,9 @@ fn prepare_for_apply(
     mut prepared: PreparedFile,
 ) -> Result<PrepareForApply, ScanError> {
     let absolute = root.join(&prepared.facts.relative);
+    if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
+        return Ok(PrepareForApply::Gone);
+    }
     let Ok(before_hash) = read_facts(root, &absolute) else {
         return Ok(if absolute.exists() {
             PrepareForApply::Skip
@@ -259,6 +261,9 @@ fn prepare_for_apply(
                 PrepareForApply::Gone
             });
         };
+        if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
+            return Ok(PrepareForApply::Gone);
+        }
         if !facts_match(&prepared, &after_hash) {
             return Ok(PrepareForApply::Skip);
         }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -177,7 +177,7 @@ fn apply_batch(
     let mut ready = Vec::with_capacity(prepared.len());
     for file in prepared {
         let relative_path = file.facts.relative.clone();
-        let outcome = match prepare_for_apply(root, cancel, file) {
+        let outcome = match prepare_for_apply(db, root, cancel, file) {
             Ok(outcome) => outcome,
             Err(error) if tolerate_file_errors => {
                 skip_changed_or_unavailable(context, root, &relative_path);
@@ -234,6 +234,7 @@ enum PrepareForApply {
 }
 
 fn prepare_for_apply(
+    db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
     mut prepared: PreparedFile,
@@ -252,7 +253,14 @@ fn prepare_for_apply(
     if !facts_match(&prepared, &before_hash) {
         return Ok(PrepareForApply::Skip);
     }
-    if prepared.hash_required {
+    let current_needs_hash = db
+        .entry_for_path(&prepared.facts.relative)?
+        .is_none_or(|entry| {
+            entry.file_size != prepared.facts.size
+                || entry.modified_ns != prepared.facts.modified_ns
+                || entry.content_hash.is_none()
+        });
+    if prepared.hash_required && (prepared.needs_hash || current_needs_hash) {
         prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
         let Ok(after_hash) = read_facts(root, &absolute) else {
             return Ok(if absolute.exists() {
@@ -277,4 +285,40 @@ fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> 
 
 fn cancel_requested(cancel: Option<&AtomicBool>, committed: bool) -> bool {
     !committed && cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PrepareForApply, prepare_for_apply};
+    use crate::sample_sources::SourceDatabase;
+    use crate::sample_sources::scanner::scan::scan_once;
+    use crate::sample_sources::scanner::scan_diff::PreparedFile;
+    use crate::sample_sources::scanner::scan_fs::read_facts;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn missing_repair_with_existing_hash_skips_prepared_hash() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("one.wav");
+        std::fs::write(&file_path, b"one").unwrap();
+        let db = SourceDatabase::open(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        db.set_missing(Path::new("one.wav"), true).unwrap();
+        let prepared = PreparedFile {
+            facts: read_facts(dir.path(), &file_path).unwrap(),
+            hash_required: true,
+            needs_hash: false,
+            requires_apply: true,
+            content_hash: None,
+        };
+
+        assert!(prepared.requires_apply);
+        assert!(!prepared.needs_hash);
+        let outcome = prepare_for_apply(&db, dir.path(), None, prepared).unwrap();
+        let PrepareForApply::Ready(prepared) = outcome else {
+            panic!("restored missing file should remain ready for apply");
+        };
+        assert!(prepared.content_hash.is_none());
+    }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -34,7 +34,7 @@ pub(super) fn walk_phase(
             if cancel_requested(cancel, committed.get()) {
                 return Err(ScanError::Canceled);
             }
-            let prepared = match prepare_diff(root, path, context) {
+            let mut prepared = match prepare_diff(root, path, context) {
                 Ok(prepared) => prepared,
                 Err(error) if committed.get() => {
                     if let Ok(relative) = path.strip_prefix(root)
@@ -54,6 +54,9 @@ pub(super) fn walk_phase(
             context.stats.total_files += 1;
             if let Some(on_progress) = on_progress.as_mut() {
                 on_progress(context.stats.total_files, path);
+            }
+            if !prepared.requires_apply {
+                prepared = refresh_noop_preparation(db, root, context, prepared)?;
             }
             if !prepared.requires_apply {
                 skip_noop(context, &prepared);
@@ -100,7 +103,10 @@ pub(super) fn apply_prepared_chunk(
     tolerate_file_errors: bool,
 ) -> Result<bool, ScanError> {
     let mut pending = Vec::with_capacity(prepared.len());
-    for file in prepared {
+    for mut file in prepared {
+        if !file.requires_apply {
+            file = refresh_noop_preparation(db, root, context, file)?;
+        }
         if file.requires_apply {
             pending.push(file);
         } else {
@@ -111,6 +117,32 @@ pub(super) fn apply_prepared_chunk(
         return Ok(false);
     }
     apply_batch(db, root, cancel, context, pending, tolerate_file_errors)
+}
+
+fn refresh_noop_preparation(
+    db: &SourceDatabase,
+    root: &Path,
+    context: &mut ScanContext,
+    prepared: PreparedFile,
+) -> Result<PreparedFile, ScanError> {
+    let relative_path = prepared.facts.relative.clone();
+    let current = db.entry_for_path(&relative_path)?;
+    if current.as_ref().is_some_and(|entry| {
+        !entry.missing
+            && entry.file_size == prepared.facts.size
+            && entry.modified_ns == prepared.facts.modified_ns
+    }) {
+        return Ok(prepared);
+    }
+    match current {
+        Some(entry) => {
+            context.existing.insert(relative_path.clone(), entry);
+        }
+        None => {
+            context.existing.remove(&relative_path);
+        }
+    }
+    prepare_diff(root, &root.join(relative_path), context)
 }
 
 pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {


### PR DESCRIPTION
## Scope
- discover file facts and compute required hashes before opening any source-database write transaction
- retain at most 64 prepared files, then revalidate and apply them in a bounded transaction
- hash immediately before apply and bracket hashing with filesystem-fact checks
- refresh current database rows inside the writer transaction before rename or missing-row metadata moves
- preload rename candidates and filesystem-existence checks before acquiring the writer
- skip unchanged file transactions and bound missing-row reconciliation to 64 items
- preserve quick, hard, targeted, rename, progress, and cancellation behavior

## Definition of Done
- traversal and hashing hold no SQLite writer transaction
- metadata writes can complete while discovery is active and survive rename/missing reconciliation
- stale staged file facts or hashes cannot overwrite the source database
- each persistence transaction and prepared-memory batch has a bounded item count
- cancellation never reports a partially committed scan as canceled

## Validation commands
- `cargo test -p wavecrate-scan --lib` (40 passed)
- `cargo clippy -p wavecrate-scan --all-targets --no-deps -- -D warnings`
- `git diff --check`

## Known limitations
- The broader dependency-inclusive clippy invocation is currently blocked on `main` by the pre-existing `CopyJournalEntry::new_copy` argument-count finding addressed independently in PR #781. The Wavecrate Scan all-target lane passes with `--no-deps`.

User review is required before merge.
