### PR TITLE
OPT-1161: Tolerate legacy read-only DBs without pending renames

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -86,7 +86,9 @@ impl PendingRenameEntry {
 impl SourceDatabase {
     /// List pending rename candidates retained after immediate pruning.
     pub fn list_pending_renames(&self) -> Result<Vec<PendingRenameEntry>, SourceDbError> {
-        let query = pending_rename_list_query(&self.connection)?;
+        let Some(query) = pending_rename_list_query(&self.connection)? else {
+            return Ok(Vec::new());
+        };
         let mut stmt = self.connection.prepare(&query).map_err(map_sql_error)?;
         let rows = stmt
             .query_map([], |row| {
@@ -138,8 +140,13 @@ impl SourceDatabase {
     }
 }
 
-fn pending_rename_list_query(connection: &rusqlite::Connection) -> Result<String, SourceDbError> {
+fn pending_rename_list_query(
+    connection: &rusqlite::Connection,
+) -> Result<Option<String>, SourceDbError> {
     let columns = super::schema::table_columns(connection, "pending_wav_renames")?;
+    if columns.is_empty() {
+        return Ok(None);
+    }
     let optional_column = |column: &'static str, fallback: &'static str| {
         if columns.contains(column) {
             column
@@ -154,11 +161,11 @@ fn pending_rename_list_query(connection: &rusqlite::Connection) -> Result<String
     let collection = optional_column("collection", "NULL AS collection");
     let tag_named = optional_column("tag_named", "0 AS tag_named");
     let file_identity = optional_column("file_identity", "NULL AS file_identity");
-    Ok(format!(
+    Ok(Some(format!(
         "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type}, locked, last_played_at, {last_curated_at}, {user_tag}, {normal_tags}, {collection}, {tag_named}, {file_identity}
          FROM pending_wav_renames
          ORDER BY path ASC"
-    ))
+    )))
 }
 
 impl<'conn> SourceWriteBatch<'conn> {

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -235,6 +235,25 @@ fn legacy_read_only_collection_query_falls_back_to_wav_files_column() {
 }
 
 #[test]
+fn legacy_read_only_database_without_pending_renames_returns_empty_list() {
+    let dir = tempdir().unwrap();
+    let connection = Connection::open(dir.path().join(DB_FILE_NAME)).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE wav_files (
+                path TEXT PRIMARY KEY,
+                file_size INTEGER NOT NULL,
+                modified_ns INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+    drop(connection);
+
+    let db = SourceDatabase::open_read_only(dir.path()).unwrap();
+    assert_eq!(db.list_pending_renames().unwrap(), Vec::new());
+}
+
+#[test]
 fn legacy_read_only_pending_renames_project_optional_defaults() {
     let dir = tempdir().unwrap();
     let connection = Connection::open(dir.path().join(DB_FILE_NAME)).unwrap();


### PR DESCRIPTION
## Scope
- detect an absent pending_wav_renames table through the existing schema introspection path
- return an empty pending-rename list before preparing feature-specific SQL
- preserve safe-default projections for legacy tables that exist without optional columns
- add an explicit read-only legacy regression fixture with a minimal wav_files table and no pending-rename table

## Definition of Done
- read-only legacy databases without pending_wav_renames return an empty list instead of a SQLite error
- existing legacy pending-rename tables with missing optional columns continue to hydrate safe defaults
- no read-only open performs schema mutation
- the new regression test fails on the previous implementation and passes with this fix

## Validation commands
- cargo test -p wavecrate-library sample_sources::db::read
- cargo test -p wavecrate-library source_db_migration_tests
- cargo check -p wavecrate-library

## Known limitations
- None for the changed behavior.
- The repository-wide request preflight currently reports pre-existing facade guard violations on main; the issue-specific validation above is green.

User review is required before merge.