### PR TITLE
OPT-1097 Wavecrate analysis: preserve all audible islands

### DIFF
--- a/crates/wavecrate-analysis/src/analysis/audio/silence.rs
+++ b/crates/wavecrate-analysis/src/analysis/audio/silence.rs
@@ -36,7 +36,7 @@ pub(super) fn trim_silence_with_hysteresis(samples: &[f32], sample_rate: u32) ->
         if !active {
             if rms_value >= threshold_on {
                 active = true;
-                active_start = Some(window_start);
+                active_start.get_or_insert(window_start);
                 active_end = Some(window_end);
             }
         } else if rms_value >= threshold_off {
@@ -243,6 +243,47 @@ mod tests {
             .map(|v| v.abs())
             .fold(0.0_f32, f32::max);
         assert!(max >= off_amp * 0.9);
+    }
+
+    #[test]
+    fn silence_trim_preserves_two_audible_islands_and_interior_silence() {
+        let sample_rate = 1000;
+        let window_size = 20;
+        let audible = db_to_linear(SILENCE_THRESHOLD_ON_DB) * 2.0;
+        let mut samples = Vec::new();
+        samples.extend(std::iter::repeat_n(0.0, window_size * 2));
+        samples.extend(std::iter::repeat_n(audible, window_size));
+        samples.extend(std::iter::repeat_n(0.0, window_size * 2));
+        samples.extend(std::iter::repeat_n(audible, window_size));
+        samples.extend(std::iter::repeat_n(0.0, window_size * 2));
+
+        let trimmed = trim_silence_with_hysteresis(&samples, sample_rate);
+
+        assert_eq!(trimmed.len(), 95);
+        assert_eq!(
+            trimmed.iter().filter(|sample| **sample == audible).count(),
+            40
+        );
+        assert!(trimmed[30..70].iter().all(|sample| *sample == 0.0));
+    }
+
+    #[test]
+    fn silence_trim_preserves_one_sample_island_with_roll_bounds() {
+        let sample_rate = 1000;
+        let mut samples = vec![0.0; 100];
+        samples[45] = 1.0;
+
+        let trimmed = trim_silence_with_hysteresis(&samples, sample_rate);
+
+        assert_eq!(trimmed.len(), 35);
+        assert_eq!(trimmed.iter().filter(|sample| **sample == 1.0).count(), 1);
+    }
+
+    #[test]
+    fn silence_trim_preserves_all_silent_input() {
+        let samples = vec![0.0; 100];
+
+        assert_eq!(trim_silence_with_hysteresis(&samples, 1000), samples);
     }
 
     #[test]


### PR DESCRIPTION
## Scope
- retain the first active window as the leading trim bound
- continue extending the trailing bound across later audible regions
- add regressions for separated audible islands, one-sample islands, and all-silent input

## Definition of Done
- trimming removes only leading and trailing silence
- interior silence and every audible island remain in the analyzed sample
- existing threshold, hysteresis, pre/post-roll, and all-silent behavior remain stable

## Validation commands
- `cargo test -p wavecrate-analysis --lib silence` (9 passed)
- `cargo test -p wavecrate-analysis --lib` (89 passed)
- `cargo clippy -p wavecrate-analysis --all-targets --no-deps -- -D warnings`
- `git diff --check`

## Known limitations
- Dependency-inclusive clippy remains independently blocked on `main` by the `CopyJournalEntry::new_copy` argument-count finding addressed in PR #781; the Wavecrate Analysis all-target lane passes with `--no-deps`.

User review is required before merge.
