### PR TITLE
Reson: make live retarget controls real-time safe

### DIFF
--- a/crates/reson/src/player/metronome.rs
+++ b/crates/reson/src/player/metronome.rs
@@ -2,6 +2,8 @@ use std::{f32::consts::TAU, time::Duration};
 
 use crate::Source;
 
+use super::PlaybackSpanHandle;
+
 const BEAT_AMPLITUDE: f32 = 0.22;
 const OFFBEAT_AMPLITUDE: f32 = 0.13;
 const BEAT_FREQUENCY_HZ: f32 = 2_400.0;
@@ -67,11 +69,14 @@ impl PlaybackMetronomeConfig {
 pub(super) struct MetronomeSource<S> {
     inner: S,
     config: PlaybackMetronomeConfig,
+    enabled: bool,
     cycle_frames: u64,
     cycle_offset_frames: u64,
     sample_index: u64,
     channels: u16,
     sample_rate: u32,
+    live_control: Option<PlaybackSpanHandle>,
+    live_revision: u64,
 }
 
 impl<S> MetronomeSource<S>
@@ -90,15 +95,56 @@ where
         Self {
             inner,
             config,
+            enabled: true,
             cycle_frames,
             cycle_offset_frames,
             sample_index: 0,
             channels,
             sample_rate,
+            live_control: None,
+            live_revision: 0,
         }
     }
 
+    pub(super) fn new_live(inner: S, live_control: PlaybackSpanHandle) -> Self {
+        let applied = live_control.applied_metronome();
+        let channels = inner.channels().max(1);
+        let sample_rate = inner.sample_rate().max(1);
+        Self {
+            inner,
+            config: PlaybackMetronomeConfig::new(applied.beat_count()),
+            enabled: applied.enabled(),
+            cycle_frames: applied.cycle_frames().max(1),
+            cycle_offset_frames: applied.phase_frames() % applied.cycle_frames().max(1),
+            sample_index: 0,
+            channels,
+            sample_rate,
+            live_control: Some(live_control),
+            live_revision: applied.revision(),
+        }
+    }
+
+    fn refresh_live_control(&mut self) {
+        let Some(control) = self.live_control.as_ref() else {
+            return;
+        };
+        let revision = control.applied_metronome_revision();
+        if revision == self.live_revision {
+            return;
+        }
+        let applied = control.applied_metronome();
+        self.live_revision = applied.revision();
+        self.enabled = applied.enabled();
+        self.config = PlaybackMetronomeConfig::new(applied.beat_count());
+        self.cycle_frames = applied.cycle_frames().max(1);
+        self.cycle_offset_frames = applied.phase_frames() % self.cycle_frames;
+        self.sample_index = 0;
+    }
+
     fn click_value(&self, frame_index: u64) -> f32 {
+        if !self.enabled {
+            return 0.0;
+        }
         let frame_in_cycle = (self.cycle_offset_frames + frame_index) % self.cycle_frames.max(1);
         let beat_interval = self.cycle_frames as f64 / f64::from(self.config.beat_count());
         if beat_interval <= f64::EPSILON {
@@ -139,10 +185,17 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         let dry = self.inner.next()?;
+        if self.sample_index.is_multiple_of(u64::from(self.channels)) {
+            self.refresh_live_control();
+        }
         let frame_index = self.sample_index / u64::from(self.channels);
         let click = self.click_value(frame_index);
         self.sample_index = self.sample_index.saturating_add(1);
-        Some((dry + click).clamp(-1.0, 1.0))
+        if self.enabled {
+            Some((dry + click).clamp(-1.0, 1.0))
+        } else {
+            Some(dry)
+        }
     }
 }
 

--- a/crates/reson/src/player/playback.rs
+++ b/crates/reson/src/player/playback.rs
@@ -244,7 +244,7 @@ impl AudioPlayer {
         };
         let progress_offset_frames =
             live_retarget_progress_offset_frames(&plan, seek_to_offset, current_frame);
-        playback_span.update_from_plan(&plan, seek_frame);
+        playback_span.update_from_plan(&plan, seek_frame, metronome);
         self.finish_span_playback(&plan, Some(progress_offset_frames));
         self.active_playback_span = Some(playback_span);
         Ok(())
@@ -358,7 +358,7 @@ impl AudioPlayer {
             let diagnostic: Box<dyn Source<Item = f32> + Send> = if let Some(samples) =
                 self.playback_samples.as_ref().cloned()
             {
-                let playback_span = PlaybackSpanHandle::from_plan(&plan);
+                let playback_span = PlaybackSpanHandle::from_plan_with_metronome(&plan, metronome);
                 let source = SpanSamplesSource::new(
                     channels,
                     sample_rate,
@@ -401,7 +401,8 @@ impl AudioPlayer {
         } else {
             let source: Box<dyn Source<Item = f32> + Send> =
                 if let Some(samples) = self.playback_samples.as_ref().cloned() {
-                    let playback_span = PlaybackSpanHandle::from_plan(&plan);
+                    let playback_span =
+                        PlaybackSpanHandle::from_plan_with_metronome(&plan, metronome);
                     let source = SpanSamplesSource::new(
                         channels,
                         sample_rate,
@@ -436,7 +437,8 @@ impl AudioPlayer {
                 EditFadeSource::new(source, self.edit_fade_handle.clone(), plan.start_seconds());
             Box::new(editable)
         };
-        let final_source = source_with_metronome(final_source, metronome, &plan);
+        let final_source =
+            source_with_metronome(final_source, metronome, &plan, active_playback_span.clone());
         log_playback_stage(
             "source_construction",
             source_started_at,
@@ -517,7 +519,7 @@ impl AudioPlayer {
         let diagnostic: Box<dyn Source<Item = f32> + Send> = if let Some(samples) =
             self.playback_samples.as_ref().cloned()
         {
-            let playback_span = PlaybackSpanHandle::from_plan(&plan);
+            let playback_span = PlaybackSpanHandle::from_plan_with_metronome(&plan, metronome);
             let source = SpanSamplesSource::new(
                 channels,
                 sample_rate,
@@ -560,7 +562,8 @@ impl AudioPlayer {
                 plan.sample_count(),
             ))
         };
-        let diagnostic = source_with_metronome(diagnostic, metronome, &plan);
+        let diagnostic =
+            source_with_metronome(diagnostic, metronome, &plan, active_playback_span.clone());
         log_playback_stage("source_construction", source_started_at, source_kind, true);
 
         let (handle, format) = self.build_sink_with_fade(diagnostic, replace_policy)?;
@@ -650,15 +653,17 @@ fn source_with_metronome(
     source: Box<dyn Source<Item = f32> + Send>,
     metronome: Option<PlaybackMetronomeConfig>,
     plan: &PlaybackSpanPlan,
+    live_control: Option<PlaybackSpanHandle>,
 ) -> Box<dyn Source<Item = f32> + Send> {
-    match metronome {
-        Some(config) => Box::new(MetronomeSource::new(
+    match (live_control, metronome) {
+        (Some(control), _) => Box::new(MetronomeSource::new_live(source, control)),
+        (None, Some(config)) => Box::new(MetronomeSource::new(
             source,
             config,
             plan.frame_count(),
             plan.seek_offset_frames(),
         )),
-        None => source,
+        (None, None) => source,
     }
 }
 

--- a/crates/reson/src/player/playback/span_samples.rs
+++ b/crates/reson/src/player/playback/span_samples.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use crate::Source;
 
-use super::super::PlaybackSpanHandle;
+use super::super::{PlaybackSpanHandle, playback_span_handle::PlaybackSpanSnapshot};
 use super::span_edge_fade::{span_edge_fade_frames, span_edge_fade_gain};
 
 pub(super) struct SpanSamplesSource {
@@ -10,6 +10,7 @@ pub(super) struct SpanSamplesSource {
     channels: u16,
     sample_rate: u32,
     playback_span: PlaybackSpanHandle,
+    active_span: PlaybackSpanSnapshot,
     mode: SpanSamplesMode,
     position_sample: u64,
     fade_frames: u64,
@@ -30,11 +31,13 @@ impl SpanSamplesSource {
         mode: SpanSamplesMode,
         position_sample: usize,
     ) -> Self {
+        let active_span = playback_span.initial_snapshot();
         Self {
             samples,
             channels: channels.max(1),
             sample_rate: sample_rate.max(1),
             playback_span,
+            active_span,
             mode,
             position_sample: position_sample as u64,
             fade_frames: 0,
@@ -46,25 +49,42 @@ impl SpanSamplesSource {
         self
     }
 
-    fn align_position_to_span(&mut self) -> bool {
-        if let Some(seek_frame) = self.playback_span.take_pending_seek_frame() {
-            self.seek_to_frame(seek_frame);
+    fn prepare_frame(&mut self) -> bool {
+        if !self
+            .position_sample
+            .is_multiple_of(u64::from(self.channels))
+        {
             return true;
         }
+
+        let previous_generation = self.active_span.generation();
+        self.active_span = self.playback_span.latest_snapshot(self.active_span);
+        let updated = self.active_span.generation() != previous_generation;
+        let mut discontinuity = false;
+        if updated && let Some(seek_frame) = self.active_span.pending_seek_frame() {
+            self.seek_to_frame(seek_frame);
+            discontinuity = true;
+        }
         let frame = self.current_frame();
-        let snapshot = self.playback_span.snapshot();
-        match self.mode {
-            SpanSamplesMode::Looped if !snapshot.contains(frame) => {
-                self.seek_to_frame(snapshot.start_frame());
+        let can_continue = match self.mode {
+            SpanSamplesMode::Looped if !self.active_span.contains(frame) => {
+                self.seek_to_frame(self.active_span.start_frame());
+                discontinuity = true;
                 true
             }
             SpanSamplesMode::Looped => true,
-            SpanSamplesMode::OneShot if frame < snapshot.start_frame() => {
-                self.seek_to_frame(snapshot.start_frame());
+            SpanSamplesMode::OneShot if frame < self.active_span.start_frame() => {
+                self.seek_to_frame(self.active_span.start_frame());
+                discontinuity = true;
                 true
             }
-            SpanSamplesMode::OneShot => frame < snapshot.end_frame(),
+            SpanSamplesMode::OneShot => frame < self.active_span.end_frame(),
+        };
+        if can_continue && (updated || discontinuity) {
+            self.playback_span
+                .publish_applied_metronome(self.active_span, self.current_frame());
         }
+        can_continue
     }
 
     fn current_frame(&self) -> u64 {
@@ -81,13 +101,13 @@ impl SpanSamplesSource {
     }
 
     fn edge_gain(&self, frame: u64) -> f32 {
-        let snapshot = self.playback_span.snapshot();
-        let frame_count = snapshot
+        let frame_count = self
+            .active_span
             .end_frame()
-            .saturating_sub(snapshot.start_frame())
+            .saturating_sub(self.active_span.start_frame())
             .max(1);
         let offset = frame
-            .saturating_sub(snapshot.start_frame())
+            .saturating_sub(self.active_span.start_frame())
             .min(frame_count - 1);
         span_edge_fade_gain(offset, frame_count, self.fade_frames)
     }
@@ -101,7 +121,7 @@ impl Iterator for SpanSamplesSource {
             return None;
         }
 
-        if !self.align_position_to_span() {
+        if !self.prepare_frame() {
             return None;
         }
         let frame = self.current_frame();
@@ -112,8 +132,10 @@ impl Iterator for SpanSamplesSource {
                 if self.mode == SpanSamplesMode::OneShot {
                     return None;
                 }
-                let start_frame = self.playback_span.snapshot().start_frame();
+                let start_frame = self.active_span.start_frame();
                 self.seek_to_frame(start_frame);
+                self.playback_span
+                    .publish_applied_metronome(self.active_span, start_frame);
                 self.sample_index()?
             }
         };
@@ -145,8 +167,8 @@ impl Source for SpanSamplesSource {
 mod tests {
     use super::*;
     use crate::player::{
-        PlaybackChannelLayout, PlaybackSeekBehavior, PlaybackSourceIdentity, PlaybackSourceKind,
-        PlaybackSpanPlan, PlaybackSpanRequest,
+        PlaybackChannelLayout, PlaybackMetronomeConfig, PlaybackSeekBehavior,
+        PlaybackSourceIdentity, PlaybackSourceKind, PlaybackSpanPlan, PlaybackSpanRequest,
     };
 
     #[test]
@@ -164,7 +186,7 @@ mod tests {
 
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(2.0));
-        handle.update_from_plan(&span_plan(1, 5, 1), None);
+        handle.update_from_plan(&span_plan(1, 5, 1), None, None);
 
         assert_eq!(source.next(), Some(3.0));
         assert_eq!(source.next(), Some(4.0));
@@ -184,7 +206,7 @@ mod tests {
             4,
         );
 
-        handle.update_from_plan(&span_plan(1, 3, 0), Some(1));
+        handle.update_from_plan(&span_plan(1, 3, 0), Some(1), None);
 
         assert_eq!(source.next(), Some(1.0));
     }
@@ -202,7 +224,7 @@ mod tests {
             2,
         );
 
-        handle.update_from_plan(&span_plan(1, 4, 1), None);
+        handle.update_from_plan(&span_plan(1, 4, 1), None, None);
 
         assert_eq!(source.next(), Some(2.0));
         assert_eq!(source.next(), Some(3.0));
@@ -224,7 +246,7 @@ mod tests {
 
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(2.0));
-        handle.update_from_plan(&span_plan(1, 5, 1), None);
+        handle.update_from_plan(&span_plan(1, 5, 1), None, None);
 
         assert_eq!(source.next(), Some(3.0));
         assert_eq!(source.next(), Some(4.0));
@@ -244,7 +266,7 @@ mod tests {
             2,
         );
 
-        handle.update_from_plan(&span_plan(1, 4, 1), None);
+        handle.update_from_plan(&span_plan(1, 4, 1), None, None);
 
         assert_eq!(source.next(), Some(2.0));
         assert_eq!(source.next(), Some(3.0));
@@ -264,7 +286,7 @@ mod tests {
             4,
         );
 
-        handle.update_from_plan(&span_plan(1, 3, 0), Some(1));
+        handle.update_from_plan(&span_plan(1, 3, 0), Some(1), None);
 
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(2.0));
@@ -300,13 +322,154 @@ mod tests {
 
         assert_eq!(source.next(), Some(0.0));
         assert_eq!(source.next(), Some(1.0));
-        handle.update_from_plan(&span_plan(0, 6, 1), None);
+        handle.update_from_plan(&span_plan(0, 6, 1), None, None);
 
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(1.0));
         assert_eq!(source.next(), Some(0.0));
         assert_eq!(source.next(), Some(0.0));
+    }
+
+    #[test]
+    fn rapid_live_updates_apply_only_complete_latest_spans() {
+        let samples = Arc::<[f32]>::from(vec![10.0, 11.0, -1.0, -1.0, 20.0, 21.0]);
+        let handle = PlaybackSpanHandle::from_plan(&span_plan(0, 2, 0));
+        let mut source = SpanSamplesSource::new(
+            1,
+            1_000,
+            samples,
+            handle.clone(),
+            SpanSamplesMode::Looped,
+            0,
+        );
+
+        for update in 0..10_000 {
+            let (start, expected) = if update % 2 == 0 {
+                (4, 20.0)
+            } else {
+                (0, 10.0)
+            };
+            handle.update_from_plan(
+                &span_plan(start, start + 2, 0),
+                Some(start),
+                Some(
+                    PlaybackMetronomeConfig::new((update % 8 + 1) as u16)
+                        .with_cycle((update + 2) as u64, update as u64),
+                ),
+            );
+            assert_eq!(source.next(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn live_metronome_phase_tracks_the_audible_frame_without_a_seek() {
+        let samples = Arc::<[f32]>::from(vec![0.0; 1_000]);
+        let initial_plan = span_plan(0, 1_000, 100);
+        let handle = PlaybackSpanHandle::from_plan_with_metronome(
+            &initial_plan,
+            Some(PlaybackMetronomeConfig::new(4).with_cycle(1_000, 100)),
+        );
+        let mut source = SpanSamplesSource::new(
+            1,
+            1_000,
+            samples,
+            handle.clone(),
+            SpanSamplesMode::Looped,
+            100,
+        );
+        assert_eq!(source.next(), Some(0.0));
+
+        handle.update_from_plan(
+            &span_plan(0, 1_000, 50),
+            None,
+            Some(PlaybackMetronomeConfig::new(3).with_cycle(800, 50)),
+        );
+        assert_eq!(source.next(), Some(0.0));
+
+        let applied = handle.applied_metronome();
+        assert!(applied.enabled());
+        assert_eq!(applied.beat_count(), 3);
+        assert_eq!(applied.cycle_frames(), 800);
+        assert_eq!(applied.phase_frames(), 101);
+    }
+
+    #[test]
+    fn live_metronome_phase_resets_on_explicit_seek_and_can_be_disabled() {
+        use crate::player::metronome::MetronomeSource;
+
+        let samples = Arc::<[f32]>::from(vec![0.0; 1_000]);
+        let initial_plan = span_plan(0, 1_000, 125);
+        let handle = PlaybackSpanHandle::from_plan_with_metronome(
+            &initial_plan,
+            Some(PlaybackMetronomeConfig::new(4).with_cycle(1_000, 125)),
+        );
+        let source = SpanSamplesSource::new(
+            1,
+            1_000,
+            samples,
+            handle.clone(),
+            SpanSamplesMode::Looped,
+            125,
+        );
+        let mut metronome = MetronomeSource::new_live(source, handle.clone());
+        assert!((0.11..0.15).contains(&metronome.next().expect("initial offbeat")));
+
+        handle.update_from_plan(
+            &span_plan(0, 1_000, 0),
+            Some(0),
+            Some(PlaybackMetronomeConfig::new(4).with_cycle(1_000, 0)),
+        );
+        assert!(metronome.next().expect("retargeted downbeat") > 0.20);
+
+        handle.update_from_plan(&span_plan(0, 1_000, 0), Some(0), None);
+        assert_eq!(metronome.next(), Some(0.0));
+    }
+
+    #[test]
+    fn disabled_live_metronome_preserves_unclamped_dry_samples() {
+        use crate::player::metronome::MetronomeSource;
+
+        let samples = Arc::<[f32]>::from(vec![1.5]);
+        let plan = span_plan(0, 1, 0);
+        let handle = PlaybackSpanHandle::from_plan_with_metronome(&plan, None);
+        let source = SpanSamplesSource::new(
+            1,
+            1_000,
+            samples,
+            handle.clone(),
+            SpanSamplesMode::Looped,
+            0,
+        );
+        let mut metronome = MetronomeSource::new_live(source, handle);
+
+        assert_eq!(metronome.next(), Some(1.5));
+    }
+
+    #[test]
+    fn loop_wrap_reanchors_live_metronome_phase_to_the_audible_start() {
+        let samples = Arc::<[f32]>::from(vec![0.0; 4]);
+        let plan = span_plan(1, 3, 0);
+        let handle = PlaybackSpanHandle::from_plan_with_metronome(
+            &plan,
+            Some(PlaybackMetronomeConfig::new(2).with_cycle(4, 1)),
+        );
+        let mut source = SpanSamplesSource::new(
+            1,
+            1_000,
+            samples,
+            handle.clone(),
+            SpanSamplesMode::Looped,
+            2,
+        );
+        assert_eq!(source.next(), Some(0.0));
+        let before_wrap = handle.applied_metronome().revision();
+
+        assert_eq!(source.next(), Some(0.0));
+
+        let applied = handle.applied_metronome();
+        assert!(applied.revision() > before_wrap);
+        assert_eq!(applied.phase_frames(), 1);
     }
 
     fn span_plan(start_frame: u64, end_frame: u64, offset_frame: u64) -> PlaybackSpanPlan {

--- a/crates/reson/src/player/playback_span_handle.rs
+++ b/crates/reson/src/player/playback_span_handle.rs
@@ -1,6 +1,11 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
-use super::PlaybackSpanPlan;
+use super::{PlaybackMetronomeConfig, PlaybackSpanPlan};
+
+const NO_PENDING_SEEK: u64 = u64::MAX;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PlaybackSpanHandle {
@@ -9,74 +14,308 @@ pub(crate) struct PlaybackSpanHandle {
 
 #[derive(Debug)]
 struct PlaybackSpanShared {
-    state: RwLock<PlaybackSpanState>,
+    pending: PlaybackControlMailbox,
+    applied_metronome: AppliedMetronomeSlot,
 }
 
-#[derive(Clone, Copy, Debug)]
-struct PlaybackSpanState {
-    start_frame: u64,
-    end_frame: u64,
-    pending_seek_frame: Option<u64>,
+/// Single-writer, single-audio-reader control mailbox.
+///
+/// The writer fills the inactive slot before one release-store publishes its
+/// generation. The audio reader makes one bounded attempt per frame and keeps
+/// its last coherent snapshot if publication changes during that attempt. It
+/// never waits for the writer, and the writer never touches the published slot.
+#[derive(Debug)]
+struct PlaybackControlMailbox {
+    published: AtomicU64,
+    slots: [PlaybackControlSlot; 2],
+}
+
+#[derive(Debug)]
+struct PlaybackControlSlot {
+    start_frame: AtomicU64,
+    end_frame: AtomicU64,
+    pending_seek_frame: AtomicU64,
+    metronome_enabled: AtomicU64,
+    metronome_beat_count: AtomicU64,
+    metronome_cycle_frames: AtomicU64,
+    metronome_anchor_frame: AtomicU64,
+    metronome_anchor_phase_frames: AtomicU64,
+}
+
+#[derive(Debug)]
+struct AppliedMetronomeSlot {
+    revision: AtomicU64,
+    enabled: AtomicU64,
+    beat_count: AtomicU64,
+    cycle_frames: AtomicU64,
+    phase_frames: AtomicU64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PlaybackSpanSnapshot {
+    generation: u64,
     start_frame: u64,
     end_frame: u64,
+    pending_seek_frame: Option<u64>,
+    metronome: PlaybackMetronomeSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PlaybackMetronomeSnapshot {
+    enabled: bool,
+    beat_count: u16,
+    cycle_frames: u64,
+    anchor_frame: u64,
+    anchor_phase_frames: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct AppliedMetronomeSnapshot {
+    revision: u64,
+    enabled: bool,
+    beat_count: u16,
+    cycle_frames: u64,
+    phase_frames: u64,
 }
 
 impl PlaybackSpanHandle {
+    #[cfg(test)]
     pub(crate) fn from_plan(plan: &PlaybackSpanPlan) -> Self {
-        let start_frame = plan.start_frame();
-        let end_frame = plan.end_frame().max(start_frame.saturating_add(1));
+        Self::from_plan_with_metronome(plan, None)
+    }
+
+    pub(crate) fn from_plan_with_metronome(
+        plan: &PlaybackSpanPlan,
+        metronome: Option<PlaybackMetronomeConfig>,
+    ) -> Self {
+        let initial = PlaybackSpanSnapshot::from_plan(1, plan, None, metronome);
+        let initial_metronome =
+            initial.metronome_at(plan.start_frame().saturating_add(plan.seek_offset_frames()));
         Self {
             shared: Arc::new(PlaybackSpanShared {
-                state: RwLock::new(PlaybackSpanState {
-                    start_frame,
-                    end_frame,
-                    pending_seek_frame: None,
-                }),
+                pending: PlaybackControlMailbox::new(initial),
+                applied_metronome: AppliedMetronomeSlot::new(initial_metronome),
             }),
         }
     }
 
-    pub(crate) fn update_from_plan(&self, plan: &PlaybackSpanPlan, seek_frame: Option<u64>) {
-        let start_frame = plan.start_frame();
-        let end_frame = plan.end_frame().max(start_frame.saturating_add(1));
-        let pending_seek_frame =
-            seek_frame.map(|frame| clamp_frame_to_span(frame, start_frame, end_frame));
-        if let Ok(mut state) = self.shared.state.write() {
-            *state = PlaybackSpanState {
-                start_frame,
-                end_frame,
-                pending_seek_frame,
-            };
+    pub(crate) fn update_from_plan(
+        &self,
+        plan: &PlaybackSpanPlan,
+        seek_frame: Option<u64>,
+        metronome: Option<PlaybackMetronomeConfig>,
+    ) {
+        self.shared.pending.publish(plan, seek_frame, metronome);
+    }
+
+    pub(crate) fn initial_snapshot(&self) -> PlaybackSpanSnapshot {
+        self.shared
+            .pending
+            .try_snapshot()
+            .expect("initial playback control transaction must be complete")
+    }
+
+    pub(crate) fn latest_snapshot(&self, fallback: PlaybackSpanSnapshot) -> PlaybackSpanSnapshot {
+        self.shared.pending.try_snapshot().unwrap_or(fallback)
+    }
+
+    pub(crate) fn publish_applied_metronome(
+        &self,
+        snapshot: PlaybackSpanSnapshot,
+        audible_frame: u64,
+    ) {
+        self.shared
+            .applied_metronome
+            .publish(snapshot.metronome_at(audible_frame));
+    }
+
+    pub(crate) fn applied_metronome(&self) -> AppliedMetronomeSnapshot {
+        self.shared.applied_metronome.snapshot()
+    }
+
+    pub(crate) fn applied_metronome_revision(&self) -> u64 {
+        self.shared.applied_metronome.revision()
+    }
+}
+
+impl PlaybackControlMailbox {
+    fn new(snapshot: PlaybackSpanSnapshot) -> Self {
+        Self {
+            published: AtomicU64::new(snapshot.generation.saturating_mul(2)),
+            slots: [
+                PlaybackControlSlot::new(snapshot),
+                PlaybackControlSlot::new(snapshot),
+            ],
         }
     }
 
-    pub(crate) fn snapshot(&self) -> PlaybackSpanSnapshot {
-        let state = self
-            .shared
-            .state
-            .read()
-            .unwrap_or_else(|err| err.into_inner());
+    fn publish(
+        &self,
+        plan: &PlaybackSpanPlan,
+        seek_frame: Option<u64>,
+        metronome: Option<PlaybackMetronomeConfig>,
+    ) {
+        let current = self.published.load(Ordering::Relaxed);
+        let generation = (current >> 1).wrapping_add(1);
+        let slot_index = ((current & 1) ^ 1) as usize;
+        let snapshot = PlaybackSpanSnapshot::from_plan(generation, plan, seek_frame, metronome);
+
+        self.slots[slot_index].store(snapshot);
+        self.published.store(
+            generation.wrapping_mul(2) | slot_index as u64,
+            Ordering::Release,
+        );
+    }
+
+    fn try_snapshot(&self) -> Option<PlaybackSpanSnapshot> {
+        let before = self.published.load(Ordering::Acquire);
+        let slot_index = (before & 1) as usize;
+        let snapshot = self.slots[slot_index].snapshot(before >> 1);
+        let after = self.published.load(Ordering::Acquire);
+        (before == after).then_some(snapshot)
+    }
+}
+
+impl PlaybackControlSlot {
+    fn new(snapshot: PlaybackSpanSnapshot) -> Self {
+        Self {
+            start_frame: AtomicU64::new(snapshot.start_frame),
+            end_frame: AtomicU64::new(snapshot.end_frame),
+            pending_seek_frame: AtomicU64::new(encode_optional_frame(snapshot.pending_seek_frame)),
+            metronome_enabled: AtomicU64::new(u64::from(snapshot.metronome.enabled)),
+            metronome_beat_count: AtomicU64::new(u64::from(snapshot.metronome.beat_count)),
+            metronome_cycle_frames: AtomicU64::new(snapshot.metronome.cycle_frames),
+            metronome_anchor_frame: AtomicU64::new(snapshot.metronome.anchor_frame),
+            metronome_anchor_phase_frames: AtomicU64::new(snapshot.metronome.anchor_phase_frames),
+        }
+    }
+
+    fn store(&self, snapshot: PlaybackSpanSnapshot) {
+        self.start_frame
+            .store(snapshot.start_frame, Ordering::Relaxed);
+        self.end_frame.store(snapshot.end_frame, Ordering::Relaxed);
+        self.pending_seek_frame.store(
+            encode_optional_frame(snapshot.pending_seek_frame),
+            Ordering::Relaxed,
+        );
+        self.metronome_enabled
+            .store(u64::from(snapshot.metronome.enabled), Ordering::Relaxed);
+        self.metronome_beat_count
+            .store(u64::from(snapshot.metronome.beat_count), Ordering::Relaxed);
+        self.metronome_cycle_frames
+            .store(snapshot.metronome.cycle_frames, Ordering::Relaxed);
+        self.metronome_anchor_frame
+            .store(snapshot.metronome.anchor_frame, Ordering::Relaxed);
+        self.metronome_anchor_phase_frames
+            .store(snapshot.metronome.anchor_phase_frames, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self, generation: u64) -> PlaybackSpanSnapshot {
         PlaybackSpanSnapshot {
-            start_frame: state.start_frame,
-            end_frame: state.end_frame,
+            generation,
+            start_frame: self.start_frame.load(Ordering::Relaxed),
+            end_frame: self.end_frame.load(Ordering::Relaxed),
+            pending_seek_frame: decode_optional_frame(
+                self.pending_seek_frame.load(Ordering::Relaxed),
+            ),
+            metronome: PlaybackMetronomeSnapshot {
+                enabled: self.metronome_enabled.load(Ordering::Relaxed) != 0,
+                beat_count: self.metronome_beat_count.load(Ordering::Relaxed) as u16,
+                cycle_frames: self.metronome_cycle_frames.load(Ordering::Relaxed),
+                anchor_frame: self.metronome_anchor_frame.load(Ordering::Relaxed),
+                anchor_phase_frames: self.metronome_anchor_phase_frames.load(Ordering::Relaxed),
+            },
+        }
+    }
+}
+
+impl AppliedMetronomeSlot {
+    fn new(snapshot: PlaybackMetronomeSnapshot) -> Self {
+        Self {
+            revision: AtomicU64::new(1),
+            enabled: AtomicU64::new(u64::from(snapshot.enabled)),
+            beat_count: AtomicU64::new(u64::from(snapshot.beat_count)),
+            cycle_frames: AtomicU64::new(snapshot.cycle_frames),
+            phase_frames: AtomicU64::new(snapshot.anchor_phase_frames),
         }
     }
 
-    pub(crate) fn take_pending_seek_frame(&self) -> Option<u64> {
-        let mut state = self
-            .shared
-            .state
-            .write()
-            .unwrap_or_else(|err| err.into_inner());
-        state.pending_seek_frame.take()
+    fn publish(&self, snapshot: PlaybackMetronomeSnapshot) {
+        self.enabled
+            .store(u64::from(snapshot.enabled), Ordering::Relaxed);
+        self.beat_count
+            .store(u64::from(snapshot.beat_count), Ordering::Relaxed);
+        self.cycle_frames
+            .store(snapshot.cycle_frames, Ordering::Relaxed);
+        self.phase_frames
+            .store(snapshot.anchor_phase_frames, Ordering::Relaxed);
+        self.revision.fetch_add(1, Ordering::Release);
+    }
+
+    fn snapshot(&self) -> AppliedMetronomeSnapshot {
+        let revision = self.revision.load(Ordering::Acquire);
+        AppliedMetronomeSnapshot {
+            revision,
+            enabled: self.enabled.load(Ordering::Relaxed) != 0,
+            beat_count: self.beat_count.load(Ordering::Relaxed) as u16,
+            cycle_frames: self.cycle_frames.load(Ordering::Relaxed),
+            phase_frames: self.phase_frames.load(Ordering::Relaxed),
+        }
+    }
+
+    fn revision(&self) -> u64 {
+        self.revision.load(Ordering::Acquire)
     }
 }
 
 impl PlaybackSpanSnapshot {
+    fn from_plan(
+        generation: u64,
+        plan: &PlaybackSpanPlan,
+        seek_frame: Option<u64>,
+        metronome: Option<PlaybackMetronomeConfig>,
+    ) -> Self {
+        let start_frame = plan.start_frame();
+        let end_frame = plan.end_frame().max(start_frame.saturating_add(1));
+        let pending_seek_frame =
+            seek_frame.map(|frame| clamp_frame_to_span(frame, start_frame, end_frame));
+        let anchor_frame = clamp_frame_to_span(
+            start_frame.saturating_add(plan.seek_offset_frames()),
+            start_frame,
+            end_frame,
+        );
+        let (enabled, beat_count, cycle_frames, anchor_phase_frames) = match metronome {
+            Some(config) => {
+                let (cycle_frames, phase_frames) =
+                    config.cycle(plan.frame_count(), plan.seek_offset_frames());
+                (
+                    true,
+                    config.beat_count(),
+                    cycle_frames.max(1),
+                    phase_frames % cycle_frames.max(1),
+                )
+            }
+            None => (false, 1, plan.frame_count().max(1), 0),
+        };
+        Self {
+            generation,
+            start_frame,
+            end_frame,
+            pending_seek_frame,
+            metronome: PlaybackMetronomeSnapshot {
+                enabled,
+                beat_count,
+                cycle_frames,
+                anchor_frame,
+                anchor_phase_frames,
+            },
+        }
+    }
+
+    pub(crate) fn generation(self) -> u64 {
+        self.generation
+    }
+
     pub(crate) fn start_frame(self) -> u64 {
         self.start_frame
     }
@@ -85,13 +324,98 @@ impl PlaybackSpanSnapshot {
         self.end_frame
     }
 
+    pub(crate) fn pending_seek_frame(self) -> Option<u64> {
+        self.pending_seek_frame
+    }
+
     pub(crate) fn contains(self, frame: u64) -> bool {
         (self.start_frame..self.end_frame).contains(&frame)
     }
+
+    fn metronome_at(self, audible_frame: u64) -> PlaybackMetronomeSnapshot {
+        let mut metronome = self.metronome;
+        metronome.anchor_phase_frames = metronome.phase_at(audible_frame);
+        metronome.anchor_frame = audible_frame;
+        metronome
+    }
+}
+
+impl PlaybackMetronomeSnapshot {
+    fn phase_at(self, frame: u64) -> u64 {
+        let cycle_frames = self.cycle_frames.max(1);
+        if frame >= self.anchor_frame {
+            return add_modulo(
+                self.anchor_phase_frames,
+                frame.saturating_sub(self.anchor_frame),
+                cycle_frames,
+            );
+        }
+        subtract_modulo(
+            self.anchor_phase_frames,
+            self.anchor_frame.saturating_sub(frame),
+            cycle_frames,
+        )
+    }
+}
+
+impl AppliedMetronomeSnapshot {
+    pub(crate) fn revision(self) -> u64 {
+        self.revision
+    }
+
+    pub(crate) fn enabled(self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn beat_count(self) -> u16 {
+        self.beat_count
+    }
+
+    pub(crate) fn cycle_frames(self) -> u64 {
+        self.cycle_frames
+    }
+
+    pub(crate) fn phase_frames(self) -> u64 {
+        self.phase_frames
+    }
+}
+
+fn encode_optional_frame(frame: Option<u64>) -> u64 {
+    frame.unwrap_or(NO_PENDING_SEEK)
+}
+
+fn decode_optional_frame(frame: u64) -> Option<u64> {
+    (frame != NO_PENDING_SEEK).then_some(frame)
 }
 
 fn clamp_frame_to_span(frame: u64, start_frame: u64, end_frame: u64) -> u64 {
     frame.clamp(start_frame, end_frame.saturating_sub(1))
+}
+
+fn add_modulo(value: u64, increment: u64, modulus: u64) -> u64 {
+    let modulus = modulus.max(1);
+    let value = value % modulus;
+    let increment = increment % modulus;
+    if increment == 0 {
+        return value;
+    }
+    let distance_to_wrap = modulus - increment;
+    if value >= distance_to_wrap {
+        value - distance_to_wrap
+    } else {
+        value + increment
+    }
+}
+
+fn subtract_modulo(value: u64, decrement: u64, modulus: u64) -> u64 {
+    let modulus = modulus.max(1);
+    let value = value % modulus;
+    let decrement = decrement % modulus;
+    if value >= decrement {
+        value - decrement
+    } else {
+        modulus - (decrement - value)
+    }
 }
 
 #[cfg(test)]
@@ -103,23 +427,107 @@ mod tests {
     };
 
     #[test]
-    fn pending_seek_is_clamped_to_updated_span() {
+    fn pending_seek_is_clamped_inside_one_coherent_update() {
         let handle = PlaybackSpanHandle::from_plan(&span_plan(0, 10, 0));
+        let initial = handle.initial_snapshot();
 
-        handle.update_from_plan(&span_plan(20, 40, 0), Some(90));
+        handle.update_from_plan(&span_plan(20, 40, 0), Some(90), None);
 
-        assert_eq!(handle.take_pending_seek_frame(), Some(39));
-        assert_eq!(handle.take_pending_seek_frame(), None);
+        let updated = handle.latest_snapshot(initial);
+        assert_eq!(updated.start_frame(), 20);
+        assert_eq!(updated.end_frame(), 40);
+        assert_eq!(updated.pending_seek_frame(), Some(39));
+    }
+
+    #[test]
+    fn rapid_updates_converge_on_the_latest_complete_transaction() {
+        let handle = PlaybackSpanHandle::from_plan(&span_plan(0, 10, 0));
+        let mut snapshot = handle.initial_snapshot();
+
+        for index in 1..=10_000_u64 {
+            let start = index * 10;
+            let metronome =
+                PlaybackMetronomeConfig::new((index % 16 + 1) as u16).with_cycle(index + 1, index);
+            handle.update_from_plan(
+                &span_plan(start, start + 10, index % 10),
+                Some(start + 5),
+                Some(metronome),
+            );
+            snapshot = handle.latest_snapshot(snapshot);
+        }
+
+        assert_eq!(snapshot.start_frame(), 100_000);
+        assert_eq!(snapshot.end_frame(), 100_010);
+        assert_eq!(snapshot.pending_seek_frame(), Some(100_005));
+        assert_eq!(snapshot.metronome.beat_count, 1);
+        assert_eq!(snapshot.metronome.cycle_frames, 10_001);
+        assert_eq!(snapshot.metronome.anchor_phase_frames, 10_000);
+    }
+
+    #[test]
+    fn an_in_progress_inactive_slot_write_does_not_disturb_audio_reads() {
+        let handle = PlaybackSpanHandle::from_plan(&span_plan(0, 10, 0));
+        let fallback = handle.initial_snapshot();
+        let published = handle.shared.pending.published.load(Ordering::Relaxed);
+        let inactive_slot = ((published & 1) ^ 1) as usize;
+        let staged = PlaybackSpanSnapshot::from_plan(
+            (published >> 1) + 1,
+            &span_plan(20, 40, 0),
+            Some(30),
+            Some(PlaybackMetronomeConfig::new(7).with_cycle(20, 10)),
+        );
+        handle.shared.pending.slots[inactive_slot].store(staged);
+
+        assert_eq!(handle.latest_snapshot(fallback), fallback);
+    }
+
+    #[test]
+    fn metronome_phase_math_handles_the_full_u64_range() {
+        let metronome = PlaybackMetronomeSnapshot {
+            enabled: true,
+            beat_count: 4,
+            cycle_frames: u64::MAX,
+            anchor_frame: 1,
+            anchor_phase_frames: u64::MAX - 1,
+        };
+
+        assert_eq!(metronome.phase_at(2), 0);
+        assert_eq!(metronome.phase_at(0), u64::MAX - 2);
+    }
+
+    #[test]
+    fn live_control_audio_path_has_no_blocking_synchronization_tokens() {
+        let sources = [
+            include_str!("playback_span_handle.rs"),
+            include_str!("playback/span_samples.rs"),
+            include_str!("metronome.rs"),
+        ];
+        let blocking_tokens = [
+            concat!("Rw", "Lock"),
+            concat!("Mu", "tex"),
+            concat!("Cond", "var"),
+            concat!(".lo", "ck("),
+            concat!(".re", "ad("),
+            concat!(".wr", "ite("),
+        ];
+
+        for token in blocking_tokens {
+            assert!(
+                sources.iter().all(|source| !source.contains(token)),
+                "live playback control path must not contain blocking token {token}"
+            );
+        }
     }
 
     fn span_plan(start_frame: u64, end_frame: u64, offset_frame: u64) -> PlaybackSpanPlan {
+        let duration = end_frame.max(1) as f32 / 1_000.0;
         PlaybackSpanPlan::new(
             PlaybackSourceIdentity::new(PlaybackSourceKind::Bytes, None),
             PlaybackChannelLayout::new(1, 1_000).expect("layout"),
             PlaybackSpanRequest::new(
                 start_frame as f32 / 1_000.0,
                 end_frame as f32 / 1_000.0,
-                1.0,
+                duration,
                 true,
                 PlaybackSeekBehavior::FrameOffset(offset_frame),
             ),

--- a/crates/reson/src/player/runtime.rs
+++ b/crates/reson/src/player/runtime.rs
@@ -589,6 +589,7 @@ fn run_playback_runtime(
     events: mpsc::Sender<PlaybackRuntimeEvent>,
 ) {
     let mut pending = VecDeque::new();
+    let mut latest_span_retarget_id = None;
     while let Some(command) = next_runtime_command(&commands, &mut pending) {
         match coalesce_command(command, &commands, &events, &mut pending) {
             CoalescedCommand::Play { id, request } => {
@@ -611,6 +612,10 @@ fn run_playback_runtime(
             }
             CoalescedCommand::CancelPendingPlayback => {}
             CoalescedCommand::RetargetSpan { id, update } => {
+                if latest_span_retarget_id.is_some_and(|latest| id <= latest) {
+                    continue;
+                }
+                latest_span_retarget_id = Some(id);
                 let event = match executor.retarget_span(update) {
                     Ok(_) => PlaybackRuntimeEvent::Progress {
                         id,
@@ -777,7 +782,12 @@ fn coalesce_span_retarget_command(
     loop {
         match pending.front() {
             Some(PlaybackRuntimeCommand::RetargetSpan { .. }) => {
-                current = pending.pop_front().expect("pending span retarget");
+                let next = pending.pop_front().expect("pending span retarget");
+                let current_id = span_retarget_id(&current).expect("current span retarget");
+                let next_id = span_retarget_id(&next).expect("next span retarget");
+                if next_id > current_id {
+                    current = next;
+                }
             }
             Some(PlaybackRuntimeCommand::Play { .. }) => {
                 return pending.pop_front().expect("pending play command");
@@ -799,6 +809,13 @@ fn coalesce_span_retarget_command(
             Some(PlaybackRuntimeCommand::SetVolume { .. }) | None => return current,
             Some(PlaybackRuntimeCommand::SetPlaybackGain { .. }) => return current,
         }
+    }
+}
+
+fn span_retarget_id(command: &PlaybackRuntimeCommand) -> Option<PlaybackRequestId> {
+    match command {
+        PlaybackRuntimeCommand::RetargetSpan { id, .. } => Some(*id),
+        _ => None,
     }
 }
 
@@ -1469,6 +1486,24 @@ mod tests {
     }
 
     #[test]
+    fn coalescing_span_retarget_ignores_a_late_stale_command() {
+        let latest_id = PlaybackRequestId(9);
+        let stale_id = PlaybackRequestId(8);
+        let (coalesced, pending, events) = coalesce_for_test(
+            retarget_command(latest_id, 0.2, 0.7),
+            vec![retarget_command(stale_id, 0.1, 0.5)],
+        );
+
+        assert!(matches!(
+            coalesced,
+            CoalescedCommand::RetargetSpan { id, update }
+                if id == latest_id && update.start == 0.2 && update.end == 0.7
+        ));
+        assert!(pending.is_empty());
+        assert!(events.is_empty());
+    }
+
+    #[test]
     fn playback_runtime_executes_span_retarget() {
         let executor = FakeExecutor::new(vec![]);
         let retargeted = executor.retargeted();
@@ -1487,6 +1522,49 @@ mod tests {
             } if event_id == id && progress.active
         ));
         assert_eq!(retargeted.lock().expect("retargeted").as_slice(), &[update]);
+    }
+
+    #[test]
+    fn playback_runtime_does_not_apply_an_out_of_order_stale_retarget() {
+        let executor = FakeExecutor::new(vec![]);
+        let retargeted = executor.retargeted();
+        let runtime =
+            spawn_executor(executor, PlaybackRuntimeConfig::default()).expect("spawn runtime");
+        let latest = span_update(0.3, 0.9, true);
+        let stale = span_update(0.1, 0.4, true);
+
+        runtime
+            .handle
+            .commands
+            .send(PlaybackRuntimeCommand::RetargetSpan {
+                id: PlaybackRequestId(9),
+                update: latest,
+            })
+            .expect("latest retarget");
+        assert!(matches!(
+            runtime.events.recv().expect("latest event"),
+            PlaybackRuntimeEvent::Progress {
+                id: PlaybackRequestId(9),
+                ..
+            }
+        ));
+        runtime
+            .handle
+            .commands
+            .send(PlaybackRuntimeCommand::RetargetSpan {
+                id: PlaybackRequestId(8),
+                update: stale,
+            })
+            .expect("stale retarget");
+
+        assert!(
+            runtime
+                .events
+                .recv_timeout(Duration::from_millis(50))
+                .is_err(),
+            "stale retarget should be discarded without producing a false progress event"
+        );
+        assert_eq!(retargeted.lock().expect("retargeted").as_slice(), &[latest]);
     }
 
     #[test]

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1620,6 +1620,14 @@ The audio engine should support:
 - clear error reporting for unsupported files, decode failures, device failures, metadata write failures, and playback failures
 - diagnostic events that make playback, decode, seek, loop, warp, render, and device bugs traceable
 
+Decoded-sample playback should keep ordinary live span edits on the existing
+source graph. Its control handoff must be non-blocking and allocation-free on
+the audio callback, and each published update must carry span bounds, explicit
+seek intent, and metronome beat/cycle/phase state as one coherent transaction.
+Rapid or out-of-order retarget commands must converge on the newest complete
+request without exposing torn state or forcing avoidable source fades and
+rebuilds.
+
 The audio engine should be designed with future extraction in mind. Wavecrate can drive its immediate requirements, but the core engine should avoid unnecessary dependency on Wavecrate-specific UI, metadata, tag, similarity, naming, or source-management concepts.
 
 The practical target is a clean internal boundary today that allows reusable audio-engine components to become their own standalone library later without rewriting the playback, editing, and extraction stack.

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -118,6 +118,8 @@ fn ramp_up_gain(offset: usize, fade_frames: usize) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -143,5 +145,86 @@ mod tests {
         assert_eq!(samples[10], samples[11]);
         assert_eq!(samples[0], 0.0);
         assert_eq!(samples[10], 0.0);
+    }
+
+    #[test]
+    fn playback_retarget_real_output_survives_rapid_span_and_metronome_updates() {
+        let Ok(player) = AudioPlayer::new() else {
+            return;
+        };
+        let runtime = PlaybackRuntime::spawn(player, PlaybackRuntimeConfig::default())
+            .expect("playback runtime");
+        let request = PlaybackRuntimeRequest {
+            source: PlaybackRuntimeSource::DecodedSamples {
+                audio_bytes: Arc::<[u8]>::from([]),
+                samples: Arc::<[f32]>::from(vec![0.0; 48_000]),
+                duration: 1.0,
+                sample_rate: 48_000,
+                channels: 1,
+            },
+            mode: PlaybackRuntimeMode::Looped {
+                start: 0.0,
+                end: 1.0,
+                offset: 0.0,
+            },
+            stream_policy: PlaybackRuntimeStreamPolicy::full(),
+            volume: 1.0,
+            playback_gain: 1.0,
+            playback_gain_normalization: None,
+            replace_policy: PlaybackRuntimeReplacePolicy::ClearPrevious,
+            edit_fade: None,
+            metronome: Some(PlaybackMetronomeConfig::new(4).with_cycle(48_000, 0)),
+        };
+        let started_id = runtime.handle.try_play(request).expect("start playback");
+        assert!(matches!(
+            runtime
+                .events
+                .recv_timeout(Duration::from_secs(2))
+                .expect("started event"),
+            PlaybackRuntimeEvent::Started(PlaybackRuntimeStarted { id, .. }) if id == started_id
+        ));
+
+        let mut latest_retarget_id = started_id;
+        for update in 0..128_u64 {
+            let start = (update % 20) as f64 / 100.0;
+            let end = (start + 0.5).min(1.0);
+            latest_retarget_id = runtime
+                .handle
+                .try_retarget_span(PlaybackRuntimeSpanUpdate {
+                    start,
+                    end,
+                    offset: start,
+                    seek_to_offset: update % 3 == 0,
+                    looped: true,
+                    playback_gain: 1.0,
+                    playback_gain_normalization: None,
+                    metronome: (update % 5 != 0).then(|| {
+                        PlaybackMetronomeConfig::new((update % 7 + 1) as u16)
+                            .with_cycle(24_000 + update, update * 17)
+                    }),
+                })
+                .expect("retarget playback");
+        }
+        let mut saw_latest_retarget = false;
+        while !saw_latest_retarget {
+            match runtime
+                .events
+                .recv_timeout(Duration::from_secs(2))
+                .expect("retarget event")
+            {
+                PlaybackRuntimeEvent::Progress { id, progress } if id == latest_retarget_id => {
+                    saw_latest_retarget = true;
+                    assert!(progress.looping);
+                    assert!(progress.error.is_none());
+                }
+                PlaybackRuntimeEvent::Progress { .. } => {}
+                other => panic!("unexpected playback runtime event: {other:?}"),
+            }
+        }
+        assert!(
+            saw_latest_retarget,
+            "rapid retargeting must converge on the newest complete request"
+        );
+        runtime.handle.try_shutdown().expect("shutdown runtime");
     }
 }


### PR DESCRIPTION
## Scope

- Replace the decoded-sample live span `RwLock` with a bounded double-buffered atomic mailbox consumed once per audio frame.
- Publish span bounds, explicit seek intent, metronome enablement, beat count, cycle, and phase as one coherent transaction.
- Re-anchor metronome phase on live configuration changes, explicit seeks, and loop wraps without rebuilding the source graph.
- Discard stale/out-of-order runtime retarget commands by monotonic request ID.
- Add deterministic stress, phase, wrap, seek, dry-path, stale-command, and real-output regression coverage.
- Document the durable live-retarget audio-engine contract in `docs/TARGET.md`.

## Definition of Done

- [x] No blocking synchronization remains in the decoded playback iterator/control path.
- [x] The audio path performs a bounded, allocation-free control read and keeps the last coherent snapshot during overlapping publication.
- [x] Span and metronome updates become audible as one transaction without rebuilding decoded playback.
- [x] Rapid updates converge on the newest complete configuration.
- [x] Explicit seek, loop wrap, one-shot behavior, edge fades, progress, and disabled-metronome dry samples remain covered.
- [x] Runtime ordering ignores late stale retarget commands.

## Validation commands

- `cargo clippy -p reson --all-targets -- -D warnings`
- `cargo test -p reson --all-targets -- --test-threads=1` — 162 passed
- `WAVECRATE_TEST_AUDIO_OUTPUT=1 cargo test -p wavecrate --lib playback_retarget -- --nocapture --test-threads=1` — passed against real output
- `git diff --check`

Broader baseline checks were also attempted:

- `bash scripts/ci.sh smoke` reaches `cargo check -p wavecrate --tests --bins` and fails on the existing unused `set_started_playback_progress` method in `src/native_app/app/state/audio/visual_progress.rs`.
- Wavecrate/Radiant all-warning clippy lanes reach existing unrelated warnings in Radiant and Wavecrate-owned files. Reson's all-target warning-free lane is green.

## Known limitations

- Streamed-file sources remain on their existing rebuild path; this PR changes only decoded-sample sources that already support live mutation.
- The full repository smoke/clippy gates remain blocked by the pre-existing baseline failures listed above.

User review is required before merge.

Linear: [OPT-1172](https://linear.app/boostnlvp/issue/OPT-1172/reson-make-live-span-retarget-controls-real-time-safe-and-update)
