### PR TITLE
Wavecrate: adopt explicit Radiant host capabilities

### DIFF
--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -276,7 +276,7 @@ fn scene_frame_clock_runs_at_60hz_even_when_idle() {
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
 
-    let activity = runtime.bridge_mut().animation_activity();
+    let activity = runtime.host_animation_activity();
 
     assert!(activity.needs_frame_message());
     assert_eq!(activity.target_fps(), Some(60));
@@ -293,7 +293,7 @@ fn scene_playback_overlay_and_frame_messages_share_native_cadence() {
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
 
-    let activity = runtime.bridge_mut().animation_activity();
+    let activity = runtime.host_animation_activity();
 
     assert!(activity.needs_frame_message());
     assert_eq!(
@@ -312,21 +312,25 @@ fn scene_playback_overlay_and_frame_messages_share_native_cadence() {
 fn scene_frame_clock_queues_gui_frame_message() {
     let mut state = gui_state_for_span_tests();
     state.ui.startup.source_scan_pending = true;
+    let messages = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+    let captured_messages = std::rc::Rc::clone(&messages);
     let bridge = radiant::app(state)
         .view(crate::native_app::test_support::state::view)
-        .handle_message(apply_gui_message_for_presentation_test)
+        .handle_message(move |state, message, context| {
+            captured_messages.borrow_mut().push(message.clone());
+            apply_gui_message_for_presentation_test(state, message, context);
+        })
         .into_bridge();
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
 
-    let activity = runtime.bridge_mut().animation_activity();
+    let activity = runtime.host_animation_activity();
 
     assert!(activity.needs_frame_message());
-    assert!(runtime.bridge_mut().queue_animation_frame());
-    assert_eq!(
-        runtime.bridge_mut().take_runtime_messages(),
-        vec![crate::native_app::test_support::state::GuiMessage::Frame]
-    );
+    assert!(runtime.host_queue_animation_frame());
+    let outcome = runtime.drain_runtime_messages();
+    assert_eq!(outcome.messages_dispatched, 1);
+    assert_eq!(*messages.borrow(), vec![GuiMessage::Frame]);
 }
 
 #[test]
@@ -344,13 +348,8 @@ fn scene_playback_frame_uses_paint_only_repaint_scope() {
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
 
-    assert!(
-        runtime
-            .bridge_mut()
-            .animation_activity()
-            .needs_frame_message()
-    );
-    assert!(runtime.bridge_mut().queue_animation_frame());
+    assert!(runtime.host_animation_activity().needs_frame_message());
+    assert!(runtime.host_queue_animation_frame());
     let command = runtime
         .bridge_mut()
         .update(crate::native_app::test_support::state::GuiMessage::Frame);
@@ -372,8 +371,8 @@ fn scene_installs_playback_cursor_transient_overlay() {
     let frame = runtime.frame(&theme);
     let mut primitives = Vec::new();
 
-    assert!(runtime.bridge_mut().has_transient_overlay_painter());
-    runtime.bridge_mut().paint_transient_overlay(
+    assert!(runtime.has_transient_overlay_host());
+    runtime.host_paint_transient_overlay(
         TransientOverlayContext::new(
             &frame.paint_plan,
             Vector2::new(900.0, 620.0),
@@ -403,7 +402,16 @@ fn scene_installs_starmap_active_audition_transient_overlay() {
     crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
         &mut state,
     );
+    crate::native_app::test_support::sample_browser::prepare_sample_browser_view(&mut state);
     state.ui.chrome.starmap_audition_queue.active_file_id = Some(selected_file);
+    assert!(state.active_starmap_audition_file_id().is_some());
+    assert!(
+        state
+            .library
+            .folder_browser
+            .cached_starmap_projection()
+            .is_some()
+    );
     let theme = radiant::theme::ThemeTokens::default();
     let bridge = radiant::app(state)
         .view(crate::native_app::test_support::state::view)
@@ -414,7 +422,14 @@ fn scene_installs_starmap_active_audition_transient_overlay() {
     let frame = runtime.frame(&theme);
     let mut primitives = Vec::new();
 
-    runtime.bridge_mut().paint_transient_overlay(
+    assert!(runtime.has_transient_overlay_host());
+    assert!(
+        frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID])
+            .is_some()
+    );
+    runtime.host_paint_transient_overlay(
         TransientOverlayContext::new(
             &frame.paint_plan,
             Vector2::new(900.0, 620.0),
@@ -450,7 +465,7 @@ fn shortcut_help_modal_suppresses_waveform_transient_overlay() {
     let frame = runtime.frame(&theme);
     let mut primitives = Vec::new();
 
-    runtime.bridge_mut().paint_transient_overlay(
+    runtime.host_paint_transient_overlay(
         TransientOverlayContext::new(
             &frame.paint_plan,
             Vector2::new(900.0, 620.0),
@@ -493,7 +508,7 @@ fn waveform_context_menu_suppresses_waveform_transient_overlay() {
     let frame = runtime.frame(&theme);
     let mut primitives = Vec::new();
 
-    runtime.bridge_mut().paint_transient_overlay(
+    runtime.host_paint_transient_overlay(
         TransientOverlayContext::new(
             &frame.paint_plan,
             Vector2::new(900.0, 620.0),

--- a/src/native_app/tests/window_chrome.rs
+++ b/src/native_app/tests/window_chrome.rs
@@ -1,5 +1,5 @@
 use super::*;
-use radiant::runtime::{NativeFileDrop, RuntimeBridge, SurfaceRuntime};
+use radiant::runtime::{NativeFileDrop, SurfaceRuntime};
 use std::{cell::RefCell, rc::Rc};
 use winit::{dpi::PhysicalPosition, event::MouseButton};
 

--- a/src/native_app/tests/window_chrome/app_bridge.rs
+++ b/src/native_app/tests/window_chrome/app_bridge.rs
@@ -188,13 +188,8 @@ fn app_bridge_scene_preserves_waveform_drag_during_playback_frame_refresh() {
         runtime.dispatch_event(Event::primary_press(press)),
         Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
     );
-    assert!(
-        runtime
-            .bridge_mut()
-            .animation_activity()
-            .needs_frame_message()
-    );
-    assert!(runtime.bridge_mut().queue_animation_frame());
+    assert!(runtime.host_animation_activity().needs_frame_message());
+    assert!(runtime.host_queue_animation_frame());
     runtime.drain_runtime_messages();
     assert_eq!(
         runtime.dispatch_event(Event::pointer_move(drag)),

--- a/src/native_app/tests/window_chrome/secondary_waveform.rs
+++ b/src/native_app/tests/window_chrome/secondary_waveform.rs
@@ -158,7 +158,7 @@ fn native_pointer_shell_preserves_waveform_drag_after_playback_frame_refresh() {
         harness.mouse_pressed(MouseButton::Left),
         Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
     );
-    harness.runtime.bridge_mut().queue_animation_frame();
+    harness.runtime.host_queue_animation_frame();
     harness.runtime.drain_runtime_messages();
     assert_eq!(
         harness.cursor_moved_logical(drag),


### PR DESCRIPTION
## Scope

- Pin `vendor/radiant` to merged Radiant PR #1419 (`efdf89740af76d618d507bbae0e725cc6345525a`).
- Migrate Wavecrate runtime tests from direct `RuntimeBridge` animation and transient-overlay calls to the explicit `SurfaceRuntime` host-capability API.
- Preserve exact queued-frame assertions by observing messages through the declarative bridge handler.
- Prepare the Starmap projection fixture before validating its transient overlay host.

## Definition of Done

- Wavecrate builds against the split RuntimeBridge capability API.
- Animation-frame scheduling and transient overlay behavior remain covered by focused tests.
- The Radiant submodule points at the canonical merged commit from PORTALSURFER/radiant#1419.
- The branch is clean, committed, and ready for user review.

## Validation commands

- `cargo test --no-run`
- `bash scripts/ci.sh smoke`
- `cargo test native_app::tests::toolbar_playback::frame_overlay` (31 passed)
- Focused playback refresh tests in `window_chrome` passed.
- `git diff --check`
- `bash scripts/agent.sh request` (all change-relevant checks passed; stopped at the pre-existing facade baseline described below)

## Known limitations

- The repository-wide agent request still reports the existing facade baseline in unchanged files: legacy `app_core` crossings, production `test_support` imports, and the existing public-module budgets tracked by OPT-529/OPT-541.
- The broader `window_chrome` module has four unrelated existing fixture/state failures; all playback-refresh tests modified by this PR pass.

Tracks OPT-1166.
Depends on and pins merged PORTALSURFER/radiant#1419.

User review is required before merge.