### PR TITLE
OPT-418: Adopt revision-backed projection and layout invalidation

### DIFF
--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -54,6 +54,8 @@ pub(in crate::native_app) struct NativeAppState {
     pub(in crate::native_app) audio: AudioAppState,
     pub(in crate::native_app) transactions: TransactionState,
     pub(in crate::native_app) metadata: MetadataAppState,
+    pub(in crate::native_app) frame_surface_revision_tracker:
+        crate::native_app::audio::playback::FrameSurfaceRevisionTracker,
     pub(in crate::native_app) playhead_frame_diagnostics:
         crate::native_app::audio::playback::PlayheadFrameDiagnosticsState,
 }

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -23,10 +23,7 @@ fn frame_clock() -> ui::FrameClock<NativeAppState, GuiMessage> {
         .fps_with(|state: &mut NativeAppState| {
             (!state.playback_visual_activity_active()).then_some(APP_FRAME_CLOCK_FPS)
         })
-        .repaint_scope(
-            |state: &mut NativeAppState| state.frame_repaint_scope_before_update(),
-            |state, scope| state.frame_can_use_paint_only(scope),
-        )
+        .surface_revisions(|state: &mut NativeAppState| state.frame_surface_revisions())
 }
 
 fn app_transient_overlay() -> ui::TransientOverlay<NativeAppState> {

--- a/src/native_app/audio/playback.rs
+++ b/src/native_app/audio/playback.rs
@@ -27,6 +27,7 @@ pub(in crate::native_app) use planner::{
 pub(in crate::native_app) use policy::{
     TaggedPlaybackMode, tagged_playback_mode_for_tag, tagged_playback_mode_for_tags,
 };
+pub(in crate::native_app) use progress::FrameSurfaceRevisionTracker;
 pub(in crate::native_app) use random_audition::RandomAuditionUnits;
 #[cfg(test)]
 pub(in crate::native_app) use random_audition::{

--- a/src/native_app/audio/playback/progress.rs
+++ b/src/native_app/audio/playback/progress.rs
@@ -3,5 +3,7 @@ mod state;
 mod telemetry;
 mod waveform_publish;
 
+pub(in crate::native_app) use telemetry::FrameSurfaceRevisionTracker;
+
 #[cfg(test)]
 mod tests;

--- a/src/native_app/audio/playback/progress/telemetry.rs
+++ b/src/native_app/audio/playback/progress/telemetry.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use radiant::runtime::{RepaintScope, SurfaceRevisions};
+
 use super::super::diagnostics::PlayheadFrameMessageDiagnostics;
 use crate::native_app::{
     app::{NativeAppState, SamplePlaybackSession},
@@ -8,13 +10,23 @@ use crate::native_app::{
     },
 };
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub(in crate::native_app) struct FrameRepaintScopeSnapshot {
+#[derive(Default)]
+/// Converts frame-relevant application state into monotonic runtime revision keys.
+pub(in crate::native_app) struct FrameSurfaceRevisionTracker {
+    last: Option<FrameSurfaceRevisionInputs>,
+    revisions: SurfaceRevisions,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FrameSurfaceRevisionInputs {
+    structure: FrameStructureState,
+    layout: FrameLayoutState,
+    projection: FrameProjectionState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FrameStructureState {
     playing: bool,
-    playback_visual_generation: u64,
-    play_selection_flash_active: bool,
-    copy_flash_frames: u8,
-    protected_source_error_flash_frames: u8,
     drag_hover_auto_expand_pending: bool,
     folder_progress_active: bool,
     normalization_progress_active: bool,
@@ -24,38 +36,64 @@ pub(in crate::native_app) struct FrameRepaintScopeSnapshot {
     sample_loading: bool,
     audio_opening: bool,
     audio_settings_error_active: bool,
-    audio_output_sample_rate: Option<u32>,
     startup_source_scan_pending: bool,
     startup_auto_load_pending: bool,
     pending_playback_start: bool,
 }
 
-impl NativeAppState {
-    pub(in crate::native_app) fn frame_repaint_scope_before_update(
-        &self,
-    ) -> FrameRepaintScopeSnapshot {
-        FrameRepaintScopeSnapshot::from_state(self)
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FrameLayoutState {
+    audio_output_sample_rate: Option<u32>,
+}
 
-    pub(in crate::native_app) fn frame_can_use_paint_only(
-        &mut self,
-        before: FrameRepaintScopeSnapshot,
-    ) -> bool {
-        let after = FrameRepaintScopeSnapshot::from_state(self);
-        let same_transient_frame_state = before.same_transient_frame_state(after);
-        let requires_surface_frame = before.requires_surface_frame();
-        let paint_only = same_transient_frame_state && !requires_surface_frame;
-        if before.playing || after.playing {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FrameProjectionState {
+    playback_visual_generation: u64,
+    play_selection_flash_active: bool,
+    copy_flash_frames: u8,
+    protected_source_error_flash_frames: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FrameSurfaceRevisionSample {
+    revisions: SurfaceRevisions,
+    scope: RepaintScope,
+    playback_involved: bool,
+}
+
+impl NativeAppState {
+    pub(in crate::native_app) fn frame_surface_revisions(&mut self) -> SurfaceRevisions {
+        let inputs = FrameSurfaceRevisionInputs::from_state(self);
+        let sample = self.frame_surface_revision_tracker.observe(inputs);
+        if sample.playback_involved {
             self.playhead_frame_diagnostics
                 .record_frame_message(PlayheadFrameMessageDiagnostics {
-                    paint_only,
-                    reason: frame_repaint_reason(
-                        same_transient_frame_state,
-                        requires_surface_frame,
-                    ),
+                    paint_only: sample.scope.is_paint_only(),
+                    reason: frame_repaint_reason(sample.scope),
                 });
         }
-        paint_only
+        sample.revisions
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn capture_frame_surface_revisions(&mut self) -> SurfaceRevisions {
+        self.frame_surface_revisions()
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn frame_can_use_paint_only_since(
+        &mut self,
+        before: SurfaceRevisions,
+    ) -> bool {
+        self.frame_scope_since(before).is_paint_only()
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn frame_scope_since(
+        &mut self,
+        before: SurfaceRevisions,
+    ) -> RepaintScope {
+        self.frame_surface_revisions().repaint_scope_since(before)
     }
 
     pub(in crate::native_app) fn observe_playhead_native_frame_diagnostics(
@@ -114,94 +152,117 @@ fn duration_ms(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000.0
 }
 
-impl FrameRepaintScopeSnapshot {
-    fn from_state(state: &NativeAppState) -> Self {
-        Self {
-            playing: state.playback_visual_activity_active(),
-            playback_visual_generation: state.waveform.current.playback_visual_generation(),
-            play_selection_flash_active: state.waveform.current.play_selection_flash_active(),
-            copy_flash_frames: state
-                .library
-                .folder_browser
-                .copy_flash_frames()
-                .max(state.waveform.current.copy_flash_frames()),
-            protected_source_error_flash_frames: state
-                .library
-                .folder_browser
-                .protected_source_error_flash_frames()
-                .max(state.waveform.current.protected_source_error_flash_frames()),
-            drag_hover_auto_expand_pending: state
-                .library
-                .folder_browser
-                .drag_hover_auto_expand_pending(),
-            folder_progress_active: state.library.folder_scan_active(),
-            normalization_progress_active: state.background.normalization_progress.is_some(),
-            file_move_progress_active: state.background.file_move_progress.is_some(),
-            source_cache_progress_active: state
-                .waveform
-                .cache
-                .active_folder_warm_folder_id
-                .is_some(),
-            waveform_loading_active: state.waveform.load.label.is_some(),
-            sample_loading: state.active_sample_load_task().is_some(),
-            audio_opening: state.background.audio_open.active().is_some(),
-            audio_settings_error_active: state.audio.settings_error.is_some(),
-            audio_output_sample_rate: state
-                .audio
-                .output_resolved
-                .as_ref()
-                .map(|output| output.sample_rate),
-            startup_source_scan_pending: state.ui.startup.source_scan_pending,
-            startup_auto_load_pending: state.ui.startup.auto_load_pending,
-            pending_playback_start: state.audio.pending_playback_start.is_some(),
+impl FrameSurfaceRevisionTracker {
+    fn observe(&mut self, current: FrameSurfaceRevisionInputs) -> FrameSurfaceRevisionSample {
+        let (scope, playback_involved) = self.last.map_or(
+            (RepaintScope::PaintOnly, current.structure.playing),
+            |previous| {
+                (
+                    current.repaint_scope_since(previous),
+                    previous.structure.playing || current.structure.playing,
+                )
+            },
+        );
+        match scope {
+            RepaintScope::Surface => {
+                self.revisions.structure = self.revisions.structure.wrapping_add(1);
+            }
+            RepaintScope::Layout => {
+                self.revisions.layout = self.revisions.layout.wrapping_add(1);
+            }
+            RepaintScope::Projection => {
+                self.revisions.projection = self.revisions.projection.wrapping_add(1);
+            }
+            RepaintScope::PaintOnly => {}
         }
-    }
-
-    fn requires_surface_frame(self) -> bool {
-        self.play_selection_flash_active
-            || self.copy_flash_frames > 0
-            || self.protected_source_error_flash_frames > 0
-            || self.folder_progress_active
-            || self.file_move_progress_active
-            || self.source_cache_progress_active
-            || self.sample_loading
-            || self.audio_opening
-            || self.startup_source_scan_pending
-            || self.startup_auto_load_pending
-            || self.pending_playback_start
-    }
-
-    fn same_transient_frame_state(self, after: Self) -> bool {
-        self.playing == after.playing
-            && self.playback_visual_generation == after.playback_visual_generation
-            && self.play_selection_flash_active == after.play_selection_flash_active
-            && self.copy_flash_frames == after.copy_flash_frames
-            && self.protected_source_error_flash_frames == after.protected_source_error_flash_frames
-            && self.drag_hover_auto_expand_pending == after.drag_hover_auto_expand_pending
-            && self.folder_progress_active == after.folder_progress_active
-            && self.normalization_progress_active == after.normalization_progress_active
-            && self.file_move_progress_active == after.file_move_progress_active
-            && self.source_cache_progress_active == after.source_cache_progress_active
-            && self.waveform_loading_active == after.waveform_loading_active
-            && self.sample_loading == after.sample_loading
-            && self.audio_opening == after.audio_opening
-            && self.audio_settings_error_active == after.audio_settings_error_active
-            && self.audio_output_sample_rate == after.audio_output_sample_rate
-            && self.startup_source_scan_pending == after.startup_source_scan_pending
-            && self.startup_auto_load_pending == after.startup_auto_load_pending
-            && self.pending_playback_start == after.pending_playback_start
+        self.last = Some(current);
+        FrameSurfaceRevisionSample {
+            revisions: self.revisions,
+            scope,
+            playback_involved,
+        }
     }
 }
 
-fn frame_repaint_reason(
-    same_transient_frame_state: bool,
-    requires_surface_frame: bool,
-) -> &'static str {
-    if requires_surface_frame {
-        "surface_frame_required"
-    } else if !same_transient_frame_state {
-        "transient_state_changed"
-    } else {
-        "paint_only"
+impl FrameSurfaceRevisionInputs {
+    fn from_state(state: &NativeAppState) -> Self {
+        Self {
+            structure: FrameStructureState {
+                playing: state.playback_visual_activity_active(),
+                drag_hover_auto_expand_pending: state
+                    .library
+                    .folder_browser
+                    .drag_hover_auto_expand_pending(),
+                folder_progress_active: state.library.folder_scan_active(),
+                normalization_progress_active: state.background.normalization_progress.is_some(),
+                file_move_progress_active: state.background.file_move_progress.is_some(),
+                source_cache_progress_active: state
+                    .waveform
+                    .cache
+                    .active_folder_warm_folder_id
+                    .is_some(),
+                waveform_loading_active: state.waveform.load.label.is_some(),
+                sample_loading: state.active_sample_load_task().is_some(),
+                audio_opening: state.background.audio_open.active().is_some(),
+                audio_settings_error_active: state.audio.settings_error.is_some(),
+                startup_source_scan_pending: state.ui.startup.source_scan_pending,
+                startup_auto_load_pending: state.ui.startup.auto_load_pending,
+                pending_playback_start: state.audio.pending_playback_start.is_some(),
+            },
+            layout: FrameLayoutState {
+                audio_output_sample_rate: state
+                    .audio
+                    .output_resolved
+                    .as_ref()
+                    .map(|output| output.sample_rate),
+            },
+            projection: FrameProjectionState {
+                playback_visual_generation: state.waveform.current.playback_visual_generation(),
+                play_selection_flash_active: state.waveform.current.play_selection_flash_active(),
+                copy_flash_frames: state
+                    .library
+                    .folder_browser
+                    .copy_flash_frames()
+                    .max(state.waveform.current.copy_flash_frames()),
+                protected_source_error_flash_frames: state
+                    .library
+                    .folder_browser
+                    .protected_source_error_flash_frames()
+                    .max(state.waveform.current.protected_source_error_flash_frames()),
+            },
+        }
+    }
+
+    fn repaint_scope_since(self, previous: Self) -> RepaintScope {
+        if self.structure != previous.structure {
+            RepaintScope::Surface
+        } else if self.layout != previous.layout {
+            RepaintScope::Layout
+        } else if self.projection != previous.projection || previous.requires_projection_refresh() {
+            RepaintScope::Projection
+        } else {
+            RepaintScope::PaintOnly
+        }
+    }
+
+    fn requires_projection_refresh(self) -> bool {
+        self.projection.play_selection_flash_active
+            || self.structure.folder_progress_active
+            || self.structure.file_move_progress_active
+            || self.structure.source_cache_progress_active
+            || self.structure.sample_loading
+            || self.structure.audio_opening
+            || self.structure.startup_source_scan_pending
+            || self.structure.startup_auto_load_pending
+            || self.structure.pending_playback_start
+    }
+}
+
+fn frame_repaint_reason(scope: RepaintScope) -> &'static str {
+    match scope {
+        RepaintScope::Surface => "structure_revision",
+        RepaintScope::Layout => "layout_revision",
+        RepaintScope::Projection => "projection_revision",
+        RepaintScope::PaintOnly => "paint_only",
     }
 }

--- a/src/native_app/audio/playback/progress/telemetry.rs
+++ b/src/native_app/audio/playback/progress/telemetry.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cell::Cell;
 use std::time::Duration;
 
 use radiant::runtime::{RepaintScope, SurfaceRevisions};
@@ -10,15 +12,21 @@ use crate::native_app::{
     },
 };
 
+#[cfg(test)]
+thread_local! {
+    static BROAD_FRAME_REVISION_OBSERVATIONS: Cell<u64> = const { Cell::new(0) };
+}
+
 #[derive(Default)]
 /// Converts frame-relevant application state into monotonic runtime revision keys.
 pub(in crate::native_app) struct FrameSurfaceRevisionTracker {
     last: Option<FrameSurfaceRevisionInputs>,
     revisions: SurfaceRevisions,
+    playback_fast_path_active: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct FrameSurfaceRevisionInputs {
+pub(in crate::native_app) struct FrameSurfaceRevisionInputs {
     structure: FrameStructureState,
     layout: FrameLayoutState,
     projection: FrameProjectionState,
@@ -55,45 +63,128 @@ struct FrameProjectionState {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct FrameSurfaceRevisionSample {
-    revisions: SurfaceRevisions,
-    scope: RepaintScope,
-    playback_involved: bool,
+pub(in crate::native_app) struct FrameSurfaceRevisionGuard {
+    before: Option<PlaybackFrameRevisionInputs>,
+    forced_surface: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PlaybackFrameRevisionInputs {
+    structure: PlaybackFrameStructureState,
+    layout: FrameLayoutState,
+    projection: PlaybackFrameProjectionState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PlaybackFrameStructureState {
+    drag_hover_auto_expand_pending: bool,
+    source_cache_progress_active: bool,
+    sample_loading: bool,
+    audio_opening: bool,
+    audio_settings_error_active: bool,
+    pending_playback_start: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PlaybackFrameProjectionState {
+    playback_visual_generation: u64,
+    play_selection_flash_active: bool,
+    copy_flash_frames: u8,
+    protected_source_error_flash_frames: u8,
+    progress_tick_bits: u32,
 }
 
 impl NativeAppState {
     pub(in crate::native_app) fn frame_surface_revisions(&mut self) -> SurfaceRevisions {
-        let inputs = FrameSurfaceRevisionInputs::from_state(self);
-        let sample = self.frame_surface_revision_tracker.observe(inputs);
-        if sample.playback_involved {
-            self.playhead_frame_diagnostics
-                .record_frame_message(PlayheadFrameMessageDiagnostics {
-                    paint_only: sample.scope.is_paint_only(),
-                    reason: frame_repaint_reason(sample.scope),
-                });
+        let playing = self.playback_visual_activity_active();
+        if playing
+            || self
+                .frame_surface_revision_tracker
+                .playback_fast_path_active
+        {
+            if playing {
+                self.frame_surface_revision_tracker
+                    .playback_fast_path_active = true;
+            }
+            return self.frame_surface_revision_tracker.revisions;
         }
-        sample.revisions
+        let inputs = FrameSurfaceRevisionInputs::from_state(self);
+        self.frame_surface_revision_tracker.observe(inputs)
     }
 
     #[cfg(test)]
-    pub(in crate::native_app) fn capture_frame_surface_revisions(&mut self) -> SurfaceRevisions {
-        self.frame_surface_revisions()
+    pub(in crate::native_app) fn capture_frame_surface_inputs(&self) -> FrameSurfaceRevisionInputs {
+        FrameSurfaceRevisionInputs::from_state(self)
     }
 
     #[cfg(test)]
     pub(in crate::native_app) fn frame_can_use_paint_only_since(
-        &mut self,
-        before: SurfaceRevisions,
+        &self,
+        before: FrameSurfaceRevisionInputs,
     ) -> bool {
         self.frame_scope_since(before).is_paint_only()
     }
 
     #[cfg(test)]
     pub(in crate::native_app) fn frame_scope_since(
-        &mut self,
-        before: SurfaceRevisions,
+        &self,
+        before: FrameSurfaceRevisionInputs,
     ) -> RepaintScope {
-        self.frame_surface_revisions().repaint_scope_since(before)
+        FrameSurfaceRevisionInputs::from_state(self).repaint_scope_since(before)
+    }
+
+    pub(in crate::native_app) fn begin_frame_surface_revision_tracking(
+        &mut self,
+    ) -> FrameSurfaceRevisionGuard {
+        let playing = self.playback_visual_activity_active();
+        let forced_surface = self
+            .frame_surface_revision_tracker
+            .playback_fast_path_active
+            && !playing;
+        if forced_surface {
+            self.frame_surface_revision_tracker
+                .bump(RepaintScope::Surface);
+            self.frame_surface_revision_tracker
+                .playback_fast_path_active = false;
+        }
+        FrameSurfaceRevisionGuard {
+            before: playing.then(|| PlaybackFrameRevisionInputs::from_state(self)),
+            forced_surface,
+        }
+    }
+
+    pub(in crate::native_app) fn finish_frame_surface_revision_tracking(
+        &mut self,
+        guard: FrameSurfaceRevisionGuard,
+    ) {
+        let playing = self.playback_visual_activity_active();
+        let after = playing.then(|| PlaybackFrameRevisionInputs::from_state(self));
+        let scope = if guard.forced_surface || guard.before.is_some() != after.is_some() {
+            RepaintScope::Surface
+        } else {
+            match (guard.before, after) {
+                (Some(before), Some(after)) => after.repaint_scope_since(before),
+                (None, None) => RepaintScope::PaintOnly,
+                _ => unreachable!("playback presence mismatch handled above"),
+            }
+        };
+        if !guard.forced_surface {
+            self.frame_surface_revision_tracker.bump(scope);
+        }
+        self.frame_surface_revision_tracker
+            .playback_fast_path_active = playing;
+        if guard.before.is_some() || after.is_some() || guard.forced_surface {
+            self.playhead_frame_diagnostics
+                .record_frame_message(PlayheadFrameMessageDiagnostics {
+                    paint_only: scope.is_paint_only(),
+                    reason: frame_repaint_reason(scope),
+                });
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn broad_frame_revision_observations() -> u64 {
+        BROAD_FRAME_REVISION_OBSERVATIONS.get()
     }
 
     pub(in crate::native_app) fn observe_playhead_native_frame_diagnostics(
@@ -153,16 +244,19 @@ fn duration_ms(duration: Duration) -> f64 {
 }
 
 impl FrameSurfaceRevisionTracker {
-    fn observe(&mut self, current: FrameSurfaceRevisionInputs) -> FrameSurfaceRevisionSample {
-        let (scope, playback_involved) = self.last.map_or(
-            (RepaintScope::PaintOnly, current.structure.playing),
-            |previous| {
-                (
-                    current.repaint_scope_since(previous),
-                    previous.structure.playing || current.structure.playing,
-                )
-            },
-        );
+    fn observe(&mut self, current: FrameSurfaceRevisionInputs) -> SurfaceRevisions {
+        #[cfg(test)]
+        BROAD_FRAME_REVISION_OBSERVATIONS
+            .set(BROAD_FRAME_REVISION_OBSERVATIONS.get().wrapping_add(1));
+        let scope = self.last.map_or(RepaintScope::PaintOnly, |previous| {
+            current.repaint_scope_since(previous)
+        });
+        self.bump(scope);
+        self.last = Some(current);
+        self.revisions
+    }
+
+    fn bump(&mut self, scope: RepaintScope) {
         match scope {
             RepaintScope::Surface => {
                 self.revisions.structure = self.revisions.structure.wrapping_add(1);
@@ -174,12 +268,6 @@ impl FrameSurfaceRevisionTracker {
                 self.revisions.projection = self.revisions.projection.wrapping_add(1);
             }
             RepaintScope::PaintOnly => {}
-        }
-        self.last = Some(current);
-        FrameSurfaceRevisionSample {
-            revisions: self.revisions,
-            scope,
-            playback_involved,
         }
     }
 }
@@ -255,6 +343,62 @@ impl FrameSurfaceRevisionInputs {
             || self.structure.startup_source_scan_pending
             || self.structure.startup_auto_load_pending
             || self.structure.pending_playback_start
+    }
+}
+
+impl PlaybackFrameRevisionInputs {
+    fn from_state(state: &NativeAppState) -> Self {
+        Self {
+            structure: PlaybackFrameStructureState {
+                drag_hover_auto_expand_pending: state
+                    .library
+                    .folder_browser
+                    .drag_hover_auto_expand_pending(),
+                source_cache_progress_active: state
+                    .waveform
+                    .cache
+                    .active_folder_warm_folder_id
+                    .is_some(),
+                sample_loading: state.active_sample_load_task().is_some(),
+                audio_opening: state.background.audio_open.active().is_some(),
+                audio_settings_error_active: state.audio.settings_error.is_some(),
+                pending_playback_start: state.audio.pending_playback_start.is_some(),
+            },
+            layout: FrameLayoutState {
+                audio_output_sample_rate: state
+                    .audio
+                    .output_resolved
+                    .as_ref()
+                    .map(|output| output.sample_rate),
+            },
+            projection: PlaybackFrameProjectionState {
+                playback_visual_generation: state.waveform.current.playback_visual_generation(),
+                play_selection_flash_active: state.waveform.current.play_selection_flash_active(),
+                copy_flash_frames: state
+                    .library
+                    .folder_browser
+                    .copy_flash_frames()
+                    .max(state.waveform.current.copy_flash_frames()),
+                protected_source_error_flash_frames: state
+                    .library
+                    .folder_browser
+                    .protected_source_error_flash_frames()
+                    .max(state.waveform.current.protected_source_error_flash_frames()),
+                progress_tick_bits: state.background.progress_tick.to_bits(),
+            },
+        }
+    }
+
+    fn repaint_scope_since(self, previous: Self) -> RepaintScope {
+        if self.structure != previous.structure {
+            RepaintScope::Surface
+        } else if self.layout != previous.layout {
+            RepaintScope::Layout
+        } else if self.projection != previous.projection {
+            RepaintScope::Projection
+        } else {
+            RepaintScope::PaintOnly
+        }
     }
 }
 

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -65,6 +65,7 @@ impl NativeAppState {
             audio,
             transactions: Default::default(),
             metadata: MetadataAppState::from_settings(&config.core),
+            frame_surface_revision_tracker: Default::default(),
             playhead_frame_diagnostics: Default::default(),
         };
         emit_gui_action(

--- a/src/native_app/shell/message_dispatch/frame.rs
+++ b/src/native_app/shell/message_dispatch/frame.rs
@@ -23,10 +23,12 @@ struct FrameDispatchProfile {
 
 impl NativeAppState {
     pub(super) fn apply_frame_message(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        let revision_guard = self.begin_frame_surface_revision_tracking();
         if self.playback_visual_activity_active() {
             self.pause_background_work_for_playback_frame();
             self.flush_pending_play_selection_playback_retarget();
             self.advance_frame(context);
+            self.finish_frame_surface_revision_tracking(revision_guard);
             return;
         }
         if !super::ui_message_diagnostics_enabled() {
@@ -42,6 +44,7 @@ impl NativeAppState {
             self.maybe_start_preview_audition_warm(context);
             self.flush_pending_play_selection_playback_retarget();
             self.advance_frame(context);
+            self.finish_frame_surface_revision_tracking(revision_guard);
             return;
         }
         let total_started_at = Instant::now();
@@ -68,6 +71,7 @@ impl NativeAppState {
             measure_frame_phase(|| self.flush_pending_play_selection_playback_retarget());
         profile.advance_frame_ms = measure_frame_phase(|| self.advance_frame(context));
         self.log_slow_frame_dispatch_profile(total_started_at.elapsed(), &profile);
+        self.finish_frame_surface_revision_tracking(revision_guard);
     }
 
     fn maybe_install_application_icon(&mut self) {

--- a/src/native_app/test_support/state.rs
+++ b/src/native_app/test_support/state.rs
@@ -78,6 +78,7 @@ impl NativeAppStateFixture {
             audio: AudioAppState::for_tests(),
             transactions: Default::default(),
             metadata: MetadataAppState::from_settings(&self.persisted_settings),
+            frame_surface_revision_tracker: Default::default(),
             playhead_frame_diagnostics: Default::default(),
         }
     }

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -6,7 +6,7 @@ fn playback_frame_uses_paint_only_when_only_playhead_changes() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -79,7 +79,7 @@ fn early_runtime_playback_handoff_still_uses_paint_only_frames() {
     state.audio.playback_progress.active = true;
     state.audio.playback_progress.progress = Some(0.25);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -93,11 +93,13 @@ fn playback_restart_refreshes_projection_to_clear_stale_playhead_visuals() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.62);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.frame_surface_revisions();
+    let guard = state.begin_frame_surface_revision_tracking();
     state.waveform.current.start_playback(0.12);
+    state.finish_frame_surface_revision_tracking(guard);
 
     assert_eq!(
-        state.frame_scope_since(before),
+        state.frame_surface_revisions().repaint_scope_since(before),
         RepaintScope::Projection,
         "retriggering playback should reproject paint state without relayout"
     );
@@ -107,7 +109,7 @@ fn playback_restart_refreshes_projection_to_clear_stale_playhead_visuals() {
 fn idle_frame_uses_paint_only_when_frame_state_is_stable() {
     let mut state = gui_state_for_span_tests();
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -123,7 +125,7 @@ fn loading_frame_uses_paint_only_when_progress_advances() {
     state.waveform.load.progress = 0.25;
     state.waveform.load.target_progress = 0.8;
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -136,7 +138,7 @@ fn loading_frame_uses_paint_only_when_progress_advances() {
 fn loading_frame_repaints_surface_when_loading_state_changes() {
     let mut state = gui_state_for_span_tests();
 
-    let before_start = state.capture_frame_surface_revisions();
+    let before_start = state.capture_frame_surface_inputs();
     state.waveform.load.label = Some(String::from("kick.wav"));
     assert_eq!(
         state.frame_scope_since(before_start),
@@ -144,7 +146,7 @@ fn loading_frame_repaints_surface_when_loading_state_changes() {
         "starting loading changes structural overlay/input state and needs a full repaint"
     );
 
-    let before_stop = state.capture_frame_surface_revisions();
+    let before_stop = state.capture_frame_surface_inputs();
     state.waveform.load.label = None;
     assert_eq!(
         state.frame_scope_since(before_stop),
@@ -159,7 +161,7 @@ fn source_cache_progress_frame_refreshes_projection_for_status_bar_animation() {
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_total = 10;
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert_eq!(
@@ -190,7 +192,7 @@ fn paused_source_cache_progress_does_not_force_playback_surface_frames() {
     );
     assert_eq!(state.waveform.cache.active_folder_warm_total, 0);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -208,7 +210,7 @@ fn copy_flash_frame_refreshes_projection_while_countdown_changes() {
         .folder_browser
         .flash_copied_file_paths([selected_file]);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert_eq!(
@@ -234,7 +236,7 @@ fn normalization_progress_frame_uses_paint_only_when_progress_is_stable() {
         },
     );
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
@@ -248,11 +250,13 @@ fn playback_frame_repaints_surface_when_playback_state_changes() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.frame_surface_revisions();
+    let guard = state.begin_frame_surface_revision_tracking();
     state.waveform.current.stop_playback();
+    state.finish_frame_surface_revision_tracking(guard);
 
     assert_eq!(
-        state.frame_scope_since(before),
+        state.frame_surface_revisions().repaint_scope_since(before),
         RepaintScope::Surface,
         "stopping playback changes toolbar/status surface state and needs a full repaint"
     );
@@ -261,7 +265,7 @@ fn playback_frame_repaints_surface_when_playback_state_changes() {
 #[test]
 fn audio_output_sample_rate_change_requests_layout_refresh() {
     let mut state = gui_state_for_span_tests();
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.audio.output_resolved = Some(crate::native_app::test_support::audio::ResolvedOutput {
         host_id: String::from("core-audio"),
         device_name: String::from("Studio"),
@@ -282,7 +286,7 @@ fn audio_output_sample_rate_change_requests_layout_refresh() {
 fn audio_output_error_repaints_surface_for_top_bar_badge() {
     let mut state = gui_state_for_span_tests();
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.audio.settings_error = Some(String::from(
         "Audio output stream error: output device disconnected",
     ));
@@ -367,22 +371,34 @@ fn scene_playback_frame_uses_paint_only_repaint_scope() {
     state.waveform.current.start_playback(0.25);
     let bridge = radiant::app(state)
         .view(crate::native_app::test_support::state::view)
-        .handle_message(|state, message, _context| {
-            if message == GuiMessage::Frame {
-                state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
-            }
-        })
+        .handle_message(apply_gui_message_for_presentation_test)
         .into_bridge();
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
+    let broad_observations = NativeAppState::broad_frame_revision_observations();
 
     assert!(runtime.host_animation_activity().needs_frame_message());
     assert!(runtime.host_queue_animation_frame());
-    let command = runtime
-        .bridge_mut()
-        .update(crate::native_app::test_support::state::GuiMessage::Frame);
+    let outcome = runtime.drain_runtime_messages();
 
-    assert!(command.requests_paint_only());
+    assert_eq!(outcome.messages_dispatched, 1);
+    assert!(outcome.paint_only_requested);
+    assert_eq!(
+        NativeAppState::broad_frame_revision_observations(),
+        broad_observations,
+        "steady playback should read the stable revision keys without rebuilding broad inputs"
+    );
+
+    assert!(runtime.host_queue_animation_frame());
+    let outcome = runtime.drain_runtime_messages();
+
+    assert_eq!(outcome.messages_dispatched, 1);
+    assert!(outcome.paint_only_requested);
+    assert_eq!(
+        NativeAppState::broad_frame_revision_observations(),
+        broad_observations,
+        "repeated playback frames must remain on the revision fast path"
+    );
 }
 
 #[test]
@@ -995,7 +1011,7 @@ fn state_with_runtime_playback(
 }
 
 fn assert_active_playback_frame_is_paint_only(state: &mut NativeAppState) {
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
     assert!(
         state.frame_can_use_paint_only_since(before),

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -1,15 +1,16 @@
 use super::*;
+use radiant::runtime::RepaintScope;
 
 #[test]
 fn playback_frame_uses_paint_only_when_only_playhead_changes() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "playback-only frames should not force full surface reprojection"
     );
 }
@@ -78,26 +79,27 @@ fn early_runtime_playback_handoff_still_uses_paint_only_frames() {
     state.audio.playback_progress.active = true;
     state.audio.playback_progress.progress = Some(0.25);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "stable runtime playback handoff frames should not force full surface reprojection"
     );
 }
 
 #[test]
-fn playback_restart_repaints_surface_to_clear_stale_playhead_visuals() {
+fn playback_restart_refreshes_projection_to_clear_stale_playhead_visuals() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.62);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.waveform.current.start_playback(0.12);
 
-    assert!(
-        !state.frame_can_use_paint_only(before),
-        "retriggering playback while already playing should clear retained playhead paint"
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Projection,
+        "retriggering playback should reproject paint state without relayout"
     );
 }
 
@@ -105,11 +107,11 @@ fn playback_restart_repaints_surface_to_clear_stale_playhead_visuals() {
 fn idle_frame_uses_paint_only_when_frame_state_is_stable() {
     let mut state = gui_state_for_span_tests();
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "stable 60Hz idle frames should not force full surface reprojection"
     );
 }
@@ -121,11 +123,11 @@ fn loading_frame_uses_paint_only_when_progress_advances() {
     state.waveform.load.progress = 0.25;
     state.waveform.load.target_progress = 0.8;
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "loading-progress-only frames should not force full surface reprojection"
     );
 }
@@ -134,33 +136,36 @@ fn loading_frame_uses_paint_only_when_progress_advances() {
 fn loading_frame_repaints_surface_when_loading_state_changes() {
     let mut state = gui_state_for_span_tests();
 
-    let before_start = state.frame_repaint_scope_before_update();
+    let before_start = state.capture_frame_surface_revisions();
     state.waveform.load.label = Some(String::from("kick.wav"));
-    assert!(
-        !state.frame_can_use_paint_only(before_start),
+    assert_eq!(
+        state.frame_scope_since(before_start),
+        RepaintScope::Surface,
         "starting loading changes structural overlay/input state and needs a full repaint"
     );
 
-    let before_stop = state.frame_repaint_scope_before_update();
+    let before_stop = state.capture_frame_surface_revisions();
     state.waveform.load.label = None;
-    assert!(
-        !state.frame_can_use_paint_only(before_stop),
+    assert_eq!(
+        state.frame_scope_since(before_stop),
+        RepaintScope::Surface,
         "finishing loading changes structural overlay/input state and needs a full repaint"
     );
 }
 
 #[test]
-fn source_cache_progress_frame_repaints_surface_for_status_bar_animation() {
+fn source_cache_progress_frame_refreshes_projection_for_status_bar_animation() {
     let mut state = gui_state_for_span_tests();
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_total = 10;
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
-    assert!(
-        !state.frame_can_use_paint_only(before),
-        "source-cache status animation changes the status surface and must not be paint-only"
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Projection,
+        "source-cache status animation should reproject without relayout"
     );
 }
 
@@ -185,17 +190,17 @@ fn paused_source_cache_progress_does_not_force_playback_surface_frames() {
     );
     assert_eq!(state.waveform.cache.active_folder_warm_total, 0);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "paused source-cache progress should not force full surface frames during playback"
     );
 }
 
 #[test]
-fn copy_flash_frame_repaints_surface_while_countdown_changes() {
+fn copy_flash_frame_refreshes_projection_while_countdown_changes() {
     let (mut state, _source_root, selected_file) =
         native_app_state_with_temp_sample("copy-flash.wav");
     state
@@ -203,12 +208,13 @@ fn copy_flash_frame_repaints_surface_while_countdown_changes() {
         .folder_browser
         .flash_copied_file_paths([selected_file]);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
-    assert!(
-        !state.frame_can_use_paint_only(before),
-        "copy flash changes sample-row chrome and must force full list repaint while it decays"
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Projection,
+        "copy flash should refresh sample-row chrome without recomputing layout"
     );
 }
 
@@ -228,11 +234,11 @@ fn normalization_progress_frame_uses_paint_only_when_progress_is_stable() {
         },
     );
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "determinate normalization progress should repaint only when progress messages arrive"
     );
 }
@@ -242,12 +248,33 @@ fn playback_frame_repaints_surface_when_playback_state_changes() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.waveform.current.stop_playback();
 
-    assert!(
-        !state.frame_can_use_paint_only(before),
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Surface,
         "stopping playback changes toolbar/status surface state and needs a full repaint"
+    );
+}
+
+#[test]
+fn audio_output_sample_rate_change_requests_layout_refresh() {
+    let mut state = gui_state_for_span_tests();
+    let before = state.capture_frame_surface_revisions();
+    state.audio.output_resolved = Some(crate::native_app::test_support::audio::ResolvedOutput {
+        host_id: String::from("core-audio"),
+        device_name: String::from("Studio"),
+        sample_rate: 48_000,
+        buffer_size_frames: None,
+        channel_count: 2,
+        used_fallback: false,
+    });
+
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Layout,
+        "sample-rate label changes should relayout without replacing widget identity"
     );
 }
 
@@ -255,13 +282,14 @@ fn playback_frame_repaints_surface_when_playback_state_changes() {
 fn audio_output_error_repaints_surface_for_top_bar_badge() {
     let mut state = gui_state_for_span_tests();
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.audio.settings_error = Some(String::from(
         "Audio output stream error: output device disconnected",
     ));
 
-    assert!(
-        !state.frame_can_use_paint_only(before),
+    assert_eq!(
+        state.frame_scope_since(before),
+        RepaintScope::Surface,
         "audio output errors change the top bar badge and need a full repaint"
     );
 }
@@ -355,6 +383,31 @@ fn scene_playback_frame_uses_paint_only_repaint_scope() {
         .update(crate::native_app::test_support::state::GuiMessage::Frame);
 
     assert!(command.requests_paint_only());
+}
+
+#[test]
+fn scene_source_cache_frame_uses_projection_repaint_scope() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
+    state.waveform.cache.active_folder_warm_total = 10;
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(|state, message, _context| {
+            if message == GuiMessage::Frame {
+                state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
+            }
+        })
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+
+    assert!(runtime.host_animation_activity().needs_frame_message());
+    assert!(runtime.host_queue_animation_frame());
+    let command = runtime
+        .bridge_mut()
+        .update(crate::native_app::test_support::state::GuiMessage::Frame);
+
+    assert_eq!(command.repaint_scope(), Some(RepaintScope::Projection));
 }
 
 #[test]
@@ -942,10 +995,10 @@ fn state_with_runtime_playback(
 }
 
 fn assert_active_playback_frame_is_paint_only(state: &mut NativeAppState) {
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "active playback cursor frames should not require retained scene rebuilds"
     );
 }

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -1041,7 +1041,7 @@ fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediate
         "playback pause should abandon deferred source-cache work immediately"
     );
 
-    let before = state.capture_frame_surface_revisions();
+    let before = state.capture_frame_surface_inputs();
     state.advance_frame(&mut ui::UiUpdateContext::default());
     assert!(
         state.frame_can_use_paint_only_since(before),

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -1041,10 +1041,10 @@ fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediate
         "playback pause should abandon deferred source-cache work immediately"
     );
 
-    let before = state.frame_repaint_scope_before_update();
+    let before = state.capture_frame_surface_revisions();
     state.advance_frame(&mut ui::UiUpdateContext::default());
     assert!(
-        state.frame_can_use_paint_only(before),
+        state.frame_can_use_paint_only_since(before),
         "a cancelled running source-cache warm must not force playback surface frames"
     );
 


### PR DESCRIPTION
## Scope
- Pin Radiant to merged PR #1422 commit `72103b62602f95fe71b6f3ce1fc58a0262ea6799`.
- Replace Wavecrate frame-clock before/after repaint snapshots with stable `SurfaceRevisions`.
- Classify structural, layout, projection, and paint-only frame changes at the application boundary.
- Move stable declarative animation paths such as source-cache progress and copy flash from full-surface refreshes to projection refreshes.

## Definition of Done
- [x] Radiant projection/layout revision stages land first.
- [x] Wavecrate pins the canonical merged Radiant commit.
- [x] The production `FrameRepaintScopeSnapshot` contract is removed.
- [x] High-frequency frame paths use monotonic revision keys and preserve correctness-first full refreshes for structural transitions.
- [x] Focused tests cover `Surface`, `Layout`, `Projection`, and `PaintOnly` routing.

## Validation
- `cargo test -p wavecrate --bin wavecrate native_app::tests::toolbar_playback::frame_overlay -q` (33 passed)
- `cargo test -p wavecrate --bin wavecrate native_app::tests::sample_browser -q` (86 passed)
- `cargo test -p wavecrate --bin wavecrate native_app::tests::waveform_playback::active_folder_cache -q` (28 passed)
- `cargo test -p wavecrate --bin wavecrate native_app::shell::message_dispatch::tests -q` (4 passed)
- `cargo test -p wavecrate --bin wavecrate native_app::tests::toolbar_playback -q` (62 passed)
- `cargo test --no-run -q`
- `bash scripts/ci.sh smoke`
- `git diff --check`

## Known limitations
None.

Radiant dependency: PORTALSURFER/radiant#1422
Linear: https://linear.app/boostnlvp/issue/OPT-418

User review is required before merge.