### PR TITLE
OPT-602: unify source DB mutations as typed write commands

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -36,6 +36,10 @@ pub use open_profiles::SourceDatabaseConnectionRole;
 pub use pending_renames::PendingRenameEntry;
 pub use types::{Rating, SampleCollection, SampleSoundType, SourceTag, SourceTagUsage, WavEntry};
 pub use util::normalize_relative_path;
+pub use write::{
+    SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
+    SourceWriteCommand,
+};
 
 /// Hidden filename used for per-source databases.
 pub const DB_FILE_NAME: &str = ".wavecrate.db";

--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -1,8 +1,17 @@
 mod batch;
+mod collections;
+mod command;
 mod database;
 mod event;
 mod mutation;
+mod paths;
+mod transaction;
 mod upsert;
+
+pub use command::{
+    SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
+    SourceWriteCommand,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -3,14 +3,12 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::{OptionalExtension, params};
+use rusqlite::params;
 
 use super::super::util::map_sql_error;
-use super::super::{
-    Rating, SampleCollection, SampleSoundType, SourceDatabase, SourceDbError, SourceWriteBatch,
-};
+use super::super::{Rating, SampleSoundType, SourceDbError, SourceWriteBatch};
+use super::command::{SourceContentHashWrite, SourceFileWrite, SourceTagWrite};
 use super::mutation::{
-    delete_path_statement, remap_analysis_sample_identity_statement, remap_wav_file_path_statement,
     update_flag_statement, update_path_i64_statement, update_path_null_statement,
     update_path_text_statement,
 };
@@ -31,10 +29,31 @@ const UPDATE_LAST_CURATED_AT_SQL: &str =
     "UPDATE wav_files SET last_curated_at = ?1 WHERE path = ?2";
 const CLEAR_LAST_CURATED_AT_SQL: &str =
     "UPDATE wav_files SET last_curated_at = NULL WHERE path = ?1";
-const UPDATE_COLLECTION_SQL: &str = "UPDATE wav_files SET collection = ?1 WHERE path = ?2";
-const CLEAR_COLLECTION_SQL: &str = "UPDATE wav_files SET collection = NULL WHERE path = ?1";
 
 impl<'conn> SourceWriteBatch<'conn> {
+    pub(super) fn apply_file_write(
+        &mut self,
+        write: SourceFileWrite<'_>,
+    ) -> Result<(), SourceDbError> {
+        let content_hash = match write.content_hash {
+            SourceContentHashWrite::Preserve => ContentHashPolicy::Preserve,
+            SourceContentHashWrite::Clear => ContentHashPolicy::Clear,
+            SourceContentHashWrite::Set(value) => ContentHashPolicy::Set(value),
+        };
+        let tag = match write.tag {
+            SourceTagWrite::Preserve => TagPolicy::Preserve,
+            SourceTagWrite::Set(value) => TagPolicy::Set(value),
+        };
+        self.upsert_file_with_policies(
+            write.relative_path,
+            write.file_size,
+            write.modified_ns,
+            content_hash,
+            tag,
+            write.missing,
+        )
+    }
+
     /// Insert or update a metadata key/value pair within the active batch.
     pub fn set_metadata(&mut self, key: &str, value: &str) -> Result<(), SourceDbError> {
         self.tx
@@ -252,162 +271,11 @@ impl<'conn> SourceWriteBatch<'conn> {
         update_path_null_statement(&self.tx, CLEAR_LAST_CURATED_AT_SQL, relative_path)
     }
 
-    /// Update the fixed collection slot for a wav row within the batch.
-    pub fn set_collection(
-        &mut self,
-        relative_path: &Path,
-        collection: Option<SampleCollection>,
-    ) -> Result<(), SourceDbError> {
-        let path_str = super::super::normalize_relative_path(relative_path)?;
-        self.tx
-            .execute(
-                "DELETE FROM wav_file_collections WHERE path = ?1",
-                params![path_str.as_str()],
-            )
-            .map_err(map_sql_error)?;
-        match collection {
-            Some(collection) => {
-                self.insert_collection_membership(path_str.as_str(), collection)?;
-                update_path_i64_statement(
-                    &self.tx,
-                    UPDATE_COLLECTION_SQL,
-                    relative_path,
-                    collection.as_i64(),
-                )?;
-                self.touch_last_curated_at(relative_path)
-            }
-            None => {
-                update_path_null_statement(&self.tx, CLEAR_COLLECTION_SQL, relative_path)?;
-                self.touch_last_curated_at(relative_path)
-            }
-        }
-    }
-
-    /// Add one fixed collection slot for a wav row without clearing other slots.
-    pub fn add_collection(
-        &mut self,
-        relative_path: &Path,
-        collection: SampleCollection,
-    ) -> Result<(), SourceDbError> {
-        let path_str = super::super::normalize_relative_path(relative_path)?;
-        self.insert_collection_membership(path_str.as_str(), collection)?;
-        self.tx
-            .execute(
-                "UPDATE wav_files
-                 SET collection = COALESCE(collection, ?1)
-                 WHERE path = ?2",
-                params![collection.as_i64(), path_str.as_str()],
-            )
-            .map_err(map_sql_error)?;
-        self.touch_last_curated_at(relative_path)
-    }
-
-    /// Remove one fixed collection slot for a wav row without clearing other slots.
-    pub fn remove_collection(
-        &mut self,
-        relative_path: &Path,
-        collection: SampleCollection,
-    ) -> Result<(), SourceDbError> {
-        let path_str = super::super::normalize_relative_path(relative_path)?;
-        self.tx
-            .execute(
-                "DELETE FROM wav_file_collections
-                 WHERE path = ?1 AND collection = ?2",
-                params![path_str.as_str(), collection.as_i64()],
-            )
-            .map_err(map_sql_error)?;
-        let first_remaining = self
-            .tx
-            .query_row(
-                "SELECT collection
-                 FROM wav_file_collections
-                 WHERE path = ?1
-                 ORDER BY collection ASC
-                 LIMIT 1",
-                params![path_str.as_str()],
-                |row| row.get::<_, i64>(0),
-            )
-            .optional()
-            .map_err(map_sql_error)?;
-        match first_remaining.and_then(SampleCollection::from_i64) {
-            Some(collection) => {
-                update_path_i64_statement(
-                    &self.tx,
-                    UPDATE_COLLECTION_SQL,
-                    relative_path,
-                    collection.as_i64(),
-                )?;
-                self.touch_last_curated_at(relative_path)
-            }
-            None => {
-                update_path_null_statement(&self.tx, CLEAR_COLLECTION_SQL, relative_path)?;
-                self.touch_last_curated_at(relative_path)
-            }
-        }
-    }
-
     pub(crate) fn touch_last_curated_at(
         &mut self,
         relative_path: &Path,
     ) -> Result<(), SourceDbError> {
         self.set_last_curated_at(relative_path, epoch_seconds())
-    }
-
-    fn insert_collection_membership(
-        &self,
-        path: &str,
-        collection: SampleCollection,
-    ) -> Result<(), SourceDbError> {
-        self.tx
-            .execute(
-                "INSERT OR IGNORE INTO wav_file_collections (path, collection)
-                 VALUES (?1, ?2)",
-                params![path, collection.as_i64()],
-            )
-            .map_err(map_sql_error)?;
-        Ok(())
-    }
-
-    /// Remove a wav row within the batch.
-    pub fn remove_file(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
-        self.paths_revision_dirty = true;
-        delete_path_statement(&self.tx, relative_path)
-    }
-
-    /// Remap a wav row and its path-keyed user metadata after a filesystem rename.
-    pub fn remap_wav_file_path(
-        &mut self,
-        old_relative_path: &Path,
-        new_relative_path: &Path,
-    ) -> Result<(), SourceDbError> {
-        self.paths_revision_dirty = true;
-        self.clear_pending_rename(old_relative_path)?;
-        self.clear_pending_rename(new_relative_path)?;
-        remap_wav_file_path_statement(&self.tx, old_relative_path, new_relative_path)
-    }
-
-    /// Remap path-derived analysis rows after a rename-only sample identity change.
-    pub fn remap_analysis_sample_identity(
-        &mut self,
-        old_relative_path: &Path,
-        new_relative_path: &Path,
-    ) -> Result<(), SourceDbError> {
-        remap_analysis_sample_identity_statement(&self.tx, old_relative_path, new_relative_path)
-    }
-
-    /// Commit all batched operations atomically.
-    pub fn commit(self) -> Result<(), SourceDbError> {
-        SourceDatabase::bump_revision(&self.tx)?;
-        if self.paths_revision_dirty {
-            SourceDatabase::bump_wav_paths_revision(&self.tx)?;
-        }
-        self.tx.commit().map_err(map_sql_error)?;
-        crate::sqlite_wal::maybe_checkpoint_database_file(
-            &self.db_path,
-            "source_db",
-            self.telemetry_label,
-        );
-        Ok(())
     }
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/write/collections.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/collections.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+
+use rusqlite::{OptionalExtension, params};
+
+use super::super::util::map_sql_error;
+use super::super::{SampleCollection, SourceDbError, SourceWriteBatch};
+use super::mutation::{update_path_i64_statement, update_path_null_statement};
+
+const UPDATE_COLLECTION_SQL: &str = "UPDATE wav_files SET collection = ?1 WHERE path = ?2";
+const CLEAR_COLLECTION_SQL: &str = "UPDATE wav_files SET collection = NULL WHERE path = ?1";
+
+impl SourceWriteBatch<'_> {
+    /// Replace every fixed collection slot for a wav row.
+    pub fn set_collection(
+        &mut self,
+        relative_path: &Path,
+        collection: Option<SampleCollection>,
+    ) -> Result<(), SourceDbError> {
+        let path_str = super::super::normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "DELETE FROM wav_file_collections WHERE path = ?1",
+                params![path_str.as_str()],
+            )
+            .map_err(map_sql_error)?;
+        if let Some(collection) = collection {
+            self.insert_collection_membership(path_str.as_str(), collection)?;
+        }
+        self.persist_legacy_collection(relative_path, collection)
+    }
+
+    /// Add one fixed collection slot for a wav row without clearing other slots.
+    pub fn add_collection(
+        &mut self,
+        relative_path: &Path,
+        collection: SampleCollection,
+    ) -> Result<(), SourceDbError> {
+        let path_str = super::super::normalize_relative_path(relative_path)?;
+        self.insert_collection_membership(path_str.as_str(), collection)?;
+        self.tx
+            .execute(
+                "UPDATE wav_files
+                 SET collection = COALESCE(collection, ?1)
+                 WHERE path = ?2",
+                params![collection.as_i64(), path_str.as_str()],
+            )
+            .map_err(map_sql_error)?;
+        self.touch_last_curated_at(relative_path)
+    }
+
+    /// Remove one fixed collection slot for a wav row without clearing other slots.
+    pub fn remove_collection(
+        &mut self,
+        relative_path: &Path,
+        collection: SampleCollection,
+    ) -> Result<(), SourceDbError> {
+        let path_str = super::super::normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "DELETE FROM wav_file_collections
+                 WHERE path = ?1 AND collection = ?2",
+                params![path_str.as_str(), collection.as_i64()],
+            )
+            .map_err(map_sql_error)?;
+        let first_remaining = self
+            .tx
+            .query_row(
+                "SELECT collection
+                 FROM wav_file_collections
+                 WHERE path = ?1
+                 ORDER BY collection ASC
+                 LIMIT 1",
+                params![path_str.as_str()],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .and_then(SampleCollection::from_i64);
+        self.persist_legacy_collection(relative_path, first_remaining)
+    }
+
+    fn persist_legacy_collection(
+        &mut self,
+        relative_path: &Path,
+        collection: Option<SampleCollection>,
+    ) -> Result<(), SourceDbError> {
+        match collection {
+            Some(collection) => update_path_i64_statement(
+                &self.tx,
+                UPDATE_COLLECTION_SQL,
+                relative_path,
+                collection.as_i64(),
+            )?,
+            None => update_path_null_statement(&self.tx, CLEAR_COLLECTION_SQL, relative_path)?,
+        }
+        self.touch_last_curated_at(relative_path)
+    }
+
+    fn insert_collection_membership(
+        &self,
+        path: &str,
+        collection: SampleCollection,
+    ) -> Result<(), SourceDbError> {
+        self.tx
+            .execute(
+                "INSERT OR IGNORE INTO wav_file_collections (path, collection)
+                 VALUES (?1, ?2)",
+                params![path, collection.as_i64()],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/command.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/command.rs
@@ -1,0 +1,235 @@
+use std::path::Path;
+
+use super::super::{
+    Rating, SampleCollection, SampleSoundType, SourceDatabase, SourceDbError, SourceWriteBatch,
+};
+
+/// Content-hash behavior for a scan-owned file upsert.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceContentHashWrite<'a> {
+    /// Preserve an existing hash when the path already exists.
+    Preserve,
+    /// Clear the stored hash so deferred hashing can refill it.
+    Clear,
+    /// Store the supplied full-file content hash.
+    Set(&'a str),
+}
+
+/// Tag behavior for a scan-owned file upsert.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceTagWrite {
+    /// Preserve an existing tag, or use neutral for a new row.
+    Preserve,
+    /// Store the supplied rating.
+    Set(Rating),
+}
+
+/// Complete typed input for inserting or refreshing one source file row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SourceFileWrite<'a> {
+    /// Path relative to the source root.
+    pub relative_path: &'a Path,
+    /// Current file size in bytes.
+    pub file_size: u64,
+    /// Current filesystem modification time in nanoseconds.
+    pub modified_ns: i64,
+    /// Content-hash persistence policy.
+    pub content_hash: SourceContentHashWrite<'a>,
+    /// Rating persistence policy.
+    pub tag: SourceTagWrite,
+    /// Whether the indexed file is unavailable on disk.
+    pub missing: bool,
+}
+
+/// Mutation applied to the fixed collection memberships of one sample.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceCollectionWrite {
+    /// Replace every membership with the optional supplied collection.
+    Replace(Option<SampleCollection>),
+    /// Add one membership without removing the others.
+    Add(SampleCollection),
+    /// Remove one membership while retaining the others.
+    Remove(SampleCollection),
+}
+
+/// Typed source-database mutation shared by one-off and caller-owned transactions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceWriteCommand<'a> {
+    /// Insert or refresh one indexed source file.
+    UpsertFile(SourceFileWrite<'a>),
+    /// Store a sample rating.
+    SetTag {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Rating to store.
+        tag: Rating,
+    },
+    /// Store a sample loop marker.
+    SetLooped {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Loop marker to store.
+        looped: bool,
+    },
+    /// Store a sample keep-lock marker.
+    SetLocked {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Keep-lock marker to store.
+        locked: bool,
+    },
+    /// Store or clear a sample sound classification.
+    SetSoundType {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Optional classification to store.
+        sound_type: Option<SampleSoundType>,
+    },
+    /// Store or clear a custom user tag.
+    SetUserTag {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Optional custom tag to store.
+        user_tag: Option<&'a str>,
+    },
+    /// Store whether the filename was derived from tag metadata.
+    SetTagNamed {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Tag-derived filename marker to store.
+        tag_named: bool,
+    },
+    /// Store whether an indexed sample is unavailable on disk.
+    SetMissing {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Missing marker to store.
+        missing: bool,
+    },
+    /// Store or clear the last-played timestamp.
+    SetLastPlayedAt {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Timestamp to store, or `None` to clear it.
+        played_at: Option<i64>,
+    },
+    /// Store or clear the last-curated timestamp.
+    SetLastCuratedAt {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Timestamp to store, or `None` to clear it.
+        curated_at: Option<i64>,
+    },
+    /// Apply one fixed-collection membership mutation.
+    SetCollection {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+        /// Collection mutation to apply.
+        mutation: SourceCollectionWrite,
+    },
+    /// Remove one indexed sample row.
+    RemoveFile {
+        /// Sample path relative to the source root.
+        path: &'a Path,
+    },
+    /// Remap a sample row and path-keyed metadata after a filesystem rename.
+    RemapWavFilePath {
+        /// Previous path relative to the source root.
+        from: &'a Path,
+        /// New path relative to the source root.
+        to: &'a Path,
+    },
+    /// Remap path-derived analysis identity after a rename.
+    RemapAnalysisSampleIdentity {
+        /// Previous path relative to the source root.
+        from: &'a Path,
+        /// New path relative to the source root.
+        to: &'a Path,
+    },
+    /// Insert or update one source metadata key.
+    SetMetadata {
+        /// Metadata key.
+        key: &'a str,
+        /// Metadata value.
+        value: &'a str,
+    },
+}
+
+impl SourceWriteCommand<'_> {
+    fn operation(self) -> &'static str {
+        match self {
+            Self::UpsertFile(_) => "source_db.upsert_file",
+            Self::SetTag { .. } => "source_db.set_tag",
+            Self::SetLooped { .. } => "source_db.set_looped",
+            Self::SetLocked { .. } => "source_db.set_locked",
+            Self::SetSoundType { .. } => "source_db.set_sound_type",
+            Self::SetUserTag { .. } => "source_db.set_user_tag",
+            Self::SetTagNamed { .. } => "source_db.set_tag_named",
+            Self::SetMissing { .. } => "source_db.set_missing",
+            Self::SetLastPlayedAt {
+                played_at: Some(_), ..
+            } => "source_db.set_last_played_at",
+            Self::SetLastPlayedAt {
+                played_at: None, ..
+            } => "source_db.clear_last_played_at",
+            Self::SetLastCuratedAt {
+                curated_at: Some(_),
+                ..
+            } => "source_db.set_last_curated_at",
+            Self::SetLastCuratedAt {
+                curated_at: None, ..
+            } => "source_db.clear_last_curated_at",
+            Self::SetCollection { .. } => "source_db.set_collection",
+            Self::RemoveFile { .. } => "source_db.remove_file",
+            Self::RemapWavFilePath { .. } => "source_db.remap_wav_file_path",
+            Self::RemapAnalysisSampleIdentity { .. } => "source_db.remap_analysis_sample_identity",
+            Self::SetMetadata { .. } => "source_db.set_metadata",
+        }
+    }
+}
+
+impl SourceDatabase {
+    /// Execute one typed mutation in its own transaction.
+    pub fn execute_write(&self, command: SourceWriteCommand<'_>) -> Result<(), SourceDbError> {
+        self.mutate_with_batch(command.operation(), |batch| batch.execute_write(command))
+    }
+}
+
+impl SourceWriteBatch<'_> {
+    /// Execute one typed mutation inside this caller-owned transaction.
+    pub fn execute_write(&mut self, command: SourceWriteCommand<'_>) -> Result<(), SourceDbError> {
+        match command {
+            SourceWriteCommand::UpsertFile(write) => self.apply_file_write(write),
+            SourceWriteCommand::SetTag { path, tag } => self.set_tag(path, tag),
+            SourceWriteCommand::SetLooped { path, looped } => self.set_looped(path, looped),
+            SourceWriteCommand::SetLocked { path, locked } => self.set_locked(path, locked),
+            SourceWriteCommand::SetSoundType { path, sound_type } => {
+                self.set_sound_type(path, sound_type)
+            }
+            SourceWriteCommand::SetUserTag { path, user_tag } => self.set_user_tag(path, user_tag),
+            SourceWriteCommand::SetTagNamed { path, tag_named } => {
+                self.set_tag_named(path, tag_named)
+            }
+            SourceWriteCommand::SetMissing { path, missing } => self.set_missing(path, missing),
+            SourceWriteCommand::SetLastPlayedAt { path, played_at } => match played_at {
+                Some(value) => self.set_last_played_at(path, value),
+                None => self.clear_last_played_at(path),
+            },
+            SourceWriteCommand::SetLastCuratedAt { path, curated_at } => match curated_at {
+                Some(value) => self.set_last_curated_at(path, value),
+                None => self.clear_last_curated_at(path),
+            },
+            SourceWriteCommand::SetCollection { path, mutation } => match mutation {
+                SourceCollectionWrite::Replace(value) => self.set_collection(path, value),
+                SourceCollectionWrite::Add(value) => self.add_collection(path, value),
+                SourceCollectionWrite::Remove(value) => self.remove_collection(path, value),
+            },
+            SourceWriteCommand::RemoveFile { path } => self.remove_file(path),
+            SourceWriteCommand::RemapWavFilePath { from, to } => self.remap_wav_file_path(from, to),
+            SourceWriteCommand::RemapAnalysisSampleIdentity { from, to } => {
+                self.remap_analysis_sample_identity(from, to)
+            }
+            SourceWriteCommand::SetMetadata { key, value } => self.set_metadata(key, value),
+        }
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -9,6 +9,7 @@ use super::super::{
     SourceWriteBatch,
 };
 use super::event::record_source_db_event;
+use super::{SourceContentHashWrite, SourceFileWrite, SourceTagWrite, SourceWriteCommand};
 
 impl SourceDatabase {
     /// Upsert a wav file row using the path relative to the source root.
@@ -18,27 +19,37 @@ impl SourceDatabase {
         file_size: u64,
         modified_ns: i64,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.upsert_file", |batch| {
-            batch.upsert_file(relative_path, file_size, modified_ns)
-        })
+        self.execute_write(SourceWriteCommand::UpsertFile(SourceFileWrite {
+            relative_path,
+            file_size,
+            modified_ns,
+            content_hash: SourceContentHashWrite::Preserve,
+            tag: SourceTagWrite::Preserve,
+            missing: false,
+        }))
     }
 
     /// Persist a keep/trash tag for a single wav file by relative path.
     pub fn set_tag(&self, relative_path: &Path, tag: Rating) -> Result<(), SourceDbError> {
-        self.set_tags_batch(&[(relative_path.to_path_buf(), tag)])
+        self.execute_write(SourceWriteCommand::SetTag {
+            path: relative_path,
+            tag,
+        })
     }
 
     /// Persist a loop marker for a single wav file by relative path.
     pub fn set_looped(&self, relative_path: &Path, looped: bool) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_looped", |batch| {
-            batch.set_looped(relative_path, looped)
+        self.execute_write(SourceWriteCommand::SetLooped {
+            path: relative_path,
+            looped,
         })
     }
 
     /// Persist a keep-lock marker for a single wav file by relative path.
     pub fn set_locked(&self, relative_path: &Path, locked: bool) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_locked", |batch| {
-            batch.set_locked(relative_path, locked)
+        self.execute_write(SourceWriteCommand::SetLocked {
+            path: relative_path,
+            locked,
         })
     }
 
@@ -48,8 +59,9 @@ impl SourceDatabase {
         relative_path: &Path,
         sound_type: Option<SampleSoundType>,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_sound_type", |batch| {
-            batch.set_sound_type(relative_path, sound_type)
+        self.execute_write(SourceWriteCommand::SetSoundType {
+            path: relative_path,
+            sound_type,
         })
     }
 
@@ -59,8 +71,9 @@ impl SourceDatabase {
         relative_path: &Path,
         user_tag: Option<&str>,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_user_tag", |batch| {
-            batch.set_user_tag(relative_path, user_tag)
+        self.execute_write(SourceWriteCommand::SetUserTag {
+            path: relative_path,
+            user_tag,
         })
     }
 
@@ -70,8 +83,9 @@ impl SourceDatabase {
         relative_path: &Path,
         tag_named: bool,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_tag_named", |batch| {
-            batch.set_tag_named(relative_path, tag_named)
+        self.execute_write(SourceWriteCommand::SetTagNamed {
+            path: relative_path,
+            tag_named,
         })
     }
 
@@ -84,7 +98,7 @@ impl SourceDatabase {
         let started_at = Instant::now();
         let mut batch = self.write_batch()?;
         for (path, tag) in updates {
-            batch.set_tag(path, *tag)?;
+            batch.execute_write(SourceWriteCommand::SetTag { path, tag: *tag })?;
         }
         let result = batch.commit();
         record_source_db_event(
@@ -98,8 +112,9 @@ impl SourceDatabase {
 
     /// Update the missing flag for a wav file by relative path.
     pub fn set_missing(&self, relative_path: &Path, missing: bool) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_missing", |batch| {
-            batch.set_missing(relative_path, missing)
+        self.execute_write(SourceWriteCommand::SetMissing {
+            path: relative_path,
+            missing,
         })
     }
 
@@ -109,15 +124,17 @@ impl SourceDatabase {
         relative_path: &Path,
         played_at: i64,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_last_played_at", |batch| {
-            batch.set_last_played_at(relative_path, played_at)
+        self.execute_write(SourceWriteCommand::SetLastPlayedAt {
+            path: relative_path,
+            played_at: Some(played_at),
         })
     }
 
     /// Clear the recorded most recent playback timestamp for a wav file.
     pub fn clear_last_played_at(&self, relative_path: &Path) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.clear_last_played_at", |batch| {
-            batch.clear_last_played_at(relative_path)
+        self.execute_write(SourceWriteCommand::SetLastPlayedAt {
+            path: relative_path,
+            played_at: None,
         })
     }
 
@@ -127,22 +144,24 @@ impl SourceDatabase {
         relative_path: &Path,
         curated_at: i64,
     ) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_last_curated_at", |batch| {
-            batch.set_last_curated_at(relative_path, curated_at)
+        self.execute_write(SourceWriteCommand::SetLastCuratedAt {
+            path: relative_path,
+            curated_at: Some(curated_at),
         })
     }
 
     /// Clear the recorded curation timestamp for a wav file.
     pub fn clear_last_curated_at(&self, relative_path: &Path) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.clear_last_curated_at", |batch| {
-            batch.clear_last_curated_at(relative_path)
+        self.execute_write(SourceWriteCommand::SetLastCuratedAt {
+            path: relative_path,
+            curated_at: None,
         })
     }
 
     /// Remove a wav file row by relative path.
     pub fn remove_file(&self, relative_path: &Path) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.remove_file", |batch| {
-            batch.remove_file(relative_path)
+        self.execute_write(SourceWriteCommand::RemoveFile {
+            path: relative_path,
         })
     }
 
@@ -162,9 +181,7 @@ impl SourceDatabase {
 
     /// Insert or update a metadata key/value pair.
     pub fn set_metadata(&self, key: &str, value: &str) -> Result<(), SourceDbError> {
-        self.mutate_with_batch("source_db.set_metadata", |batch| {
-            batch.set_metadata(key, value)
-        })
+        self.execute_write(SourceWriteCommand::SetMetadata { key, value })
     }
 
     pub(super) fn bump_revision(conn: &rusqlite::Connection) -> Result<(), SourceDbError> {
@@ -188,7 +205,7 @@ impl SourceDatabase {
         Ok(())
     }
 
-    fn mutate_with_batch(
+    pub(super) fn mutate_with_batch(
         &self,
         operation: &'static str,
         mutate: impl FnOnce(&mut SourceWriteBatch<'_>) -> Result<(), SourceDbError>,

--- a/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use super::super::{SourceDbError, SourceWriteBatch};
+use super::mutation::{
+    delete_path_statement, remap_analysis_sample_identity_statement, remap_wav_file_path_statement,
+};
+
+impl SourceWriteBatch<'_> {
+    /// Remove a wav row within the batch.
+    pub fn remove_file(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
+        self.paths_revision_dirty = true;
+        delete_path_statement(&self.tx, relative_path)
+    }
+
+    /// Remap a wav row and its path-keyed user metadata after a filesystem rename.
+    pub fn remap_wav_file_path(
+        &mut self,
+        old_relative_path: &Path,
+        new_relative_path: &Path,
+    ) -> Result<(), SourceDbError> {
+        self.paths_revision_dirty = true;
+        self.clear_pending_rename(old_relative_path)?;
+        self.clear_pending_rename(new_relative_path)?;
+        remap_wav_file_path_statement(&self.tx, old_relative_path, new_relative_path)
+    }
+
+    /// Remap path-derived analysis rows after a rename-only sample identity change.
+    pub fn remap_analysis_sample_identity(
+        &mut self,
+        old_relative_path: &Path,
+        new_relative_path: &Path,
+    ) -> Result<(), SourceDbError> {
+        remap_analysis_sample_identity_statement(&self.tx, old_relative_path, new_relative_path)
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/tests/command.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/tests/command.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use tempfile::tempdir;
+
+use super::super::super::{
+    Rating, SourceContentHashWrite, SourceDatabase, SourceFileWrite, SourceTagWrite,
+    SourceWriteCommand,
+};
+use super::helpers::{revision_value, row_snapshot, wav_paths_revision_value};
+
+fn upsert(path: &Path) -> SourceWriteCommand<'_> {
+    SourceWriteCommand::UpsertFile(SourceFileWrite {
+        relative_path: path,
+        file_size: 10,
+        modified_ns: 5,
+        content_hash: SourceContentHashWrite::Set("hash"),
+        tag: SourceTagWrite::Preserve,
+        missing: false,
+    })
+}
+
+#[test]
+fn typed_commands_share_one_off_and_batch_semantics() {
+    let direct_dir = tempdir().unwrap();
+    let direct = SourceDatabase::open(direct_dir.path()).unwrap();
+    direct.execute_write(upsert(Path::new("one.wav"))).unwrap();
+    direct
+        .execute_write(SourceWriteCommand::SetTag {
+            path: Path::new("one.wav"),
+            tag: Rating::KEEP_1,
+        })
+        .unwrap();
+
+    let batch_dir = tempdir().unwrap();
+    let batched = SourceDatabase::open(batch_dir.path()).unwrap();
+    let mut batch = batched.write_batch().unwrap();
+    batch.execute_write(upsert(Path::new("one.wav"))).unwrap();
+    batch
+        .execute_write(SourceWriteCommand::SetTag {
+            path: Path::new("one.wav"),
+            tag: Rating::KEEP_1,
+        })
+        .unwrap();
+    batch.commit().unwrap();
+
+    assert_eq!(row_snapshot(&direct), row_snapshot(&batched));
+    assert_eq!(revision_value(&direct), 2);
+    assert_eq!(revision_value(&batched), 1);
+    assert_eq!(wav_paths_revision_value(&direct), 1);
+    assert_eq!(wav_paths_revision_value(&batched), 1);
+}
+
+#[test]
+fn metadata_commands_do_not_dirty_the_wav_path_revision() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    db.execute_write(upsert(Path::new("one.wav"))).unwrap();
+
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .execute_write(SourceWriteCommand::SetMissing {
+            path: Path::new("one.wav"),
+            missing: true,
+        })
+        .unwrap();
+    batch
+        .execute_write(SourceWriteCommand::SetMetadata {
+            key: "probe",
+            value: "complete",
+        })
+        .unwrap();
+    batch.commit().unwrap();
+
+    assert_eq!(revision_value(&db), 2);
+    assert_eq!(wav_paths_revision_value(&db), 1);
+    assert_eq!(
+        db.get_metadata("probe").unwrap().as_deref(),
+        Some("complete")
+    );
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/tests/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/tests/mod.rs
@@ -1,3 +1,4 @@
+mod command;
 mod helpers;
 mod remap;
 mod revision;

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -1,0 +1,19 @@
+use super::super::util::map_sql_error;
+use super::super::{SourceDatabase, SourceDbError, SourceWriteBatch};
+
+impl SourceWriteBatch<'_> {
+    /// Commit all batched operations atomically.
+    pub fn commit(self) -> Result<(), SourceDbError> {
+        SourceDatabase::bump_revision(&self.tx)?;
+        if self.paths_revision_dirty {
+            SourceDatabase::bump_wav_paths_revision(&self.tx)?;
+        }
+        self.tx.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(
+            &self.db_path,
+            "source_db",
+            self.telemetry_label,
+        );
+        Ok(())
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -14,8 +14,9 @@ pub use audio_support::{
 };
 pub use db::normalize_relative_path;
 pub use db::{
-    DB_FILE_NAME, Rating, SampleCollection, SourceDatabase, SourceDatabaseConnectionRole,
-    SourceDbError, SourceTag, SourceTagUsage, WavEntry,
+    DB_FILE_NAME, Rating, SampleCollection, SourceCollectionWrite, SourceContentHashWrite,
+    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceTag,
+    SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -33,9 +33,11 @@ pub mod db {
         DB_FILE_NAME, LEGACY_DB_FILE_NAME, META_DEFERRED_MAINTENANCE_REVISION,
         META_DEFERRED_MAINTENANCE_SCHEMA, META_LAST_SCAN_COMPLETED_AT,
         META_LAST_SIMILARITY_PREP_SCAN_AT, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
-        SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceDatabase,
-        SourceDatabaseConnectionRole, SourceDbError, SourceTag, SourceTagUsage, SourceWriteBatch,
-        WavEntry, file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
+        SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceCollectionWrite,
+        SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError,
+        SourceFileWrite, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch,
+        SourceWriteCommand, WavEntry, file_ops_journal, normalize_relative_path, read, schema,
+        tags, util, write,
     };
     #[cfg(debug_assertions)]
     pub use wavecrate_library::sample_sources::db::{
@@ -80,8 +82,9 @@ pub use wavecrate_library::sample_sources::{
     DB_FILE_NAME, HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity,
     HarvestFileKey, HarvestFileRecord, HarvestMetadataSnapshot, HarvestSourceRange, HarvestState,
     LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation, Rating, SampleSource,
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceId, SourceMetadataStorage,
-    SourceRole, WavEntry, database_path_for, default_primary_import_folder, normalize_path,
+    SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
+    SourceDbError, SourceFileWrite, SourceId, SourceMetadataStorage, SourceRole, SourceTagWrite,
+    SourceWriteCommand, WavEntry, database_path_for, default_primary_import_folder, normalize_path,
 };
 pub use wavecrate_scan::sample_sources::ScanTracker;
 pub use wavecrate_scan::sample_sources::{


### PR DESCRIPTION
## Scope

- introduce a public `SourceWriteCommand` model covering scan upserts, sample metadata, collection membership, path removal/remap, analysis identity remap, and metadata keys
- allow the same command to execute as a one-off `SourceDatabase` write or inside a caller-owned `SourceWriteBatch`
- route the existing direct convenience APIs through the typed command path for compatibility
- preserve the existing immediate transaction, revision bump, wav-path revision, WAL checkpoint, tag, and collection semantics
- split collection persistence, path mutations, and transaction commit ownership out of the oversized batch implementation
- add focused parity and revision-policy tests for direct and batched command execution

## Definition of Done

- [x] one-off and grouped writes share one typed mutation model
- [x] caller-owned transaction boundaries remain explicit through `SourceWriteBatch`
- [x] file-path-changing commands dirty the wav-path revision while metadata-only commands do not
- [x] WAL checkpoint and revision behavior is preserved
- [x] `batch.rs` is reduced from 419 lines to 287 lines and each extracted owner stays below the cleanup target
- [x] focused and package-wide source DB tests pass

## Validation commands

- `cargo test -p wavecrate-library typed_commands -- --quiet`
- `cargo test -p wavecrate-library metadata_commands_do_not_dirty_the_wav_path_revision -- --quiet`
- `cargo test -p wavecrate-library -- --quiet` (144 passed)
- `cargo test -p wavecrate --lib metadata_tag -- --nocapture` (filter currently matches 0 tests)
- `cargo check -p wavecrate --no-default-features`
- `cargo check -p wavecrate --all-targets`
- `git diff --check`

## Known limitations

- Existing named convenience methods remain as compatibility entrypoints, but their one-off implementations now delegate through `SourceWriteCommand`; callers can migrate incrementally without behavior churn.
- Raw SQLite connection migration remains separately scoped to OPT-603.

User review is required before merge.