### PR TITLE
OPT-1083 Make playmark resize handles easier to grab

### DIFF
--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -14,8 +14,9 @@ use super::{
     widget_geometry::{
         EDIT_GAIN_HANDLE_HEIGHT, EDIT_GAIN_HANDLE_WIDTH, SELECTION_RESIZE_HANDLE_STRIP_HEIGHT,
         edit_gain_handle_rect_for_geometry, edit_selection_resize_edge_bounds,
-        edit_selection_resize_edge_visible, selection_export_handle_style,
-        selection_move_handle_style, selection_resize_edge_style, waveform_selection_edge_role,
+        edit_selection_resize_edge_visible, play_selection_resize_edge_style,
+        selection_export_handle_style, selection_move_handle_style, selection_resize_edge_style,
+        waveform_selection_edge_role,
     },
 };
 
@@ -198,7 +199,7 @@ impl WaveformWidget {
             handle_paint,
             geometry,
             CanvasSelectionAffordanceStyle::new()
-                .with_edge(selection_resize_edge_style())
+                .with_edge(play_selection_resize_edge_style())
                 .with_body(selection_move_handle_style())
                 .with_trailing_control(selection_export_handle_style()),
             style.affordance_paint_parts(
@@ -317,7 +318,7 @@ impl WaveformWidget {
                     &mut paint,
                     geometry,
                     CanvasSelectionAffordanceStyle::new()
-                        .with_edge(selection_resize_edge_style())
+                        .with_edge(play_selection_resize_edge_style())
                         .with_body(selection_move_handle_style())
                         .with_trailing_control(selection_export_handle_style()),
                     style.affordance_paint_parts(
@@ -398,6 +399,7 @@ impl WaveformWidget {
             edge_bounds,
             role,
             PLAY_HANDLE_ACTION_HOVER_COLOR.with_alpha(PLAY_HANDLE_DRAG_GHOST_ALPHA),
+            play_selection_resize_edge_style(),
         );
     }
 
@@ -636,6 +638,7 @@ impl WaveformWidget {
                     bounds.top_edge_strip(SELECTION_RESIZE_HANDLE_STRIP_HEIGHT),
                     hover.role,
                     play_selection_handle_hover_color(hover.role),
+                    play_selection_resize_edge_style(),
                 );
             }
             super::WaveformSelectionKind::Edit => {
@@ -656,6 +659,7 @@ impl WaveformWidget {
                     edge_bounds,
                     hover.role,
                     EDIT_SELECTION_COLOR.with_alpha(HANDLE_HOVER_ALPHA),
+                    selection_resize_edge_style(),
                 );
             }
         }
@@ -747,6 +751,7 @@ impl WaveformWidget {
         edge_bounds: Rect,
         role: DragHandleRole,
         color: Rgba8,
+        edge_style: radiant::gui::visualization::CanvasSelectionEdgeVisualStyle,
     ) {
         let widget_id = paint.widget_id();
         match role {
@@ -761,7 +766,7 @@ impl WaveformWidget {
                 geometry.push_edge_visual_fill(
                     paint.primitives_mut(),
                     widget_id,
-                    selection_resize_edge_style().paint_parts(edge_bounds, role, color),
+                    edge_style.paint_parts(edge_bounds, role, color),
                 );
             }
             DragHandleRole::TrailingControl => {

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -219,8 +219,8 @@ fn playmark_resize_handle_hover_paints_bright_overlay() {
     let plan = runtime_overlay_plan(&widget, bounds);
     let fills = fill_rects(&plan);
     assert!(fills.iter().any(|fill| {
-        (fill.rect.min.x - 116.5).abs() < 0.001
-            && (fill.rect.max.x - 123.5).abs() < 0.001
+        (fill.rect.min.x - 115.5).abs() < 0.001
+            && (fill.rect.max.x - 124.5).abs() < 0.001
             && (fill.rect.min.y - 0.0).abs() < 0.001
             && (fill.rect.max.y - 22.0).abs() < 0.001
             && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 202, 112, 255)
@@ -338,15 +338,15 @@ fn playmark_resize_handles_paint_above_boundary_and_play_start_lines() {
             && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (204, 255, 255, 245)
     });
     let left_handle = fill_index(&fills, "left playmark resize handle", |fill| {
-        (fill.rect.min.x - 36.5).abs() < 0.001
-            && (fill.rect.max.x - 43.5).abs() < 0.001
+        (fill.rect.min.x - 35.5).abs() < 0.001
+            && (fill.rect.max.x - 44.5).abs() < 0.001
             && (fill.rect.min.y - 0.0).abs() < 0.001
             && (fill.rect.max.y - 22.0).abs() < 0.001
             && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 220)
     });
     let right_handle = fill_index(&fills, "right playmark resize handle", |fill| {
-        (fill.rect.min.x - 116.5).abs() < 0.001
-            && (fill.rect.max.x - 123.5).abs() < 0.001
+        (fill.rect.min.x - 115.5).abs() < 0.001
+            && (fill.rect.max.x - 124.5).abs() < 0.001
             && (fill.rect.min.y - 0.0).abs() < 0.001
             && (fill.rect.max.y - 22.0).abs() < 0.001
             && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 142, 92, 220)
@@ -918,8 +918,8 @@ fn playmark_resize_drag_ghost_paints_active_handle_without_double_painting_selec
 
     assert!(
         runtime_fills.iter().any(|fill| {
-            (fill.rect.min.x - 156.5).abs() < 0.001
-                && (fill.rect.max.x - 163.5).abs() < 0.001
+            (fill.rect.min.x - 155.5).abs() < 0.001
+                && (fill.rect.max.x - 164.5).abs() < 0.001
                 && (fill.rect.min.y - 0.0).abs() < 0.001
                 && (fill.rect.max.y - 22.0).abs() < 0.001
                 && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (255, 202, 112, 178)

--- a/src/native_app/waveform/tests/widget_input.rs
+++ b/src/native_app/waveform/tests/widget_input.rs
@@ -1048,6 +1048,166 @@ fn primary_press_on_playmark_handle_starts_resize_instead_of_new_selection() {
 }
 
 #[test]
+fn playmark_resize_target_extends_beyond_painted_handle_without_stealing_distant_clicks() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    for (point, expected_edge) in [
+        (Point::new(34.0, 8.0), WaveformSelectionEdge::Start),
+        (Point::new(126.0, 8.0), WaveformSelectionEdge::End),
+    ] {
+        let mut widget = waveform_widget_for_state(&state);
+        assert!(
+            widget
+                .handle_input(bounds, WidgetInput::pointer_move(point))
+                .is_none()
+        );
+        assert_eq!(
+            widget.hovered_selection_handle.map(|hover| hover.role),
+            Some(super::super::widget_geometry::waveform_selection_edge_role(
+                expected_edge
+            )),
+            "expanded hit target should provide hover feedback"
+        );
+
+        let interaction = widget
+            .handle_input(bounds, WidgetInput::primary_press(point))
+            .expect("expanded target should begin resize")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert_eq!(
+            interaction,
+            WaveformInteraction::BeginSelectionResize {
+                kind: WaveformSelectionKind::Play,
+                edge: expected_edge,
+                visible_ratio: point.x / bounds.width(),
+            }
+        );
+    }
+
+    let mut widget = waveform_widget_for_state(&state);
+    let outside = Point::new(128.0, 8.0);
+    assert!(
+        widget
+            .handle_input(bounds, WidgetInput::pointer_move(outside))
+            .is_none()
+    );
+    assert_eq!(widget.hovered_selection_handle, None);
+    assert_eq!(widget.hover_cursor_ratio, Some(0.64));
+    let interaction = widget
+        .handle_input(bounds, WidgetInput::primary_press(outside))
+        .expect("click outside resize tolerance should retain selection creation")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert_eq!(
+        interaction,
+        WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Play,
+            visible_ratio: 0.64,
+        }
+    );
+}
+
+#[test]
+fn playmark_resize_target_tracks_edges_at_multiple_zoom_depths() {
+    let bounds = Rect::from_size(200.0, 80.0);
+    for viewport in [
+        WaveformViewport::full(48_000),
+        WaveformViewport {
+            start: 6_000,
+            end: 42_000,
+        },
+        WaveformViewport {
+            start: 22_000,
+            end: 26_000,
+        },
+    ] {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.viewport = viewport;
+        let start = state.absolute_ratio_from_visible(0.2);
+        let end = state.absolute_ratio_from_visible(0.6);
+        state.play_selection = Some(wavecrate::selection::SelectionRange::new(start, end));
+        state.play_mark_ratio = Some(start);
+
+        for (point, expected_edge) in [
+            (Point::new(34.0, 8.0), WaveformSelectionEdge::Start),
+            (Point::new(126.0, 8.0), WaveformSelectionEdge::End),
+        ] {
+            let mut widget = waveform_widget_for_state(&state);
+            let interaction = widget
+                .handle_input(bounds, WidgetInput::primary_press(point))
+                .expect("zoomed expanded target should begin resize")
+                .typed_copied::<WaveformInteraction>()
+                .expect("waveform interaction");
+            assert!(matches!(
+                interaction,
+                WaveformInteraction::BeginSelectionResize { edge, .. } if edge == expected_edge
+            ));
+        }
+    }
+}
+
+#[test]
+fn playmark_resize_target_uses_logical_pixels_at_high_dpi() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.play_mark_ratio = Some(0.2);
+    let bounds = Rect::from_size(200.0, 80.0);
+    let dpi = radiant::theme::DpiScale::new(2.0);
+    let physical = Point::new(dpi.logical_to_physical(126.0), dpi.logical_to_physical(8.0));
+    let logical = Point::new(
+        dpi.physical_to_logical(physical.x),
+        dpi.physical_to_logical(physical.y),
+    );
+    let mut widget = waveform_widget_for_state(&state);
+
+    let interaction = widget
+        .handle_input(bounds, WidgetInput::primary_press(logical))
+        .expect("DPI-normalized point should remain in the expanded target")
+        .typed_copied::<WaveformInteraction>()
+        .expect("waveform interaction");
+    assert!(matches!(
+        interaction,
+        WaveformInteraction::BeginSelectionResize {
+            edge: WaveformSelectionEdge::End,
+            ..
+        }
+    ));
+    assert_eq!(
+        dpi.logical_to_physical(
+            super::super::widget_geometry::PLAY_SELECTION_RESIZE_HANDLE_HIT_WIDTH
+        ),
+        30.0
+    );
+}
+
+#[test]
+fn overlapping_playmark_resize_targets_choose_nearest_edge_with_stable_tie() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.5, 0.54));
+    state.play_mark_ratio = Some(0.5);
+    let bounds = Rect::from_size(200.0, 80.0);
+
+    for (x, expected_edge) in [
+        (104.0, WaveformSelectionEdge::Start),
+        (105.0, WaveformSelectionEdge::End),
+    ] {
+        let mut widget = waveform_widget_for_state(&state);
+        let interaction = widget
+            .handle_input(bounds, WidgetInput::primary_press(Point::new(x, 8.0)))
+            .expect("overlapping target should begin deterministic resize")
+            .typed_copied::<WaveformInteraction>()
+            .expect("waveform interaction");
+        assert!(matches!(
+            interaction,
+            WaveformInteraction::BeginSelectionResize { edge, .. } if edge == expected_edge
+        ));
+    }
+}
+
+#[test]
 fn primary_press_on_playmark_top_handle_starts_move() {
     let mut state = WaveformState::synthetic_for_tests();
     state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.6));

--- a/src/native_app/waveform/widget_geometry.rs
+++ b/src/native_app/waveform/widget_geometry.rs
@@ -13,6 +13,8 @@ pub(super) const SELECTION_MOVE_HANDLE_END_INSET: f32 = 9.0;
 pub(super) const SELECTION_EXPORT_HANDLE_SIZE: f32 = 16.0;
 pub(super) const SELECTION_RESIZE_HANDLE_WIDTH: f32 = 7.0;
 pub(super) const SELECTION_RESIZE_HANDLE_STRIP_HEIGHT: f32 = 22.0;
+pub(super) const PLAY_SELECTION_RESIZE_HANDLE_WIDTH: f32 = 9.0;
+pub(super) const PLAY_SELECTION_RESIZE_HANDLE_HIT_WIDTH: f32 = 15.0;
 pub(super) const EDIT_GAIN_HANDLE_WIDTH: f32 = 12.0;
 pub(super) const EDIT_GAIN_HANDLE_HEIGHT: f32 = 10.0;
 pub(super) const EDIT_GAIN_HANDLE_HIT_SIZE: f32 = 18.0;
@@ -116,16 +118,8 @@ impl WaveformWidget {
         bounds: Rect,
         position: Point,
     ) -> Option<WaveformSelectionEdge> {
-        let role = self
-            .selection_geometry(bounds, self.play_selection)
-            .and_then(|geometry| {
-                selection_resize_affordance_style().affordance_at_point(
-                    geometry,
-                    bounds.top_edge_strip(SELECTION_RESIZE_HANDLE_STRIP_HEIGHT),
-                    position,
-                )
-            })?;
-        waveform_selection_edge(role)
+        let geometry = self.selection_geometry(bounds, self.play_selection)?;
+        play_selection_resize_edge_at(geometry, bounds, position)
     }
 
     fn edit_selection_resize_handle_at(
@@ -152,18 +146,21 @@ impl WaveformWidget {
         bounds: Rect,
         position: Point,
     ) -> Option<WaveformSelectionHandleHover> {
-        self.selection_geometry(bounds, self.play_selection)
-            .and_then(|geometry| {
-                selection_move_resize_affordance_style().affordance_at_point(
-                    geometry,
-                    bounds.top_edge_strip(SELECTION_RESIZE_HANDLE_STRIP_HEIGHT),
-                    position,
-                )
-            })
-            .map(|role| WaveformSelectionHandleHover {
-                kind: WaveformSelectionKind::Play,
-                role,
-            })
+        let geometry = self.selection_geometry(bounds, self.play_selection)?;
+        let role = if selection_export_affordance_style()
+            .affordance_at_point(geometry, bounds, position)
+            == Some(DragHandleRole::TrailingControl)
+        {
+            DragHandleRole::TrailingControl
+        } else if let Some(edge) = play_selection_resize_edge_at(geometry, bounds, position) {
+            waveform_selection_edge_role(edge)
+        } else {
+            selection_move_affordance_style().affordance_at_point(geometry, bounds, position)?
+        };
+        Some(WaveformSelectionHandleHover {
+            kind: WaveformSelectionKind::Play,
+            role,
+        })
     }
 
     fn edit_selection_handle_hover_at(
@@ -238,13 +235,6 @@ fn selection_resize_affordance_style() -> CanvasSelectionAffordanceStyle {
     CanvasSelectionAffordanceStyle::new().with_edge(selection_resize_edge_style())
 }
 
-fn selection_move_resize_affordance_style() -> CanvasSelectionAffordanceStyle {
-    CanvasSelectionAffordanceStyle::new()
-        .with_body(selection_move_handle_style())
-        .with_edge(selection_resize_edge_style())
-        .with_trailing_control(selection_export_handle_style())
-}
-
 pub(super) const fn selection_move_handle_style() -> CanvasSelectionBodyHandleStyle {
     CanvasSelectionBodyHandleStyle::new(
         SELECTION_MOVE_HANDLE_HEIGHT,
@@ -256,6 +246,63 @@ pub(super) const fn selection_move_handle_style() -> CanvasSelectionBodyHandleSt
 
 pub(super) const fn selection_resize_edge_style() -> CanvasSelectionEdgeVisualStyle {
     CanvasSelectionEdgeVisualStyle::new(SELECTION_RESIZE_HANDLE_WIDTH, 0.0)
+}
+
+pub(super) const fn play_selection_resize_edge_style() -> CanvasSelectionEdgeVisualStyle {
+    CanvasSelectionEdgeVisualStyle::new(PLAY_SELECTION_RESIZE_HANDLE_WIDTH, 0.0)
+}
+
+const fn play_selection_resize_hit_style() -> CanvasSelectionEdgeVisualStyle {
+    CanvasSelectionEdgeVisualStyle::new(PLAY_SELECTION_RESIZE_HANDLE_HIT_WIDTH, 0.0)
+}
+
+fn play_selection_resize_edge_at(
+    geometry: CanvasSelectionGeometry,
+    bounds: Rect,
+    position: Point,
+) -> Option<WaveformSelectionEdge> {
+    let edge_bounds = bounds.top_edge_strip(SELECTION_RESIZE_HANDLE_STRIP_HEIGHT);
+    let style = play_selection_resize_hit_style();
+    let start_rect = geometry.edge_visual_rect(
+        edge_bounds,
+        DragHandleRole::Start,
+        style.width,
+        style.vertical_inset,
+    );
+    let end_rect = geometry.edge_visual_rect(
+        edge_bounds,
+        DragHandleRole::End,
+        style.width,
+        style.vertical_inset,
+    );
+    nearest_selection_edge(
+        position,
+        geometry.rect.min.x,
+        start_rect,
+        geometry.rect.max.x,
+        end_rect,
+    )
+}
+
+fn nearest_selection_edge(
+    position: Point,
+    start_x: f32,
+    start_rect: Option<Rect>,
+    end_x: f32,
+    end_rect: Option<Rect>,
+) -> Option<WaveformSelectionEdge> {
+    let start_distance = start_rect
+        .filter(|rect| rect.contains(position))
+        .map(|_| (position.x - start_x).abs());
+    let end_distance = end_rect
+        .filter(|rect| rect.contains(position))
+        .map(|_| (position.x - end_x).abs());
+    match (start_distance, end_distance) {
+        (Some(start), Some(end)) if end < start => Some(WaveformSelectionEdge::End),
+        (Some(_), Some(_)) | (Some(_), None) => Some(WaveformSelectionEdge::Start),
+        (None, Some(_)) => Some(WaveformSelectionEdge::End),
+        (None, None) => None,
+    }
 }
 
 pub(super) const fn selection_export_handle_style() -> CanvasSelectionTrailingControlStyle {


### PR DESCRIPTION
## Scope

- Increase playmark resize handles from 7 to 9 logical pixels without changing editmark chrome.
- Add a 15-logical-pixel playmark-only hit target shared by hover and press routing.
- Resolve overlapping narrow-playmark targets by nearest edge, with a stable start-edge tie.
- Keep the selected edge captured through live drag and release using the existing active-drag contract.
- Add geometry, DPI, zoom, overlap, routing, paint, preview, and commit regressions.

## Definition of Done

- Playmark handles are visibly and interactively easier to acquire.
- Hover feedback and press routing agree across the expanded target.
- Narrow overlapping targets select the nearest edge deterministically.
- Clicks beyond the tolerance retain selection-creation behavior.
- Resize preview and committed selection semantics remain unchanged.

## Validation commands

- `cargo test -p wavecrate playmark_resize`
- `cargo check -p wavecrate --all-targets`
- Scoped `cargo fmt` on the four changed Rust files
- `git diff --check`

## Known limitations

- Manual desktop mouse comparison was unavailable while the user was away; automated logical-pixel, 2x DPI, pointer-routing, and paint coverage substitutes for that check.

User review is required before merge.

Linear: OPT-1083
