### PR TITLE
OPT-601: simplify source DB access into role-scoped contracts

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -24,6 +24,8 @@ pub mod write;
 pub mod util;
 
 mod rating_tests;
+#[cfg(test)]
+mod role_contract_tests;
 
 pub use error::SourceDbError;
 pub(crate) use open::SourceDatabaseOpenMode;
@@ -71,14 +73,22 @@ pub struct SourceWriteBatch<'conn> {
 }
 
 impl SourceDatabase {
-    /// Open (or create) the database that lives inside the source folder.
-    pub fn open(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+    /// Open a writable source database for general source-owned mutations.
+    ///
+    /// This preserves the complete schema and cleanup behavior used by the
+    /// legacy `open` entrypoint while making write intent explicit to callers.
+    pub fn open_for_source_write(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
         let root = root.as_ref();
         open::open_source_database(
             root,
             open::should_open_source_db_read_only(),
             open::SourceDatabaseOpenMode::Full,
         )
+    }
+
+    /// Open (or create) the database that lives inside the source folder.
+    pub fn open(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+        Self::open_for_source_write(root)
     }
 
     /// Open (or create) a source database stored outside the source root.
@@ -97,17 +107,21 @@ impl SourceDatabase {
         )
     }
 
-    /// Open (or create) the database using startup-friendly schema work only.
-    ///
-    /// This preserves required table/index compatibility while deferring expensive
-    /// path validation/cleanup to a background maintenance job.
-    pub fn open_fast(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
-        let root = root.as_ref();
+    /// Open a writable external source database for general source-owned mutations.
+    pub fn open_for_source_write_with_database_root(
+        root: impl AsRef<Path>,
+        database_root: impl AsRef<Path>,
+    ) -> Result<Self, SourceDbError> {
+        Self::open_with_database_root(root, database_root)
+    }
+
+    /// Open a startup-friendly database for a background job.
+    pub fn open_for_background_job(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
         Self::open_with_role(root, SourceDatabaseConnectionRole::JobWorker)
     }
 
-    /// Open a startup-friendly source database stored outside the source root.
-    pub fn open_fast_with_database_root(
+    /// Open a startup-friendly external database for a background job.
+    pub fn open_for_background_job_with_database_root(
         root: impl AsRef<Path>,
         database_root: impl AsRef<Path>,
     ) -> Result<Self, SourceDbError> {
@@ -118,13 +132,26 @@ impl SourceDatabase {
         )
     }
 
-    /// Open an existing database in read-only mode without applying schema migrations.
-    pub fn open_read_only(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+    /// Open a startup-friendly database owned by source scanning.
+    pub fn open_for_scan(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+        Self::open_for_background_job(root)
+    }
+
+    /// Open a startup-friendly external database owned by source scanning.
+    pub fn open_for_scan_with_database_root(
+        root: impl AsRef<Path>,
+        database_root: impl AsRef<Path>,
+    ) -> Result<Self, SourceDbError> {
+        Self::open_for_background_job_with_database_root(root, database_root)
+    }
+
+    /// Open an existing database for UI-owned read access.
+    pub fn open_for_ui_read(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
         Self::open_with_role(root, SourceDatabaseConnectionRole::UiRead)
     }
 
-    /// Open an external source database in read-only mode.
-    pub fn open_read_only_with_database_root(
+    /// Open an external database for UI-owned read access.
+    pub fn open_for_ui_read_with_database_root(
         root: impl AsRef<Path>,
         database_root: impl AsRef<Path>,
     ) -> Result<Self, SourceDbError> {
@@ -133,6 +160,40 @@ impl SourceDatabase {
             database_root,
             SourceDatabaseConnectionRole::UiRead,
         )
+    }
+
+    /// Open a source database for deferred schema and cleanup maintenance.
+    pub fn open_for_maintenance(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+        Self::open_with_role(root, SourceDatabaseConnectionRole::Maintenance)
+    }
+
+    /// Open (or create) the database using startup-friendly schema work only.
+    ///
+    /// This preserves required table/index compatibility while deferring expensive
+    /// path validation/cleanup to a background maintenance job.
+    pub fn open_fast(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+        Self::open_for_background_job(root)
+    }
+
+    /// Open a startup-friendly source database stored outside the source root.
+    pub fn open_fast_with_database_root(
+        root: impl AsRef<Path>,
+        database_root: impl AsRef<Path>,
+    ) -> Result<Self, SourceDbError> {
+        Self::open_for_background_job_with_database_root(root, database_root)
+    }
+
+    /// Open an existing database in read-only mode without applying schema migrations.
+    pub fn open_read_only(root: impl AsRef<Path>) -> Result<Self, SourceDbError> {
+        Self::open_for_ui_read(root)
+    }
+
+    /// Open an external source database in read-only mode.
+    pub fn open_read_only_with_database_root(
+        root: impl AsRef<Path>,
+        database_root: impl AsRef<Path>,
+    ) -> Result<Self, SourceDbError> {
+        Self::open_for_ui_read_with_database_root(root, database_root)
     }
 
     /// Open a source database using one explicit runtime role profile.

--- a/crates/wavecrate-library/src/sample_sources/db/role_contract_tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/role_contract_tests.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use tempfile::tempdir;
+
+use super::SourceDatabase;
+
+#[test]
+fn role_scoped_entrypoints_preserve_read_write_contracts() {
+    let dir = tempdir().unwrap();
+    let writer = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    writer.upsert_file(Path::new("one.wav"), 10, 5).unwrap();
+
+    let ui_read = SourceDatabase::open_for_ui_read(dir.path()).unwrap();
+    assert_eq!(ui_read.count_files().unwrap(), 1);
+
+    let background = SourceDatabase::open_for_background_job(dir.path()).unwrap();
+    background
+        .set_metadata("contract_probe", "background")
+        .unwrap();
+
+    let maintenance = SourceDatabase::open_for_maintenance(dir.path()).unwrap();
+    assert_eq!(
+        maintenance
+            .get_metadata("contract_probe")
+            .unwrap()
+            .as_deref(),
+        Some("background")
+    );
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -72,7 +72,7 @@ fn scan(
 /// Useful for fire-and-forget refreshes without blocking the UI thread.
 pub fn scan_in_background(root: PathBuf) -> thread::JoinHandle<Result<ScanStats, ScanError>> {
     thread::spawn(move || {
-        let db = SourceDatabase::open_fast(&root)?;
+        let db = SourceDatabase::open_for_scan(&root)?;
         let stats = scan_once(&db)?;
         if stats.hashes_pending > 0 {
             schedule_deep_hash_scan(root);
@@ -93,7 +93,7 @@ pub fn schedule_deep_hash_scan(root: PathBuf) {
 pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: PathBuf) {
     thread::spawn(move || {
         let result = (|| -> Result<(), ScanError> {
-            let db = SourceDatabase::open_fast_with_database_root(root, database_root)?;
+            let db = SourceDatabase::open_for_scan_with_database_root(root, database_root)?;
             let _ = super::super::scan_hash::deep_hash_scan(&db, None)?;
             Ok(())
         })();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -202,10 +202,10 @@ mod tests {
     fn deep_hash_scan_checks_cancel_before_writer_lock() {
         let dir = tempfile::tempdir().expect("temp source");
         std::fs::write(dir.path().join("pending.wav"), b"pending").expect("write wav");
-        let db = SourceDatabase::open(dir.path()).expect("source db");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
         db.upsert_file(Path::new("pending.wav"), 7, 10)
             .expect("file row");
-        let lock_db = SourceDatabase::open(dir.path()).expect("lock db");
+        let lock_db = SourceDatabase::open_for_source_write(dir.path()).expect("lock db");
         let _writer = lock_db.write_batch().expect("writer lock");
         let cancel = AtomicBool::new(true);
 

--- a/src/app/controller/jobs/source_db_maintenance.rs
+++ b/src/app/controller/jobs/source_db_maintenance.rs
@@ -1,9 +1,9 @@
 use super::retry_policy::{DEFERRED_MAINTENANCE_MAX_ATTEMPTS, DEFERRED_MAINTENANCE_RETRY_DELAY};
 use super::{SourceDbMaintenanceJob, SourceDbMaintenanceOutcome, SourceDbMaintenanceRefresh};
 use crate::app::controller::library::analysis_jobs;
+use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::file_ops_journal;
 use crate::sample_sources::scanner::{scan_once, schedule_deep_hash_scan};
-use crate::sample_sources::{SourceDatabase, SourceDatabaseConnectionRole};
 
 mod markers;
 mod refresh;
@@ -92,7 +92,7 @@ fn run_source_db_maintenance_with_retries(
 }
 
 fn open_maintenance_probe(job: &SourceDbMaintenanceJob) -> Result<SourceDatabase, String> {
-    SourceDatabase::open_with_role(&job.source_root, SourceDatabaseConnectionRole::Maintenance)
+    SourceDatabase::open_for_maintenance(&job.source_root)
         .map_err(|err| format!("Open source DB failed: {err}"))
 }
 

--- a/src/app/controller/library/analysis_jobs/enqueue/scan.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/scan.rs
@@ -22,8 +22,8 @@ pub(crate) fn stage_samples_for_source(
     source: &crate::sample_sources::SampleSource,
     _include_missing_entries: bool,
 ) -> Result<Vec<db::SampleMetadata>, String> {
-    let source_db =
-        crate::sample_sources::SourceDatabase::open(&source.root).map_err(|err| err.to_string())?;
+    let source_db = crate::sample_sources::SourceDatabase::open_for_source_write(&source.root)
+        .map_err(|err| err.to_string())?;
     let entries = source_db.list_files().map_err(|err| err.to_string())?;
     if entries.is_empty() {
         return Ok(Vec::new());

--- a/src/app/controller/library/analysis_jobs/pool/job_progress.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress.rs
@@ -198,7 +198,8 @@ mod tests {
         let _config_guard = crate::app_dirs::ConfigBaseGuard::set(config_dir.path().to_path_buf());
         let source_dir = TempDir::new().unwrap();
         let source = crate::sample_sources::SampleSource::new(source_dir.path().to_path_buf());
-        crate::sample_sources::SourceDatabase::open(&source.root).expect("seed source db");
+        crate::sample_sources::SourceDatabase::open_for_source_write(&source.root)
+            .expect("seed source db");
         crate::sample_sources::library::save(&crate::sample_sources::library::LibraryState {
             sources: vec![source.clone()],
         })

--- a/src/app/controller/library/browser_controller/actions/metadata/planning/controller.rs
+++ b/src/app/controller/library/browser_controller/actions/metadata/planning/controller.rs
@@ -9,7 +9,7 @@ impl BrowserController<'_> {
         paths: &[PathBuf],
     ) -> Result<Vec<SampleAutoRenameRequest>, String> {
         let started_at = Instant::now();
-        let db = crate::sample_sources::SourceDatabase::open_read_only(&source.root)
+        let db = crate::sample_sources::SourceDatabase::open_for_ui_read(&source.root)
             .map_err(|err| format!("Database unavailable: {err}"))?;
         let mut requests = Vec::with_capacity(paths.len());
         let mut reserved_targets = HashSet::new();

--- a/src/app/controller/library/browser_controller/actions/metadata/planning/worker.rs
+++ b/src/app/controller/library/browser_controller/actions/metadata/planning/worker.rs
@@ -33,7 +33,7 @@ fn prepare_auto_rename_requests_from_snapshot(
     progress: &FileOpProgressSender,
 ) -> Result<Vec<SampleAutoRenameRequest>, String> {
     let started_at = Instant::now();
-    let db = crate::sample_sources::SourceDatabase::open_read_only(&snapshot.source.root)
+    let db = crate::sample_sources::SourceDatabase::open_for_ui_read(&snapshot.source.root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     let bpm_sample_ids = snapshot
         .paths

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation/auto_rename.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation/auto_rename.rs
@@ -13,10 +13,7 @@ pub(crate) fn run_sample_auto_rename_job(
         .iter()
         .map(|request| request.old_relative.clone())
         .collect::<Vec<_>>();
-    let db = match crate::sample_sources::SourceDatabase::open_with_role(
-        &source.root,
-        crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
-    ) {
+    let db = match crate::sample_sources::SourceDatabase::open_for_background_job(&source.root) {
         Ok(db) => db,
         Err(err) => {
             return SampleAutoRenameResult {

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation/rename.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation/rename.rs
@@ -16,11 +16,8 @@ pub(in crate::app::controller::library::browser_controller::helpers) fn perform_
     fallback_user_tag: Option<String>,
     fallback_tag_named: Option<bool>,
 ) -> Result<WavEntry, String> {
-    let db = crate::sample_sources::SourceDatabase::open_with_role(
-        &source.root,
-        crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
-    )
-    .map_err(|err| format!("Database unavailable: {err}"))?;
+    let db = crate::sample_sources::SourceDatabase::open_for_background_job(&source.root)
+        .map_err(|err| format!("Database unavailable: {err}"))?;
     perform_sample_rename_with_db(
         source,
         &db,

--- a/src/app/controller/library/scans/worker.rs
+++ b/src/app/controller/library/scans/worker.rs
@@ -40,7 +40,7 @@ fn run_scan_worker(
     cancel: &AtomicBool,
     mut progress: impl FnMut(usize, &Path),
 ) -> Result<ScanStats, scanner::ScanError> {
-    let db = SourceDatabase::open_fast(root)?;
+    let db = SourceDatabase::open_for_background_job(root)?;
     let stats = if mode == ScanMode::Targeted {
         scanner::sync_paths_with_progress(
             &db,

--- a/src/app/controller/library/selection_edits/background.rs
+++ b/src/app/controller/library/selection_edits/background.rs
@@ -160,7 +160,7 @@ fn run_selection_edit_commit_job(
     let result = (|| {
         let backup =
             crate::app::controller::undo::OverwriteBackup::capture_before(&target.absolute_path)?;
-        let db = crate::sample_sources::SourceDatabase::open(&target.source.root)
+        let db = crate::sample_sources::SourceDatabase::open_for_source_write(&target.source.root)
             .map_err(|err| format!("Database unavailable: {err}"))?;
         let tag = db
             .tag_for_path(&target.relative_path)

--- a/src/app/controller/library/selection_edits/undo_entries.rs
+++ b/src/app/controller/library/selection_edits/undo_entries.rs
@@ -163,7 +163,7 @@ fn capture_current_restore_metadata(
             normal_tags: entry.normal_tags.clone(),
         };
     }
-    if let Ok(db) = crate::sample_sources::SourceDatabase::open_fast(&source.root) {
+    if let Ok(db) = crate::sample_sources::SourceDatabase::open_for_background_job(&source.root) {
         if let Ok(Some(tag)) = db.tag_for_path(relative_path) {
             metadata.tag = tag;
         }

--- a/src/app/controller/library/selection_export/background_recording.rs
+++ b/src/app/controller/library/selection_export/background_recording.rs
@@ -60,7 +60,7 @@ pub(super) fn record_clip_entry(
         snapshot.target_tag.unwrap_or(Rating::NEUTRAL),
         snapshot.looped,
     )?;
-    let db = SourceDatabase::open_fast(&source.root)
+    let db = SourceDatabase::open_for_background_job(&source.root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     db.upsert_file(&entry.relative_path, entry.file_size, entry.modified_ns)
         .map_err(|err| format!("Failed to register clip: {err}"))?;
@@ -92,7 +92,7 @@ pub(super) fn record_crop_entry(
     entry.looped = false;
     entry.tag = snapshot.target_tag.unwrap_or(Rating::NEUTRAL);
     let source = sample_source(snapshot);
-    let db = SourceDatabase::open_fast(&source.root)
+    let db = SourceDatabase::open_for_background_job(&source.root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     db.upsert_file(&entry.relative_path, entry.file_size, entry.modified_ns)
         .map_err(|err| format!("Failed to sync database entry: {err}"))?;
@@ -114,7 +114,7 @@ pub(super) fn record_slice_batch_entry(
     )?;
     let source =
         SampleSource::new_with_id(snapshot.source_id.clone(), snapshot.source_root.clone());
-    let db = SourceDatabase::open_fast(&source.root)
+    let db = SourceDatabase::open_for_background_job(&source.root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     db.upsert_file(&entry.relative_path, entry.file_size, entry.modified_ns)
         .map_err(|err| format!("Failed to register slice: {err}"))?;

--- a/src/app/controller/library/selection_export/completion.rs
+++ b/src/app/controller/library/selection_export/completion.rs
@@ -343,7 +343,7 @@ fn harvest_metadata_snapshot_from_entry(entry: Option<&WavEntry>) -> HarvestMeta
 }
 
 fn source_db_entry(source_root: &Path, relative_path: &Path) -> Option<WavEntry> {
-    let db = SourceDatabase::open_read_only(source_root.to_path_buf()).ok()?;
+    let db = SourceDatabase::open_for_ui_read(source_root.to_path_buf()).ok()?;
     db.list_files()
         .ok()?
         .into_iter()

--- a/src/app/controller/library/similarity_prep/db.rs
+++ b/src/app/controller/library/similarity_prep/db.rs
@@ -3,7 +3,7 @@ use crate::sample_sources::{SampleSource, SourceDatabase, SourceId};
 use std::collections::HashSet;
 
 pub(crate) fn read_source_scan_timestamp(source: &SampleSource) -> Option<i64> {
-    let db = SourceDatabase::open_fast(&source.root).ok()?;
+    let db = SourceDatabase::open_for_background_job(&source.root).ok()?;
     db.get_metadata(crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT)
         .ok()
         .flatten()
@@ -11,7 +11,7 @@ pub(crate) fn read_source_scan_timestamp(source: &SampleSource) -> Option<i64> {
 }
 
 pub(crate) fn read_source_prep_timestamp(source: &SampleSource) -> Option<i64> {
-    let db = SourceDatabase::open_fast(&source.root).ok()?;
+    let db = SourceDatabase::open_for_background_job(&source.root).ok()?;
     db.get_metadata(crate::sample_sources::db::META_LAST_SIMILARITY_PREP_SCAN_AT)
         .ok()
         .flatten()
@@ -23,7 +23,8 @@ pub(crate) fn record_similarity_prep_scan_timestamp(
     source: &SampleSource,
     scan_completed_at: i64,
 ) -> Result<(), String> {
-    let db = SourceDatabase::open_fast(&source.root).map_err(|err| err.to_string())?;
+    let db =
+        SourceDatabase::open_for_background_job(&source.root).map_err(|err| err.to_string())?;
     db.set_metadata(
         crate::sample_sources::db::META_LAST_SIMILARITY_PREP_SCAN_AT,
         &scan_completed_at.to_string(),
@@ -85,7 +86,8 @@ pub(crate) fn source_has_aspect_descriptors(source: &SampleSource) -> bool {
 
 /// Handles current present sample ids.
 fn current_present_sample_ids(source: &SampleSource) -> Result<Vec<String>, String> {
-    let source_db = SourceDatabase::open_fast(&source.root).map_err(|err| err.to_string())?;
+    let source_db =
+        SourceDatabase::open_for_background_job(&source.root).map_err(|err| err.to_string())?;
     let entries = source_db.list_files().map_err(|err| err.to_string())?;
     Ok(entries
         .into_iter()
@@ -290,7 +292,7 @@ mod tests {
         let root = dir.path().join("source");
         std::fs::create_dir_all(&root).unwrap();
         let source = SampleSource::new(root);
-        let db = SourceDatabase::open(&source.root).unwrap();
+        let db = SourceDatabase::open_for_source_write(&source.root).unwrap();
         db.upsert_file(std::path::Path::new("old-a.wav"), 1, 1)
             .unwrap();
         db.upsert_file(std::path::Path::new("old-b.wav"), 1, 1)

--- a/src/app/controller/library/source_folders/actions/rename_move_delete/delete_execution.rs
+++ b/src/app/controller/library/source_folders/actions/rename_move_delete/delete_execution.rs
@@ -112,7 +112,7 @@ impl AppController {
                     target_path,
                     entries,
                 )?;
-                let db = crate::sample_sources::SourceDatabase::open(&source.root)
+                let db = crate::sample_sources::SourceDatabase::open_for_source_write(&source.root)
                     .map_err(|err| format!("Database unavailable: {err}"))?;
                 let mut batch = db
                     .write_batch()
@@ -163,7 +163,7 @@ pub(super) fn run_folder_delete_job(
         &entries,
     )
     .and_then(|staged| {
-        let db = crate::sample_sources::SourceDatabase::open(&source.root)
+        let db = crate::sample_sources::SourceDatabase::open_for_source_write(&source.root)
             .map_err(|err| format!("Database unavailable: {err}"))?;
         let mut batch = db
             .write_batch()

--- a/src/app/controller/library/source_folders/actions/rename_move_delete/rename_execution.rs
+++ b/src/app/controller/library/source_folders/actions/rename_move_delete/rename_execution.rs
@@ -47,7 +47,7 @@ fn rewrite_folder_entries(
     new_folder: &Path,
     affected: &[WavEntry],
 ) -> Result<Vec<WavEntry>, String> {
-    let db = crate::sample_sources::SourceDatabase::open(source_root)
+    let db = crate::sample_sources::SourceDatabase::open_for_source_write(source_root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     let mut batch = db
         .write_batch()

--- a/src/app/controller/library/source_folders/delete_recovery/retained_restore_reconcile.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/retained_restore_reconcile.rs
@@ -157,8 +157,8 @@ fn restore_rows_in_db(source: &SampleSource, entries: &[WavEntry]) -> Result<(),
     if entries.is_empty() {
         return Ok(());
     }
-    let db =
-        SourceDatabase::open(&source.root).map_err(|err| format!("Database unavailable: {err}"))?;
+    let db = SourceDatabase::open_for_source_write(&source.root)
+        .map_err(|err| format!("Database unavailable: {err}"))?;
     let mut batch = db
         .write_batch()
         .map_err(|err| format!("Failed to start database update: {err}"))?;

--- a/src/app/controller/library/sources/lifecycle/add.rs
+++ b/src/app/controller/library/sources/lifecycle/add.rs
@@ -261,7 +261,7 @@ fn validate_add_source_root(
 
 fn run_source_add_prepare(job: SourceAddJob) -> SourceAddPreparedResult {
     let started_at = Instant::now();
-    let result = SourceDatabase::open(&job.source.root)
+    let result = SourceDatabase::open_for_source_write(&job.source.root)
         .map(|_| ())
         .map_err(|err| {
             let error = format!("Failed to create database: {err}");

--- a/src/app/controller/library/sources/lifecycle/remap.rs
+++ b/src/app/controller/library/sources/lifecycle/remap.rs
@@ -120,7 +120,7 @@ fn prepare_database_for_remap(
     normalized: &PathBuf,
     started_at: Instant,
 ) -> Result<(), String> {
-    if let Err(err) = SourceDatabase::open(normalized) {
+    if let Err(err) = SourceDatabase::open_for_source_write(normalized) {
         let error = format!("Failed to prepare database: {err}");
         record_source_lifecycle_event(
             "sources.remap",

--- a/src/app/controller/library/trash/moves.rs
+++ b/src/app/controller/library/trash/moves.rs
@@ -148,7 +148,7 @@ impl AppController {
         let mut moved_paths = Vec::new();
         let mut affected_sources = std::collections::HashSet::new();
         for (source, entry) in samples {
-            let db = match SourceDatabase::open(&source.root) {
+            let db = match SourceDatabase::open_for_source_write(&source.root) {
                 Ok(db) => db,
                 Err(err) => {
                     errors.push(format!("{}: {err}", source.root.display()));

--- a/src/app/controller/library/trash_move/execution.rs
+++ b/src/app/controller/library/trash_move/execution.rs
@@ -48,7 +48,7 @@ where
         if cancel.load(Ordering::Relaxed) {
             break;
         }
-        let db = match SourceDatabase::open(&source.root) {
+        let db = match SourceDatabase::open_for_source_write(&source.root) {
             Ok(db) => db,
             Err(err) => {
                 errors.push(format!("{}: {err}", source.root.display()));
@@ -94,7 +94,7 @@ where
         if cancel.load(Ordering::Relaxed) {
             break;
         }
-        let db = match SourceDatabase::open(&source.root) {
+        let db = match SourceDatabase::open_for_source_write(&source.root) {
             Ok(db) => db,
             Err(err) => {
                 errors.push(format!("{}: {err}", source.root.display()));

--- a/src/app/controller/library/wav_entries_loader.rs
+++ b/src/app/controller/library/wav_entries_loader.rs
@@ -100,7 +100,7 @@ fn load_entries_with_options(
     job: &WavLoadJob,
     options: LoadEntriesOptions,
 ) -> (Result<Vec<WavEntry>, LoadEntriesError>, usize) {
-    let db = match SourceDatabase::open_fast(&job.root) {
+    let db = match SourceDatabase::open_for_background_job(&job.root) {
         Ok(db) => db,
         Err(err) => return (Err(LoadEntriesError::Db(err)), 0),
     };

--- a/src/app/controller/library/wavs/browser_search_worker/pipeline/stages/source_cache/source_db_stage.rs
+++ b/src/app/controller/library/wavs/browser_search_worker/pipeline/stages/source_cache/source_db_stage.rs
@@ -20,10 +20,7 @@ pub(in super::super::super) fn ensure_search_cache_ready_for_job(
     let db_stamp = DbFileStamp::from_path(&db_path);
     let source_changed = cache.source_id.as_deref() != Some(source_id)
         || cache.source_root.as_ref() != Some(&job.source_root);
-    match crate::sample_sources::SourceDatabase::open_with_role(
-        &job.source_root,
-        crate::sample_sources::SourceDatabaseConnectionRole::UiRead,
-    ) {
+    match crate::sample_sources::SourceDatabase::open_for_ui_read(&job.source_root) {
         Ok(db) => {
             cache.db = Some(db);
             apply_reopened_source_db(cache, job, source_id, db_stamp, source_changed);

--- a/src/app/controller/library/wavs/metadata_async/analysis_ops.rs
+++ b/src/app/controller/library/wavs/metadata_async/analysis_ops.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 pub(super) fn run_analysis_metadata_ops(job: &MetadataMutationJob) -> Result<(), String> {
     let mut conn = analysis_jobs::open_source_db(&job.source_root)?;
-    let source_db = SourceDatabase::open_read_only(&job.source_root)
+    let source_db = SourceDatabase::open_for_ui_read(&job.source_root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     let duration_updates = collect_loaded_duration_updates(job, &source_db)?;
     let bpm_ops: Vec<_> = job

--- a/src/app/controller/library/wavs/metadata_async/source_ops.rs
+++ b/src/app/controller/library/wavs/metadata_async/source_ops.rs
@@ -6,7 +6,8 @@ use tracing::info;
 
 pub(super) fn run_source_metadata_ops(job: &MetadataMutationJob) -> Result<(), String> {
     let started_at = Instant::now();
-    let db = SourceDatabase::open_fast(&job.source_root).map_err(|err| err.to_string())?;
+    let db =
+        SourceDatabase::open_for_background_job(&job.source_root).map_err(|err| err.to_string())?;
     let resolved_ops = job
         .source_ops
         .iter()

--- a/src/app/controller/playback/loop_crossfade/undo_ops.rs
+++ b/src/app/controller/playback/loop_crossfade/undo_ops.rs
@@ -115,7 +115,7 @@ fn capture_current_loop_crossfade_restore_metadata(
             normal_tags: entry.normal_tags.clone(),
         };
     }
-    if let Ok(db) = crate::sample_sources::SourceDatabase::open_fast(&source.root) {
+    if let Ok(db) = crate::sample_sources::SourceDatabase::open_for_background_job(&source.root) {
         if let Ok(Some(tag)) = db.tag_for_path(relative_path) {
             metadata.tag = tag;
         }

--- a/src/app/controller/playback/recording/path.rs
+++ b/src/app/controller/playback/recording/path.rs
@@ -106,7 +106,7 @@ fn ensure_recordings_source(
             SampleSource::new(root.clone())
         }
     };
-    SourceDatabase::open(&root)
+    SourceDatabase::open_for_source_write(&root)
         .map_err(|err| format!("Failed to create recordings database: {err}"))?;
     let _ = controller.cache_db(&source);
     controller.library.sources.push(source.clone());

--- a/src/app/controller/state/cache/library.rs
+++ b/src/app/controller/state/cache/library.rs
@@ -55,7 +55,7 @@ impl LibraryCacheState {
         if let Some(existing) = self.db.get(&source.id) {
             return Ok(existing.clone());
         }
-        let db = Rc::new(SourceDatabase::open_fast(&source.root)?);
+        let db = Rc::new(SourceDatabase::open_for_background_job(&source.root)?);
         self.db.insert(source.id.clone(), db.clone());
         Ok(db)
     }

--- a/src/app/controller/ui/clipboard_paste/source_job/mod.rs
+++ b/src/app/controller/ui/clipboard_paste/source_job/mod.rs
@@ -136,7 +136,7 @@ mod tests {
         let (mut controller, source) = dummy_controller();
         controller.library.sources.push(source.clone());
         controller.cache_db(&source).unwrap();
-        let db = SourceDatabase::open(&source.root).unwrap();
+        let db = SourceDatabase::open_for_source_write(&source.root).unwrap();
         let op_id = file_ops_journal::new_op_id();
         let relative = PathBuf::from("Drums").join("kick.wav");
         let staged_relative =

--- a/src/app/controller/ui/clipboard_paste/source_job/prepare.rs
+++ b/src/app/controller/ui/clipboard_paste/source_job/prepare.rs
@@ -27,7 +27,7 @@ impl SourcePasteContext {
                 target_root.display()
             ));
         }
-        let db = SourceDatabase::open(&job.source_root)
+        let db = SourceDatabase::open_for_source_write(&job.source_root)
             .map_err(|err| format!("Failed to open source DB: {err}"))?;
         Ok(Self {
             source_id: job.source_id,

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/drop_targets/worker.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/drop_targets/worker.rs
@@ -62,7 +62,7 @@ pub(super) fn run_drop_target_transfer_task(
             cancelled,
         };
     }
-    let target_db = match SourceDatabase::open(&target_root) {
+    let target_db = match SourceDatabase::open_for_source_write(&target_root) {
         Ok(db) => db,
         Err(err) => {
             errors.push(format!("Failed to open target DB: {err}"));

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/drop_targets/worker/request_context.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/drop_targets/worker/request_context.rs
@@ -33,7 +33,7 @@ pub(super) fn source_db_for<'a>(
         return Ok(target_db);
     }
     if !source_dbs.contains_key(source_root) {
-        let db = SourceDatabase::open(source_root)
+        let db = SourceDatabase::open_for_source_write(source_root)
             .map_err(|err| format!("Failed to open source DB: {err}"))?;
         source_dbs.insert(source_root.to_path_buf(), db);
     }

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker.rs
@@ -135,7 +135,7 @@ pub(super) fn run_folder_sample_move_task(
             cancelled,
         };
     }
-    let db = match SourceDatabase::open(&source_root) {
+    let db = match SourceDatabase::open_for_source_write(&source_root) {
         Ok(db) => db,
         Err(err) => {
             errors.push(format!("Failed to open source DB: {err}"));

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker/folder_move_task/request_validation.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker/folder_move_task/request_validation.rs
@@ -6,7 +6,7 @@ pub(super) fn prepare_folder_move_transaction(
     request: FolderMoveRequest,
 ) -> Result<FolderMoveTransaction, FolderMoveResult> {
     let prepared = prepare_folder_move(&request)?;
-    let db = SourceDatabase::open(&request.source_root).map_err(|err| {
+    let db = SourceDatabase::open_for_source_write(&request.source_root).map_err(|err| {
         error_result(
             &request,
             prepared.new_relative.clone(),

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker.rs
@@ -62,7 +62,7 @@ pub(super) fn run_source_move_task(
             cancelled,
         };
     }
-    let target_db = match SourceDatabase::open(&target_root) {
+    let target_db = match SourceDatabase::open_for_source_write(&target_root) {
         Ok(db) => db,
         Err(err) => {
             errors.push(format!("Failed to open target DB: {err}"));

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/transaction.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/transaction.rs
@@ -303,10 +303,11 @@ fn source_db_for_request<'a>(
 ) -> Result<&'a mut SourceDatabase, String> {
     match source_dbs.entry(source_root.to_path_buf()) {
         std::collections::hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
-        std::collections::hash_map::Entry::Vacant(entry) => match SourceDatabase::open(source_root)
-        {
-            Ok(db) => Ok(entry.insert(db)),
-            Err(err) => Err(format!("Failed to open source DB: {err}")),
-        },
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            match SourceDatabase::open_for_source_write(source_root) {
+                Ok(db) => Ok(entry.insert(db)),
+                Err(err) => Err(format!("Failed to open source DB: {err}")),
+            }
+        }
     }
 }

--- a/src/app/controller/ui/waveform_slide/commit.rs
+++ b/src/app/controller/ui/waveform_slide/commit.rs
@@ -50,7 +50,7 @@ fn commit_waveform_slide(
     let spec = slide_wav_spec(state.spec_channels, state.sample_rate);
     write_waveform_wav(&state.absolute_path, rotated, spec)?;
     let (file_size, modified_ns) = file_metadata(&state.absolute_path)?;
-    let db = crate::sample_sources::SourceDatabase::open(&state.source.root)
+    let db = crate::sample_sources::SourceDatabase::open_for_source_write(&state.source.root)
         .map_err(|err| format!("Database unavailable: {err}"))?;
     let tag = db
         .tag_for_path(&state.relative_path)

--- a/src/app/controller/undo_jobs.rs
+++ b/src/app/controller/undo_jobs.rs
@@ -268,7 +268,8 @@ fn ensure_parent_dir(path: &Path) -> Result<(), String> {
 }
 
 fn open_source_db(source_root: &Path) -> Result<SourceDatabase, String> {
-    SourceDatabase::open(source_root).map_err(|err| format!("Database unavailable: {err}"))
+    SourceDatabase::open_for_source_write(source_root)
+        .map_err(|err| format!("Database unavailable: {err}"))
 }
 
 fn delete_sample_file_if_present(path: &Path) -> Result<(), String> {

--- a/src/native_app/metadata/persistence.rs
+++ b/src/native_app/metadata/persistence.rs
@@ -197,7 +197,7 @@ pub(super) fn load_persisted_metadata_tag_map_for_source(
     source_root: &Path,
     source_database_root: &Path,
 ) -> Result<HashMap<String, Vec<String>>, String> {
-    let db = match SourceDatabase::open_read_only_with_database_root(
+    let db = match SourceDatabase::open_for_ui_read_with_database_root(
         source_root,
         source_database_root,
     ) {

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -24,7 +24,7 @@ pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap
 >;
 
 pub(super) fn source_rating_map(root: &Path, database_root: &Path) -> SourceMetadataMap {
-    let Ok(db) = SourceDatabase::open_read_only_with_database_root(root, database_root) else {
+    let Ok(db) = SourceDatabase::open_for_ui_read_with_database_root(root, database_root) else {
         return HashMap::new();
     };
     let Ok(entries) = db.list_files() else {
@@ -303,7 +303,7 @@ fn source_file_metadata(
     Option<i64>,
 )> {
     let relative = path.strip_prefix(source_root).ok()?;
-    let db = SourceDatabase::open_read_only_with_database_root(source_root, source_database_root)
+    let db = SourceDatabase::open_for_ui_read_with_database_root(source_root, source_database_root)
         .ok()?;
     let entry = db.entry_for_path(relative).ok()??;
     let collections = db.collections_for_path(relative).unwrap_or_default();

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -77,11 +77,13 @@ fn sync_source_database(
     request: &FolderScanRequest,
     progress: &mut impl FnMut(FolderScanProgress),
 ) -> Option<String> {
-    let db =
-        match SourceDatabase::open_fast_with_database_root(&request.root, &request.database_root) {
-            Ok(db) => db,
-            Err(err) => return Some(format!("open source index: {err}")),
-        };
+    let db = match SourceDatabase::open_for_background_job_with_database_root(
+        &request.root,
+        &request.database_root,
+    ) {
+        Ok(db) => db,
+        Err(err) => return Some(format!("open source index: {err}")),
+    };
     let mut sync_progress = |completed: usize, path: &Path| {
         progress(FolderScanProgress {
             task_id: request.task_id,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -11,7 +11,7 @@ pub(super) fn sync_source_database_paths(
     paths: Vec<PathBuf>,
     changed_count: usize,
 ) -> SourceFilesystemSyncResult {
-    let result = SourceDatabase::open_fast_with_database_root(&root, &database_root)
+    let result = SourceDatabase::open_for_background_job_with_database_root(&root, &database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
             scanner::sync_paths(&db, &paths).map_err(|err| format!("sync source index: {err}"))

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -753,7 +753,7 @@ pub(super) fn open_fast_source_db(source: &SampleSource) -> Result<SourceDatabas
     let database_root = source
         .database_root()
         .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
-    SourceDatabase::open_fast_with_database_root(&source.root, database_root)
+    SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
         .map_err(|err| format!("Open source DB failed: {err}"))
 }
 

--- a/src/sample_sources/duplicate_file_ops.rs
+++ b/src/sample_sources/duplicate_file_ops.rs
@@ -343,7 +343,7 @@ mod tests {
         let first_collision = root.join("kick_copy001.wav");
         fs::write(&source, [1_u8, 2, 3, 4]).expect("write source");
         fs::write(&first_collision, [9_u8]).expect("write collision");
-        let db = SourceDatabase::open(root).expect("open db");
+        let db = SourceDatabase::open_for_source_write(root).expect("open db");
         db.upsert_file(Path::new("kick.wav"), 4, 1)
             .expect("upsert source");
         db.set_tag(Path::new("kick.wav"), Rating::new(2))
@@ -435,7 +435,7 @@ mod tests {
         .expect("duplicate double");
 
         assert_eq!(result.destination, temp.path().join("loop_doubled.wav"));
-        let db = SourceDatabase::open(temp.path()).expect("open db");
+        let db = SourceDatabase::open_for_source_write(temp.path()).expect("open db");
         assert!(
             db.entry_for_path(Path::new("loop_doubled.wav"))
                 .expect("read doubled entry")

--- a/src/sample_sources/harvest_seen.rs
+++ b/src/sample_sources/harvest_seen.rs
@@ -40,7 +40,7 @@ pub fn persist_harvest_seen(request: HarvestSeenPersistRequest) -> HarvestSeenPe
 fn persist_harvest_seen_inner(request: &HarvestSeenPersistRequest) -> Result<(), String> {
     let path = request.source_root.join(&request.relative_path);
     let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(&path);
-    let entry = SourceDatabase::open_read_only_with_database_root(
+    let entry = SourceDatabase::open_for_ui_read_with_database_root(
         &request.source_root,
         &request.source_database_root,
     )

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -35,7 +35,7 @@ pub mod db {
         META_LAST_SIMILARITY_PREP_SCAN_AT, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
         SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceDatabase,
         SourceDatabaseConnectionRole, SourceDbError, SourceTag, SourceTagUsage, SourceWriteBatch,
-        WavEntry, file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
+        WavEntry, file_ops_journal, normalize_relative_path, read,
     };
     #[cfg(debug_assertions)]
     pub use wavecrate_library::sample_sources::db::{


### PR DESCRIPTION
## Scope

- add intention-revealing source DB entrypoints for source writes, UI reads, background jobs, scans, user metadata edits, playback history, and maintenance
- preserve the existing SQLite connection flags, startup/full schema modes, busy timeouts, and read-only environment behavior
- migrate Wavecrate production and scan callers away from ambiguous `open`, `open_fast`, `open_read_only`, and explicit `open_with_role` choices
- trim unused low-level `schema`, `tags`, `util`, and `write` module re-exports from the Wavecrate compatibility facade
- add a library-level contract test covering the named read/write profiles

## Definition of Done

- [x] production callers identify their intended source DB role at the open call site
- [x] app/controller/native workflows no longer choose generic open modes or role enum variants for wrapped source DB access
- [x] connection and schema behavior remains compatible
- [x] the app-facing compatibility facade exposes fewer low-level persistence modules
- [x] focused source DB and compile validation passes

## Validation commands

- `cargo test -p wavecrate-library role_scoped_entrypoints_preserve_read_write_contracts -- --quiet`
- `cargo test -p wavecrate-library -- --quiet` (143 passed)
- `cargo test -p wavecrate --lib source_db -- --nocapture` (15 passed, 1 existing ignored)
- `cargo check -p wavecrate --no-default-features`
- `cargo check -p wavecrate --all-targets`
- `git diff --check`
- `bash scripts/check.sh wavecrate-facades` (reports pre-existing main-branch facade/test-support violations outside this PR; this change introduces none)

## Known limitations

- Raw `rusqlite::Connection` escape hatches remain intentionally unchanged for the separately scoped OPT-603 migration.
- The facade guardrail is not globally green because current `main` still contains unrelated, already-tracked app-core and native test-support violations.

User review is required before merge.