### PR TITLE
OPT-605: Split journal persistence from recovery

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/decode.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/decode.rs
@@ -1,0 +1,169 @@
+use std::path::PathBuf;
+
+use super::super::Rating;
+use super::super::util::parse_relative_path_from_db;
+use super::entry::{FileOpJournalEntry, FileOpKind, FileOpStage};
+
+/// Result of decoding journal rows, partitioned by valid and malformed entries.
+#[derive(Debug, Default)]
+pub struct ListedJournalEntries {
+    pub entries: Vec<FileOpJournalEntry>,
+    pub malformed: Vec<MalformedJournalEntry>,
+}
+
+/// Description of one malformed journal row that cannot be reconciled safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MalformedJournalEntry {
+    pub id: Option<String>,
+    pub detail: String,
+}
+
+impl MalformedJournalEntry {
+    fn new(id: Option<String>, detail: impl Into<String>) -> Self {
+        Self {
+            id,
+            detail: detail.into(),
+        }
+    }
+
+    pub(super) fn describe(&self) -> String {
+        match self.id.as_deref() {
+            Some(id) => format!("Malformed file-ops journal entry {id}: {}", self.detail),
+            None => format!("Malformed file-ops journal entry: {}", self.detail),
+        }
+    }
+}
+
+pub(super) fn decode_journal_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<FileOpJournalEntry, MalformedJournalEntry> {
+    let id: String = row
+        .get(0)
+        .map_err(|err| malformed_column_error(None, "id", err))?;
+    let op_type: String = row
+        .get(1)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "op_type", err))?;
+    let stage_text: String = row
+        .get(2)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "stage", err))?;
+    let kind = FileOpKind::from_str(op_type.as_str()).ok_or_else(|| {
+        MalformedJournalEntry::new(
+            Some(id.clone()),
+            format!("unknown op_type value `{op_type}`"),
+        )
+    })?;
+    let stage = FileOpStage::from_str(stage_text.as_str()).ok_or_else(|| {
+        MalformedJournalEntry::new(
+            Some(id.clone()),
+            format!("unknown stage value `{stage_text}`"),
+        )
+    })?;
+    let source_root: Option<String> = row
+        .get(3)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "source_root", err))?;
+    let source_relative_raw: Option<String> = row
+        .get(4)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "source_relative", err))?;
+    let target_relative_raw: String = row
+        .get(5)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "target_relative", err))?;
+    let staged_relative_raw: Option<String> = row
+        .get(6)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "staged_relative", err))?;
+    let file_size = row
+        .get::<_, Option<i64>>(7)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "file_size", err))?
+        .map(|size| {
+            if size < 0 {
+                Err(MalformedJournalEntry::new(
+                    Some(id.clone()),
+                    format!("file_size must be non-negative, got {size}"),
+                ))
+            } else {
+                Ok(size as u64)
+            }
+        })
+        .transpose()?;
+    let modified_ns: Option<i64> = row
+        .get(8)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "modified_ns", err))?;
+    let tag = row
+        .get::<_, Option<i64>>(9)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "tag", err))?
+        .map(Rating::from_i64);
+    let looped = row
+        .get::<_, Option<i64>>(10)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "looped", err))?
+        .map(|flag| flag != 0);
+    let locked = row
+        .get::<_, Option<i64>>(11)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "locked", err))?
+        .map(|flag| flag != 0);
+    let last_played_at = row
+        .get(12)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "last_played_at", err))?;
+    let last_curated_at = row
+        .get(13)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "last_curated_at", err))?;
+    let created_at = row
+        .get(14)
+        .map_err(|err| malformed_column_error(Some(id.as_str()), "created_at", err))?;
+    Ok(FileOpJournalEntry {
+        id: id.clone(),
+        kind,
+        stage,
+        source_root: source_root.map(PathBuf::from),
+        source_relative: parse_optional_path(&id, "source_relative", source_relative_raw)?,
+        target_relative: parse_required_path(&id, "target_relative", target_relative_raw)?,
+        staged_relative: parse_optional_path(&id, "staged_relative", staged_relative_raw)?,
+        file_size,
+        modified_ns,
+        tag,
+        looped,
+        locked,
+        last_played_at,
+        last_curated_at,
+        created_at,
+    })
+}
+
+fn malformed_column_error(
+    id: Option<&str>,
+    column: &str,
+    error: rusqlite::Error,
+) -> MalformedJournalEntry {
+    MalformedJournalEntry::new(
+        id.map(str::to_string),
+        format!("invalid `{column}` column: {error}"),
+    )
+}
+
+fn parse_optional_path(
+    id: &str,
+    column: &str,
+    value: Option<String>,
+) -> Result<Option<PathBuf>, MalformedJournalEntry> {
+    value
+        .map(|path| {
+            parse_relative_path_from_db(&path).map_err(|error| {
+                MalformedJournalEntry::new(
+                    Some(id.to_string()),
+                    format!("invalid `{column}` path `{path}`: {error}"),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn parse_required_path(
+    id: &str,
+    column: &str,
+    value: String,
+) -> Result<PathBuf, MalformedJournalEntry> {
+    parse_relative_path_from_db(&value).map_err(|error| {
+        MalformedJournalEntry::new(
+            Some(id.to_string()),
+            format!("invalid `{column}` path `{value}`: {error}"),
+        )
+    })
+}

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/mod.rs
@@ -14,8 +14,10 @@
 
 use super::{SourceDatabase, SourceDbError};
 
+mod decode;
 mod entry;
 mod reconcile;
+mod recovery_io;
 mod store;
 #[cfg(test)]
 mod tests;
@@ -26,11 +28,11 @@ pub use entry::{
 /// Summary of the work performed while reconciling pending journal entries.
 pub type FileOpReconcileSummary = reconcile::FileOpReconcileSummary;
 /// Result of loading journal rows during tests.
-pub type ListedJournalEntries = store::ListedJournalEntries;
+pub type ListedJournalEntries = decode::ListedJournalEntries;
 
 /// Insert a new journal entry before mutating the filesystem.
 pub fn insert_entry(db: &SourceDatabase, entry: &FileOpJournalEntry) -> Result<(), SourceDbError> {
-    store::insert_entry(db, entry)
+    store::FileOpJournalStore::new(db).insert(entry)
 }
 
 /// Update a journal entry stage and optional metadata after filesystem work.
@@ -41,17 +43,17 @@ pub fn update_stage(
     file_size: Option<u64>,
     modified_ns: Option<i64>,
 ) -> Result<(), SourceDbError> {
-    store::update_stage(db, id, stage, file_size, modified_ns)
+    store::FileOpJournalStore::new(db).update_stage(id, stage, file_size, modified_ns)
 }
 
 /// Remove a resolved journal entry after reconciliation.
 pub fn remove_entry(db: &SourceDatabase, id: &str) -> Result<(), SourceDbError> {
-    store::remove_entry(db, id)
+    store::FileOpJournalStore::new(db).remove(id)
 }
 
 /// Load all pending journal entries for reconciliation.
 pub fn list_entries(db: &SourceDatabase) -> Result<ListedJournalEntries, SourceDbError> {
-    store::list_entries(db)
+    store::FileOpJournalStore::new(db).list()
 }
 
 /// Reconcile all pending file ops against the filesystem and database.

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/reconcile.rs
@@ -4,7 +4,18 @@ use std::time::UNIX_EPOCH;
 use super::super::SourceDatabase;
 use super::FileOpJournalEntry;
 use super::entry::{FileOpKind, FileOpStage};
-use super::store::{list_entries, remove_entry};
+use super::recovery_io::{
+    RecoveryFilesystem, RecoverySourceDatabases, SourceDatabaseRecoveryAccess,
+    SystemRecoveryFilesystem,
+};
+use super::store::FileOpJournalStore;
+
+struct FileOpRecoveryCoordinator<'a, F, D> {
+    target_db: &'a SourceDatabase,
+    journal: FileOpJournalStore<'a>,
+    filesystem: F,
+    source_databases: D,
+}
 
 /// Summary of reconciliation work performed for pending file ops.
 #[derive(Debug, Default)]
@@ -19,58 +30,85 @@ pub struct FileOpReconcileSummary {
 
 /// Reconcile all pending file ops against the filesystem and database.
 pub fn reconcile_pending_ops(db: &SourceDatabase) -> Result<FileOpReconcileSummary, String> {
-    let listed = list_entries(db).map_err(|err| err.to_string())?;
-    let mut summary = FileOpReconcileSummary {
-        total: listed.entries.len() + listed.malformed.len(),
-        completed: 0,
-        errors: Vec::new(),
-    };
-    for malformed in listed.malformed {
-        let message = malformed.describe();
-        if let Some(id) = malformed.id.as_deref() {
-            match remove_entry(db, id) {
-                Ok(()) => summary
-                    .errors
-                    .push(format!("{message}; dropped malformed journal row")),
-                Err(err) => summary.errors.push(format!(
-                    "{message}; failed to drop malformed row {id}: {err}"
-                )),
-            }
-        } else {
-            summary.errors.push(message);
-        }
+    FileOpRecoveryCoordinator {
+        target_db: db,
+        journal: FileOpJournalStore::new(db),
+        filesystem: SystemRecoveryFilesystem,
+        source_databases: SourceDatabaseRecoveryAccess,
     }
-    for entry in listed.entries {
-        match reconcile_entry(db, &entry) {
-            Ok(()) => {
-                if let Err(err) = remove_entry(db, &entry.id) {
-                    summary.errors.push(format!(
-                        "Failed to remove journal entry {}: {err}",
-                        entry.id
-                    ));
-                } else {
-                    summary.completed += 1;
-                }
-            }
-            Err(err) => summary.errors.push(err),
-        }
-    }
-    Ok(summary)
+    .reconcile()
 }
 
-fn reconcile_entry(db: &SourceDatabase, entry: &FileOpJournalEntry) -> Result<(), String> {
+impl<F: RecoveryFilesystem, D: RecoverySourceDatabases> FileOpRecoveryCoordinator<'_, F, D> {
+    fn reconcile(&self) -> Result<FileOpReconcileSummary, String> {
+        let listed = self.journal.list().map_err(|err| err.to_string())?;
+        let mut summary = FileOpReconcileSummary {
+            total: listed.entries.len() + listed.malformed.len(),
+            completed: 0,
+            errors: Vec::new(),
+        };
+        for malformed in listed.malformed {
+            let message = malformed.describe();
+            if let Some(id) = malformed.id.as_deref() {
+                match self.journal.remove(id) {
+                    Ok(()) => summary
+                        .errors
+                        .push(format!("{message}; dropped malformed journal row")),
+                    Err(err) => summary.errors.push(format!(
+                        "{message}; failed to drop malformed row {id}: {err}"
+                    )),
+                }
+            } else {
+                summary.errors.push(message);
+            }
+        }
+        for entry in listed.entries {
+            match reconcile_entry(
+                self.target_db,
+                &entry,
+                &self.filesystem,
+                &self.source_databases,
+            ) {
+                Ok(()) => {
+                    if let Err(err) = self.journal.remove(&entry.id) {
+                        summary.errors.push(format!(
+                            "Failed to remove journal entry {}: {err}",
+                            entry.id
+                        ));
+                    } else {
+                        summary.completed += 1;
+                    }
+                }
+                Err(err) => summary.errors.push(err),
+            }
+        }
+        Ok(summary)
+    }
+}
+
+fn reconcile_entry(
+    db: &SourceDatabase,
+    entry: &FileOpJournalEntry,
+    filesystem: &impl RecoveryFilesystem,
+    source_databases: &impl RecoverySourceDatabases,
+) -> Result<(), String> {
     let target_root = db.root();
     let target_absolute = target_root.join(&entry.target_relative);
     let staged_absolute = entry
         .staged_relative
         .as_ref()
         .map(|path| target_root.join(path));
-    validate_staged_file_identity(entry, staged_absolute.as_deref())?;
-    validate_existing_target_identity(entry, staged_absolute.as_deref(), &target_absolute)?;
-    reconcile_staged_file(staged_absolute.as_deref(), &target_absolute)?;
-    let target_exists = reconcile_target_entry(db, entry, &target_absolute)?;
+    validate_staged_file_identity(entry, staged_absolute.as_deref(), filesystem)?;
+    validate_existing_target_identity(
+        entry,
+        staged_absolute.as_deref(),
+        &target_absolute,
+        filesystem,
+    )?;
+    reconcile_staged_file(staged_absolute.as_deref(), &target_absolute, filesystem)?;
+    let target_exists = reconcile_target_entry(db, entry, &target_absolute, filesystem)?;
     if entry.kind == FileOpKind::Move {
-        reconcile_source_entry(db, entry, target_exists)?;
+        reconcile_source_entry(db, entry, target_exists, filesystem, source_databases)?;
     }
     Ok(())
 }
@@ -79,22 +117,26 @@ fn reconcile_entry(db: &SourceDatabase, entry: &FileOpJournalEntry) -> Result<()
 fn reconcile_staged_file(
     staged_absolute: Option<&Path>,
     target_absolute: &Path,
+    filesystem: &impl RecoveryFilesystem,
 ) -> Result<(), String> {
     let Some(staged_absolute) = staged_absolute else {
         return Ok(());
     };
-    if !staged_absolute.is_file() {
+    if !filesystem.is_file(staged_absolute) {
         return Ok(());
     }
-    if !target_absolute.is_file() {
+    if !filesystem.is_file(target_absolute) {
         if let Some(parent) = target_absolute.parent() {
-            std::fs::create_dir_all(parent)
+            filesystem
+                .create_dir_all(parent)
                 .map_err(|err| format!("Failed to create target dir: {err}"))?;
         }
-        std::fs::rename(staged_absolute, target_absolute)
+        filesystem
+            .rename(staged_absolute, target_absolute)
             .map_err(|err| format!("Failed to finalize staged file: {err}"))?;
     } else {
-        std::fs::remove_file(staged_absolute)
+        filesystem
+            .remove_file(staged_absolute)
             .map_err(|err| format!("Failed to remove staged file: {err}"))?;
     }
     Ok(())
@@ -103,11 +145,12 @@ fn reconcile_staged_file(
 fn validate_staged_file_identity(
     entry: &FileOpJournalEntry,
     staged_absolute: Option<&Path>,
+    filesystem: &impl RecoveryFilesystem,
 ) -> Result<(), String> {
     let Some(staged_absolute) = staged_absolute else {
         return Ok(());
     };
-    if !staged_absolute.is_file() {
+    if !filesystem.is_file(staged_absolute) {
         return Ok(());
     }
     validate_identity_match(
@@ -115,6 +158,7 @@ fn validate_staged_file_identity(
         staged_absolute,
         "staged",
         "staged file no longer matches the recorded journal metadata",
+        filesystem,
     )
 }
 
@@ -122,8 +166,9 @@ fn validate_existing_target_identity(
     entry: &FileOpJournalEntry,
     staged_absolute: Option<&Path>,
     target_absolute: &Path,
+    filesystem: &impl RecoveryFilesystem,
 ) -> Result<(), String> {
-    if !target_absolute.is_file() {
+    if !filesystem.is_file(target_absolute) {
         return Ok(());
     }
     if entry.file_size.is_none() || entry.modified_ns.is_none() {
@@ -131,7 +176,7 @@ fn validate_existing_target_identity(
             "Deferred file-op recovery for {}: target file {} exists but journaled identity is incomplete; {}",
             entry.id,
             target_absolute.display(),
-            staged_copy_resolution_suffix(staged_absolute)
+            staged_copy_resolution_suffix(staged_absolute, filesystem)
         ));
     }
     validate_identity_match(
@@ -140,13 +185,17 @@ fn validate_existing_target_identity(
         "target",
         &format!(
             "target path was reused before recovery replay{}",
-            staged_copy_resolution_suffix(staged_absolute)
+            staged_copy_resolution_suffix(staged_absolute, filesystem)
         ),
+        filesystem,
     )
 }
 
-fn staged_copy_resolution_suffix(staged_absolute: Option<&Path>) -> String {
-    if staged_absolute.is_some_and(Path::is_file) {
+fn staged_copy_resolution_suffix(
+    staged_absolute: Option<&Path>,
+    filesystem: &impl RecoveryFilesystem,
+) -> String {
+    if staged_absolute.is_some_and(|path| filesystem.is_file(path)) {
         format!(
             "; leaving staged copy at {} intact",
             staged_absolute.expect("checked above").display()
@@ -161,6 +210,7 @@ fn validate_identity_match(
     path: &Path,
     location: &str,
     mismatch_reason: &str,
+    filesystem: &impl RecoveryFilesystem,
 ) -> Result<(), String> {
     let Some(expected_file_size) = entry.file_size else {
         return Ok(());
@@ -168,7 +218,7 @@ fn validate_identity_match(
     let Some(expected_modified_ns) = entry.modified_ns else {
         return Ok(());
     };
-    let actual = file_metadata(path)?;
+    let actual = file_metadata(path, filesystem)?;
     if actual == (expected_file_size, expected_modified_ns) {
         return Ok(());
     }
@@ -190,9 +240,10 @@ fn reconcile_target_entry(
     db: &SourceDatabase,
     entry: &FileOpJournalEntry,
     target_absolute: &Path,
+    filesystem: &impl RecoveryFilesystem,
 ) -> Result<bool, String> {
-    if target_absolute.is_file() {
-        let (file_size, modified_ns) = file_metadata(target_absolute)?;
+    if filesystem.is_file(target_absolute) {
+        let (file_size, modified_ns) = file_metadata(target_absolute, filesystem)?;
         let mut batch = db.write_batch().map_err(|err| err.to_string())?;
         match entry.kind {
             FileOpKind::Copy => batch
@@ -248,6 +299,8 @@ fn reconcile_source_entry(
     target_db: &SourceDatabase,
     entry: &FileOpJournalEntry,
     target_exists: bool,
+    filesystem: &impl RecoveryFilesystem,
+    source_databases: &impl RecoverySourceDatabases,
 ) -> Result<(), String> {
     let Some(source_root) = entry.source_root.as_ref() else {
         return Ok(());
@@ -266,12 +319,11 @@ fn reconcile_source_entry(
         return Ok(());
     }
     let source_absolute = source_root.join(source_relative);
-    if source_absolute.is_file() && !target_exists {
+    if filesystem.is_file(&source_absolute) && !target_exists {
         return Ok(());
     }
-    let source_db = SourceDatabase::open(source_root)
-        .map_err(|err| format!("Failed to open source DB for recovery: {err}"))?;
-    if !source_absolute.is_file() {
+    let source_db = source_databases.open(source_root)?;
+    if !filesystem.is_file(&source_absolute) {
         source_db
             .remove_file(source_relative)
             .map_err(|err| format!("Failed to drop source DB row: {err}"))?;
@@ -289,8 +341,9 @@ fn should_defer_source_cleanup(entry: &FileOpJournalEntry, target_exists: bool) 
     target_exists && entry.stage != FileOpStage::SourceDb
 }
 
-fn file_metadata(path: &Path) -> Result<(u64, i64), String> {
-    let metadata = std::fs::metadata(path)
+fn file_metadata(path: &Path, filesystem: &impl RecoveryFilesystem) -> Result<(u64, i64), String> {
+    let metadata = filesystem
+        .metadata(path)
         .map_err(|err| format!("Failed to read {}: {err}", path.display()))?;
     let modified_ns = metadata
         .modified()

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+use super::super::SourceDatabase;
+
+pub(super) trait RecoveryFilesystem {
+    fn is_file(&self, path: &Path) -> bool;
+    fn create_dir_all(&self, path: &Path) -> Result<(), std::io::Error>;
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), std::io::Error>;
+    fn remove_file(&self, path: &Path) -> Result<(), std::io::Error>;
+    fn metadata(&self, path: &Path) -> Result<std::fs::Metadata, std::io::Error>;
+}
+
+pub(super) struct SystemRecoveryFilesystem;
+
+impl RecoveryFilesystem for SystemRecoveryFilesystem {
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+
+    fn create_dir_all(&self, path: &Path) -> Result<(), std::io::Error> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> Result<(), std::io::Error> {
+        std::fs::rename(from, to)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<(), std::io::Error> {
+        std::fs::remove_file(path)
+    }
+
+    fn metadata(&self, path: &Path) -> Result<std::fs::Metadata, std::io::Error> {
+        std::fs::metadata(path)
+    }
+}
+
+pub(super) trait RecoverySourceDatabases {
+    fn open(&self, root: &Path) -> Result<SourceDatabase, String>;
+}
+
+pub(super) struct SourceDatabaseRecoveryAccess;
+
+impl RecoverySourceDatabases for SourceDatabaseRecoveryAccess {
+    fn open(&self, root: &Path) -> Result<SourceDatabase, String> {
+        SourceDatabase::open(root)
+            .map_err(|error| format!("Failed to open source DB for recovery: {error}"))
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/store.rs
@@ -1,44 +1,40 @@
-use std::path::PathBuf;
-
 use rusqlite::params;
 
-use super::super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
-use super::super::{Rating, SourceDatabase, SourceDbError};
-use super::entry::{FileOpJournalEntry, FileOpKind, FileOpStage};
+use super::super::util::{map_sql_error, normalize_relative_path};
+use super::super::{SourceDatabase, SourceDbError};
+use super::decode::{ListedJournalEntries, decode_journal_row};
+use super::entry::{FileOpJournalEntry, FileOpStage};
 
-/// Result of loading journal rows, partitioned by valid and malformed entries.
-#[derive(Debug, Default)]
-pub struct ListedJournalEntries {
-    /// Well-formed entries ready for reconciliation.
-    pub entries: Vec<FileOpJournalEntry>,
-    /// Malformed rows that could not be decoded safely.
-    pub malformed: Vec<MalformedJournalEntry>,
+/// Narrow persistence boundary for durable file-operation journal rows.
+pub(crate) struct FileOpJournalStore<'a> {
+    db: &'a SourceDatabase,
 }
 
-/// Description of one malformed journal row that cannot be reconciled safely.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MalformedJournalEntry {
-    /// Journal row id when one could be decoded.
-    pub id: Option<String>,
-    /// Human-readable explanation of what was malformed.
-    pub detail: String,
-}
-
-impl MalformedJournalEntry {
-    /// Build one malformed-row descriptor with optional row id context.
-    pub(super) fn new(id: Option<String>, detail: impl Into<String>) -> Self {
-        Self {
-            id,
-            detail: detail.into(),
-        }
+impl<'a> FileOpJournalStore<'a> {
+    pub(crate) fn new(db: &'a SourceDatabase) -> Self {
+        Self { db }
     }
 
-    /// Render one human-readable malformed-row error message for reconcile summaries.
-    pub(super) fn describe(&self) -> String {
-        match self.id.as_deref() {
-            Some(id) => format!("Malformed file-ops journal entry {id}: {}", self.detail),
-            None => format!("Malformed file-ops journal entry: {}", self.detail),
-        }
+    pub(crate) fn insert(&self, entry: &FileOpJournalEntry) -> Result<(), SourceDbError> {
+        insert_entry(self.db, entry)
+    }
+
+    pub(crate) fn update_stage(
+        &self,
+        id: &str,
+        stage: FileOpStage,
+        file_size: Option<u64>,
+        modified_ns: Option<i64>,
+    ) -> Result<(), SourceDbError> {
+        update_stage(self.db, id, stage, file_size, modified_ns)
+    }
+
+    pub(crate) fn remove(&self, id: &str) -> Result<(), SourceDbError> {
+        remove_entry(self.db, id)
+    }
+
+    pub(crate) fn list(&self) -> Result<ListedJournalEntries, SourceDbError> {
+        list_entries(self.db)
     }
 }
 
@@ -147,145 +143,4 @@ pub(crate) fn list_entries(db: &SourceDatabase) -> Result<ListedJournalEntries, 
         }
     }
     Ok(listed)
-}
-
-/// Decode one persisted journal row into a typed recovery entry.
-fn decode_journal_row(
-    row: &rusqlite::Row<'_>,
-) -> Result<FileOpJournalEntry, MalformedJournalEntry> {
-    let id: String = row
-        .get(0)
-        .map_err(|err| malformed_column_error(None, "id", err))?;
-    let op_type: String = row
-        .get(1)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "op_type", err))?;
-    let stage_text: String = row
-        .get(2)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "stage", err))?;
-    let kind = FileOpKind::from_str(op_type.as_str()).ok_or_else(|| {
-        MalformedJournalEntry::new(
-            Some(id.clone()),
-            format!("unknown op_type value `{op_type}`"),
-        )
-    })?;
-    let stage = FileOpStage::from_str(stage_text.as_str()).ok_or_else(|| {
-        MalformedJournalEntry::new(
-            Some(id.clone()),
-            format!("unknown stage value `{stage_text}`"),
-        )
-    })?;
-    let source_root: Option<String> = row
-        .get(3)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "source_root", err))?;
-    let source_relative_raw: Option<String> = row
-        .get(4)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "source_relative", err))?;
-    let target_relative_raw: String = row
-        .get(5)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "target_relative", err))?;
-    let staged_relative_raw: Option<String> = row
-        .get(6)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "staged_relative", err))?;
-    let file_size = row
-        .get::<_, Option<i64>>(7)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "file_size", err))?
-        .map(|size| {
-            if size < 0 {
-                Err(MalformedJournalEntry::new(
-                    Some(id.clone()),
-                    format!("file_size must be non-negative, got {size}"),
-                ))
-            } else {
-                Ok(size as u64)
-            }
-        })
-        .transpose()?;
-    let modified_ns: Option<i64> = row
-        .get(8)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "modified_ns", err))?;
-    let tag = row
-        .get::<_, Option<i64>>(9)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "tag", err))?
-        .map(Rating::from_i64);
-    let looped = row
-        .get::<_, Option<i64>>(10)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "looped", err))?
-        .map(|flag| flag != 0);
-    let locked = row
-        .get::<_, Option<i64>>(11)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "locked", err))?
-        .map(|flag| flag != 0);
-    let last_played_at: Option<i64> = row
-        .get(12)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "last_played_at", err))?;
-    let last_curated_at: Option<i64> = row
-        .get(13)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "last_curated_at", err))?;
-    let created_at: i64 = row
-        .get(14)
-        .map_err(|err| malformed_column_error(Some(id.as_str()), "created_at", err))?;
-    let source_relative =
-        parse_optional_relative_path_column(id.as_str(), "source_relative", source_relative_raw)?;
-    let target_relative =
-        parse_required_relative_path_column(id.as_str(), "target_relative", target_relative_raw)?;
-    let staged_relative =
-        parse_optional_relative_path_column(id.as_str(), "staged_relative", staged_relative_raw)?;
-    Ok(FileOpJournalEntry {
-        id,
-        kind,
-        stage,
-        source_root: source_root.map(PathBuf::from),
-        source_relative,
-        target_relative,
-        staged_relative,
-        file_size,
-        modified_ns,
-        tag,
-        looped,
-        locked,
-        last_played_at,
-        last_curated_at,
-        created_at,
-    })
-}
-
-/// Map one sqlite column read failure to a malformed-row descriptor.
-fn malformed_column_error(
-    id: Option<&str>,
-    column: &str,
-    err: rusqlite::Error,
-) -> MalformedJournalEntry {
-    let detail = format!("invalid `{column}` column: {err}");
-    MalformedJournalEntry::new(id.map(str::to_string), detail)
-}
-
-/// Parse one optional relative-path column while preserving row-id context.
-fn parse_optional_relative_path_column(
-    id: &str,
-    column: &str,
-    value: Option<String>,
-) -> Result<Option<PathBuf>, MalformedJournalEntry> {
-    match value {
-        Some(path) => parse_relative_path_from_db(&path).map(Some).map_err(|err| {
-            MalformedJournalEntry::new(
-                Some(id.to_string()),
-                format!("invalid `{column}` path `{path}`: {err}"),
-            )
-        }),
-        None => Ok(None),
-    }
-}
-
-/// Parse one required relative-path column while preserving row-id context.
-fn parse_required_relative_path_column(
-    id: &str,
-    column: &str,
-    value: String,
-) -> Result<PathBuf, MalformedJournalEntry> {
-    parse_relative_path_from_db(&value).map_err(|err| {
-        MalformedJournalEntry::new(
-            Some(id.to_string()),
-            format!("invalid `{column}` path `{value}`: {err}"),
-        )
-    })
 }


### PR DESCRIPTION
## Scope
- introduce a narrow file-operation journal persistence store for insert, stage, remove, and list operations
- move raw row decoding and malformed-row classification into a dedicated decoder module
- model recovery as a coordinator over explicit journal, filesystem, and cross-source database dependencies
- keep the public journal facade and crash-recovery ordering stable
- preserve all existing staged-file, target-row, source-row, malformed-row, and offline-source behavior

## Definition of Done
- journal persistence is a small explicit API
- row decoding is separate from persistence and recovery policy
- filesystem mutations and cross-source database opens are named recovery dependencies
- existing recovery behavior and crash-safety coverage remain green

## Validation commands
- `cargo test -p wavecrate-library file_ops_journal -- --quiet` (12 passed)
- `cargo test -p wavecrate-library -- --quiet` (142 passed)
- `cargo check -p wavecrate --all-targets`

## Known limitations
- None

User review is required before merge.