### PR TITLE
OPT-922 Audit live playmark-loop retargeting correctness

### DIFF
--- a/src/native_app/audio/playback/loop_control.rs
+++ b/src/native_app/audio/playback/loop_control.rs
@@ -504,9 +504,33 @@ fn interpolate_runtime_progress_ratio(
 
 #[cfg(test)]
 mod tests {
+    use crate::native_app::app::PendingPlaySelectionRetargetCycle;
     use crate::native_app::test_support::state::NativeAppStateFixture;
     use std::time::{Duration, Instant};
     use wavecrate::audio::PlaybackRuntimeProgress;
+
+    #[test]
+    fn pending_live_retarget_uses_latest_shortened_end_as_boundary() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.pending_play_selection_retarget_cycle =
+            Some(PendingPlaySelectionRetargetCycle::new(0.80, Some(0.40)));
+
+        assert!(!state.pending_play_selection_retarget_boundary_reached(0.50, 0.55));
+        assert!(state.pending_play_selection_retarget_boundary_reached(0.545, 0.55));
+    }
+
+    #[test]
+    fn pending_live_retarget_detects_old_loop_wrap_for_moved_range() {
+        let mut state = NativeAppStateFixture::default()
+            .with_synthetic_waveform()
+            .build();
+        state.waveform.pending_play_selection_retarget_cycle =
+            Some(PendingPlaySelectionRetargetCycle::new(0.60, Some(0.59)));
+
+        assert!(state.pending_play_selection_retarget_boundary_reached(0.21, 0.80));
+    }
 
     #[test]
     fn runtime_waveform_progress_interpolates_between_snapshots() {


### PR DESCRIPTION
## Scope

- Audit live playmark-loop retarget ownership from waveform preview/commit through host playback state and Reson source updates.
- Add deterministic coverage for shortened-end boundary selection and old-loop-wrap detection.
- Document the scenario matrix, validation evidence, and observability gaps on OPT-922.
- Create linked bug OPT-1144 for the confirmed late-runtime-start ordering defect.

## Definition of Done

- Ownership boundaries and event flow are documented.
- Resize/move boundary and wrap behavior have deterministic test coverage.
- Loop toggles, runtime coalescing, odd-frame spans, and all Wavecrate targets are validated.
- Real audio-output failures are reproduced and tracked separately without changing production semantics in this audit.

## Validation commands

Passing:

- `cargo test -p wavecrate pending_live_retarget_ -- --nocapture`
- `cargo test -p wavecrate loop_toggle -- --nocapture`
- `cargo test -p reson span_retarget -- --nocapture`
- `cargo test -p reson odd_frame_span -- --nocapture`
- `cargo check -p wavecrate --all-targets`

Expected audit findings:

- `WAVECRATE_TEST_AUDIO_OUTPUT=1 cargo test -p wavecrate looped_playback_retarget -- --nocapture` — 0 passed, 4 failed; tracked by OPT-1144.
- `WAVECRATE_TEST_AUDIO_OUTPUT=1 cargo test -p wavecrate one_shot_playback_retarget -- --nocapture --test-threads=1` — 1 passed, 2 failed; tracked by OPT-1144.

## Known limitations

- This audit intentionally does not fix OPT-1144.
- Audible manual comparison beyond the opt-in real-output test harness was not performed.

User review is required before merge.