### PR TITLE
OPT-1082 Make waveform detail follow zoom level

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -359,6 +359,7 @@ pub(in crate::native_app) enum GuiMessage {
     CancelBrowserDragOnSampleList,
     DropWaveformSelectionOnSampleList,
     Waveform(WaveformInteraction),
+    WaveformDetailRefined(crate::native_app::waveform::WaveformDetailResult),
     WaveformFileDrop(NativeFileDrop),
     Frame,
 }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -250,6 +250,9 @@ impl NativeAppState {
                 self.apply_navigation_dispatch(message, context);
             }
             GuiMessage::Waveform(message) => self.apply_waveform_message(message, context),
+            GuiMessage::WaveformDetailRefined(result) => {
+                self.finish_waveform_detail_refinement(result, context);
+            }
             GuiMessage::Frame => self.apply_frame_message(context),
         }
     }

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -44,6 +44,7 @@ impl NativeAppState {
             return;
         }
         self.waveform.current.apply_interaction(message);
+        self.queue_waveform_detail_refinement(context);
         if matches!(message, WaveformInteraction::FinishSampleSlide { .. })
             && let Some(frame_offset) = self
                 .waveform
@@ -95,6 +96,26 @@ impl NativeAppState {
             self.maybe_open_audio_player(context);
             self.play_waveform_from_ratio(start_ratio, context);
         }
+    }
+
+    pub(super) fn finish_waveform_detail_refinement(
+        &mut self,
+        result: crate::native_app::waveform::WaveformDetailResult,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.waveform.current.apply_detail_result(result);
+        self.queue_waveform_detail_refinement(context);
+    }
+
+    fn queue_waveform_detail_refinement(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        let Some(key) = self.waveform.current.desired_detail_key() else {
+            return;
+        };
+        self.waveform.current.mark_detail_pending(key.clone());
+        context.business().background("gui-waveform-detail").run(
+            move |_| crate::native_app::waveform::load_wav_detail_summary(key),
+            GuiMessage::WaveformDetailRefined,
+        );
     }
 
     fn play_selection_transaction_begin_snapshot(

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -36,7 +36,7 @@ pub(in crate::native_app) use state_extraction::{
 };
 mod state_file;
 mod state_interaction;
-pub(in crate::native_app) use state::WaveformState;
+pub(in crate::native_app) use state::{WaveformDetailKey, WaveformDetailResult, WaveformState};
 mod state_loading;
 mod state_marked_ranges;
 mod state_playback;
@@ -67,8 +67,9 @@ pub(in crate::native_app) use audio_file::{
     flush_background_waveform_cache_stores_for_shutdown, instant_waveform_head_preview_from_clip,
     invalidate_persisted_waveform_cache_path, invalidate_persisted_waveform_cache_paths,
     load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
-    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
-    should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
+    load_wav_detail_summary, mark_cached_waveform_file_source_warm_attempted,
+    remap_persisted_waveform_cache_after_move, should_use_file_backed_wav_decode,
+    should_use_file_backed_wav_decode_for_entry,
 };
 #[cfg(test)]
 pub(super) use audio_file::{
@@ -77,6 +78,8 @@ pub(super) use audio_file::{
 };
 
 mod similar_sections;
+#[cfg(test)]
+use audio_file::load_wav_waveform_summary_from_path_with_progress;
 #[cfg(test)]
 use audio_file::{downmix_to_mono, split_frequency_bands, waveform_file_from_mono_samples};
 pub(in crate::native_app) use similar_sections::{

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -78,3 +78,6 @@ pub(in crate::native_app) use visual_preview::{
     InstantWaveformPreview, InstantWaveformPreviewTier, instant_waveform_head_preview_from_clip,
 };
 pub(in crate::native_app::waveform) use wav_decode::read_wav_playback_samples;
+pub(in crate::native_app) use wav_summary::load_wav_detail_summary;
+#[cfg(test)]
+pub(super) use wav_summary::load_wav_waveform_summary_from_path_with_progress;

--- a/src/native_app/waveform/audio_file/model.rs
+++ b/src/native_app/waveform/audio_file/model.rs
@@ -4,6 +4,7 @@ use std::{
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
+    time::SystemTime,
 };
 
 #[derive(Clone, Debug)]
@@ -83,9 +84,37 @@ impl WaveformFile {
             return None;
         }
         let mut file = self.clone();
-        file.path = mapped_path;
+        file.apply_remapped_path(mapped_path);
         file.playback_cache_file = None;
         Some(file)
+    }
+
+    pub(in crate::native_app::waveform) fn rewrite_path_prefix(
+        &mut self,
+        old_path: &Path,
+        new_path: &Path,
+    ) -> bool {
+        let Some(mapped_path) = remapped_waveform_path(&self.path, old_path, new_path) else {
+            return false;
+        };
+        if mapped_path == self.path {
+            return false;
+        }
+        self.apply_remapped_path(mapped_path);
+        true
+    }
+
+    fn apply_remapped_path(&mut self, mapped_path: PathBuf) {
+        self.path = mapped_path;
+        if let Ok(metadata) = std::fs::metadata(&self.path) {
+            self.content_revision = content_revision_for_path_metadata(
+                &self.path,
+                &metadata,
+                self.sample_rate,
+                self.channels,
+                self.frames,
+            );
+        }
     }
 
     pub(in crate::native_app::waveform) fn has_loaded_sample_metadata(&self) -> bool {
@@ -121,6 +150,32 @@ impl WaveformFile {
     pub(in crate::native_app::waveform) fn content_revision(&self) -> u64 {
         self.content_revision
     }
+}
+
+pub(super) fn content_revision_for_path_metadata(
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    sample_rate: u32,
+    channels: usize,
+    frames: usize,
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    metadata.len().hash(&mut hasher);
+    modified_ns(metadata).hash(&mut hasher);
+    sample_rate.hash(&mut hasher);
+    channels.hash(&mut hasher);
+    frames.hash(&mut hasher);
+    hasher.finish().max(1)
+}
+
+fn modified_ns(metadata: &std::fs::Metadata) -> u128 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
 }
 
 fn remapped_waveform_path(path: &Path, old_path: &Path, new_path: &Path) -> Option<PathBuf> {

--- a/src/native_app/waveform/audio_file/wav_summary.rs
+++ b/src/native_app/waveform/audio_file/wav_summary.rs
@@ -11,13 +11,100 @@ use wavecrate::audio::{Source, decoder::SymphoniaDecoder};
 
 use super::{
     WaveformFile, report_phase_progress_throttled,
+    wav_format::{integer_sample_max_i32, integer_sample_max_i64},
     wav_summary_builder::{
         MAX_STREAMING_WAV_SUMMARY_BUCKETS, STREAMING_WAV_SUMMARY_BUILD_END,
         STREAMING_WAV_SUMMARY_READ_END, StreamingWavSummaryBuilder,
         streaming_summary_bucket_frames,
     },
-    wav_summary_hound::read_wav_summary_with_progress,
+    wav_summary_hound::{
+        read_float_frame_peak, read_i16_frame_peak, read_i32_frame_peak,
+        read_wav_summary_with_progress,
+    },
 };
+
+pub(in crate::native_app) fn load_wav_detail_summary(
+    key: crate::native_app::waveform::WaveformDetailKey,
+) -> crate::native_app::waveform::WaveformDetailResult {
+    let started_at = Instant::now();
+    let summary = (|| {
+        let mut reader = hound::WavReader::open(&key.path)
+            .map_err(|error| format!("failed to open detail WAV: {error}"))?;
+        let spec = reader.spec();
+        let channels = usize::from(spec.channels).max(1);
+        let source_frames = reader.duration() as usize;
+        let end = key.end_frame.min(source_frames);
+        let start = key.start_frame.min(end);
+        let visible = end.saturating_sub(start);
+        if visible == 0 || start > u32::MAX as usize {
+            return Err(String::from("waveform detail range is unavailable"));
+        }
+        let metadata_before = std::fs::metadata(&key.path)
+            .map_err(|error| format!("failed to inspect detail WAV: {error}"))?;
+        let revision_before = content_revision_for_path_metadata(
+            &key.path,
+            &metadata_before,
+            spec.sample_rate,
+            channels,
+            source_frames,
+        );
+        if revision_before != key.content_revision {
+            return Err(String::from("stale waveform detail request"));
+        }
+        reader
+            .seek(start as u32)
+            .map_err(|error| format!("failed to seek detail WAV: {error}"))?;
+        let bucket_frames = visible.div_ceil(MAX_STREAMING_WAV_SUMMARY_BUCKETS).max(1);
+        let mut builder = StreamingWavSummaryBuilder::new(spec.sample_rate, bucket_frames);
+        match spec.sample_format {
+            hound::SampleFormat::Float => {
+                let mut samples = reader.samples::<f32>();
+                for _ in 0..visible {
+                    builder.push_peak(read_float_frame_peak(&mut samples, channels)?);
+                }
+            }
+            hound::SampleFormat::Int if spec.bits_per_sample <= 16 => {
+                let max = integer_sample_max_i32(spec.bits_per_sample);
+                let mut samples = reader.samples::<i16>();
+                for _ in 0..visible {
+                    builder.push_peak(read_i16_frame_peak(&mut samples, channels, max)?);
+                }
+            }
+            hound::SampleFormat::Int => {
+                let max = integer_sample_max_i64(spec.bits_per_sample);
+                let mut samples = reader.samples::<i32>();
+                for _ in 0..visible {
+                    builder.push_peak(read_i32_frame_peak(&mut samples, channels, max)?);
+                }
+            }
+        }
+        let summary = builder.finish(0.0, 1.0, &|_| {}, &|| false)?;
+        let metadata_after = std::fs::metadata(&key.path)
+            .map_err(|error| format!("failed to revalidate detail WAV: {error}"))?;
+        let revision_after = content_revision_for_path_metadata(
+            &key.path,
+            &metadata_after,
+            spec.sample_rate,
+            channels,
+            source_frames,
+        );
+        if revision_after != key.content_revision {
+            return Err(String::from("stale waveform detail result"));
+        }
+        Ok(Arc::new(summary))
+    })();
+    tracing::debug!(
+        target: "wavecrate::waveform_detail",
+        event = "waveform.detail.refinement",
+        path = %key.path.display(),
+        start_frame = key.start_frame,
+        end_frame = key.end_frame,
+        elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0,
+        outcome = if summary.is_ok() { "ready" } else { "rejected" },
+        "Waveform viewport detail refinement finished"
+    );
+    crate::native_app::waveform::WaveformDetailResult { key, summary }
+}
 
 pub(in crate::native_app::waveform) fn load_wav_waveform_summary_from_path_with_progress(
     path: PathBuf,

--- a/src/native_app/waveform/audio_file/wav_summary.rs
+++ b/src/native_app/waveform/audio_file/wav_summary.rs
@@ -1,16 +1,16 @@
 use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use crate::native_app::waveform::audio_file::diagnostics::log_audio_load_timing;
 use wavecrate::audio::{Source, decoder::SymphoniaDecoder};
 
 use super::{
-    WaveformFile, report_phase_progress_throttled,
+    WaveformFile,
+    model::content_revision_for_path_metadata,
+    report_phase_progress_throttled,
     wav_format::{integer_sample_max_i32, integer_sample_max_i64},
     wav_summary_builder::{
         MAX_STREAMING_WAV_SUMMARY_BUCKETS, STREAMING_WAV_SUMMARY_BUILD_END,
@@ -322,32 +322,6 @@ fn estimate_frames_from_file_size(bytes: u64, channels: usize) -> usize {
     usize::try_from(bytes / bytes_per_frame)
         .unwrap_or(usize::MAX)
         .max(1)
-}
-
-fn content_revision_for_path_metadata(
-    path: &Path,
-    metadata: &std::fs::Metadata,
-    sample_rate: u32,
-    channels: usize,
-    frames: usize,
-) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    path.hash(&mut hasher);
-    metadata.len().hash(&mut hasher);
-    modified_ns(metadata).hash(&mut hasher);
-    sample_rate.hash(&mut hasher);
-    channels.hash(&mut hasher);
-    frames.hash(&mut hasher);
-    hasher.finish().max(1)
-}
-
-fn modified_ns(metadata: &std::fs::Metadata) -> u128 {
-    metadata
-        .modified()
-        .ok()
-        .and_then(|modified| modified.duration_since(SystemTime::UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/src/native_app/waveform/audio_file/wav_summary_hound.rs
+++ b/src/native_app/waveform/audio_file/wav_summary_hound.rs
@@ -123,7 +123,7 @@ fn read_i32_summary<R: std::io::Read>(
     Ok(())
 }
 
-fn read_float_frame_peak<R: std::io::Read>(
+pub(super) fn read_float_frame_peak<R: std::io::Read>(
     samples: &mut hound::WavSamples<'_, R, f32>,
     channels: usize,
 ) -> Result<f32, String> {
@@ -142,7 +142,7 @@ fn read_float_frame_peak<R: std::io::Read>(
     Ok(peak.clamp(-1.0, 1.0))
 }
 
-fn read_i16_frame_peak<R: std::io::Read>(
+pub(super) fn read_i16_frame_peak<R: std::io::Read>(
     samples: &mut hound::WavSamples<'_, R, i16>,
     channels: usize,
     max: f32,
@@ -162,7 +162,7 @@ fn read_i16_frame_peak<R: std::io::Read>(
     Ok(peak.clamp(-1.0, 1.0))
 }
 
-fn read_i32_frame_peak<R: std::io::Read>(
+pub(super) fn read_i32_frame_peak<R: std::io::Read>(
     samples: &mut hound::WavSamples<'_, R, i32>,
     channels: usize,
     max: f32,

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -67,6 +67,9 @@ impl WaveformState {
         if self.pending_detail_key.is_some() || !super::audio_file::is_wav_path(&self.file.path) {
             return None;
         }
+        if self.viewport.extends_beyond_audio(self.file.frames) {
+            return None;
+        }
         let range = self
             .viewport
             .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES);
@@ -136,7 +139,8 @@ impl WaveformState {
 
     pub(in crate::native_app::waveform) fn render_detail(&self) -> Option<&WaveformDetailSummary> {
         self.detail_summary.as_ref().filter(|detail| {
-            detail.key.path == self.file.path
+            !self.viewport.extends_beyond_audio(self.file.frames)
+                && detail.key.path == self.file.path
                 && detail.key.content_revision == self.file.content_revision()
                 && detail.key.start_frame
                     == self

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -6,6 +6,30 @@ use std::{
 use wavecrate::selection::SelectionRange;
 
 use super::{WaveformDrag, WaveformFile, WaveformViewport, similar_sections::SimilarSectionsState};
+use radiant::runtime::GpuSignalSummary;
+
+const DETAIL_MAX_BUCKETS: usize = 65_536;
+const DETAIL_MAX_VISIBLE_FRAMES: usize = 8 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct WaveformDetailKey {
+    pub path: PathBuf,
+    pub content_revision: u64,
+    pub start_frame: usize,
+    pub end_frame: usize,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct WaveformDetailResult {
+    pub key: WaveformDetailKey,
+    pub summary: Result<Arc<GpuSignalSummary>, String>,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::native_app::waveform) struct WaveformDetailSummary {
+    pub key: WaveformDetailKey,
+    pub summary: Arc<GpuSignalSummary>,
+}
 
 #[derive(Clone, Debug)]
 pub(in crate::native_app) struct WaveformState {
@@ -33,6 +57,99 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) pending_playback_start: Option<f32>,
     pub(in crate::native_app::waveform) pending_sample_slide_frame_offset: Option<i64>,
     pub(in crate::native_app::waveform) normalized_audition_gain_cache: NormalizedAuditionGainCache,
+    pub(in crate::native_app::waveform) detail_summary: Option<WaveformDetailSummary>,
+    pub(in crate::native_app::waveform) pending_detail_key: Option<WaveformDetailKey>,
+    pub(in crate::native_app::waveform) failed_detail_key: Option<WaveformDetailKey>,
+}
+
+impl WaveformState {
+    pub(in crate::native_app) fn desired_detail_key(&self) -> Option<WaveformDetailKey> {
+        if self.pending_detail_key.is_some() || !super::audio_file::is_wav_path(&self.file.path) {
+            return None;
+        }
+        let range = self
+            .viewport
+            .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES);
+        let visible = range.end.saturating_sub(range.start);
+        if visible == 0 || visible > DETAIL_MAX_VISIBLE_FRAMES {
+            return None;
+        }
+        let overview_bucket_frames = self.file.gpu_signal_summary.levels.first()?.bucket_frames;
+        let target_bucket_frames = visible.div_ceil(DETAIL_MAX_BUCKETS).max(1);
+        if overview_bucket_frames <= target_bucket_frames {
+            return None;
+        }
+        let key = WaveformDetailKey {
+            path: self.file.path.clone(),
+            content_revision: self.file.content_revision(),
+            start_frame: range.start,
+            end_frame: range.end,
+        };
+        if self
+            .detail_summary
+            .as_ref()
+            .is_some_and(|detail| detail.key == key)
+        {
+            return None;
+        }
+        if self.failed_detail_key.as_ref() == Some(&key) {
+            return None;
+        }
+        Some(key)
+    }
+
+    pub(in crate::native_app) fn mark_detail_pending(&mut self, key: WaveformDetailKey) {
+        self.pending_detail_key = Some(key);
+    }
+
+    pub(in crate::native_app) fn apply_detail_result(&mut self, result: WaveformDetailResult) {
+        if self.pending_detail_key.as_ref() != Some(&result.key) {
+            return;
+        }
+        self.pending_detail_key = None;
+        let current = WaveformDetailKey {
+            path: self.file.path.clone(),
+            content_revision: self.file.content_revision(),
+            start_frame: self
+                .viewport
+                .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES)
+                .start,
+            end_frame: self
+                .viewport
+                .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES)
+                .end,
+        };
+        if current != result.key {
+            return;
+        }
+        match result.summary {
+            Ok(summary) => {
+                self.failed_detail_key = None;
+                self.detail_summary = Some(WaveformDetailSummary {
+                    key: result.key,
+                    summary,
+                });
+            }
+            Err(_) => self.failed_detail_key = Some(result.key),
+        }
+    }
+
+    pub(in crate::native_app::waveform) fn render_detail(&self) -> Option<&WaveformDetailSummary> {
+        self.detail_summary.as_ref().filter(|detail| {
+            detail.key.path == self.file.path
+                && detail.key.content_revision == self.file.content_revision()
+                && detail.key.start_frame
+                    == self
+                        .viewport
+                        .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES)
+                        .start
+                && detail.key.end_frame
+                    == self
+                        .viewport
+                        .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES)
+                        .end
+        })
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/native_app/waveform/state_file.rs
+++ b/src/native_app/waveform/state_file.rs
@@ -43,15 +43,13 @@ impl WaveformState {
         old_path: &std::path::Path,
         new_path: &std::path::Path,
     ) -> bool {
-        if self.file.path == old_path {
-            Arc::make_mut(&mut self.file).path = new_path.to_path_buf();
-            return true;
+        if !Arc::make_mut(&mut self.file).rewrite_path_prefix(old_path, new_path) {
+            return false;
         }
-        if let Ok(relative) = self.file.path.strip_prefix(old_path) {
-            Arc::make_mut(&mut self.file).path = new_path.join(relative);
-            return true;
-        }
-        false
+        self.detail_summary = None;
+        self.pending_detail_key = None;
+        self.failed_detail_key = None;
+        true
     }
 
     pub(in crate::native_app) fn has_loaded_sample(&self) -> bool {

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -152,6 +152,9 @@ impl WaveformState {
             pending_playback_start: None,
             pending_sample_slide_frame_offset: None,
             normalized_audition_gain_cache: Default::default(),
+            detail_summary: None,
+            pending_detail_key: None,
+            failed_detail_key: None,
         }
     }
 

--- a/src/native_app/waveform/tests/mod.rs
+++ b/src/native_app/waveform/tests/mod.rs
@@ -62,9 +62,10 @@ fn waveform_signal_surface_plan(
     edit_selection: Option<wavecrate::selection::SelectionRange>,
     sample_slide_frame_offset: Option<i64>,
 ) -> SurfacePaintPlan {
+    let mut state = WaveformState::from_cached_file(file);
+    state.viewport = viewport;
     let view = waveform_signal_surface_view(
-        file,
-        viewport,
+        &state,
         gain_preview_for_selection(edit_selection),
         sample_slide_frame_offset,
     )

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -32,8 +32,12 @@ fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
     let result = super::super::load_wav_detail_summary(key);
     assert!(result.summary.is_ok());
     state.apply_detail_result(result);
+    state.edit_selection = Some(
+        wavecrate::selection::SelectionRange::new(1088.0 / 4096.0, 1216.0 / 4096.0).with_gain(0.5),
+    );
 
-    let view = waveform_signal_surface_view(&state, None, None)
+    let gain_preview = signal_gain_preview_for_state(&state, false);
+    let view = waveform_signal_surface_view(&state, gain_preview, None)
         .id(crate::native_app::test_support::waveform::WAVEFORM_SIGNAL_WIDGET_ID)
         .size(200.0, 80.0);
     let surface_view = view.into_surface();
@@ -45,6 +49,7 @@ fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
         frames,
         frame_range,
         summary,
+        gain_preview,
         ..
     } = &surface.content
     else {
@@ -52,6 +57,9 @@ fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
     };
     assert_eq!(*frames, 256);
     assert_eq!(*frame_range, [0.0, 256.0]);
+    let gain_preview = gain_preview.expect("detail gain preview");
+    assert!((gain_preview.start - 0.25).abs() < 0.0001);
+    assert!((gain_preview.end - 0.75).abs() < 0.0001);
     assert_eq!(summary.levels[0].bucket_frames, 2);
     assert_eq!(
         summary.levels[0].buckets, short.gpu_signal_summary.levels[0].buckets,
@@ -64,6 +72,69 @@ fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
             .any(|bucket| bucket.max > 0.9),
         "narrow transient in the visible long-file range should survive refinement"
     );
+}
+
+#[test]
+fn waveform_detail_preserves_virtual_silence_margin_with_overview_rendering() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("virtual-margin-detail.wav");
+    write_test_wav_i16(&path, &vec![0_i16; 4096]);
+    let file =
+        super::super::load_wav_waveform_summary_from_path_with_progress(path, &|_| {}, &|| false)
+            .unwrap();
+    let mut state = WaveformState::from_cached_file(Arc::new(file));
+    state.viewport = WaveformViewport {
+        start: -128,
+        end: 128,
+    };
+
+    assert_eq!(state.desired_detail_key(), None);
+
+    let view = waveform_signal_surface_view(&state, None, None)
+        .id(crate::native_app::test_support::waveform::WAVEFORM_SIGNAL_WIDGET_ID)
+        .size(200.0, 80.0);
+    let surface_view = view.into_surface();
+    let bounds = Rect::from_size(200.0, 80.0);
+    let layout = radiant::layout::layout_tree(&surface_view.layout_node(), bounds);
+    let plan = surface_view.paint_plan(&layout, &ThemeTokens::default());
+    let surface = plan.gpu_surfaces().next().unwrap();
+    let GpuSurfaceContent::SignalSummaryBands {
+        frames,
+        frame_range,
+        ..
+    } = &surface.content
+    else {
+        panic!("expected overview signal surface");
+    };
+    assert_eq!(*frames, 4096);
+    assert_eq!(*frame_range, [-128.0, 128.0]);
+}
+
+#[test]
+fn moved_file_backed_wav_recomputes_detail_revision_for_new_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let old_path = temp.path().join("before-move.wav");
+    let new_path = temp.path().join("after-move.wav");
+    write_test_wav_i16(&old_path, &vec![0_i16; 4096]);
+    let file = super::super::load_wav_waveform_summary_from_path_with_progress(
+        old_path.clone(),
+        &|_| {},
+        &|| false,
+    )
+    .unwrap();
+    let old_revision = file.content_revision();
+    let mut state = WaveformState::from_cached_file(Arc::new(file));
+    state.viewport = WaveformViewport { start: 0, end: 256 };
+    let old_key = state.desired_detail_key().expect("original WAV detail key");
+    state.mark_detail_pending(old_key);
+    std::fs::rename(&old_path, &new_path).unwrap();
+
+    assert!(state.rewrite_path_prefix(&old_path, &new_path));
+    assert_ne!(state.file().content_revision(), old_revision);
+    let key = state.desired_detail_key().expect("moved WAV detail key");
+    let result = super::super::load_wav_detail_summary(key);
+
+    assert!(result.summary.is_ok());
 }
 
 #[test]

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -1,6 +1,106 @@
 use super::*;
 
 #[test]
+fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("long-detail.wav");
+    let mut samples = vec![0_i16; 4096];
+    samples[1152] = i16::MAX;
+    write_test_wav_i16(&path, &samples);
+    let short_path = temp.path().join("short-detail.wav");
+    write_test_wav_i16(&short_path, &samples[1024..1280]);
+    let short = super::super::load_wav_waveform_summary_from_path_with_progress(
+        short_path,
+        &|_| {},
+        &|| false,
+    )
+    .unwrap();
+    let file =
+        super::super::load_wav_waveform_summary_from_path_with_progress(path, &|_| {}, &|| false)
+            .unwrap();
+    assert!(file.gpu_signal_summary.levels[0].bucket_frames > 1);
+    let mut state = WaveformState::from_cached_file(Arc::new(file));
+    state.viewport = WaveformViewport {
+        start: 1024,
+        end: 1280,
+    };
+    let key = state
+        .desired_detail_key()
+        .expect("coarse overview should refine");
+    state.mark_detail_pending(key.clone());
+
+    let result = super::super::load_wav_detail_summary(key);
+    assert!(result.summary.is_ok());
+    state.apply_detail_result(result);
+
+    let view = waveform_signal_surface_view(&state, None, None)
+        .id(crate::native_app::test_support::waveform::WAVEFORM_SIGNAL_WIDGET_ID)
+        .size(200.0, 80.0);
+    let surface_view = view.into_surface();
+    let bounds = Rect::from_size(200.0, 80.0);
+    let layout = radiant::layout::layout_tree(&surface_view.layout_node(), bounds);
+    let plan = surface_view.paint_plan(&layout, &ThemeTokens::default());
+    let surface = plan.gpu_surfaces().next().unwrap();
+    let GpuSurfaceContent::SignalSummaryBands {
+        frames,
+        frame_range,
+        summary,
+        ..
+    } = &surface.content
+    else {
+        panic!("expected detail signal surface");
+    };
+    assert_eq!(*frames, 256);
+    assert_eq!(*frame_range, [0.0, 256.0]);
+    assert_eq!(summary.levels[0].bucket_frames, 2);
+    assert_eq!(
+        summary.levels[0].buckets, short.gpu_signal_summary.levels[0].buckets,
+        "equal samples-per-pixel should produce equal detail for short and long files"
+    );
+    assert!(
+        summary.levels[0]
+            .buckets
+            .iter()
+            .any(|bucket| bucket.max > 0.9),
+        "narrow transient in the visible long-file range should survive refinement"
+    );
+}
+
+#[test]
+fn waveform_detail_requests_are_single_flight_and_reject_stale_source_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("stale-detail.wav");
+    write_test_wav_i16(&path, &vec![1_i16; 4096]);
+    let file = super::super::load_wav_waveform_summary_from_path_with_progress(
+        path.clone(),
+        &|_| {},
+        &|| false,
+    )
+    .unwrap();
+    let mut state = WaveformState::from_cached_file(Arc::new(file));
+    state.viewport = WaveformViewport { start: 0, end: 256 };
+    let key = state.desired_detail_key().unwrap();
+    state.mark_detail_pending(key.clone());
+    assert!(state.desired_detail_key().is_none());
+    write_test_wav_i16(&path, &vec![2_i16; 4096]);
+
+    let result = super::super::load_wav_detail_summary(key);
+
+    assert!(
+        result
+            .clone()
+            .summary
+            .unwrap_err()
+            .contains("stale waveform detail")
+    );
+    state.apply_detail_result(result);
+    assert!(
+        state.desired_detail_key().is_none(),
+        "a failed identity should not create a completion/retry loop"
+    );
+}
+
+#[test]
 fn signal_widget_paints_gpu_surface_without_app_overlay_handles() {
     let state = WaveformState::synthetic_for_tests();
     let plan =

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -78,8 +78,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
 
     ui::stack([
         waveform_signal_surface_view(
-            state.file(),
-            state.viewport(),
+            state,
             signal_gain_preview_for_state(state, normalized_audition_enabled),
             state.pending_sample_slide_frame_offset,
         )
@@ -116,19 +115,36 @@ fn active_edit_selection_drag_skips_signal_preview(
 }
 
 pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
-    file: Arc<WaveformFile>,
-    viewport: WaveformViewport,
+    state: &WaveformState,
     gain_preview: Option<radiant::runtime::GpuSignalGainPreview>,
     sample_slide_frame_offset: Option<i64>,
 ) -> ui::View<GuiMessage> {
+    let file = state.file();
+    let viewport = state.viewport();
+    let (frames, frame_range, summary, detail_revision) =
+        if let Some(detail) = state.render_detail() {
+            (
+                detail.summary.frames,
+                [0.0, detail.summary.frames as f32],
+                Arc::clone(&detail.summary),
+                detail.key.start_frame as u64 ^ (detail.key.end_frame as u64).rotate_left(17),
+            )
+        } else {
+            (
+                file.frames,
+                viewport.frame_range(),
+                Arc::clone(&file.gpu_signal_summary),
+                0,
+            )
+        };
     gpu_surface_with_capabilities(
         file.path_hash(),
-        file.content_revision(),
+        file.content_revision() ^ detail_revision,
         GpuSurfaceContent::SignalSummaryBands {
-            frames: file.frames,
+            frames,
             band_count: super::BAND_COUNT,
-            frame_range: viewport.frame_range(),
-            summary: Arc::clone(&file.gpu_signal_summary),
+            frame_range,
+            summary,
             gain_preview,
             sample_slide_frame_offset: sample_slide_frame_offset.unwrap_or(0),
         },

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -121,22 +121,28 @@ pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
 ) -> ui::View<GuiMessage> {
     let file = state.file();
     let viewport = state.viewport();
-    let (frames, frame_range, summary, detail_revision) =
-        if let Some(detail) = state.render_detail() {
-            (
-                detail.summary.frames,
-                [0.0, detail.summary.frames as f32],
-                Arc::clone(&detail.summary),
-                detail.key.start_frame as u64 ^ (detail.key.end_frame as u64).rotate_left(17),
-            )
-        } else {
-            (
-                file.frames,
-                viewport.frame_range(),
-                Arc::clone(&file.gpu_signal_summary),
-                0,
-            )
-        };
+    let detail = state
+        .render_detail()
+        .filter(|_| sample_slide_frame_offset.unwrap_or(0) == 0);
+    let (frames, frame_range, summary, gain_preview, detail_revision) = if let Some(detail) = detail
+    {
+        (
+            detail.summary.frames,
+            [0.0, detail.summary.frames as f32],
+            Arc::clone(&detail.summary),
+            gain_preview
+                .map(|preview| remap_gain_preview_to_detail(preview, file.frames, &detail.key)),
+            detail.key.start_frame as u64 ^ (detail.key.end_frame as u64).rotate_left(17),
+        )
+    } else {
+        (
+            file.frames,
+            viewport.frame_range(),
+            Arc::clone(&file.gpu_signal_summary),
+            gain_preview,
+            0,
+        )
+    };
     gpu_surface_with_capabilities(
         file.path_hash(),
         file.content_revision() ^ detail_revision,
@@ -154,6 +160,19 @@ pub(in crate::native_app::waveform) fn waveform_signal_surface_view(
             runtime_overlays: Default::default(),
         },
     )
+}
+
+fn remap_gain_preview_to_detail(
+    mut preview: radiant::runtime::GpuSignalGainPreview,
+    source_frames: usize,
+    key: &super::WaveformDetailKey,
+) -> radiant::runtime::GpuSignalGainPreview {
+    let source_frames = source_frames.max(1) as f32;
+    let detail_start = key.start_frame as f32 / source_frames;
+    let detail_width = key.end_frame.saturating_sub(key.start_frame).max(1) as f32 / source_frames;
+    preview.start = (preview.start - detail_start) / detail_width;
+    preview.end = (preview.end - detail_start) / detail_width;
+    preview
 }
 
 pub(in crate::native_app::waveform) fn signal_gain_preview_for_state(


### PR DESCRIPTION
## Scope

- Add viewport-aware detail refinement for coarse file-backed WAV overviews.
- Decode only the current visible range on a background business worker while retaining the overview.
- Cap each request at 8,388,608 visible frames and 65,536 summary buckets.
- Coalesce rapid zoom/pan changes to one in-flight request and request the newest viewport after stale completion.
- Gate publication by path, source content revision, and exact frame viewport.
- Render refined summaries in local viewport coordinates so overlays remain frame-aligned.
- Add diagnostics and duration-independent detail, transient, single-flight, and stale-result regressions.

## Definition of Done

- Long file-backed WAVs progressively reveal finer detail when zoomed instead of magnifying overview buckets.
- Equal local content at equal samples-per-pixel produces equal peak buckets regardless of total file duration.
- Overview rendering remains immediately available during refinement.
- Work, memory, and published summaries are explicitly bounded.
- Stale source/viewport work is rejected and cannot create retry loops.

## Validation commands

- `cargo test -p wavecrate waveform_detail`
- `cargo test -p wavecrate zoomed_long_wav_refines_visible_range_independently_of_total_duration`
- `cargo check -p wavecrate --all-targets`
- scoped formatting and `git diff --check`

## Known limitations

- Progressive range refinement currently targets seekable WAV sources, which are the long-file file-backed path; other decoded formats retain their existing full decoded summaries.
- Manual DAW comparison and live latency/memory capture were unavailable while the user was away; automated equivalence, transient, bound, coalescing, and stale-identity coverage is included.

User review is required before merge.

Linear: OPT-1082
