### PR TITLE
OPT-814 Fix folder context Open in Explorer command

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -237,7 +237,15 @@ pub(in crate::native_app) enum GuiMessage {
     },
     CancelFileMoveConflicts,
     CopyContextPath,
-    OpenContextTarget,
+    OpenContextTarget {
+        kind: BrowserContextTargetKind,
+        path: PathBuf,
+    },
+    ContextTargetOpenValidated {
+        kind: BrowserContextTargetKind,
+        path: PathBuf,
+        result: Result<(), String>,
+    },
     CreateFolderAtContextTarget,
     RenameContextFolder,
     ContextFolderCreateFinished {

--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -110,7 +110,7 @@ fn context_menu_commands(
         return missing_sample_context_menu_commands(menu);
     }
     let mut actions = vec![
-        context_menu_command(&menu.kind, action_label, GuiMessage::OpenContextTarget),
+        context_menu_command(&menu.kind, action_label, open_target_message(menu)),
         context_menu_command(&menu.kind, "Copy Path", GuiMessage::CopyContextPath),
     ];
     if matches!(
@@ -223,6 +223,13 @@ fn context_menu_commands(
         );
     }
     actions
+}
+
+pub(in crate::native_app) fn open_target_message(menu: &BrowserContextMenu) -> GuiMessage {
+    GuiMessage::OpenContextTarget {
+        kind: menu.kind.clone(),
+        path: menu.path.clone(),
+    }
 }
 
 fn source_protection_label(role: SourceRole) -> &'static str {

--- a/src/native_app/sample_library/context_menu_target.rs
+++ b/src/native_app/sample_library/context_menu_target.rs
@@ -76,6 +76,33 @@ pub(in crate::native_app) fn target_available(
     true
 }
 
+pub(in crate::native_app) fn validate_open_target(
+    kind: &BrowserContextTargetKind,
+    path: &Path,
+) -> Result<(), String> {
+    let exists = path
+        .try_exists()
+        .map_err(|error| format!("Cannot access {}: {error}", path.display()))?;
+    if !exists {
+        return Err(missing_target_message(kind).to_string());
+    }
+
+    match kind {
+        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder if !path.is_dir() => {
+            Err(format!("Not a folder: {}", path.display()))
+        }
+        BrowserContextTargetKind::Sample if !path.is_file() => {
+            Err(format!("Not a file: {}", path.display()))
+        }
+        BrowserContextTargetKind::Collection | BrowserContextTargetKind::MetadataTag => {
+            Err(missing_target_message(kind).to_string())
+        }
+        BrowserContextTargetKind::Source
+        | BrowserContextTargetKind::Folder
+        | BrowserContextTargetKind::Sample => Ok(()),
+    }
+}
+
 pub(in crate::native_app) fn missing_target_message(
     kind: &BrowserContextTargetKind,
 ) -> &'static str {

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -158,7 +158,8 @@ impl NativeAppState {
             | GuiMessage::CopyContextPath
             | GuiMessage::TrashFolderDialogFinished(_)
             | GuiMessage::ContextPathCopyFinished { .. }
-            | GuiMessage::OpenContextTarget
+            | GuiMessage::OpenContextTarget { .. }
+            | GuiMessage::ContextTargetOpenValidated { .. }
             | GuiMessage::CreateFolderAtContextTarget
             | GuiMessage::RenameContextFolder
             | GuiMessage::ContextFolderCreateFinished { .. }

--- a/src/native_app/shell/message_dispatch/files.rs
+++ b/src/native_app/shell/message_dispatch/files.rs
@@ -130,7 +130,12 @@ impl NativeAppState {
             GuiMessage::ContextPathCopyFinished { kind, path, result } => {
                 self.finish_context_path_copy(kind, path, result);
             }
-            GuiMessage::OpenContextTarget => self.open_context_target(context),
+            GuiMessage::OpenContextTarget { kind, path } => {
+                self.open_context_target(kind, path, context)
+            }
+            GuiMessage::ContextTargetOpenValidated { kind, path, result } => {
+                self.finish_context_target_validation(kind, path, result, context)
+            }
             GuiMessage::CreateFolderAtContextTarget => {
                 self.create_folder_at_context_target(context)
             }

--- a/src/native_app/tests/shortcuts_context/context_menu.rs
+++ b/src/native_app/tests/shortcuts_context/context_menu.rs
@@ -1,5 +1,6 @@
 use crate::native_app::{
-    sample_library::context_menu_target::target_available,
+    app_chrome::browser_context_menu::open_target_message,
+    sample_library::context_menu_target::{target_available, validate_open_target},
     test_support::{
         context_menu::{BrowserContextMenu, BrowserContextTargetKind, WaveformContextMenu},
         state::{FolderBrowserMessage, GuiMessage, NativeAppState, default_gui_shortcuts},
@@ -133,6 +134,82 @@ fn context_menu_availability_does_not_probe_disk() {
     std::fs::remove_file(&sample).expect("remove sample");
     assert!(target_available(&BrowserContextTargetKind::Sample, &sample));
     let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn context_target_validation_rejects_missing_and_wrong_kind_paths() {
+    let root = std::env::temp_dir().join(format!(
+        "wavecrate-context-validation-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).expect("create temp root");
+    let sample = root.join("kick.wav");
+    std::fs::write(&sample, [0_u8; 8]).expect("write sample");
+
+    assert_eq!(
+        validate_open_target(&BrowserContextTargetKind::Folder, &root),
+        Ok(())
+    );
+    assert_eq!(
+        validate_open_target(&BrowserContextTargetKind::Sample, &sample),
+        Ok(())
+    );
+    assert!(
+        validate_open_target(&BrowserContextTargetKind::Folder, &sample)
+            .expect_err("file cannot be opened as folder")
+            .starts_with("Not a folder:")
+    );
+    assert_eq!(
+        validate_open_target(&BrowserContextTargetKind::Folder, &root.join("missing")),
+        Err(String::from("Folder is missing"))
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn folder_open_message_captures_the_right_clicked_target() {
+    let right_clicked = PathBuf::from("C:\\samples\\drums");
+    let menu = BrowserContextMenu {
+        kind: BrowserContextTargetKind::Folder,
+        path: right_clicked.clone(),
+        source_id: None,
+        source_role: wavecrate::sample_sources::SourceRole::Normal,
+        source_removable: false,
+        folder_locked: false,
+        folder_lock_inherited: false,
+        metadata_tag: None,
+        collection: None,
+        sample_missing: false,
+        sample_keep_locked: false,
+        anchor: Point::new(12.0, 24.0),
+        title: String::from("drums"),
+    };
+
+    assert_eq!(
+        open_target_message(&menu),
+        GuiMessage::OpenContextTarget {
+            kind: BrowserContextTargetKind::Folder,
+            path: right_clicked,
+        }
+    );
+}
+
+#[test]
+fn folder_open_closes_the_menu_before_validation_completes() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.browser_interaction.context_menu = Some(sample_context_menu("unrelated.wav"));
+
+    state.open_context_target(
+        BrowserContextTargetKind::Folder,
+        PathBuf::from("C:\\samples\\drums"),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert_eq!(state.ui.browser_interaction.context_menu, None);
 }
 
 #[test]

--- a/src/native_app/workflows/context_menu_actions/platform.rs
+++ b/src/native_app/workflows/context_menu_actions/platform.rs
@@ -87,27 +87,57 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn open_context_target(
         &mut self,
+        kind: BrowserContextTargetKind,
+        path: PathBuf,
         context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
-        let Some(menu) = self.ui.browser_interaction.context_menu.take() else {
-            return;
-        };
-        if !context_menu::target_available(&menu.kind, &menu.path) {
-            let error = context_menu::missing_target_message(&menu.kind);
-            self.ui.status.sample = error.to_string();
+        self.ui.browser_interaction.context_menu = None;
+        let validation_kind = kind.clone();
+        let validation_path = path.clone();
+        let completion_kind = kind.clone();
+        let completion_path = path.clone();
+        context
+            .business()
+            .blocking_io("gui-context-target-validate")
+            .run(
+                move |_| context_menu::validate_open_target(&validation_kind, &validation_path),
+                move |result| GuiMessage::ContextTargetOpenValidated {
+                    kind: completion_kind,
+                    path: completion_path,
+                    result,
+                },
+            );
+        emit_gui_action(
+            "browser.context_menu.open_explorer",
+            Some(context_menu::pane(&kind)),
+            Some(context_menu::target_label(&path).as_str()),
+            "validating",
+            started_at,
+            None,
+        );
+    }
+
+    pub(in crate::native_app) fn finish_context_target_validation(
+        &mut self,
+        kind: BrowserContextTargetKind,
+        path: PathBuf,
+        result: Result<(), String>,
+        context: &mut radiant::prelude::UiUpdateContext<GuiMessage>,
+    ) {
+        let started_at = Instant::now();
+        if let Err(error) = result {
+            self.ui.status.sample = error.clone();
             emit_gui_action(
                 "browser.context_menu.open_explorer",
-                Some(context_menu::pane(&menu.kind)),
-                Some(context_menu::target_label(&menu.path).as_str()),
+                Some(context_menu::pane(&kind)),
+                Some(context_menu::target_label(&path).as_str()),
                 "error",
                 started_at,
-                Some(error),
+                Some(&error),
             );
             return;
         }
-        let kind = menu.kind;
-        let path = menu.path;
         match kind {
             BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder => {
                 let completion_kind = kind.clone();


### PR DESCRIPTION
## Scope
- carry the right-clicked folder path in the menu command instead of consulting mutable selection/menu state later
- close the context menu immediately when the command is accepted
- validate missing, inaccessible, and wrong-kind paths off the UI thread before invoking the OS file manager
- preserve visible status reporting for validation and platform-launch failures

## Definition of Done
- Open in Explorer/Finder/File Manager targets the right-clicked folder
- later selection or hover changes cannot redirect the command
- the menu closes after activation
- invalid targets and launch failures produce visible status errors
- focused tests and repository smoke checks pass

## Validation commands
- cargo test --no-default-features --bin wavecrate shortcuts_context::context_menu
- cargo check --all-targets --no-default-features
- bash scripts/ci.sh smoke
- git diff --check

## Known limitations
None

User review is required before merge.