### PR TITLE
OPT-1093 Make batch trash partial-failure safe

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -40,6 +40,7 @@ use crate::native_app::sample_library::similarity_prep::{
     SimilarityPrepEnqueueResult, SimilarityPrepStatusResult,
 };
 use crate::native_app::sample_library::similarity_scores::SimilarityScoresResult;
+use crate::native_app::sample_library::trash_actions::movement::TrashMoveOutcome;
 use crate::native_app::waveform::WaveformInteraction;
 use crate::native_app::waveform::{SimilarSectionsResult, WaveformExtractionCompletion};
 use crate::native_app::waveform_edits::WaveformDestructiveEditResult;
@@ -255,7 +256,7 @@ pub(in crate::native_app) enum GuiMessage {
         target: TrashMoveTarget,
         action: &'static str,
         started_at: Instant,
-        result: Result<Vec<PathBuf>, String>,
+        outcomes: Vec<TrashMoveOutcome>,
     },
     RefreshContextSource,
     ProcessContextSource,

--- a/src/native_app/sample_library/folder_browser/delete_workflow.rs
+++ b/src/native_app/sample_library/folder_browser/delete_workflow.rs
@@ -119,13 +119,18 @@ impl FolderBrowserState {
 
     #[cfg(test)]
     pub(in crate::native_app) fn discard_trashed_file_paths(&mut self, paths: &[PathBuf]) -> bool {
-        self.discard_trashed_file_paths_matching_tags(paths, &HashMap::new())
+        self.discard_trashed_file_paths_matching_tags_preserving_selection(
+            paths,
+            &HashMap::new(),
+            &[],
+        )
     }
 
-    pub(in crate::native_app) fn discard_trashed_file_paths_matching_tags(
+    pub(in crate::native_app) fn discard_trashed_file_paths_matching_tags_preserving_selection(
         &mut self,
         paths: &[PathBuf],
         tags_by_file: &HashMap<String, Vec<String>>,
+        preserved_selected_paths: &[PathBuf],
     ) -> bool {
         let target_ids = paths
             .iter()
@@ -139,6 +144,11 @@ impl FolderBrowserState {
             .as_deref()
             .is_some_and(|id| target_ids.contains(id));
         let before_visible_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
+        let preserved_selected_ids = preserved_selected_paths
+            .iter()
+            .map(|path| path_id(path))
+            .filter(|id| self.selection.selected_file_ids().contains(id))
+            .collect::<HashSet<_>>();
         let changed = self.mutate_selected_source_trees(|root_folder| {
             root_folder.remove_files_by_ids(&target_ids)
         });
@@ -158,7 +168,19 @@ impl FolderBrowserState {
             })
             .flatten();
         self.selection.discard_files(&target_ids);
-        if let Some(fallback_id) = fallback_id {
+        if focused_removed && !preserved_selected_ids.is_empty() {
+            let preserved_focus = focused_id
+                .filter(|id| preserved_selected_ids.contains(id))
+                .or_else(|| {
+                    before_visible_ids
+                        .iter()
+                        .find(|id| preserved_selected_ids.contains(*id))
+                        .cloned()
+                })
+                .expect("preserved selection has a visible focus candidate");
+            self.selection
+                .restore_file_selection(preserved_focus, preserved_selected_ids);
+        } else if let Some(fallback_id) = fallback_id {
             self.selection.set_focus_file_set(fallback_id);
         }
         self.reconcile_file_view_after_tagged_content_change(tags_by_file);

--- a/src/native_app/sample_library/folder_browser/selection_state/files.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state/files.rs
@@ -215,6 +215,16 @@ impl BrowserSelectionState {
         self.selected_file_ids_explicit = false;
     }
 
+    pub(in crate::native_app::sample_library::folder_browser) fn restore_file_selection(
+        &mut self,
+        focused_id: String,
+        selected_ids: HashSet<String>,
+    ) {
+        self.selected_file = Some(focused_id);
+        self.selected_file_ids_explicit = selected_ids.len() > 1;
+        self.selected_file_ids = selected_ids;
+    }
+
     fn file_selection_model(&self) -> FileSelectionModel {
         FileSelectionModel::new(
             self.selected_file.clone(),

--- a/src/native_app/sample_library/folder_browser/tests/delete.rs
+++ b/src/native_app/sample_library/folder_browser/tests/delete.rs
@@ -218,6 +218,37 @@ fn trashed_explicit_file_selection_focuses_next_sample_after_focused_row() {
 }
 
 #[test]
+fn partial_trash_keeps_failed_selected_file_selected_for_retry() {
+    let root = temp_source_root("wavecrate-gui-file-trash-partial-selection");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let moved = drums.join("a.wav");
+    let unselected = drums.join("b.wav");
+    let failed = drums.join("c.wav");
+    for file in [&moved, &unselected, &failed] {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.selection.selected_file = Some(path_id(&moved));
+    browser.selection.selected_file_ids = [path_id(&moved), path_id(&failed)].into_iter().collect();
+    browser.selection.selected_file_ids_explicit = true;
+
+    assert!(
+        browser.discard_trashed_file_paths_matching_tags_preserving_selection(
+            std::slice::from_ref(&moved),
+            &std::collections::HashMap::new(),
+            std::slice::from_ref(&failed),
+        )
+    );
+
+    assert_eq!(browser.selected_file_id(), Some(path_id(&failed).as_str()));
+    assert_eq!(browser.selected_file_paths(), vec![failed.clone()]);
+    assert!(!browser.is_file_selected(path_id(&unselected).as_str()));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn root_folder_delete_is_rejected_from_tree() {
     let root = temp_source_root("wavecrate-gui-root-delete");
     let browser = FolderBrowserState::from_root(root.clone());

--- a/src/native_app/sample_library/trash_actions.rs
+++ b/src/native_app/sample_library/trash_actions.rs
@@ -1,4 +1,4 @@
 mod cleanup;
 mod config;
-mod movement;
+pub(in crate::native_app) mod movement;
 mod routing;

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -160,8 +160,24 @@ fn reserve_trash_path(
 }
 
 fn trash_reservation_marker(trash_folder: &Path, candidate: &Path) -> PathBuf {
+    trash_reservation_marker_with_case_policy(
+        trash_folder,
+        candidate,
+        cfg!(any(target_os = "windows", target_os = "macos")),
+    )
+}
+
+fn trash_reservation_marker_with_case_policy(
+    trash_folder: &Path,
+    candidate: &Path,
+    case_insensitive: bool,
+) -> PathBuf {
     let mut hasher = DefaultHasher::new();
-    candidate.hash(&mut hasher);
+    if case_insensitive {
+        candidate.to_string_lossy().to_lowercase().hash(&mut hasher);
+    } else {
+        candidate.hash(&mut hasher);
+    }
     trash_folder.join(format!(
         ".wavecrate-trash-reservation-{:016x}",
         hasher.finish()
@@ -171,14 +187,76 @@ fn trash_reservation_marker(trash_folder: &Path, candidate: &Path) -> PathBuf {
 fn move_path(source: &Path, destination: &Path) -> Result<(), String> {
     match rename_no_replace(source, destination) {
         Ok(()) => Ok(()),
-        Err(rename_error) => fallback_move_path(source, destination, &rename_error),
+        Err(rename_error) => move_path_after_no_replace_error(source, destination, rename_error),
     }
+}
+
+fn move_path_after_no_replace_error(
+    source: &Path,
+    destination: &Path,
+    rename_error: io::Error,
+) -> Result<(), String> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let rename_error = if no_replace_rename_is_unsupported(&rename_error) {
+        match rename_via_owned_placeholder(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error) => error,
+        }
+    } else {
+        rename_error
+    };
+
+    if rename_error.kind() == io::ErrorKind::CrossesDevices {
+        return fallback_move_path(source, destination, &rename_error);
+    }
+    let kind = if source.is_dir() { "folder" } else { "file" };
+    Err(format!("Move {kind} to trash failed: {rename_error}"))
 }
 
 #[cfg(target_os = "windows")]
 fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
-    // Windows rename already refuses to replace an existing destination.
-    fs::rename(source, destination)
+    use std::os::windows::ffi::OsStrExt;
+    use windows::{
+        Win32::{
+            Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_NOT_SAME_DEVICE},
+            Storage::FileSystem::{MOVE_FILE_FLAGS, MoveFileExW},
+        },
+        core::{HRESULT, PCWSTR},
+    };
+
+    fn wide_path(path: &Path) -> io::Result<Vec<u16>> {
+        let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        if wide.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "trash move path contains an interior NUL code unit",
+            ));
+        }
+        wide.push(0);
+        Ok(wide)
+    }
+
+    let source = wide_path(source)?;
+    let destination = wide_path(destination)?;
+    let result = unsafe {
+        MoveFileExW(
+            PCWSTR(source.as_ptr()),
+            PCWSTR(destination.as_ptr()),
+            MOVE_FILE_FLAGS(0),
+        )
+    };
+    result.map_err(|error| {
+        let code = error.code();
+        if code == HRESULT::from_win32(ERROR_ALREADY_EXISTS.0)
+            || code == HRESULT::from_win32(ERROR_FILE_EXISTS.0)
+        {
+            io::Error::from(io::ErrorKind::AlreadyExists)
+        } else if code == HRESULT::from_win32(ERROR_NOT_SAME_DEVICE.0) {
+            io::Error::from(io::ErrorKind::CrossesDevices)
+        } else {
+            io::Error::other(error)
+        }
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -211,6 +289,64 @@ fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
         Ok(())
     } else {
         Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn no_replace_rename_is_unsupported(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::ENOSYS | libc::EINVAL | libc::EOPNOTSUPP)
+    )
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", all(test, unix)))]
+fn rename_via_owned_placeholder(source: &Path, destination: &Path) -> io::Result<()> {
+    let is_directory = source.is_dir();
+    let placeholder = if is_directory {
+        fs::create_dir(destination)?;
+        File::open(destination)?
+    } else {
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(destination)?
+    };
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            cleanup_owned_placeholder(destination, is_directory, &placeholder);
+            Err(error)
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", all(test, unix)))]
+fn cleanup_owned_placeholder(destination: &Path, is_directory: bool, placeholder: &File) {
+    use std::os::unix::fs::MetadataExt;
+
+    let Ok(expected) = placeholder.metadata() else {
+        return;
+    };
+    let Ok(actual) = fs::symlink_metadata(destination) else {
+        return;
+    };
+    if expected.dev() != actual.dev() || expected.ino() != actual.ino() {
+        return;
+    }
+    let cleanup = if is_directory {
+        fs::remove_dir(destination)
+    } else {
+        fs::remove_file(destination)
+    };
+    if let Err(error) = cleanup
+        && error.kind() != io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            path = %destination.display(),
+            error = %error,
+            "Failed to remove reserved trash rename placeholder"
+        );
     }
 }
 
@@ -450,6 +586,22 @@ mod tests {
         assert!(!marker.exists());
     }
 
+    #[test]
+    fn case_insensitive_reservation_markers_merge_case_only_destinations() {
+        let trash = Path::new("/trash");
+        let upper = trash.join("Kick.wav");
+        let lower = trash.join("kick.wav");
+
+        assert_eq!(
+            trash_reservation_marker_with_case_policy(trash, &upper, true),
+            trash_reservation_marker_with_case_policy(trash, &lower, true)
+        );
+        assert_ne!(
+            trash_reservation_marker_with_case_policy(trash, &upper, false),
+            trash_reservation_marker_with_case_policy(trash, &lower, false)
+        );
+    }
+
     #[cfg(any(
         target_os = "windows",
         target_os = "macos",
@@ -488,6 +640,86 @@ mod tests {
 
         assert!(!source.exists());
         assert_eq!(fs::read(&destination).unwrap(), b"source");
+    }
+
+    #[test]
+    fn non_cross_device_rename_errors_do_not_start_copy_fallback() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("destination.wav");
+        fs::write(&source, b"source").unwrap();
+
+        let error = move_path_after_no_replace_error(
+            &source,
+            &destination,
+            io::Error::from(io::ErrorKind::PermissionDenied),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("Move file to trash failed"));
+        assert_eq!(fs::read(&source).unwrap(), b"source");
+        assert!(!destination.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_placeholders_enable_same_volume_file_and_directory_renames() {
+        let temp = tempdir().unwrap();
+        let source_file = temp.path().join("source.wav");
+        let destination_file = temp.path().join("trash.wav");
+        let source_dir = temp.path().join("source-folder");
+        let destination_dir = temp.path().join("trash-folder");
+        fs::write(&source_file, b"source").unwrap();
+        fs::create_dir(&source_dir).unwrap();
+        fs::write(source_dir.join("child.wav"), b"child").unwrap();
+
+        rename_via_owned_placeholder(&source_file, &destination_file).unwrap();
+        rename_via_owned_placeholder(&source_dir, &destination_dir).unwrap();
+
+        assert!(!source_file.exists());
+        assert_eq!(fs::read(destination_file).unwrap(), b"source");
+        assert!(!source_dir.exists());
+        assert_eq!(
+            fs::read(destination_dir.join("child.wav")).unwrap(),
+            b"child"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_placeholder_cleanup_preserves_a_replaced_destination() {
+        let temp = tempdir().unwrap();
+        let destination = temp.path().join("trash.wav");
+        let placeholder = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&destination)
+            .unwrap();
+        fs::remove_file(&destination).unwrap();
+        fs::write(&destination, b"external").unwrap();
+
+        cleanup_owned_placeholder(&destination, false, &placeholder);
+
+        assert_eq!(fs::read(destination).unwrap(), b"external");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn unsupported_atomic_rename_uses_owned_same_volume_placeholder() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("trash.wav");
+        fs::write(&source, b"source").unwrap();
+
+        move_path_after_no_replace_error(
+            &source,
+            &destination,
+            io::Error::from_raw_os_error(libc::ENOSYS),
+        )
+        .unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(destination).unwrap(), b"source");
     }
 
     #[cfg(unix)]

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -45,7 +45,7 @@ fn move_path_to_configured_trash_inner(
     path: &Path,
     trash_folder: Option<&Path>,
 ) -> TrashMoveResult {
-    match path.try_exists() {
+    match path_entry_exists(path) {
         Ok(true) => {}
         Ok(false) => return TrashMoveResult::Missing,
         Err(error) => {
@@ -129,7 +129,7 @@ fn reserve_trash_path(
             name.into()
         };
         let candidate = trash_folder.join(name);
-        match trash_entry_exists(&candidate) {
+        match path_entry_exists(&candidate) {
             Ok(true) => continue,
             Ok(false) => {}
             Err(error) => {
@@ -146,7 +146,7 @@ fn reserve_trash_path(
             .open(&marker)
         {
             Ok(file) => {
-                match trash_entry_exists(&candidate) {
+                match path_entry_exists(&candidate) {
                     Ok(true) => {
                         drop(file);
                         let _ = fs::remove_file(marker);
@@ -177,7 +177,7 @@ fn reserve_trash_path(
     ))
 }
 
-fn trash_entry_exists(path: &Path) -> io::Result<bool> {
+fn path_entry_exists(path: &Path) -> io::Result<bool> {
     match fs::symlink_metadata(path) {
         Ok(_) => Ok(true),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
@@ -639,6 +639,28 @@ mod tests {
         );
         assert_eq!(fs::read(moved_path).unwrap(), b"kick");
         assert!(fs::symlink_metadata(broken_link).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_source_symlink_is_reported_as_failed_instead_of_missing() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source = temp.path().join("kick.wav");
+        fs::create_dir(&trash).unwrap();
+        symlink(temp.path().join("missing.wav"), &source).unwrap();
+        assert!(!source.exists());
+
+        let outcome = move_path_to_configured_trash(&source, Some(&trash));
+
+        assert!(matches!(
+            outcome.result,
+            TrashMoveResult::Failed { ref error }
+                if error.starts_with("Trash source is unavailable:")
+        ));
+        assert!(fs::symlink_metadata(source).is_ok());
     }
 
     #[test]

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -208,8 +208,11 @@ fn fallback_move_path(
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
     let mut directory_permissions = Vec::new();
+    let root_permissions = fs::metadata(source)?.permissions();
+    fs::create_dir(destination)?;
     let copy_result =
-        copy_dir_tree(source, destination, &mut directory_permissions).and_then(|()| {
+        copy_dir_contents(source, destination, &mut directory_permissions).and_then(|()| {
+            directory_permissions.push((destination.to_path_buf(), root_permissions));
             for (path, permissions) in directory_permissions {
                 fs::set_permissions(path, permissions)?;
             }
@@ -228,6 +231,16 @@ fn copy_dir_tree(
 ) -> io::Result<()> {
     let permissions = fs::metadata(source)?.permissions();
     fs::create_dir(destination)?;
+    copy_dir_contents(source, destination, directory_permissions)?;
+    directory_permissions.push((destination.to_path_buf(), permissions));
+    Ok(())
+}
+
+fn copy_dir_contents(
+    source: &Path,
+    destination: &Path,
+    directory_permissions: &mut Vec<(PathBuf, fs::Permissions)>,
+) -> io::Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let target = destination.join(entry.file_name());
@@ -237,9 +250,6 @@ fn copy_dir_tree(
             copy_file_exclusive(&entry.path(), &target)?;
         }
     }
-    // Post-order application keeps every parent traversable until all child
-    // modes have been restored and the complete copy is known to be durable.
-    directory_permissions.push((destination.to_path_buf(), permissions));
     Ok(())
 }
 
@@ -583,5 +593,30 @@ mod tests {
         assert!(error.contains("fallback failed"));
         assert_eq!(fs::read(&destination).unwrap(), b"external");
         assert_eq!(fs::read(&source).unwrap(), b"source");
+    }
+
+    #[test]
+    fn directory_fallback_does_not_remove_destination_created_by_another_actor() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("source.wav"), b"source").unwrap();
+        fs::create_dir(&destination).unwrap();
+        fs::write(destination.join("external.wav"), b"external").unwrap();
+
+        let error = fallback_move_path(
+            &source,
+            &destination,
+            &io::Error::from(io::ErrorKind::CrossesDevices),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("fallback failed"));
+        assert_eq!(
+            fs::read(destination.join("external.wav")).unwrap(),
+            b"external"
+        );
+        assert_eq!(fs::read(source.join("source.wav")).unwrap(), b"source");
     }
 }

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -1,73 +1,154 @@
 use std::{
-    fs,
+    fs::{self, File, OpenOptions},
+    io,
     path::{Path, PathBuf},
 };
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct TrashMoveOutcome {
+    pub source: PathBuf,
+    pub result: TrashMoveResult,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) enum TrashMoveResult {
+    Moved { destination: PathBuf },
+    Missing,
+    Failed { error: String },
+}
 
 pub(super) fn move_paths_to_configured_trash(
     paths: &[PathBuf],
     trash_folder: Option<&Path>,
-) -> Result<Vec<PathBuf>, String> {
-    let mut moved = Vec::with_capacity(paths.len());
-    for path in paths {
-        moved.push(move_path_to_configured_trash(path, trash_folder)?);
-    }
-    Ok(moved)
+) -> Vec<TrashMoveOutcome> {
+    paths
+        .iter()
+        .map(|path| move_path_to_configured_trash(path, trash_folder))
+        .collect()
 }
 
 pub(super) fn move_path_to_configured_trash(
     path: &Path,
     trash_folder: Option<&Path>,
-) -> Result<PathBuf, String> {
-    if !path.exists() {
-        return Err(format!("Trash move failed: {} is missing", path.display()));
+) -> TrashMoveOutcome {
+    let source_path = path.to_path_buf();
+    let result = move_path_to_configured_trash_inner(path, trash_folder);
+    TrashMoveOutcome {
+        source: source_path,
+        result,
     }
-    let trash_folder = trash_folder.ok_or_else(|| {
-        String::from("Set a trash folder in Settings > General before deleting files")
-    })?;
-    fs::create_dir_all(trash_folder).map_err(|err| format!("Create trash folder failed: {err}"))?;
-    let trash_folder = trash_folder
-        .canonicalize()
-        .map_err(|err| format!("Trash folder is unavailable: {err}"))?;
-    let source = path
-        .canonicalize()
-        .map_err(|err| format!("Trash source is unavailable: {err}"))?;
-    if source.starts_with(&trash_folder) {
-        return Err(String::from(
-            "Selected item is already inside the trash folder",
-        ));
-    }
-    if trash_folder.starts_with(&source) {
-        return Err(String::from(
-            "Trash folder cannot be inside the item being deleted",
-        ));
-    }
-    let destination = next_available_trash_path(&trash_folder, &source)?;
-    move_path(&source, &destination)?;
-    Ok(destination)
 }
 
-fn next_available_trash_path(trash_folder: &Path, source: &Path) -> Result<PathBuf, String> {
+fn move_path_to_configured_trash_inner(
+    path: &Path,
+    trash_folder: Option<&Path>,
+) -> TrashMoveResult {
+    if !path.exists() {
+        return TrashMoveResult::Missing;
+    }
+    let moved = (|| {
+        let trash_folder = trash_folder.ok_or_else(|| {
+            String::from("Set a trash folder in Settings > General before deleting files")
+        })?;
+        fs::create_dir_all(trash_folder)
+            .map_err(|err| format!("Create trash folder failed: {err}"))?;
+        let trash_folder = trash_folder
+            .canonicalize()
+            .map_err(|err| format!("Trash folder is unavailable: {err}"))?;
+        let source = path
+            .canonicalize()
+            .map_err(|err| format!("Trash source is unavailable: {err}"))?;
+        if source.starts_with(&trash_folder) {
+            return Err(String::from(
+                "Selected item is already inside the trash folder",
+            ));
+        }
+        if trash_folder.starts_with(&source) {
+            return Err(String::from(
+                "Trash folder cannot be inside the item being deleted",
+            ));
+        }
+        let reservation = reserve_trash_path(&trash_folder, &source)?;
+        move_path(&source, reservation.destination())?;
+        Ok(reservation.destination().to_path_buf())
+    })();
+    match moved {
+        Ok(destination) => TrashMoveResult::Moved { destination },
+        Err(error) => TrashMoveResult::Failed { error },
+    }
+}
+
+struct TrashDestinationReservation {
+    destination: PathBuf,
+    marker: PathBuf,
+    _file: File,
+}
+
+impl TrashDestinationReservation {
+    fn destination(&self) -> &Path {
+        &self.destination
+    }
+}
+
+impl Drop for TrashDestinationReservation {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.marker);
+    }
+}
+
+fn reserve_trash_path(
+    trash_folder: &Path,
+    source: &Path,
+) -> Result<TrashDestinationReservation, String> {
     let file_name = source
         .file_name()
         .ok_or_else(|| format!("Trash move failed: {} has no file name", source.display()))?;
-    let candidate = trash_folder.join(file_name);
-    if !candidate.exists() {
-        return Ok(candidate);
-    }
     let stem = source
         .file_stem()
         .map(|stem| stem.to_string_lossy().to_string())
         .unwrap_or_else(|| file_name.to_string_lossy().to_string());
     let extension = source.extension().map(|extension| extension.to_os_string());
-    for index in 2..10_000 {
-        let mut name = format!("{stem} {index}");
-        if let Some(extension) = &extension {
-            name.push('.');
-            name.push_str(&extension.to_string_lossy());
-        }
+    for index in 1..10_000 {
+        let name = if index == 1 {
+            file_name.to_os_string()
+        } else {
+            let mut name = format!("{stem} {index}");
+            if let Some(extension) = &extension {
+                name.push('.');
+                name.push_str(&extension.to_string_lossy());
+            }
+            name.into()
+        };
         let candidate = trash_folder.join(name);
-        if !candidate.exists() {
-            return Ok(candidate);
+        if candidate.exists() {
+            continue;
+        }
+        let marker = candidate.with_extension(format!(
+            "{}wavecrate-trash-reservation",
+            candidate
+                .extension()
+                .map(|value| format!("{}.", value.to_string_lossy()))
+                .unwrap_or_default()
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker)
+        {
+            Ok(file) => {
+                if candidate.exists() {
+                    drop(file);
+                    let _ = fs::remove_file(marker);
+                    continue;
+                }
+                return Ok(TrashDestinationReservation {
+                    destination: candidate,
+                    marker,
+                    _file: file,
+                });
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(format!("Reserve trash destination failed: {error}")),
         }
     }
     Err(String::from(
@@ -78,43 +159,67 @@ fn next_available_trash_path(trash_folder: &Path, source: &Path) -> Result<PathB
 fn move_path(source: &Path, destination: &Path) -> Result<(), String> {
     match fs::rename(source, destination) {
         Ok(()) => Ok(()),
-        Err(rename_error) => {
-            if source.is_dir() {
-                copy_dir_all(source, destination)
-                    .and_then(|()| fs::remove_dir_all(source))
-                    .map_err(|err| {
-                        format!(
-                            "Move folder to trash failed: {rename_error}; fallback failed: {err}"
-                        )
-                    })
-            } else {
-                fs::copy(source, destination)
-                    .and_then(|_| fs::remove_file(source))
-                    .map_err(|err| {
-                        format!("Move file to trash failed: {rename_error}; fallback failed: {err}")
-                    })
-            }
-        }
+        Err(rename_error) => fallback_move_path(source, destination, &rename_error),
+    }
+}
+
+fn fallback_move_path(
+    source: &Path,
+    destination: &Path,
+    rename_error: &io::Error,
+) -> Result<(), String> {
+    let fallback = if source.is_dir() {
+        copy_dir_all(source, destination).and_then(|()| fs::remove_dir_all(source))
+    } else {
+        copy_file_exclusive(source, destination).and_then(|()| fs::remove_file(source))
+    };
+    if let Err(error) = fallback {
+        remove_partial_destination(destination);
+        let kind = if source.is_dir() { "folder" } else { "file" };
+        Err(format!(
+            "Move {kind} to trash failed: {rename_error}; fallback failed: {error}"
+        ))
+    } else {
+        Ok(())
     }
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
-    fs::create_dir_all(destination)?;
+    fs::create_dir(destination)?;
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let target = destination.join(entry.file_name());
         if entry.file_type()?.is_dir() {
             copy_dir_all(&entry.path(), &target)?;
         } else {
-            fs::copy(entry.path(), target)?;
+            copy_file_exclusive(&entry.path(), &target)?;
         }
     }
     Ok(())
 }
 
+fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {
+    let mut input = File::open(source)?;
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)?;
+    io::copy(&mut input, &mut output)?;
+    output.sync_all()
+}
+
+fn remove_partial_destination(destination: &Path) {
+    if destination.is_dir() {
+        let _ = fs::remove_dir_all(destination);
+    } else {
+        let _ = fs::remove_file(destination);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
     use tempfile::tempdir;
 
     #[test]
@@ -129,9 +234,9 @@ mod tests {
         fs::write(trash.join("kick.wav"), b"old").unwrap();
         fs::write(trash.join("kick 2.wav"), b"old").unwrap();
 
-        let destination = next_available_trash_path(&trash, &source).unwrap();
+        let destination = reserve_trash_path(&trash, &source).unwrap();
 
-        assert_eq!(destination, trash.join("kick 3.wav"));
+        assert_eq!(destination.destination(), trash.join("kick 3.wav"));
     }
 
     #[test]
@@ -150,5 +255,86 @@ mod tests {
             fs::read(destination.join("nested").join("child.wav")).unwrap(),
             b"child"
         );
+    }
+
+    #[test]
+    fn batch_retains_successes_when_a_later_source_is_missing() {
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source_root = temp.path().join("source");
+        fs::create_dir_all(&source_root).unwrap();
+        let first = source_root.join("first.wav");
+        let missing = source_root.join("missing.wav");
+        fs::write(&first, b"first").unwrap();
+
+        let outcomes =
+            move_paths_to_configured_trash(&[first.clone(), missing.clone()], Some(&trash));
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(matches!(outcomes[0].result, TrashMoveResult::Moved { .. }));
+        assert_eq!(outcomes[1].result, TrashMoveResult::Missing);
+        assert!(!first.exists());
+        assert_eq!(fs::read(trash.join("first.wav")).unwrap(), b"first");
+    }
+
+    #[test]
+    fn concurrent_same_name_trash_moves_preserve_both_payloads() {
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let left_root = temp.path().join("left");
+        let right_root = temp.path().join("right");
+        fs::create_dir_all(&left_root).unwrap();
+        fs::create_dir_all(&right_root).unwrap();
+        let left = left_root.join("kick.wav");
+        let right = right_root.join("kick.wav");
+        fs::write(&left, b"left").unwrap();
+        fs::write(&right, b"right").unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles = [left, right].map(|source| {
+            let barrier = Arc::clone(&barrier);
+            let trash = trash.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                move_path_to_configured_trash(&source, Some(&trash))
+            })
+        });
+        let outcomes = handles.map(|handle| handle.join().unwrap());
+
+        assert!(
+            outcomes
+                .iter()
+                .all(|outcome| matches!(outcome.result, TrashMoveResult::Moved { .. }))
+        );
+        let mut payloads = fs::read_dir(&trash)
+            .unwrap()
+            .map(|entry| fs::read(entry.unwrap().path()).unwrap())
+            .collect::<Vec<_>>();
+        payloads.sort();
+        assert_eq!(payloads, vec![b"left".to_vec(), b"right".to_vec()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_fallback_copy_removes_partial_destination() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("copied.wav"), b"copied").unwrap();
+        symlink(source.join("missing.wav"), source.join("broken.wav")).unwrap();
+
+        let error = fallback_move_path(
+            &source,
+            &destination,
+            &io::Error::from(io::ErrorKind::CrossesDevices),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("fallback failed"));
+        assert!(source.exists());
+        assert!(!destination.exists());
     }
 }

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -169,10 +169,74 @@ fn trash_reservation_marker(trash_folder: &Path, candidate: &Path) -> PathBuf {
 }
 
 fn move_path(source: &Path, destination: &Path) -> Result<(), String> {
-    match fs::rename(source, destination) {
+    match rename_no_replace(source, destination) {
         Ok(()) => Ok(()),
         Err(rename_error) => fallback_move_path(source, destination, &rename_error),
     }
+}
+
+#[cfg(target_os = "windows")]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    // Windows rename already refuses to replace an existing destination.
+    fs::rename(source, destination)
+}
+
+#[cfg(target_os = "macos")]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result =
+        unsafe { libc::renamex_np(source.as_ptr(), destination.as_ptr(), libc::RENAME_EXCL) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+fn path_to_c_string(path: &Path) -> io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "trash move path contains an interior NUL byte",
+        )
+    })
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "android"
+)))]
+fn rename_no_replace(_source: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable on this platform",
+    ))
 }
 
 fn fallback_move_path(
@@ -384,6 +448,46 @@ mod tests {
         drop(reservation);
 
         assert!(!marker.exists());
+    }
+
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android"
+    ))]
+    #[test]
+    fn no_replace_rename_preserves_an_existing_destination() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("destination.wav");
+        fs::write(&source, b"source").unwrap();
+        fs::write(&destination, b"existing").unwrap();
+
+        let error = rename_no_replace(&source, &destination).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&source).unwrap(), b"source");
+        assert_eq!(fs::read(&destination).unwrap(), b"existing");
+    }
+
+    #[cfg(any(
+        target_os = "windows",
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android"
+    ))]
+    #[test]
+    fn no_replace_rename_moves_into_an_absent_destination() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("destination.wav");
+        fs::write(&source, b"source").unwrap();
+
+        rename_no_replace(&source, &destination).unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"source");
     }
 
     #[cfg(unix)]

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -129,8 +129,15 @@ fn reserve_trash_path(
             name.into()
         };
         let candidate = trash_folder.join(name);
-        if candidate.exists() {
-            continue;
+        match trash_entry_exists(&candidate) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(error) => {
+                return Err(format!(
+                    "Inspect trash destination {} failed: {error}",
+                    candidate.display()
+                ));
+            }
         }
         let marker = trash_reservation_marker(trash_folder, &candidate);
         match OpenOptions::new()
@@ -139,10 +146,21 @@ fn reserve_trash_path(
             .open(&marker)
         {
             Ok(file) => {
-                if candidate.exists() {
-                    drop(file);
-                    let _ = fs::remove_file(marker);
-                    continue;
+                match trash_entry_exists(&candidate) {
+                    Ok(true) => {
+                        drop(file);
+                        let _ = fs::remove_file(marker);
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        drop(file);
+                        let _ = fs::remove_file(marker);
+                        return Err(format!(
+                            "Inspect trash destination {} failed: {error}",
+                            candidate.display()
+                        ));
+                    }
                 }
                 return Ok(TrashDestinationReservation {
                     destination: candidate,
@@ -157,6 +175,14 @@ fn reserve_trash_path(
     Err(String::from(
         "Trash folder contains too many matching names",
     ))
+}
+
+fn trash_entry_exists(path: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 fn trash_reservation_marker(trash_folder: &Path, candidate: &Path) -> PathBuf {
@@ -584,6 +610,35 @@ mod tests {
         drop(reservation);
 
         assert!(!marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn trash_move_numbers_past_a_broken_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source_root = temp.path().join("source");
+        fs::create_dir(&trash).unwrap();
+        fs::create_dir(&source_root).unwrap();
+        let source = source_root.join("kick.wav");
+        fs::write(&source, b"kick").unwrap();
+        let broken_link = trash.join("kick.wav");
+        symlink(trash.join("missing.wav"), &broken_link).unwrap();
+        assert!(!broken_link.exists());
+
+        let outcome = move_path_to_configured_trash(&source, Some(&trash));
+        let moved_path = trash.canonicalize().unwrap().join("kick 2.wav");
+
+        assert_eq!(
+            outcome.result,
+            TrashMoveResult::Moved {
+                destination: moved_path.clone()
+            }
+        );
+        assert_eq!(fs::read(moved_path).unwrap(), b"kick");
+        assert!(fs::symlink_metadata(broken_link).is_ok());
     }
 
     #[test]

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::hash_map::DefaultHasher,
     fs::{self, File, OpenOptions},
+    hash::{Hash, Hasher},
     io,
     path::{Path, PathBuf},
 };
@@ -87,7 +89,7 @@ fn move_path_to_configured_trash_inner(
 struct TrashDestinationReservation {
     destination: PathBuf,
     marker: PathBuf,
-    _file: File,
+    file: Option<File>,
 }
 
 impl TrashDestinationReservation {
@@ -98,6 +100,7 @@ impl TrashDestinationReservation {
 
 impl Drop for TrashDestinationReservation {
     fn drop(&mut self) {
+        drop(self.file.take());
         let _ = fs::remove_file(&self.marker);
     }
 }
@@ -129,13 +132,7 @@ fn reserve_trash_path(
         if candidate.exists() {
             continue;
         }
-        let marker = candidate.with_extension(format!(
-            "{}wavecrate-trash-reservation",
-            candidate
-                .extension()
-                .map(|value| format!("{}.", value.to_string_lossy()))
-                .unwrap_or_default()
-        ));
+        let marker = trash_reservation_marker(trash_folder, &candidate);
         match OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -150,7 +147,7 @@ fn reserve_trash_path(
                 return Ok(TrashDestinationReservation {
                     destination: candidate,
                     marker,
-                    _file: file,
+                    file: Some(file),
                 });
             }
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
@@ -159,6 +156,15 @@ fn reserve_trash_path(
     }
     Err(String::from(
         "Trash folder contains too many matching names",
+    ))
+}
+
+fn trash_reservation_marker(trash_folder: &Path, candidate: &Path) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    candidate.hash(&mut hasher);
+    trash_folder.join(format!(
+        ".wavecrate-trash-reservation-{:016x}",
+        hasher.finish()
     ))
 }
 
@@ -181,7 +187,6 @@ fn fallback_move_path(
         copy_file_exclusive(source, destination)
     };
     if let Err(error) = copy_result {
-        remove_partial_destination(destination);
         let kind = if is_directory { "folder" } else { "file" };
         return Err(format!(
             "Move {kind} to trash failed: {rename_error}; fallback failed: {error}"
@@ -203,16 +208,22 @@ fn fallback_move_path(
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
     fs::create_dir(destination)?;
-    for entry in fs::read_dir(source)? {
-        let entry = entry?;
-        let target = destination.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_all(&entry.path(), &target)?;
-        } else {
-            copy_file_exclusive(&entry.path(), &target)?;
+    let copy_result = (|| {
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let target = destination.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_dir_all(&entry.path(), &target)?;
+            } else {
+                copy_file_exclusive(&entry.path(), &target)?;
+            }
         }
+        fs::set_permissions(destination, fs::metadata(source)?.permissions())
+    })();
+    if copy_result.is_err() {
+        let _ = fs::remove_dir_all(destination);
     }
-    Ok(())
+    copy_result
 }
 
 fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {
@@ -221,16 +232,16 @@ fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {
         .write(true)
         .create_new(true)
         .open(destination)?;
-    io::copy(&mut input, &mut output)?;
-    output.sync_all()
-}
-
-fn remove_partial_destination(destination: &Path) {
-    if destination.is_dir() {
-        let _ = fs::remove_dir_all(destination);
-    } else {
+    let copy_result = (|| {
+        io::copy(&mut input, &mut output)?;
+        output.sync_all()?;
+        fs::set_permissions(destination, fs::metadata(source)?.permissions())
+    })();
+    if copy_result.is_err() {
+        drop(output);
         let _ = fs::remove_file(destination);
     }
+    copy_result
 }
 
 #[cfg(test)]
@@ -257,6 +268,47 @@ mod tests {
     }
 
     #[test]
+    fn reservation_drop_closes_and_removes_marker() {
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source = temp.path().join("kick.wav");
+        fs::create_dir(&trash).unwrap();
+        fs::write(&source, b"kick").unwrap();
+        let reservation = reserve_trash_path(&trash, &source).unwrap();
+        let marker = reservation.marker.clone();
+        assert!(marker.exists());
+
+        drop(reservation);
+
+        assert!(!marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reservation_marker_stays_bounded_for_long_valid_file_names() {
+        let temp = tempdir().unwrap();
+        let trash = temp.path().join("trash");
+        let source_root = temp.path().join("source");
+        fs::create_dir(&trash).unwrap();
+        fs::create_dir(&source_root).unwrap();
+        let source = source_root.join(format!("{}.wav", "x".repeat(245)));
+        fs::write(&source, b"long name").unwrap();
+
+        let reservation = reserve_trash_path(&trash, &source).unwrap();
+
+        assert_eq!(reservation.destination().file_name(), source.file_name());
+        assert!(
+            reservation
+                .marker
+                .file_name()
+                .unwrap()
+                .as_encoded_bytes()
+                .len()
+                < 100
+        );
+    }
+
+    #[test]
     fn recursive_copy_preserves_nested_files() {
         let temp = tempdir().unwrap();
         let source = temp.path().join("source");
@@ -271,6 +323,39 @@ mod tests {
         assert_eq!(
             fs::read(destination.join("nested").join("child.wav")).unwrap(),
             b"child"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fallback_copies_preserve_file_and_directory_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("private.wav"), b"private").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o750)).unwrap();
+        fs::set_permissions(
+            source.join("private.wav"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+
+        copy_dir_all(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
+        assert_eq!(
+            fs::metadata(destination.join("private.wav"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
         );
     }
 
@@ -353,5 +438,25 @@ mod tests {
         assert!(error.contains("fallback failed"));
         assert!(source.exists());
         assert!(!destination.exists());
+    }
+
+    #[test]
+    fn fallback_does_not_remove_destination_created_by_another_actor() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("destination.wav");
+        fs::write(&source, b"source").unwrap();
+        fs::write(&destination, b"external").unwrap();
+
+        let error = fallback_move_path(
+            &source,
+            &destination,
+            &io::Error::from(io::ErrorKind::CrossesDevices),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("fallback failed"));
+        assert_eq!(fs::read(&destination).unwrap(), b"external");
+        assert_eq!(fs::read(&source).unwrap(), b"source");
     }
 }

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -207,6 +207,7 @@ fn fallback_move_path(
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let permissions = fs::metadata(source)?.permissions();
     fs::create_dir(destination)?;
     let copy_result = (|| {
         for entry in fs::read_dir(source)? {
@@ -218,7 +219,7 @@ fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
                 copy_file_exclusive(&entry.path(), &target)?;
             }
         }
-        fs::set_permissions(destination, fs::metadata(source)?.permissions())
+        fs::set_permissions(destination, permissions)
     })();
     if copy_result.is_err() {
         let _ = fs::remove_dir_all(destination);
@@ -227,7 +228,16 @@ fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
 }
 
 fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {
-    let mut input = File::open(source)?;
+    let input = File::open(source)?;
+    let permissions = input.metadata()?.permissions();
+    copy_open_file_exclusive(input, permissions, destination)
+}
+
+fn copy_open_file_exclusive(
+    mut input: File,
+    permissions: fs::Permissions,
+    destination: &Path,
+) -> io::Result<()> {
     let mut output = OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -235,7 +245,7 @@ fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {
     let copy_result = (|| {
         io::copy(&mut input, &mut output)?;
         output.sync_all()?;
-        fs::set_permissions(destination, fs::metadata(source)?.permissions())
+        fs::set_permissions(destination, permissions)
     })();
     if copy_result.is_err() {
         drop(output);
@@ -357,6 +367,21 @@ mod tests {
                 & 0o777,
             0o600
         );
+    }
+
+    #[test]
+    fn completed_copy_survives_when_source_path_disappears_after_open() {
+        let temp = tempdir().unwrap();
+        let source = temp.path().join("source.wav");
+        let destination = temp.path().join("trash.wav");
+        fs::write(&source, b"only copy").unwrap();
+        let input = File::open(&source).unwrap();
+        let permissions = input.metadata().unwrap().permissions();
+        fs::remove_file(&source).unwrap();
+
+        copy_open_file_exclusive(input, permissions, &destination).unwrap();
+
+        assert_eq!(fs::read(destination).unwrap(), b"only copy");
     }
 
     #[test]

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -43,8 +43,14 @@ fn move_path_to_configured_trash_inner(
     path: &Path,
     trash_folder: Option<&Path>,
 ) -> TrashMoveResult {
-    if !path.exists() {
-        return TrashMoveResult::Missing;
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return TrashMoveResult::Missing,
+        Err(error) => {
+            return TrashMoveResult::Failed {
+                error: format!("Trash source is unavailable: {error}"),
+            };
+        }
     }
     let moved = (|| {
         let trash_folder = trash_folder.ok_or_else(|| {
@@ -168,20 +174,31 @@ fn fallback_move_path(
     destination: &Path,
     rename_error: &io::Error,
 ) -> Result<(), String> {
-    let fallback = if source.is_dir() {
-        copy_dir_all(source, destination).and_then(|()| fs::remove_dir_all(source))
+    let is_directory = source.is_dir();
+    let copy_result = if is_directory {
+        copy_dir_all(source, destination)
     } else {
-        copy_file_exclusive(source, destination).and_then(|()| fs::remove_file(source))
+        copy_file_exclusive(source, destination)
     };
-    if let Err(error) = fallback {
+    if let Err(error) = copy_result {
         remove_partial_destination(destination);
-        let kind = if source.is_dir() { "folder" } else { "file" };
-        Err(format!(
+        let kind = if is_directory { "folder" } else { "file" };
+        return Err(format!(
             "Move {kind} to trash failed: {rename_error}; fallback failed: {error}"
-        ))
-    } else {
-        Ok(())
+        ));
     }
+    let cleanup_result = if is_directory {
+        fs::remove_dir_all(source)
+    } else {
+        fs::remove_file(source)
+    };
+    if let Err(error) = cleanup_result {
+        let kind = if is_directory { "folder" } else { "file" };
+        return Err(format!(
+            "Move {kind} to trash copied successfully, but source cleanup failed: {error}; the trash copy was preserved"
+        ));
+    }
+    Ok(())
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -222,9 +222,49 @@ fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
         fs::set_permissions(destination, permissions)
     })();
     if copy_result.is_err() {
-        let _ = fs::remove_dir_all(destination);
+        cleanup_partial_directory(destination);
     }
     copy_result
+}
+
+fn cleanup_partial_directory(destination: &Path) {
+    #[cfg(windows)]
+    clear_readonly_permissions(destination);
+    if let Err(error) = fs::remove_dir_all(destination)
+        && error.kind() != io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            path = %destination.display(),
+            error = %error,
+            "Failed to remove partial trash fallback copy"
+        );
+    }
+}
+
+#[cfg(windows)]
+fn clear_readonly_permissions(path: &Path) {
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let child = entry.path();
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+                clear_readonly_permissions(&child);
+            }
+            if let Ok(metadata) = fs::metadata(&child) {
+                let mut permissions = metadata.permissions();
+                if permissions.readonly() {
+                    permissions.set_readonly(false);
+                    let _ = fs::set_permissions(&child, permissions);
+                }
+            }
+        }
+    }
+    if let Ok(metadata) = fs::metadata(path) {
+        let mut permissions = metadata.permissions();
+        if permissions.readonly() {
+            permissions.set_readonly(false);
+            let _ = fs::set_permissions(path, permissions);
+        }
+    }
 }
 
 fn copy_file_exclusive(source: &Path, destination: &Path) -> io::Result<()> {

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -240,8 +240,66 @@ fn move_path_after_no_replace_error(
 }
 
 #[cfg(target_os = "windows")]
-fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+fn windows_wide_path(path: &Path) -> io::Result<Vec<u16>> {
     use std::os::windows::ffi::OsStrExt;
+
+    const LEGACY_MAX_PATH: usize = 248;
+    const SEP: u16 = b'\\' as u16;
+    const ALT_SEP: u16 = b'/' as u16;
+    const QUERY: u16 = b'?' as u16;
+    const COLON: u16 = b':' as u16;
+    const DOT: u16 = b'.' as u16;
+    const VERBATIM_PREFIX: &[u16] = &[SEP, SEP, QUERY, SEP];
+    const NT_PREFIX: &[u16] = &[SEP, QUERY, QUERY, SEP];
+    const UNC_PREFIX: &[u16] = &[
+        SEP,
+        SEP,
+        QUERY,
+        SEP,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        SEP,
+    ];
+
+    let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    if wide.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "trash move path contains an interior NUL code unit",
+        ));
+    }
+    if wide.is_empty() || wide.starts_with(VERBATIM_PREFIX) || wide.starts_with(NT_PREFIX) {
+        wide.push(0);
+        return Ok(wide);
+    }
+    if wide.len() + 1 < LEGACY_MAX_PATH
+        && (matches!(wide.as_slice(), [drive, COLON, SEP | ALT_SEP, ..] if *drive != SEP && *drive != ALT_SEP)
+            || matches!(wide.as_slice(), [SEP | ALT_SEP, SEP | ALT_SEP, ..]))
+    {
+        wide.push(0);
+        return Ok(wide);
+    }
+
+    let absolute = std::path::absolute(path)?;
+    let absolute = absolute.as_os_str().encode_wide().collect::<Vec<_>>();
+    let (prefix, skip) = match absolute.as_slice() {
+        [_, COLON, SEP, ..] => (VERBATIM_PREFIX, 0),
+        [SEP, SEP, DOT, SEP, ..] => (VERBATIM_PREFIX, 4),
+        [SEP, SEP, QUERY, SEP, ..] | [SEP, QUERY, QUERY, SEP, ..] => (&[][..], 0),
+        [SEP, SEP, ..] => (UNC_PREFIX, 2),
+        _ => (&[][..], 0),
+    };
+    wide.clear();
+    wide.reserve(prefix.len() + absolute.len() + 1);
+    wide.extend_from_slice(prefix);
+    wide.extend_from_slice(&absolute[skip..]);
+    wide.push(0);
+    Ok(wide)
+}
+
+#[cfg(target_os = "windows")]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
     use windows::{
         Win32::{
             Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_NOT_SAME_DEVICE},
@@ -250,20 +308,8 @@ fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
         core::{HRESULT, PCWSTR},
     };
 
-    fn wide_path(path: &Path) -> io::Result<Vec<u16>> {
-        let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
-        if wide.contains(&0) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "trash move path contains an interior NUL code unit",
-            ));
-        }
-        wide.push(0);
-        Ok(wide)
-    }
-
-    let source = wide_path(source)?;
-    let destination = wide_path(destination)?;
+    let source = windows_wide_path(source)?;
+    let destination = windows_wide_path(destination)?;
     let result = unsafe {
         MoveFileExW(
             PCWSTR(source.as_ptr()),
@@ -677,6 +723,28 @@ mod tests {
             trash_reservation_marker_with_case_policy(trash, &upper, false),
             trash_reservation_marker_with_case_policy(trash, &lower, false)
         );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_move_paths_preserve_short_and_extend_long_names() {
+        fn decoded(path: &Path) -> String {
+            let wide = windows_wide_path(path).unwrap();
+            String::from_utf16(wide.strip_suffix(&[0]).unwrap()).unwrap()
+        }
+
+        let short = Path::new(r"C:\packs\kick.wav");
+        assert_eq!(decoded(short), short.to_string_lossy());
+
+        let tail = format!(r"{}kick.wav", "nested\\".repeat(50));
+        let long_drive = PathBuf::from(format!(r"C:\packs\{tail}"));
+        assert_eq!(decoded(&long_drive), format!(r"\\?\C:\packs\{tail}"));
+
+        let long_unc = PathBuf::from(format!(r"\\server\share\{tail}"));
+        assert_eq!(decoded(&long_unc), format!(r"\\?\UNC\server\share\{tail}"));
+
+        let verbatim = PathBuf::from(format!(r"\\?\C:\packs\{tail}"));
+        assert_eq!(decoded(&verbatim), verbatim.to_string_lossy());
     }
 
     #[cfg(any(

--- a/src/native_app/sample_library/trash_actions/movement.rs
+++ b/src/native_app/sample_library/trash_actions/movement.rs
@@ -207,29 +207,44 @@ fn fallback_move_path(
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) -> std::io::Result<()> {
-    let permissions = fs::metadata(source)?.permissions();
-    fs::create_dir(destination)?;
-    let copy_result = (|| {
-        for entry in fs::read_dir(source)? {
-            let entry = entry?;
-            let target = destination.join(entry.file_name());
-            if entry.file_type()?.is_dir() {
-                copy_dir_all(&entry.path(), &target)?;
-            } else {
-                copy_file_exclusive(&entry.path(), &target)?;
+    let mut directory_permissions = Vec::new();
+    let copy_result =
+        copy_dir_tree(source, destination, &mut directory_permissions).and_then(|()| {
+            for (path, permissions) in directory_permissions {
+                fs::set_permissions(path, permissions)?;
             }
-        }
-        fs::set_permissions(destination, permissions)
-    })();
+            Ok(())
+        });
     if copy_result.is_err() {
         cleanup_partial_directory(destination);
     }
     copy_result
 }
 
+fn copy_dir_tree(
+    source: &Path,
+    destination: &Path,
+    directory_permissions: &mut Vec<(PathBuf, fs::Permissions)>,
+) -> io::Result<()> {
+    let permissions = fs::metadata(source)?.permissions();
+    fs::create_dir(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let target = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_tree(&entry.path(), &target, directory_permissions)?;
+        } else {
+            copy_file_exclusive(&entry.path(), &target)?;
+        }
+    }
+    // Post-order application keeps every parent traversable until all child
+    // modes have been restored and the complete copy is known to be durable.
+    directory_permissions.push((destination.to_path_buf(), permissions));
+    Ok(())
+}
+
 fn cleanup_partial_directory(destination: &Path) {
-    #[cfg(windows)]
-    clear_readonly_permissions(destination);
+    make_tree_removable(destination);
     if let Err(error) = fs::remove_dir_all(destination)
         && error.kind() != io::ErrorKind::NotFound
     {
@@ -240,6 +255,34 @@ fn cleanup_partial_directory(destination: &Path) {
         );
     }
 }
+
+#[cfg(unix)]
+fn make_tree_removable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return;
+    };
+    if !metadata.file_type().is_dir() {
+        return;
+    }
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(permissions.mode() | 0o700);
+    let _ = fs::set_permissions(path, permissions);
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            make_tree_removable(&entry.path());
+        }
+    }
+}
+
+#[cfg(windows)]
+fn make_tree_removable(path: &Path) {
+    clear_readonly_permissions(path);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn make_tree_removable(_path: &Path) {}
 
 #[cfg(windows)]
 fn clear_readonly_permissions(path: &Path) {
@@ -502,6 +545,23 @@ mod tests {
 
         assert!(error.contains("fallback failed"));
         assert!(source.exists());
+        assert!(!destination.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn partial_cleanup_removes_restrictive_copied_subdirectories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let destination = temp.path().join("partial");
+        let restricted = destination.join("restricted");
+        fs::create_dir_all(&restricted).unwrap();
+        fs::write(restricted.join("copied.wav"), b"copied").unwrap();
+        fs::set_permissions(&restricted, fs::Permissions::from_mode(0o500)).unwrap();
+
+        cleanup_partial_directory(&destination);
+
         assert!(!destination.exists());
     }
 

--- a/src/native_app/sample_library/trash_actions/routing.rs
+++ b/src/native_app/sample_library/trash_actions/routing.rs
@@ -279,6 +279,15 @@ impl NativeAppState {
             .iter()
             .filter(|outcome| matches!(outcome.result, TrashMoveResult::Moved { .. }))
             .count();
+        let missing_count = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome.result, TrashMoveResult::Missing))
+            .count();
+        let failed_paths = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome.result, TrashMoveResult::Failed { .. }))
+            .map(|outcome| outcome.source.clone())
+            .collect::<Vec<_>>();
         let failures = outcomes
             .iter()
             .filter_map(|outcome| match &outcome.result {
@@ -297,9 +306,10 @@ impl NativeAppState {
         let discarded = self
             .library
             .folder_browser
-            .discard_trashed_file_paths_matching_tags(
+            .discard_trashed_file_paths_matching_tags_preserving_selection(
                 &reconciled_paths,
                 &self.metadata.tags_by_file,
+                &failed_paths,
             );
         let selected_after_trash = if discarded {
             self.library
@@ -320,25 +330,15 @@ impl NativeAppState {
             loaded_removed,
             context,
         );
+        let (status, outcome) =
+            trash_batch_completion(moved_count, missing_count, &failures, action);
+        self.ui.status.sample = status;
         let noun = if moved_count == 1 { "file" } else { "files" };
-        self.ui.status.sample = if failures.is_empty() {
-            trash_move_finished_status(moved_count, noun, action)
-        } else {
-            format!(
-                "Moved {moved_count} {noun} to trash; {} failed: {}",
-                failures.len(),
-                failures.join("; ")
-            )
-        };
         emit_gui_action(
             action,
             Some("browser"),
             Some(&format!("{moved_count} {noun}")),
-            if failures.is_empty() {
-                "success"
-            } else {
-                "partial"
-            },
+            outcome,
             started_at,
             failures.first().copied(),
         );
@@ -467,6 +467,86 @@ impl NativeAppState {
         } else {
             vec![path]
         }
+    }
+}
+
+fn trash_batch_completion(
+    moved_count: usize,
+    missing_count: usize,
+    failures: &[&str],
+    action: &str,
+) -> (String, &'static str) {
+    let noun = if moved_count == 1 { "file" } else { "files" };
+    let failure_summary = bounded_failure_summary(failures);
+    if moved_count == 0 && !failures.is_empty() {
+        return (
+            format!(
+                "Failed to move {} files to trash: {failure_summary}",
+                failures.len()
+            ),
+            "error",
+        );
+    }
+    if !failures.is_empty() {
+        return (
+            format!(
+                "Moved {moved_count} {noun} to trash; {} failed: {failure_summary}",
+                failures.len()
+            ),
+            "partial",
+        );
+    }
+    if moved_count == 0 && missing_count > 0 {
+        let noun = if missing_count == 1 { "file" } else { "files" };
+        return (
+            format!("Removed {missing_count} missing {noun} from the browser"),
+            "reconciled",
+        );
+    }
+    (
+        trash_move_finished_status(moved_count, noun, action),
+        "success",
+    )
+}
+
+fn bounded_failure_summary(failures: &[&str]) -> String {
+    const MAX_VISIBLE_FAILURES: usize = 3;
+    let mut summary = failures
+        .iter()
+        .take(MAX_VISIBLE_FAILURES)
+        .copied()
+        .collect::<Vec<_>>()
+        .join("; ");
+    let remaining = failures.len().saturating_sub(MAX_VISIBLE_FAILURES);
+    if remaining > 0 {
+        summary.push_str(&format!("; and {remaining} more"));
+    }
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_failed_batch_reports_error_and_caps_details() {
+        let failures = ["one", "two", "three", "four", "five"];
+
+        let (status, outcome) = trash_batch_completion(0, 0, &failures, "trash");
+
+        assert_eq!(outcome, "error");
+        assert_eq!(
+            status,
+            "Failed to move 5 files to trash: one; two; three; and 2 more"
+        );
+    }
+
+    #[test]
+    fn missing_only_batch_reports_reconciliation() {
+        let (status, outcome) = trash_batch_completion(0, 2, &[], "trash");
+
+        assert_eq!(outcome, "reconciled");
+        assert_eq!(status, "Removed 2 missing files from the browser");
     }
 }
 

--- a/src/native_app/sample_library/trash_actions/routing.rs
+++ b/src/native_app/sample_library/trash_actions/routing.rs
@@ -1,6 +1,9 @@
 use std::{path::PathBuf, time::Instant};
 
-use super::movement::{move_path_to_configured_trash, move_paths_to_configured_trash};
+use super::movement::{
+    TrashMoveOutcome, TrashMoveResult, move_path_to_configured_trash,
+    move_paths_to_configured_trash,
+};
 use crate::native_app::app::{
     GuiMessage, NativeAppState, PendingFolderDelete, TrashMoveTarget, emit_gui_action,
     sample_path_label,
@@ -184,15 +187,17 @@ impl NativeAppState {
             {
                 let path = path.clone();
                 move |_| {
-                    move_path_to_configured_trash(&path, trash_folder.as_deref())
-                        .map(|destination| vec![destination])
+                    vec![move_path_to_configured_trash(
+                        &path,
+                        trash_folder.as_deref(),
+                    )]
                 }
             },
-            move |result| GuiMessage::TrashMoveFinished {
+            move |outcomes| GuiMessage::TrashMoveFinished {
                 target: TrashMoveTarget::Folder(path),
                 action,
                 started_at,
-                result,
+                outcomes,
             },
         );
     }
@@ -202,22 +207,31 @@ impl NativeAppState {
         target: TrashMoveTarget,
         action: &'static str,
         started_at: Instant,
-        result: Result<Vec<PathBuf>, String>,
+        outcomes: Vec<TrashMoveOutcome>,
         context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
     ) {
-        match (target, result) {
-            (TrashMoveTarget::Folder(path), Ok(moved)) => {
-                let destination = moved.first().cloned().unwrap_or_else(|| path.clone());
-                self.finish_folder_trash_move(path, destination, action, started_at);
+        match target {
+            TrashMoveTarget::Folder(path) => {
+                match outcomes.first().map(|outcome| &outcome.result) {
+                    Some(TrashMoveResult::Moved { destination }) => {
+                        self.finish_folder_trash_move(path, destination.clone(), action, started_at)
+                    }
+                    Some(TrashMoveResult::Missing) => {
+                        self.finish_folder_trash_move_missing(path, action, started_at);
+                    }
+                    Some(TrashMoveResult::Failed { error }) => {
+                        self.finish_trash_move_error(Some(path), action, started_at, error.clone())
+                    }
+                    None => self.finish_trash_move_error(
+                        Some(path),
+                        action,
+                        started_at,
+                        String::from("Trash move produced no outcome"),
+                    ),
+                }
             }
-            (TrashMoveTarget::Files(paths), Ok(moved)) => {
-                self.finish_file_trash_move(paths, moved.len(), action, started_at, context);
-            }
-            (TrashMoveTarget::Folder(path), Err(error)) => {
-                self.finish_folder_trash_move_error(path, action, started_at, error);
-            }
-            (TrashMoveTarget::Files(_), Err(error)) => {
-                self.finish_trash_move_error(None, action, started_at, error);
+            TrashMoveTarget::Files(_) => {
+                self.finish_file_trash_move(outcomes, action, started_at, context);
             }
         }
     }
@@ -246,24 +260,47 @@ impl NativeAppState {
 
     fn finish_file_trash_move(
         &mut self,
-        paths: Vec<PathBuf>,
-        moved_count: usize,
+        outcomes: Vec<TrashMoveOutcome>,
         action: &'static str,
         started_at: Instant,
         context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
     ) {
+        let reconciled_paths = outcomes
+            .iter()
+            .filter(|outcome| {
+                matches!(
+                    outcome.result,
+                    TrashMoveResult::Moved { .. } | TrashMoveResult::Missing
+                )
+            })
+            .map(|outcome| outcome.source.clone())
+            .collect::<Vec<_>>();
+        let moved_count = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome.result, TrashMoveResult::Moved { .. }))
+            .count();
+        let failures = outcomes
+            .iter()
+            .filter_map(|outcome| match &outcome.result {
+                TrashMoveResult::Failed { error } => Some(error.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
         let previous_selected = self
             .library
             .folder_browser
             .selected_file_id()
             .map(str::to_owned);
-        let loaded_removed = paths
+        let loaded_removed = reconciled_paths
             .iter()
             .any(|path| self.waveform.current.path() == path.as_path());
         let discarded = self
             .library
             .folder_browser
-            .discard_trashed_file_paths_matching_tags(&paths, &self.metadata.tags_by_file);
+            .discard_trashed_file_paths_matching_tags(
+                &reconciled_paths,
+                &self.metadata.tags_by_file,
+            );
         let selected_after_trash = if discarded {
             self.library
                 .folder_browser
@@ -274,7 +311,7 @@ impl NativeAppState {
         };
         let focus_changed =
             discarded && previous_selected.as_deref() != selected_after_trash.as_deref();
-        for path in &paths {
+        for path in &reconciled_paths {
             self.clear_loaded_sample_if_exact(path);
         }
         self.load_selected_sample_after_trash_if_needed(
@@ -284,14 +321,26 @@ impl NativeAppState {
             context,
         );
         let noun = if moved_count == 1 { "file" } else { "files" };
-        self.ui.status.sample = trash_move_finished_status(moved_count, noun, action);
+        self.ui.status.sample = if failures.is_empty() {
+            trash_move_finished_status(moved_count, noun, action)
+        } else {
+            format!(
+                "Moved {moved_count} {noun} to trash; {} failed: {}",
+                failures.len(),
+                failures.join("; ")
+            )
+        };
         emit_gui_action(
             action,
             Some("browser"),
             Some(&format!("{moved_count} {noun}")),
-            "success",
+            if failures.is_empty() {
+                "success"
+            } else {
+                "partial"
+            },
             started_at,
-            None,
+            failures.first().copied(),
         );
     }
 
@@ -329,32 +378,27 @@ impl NativeAppState {
         self.load_navigation_sample(selected, context);
     }
 
-    fn finish_folder_trash_move_error(
+    fn finish_folder_trash_move_missing(
         &mut self,
         path: PathBuf,
         action: &'static str,
         started_at: Instant,
-        error: String,
     ) {
-        if is_missing_trash_move_error(&error) {
-            self.library
-                .folder_browser
-                .discard_trashed_folder_path(&path);
-            self.clear_loaded_sample_if_path_within(&path);
-            let label = sample_path_label(&path);
-            self.ui.status.sample =
-                format!("Folder {label} no longer exists; removed it from the browser");
-            emit_gui_action(
-                action,
-                Some("folder_browser"),
-                Some(label.as_str()),
-                "reconciled",
-                started_at,
-                Some("folder missing"),
-            );
-            return;
-        }
-        self.finish_trash_move_error(Some(path), action, started_at, error);
+        self.library
+            .folder_browser
+            .discard_trashed_folder_path(&path);
+        self.clear_loaded_sample_if_path_within(&path);
+        let label = sample_path_label(&path);
+        self.ui.status.sample =
+            format!("Folder {label} no longer exists; removed it from the browser");
+        emit_gui_action(
+            action,
+            Some("folder_browser"),
+            Some(label.as_str()),
+            "reconciled",
+            started_at,
+            Some("folder missing"),
+        );
     }
 
     fn finish_trash_move_error(
@@ -407,11 +451,11 @@ impl NativeAppState {
                 let paths = paths.clone();
                 move |_| move_paths_to_configured_trash(&paths, trash_folder.as_deref())
             },
-            move |result| GuiMessage::TrashMoveFinished {
+            move |outcomes| GuiMessage::TrashMoveFinished {
                 target: TrashMoveTarget::Files(paths),
                 action,
                 started_at,
-                result,
+                outcomes,
             },
         );
     }
@@ -444,8 +488,4 @@ fn trash_move_finished_status(count: usize, noun: &str, action: &str) -> String 
         return format!("Moved {count} {noun} to trash after fourth negative rating");
     }
     format!("Moved {count} {noun} to trash")
-}
-
-fn is_missing_trash_move_error(error: &str) -> bool {
-    error.starts_with("Trash move failed: ") && error.ends_with(" is missing")
 }

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -150,8 +150,8 @@ impl NativeAppState {
                 target,
                 action,
                 started_at,
-                result,
-            } => self.finish_trash_move(target, action, started_at, result, context),
+                outcomes,
+            } => self.finish_trash_move(target, action, started_at, outcomes, context),
             GuiMessage::ContextTargetOpenFinished { kind, path, result } => {
                 self.finish_context_target_open(kind, path, result);
             }

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -1634,12 +1634,17 @@ fn trashing_selected_block_materializes_remaining_rows_and_loads_next_sample() {
     for path in &trashed {
         fs::remove_file(path).expect("trash source removal");
     }
-    let moved = trashed
+    let outcomes = trashed
         .iter()
         .map(|path| {
-            trash_root
-                .path()
-                .join(path.file_name().expect("sample file name"))
+            crate::native_app::sample_library::trash_actions::movement::TrashMoveOutcome {
+                source: path.clone(),
+                result: crate::native_app::sample_library::trash_actions::movement::TrashMoveResult::Moved {
+                    destination: trash_root
+                        .path()
+                        .join(path.file_name().expect("sample file name")),
+                },
+            }
         })
         .collect::<Vec<_>>();
     let mut context = radiant::prelude::UiUpdateContext::default();
@@ -1648,7 +1653,7 @@ fn trashing_selected_block_materializes_remaining_rows_and_loads_next_sample() {
         crate::native_app::app::TrashMoveTarget::Files(trashed),
         "browser.delete_selected_files",
         std::time::Instant::now(),
-        Ok(moved),
+        outcomes,
         &mut context,
     );
 
@@ -1684,6 +1689,76 @@ fn trashing_selected_block_materializes_remaining_rows_and_loads_next_sample() {
             .any(|stem| stem == "sample_068"),
         "remaining rows should include the next sample after the trashed block: {:?}",
         projection.first_stems
+    );
+}
+
+#[test]
+fn partial_batch_trash_reconciles_moved_rows_and_keeps_failed_rows() {
+    use crate::native_app::sample_library::trash_actions::movement::{
+        TrashMoveOutcome, TrashMoveResult,
+    };
+
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    let moved = source_root.path().join("a-moved.wav");
+    let failed = source_root.path().join("b-failed.wav");
+    let untouched = source_root.path().join("c-untouched.wav");
+    for sample in [&moved, &failed, &untouched] {
+        write_test_wav_i16(sample, &[0, 256, -256, 512]);
+    }
+    state.library.folder_browser =
+        FolderBrowserState::from_sample_sources(&[wavecrate::sample_sources::SampleSource::new(
+            source_root.path().to_path_buf(),
+        )]);
+    state
+        .library
+        .folder_browser
+        .select_file(moved.display().to_string());
+    fs::remove_file(&moved).expect("simulate completed first trash move");
+    let mut context = radiant::prelude::UiUpdateContext::default();
+
+    state.finish_trash_move(
+        crate::native_app::app::TrashMoveTarget::Files(vec![moved.clone(), failed.clone()]),
+        "browser.delete_selected_files",
+        std::time::Instant::now(),
+        vec![
+            TrashMoveOutcome {
+                source: moved.clone(),
+                result: TrashMoveResult::Moved {
+                    destination: source_root.path().join("trash").join("a-moved.wav"),
+                },
+            },
+            TrashMoveOutcome {
+                source: failed.clone(),
+                result: TrashMoveResult::Failed {
+                    error: String::from("injected second-item failure"),
+                },
+            },
+        ],
+        &mut context,
+    );
+
+    let visible = state.library.folder_browser.selected_audio_files();
+    assert!(!visible.iter().any(|file| file.name == "a-moved.wav"));
+    assert!(visible.iter().any(|file| file.name == "b-failed.wav"));
+    assert!(visible.iter().any(|file| file.name == "c-untouched.wav"));
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        Some(failed.display().to_string().as_str())
+    );
+    assert!(
+        state
+            .ui
+            .status
+            .sample
+            .contains("Moved 1 file to trash; 1 failed")
+    );
+    assert!(
+        state
+            .ui
+            .status
+            .sample
+            .contains("injected second-item failure")
     );
 }
 


### PR DESCRIPTION
## Scope

- return one observable trash outcome per source path instead of short-circuiting a batch
- reconcile every moved or already-missing file even when another item fails
- atomically reserve numbered trash destinations so concurrent same-name moves preserve both payloads
- use exclusive fallback copies and remove partial destinations when copy or source cleanup fails
- preserve loaded-sample and browser-selection cleanup for the successfully reconciled subset

## Definition of Done

- [x] a later filesystem failure cannot hide earlier successful moves from browser reconciliation
- [x] concurrent same-name trash requests cannot overwrite one another
- [x] partial cross-filesystem copies are removed on failure
- [x] each requested path has an explicit moved, missing, or failed outcome
- [x] focused tests cover partial batch failure, collision races, copy cleanup, and selection reconciliation

## Validation commands

- `cargo test -p wavecrate native_app::sample_library::trash_actions::movement::tests -- --nocapture`
- `cargo test -p wavecrate partial_batch_trash_reconciles_moved_rows_and_keeps_failed_rows -- --nocapture`
- `cargo check -p wavecrate --all-targets`
- `cargo test -p wavecrate trash -- --nocapture` (26 native trash tests passed; two unrelated existing native tests failed)
- `cargo clippy -p wavecrate --all-targets --no-deps -- -D warnings` (blocked by existing main findings outside this scope)

## Known limitations

- Manual desktop interaction testing was unavailable while the user was away.
- The broad trash-name filter includes two existing failures: `trashing_selected_block_materializes_remaining_rows_and_loads_next_sample` and `third_negative_rating_does_not_auto_trash_selected_file`.
- Strict Clippy is blocked by existing findings in selection export, macOS external drag, duplicate WAV handling, cross-source metadata persistence, and one test-only updater helper.

User review is required before merge.
