### PR TITLE
Pin lossless Radiant projection and restore Wavecrate build

### DIFF
--- a/src/native_app/audio/playback/progress/events.rs
+++ b/src/native_app/audio/playback/progress/events.rs
@@ -154,7 +154,7 @@ impl NativeAppState {
         self.audio.output_resolved = Some(output);
         self.audio.current_playback_span = source_updates_waveform.then_some(span);
         self.audio
-            .set_authoritative_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
+            .set_started_playback_progress(wavecrate::audio::PlaybackRuntimeProgress {
                 active: true,
                 elapsed: Some(Duration::ZERO),
                 looping: self.audio.loop_playback,


### PR DESCRIPTION
## Scope

- Pin `vendor/radiant` to merged Radiant PR #1421 (`1e8eacf3`).
- Route runtime `Started` events through `set_started_playback_progress` so the semantic API introduced by PR #817 is used by production code.
- Restore `cargo run -r` without weakening `deny(warnings)` or suppressing dead code.

## Definition of Done

- Wavecrate consumes the merged lossless `ViewProjection` contract.
- The Started-event playback path explicitly reanchors visual progress.
- Wavecrate compiles all test targets without the unused-method error.
- The optimized application build launches successfully.

## Validation commands

- `cargo run -r` — optimized build completed and the application launched against the normal user database and log paths.
- `cargo test --no-run`
- `cargo test runtime_waveform_progress_restart_snapshot_resets_visual_clock -j1`
- `cargo test --bin wavecrate pending_runtime_restart_ignores_progress_until_started_event -j1`
- `cargo test --bin wavecrate restarted_playback_cursor_overlay_begins_new_smooth_sequence -j1`
- `bash scripts/ci.sh smoke`
- `git diff --check`

## Known limitations

None.

User review is required before merge.

Linear: OPT-1165

Upstream: PORTALSURFER/radiant#1421