### PR TITLE
Keep multiband waveform colors stable while zooming

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2077,6 +2077,8 @@ If exact loading progress is temporarily unavailable, the waveform surface shoul
 
 Waveform rendering should preserve the current multiband visual style rather than falling back to a plain single-envelope waveform. The waveform should distinguish useful frequency or energy bands so users can visually scan transients, bass-heavy material, noisy textures, tonal material, and quiet sections faster.
 
+Multiband normalization is a file-level visual contract. Overview and viewport-detail summaries for the same audio identity must reuse the same normalization profile so progressive refinement and zoom-level changes do not recolor the waveform or introduce visible band-color flicker. Cache identity and format versioning must invalidate summaries that do not carry the required profile.
+
 Waveform visual quality should improve where practical through antialiasing, cleaner band blending, stable peak rendering, and other polish that makes the waveform easier to read. These improvements must not compromise interaction latency. Zooming, panning, playhead updates, selection dragging, fade-handle dragging, envelope previews, hover feedback, and edit overlays should remain realtime-feeling.
 
 The hard performance target is interaction first: if a visual improvement causes noticeable latency in zoom, scroll, selection, fade handles, or playback-position feedback, the implementation should use cached levels of detail, GPU primitives, simplified preview rendering, or disable that enhancement at the current zoom level rather than making waveform interaction feel slow.

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -72,6 +72,7 @@ pub(in crate::native_app) use model::{
 };
 pub(in crate::native_app) use preview::{PreviewAuditionClip, decode_wav_preview_clip};
 pub(super) use progress::{cooperate_with_ui, report_phase_progress_throttled};
+pub(in crate::native_app) use visual_bands::VisualBandNormalization;
 #[cfg(test)]
 pub(super) use visual_bands::split_frequency_bands;
 pub(in crate::native_app) use visual_preview::{

--- a/src/native_app/waveform/audio_file/construction.rs
+++ b/src/native_app/waveform/audio_file/construction.rs
@@ -117,14 +117,15 @@ pub(in crate::native_app::waveform) fn waveform_file_from_mono_samples_with_prog
     progress: &impl Fn(f32),
     cancelled: &impl Fn() -> bool,
 ) -> Result<WaveformFile, String> {
-    let gpu_signal_samples = split_frequency_bands_with_progress_and_cancel(
-        &mono_samples,
-        sample_rate,
-        0.62,
-        0.9,
-        progress,
-        cancelled,
-    )?;
+    let (gpu_signal_samples, visual_band_normalization) =
+        split_frequency_bands_with_progress_and_cancel(
+            &mono_samples,
+            sample_rate,
+            0.62,
+            0.9,
+            progress,
+            cancelled,
+        )?;
     let gpu_signal_summary = Arc::new(gpu_signal_summary_with_progress_and_cancel(
         &gpu_signal_samples,
         mono_samples.len(),
@@ -142,6 +143,7 @@ pub(in crate::native_app::waveform) fn waveform_file_from_mono_samples_with_prog
         sample_rate,
         channels,
         frames: mono_samples.len(),
+        visual_band_normalization,
         gpu_signal_summary,
     })
 }

--- a/src/native_app/waveform/audio_file/model.rs
+++ b/src/native_app/waveform/audio_file/model.rs
@@ -7,6 +7,8 @@ use std::{
     time::SystemTime,
 };
 
+use super::visual_bands::VisualBandNormalization;
+
 #[derive(Clone, Debug)]
 pub(in crate::native_app) struct WaveformFile {
     pub(in crate::native_app::waveform) path: PathBuf,
@@ -17,6 +19,7 @@ pub(in crate::native_app) struct WaveformFile {
     pub(in crate::native_app::waveform) sample_rate: u32,
     pub(in crate::native_app::waveform) channels: usize,
     pub(in crate::native_app::waveform) frames: usize,
+    pub(in crate::native_app::waveform) visual_band_normalization: VisualBandNormalization,
     pub(in crate::native_app::waveform) gpu_signal_summary: Arc<GpuSignalSummary>,
 }
 

--- a/src/native_app/waveform/audio_file/visual_bands.rs
+++ b/src/native_app/waveform/audio_file/visual_bands.rs
@@ -1,7 +1,40 @@
 use radiant::runtime::GpuSignalSummaryBucket;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use super::super::BAND_COUNT;
+
+const VISUAL_BAND_COUNT: usize = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(in crate::native_app) struct VisualBandNormalization {
+    gain_bits: [u32; VISUAL_BAND_COUNT],
+}
+
+impl VisualBandNormalization {
+    pub(in crate::native_app::waveform) const IDENTITY: Self = Self {
+        gain_bits: [1.0_f32.to_bits(); VISUAL_BAND_COUNT],
+    };
+
+    pub(in crate::native_app::waveform) fn from_gains(
+        gains: [f32; VISUAL_BAND_COUNT],
+    ) -> Option<Self> {
+        gains
+            .iter()
+            .all(|gain| gain.is_finite() && *gain > 0.0 && *gain <= 4.0)
+            .then(|| Self {
+                gain_bits: gains.map(f32::to_bits),
+            })
+    }
+
+    pub(in crate::native_app::waveform) fn gains(self) -> [f32; VISUAL_BAND_COUNT] {
+        self.gain_bits.map(f32::from_bits)
+    }
+
+    pub(in crate::native_app::waveform) fn is_valid(self) -> bool {
+        Self::from_gains(self.gains()).is_some()
+    }
+}
 
 #[cfg(test)]
 pub(in crate::native_app::waveform) fn split_frequency_bands(
@@ -12,6 +45,7 @@ pub(in crate::native_app::waveform) fn split_frequency_bands(
         false
     })
     .expect("non-cancellable band split cannot be cancelled")
+    .0
 }
 
 pub(in crate::native_app::waveform) fn split_frequency_bands_with_progress_and_cancel(
@@ -21,9 +55,9 @@ pub(in crate::native_app::waveform) fn split_frequency_bands_with_progress_and_c
     end: f32,
     progress: &impl Fn(f32),
     cancelled: &impl Fn() -> bool,
-) -> Result<Arc<[f32]>, String> {
+) -> Result<(Arc<[f32]>, VisualBandNormalization), String> {
     if samples.is_empty() {
-        return Ok(Arc::from([]));
+        return Ok((Arc::from([]), VisualBandNormalization::IDENTITY));
     }
     let filter_end = start + (end - start) * 0.76;
     let normalize_end = start + (end - start) * 0.98;
@@ -43,7 +77,7 @@ pub(in crate::native_app::waveform) fn split_frequency_bands_with_progress_and_c
         );
     }
     progress(filter_end);
-    normalize_visual_band_peaks_with_progress(
+    let normalization = normalize_visual_band_peaks_with_progress(
         &mut bands,
         filter_end,
         normalize_end,
@@ -51,7 +85,7 @@ pub(in crate::native_app::waveform) fn split_frequency_bands_with_progress_and_c
         cancelled,
     )?;
     progress(end);
-    Ok(bands.into())
+    Ok((bands.into(), normalization))
 }
 
 pub(in crate::native_app::waveform) struct VisualBandFrameProcessor {
@@ -109,36 +143,36 @@ pub(in crate::native_app::waveform) fn normalize_visual_band_summary_buckets(
     buckets: &mut [GpuSignalSummaryBucket],
     band_count: usize,
     cancelled: &impl Fn() -> bool,
-) -> Result<(), String> {
+) -> Result<VisualBandNormalization, String> {
     if band_count < BAND_COUNT || buckets.is_empty() {
-        return Ok(());
+        return Ok(VisualBandNormalization::IDENTITY);
     }
     let raw_peak = summary_band_peak(buckets, band_count, 3, cancelled)?;
-    if raw_peak <= 0.000_01 || !raw_peak.is_finite() {
-        return Ok(());
-    }
     let peaks = [
         summary_band_peak(buckets, band_count, 0, cancelled)?,
         summary_band_peak(buckets, band_count, 1, cancelled)?,
         summary_band_peak(buckets, band_count, 2, cancelled)?,
     ];
-    let spectral_total = peaks.iter().copied().sum::<f32>().max(0.000_01);
-    let targets = [raw_peak * 0.98, raw_peak * 0.74, raw_peak * 0.34];
-    let boost_thresholds = [raw_peak * 0.08, raw_peak * 0.05, raw_peak * 0.035];
-    let max_gains = [2.6_f32, 2.8, 2.4];
-    for band in 0..3 {
-        let peak = peaks[band];
-        if peak <= 0.000_01 || !peak.is_finite() {
-            continue;
-        }
-        let energy_share = peak / spectral_total;
-        let target = targets[band] * smoothstep_scalar(0.12, 0.55, energy_share);
-        let max_gain = if peak < boost_thresholds[band] {
-            1.0
-        } else {
-            max_gains[band]
-        };
-        let gain = (target / peak).clamp(0.25, max_gain);
+    let normalization = visual_band_normalization(raw_peak, peaks);
+    apply_visual_band_normalization_to_summary_buckets(
+        buckets,
+        band_count,
+        normalization,
+        cancelled,
+    )?;
+    Ok(normalization)
+}
+
+pub(in crate::native_app::waveform) fn apply_visual_band_normalization_to_summary_buckets(
+    buckets: &mut [GpuSignalSummaryBucket],
+    band_count: usize,
+    normalization: VisualBandNormalization,
+    cancelled: &impl Fn() -> bool,
+) -> Result<(), String> {
+    if band_count < BAND_COUNT || buckets.is_empty() || !normalization.is_valid() {
+        return Ok(());
+    }
+    for (band, gain) in normalization.gains().into_iter().enumerate() {
         for (index, frame) in buckets.chunks_exact_mut(band_count).enumerate() {
             if cancelled() {
                 return Err(String::from("cancelled"));
@@ -176,33 +210,15 @@ fn normalize_visual_band_peaks_with_progress(
     end: f32,
     progress: &impl Fn(f32),
     cancelled: &impl Fn() -> bool,
-) -> Result<(), String> {
+) -> Result<VisualBandNormalization, String> {
     let raw_peak = raw_band_peak(bands, cancelled)?;
-    if raw_peak <= 0.000_01 || !raw_peak.is_finite() {
-        return Ok(());
-    }
     let peaks = [
         visual_band_peak(bands, 0, cancelled)?,
         visual_band_peak(bands, 1, cancelled)?,
         visual_band_peak(bands, 2, cancelled)?,
     ];
-    let spectral_total = peaks.iter().copied().sum::<f32>().max(0.000_01);
-    let targets = [raw_peak * 0.98, raw_peak * 0.74, raw_peak * 0.34];
-    let boost_thresholds = [raw_peak * 0.08, raw_peak * 0.05, raw_peak * 0.035];
-    let max_gains = [2.6_f32, 2.8, 2.4];
-    for band in 0..3 {
-        let peak = peaks[band];
-        if peak <= 0.000_01 || !peak.is_finite() {
-            continue;
-        }
-        let energy_share = peak / spectral_total;
-        let target = targets[band] * smoothstep_scalar(0.12, 0.55, energy_share);
-        let max_gain = if peak < boost_thresholds[band] {
-            1.0
-        } else {
-            max_gains[band]
-        };
-        let gain = (target / peak).clamp(0.25, max_gain);
+    let normalization = visual_band_normalization(raw_peak, peaks);
+    for (band, gain) in normalization.gains().into_iter().enumerate() {
         let frame_count = bands.len() / BAND_COUNT;
         for (index, frame) in bands.chunks_exact_mut(BAND_COUNT).enumerate() {
             if cancelled() {
@@ -221,7 +237,36 @@ fn normalize_visual_band_peaks_with_progress(
         }
     }
     progress(end);
-    Ok(())
+    Ok(normalization)
+}
+
+fn visual_band_normalization(
+    raw_peak: f32,
+    peaks: [f32; VISUAL_BAND_COUNT],
+) -> VisualBandNormalization {
+    if raw_peak <= 0.000_01 || !raw_peak.is_finite() {
+        return VisualBandNormalization::IDENTITY;
+    }
+    let spectral_total = peaks.iter().copied().sum::<f32>().max(0.000_01);
+    let targets = [raw_peak * 0.98, raw_peak * 0.74, raw_peak * 0.34];
+    let boost_thresholds = [raw_peak * 0.08, raw_peak * 0.05, raw_peak * 0.035];
+    let max_gains = [2.6_f32, 2.8, 2.4];
+    let mut gains = [1.0; VISUAL_BAND_COUNT];
+    for band in 0..VISUAL_BAND_COUNT {
+        let peak = peaks[band];
+        if peak <= 0.000_01 || !peak.is_finite() {
+            continue;
+        }
+        let energy_share = peak / spectral_total;
+        let target = targets[band] * smoothstep_scalar(0.12, 0.55, energy_share);
+        let max_gain = if peak < boost_thresholds[band] {
+            1.0
+        } else {
+            max_gains[band]
+        };
+        gains[band] = (target / peak).clamp(0.25, max_gain);
+    }
+    VisualBandNormalization::from_gains(gains).unwrap_or(VisualBandNormalization::IDENTITY)
 }
 
 fn raw_band_peak(bands: &[f32], cancelled: &impl Fn() -> bool) -> Result<f32, String> {

--- a/src/native_app/waveform/audio_file/visual_preview.rs
+++ b/src/native_app/waveform/audio_file/visual_preview.rs
@@ -163,6 +163,8 @@ mod tests {
             sample_rate: 48_000,
             channels: 1,
             frames: 1,
+            visual_band_normalization:
+                crate::native_app::waveform::audio_file::VisualBandNormalization::IDENTITY,
             gpu_signal_summary: Arc::new(GpuSignalSummary {
                 frames: 1,
                 band_count: 1,

--- a/src/native_app/waveform/audio_file/wav_summary.rs
+++ b/src/native_app/waveform/audio_file/wav_summary.rs
@@ -78,7 +78,13 @@ pub(in crate::native_app) fn load_wav_detail_summary(
                 }
             }
         }
-        let summary = builder.finish(0.0, 1.0, &|_| {}, &|| false)?;
+        let summary = builder.finish_with_normalization(
+            key.visual_band_normalization,
+            0.0,
+            1.0,
+            &|_| {},
+            &|| false,
+        )?;
         let metadata_after = std::fs::metadata(&key.path)
             .map_err(|error| format!("failed to revalidate detail WAV: {error}"))?;
         let revision_after = content_revision_for_path_metadata(
@@ -222,7 +228,7 @@ fn finish_streaming_summary_file(
         return Err(String::from("cancelled"));
     }
     let summary_started_at = Instant::now();
-    let summary = builder.finish(
+    let (summary, visual_band_normalization) = builder.finish(
         STREAMING_WAV_SUMMARY_READ_END,
         STREAMING_WAV_SUMMARY_BUILD_END,
         progress,
@@ -247,6 +253,7 @@ fn finish_streaming_summary_file(
         sample_rate,
         channels,
         frames,
+        visual_band_normalization,
         gpu_signal_summary: Arc::new(summary),
     })
 }

--- a/src/native_app/waveform/audio_file/wav_summary_builder.rs
+++ b/src/native_app/waveform/audio_file/wav_summary_builder.rs
@@ -6,7 +6,10 @@ use super::{
     signal_summary::{
         BaseSignalSummaryLevel, gpu_signal_summary_from_base_buckets_with_progress_and_cancel,
     },
-    visual_bands::{VisualBandFrameProcessor, normalize_visual_band_summary_buckets},
+    visual_bands::{
+        VisualBandFrameProcessor, VisualBandNormalization,
+        apply_visual_band_normalization_to_summary_buckets, normalize_visual_band_summary_buckets,
+    },
 };
 
 pub(super) const STREAMING_WAV_SUMMARY_READ_END: f32 = 0.88;
@@ -71,9 +74,39 @@ impl StreamingWavSummaryBuilder {
         end: f32,
         progress: &impl Fn(f32),
         cancelled: &impl Fn() -> bool,
+    ) -> Result<(radiant::runtime::GpuSignalSummary, VisualBandNormalization), String> {
+        self.flush_current_bucket();
+        let normalization =
+            normalize_visual_band_summary_buckets(&mut self.buckets, BAND_COUNT, cancelled)?;
+        let summary = self.finish_summary(start, end, progress, cancelled)?;
+        Ok((summary, normalization))
+    }
+
+    pub(super) fn finish_with_normalization(
+        mut self,
+        normalization: VisualBandNormalization,
+        start: f32,
+        end: f32,
+        progress: &impl Fn(f32),
+        cancelled: &impl Fn() -> bool,
     ) -> Result<radiant::runtime::GpuSignalSummary, String> {
         self.flush_current_bucket();
-        normalize_visual_band_summary_buckets(&mut self.buckets, BAND_COUNT, cancelled)?;
+        apply_visual_band_normalization_to_summary_buckets(
+            &mut self.buckets,
+            BAND_COUNT,
+            normalization,
+            cancelled,
+        )?;
+        self.finish_summary(start, end, progress, cancelled)
+    }
+
+    fn finish_summary(
+        self,
+        start: f32,
+        end: f32,
+        progress: &impl Fn(f32),
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<radiant::runtime::GpuSignalSummary, String> {
         let base = Arc::<[GpuSignalSummaryBucket]>::from(self.buckets);
         gpu_signal_summary_from_base_buckets_with_progress_and_cancel(
             BaseSignalSummaryLevel {
@@ -114,4 +147,77 @@ fn empty_summary_bucket() -> Vec<GpuSignalSummaryBucket> {
         };
         BAND_COUNT
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn viewport_summary_reuses_full_sample_band_normalization() {
+        let sample_rate = 48_000;
+        let low = tone(sample_rate, 70.0, 4_800);
+        let high = tone(sample_rate, 7_200.0, 4_800);
+        let full = low
+            .into_iter()
+            .chain(high.iter().copied())
+            .collect::<Vec<_>>();
+        let (_, full_normalization) = finish(&full, None);
+        let (_, viewport_normalization) = finish(&high, None);
+
+        assert_ne!(
+            full_normalization, viewport_normalization,
+            "the regression fixture must distinguish full-sample and viewport-local color gains"
+        );
+
+        let (first, _) = finish(&high, Some(full_normalization));
+        let (second, _) = finish(&high, Some(full_normalization));
+        assert_eq!(first, second);
+
+        let (identity, _) = finish(&high, Some(VisualBandNormalization::IDENTITY));
+        for (band, gain) in full_normalization.gains().into_iter().enumerate() {
+            let expected = (summary_peak(&identity, band) * gain).min(1.0);
+            let actual = summary_peak(&first, band);
+            assert!(
+                (actual - expected).abs() < 0.000_1,
+                "band {band} should use the retained full-sample gain: expected {expected}, got {actual}"
+            );
+        }
+    }
+
+    fn finish(
+        samples: &[f32],
+        normalization: Option<VisualBandNormalization>,
+    ) -> (radiant::runtime::GpuSignalSummary, VisualBandNormalization) {
+        let mut builder = StreamingWavSummaryBuilder::new(48_000, 8);
+        for sample in samples {
+            builder.push_peak(*sample);
+        }
+        match normalization {
+            Some(normalization) => (
+                builder
+                    .finish_with_normalization(normalization, 0.0, 1.0, &|_| {}, &|| false)
+                    .unwrap(),
+                normalization,
+            ),
+            None => builder.finish(0.0, 1.0, &|_| {}, &|| false).unwrap(),
+        }
+    }
+
+    fn tone(sample_rate: u32, frequency: f32, frames: usize) -> Vec<f32> {
+        (0..frames)
+            .map(|frame| {
+                let time = frame as f32 / sample_rate as f32;
+                (std::f32::consts::TAU * frequency * time).sin() * 0.8
+            })
+            .collect()
+    }
+
+    fn summary_peak(summary: &radiant::runtime::GpuSignalSummary, band: usize) -> f32 {
+        summary.levels[0]
+            .buckets
+            .chunks_exact(BAND_COUNT)
+            .map(|frame| frame[band].min.abs().max(frame[band].max.abs()))
+            .fold(0.0_f32, f32::max)
+    }
 }

--- a/src/native_app/waveform/audio_file/waveform_cache/format.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/format.rs
@@ -9,11 +9,11 @@ use super::identity::{
     CacheIdentity, cache_path_for_identity, playback_sidecar_path, playback_sidecar_valid,
 };
 use crate::native_app::waveform::audio_file::{
-    PersistedPlaybackCacheFile, PersistedPlaybackDescriptor, WaveformFile,
+    PersistedPlaybackCacheFile, PersistedPlaybackDescriptor, VisualBandNormalization, WaveformFile,
     content_revision_for_audio_bytes,
 };
 
-pub(super) const CACHE_FORMAT_VERSION: u32 = 3;
+pub(super) const CACHE_FORMAT_VERSION: u32 = 4;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(super) struct CachedWaveformFile {
@@ -25,6 +25,7 @@ pub(super) struct CachedWaveformFile {
     sample_rate: u32,
     channels: usize,
     frames: usize,
+    visual_band_normalization: VisualBandNormalization,
     summary: CachedGpuSignalSummary,
     pub(super) playback_cache: Option<CachedPlaybackCacheFile>,
 }
@@ -81,6 +82,7 @@ impl CachedWaveformFile {
             sample_rate: file.sample_rate,
             channels: file.channels,
             frames: file.frames,
+            visual_band_normalization: file.visual_band_normalization,
             summary: CachedGpuSignalSummary::from_summary(&file.gpu_signal_summary),
             playback_cache,
         }
@@ -106,6 +108,7 @@ impl CachedWaveformFile {
             sample_rate: self.sample_rate,
             channels: self.channels,
             frames: self.frames,
+            visual_band_normalization: self.visual_band_normalization,
             gpu_signal_summary: Arc::new(self.summary.into_summary()?),
         })
     }
@@ -131,6 +134,7 @@ impl CachedWaveformFile {
             sample_rate: self.sample_rate,
             channels: self.channels,
             frames: self.frames,
+            visual_band_normalization: self.visual_band_normalization,
             gpu_signal_summary: Arc::new(self.summary.into_summary()?),
         })
     }
@@ -154,6 +158,7 @@ impl CachedWaveformFile {
             sample_rate: self.sample_rate,
             channels: self.channels,
             frames: self.frames,
+            visual_band_normalization: self.visual_band_normalization,
             gpu_signal_summary: Arc::new(self.summary.into_summary()?),
         })
     }
@@ -166,6 +171,7 @@ impl CachedWaveformFile {
             && self.sample_rate != 0
             && self.channels != 0
             && self.frames != 0
+            && self.visual_band_normalization.is_valid()
     }
 
     pub(super) fn playback_cache_file(

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/format_payload.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/format_payload.rs
@@ -23,6 +23,10 @@ fn waveform_cache_round_trips_summary_payload() {
     assert_eq!(cached.path, path);
     assert_eq!(cached.sample_rate, file.sample_rate);
     assert_eq!(cached.frames, file.frames);
+    assert_eq!(
+        cached.visual_band_normalization,
+        file.visual_band_normalization
+    );
     assert_eq!(cached.gpu_signal_summary, file.gpu_signal_summary);
     assert!(cached.playback_samples.is_none());
     assert!(cached.playback_cache_file.is_none());

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -5,7 +5,10 @@ use std::{
 
 use wavecrate::selection::SelectionRange;
 
-use super::{WaveformDrag, WaveformFile, WaveformViewport, similar_sections::SimilarSectionsState};
+use super::{
+    WaveformDrag, WaveformFile, WaveformViewport, audio_file::VisualBandNormalization,
+    similar_sections::SimilarSectionsState,
+};
 use radiant::runtime::GpuSignalSummary;
 
 const DETAIL_MAX_BUCKETS: usize = 65_536;
@@ -17,6 +20,7 @@ pub(in crate::native_app) struct WaveformDetailKey {
     pub content_revision: u64,
     pub start_frame: usize,
     pub end_frame: usize,
+    pub visual_band_normalization: VisualBandNormalization,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -87,6 +91,7 @@ impl WaveformState {
             content_revision: self.file.content_revision(),
             start_frame: range.start,
             end_frame: range.end,
+            visual_band_normalization: self.file.visual_band_normalization,
         };
         if self
             .detail_summary
@@ -121,6 +126,7 @@ impl WaveformState {
                 .viewport
                 .clamped_index_viewport(self.file.frames, super::MIN_VISIBLE_FRAMES)
                 .end,
+            visual_band_normalization: self.file.visual_band_normalization,
         };
         if current != result.key {
             return;
@@ -142,6 +148,7 @@ impl WaveformState {
             !self.viewport.extends_beyond_audio(self.file.frames)
                 && detail.key.path == self.file.path
                 && detail.key.content_revision == self.file.content_revision()
+                && detail.key.visual_band_normalization == self.file.visual_band_normalization
                 && detail.key.start_frame
                     == self
                         .viewport

--- a/src/native_app/waveform/tests/signal_widget.rs
+++ b/src/native_app/waveform/tests/signal_widget.rs
@@ -27,6 +27,11 @@ fn zoomed_long_wav_refines_visible_range_independently_of_total_duration() {
     let key = state
         .desired_detail_key()
         .expect("coarse overview should refine");
+    assert_eq!(
+        key.visual_band_normalization,
+        state.file().visual_band_normalization,
+        "detail refinement must retain the full-sample color normalization"
+    );
     state.mark_detail_pending(key.clone());
 
     let result = super::super::load_wav_detail_summary(key);
@@ -168,6 +173,39 @@ fn waveform_detail_requests_are_single_flight_and_reject_stale_source_identity()
     assert!(
         state.desired_detail_key().is_none(),
         "a failed identity should not create a completion/retry loop"
+    );
+}
+
+#[test]
+fn waveform_detail_rejects_a_stale_color_normalization_profile() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("stale-detail-normalization.wav");
+    write_test_wav_i16(&path, &vec![1_i16; 4096]);
+    let file =
+        super::super::load_wav_waveform_summary_from_path_with_progress(path, &|_| {}, &|| false)
+            .unwrap();
+    let mut state = WaveformState::from_cached_file(Arc::new(file));
+    state.viewport = WaveformViewport { start: 0, end: 256 };
+    let key = state.desired_detail_key().unwrap();
+    state.mark_detail_pending(key.clone());
+    let summary = state.file.gpu_signal_summary.clone();
+
+    let mut updated_file = (*state.file).clone();
+    updated_file.visual_band_normalization =
+        super::super::audio_file::VisualBandNormalization::from_gains([1.1, 1.0, 1.0]).unwrap();
+    state.file = Arc::new(updated_file);
+    state.apply_detail_result(super::super::WaveformDetailResult {
+        key,
+        summary: Ok(summary),
+    });
+
+    assert!(state.render_detail().is_none());
+    assert_eq!(
+        state
+            .desired_detail_key()
+            .expect("the updated color profile should request fresh detail")
+            .visual_band_normalization,
+        state.file.visual_band_normalization
     );
 }
 


### PR DESCRIPTION
## Scope

- retain one full-file multiband normalization profile on every loaded waveform
- reuse that profile when viewport-detail summaries replace the overview during zoom
- include the profile in detail request identity so stale refinements cannot be rendered
- persist the profile in waveform cache format v4 and invalidate older cache entries
- document stable multiband normalization as a waveform rendering contract

## Root cause

Long WAV overview and viewport-detail summaries normalized their low, mid, and high bands independently. Each zoomed viewport therefore derived different gains from its local audio content, so progressive detail refinement visibly recolored the waveform.

## Definition of Done

- overview and detail summaries for one audio file use the same band gains
- zoom-driven detail refinement cannot apply a stale normalization profile
- cached waveform summaries preserve the profile across restarts
- existing waveform behavior remains covered and green

## Validation commands

- `cargo test -p wavecrate native_app::waveform:: -- --nocapture` — 237 passed
- `cargo test -p wavecrate browser_focus_transition_commit_keeps_browser_and_waveform_targets_aligned -- --nocapture` — passed in isolation after a full-suite flaky failure
- `cargo test -p wavecrate folder_move_db_write_failure_rolls_back_source_and_db_state -- --nocapture` — passed in isolation after a full-suite flaky failure
- `cargo clippy -p wavecrate --all-targets -- --cap-lints warn` — completed; only pre-existing warnings
- `git diff --check` — passed

## Known limitations

- Full `cargo test -p wavecrate` runs remain load-sensitive outside this scope. One run had a browser-focus transition failure; a second had one folder-move temp/WAL failure that poisoned eight sibling tests. Both root failures passed immediately in isolation.
- Strict Clippy remains blocked by three pre-existing Radiant lints.
- Repository-wide formatting and facade guardrails report pre-existing unrelated violations.

User review is required before merge.

Linear: [OPT-1163](https://linear.app/boostnlvp/issue/OPT-1163/wavecrate-keep-multiband-waveform-colors-stable-while-zooming)