### PR TITLE
OPT-1084 Group random section play with Play

### DIFF
--- a/src/native_app/app_chrome/toolbar/projection.rs
+++ b/src/native_app/app_chrome/toolbar/projection.rs
@@ -10,15 +10,16 @@ use crate::native_app::app_chrome::toolbar::{
 use crate::native_app::app_chrome::view_models::toolbar::MainToolbarViewModel;
 
 const FOCUS_LOADED_TOOLTIP: &str = "Focus the loaded sample in the browser.";
-const LOOP_TOOLTIP: &str = "Loop preview playback.";
-const RANDOM_TOOLTIP: &str = "Random section playback\nClick: play a random section now.\nShift-click: pick a random listed sample first.\nCommand-click: make Space use random sections.";
+const LOOP_TOOLTIP: &str = "Loop";
+const RANDOM_TOOLTIP: &str = "Play random section\nClick: play a random section now.\nShift-click: pick a random listed sample first.\nCommand-click: make Space use random sections.";
 const SIMILAR_SECTIONS_TOOLTIP: &str = "Mark sections similar to the playmark selection.\nSet a playmark first, then toggle this to scan the loaded sample.";
 const ZERO_CROSSING_SNAP_TOOLTIP: &str = "Snap play and edit mark edges to nearby zero crossings.";
 const BEAT_GUIDES_TOOLTIP: &str = "Show beat guide lines inside the play selection.";
 const METRONOME_TOOLTIP: &str = "Play a metronome from the beat guide divisions.";
 const BEAT_GUIDE_COUNT_TOOLTIP: &str = "Beat guide divisions.";
 const APPLY_EDIT_MARK_EDITS_TOOLTIP: &str = "Apply edit mark gain and fade edits.";
-const PLAY_TOOLTIP: &str = "Play the selected sample.";
+const PLAY_TOOLTIP: &str = "Play";
+const PAUSE_TOOLTIP: &str = "Pause";
 const STOP_TOOLTIP: &str = "Stop preview playback.";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -44,14 +45,6 @@ impl ToolbarProjection {
                 true,
                 model.loop_playback,
                 LOOP_TOOLTIP,
-            )
-            .into(),
-            ToolbarIconButtonProjection::new(
-                TOOLBAR_RANDOM_ID,
-                ToolbarIcon::Random,
-                model.random_available,
-                model.sticky_random_sample_range_playback,
-                RANDOM_TOOLTIP,
             )
             .into(),
             ToolbarIconButtonProjection::new(
@@ -104,11 +97,25 @@ impl ToolbarProjection {
 
         controls.push(
             ToolbarIconButtonProjection::new(
+                TOOLBAR_RANDOM_ID,
+                ToolbarIcon::Random,
+                model.random_available,
+                model.sticky_random_sample_range_playback,
+                RANDOM_TOOLTIP,
+            )
+            .into(),
+        );
+        controls.push(
+            ToolbarIconButtonProjection::new(
                 TOOLBAR_PLAY_ID,
                 ToolbarIcon::Play,
                 true,
                 model.playing,
-                PLAY_TOOLTIP,
+                if model.playing {
+                    PAUSE_TOOLTIP
+                } else {
+                    PLAY_TOOLTIP
+                },
             )
             .into(),
         );

--- a/src/native_app/app_chrome/toolbar/projection.rs
+++ b/src/native_app/app_chrome/toolbar/projection.rs
@@ -19,7 +19,6 @@ const METRONOME_TOOLTIP: &str = "Play a metronome from the beat guide divisions.
 const BEAT_GUIDE_COUNT_TOOLTIP: &str = "Beat guide divisions.";
 const APPLY_EDIT_MARK_EDITS_TOOLTIP: &str = "Apply edit mark gain and fade edits.";
 const PLAY_TOOLTIP: &str = "Play";
-const PAUSE_TOOLTIP: &str = "Pause";
 const STOP_TOOLTIP: &str = "Stop preview playback.";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -111,11 +110,7 @@ impl ToolbarProjection {
                 ToolbarIcon::Play,
                 true,
                 model.playing,
-                if model.playing {
-                    PAUSE_TOOLTIP
-                } else {
-                    PLAY_TOOLTIP
-                },
+                PLAY_TOOLTIP,
             )
             .into(),
         );

--- a/src/native_app/tests/toolbar_playback/basics.rs
+++ b/src/native_app/tests/toolbar_playback/basics.rs
@@ -226,27 +226,24 @@ fn main_toolbar_control_projection_makes_order_and_identity_explicit() {
     );
     assert_eq!(icon_control(1).icon, ToolbarIcon::Loop);
     assert!(icon_control(1).active);
-    assert_eq!(icon_control(2).icon, ToolbarIcon::Random);
-    assert!(icon_control(2).enabled);
+    assert_eq!(icon_control(1).tooltip, "Loop");
+    assert_eq!(icon_control(2).icon, ToolbarIcon::SimilarSections);
+    assert!(icon_control(2).icon_enabled);
     assert!(icon_control(2).active);
-    assert!(icon_control(2).tooltip.contains("Shift-click"));
-    assert_eq!(icon_control(3).icon, ToolbarIcon::SimilarSections);
-    assert!(icon_control(3).icon_enabled);
+    assert_eq!(icon_control(3).icon, ToolbarIcon::ZeroCrossingSnap);
     assert!(icon_control(3).active);
-    assert_eq!(icon_control(4).icon, ToolbarIcon::ZeroCrossingSnap);
-    assert!(icon_control(4).active);
     assert_eq!(
-        icon_control(4).tooltip,
+        icon_control(3).tooltip,
         "Snap play and edit mark edges to nearby zero crossings."
     );
     assert_eq!(
-        icon_control(4).id,
+        icon_control(3).id,
         crate::native_app::test_support::toolbar::TOOLBAR_ZERO_CROSSING_SNAP_ID
     );
-    assert_eq!(icon_control(5).icon, ToolbarIcon::BeatGuides);
-    assert!(icon_control(5).active);
+    assert_eq!(icon_control(4).icon, ToolbarIcon::BeatGuides);
+    assert!(icon_control(4).active);
     assert!(matches!(
-        projection.controls[6],
+        projection.controls[5],
         ToolbarControlProjection::BeatGuideCountField {
             count: 8,
             id: crate::native_app::test_support::toolbar::TOOLBAR_BEAT_GUIDE_COUNT_ID,
@@ -254,27 +251,32 @@ fn main_toolbar_control_projection_makes_order_and_identity_explicit() {
             tooltip: "Beat guide divisions.",
         }
     ));
-    assert_eq!(icon_control(7).icon, ToolbarIcon::Metronome);
+    assert_eq!(icon_control(6).icon, ToolbarIcon::Metronome);
     assert_eq!(
-        icon_control(7).id,
+        icon_control(6).id,
         crate::native_app::test_support::toolbar::TOOLBAR_METRONOME_ID
     );
-    assert!(icon_control(7).active);
+    assert!(icon_control(6).active);
     assert_eq!(
-        icon_control(7).tooltip,
+        icon_control(6).tooltip,
         "Play a metronome from the beat guide divisions."
     );
 
     assert!(matches!(
-        projection.controls[8],
+        projection.controls[7],
         ToolbarControlProjection::ApplyEditMarkEdits {
             id: crate::native_app::test_support::toolbar::TOOLBAR_APPLY_EDIT_MARK_EDITS_ID,
             tooltip: "Apply edit mark gain and fade edits.",
         }
     ));
 
+    assert_eq!(icon_control(8).icon, ToolbarIcon::Random);
+    assert!(icon_control(8).enabled);
+    assert!(icon_control(8).active);
+    assert!(icon_control(8).tooltip.starts_with("Play random section"));
     assert_eq!(icon_control(9).icon, ToolbarIcon::Play);
     assert!(!icon_control(9).active);
+    assert_eq!(icon_control(9).tooltip, "Play");
     assert_eq!(icon_control(10).icon, ToolbarIcon::Stop);
     assert_eq!(
         icon_control(10).id,
@@ -333,7 +335,7 @@ fn random_toolbar_help_tooltip_paints_multiline_guidance() {
     runtime.dispatch_event(Event::pointer_move(random.center()));
 
     let frame = runtime.frame_with_default_theme();
-    assert!(frame.paint_plan.contains_text("Random section playback"));
+    assert!(frame.paint_plan.contains_text("Play random section"));
     assert!(
         frame
             .paint_plan


### PR DESCRIPTION
## Scope

- move Random Section Play immediately before Play/Pause in toolbar composition and focus order
- leave Loop in the earlier playback-mode group, separated by the editing/metronome controls
- preserve stable control IDs, actions, modifiers, sizing, active states, and hotkeys
- clarify tooltips as `Play random section`, `Play` / `Pause`, and `Loop`
- update projection and rendered-tooltip regressions for the new order

## Definition of Done

- [x] Random Section Play is immediately left of Play/Pause
- [x] Loop is visually and semantically separated
- [x] control identity and action routing are unchanged
- [x] focus order follows visual order
- [x] toolbar sizing remains unchanged

## Validation commands

- `cargo test -p wavecrate native_app::tests::toolbar_playback::basics -- --nocapture`
- `cargo test -p wavecrate toolbar_playback -- --nocapture` (58 passed; one unrelated Starmap overlay test failed in the broad filter)

## Known limitations

- Manual normal/narrow/high-DPI desktop validation was unavailable while the user was away.
- The broad toolbar filter includes one unrelated existing Starmap transient-overlay failure; all 14 focused toolbar basics tests pass.

User review is required before merge.
