### PR TITLE
OPT-1077 Adopt fluent Radiant menu builders

### DIFF
--- a/src/native_app/app_chrome/browser_context_menu.rs
+++ b/src/native_app/app_chrome/browser_context_menu.rs
@@ -72,11 +72,12 @@ pub(in crate::native_app) fn overlay(
     menu: &BrowserContextMenu,
     harvest_active: bool,
 ) -> ui::View<GuiMessage> {
-    ui::anchored_message_menu_overlay_auto_width(
-        menu.anchor,
+    ui::context_menu(
         menu.title.clone(),
         context_menu_commands(menu, harvest_active),
     )
+    .anchor(menu.anchor)
+    .view()
 }
 
 fn context_menu_commands(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/tag_completion.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/tag_completion.rs
@@ -25,29 +25,29 @@ pub(in crate::native_app) fn tag_completion_overlay(
         .collect::<Vec<_>>();
     let hover_option_values = option_values.clone();
     let parts = tag_completion_options(options, content_width);
-    ui::compact_option_list_anchored_with_interaction(
-        ui::CompactOptionListAnchoredParts::new(
-            parts,
-            content_width,
-            ui::LayerHorizontalAnchor::Start,
-            ui::LayerVerticalAnchor::End,
-            inset_x,
-            inset_y,
-        ),
-        move |index| {
+    ui::compact_option_list(parts)
+        .filter_map_activate(move |index| {
             option_values
                 .get(index)
                 .cloned()
                 .map(|tag| GuiMessage::Metadata(MetadataMessage::SelectMetadataTagCompletion(tag)))
-        },
-        move |index| {
+        })
+        .filter_map_hover(move |index| {
             hover_option_values
                 .get(index)
                 .cloned()
                 .map(|tag| GuiMessage::Metadata(MetadataMessage::HoverMetadataTagCompletion(tag)))
-        },
-    )
-    .key("metadata-tag-completion-overlay")
+        })
+        .anchored(
+            ui::CompactOptionListAnchor::new(
+                content_width,
+                ui::LayerHorizontalAnchor::Start,
+                ui::LayerVerticalAnchor::End,
+            )
+            .inset(inset_x, inset_y),
+        )
+        .view()
+        .key("metadata-tag-completion-overlay")
 }
 
 fn tag_completion_options(

--- a/src/native_app/app_chrome/waveform_context_menu.rs
+++ b/src/native_app/app_chrome/waveform_context_menu.rs
@@ -8,7 +8,10 @@ use crate::native_app::waveform::{WaveformContextMenu, WaveformInteraction};
 pub(in crate::native_app) fn overlay(menu: &WaveformContextMenu) -> ui::View<GuiMessage> {
     let commands = playmark_context_menu_commands(menu.extract_to_harvest_destination);
     let size = overlay_size(&menu.title, &commands);
-    ui::message_context_menu_overlay(menu.anchor, size, menu.title.clone(), commands)
+    ui::context_menu(menu.title.clone(), commands)
+        .anchor(menu.anchor)
+        .size(size)
+        .view()
 }
 
 pub(in crate::native_app) fn overlay_rect(menu: &WaveformContextMenu) -> ui::Rect {


### PR DESCRIPTION
## Scope

- Pin `vendor/radiant` to the merged fluent-builder implementation from PORTALSURFER/radiant#1418.
- Migrate browser and waveform context menus from suffix-based free functions to `context_menu(...).anchor(...)` builders.
- Migrate metadata tag completion from the anchored interaction wrapper to `compact_option_list(...)` with conditional activation/hover mapping and explicit anchored placement.
- Remove all Wavecrate call sites for the retired menu and compact option-list wrapper names.

## Definition of Done

- Wavecrate uses the consolidated fluent menu and option-list APIs.
- Existing menu sizing, anchoring, activation, and hover behavior remain covered.
- Wavecrate compiles against the merged Radiant pin.
- Focused Radiant menu and option-list regression tests pass.
- The working tree is clean and all intended changes are committed.

## Validation commands

- `cargo check -p wavecrate -j1` — passed.
- `cargo test -p wavecrate metadata_category_completion -j1` — passed (4 tests).
- `cargo test -p wavecrate folder_browser_metadata_category_completion_renders_above_tag_input -j1` — passed.
- `cargo test --manifest-path vendor/radiant/Cargo.toml menu -j1` — passed (including public API and guardrail coverage).
- `cargo test --manifest-path vendor/radiant/Cargo.toml option_list -j1` — passed (including public API coverage).
- `git diff --check` — passed.
- `cargo test -p wavecrate browser_context_menu -j1` — 50 passed; one unrelated test failure documented below.

## Known limitations

- `sample_context_menu_open_harvest_destination_requires_primary_source` fails in untouched harvest-routing state setup, expecting the missing-Primary-source status while the fixture resolves a harvest destination. It reproduces in isolation and is outside this builder migration.
- `bash scripts/agent.sh request` reaches the existing application-facade architecture guardrail violations after its earlier checks pass; none of those reported files are changed here.

User review is required before merge.