### PR TITLE
Keep source indexing from blocking the UI

### DIFF
--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -90,7 +90,7 @@ mod tests {
     use std::{fs, sync::mpsc};
 
     use crate::native_app::sample_library::folder_browser::scan::{
-        FolderScanItem, FolderScanRequest,
+        FolderScanItem, FolderScanRequest, INDEX_PROGRESS_REPORT_INTERVAL,
     };
 
     use super::{DISCOVERY_BATCH_SIZE, FolderScanWorkerEvent, run_folder_scan_worker_with_emit};
@@ -150,24 +150,35 @@ mod tests {
 
     #[test]
     fn large_scan_worker_keeps_every_ui_discovery_message_bounded() {
-        let root = temp_source_with_wavs(DISCOVERY_BATCH_SIZE * 16);
+        let file_count = DISCOVERY_BATCH_SIZE * 16;
+        let root = temp_source_with_wavs(file_count);
         let (sender, receiver) = mpsc::channel();
 
         let result = run_folder_scan_worker_with_emit(scan_request(&root), move |event| {
             sender.send(event).is_ok()
         });
 
-        let batches = receiver
-            .try_iter()
+        let events = receiver.try_iter().collect::<Vec<_>>();
+        let batches = events
+            .iter()
             .filter_map(|message| match message {
-                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events),
+                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch.events.as_slice()),
                 _ => None,
             })
             .collect::<Vec<_>>();
-        let batch_lengths = batches.iter().map(Vec::len).collect::<Vec<_>>();
+        let indexing_progress_count = events
+            .iter()
+            .filter(|message| {
+                matches!(
+                    message,
+                    FolderScanWorkerEvent::Progress(progress) if progress.phase == "Indexing"
+                )
+            })
+            .count();
+        let batch_lengths = batches.iter().map(|batch| batch.len()).collect::<Vec<_>>();
         let published_file_count = batches
             .iter()
-            .flatten()
+            .flat_map(|batch| batch.iter())
             .filter(|event| matches!(event.item, FolderScanItem::File(_)))
             .count();
         assert!(batch_lengths.len() > 1);
@@ -177,6 +188,11 @@ mod tests {
                 .all(|count| *count <= DISCOVERY_BATCH_SIZE)
         );
         assert_eq!(published_file_count, result.scan.file_count);
-        assert_eq!(result.audio_file_paths.len(), DISCOVERY_BATCH_SIZE * 16);
+        assert_eq!(result.audio_file_paths.len(), file_count);
+        assert_eq!(
+            indexing_progress_count,
+            1 + file_count / INDEX_PROGRESS_REPORT_INTERVAL,
+            "indexing progress must stay bounded so a large background scan cannot saturate the UI queue"
+        );
     }
 }

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -5,6 +5,8 @@ pub(in crate::native_app) use super::scan_types::{
     FolderScanResult, FolderTreeRefreshRequest, FolderTreeRefreshResult, FolderVerifyResult,
     PreparedFolderScanResult,
 };
+#[cfg(test)]
+pub(in crate::native_app) use super::scanning::INDEX_PROGRESS_REPORT_INTERVAL;
 pub(in crate::native_app) use super::scanning::{
     refresh_folder_tree_only, scan_source_with_progress, verify_direct_folder,
 };

--- a/src/native_app/sample_library/folder_browser/scanning.rs
+++ b/src/native_app/sample_library/folder_browser/scanning.rs
@@ -9,6 +9,8 @@ pub(super) use discovery_merge::{merge_scan_discovery, upsert_file, upsert_folde
 pub(super) use file_entry_metadata::file_entry;
 pub(in crate::native_app::sample_library::folder_browser) use metadata::refreshed_file_entries_for_paths;
 pub(super) use metadata::{SourceMetadataMap, file_entry_for_source_path};
+#[cfg(test)]
+pub(in crate::native_app) use progress::INDEX_PROGRESS_REPORT_INTERVAL;
 pub(in crate::native_app) use progress::scan_source_with_progress;
 pub(in crate::native_app) use traversal::refresh_folder_tree_only;
 pub(super) use traversal::{load_folder_at_path, load_source_snapshot, placeholder_folder};

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -15,6 +15,9 @@ use super::{
 };
 use wavecrate::sample_sources::{SourceDatabase, scanner};
 
+/// Publish at most one source-index progress update per bounded file batch.
+pub(in crate::native_app) const INDEX_PROGRESS_REPORT_INTERVAL: usize = 128;
+
 pub(in crate::native_app) fn scan_source_with_progress(
     request: FolderScanRequest,
     mut progress: impl FnMut(FolderScanProgress),
@@ -79,6 +82,9 @@ fn sync_source_database(
         Err(err) => return Some(format!("open source index: {err}")),
     };
     let mut sync_progress = |completed: usize, path: &Path| {
+        if completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL) {
+            return;
+        }
         progress(FolderScanProgress {
             task_id: request.task_id,
             source_id: request.source_id.clone(),


### PR DESCRIPTION
## Scope

- Bound source-database indexing progress updates so large background scans cannot saturate the UI event queue.
- Preserve the first progress signal, then report once per 128 indexed files.
- Extend the large-source worker regression test to prove discovery stays complete and bounded while indexing progress is throttled.

## Definition of Done

- Source indexing remains owned by the background scan worker.
- Selecting another source remains responsive while a large source scan is active.
- Indexing progress traffic is bounded without dropping discovery results or completion/error events.
- Focused, repository, performance-scale, and real-app validation pass for the exact implementation tree.

## Validation

- `cargo test --bin wavecrate large_scan_worker_keeps_every_ui_discovery_message_bounded -- --nocapture`
- `cargo test --bin wavecrate source_scan_worker::tests -- --nocapture`
- `bash scripts/check.sh non-blocking-architecture`
- `bash scripts/ci.sh smoke`
- `bash scripts/ci.sh agent` — 1,909 Wavecrate tests passed; 20 ignored; 0 failed, plus Radiant checks
- `git diff --check`
- Real release-build UI check against a 9,097-file source: a second source selection was accepted and rendered while scanning remained active; the two-click/state roundtrip completed in 818 ms.
- Scale comparison: indexing progress messages reduced from 9,097 to 72 for that source (about 99.2%) while discovery results remain complete.

## Known limitations

None.

User review is required before merge.
