### PR TITLE
OPT-1096 Wavecrate scan: verify identity before rename transfer

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -11,6 +11,7 @@ mod open_profiles;
 mod pending_renames;
 /// Read-only database queries for sample sources.
 pub mod read;
+mod rename_destinations;
 /// SQLite schema management for sample source databases.
 pub mod schema;
 /// Durable per-source tag catalog and sample assignment helpers.

--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -22,6 +22,8 @@ pub struct PendingRenameEntry {
     pub modified_ns: i64,
     /// Last known content hash, if one was computed before pruning.
     pub content_hash: Option<String>,
+    /// Stable filesystem-object identity captured before pruning, when supported.
+    pub file_identity: Option<String>,
     /// Current rating/tag for the file.
     pub tag: Rating,
     /// Whether the sample was marked looped.
@@ -96,6 +98,7 @@ impl SourceDatabase {
                     file_size,
                     modified_ns: row.get(2)?,
                     content_hash: row.get(3)?,
+                    file_identity: row.get(14)?,
                     tag: Rating::from_i64(row.get::<_, i64>(4)?),
                     looped: row.get::<_, i64>(5)? != 0,
                     sound_type: row
@@ -128,6 +131,16 @@ impl<'conn> SourceWriteBatch<'conn> {
     pub fn stage_pending_rename(&mut self, entry: &WavEntry) -> Result<(), SourceDbError> {
         let path = normalize_relative_path(&entry.relative_path)?;
         let normal_tags = encode_normal_tags(&self.tag_labels_for_path(&entry.relative_path)?)?;
+        let file_identity = self
+            .tx
+            .query_row(
+                "SELECT file_identity FROM wav_files WHERE path = ?1",
+                params![path.as_str()],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .flatten();
         let collection = self
             .tx
             .query_row(
@@ -142,8 +155,8 @@ impl<'conn> SourceWriteBatch<'conn> {
         self.tx
             .prepare_cached(
                 "INSERT INTO pending_wav_renames (
-                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named, file_identity
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
                  ON CONFLICT(path) DO UPDATE SET
                      file_size = excluded.file_size,
                      modified_ns = excluded.modified_ns,
@@ -157,7 +170,8 @@ impl<'conn> SourceWriteBatch<'conn> {
                      user_tag = excluded.user_tag,
                      normal_tags = excluded.normal_tags,
                      collection = excluded.collection,
-                     tag_named = excluded.tag_named",
+                     tag_named = excluded.tag_named,
+                     file_identity = excluded.file_identity",
             )
             .map_err(map_sql_error)?
             .execute(params![
@@ -175,6 +189,7 @@ impl<'conn> SourceWriteBatch<'conn> {
                 normal_tags.as_deref(),
                 collection.map(SampleCollection::as_i64),
                 entry.tag_named as i64,
+                file_identity,
             ])
             .map_err(map_sql_error)?;
         Ok(())
@@ -217,6 +232,20 @@ impl<'conn> SourceWriteBatch<'conn> {
     ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
         let sql = pending_rename_select_with_where(&self.tx, "content_hash = ?1 LIMIT 2")?;
         self.take_unique_pending_rename(&sql, params![hash])
+    }
+
+    /// Claim one unique retained rename candidate by stable filesystem identity.
+    pub fn take_pending_rename_by_file_identity(
+        &mut self,
+        file_identity: &str,
+        file_size: u64,
+        modified_ns: i64,
+    ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
+        let sql = pending_rename_select_with_where(
+            &self.tx,
+            "file_identity = ?1 AND file_size = ?2 AND modified_ns = ?3 LIMIT 2",
+        )?;
+        self.take_unique_pending_rename(&sql, params![file_identity, file_size as i64, modified_ns])
     }
 
     /// Claim one unique retained rename candidate by file facts.
@@ -264,6 +293,7 @@ impl<'conn> SourceWriteBatch<'conn> {
                     file_size,
                     modified_ns: row.get(2)?,
                     content_hash: row.get(3)?,
+                    file_identity: row.get(14)?,
                     tag: Rating::from_i64(row.get::<_, i64>(4)?),
                     looped: row.get::<_, i64>(5)? != 0,
                     sound_type: row
@@ -333,8 +363,13 @@ fn pending_rename_select_with_where(
     } else {
         "NULL AS collection".to_string()
     };
+    let file_identity_column = if columns.contains("file_identity") {
+        "file_identity".to_string()
+    } else {
+        "NULL AS file_identity".to_string()
+    };
     Ok(format!(
-        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type_column}, locked, last_played_at, {last_curated_at_column}, {user_tag_column}, {normal_tags_column}, {collection_column}, {tag_named_column}
+        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type_column}, locked, last_played_at, {last_curated_at_column}, {user_tag_column}, {normal_tags_column}, {collection_column}, {tag_named_column}, {file_identity_column}
          FROM pending_wav_renames
          WHERE {predicate_sql}"
     ))

--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -1,0 +1,127 @@
+use std::path::{Path, PathBuf};
+
+use rusqlite::{OptionalExtension, params};
+
+use super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
+use super::{SourceDatabase, SourceDbError, SourceWriteBatch};
+
+const TARGETED_SCAN_GENERATION_KEY: &str = "targeted_scan_generation_v1";
+
+impl SourceDatabase {
+    /// List destination paths discovered in the current or immediately previous targeted scan.
+    pub fn list_pending_rename_destinations(&self) -> Result<Vec<PathBuf>, SourceDbError> {
+        let generation = self
+            .get_metadata(TARGETED_SCAN_GENERATION_KEY)?
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        let oldest = generation.saturating_sub(1);
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT path
+                 FROM pending_wav_rename_destinations
+                 WHERE scan_generation >= ?1
+                 ORDER BY path ASC",
+            )
+            .map_err(map_sql_error)?;
+        let rows = statement
+            .query_map(params![oldest as i64], |row| row.get::<_, String>(0))
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|path| match parse_relative_path_from_db(&path) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!(%error, "Skipping invalid pending rename destination path");
+                    None
+                }
+            })
+            .collect())
+    }
+}
+
+impl SourceWriteBatch<'_> {
+    /// Begin a targeted watcher scan and expire candidates older than one prior batch.
+    pub fn begin_targeted_scan_generation(&mut self) -> Result<u64, SourceDbError> {
+        let current = self
+            .tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![TARGETED_SCAN_GENERATION_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        let generation = current.saturating_add(1);
+        self.set_metadata(TARGETED_SCAN_GENERATION_KEY, &generation.to_string())?;
+        self.tx
+            .execute(
+                "DELETE FROM pending_wav_rename_destinations WHERE scan_generation < ?1",
+                params![generation.saturating_sub(1) as i64],
+            )
+            .map_err(map_sql_error)?;
+        Ok(generation)
+    }
+
+    /// Start a full quick-scan candidate snapshot at the current watcher generation.
+    pub fn begin_quick_scan_rename_candidates(&mut self) -> Result<u64, SourceDbError> {
+        let generation = self
+            .tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![TARGETED_SCAN_GENERATION_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        self.clear_all_pending_rename_destinations()?;
+        Ok(generation)
+    }
+
+    /// Retain a newly discovered targeted path across the next watcher batch.
+    pub fn stage_pending_rename_destination(
+        &mut self,
+        relative_path: &Path,
+        generation: u64,
+    ) -> Result<(), SourceDbError> {
+        let path = normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "INSERT INTO pending_wav_rename_destinations (path, scan_generation)
+                 VALUES (?1, ?2)
+                 ON CONFLICT(path) DO UPDATE SET scan_generation = excluded.scan_generation",
+                params![path, generation as i64],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    /// Forget a destination after it has been consumed by proven rename reconciliation.
+    pub fn clear_pending_rename_destination(
+        &mut self,
+        relative_path: &Path,
+    ) -> Result<(), SourceDbError> {
+        let path = normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "DELETE FROM pending_wav_rename_destinations WHERE path = ?1",
+                params![path],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    /// Drop all retained destination candidates during authoritative rebuilds.
+    pub fn clear_all_pending_rename_destinations(&mut self) -> Result<(), SourceDbError> {
+        self.tx
+            .execute("DELETE FROM pending_wav_rename_destinations", [])
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -6,6 +6,22 @@ use super::util::{map_sql_error, normalize_relative_path, parse_relative_path_fr
 use super::{SourceDatabase, SourceDbError, SourceWriteBatch};
 
 const TARGETED_SCAN_GENERATION_KEY: &str = "targeted_scan_generation_v1";
+const RENAME_CANDIDATE_LAST_SCAN_KIND_KEY: &str = "rename_candidate_last_scan_kind_v1";
+
+#[derive(Clone, Copy)]
+enum RenameCandidateScanKind {
+    Targeted,
+    Quick,
+}
+
+impl RenameCandidateScanKind {
+    fn token(self) -> &'static str {
+        match self {
+            Self::Targeted => "targeted",
+            Self::Quick => "quick",
+        }
+    }
+}
 
 impl SourceDatabase {
     /// List destination paths discovered in the current or immediately previous targeted scan.
@@ -45,6 +61,18 @@ impl SourceDatabase {
 impl SourceWriteBatch<'_> {
     /// Begin a targeted watcher scan and expire candidates older than one prior batch.
     pub fn begin_targeted_scan_generation(&mut self) -> Result<u64, SourceDbError> {
+        self.begin_rename_candidate_generation(RenameCandidateScanKind::Targeted)
+    }
+
+    /// Start a full quick scan while carrying destinations from one immediately prior scan.
+    pub fn begin_quick_scan_rename_candidates(&mut self) -> Result<u64, SourceDbError> {
+        self.begin_rename_candidate_generation(RenameCandidateScanKind::Quick)
+    }
+
+    fn begin_rename_candidate_generation(
+        &mut self,
+        kind: RenameCandidateScanKind,
+    ) -> Result<u64, SourceDbError> {
         let current = self
             .tx
             .query_row(
@@ -56,30 +84,30 @@ impl SourceWriteBatch<'_> {
             .map_err(map_sql_error)?
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(0);
-        let generation = current.saturating_add(1);
+        let last_kind = self
+            .tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![RENAME_CANDIDATE_LAST_SCAN_KIND_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?;
+        let generation = if matches!(kind, RenameCandidateScanKind::Targeted)
+            && last_kind.as_deref() == Some(RenameCandidateScanKind::Quick.token())
+        {
+            current.max(1)
+        } else {
+            current.saturating_add(1)
+        };
         self.set_metadata(TARGETED_SCAN_GENERATION_KEY, &generation.to_string())?;
+        self.set_metadata(RENAME_CANDIDATE_LAST_SCAN_KIND_KEY, kind.token())?;
         self.tx
             .execute(
                 "DELETE FROM pending_wav_rename_destinations WHERE scan_generation < ?1",
                 params![generation.saturating_sub(1) as i64],
             )
             .map_err(map_sql_error)?;
-        Ok(generation)
-    }
-
-    /// Start a full quick scan without discarding destinations carried from watcher batches.
-    pub fn begin_quick_scan_rename_candidates(&mut self) -> Result<u64, SourceDbError> {
-        let generation = self
-            .tx
-            .query_row(
-                "SELECT value FROM metadata WHERE key = ?1",
-                params![TARGETED_SCAN_GENERATION_KEY],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()
-            .map_err(map_sql_error)?
-            .and_then(|value| value.parse::<u64>().ok())
-            .unwrap_or(0);
         Ok(generation)
     }
 

--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -67,7 +67,7 @@ impl SourceWriteBatch<'_> {
         Ok(generation)
     }
 
-    /// Start a full quick-scan candidate snapshot at the current watcher generation.
+    /// Start a full quick scan without discarding destinations carried from watcher batches.
     pub fn begin_quick_scan_rename_candidates(&mut self) -> Result<u64, SourceDbError> {
         let generation = self
             .tx
@@ -80,7 +80,6 @@ impl SourceWriteBatch<'_> {
             .map_err(map_sql_error)?
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(0);
-        self.clear_all_pending_rename_destinations()?;
         Ok(generation)
     }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -219,6 +219,10 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         normal_tags TEXT,
         collection INTEGER,
         tag_named INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
+        path TEXT PRIMARY KEY,
+        scan_generation INTEGER NOT NULL
     );";
 
 const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -23,7 +23,8 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         extension TEXT NOT NULL DEFAULT '',
         last_played_at INTEGER,
         last_curated_at INTEGER,
-        collection INTEGER
+        collection INTEGER,
+        file_identity TEXT
     );
     CREATE TABLE IF NOT EXISTS source_tags (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -218,7 +219,8 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         user_tag TEXT,
         normal_tags TEXT,
         collection INTEGER,
-        tag_named INTEGER NOT NULL DEFAULT 0
+        tag_named INTEGER NOT NULL DEFAULT 0,
+        file_identity TEXT
     );
     CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
         path TEXT PRIMARY KEY,
@@ -235,6 +237,8 @@ const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing
          ON wav_file_collections(collection);
      CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_hash
          ON pending_wav_renames (content_hash);
+     CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_file_identity
+         ON pending_wav_renames (file_identity);
      CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_facts
          ON pending_wav_renames (file_size, modified_ns);
      CREATE INDEX IF NOT EXISTS idx_analysis_jobs_source_job_status_created

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -48,7 +48,20 @@ fn apply_structural_migrations(connection: &Connection) -> Result<(), SourceDbEr
     ensure_feature_metric_columns(connection, "analysis_cache_features")?;
     ensure_tag_catalog_schema(connection)?;
     ensure_collection_membership_schema(connection)?;
+    ensure_pending_rename_destination_schema(connection)?;
     ensure_aspect_descriptor_tables(connection)?;
+    Ok(())
+}
+
+fn ensure_pending_rename_destination_schema(connection: &Connection) -> Result<(), SourceDbError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
+                path TEXT PRIMARY KEY,
+                scan_generation INTEGER NOT NULL
+            );",
+        )
+        .map_err(map_sql_error)?;
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
@@ -64,6 +64,11 @@ pub(super) fn ensure_wav_files_optional_columns(
         &columns,
         OptionalColumn::new("wav_files", "collection", "INTEGER"),
     )?;
+    add_column_if_missing(
+        connection,
+        &columns,
+        OptionalColumn::new("wav_files", "file_identity", "TEXT"),
+    )?;
     Ok(())
 }
 
@@ -107,6 +112,11 @@ pub(super) fn ensure_pending_rename_optional_columns(
             "tag_named",
             "INTEGER NOT NULL DEFAULT 0",
         ),
+    )?;
+    add_column_if_missing(
+        connection,
+        &columns,
+        OptionalColumn::new("pending_wav_renames", "file_identity", "TEXT"),
     )?;
     Ok(())
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -58,6 +58,25 @@ fn pending_rename_migration_adds_extended_metadata_columns() {
     assert!(columns.contains("sound_type"));
     assert!(columns.contains("user_tag"));
     assert!(columns.contains("normal_tags"));
+    assert!(columns.contains("file_identity"));
+}
+
+#[test]
+fn wav_file_migration_adds_stable_file_identity_column() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL
+        );",
+    )
+    .unwrap();
+
+    ensure_wav_files_optional_columns(&conn).unwrap();
+
+    let columns = table_columns(&conn, "wav_files").unwrap();
+    assert!(columns.contains("file_identity"));
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use migrations::table_columns;
 /// A matching stamp means the file has already passed the full schema-assurance
 /// path once. Current-stamped opens still run low-cost additive table/column
 /// repairs, but they skip index rebuilds and deferred cleanup work.
-pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 5;
+pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 6;
 
 /// Apply the full source-database schema, including deferred cleanup work.
 pub(super) fn apply_schema(connection: &Connection) -> Result<SchemaApplyOutcome, SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -139,6 +139,46 @@ impl<'conn> SourceWriteBatch<'conn> {
         )
     }
 
+    /// Insert or update a wav file with a specific tag while leaving its hash unset.
+    pub fn upsert_file_without_hash_and_tag(
+        &mut self,
+        relative_path: &Path,
+        file_size: u64,
+        modified_ns: i64,
+        tag: Rating,
+        missing: bool,
+    ) -> Result<(), SourceDbError> {
+        self.upsert_file_with_policies(
+            relative_path,
+            file_size,
+            modified_ns,
+            ContentHashPolicy::Clear,
+            TagPolicy::Set(tag),
+            missing,
+        )
+    }
+
+    /// Persist the stable filesystem-object identity observed by the scanner.
+    pub fn set_file_identity(
+        &mut self,
+        relative_path: &Path,
+        file_identity: Option<&str>,
+    ) -> Result<(), SourceDbError> {
+        match file_identity {
+            Some(identity) => update_path_text_statement(
+                &self.tx,
+                "UPDATE wav_files SET file_identity = ?1 WHERE path = ?2",
+                relative_path,
+                identity,
+            ),
+            None => update_path_null_statement(
+                &self.tx,
+                "UPDATE wav_files SET file_identity = NULL WHERE path = ?1",
+                relative_path,
+            ),
+        }
+    }
+
     fn upsert_file_with_policies(
         &mut self,
         relative_path: &Path,

--- a/crates/wavecrate-library/src/sample_sources/db/write/mutation.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/mutation.rs
@@ -114,11 +114,11 @@ pub(super) fn remap_wav_file_path_statement(
             "INSERT INTO wav_files (
                  path, file_size, modified_ns, tag, looped, locked, sound_type,
                  user_tag, tag_named, missing, extension, last_played_at, last_curated_at,
-                 collection
+                 collection, file_identity
              )
              SELECT ?2, file_size, modified_ns, tag, looped, locked, sound_type,
                     user_tag, tag_named, missing, extension, last_played_at, last_curated_at,
-                    collection
+                    collection, file_identity
              FROM wav_files
              WHERE path = ?1",
         )

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -9,7 +9,7 @@ pub mod sample_sources;
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
-    sync_paths_with_progress,
+    complete_deferred_hashes, complete_deferred_rename_candidates, hard_rescan, scan_in_background,
+    scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -8,7 +8,8 @@ pub mod sample_sources;
 
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
-    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+    complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
+    sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -9,8 +9,8 @@ mod scan_walk;
 
 pub use scan::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+    complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
+    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -9,7 +9,8 @@ mod scan_walk;
 
 pub use scan::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -8,8 +8,8 @@ mod scan_paths;
 mod scan_walk;
 
 pub use scan::{
-    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+    complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::WavEntry;
+use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
 
 use super::{ScanError, ScanMode, ScanStats};
 
@@ -29,6 +29,22 @@ impl ScanContext {
             mode,
             rename_candidate_generation: None,
         }
+    }
+
+    pub(in crate::sample_sources::scanner) fn ensure_rename_candidate_generation(
+        &mut self,
+        batch: &mut SourceWriteBatch<'_>,
+    ) -> Result<(), ScanError> {
+        if self.rename_candidate_generation.is_some() || self.mode == ScanMode::Hard {
+            return Ok(());
+        }
+        let generation = match self.mode {
+            ScanMode::Targeted => batch.begin_targeted_scan_generation()?,
+            ScanMode::Quick => batch.begin_quick_scan_rename_candidates()?,
+            ScanMode::Hard => unreachable!("hard scans do not track rename destinations"),
+        };
+        self.rename_candidate_generation = Some(generation);
+        Ok(())
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -10,6 +10,7 @@ pub(crate) struct ScanContext {
     pub(crate) existing: HashMap<PathBuf, WavEntry>,
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
+    pub(crate) rename_candidate_generation: Option<u64>,
 }
 
 impl ScanContext {
@@ -26,6 +27,7 @@ impl ScanContext {
             existing,
             stats: ScanStats::default(),
             mode,
+            rename_candidate_generation: None,
         }
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -6,8 +6,8 @@ mod stats;
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
-    ScanMode, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    ScanMode, complete_deferred_hashes, hard_rescan, scan_in_background, scan_once,
+    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -6,9 +6,9 @@ mod stats;
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
-    ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+    complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
+    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -6,8 +6,9 @@ mod stats;
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
-    ScanMode, complete_deferred_hashes, hard_rescan, scan_in_background, scan_once,
-    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -95,8 +95,11 @@ pub fn complete_deferred_hashes_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
-    let pending_renames = db.list_pending_renames()?;
-    if stats.hashes_pending == 0 && pending_renames.is_empty() {
+    let persisted_candidates = db.list_pending_rename_destinations()?;
+    if stats.hashes_pending == 0
+        && stats.rename_candidate_paths.is_empty()
+        && persisted_candidates.is_empty()
+    {
         return Ok(stats);
     }
     let rename_candidates = stats

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -66,11 +66,26 @@ pub fn scan_in_background(root: PathBuf) -> thread::JoinHandle<Result<ScanStats,
     thread::spawn(move || {
         let db = SourceDatabase::open_for_scan(&root)?;
         let stats = scan_once(&db)?;
-        if stats.hashes_pending > 0 {
-            schedule_deep_hash_scan(root);
-        }
-        Ok(stats)
+        complete_deferred_hashes(&db, stats)
     })
+}
+
+/// Complete deferred content hashing and proven pending-rename reconciliation
+/// before publishing scan results to cache consumers.
+///
+/// Callers should use this from their existing background worker. Hashing runs
+/// without a source write transaction; only the final backfill/reconciliation
+/// uses a short write batch.
+pub fn complete_deferred_hashes(
+    db: &SourceDatabase,
+    mut stats: ScanStats,
+) -> Result<ScanStats, ScanError> {
+    if stats.hashes_pending == 0 && db.list_pending_renames()?.is_empty() {
+        return Ok(stats);
+    }
+    let deferred = super::super::scan_hash::deep_hash_scan(db, None)?;
+    stats.merge_deferred_hashes(deferred);
+    Ok(stats)
 }
 
 /// Spawn a detached deep-hash pass to backfill content hashes after quick scans.

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -56,6 +56,11 @@ fn scan(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
+    if mode == ScanMode::Quick {
+        let mut batch = db.write_batch()?;
+        context.rename_candidate_generation = Some(batch.begin_quick_scan_rename_candidates()?);
+        batch.commit()?;
+    }
     walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
     db_sync_phase(db, &mut context)?;
     Ok(context.stats)
@@ -90,13 +95,7 @@ pub fn complete_deferred_hashes_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
-    let pending_renames = match db.list_pending_renames() {
-        Ok(pending) => pending,
-        Err(error) => {
-            tracing::warn!("Could not inspect deferred rename state: {error}");
-            return Ok(stats);
-        }
-    };
+    let pending_renames = db.list_pending_renames()?;
     if stats.hashes_pending == 0 && pending_renames.is_empty() {
         return Ok(stats);
     }
@@ -105,12 +104,8 @@ pub fn complete_deferred_hashes_with_cancel(
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
-    match super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates) {
-        Ok(deferred) => stats.merge_deferred_hashes(deferred),
-        Err(error) => {
-            tracing::warn!("Deferred deep-hash scan did not complete: {error}");
-        }
-    }
+    let deferred = super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates)?;
+    stats.merge_deferred_hashes(deferred);
     Ok(stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::thread;
@@ -78,13 +79,38 @@ pub fn scan_in_background(root: PathBuf) -> thread::JoinHandle<Result<ScanStats,
 /// uses a short write batch.
 pub fn complete_deferred_hashes(
     db: &SourceDatabase,
-    mut stats: ScanStats,
+    stats: ScanStats,
 ) -> Result<ScanStats, ScanError> {
-    if stats.hashes_pending == 0 && db.list_pending_renames()?.is_empty() {
+    complete_deferred_hashes_with_cancel(db, stats, None)
+}
+
+/// Complete deferred hashing while honoring the owning scan's cancellation flag.
+pub fn complete_deferred_hashes_with_cancel(
+    db: &SourceDatabase,
+    mut stats: ScanStats,
+    cancel: Option<&AtomicBool>,
+) -> Result<ScanStats, ScanError> {
+    let pending_renames = match db.list_pending_renames() {
+        Ok(pending) => pending,
+        Err(error) => {
+            tracing::warn!("Could not inspect deferred rename state: {error}");
+            return Ok(stats);
+        }
+    };
+    if stats.hashes_pending == 0 && pending_renames.is_empty() {
         return Ok(stats);
     }
-    let deferred = super::super::scan_hash::deep_hash_scan(db, None)?;
-    stats.merge_deferred_hashes(deferred);
+    let rename_candidates = stats
+        .rename_candidate_paths
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    match super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates) {
+        Ok(deferred) => stats.merge_deferred_hashes(deferred),
+        Err(error) => {
+            tracing::warn!("Deferred deep-hash scan did not complete: {error}");
+        }
+    }
     Ok(stats)
 }
 
@@ -101,7 +127,7 @@ pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: 
     thread::spawn(move || {
         let result = (|| -> Result<(), ScanError> {
             let db = SourceDatabase::open_for_scan_with_database_root(root, database_root)?;
-            let _ = super::super::scan_hash::deep_hash_scan(&db, None)?;
+            let _ = super::super::scan_hash::deep_hash_scan(&db, None, &HashSet::new())?;
             Ok(())
         })();
         if let Err(err) = result {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -56,11 +56,6 @@ fn scan(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
-    if mode == ScanMode::Quick {
-        let mut batch = db.write_batch()?;
-        context.rename_candidate_generation = Some(batch.begin_quick_scan_rename_candidates()?);
-        batch.commit()?;
-    }
     walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
     db_sync_phase(db, &mut context)?;
     Ok(context.stats)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -107,7 +107,12 @@ pub fn complete_deferred_hashes_with_cancel(
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
-    let deferred = super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates)?;
+    let scope = if stats.hashes_pending > 0 {
+        super::super::scan_hash::DeferredHashScope::AllUnhashed
+    } else {
+        super::super::scan_hash::DeferredHashScope::RenameCandidates
+    };
+    let deferred = super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates, scope)?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)
 }
@@ -125,7 +130,12 @@ pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: 
     thread::spawn(move || {
         let result = (|| -> Result<(), ScanError> {
             let db = SourceDatabase::open_for_scan_with_database_root(root, database_root)?;
-            let _ = super::super::scan_hash::deep_hash_scan(&db, None, &HashSet::new())?;
+            let _ = super::super::scan_hash::deep_hash_scan(
+                &db,
+                None,
+                &HashSet::new(),
+                super::super::scan_hash::DeferredHashScope::AllUnhashed,
+            )?;
             Ok(())
         })();
         if let Err(err) = result {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -84,6 +84,37 @@ pub fn complete_deferred_hashes(
     complete_deferred_hashes_with_cancel(db, stats, None)
 }
 
+/// Reconcile only proven rename destinations before publishing latency-sensitive results.
+///
+/// Unrelated large-file hash backfills remain deferred. A cold import with no
+/// pending source rows returns immediately even though its new paths are tracked
+/// as possible destinations for a following watcher batch.
+pub fn complete_deferred_rename_candidates(
+    db: &SourceDatabase,
+    mut stats: ScanStats,
+) -> Result<ScanStats, ScanError> {
+    if db.list_pending_renames()?.is_empty() {
+        return Ok(stats);
+    }
+    let persisted_candidates = db.list_pending_rename_destinations()?;
+    if stats.rename_candidate_paths.is_empty() && persisted_candidates.is_empty() {
+        return Ok(stats);
+    }
+    let rename_candidates = stats
+        .rename_candidate_paths
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let deferred = super::super::scan_hash::deep_hash_scan(
+        db,
+        None,
+        &rename_candidates,
+        super::super::scan_hash::DeferredHashScope::RenameCandidates,
+    )?;
+    stats.merge_deferred_hashes(deferred);
+    Ok(stats)
+}
+
 /// Complete deferred hashing while honoring the owning scan's cancellation flag.
 pub fn complete_deferred_hashes_with_cancel(
     db: &SourceDatabase,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -25,6 +25,9 @@ pub struct ScanStats {
     pub renamed_samples: Vec<RenamedSample>,
     /// Detailed list of changed samples.
     pub changed_samples: Vec<ChangedSample>,
+    /// Newly inserted paths from this scan that are eligible as rename destinations.
+    #[doc(hidden)]
+    pub rename_candidate_paths: Vec<PathBuf>,
 }
 
 impl ScanStats {
@@ -35,6 +38,10 @@ impl ScanStats {
         self.updated_samples.append(&mut deferred.updated_samples);
         self.renamed_samples.append(&mut deferred.renamed_samples);
         self.changed_samples.append(&mut deferred.changed_samples);
+    }
+
+    pub(crate) fn record_rename_candidate(&mut self, path: PathBuf) {
+        self.rename_candidate_paths.push(path);
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -27,6 +27,17 @@ pub struct ScanStats {
     pub changed_samples: Vec<ChangedSample>,
 }
 
+impl ScanStats {
+    pub(super) fn merge_deferred_hashes(&mut self, mut deferred: Self) {
+        self.hashes_computed += deferred.hashes_computed;
+        self.hashes_pending = self.hashes_pending.saturating_sub(deferred.hashes_computed);
+        self.renames_reconciled += deferred.renames_reconciled;
+        self.updated_samples.append(&mut deferred.updated_samples);
+        self.renamed_samples.append(&mut deferred.renamed_samples);
+        self.changed_samples.append(&mut deferred.changed_samples);
+    }
+}
+
 /// Metadata describing a sample whose tracked file facts changed without moving.
 #[derive(Debug, Clone)]
 pub struct UpdatedSample {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::sample_sources::db::SampleSoundType;
+use crate::sync_paths;
+use std::path::PathBuf;
 
 #[test]
 fn scan_detects_rename_and_preserves_tag() {
@@ -268,17 +270,19 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
     db.assign_tag_to_path(Path::new("one.wav"), "Sweep")
         .unwrap();
 
-    {
+    let original_facts = {
         let entry = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+        let facts = (entry.file_size, entry.modified_ns);
         let mut batch = db.write_batch().unwrap();
         batch.stage_pending_rename(&entry).unwrap();
         batch.remove_file(Path::new("one.wav")).unwrap();
         batch.commit().unwrap();
-    }
+        facts
+    };
     std::fs::rename(&old_path, &new_path).unwrap();
     let mut batch = db.write_batch().unwrap();
     batch
-        .upsert_file_without_hash(Path::new("two.wav"), 9 * 1024 * 1024, 0)
+        .upsert_file_without_hash(Path::new("two.wav"), original_facts.0, original_facts.1)
         .unwrap();
     batch.commit().unwrap();
 
@@ -298,6 +302,79 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
     assert_eq!(rows[0].sound_type, Some(SampleSoundType::Fx));
     assert_eq!(rows[0].user_tag.as_deref(), Some("Sweep"));
     assert_eq!(rows[0].normal_tags, vec!["Sweep"]);
+    assert!(db.list_pending_renames().unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
+    let dir = tempdir().unwrap();
+    let original = dir.path().join("a.wav");
+    let duplicate = dir.path().join("b.wav");
+    let renamed = dir.path().join("c.wav");
+    let payload = vec![7u8; 9 * 1024 * 1024];
+    std::fs::write(&original, &payload).unwrap();
+    set_file_times(&original, 1_700_000_000, 0);
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("a.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::write(&duplicate, &payload).unwrap();
+    set_file_times(&duplicate, 1_700_000_100, 0);
+    let duplicate_scan = scan_once(&db).unwrap();
+    assert_eq!(duplicate_scan.hashes_pending, 1);
+
+    std::fs::rename(&original, &renamed).unwrap();
+    let rename_scan = scan_once(&db).unwrap();
+    assert_eq!(rename_scan.hashes_pending, 2);
+    assert_eq!(rename_scan.renames_reconciled, 0);
+
+    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+    assert_eq!(deep.hashes_computed, 2);
+    assert_eq!(deep.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("b.wav")).unwrap().unwrap().tag,
+        Rating::NEUTRAL
+    );
+    assert_eq!(
+        db.entry_for_path(Path::new("c.wav")).unwrap().unwrap().tag,
+        Rating::KEEP_1
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn deferred_completion_reconciles_new_path_before_hashed_delete_returns() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    std::fs::write(&old, b"same-content").unwrap();
+    set_file_times(&old, 1_700_000_000, 0);
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::copy(&old, &new).unwrap();
+    set_file_times(&new, 1_700_000_000, 0);
+    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
+    assert_eq!(added.renames_reconciled, 0);
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    assert_eq!(removed.hashes_pending, 0);
+    assert_eq!(removed.missing, 1);
+
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+    assert_eq!(completed.renames_reconciled, 1);
+    assert_eq!(completed.renamed_samples.len(), 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
     assert!(db.list_pending_renames().unwrap().is_empty());
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -203,6 +203,7 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         &db,
         None,
         &rename_candidates(&["two.wav"]),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
     )
     .unwrap();
     assert_eq!(deep_stats.hashes_computed, 1);
@@ -242,9 +243,13 @@ fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
 
     let quick = scan_once(&db).unwrap();
     assert_eq!(quick.hashes_pending, 1);
-    let deferred =
-        crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None, &HashSet::new())
-            .unwrap();
+    let deferred = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &HashSet::new(),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+    )
+    .unwrap();
 
     assert_eq!(deferred.renames_reconciled, 1);
     assert_eq!(
@@ -280,6 +285,7 @@ fn large_rename_reconciles_when_unchanged_duplicate_remains() {
         &db,
         None,
         &rename_candidates(&["c.wav"]),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
     )
     .unwrap();
     assert_eq!(deep.renames_reconciled, 1);
@@ -334,6 +340,7 @@ fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
         &db,
         None,
         &rename_candidates(&["new.wav"]),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
     )
     .unwrap();
 
@@ -400,6 +407,7 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
         &db,
         None,
         &rename_candidates(&["two.wav"]),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
     )
     .unwrap();
     assert_eq!(deep_stats.renames_reconciled, 1);
@@ -443,6 +451,7 @@ fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
         &db,
         None,
         &rename_candidates(&["b.wav", "c.wav"]),
+        crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
     )
     .unwrap();
     assert_eq!(deep.hashes_computed, 2);
@@ -539,6 +548,72 @@ fn targeted_split_batches_preserve_large_rename_destination() {
     );
     assert!(db.list_pending_renames().unwrap().is_empty());
     assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_destination_expires_after_two_full_quick_scans() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    std::fs::write(&old, b"same-content").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    std::fs::copy(&old, &new).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
+    complete_deferred_hashes(&db, added).unwrap();
+
+    scan_once(&db).unwrap();
+    assert_eq!(
+        db.list_pending_rename_destinations().unwrap(),
+        vec![PathBuf::from("new.wav")]
+    );
+    scan_once(&db).unwrap();
+
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+}
+
+#[test]
+fn rename_candidate_completion_does_not_backfill_unrelated_large_files() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    let unrelated = dir.path().join("unrelated-large.wav");
+    std::fs::write(&old, b"same-content").unwrap();
+    std::fs::write(&unrelated, vec![9_u8; 9 * 1024 * 1024]).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    let unrelated_entry = db
+        .entry_for_path(Path::new("unrelated-large.wav"))
+        .unwrap()
+        .unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .upsert_file_without_hash(
+            &unrelated_entry.relative_path,
+            unrelated_entry.file_size,
+            unrelated_entry.modified_ns,
+        )
+        .unwrap();
+    batch.commit().unwrap();
+
+    std::fs::copy(&old, &new).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
+    complete_deferred_hashes(&db, added).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 1);
+    assert_eq!(completed.hashes_computed, 0);
+    assert!(
+        db.entry_for_path(Path::new("unrelated-large.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -155,6 +155,27 @@ fn canceled_deferred_hashing_reports_cancellation_after_quick_scan_commit() {
 }
 
 #[test]
+fn candidate_completion_keeps_cold_large_import_hashing_deferred() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("large.wav"), vec![0_u8; 9 * 1024 * 1024]).unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let stats = scan_once(&db).unwrap();
+    assert_eq!(stats.hashes_pending, 1);
+
+    let completed = complete_deferred_rename_candidates(&db, stats).unwrap();
+
+    assert_eq!(completed.hashes_pending, 1);
+    assert_eq!(completed.hashes_computed, 0);
+    assert!(
+        db.entry_for_path(Path::new("large.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash
+            .is_none()
+    );
+}
+
+#[test]
 fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -574,6 +574,72 @@ fn targeted_destination_expires_after_two_full_quick_scans() {
 }
 
 #[test]
+fn retained_destination_is_revalidated_before_identity_transfer() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    std::fs::write(&old, b"original-content").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    std::fs::copy(&old, &new).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
+    complete_deferred_hashes(&db, added).unwrap();
+
+    std::fs::write(&new, b"replacement-content").unwrap();
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+}
+
+#[test]
+fn retained_destination_stays_ambiguous_when_duplicate_live_path_exists() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let duplicate = dir.path().join("duplicate.wav");
+    let candidate = dir.path().join("candidate.wav");
+    let payload = vec![7_u8; 9 * 1024 * 1024];
+    std::fs::write(&old, &payload).unwrap();
+    std::fs::write(&duplicate, &payload).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    complete_deferred_hashes(&db, removed).unwrap();
+
+    std::fs::copy(&duplicate, &candidate).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("candidate.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, added).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(
+        db.entry_for_path(Path::new("candidate.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+    assert!(
+        db.list_pending_renames()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.relative_path == Path::new("old.wav"))
+    );
+}
+
+#[test]
 fn rename_candidate_completion_does_not_backfill_unrelated_large_files() {
     let dir = tempdir().unwrap();
     let old = dir.path().join("old.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -229,6 +229,73 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
     );
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn large_rename_before_initial_hash_uses_stable_file_identity() {
+    let dir = tempdir().unwrap();
+    let first_path = dir.path().join("one.wav");
+    let second_path = dir.path().join("two.wav");
+    std::fs::write(&first_path, vec![3u8; 9 * 1024 * 1024]).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let initial = scan_once(&db).unwrap();
+    assert_eq!(initial.hashes_pending, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("one.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash,
+        None
+    );
+    db.set_tag(Path::new("one.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::rename(&first_path, &second_path).unwrap();
+    let quick = scan_once(&db).unwrap();
+    assert_eq!(quick.renames_reconciled, 0);
+    assert_eq!(quick.hashes_pending, 1);
+
+    let completed = complete_deferred_hashes(&db, quick).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 1);
+    let renamed = db.entry_for_path(Path::new("two.wav")).unwrap().unwrap();
+    assert_eq!(renamed.tag, Rating::KEEP_1);
+    assert!(renamed.content_hash.is_some());
+    assert!(db.list_pending_renames().unwrap().is_empty());
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn copy_delete_before_initial_hash_does_not_transfer_identity() {
+    let dir = tempdir().unwrap();
+    let first_path = dir.path().join("one.wav");
+    let second_path = dir.path().join("two.wav");
+    std::fs::write(&first_path, vec![4u8; 9 * 1024 * 1024]).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("one.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::copy(&first_path, &second_path).unwrap();
+    std::fs::remove_file(&first_path).unwrap();
+    let quick = scan_once(&db).unwrap();
+    let completed = complete_deferred_hashes(&db, quick).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(
+        db.entry_for_path(Path::new("two.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+    assert!(
+        db.list_pending_renames()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.relative_path == Path::new("one.wav"))
+    );
+}
+
 #[test]
 fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
     let dir = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -140,7 +140,7 @@ fn quick_scan_defers_hash_for_large_file() {
 }
 
 #[test]
-fn canceled_deferred_hashing_still_returns_committed_quick_scan_stats() {
+fn canceled_deferred_hashing_reports_cancellation_after_quick_scan_commit() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("large.wav");
     std::fs::write(&file_path, vec![0u8; 9 * 1024 * 1024]).unwrap();
@@ -148,10 +148,9 @@ fn canceled_deferred_hashing_still_returns_committed_quick_scan_stats() {
     let stats = scan_once(&db).unwrap();
     let cancel = std::sync::atomic::AtomicBool::new(true);
 
-    let completed = complete_deferred_hashes_with_cancel(&db, stats, Some(&cancel)).unwrap();
+    let result = complete_deferred_hashes_with_cancel(&db, stats, Some(&cancel));
 
-    assert_eq!(completed.added, 1);
-    assert_eq!(completed.hashes_pending, 1);
+    assert!(matches!(result, Err(ScanError::Canceled)));
     assert!(db.entry_for_path(Path::new("large.wav")).unwrap().is_some());
 }
 
@@ -227,6 +226,35 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         sample_id_count(dir.path(), "features", "source::two.wav"),
         1
     );
+}
+
+#[test]
+fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    std::fs::write(&old, vec![5_u8; 9 * 1024 * 1024]).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    std::fs::rename(&old, &new).unwrap();
+
+    let quick = scan_once(&db).unwrap();
+    assert_eq!(quick.hashes_pending, 1);
+    let deferred =
+        crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None, &HashSet::new())
+            .unwrap();
+
+    assert_eq!(deferred.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+    assert!(db.list_pending_renames().unwrap().is_empty());
 }
 
 #[test]
@@ -469,6 +497,76 @@ fn deferred_completion_reconciles_unique_hash_even_when_mtime_changes() {
         Rating::KEEP_1
     );
     assert!(db.list_pending_renames().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_split_batches_preserve_large_rename_destination() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let new = dir.path().join("new.wav");
+    std::fs::write(&old, vec![7_u8; 9 * 1024 * 1024]).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::copy(&old, &new).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
+    let added = complete_deferred_hashes(&db, added).unwrap();
+    assert_eq!(added.hashes_pending, 0);
+    assert_eq!(
+        db.list_pending_rename_destinations().unwrap(),
+        vec![PathBuf::from("new.wav")]
+    );
+
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_destination_expires_after_an_unrelated_batch() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let duplicate = dir.path().join("duplicate.wav");
+    let unrelated = dir.path().join("unrelated.wav");
+    std::fs::write(&old, b"same-content").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::copy(&old, &duplicate).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("duplicate.wav")]).unwrap();
+    complete_deferred_hashes(&db, added).unwrap();
+
+    std::fs::write(&unrelated, b"different").unwrap();
+    let unrelated_stats = sync_paths(&db, &[PathBuf::from("unrelated.wav")]).unwrap();
+    complete_deferred_hashes(&db, unrelated_stats).unwrap();
+
+    std::fs::remove_file(&old).unwrap();
+    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(
+        db.entry_for_path(Path::new("duplicate.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -1,7 +1,12 @@
 use super::*;
 use crate::sample_sources::db::SampleSoundType;
 use crate::sync_paths;
+use std::collections::HashSet;
 use std::path::PathBuf;
+
+fn rename_candidates(paths: &[&str]) -> HashSet<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
 
 #[test]
 fn scan_detects_rename_and_preserves_tag() {
@@ -121,6 +126,33 @@ fn quick_scan_defers_hash_for_large_file() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert!(rows[0].content_hash.is_none());
+
+    let completed = complete_deferred_hashes(&db, stats).unwrap();
+    assert_eq!(completed.hashes_pending, 0);
+    assert!(
+        db.entry_for_path(Path::new("large.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash
+            .is_some(),
+        "scan consumers should receive the result only after the initial large-file hash is durable"
+    );
+}
+
+#[test]
+fn canceled_deferred_hashing_still_returns_committed_quick_scan_stats() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("large.wav");
+    std::fs::write(&file_path, vec![0u8; 9 * 1024 * 1024]).unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let stats = scan_once(&db).unwrap();
+    let cancel = std::sync::atomic::AtomicBool::new(true);
+
+    let completed = complete_deferred_hashes_with_cancel(&db, stats, Some(&cancel)).unwrap();
+
+    assert_eq!(completed.added, 1);
+    assert_eq!(completed.hashes_pending, 1);
+    assert!(db.entry_for_path(Path::new("large.wav")).unwrap().is_some());
 }
 
 #[test]
@@ -168,7 +200,12 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
     drop(db);
 
     let db = SourceDatabase::open(dir.path()).unwrap();
-    let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+    let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &rename_candidates(&["two.wav"]),
+    )
+    .unwrap();
     assert_eq!(deep_stats.hashes_computed, 1);
     assert_eq!(deep_stats.renames_reconciled, 1);
 
@@ -190,6 +227,40 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         sample_id_count(dir.path(), "features", "source::two.wav"),
         1
     );
+}
+
+#[test]
+fn large_rename_reconciles_when_unchanged_duplicate_remains() {
+    let dir = tempdir().unwrap();
+    let original = dir.path().join("a.wav");
+    let duplicate = dir.path().join("b.wav");
+    let renamed = dir.path().join("c.wav");
+    let payload = vec![7u8; 9 * 1024 * 1024];
+    std::fs::write(&original, &payload).unwrap();
+    std::fs::write(&duplicate, &payload).unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("a.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("a.wav"), Some("Original metadata"))
+        .unwrap();
+
+    std::fs::rename(&original, &renamed).unwrap();
+    let stats = scan_once(&db).unwrap();
+    assert_eq!(stats.renames_reconciled, 0);
+    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &rename_candidates(&["c.wav"]),
+    )
+    .unwrap();
+    assert_eq!(deep.renames_reconciled, 1);
+
+    let duplicate_entry = db.entry_for_path(Path::new("b.wav")).unwrap().unwrap();
+    assert_eq!(duplicate_entry.tag, Rating::NEUTRAL);
+    let renamed_entry = db.entry_for_path(Path::new("c.wav")).unwrap().unwrap();
+    assert_eq!(renamed_entry.tag, Rating::KEEP_1);
+    assert_eq!(renamed_entry.user_tag.as_deref(), Some("Original metadata"));
 }
 
 #[cfg(unix)]
@@ -231,7 +302,12 @@ fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
     drop(db);
 
     let db = SourceDatabase::open(dir.path()).unwrap();
-    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &rename_candidates(&["new.wav"]),
+    )
+    .unwrap();
 
     assert_eq!(deep.renames_reconciled, 0);
     let new_entry = db.entry_for_path(Path::new("new.wav")).unwrap().unwrap();
@@ -292,7 +368,12 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
     assert_eq!(pending_before_deep[0].user_tag.as_deref(), Some("Sweep"));
     assert_eq!(pending_before_deep[0].normal_tags, vec!["Sweep"]);
 
-    let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+    let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &rename_candidates(&["two.wav"]),
+    )
+    .unwrap();
     assert_eq!(deep_stats.renames_reconciled, 1);
 
     let rows = db.list_files().unwrap();
@@ -330,7 +411,12 @@ fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
     assert_eq!(rename_scan.hashes_pending, 2);
     assert_eq!(rename_scan.renames_reconciled, 0);
 
-    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
+        &db,
+        None,
+        &rename_candidates(&["b.wav", "c.wav"]),
+    )
+    .unwrap();
     assert_eq!(deep.hashes_computed, 2);
     assert_eq!(deep.renames_reconciled, 1);
     assert_eq!(
@@ -345,11 +431,11 @@ fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
 
 #[cfg(unix)]
 #[test]
-fn deferred_completion_reconciles_new_path_before_hashed_delete_returns() {
+fn deferred_completion_reconciles_unique_hash_even_when_mtime_changes() {
     let dir = tempdir().unwrap();
     let old = dir.path().join("old.wav");
     let new = dir.path().join("new.wav");
-    std::fs::write(&old, b"same-content").unwrap();
+    std::fs::write(&old, vec![7_u8; 9 * 1024 * 1024]).unwrap();
     set_file_times(&old, 1_700_000_000, 0);
 
     let db = SourceDatabase::open(dir.path()).unwrap();
@@ -357,13 +443,20 @@ fn deferred_completion_reconciles_new_path_before_hashed_delete_returns() {
     db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
 
     std::fs::copy(&old, &new).unwrap();
-    set_file_times(&new, 1_700_000_000, 0);
-    let added = sync_paths(&db, &[PathBuf::from("new.wav")]).unwrap();
-    assert_eq!(added.renames_reconciled, 0);
+    set_file_times(&new, 1_700_000_100, 0);
     std::fs::remove_file(&old).unwrap();
-    let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
-    assert_eq!(removed.hashes_pending, 0);
+    let removed = sync_paths(&db, &[PathBuf::from("new.wav"), PathBuf::from("old.wav")]).unwrap();
     assert_eq!(removed.missing, 1);
+    assert_eq!(
+        removed.rename_candidate_paths,
+        vec![PathBuf::from("new.wav")]
+    );
+    assert!(
+        db.list_pending_renames()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.content_hash.is_some())
+    );
 
     let completed = complete_deferred_hashes(&db, removed).unwrap();
     assert_eq!(completed.renames_reconciled, 1);
@@ -376,6 +469,39 @@ fn deferred_completion_reconciles_new_path_before_hashed_delete_returns() {
         Rating::KEEP_1
     );
     assert!(db.list_pending_renames().unwrap().is_empty());
+}
+
+#[test]
+fn deferred_completion_does_not_treat_plain_delete_as_duplicate_rename() {
+    let dir = tempdir().unwrap();
+    let deleted = dir.path().join("deleted.wav");
+    let duplicate = dir.path().join("duplicate.wav");
+    std::fs::write(&deleted, b"same-content").unwrap();
+    std::fs::write(&duplicate, b"same-content").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("deleted.wav"), Rating::KEEP_1)
+        .unwrap();
+    std::fs::remove_file(&deleted).unwrap();
+
+    let removed = sync_paths(&db, &[PathBuf::from("deleted.wav")]).unwrap();
+    let completed = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(
+        db.entry_for_path(Path::new("duplicate.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+    assert!(
+        db.list_pending_renames()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.relative_path == Path::new("deleted.wav"))
+    );
 }
 
 #[cfg(unix)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -518,6 +518,12 @@ fn targeted_split_batches_preserve_large_rename_destination() {
         db.list_pending_rename_destinations().unwrap(),
         vec![PathBuf::from("new.wav")]
     );
+    scan_once(&db).unwrap();
+    assert_eq!(
+        db.list_pending_rename_destinations().unwrap(),
+        vec![PathBuf::from("new.wav")],
+        "a full quick scan between watcher halves must carry the destination"
+    );
 
     std::fs::remove_file(&old).unwrap();
     let removed = sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
@@ -574,11 +580,22 @@ fn deferred_completion_does_not_treat_plain_delete_as_duplicate_rename() {
     let dir = tempdir().unwrap();
     let deleted = dir.path().join("deleted.wav");
     let duplicate = dir.path().join("duplicate.wav");
+    let unrelated_large = dir.path().join("unrelated-large.wav");
     std::fs::write(&deleted, b"same-content").unwrap();
     std::fs::write(&duplicate, b"same-content").unwrap();
+    std::fs::write(&unrelated_large, vec![9_u8; 9 * 1024 * 1024]).unwrap();
 
     let db = SourceDatabase::open(dir.path()).unwrap();
     hard_rescan(&db).unwrap();
+    let large = db
+        .entry_for_path(Path::new("unrelated-large.wav"))
+        .unwrap()
+        .unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .upsert_file_without_hash(&large.relative_path, large.file_size, large.modified_ns)
+        .unwrap();
+    batch.commit().unwrap();
     db.set_tag(Path::new("deleted.wav"), Rating::KEEP_1)
         .unwrap();
     std::fs::remove_file(&deleted).unwrap();
@@ -587,6 +604,15 @@ fn deferred_completion_does_not_treat_plain_delete_as_duplicate_rename() {
     let completed = complete_deferred_hashes(&db, removed).unwrap();
 
     assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(completed.hashes_computed, 0);
+    assert!(
+        db.entry_for_path(Path::new("unrelated-large.wav"))
+            .unwrap()
+            .unwrap()
+            .content_hash
+            .is_none(),
+        "plain deletes must not trigger unrelated deferred backfill"
+    );
     assert_eq!(
         db.entry_for_path(Path::new("duplicate.wav"))
             .unwrap()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -122,7 +122,7 @@ fn quick_scan_defers_hash_for_large_file() {
 }
 
 #[test]
-fn quick_scan_reconciles_large_rename_and_preserves_tag() {
+fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");
     let second_path = dir.path().join("two.wav");
@@ -137,25 +137,38 @@ fn quick_scan_reconciles_large_rename_and_preserves_tag() {
         .unwrap();
     db.assign_tag_to_path(Path::new("one.wav"), "Night Pad")
         .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::one.wav", "one.wav");
 
     std::fs::rename(&first_path, &second_path).unwrap();
     let stats = scan_once(&db).unwrap();
-    assert_eq!(stats.renames_reconciled, 1);
+    assert_eq!(stats.renames_reconciled, 0);
+    assert_eq!(stats.added, 1);
+    assert_eq!(stats.missing, 1);
     assert_eq!(stats.hashes_pending, 1);
 
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("two.wav"));
-    assert_eq!(rows[0].tag, Rating::KEEP_1);
-    assert_eq!(rows[0].sound_type, Some(SampleSoundType::Texture));
-    assert_eq!(rows[0].user_tag.as_deref(), Some("Night Pad"));
-    assert_eq!(rows[0].normal_tags, vec!["Night Pad"]);
+    assert_eq!(rows[0].tag, Rating::NEUTRAL);
+    assert_eq!(rows[0].sound_type, None);
+    assert_eq!(rows[0].user_tag, None);
+    assert!(rows[0].normal_tags.is_empty());
     assert!(!rows[0].missing);
     assert!(rows[0].content_hash.is_none());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::one.wav"),
+        1
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::two.wav"),
+        0
+    );
+    drop(db);
 
+    let db = SourceDatabase::open(dir.path()).unwrap();
     let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
     assert_eq!(deep_stats.hashes_computed, 1);
-    assert_eq!(deep_stats.renames_reconciled, 0);
+    assert_eq!(deep_stats.renames_reconciled, 1);
 
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
@@ -166,6 +179,76 @@ fn quick_scan_reconciles_large_rename_and_preserves_tag() {
     assert_eq!(rows[0].normal_tags, vec!["Night Pad"]);
     assert!(!rows[0].missing);
     assert!(rows[0].content_hash.is_some());
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::one.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::two.wav"),
+        1
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
+    let dir = tempdir().unwrap();
+    let old_path = dir.path().join("old.wav");
+    let new_path = dir.path().join("new.wav");
+    let file_size = 9 * 1024 * 1024;
+    let timestamp = 1_700_000_000;
+    std::fs::write(&old_path, vec![0_u8; file_size]).unwrap();
+    set_file_times(&old_path, timestamp, 0);
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("Must stay pending"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::remove_file(&old_path).unwrap();
+    std::fs::write(&new_path, vec![1_u8; file_size]).unwrap();
+    set_file_times(&new_path, timestamp, 0);
+    let quick = scan_once(&db).unwrap();
+
+    assert_eq!(quick.renames_reconciled, 0);
+    assert_eq!(quick.added, 1);
+    assert_eq!(quick.missing, 1);
+    let new_entry = db.entry_for_path(Path::new("new.wav")).unwrap().unwrap();
+    assert_eq!(new_entry.tag, Rating::NEUTRAL);
+    assert_eq!(new_entry.user_tag, None);
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        1
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::new.wav"),
+        0
+    );
+    drop(db);
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let deep = crate::sample_sources::scanner::scan_hash::deep_hash_scan(&db, None).unwrap();
+
+    assert_eq!(deep.renames_reconciled, 0);
+    let new_entry = db.entry_for_path(Path::new("new.wav")).unwrap().unwrap();
+    assert_eq!(new_entry.tag, Rating::NEUTRAL);
+    assert_eq!(new_entry.user_tag, None);
+    let pending = db.list_pending_renames().unwrap();
+    assert!(pending.iter().any(|entry| {
+        entry.relative_path == Path::new("old.wav")
+            && entry.tag == Rating::KEEP_1
+            && entry.user_tag.as_deref() == Some("Must stay pending")
+    }));
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        1
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::new.wav"),
+        0
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -24,11 +24,13 @@ pub(super) fn db_sync_phase(
             break;
         }
         let mut batch = db.write_batch()?;
+        context.ensure_rename_candidate_generation(&mut batch)?;
         mark_missing(db, &mut batch, chunk, &mut context.stats, context.mode)?;
         batch.commit()?;
     }
 
     let mut batch = db.write_batch()?;
+    context.ensure_rename_candidate_generation(&mut batch)?;
     if context.mode == ScanMode::Hard {
         batch.clear_all_pending_renames()?;
         batch.clear_all_pending_rename_destinations()?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -31,6 +31,7 @@ pub(super) fn db_sync_phase(
     let mut batch = db.write_batch()?;
     if context.mode == ScanMode::Hard {
         batch.clear_all_pending_renames()?;
+        batch.clear_all_pending_rename_destinations()?;
     }
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -150,6 +150,7 @@ pub(super) fn apply_diff(
                 }
                 batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
                 context.stats.added += 1;
+                context.stats.record_rename_candidate(path.clone());
                 context.stats.content_changed += 1;
                 context.stats.hashes_computed += 1;
                 context.stats.changed_samples.push(ChangedSample {
@@ -163,6 +164,7 @@ pub(super) fn apply_diff(
                 // removed row pending until deep hashing can prove a match.
                 batch.upsert_file_without_hash(&path, facts.size, facts.modified_ns)?;
                 context.stats.added += 1;
+                context.stats.record_rename_candidate(path.clone());
                 context.stats.hashes_pending += 1;
             }
         }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -73,6 +73,7 @@ pub(super) fn apply_diff(
                     context.stats.hashes_pending += 1;
                 }
             }
+            batch.set_file_identity(&path, facts.file_identity.as_deref())?;
         }
         Some(entry) => {
             let previous_hash = entry.content_hash.as_deref();
@@ -105,6 +106,7 @@ pub(super) fn apply_diff(
                     content_hash: None,
                 });
             }
+            batch.set_file_identity(&path, facts.file_identity.as_deref())?;
             context.stats.updated += 1;
         }
         None => {
@@ -119,7 +121,8 @@ pub(super) fn apply_diff(
                     &hash,
                 )? {
                     let old_relative_path = entry.relative_path.clone();
-                    apply_rename(batch, &path, &facts, &hash, entry, None)?;
+                    apply_rename(batch, &path, &facts, Some(&hash), entry, None)?;
+                    batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                     context.stats.updated += 1;
                     context.stats.renames_reconciled += 1;
                     context.stats.renamed_samples.push(RenamedSample {
@@ -135,7 +138,8 @@ pub(super) fn apply_diff(
                     let normal_tags = entry.normal_tags.clone();
                     let entry = entry.into_wav_entry();
                     let old_relative_path = entry.relative_path.clone();
-                    apply_rename(batch, &path, &facts, &hash, entry, Some(&normal_tags))?;
+                    apply_rename(batch, &path, &facts, Some(&hash), entry, Some(&normal_tags))?;
+                    batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                     context.stats.updated += 1;
                     context.stats.renames_reconciled += 1;
                     context.stats.hashes_computed += 1;
@@ -149,6 +153,7 @@ pub(super) fn apply_diff(
                     return Ok(());
                 }
                 batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
+                batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                 if let Some(generation) = context.rename_candidate_generation {
                     batch.stage_pending_rename_destination(&path, generation)?;
                 }
@@ -163,9 +168,34 @@ pub(super) fn apply_diff(
                     content_hash: hash,
                 });
             } else {
-                // Size and modification time are not content identity. Keep any
-                // removed row pending until deep hashing can prove a match.
+                // Size and modification time are not identity. Recover only a
+                // unique same-file move here; otherwise wait for deep hashing.
+                if let Some(file_identity) = facts.file_identity.as_deref()
+                    && let Some(entry) = batch.take_pending_rename_by_file_identity(
+                        file_identity,
+                        facts.size,
+                        facts.modified_ns,
+                    )?
+                {
+                    let normal_tags = entry.normal_tags.clone();
+                    let entry = entry.into_wav_entry();
+                    let old_relative_path = entry.relative_path.clone();
+                    apply_rename(batch, &path, &facts, None, entry, Some(&normal_tags))?;
+                    batch.set_file_identity(&path, Some(file_identity))?;
+                    context.stats.updated += 1;
+                    context.stats.renames_reconciled += 1;
+                    context.stats.hashes_pending += 1;
+                    context.stats.renamed_samples.push(RenamedSample {
+                        old_relative_path,
+                        new_relative_path: path.clone(),
+                        file_size: facts.size,
+                        modified_ns: facts.modified_ns,
+                        content_hash: None,
+                    });
+                    return Ok(());
+                }
                 batch.upsert_file_without_hash(&path, facts.size, facts.modified_ns)?;
+                batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                 if let Some(generation) = context.rename_candidate_generation {
                     batch.stage_pending_rename_destination(&path, generation)?;
                 }
@@ -209,18 +239,28 @@ fn apply_rename(
     batch: &mut SourceWriteBatch<'_>,
     new_path: &Path,
     facts: &FileFacts,
-    hash: &str,
+    hash: Option<&str>,
     entry: WavEntry,
     retained_normal_tags: Option<&[String]>,
 ) -> Result<(), ScanError> {
-    batch.upsert_file_with_hash_and_tag(
-        new_path,
-        facts.size,
-        facts.modified_ns,
-        hash,
-        entry.tag,
-        false,
-    )?;
+    if let Some(hash) = hash {
+        batch.upsert_file_with_hash_and_tag(
+            new_path,
+            facts.size,
+            facts.modified_ns,
+            hash,
+            entry.tag,
+            false,
+        )?;
+    } else {
+        batch.upsert_file_without_hash_and_tag(
+            new_path,
+            facts.size,
+            facts.modified_ns,
+            entry.tag,
+            false,
+        )?;
+    }
     if entry.looped {
         batch.set_looped(new_path, entry.looped)?;
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -149,6 +149,9 @@ pub(super) fn apply_diff(
                     return Ok(());
                 }
                 batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
+                if let Some(generation) = context.rename_candidate_generation {
+                    batch.stage_pending_rename_destination(&path, generation)?;
+                }
                 context.stats.added += 1;
                 context.stats.record_rename_candidate(path.clone());
                 context.stats.content_changed += 1;
@@ -163,6 +166,9 @@ pub(super) fn apply_diff(
                 // Size and modification time are not content identity. Keep any
                 // removed row pending until deep hashing can prove a match.
                 batch.upsert_file_without_hash(&path, facts.size, facts.modified_ns)?;
+                if let Some(generation) = context.rename_candidate_generation {
+                    batch.stage_pending_rename_destination(&path, generation)?;
+                }
                 context.stats.added += 1;
                 context.stats.record_rename_candidate(path.clone());
                 context.stats.hashes_pending += 1;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -24,7 +24,6 @@ pub(super) struct PreparedFile {
 #[derive(Default)]
 pub(super) struct RenameCandidateCache {
     by_hash: HashMap<String, Vec<PathBuf>>,
-    by_facts: HashMap<(u64, i64), Vec<PathBuf>>,
 }
 
 impl RenameCandidateCache {
@@ -38,20 +37,6 @@ impl RenameCandidateCache {
             self.by_hash.insert(hash.to_owned(), paths);
         }
         Ok(self.by_hash.get(hash).expect("hash cache populated"))
-    }
-
-    fn paths_with_facts<'a>(
-        &'a mut self,
-        batch: &SourceWriteBatch<'_>,
-        size: u64,
-        modified_ns: i64,
-    ) -> Result<&'a [PathBuf], ScanError> {
-        let key = (size, modified_ns);
-        if !self.by_facts.contains_key(&key) {
-            let paths = batch.list_paths_with_file_facts(size, modified_ns)?;
-            self.by_facts.insert(key, paths);
-        }
-        Ok(self.by_facts.get(&key).expect("facts cache populated"))
     }
 }
 
@@ -174,48 +159,8 @@ pub(super) fn apply_diff(
                     content_hash: hash,
                 });
             } else {
-                if let Some(entry) = take_rename_candidate_by_facts(
-                    db,
-                    batch,
-                    rename_candidates,
-                    context,
-                    root,
-                    facts.size,
-                    facts.modified_ns,
-                )? {
-                    let old_relative_path = entry.relative_path.clone();
-                    apply_rename_without_hash(batch, &path, &facts, entry, None)?;
-                    context.stats.updated += 1;
-                    context.stats.renames_reconciled += 1;
-                    context.stats.hashes_pending += 1;
-                    context.stats.renamed_samples.push(RenamedSample {
-                        old_relative_path,
-                        new_relative_path: path.clone(),
-                        file_size: facts.size,
-                        modified_ns: facts.modified_ns,
-                        content_hash: None,
-                    });
-                    return Ok(());
-                }
-                if let Some(entry) =
-                    batch.take_pending_rename_by_facts(facts.size, facts.modified_ns)?
-                {
-                    let normal_tags = entry.normal_tags.clone();
-                    let entry = entry.into_wav_entry();
-                    let old_relative_path = entry.relative_path.clone();
-                    apply_rename_without_hash(batch, &path, &facts, entry, Some(&normal_tags))?;
-                    context.stats.updated += 1;
-                    context.stats.renames_reconciled += 1;
-                    context.stats.hashes_pending += 1;
-                    context.stats.renamed_samples.push(RenamedSample {
-                        old_relative_path,
-                        new_relative_path: path.clone(),
-                        file_size: facts.size,
-                        modified_ns: facts.modified_ns,
-                        content_hash: None,
-                    });
-                    return Ok(());
-                }
+                // Size and modification time are not content identity. Keep any
+                // removed row pending until deep hashing can prove a match.
                 batch.upsert_file_without_hash(&path, facts.size, facts.modified_ns)?;
                 context.stats.added += 1;
                 context.stats.hashes_pending += 1;
@@ -294,41 +239,6 @@ fn apply_rename(
     Ok(())
 }
 
-fn apply_rename_without_hash(
-    batch: &mut SourceWriteBatch<'_>,
-    new_path: &Path,
-    facts: &FileFacts,
-    entry: WavEntry,
-    retained_normal_tags: Option<&[String]>,
-) -> Result<(), ScanError> {
-    batch.upsert_file_without_hash(new_path, facts.size, facts.modified_ns)?;
-    batch.set_tag(new_path, entry.tag)?;
-    if entry.looped {
-        batch.set_looped(new_path, entry.looped)?;
-    }
-    if entry.sound_type.is_some() {
-        batch.set_sound_type(new_path, entry.sound_type)?;
-    }
-    if entry.locked {
-        batch.set_locked(new_path, entry.locked)?;
-    }
-    if let Some(last_played_at) = entry.last_played_at {
-        batch.set_last_played_at(new_path, last_played_at)?;
-    }
-    if entry.user_tag.is_some() {
-        batch.set_user_tag(new_path, entry.user_tag.as_deref())?;
-    }
-    batch.set_tag_named(new_path, entry.tag_named)?;
-    if let Some(normal_tags) = retained_normal_tags {
-        batch.replace_tags_for_path(new_path, normal_tags)?;
-    } else {
-        batch.copy_tags_between_paths(&entry.relative_path, new_path)?;
-    }
-    batch.remove_file(&entry.relative_path)?;
-    batch.remap_analysis_sample_identity(&entry.relative_path, new_path)?;
-    Ok(())
-}
-
 fn take_rename_candidate_by_hash(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
@@ -346,30 +256,6 @@ fn take_rename_candidate_by_hash(
         return Ok(None);
     };
     if entry.content_hash.as_deref() != Some(hash) {
-        return Ok(None);
-    }
-    let _ = context.existing.remove(&path);
-    Ok(Some(entry))
-}
-
-fn take_rename_candidate_by_facts(
-    db: &SourceDatabase,
-    batch: &mut SourceWriteBatch<'_>,
-    rename_candidates: &mut RenameCandidateCache,
-    context: &mut ScanContext,
-    root: &Path,
-    size: u64,
-    modified_ns: i64,
-) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates = rename_candidates.paths_with_facts(batch, size, modified_ns)?;
-    let path = unique_missing_path_in_scope(current_candidates, context, root);
-    let Some(path) = path else {
-        return Ok(None);
-    };
-    let Some(entry) = db.entry_for_path(&path)? else {
-        return Ok(None);
-    };
-    if entry.file_size != size || entry.modified_ns != modified_ns {
         return Ok(None);
     }
     let _ = context.existing.remove(&path);
@@ -472,30 +358,6 @@ mod tests {
 
         assert_eq!(
             cache.paths_with_hash(&batch, "same").unwrap(),
-            &[PathBuf::from("one.wav")]
-        );
-    }
-
-    #[test]
-    fn rename_candidate_cache_reuses_facts_lookup_within_batch() {
-        let root = tempfile::tempdir().unwrap();
-        let db = SourceDatabase::open(root.path()).unwrap();
-        let mut batch = db.write_batch().unwrap();
-        batch
-            .upsert_file_without_hash(Path::new("one.wav"), 4, 1)
-            .unwrap();
-        let mut cache = RenameCandidateCache::default();
-
-        assert_eq!(
-            cache.paths_with_facts(&batch, 4, 1).unwrap(),
-            &[PathBuf::from("one.wav")]
-        );
-        batch
-            .upsert_file_without_hash(Path::new("two.wav"), 4, 1)
-            .unwrap();
-
-        assert_eq!(
-            cache.paths_with_facts(&batch, 4, 1).unwrap(),
             &[PathBuf::from("one.wav")]
         );
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -17,6 +17,7 @@ pub(super) struct FileFacts {
     pub(super) relative: PathBuf,
     pub(super) size: u64,
     pub(super) modified_ns: i64,
+    pub(super) file_identity: Option<String>,
 }
 
 pub(super) fn ensure_root_dir(db: &SourceDatabase) -> Result<PathBuf, ScanError> {
@@ -117,7 +118,31 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
         relative,
         size: meta.len(),
         modified_ns,
+        file_identity: stable_file_identity(&meta),
     })
+}
+
+#[cfg(unix)]
+fn stable_file_identity(metadata: &fs::Metadata) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(format!("unix:{}:{}", metadata.dev(), metadata.ino()))
+}
+
+#[cfg(windows)]
+fn stable_file_identity(metadata: &fs::Metadata) -> Option<String> {
+    use std::os::windows::fs::MetadataExt;
+
+    Some(format!(
+        "windows:{}:{}",
+        metadata.volume_serial_number()?,
+        metadata.file_index()?
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn stable_file_identity(_metadata: &fs::Metadata) -> Option<String> {
+    None
 }
 
 pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -19,6 +19,7 @@ struct HashBackfill {
 pub(super) fn deep_hash_scan(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
     let entries = db.list_files()?;
@@ -103,6 +104,7 @@ pub(super) fn deep_hash_scan(
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
+        rename_candidates,
     )?;
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
@@ -116,6 +118,7 @@ fn reconcile_missing_renames(
     entries_by_path: &HashMap<PathBuf, WavEntry>,
     present_by_hash: &HashMap<String, Vec<PathBuf>>,
     pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
+    rename_candidates: &HashSet<PathBuf>,
 ) -> Result<Vec<RenamedSample>, ScanError> {
     let mut reconciled = Vec::new();
     for (hash, pending_entries) in pending_by_hash {
@@ -125,23 +128,32 @@ fn reconcile_missing_renames(
         let Some(present_paths) = present_by_hash.get(hash) else {
             continue;
         };
-        let matching_facts = present_paths
+        let candidates = present_paths
             .iter()
-            .filter(|path| {
-                entries_by_path.get(*path).is_some_and(|entry| {
-                    entry.file_size == pending_entries[0].file_size
-                        && entry.modified_ns == pending_entries[0].modified_ns
-                })
-            })
+            .filter(|path| rename_candidates.contains(*path))
             .collect::<Vec<_>>();
-        let [present_path] = matching_facts.as_slice() else {
-            continue;
+        let present_path = if candidates.len() == 1 {
+            candidates[0]
+        } else {
+            let matching_facts = candidates
+                .iter()
+                .copied()
+                .filter(|path| {
+                    entries_by_path.get(*path).is_some_and(|entry| {
+                        entry.file_size == pending_entries[0].file_size
+                            && entry.modified_ns == pending_entries[0].modified_ns
+                    })
+                })
+                .collect::<Vec<_>>();
+            let [present_path] = matching_facts.as_slice() else {
+                continue;
+            };
+            *present_path
         };
-        let present_path = *present_path;
-        let pending_entry = &pending_entries[0];
-        if pending_entry.relative_path == *present_path {
+        if pending_entries[0].relative_path == *present_path {
             continue;
         }
+        let pending_entry = &pending_entries[0];
         let Some(present_entry) = entries_by_path.get(present_path) else {
             continue;
         };
@@ -218,7 +230,7 @@ mod tests {
         let _writer = lock_db.write_batch().expect("writer lock");
         let cancel = AtomicBool::new(true);
 
-        let result = deep_hash_scan(&db, Some(&cancel));
+        let result = deep_hash_scan(&db, Some(&cancel), &HashSet::new());
 
         assert!(matches!(result, Err(ScanError::Canceled)));
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -16,10 +16,17 @@ struct HashBackfill {
     content_hash: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DeferredHashScope {
+    AllUnhashed,
+    RenameCandidates,
+}
+
 pub(super) fn deep_hash_scan(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
     rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
     let entries = db.list_files()?;
@@ -29,9 +36,12 @@ pub(super) fn deep_hash_scan(
         .collect();
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
-    let has_unhashed_files = entries_by_path.values().any(|entry| {
-        !entry.missing && entry.content_hash.is_none() && root.join(&entry.relative_path).is_file()
-    });
+    let has_unhashed_files = scope == DeferredHashScope::AllUnhashed
+        && entries_by_path.values().any(|entry| {
+            !entry.missing
+                && entry.content_hash.is_none()
+                && root.join(&entry.relative_path).is_file()
+        });
     if !has_unhashed_files && rename_candidates.is_empty() {
         return Ok(ScanStats::default());
     }
@@ -67,6 +77,11 @@ pub(super) fn deep_hash_scan(
             return Err(ScanError::Canceled);
         }
         if entry.missing || entry.content_hash.is_some() {
+            continue;
+        }
+        if scope == DeferredHashScope::RenameCandidates
+            && !rename_candidates.contains(&entry.relative_path)
+        {
             continue;
         }
         let absolute = root.join(&entry.relative_path);
@@ -239,7 +254,12 @@ mod tests {
         let _writer = lock_db.write_batch().expect("writer lock");
         let cancel = AtomicBool::new(true);
 
-        let result = deep_hash_scan(&db, Some(&cancel), &HashSet::new());
+        let result = deep_hash_scan(
+            &db,
+            Some(&cancel),
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+        );
 
         assert!(matches!(result, Err(ScanError::Canceled)));
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -14,6 +14,7 @@ struct HashBackfill {
     file_size: u64,
     modified_ns: i64,
     content_hash: String,
+    file_identity: Option<String>,
 }
 
 fn is_supported_regular_audio_file(path: &std::path::Path) -> bool {
@@ -54,6 +55,8 @@ pub(super) fn deep_hash_scan(
     let mut stats = ScanStats::default();
     let mut present_by_hash = HashMap::new();
     let mut pending_by_hash = HashMap::new();
+    let mut present_by_file_identity = HashMap::new();
+    let mut pending_by_file_identity = HashMap::new();
     let mut hash_backfills = Vec::new();
 
     for entry in entries_by_path.values() {
@@ -72,6 +75,12 @@ pub(super) fn deep_hash_scan(
             .push(entry.relative_path.clone());
     }
     for entry in pending_entries {
+        if let Some(file_identity) = entry.file_identity.as_deref() {
+            pending_by_file_identity
+                .entry(file_identity.to_string())
+                .or_insert_with(Vec::new)
+                .push(entry.clone());
+        }
         let Some(hash) = entry.content_hash.as_deref() else {
             continue;
         };
@@ -109,6 +118,7 @@ pub(super) fn deep_hash_scan(
             file_size: facts.size,
             modified_ns: facts.modified_ns,
             content_hash: hash.clone(),
+            file_identity: facts.file_identity,
         });
         entry.file_size = facts.size;
         entry.modified_ns = facts.modified_ns;
@@ -120,6 +130,19 @@ pub(super) fn deep_hash_scan(
         if was_unhashed {
             stats.hashes_computed += 1;
         }
+    }
+
+    for backfill in &hash_backfills {
+        if !rename_candidates.contains(&backfill.relative_path) {
+            continue;
+        }
+        let Some(file_identity) = backfill.file_identity.as_ref() else {
+            continue;
+        };
+        present_by_file_identity
+            .entry(file_identity.clone())
+            .or_insert_with(Vec::new)
+            .push(backfill.relative_path.clone());
     }
 
     if let Some(cancel) = cancel
@@ -136,20 +159,84 @@ pub(super) fn deep_hash_scan(
             backfill.modified_ns,
             &backfill.content_hash,
         )?;
+        batch.set_file_identity(&backfill.relative_path, backfill.file_identity.as_deref())?;
     }
 
-    let renamed_samples = reconcile_missing_renames(
+    let mut renamed_samples = reconcile_missing_renames(
         &mut batch,
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
         &rename_candidates,
     )?;
+    let already_reconciled = renamed_samples
+        .iter()
+        .flat_map(|renamed| {
+            [
+                renamed.old_relative_path.clone(),
+                renamed.new_relative_path.clone(),
+            ]
+        })
+        .collect::<HashSet<_>>();
+    renamed_samples.extend(reconcile_same_file_renames(
+        &mut batch,
+        &entries_by_path,
+        &present_by_file_identity,
+        &pending_by_file_identity,
+        &already_reconciled,
+    )?);
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
 
     batch.commit()?;
     Ok(stats)
+}
+
+fn reconcile_same_file_renames(
+    batch: &mut SourceWriteBatch<'_>,
+    entries_by_path: &HashMap<PathBuf, WavEntry>,
+    present_by_file_identity: &HashMap<String, Vec<PathBuf>>,
+    pending_by_file_identity: &HashMap<String, Vec<PendingRenameEntry>>,
+    already_reconciled: &HashSet<PathBuf>,
+) -> Result<Vec<RenamedSample>, ScanError> {
+    let mut reconciled = Vec::new();
+    for (file_identity, pending_entries) in pending_by_file_identity {
+        let [pending_entry] = pending_entries.as_slice() else {
+            continue;
+        };
+        let Some(present_paths) = present_by_file_identity.get(file_identity) else {
+            continue;
+        };
+        let [present_path] = present_paths.as_slice() else {
+            continue;
+        };
+        if pending_entry.relative_path == *present_path
+            || already_reconciled.contains(&pending_entry.relative_path)
+            || already_reconciled.contains(present_path)
+        {
+            continue;
+        }
+        let Some(present_entry) = entries_by_path.get(present_path) else {
+            continue;
+        };
+        if present_entry.file_size != pending_entry.file_size
+            || present_entry.modified_ns != pending_entry.modified_ns
+        {
+            continue;
+        }
+        let Some(hash) = present_entry.content_hash.as_deref() else {
+            continue;
+        };
+        apply_deep_rename(batch, present_entry, pending_entry, hash)?;
+        reconciled.push(RenamedSample {
+            old_relative_path: pending_entry.relative_path.clone(),
+            new_relative_path: present_entry.relative_path.clone(),
+            file_size: present_entry.file_size,
+            modified_ns: present_entry.modified_ns,
+            content_hash: Some(hash.to_string()),
+        });
+    }
+    Ok(reconciled)
 }
 
 fn reconcile_missing_renames(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -103,10 +103,6 @@ pub(super) fn deep_hash_scan(
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
-        &hash_backfills
-            .iter()
-            .map(|backfill| backfill.relative_path.clone())
-            .collect(),
     )?;
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
@@ -120,7 +116,6 @@ fn reconcile_missing_renames(
     entries_by_path: &HashMap<PathBuf, WavEntry>,
     present_by_hash: &HashMap<String, Vec<PathBuf>>,
     pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
-    backfilled_paths: &HashSet<PathBuf>,
 ) -> Result<Vec<RenamedSample>, ScanError> {
     let mut reconciled = Vec::new();
     for (hash, pending_entries) in pending_by_hash {
@@ -130,15 +125,19 @@ fn reconcile_missing_renames(
         let Some(present_paths) = present_by_hash.get(hash) else {
             continue;
         };
-        let newly_hashed = present_paths
+        let matching_facts = present_paths
             .iter()
-            .filter(|path| backfilled_paths.contains(*path))
+            .filter(|path| {
+                entries_by_path.get(*path).is_some_and(|entry| {
+                    entry.file_size == pending_entries[0].file_size
+                        && entry.modified_ns == pending_entries[0].modified_ns
+                })
+            })
             .collect::<Vec<_>>();
-        let present_path = match newly_hashed.as_slice() {
-            [path] => *path,
-            [] if present_paths.len() == 1 => &present_paths[0],
-            _ => continue,
+        let [present_path] = matching_facts.as_slice() else {
+            continue;
         };
+        let present_path = *present_path;
         let pending_entry = &pending_entries[0];
         if pending_entry.relative_path == *present_path {
             continue;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -28,6 +28,8 @@ pub(super) fn deep_hash_scan(
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect();
     let pending_entries = db.list_pending_renames()?;
+    let mut rename_candidates = rename_candidates.clone();
+    rename_candidates.extend(db.list_pending_rename_destinations()?);
     let mut stats = ScanStats::default();
     let mut present_by_hash = HashMap::new();
     let mut pending_by_hash = HashMap::new();
@@ -104,7 +106,7 @@ pub(super) fn deep_hash_scan(
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
-        rename_candidates,
+        &rename_candidates,
     )?;
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
@@ -176,6 +178,7 @@ fn apply_deep_rename(
     hash: &str,
 ) -> Result<(), ScanError> {
     batch.clear_pending_rename(&pending_entry.relative_path)?;
+    batch.clear_pending_rename_destination(&present_entry.relative_path)?;
     batch.upsert_file_with_hash_and_tag(
         &present_entry.relative_path,
         present_entry.file_size,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -27,9 +27,15 @@ pub(super) fn deep_hash_scan(
         .into_iter()
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect();
-    let pending_entries = db.list_pending_renames()?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
+    let has_unhashed_files = entries_by_path.values().any(|entry| {
+        !entry.missing && entry.content_hash.is_none() && root.join(&entry.relative_path).is_file()
+    });
+    if !has_unhashed_files && rename_candidates.is_empty() {
+        return Ok(ScanStats::default());
+    }
+    let pending_entries = db.list_pending_renames()?;
     let mut stats = ScanStats::default();
     let mut present_by_hash = HashMap::new();
     let mut pending_by_hash = HashMap::new();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{PendingRenameEntry, SourceWriteBatch, WavEntry};
+use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
 use super::scan::{RenamedSample, ScanError, ScanStats};
 use super::scan_fs::{compute_content_hash, ensure_root_dir, read_facts};
@@ -14,6 +14,11 @@ struct HashBackfill {
     file_size: u64,
     modified_ns: i64,
     content_hash: String,
+}
+
+fn is_supported_regular_audio_file(path: &std::path::Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
+        && is_supported_audio(path)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,6 +57,12 @@ pub(super) fn deep_hash_scan(
     let mut hash_backfills = Vec::new();
 
     for entry in entries_by_path.values() {
+        if entry.missing
+            || rename_candidates.contains(&entry.relative_path)
+            || !is_supported_regular_audio_file(&root.join(&entry.relative_path))
+        {
+            continue;
+        }
         let Some(hash) = entry.content_hash.as_deref() else {
             continue;
         };
@@ -76,16 +87,19 @@ pub(super) fn deep_hash_scan(
         {
             return Err(ScanError::Canceled);
         }
-        if entry.missing || entry.content_hash.is_some() {
+        if entry.missing {
             continue;
         }
-        if scope == DeferredHashScope::RenameCandidates
-            && !rename_candidates.contains(&entry.relative_path)
-        {
+        let is_rename_candidate = rename_candidates.contains(&entry.relative_path);
+        if entry.content_hash.is_some() && !is_rename_candidate {
             continue;
         }
+        if scope == DeferredHashScope::RenameCandidates && !is_rename_candidate {
+            continue;
+        }
+        let was_unhashed = entry.content_hash.is_none();
         let absolute = root.join(&entry.relative_path);
-        if !absolute.exists() {
+        if !is_supported_regular_audio_file(&absolute) {
             continue;
         }
         let facts = read_facts(&root, &absolute)?;
@@ -103,7 +117,9 @@ pub(super) fn deep_hash_scan(
             .entry(hash)
             .or_insert_with(Vec::new)
             .push(entry.relative_path.clone());
-        stats.hashes_computed += 1;
+        if was_unhashed {
+            stats.hashes_computed += 1;
+        }
     }
 
     if let Some(cancel) = cancel
@@ -155,12 +171,11 @@ fn reconcile_missing_renames(
             .iter()
             .filter(|path| rename_candidates.contains(*path))
             .collect::<Vec<_>>();
-        let present_path = if candidates.len() == 1 {
+        let present_path = if present_paths.len() == 1 && candidates.len() == 1 {
             candidates[0]
         } else {
-            let matching_facts = candidates
+            let matching_facts = present_paths
                 .iter()
-                .copied()
                 .filter(|path| {
                     entries_by_path.get(*path).is_some_and(|entry| {
                         entry.file_size == pending_entries[0].file_size
@@ -171,6 +186,9 @@ fn reconcile_missing_renames(
             let [present_path] = matching_facts.as_slice() else {
                 continue;
             };
+            if !rename_candidates.contains(*present_path) {
+                continue;
+            }
             *present_path
         };
         if pending_entries[0].relative_path == *present_path {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -130,15 +130,15 @@ fn reconcile_missing_renames(
         let Some(present_paths) = present_by_hash.get(hash) else {
             continue;
         };
-        let mut newly_hashed = present_paths
+        let newly_hashed = present_paths
             .iter()
-            .filter(|path| backfilled_paths.contains(*path));
-        let Some(present_path) = newly_hashed.next() else {
-            continue;
+            .filter(|path| backfilled_paths.contains(*path))
+            .collect::<Vec<_>>();
+        let present_path = match newly_hashed.as_slice() {
+            [path] => *path,
+            [] if present_paths.len() == 1 => &present_paths[0],
+            _ => continue,
         };
-        if newly_hashed.next().is_some() {
-            continue;
-        }
         let pending_entry = &pending_entries[0];
         if pending_entry.relative_path == *present_path {
             continue;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -103,6 +103,10 @@ pub(super) fn deep_hash_scan(
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
+        &hash_backfills
+            .iter()
+            .map(|backfill| backfill.relative_path.clone())
+            .collect(),
     )?;
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
@@ -116,6 +120,7 @@ fn reconcile_missing_renames(
     entries_by_path: &HashMap<PathBuf, WavEntry>,
     present_by_hash: &HashMap<String, Vec<PathBuf>>,
     pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
+    backfilled_paths: &HashSet<PathBuf>,
 ) -> Result<Vec<RenamedSample>, ScanError> {
     let mut reconciled = Vec::new();
     for (hash, pending_entries) in pending_by_hash {
@@ -125,11 +130,16 @@ fn reconcile_missing_renames(
         let Some(present_paths) = present_by_hash.get(hash) else {
             continue;
         };
-        if present_paths.len() != 1 {
+        let mut newly_hashed = present_paths
+            .iter()
+            .filter(|path| backfilled_paths.contains(*path));
+        let Some(present_path) = newly_hashed.next() else {
+            continue;
+        };
+        if newly_hashed.next().is_some() {
             continue;
         }
         let pending_entry = &pending_entries[0];
-        let present_path = &present_paths[0];
         if pending_entry.relative_path == *present_path {
             continue;
         }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -36,9 +36,6 @@ pub fn sync_paths_with_progress(
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
-    let mut generation_batch = db.write_batch()?;
-    context.rename_candidate_generation = Some(generation_batch.begin_targeted_scan_generation()?);
-    generation_batch.commit()?;
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     for relative_path in targets.current_files {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -36,6 +36,9 @@ pub fn sync_paths_with_progress(
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
+    let mut generation_batch = db.write_batch()?;
+    context.rename_candidate_generation = Some(generation_batch.begin_targeted_scan_generation()?);
+    generation_batch.commit()?;
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     for relative_path in targets.current_files {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -238,6 +238,7 @@ fn apply_batch(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    context.ensure_rename_candidate_generation(&mut batch)?;
     let mut rename_candidates = RenameCandidateCache::default();
     for file in ready {
         let relative_path = file.facts.relative.clone();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -315,7 +315,9 @@ fn prepare_for_apply(
 }
 
 fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
-    current.size == prepared.facts.size && current.modified_ns == prepared.facts.modified_ns
+    current.size == prepared.facts.size
+        && current.modified_ns == prepared.facts.modified_ns
+        && current.file_identity == prepared.facts.file_identity
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>, committed: bool) -> bool {

--- a/src/app/controller/jobs/source_db_maintenance.rs
+++ b/src/app/controller/jobs/source_db_maintenance.rs
@@ -3,7 +3,7 @@ use super::{SourceDbMaintenanceJob, SourceDbMaintenanceOutcome, SourceDbMaintena
 use crate::app::controller::library::analysis_jobs;
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::file_ops_journal;
-use crate::sample_sources::scanner::{complete_deferred_hashes, scan_once};
+use crate::sample_sources::scanner::{ScanStats, complete_deferred_hashes, scan_once};
 
 mod markers;
 mod refresh;
@@ -125,14 +125,27 @@ fn rescan_empty_source_if_needed(
 }
 
 fn rescan_empty_source(
-    _job: &SourceDbMaintenanceJob,
+    job: &SourceDbMaintenanceJob,
     probe: &SourceDatabase,
 ) -> Result<bool, String> {
-    let stats =
+    let committed =
         scan_once(probe).map_err(|err| format!("Deferred empty-source scan failed: {err}"))?;
-    let stats = complete_deferred_hashes(probe, stats)
-        .map_err(|err| format!("Finish deferred empty-source hashing failed: {err}"))?;
-    Ok(scan_changed_source(&stats))
+    match complete_deferred_hashes(probe, committed.clone()) {
+        Ok(completed) => Ok(scan_changed_after_deferred(&committed, Some(&completed))),
+        Err(error) => {
+            tracing::warn!(
+                source_id = %job.source_id,
+                source_root = %job.source_root.display(),
+                %error,
+                "Deferred hashing failed after the empty-source scan committed"
+            );
+            Ok(scan_changed_after_deferred(&committed, None))
+        }
+    }
+}
+
+fn scan_changed_after_deferred(committed: &ScanStats, completed: Option<&ScanStats>) -> bool {
+    scan_changed_source(completed.unwrap_or(committed))
 }
 
 fn maintenance_error(

--- a/src/app/controller/jobs/source_db_maintenance.rs
+++ b/src/app/controller/jobs/source_db_maintenance.rs
@@ -3,7 +3,7 @@ use super::{SourceDbMaintenanceJob, SourceDbMaintenanceOutcome, SourceDbMaintena
 use crate::app::controller::library::analysis_jobs;
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::file_ops_journal;
-use crate::sample_sources::scanner::{scan_once, schedule_deep_hash_scan};
+use crate::sample_sources::scanner::{complete_deferred_hashes, scan_once};
 
 mod markers;
 mod refresh;
@@ -125,14 +125,13 @@ fn rescan_empty_source_if_needed(
 }
 
 fn rescan_empty_source(
-    job: &SourceDbMaintenanceJob,
+    _job: &SourceDbMaintenanceJob,
     probe: &SourceDatabase,
 ) -> Result<bool, String> {
     let stats =
         scan_once(probe).map_err(|err| format!("Deferred empty-source scan failed: {err}"))?;
-    if stats.hashes_pending > 0 {
-        schedule_deep_hash_scan(job.source_root.clone());
-    }
+    let stats = complete_deferred_hashes(probe, stats)
+        .map_err(|err| format!("Finish deferred empty-source hashing failed: {err}"))?;
     Ok(scan_changed_source(&stats))
 }
 

--- a/src/app/controller/jobs/source_db_maintenance/tests.rs
+++ b/src/app/controller/jobs/source_db_maintenance/tests.rs
@@ -78,6 +78,16 @@ fn source_db_maintenance_defers_quietly_during_same_source_file_op() {
 }
 
 #[test]
+fn deferred_hash_failure_preserves_committed_empty_source_refresh() {
+    let committed = crate::sample_sources::scanner::ScanStats {
+        added: 1,
+        ..Default::default()
+    };
+
+    assert!(scan_changed_after_deferred(&committed, None));
+}
+
+#[test]
 /// Verifies deferred maintenance retry records source scoped telemetry.
 fn deferred_maintenance_retry_records_source_scoped_telemetry() {
     let temp = tempdir().expect("create temp dir");

--- a/src/app/controller/library/scans/worker.rs
+++ b/src/app/controller/library/scans/worker.rs
@@ -51,8 +51,5 @@ fn run_scan_worker(
     } else {
         scanner::scan_with_progress(&db, mode, Some(cancel), &mut progress)?
     };
-    if stats.hashes_pending > 0 {
-        scanner::schedule_deep_hash_scan(root.to_path_buf());
-    }
-    Ok(stats)
+    scanner::complete_deferred_hashes(&db, stats)
 }

--- a/src/app/controller/library/scans/worker.rs
+++ b/src/app/controller/library/scans/worker.rs
@@ -51,5 +51,5 @@ fn run_scan_worker(
     } else {
         scanner::scan_with_progress(&db, mode, Some(cancel), &mut progress)?
     };
-    scanner::complete_deferred_hashes(&db, stats)
+    scanner::complete_deferred_hashes_with_cancel(&db, stats, Some(cancel))
 }

--- a/src/app/controller/library/scans/worker.rs
+++ b/src/app/controller/library/scans/worker.rs
@@ -51,5 +51,47 @@ fn run_scan_worker(
     } else {
         scanner::scan_with_progress(&db, mode, Some(cancel), &mut progress)?
     };
-    scanner::complete_deferred_hashes_with_cancel(&db, stats, Some(cancel))
+    Ok(complete_deferred_hashes_preserving_committed(
+        &db, stats, cancel,
+    ))
+}
+
+fn complete_deferred_hashes_preserving_committed(
+    db: &SourceDatabase,
+    stats: ScanStats,
+    cancel: &AtomicBool,
+) -> ScanStats {
+    let committed = stats.clone();
+    match scanner::complete_deferred_hashes_with_cancel(db, stats, Some(cancel)) {
+        Ok(completed) => completed,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "Deferred source hashing failed after scan changes were committed"
+            );
+            committed
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    #[test]
+    fn deferred_failure_preserves_committed_quick_scan_stats() {
+        let root = tempfile::tempdir().expect("source");
+        std::fs::write(root.path().join("large.wav"), vec![1_u8; 9 * 1024 * 1024])
+            .expect("large wav");
+        let db = SourceDatabase::open(root.path()).expect("source db");
+        let stats = scanner::scan_once(&db).expect("quick scan");
+        let cancel = AtomicBool::new(true);
+
+        let completed = complete_deferred_hashes_preserving_committed(&db, stats, &cancel);
+
+        assert_eq!(completed.added, 1);
+        assert_eq!(completed.hashes_pending, 1);
+        assert!(db.entry_for_path(Path::new("large.wav")).unwrap().is_some());
+    }
 }

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -377,7 +377,12 @@ pub(in crate::native_app) enum GuiMessage {
 pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) source_id: String,
     pub(in crate::native_app) changed_count: usize,
-    pub(in crate::native_app) result: Result<(), String>,
+    pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
+    pub(in crate::native_app) renames_reconciled: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -19,7 +19,8 @@ pub(in crate::native_app) use loading::{
 };
 pub(in crate::native_app) use message::{
     GuiMessage, MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult,
-    SourceFilesystemSyncResult, TrashMoveTarget, VolumeSettingsPersistResult,
+    SourceFilesystemSyncResult, SourceFilesystemSyncSuccess, TrashMoveTarget,
+    VolumeSettingsPersistResult,
 };
 pub(in crate::native_app) use progress::{
     FileMoveProgress, NormalizationFailure, NormalizationHarvestDerivation, NormalizationProgress,

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -90,15 +90,9 @@ fn sync_source_database(
         });
     };
     match scanner::scan_with_progress(&db, scanner::ScanMode::Quick, None, &mut sync_progress) {
-        Ok(stats) => {
-            if stats.hashes_pending > 0 {
-                scanner::schedule_deep_hash_scan_with_database_root(
-                    request.root.clone(),
-                    request.database_root.clone(),
-                );
-            }
-            None
-        }
+        Ok(stats) => scanner::complete_deferred_hashes(&db, stats)
+            .err()
+            .map(|err| format!("finish deferred source hashing: {err}")),
         Err(err) => Some(format!("sync source index: {err}")),
     }
 }

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -98,9 +98,17 @@ fn sync_source_database(
         Ok(stats) => stats,
         Err(err) => return Some(format!("sync source index: {err}")),
     };
-    scanner::complete_deferred_hashes(&db, stats)
-        .map(|_| None)
-        .unwrap_or_else(|err| Some(format!("finish deferred source hashing: {err}")))
+    let completed = match scanner::complete_deferred_rename_candidates(&db, stats) {
+        Ok(completed) => completed,
+        Err(err) => return Some(format!("finish deferred rename hashing: {err}")),
+    };
+    if completed.hashes_pending > 0 {
+        scanner::schedule_deep_hash_scan_with_database_root(
+            request.root.clone(),
+            request.database_root.clone(),
+        );
+    }
+    None
 }
 
 struct ScanProgressCounter {

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -90,9 +90,13 @@ fn sync_source_database(
         });
     };
     match scanner::scan_with_progress(&db, scanner::ScanMode::Quick, None, &mut sync_progress) {
-        Ok(stats) => scanner::complete_deferred_hashes(&db, stats)
-            .err()
-            .map(|err| format!("finish deferred source hashing: {err}")),
+        Ok(_) => {
+            scanner::schedule_deep_hash_scan_with_database_root(
+                request.root.clone(),
+                request.database_root.clone(),
+            );
+            None
+        }
         Err(err) => Some(format!("sync source index: {err}")),
     }
 }

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -20,7 +20,13 @@ pub(in crate::native_app) fn scan_source_with_progress(
     mut progress: impl FnMut(FolderScanProgress),
     mut discovered: impl FnMut(FolderScanDiscovery),
 ) -> FolderScanResult {
-    let ratings = if request.root.is_dir() {
+    let source_root_available = request.root.is_dir();
+    let source_db_error = if source_root_available {
+        sync_source_database(&request, &mut progress)
+    } else {
+        None
+    };
+    let ratings = if source_root_available {
         source_rating_map_with_rating_decay(
             &request.root,
             &request.database_root,
@@ -48,12 +54,6 @@ pub(in crate::native_app) fn scan_source_with_progress(
     let file_count = scan.counter.files;
     let folder_count = scan.counter.folders;
     drop(scan);
-    let source_db_error = if request.root.is_dir() {
-        sync_source_database(&request, &mut progress)
-    } else {
-        None
-    };
-    let source_root_available = request.root.is_dir();
     FolderScanResult {
         task_id: request.task_id,
         source_id: request.source_id,
@@ -89,16 +89,18 @@ fn sync_source_database(
             detail: path.display().to_string(),
         });
     };
-    match scanner::scan_with_progress(&db, scanner::ScanMode::Quick, None, &mut sync_progress) {
-        Ok(_) => {
-            scanner::schedule_deep_hash_scan_with_database_root(
-                request.root.clone(),
-                request.database_root.clone(),
-            );
-            None
-        }
-        Err(err) => Some(format!("sync source index: {err}")),
-    }
+    let stats = match scanner::scan_with_progress(
+        &db,
+        scanner::ScanMode::Quick,
+        None,
+        &mut sync_progress,
+    ) {
+        Ok(stats) => stats,
+        Err(err) => return Some(format!("sync source index: {err}")),
+    };
+    scanner::complete_deferred_hashes(&db, stats)
+        .map(|_| None)
+        .unwrap_or_else(|err| Some(format!("finish deferred source hashing: {err}")))
 }
 
 struct ScanProgressCounter {

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -127,6 +127,51 @@ fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
 }
 
 #[test]
+fn source_scan_publishes_restored_rating_after_large_rename() {
+    let root = temp_source_root("wavecrate-gui-large-rename");
+    let old_path = root.join("old.wav");
+    let new_path = root.join("new.wav");
+    fs::write(&old_path, vec![7_u8; 9 * 1024 * 1024]).expect("write large wav");
+    let mut browser = FolderBrowserState::load_default();
+    let initial_request = browser
+        .begin_add_source_path(root.clone(), 42)
+        .expect("new source should request scan");
+    assert!(browser.apply_scan_finished(scan_source_with_progress(
+        initial_request,
+        |_| {},
+        |_| {}
+    )));
+
+    let db = SourceDatabase::open(&root).expect("source db");
+    db.set_tag(std::path::Path::new("old.wav"), Rating::KEEP_1)
+        .expect("rate original file");
+    fs::rename(&old_path, &new_path).expect("rename large wav");
+
+    let request = browser
+        .begin_selected_source_scan(43)
+        .expect("selected source refresh should queue");
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    let renamed = result
+        .folder
+        .all_files()
+        .into_iter()
+        .find(|file| file.name == "new.wav")
+        .expect("renamed file");
+
+    assert_eq!(result.source_db_error, None);
+    assert_eq!(renamed.rating, Rating::KEEP_1);
+    assert_eq!(
+        db.entry_for_path(std::path::Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn non_wav_audio_looking_files_are_visible_but_not_supported_audio() {
     let root = temp_source_root("wavecrate-gui-unsupported-audio");
     let drums = root.join("drums");

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -81,16 +81,23 @@ impl NativeAppState {
     pub(in crate::native_app) fn finish_source_filesystem_sync(
         &mut self,
         result: SourceFilesystemSyncResult,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        if let Err(error) = result.result {
-            tracing::warn!(
-                source_id = %result.source_id,
-                changed_count = result.changed_count,
-                error = %error,
-                "Failed to sync source database after filesystem change"
-            );
-            if result.source_id == self.library.folder_browser.selected_source_id() {
-                self.ui.status.sample = format!("Source sync failed: {error}");
+        match result.result {
+            Ok(success) if success.renames_reconciled > 0 => {
+                self.queue_filesystem_source_refresh(result.source_id, Instant::now(), context);
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    source_id = %result.source_id,
+                    changed_count = result.changed_count,
+                    error = %error,
+                    "Failed to sync source database after filesystem change"
+                );
+                if result.source_id == self.library.folder_browser.selected_source_id() {
+                    self.ui.status.sample = format!("Source sync failed: {error}");
+                }
             }
         }
     }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use wavecrate::sample_sources::{SourceDatabase, scanner};
 
-use crate::native_app::app::SourceFilesystemSyncResult;
+use crate::native_app::app::{SourceFilesystemSyncResult, SourceFilesystemSyncSuccess};
 
 pub(super) fn sync_source_database_paths(
     source_id: String,
@@ -16,18 +16,69 @@ pub(super) fn sync_source_database_paths(
         .and_then(|db| {
             let stats = scanner::sync_paths(&db, &paths)
                 .map_err(|err| format!("sync source index: {err}"))?;
-            if let Err(error) = scanner::complete_deferred_hashes(&db, stats) {
-                tracing::warn!(
-                    source_id,
-                    error = %error,
-                    "Deferred source hashing failed after filesystem sync committed"
-                );
-            }
-            Ok(())
+            let committed = stats.clone();
+            let completed = match scanner::complete_deferred_hashes(&db, stats) {
+                Ok(completed) => completed,
+                Err(error) => {
+                    tracing::warn!(
+                        source_id,
+                        error = %error,
+                        "Deferred source hashing failed after filesystem sync committed"
+                    );
+                    committed
+                }
+            };
+            Ok(SourceFilesystemSyncSuccess {
+                renames_reconciled: completed.renames_reconciled,
+            })
         });
     SourceFilesystemSyncResult {
         source_id,
         changed_count,
         result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
+
+    use super::{SourceFilesystemSyncSuccess, sync_source_database_paths};
+
+    #[test]
+    fn filesystem_sync_returns_deferred_rename_results_for_refresh() {
+        let root = tempfile::tempdir().expect("source root");
+        let old = root.path().join("old.wav");
+        let new = root.path().join("new.wav");
+        std::fs::write(&old, vec![5_u8; 9 * 1024 * 1024]).expect("large wav");
+        let db = SourceDatabase::open(root.path()).expect("source db");
+        scanner::hard_rescan(&db).expect("initial scan");
+        db.set_tag(Path::new("old.wav"), Rating::KEEP_1)
+            .expect("tag old path");
+        std::fs::rename(&old, &new).expect("rename wav");
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("old.wav"), PathBuf::from("new.wav")],
+            2,
+        );
+
+        assert_eq!(
+            result.result,
+            Ok(SourceFilesystemSyncSuccess {
+                renames_reconciled: 1
+            })
+        );
+        assert_eq!(
+            db.entry_for_path(Path::new("new.wav"))
+                .unwrap()
+                .unwrap()
+                .tag,
+            Rating::KEEP_1
+        );
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -16,12 +16,8 @@ pub(super) fn sync_source_database_paths(
         .and_then(|db| {
             let stats = scanner::sync_paths(&db, &paths)
                 .map_err(|err| format!("sync source index: {err}"))?;
-            if stats.hashes_pending > 0 {
-                scanner::schedule_deep_hash_scan_with_database_root(
-                    root.clone(),
-                    database_root.clone(),
-                );
-            }
+            scanner::complete_deferred_hashes(&db, stats)
+                .map_err(|err| format!("finish deferred source hashing: {err}"))?;
             Ok(())
         });
     SourceFilesystemSyncResult {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -16,8 +16,13 @@ pub(super) fn sync_source_database_paths(
         .and_then(|db| {
             let stats = scanner::sync_paths(&db, &paths)
                 .map_err(|err| format!("sync source index: {err}"))?;
-            scanner::complete_deferred_hashes(&db, stats)
-                .map_err(|err| format!("finish deferred source hashing: {err}"))?;
+            if let Err(error) = scanner::complete_deferred_hashes(&db, stats) {
+                tracing::warn!(
+                    source_id,
+                    error = %error,
+                    "Deferred source hashing failed after filesystem sync committed"
+                );
+            }
             Ok(())
         });
     SourceFilesystemSyncResult {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -14,9 +14,16 @@ pub(super) fn sync_source_database_paths(
     let result = SourceDatabase::open_for_background_job_with_database_root(&root, &database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            scanner::sync_paths(&db, &paths).map_err(|err| format!("sync source index: {err}"))
-        })
-        .map(|_| ());
+            let stats = scanner::sync_paths(&db, &paths)
+                .map_err(|err| format!("sync source index: {err}"))?;
+            if stats.hashes_pending > 0 {
+                scanner::schedule_deep_hash_scan_with_database_root(
+                    root.clone(),
+                    database_root.clone(),
+                );
+            }
+            Ok(())
+        });
     SourceFilesystemSyncResult {
         source_id,
         changed_count,

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -282,12 +282,8 @@ fn ensure_source_database_scanned(source: &SampleSource) -> Result<(), String> {
     }
     let stats = scanner::scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {})
         .map_err(|err| format!("Sync source index failed: {err}"))?;
-    if stats.hashes_pending > 0 {
-        let database_root = source
-            .database_root()
-            .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
-        scanner::schedule_deep_hash_scan_with_database_root(source.root.clone(), database_root);
-    }
+    scanner::complete_deferred_hashes(&db, stats)
+        .map_err(|err| format!("Finish deferred source hashing failed: {err}"))?;
     Ok(())
 }
 

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -71,7 +71,7 @@ impl NativeAppState {
                 self.refresh_source_after_filesystem_change(source_id, paths, overflowed, context);
             }
             GuiMessage::SourceFilesystemSyncFinished(result) => {
-                self.finish_source_filesystem_sync(result);
+                self.finish_source_filesystem_sync(result, context);
             }
             GuiMessage::NormalizationProgress(progress) => {
                 self.apply_normalization_progress(progress);

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -22,9 +22,10 @@ pub mod scan_state {
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-        complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
-        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+        complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+        complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
+        scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+        sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -22,9 +22,9 @@ pub mod scan_state {
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-        complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-        schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
-        sync_paths_with_progress,
+        complete_deferred_hashes, complete_deferred_hashes_with_cancel, hard_rescan,
+        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -21,9 +21,10 @@ pub mod scan_state {
 /// Source scanning logic.
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
-        ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, hard_rescan,
-        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+        ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+        complete_deferred_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+        schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
+        sync_paths_with_progress,
     };
 }
 


### PR DESCRIPTION
## Scope
- remove immediate rename and pending-rename identity transfer based only on size/mtime
- add unmatched large files neutrally and retain removed metadata as pending
- let deep hashing transfer metadata and analysis identity only after an exact content-hash match
- remove the obsolete facts-candidate cache and no-hash rename mutation path

## Definition of Done
- unrelated same-size/same-mtime files never inherit identity, ratings, tags, or analysis artifacts
- genuine large renames reconcile after deep hashing
- deferred rename state survives database restart
- small/already-hashable rename handling remains immediate and hash-authoritative

## Validation commands
- `cargo test -p wavecrate-scan --lib rename_reconciliation` (6 passed)
- `cargo test -p wavecrate-scan --lib` (33 passed)
- `cargo clippy -p wavecrate-scan --all-targets --no-deps -- -D warnings`
- `git diff --check`

## Known limitations
- Dependency-inclusive clippy remains independently blocked on `main` by the `CopyJournalEntry::new_copy` argument-count finding addressed in PR #781; the Wavecrate Scan all-target lane passes with `--no-deps`.

User review is required before merge.
