### PR TITLE
Preserve collections and curation timestamps across scan rename recovery

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -14,6 +14,7 @@ mod pending_renames;
 /// Read-only database queries for sample sources.
 pub mod read;
 mod rename_destinations;
+mod rename_metadata;
 /// SQLite schema management for sample source databases.
 pub mod schema;
 /// Durable per-source tag catalog and sample assignment helpers.
@@ -39,6 +40,7 @@ pub use open::{test_reset_source_db_open_total_count, test_source_db_open_total_
 pub use open_profiles::SourceDatabaseConnectionRole;
 /// Metadata retained for a pruned row so later scans can recover rename state.
 pub use pending_renames::PendingRenameEntry;
+pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{Rating, SampleCollection, SampleSoundType, SourceTag, SourceTagUsage, WavEntry};
 pub use util::normalize_relative_path;
 pub use write::{

--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -4,23 +4,23 @@ use rusqlite::{OptionalExtension, params};
 
 use super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
 use super::{
-    Rating, SampleCollection, SampleSoundType, SourceDatabase, SourceDbError, SourceWriteBatch,
-    WavEntry,
+    Rating, RenameMetadataSnapshot, SampleCollection, SampleSoundType, SourceDatabase,
+    SourceDbError, SourceWriteBatch, WavEntry,
 };
 
 const DELETE_PENDING_RENAME_SQL: &str = "DELETE FROM pending_wav_renames WHERE path = ?1";
 const TAKE_PENDING_RENAME_BY_HASH_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
      FROM pending_wav_renames
      WHERE content_hash = ?1
      LIMIT 2";
 const TAKE_PENDING_RENAME_BY_FILE_IDENTITY_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
      FROM pending_wav_renames
      WHERE file_identity = ?1 AND file_size = ?2 AND modified_ns = ?3
      LIMIT 2";
 const TAKE_PENDING_RENAME_BY_FACTS_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
      FROM pending_wav_renames
      WHERE file_size = ?1 AND modified_ns = ?2
      LIMIT 2";
@@ -39,48 +39,8 @@ pub struct PendingRenameEntry {
     pub content_hash: Option<String>,
     /// Stable filesystem-object identity captured before pruning, when supported.
     pub file_identity: Option<String>,
-    /// Current rating/tag for the file.
-    pub tag: Rating,
-    /// Whether the sample was marked looped.
-    pub looped: bool,
-    /// Last known canonical sound classification, if present.
-    pub sound_type: Option<SampleSoundType>,
-    /// Whether the sample was marked locked.
-    pub locked: bool,
-    /// Epoch seconds of the most recent playback, if available.
-    pub last_played_at: Option<i64>,
-    /// Epoch seconds of the most recent explicit curation decision, if available.
-    pub last_curated_at: Option<i64>,
-    /// Last known user-authored custom tag, if present.
-    pub user_tag: Option<String>,
-    /// Last known normal library tag labels assigned to this sample.
-    pub normal_tags: Vec<String>,
-    /// Last known fixed collection slot assigned to this sample.
-    pub collection: Option<SampleCollection>,
-    /// Whether the sample filename was known to be tag-derived.
-    pub tag_named: bool,
-}
-
-impl PendingRenameEntry {
-    /// Convert the retained metadata back into a wav-entry snapshot.
-    pub fn into_wav_entry(self) -> WavEntry {
-        WavEntry {
-            relative_path: self.relative_path,
-            file_size: self.file_size,
-            modified_ns: self.modified_ns,
-            content_hash: self.content_hash,
-            tag: self.tag,
-            looped: self.looped,
-            sound_type: self.sound_type,
-            locked: self.locked,
-            missing: false,
-            last_played_at: self.last_played_at,
-            last_curated_at: self.last_curated_at,
-            user_tag: self.user_tag,
-            normal_tags: self.normal_tags,
-            tag_named: self.tag_named,
-        }
-    }
+    /// Complete user metadata restored when the rename is reconciled.
+    pub metadata: RenameMetadataSnapshot,
 }
 
 impl SourceDatabase {
@@ -115,22 +75,8 @@ impl SourceDatabase {
                     file_size,
                     modified_ns: row.get(2)?,
                     content_hash: row.get(3)?,
-                    file_identity: row.get(14)?,
-                    tag: Rating::from_i64(row.get::<_, i64>(4)?),
-                    looped: row.get::<_, i64>(5)? != 0,
-                    sound_type: row
-                        .get::<_, Option<String>>(6)?
-                        .as_deref()
-                        .and_then(SampleSoundType::from_token),
-                    locked: row.get::<_, i64>(7)? != 0,
-                    last_played_at: row.get(8)?,
-                    last_curated_at: row.get(9)?,
-                    user_tag: row.get(10)?,
-                    normal_tags: decode_normal_tags(row.get(11)?),
-                    collection: row
-                        .get::<_, Option<i64>>(12)?
-                        .and_then(SampleCollection::from_i64),
-                    tag_named: row.get::<_, i64>(13)? != 0,
+                    file_identity: row.get(15)?,
+                    metadata: metadata_from_row(row)?,
                 }))
             })
             .map_err(map_sql_error)?
@@ -159,10 +105,11 @@ fn pending_rename_list_query(
     let user_tag = optional_column("user_tag", "NULL AS user_tag");
     let normal_tags = optional_column("normal_tags", "NULL AS normal_tags");
     let collection = optional_column("collection", "NULL AS collection");
+    let collections = optional_column("collections", "NULL AS collections");
     let tag_named = optional_column("tag_named", "0 AS tag_named");
     let file_identity = optional_column("file_identity", "NULL AS file_identity");
     Ok(Some(format!(
-        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type}, locked, last_played_at, {last_curated_at}, {user_tag}, {normal_tags}, {collection}, {tag_named}, {file_identity}
+        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type}, locked, last_played_at, {last_curated_at}, {user_tag}, {normal_tags}, {collection}, {collections}, {tag_named}, {file_identity}
          FROM pending_wav_renames
          ORDER BY path ASC"
     )))
@@ -175,7 +122,10 @@ impl<'conn> SourceWriteBatch<'conn> {
     /// quick scan can reconcile path changes without losing user metadata.
     pub fn stage_pending_rename(&mut self, entry: &WavEntry) -> Result<(), SourceDbError> {
         let path = normalize_relative_path(&entry.relative_path)?;
-        let normal_tags = encode_normal_tags(&self.tag_labels_for_path(&entry.relative_path)?)?;
+        let metadata = self.snapshot_rename_metadata(&entry.relative_path)?;
+        let normal_tags = encode_normal_tags(&metadata.normal_tags)?;
+        let collections = encode_collections(&metadata.collections)?;
+        let legacy_collection = metadata.collections.first().copied();
         let file_identity = self
             .tx
             .query_row(
@@ -186,26 +136,11 @@ impl<'conn> SourceWriteBatch<'conn> {
             .optional()
             .map_err(map_sql_error)?
             .flatten();
-        let collection = self
-            .tx
-            .query_row(
-                "SELECT collection
-                 FROM wav_file_collections
-                 WHERE path = ?1
-                 ORDER BY collection ASC
-                 LIMIT 1",
-                params![path.as_str()],
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .optional()
-            .map_err(map_sql_error)?
-            .flatten()
-            .and_then(SampleCollection::from_i64);
         self.tx
             .prepare_cached(
                 "INSERT INTO pending_wav_renames (
-                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, tag_named, file_identity
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
                  ON CONFLICT(path) DO UPDATE SET
                      file_size = excluded.file_size,
                      modified_ns = excluded.modified_ns,
@@ -219,6 +154,7 @@ impl<'conn> SourceWriteBatch<'conn> {
                      user_tag = excluded.user_tag,
                      normal_tags = excluded.normal_tags,
                      collection = excluded.collection,
+                     collections = excluded.collections,
                      tag_named = excluded.tag_named,
                      file_identity = excluded.file_identity",
             )
@@ -228,16 +164,17 @@ impl<'conn> SourceWriteBatch<'conn> {
                 entry.file_size as i64,
                 entry.modified_ns,
                 entry.content_hash.as_deref(),
-                entry.tag.as_i64(),
-                entry.looped as i64,
-                entry.sound_type.map(SampleSoundType::token),
-                entry.locked as i64,
-                entry.last_played_at,
-                entry.last_curated_at,
-                entry.user_tag.as_deref(),
+                metadata.tag.as_i64(),
+                metadata.looped as i64,
+                metadata.sound_type.map(SampleSoundType::token),
+                metadata.locked as i64,
+                metadata.last_played_at,
+                metadata.last_curated_at,
+                metadata.user_tag.as_deref(),
                 normal_tags.as_deref(),
-                collection.map(SampleCollection::as_i64),
-                entry.tag_named as i64,
+                legacy_collection.map(SampleCollection::as_i64),
+                collections.as_deref(),
+                metadata.tag_named as i64,
                 file_identity,
             ])
             .map_err(map_sql_error)?;
@@ -339,22 +276,8 @@ impl<'conn> SourceWriteBatch<'conn> {
                     file_size,
                     modified_ns: row.get(2)?,
                     content_hash: row.get(3)?,
-                    file_identity: row.get(14)?,
-                    tag: Rating::from_i64(row.get::<_, i64>(4)?),
-                    looped: row.get::<_, i64>(5)? != 0,
-                    sound_type: row
-                        .get::<_, Option<String>>(6)?
-                        .as_deref()
-                        .and_then(SampleSoundType::from_token),
-                    locked: row.get::<_, i64>(7)? != 0,
-                    last_played_at: row.get(8)?,
-                    last_curated_at: row.get(9)?,
-                    user_tag: row.get(10)?,
-                    normal_tags: decode_normal_tags(row.get(11)?),
-                    collection: row
-                        .get::<_, Option<i64>>(12)?
-                        .and_then(SampleCollection::from_i64),
-                    tag_named: row.get::<_, i64>(13)? != 0,
+                    file_identity: row.get(15)?,
+                    metadata: metadata_from_row(row)?,
                 })
             })
             .map_err(map_sql_error)?
@@ -370,6 +293,24 @@ impl<'conn> SourceWriteBatch<'conn> {
     }
 }
 
+fn metadata_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RenameMetadataSnapshot> {
+    Ok(RenameMetadataSnapshot {
+        tag: Rating::from_i64(row.get::<_, i64>(4)?),
+        looped: row.get::<_, i64>(5)? != 0,
+        sound_type: row
+            .get::<_, Option<String>>(6)?
+            .as_deref()
+            .and_then(SampleSoundType::from_token),
+        locked: row.get::<_, i64>(7)? != 0,
+        last_played_at: row.get(8)?,
+        last_curated_at: row.get(9)?,
+        user_tag: row.get(10)?,
+        normal_tags: decode_normal_tags(row.get(11)?),
+        collections: decode_collections(row.get(13)?, row.get(12)?),
+        tag_named: row.get::<_, i64>(14)? != 0,
+    })
+}
+
 fn encode_normal_tags(labels: &[String]) -> Result<Option<String>, SourceDbError> {
     if labels.is_empty() {
         return Ok(None);
@@ -383,4 +324,34 @@ fn decode_normal_tags(value: Option<String>) -> Vec<String> {
     value
         .and_then(|raw| serde_json::from_str::<Vec<String>>(&raw).ok())
         .unwrap_or_default()
+}
+
+fn encode_collections(collections: &[SampleCollection]) -> Result<Option<String>, SourceDbError> {
+    let values = collections
+        .iter()
+        .copied()
+        .map(SampleCollection::as_i64)
+        .collect::<Vec<_>>();
+    serde_json::to_string(&values)
+        .map(Some)
+        .map_err(|_| SourceDbError::Unexpected)
+}
+
+fn decode_collections(
+    value: Option<String>,
+    legacy_collection: Option<i64>,
+) -> Vec<SampleCollection> {
+    let Some(values) = value.and_then(|raw| serde_json::from_str::<Vec<i64>>(&raw).ok()) else {
+        return legacy_collection
+            .and_then(SampleCollection::from_i64)
+            .into_iter()
+            .collect();
+    };
+    let mut collections = values
+        .into_iter()
+        .filter_map(SampleCollection::from_i64)
+        .collect::<Vec<_>>();
+    collections.sort_by_key(|collection| collection.index());
+    collections.dedup();
+    collections
 }

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -267,12 +267,14 @@ fn legacy_read_only_pending_renames_project_optional_defaults() {
                 tag INTEGER NOT NULL,
                 looped INTEGER NOT NULL,
                 locked INTEGER NOT NULL,
-                last_played_at INTEGER
+                last_played_at INTEGER,
+                collection INTEGER
             );
             INSERT INTO pending_wav_renames (
-                path, file_size, modified_ns, content_hash, tag, looped, locked, last_played_at
+                path, file_size, modified_ns, content_hash, tag, looped, locked,
+                last_played_at, collection
             ) VALUES (
-                'legacy.wav', 10, 5, 'hash-a', 1, 1, 1, 42
+                'legacy.wav', 10, 5, 'hash-a', 1, 1, 1, 42, 2
             );",
         )
         .unwrap();
@@ -287,16 +289,19 @@ fn legacy_read_only_pending_renames_project_optional_defaults() {
     assert_eq!(entry.modified_ns, 5);
     assert_eq!(entry.content_hash.as_deref(), Some("hash-a"));
     assert_eq!(entry.file_identity, None);
-    assert_eq!(entry.tag, Rating::KEEP_1);
-    assert!(entry.looped);
-    assert!(entry.locked);
-    assert_eq!(entry.last_played_at, Some(42));
-    assert_eq!(entry.sound_type, None);
-    assert_eq!(entry.last_curated_at, None);
-    assert_eq!(entry.user_tag, None);
-    assert!(entry.normal_tags.is_empty());
-    assert_eq!(entry.collection, None);
-    assert!(!entry.tag_named);
+    assert_eq!(entry.metadata.tag, Rating::KEEP_1);
+    assert!(entry.metadata.looped);
+    assert!(entry.metadata.locked);
+    assert_eq!(entry.metadata.last_played_at, Some(42));
+    assert_eq!(entry.metadata.sound_type, None);
+    assert_eq!(entry.metadata.last_curated_at, None);
+    assert_eq!(entry.metadata.user_tag, None);
+    assert!(entry.metadata.normal_tags.is_empty());
+    assert_eq!(
+        entry.metadata.collections,
+        vec![SampleCollection::new(2).unwrap()]
+    );
+    assert!(!entry.metadata.tag_named);
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/rename_metadata.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_metadata.rs
@@ -1,0 +1,129 @@
+use std::path::Path;
+
+use rusqlite::params;
+
+use super::util::map_sql_error;
+use super::{Rating, SampleCollection, SampleSoundType, SourceDbError, SourceWriteBatch};
+
+/// Complete user metadata retained while scan reconciliation moves a sample identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameMetadataSnapshot {
+    /// Rating assigned to the sample.
+    pub tag: Rating,
+    /// Whether the sample is marked as a loop.
+    pub looped: bool,
+    /// Canonical sound classification, when assigned.
+    pub sound_type: Option<SampleSoundType>,
+    /// Whether the highest keep state is locked.
+    pub locked: bool,
+    /// Most recent playback timestamp, when recorded.
+    pub last_played_at: Option<i64>,
+    /// Most recent explicit curation timestamp, including an intentionally unset value.
+    pub last_curated_at: Option<i64>,
+    /// User-authored custom tag, when assigned.
+    pub user_tag: Option<String>,
+    /// Normal library tag labels assigned to the sample.
+    pub normal_tags: Vec<String>,
+    /// Every fixed collection membership assigned to the sample.
+    pub collections: Vec<SampleCollection>,
+    /// Whether the filename was produced from tag metadata.
+    pub tag_named: bool,
+}
+
+impl SourceWriteBatch<'_> {
+    /// Capture the complete rename-recovery metadata contract in the active transaction.
+    pub fn snapshot_rename_metadata(
+        &mut self,
+        relative_path: &Path,
+    ) -> Result<RenameMetadataSnapshot, SourceDbError> {
+        let path = super::normalize_relative_path(relative_path)?;
+        let (tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, tag_named) =
+            self.tx
+                .query_row(
+                    "SELECT tag, looped, sound_type, locked, last_played_at,
+                        last_curated_at, user_tag, tag_named
+                 FROM wav_files
+                 WHERE path = ?1",
+                    params![path.as_str()],
+                    |row| {
+                        Ok((
+                            Rating::from_i64(row.get::<_, i64>(0)?),
+                            row.get::<_, i64>(1)? != 0,
+                            row.get::<_, Option<String>>(2)?
+                                .as_deref()
+                                .and_then(SampleSoundType::from_token),
+                            row.get::<_, i64>(3)? != 0,
+                            row.get(4)?,
+                            row.get(5)?,
+                            row.get(6)?,
+                            row.get::<_, i64>(7)? != 0,
+                        ))
+                    },
+                )
+                .map_err(map_sql_error)?;
+        let mut statement = self
+            .tx
+            .prepare_cached(
+                "SELECT collection
+                 FROM wav_file_collections
+                 WHERE path = ?1
+                 ORDER BY collection ASC",
+            )
+            .map_err(map_sql_error)?;
+        let stored_collections = statement
+            .query_map(params![path], |row| row.get::<_, i64>(0))
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        let collections = stored_collections
+            .into_iter()
+            .filter_map(SampleCollection::from_i64)
+            .collect();
+        drop(statement);
+        let normal_tags = self.tag_labels_for_path(relative_path)?;
+
+        Ok(RenameMetadataSnapshot {
+            tag,
+            looped,
+            sound_type,
+            locked,
+            last_played_at,
+            last_curated_at,
+            user_tag,
+            normal_tags,
+            collections,
+            tag_named,
+        })
+    }
+
+    /// Restore a complete rename snapshot without recording a new curation event.
+    ///
+    /// Callers must invoke this inside the same write batch that reconciles the
+    /// row. The historical curation timestamp is deliberately written last,
+    /// after metadata setters that normally mark explicit user curation.
+    pub fn restore_rename_metadata(
+        &mut self,
+        relative_path: &Path,
+        metadata: &RenameMetadataSnapshot,
+    ) -> Result<(), SourceDbError> {
+        self.set_tag(relative_path, metadata.tag)?;
+        self.set_looped(relative_path, metadata.looped)?;
+        self.set_sound_type(relative_path, metadata.sound_type)?;
+        self.set_locked(relative_path, metadata.locked)?;
+        match metadata.last_played_at {
+            Some(last_played_at) => self.set_last_played_at(relative_path, last_played_at)?,
+            None => self.clear_last_played_at(relative_path)?,
+        }
+        self.set_user_tag(relative_path, metadata.user_tag.as_deref())?;
+        self.set_tag_named(relative_path, metadata.tag_named)?;
+        self.replace_tags_for_path(relative_path, &metadata.normal_tags)?;
+        self.set_collection(relative_path, None)?;
+        for collection in &metadata.collections {
+            self.add_collection(relative_path, *collection)?;
+        }
+        match metadata.last_curated_at {
+            Some(last_curated_at) => self.set_last_curated_at(relative_path, last_curated_at),
+            None => self.clear_last_curated_at(relative_path),
+        }
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -219,6 +219,7 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         user_tag TEXT,
         normal_tags TEXT,
         collection INTEGER,
+        collections TEXT,
         tag_named INTEGER NOT NULL DEFAULT 0,
         file_identity TEXT
     );

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
@@ -107,6 +107,11 @@ pub(super) fn ensure_pending_rename_optional_columns(
     add_column_if_missing(
         connection,
         &columns,
+        OptionalColumn::new("pending_wav_renames", "collections", "TEXT"),
+    )?;
+    add_column_if_missing(
+        connection,
+        &columns,
         OptionalColumn::new(
             "pending_wav_renames",
             "tag_named",

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::sample_sources::db::SampleSoundType;
+use crate::sample_sources::db::{SampleCollection, SampleSoundType};
 use crate::sync_paths;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -24,6 +24,21 @@ fn scan_detects_rename_and_preserves_tag() {
         .unwrap();
     db.assign_tag_to_path(Path::new("one.wav"), "Analog Kick")
         .unwrap();
+    let historical_curation = 1_650_000_123;
+    let expected_collections = [
+        SampleCollection::new(1).unwrap(),
+        SampleCollection::new(4).unwrap(),
+    ];
+    let mut batch = db.write_batch().unwrap();
+    for collection in expected_collections {
+        batch
+            .add_collection(Path::new("one.wav"), collection)
+            .unwrap();
+    }
+    batch
+        .set_last_curated_at(Path::new("one.wav"), historical_curation)
+        .unwrap();
+    batch.commit().unwrap();
     insert_analysis_artifacts(dir.path(), "source::one.wav", "one.wav");
 
     std::fs::rename(&first_path, &second_path).unwrap();
@@ -41,6 +56,11 @@ fn scan_detects_rename_and_preserves_tag() {
     assert_eq!(rows[0].sound_type, Some(SampleSoundType::Kick));
     assert_eq!(rows[0].user_tag.as_deref(), Some("Vintage FX"));
     assert_eq!(rows[0].normal_tags, vec!["Analog Kick"]);
+    assert_eq!(rows[0].last_curated_at, Some(historical_curation));
+    assert_eq!(
+        db.collections_for_path(Path::new("two.wav")).unwrap(),
+        expected_collections
+    );
     assert!(!rows[0].missing);
     assert_eq!(
         sample_id_count(dir.path(), "features", "source::one.wav"),
@@ -53,6 +73,31 @@ fn scan_detects_rename_and_preserves_tag() {
     assert_eq!(
         analysis_job_relative_path(dir.path(), "source::two.wav"),
         "two.wav"
+    );
+}
+
+#[test]
+fn scan_detected_rename_preserves_unset_curation_timestamp() {
+    let dir = tempdir().unwrap();
+    let old_path = dir.path().join("old.wav");
+    let new_path = dir.path().join("new.wav");
+    std::fs::write(&old_path, b"same sample").unwrap();
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.clear_last_curated_at(Path::new("old.wav")).unwrap();
+
+    std::fs::rename(old_path, new_path).unwrap();
+    let stats = scan_once(&db).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .last_curated_at,
+        None
     );
 }
 
@@ -109,7 +154,7 @@ fn pending_rename_staging_refreshes_metadata_changed_during_discovery() {
         .iter()
         .find(|entry| entry.relative_path == Path::new("removed.wav"))
         .expect("removed path must be staged");
-    assert_eq!(removed.tag, Rating::KEEP_1);
+    assert_eq!(removed.metadata.tag, Rating::KEEP_1);
 }
 
 #[test]
@@ -191,6 +236,21 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         .unwrap();
     db.assign_tag_to_path(Path::new("one.wav"), "Night Pad")
         .unwrap();
+    let historical_curation = 1_640_000_456;
+    let expected_collections = [
+        SampleCollection::new(0).unwrap(),
+        SampleCollection::new(5).unwrap(),
+    ];
+    let mut batch = db.write_batch().unwrap();
+    for collection in expected_collections {
+        batch
+            .add_collection(Path::new("one.wav"), collection)
+            .unwrap();
+    }
+    batch
+        .set_last_curated_at(Path::new("one.wav"), historical_curation)
+        .unwrap();
+    batch.commit().unwrap();
     insert_analysis_artifacts(dir.path(), "source::one.wav", "one.wav");
 
     std::fs::rename(&first_path, &second_path).unwrap();
@@ -237,6 +297,11 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
     assert_eq!(rows[0].sound_type, Some(SampleSoundType::Texture));
     assert_eq!(rows[0].user_tag.as_deref(), Some("Night Pad"));
     assert_eq!(rows[0].normal_tags, vec!["Night Pad"]);
+    assert_eq!(rows[0].last_curated_at, Some(historical_curation));
+    assert_eq!(
+        db.collections_for_path(Path::new("two.wav")).unwrap(),
+        expected_collections
+    );
     assert!(!rows[0].missing);
     assert!(rows[0].content_hash.is_some());
     assert!(db.list_pending_renames().unwrap().is_empty());
@@ -439,8 +504,8 @@ fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
     let pending = db.list_pending_renames().unwrap();
     assert!(pending.iter().any(|entry| {
         entry.relative_path == Path::new("old.wav")
-            && entry.tag == Rating::KEEP_1
-            && entry.user_tag.as_deref() == Some("Must stay pending")
+            && entry.metadata.tag == Rating::KEEP_1
+            && entry.metadata.user_tag.as_deref() == Some("Must stay pending")
     }));
     assert_eq!(
         sample_id_count(dir.path(), "features", "source::old.wav"),
@@ -487,9 +552,15 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
 
     let pending_before_deep = db.list_pending_renames().unwrap();
     assert_eq!(pending_before_deep.len(), 1);
-    assert_eq!(pending_before_deep[0].sound_type, Some(SampleSoundType::Fx));
-    assert_eq!(pending_before_deep[0].user_tag.as_deref(), Some("Sweep"));
-    assert_eq!(pending_before_deep[0].normal_tags, vec!["Sweep"]);
+    assert_eq!(
+        pending_before_deep[0].metadata.sound_type,
+        Some(SampleSoundType::Fx)
+    );
+    assert_eq!(
+        pending_before_deep[0].metadata.user_tag.as_deref(),
+        Some("Sweep")
+    );
+    assert_eq!(pending_before_deep[0].metadata.normal_tags, vec!["Sweep"]);
 
     let deep_stats = crate::sample_sources::scanner::scan_hash::deep_hash_scan(
         &db,
@@ -892,9 +963,9 @@ fn quick_scan_avoids_ambiguous_large_rename() {
     assert_eq!(rows[0].tag, Rating::NEUTRAL);
     let pending = db.list_pending_renames().unwrap();
     assert_eq!(pending.len(), 2);
-    assert!(pending
-        .iter()
-        .any(|entry| entry.relative_path == Path::new("one.wav") && entry.tag == Rating::KEEP_1));
+    assert!(pending.iter().any(|entry| {
+        entry.relative_path == Path::new("one.wav") && entry.metadata.tag == Rating::KEEP_1
+    }));
 }
 
 fn insert_analysis_artifacts(root: &Path, sample_id: &str, relative_path: &str) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
+use crate::sample_sources::db::{RenameMetadataSnapshot, SourceWriteBatch, WavEntry};
 
 use super::scan::{
     ChangedSample, RenamedSample, ScanContext, ScanError, ScanMode, ScanStats, UpdatedSample,
@@ -121,7 +121,15 @@ pub(super) fn apply_diff(
                     &hash,
                 )? {
                     let old_relative_path = entry.relative_path.clone();
-                    apply_rename(batch, &path, &facts, Some(&hash), entry, None)?;
+                    let metadata = batch.snapshot_rename_metadata(&entry.relative_path)?;
+                    apply_rename(
+                        batch,
+                        &path,
+                        &facts,
+                        Some(&hash),
+                        &old_relative_path,
+                        &metadata,
+                    )?;
                     batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                     context.stats.updated += 1;
                     context.stats.renames_reconciled += 1;
@@ -135,10 +143,15 @@ pub(super) fn apply_diff(
                     return Ok(());
                 }
                 if let Some(entry) = batch.take_pending_rename_by_hash(&hash)? {
-                    let normal_tags = entry.normal_tags.clone();
-                    let entry = entry.into_wav_entry();
                     let old_relative_path = entry.relative_path.clone();
-                    apply_rename(batch, &path, &facts, Some(&hash), entry, Some(&normal_tags))?;
+                    apply_rename(
+                        batch,
+                        &path,
+                        &facts,
+                        Some(&hash),
+                        &old_relative_path,
+                        &entry.metadata,
+                    )?;
                     batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                     context.stats.updated += 1;
                     context.stats.renames_reconciled += 1;
@@ -177,10 +190,15 @@ pub(super) fn apply_diff(
                         facts.modified_ns,
                     )?
                 {
-                    let normal_tags = entry.normal_tags.clone();
-                    let entry = entry.into_wav_entry();
                     let old_relative_path = entry.relative_path.clone();
-                    apply_rename(batch, &path, &facts, None, entry, Some(&normal_tags))?;
+                    apply_rename(
+                        batch,
+                        &path,
+                        &facts,
+                        None,
+                        &old_relative_path,
+                        &entry.metadata,
+                    )?;
                     batch.set_file_identity(&path, Some(file_identity))?;
                     context.stats.updated += 1;
                     context.stats.renames_reconciled += 1;
@@ -240,8 +258,8 @@ fn apply_rename(
     new_path: &Path,
     facts: &FileFacts,
     hash: Option<&str>,
-    entry: WavEntry,
-    retained_normal_tags: Option<&[String]>,
+    old_path: &Path,
+    metadata: &RenameMetadataSnapshot,
 ) -> Result<(), ScanError> {
     if let Some(hash) = hash {
         batch.upsert_file_with_hash_and_tag(
@@ -249,7 +267,7 @@ fn apply_rename(
             facts.size,
             facts.modified_ns,
             hash,
-            entry.tag,
+            metadata.tag,
             false,
         )?;
     } else {
@@ -257,33 +275,13 @@ fn apply_rename(
             new_path,
             facts.size,
             facts.modified_ns,
-            entry.tag,
+            metadata.tag,
             false,
         )?;
     }
-    if entry.looped {
-        batch.set_looped(new_path, entry.looped)?;
-    }
-    if entry.sound_type.is_some() {
-        batch.set_sound_type(new_path, entry.sound_type)?;
-    }
-    if entry.locked {
-        batch.set_locked(new_path, entry.locked)?;
-    }
-    if let Some(last_played_at) = entry.last_played_at {
-        batch.set_last_played_at(new_path, last_played_at)?;
-    }
-    if entry.user_tag.is_some() {
-        batch.set_user_tag(new_path, entry.user_tag.as_deref())?;
-    }
-    batch.set_tag_named(new_path, entry.tag_named)?;
-    if let Some(normal_tags) = retained_normal_tags {
-        batch.replace_tags_for_path(new_path, normal_tags)?;
-    } else {
-        batch.copy_tags_between_paths(&entry.relative_path, new_path)?;
-    }
-    batch.remove_file(&entry.relative_path)?;
-    batch.remap_analysis_sample_identity(&entry.relative_path, new_path)?;
+    batch.restore_rename_metadata(new_path, metadata)?;
+    batch.remove_file(old_path)?;
+    batch.remap_analysis_sample_identity(old_path, new_path)?;
     Ok(())
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -310,29 +310,10 @@ fn apply_deep_rename(
         present_entry.file_size,
         present_entry.modified_ns,
         hash,
-        pending_entry.tag,
+        pending_entry.metadata.tag,
         false,
     )?;
-    if pending_entry.looped {
-        batch.set_looped(&present_entry.relative_path, pending_entry.looped)?;
-    }
-    if pending_entry.sound_type.is_some() {
-        batch.set_sound_type(&present_entry.relative_path, pending_entry.sound_type)?;
-    }
-    if pending_entry.locked {
-        batch.set_locked(&present_entry.relative_path, pending_entry.locked)?;
-    }
-    if let Some(last_played_at) = pending_entry.last_played_at {
-        batch.set_last_played_at(&present_entry.relative_path, last_played_at)?;
-    }
-    if pending_entry.user_tag.is_some() {
-        batch.set_user_tag(
-            &present_entry.relative_path,
-            pending_entry.user_tag.as_deref(),
-        )?;
-    }
-    batch.set_tag_named(&present_entry.relative_path, pending_entry.tag_named)?;
-    batch.replace_tags_for_path(&present_entry.relative_path, &pending_entry.normal_tags)?;
+    batch.restore_rename_metadata(&present_entry.relative_path, &pending_entry.metadata)?;
     batch.remap_analysis_sample_identity(
         &pending_entry.relative_path,
         &present_entry.relative_path,

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1196,6 +1196,8 @@ When a file disappears, Wavecrate should retain metadata as unavailable state un
 
 When reconciliation determines that a file was renamed outside Wavecrate, Wavecrate should keep the same Sample ID where file identity matches and update the disk path/filename state without changing the label.
 
+Scan-based rename reconciliation should preserve the complete user-metadata snapshot atomically, including every collection membership and the exact prior curation timestamp. Reconciliation is not a new curation event: an unset curation timestamp should remain unset, and metadata staged for deferred rename recovery should remain durable across restart and schema migration.
+
 External filesystem changes detected by file watching or rescan should be reconciled as external state changes, not added to the Wavecrate undo stack. This includes external renames, moves, deletes, additions, and overwrites. Undo should only cover actions initiated inside Wavecrate.
 
 When a file is changed outside Wavecrate, Wavecrate should invalidate stale waveform, audio-analysis, BPM, transient, silence, similarity, embedded-ID, and display-name-derived state as needed. It should not silently reuse stale analysis for changed audio.

--- a/tests/unit/source_db_migration_tests/fixtures.rs
+++ b/tests/unit/source_db_migration_tests/fixtures.rs
@@ -228,6 +228,7 @@ pub(super) const SOURCE_DB_SCHEMA_CONTRACT: &[TableContract] = &[
             "user_tag",
             "normal_tags",
             "collection",
+            "collections",
             "tag_named",
         ],
     },

--- a/tests/unit/source_db_migration_tests/pending_rename.rs
+++ b/tests/unit/source_db_migration_tests/pending_rename.rs
@@ -25,16 +25,17 @@ fn pending_rename_migration_adds_metadata_columns_and_keeps_legacy_rows_readable
     let columns = column_names(&db.connection, "pending_wav_renames");
     assert!(columns.iter().any(|column| column == "sound_type"));
     assert!(columns.iter().any(|column| column == "user_tag"));
+    assert!(columns.iter().any(|column| column == "collections"));
 
     let pending = db.list_pending_renames().unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].relative_path, std::path::Path::new("legacy.wav"));
-    assert_eq!(pending[0].tag, Rating::KEEP_1);
-    assert!(pending[0].looped);
-    assert!(pending[0].locked);
-    assert_eq!(pending[0].last_played_at, Some(42));
-    assert_eq!(pending[0].sound_type, None);
-    assert_eq!(pending[0].user_tag, None);
+    assert_eq!(pending[0].metadata.tag, Rating::KEEP_1);
+    assert!(pending[0].metadata.looped);
+    assert!(pending[0].metadata.locked);
+    assert_eq!(pending[0].metadata.last_played_at, Some(42));
+    assert_eq!(pending[0].metadata.sound_type, None);
+    assert_eq!(pending[0].metadata.user_tag, None);
 }
 
 #[test]
@@ -66,6 +67,7 @@ fn current_stamped_pending_rename_table_repairs_missing_metadata_columns() {
     let columns = column_names(&db.connection, "pending_wav_renames");
     assert!(columns.iter().any(|column| column == "sound_type"));
     assert!(columns.iter().any(|column| column == "user_tag"));
+    assert!(columns.iter().any(|column| column == "collections"));
 
     let pending = db.list_pending_renames().unwrap();
     assert_eq!(pending.len(), 1);
@@ -73,6 +75,64 @@ fn current_stamped_pending_rename_table_repairs_missing_metadata_columns() {
         pending[0].relative_path,
         std::path::Path::new("current-stamped.wav")
     );
-    assert_eq!(pending[0].sound_type, None);
-    assert_eq!(pending[0].user_tag, None);
+    assert_eq!(pending[0].metadata.sound_type, None);
+    assert_eq!(pending[0].metadata.user_tag, None);
+}
+
+#[test]
+fn legacy_single_collection_pending_row_restores_membership() {
+    let dir = with_legacy_db(
+        "CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            tag INTEGER NOT NULL DEFAULT 0,
+            looped INTEGER NOT NULL DEFAULT 0,
+            locked INTEGER NOT NULL DEFAULT 0,
+            missing INTEGER NOT NULL DEFAULT 0,
+            extension TEXT NOT NULL DEFAULT '',
+            collection INTEGER
+        );
+        CREATE TABLE pending_wav_renames (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            content_hash TEXT,
+            tag INTEGER NOT NULL,
+            looped INTEGER NOT NULL,
+            locked INTEGER NOT NULL,
+            last_played_at INTEGER,
+            collection INTEGER
+        );
+        INSERT INTO pending_wav_renames (
+            path, file_size, modified_ns, content_hash, tag, looped, locked,
+            last_played_at, collection
+        ) VALUES (
+            'legacy.wav', 10, 5, 'hash-a', 1, 0, 0, NULL, 3
+        );",
+    );
+
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let columns = column_names(&db.connection, "pending_wav_renames");
+    assert!(columns.iter().any(|column| column == "collections"));
+    let pending = db.list_pending_renames().unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(
+        pending[0].metadata.collections,
+        vec![SampleCollection::new(3).unwrap()]
+    );
+
+    db.upsert_file(std::path::Path::new("restored.wav"), 10, 5)
+        .unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .restore_rename_metadata(std::path::Path::new("restored.wav"), &pending[0].metadata)
+        .unwrap();
+    batch.commit().unwrap();
+
+    assert_eq!(
+        db.collections_for_path(std::path::Path::new("restored.wav"))
+            .unwrap(),
+        vec![SampleCollection::new(3).unwrap()]
+    );
 }


### PR DESCRIPTION
## Scope

- Introduce one transactional rename-metadata snapshot/restore contract shared by direct quick-scan reconciliation and deferred deep-hash replay.
- Preserve every canonical `wav_file_collections` membership and restore the exact prior `last_curated_at` value after curation-touching setters run.
- Add an additive `pending_wav_renames.collections` JSON projection while retaining the legacy single `collection` column as a backward-compatible fallback.
- Document the durable scan-reconciliation metadata contract in `docs/TARGET.md`.

## Root cause and impact

The two reconciliation paths replayed selected metadata independently. Direct reconciliation omitted collections and curation time, while pending rename persistence retained only the first collection. Metadata setters also touched `last_curated_at`, making an external rename look like new user curation. This could silently remove collection memberships and alter curation-based ordering or filtering.

## Definition of Done

- [x] Direct scan-recognized renames preserve all collection memberships.
- [x] Deferred rename replay preserves all memberships across database reopen.
- [x] Both paths preserve exact historical `last_curated_at`, including `NULL`.
- [x] Legacy pending rows with only the single `collection` column remain readable, migratable, and safely restorable.
- [x] Direct and deferred paths use the same complete metadata restoration helper inside their write transaction.

## Validation commands

- `cargo test -p wavecrate-scan --lib` — 70 passed
- `cargo test -p wavecrate-library source_db_migration_tests` — 11 passed
- `cargo test -p wavecrate-library sample_sources::db::read` — 12 passed
- `cargo check -p wavecrate-library` — passed
- `cargo test -p wavecrate-library` — 163 passed
- `cargo clippy -p wavecrate-library -p wavecrate-scan --all-targets -- -D warnings` — passed

## Known limitations

None.

User review is required before merge.

Linear: [OPT-1160](https://linear.app/boostnlvp/issue/OPT-1160/wavecrate-scan-preserve-collections-and-curation-timestamps-across)