### PR TITLE
Migrate pending rename test assertions to metadata snapshots

### DIFF
--- a/src/app/controller/tests/missing.rs
+++ b/src/app/controller/tests/missing.rs
@@ -200,12 +200,18 @@ fn prune_missing_sample_removes_cache_and_db_entry_when_inactive() {
     let pending = db.list_pending_renames().unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].relative_path, PathBuf::from("one.wav"));
-    assert_eq!(pending[0].tag, crate::sample_sources::Rating::KEEP_1);
     assert_eq!(
-        pending[0].sound_type,
+        pending[0].metadata.tag,
+        crate::sample_sources::Rating::KEEP_1
+    );
+    assert_eq!(
+        pending[0].metadata.sound_type,
         Some(crate::sample_sources::SampleSoundType::Seq)
     );
-    assert_eq!(pending[0].user_tag.as_deref(), Some("Recovered Tag"));
+    assert_eq!(
+        pending[0].metadata.user_tag.as_deref(),
+        Some("Recovered Tag")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Migrate stale `PendingRenameEntry` test assertions to `RenameMetadataSnapshot` via `entry.metadata`.
- Preserve coverage for rating, sound type, and user-tag retention during inactive missing-sample pruning.
- Confirm no other tests directly access the removed pending-rename fields.

Linear: OPT-1164

## Definition of Done

- [x] All stale `PendingRenameEntry` field accesses use the current metadata snapshot API.
- [x] The focused prune/rename-recovery test passes and continues to prove rating, sound type, and user-tag preservation.
- [x] All Wavecrate test targets compile.
- [x] Smoke validation passes.
- [x] The working tree contains only the dedicated committed change.

## Validation commands

- `cargo test app::controller::tests::missing::prune_missing_sample_removes_cache_and_db_entry_when_inactive -- --exact`
- `cargo test --no-run`
- `bash scripts/ci.sh smoke`
- `git diff --check`
- `rg -n "pending\[[^]]+\]\.(tag|sound_type|user_tag|collection_id|imported_at|last_used_at)" --glob "*.rs" .` (no matches)

## Known limitations

None.

User review is required before merge.