### PR TITLE
OPT-1171: Keep live loop playhead synchronized

### DIFF
--- a/crates/reson/src/player/playback.rs
+++ b/crates/reson/src/player/playback.rs
@@ -235,8 +235,17 @@ impl AudioPlayer {
                 .saturating_add(plan.seek_offset_frames())
                 .min(plan.end_frame().saturating_sub(1)),
         );
+        // Preserve the runtime-time source position, not the request-time UI
+        // offset: command queue latency otherwise becomes permanent clock drift.
+        let current_frame = if seek_to_offset {
+            None
+        } else {
+            self.progress_frame()
+        };
+        let progress_offset_frames =
+            live_retarget_progress_offset_frames(&plan, seek_to_offset, current_frame);
         playback_span.update_from_plan(&plan, seek_frame);
-        self.finish_span_playback(&plan, Some(plan.seek_offset_frames()));
+        self.finish_span_playback(&plan, Some(progress_offset_frames));
         self.active_playback_span = Some(playback_span);
         Ok(())
     }
@@ -616,6 +625,26 @@ impl AudioPlayer {
             .unwrap_or("none")
     }
 }
+
+fn live_retarget_progress_offset_frames(
+    plan: &PlaybackSpanPlan,
+    seek_to_offset: bool,
+    current_frame: Option<u64>,
+) -> u64 {
+    if seek_to_offset {
+        return plan.seek_offset_frames();
+    }
+    match current_frame {
+        Some(frame) if (plan.start_frame()..plan.end_frame()).contains(&frame) => {
+            frame.saturating_sub(plan.start_frame())
+        }
+        Some(_) => 0,
+        None => plan.seek_offset_frames(),
+    }
+}
+
+#[cfg(test)]
+mod retarget_progress_tests;
 
 fn source_with_metronome(
     source: Box<dyn Source<Item = f32> + Send>,

--- a/crates/reson/src/player/playback/retarget_progress_tests.rs
+++ b/crates/reson/src/player/playback/retarget_progress_tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+use crate::player::{
+    PlaybackChannelLayout, PlaybackSeekBehavior, PlaybackSourceIdentity, PlaybackSourceKind,
+    PlaybackSpanRequest,
+};
+
+fn span_plan(offset_frame: u64) -> PlaybackSpanPlan {
+    PlaybackSpanPlan::new(
+        PlaybackSourceIdentity::new(PlaybackSourceKind::Bytes, None),
+        PlaybackChannelLayout::new(1, 1_000).expect("layout"),
+        PlaybackSpanRequest::new(
+            0.2,
+            0.8,
+            1.0,
+            true,
+            PlaybackSeekBehavior::FrameOffset(offset_frame),
+        ),
+    )
+    .expect("span plan")
+}
+
+#[test]
+fn non_seeking_retarget_rebases_progress_from_runtime_time() {
+    let plan = span_plan(40);
+
+    let offset = live_retarget_progress_offset_frames(&plan, false, Some(525));
+
+    assert_eq!(offset, 325);
+}
+
+#[test]
+fn non_seeking_retarget_wraps_progress_that_left_the_new_span() {
+    let plan = span_plan(40);
+
+    let offset = live_retarget_progress_offset_frames(&plan, false, Some(825));
+
+    assert_eq!(offset, 0);
+}
+
+#[test]
+fn seeking_retarget_uses_the_requested_offset() {
+    let plan = span_plan(40);
+
+    let offset = live_retarget_progress_offset_frames(&plan, true, Some(525));
+
+    assert_eq!(offset, 40);
+}

--- a/crates/reson/src/player/progress.rs
+++ b/crates/reson/src/player/progress.rs
@@ -9,32 +9,21 @@ impl AudioPlayer {
     /// Current playback progress as a 0-1 fraction.
     pub fn progress(&self) -> Option<f32> {
         let duration = self.track_duration?;
-        let started_at = self.started_at?;
         if duration <= 0.0 {
             return None;
         }
 
-        let elapsed = self.elapsed_since(started_at);
-        if let (Some(sample_rate), Some(track_frames), Some((span_start, span_end))) = (
-            self.sample_rate,
-            self.track_total_frames,
-            self.play_span_frames,
-        ) {
-            let span_frames = span_end.saturating_sub(span_start).max(1);
-            let elapsed_frames = duration_to_frames_floor(elapsed, sample_rate);
-            let base_offset = self.loop_offset_frames.unwrap_or(0).min(span_frames);
-            let within_span = if self.looping {
-                (base_offset % span_frames).saturating_add(elapsed_frames) % span_frames
-            } else {
-                base_offset.saturating_add(elapsed_frames).min(span_frames)
-            };
-            let absolute_frame = span_start.saturating_add(within_span).min(track_frames);
+        if let (Some(track_frames), Some(absolute_frame)) =
+            (self.track_total_frames, self.progress_frame())
+        {
             if track_frames == 0 {
                 return None;
             }
             return Some(((absolute_frame as f64 / track_frames as f64) as f32).clamp(0.0, 1.0));
         }
 
+        let started_at = self.started_at?;
+        let elapsed = self.elapsed_since(started_at);
         let (span_start, span_end) = self.play_span.unwrap_or((0.0, duration));
         let span_length_secs = (span_end - span_start).max(f32::EPSILON);
         let span_length = duration_from_secs_f32(span_length_secs);
@@ -49,6 +38,22 @@ impl AudioPlayer {
         };
         let absolute_secs = span_start as f64 + within_span.as_secs_f64();
         Some(((absolute_secs / duration as f64) as f32).clamp(0.0, 1.0))
+    }
+
+    pub(super) fn progress_frame(&self) -> Option<u64> {
+        let started_at = self.started_at?;
+        let sample_rate = self.sample_rate?;
+        let track_frames = self.track_total_frames?;
+        let (span_start, span_end) = self.play_span_frames?;
+        let span_frames = span_end.saturating_sub(span_start).max(1);
+        let elapsed_frames = duration_to_frames_floor(self.elapsed_since(started_at), sample_rate);
+        let base_offset = self.loop_offset_frames.unwrap_or(0).min(span_frames);
+        let within_span = if self.looping {
+            (base_offset % span_frames).saturating_add(elapsed_frames) % span_frames
+        } else {
+            base_offset.saturating_add(elapsed_frames).min(span_frames)
+        };
+        Some(span_start.saturating_add(within_span).min(track_frames))
     }
 
     /// True while the sink is still playing the queued audio.

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::mpsc::Receiver,
-    time::{Duration, Instant},
-};
+use std::{sync::mpsc::Receiver, time::Instant};
 
 use wavecrate::audio::{
     AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, AudioPlayer, PlaybackRequestId,
@@ -16,11 +13,11 @@ use crate::native_app::audio::{
 };
 
 mod span_retarget;
+mod visual_progress;
 
 pub(in crate::native_app) use span_retarget::PlaybackSpanRetargetRejection;
 use span_retarget::PlaybackSpanRetargetState;
-
-const PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE: Duration = Duration::from_millis(8);
+use visual_progress::PlaybackVisualProgress;
 
 pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) player: Option<AudioPlayer>,
@@ -49,15 +46,6 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) playback_events: Option<Receiver<PlaybackRuntimeEvent>>,
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
     pub(in crate::native_app) playback_visual_progress: Option<PlaybackVisualProgress>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(in crate::native_app) struct PlaybackVisualProgress {
-    pub(in crate::native_app) anchor_ratio: f32,
-    pub(in crate::native_app) anchor_at: Instant,
-    pub(in crate::native_app) anchor_animation_time: Option<Duration>,
-    pub(in crate::native_app) span: Option<(f32, f32)>,
-    pub(in crate::native_app) looping: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -346,93 +334,6 @@ impl AudioAppState {
         self.sample_playback_session = None;
     }
 
-    pub(in crate::native_app) fn set_playback_progress(
-        &mut self,
-        progress: PlaybackRuntimeProgress,
-    ) {
-        self.playback_progress = progress;
-        self.sync_playback_visual_progress(false);
-    }
-
-    pub(in crate::native_app) fn set_started_playback_progress(
-        &mut self,
-        progress: PlaybackRuntimeProgress,
-    ) {
-        self.playback_progress = progress;
-        self.sync_playback_visual_progress(true);
-    }
-
-    pub(in crate::native_app) fn clear_playback_progress(&mut self) {
-        self.playback_progress = PlaybackRuntimeProgress::default();
-        self.playback_visual_progress = None;
-    }
-
-    pub(in crate::native_app) fn reset_playback_visual_progress(
-        &mut self,
-        anchor_ratio: f32,
-        looping: bool,
-    ) {
-        self.playback_visual_progress = Some(PlaybackVisualProgress {
-            anchor_ratio: anchor_ratio.clamp(0.0, 1.0),
-            anchor_at: Instant::now(),
-            anchor_animation_time: None,
-            span: self.current_playback_span,
-            looping,
-        });
-    }
-
-    fn sync_playback_visual_progress(&mut self, force: bool) {
-        if !self.playback_progress.active {
-            self.playback_visual_progress = None;
-            return;
-        }
-        let Some(progress) = self.playback_progress.progress else {
-            return;
-        };
-        let span = self.current_playback_span;
-        let looping = self.playback_progress.looping;
-        let clock_mismatch = self
-            .playback_visual_progress
-            .is_some_and(|clock| clock.span != span || clock.looping != looping);
-        let delayed_unpainted_anchor = self.delayed_unpainted_playback_anchor_needs_refresh();
-        if force
-            || self.playback_visual_progress.is_none()
-            || clock_mismatch
-            || delayed_unpainted_anchor
-        {
-            self.reset_playback_visual_progress(progress, looping);
-        }
-    }
-
-    fn delayed_unpainted_playback_anchor_needs_refresh(&self) -> bool {
-        let Some(clock) = self.playback_visual_progress else {
-            return false;
-        };
-        if clock.anchor_animation_time.is_some() {
-            return false;
-        }
-        let Some(runtime_elapsed) = self.playback_progress.elapsed else {
-            return false;
-        };
-        runtime_elapsed.saturating_add(PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE)
-            >= clock.anchor_at.elapsed()
-    }
-
-    pub(in crate::native_app) fn promote_sample_playback_session_to_waveform(
-        &mut self,
-        path: &str,
-    ) -> bool {
-        let Some(session) = self.sample_playback_session.as_mut() else {
-            return false;
-        };
-        if session.request.path != path || session.source_kind == "preview_samples" {
-            return false;
-        }
-        session.request.visibility = SamplePlaybackVisibility::Waveform;
-        session.state = SamplePlaybackSessionState::WaveformVisible;
-        true
-    }
-
     pub(in crate::native_app) fn active_sample_playback_path(&self) -> Option<&str> {
         self.sample_playback_session
             .as_ref()
@@ -490,17 +391,5 @@ impl AudioAppState {
         if let Some(session) = self.sample_playback_session.as_mut() {
             session.set_confirmed_span(span);
         }
-    }
-
-    #[cfg(test)]
-    pub(in crate::native_app) fn record_span_retarget_for_tests(
-        &mut self,
-        request_id: u64,
-        span: (f32, f32),
-    ) {
-        self.sample_playback_session
-            .as_mut()
-            .expect("sample playback session")
-            .record_span_retarget_id(request_id, span);
     }
 }

--- a/src/native_app/app/state/audio/span_retarget.rs
+++ b/src/native_app/app/state/audio/span_retarget.rs
@@ -1,4 +1,6 @@
-use super::SamplePlaybackSession;
+use super::{
+    AudioAppState, SamplePlaybackSession, SamplePlaybackSessionState, SamplePlaybackVisibility,
+};
 use wavecrate::audio::PlaybackRequestId;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -48,6 +50,10 @@ impl SamplePlaybackSession {
         !self.span_retarget.pending.is_empty()
     }
 
+    pub(in crate::native_app) fn confirmed_span(&self) -> (f32, f32) {
+        self.span_retarget.confirmed_span
+    }
+
     pub(in crate::native_app) fn confirm_span_retarget(
         &mut self,
         request_id: PlaybackRequestId,
@@ -55,7 +61,7 @@ impl SamplePlaybackSession {
         self.confirm_span_retarget_id(request_id.get())
     }
 
-    fn confirm_span_retarget_id(&mut self, request_id: u64) -> bool {
+    pub(super) fn confirm_span_retarget_id(&mut self, request_id: u64) -> bool {
         let Some(index) = self
             .span_retarget
             .pending
@@ -102,6 +108,46 @@ impl SamplePlaybackSession {
     }
 }
 
+impl AudioAppState {
+    pub(in crate::native_app) fn promote_sample_playback_session_to_waveform(
+        &mut self,
+        path: &str,
+    ) -> bool {
+        let Some(session) = self.sample_playback_session.as_mut() else {
+            return false;
+        };
+        if session.request.path != path || session.source_kind == "preview_samples" {
+            return false;
+        }
+        session.request.visibility = SamplePlaybackVisibility::Waveform;
+        session.state = SamplePlaybackSessionState::WaveformVisible;
+        true
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn record_span_retarget_for_tests(
+        &mut self,
+        request_id: u64,
+        span: (f32, f32),
+    ) {
+        self.sample_playback_session
+            .as_mut()
+            .expect("sample playback session")
+            .record_span_retarget_id(request_id, span);
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn confirm_span_retarget_for_tests(
+        &mut self,
+        request_id: u64,
+    ) -> bool {
+        self.sample_playback_session
+            .as_mut()
+            .expect("sample playback session")
+            .confirm_span_retarget_id(request_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Instant;
@@ -138,6 +184,7 @@ mod tests {
 
         assert_eq!(session.request.span, (0.25, 0.60));
         assert!(session.has_pending_span_retarget());
+        assert_eq!(session.confirmed_span(), (0.0, 1.0));
     }
 
     #[test]

--- a/src/native_app/app/state/audio/visual_progress.rs
+++ b/src/native_app/app/state/audio/visual_progress.rs
@@ -1,0 +1,108 @@
+use std::time::{Duration, Instant};
+
+use wavecrate::audio::PlaybackRuntimeProgress;
+
+use super::{AudioAppState, SamplePlaybackSession};
+
+const PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE: Duration = Duration::from_millis(8);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::native_app) struct PlaybackVisualProgress {
+    pub(in crate::native_app) anchor_ratio: f32,
+    pub(in crate::native_app) anchor_at: Instant,
+    pub(in crate::native_app) anchor_animation_time: Option<Duration>,
+    pub(in crate::native_app) span: Option<(f32, f32)>,
+    pub(in crate::native_app) looping: bool,
+}
+
+impl AudioAppState {
+    pub(in crate::native_app) fn set_playback_progress(
+        &mut self,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        self.playback_progress = progress;
+        self.sync_playback_visual_progress(false);
+    }
+
+    pub(in crate::native_app) fn set_authoritative_playback_progress(
+        &mut self,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        self.playback_progress = progress;
+        self.sync_playback_visual_progress(true);
+    }
+
+    pub(in crate::native_app) fn set_started_playback_progress(
+        &mut self,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        self.set_authoritative_playback_progress(progress);
+    }
+
+    pub(in crate::native_app) fn clear_playback_progress(&mut self) {
+        self.playback_progress = PlaybackRuntimeProgress::default();
+        self.playback_visual_progress = None;
+    }
+
+    pub(in crate::native_app) fn reset_playback_visual_progress(
+        &mut self,
+        anchor_ratio: f32,
+        looping: bool,
+    ) {
+        let span = self.playback_visual_span();
+        self.playback_visual_progress = Some(PlaybackVisualProgress {
+            anchor_ratio: anchor_ratio.clamp(0.0, 1.0),
+            anchor_at: Instant::now(),
+            anchor_animation_time: None,
+            span,
+            looping,
+        });
+    }
+
+    fn sync_playback_visual_progress(&mut self, force: bool) {
+        if !self.playback_progress.active {
+            self.playback_visual_progress = None;
+            return;
+        }
+        let Some(progress) = self.playback_progress.progress else {
+            return;
+        };
+        let span = self.playback_visual_span();
+        let looping = self.playback_progress.looping;
+        let clock_mismatch = self
+            .playback_visual_progress
+            .is_some_and(|clock| clock.span != span || clock.looping != looping);
+        let delayed_unpainted_anchor = self.delayed_unpainted_playback_anchor_needs_refresh();
+        if force
+            || self.playback_visual_progress.is_none()
+            || clock_mismatch
+            || delayed_unpainted_anchor
+        {
+            self.reset_playback_visual_progress(progress, looping);
+        }
+    }
+
+    fn playback_visual_span(&self) -> Option<(f32, f32)> {
+        // Requested bounds can lead the audio runtime while a live retarget is
+        // queued. Project the playhead through the last audible confirmation.
+        self.sample_playback_session
+            .as_ref()
+            .filter(|session| session.request.visibility.updates_waveform_playhead())
+            .map(SamplePlaybackSession::confirmed_span)
+            .or(self.current_playback_span)
+    }
+
+    fn delayed_unpainted_playback_anchor_needs_refresh(&self) -> bool {
+        let Some(clock) = self.playback_visual_progress else {
+            return false;
+        };
+        if clock.anchor_animation_time.is_some() {
+            return false;
+        }
+        let Some(runtime_elapsed) = self.playback_progress.elapsed else {
+            return false;
+        };
+        runtime_elapsed.saturating_add(PLAYBACK_VISUAL_PROGRESS_ELAPSED_TOLERANCE)
+            >= clock.anchor_at.elapsed()
+    }
+}

--- a/src/native_app/audio/playback/progress/events.rs
+++ b/src/native_app/audio/playback/progress/events.rs
@@ -69,10 +69,16 @@ impl NativeAppState {
             }
             PlaybackRuntimeEvent::Stopped { .. } => {}
             PlaybackRuntimeEvent::Progress { id, progress } => {
-                if let Some(session) = self.audio.sample_playback_session.as_mut() {
-                    session.confirm_span_retarget(id);
+                let confirmed_retarget = self
+                    .audio
+                    .sample_playback_session
+                    .as_mut()
+                    .is_some_and(|session| session.confirm_span_retarget(id));
+                if confirmed_retarget {
+                    self.apply_authoritative_runtime_playback_progress(progress);
+                } else {
+                    self.apply_runtime_playback_progress(progress);
                 }
-                self.apply_runtime_playback_progress(progress)
             }
         }
     }
@@ -82,6 +88,13 @@ impl NativeAppState {
             return;
         }
         self.audio.set_playback_progress(progress);
+    }
+
+    fn apply_authoritative_runtime_playback_progress(&mut self, progress: PlaybackRuntimeProgress) {
+        if self.audio.active_sample_playback_pending_runtime() {
+            return;
+        }
+        self.audio.set_authoritative_playback_progress(progress);
     }
 
     fn finish_runtime_playback_started(&mut self, started: PlaybackRuntimeStarted) {
@@ -141,7 +154,7 @@ impl NativeAppState {
         self.audio.output_resolved = Some(output);
         self.audio.current_playback_span = source_updates_waveform.then_some(span);
         self.audio
-            .set_started_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
+            .set_authoritative_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
                 active: true,
                 elapsed: Some(Duration::ZERO),
                 looping: self.audio.loop_playback,
@@ -293,58 +306,5 @@ impl NativeAppState {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{path::PathBuf, sync::Arc};
-
-    use super::*;
-    use crate::native_app::{
-        app::{SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest},
-        test_support::state::{NativeAppStateFixture, WaveformState},
-        waveform::test_decoded_waveform_file_from_mono_samples,
-    };
-
-    #[test]
-    fn late_original_start_preserves_newer_live_retarget_span_and_anchor() {
-        let path = PathBuf::from("late-start-retarget.wav");
-        let file =
-            test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
-        let mut state = NativeAppStateFixture::default().build();
-        state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
-        state.waveform.current.start_playback(0.0);
-        state.audio.current_playback_span = Some((0.0, 1.0));
-        let request = SamplePlaybackRequest::waveform(
-            path.display().to_string(),
-            (0.0, 1.0),
-            SamplePlaybackIntent::WaveformSpan,
-            "waveform",
-            SamplePlaybackHistory::Record,
-        );
-        state
-            .audio
-            .start_resolving_sample_playback_session(request, "decoded_samples");
-        state
-            .audio
-            .sample_playback_session
-            .as_mut()
-            .expect("sample playback session")
-            .runtime_request_id = Some(1);
-        state.audio.record_span_retarget_for_tests(2, (0.25, 0.60));
-        state.audio.current_playback_span = Some((0.25, 0.60));
-        state.audio.reset_playback_visual_progress(0.25, true);
-        state.waveform.current.start_playback(0.25);
-
-        state.finish_runtime_playback_started_parts(1, ResolvedOutput::default(), 0.0);
-
-        assert_eq!(state.audio.current_playback_span, Some((0.25, 0.60)));
-        assert_eq!(state.audio.playback_progress.progress, Some(0.25));
-        assert_eq!(state.waveform.current.playhead_ratio(), Some(0.25));
-        assert!(matches!(
-            state
-                .audio
-                .sample_playback_session
-                .as_ref()
-                .map(|session| &session.state),
-            Some(SamplePlaybackSessionState::WaveformVisible)
-        ));
-    }
-}
+#[path = "events_tests.rs"]
+mod tests;

--- a/src/native_app/audio/playback/progress/events_tests.rs
+++ b/src/native_app/audio/playback/progress/events_tests.rs
@@ -1,0 +1,110 @@
+use std::{path::PathBuf, sync::Arc};
+
+use super::*;
+use crate::native_app::{
+    app::{SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackRequest},
+    test_support::state::{NativeAppStateFixture, WaveformState},
+    waveform::test_decoded_waveform_file_from_mono_samples,
+};
+
+#[test]
+fn late_original_start_preserves_newer_live_retarget_span_and_anchor() {
+    let path = PathBuf::from("late-start-retarget.wav");
+    let file =
+        test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
+    let mut state = NativeAppStateFixture::default().build();
+    state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+    state.waveform.current.start_playback(0.0);
+    state.audio.current_playback_span = Some((0.0, 1.0));
+    let request = SamplePlaybackRequest::waveform(
+        path.display().to_string(),
+        (0.0, 1.0),
+        SamplePlaybackIntent::WaveformSpan,
+        "waveform",
+        SamplePlaybackHistory::Record,
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "decoded_samples");
+    state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("sample playback session")
+        .runtime_request_id = Some(1);
+    state.audio.record_span_retarget_for_tests(2, (0.25, 0.60));
+    state.audio.current_playback_span = Some((0.25, 0.60));
+    state.audio.reset_playback_visual_progress(0.25, true);
+    assert_eq!(
+        state.audio.playback_visual_progress.map(|clock| clock.span),
+        Some(Some((0.0, 1.0))),
+        "pending requested bounds must not become the audible visual span"
+    );
+    state.waveform.current.start_playback(0.25);
+
+    state.finish_runtime_playback_started_parts(1, ResolvedOutput::default(), 0.0);
+
+    assert_eq!(state.audio.current_playback_span, Some((0.25, 0.60)));
+    assert_eq!(state.audio.playback_progress.progress, Some(0.25));
+    assert_eq!(state.waveform.current.playhead_ratio(), Some(0.25));
+    assert!(matches!(
+        state
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .map(|session| &session.state),
+        Some(SamplePlaybackSessionState::WaveformVisible)
+    ));
+}
+
+#[test]
+fn confirmed_retarget_reanchors_visual_progress_to_the_audible_span() {
+    let path = PathBuf::from("confirmed-retarget.wav");
+    let file =
+        test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
+    let mut state = NativeAppStateFixture::default().build();
+    state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+    state.waveform.current.start_playback(0.20);
+    state.audio.current_playback_span = Some((0.20, 0.60));
+    let request = SamplePlaybackRequest::waveform(
+        path.display().to_string(),
+        (0.20, 0.60),
+        SamplePlaybackIntent::WaveformSpan,
+        "waveform",
+        SamplePlaybackHistory::Record,
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "decoded_samples");
+    state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("sample playback session")
+        .runtime_request_id = Some(1);
+    state.finish_runtime_playback_started_parts(1, ResolvedOutput::default(), 0.20);
+
+    state.audio.record_span_retarget_for_tests(2, (0.20, 0.80));
+    state.audio.current_playback_span = Some((0.20, 0.80));
+    state.audio.reset_playback_visual_progress(0.35, true);
+    assert_eq!(
+        state.audio.playback_visual_progress.map(|clock| clock.span),
+        Some(Some((0.20, 0.60)))
+    );
+
+    assert!(state.audio.confirm_span_retarget_for_tests(2));
+    state.apply_authoritative_runtime_playback_progress(PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(Duration::ZERO),
+        looping: true,
+        progress: Some(0.55),
+        error: None,
+    });
+
+    let clock = state
+        .audio
+        .playback_visual_progress
+        .expect("visual progress clock");
+    assert_eq!(clock.span, Some((0.20, 0.80)));
+    assert_eq!(clock.anchor_ratio, 0.55);
+}


### PR DESCRIPTION
## Scope

- Rebase Reson progress from the runtime-time frame when live loop bounds change without a seek.
- Keep visual projection on the last runtime-confirmed audible span while newer retarget commands are queued.
- Re-anchor visual progress authoritatively when the runtime confirms each retarget.
- Split playback visual-progress and event tests into focused modules within the source-size budget.
- Capture the adjacent real-time metronome/control-block redesign as OPT-1172.

## Definition of Done

- Live playmark edits cannot permanently offset the progress clock by command-queue latency.
- Pending requested bounds do not make the playhead lead audible playback.
- Runtime confirmation atomically advances the audible visual span and progress anchor.
- Existing seek, loop-wrap, stale-start, and rapid-retarget behavior remains covered.

## Validation

- cargo test -p reson retarget -- --nocapture (8 passed)
- cargo clippy -p reson --all-targets -- -D warnings
- cargo test -p wavecrate confirmed_retarget_reanchors_visual_progress_to_the_audible_span -- --nocapture (passed before final test-module-only split)
- cargo test -p wavecrate retarget_ -- --nocapture (2 lib + 13 bin passed before final test-module-only split)
- cargo test -p wavecrate loop_toggle -- --nocapture (7 passed)
- WAVECRATE_TEST_AUDIO_OUTPUT=1 cargo test -p wavecrate playback_retarget -- --nocapture --test-threads=1 (9 passed with real audio output)
- cargo test -p reson progress -- --nocapture (19 passed)
- cargo test --no-run (passed before final test-module-only split)
- rustfmt --edition 2024 --check on every changed Rust file
- git diff --check
- file-size budget check (5 changed Wavecrate files, all passed)

## Known limitations

- OPT-1172 tracks replacing the decoded-source PlaybackSpanHandle RwLock with a non-blocking coherent control block and updating metronome phase in place during live retargets. Rebuilding audio on every drag was intentionally avoided.
- The final Wavecrate compile rerun was blocked by the same baseline macOS rustc stall reproduced before implementation; the process parked at 0% CPU while compiling untouched Radiant. Earlier focused Wavecrate and real-output validations passed.
- Full Wavecrate clippy remains blocked by existing untouched Radiant type_complexity and too_many_arguments warnings.

User review is required before merge.