### PR TITLE
OPT-814 Isolate context target validation worker

### DIFF
--- a/src/native_app/sample_library/context_menu_target.rs
+++ b/src/native_app/sample_library/context_menu_target.rs
@@ -4,6 +4,8 @@ use radiant::gui::types::Point;
 use std::path::{Path, PathBuf};
 use wavecrate::sample_sources::{SampleCollection, SourceRole};
 
+mod validation_worker;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum BrowserContextTargetKind {
     Source,
@@ -80,27 +82,7 @@ pub(in crate::native_app) fn validate_open_target(
     kind: &BrowserContextTargetKind,
     path: &Path,
 ) -> Result<(), String> {
-    let exists = path
-        .try_exists()
-        .map_err(|error| format!("Cannot access {}: {error}", path.display()))?;
-    if !exists {
-        return Err(missing_target_message(kind).to_string());
-    }
-
-    match kind {
-        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder if !path.is_dir() => {
-            Err(format!("Not a folder: {}", path.display()))
-        }
-        BrowserContextTargetKind::Sample if !path.is_file() => {
-            Err(format!("Not a file: {}", path.display()))
-        }
-        BrowserContextTargetKind::Collection | BrowserContextTargetKind::MetadataTag => {
-            Err(missing_target_message(kind).to_string())
-        }
-        BrowserContextTargetKind::Source
-        | BrowserContextTargetKind::Folder
-        | BrowserContextTargetKind::Sample => Ok(()),
-    }
+    validation_worker::validate_open_target(kind, path)
 }
 
 pub(in crate::native_app) fn missing_target_message(

--- a/src/native_app/sample_library/context_menu_target/validation_worker.rs
+++ b/src/native_app/sample_library/context_menu_target/validation_worker.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use super::{BrowserContextTargetKind, missing_target_message};
+
+pub(super) fn validate_open_target(
+    kind: &BrowserContextTargetKind,
+    path: &Path,
+) -> Result<(), String> {
+    let exists = path
+        .try_exists()
+        .map_err(|error| format!("Cannot access {}: {error}", path.display()))?;
+    if !exists {
+        return Err(missing_target_message(kind).to_string());
+    }
+
+    match kind {
+        BrowserContextTargetKind::Source | BrowserContextTargetKind::Folder if !path.is_dir() => {
+            Err(format!("Not a folder: {}", path.display()))
+        }
+        BrowserContextTargetKind::Sample if !path.is_file() => {
+            Err(format!("Not a file: {}", path.display()))
+        }
+        BrowserContextTargetKind::Collection | BrowserContextTargetKind::MetadataTag => {
+            Err(missing_target_message(kind).to_string())
+        }
+        BrowserContextTargetKind::Source
+        | BrowserContextTargetKind::Folder
+        | BrowserContextTargetKind::Sample => Ok(()),
+    }
+}

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -817,6 +817,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "folder creation worker",
         ),
         (
+            "src/native_app/sample_library/context_menu_target/validation_worker.rs",
+            "context-menu target validation worker",
+        ),
+        (
             "src/native_app/sample_library/folder_browser/source_scan_cache.rs",
             "source scan cache worker",
         ),


### PR DESCRIPTION
## Scope
- move context-menu filesystem validation into an explicit BusinessRuntime worker module
- register that worker boundary with the non-blocking architecture guardrail
- preserve the merged OPT-814 target validation and status behavior

## Definition of Done
- the native-app non-blocking guardrail accepts context target validation only at its worker boundary
- focused context-menu behavior remains green
- repository smoke validation passes

## Validation commands
- cargo test -p wavecrate --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis
- cargo test --no-default-features --bin wavecrate shortcuts_context::context_menu
- bash scripts/ci.sh smoke
- git diff --check

## Known limitations
None

User review is required before merge.