### PR TITLE
Document the RC stabilization lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,29 @@ likely to miss important reasoning.
 - Linear project: `Wavecrate` — https://linear.app/boostnlvp/project/wavecrate-7230ebfad82d
 - Primary docs entrypoint: `docs/README.md`
 
+## Release Lifecycle
+- Normal development always lands through dedicated PRs into `main`.
+- Publishing the first `vX.Y.Z-rc.1` is an explicit decision to enter the
+  stabilization phase for `X.Y.Z`. It does not freeze `main` or stop the normal
+  PR pipeline. Development continues through PRs into `main`, but release-train
+  scope should be limited to stability work such as bug fixes, regressions,
+  reliability, performance, packaging, and release blockers. New feature work
+  waits until the stabilization phase ends unless the user explicitly changes
+  the release scope.
+- `release/X.Y` is a persistent release coordination branch, not a disposable
+  feature branch. Preserve its remote branch when an RC preparation PR merges.
+- If stability changes intended for `X.Y.Z` land on `main` after the latest RC, advance
+  `release/X.Y` from the current `main` commit and publish the next RC before a
+  stable release. Stable must promote the exact commit already published and
+  reviewed as the latest `vX.Y.Z-rc.N`; it must never silently include newer,
+  un-RCed commits from `main`.
+- A stable release requires an explicit user instruction such as "release
+  X.Y.Z stable" or "promote RC N to stable." PR approval, `approved`, sign-off,
+  or acceptance of an RC authorizes the applicable PR merge and cleanup only;
+  it never authorizes dispatching the stable release workflow.
+- See `docs/TEST.md` for the operator sequence and `docs/ENV_VARS.md` for the
+  release commands and invariants.
+
 ## Planning System
 - Linear is the source of truth for planning and backlog state in this repo.
 - When a plan is needed, create or update Linear issues in the `Wavecrate` project under the `PORTALSURFER` team.

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -63,6 +63,30 @@ Wavecrate has four public release workflows:
 - `.github/workflows/release-stable.yml`
   - manual stable releases from `release/X.Y`
 
+### Release lifecycle policy
+
+Development is continuous on `main` through ordinary PRs. Publishing the first
+RC for `X.Y.Z` signals that the project has entered stabilization for that
+version; it does not freeze `main`, stop PRs, or authorize stable publication.
+From that point, release-train work should focus on stability: bug fixes,
+regressions, reliability, performance, packaging, and release blockers. New
+features wait until stabilization ends unless the release scope is explicitly
+changed.
+
+The remote `release/X.Y` branch is the persistent coordination ref for the
+candidate being tested. Preserve it when an RC preparation PR merges. If fixes
+land on `main` after RC1, update `release/X.Y` from the current `main` commit at
+the same target version and publish RC2 (and later RCs as needed). The stable
+workflow deliberately requires the latest `vX.Y.Z-rc.N` tag and
+`release/X.Y` to point at the same commit, so stable cannot silently include
+changes that were never published as an RC.
+
+Stable publication requires an explicit operator decision such as "release
+X.Y.Z stable" or "promote RC N to stable." PR approval, `approved`, sign-off,
+or acceptance of an RC only authorizes the relevant PR merge and cleanup. None
+of those phrases alone authorizes `release-stable.yml` or
+`scripts/release.sh stable --dispatch`.
+
 Nightly runs publish rolling `nightly` builds for Windows x86_64 plus macOS
 x86_64/aarch64 assets from the current `main` commit. The schedule is
 `19:30 UTC` (evening in Europe/Amsterdam), and `workflow_dispatch` provides a
@@ -114,9 +138,21 @@ scripts/internal/release/prepare_release_train.py \
 
 Use the workflow dry run first when preparing a new train, then re-run with
 `push_branch=true` once the source commit and version are correct. After prep,
-run the RC workflow against the prepared `release/X.Y` branch. Stable promotion
-then runs against the same release branch after the latest `vX.Y.Z-rc.N` tag has
-passed review.
+run the RC workflow against the prepared `release/X.Y` branch. After later
+stability PRs merge to `main`, update the same release branch at the unchanged
+target version with:
+
+```bash
+scripts/internal/release/prepare_release_train.py \
+  --version X.Y.Z \
+  --source-ref main \
+  --push
+```
+
+Publish the next RC from that updated branch. Passing review makes the latest
+RC eligible for promotion; it does not dispatch stable. Stable promotion runs
+against the same release branch only after a separate explicit stable-release
+instruction.
 
 The release workflows keep channel policy in YAML but share operational helpers
 under `scripts/internal/release/`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,12 +11,14 @@ Machine-consumed check allowlists do not live here anymore. They now live under
 ## Canonical docs
 
 - `docs/ENV_VARS.md`
-  - environment variable reference and safety notes
+  - environment variable reference, release lifecycle/operator commands, and
+    safety notes
 - `docs/DATABASE_MIGRATIONS.md`
   - SQLite schema-change contract, migration rules, read-only compatibility,
     and database validation commands
 - `docs/TEST.md`
-  - development workflow, validation gates, and test suite map
+  - development workflow, RC/stable promotion policy, validation gates, and
+    test suite map
 - `docs/TARGET.md`
   - product target, architecture ownership, runtime contracts, recovery rules,
     automation surfaces, data formats, UI/performance direction, and the

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2620,6 +2620,29 @@ Updater behavior is intentionally conservative:
 
 See `docs/TROUBLESHOOTING.md` and `docs/ENV_VARS.md` for diagnostics and overrides.
 
+### Release Lifecycle
+
+Wavecrate uses continuous development on `main`. All ordinary development,
+including stabilization fixes, continues through the normal PR pipeline.
+
+Publishing the first RC for a target version is the explicit boundary that
+starts stabilization. It changes the scope of release-train work toward bugs,
+regressions, reliability, performance, packaging, and release blockers; it does
+not freeze `main` or automatically authorize a stable release. New features
+should wait until stabilization ends unless the release scope is explicitly
+changed.
+
+The remote `release/X.Y` branch is a persistent coordination ref for the latest
+candidate snapshot. When stabilization changes intended for the release land
+on `main`, update that ref and publish another RC. A stable release must promote
+the exact commit already published and reviewed as the latest RC, never newer
+un-RCed release work from `main`.
+
+Stable publication is a separate explicit product decision. PR approval,
+`approved`, sign-off, or RC acceptance can authorize merge and cleanup, but none
+of them authorize a stable release unless the user explicitly asks to release
+or promote the version as stable.
+
 ### Data-Format Notes
 
 Keep these formats stable unless there is a coordinated migration:

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -36,6 +36,44 @@ GitHub Actions owns release packaging, upload, and the release workflow
 validation gates. Local wrappers remain the primary validation contract for
 development and release-risk checks:
 
+### Release lifecycle and promotion policy
+
+Wavecrate develops continuously on `main` through the normal PR pipeline. The
+first RC for a version is a project decision to enter stabilization, not a
+branch freeze or an automatic precursor to an immediate stable release.
+
+1. Develop normally through PRs into `main`.
+2. When the current product is ready for stabilization, prepare `release/X.Y`
+   from `main` and publish `vX.Y.Z-rc.1`.
+3. Continue normal PRs into `main`, limiting the release train to stability
+   work: bug fixes, regression fixes, reliability, performance, packaging, and
+   release blockers. Feature work waits until stabilization ends unless the
+   release scope is explicitly changed.
+4. When fixes have landed after an RC, move the release branch to the current
+   `main` commit with the same target version and publish the next RC:
+
+   ```bash
+   scripts/internal/release/prepare_release_train.py \
+     --version X.Y.Z \
+     --source-ref main \
+     --push
+   scripts/release.sh rc \
+     --version X.Y.Z \
+     --rc-number N \
+     --branch release/X.Y \
+     --dispatch
+   ```
+
+5. Trigger stable only after an explicit stable-release decision. The stable
+   workflow promotes the exact latest RC commit; if later changes intended for
+   `X.Y.Z` have not been published as an RC, publish another RC first. PR
+   approval, `approved`, sign-off, or RC acceptance does not authorize stable
+   publication.
+
+Keep the remote `release/X.Y` branch as the release coordination ref. It is not
+a disposable feature branch and must remain available for subsequent RCs and
+the eventual explicit stable promotion.
+
 | Lane | GitHub job | Local command | Policy |
 | --- | --- | --- | --- |
 | Format and guardrails | none | `scripts/ci.* local` includes the required guardrails; use `scripts/check.* <name>` for focused reruns | Run locally before broad/risky changes |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,9 @@ dispatcher maps. These are the public entrypoints people should run directly:
 - `release.sh`: Bash release orchestration for release-train prep and explicit
   RC/stable GitHub workflow dispatch. It derives major, minor, and patch targets
   from the resolved source release package version and delegates
-  packaging/publication to the existing release workflows.
+  packaging/publication to the existing release workflows. RC publication
+  starts stabilization while normal PRs continue on `main`; stable publication
+  remains a separate explicit action and is never implied by PR or RC approval.
 - `gui.ps1`: Windows GUI validation lanes.
 
 PowerShell compatibility wrappers also remain available for the older

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -40,6 +40,9 @@ const VERIFY_PORTALSURFER_UPLOAD_CATALOG_SCRIPT: &str =
     include_str!("../scripts/internal/release/verify_portalsurfer_upload_catalog.py");
 const VERIFY_PUBLISHED_RELEASE_SCRIPT: &str =
     include_str!("../scripts/internal/release/verify_published_release.py");
+const AGENT_DOCS: &str = include_str!("../AGENTS.md");
+const ENV_VAR_DOCS: &str = include_str!("../docs/ENV_VARS.md");
+const SCRIPTS_DOCS: &str = include_str!("../scripts/README.md");
 const TEST_DOCS: &str = include_str!("../docs/TEST.md");
 const TARGET_DOCS: &str = include_str!("../docs/TARGET.md");
 const GETTING_STARTED_DOCS: &str = include_str!("../docs/book/src/getting-started.md");
@@ -374,6 +377,42 @@ fn release_surfaces_describe_supported_artifacts_without_setup_contracts() {
             );
         }
     }
+}
+
+#[test]
+fn release_lifecycle_docs_separate_rc_stabilization_from_stable_promotion() {
+    for (surface, contents) in [
+        ("AGENTS.md", AGENT_DOCS),
+        ("docs/ENV_VARS.md", ENV_VAR_DOCS),
+        ("docs/TEST.md", TEST_DOCS),
+        ("docs/TARGET.md", TARGET_DOCS),
+        ("scripts/README.md", SCRIPTS_DOCS),
+    ] {
+        assert!(
+            contents.contains("stabilization"),
+            "{surface} must explain that an RC starts stabilization"
+        );
+        assert!(
+            contents.contains("explicit") && contents.contains("stable"),
+            "{surface} must keep stable publication behind an explicit decision"
+        );
+    }
+
+    assert!(
+        AGENT_DOCS.contains("it never authorizes dispatching the stable release workflow"),
+        "AGENTS.md must not let ordinary approval dispatch stable"
+    );
+    assert!(
+        TEST_DOCS.contains("Continue normal PRs into `main`")
+            && TEST_DOCS.contains("published as an RC"),
+        "docs/TEST.md must describe continuous stabilization work and re-RC promotion"
+    );
+    assert!(
+        ENV_VAR_DOCS.contains("--version X.Y.Z")
+            && ENV_VAR_DOCS.contains("--source-ref main")
+            && ENV_VAR_DOCS.contains("--push"),
+        "docs/ENV_VARS.md must show how to advance a train at the same version"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Define RC1 as the explicit start of a stabilization phase, not a freeze of `main` or an automatic stable release.
- Keep normal PR development flowing into `main` while limiting the active release train to stability work.
- Document how later stabilization fixes require an updated `release/X.Y` candidate and another RC before stable promotion.
- Define `release/X.Y` as a persistent release coordination branch rather than a disposable feature branch.
- Require a separate explicit user instruction before dispatching any stable release; ordinary PR approval, `approved`, sign-off, or RC acceptance is insufficient.
- Add release-contract coverage so the policy cannot silently drift across agent and operator documentation.

## Definition of Done

- `AGENTS.md` states the approval and release-branch rules agents must follow.
- Canonical developer, operator, target, and script documentation describe the same lifecycle.
- The documented subsequent-RC command advances the release branch from `main` at the unchanged target version.
- Release contract tests enforce the distinction between RC stabilization and explicit stable promotion.

## Validation commands

- `rustfmt --edition 2024 --check tests/release_contract.rs`
- `git diff --check`
- `bash scripts/check.sh docs-index`
- `cargo test --locked --test release_contract release_lifecycle_docs_separate_rc_stabilization_from_stable_promotion -- --exact`
- `cargo test --locked --test release_contract`
- `bash scripts/agent.sh request` (reaches the pre-existing Wavecrate facade violations after all preceding guardrail stages pass)

## Known limitations

- The repository-wide agent preflight remains blocked by pre-existing Wavecrate facade violations unrelated to this documentation change.
- This PR clarifies policy and commands; it does not change the release workflow implementation.

User review is required before merge.
