### PR TITLE
OPT-1168: migrate Wavecrate to explicit Radiant owners

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -94,7 +94,7 @@ pub(in crate::native_app) enum GuiMessage {
         path: String,
         drag: DragHandleMessage,
     },
-    ExternalDragCompleted(Result<ui::ExternalDragOutcome, String>),
+    ExternalDragCompleted(Result<radiant::runtime::ExternalDragOutcome, String>),
     ExternalWaveformFileDropFinished {
         source: PathBuf,
         started_at: Instant,

--- a/src/native_app/app_chrome/library_browser/library_sidebar/collections_section.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/collections_section.rs
@@ -25,7 +25,7 @@ const COLLECTIONS_RESIZE_HEADER_ID: u64 = widget_ids::COLLECTIONS_RESIZE_HEADER_
 pub(super) fn collections_section(model: &CollectionsSectionViewModel) -> ui::View<GuiMessage> {
     let rows = model.rows.iter().map(collection_row).collect::<Vec<_>>();
     ui::panel_section_from_header_parts(
-        ui::PanelSectionHeaderParts::resize_header(
+        radiant::application::PanelSectionHeaderParts::resize_header(
             "collections-resize-header",
             SIDEBAR_PANEL_HEADER_HEIGHT,
             ui::scroll(

--- a/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/filter_section.rs
@@ -32,7 +32,7 @@ const HARVEST_FILTER_ROW_INDEX: usize = 3;
 
 pub(super) fn filter_section(model: &FilterSectionViewModel) -> ui::View<GuiMessage> {
     let panel = ui::panel_section_from_header_parts(
-        ui::PanelSectionHeaderParts::resize_header(
+        radiant::application::PanelSectionHeaderParts::resize_header(
             "filter-resize-header",
             SIDEBAR_PANEL_HEADER_HEIGHT,
             filter_controls(model),

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree.rs
@@ -47,7 +47,7 @@ fn folder_tree_window(
     visible_folders: Vec<VisibleFolder>,
     window: ui::VirtualListWindow,
 ) -> ui::View<GuiMessage> {
-    ui::virtual_tree_list_windowed(
+    radiant::application::virtual_tree_list_windowed(
         window,
         TREE_ROW_HEIGHT,
         &folder_tree_guide_rows(&visible_folders),

--- a/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/folder_tree/rows.rs
@@ -198,7 +198,7 @@ pub(super) fn folder_tree_palette_for_tests(theme: &ui::ThemeTokens) -> ui::Dens
 
 pub(super) fn folder_tree_selected_hover_marker() -> ui::DenseRowMarkerStyle {
     ui::DenseRowMarkerStyle::new(
-        ui::DenseRowMarkerParts::leading(FOLDER_TREE_SELECTED_HOVER_MARKER_WIDTH)
+        radiant::gui::list::DenseRowMarkerParts::leading(FOLDER_TREE_SELECTED_HOVER_MARKER_WIDTH)
             .edge_inset(1.0)
             .vertical_inset(3.0),
         ui::ThemeTokens::default()

--- a/src/native_app/app_chrome/library_browser/library_sidebar/tag_completion.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/tag_completion.rs
@@ -53,7 +53,7 @@ pub(in crate::native_app) fn tag_completion_overlay(
 fn tag_completion_options(
     options: &[MetadataTagCompletionOption],
     content_width: f32,
-) -> ui::CompactOptionListParts {
+) -> radiant::application::CompactOptionListParts {
     let tag_width = (content_width * 0.48).clamp(70.0, 140.0);
     let items = options
         .iter()
@@ -63,7 +63,7 @@ fn tag_completion_options(
                 .selected(option.selected)
         })
         .collect::<Vec<_>>();
-    ui::CompactOptionListParts::new(items, tag_width)
+    radiant::application::CompactOptionListParts::new(items, tag_width)
         .max_visible_rows(MAX_TAG_COMPLETION_ROWS)
         .row_height(TAG_COMPLETION_ROW_HEIGHT)
         .vertical_chrome(TAG_COMPLETION_POPUP_VERTICAL_CHROME)

--- a/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/tag_editor.rs
@@ -71,7 +71,7 @@ fn tag_entry_field(field: TagEditorFieldProjection) -> ui::View<GuiMessage> {
 
 fn metadata_sidebar_panel(content: ui::View<GuiMessage>, height: f32) -> ui::View<GuiMessage> {
     let panel = ui::panel_section_from_header_parts(
-        ui::PanelSectionHeaderParts::resize_header(
+        radiant::application::PanelSectionHeaderParts::resize_header(
             "metadata-resize-header",
             SIDEBAR_PANEL_HEADER_HEIGHT,
             content,

--- a/src/native_app/app_chrome/library_browser/sample_browser_view.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view.rs
@@ -14,7 +14,7 @@ mod header;
 mod hit_target;
 #[cfg(test)]
 pub(in crate::native_app) use hit_target::{
-    sample_file_hit_target_for_tests, SampleFileHitTargetModel,
+    SampleFileHitTargetModel, sample_file_hit_target_for_tests,
 };
 mod cells;
 mod identity;
@@ -22,7 +22,7 @@ mod row_projection;
 mod row_widgets;
 mod rows;
 mod starmap_view;
-use header::{sample_browser_header_bar, sample_similarity_controls_bar, SampleBrowserHeaderBar};
+use header::{SampleBrowserHeaderBar, sample_browser_header_bar, sample_similarity_controls_bar};
 use rows::sample_browser_rows;
 pub(in crate::native_app) use starmap_view::paint_active_starmap_audition_overlay;
 use starmap_view::starmap_view;
@@ -182,14 +182,17 @@ mod tests {
     use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMessage;
     use crate::native_app::sample_library::folder_browser::projection::VisibleSampleList;
     use crate::native_app::sample_library::folder_browser::starmap::{
-        starmap_cluster_palette_color, StarmapItem, StarmapStatus,
+        StarmapItem, StarmapStatus, starmap_cluster_palette_color,
     };
     use crate::native_app::ui::ids as widget_ids;
 
     #[test]
     fn sample_list_stacked_pointer_targets_route_each_event_to_matching_domain_action() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let columns = Vec::new();
         let position = ui::Point::new(12.0, 12.0);
@@ -250,7 +253,10 @@ mod tests {
     #[test]
     fn starmap_mode_paints_search_input_bound_to_name_filter() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let columns = Vec::new();
 
@@ -312,7 +318,10 @@ mod tests {
     #[test]
     fn starmap_mode_paints_incomplete_similarity_status() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
 
         let frame = sample_browser(SampleBrowserViewModel {
@@ -373,7 +382,10 @@ mod tests {
     #[test]
     fn starmap_mode_paints_viewport_controls() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
 
         let frame = sample_browser(SampleBrowserViewModel {
@@ -535,7 +547,10 @@ mod tests {
     #[test]
     fn starmap_mode_empty_state_matches_curation_context() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
 
         let frame = sample_browser(SampleBrowserViewModel {
@@ -571,15 +586,20 @@ mod tests {
         .view_frame_at_size_with_default_theme(Vector2::new(520.0, 320.0));
 
         assert!(frame.paint_plan.contains_text("No files left to curate"));
-        assert!(!frame
-            .paint_plan
-            .contains_text("No audio files in selected folder"));
+        assert!(
+            !frame
+                .paint_plan
+                .contains_text("No audio files in selected folder")
+        );
     }
 
     #[test]
     fn starmap_status_overlay_does_not_block_node_selection() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let sample_path = String::from("/samples/kick.wav");
         let bridge = DeclarativeOwnedRuntimeBridge::new(
@@ -662,7 +682,10 @@ mod tests {
     #[test]
     fn starmap_status_overlay_does_not_block_wheel_zoom() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let bridge = DeclarativeOwnedRuntimeBridge::new(
             Vec::<GuiMessage>::new(),
@@ -723,8 +746,10 @@ mod tests {
         );
         let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(520.0, 320.0));
 
-        assert!(runtime
-            .wheel_or_scroll_at(ui::Point::new(260.0, 160.0), ui::Vector2::new(0.0, -120.0),));
+        assert!(
+            runtime
+                .wheel_or_scroll_at(ui::Point::new(260.0, 160.0), ui::Vector2::new(0.0, -120.0),)
+        );
 
         assert_eq!(
             runtime.bridge().state(),
@@ -740,7 +765,10 @@ mod tests {
     #[test]
     fn starmap_runtime_drag_auditions_each_crossed_node() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let left_path = String::from("/samples/kick.wav");
         let right_path = String::from("/samples/snare.wav");
@@ -848,7 +876,10 @@ mod tests {
     #[test]
     fn starmap_runtime_drag_overlay_tracks_deferred_pointer_move_before_surface_refresh() {
         let metadata_tags_by_file = HashMap::<String, Vec<String>>::new();
-        let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+        let sort = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
         let similarity_controls = SimilarityAspectSettings::default();
         let left_path = String::from("/samples/kick.wav");
         let right_path = String::from("/samples/snare.wav");

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/cells.rs
@@ -113,7 +113,7 @@ fn render_playback_type_cell(label: String, available: bool, width: f32) -> ui::
 }
 
 fn sample_rename_cell(rename: FileRenameView, width: f32) -> ui::View<GuiMessage> {
-    ui::compact_details_cell(
+    radiant::application::compact_details_cell(
         ui::text_input(rename.draft)
             .selection(rename.selection_start, rename.selection_end)
             .message_event(|message| {
@@ -166,7 +166,7 @@ fn render_similarity_cell(
     } else {
         ui::text("N/A").muted_text().height(18.0).fill_width()
     };
-    ui::compact_details_cell(content, Some(width))
+    radiant::application::compact_details_cell(content, Some(width))
 }
 
 /// Render one passive similarity aspect indicator.
@@ -306,7 +306,7 @@ fn compact_text(text: impl Into<ui::TextContent>) -> ui::View<GuiMessage> {
 
 fn compact_column_content_cell(content: ui::View<GuiMessage>, width: f32) -> ui::View<GuiMessage> {
     let content_width = (width - COMPACT_COLUMN_CONTENT_TRAILING_GUTTER).max(0.0);
-    ui::compact_details_cell(
+    radiant::application::compact_details_cell(
         ui::row([content.width(content_width).height(20.0)])
             .spacing(0.0)
             .height(20.0),

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/header.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/header.rs
@@ -30,7 +30,7 @@ const SAMPLE_BROWSER_ICON_TINTS: ui::SvgIconTintPalette = ui::SvgIconTintPalette
 
 pub(super) struct SampleBrowserHeaderBar<'a> {
     pub(super) columns: &'a [&'a FileColumn],
-    pub(super) sort: &'a ui::DetailsSort,
+    pub(super) sort: &'a radiant::application::DetailsSort,
     pub(super) drag_feedback: Option<&'a FileColumnDragFeedback>,
     pub(super) mode: SampleNameViewMode,
     pub(super) random_navigation_enabled: bool,
@@ -153,14 +153,14 @@ static MAP_ICON: ui::SvgIconTintCache = ui::SvgIconTintCache::new(
 
 fn sample_browser_header(
     columns: Vec<HeaderColumnProjection<'_>>,
-    sort: &ui::DetailsSort,
+    sort: &radiant::application::DetailsSort,
     drag_marker_x: Option<f32>,
     similarity_header: SampleSimilarityHeaderProjection,
 ) -> ui::View<GuiMessage> {
     let header_cells = columns
         .iter()
         .flat_map(|column| sample_header_cells(column, sort, &similarity_header));
-    let details_header = ui::compact_details_header_row(header_cells)
+    let details_header = radiant::application::compact_details_header_row(header_cells)
         .fill_width()
         .height(24.0);
     let details_header = match drag_marker_x {
@@ -190,14 +190,18 @@ fn column_drop_marker(x: f32) -> ui::View<GuiMessage> {
 
 fn sample_header_cell(
     projection: &HeaderColumnProjection<'_>,
-    sort: &ui::DetailsSort,
+    sort: &radiant::application::DetailsSort,
 ) -> ui::View<GuiMessage> {
     let column = projection.column;
     let sort_id = column.id.clone();
     let drag_id = column.id.clone();
     let resize_id = column.id.clone();
-    let label = ui::details_sort_label(column.label.as_str(), column.id.as_str(), Some(sort));
-    ui::compact_resizable_details_header_cell(
+    let label = radiant::application::details_sort_label(
+        column.label.as_str(),
+        column.id.as_str(),
+        Some(sort),
+    );
+    radiant::application::compact_resizable_details_header_cell(
         label,
         column.width,
         GuiMessage::FolderBrowser(FolderBrowserMessage::SortFileColumn(sort_id)),
@@ -216,7 +220,7 @@ fn sample_header_cell(
 
 fn sample_header_cells(
     column: &HeaderColumnProjection<'_>,
-    sort: &ui::DetailsSort,
+    sort: &radiant::application::DetailsSort,
     similarity_header: &SampleSimilarityHeaderProjection,
 ) -> Vec<ui::View<GuiMessage>> {
     let mut cells = vec![sample_header_cell(column, sort)];
@@ -247,7 +251,7 @@ fn sample_similarity_header_cell(
             .height(20.0)
             .fill_width(),
     );
-    ui::compact_details_cell(
+    radiant::application::compact_details_cell(
         ui::row(header_parts).spacing(3.0).height(20.0).fill_width(),
         Some(SAMPLE_SIMILARITY_SCORE_COLUMN_WIDTH),
     )

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/header/projection.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/header/projection.rs
@@ -1,5 +1,3 @@
-use radiant::prelude as ui;
-
 use crate::native_app::app::SampleNameViewMode;
 use crate::native_app::sample_library::folder_browser::model::{FileColumn, FileColumnKind};
 use wavecrate::sample_sources::config::SimilarityAspectSettings;
@@ -15,7 +13,7 @@ pub(super) const STARMAP_VIEW_TOOLTIP: &str = "Switch between list and Starmap v
 
 pub(super) struct SampleBrowserHeaderProjection<'a> {
     pub(super) columns: Vec<HeaderColumnProjection<'a>>,
-    pub(super) sort: &'a ui::DetailsSort,
+    pub(super) sort: &'a radiant::application::DetailsSort,
     pub(super) drag_marker_x: Option<f32>,
     pub(super) random_navigation: RandomNavigationButtonProjection,
     pub(super) map_view: StarmapViewButtonProjection,

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/header/tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/header/tests.rs
@@ -81,7 +81,10 @@ fn header_bar_projection_collects_controls_columns_and_drag_marker() {
     let name = FileColumn::for_tests("name", "Name", 240.0);
     let size = FileColumn::for_tests("size", "Size", 78.0);
     let columns = [&name, &size];
-    let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+    let sort = radiant::application::DetailsSort::new(
+        "name",
+        radiant::application::SortDirection::Ascending,
+    );
     let drag_feedback = FileColumnDragFeedback {
         label: "Name".to_string(),
         pointer: ui::Point::new(42.0, 9.0),
@@ -119,7 +122,10 @@ fn header_bar_projection_hides_list_columns_in_map_mode() {
     let name = FileColumn::for_tests("name", "Name", 240.0);
     let size = FileColumn::for_tests("size", "Size", 78.0);
     let columns = [&name, &size];
-    let sort = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
+    let sort = radiant::application::DetailsSort::new(
+        "name",
+        radiant::application::SortDirection::Ascending,
+    );
     let drag_feedback = FileColumnDragFeedback {
         label: "Name".to_string(),
         pointer: ui::Point::new(42.0, 9.0),

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/hit_target.rs
@@ -122,7 +122,7 @@ fn sample_file_hit_target_builder(
         .leading_marker_if(
             model.explicitly_selected || model.cut_pending || model.missing,
             ui::DenseRowMarkerStyle::new(
-                ui::DenseRowMarkerParts::leading(3.0).vertical_inset(4.0),
+                radiant::gui::list::DenseRowMarkerParts::leading(3.0).vertical_inset(4.0),
                 if model.missing {
                     MISSING_MARKER
                 } else if model.cut_pending {
@@ -134,7 +134,10 @@ fn sample_file_hit_target_builder(
         )
         .trailing_marker_if(
             model.cached && !model.explicitly_selected && !model.copy_flash && !model.cut_pending,
-            ui::DenseRowMarkerStyle::new(ui::DenseRowMarkerParts::trailing(2.0), CACHED_MARKER),
+            ui::DenseRowMarkerStyle::new(
+                radiant::gui::list::DenseRowMarkerParts::trailing(2.0),
+                CACHED_MARKER,
+            ),
         )
         .outline_if(model.focused, sample_file_focus_outline());
     if let Some(palette) = sample_file_row_palette(model) {
@@ -145,13 +148,13 @@ fn sample_file_hit_target_builder(
 }
 
 fn sample_file_row_policy(model: &SampleFileHitTargetModel<'_>) -> ui::DenseRowPolicy {
-    let visual_state = ui::InteractiveRowVisualStateParts {
+    let visual_state = radiant::widgets::InteractiveRowVisualStateParts {
         selected: model.explicitly_selected
             || model.copy_flash
             || model.protected_source_error_flash
             || model.cut_pending
             || model.missing,
-        ..ui::InteractiveRowVisualStateParts::default()
+        ..radiant::widgets::InteractiveRowVisualStateParts::default()
     };
     ui::DenseRowPolicy::with_visual_state(visual_state)
         .tracked_drag_source(model.drag_active, model.drag_source)

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/identity.rs
@@ -31,8 +31,8 @@ pub(super) fn retained_sample_header_cell_id(column_id: &str) -> u64 {
 /// Radiant-derived child ids for a retained sample header cell.
 pub(super) fn retained_sample_header_child_ids(
     column_id: &str,
-) -> radiant::prelude::CompactDetailsHeaderCellIds {
-    radiant::prelude::CompactDetailsHeaderCellIds::from_cell_id(retained_sample_header_cell_id(
+) -> radiant::application::CompactDetailsHeaderCellIds {
+    radiant::application::CompactDetailsHeaderCellIds::from_cell_id(retained_sample_header_cell_id(
         column_id,
     ))
 }
@@ -94,13 +94,15 @@ mod tests {
 
         assert_eq!(
             child_ids.sort_drag,
-            Some(radiant::prelude::compact_details_header_sort_drag_id(
+            Some(radiant::application::compact_details_header_sort_drag_id(
                 cell_id
             ))
         );
         assert_eq!(
             child_ids.resize,
-            Some(radiant::prelude::compact_details_header_resize_id(cell_id))
+            Some(radiant::application::compact_details_header_resize_id(
+                cell_id
+            ))
         );
     }
 

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows.rs
@@ -75,7 +75,8 @@ fn sample_browser_row(
             row.similarity_strength,
             help_tooltips_enabled,
         ),
-        ui::compact_details_row(row.columns.into_iter().map(sample_column_cell)).fill_width(),
+        radiant::application::compact_details_row(row.columns.into_iter().map(sample_column_cell))
+            .fill_width(),
     ])
     .spacing(0.0)
     .fill_width()

--- a/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
+++ b/src/native_app/app_chrome/library_browser/sample_browser_view/rows_tests.rs
@@ -9,12 +9,7 @@ use super::super::row_widgets::RatingIndicator;
 use super::super::similarity_aspect_color;
 use super::*;
 use crate::native_app::sample_library::folder_browser::{FolderBrowserState, model::FileEntry};
-use radiant::{
-    layout::Vector2,
-    prelude::{self as ui, IntoView},
-    runtime::PaintPrimitive,
-    theme::ThemeTokens,
-};
+use radiant::{layout::Vector2, prelude::IntoView, runtime::PaintPrimitive, theme::ThemeTokens};
 use wavecrate::sample_sources::{Rating, SampleCollection};
 
 /// Builds a representative file entry for row rendering tests.
@@ -393,7 +388,7 @@ fn compact_column_content_stays_inside_adjacent_column_boundaries() {
     let harvest_start = rating_start + rating_width + column_spacing;
     let collection_start = harvest_start + harvest_width + column_spacing;
     let row_width = collection_start + collection_width + row_padding;
-    let frame = ui::compact_details_row([
+    let frame = radiant::application::compact_details_row([
         sample_file_cell(
             String::from("KAB1_0_AmenBreak_Original_FullStem"),
             name_width,

--- a/src/native_app/app_chrome/metadata_tag_library.rs
+++ b/src/native_app/app_chrome/metadata_tag_library.rs
@@ -23,8 +23,8 @@ fn panel_from_projection(projection: MetadataTagLibraryProjection) -> ui::View<G
         .into_iter()
         .map(category_group)
         .collect::<Vec<_>>();
-    ui::closeable_panel_section_from_parts(
-        ui::PanelSectionParts::new(
+    radiant::application::closeable_panel_section_from_parts(
+        radiant::application::PanelSectionParts::new(
             "Tag Editor",
             ui::scroll(ui::column(groups).spacing(3.0).fill_width())
                 .fill_width()

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -35,8 +35,8 @@ fn app_transient_overlay() -> ui::TransientOverlay<NativeAppState> {
 
 fn paint_app_transient_overlay(
     state: &mut NativeAppState,
-    context: ui::TransientOverlayContext<'_>,
-    primitives: &mut Vec<ui::PaintPrimitive>,
+    context: radiant::runtime::TransientOverlayContext<'_>,
+    primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
 ) {
     state.paint_waveform_transient_overlay(context, primitives);
     paint_starmap_active_audition_overlay(state, context, primitives);
@@ -44,8 +44,8 @@ fn paint_app_transient_overlay(
 
 fn paint_starmap_active_audition_overlay(
     state: &mut NativeAppState,
-    context: ui::TransientOverlayContext<'_>,
-    primitives: &mut Vec<ui::PaintPrimitive>,
+    context: radiant::runtime::TransientOverlayContext<'_>,
+    primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
 ) {
     let Some(active_file_id) = state.active_starmap_audition_file_id() else {
         return;

--- a/src/native_app/app_chrome/settings/top_bar.rs
+++ b/src/native_app/app_chrome/settings/top_bar.rs
@@ -59,8 +59,8 @@ struct ControlSize {
 
 pub(in crate::native_app) fn top_control_bar(state: &NativeAppState) -> ui::View<GuiMessage> {
     let projection = TopControlBarProjection::from_app_state(state);
-    ui::toolbar_from_parts(
-        ui::ToolbarParts::new([
+    radiant::application::toolbar_from_parts(
+        radiant::application::ToolbarParts::new([
             volume_slider(projection.volume.value)
                 .tooltip_if(projection.help_tooltips_enabled, projection.volume.tooltip),
             normalized_audition_button(projection.normalized_audition).tooltip_if(

--- a/src/native_app/app_chrome/settings/window/dropdowns.rs
+++ b/src/native_app/app_chrome/settings/window/dropdowns.rs
@@ -59,8 +59,8 @@ pub(super) fn audio_settings_dropdown_overlay(
         SETTINGS_CONTENT_WIDTH,
         ui::dropdown_menu_height(options.len()),
     );
-    ui::anchored_popover_from_parts(
-        ui::AnchoredPopoverParts::below(ui::dropdown_menu(options), anchor, size)
+    radiant::application::anchored_popover_from_parts(
+        radiant::application::AnchoredPopoverParts::below(ui::dropdown_menu(options), anchor, size)
             .gap(AUDIO_SETTINGS_DROPDOWN_GAP),
     )
 }

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -104,8 +104,8 @@ fn job_details_popover_from_projection(
     )
     .spacing(5.0)
     .fill_width();
-    ui::closeable_dialog_layer_from_parts(
-        ui::DialogLayerParts::new(
+    radiant::application::closeable_dialog_layer_from_parts(
+        radiant::application::DialogLayerParts::new(
             projection.title,
             content,
             ui::WidgetTone::Neutral,

--- a/src/native_app/app_chrome/toolbar.rs
+++ b/src/native_app/app_chrome/toolbar.rs
@@ -32,7 +32,9 @@ pub(in crate::native_app) fn main_toolbar(model: MainToolbarViewModel) -> ui::Vi
         .map(|control| toolbar_control(*control, projection.help_tooltips_enabled))
         .collect::<Vec<_>>();
 
-    ui::toolbar_from_parts(ui::ToolbarParts::new(controls).alignment(ui::ToolbarAlignment::End))
+    radiant::application::toolbar_from_parts(
+        radiant::application::ToolbarParts::new(controls).alignment(ui::ToolbarAlignment::End),
+    )
 }
 
 fn toolbar_control(

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -164,7 +164,7 @@ impl Widget for BeatGuideCountInputWidget {
 
     fn append_paint(
         &self,
-        primitives: &mut Vec<ui::PaintPrimitive>,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
         bounds: ui::Rect,
         layout: &ui::LayoutOutput,
         theme: &ui::ThemeTokens,

--- a/src/native_app/sample_library/drag_drop_actions/drag_session.rs
+++ b/src/native_app/sample_library/drag_drop_actions/drag_session.rs
@@ -42,7 +42,7 @@ impl NativeAppState {
         let path_count = external
             .as_ref()
             .map(|request| match &request.payload {
-                ui::ExternalDragPayload::Files(paths) => paths.len(),
+                radiant::runtime::ExternalDragPayload::Files(paths) => paths.len(),
             })
             .unwrap_or_default();
         tracing::debug!(

--- a/src/native_app/sample_library/drag_drop_actions/external.rs
+++ b/src/native_app/sample_library/drag_drop_actions/external.rs
@@ -378,7 +378,7 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn external_drag_completed(
         &mut self,
-        result: Result<ui::ExternalDragOutcome, String>,
+        result: Result<radiant::runtime::ExternalDragOutcome, String>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         tracing::debug!(
@@ -405,30 +405,33 @@ impl NativeAppState {
         self.clear_pending_internal_file_drag_paths();
         self.ui.status.sample = match result {
             Ok(outcome) if outcome.accepted() => match outcome.effect {
-                ui::ExternalDragEffect::Copy | ui::ExternalDragEffect::Link => {
+                radiant::runtime::ExternalDragEffect::Copy
+                | radiant::runtime::ExternalDragEffect::Link => {
                     let rating_error = if handoff_adds_keep_rating {
                         self.add_keep_rating_to_handoff_paths(&handoff_paths).err()
                     } else {
                         None
                     };
                     match (outcome.effect, rating_error) {
-                        (ui::ExternalDragEffect::Copy, None) => {
+                        (radiant::runtime::ExternalDragEffect::Copy, None) => {
                             String::from("Dragged item externally")
                         }
-                        (ui::ExternalDragEffect::Link, None) => {
+                        (radiant::runtime::ExternalDragEffect::Link, None) => {
                             String::from("Linked item externally")
                         }
-                        (ui::ExternalDragEffect::Copy, Some(error)) => {
+                        (radiant::runtime::ExternalDragEffect::Copy, Some(error)) => {
                             format!("Dragged item externally; rating update failed: {error}")
                         }
-                        (ui::ExternalDragEffect::Link, Some(error)) => {
+                        (radiant::runtime::ExternalDragEffect::Link, Some(error)) => {
                             format!("Linked item externally; rating update failed: {error}")
                         }
                         _ => unreachable!("only copy/link outcomes are matched"),
                     }
                 }
-                ui::ExternalDragEffect::Move => String::from("Moved item externally"),
-                ui::ExternalDragEffect::None => String::from("External drag cancelled"),
+                radiant::runtime::ExternalDragEffect::Move => String::from("Moved item externally"),
+                radiant::runtime::ExternalDragEffect::None => {
+                    String::from("External drag cancelled")
+                }
             },
             Ok(_) => String::from("External drag cancelled"),
             Err(error) => format!("External drag failed: {error}"),

--- a/src/native_app/sample_library/drag_drop_actions/pending_paths.rs
+++ b/src/native_app/sample_library/drag_drop_actions/pending_paths.rs
@@ -1,13 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use radiant::prelude as ui;
-
 use crate::native_app::app::NativeAppState;
 
 impl NativeAppState {
     pub(in crate::native_app) fn arm_pending_internal_file_drag_paths(
         &mut self,
-        request: Option<&ui::ExternalDragRequest>,
+        request: Option<&radiant::runtime::ExternalDragRequest>,
         add_keep_rating: bool,
     ) {
         self.ui
@@ -17,7 +15,8 @@ impl NativeAppState {
         self.ui
             .browser_interaction
             .pending_internal_file_drag_adds_keep_rating = false;
-        let Some(ui::ExternalDragPayload::Files(paths)) = request.map(|request| &request.payload)
+        let Some(radiant::runtime::ExternalDragPayload::Files(paths)) =
+            request.map(|request| &request.payload)
         else {
             return;
         };

--- a/src/native_app/sample_library/folder_browser/drag_drop/preview.rs
+++ b/src/native_app/sample_library/folder_browser/drag_drop/preview.rs
@@ -41,19 +41,21 @@ impl FolderBrowserState {
         }
     }
 
-    pub(in crate::native_app) fn external_drag_request(&self) -> Option<ui::ExternalDragRequest> {
+    pub(in crate::native_app) fn external_drag_request(
+        &self,
+    ) -> Option<radiant::runtime::ExternalDragRequest> {
         let drag = self.drag_drop.drag.as_ref()?;
         let label = self.drag_preview_label(drag)?;
         let FolderBrowserDrag::Files { file_ids, .. } = drag else {
             return match drag {
-                FolderBrowserDrag::ExtractedFile { path } => {
-                    Some(ui::ExternalDragRequest::files([path.clone()], label))
-                }
+                FolderBrowserDrag::ExtractedFile { path } => Some(
+                    radiant::runtime::ExternalDragRequest::files([path.clone()], label),
+                ),
                 _ => None,
             };
         };
         let paths = file_ids.iter().map(PathBuf::from).collect::<Vec<_>>();
-        Some(ui::ExternalDragRequest::files(paths, label))
+        Some(radiant::runtime::ExternalDragRequest::files(paths, label))
     }
 
     fn drag_preview_label(&self, drag: &FolderBrowserDrag) -> Option<String> {

--- a/src/native_app/sample_library/folder_browser/file_columns/drag.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/drag.rs
@@ -1,4 +1,4 @@
-use radiant::{prelude as ui, widgets::DragHandleMessage};
+use radiant::widgets::DragHandleMessage;
 
 use super::super::{FileColumnDragFeedback, FileColumnKind, FolderBrowserState};
 use super::layout::file_column_visible_in_context;
@@ -12,7 +12,7 @@ impl FolderBrowserState {
         &self,
     ) -> Option<FileColumnDragFeedback> {
         let drag = self.sample_list.file_column_reorder.as_ref()?;
-        let feedback = ui::details_column_drag_feedback(
+        let feedback = radiant::application::details_column_drag_feedback(
             drag,
             &self.visible_file_column_placements(),
             FILE_COLUMN_GAP,
@@ -45,7 +45,7 @@ impl FolderBrowserState {
             .iter()
             .find(|column| column.kind == kind)
             .map(|column| column.width);
-        let Some(update) = ui::update_details_column_resize_drag(
+        let Some(update) = radiant::application::update_details_column_resize_drag(
             &mut self.sample_list.file_column_resize,
             kind.id().to_owned(),
             message,
@@ -78,7 +78,7 @@ impl FolderBrowserState {
         let collection_active = self.collection_focus_active();
         let curation_active = self.curation_mode_enabled();
         let harvest_active = self.harvest_mode_active();
-        ui::update_visible_details_column_reorder_drag(
+        radiant::application::update_visible_details_column_reorder_drag(
             &mut self.sample_list.file_column_reorder,
             &mut self.sample_list.file_columns,
             kind.id().to_owned(),

--- a/src/native_app/sample_library/folder_browser/file_columns/layout.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/layout.rs
@@ -1,5 +1,3 @@
-use radiant::prelude as ui;
-
 use super::super::{FileColumn, FileColumnKind, FolderBrowserState};
 
 impl FolderBrowserState {
@@ -21,11 +19,13 @@ impl FolderBrowserState {
             .collect()
     }
 
-    pub(in crate::native_app) fn file_sort(&self) -> &ui::DetailsSort {
+    pub(in crate::native_app) fn file_sort(&self) -> &radiant::application::DetailsSort {
         &self.sample_list.file_sort
     }
 
-    pub(super) fn visible_file_column_placements(&self) -> Vec<ui::DetailsColumnPlacement> {
+    pub(super) fn visible_file_column_placements(
+        &self,
+    ) -> Vec<radiant::application::DetailsColumnPlacement> {
         details_column_placements(self.visible_file_columns())
     }
 }
@@ -46,9 +46,11 @@ pub(super) fn file_column_visible_in_context(
 
 pub(super) fn details_column_placements<'a>(
     columns: impl IntoIterator<Item = &'a FileColumn>,
-) -> Vec<ui::DetailsColumnPlacement> {
+) -> Vec<radiant::application::DetailsColumnPlacement> {
     columns
         .into_iter()
-        .map(|column| ui::DetailsColumnPlacement::new(column.id.as_str(), column.width))
+        .map(|column| {
+            radiant::application::DetailsColumnPlacement::new(column.id.as_str(), column.width)
+        })
         .collect()
 }

--- a/src/native_app/sample_library/folder_browser/file_columns/ordering.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/ordering.rs
@@ -1,4 +1,3 @@
-use radiant::prelude as ui;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -16,8 +15,10 @@ impl FolderBrowserState {
         if self.sample_list.file_sort.column_id == column_id {
             self.sample_list.file_sort.direction = self.sample_list.file_sort.direction.toggled();
         } else {
-            self.sample_list.file_sort =
-                ui::DetailsSort::new(column_id.to_owned(), ui::SortDirection::Ascending);
+            self.sample_list.file_sort = radiant::application::DetailsSort::new(
+                column_id.to_owned(),
+                radiant::application::SortDirection::Ascending,
+            );
         }
     }
 
@@ -44,7 +45,7 @@ impl FolderBrowserState {
         } else {
             sort_file_refs_by_column_kind(kind, files, tags_by_file);
         }
-        if self.sample_list.file_sort.direction == ui::SortDirection::Descending {
+        if self.sample_list.file_sort.direction == radiant::application::SortDirection::Descending {
             files.reverse();
         }
         if self.filters.curation.enabled
@@ -134,7 +135,9 @@ pub(in crate::native_app) fn sort_file_indices_by_column_kind(
     }
 }
 
-pub(in crate::native_app) fn sort_kind_for_details_sort(sort: &ui::DetailsSort) -> FileColumnKind {
+pub(in crate::native_app) fn sort_kind_for_details_sort(
+    sort: &radiant::application::DetailsSort,
+) -> FileColumnKind {
     FileColumnKind::from_id(sort.column_id.as_str()).unwrap_or(FileColumnKind::Name)
 }
 

--- a/src/native_app/sample_library/folder_browser/file_columns/tests.rs
+++ b/src/native_app/sample_library/folder_browser/file_columns/tests.rs
@@ -1,4 +1,3 @@
-use radiant::prelude as ui;
 use std::collections::HashMap;
 use wavecrate::sample_sources::{Rating, SampleCollection};
 
@@ -201,9 +200,9 @@ fn typed_file_column_kinds_map_to_sort_behavior() {
 #[test]
 fn unknown_sort_id_falls_back_to_name_kind() {
     assert_eq!(
-        sort_kind_for_details_sort(&ui::DetailsSort::new(
+        sort_kind_for_details_sort(&radiant::application::DetailsSort::new(
             "missing-column",
-            ui::SortDirection::Ascending,
+            radiant::application::SortDirection::Ascending,
         )),
         FileColumnKind::Name
     );

--- a/src/native_app/sample_library/folder_browser/sample_queries/ordering.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries/ordering.rs
@@ -1,4 +1,3 @@
-use radiant::prelude as ui;
 use std::collections::HashMap;
 
 use super::super::file_columns::{sort_file_indices_by_column_kind, sort_kind_for_details_sort};
@@ -34,7 +33,7 @@ fn sort_file_indices_with_tag_metadata(
         indices,
         tags_by_file,
     );
-    if state.sample_list.file_sort.direction == ui::SortDirection::Descending {
+    if state.sample_list.file_sort.direction == radiant::application::SortDirection::Descending {
         indices.reverse();
     }
     if state.filters.curation.enabled

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -38,7 +38,7 @@ pub(in crate::native_app) struct VisibleSampleList<'a> {
     pub(in crate::native_app) window: ui::VirtualListWindow,
     pub(in crate::native_app) rows: Vec<VisibleSampleRow<'a>>,
     pub(in crate::native_app) columns: Vec<&'a FileColumn>,
-    pub(in crate::native_app) sort: &'a ui::DetailsSort,
+    pub(in crate::native_app) sort: &'a radiant::application::DetailsSort,
     pub(in crate::native_app) similarity_mode_active: bool,
     pub(in crate::native_app) similarity_controls: &'a SimilarityAspectSettings,
 }
@@ -72,9 +72,9 @@ pub(in crate::native_app) struct VisibleSampleRow<'a> {
 #[derive(Clone, Debug)]
 pub(super) struct SampleListState {
     pub(super) file_columns: Vec<FileColumn>,
-    pub(super) file_sort: ui::DetailsSort,
-    pub(super) file_column_resize: Option<ui::DetailsColumnResizeDrag>,
-    pub(super) file_column_reorder: Option<ui::DetailsColumnReorderDrag>,
+    pub(super) file_sort: radiant::application::DetailsSort,
+    pub(super) file_column_resize: Option<radiant::application::DetailsColumnResizeDrag>,
+    pub(super) file_column_reorder: Option<radiant::application::DetailsColumnReorderDrag>,
     pub(super) similarity_controls: SimilarityAspectSettings,
     pub(super) similarity: Option<SimilarityBrowserState>,
     pub(super) random_navigation: RandomNavigationState,
@@ -101,7 +101,10 @@ impl SampleListState {
     pub(super) fn new() -> Self {
         Self {
             file_columns: default_file_columns(),
-            file_sort: ui::DetailsSort::new("name", ui::SortDirection::Ascending),
+            file_sort: radiant::application::DetailsSort::new(
+                "name",
+                radiant::application::SortDirection::Ascending,
+            ),
             file_column_resize: None,
             file_column_reorder: None,
             similarity_controls: SimilarityAspectSettings::default(),
@@ -382,7 +385,7 @@ pub(super) struct VisibleSampleProjectionRequest<'a> {
     rating_filter: &'a str,
     curation_filter: &'a str,
     listing_reveal_id: Option<&'a str>,
-    sort: &'a ui::DetailsSort,
+    sort: &'a radiant::application::DetailsSort,
     similarity_anchor_id: Option<&'a str>,
     content_revision: u64,
     playback_type_tag_sort: bool,
@@ -394,7 +397,7 @@ impl<'a> VisibleSampleProjectionRequest<'a> {
         name_filter: &'a str,
         rating_filter: &'a str,
         curation_filter: &'a str,
-        sort: &'a ui::DetailsSort,
+        sort: &'a radiant::application::DetailsSort,
         similarity_anchor_id: Option<&'a str>,
         content_revision: u64,
     ) -> Self {
@@ -429,7 +432,7 @@ impl<'a> VisibleSampleProjectionRequest<'a> {
             self.curation_filter.to_owned(),
             self.listing_reveal_id.map(str::to_owned),
             self.sort.column_id.clone(),
-            self.sort.direction == ui::SortDirection::Descending,
+            self.sort.direction == radiant::application::SortDirection::Descending,
             self.similarity_anchor_id.map(str::to_owned),
             self.content_revision,
             self.playback_type_tag_sort,
@@ -881,8 +884,14 @@ mod tests {
 
     #[test]
     fn projection_request_key_tracks_query_and_revision_inputs() {
-        let ascending = ui::DetailsSort::new("name", ui::SortDirection::Ascending);
-        let descending = ui::DetailsSort::new("size", ui::SortDirection::Descending);
+        let ascending = radiant::application::DetailsSort::new(
+            "name",
+            radiant::application::SortDirection::Ascending,
+        );
+        let descending = radiant::application::DetailsSort::new(
+            "size",
+            radiant::application::SortDirection::Descending,
+        );
 
         assert_ne!(
             VisibleSampleProjectionRequest::new("folder", "kick", "", "", &ascending, None, 4)

--- a/src/native_app/tests/file_operations.rs
+++ b/src/native_app/tests/file_operations.rs
@@ -286,8 +286,8 @@ fn accepted_external_file_drag_adds_keep_rating() {
     state.arm_browser_drag(&mut context);
 
     state.external_drag_completed(
-        Ok(ui::ExternalDragOutcome {
-            effect: ui::ExternalDragEffect::Copy,
+        Ok(radiant::runtime::ExternalDragOutcome {
+            effect: radiant::runtime::ExternalDragEffect::Copy,
         }),
         &mut context,
     );
@@ -359,8 +359,8 @@ fn accepted_waveform_selection_external_drag_does_not_add_whole_file_keep_rating
 
     let mut completion_context = ui::UiUpdateContext::default();
     state.external_drag_completed(
-        Ok(ui::ExternalDragOutcome {
-            effect: ui::ExternalDragEffect::Copy,
+        Ok(radiant::runtime::ExternalDragOutcome {
+            effect: radiant::runtime::ExternalDragEffect::Copy,
         }),
         &mut completion_context,
     );

--- a/src/native_app/tests/sample_browser/column_headers.rs
+++ b/src/native_app/tests/sample_browser/column_headers.rs
@@ -105,7 +105,10 @@ fn full_gui_column_header_click_toggles_sort_direction() {
     );
     let sort = runtime.bridge().state().library.folder_browser.file_sort();
     assert_eq!(sort.column_id, "size");
-    assert_eq!(sort.direction, radiant::prelude::SortDirection::Ascending);
+    assert_eq!(
+        sort.direction,
+        radiant::application::SortDirection::Ascending
+    );
     assert_eq!(
         rendered_sample_stems(&runtime.frame_with_default_theme(), &stems),
         ["gamma", "alpha", "beta"]
@@ -118,7 +121,10 @@ fn full_gui_column_header_click_toggles_sort_direction() {
     );
     let sort = runtime.bridge().state().library.folder_browser.file_sort();
     assert_eq!(sort.column_id, "size");
-    assert_eq!(sort.direction, radiant::prelude::SortDirection::Descending);
+    assert_eq!(
+        sort.direction,
+        radiant::application::SortDirection::Descending
+    );
     assert_eq!(
         rendered_sample_stems(&runtime.frame_with_default_theme(), &stems),
         ["beta", "alpha", "gamma"]

--- a/src/native_app/tests/sample_browser/column_reorder.rs
+++ b/src/native_app/tests/sample_browser/column_reorder.rs
@@ -171,18 +171,20 @@ fn full_gui_column_drag_marker_uses_header_local_coordinates() {
     let state = crate::native_app::test_support::state::NativeAppState::load_default()
         .expect("default state loads");
     let mut runtime = native_runtime_for_tests(state, Vector2::new(1100.0, 620.0));
-    let rating_header_id =
-        radiant::prelude::compact_details_header_sort_drag_id(radiant::widgets::stable_widget_id(
+    let rating_header_id = radiant::application::compact_details_header_sort_drag_id(
+        radiant::widgets::stable_widget_id(
             crate::native_app::ui::ids::RETAINED_SAMPLE_HEADER_CELL_ID,
             "rating",
-        ));
-    let size_header_id =
-        radiant::prelude::compact_details_header_sort_drag_id(radiant::widgets::stable_widget_id(
+        ),
+    );
+    let size_header_id = radiant::application::compact_details_header_sort_drag_id(
+        radiant::widgets::stable_widget_id(
             crate::native_app::ui::ids::RETAINED_SAMPLE_HEADER_CELL_ID,
             "size",
-        ));
+        ),
+    );
     let extension_resize_id =
-        radiant::prelude::compact_details_header_resize_id(radiant::widgets::stable_widget_id(
+        radiant::application::compact_details_header_resize_id(radiant::widgets::stable_widget_id(
             crate::native_app::ui::ids::RETAINED_SAMPLE_HEADER_CELL_ID,
             "extension",
         ));

--- a/src/native_app/tests/shortcuts_context/context_menu.rs
+++ b/src/native_app/tests/shortcuts_context/context_menu.rs
@@ -240,7 +240,7 @@ fn context_path_copy_completion_updates_status() {
     state.finish_context_path_copy(
         BrowserContextTargetKind::Sample,
         PathBuf::from("C:\\samples\\kick.wav"),
-        Ok(ui::PlatformResponse::Completed),
+        Ok(radiant::runtime::PlatformResponse::Completed),
     );
     assert_eq!(state.ui.status.sample, "Copied path");
 
@@ -262,7 +262,7 @@ fn context_target_open_completion_updates_status() {
     state.finish_context_target_open(
         BrowserContextTargetKind::Sample,
         PathBuf::from("C:\\samples\\kick.wav"),
-        Ok(ui::PlatformResponse::Completed),
+        Ok(radiant::runtime::PlatformResponse::Completed),
     );
     assert_eq!(state.ui.status.sample, "Revealed sample");
 

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -357,7 +357,7 @@ fn platform_copy_file_paths(
 ) -> Option<Vec<PathBuf>> {
     match command {
         radiant::runtime::Command::PlatformRequest {
-            request: ui::PlatformRequest::CopyFilePaths(paths),
+            request: radiant::runtime::PlatformRequest::CopyFilePaths(paths),
             ..
         } => Some(paths),
         radiant::runtime::Command::Batch(commands) => {
@@ -372,7 +372,7 @@ fn external_drag_file_paths(
 ) -> Option<Vec<PathBuf>> {
     match command {
         radiant::runtime::Command::BeginExternalDrag { request, .. } => match request.payload {
-            ui::ExternalDragPayload::Files(paths) => Some(paths),
+            radiant::runtime::ExternalDragPayload::Files(paths) => Some(paths),
         },
         radiant::runtime::Command::Batch(commands) => {
             commands.into_iter().find_map(external_drag_file_paths)


### PR DESCRIPTION
## Scope

- Pin `vendor/radiant` to merged Radiant PR #1423 (`fee19cbdbd0200b3ba92460f075ddbf8fb13ecee`).
- Move specialist details-list, named-parts, low-level paint, platform protocol, and external-drag call sites from `radiant::prelude` to their explicit public owner modules.
- Preserve Wavecrate behavior while making the common-prelude boundary visible at application call sites.

## Definition of Done

- Wavecrate compiles against the canonical merged Radiant OPT-1168 commit.
- Specialist APIs use explicit `radiant::application`, `radiant::runtime`, or `radiant::gui` ownership.
- The diff contains no compatibility aliases or menu/option-list constructor consolidation.
- The branch is formatted and repository smoke validation passes.

## Validation

- `cargo check -p wavecrate`
- `cargo test --no-run`
- `bash scripts/ci.sh smoke`
- `rustfmt --edition 2024 --check` for every changed Rust file
- `git diff --check main...HEAD`

## Known limitations

- `cargo fmt --all -- --check` is not a usable whole-workspace signal because current `main` has unrelated formatting drift in `crates/reson/src/player/playback.rs`; every changed Rust file was checked directly with rustfmt.

User review is required before merge.