### PR TITLE
OPT-603: Add role-scoped source DB sessions

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/open_profiles.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open_profiles.rs
@@ -11,6 +11,8 @@ use super::SourceDatabaseOpenMode;
 pub enum SourceDatabaseConnectionRole {
     /// Read-only connection profile for cached UI queries and progress polling.
     UiRead,
+    /// Read-only connection profile for background queries that may wait behind writers.
+    BackgroundRead,
     /// Read-write profile for analysis enqueue/claim/finalization workers.
     JobWorker,
     /// Read-write profile for deliberate user-authored source metadata updates.
@@ -25,6 +27,7 @@ impl SourceDatabaseConnectionRole {
     pub(super) fn label(self) -> &'static str {
         match self {
             Self::UiRead => "ui_read",
+            Self::BackgroundRead => "background_read",
             Self::JobWorker => "job_worker",
             Self::UserMetadataWrite => "user_metadata_write",
             Self::PlaybackHistoryWrite => "playback_history_write",
@@ -34,7 +37,7 @@ impl SourceDatabaseConnectionRole {
 
     pub(super) fn open_flags(self) -> OpenFlags {
         match self {
-            Self::UiRead => OpenFlags::SQLITE_OPEN_READ_ONLY,
+            Self::UiRead | Self::BackgroundRead => OpenFlags::SQLITE_OPEN_READ_ONLY,
             Self::JobWorker
             | Self::UserMetadataWrite
             | Self::PlaybackHistoryWrite
@@ -47,6 +50,7 @@ impl SourceDatabaseConnectionRole {
     pub(super) fn open_mode(self) -> SourceDatabaseOpenMode {
         match self {
             Self::UiRead
+            | Self::BackgroundRead
             | Self::JobWorker
             | Self::UserMetadataWrite
             | Self::PlaybackHistoryWrite => SourceDatabaseOpenMode::Fast,
@@ -55,14 +59,17 @@ impl SourceDatabaseConnectionRole {
     }
 
     pub(super) fn uses_read_only_connection(self) -> bool {
-        matches!(self, Self::UiRead)
+        matches!(self, Self::UiRead | Self::BackgroundRead)
     }
 
     pub(super) fn busy_timeout_ms(self) -> u64 {
         match self {
             Self::UiRead => 25,
             Self::PlaybackHistoryWrite => 100,
-            Self::JobWorker | Self::UserMetadataWrite | Self::Maintenance => 5_000,
+            Self::BackgroundRead
+            | Self::JobWorker
+            | Self::UserMetadataWrite
+            | Self::Maintenance => 5_000,
         }
     }
 }

--- a/src/app/controller/jobs.rs
+++ b/src/app/controller/jobs.rs
@@ -107,6 +107,8 @@ pub(crate) struct ControllerJobs {
     pub(super) pending_playback: Option<PendingPlayback>,
     pub(super) pending_recording_waveform: Option<PendingRecordingWaveform>,
     pub(super) pending_slice_batch_export: Option<PendingSliceBatchExport>,
+    pending_umap_build: Option<UmapBuildJob>,
+    pending_umap_cluster_build: Option<UmapClusterBuildJob>,
     request_counters: JobRequestCounters,
     in_progress: JobInProgressState,
     cancel_handles: JobCancelHandles,

--- a/src/app/controller/jobs/dispatch_runtime.rs
+++ b/src/app/controller/jobs/dispatch_runtime.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::app::controller::AppController;
+use crate::app::controller::library::source_write_priority;
 
 impl ControllerJobs {
     /// Return whether deferred source DB maintenance is currently running.
@@ -48,12 +49,12 @@ impl ControllerJobs {
 
     /// Return whether a UMAP build is currently running.
     pub(in super::super) fn umap_build_in_progress(&self) -> bool {
-        self.in_progress.umap_build
+        self.in_progress.umap_build || self.pending_umap_build.is_some()
     }
 
     /// Return whether a UMAP cluster build is currently running.
     pub(in super::super) fn umap_cluster_build_in_progress(&self) -> bool {
-        self.in_progress.umap_cluster_build
+        self.in_progress.umap_cluster_build || self.pending_umap_cluster_build.is_some()
     }
 
     /// Start one UMAP build if no existing build is active.
@@ -61,6 +62,7 @@ impl ControllerJobs {
         if self.in_progress.umap_build {
             return;
         }
+        self.pending_umap_build = None;
         self.in_progress.umap_build = true;
         self.spawn_one_shot_job(
             true,
@@ -70,10 +72,7 @@ impl ControllerJobs {
                     &job.umap_version,
                     &job.source_id,
                 );
-                UmapBuildResult {
-                    umap_version: job.umap_version,
-                    result,
-                }
+                UmapBuildResult { job, result }
             },
             JobMessage::UmapBuilt,
         );
@@ -84,11 +83,17 @@ impl ControllerJobs {
         self.in_progress.umap_build = false;
     }
 
+    /// Retain a layout build that yielded to a same-source file operation.
+    pub(in super::super) fn defer_umap_build(&mut self, job: UmapBuildJob) {
+        self.pending_umap_build = Some(job);
+    }
+
     /// Start one UMAP cluster build if no existing build is active.
     pub(in super::super) fn begin_umap_cluster_build(&mut self, job: UmapClusterBuildJob) {
         if self.in_progress.umap_cluster_build {
             return;
         }
+        self.pending_umap_cluster_build = None;
         self.in_progress.umap_cluster_build = true;
         self.spawn_one_shot_job(
             true,
@@ -98,10 +103,7 @@ impl ControllerJobs {
                     &job.umap_version,
                     job.source_id.as_ref(),
                 );
-                UmapClusterBuildResult {
-                    source_id: job.source_id,
-                    result,
-                }
+                UmapClusterBuildResult { job, result }
             },
             JobMessage::UmapClustersBuilt,
         );
@@ -110,6 +112,57 @@ impl ControllerJobs {
     /// Clear UMAP cluster build in-progress state.
     pub(in super::super) fn clear_umap_cluster_build(&mut self) {
         self.in_progress.umap_cluster_build = false;
+    }
+
+    /// Retain a cluster build that yielded to a same-source file operation.
+    pub(in super::super) fn defer_umap_cluster_build(&mut self, job: UmapClusterBuildJob) {
+        self.pending_umap_cluster_build = Some(job);
+    }
+
+    /// Resume Starmap writes whose source-local file-op priority window cleared.
+    pub(in super::super) fn resume_deferred_starmap_writes(&mut self) {
+        if let Some(job) = self.take_ready_deferred_umap_build() {
+            self.begin_umap_build(job);
+        }
+        if let Some(job) = self.take_ready_deferred_umap_cluster_build() {
+            self.begin_umap_cluster_build(job);
+        }
+    }
+
+    fn take_ready_deferred_umap_build(&mut self) -> Option<UmapBuildJob> {
+        if self.in_progress.umap_build
+            || self.pending_umap_build.as_ref().is_some_and(|job| {
+                source_write_priority::file_op_write_priority_active(&job.source_id)
+            })
+        {
+            return None;
+        }
+        self.pending_umap_build.take()
+    }
+
+    fn take_ready_deferred_umap_cluster_build(&mut self) -> Option<UmapClusterBuildJob> {
+        if self.in_progress.umap_cluster_build
+            || self
+                .pending_umap_cluster_build
+                .as_ref()
+                .and_then(|job| job.source_id.as_ref())
+                .is_some_and(source_write_priority::file_op_write_priority_active)
+        {
+            return None;
+        }
+        self.pending_umap_cluster_build.take()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_ready_deferred_umap_build_for_tests(&mut self) -> Option<UmapBuildJob> {
+        self.take_ready_deferred_umap_build()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_ready_deferred_umap_cluster_build_for_tests(
+        &mut self,
+    ) -> Option<UmapClusterBuildJob> {
+        self.take_ready_deferred_umap_cluster_build()
     }
 
     /// Start one update check if no existing check is active.

--- a/src/app/controller/jobs/lifecycle.rs
+++ b/src/app/controller/jobs/lifecycle.rs
@@ -73,6 +73,8 @@ impl ControllerJobs {
             pending_playback: None,
             pending_recording_waveform: None,
             pending_slice_batch_export: None,
+            pending_umap_build: None,
+            pending_umap_cluster_build: None,
             request_counters: JobRequestCounters::default(),
             in_progress: JobInProgressState::default(),
             cancel_handles: JobCancelHandles::default(),

--- a/src/app/controller/jobs/messages/similarity_types.rs
+++ b/src/app/controller/jobs/messages/similarity_types.rs
@@ -10,11 +10,20 @@ pub(crate) struct UmapBuildJob {
     pub(crate) source_id: SourceId,
 }
 
+/// Completion state for a Starmap write attempt.
+#[derive(Debug)]
+pub(crate) enum StarmapWriteOutcome<T> {
+    /// The write completed and produced its result.
+    Completed(T),
+    /// A same-source file operation owns write priority; retain and retry the job.
+    DeferredForFileOp,
+}
+
 /// Result of one UMAP build attempt.
 #[derive(Debug)]
 pub(crate) struct UmapBuildResult {
-    pub(crate) umap_version: String,
-    pub(crate) result: Result<(), String>,
+    pub(crate) job: UmapBuildJob,
+    pub(crate) result: Result<StarmapWriteOutcome<()>, String>,
 }
 
 /// Request to cluster the current UMAP projection.
@@ -28,8 +37,9 @@ pub(crate) struct UmapClusterBuildJob {
 /// Result of one UMAP clustering pass.
 #[derive(Debug)]
 pub(crate) struct UmapClusterBuildResult {
-    pub(crate) source_id: Option<SourceId>,
-    pub(crate) result: Result<wavecrate_analysis::hdbscan::HdbscanStats, String>,
+    pub(crate) job: UmapClusterBuildJob,
+    pub(crate) result:
+        Result<StarmapWriteOutcome<wavecrate_analysis::hdbscan::HdbscanStats>, String>,
 }
 
 /// Final prepared similarity payload applied back to controller state.

--- a/src/app/controller/library/analysis_jobs/db/connection.rs
+++ b/src/app/controller/library/analysis_jobs/db/connection.rs
@@ -7,7 +7,7 @@ use std::{
 /// Writable source-database session for analysis workers and enqueue operations.
 pub(crate) struct AnalysisJobSession(Connection);
 
-/// Read-only source-database session for UI progress and similarity queries.
+/// Read-only source-database session for UI progress and side-effect-free cached queries.
 pub(crate) struct AnalysisReadSession(Connection);
 
 /// Writable source-database session for deferred cleanup and schema-sensitive work.

--- a/src/app/controller/library/analysis_jobs/db/connection.rs
+++ b/src/app/controller/library/analysis_jobs/db/connection.rs
@@ -7,7 +7,7 @@ use std::{
 /// Writable source-database session for analysis workers and enqueue operations.
 pub(crate) struct AnalysisJobSession(Connection);
 
-/// Read-only source-database session for UI progress and side-effect-free cached queries.
+/// Read-only source-database session for side-effect-free queries.
 pub(crate) struct AnalysisReadSession(Connection);
 
 /// Writable source-database session for deferred cleanup and schema-sensitive work.
@@ -66,6 +66,18 @@ pub(crate) fn open_source_db_ui_read(source_root: &Path) -> Result<AnalysisReadS
     .map_err(|err| format!("Open source DB failed: {err}"))
 }
 
+/// Open a read-only source DB connection for background queries that may wait behind writers.
+pub(crate) fn open_source_db_background_read(
+    source_root: &Path,
+) -> Result<AnalysisReadSession, String> {
+    crate::sample_sources::SourceDatabase::open_connection_with_role(
+        source_root,
+        crate::sample_sources::SourceDatabaseConnectionRole::BackgroundRead,
+    )
+    .map(AnalysisReadSession)
+    .map_err(|err| format!("Open source DB failed: {err}"))
+}
+
 /// Open a full maintenance connection for cleanup and deferred schema-sensitive work.
 pub(crate) fn open_source_db_maintenance(
     source_root: &Path,
@@ -94,6 +106,19 @@ mod tests {
         let reader = open_source_db_ui_read(root.path()).expect("read session");
         let write_error = reader.execute("INSERT INTO role_probe (value) VALUES (1)", []);
         assert!(write_error.is_err(), "UI-read sessions must reject writes");
+
+        let background_reader =
+            open_source_db_background_read(root.path()).expect("background read session");
+        let busy_timeout: i64 = background_reader
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("background read timeout");
+        assert_eq!(busy_timeout, 5_000);
+        let write_error =
+            background_reader.execute("INSERT INTO role_probe (value) VALUES (1)", []);
+        assert!(
+            write_error.is_err(),
+            "background-read sessions must reject writes"
+        );
 
         let maintenance = open_source_db_maintenance(root.path()).expect("maintenance session");
         maintenance

--- a/src/app/controller/library/analysis_jobs/db/connection.rs
+++ b/src/app/controller/library/analysis_jobs/db/connection.rs
@@ -1,28 +1,103 @@
 use rusqlite::Connection;
-use std::path::Path;
+use std::{
+    ops::{Deref, DerefMut},
+    path::Path,
+};
 
-pub(crate) fn open_source_db(source_root: &Path) -> Result<Connection, String> {
+/// Writable source-database session for analysis workers and enqueue operations.
+pub(crate) struct AnalysisJobSession(Connection);
+
+/// Read-only source-database session for UI progress and similarity queries.
+pub(crate) struct AnalysisReadSession(Connection);
+
+/// Writable source-database session for deferred cleanup and schema-sensitive work.
+pub(crate) struct AnalysisMaintenanceSession(Connection);
+
+macro_rules! impl_session_deref {
+    ($session:ty) => {
+        impl Deref for $session {
+            type Target = Connection;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}
+
+impl_session_deref!(AnalysisJobSession);
+impl_session_deref!(AnalysisReadSession);
+impl_session_deref!(AnalysisMaintenanceSession);
+
+impl DerefMut for AnalysisJobSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl DerefMut for AnalysisReadSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl DerefMut for AnalysisMaintenanceSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub(crate) fn open_source_db(source_root: &Path) -> Result<AnalysisJobSession, String> {
     crate::sample_sources::SourceDatabase::open_connection_with_role(
         source_root,
         crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
     )
+    .map(AnalysisJobSession)
     .map_err(|err| format!("Open source DB failed: {err}"))
 }
 
 /// Open a read-only source DB connection for long-lived or latency-sensitive UI queries.
-pub(crate) fn open_source_db_ui_read(source_root: &Path) -> Result<Connection, String> {
+pub(crate) fn open_source_db_ui_read(source_root: &Path) -> Result<AnalysisReadSession, String> {
     crate::sample_sources::SourceDatabase::open_connection_with_role(
         source_root,
         crate::sample_sources::SourceDatabaseConnectionRole::UiRead,
     )
+    .map(AnalysisReadSession)
     .map_err(|err| format!("Open source DB failed: {err}"))
 }
 
 /// Open a full maintenance connection for cleanup and deferred schema-sensitive work.
-pub(crate) fn open_source_db_maintenance(source_root: &Path) -> Result<Connection, String> {
+pub(crate) fn open_source_db_maintenance(
+    source_root: &Path,
+) -> Result<AnalysisMaintenanceSession, String> {
     crate::sample_sources::SourceDatabase::open_connection_with_role(
         source_root,
         crate::sample_sources::SourceDatabaseConnectionRole::Maintenance,
     )
+    .map(AnalysisMaintenanceSession)
     .map_err(|err| format!("Open source DB failed: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_sessions_enforce_read_only_and_writable_profiles() {
+        let root = tempfile::tempdir().expect("source root");
+        let worker = open_source_db(root.path()).expect("worker session");
+        worker
+            .execute_batch("CREATE TABLE IF NOT EXISTS role_probe (value INTEGER);")
+            .expect("worker session should write");
+        drop(worker);
+
+        let reader = open_source_db_ui_read(root.path()).expect("read session");
+        let write_error = reader.execute("INSERT INTO role_probe (value) VALUES (1)", []);
+        assert!(write_error.is_err(), "UI-read sessions must reject writes");
+
+        let maintenance = open_source_db_maintenance(root.path()).expect("maintenance session");
+        maintenance
+            .execute("INSERT INTO role_probe (value) VALUES (2)", [])
+            .expect("maintenance session should write");
+    }
 }

--- a/src/app/controller/library/analysis_jobs/db/mod.rs
+++ b/src/app/controller/library/analysis_jobs/db/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use cleanup::{
 };
 pub(crate) use connection::{
     AnalysisJobSession, AnalysisMaintenanceSession, AnalysisReadSession, open_source_db,
-    open_source_db_maintenance, open_source_db_ui_read,
+    open_source_db_background_read, open_source_db_maintenance, open_source_db_ui_read,
 };
 #[cfg(test)]
 pub(crate) use constants::DEFAULT_JOB_TYPE;

--- a/src/app/controller/library/analysis_jobs/db/mod.rs
+++ b/src/app/controller/library/analysis_jobs/db/mod.rs
@@ -35,7 +35,10 @@ pub(crate) use cleanup::purge_orphaned_samples_in_tx;
 pub(crate) use cleanup::{
     fail_stale_running_jobs_with_sources, prune_jobs_for_missing_sources, reset_running_to_pending,
 };
-pub(crate) use connection::{open_source_db, open_source_db_maintenance, open_source_db_ui_read};
+pub(crate) use connection::{
+    AnalysisJobSession, AnalysisMaintenanceSession, AnalysisReadSession, open_source_db,
+    open_source_db_maintenance, open_source_db_ui_read,
+};
 #[cfg(test)]
 pub(crate) use constants::DEFAULT_JOB_TYPE;
 pub(crate) use constants::{

--- a/src/app/controller/library/analysis_jobs/enqueue/enqueue_samples/duration_probe.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/enqueue_samples/duration_probe.rs
@@ -11,7 +11,7 @@ pub(crate) fn update_missing_durations_for_source(
 }
 
 pub(super) fn update_missing_sample_durations(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     source: &crate::sample_sources::SampleSource,
     samples: &[db::SampleMetadata],
 ) -> Result<usize, String> {

--- a/src/app/controller/library/analysis_jobs/enqueue/enqueue_samples/staged_samples.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/enqueue_samples/staged_samples.rs
@@ -2,7 +2,7 @@ use super::duration_probe::update_missing_sample_durations;
 use super::*;
 
 pub(super) fn enqueue_from_staged_samples(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     source: &crate::sample_sources::SampleSource,
     staged_samples: Vec<db::SampleMetadata>,
     job_type: &str,

--- a/src/app/controller/library/analysis_jobs/enqueue/invalidate/planning.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/invalidate/planning.rs
@@ -31,7 +31,7 @@ pub(crate) fn collect_changed_sample_updates(
 }
 
 pub(crate) fn collect_backfill_updates(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     job_type: &str,
     force_full: bool,
 ) -> Result<BackfillUpdates, String> {
@@ -65,7 +65,7 @@ pub(crate) fn collect_backfill_updates(
 }
 
 pub(crate) fn build_backfill_plan(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     staged_samples: &[db::SampleMetadata],
     job_type: &str,
     force_full: bool,

--- a/src/app/controller/library/analysis_jobs/enqueue/invalidate/queries.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/invalidate/queries.rs
@@ -3,7 +3,7 @@ use crate::app::controller::library::analysis_jobs::db;
 use rusqlite::params;
 
 pub(super) fn fetch_failed_backfill_jobs(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     job_type: &str,
     source_id: &str,
 ) -> Result<Vec<String>, String> {
@@ -32,7 +32,7 @@ pub(super) fn fetch_failed_backfill_jobs(
 }
 
 pub(super) fn fetch_force_backfill_jobs(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     job_type: &str,
 ) -> Result<QueuedBackfillJobs, String> {
     let mut sample_metadata = Vec::new();
@@ -81,7 +81,7 @@ pub(super) fn fetch_force_backfill_jobs(
 }
 
 pub(super) fn fetch_backfill_invalidations(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     current_version: &str,
 ) -> Result<Vec<String>, String> {
     let mut invalidate = Vec::new();
@@ -112,7 +112,7 @@ pub(super) fn fetch_backfill_invalidations(
 }
 
 pub(super) fn fetch_backfill_jobs(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     current_version: &str,
     job_type: &str,
     model_id: &str,

--- a/src/app/controller/library/analysis_jobs/enqueue/persist.rs
+++ b/src/app/controller/library/analysis_jobs/enqueue/persist.rs
@@ -3,7 +3,7 @@ use crate::app::controller::library::analysis_jobs::db::telemetry;
 use crate::app::controller::library::analysis_jobs::types::AnalysisProgress;
 
 pub(crate) fn write_changed_samples(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     source_root: &std::path::Path,
     sample_metadata: &[db::SampleMetadata],
     invalidate: &[String],
@@ -31,7 +31,7 @@ pub(crate) fn write_changed_samples(
 }
 
 pub(crate) fn write_backfill_samples(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     source_root: &std::path::Path,
     sample_metadata: &[db::SampleMetadata],
     invalidate: &[String],
@@ -54,7 +54,7 @@ pub(crate) fn write_backfill_samples(
 }
 
 pub(crate) fn stage_backfill_samples(
-    conn: &mut rusqlite::Connection,
+    conn: &mut db::AnalysisJobSession,
     samples: &[db::SampleMetadata],
 ) -> Result<(), String> {
     prepare_backfill_staging(conn)?;
@@ -89,7 +89,7 @@ pub(crate) fn stage_backfill_samples(
     Ok(())
 }
 
-fn prepare_backfill_staging(conn: &mut rusqlite::Connection) -> Result<(), String> {
+fn prepare_backfill_staging(conn: &mut db::AnalysisJobSession) -> Result<(), String> {
     conn.execute_batch(
         "CREATE TEMP TABLE IF NOT EXISTS temp_backfill_samples (
             sample_id TEXT PRIMARY KEY,

--- a/src/app/controller/library/analysis_jobs/mod.rs
+++ b/src/app/controller/library/analysis_jobs/mod.rs
@@ -12,10 +12,13 @@ pub(crate) use db::sample_bpm;
 #[cfg(test)]
 pub(crate) use db::update_sample_bpm;
 pub(crate) use db::{
+    AnalysisJobSession, AnalysisReadSession, open_source_db, open_source_db_maintenance,
+    open_source_db_ui_read,
+};
+pub(crate) use db::{
     SampleMetadata, build_sample_id, parse_sample_id, update_sample_duration,
     update_sample_long_mark,
 };
-pub(crate) use db::{open_source_db, open_source_db_maintenance, open_source_db_ui_read};
 pub(crate) use enqueue::enqueue_jobs_for_source;
 pub(crate) use enqueue::enqueue_jobs_for_source_backfill;
 pub(crate) use enqueue::enqueue_jobs_for_source_backfill_full;

--- a/src/app/controller/library/analysis_jobs/mod.rs
+++ b/src/app/controller/library/analysis_jobs/mod.rs
@@ -12,8 +12,8 @@ pub(crate) use db::sample_bpm;
 #[cfg(test)]
 pub(crate) use db::update_sample_bpm;
 pub(crate) use db::{
-    AnalysisJobSession, AnalysisReadSession, open_source_db, open_source_db_maintenance,
-    open_source_db_ui_read,
+    AnalysisJobSession, AnalysisReadSession, open_source_db, open_source_db_background_read,
+    open_source_db_maintenance, open_source_db_ui_read,
 };
 pub(crate) use db::{
     SampleMetadata, build_sample_id, parse_sample_id, update_sample_duration,

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/claim.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/claim.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 pub(crate) struct SourceClaimDb {
     pub(crate) source: crate::sample_sources::SampleSource,
-    pub(crate) conn: rusqlite::Connection,
+    pub(crate) conn: db::AnalysisJobSession,
 }
 
 pub(crate) const SOURCE_REFRESH_INTERVAL: Duration = Duration::from_secs(5);

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/execution.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/execution.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rusqlite::Connection;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use tracing::warn;
 
@@ -22,7 +23,7 @@ pub(super) type DecodedBatchMap =
     HashMap<std::path::PathBuf, Vec<(analysis_db::ClaimedJob, wavecrate_analysis::AnalysisAudio)>>;
 
 struct BatchProcessContext<'a> {
-    connections: &'a mut HashMap<std::path::PathBuf, Connection>,
+    connections: &'a mut db::AnalysisConnections,
     allowed_source_ids: &'a AllowedSourceIds,
     log_jobs: bool,
     settings: &'a BatchSettings,
@@ -59,7 +60,7 @@ pub(super) fn current_batch_settings(
 
 pub(super) fn process_batch(
     batch: Vec<DecodedWork>,
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     allowed_source_ids: &AllowedSourceIds,
     log_jobs: bool,
     settings: &BatchSettings,
@@ -137,7 +138,7 @@ impl BatchProcessContext<'_> {
 
 fn run_work_item(
     work: DecodedWork,
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     settings: &BatchSettings,
     batch_job: &mut Option<(analysis_db::ClaimedJob, wavecrate_analysis::AnalysisAudio)>,
     immediate_job: &mut Option<(analysis_db::ClaimedJob, Result<(), String>)>,
@@ -214,7 +215,7 @@ fn handle_analysis_work(
 
 pub(super) fn immediate_jobs_with_decoded_batches(
     decoded_batches: DecodedBatchMap,
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     settings: &BatchSettings,
 ) -> Vec<ImmediateJob> {
     let mut immediate_jobs = Vec::new();
@@ -233,7 +234,7 @@ pub(super) fn immediate_jobs_with_decoded_batches(
 fn run_decoded_batch(
     source_root: std::path::PathBuf,
     jobs: Vec<(analysis_db::ClaimedJob, wavecrate_analysis::AnalysisAudio)>,
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     settings: &BatchSettings,
     immediate_jobs: &mut Vec<ImmediateJob>,
 ) {

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/finalization.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/finalization.rs
@@ -23,7 +23,7 @@ pub(super) fn flush_deferred_updates(
 }
 
 pub(super) fn release_disallowed_work(
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     work: &DecodedWork,
     log_jobs: bool,
     decode_queue: &super::super::DecodedQueue,

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/mod.rs
@@ -1,5 +1,4 @@
 use crate::app::controller::library::analysis_jobs::db as analysis_db;
-use rusqlite::Connection;
 use std::collections::HashMap;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -42,7 +41,7 @@ fn run_compute_worker(context: ComputeWorkerContext) {
     let log_jobs = logging::analysis_log_enabled();
     let log_queue = logging::analysis_log_queue_enabled();
     let mut last_queue_log = Instant::now();
-    let mut connections: HashMap<std::path::PathBuf, Connection> = HashMap::new();
+    let mut connections = db::AnalysisConnections::new();
     let mut deferred_updates: Vec<db::DeferredJobUpdate> = Vec::new();
     let embedding_batch_max = wavecrate_analysis::similarity::SIMILARITY_BATCH_MAX;
     loop {

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/db.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/db.rs
@@ -7,12 +7,13 @@ use crate::app::controller::jobs::{JobMessage, JobMessageSender};
 use crate::app::controller::library::analysis_jobs::db as analysis_db;
 use crate::app::controller::library::analysis_jobs::types::AnalysisJobMessage;
 use crate::logging::{ActionDebugEvent, emit_action_debug_event};
-use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
+
+pub(crate) type AnalysisConnections = HashMap<std::path::PathBuf, analysis_db::AnalysisJobSession>;
 
 /// Deferred status update retried after a temporary source-DB-open failure.
 pub(crate) struct DeferredJobUpdate {
@@ -22,7 +23,7 @@ pub(crate) struct DeferredJobUpdate {
 
 /// Shared state for finalizing claimed jobs and broadcasting progress updates.
 pub(crate) struct FinalizeJobContext<'a> {
-    pub(crate) connections: &'a mut HashMap<std::path::PathBuf, Connection>,
+    pub(crate) connections: &'a mut AnalysisConnections,
     pub(crate) decode_queue: &'a DecodedQueue,
     pub(crate) tx: &'a JobMessageSender,
     pub(crate) progress_cache: &'a Arc<RwLock<ProgressCache>>,
@@ -157,9 +158,9 @@ pub(crate) fn flush_deferred_updates(
 }
 
 pub(crate) fn open_connection_with_retry<'a>(
-    connections: &'a mut HashMap<std::path::PathBuf, Connection>,
+    connections: &'a mut AnalysisConnections,
     source_root: &std::path::Path,
-) -> Result<&'a mut Connection, String> {
+) -> Result<&'a mut analysis_db::AnalysisJobSession, String> {
     match connections.entry(source_root.to_path_buf()) {
         std::collections::hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
         std::collections::hash_map::Entry::Vacant(entry) => {

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/decoder_worker.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/decoder_worker.rs
@@ -1,6 +1,4 @@
 use crate::app::controller::library::analysis_jobs::db as analysis_db;
-use rusqlite::Connection;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -44,7 +42,7 @@ fn run_decoder_worker(context: DecoderWorkerContext) {
     lower_worker_priority();
     let log_jobs = logging::analysis_log_enabled();
     let decode_queue_target = decode_queue_target.max(1);
-    let mut connections: HashMap<std::path::PathBuf, Connection> = HashMap::new();
+    let mut connections = db::AnalysisConnections::new();
     let mut wake_counter = 0u64;
     loop {
         if shutdown.load(Ordering::Relaxed) {
@@ -157,7 +155,7 @@ fn claim_next_job(
 }
 
 fn release_disallowed_job(
-    connections: &mut HashMap<std::path::PathBuf, Connection>,
+    connections: &mut db::AnalysisConnections,
     job: &analysis_db::ClaimedJob,
 ) {
     if let Ok(conn) = db::open_connection_with_retry(connections, &job.source_root) {

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/heartbeat.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/heartbeat.rs
@@ -1,12 +1,11 @@
 use crate::app::controller::library::analysis_jobs::db as analysis_db;
-use rusqlite::Connection;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use super::db::open_connection_with_retry;
+use super::db::{AnalysisConnections, open_connection_with_retry};
 
 struct DecodeHeartbeatState {
     counter: u64,
@@ -143,7 +142,7 @@ pub(crate) fn spawn_decode_heartbeat_worker(
 }
 
 fn run_decode_heartbeat_worker(tracker: Arc<DecodeHeartbeatTracker>) {
-    let mut connections = HashMap::<PathBuf, Connection>::new();
+    let mut connections = AnalysisConnections::new();
     let mut seen_counter = 0u64;
     let mut last_touch = Instant::now() - tracker.interval;
     loop {

--- a/src/app/controller/library/analysis_jobs/pool/job_progress.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress.rs
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_sources_defers_new_maintenance_open_during_file_op_priority() {
+    fn refresh_sources_drops_tracked_maintenance_session_during_file_op_priority() {
         let config_dir = TempDir::new().unwrap();
         let _config_guard = crate::app_dirs::ConfigBaseGuard::set(config_dir.path().to_path_buf());
         let source_dir = TempDir::new().unwrap();
@@ -233,25 +233,33 @@ mod tests {
             sources: vec![source.clone()],
         })
         .unwrap();
-        crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
         let mut sources = Vec::<ProgressSourceDb>::new();
         let mut last_refresh = Instant::now() - SOURCE_REFRESH_INTERVAL;
+        assert!(refresh_sources(&mut sources, &mut last_refresh, None));
+        assert_eq!(sources.len(), 1);
+        crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
 
         {
             let _guard = FileOpWritePriorityGuard::new(&source.id);
+            last_refresh = Instant::now() - SOURCE_REFRESH_INTERVAL;
 
-            assert!(!refresh_sources(&mut sources, &mut last_refresh, None));
+            assert!(refresh_sources(&mut sources, &mut last_refresh, None));
             assert!(sources.is_empty());
             assert_eq!(
                 crate::sample_sources::db::test_source_db_open_total_count(&source.root),
                 0,
-                "progress discovery must not open maintenance while a file op owns the source"
+                "progress discovery must drop the tracked session without opening a replacement"
             );
         }
 
         last_refresh = Instant::now() - SOURCE_REFRESH_INTERVAL;
         assert!(refresh_sources(&mut sources, &mut last_refresh, None));
         assert_eq!(sources.len(), 1);
+        assert_eq!(
+            crate::sample_sources::db::test_source_db_open_total_count(&source.root),
+            1,
+            "progress discovery should reopen maintenance after file-op priority clears"
+        );
     }
 
     #[test]

--- a/src/app/controller/library/analysis_jobs/pool/job_progress.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress.rs
@@ -38,7 +38,7 @@ mod tests {
     #[test]
     fn cleanup_runs_without_workers() {
         let dir = TempDir::new().unwrap();
-        let conn = db::open_source_db(dir.path()).unwrap();
+        let conn = db::open_source_db_maintenance(dir.path()).unwrap();
         let now = now_epoch_seconds();
         conn.execute(
             "INSERT INTO analysis_jobs (sample_id, job_type, status, attempts, created_at, running_at)
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     fn cleanup_updates_cache_and_emits_message() {
         let dir = TempDir::new().unwrap();
-        let conn = db::open_source_db(dir.path()).unwrap();
+        let conn = db::open_source_db_maintenance(dir.path()).unwrap();
         conn.execute(
             "INSERT INTO wav_files (path, file_size, modified_ns, missing)
              VALUES (?1, 1, 0, 0)",
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn current_progress_all_reuses_cache_without_db_refresh() {
         let dir = TempDir::new().unwrap();
-        let conn = db::open_source_db(dir.path()).unwrap();
+        let conn = db::open_source_db_maintenance(dir.path()).unwrap();
         let source_id = crate::sample_sources::SourceId::from_string("source".to_string());
         let sources = vec![ProgressSourceDb {
             source_id: source_id.clone(),
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn seed_missing_progress_populates_only_missing_sources() {
         let dir = TempDir::new().unwrap();
-        let conn = db::open_source_db(dir.path()).unwrap();
+        let conn = db::open_source_db_maintenance(dir.path()).unwrap();
         conn.execute(
             "INSERT INTO wav_files (path, file_size, modified_ns, missing)
              VALUES (?1, 1, 0, 0)",

--- a/src/app/controller/library/analysis_jobs/pool/job_progress.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress.rs
@@ -27,6 +27,7 @@ mod tests {
     use crate::app::controller::library::analysis_jobs::types::{
         AnalysisJobMessage, AnalysisProgress,
     };
+    use crate::app::controller::library::source_write_priority::FileOpWritePriorityGuard;
     use radiant::gui::repaint::SharedRepaintSignal;
     use std::sync::{Arc, RwLock};
     use std::time::{Duration, Instant};
@@ -219,6 +220,38 @@ mod tests {
             0,
             "periodic progress refresh must reuse the existing UI-read connection"
         );
+    }
+
+    #[test]
+    fn refresh_sources_defers_new_maintenance_open_during_file_op_priority() {
+        let config_dir = TempDir::new().unwrap();
+        let _config_guard = crate::app_dirs::ConfigBaseGuard::set(config_dir.path().to_path_buf());
+        let source_dir = TempDir::new().unwrap();
+        let source = crate::sample_sources::SampleSource::new(source_dir.path().to_path_buf());
+        crate::sample_sources::SourceDatabase::open(&source.root).expect("seed source db");
+        crate::sample_sources::library::save(&crate::sample_sources::library::LibraryState {
+            sources: vec![source.clone()],
+        })
+        .unwrap();
+        crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+        let mut sources = Vec::<ProgressSourceDb>::new();
+        let mut last_refresh = Instant::now() - SOURCE_REFRESH_INTERVAL;
+
+        {
+            let _guard = FileOpWritePriorityGuard::new(&source.id);
+
+            assert!(!refresh_sources(&mut sources, &mut last_refresh, None));
+            assert!(sources.is_empty());
+            assert_eq!(
+                crate::sample_sources::db::test_source_db_open_total_count(&source.root),
+                0,
+                "progress discovery must not open maintenance while a file op owns the source"
+            );
+        }
+
+        last_refresh = Instant::now() - SOURCE_REFRESH_INTERVAL;
+        assert!(refresh_sources(&mut sources, &mut last_refresh, None));
+        assert_eq!(sources.len(), 1);
     }
 
     #[test]

--- a/src/app/controller/library/analysis_jobs/pool/job_progress.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress.rs
@@ -78,6 +78,67 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_skips_retained_session_during_file_op_priority() {
+        let dir = TempDir::new().unwrap();
+        let conn = db::open_source_db_maintenance(dir.path()).unwrap();
+        let now = now_epoch_seconds();
+        conn.execute(
+            "INSERT INTO analysis_jobs (sample_id, job_type, status, attempts, created_at, running_at)
+             VALUES (?1, ?2, 'running', 1, ?3, ?4)",
+            rusqlite::params![
+                "source::stale.wav",
+                db::ANALYZE_SAMPLE_JOB_TYPE,
+                now,
+                now - 120
+            ],
+        )
+        .unwrap();
+        let source_id = crate::sample_sources::SourceId::from_string("source".to_string());
+        let mut sources = vec![ProgressSourceDb {
+            source_id: source_id.clone(),
+            source_root: dir.path().to_path_buf(),
+            conn,
+        }];
+        let cache = Arc::new(RwLock::new(ProgressCache::default()));
+        let (tx, _rx) = std::sync::mpsc::sync_channel(1);
+        let tx = JobMessageSender::new(tx);
+        let stale_before = now - 10;
+        let signal = Arc::new(SharedRepaintSignal::default());
+
+        {
+            let _guard = FileOpWritePriorityGuard::new(&source_id);
+
+            assert_eq!(
+                cleanup_stale_jobs(&mut sources, stale_before, &cache, &tx, &signal),
+                0
+            );
+            let status: String = sources[0]
+                .conn
+                .query_row(
+                    "SELECT status FROM analysis_jobs WHERE sample_id = ?1",
+                    rusqlite::params!["source::stale.wav"],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(status, "running");
+        }
+
+        assert_eq!(
+            cleanup_stale_jobs(&mut sources, stale_before, &cache, &tx, &signal),
+            1
+        );
+        let status: String = sources[0]
+            .conn
+            .query_row(
+                "SELECT status FROM analysis_jobs WHERE sample_id = ?1",
+                rusqlite::params!["source::stale.wav"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+    }
+
+    #[test]
     fn cleanup_updates_cache_and_emits_message() {
         let dir = TempDir::new().unwrap();
         let conn = db::open_source_db_maintenance(dir.path()).unwrap();

--- a/src/app/controller/library/analysis_jobs/pool/job_progress/cleanup.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress/cleanup.rs
@@ -1,7 +1,7 @@
 use super::source_discovery::ProgressSourceDb;
 use crate::app::controller::jobs::{JobMessage, JobMessageSender};
-use crate::app::controller::library::analysis_jobs::db;
 use crate::app::controller::library::analysis_jobs::types::AnalysisJobMessage;
+use crate::app::controller::library::{analysis_jobs::db, source_write_priority};
 use radiant::gui::repaint::SharedRepaintSignal;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -20,6 +20,9 @@ pub(super) fn cleanup_stale_jobs(
     let mut changed = 0;
     let mut touched_sources = std::collections::HashSet::new();
     for source in &mut *sources {
+        if source_write_priority::file_op_write_priority_active(&source.source_id) {
+            continue;
+        }
         if let Ok((updated, source_ids)) =
             db::fail_stale_running_jobs_with_sources(&source.conn, stale_before)
             && updated > 0

--- a/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
@@ -1,4 +1,4 @@
-use crate::app::controller::library::analysis_jobs::db;
+use crate::app::controller::library::{analysis_jobs::db, source_write_priority};
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
@@ -47,10 +47,15 @@ pub(super) fn refresh_sources(
         }
         let conn = match reusable.remove(&(source.id.clone(), source.root.clone())) {
             Some(conn) => conn,
-            None => match db::open_source_db_maintenance(&source.root) {
-                Ok(conn) => conn,
-                Err(_) => continue,
-            },
+            None => {
+                if source_write_priority::file_op_write_priority_active(&source.id) {
+                    continue;
+                }
+                match db::open_source_db_maintenance(&source.root) {
+                    Ok(conn) => conn,
+                    Err(_) => continue,
+                }
+            }
         };
         next.push(ProgressSourceDb {
             source_id: source.id.clone(),

--- a/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
@@ -45,17 +45,15 @@ pub(super) fn refresh_sources(
         {
             continue;
         }
+        if source_write_priority::file_op_write_priority_active(&source.id) {
+            continue;
+        }
         let conn = match reusable.remove(&(source.id.clone(), source.root.clone())) {
             Some(conn) => conn,
-            None => {
-                if source_write_priority::file_op_write_priority_active(&source.id) {
-                    continue;
-                }
-                match db::open_source_db_maintenance(&source.root) {
-                    Ok(conn) => conn,
-                    Err(_) => continue,
-                }
-            }
+            None => match db::open_source_db_maintenance(&source.root) {
+                Ok(conn) => conn,
+                Err(_) => continue,
+            },
         };
         next.push(ProgressSourceDb {
             source_id: source.id.clone(),

--- a/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_progress/source_discovery.rs
@@ -1,5 +1,4 @@
 use crate::app::controller::library::analysis_jobs::db;
-use rusqlite::Connection;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
@@ -9,7 +8,7 @@ use super::SOURCE_REFRESH_INTERVAL;
 pub(super) struct ProgressSourceDb {
     pub(super) source_id: crate::sample_sources::SourceId,
     pub(super) source_root: std::path::PathBuf,
-    pub(super) conn: Connection,
+    pub(super) conn: db::AnalysisMaintenanceSession,
 }
 
 /// Refresh the open source list on the poller's periodic cadence.
@@ -48,7 +47,7 @@ pub(super) fn refresh_sources(
         }
         let conn = match reusable.remove(&(source.id.clone(), source.root.clone())) {
             Some(conn) => conn,
-            None => match db::open_source_db_ui_read(&source.root) {
+            None => match db::open_source_db_maintenance(&source.root) {
                 Ok(conn) => conn,
                 Err(_) => continue,
             },

--- a/src/app/controller/library/background_jobs/polling/mod.rs
+++ b/src/app/controller/library/background_jobs/polling/mod.rs
@@ -15,6 +15,7 @@ impl AppController {
     /// Drain queued background job messages and apply their side effects.
     pub(crate) fn poll_background_jobs(&mut self) {
         self.apply_progress_cancel_request();
+        self.runtime.jobs.resume_deferred_starmap_writes();
         if self.has_pending_browser_focus_commit() {
             self.flush_pending_browser_focus_commit();
         }

--- a/src/app/controller/library/background_jobs/polling/mod.rs
+++ b/src/app/controller/library/background_jobs/polling/mod.rs
@@ -22,11 +22,13 @@ impl AppController {
         let mut applied = 0usize;
         while applied < MAX_BACKGROUND_MESSAGES_PER_POLL {
             let Some(message) = self.try_next_background_job_message() else {
+                self.runtime.jobs.resume_deferred_starmap_writes();
                 return;
             };
             self.handle_background_job_message(message);
             applied += 1;
         }
+        self.runtime.jobs.resume_deferred_starmap_writes();
         self.runtime.jobs.request_repaint();
     }
 

--- a/src/app/controller/library/background_jobs/polling/runtime_handlers.rs
+++ b/src/app/controller/library/background_jobs/polling/runtime_handlers.rs
@@ -125,7 +125,7 @@ impl AppController {
     pub(super) fn handle_umap_built_message(&mut self, message: UmapBuildResult) {
         self.runtime.jobs.clear_umap_build();
         match message.result {
-            Ok(()) => {
+            Ok(crate::app::controller::jobs::StarmapWriteOutcome::Completed(())) => {
                 self.ui.map.bounds = None;
                 self.ui.map.cached_bounds_source_id = None;
                 self.ui.map.cached_bounds_umap_version = None;
@@ -136,9 +136,12 @@ impl AppController {
                 self.mark_map_dataset_projection_revision_dirty();
                 self.mark_map_query_projection_revision_dirty();
                 self.set_status(
-                    format!("Starmap layout {} built", message.umap_version),
+                    format!("Starmap layout {} built", message.job.umap_version),
                     StatusTone::Info,
                 );
+            }
+            Ok(crate::app::controller::jobs::StarmapWriteOutcome::DeferredForFileOp) => {
+                self.runtime.jobs.defer_umap_build(message.job);
             }
             Err(err) => {
                 self.set_status(
@@ -153,7 +156,7 @@ impl AppController {
     pub(super) fn handle_umap_clusters_built_message(&mut self, message: UmapClusterBuildResult) {
         self.runtime.jobs.clear_umap_cluster_build();
         match message.result {
-            Ok(stats) => {
+            Ok(crate::app::controller::jobs::StarmapWriteOutcome::Completed(stats)) => {
                 self.ui.map.last_query = None;
                 self.ui.map.cached_points.clear();
                 self.ui.map.cached_points_source_id = None;
@@ -164,6 +167,7 @@ impl AppController {
                 self.mark_map_dataset_projection_revision_dirty();
                 self.mark_map_query_projection_revision_dirty();
                 let scope = message
+                    .job
                     .source_id
                     .as_ref()
                     .map(|id| id.as_str())
@@ -176,6 +180,9 @@ impl AppController {
                     ),
                     StatusTone::Info,
                 );
+            }
+            Ok(crate::app::controller::jobs::StarmapWriteOutcome::DeferredForFileOp) => {
+                self.runtime.jobs.defer_umap_cluster_build(message.job);
             }
             Err(err) => {
                 self.set_status(format!("Cluster build failed: {err}"), StatusTone::Error);

--- a/src/app/controller/library/background_jobs/polling/tests/poll.rs
+++ b/src/app/controller/library/background_jobs/polling/tests/poll.rs
@@ -1,5 +1,11 @@
 use super::*;
+use crate::app::controller::jobs::{
+    FileOpMessage, FileOpResult, SampleAutoRenameResult, StarmapWriteOutcome, UmapBuildJob,
+    UmapBuildResult,
+};
 use crate::app::controller::test_support::dummy_controller;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 #[test]
 fn poll_background_jobs_limits_messages_per_pass() {
@@ -30,4 +36,54 @@ fn poll_background_jobs_limits_messages_per_pass() {
         remaining += 1;
     }
     assert_eq!(remaining, 2);
+}
+
+#[test]
+fn poll_background_jobs_resumes_starmap_write_after_file_op_finishes() {
+    let (mut controller, source) = dummy_controller();
+    controller.library.sources.push(source.clone());
+    let pending_path = PathBuf::from("sample.wav");
+    controller.begin_pending_file_mutation(&source.id, [pending_path.clone()]);
+    controller.apply_background_job_message_for_tests(JobMessage::UmapBuilt(UmapBuildResult {
+        job: UmapBuildJob {
+            model_id: "model-v1".to_string(),
+            umap_version: "umap-v1".to_string(),
+            source_id: source.id.clone(),
+        },
+        result: Ok(StarmapWriteOutcome::DeferredForFileOp),
+    }));
+    controller
+        .runtime
+        .jobs
+        .message_sender()
+        .send(JobMessage::FileOps(FileOpMessage::Finished(
+            FileOpResult::SampleAutoRename(SampleAutoRenameResult {
+                source_id: source.id.clone(),
+                requested_paths: vec![pending_path],
+                renamed: Vec::new(),
+                skipped: Vec::new(),
+                errors: Vec::new(),
+            }),
+        )))
+        .expect("queue file-op completion");
+
+    controller.poll_background_jobs();
+
+    assert!(!controller.source_has_pending_file_mutations(&source.id));
+    assert!(controller.runtime.jobs.umap_build_in_progress());
+    assert!(
+        controller
+            .runtime
+            .jobs
+            .take_ready_deferred_umap_build_for_tests()
+            .is_none(),
+        "the post-drain retry should already have promoted the deferred layout job"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while controller.runtime.jobs.umap_build_in_progress() && Instant::now() < deadline {
+        controller.poll_background_jobs();
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(!controller.runtime.jobs.umap_build_in_progress());
 }

--- a/src/app/controller/library/background_jobs/polling/tests/similarity.rs
+++ b/src/app/controller/library/background_jobs/polling/tests/similarity.rs
@@ -1,12 +1,83 @@
 use super::*;
 use crate::app::controller::jobs::{
     FocusedSimilarityPaths, FocusedSimilarityResult, LoadedSimilarityQueryResult,
+    StarmapWriteOutcome, UmapBuildJob, UmapBuildResult, UmapClusterBuildJob,
+    UmapClusterBuildResult,
 };
-use crate::app::controller::test_support::{prepare_with_source_and_wav_entries, sample_entry};
+use crate::app::controller::library::source_write_priority::FileOpWritePriorityGuard;
+use crate::app::controller::test_support::{
+    dummy_controller, prepare_with_source_and_wav_entries, sample_entry,
+};
 use crate::app::state::{SampleBrowserSort, SimilarQuery, empty_similarity_aspect_score_rows};
 use crate::sample_sources::Rating;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+#[test]
+fn deferred_starmap_writes_requeue_only_after_file_op_priority_clears() {
+    let (mut controller, source) = dummy_controller();
+    let layout_job = UmapBuildJob {
+        model_id: "model-v1".to_string(),
+        umap_version: "umap-v1".to_string(),
+        source_id: source.id.clone(),
+    };
+    let cluster_job = UmapClusterBuildJob {
+        model_id: "model-v1".to_string(),
+        umap_version: "umap-v1".to_string(),
+        source_id: Some(source.id.clone()),
+    };
+    let guard = FileOpWritePriorityGuard::new(&source.id);
+
+    controller.apply_background_job_message_for_tests(JobMessage::UmapBuilt(UmapBuildResult {
+        job: layout_job.clone(),
+        result: Ok(StarmapWriteOutcome::DeferredForFileOp),
+    }));
+    controller.apply_background_job_message_for_tests(JobMessage::UmapClustersBuilt(
+        UmapClusterBuildResult {
+            job: cluster_job.clone(),
+            result: Ok(StarmapWriteOutcome::DeferredForFileOp),
+        },
+    ));
+
+    assert!(controller.runtime.jobs.umap_build_in_progress());
+    assert!(controller.runtime.jobs.umap_cluster_build_in_progress());
+    assert!(
+        controller
+            .runtime
+            .jobs
+            .take_ready_deferred_umap_build_for_tests()
+            .is_none()
+    );
+    assert!(
+        controller
+            .runtime
+            .jobs
+            .take_ready_deferred_umap_cluster_build_for_tests()
+            .is_none()
+    );
+    assert!(!controller.ui.status.text.contains("failed"));
+
+    drop(guard);
+
+    let resumed_layout = controller
+        .runtime
+        .jobs
+        .take_ready_deferred_umap_build_for_tests()
+        .expect("layout job should become ready after file-op priority clears");
+    let resumed_cluster = controller
+        .runtime
+        .jobs
+        .take_ready_deferred_umap_cluster_build_for_tests()
+        .expect("cluster job should become ready after file-op priority clears");
+    assert_eq!(resumed_layout.model_id, layout_job.model_id);
+    assert_eq!(resumed_layout.umap_version, layout_job.umap_version);
+    assert_eq!(resumed_layout.source_id, layout_job.source_id);
+    assert_eq!(resumed_cluster.model_id, cluster_job.model_id);
+    assert_eq!(resumed_cluster.umap_version, cluster_job.umap_version);
+    assert_eq!(resumed_cluster.source_id, cluster_job.source_id);
+    assert!(!controller.runtime.jobs.umap_build_in_progress());
+    assert!(!controller.runtime.jobs.umap_cluster_build_in_progress());
+}
 
 #[test]
 fn focused_similarity_message_ignores_stale_result_then_applies_matching_highlight() {

--- a/src/app/controller/library/similarity_prep/db.rs
+++ b/src/app/controller/library/similarity_prep/db.rs
@@ -38,7 +38,7 @@ pub(crate) fn source_has_embeddings(source: &SampleSource) -> bool {
     if sample_ids.is_empty() {
         return true;
     }
-    let Ok(conn) = analysis_jobs::open_source_db(&source.root) else {
+    let Ok(conn) = analysis_jobs::open_source_db_ui_read(&source.root) else {
         return false;
     };
     let model_id = wavecrate_analysis::similarity::SIMILARITY_MODEL_ID;
@@ -54,7 +54,7 @@ pub(crate) fn source_has_layout(source: &SampleSource, umap_version: &str) -> bo
     if sample_ids.is_empty() {
         return true;
     }
-    let Ok(conn) = analysis_jobs::open_source_db(&source.root) else {
+    let Ok(conn) = analysis_jobs::open_source_db_ui_read(&source.root) else {
         return false;
     };
     let model_id = wavecrate_analysis::similarity::SIMILARITY_MODEL_ID;
@@ -76,7 +76,7 @@ pub(crate) fn source_has_aspect_descriptors(source: &SampleSource) -> bool {
     if sample_ids.is_empty() {
         return true;
     }
-    let Ok(conn) = analysis_jobs::open_source_db(&source.root) else {
+    let Ok(conn) = analysis_jobs::open_source_db_ui_read(&source.root) else {
         return false;
     };
     let sample_id_prefix = format!("{}::%", source.id.as_str());
@@ -194,7 +194,7 @@ pub(crate) fn count_umap_layout_rows(
 
 pub(crate) fn open_source_db_for_similarity(
     source_id: &SourceId,
-) -> Result<rusqlite::Connection, String> {
+) -> Result<analysis_jobs::AnalysisJobSession, String> {
     let state = crate::sample_sources::library::load().map_err(|err| err.to_string())?;
     let source = state
         .sources

--- a/src/app/controller/library/similarity_prep/plan.rs
+++ b/src/app/controller/library/similarity_prep/plan.rs
@@ -87,7 +87,7 @@ mod tests {
         fn open_source_db_for_similarity(
             &self,
             _source_id: &SourceId,
-        ) -> Result<rusqlite::Connection, String> {
+        ) -> Result<analysis_jobs::AnalysisJobSession, String> {
             Err("not needed".to_string())
         }
 

--- a/src/app/controller/library/similarity_prep/progress/tests.rs
+++ b/src/app/controller/library/similarity_prep/progress/tests.rs
@@ -50,7 +50,7 @@ impl SimilarityPrepStore for EmbeddingProgressErrorStore {
     fn open_source_db_for_similarity(
         &self,
         _source_id: &SourceId,
-    ) -> Result<rusqlite::Connection, String> {
+    ) -> Result<analysis_jobs::AnalysisJobSession, String> {
         Err("not needed".to_string())
     }
 

--- a/src/app/controller/library/similarity_prep/store.rs
+++ b/src/app/controller/library/similarity_prep/store.rs
@@ -24,7 +24,7 @@ pub(crate) trait SimilarityPrepStore {
     fn open_source_db_for_similarity(
         &self,
         source_id: &SourceId,
-    ) -> Result<rusqlite::Connection, String>;
+    ) -> Result<analysis_jobs::AnalysisJobSession, String>;
     fn count_umap_layout_rows(
         &self,
         conn: &rusqlite::Connection,
@@ -80,7 +80,7 @@ impl SimilarityPrepStore for DbSimilarityPrepStore {
     fn open_source_db_for_similarity(
         &self,
         source_id: &SourceId,
-    ) -> Result<rusqlite::Connection, String> {
+    ) -> Result<analysis_jobs::AnalysisJobSession, String> {
         db::open_source_db_for_similarity(source_id)
     }
 

--- a/src/app/controller/library/wavs/similar/background/compute.rs
+++ b/src/app/controller/library/wavs/similar/background/compute.rs
@@ -47,8 +47,7 @@ pub(crate) struct LoadedSimilarityQueryJob {
 pub(crate) fn compute_focused_similarity(
     job: FocusedSimilarityJob,
 ) -> Result<Option<FocusedSimilarityPaths>, String> {
-    let conn =
-        crate::app::controller::library::analysis_jobs::open_source_db_ui_read(&job.source_root)?;
+    let conn = crate::app::controller::library::analysis_jobs::open_source_db(&job.source_root)?;
     let neighbours = wavecrate_analysis::ann_index::find_similar(
         &conn,
         &job.sample_id,
@@ -231,7 +230,6 @@ mod tests {
             ],
         )
         .expect("insert embedding");
-        wavecrate_analysis::rebuild_ann_index(&conn).expect("rebuild ann index");
     }
 
     fn set_fast_similarity_metadata(
@@ -266,8 +264,14 @@ mod tests {
         .expect("count jobs")
     }
 
+    fn count_ann_index_metadata(source: &crate::sample_sources::SampleSource) -> i64 {
+        let conn = analysis_jobs::open_source_db_ui_read(&source.root).expect("open source db");
+        conn.query_row("SELECT COUNT(*) FROM ann_index_meta", [], |row| row.get(0))
+            .expect("count ANN metadata")
+    }
+
     #[test]
-    fn compute_focused_similarity_stays_read_only_with_fast_prep_rows() {
+    fn compute_focused_similarity_rebuilds_missing_ann_index_without_enqueuing_jobs() {
         let (mut controller, source) = prepare_with_source_and_wav_entries(vec![
             sample_entry("anchor.wav", Rating::NEUTRAL),
             sample_entry("near.wav", Rating::NEUTRAL),
@@ -277,6 +281,7 @@ mod tests {
         insert_similarity_embedding(&source, "anchor.wav", 1.0, 0.0);
         insert_similarity_embedding(&source, "near.wav", 0.95, 0.05);
         let sample_id = set_fast_similarity_metadata(&source, "anchor.wav", fast_sample_rate);
+        assert_eq!(count_ann_index_metadata(&source), 0);
 
         let result = compute_focused_similarity(FocusedSimilarityJob {
             request_id: 1,
@@ -289,6 +294,7 @@ mod tests {
         .expect("focused similarity");
 
         assert!(result.is_some());
+        assert_eq!(count_ann_index_metadata(&source), 1);
         assert_eq!(count_analysis_jobs(&source, &sample_id), 0);
     }
 }

--- a/src/app/controller/library/wavs/similar/background/compute.rs
+++ b/src/app/controller/library/wavs/similar/background/compute.rs
@@ -88,8 +88,9 @@ pub(crate) fn compute_focused_similarity(
 pub(crate) fn compute_loaded_similarity_query(
     job: LoadedSimilarityQueryJob,
 ) -> Result<crate::app::controller::state::runtime::LoadedSimilarityQueryData, String> {
-    let conn =
-        crate::app::controller::library::analysis_jobs::open_source_db_ui_read(&job.source_root)?;
+    let conn = crate::app::controller::library::analysis_jobs::open_source_db_background_read(
+        &job.source_root,
+    )?;
     let request = loaded::build_loaded_similarity_request(
         &job.source_id,
         &job.relative_path,

--- a/src/app/controller/library/wavs/similar/background/compute.rs
+++ b/src/app/controller/library/wavs/similar/background/compute.rs
@@ -47,7 +47,8 @@ pub(crate) struct LoadedSimilarityQueryJob {
 pub(crate) fn compute_focused_similarity(
     job: FocusedSimilarityJob,
 ) -> Result<Option<FocusedSimilarityPaths>, String> {
-    let conn = crate::app::controller::library::analysis_jobs::open_source_db(&job.source_root)?;
+    let conn =
+        crate::app::controller::library::analysis_jobs::open_source_db_ui_read(&job.source_root)?;
     let neighbours = wavecrate_analysis::ann_index::find_similar(
         &conn,
         &job.sample_id,
@@ -88,7 +89,8 @@ pub(crate) fn compute_focused_similarity(
 pub(crate) fn compute_loaded_similarity_query(
     job: LoadedSimilarityQueryJob,
 ) -> Result<crate::app::controller::state::runtime::LoadedSimilarityQueryData, String> {
-    let conn = crate::app::controller::library::analysis_jobs::open_source_db(&job.source_root)?;
+    let conn =
+        crate::app::controller::library::analysis_jobs::open_source_db_ui_read(&job.source_root)?;
     let request = loaded::build_loaded_similarity_request(
         &job.source_id,
         &job.relative_path,

--- a/src/app/controller/library/wavs/similar/resolve/repository/source_lookup.rs
+++ b/src/app/controller/library/wavs/similar/resolve/repository/source_lookup.rs
@@ -55,12 +55,30 @@ fn resolve_sample_id_for_entry(
 pub(crate) fn open_source_db_for_id(
     controller: &AppController,
     source_id: &SourceId,
-) -> Result<analysis_jobs::AnalysisReadSession, String> {
+) -> Result<analysis_jobs::AnalysisJobSession, String> {
     let source = controller
         .library
         .sources
         .iter()
         .find(|source| &source.id == source_id)
         .ok_or_else(|| "Source not found".to_string())?;
-    analysis_jobs::open_source_db_ui_read(&source.root)
+    analysis_jobs::open_source_db(&source.root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::controller::test_support::{prepare_with_source_and_wav_entries, sample_entry};
+    use crate::sample_sources::Rating;
+
+    #[test]
+    fn foreground_similarity_session_allows_ann_metadata_writes() {
+        let (controller, source) =
+            prepare_with_source_and_wav_entries(vec![sample_entry("anchor.wav", Rating::NEUTRAL)]);
+
+        let conn = open_source_db_for_id(&controller, &source.id).expect("similarity session");
+
+        conn.execute("DELETE FROM ann_index_meta", [])
+            .expect("ANN-backed similarity requires a writable session");
+    }
 }

--- a/src/app/controller/library/wavs/similar/resolve/repository/source_lookup.rs
+++ b/src/app/controller/library/wavs/similar/resolve/repository/source_lookup.rs
@@ -55,12 +55,12 @@ fn resolve_sample_id_for_entry(
 pub(crate) fn open_source_db_for_id(
     controller: &AppController,
     source_id: &SourceId,
-) -> Result<rusqlite::Connection, String> {
+) -> Result<analysis_jobs::AnalysisReadSession, String> {
     let source = controller
         .library
         .sources
         .iter()
         .find(|source| &source.id == source_id)
         .ok_or_else(|| "Source not found".to_string())?;
-    analysis_jobs::open_source_db(&source.root)
+    analysis_jobs::open_source_db_ui_read(&source.root)
 }

--- a/src/app/controller/state/runtime/map_runtime.rs
+++ b/src/app/controller/state/runtime/map_runtime.rs
@@ -1,11 +1,11 @@
 //! Runtime state for retained map-query database connections.
 
+use crate::app::controller::library::analysis_jobs::AnalysisReadSession;
 use crate::sample_sources::SourceId;
-use rusqlite::Connection;
 use std::collections::HashMap;
 
 /// Reused map-query SQLite connections keyed by source id.
 #[derive(Default)]
 pub(crate) struct MapRuntimeState {
-    pub(crate) query_connections: HashMap<SourceId, Connection>,
+    pub(crate) query_connections: HashMap<SourceId, AnalysisReadSession>,
 }

--- a/src/app/controller/ui/starmap_view/connections.rs
+++ b/src/app/controller/ui/starmap_view/connections.rs
@@ -38,15 +38,18 @@ pub(super) fn open_cached_source_db<'a>(
         .map
         .query_connections
         .get_mut(&source_id)
+        .map(|session| &mut **session)
         .ok_or_else(|| "Map query connection missing after open".to_string())
 }
 
-pub(super) fn open_source_db_for_id(source_id: &SourceId) -> Result<Connection, String> {
+pub(super) fn open_source_db_for_id(
+    source_id: &SourceId,
+) -> Result<analysis_jobs::AnalysisJobSession, String> {
     let state = crate::sample_sources::library::load().map_err(|err| err.to_string())?;
     let source = state
         .sources
         .iter()
         .find(|source| &source.id == source_id)
         .ok_or_else(|| "Source not found".to_string())?;
-    analysis_jobs::open_source_db_ui_read(&source.root)
+    analysis_jobs::open_source_db(&source.root)
 }

--- a/src/app/controller/ui/starmap_view/connections.rs
+++ b/src/app/controller/ui/starmap_view/connections.rs
@@ -5,6 +5,11 @@ use rusqlite::Connection;
 
 use super::*;
 
+pub(super) enum StarmapWriteSession {
+    Ready(analysis_jobs::AnalysisJobSession),
+    DeferredForFileOp,
+}
+
 /// Return a cached per-source map-query connection, opening it on first use.
 pub(super) fn open_cached_source_db<'a>(
     controller: &'a mut AppController,
@@ -42,11 +47,9 @@ pub(super) fn open_cached_source_db<'a>(
         .ok_or_else(|| "Map query connection missing after open".to_string())
 }
 
-pub(super) fn open_source_db_for_id(
-    source_id: &SourceId,
-) -> Result<analysis_jobs::AnalysisJobSession, String> {
+pub(super) fn open_source_db_for_id(source_id: &SourceId) -> Result<StarmapWriteSession, String> {
     if source_write_priority::file_op_write_priority_active(source_id) {
-        return Err("Starmap write deferred while a source file operation is active".to_string());
+        return Ok(StarmapWriteSession::DeferredForFileOp);
     }
     let state = crate::sample_sources::library::load().map_err(|err| err.to_string())?;
     let source = state
@@ -54,7 +57,7 @@ pub(super) fn open_source_db_for_id(
         .iter()
         .find(|source| &source.id == source_id)
         .ok_or_else(|| "Source not found".to_string())?;
-    analysis_jobs::open_source_db(&source.root)
+    analysis_jobs::open_source_db(&source.root).map(StarmapWriteSession::Ready)
 }
 
 #[cfg(test)]
@@ -78,11 +81,10 @@ mod tests {
 
         {
             let _guard = FileOpWritePriorityGuard::new(&source.id);
-            let err = open_source_db_for_id(&source.id)
-                .err()
-                .expect("Starmap writer should defer during a same-source file op");
+            let session = open_source_db_for_id(&source.id)
+                .expect("Starmap file-op deferral should not be reported as a failure");
 
-            assert!(err.contains("Starmap write deferred"));
+            assert!(matches!(session, StarmapWriteSession::DeferredForFileOp));
             assert_eq!(
                 crate::sample_sources::db::test_source_db_open_total_count(&source.root),
                 0,
@@ -90,8 +92,9 @@ mod tests {
             );
         }
 
-        let _session = open_source_db_for_id(&source.id)
+        let session = open_source_db_for_id(&source.id)
             .expect("Starmap writer should open after file-op priority clears");
+        assert!(matches!(session, StarmapWriteSession::Ready(_)));
         assert_eq!(
             crate::sample_sources::db::test_source_db_open_total_count(&source.root),
             1

--- a/src/app/controller/ui/starmap_view/connections.rs
+++ b/src/app/controller/ui/starmap_view/connections.rs
@@ -1,6 +1,6 @@
 //! Connection helpers for map-view queries and background layout jobs.
 
-use crate::app::controller::library::analysis_jobs;
+use crate::app::controller::library::{analysis_jobs, source_write_priority};
 use rusqlite::Connection;
 
 use super::*;
@@ -45,6 +45,9 @@ pub(super) fn open_cached_source_db<'a>(
 pub(super) fn open_source_db_for_id(
     source_id: &SourceId,
 ) -> Result<analysis_jobs::AnalysisJobSession, String> {
+    if source_write_priority::file_op_write_priority_active(source_id) {
+        return Err("Starmap write deferred while a source file operation is active".to_string());
+    }
     let state = crate::sample_sources::library::load().map_err(|err| err.to_string())?;
     let source = state
         .sources
@@ -52,4 +55,46 @@ pub(super) fn open_source_db_for_id(
         .find(|source| &source.id == source_id)
         .ok_or_else(|| "Source not found".to_string())?;
     analysis_jobs::open_source_db(&source.root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::controller::library::source_write_priority::FileOpWritePriorityGuard;
+    use tempfile::TempDir;
+
+    #[test]
+    fn writable_starmap_session_defers_during_same_source_file_op() {
+        let config_dir = TempDir::new().expect("create config dir");
+        let _config_guard = crate::app_dirs::ConfigBaseGuard::set(config_dir.path().to_path_buf());
+        let source_dir = TempDir::new().expect("create source dir");
+        let source = crate::sample_sources::SampleSource::new(source_dir.path().to_path_buf());
+        crate::sample_sources::SourceDatabase::open(&source.root).expect("seed source db");
+        crate::sample_sources::library::save(&crate::sample_sources::library::LibraryState {
+            sources: vec![source.clone()],
+        })
+        .expect("save source library");
+        crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+
+        {
+            let _guard = FileOpWritePriorityGuard::new(&source.id);
+            let err = open_source_db_for_id(&source.id)
+                .err()
+                .expect("Starmap writer should defer during a same-source file op");
+
+            assert!(err.contains("Starmap write deferred"));
+            assert_eq!(
+                crate::sample_sources::db::test_source_db_open_total_count(&source.root),
+                0,
+                "Starmap writer must not open the source DB during file-op priority"
+            );
+        }
+
+        let _session = open_source_db_for_id(&source.id)
+            .expect("Starmap writer should open after file-op priority clears");
+        assert_eq!(
+            crate::sample_sources::db::test_source_db_open_total_count(&source.root),
+            1
+        );
+    }
 }

--- a/src/app/controller/ui/starmap_view/jobs.rs
+++ b/src/app/controller/ui/starmap_view/jobs.rs
@@ -2,7 +2,7 @@
 
 use crate::app::controller::library::similarity_prep::DEFAULT_CLUSTER_MIN_SIZE;
 
-use super::connections::open_source_db_for_id;
+use super::connections::{StarmapWriteSession, open_source_db_for_id};
 use super::*;
 
 impl AppController {
@@ -50,21 +50,28 @@ pub(crate) fn run_umap_build(
     model_id: &str,
     umap_version: &str,
     source_id: &SourceId,
-) -> Result<(), String> {
-    let mut conn = open_source_db_for_id(source_id)?;
+) -> Result<super::super::jobs::StarmapWriteOutcome<()>, String> {
+    let StarmapWriteSession::Ready(mut conn) = open_source_db_for_id(source_id)? else {
+        return Ok(super::super::jobs::StarmapWriteOutcome::DeferredForFileOp);
+    };
     wavecrate_analysis::build_map_layout(&mut conn, model_id, umap_version, 0, 0.95)?;
-    Ok(())
+    Ok(super::super::jobs::StarmapWriteOutcome::Completed(()))
 }
 
 pub(crate) fn run_umap_cluster_build(
     model_id: &str,
     umap_version: &str,
     source_id: Option<&SourceId>,
-) -> Result<wavecrate_analysis::hdbscan::HdbscanStats, String> {
+) -> Result<
+    super::super::jobs::StarmapWriteOutcome<wavecrate_analysis::hdbscan::HdbscanStats>,
+    String,
+> {
     let Some(source_id) = source_id else {
         return Err("Missing source for cluster build".to_string());
     };
-    let mut conn = open_source_db_for_id(source_id)?;
+    let StarmapWriteSession::Ready(mut conn) = open_source_db_for_id(source_id)? else {
+        return Ok(super::super::jobs::StarmapWriteOutcome::DeferredForFileOp);
+    };
     let sample_id_prefix = Some(format!("{}::%", source_id.as_str()));
     wavecrate_analysis::hdbscan::build_hdbscan_clusters_for_sample_id_prefix(
         &mut conn,
@@ -78,4 +85,5 @@ pub(crate) fn run_umap_cluster_build(
             allow_single_cluster: false,
         },
     )
+    .map(super::super::jobs::StarmapWriteOutcome::Completed)
 }


### PR DESCRIPTION
## Scope
- introduce role-scoped analysis job, UI-read, and maintenance source-DB sessions
- retain those session roles through worker pools, progress polling, similarity lookup, and Starmap connection caches
- move analysis enqueue/invalidation helpers from raw connection parameters to job-worker sessions
- correct stale-job progress cleanup to use a maintenance session instead of a read-only connection
- preserve current SQL, scheduling, claim, and similarity behavior

## Definition of Done
- app/controller analysis enqueue and similarity lookup code no longer opens or passes raw source-DB connections for normal work
- worker, UI-read, and maintenance roles are explicit in session types and enforced by the source-DB open profile
- SQL remains in the existing focused persistence/repository modules
- role enforcement has regression coverage

## Validation commands
- `cargo test -p wavecrate --lib analysis_jobs::db -- --nocapture` (40 passed, 1 ignored)
- `cargo test -p wavecrate --lib source_db -- --nocapture` (15 passed, 1 ignored)
- `cargo test -p wavecrate --lib analysis_jobs::enqueue -- --nocapture` (11 passed)
- `cargo test -p wavecrate --lib analysis_jobs::pool::job_claim -- --nocapture` (20 passed)
- `cargo test -p wavecrate --lib wavs::similar -- --nocapture` (26 passed)
- `cargo test -p wavecrate --lib similarity_prep -- --nocapture` (23 passed)
- `cargo check -p wavecrate --all-targets`
- `cargo check -p wavecrate --no-default-features`

## Known limitations
- None

User review is required before merge.