### PR TITLE
OPT-606: Harden progress snapshot contracts

### DIFF
--- a/src/app/controller/library/analysis_jobs/db/progress_snapshot/delta.rs
+++ b/src/app/controller/library/analysis_jobs/db/progress_snapshot/delta.rs
@@ -89,4 +89,25 @@ mod tests {
         assert_eq!(deltas.get("analyze"), Some(&(-1, 1, 1, 0)));
         assert_eq!(deltas.get("embed"), Some(&(0, 0, 0, -1)));
     }
+
+    #[test]
+    fn state_deltas_cancel_intermediate_states_across_one_batch() {
+        let deltas = state_deltas([
+            (
+                Some(state("analyze", "pending", true)),
+                Some(state("analyze", "running", true)),
+            ),
+            (
+                Some(state("analyze", "running", true)),
+                Some(state("analyze", "done", true)),
+            ),
+            (
+                Some(state("embed", "failed", true)),
+                Some(state("embed", "failed", false)),
+            ),
+        ]);
+
+        assert_eq!(deltas.get("analyze"), Some(&(-1, 0, 1, 0)));
+        assert_eq!(deltas.get("embed"), Some(&(0, 0, 0, -1)));
+    }
 }

--- a/src/app/controller/library/analysis_jobs/db/progress_snapshot/freshness.rs
+++ b/src/app/controller/library/analysis_jobs/db/progress_snapshot/freshness.rs
@@ -46,3 +46,38 @@ fn current_wav_paths_revision(conn: &Connection) -> Result<Option<String>, Strin
     .optional()
     .map_err(|err| err.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freshness_tracks_revision_changes_and_missing_revision_state() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);")
+            .unwrap();
+        conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, '7')",
+            params![META_WAV_PATHS_REVISION],
+        )
+        .unwrap();
+
+        store_analyze_snapshot_wav_paths_revision(&conn).unwrap();
+        assert!(analyze_snapshot_is_fresh(&conn).unwrap());
+
+        conn.execute(
+            "UPDATE metadata SET value = '8' WHERE key = ?1",
+            params![META_WAV_PATHS_REVISION],
+        )
+        .unwrap();
+        assert!(!analyze_snapshot_is_fresh(&conn).unwrap());
+
+        conn.execute(
+            "DELETE FROM metadata WHERE key = ?1",
+            params![META_WAV_PATHS_REVISION],
+        )
+        .unwrap();
+        store_analyze_snapshot_wav_paths_revision(&conn).unwrap();
+        assert!(analyze_snapshot_is_fresh(&conn).unwrap());
+    }
+}


### PR DESCRIPTION
## Scope
- verify the requested progress-snapshot ownership split already present on `main` in commit `99a37f298`
- add pure transition coverage proving intermediate states cancel across one batched delta
- add SQLite-backed freshness coverage for revision match, revision drift, and missing-revision reset
- preserve the existing 87-line facade and separate schema, read/write, states, freshness, decode, and delta contracts

## Definition of Done
- `progress_snapshot.rs` remains a small role-oriented facade
- pure delta behavior is testable without SQLite
- wav-path revision invalidation behavior is covered by a focused SQLite test
- the full analysis-job database suite remains green

## Validation commands
- `cargo test -p wavecrate --lib progress_snapshot -- --nocapture` (4 passed)
- `cargo test -p wavecrate --lib analysis_jobs::db -- --quiet` (41 passed, 1 ignored)
- `cargo check -p wavecrate --all-targets`

## Known limitations
- The structural split itself predates this branch in main commit `99a37f298`; this PR completes the open ticket with the missing focused contract coverage rather than duplicating that implementation.

User review is required before merge.