### PR TITLE
Wavecrate: add bounded always-on source processing supervisor

### DIFF
--- a/crates/wavecrate-analysis/src/analysis/ann_index/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod update;
 mod update;
 
 use crate::analysis::{decode_f32_le_blob, similarity};
-use rusqlite::Connection;
+use rusqlite::{Connection, TransactionBehavior};
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, RwLock};
 
@@ -120,6 +120,32 @@ where
 /// Flush any buffered ANN insertions to the on-disk index.
 pub fn flush_pending_inserts(conn: &Connection) -> Result<(), String> {
     with_index_state_mut(conn, |state| update::flush_pending_inserts(conn, state))
+}
+
+/// Flush buffered ANN insertions only while a transactional generation fence is current.
+///
+/// The immediate SQLite transaction remains open while the index container and its database
+/// metadata are published, preventing a source mutation from crossing the generation check.
+pub fn flush_pending_inserts_with_publication_fence(
+    conn: &mut Connection,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|err| format!("Start ANN publication transaction failed: {err}"))?;
+    if !publication_fence(&tx)? {
+        tx.rollback()
+            .map_err(|err| format!("Roll back stale ANN publication failed: {err}"))?;
+        return Ok(false);
+    }
+    let state_arc = get_index_entry(&tx)?;
+    let mut state = state_arc
+        .write()
+        .map_err(|_| "ANN index state lock poisoned")?;
+    update::flush_pending_inserts(&tx, &mut state)?;
+    tx.commit()
+        .map_err(|err| format!("Commit ANN publication failed: {err}"))?;
+    Ok(true)
 }
 
 /// Find the `k` nearest neighbors for a stored sample id.

--- a/crates/wavecrate-analysis/src/analysis/ann_index/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index/mod.rs
@@ -324,6 +324,34 @@ pub fn rebuild_index(conn: &Connection) -> Result<(), String> {
     Ok(())
 }
 
+/// Rebuild and publish the complete ANN index only while an exact fence remains current.
+pub fn rebuild_index_with_publication_fence(
+    conn: &mut Connection,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
+    let params = state::default_params();
+    let index_path = storage::default_index_path(conn)?;
+    let mut state = build::build_index_from_db(conn, params, index_path)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|err| format!("Start ANN rebuild publication transaction failed: {err}"))?;
+    if !publication_fence(&tx)? {
+        tx.rollback()
+            .map_err(|err| format!("Roll back stale ANN rebuild failed: {err}"))?;
+        return Ok(false);
+    }
+    update::flush_index(&tx, &mut state)?;
+    tx.commit()
+        .map_err(|err| format!("Commit ANN rebuild publication failed: {err}"))?;
+    let key = storage::index_key(conn)?;
+    let wrapped_state = Arc::new(RwLock::new(state));
+    let mut guard = ANN_INDEX
+        .write()
+        .map_err(|_| "ANN index lock poisoned".to_string())?;
+    guard.insert(key, wrapped_state);
+    Ok(true)
+}
+
 fn load_embedding(conn: &Connection, sample_id: &str) -> Result<Vec<f32>, String> {
     let blob: Vec<u8> = conn
         .query_row(

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/mod.rs
@@ -89,13 +89,13 @@ pub(super) fn write_legacy_ann_files(
     ann_storage::save_legacy_id_map(&id_map_path, &state.id_map).unwrap();
 }
 
-pub(super) fn with_ann_test_db<T>(f: impl FnOnce(&Connection) -> T) -> T {
+pub(super) fn with_ann_test_db<T>(f: impl FnOnce(&mut Connection) -> T) -> T {
     let _lock = ANN_TEST_LOCK.lock().expect("ann test lock poisoned");
     let temp = tempdir().unwrap();
     let _guard = ConfigBaseGuard::set(temp.path().to_path_buf());
-    let conn = Connection::open_in_memory().unwrap();
+    let mut conn = Connection::open_in_memory().unwrap();
     create_ann_tables(&conn);
-    f(&conn)
+    f(&mut conn)
 }
 
 pub(super) fn load_disk_state(

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
@@ -49,6 +49,49 @@ fn ann_index_upsert_embeddings_batch_only_appends_new_ids() {
 }
 
 #[test]
+fn stale_generation_rejects_ann_container_and_metadata_publication() {
+    with_ann_test_db(|conn| {
+        let dim = similarity::SIMILARITY_DIM;
+        insert_embeddings(conn, dim, &basic_samples(dim));
+        ann_index::rebuild_index(conn).expect("ANN rebuild");
+
+        let fresh = normalize(unit_vec(dim, 4));
+        insert_embeddings(conn, dim, &[("s4", fresh.clone())]);
+        ann_index::upsert_embedding(conn, "s4", &fresh).expect("stage ANN insert");
+
+        let published =
+            ann_index::flush_pending_inserts_with_publication_fence(conn, &|_| Ok(false))
+                .expect("reject stale ANN publication");
+
+        assert!(!published);
+        assert_eq!(load_disk_state(conn).id_map.len(), 3);
+    });
+}
+
+#[test]
+fn stale_generation_rejects_lazy_ann_build_before_it_publishes() {
+    with_ann_test_db(|conn| {
+        let dim = similarity::SIMILARITY_DIM;
+        insert_embeddings(conn, dim, &basic_samples(dim));
+        let index_path = ann_storage::default_index_path(conn).expect("ANN index path");
+
+        let published =
+            ann_index::flush_pending_inserts_with_publication_fence(conn, &|_| Ok(false))
+                .expect("reject stale lazy ANN build");
+
+        assert!(!published);
+        assert!(!index_path.exists());
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM ann_index_meta", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .expect("count ANN metadata"),
+            0
+        );
+    });
+}
+
+#[test]
 fn ann_index_batch_validation_failure_leaves_state_unchanged() {
     with_ann_test_db(|conn| {
         let dim = similarity::SIMILARITY_DIM;

--- a/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
+++ b/crates/wavecrate-analysis/src/analysis/ann_index_tests/updates.rs
@@ -92,6 +92,36 @@ fn stale_generation_rejects_lazy_ann_build_before_it_publishes() {
 }
 
 #[test]
+fn fenced_ann_rebuild_replaces_stale_container_from_authoritative_embeddings() {
+    with_ann_test_db(|conn| {
+        let dim = similarity::SIMILARITY_DIM;
+        insert_embeddings(conn, dim, &basic_samples(dim));
+        ann_index::rebuild_index(conn).expect("initial ANN rebuild");
+
+        let replacement = normalize(unit_vec(dim, 4));
+        let fresh = normalize(unit_vec(dim, 5));
+        conn.execute(
+            "UPDATE embeddings SET vec = ?1 WHERE sample_id = 's1'",
+            [crate::analysis::vector::encode_f32_le_blob(&replacement)],
+        )
+        .expect("replace authoritative embedding");
+        conn.execute("DELETE FROM embeddings WHERE sample_id = 's2'", [])
+            .expect("remove authoritative embedding");
+        insert_embeddings(conn, dim, &[("s4", fresh)]);
+
+        let published = ann_index::rebuild_index_with_publication_fence(conn, &|_| Ok(true))
+            .expect("publish fenced ANN rebuild");
+
+        assert!(published);
+        let state = load_disk_state(conn);
+        assert_eq!(state.id_map, vec!["s1", "s3", "s4"]);
+        let nearest = state.hnsw.search(&replacement, 1, 16);
+        assert_eq!(nearest.len(), 1);
+        assert_eq!(state.id_map[nearest[0].d_id], "s1");
+    });
+}
+
+#[test]
 fn ann_index_batch_validation_failure_leaves_state_unchanged() {
     with_ann_test_db(|conn| {
         let dim = similarity::SIMILARITY_DIM;

--- a/crates/wavecrate-analysis/src/analysis/hdbscan/mapping.rs
+++ b/crates/wavecrate-analysis/src/analysis/hdbscan/mapping.rs
@@ -1,4 +1,4 @@
-use rusqlite::{Connection, Transaction, params};
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -131,16 +131,22 @@ fn min_max_cluster_size(cluster_counts: &HashMap<i32, usize>) -> (usize, usize) 
     (min_size, max_size)
 }
 
-pub fn write_clusters(
+pub fn write_clusters_with_publication_fence(
     conn: &mut Connection,
     sample_ids: &[String],
     labels: &[i32],
     model_id: &str,
     method: &str,
     umap_version: &str,
-) -> Result<(), String> {
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
     let now = now_epoch_seconds()?;
     let tx = start_cluster_tx(conn)?;
+    if !publication_fence(&tx)? {
+        tx.rollback()
+            .map_err(|err| format!("Roll back stale cluster publication failed: {err}"))?;
+        return Ok(false);
+    }
     {
         let mut stmt = prepare_cluster_insert(&tx)?;
         insert_cluster_rows(
@@ -155,11 +161,11 @@ pub fn write_clusters(
     }
     tx.commit()
         .map_err(|err| format!("Commit clusters failed: {err}"))?;
-    Ok(())
+    Ok(true)
 }
 
 fn start_cluster_tx(conn: &mut Connection) -> Result<Transaction<'_>, String> {
-    conn.transaction()
+    conn.transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(|err| format!("Start transaction failed: {err}"))
 }
 
@@ -242,5 +248,44 @@ mod tests {
         let mut labels = vec![5, 5, 2];
         remap_labels_deterministic(&sample_ids, &mut labels).unwrap();
         assert_eq!(labels, vec![0, 0, 1]);
+    }
+
+    #[test]
+    fn stale_generation_rejects_cluster_rows_inside_publication_transaction() {
+        let mut connection = Connection::open_in_memory().expect("open database");
+        connection
+            .execute_batch(
+                "CREATE TABLE hdbscan_clusters (
+                    sample_id TEXT NOT NULL,
+                    model_id TEXT NOT NULL,
+                    method TEXT NOT NULL,
+                    umap_version TEXT NOT NULL,
+                    cluster_id INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    PRIMARY KEY (sample_id, model_id, method, umap_version)
+                ) WITHOUT ROWID;",
+            )
+            .expect("create cluster table");
+
+        let published = write_clusters_with_publication_fence(
+            &mut connection,
+            &["source::sample".to_string()],
+            &[0],
+            "model-v1",
+            "umap",
+            "layout-v1",
+            &|_| Ok(false),
+        )
+        .expect("reject stale clusters");
+
+        assert!(!published);
+        assert_eq!(
+            connection
+                .query_row("SELECT COUNT(*) FROM hdbscan_clusters", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count cluster rows"),
+            0
+        );
     }
 }

--- a/crates/wavecrate-analysis/src/analysis/hdbscan/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/hdbscan/mod.rs
@@ -8,9 +8,7 @@ use rusqlite::Connection;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use self::engine::load_cluster_data;
-use self::mapping::{
-    assign_all_points_to_clusters, remap_labels_deterministic, summarize_labels, write_clusters,
-};
+use self::mapping::{assign_all_points_to_clusters, remap_labels_deterministic, summarize_labels};
 use self::validation::{ensure_non_empty, validate_request};
 
 /// Input space to use when clustering with HDBSCAN.
@@ -100,6 +98,33 @@ pub fn build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
     config: HdbscanConfig,
     cancel: &AtomicBool,
 ) -> Result<HdbscanStats, String> {
+    build_hdbscan_clusters_for_sample_id_prefix_with_cancel_and_publication_fence(
+        conn,
+        model_id,
+        method,
+        umap_version,
+        sample_id_prefix,
+        config,
+        cancel,
+        &|_| Ok(true),
+    )?
+    .ok_or_else(|| "HDBSCAN publication fence unexpectedly rejected".to_string())
+}
+
+/// Build clusters and publish them only while a transactional generation fence is current.
+///
+/// The fence runs after an immediate SQLite write transaction begins, preventing a concurrent
+/// source mutation from committing between the check and the cluster assignments.
+pub fn build_hdbscan_clusters_for_sample_id_prefix_with_cancel_and_publication_fence(
+    conn: &mut Connection,
+    model_id: &str,
+    method: HdbscanMethod,
+    umap_version: Option<&str>,
+    sample_id_prefix: Option<&str>,
+    config: HdbscanConfig,
+    cancel: &AtomicBool,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<Option<HdbscanStats>, String> {
     validate_request(method, umap_version, config)?;
     if cancel.load(Ordering::Acquire) {
         return Err("HDBSCAN cancelled before loading data".to_string());
@@ -115,13 +140,14 @@ pub fn build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
     }
     let stats = summarize_labels(&labels);
     let version = umap_version.unwrap_or("");
-    write_clusters(
+    let published = mapping::write_clusters_with_publication_fence(
         conn,
         &sample_ids,
         &labels,
         model_id,
         method.as_str(),
         version,
+        publication_fence,
     )?;
-    Ok(stats)
+    Ok(published.then_some(stats))
 }

--- a/crates/wavecrate-analysis/src/analysis/hdbscan/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/hdbscan/mod.rs
@@ -5,6 +5,7 @@ mod mapping;
 mod validation;
 
 use rusqlite::Connection;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use self::engine::load_cluster_data;
 use self::mapping::{
@@ -77,13 +78,41 @@ pub fn build_hdbscan_clusters_for_sample_id_prefix(
     sample_id_prefix: Option<&str>,
     config: HdbscanConfig,
 ) -> Result<HdbscanStats, String> {
+    let cancel = AtomicBool::new(false);
+    build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
+        conn,
+        model_id,
+        method,
+        umap_version,
+        sample_id_prefix,
+        config,
+        &cancel,
+    )
+}
+
+/// Build clusters while fencing durable publication when cancellation is requested.
+pub fn build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
+    conn: &mut Connection,
+    model_id: &str,
+    method: HdbscanMethod,
+    umap_version: Option<&str>,
+    sample_id_prefix: Option<&str>,
+    config: HdbscanConfig,
+    cancel: &AtomicBool,
+) -> Result<HdbscanStats, String> {
     validate_request(method, umap_version, config)?;
+    if cancel.load(Ordering::Acquire) {
+        return Err("HDBSCAN cancelled before loading data".to_string());
+    }
     let (sample_ids, data) =
         load_cluster_data(conn, model_id, method, umap_version, sample_id_prefix)?;
     ensure_non_empty(&data)?;
     let mut labels = engine::run_hdbscan(&data, config)?;
     assign_all_points_to_clusters(&data, &mut labels);
     remap_labels_deterministic(&sample_ids, &mut labels)?;
+    if cancel.load(Ordering::Acquire) {
+        return Err("HDBSCAN cancelled before publication".to_string());
+    }
     let stats = summarize_labels(&labels);
     let version = umap_version.unwrap_or("");
     write_clusters(

--- a/crates/wavecrate-analysis/src/analysis/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/mod.rs
@@ -22,7 +22,8 @@ pub mod vector;
 pub(crate) mod version;
 
 pub use umap::{
-    MapLayoutReport, build_map_layout, build_map_layout_with_cancel, default_layout_report_path,
+    MapLayoutReport, build_map_layout, build_map_layout_with_cancel,
+    build_map_layout_with_cancel_and_publication_fence, default_layout_report_path,
     write_layout_report,
 };
 pub use vector::decode_f32_le_blob;
@@ -118,6 +119,14 @@ pub fn rebuild_ann_index(conn: &Connection) -> Result<(), String> {
 /// Flush any pending ANN insertions without forcing a rebuild.
 pub fn flush_ann_index(conn: &Connection) -> Result<(), String> {
     ann_index::flush_pending_inserts(conn)
+}
+
+/// Flush pending ANN insertions while an exact transactional generation fence remains current.
+pub fn flush_ann_index_with_publication_fence(
+    conn: &mut Connection,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
+    ann_index::flush_pending_inserts_with_publication_fence(conn, publication_fence)
 }
 
 #[cfg(test)]

--- a/crates/wavecrate-analysis/src/analysis/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/mod.rs
@@ -22,7 +22,8 @@ pub mod vector;
 pub(crate) mod version;
 
 pub use umap::{
-    MapLayoutReport, build_map_layout, default_layout_report_path, write_layout_report,
+    MapLayoutReport, build_map_layout, build_map_layout_with_cancel, default_layout_report_path,
+    write_layout_report,
 };
 pub use vector::decode_f32_le_blob;
 pub use vector::{FEATURE_VECTOR_LEN_V1, FEATURE_VERSION_V1};

--- a/crates/wavecrate-analysis/src/analysis/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/mod.rs
@@ -116,6 +116,14 @@ pub fn rebuild_ann_index(conn: &Connection) -> Result<(), String> {
     ann_index::rebuild_index(conn)
 }
 
+/// Rebuild the ANN index from authoritative embeddings while a publication fence is current.
+pub fn rebuild_ann_index_with_publication_fence(
+    conn: &mut Connection,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
+    ann_index::rebuild_index_with_publication_fence(conn, publication_fence)
+}
+
 /// Flush any pending ANN insertions without forcing a rebuild.
 pub fn flush_ann_index(conn: &Connection) -> Result<(), String> {
     ann_index::flush_pending_inserts(conn)

--- a/crates/wavecrate-analysis/src/analysis/umap/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/umap/mod.rs
@@ -9,7 +9,10 @@ mod report;
 mod storage;
 
 use rusqlite::Connection;
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use projection::compute_tsne;
 use report::validate_layout;
@@ -30,8 +33,27 @@ pub fn build_map_layout(
     seed: u64,
     min_coverage: f32,
 ) -> Result<MapLayoutReport, String> {
+    let cancel = AtomicBool::new(false);
+    build_map_layout_with_cancel(conn, model_id, layout_version, seed, min_coverage, &cancel)
+}
+
+/// Build a starmap layout while fencing durable publication when cancellation is requested.
+pub fn build_map_layout_with_cancel(
+    conn: &mut Connection,
+    model_id: &str,
+    layout_version: &str,
+    seed: u64,
+    min_coverage: f32,
+    cancel: &AtomicBool,
+) -> Result<MapLayoutReport, String> {
     let (sample_ids, vectors, dim) = load_embeddings(conn, model_id)?;
+    if cancel.load(Ordering::Acquire) {
+        return Err("Starmap layout cancelled before projection".to_string());
+    }
     let layout = build_layout(vectors, dim, seed)?;
+    if cancel.load(Ordering::Acquire) {
+        return Err("Starmap layout cancelled before publication".to_string());
+    }
     persist_and_validate_layout(conn, &sample_ids, &layout, model_id, layout_version)?;
     validate_layout(&layout, min_coverage)
 }

--- a/crates/wavecrate-analysis/src/analysis/umap/mod.rs
+++ b/crates/wavecrate-analysis/src/analysis/umap/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use projection::compute_tsne;
 use report::validate_layout;
 pub use report::{MapLayoutReport, UmapReport, default_layout_report_path, write_layout_report};
-use storage::{load_embeddings, write_layout};
+use storage::{load_embeddings, write_layout_with_publication_fence};
 
 type LayoutPoint = [f32; 2];
 
@@ -46,6 +46,31 @@ pub fn build_map_layout_with_cancel(
     min_coverage: f32,
     cancel: &AtomicBool,
 ) -> Result<MapLayoutReport, String> {
+    build_map_layout_with_cancel_and_publication_fence(
+        conn,
+        model_id,
+        layout_version,
+        seed,
+        min_coverage,
+        cancel,
+        &|_| Ok(true),
+    )?
+    .ok_or_else(|| "Starmap layout publication fence unexpectedly rejected".to_string())
+}
+
+/// Build a starmap layout and publish it only while a transactional generation fence is current.
+///
+/// The fence runs after an immediate SQLite write transaction begins, so a concurrent source
+/// mutation cannot commit between the generation check and the layout rows.
+pub fn build_map_layout_with_cancel_and_publication_fence(
+    conn: &mut Connection,
+    model_id: &str,
+    layout_version: &str,
+    seed: u64,
+    min_coverage: f32,
+    cancel: &AtomicBool,
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<Option<MapLayoutReport>, String> {
     let (sample_ids, vectors, dim) = load_embeddings(conn, model_id)?;
     if cancel.load(Ordering::Acquire) {
         return Err("Starmap layout cancelled before projection".to_string());
@@ -54,8 +79,18 @@ pub fn build_map_layout_with_cancel(
     if cancel.load(Ordering::Acquire) {
         return Err("Starmap layout cancelled before publication".to_string());
     }
-    persist_and_validate_layout(conn, &sample_ids, &layout, model_id, layout_version)?;
-    validate_layout(&layout, min_coverage)
+    let published = persist_and_validate_layout_with_fence(
+        conn,
+        &sample_ids,
+        &layout,
+        model_id,
+        layout_version,
+        publication_fence,
+    )?;
+    if !published {
+        return Ok(None);
+    }
+    validate_layout(&layout, min_coverage).map(Some)
 }
 
 /// Build and persist a 2D layout through the legacy UMAP-named entrypoint.
@@ -86,16 +121,27 @@ fn build_layout(vectors: Vec<f64>, dim: usize, seed: u64) -> Result<Vec<LayoutPo
     compute_tsne(vectors, dim, seed)
 }
 
-fn persist_and_validate_layout(
+fn persist_and_validate_layout_with_fence(
     conn: &mut Connection,
     sample_ids: &[String],
     layout: &[LayoutPoint],
     model_id: &str,
     layout_version: &str,
-) -> Result<(), String> {
-    let inserted = write_layout(conn, sample_ids, layout, model_id, layout_version)?;
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<bool, String> {
+    let Some(inserted) = write_layout_with_publication_fence(
+        conn,
+        sample_ids,
+        layout,
+        model_id,
+        layout_version,
+        publication_fence,
+    )?
+    else {
+        return Ok(false);
+    };
     validate_insert_count(inserted, sample_ids.len())?;
-    Ok(())
+    Ok(true)
 }
 
 fn validate_insert_count(inserted: usize, expected: usize) -> Result<(), String> {

--- a/crates/wavecrate-analysis/src/analysis/umap/storage.rs
+++ b/crates/wavecrate-analysis/src/analysis/umap/storage.rs
@@ -1,7 +1,7 @@
 //! Similarity-map embedding load and persistence helpers.
 
 use crate::analysis::decode_f32_le_blob;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, TransactionBehavior, params};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::LayoutPoint;
@@ -23,17 +23,23 @@ pub(super) fn load_embeddings(
 }
 
 /// Persist one projected layout into the legacy `layout_umap` compatibility table.
-pub(super) fn write_layout(
+pub(super) fn write_layout_with_publication_fence(
     conn: &mut Connection,
     sample_ids: &[String],
     layout: &[LayoutPoint],
     model_id: &str,
     umap_version: &str,
-) -> Result<usize, String> {
+    publication_fence: &impl Fn(&Connection) -> Result<bool, String>,
+) -> Result<Option<usize>, String> {
     let now = current_unix_timestamp()?;
     let tx = conn
-        .transaction()
+        .transaction_with_behavior(TransactionBehavior::Immediate)
         .map_err(|err| format!("Start transaction failed: {err}"))?;
+    if !publication_fence(&tx)? {
+        tx.rollback()
+            .map_err(|err| format!("Roll back stale layout publication failed: {err}"))?;
+        return Ok(None);
+    }
     let mut stmt = tx
         .prepare(
             "INSERT INTO layout_umap (sample_id, model_id, umap_version, x, y, created_at)
@@ -60,7 +66,7 @@ pub(super) fn write_layout(
     drop(stmt);
     tx.commit()
         .map_err(|err| format!("Commit layout failed: {err}"))?;
-    Ok(sample_ids.len())
+    Ok(Some(sample_ids.len()))
 }
 
 fn count_embeddings(conn: &Connection, model_id: &str) -> Result<usize, String> {
@@ -161,4 +167,46 @@ fn current_unix_timestamp() -> Result<i64, String> {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
         .map_err(|_| "Invalid system time".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_generation_rejects_layout_rows_inside_publication_transaction() {
+        let mut connection = Connection::open_in_memory().expect("open database");
+        connection
+            .execute_batch(
+                "CREATE TABLE layout_umap (
+                    sample_id TEXT PRIMARY KEY,
+                    model_id TEXT NOT NULL,
+                    umap_version TEXT NOT NULL,
+                    x REAL NOT NULL,
+                    y REAL NOT NULL,
+                    created_at INTEGER NOT NULL
+                ) WITHOUT ROWID;",
+            )
+            .expect("create layout table");
+
+        let published = write_layout_with_publication_fence(
+            &mut connection,
+            &["source::sample".to_string()],
+            &[[0.25, -0.5]],
+            "model-v1",
+            "layout-v1",
+            &|_| Ok(false),
+        )
+        .expect("reject stale layout");
+
+        assert_eq!(published, None);
+        assert_eq!(
+            connection
+                .query_row("SELECT COUNT(*) FROM layout_umap", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .expect("count layout rows"),
+            0
+        );
+    }
 }

--- a/crates/wavecrate-analysis/src/lib.rs
+++ b/crates/wavecrate-analysis/src/lib.rs
@@ -10,11 +10,12 @@ mod app_dirs;
 pub use analysis::LIGHT_DSP_VECTOR_LEN;
 pub use analysis::{
     FEATURE_VECTOR_LEN_V1, FEATURE_VERSION_V1, MapLayoutReport, build_map_layout,
-    compute_feature_vector_v1_for_decoded_audio, compute_feature_vector_v1_for_mono_samples,
-    compute_feature_vector_v1_for_path, compute_similarity_embedding_for_mono_samples,
-    compute_similarity_embedding_for_path, decode_f32_le_blob, default_layout_report_path,
-    flush_ann_index, infer_embedding, light_dsp_from_features_v1, preprocess_mono_for_embedding,
-    rebuild_ann_index, write_layout_report,
+    build_map_layout_with_cancel, compute_feature_vector_v1_for_decoded_audio,
+    compute_feature_vector_v1_for_mono_samples, compute_feature_vector_v1_for_path,
+    compute_similarity_embedding_for_mono_samples, compute_similarity_embedding_for_path,
+    decode_f32_le_blob, default_layout_report_path, flush_ann_index, infer_embedding,
+    light_dsp_from_features_v1, preprocess_mono_for_embedding, rebuild_ann_index,
+    write_layout_report,
 };
 pub use analysis::{ann_index, aspects, hdbscan, similarity, umap, vector};
 

--- a/crates/wavecrate-analysis/src/lib.rs
+++ b/crates/wavecrate-analysis/src/lib.rs
@@ -10,10 +10,11 @@ mod app_dirs;
 pub use analysis::LIGHT_DSP_VECTOR_LEN;
 pub use analysis::{
     FEATURE_VECTOR_LEN_V1, FEATURE_VERSION_V1, MapLayoutReport, build_map_layout,
-    build_map_layout_with_cancel, compute_feature_vector_v1_for_decoded_audio,
-    compute_feature_vector_v1_for_mono_samples, compute_feature_vector_v1_for_path,
-    compute_similarity_embedding_for_mono_samples, compute_similarity_embedding_for_path,
-    decode_f32_le_blob, default_layout_report_path, flush_ann_index, infer_embedding,
+    build_map_layout_with_cancel, build_map_layout_with_cancel_and_publication_fence,
+    compute_feature_vector_v1_for_decoded_audio, compute_feature_vector_v1_for_mono_samples,
+    compute_feature_vector_v1_for_path, compute_similarity_embedding_for_mono_samples,
+    compute_similarity_embedding_for_path, decode_f32_le_blob, default_layout_report_path,
+    flush_ann_index, flush_ann_index_with_publication_fence, infer_embedding,
     light_dsp_from_features_v1, preprocess_mono_for_embedding, rebuild_ann_index,
     write_layout_report,
 };

--- a/crates/wavecrate-analysis/src/lib.rs
+++ b/crates/wavecrate-analysis/src/lib.rs
@@ -16,7 +16,7 @@ pub use analysis::{
     compute_similarity_embedding_for_path, decode_f32_le_blob, default_layout_report_path,
     flush_ann_index, flush_ann_index_with_publication_fence, infer_embedding,
     light_dsp_from_features_v1, preprocess_mono_for_embedding, rebuild_ann_index,
-    write_layout_report,
+    rebuild_ann_index_with_publication_fence, write_layout_report,
 };
 pub use analysis::{ann_index, aspects, hdbscan, similarity, umap, vector};
 

--- a/crates/wavecrate-library/src/sample_sources/db/open/read_only.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open/read_only.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 
 use super::paths;
 use crate::sample_sources::db::{
@@ -21,7 +21,7 @@ pub(super) fn open_read_only_source_database(
         .ok_or_else(|| SourceDbError::ReadOnlyDatabaseMissing(database_root.join(DB_FILE_NAME)))?;
 
     let connect_started = std::time::Instant::now();
-    let connection = match Connection::open_with_flags(&db_path, role.open_flags()) {
+    let connection = match Connection::open_with_flags(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
         Ok(connection) => {
             telemetry::record_open_phase(
                 root,
@@ -102,4 +102,45 @@ pub(super) fn open_read_only_source_database(
         Ok(()),
     );
     Ok(db)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::MAIN_DB;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn read_only_open_stays_read_only_for_writable_roles() {
+        let directory = tempdir().expect("temporary source");
+        let writable = SourceDatabase::open_for_source_write(directory.path())
+            .expect("create source database");
+        writable
+            .set_metadata("read_only_probe", "before")
+            .expect("seed metadata");
+        drop(writable);
+
+        let read_only = open_read_only_source_database(
+            directory.path(),
+            directory.path(),
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open job-worker role read-only");
+
+        assert!(
+            read_only.connection.is_readonly(MAIN_DB).unwrap(),
+            "the read-only entrypoint must override writable role flags"
+        );
+        assert!(
+            read_only
+                .connection
+                .execute(
+                    "INSERT OR REPLACE INTO metadata (key, value) VALUES ('read_only_probe', 'after')",
+                    [],
+                )
+                .is_err(),
+            "read-only source connections must reject writes"
+        );
+    }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -68,6 +68,27 @@ impl SourceDatabase {
         )
     }
 
+    /// Fetch a bounded path-ordered batch that still needs a deep content hash.
+    pub fn list_pending_hash_files(&self, limit: usize) -> Result<Vec<WavEntry>, SourceDbError> {
+        let filter = wav_file_supported_audio_filter(self)?;
+        let columns = wav_file_select_columns(self)?;
+        let sql = format!(
+            "SELECT {columns}
+             FROM wav_files
+             WHERE {filter}
+               AND missing = 0
+               AND content_hash IS NULL
+             ORDER BY path ASC
+             LIMIT ?1"
+        );
+        collect_wav_entries(
+            self,
+            &sql,
+            [i64::try_from(limit).unwrap_or(i64::MAX)],
+            "Skipping pending hash row with invalid relative path",
+        )
+    }
+
     /// Fetch tracked wav files whose paths are at or below the provided relative path.
     pub fn list_files_under_path(
         &self,

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -34,6 +34,31 @@ fn list_files_page_orders_supported_audio_and_applies_offsets() {
 }
 
 #[test]
+fn pending_hash_query_is_bounded_and_excludes_missing_or_hashed_rows() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    for name in ["delta.wav", "alpha.wav", "charlie.wav", "bravo.wav"] {
+        db.upsert_file(Path::new(name), 10, 5).unwrap();
+    }
+    db.connection
+        .execute(
+            "UPDATE wav_files SET content_hash = 'hash' WHERE path = 'alpha.wav'",
+            [],
+        )
+        .unwrap();
+    db.set_missing(Path::new("bravo.wav"), true).unwrap();
+
+    let paths = db
+        .list_pending_hash_files(1)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.relative_path)
+        .collect::<Vec<_>>();
+
+    assert_eq!(paths, vec![PathBuf::from("charlie.wav")]);
+}
+
+#[test]
 fn audio_queries_ignore_appledouble_sidecars() {
     let dir = tempdir().unwrap();
     let db = SourceDatabase::open(dir.path()).unwrap();

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -57,6 +57,7 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         running_at INTEGER,
         last_error TEXT,
         readiness_managed INTEGER NOT NULL DEFAULT 0,
+        readiness_claim_generation INTEGER NOT NULL DEFAULT 0,
         readiness_scope_kind TEXT,
         readiness_scope_id TEXT,
         readiness_stage TEXT,

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/analysis_jobs.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/analysis_jobs.rs
@@ -45,6 +45,7 @@ pub(super) fn ensure_analysis_jobs_optional_columns(
     backfill_analysis_jobs_relative_path(connection)?;
     for (column, definition) in [
         ("readiness_managed", "INTEGER NOT NULL DEFAULT 0"),
+        ("readiness_claim_generation", "INTEGER NOT NULL DEFAULT 0"),
         ("readiness_scope_kind", "TEXT"),
         ("readiness_scope_id", "TEXT"),
         ("readiness_stage", "TEXT"),

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -165,6 +165,7 @@ fn readiness_schema_repairs_current_stamped_analysis_storage() {
 
     let job_columns = table_columns(&conn, "analysis_jobs").unwrap();
     assert!(job_columns.contains("readiness_managed"));
+    assert!(job_columns.contains("readiness_claim_generation"));
     assert!(job_columns.contains("source_generation"));
     assert!(job_columns.contains("lease_expires_at"));
     let source_columns = table_columns(&conn, "source_readiness_sources").unwrap();

--- a/crates/wavecrate-library/src/sample_sources/library/schema_defs.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/schema_defs.rs
@@ -43,6 +43,7 @@ impl LibraryDatabase {
                     attempts INTEGER NOT NULL DEFAULT 0,
                     created_at INTEGER NOT NULL,
                     last_error TEXT,
+                    readiness_claim_generation INTEGER NOT NULL DEFAULT 0,
                     UNIQUE(sample_id, job_type)
                  );
                  CREATE INDEX IF NOT EXISTS idx_analysis_jobs_status_created_id

--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -9,8 +9,10 @@ mod snapshot;
 mod store;
 
 pub use model::{
-    ReadinessArtifact, ReadinessEligibility, ReadinessScopeKind, ReadinessStage, ReadinessTarget,
-    SourceAvailability,
+    ClaimedReadinessWork, ReadinessArtifact, ReadinessEligibility, ReadinessFailureClassification,
+    ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
+    ReadinessScopeKind, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
+    ReadinessWorkStats, SourceAvailability,
 };
 pub use snapshot::{
     ArtifactPublishOutcome, ReadinessActivity, ReadinessClassification, ReadinessDeficit,
@@ -19,7 +21,9 @@ pub use snapshot::{
 #[cfg(test)]
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
-    ReadinessError, persist_readiness_deficits, publish_readiness_artifact, reconcile_readiness,
+    ReadinessError, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+    fail_readiness_work, persist_readiness_deficits, publish_readiness_artifact,
+    readiness_work_stats, reconcile_readiness, release_readiness_work, renew_readiness_lease,
     replace_readiness_targets,
 };
 

--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -22,9 +22,10 @@ pub use snapshot::{
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
     ReadinessError, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-    fail_readiness_work, persist_readiness_deficits, publish_readiness_artifact,
-    readiness_work_stats, reconcile_readiness, release_readiness_work, renew_readiness_lease,
-    replace_readiness_targets,
+    fail_readiness_work, persist_readiness_deficits, persist_readiness_deficits_with_cancel,
+    publish_readiness_artifact, readiness_work_stats, reconcile_readiness,
+    reconcile_readiness_with_cancel, release_readiness_work, renew_readiness_lease,
+    replace_readiness_targets, replace_readiness_targets_with_cancel,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-library/src/sample_sources/readiness/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/model.rs
@@ -257,14 +257,17 @@ impl ReadinessArtifact {
 
 /// One durably claimed readiness unit tied to the exact target observed at claim time.
 ///
-/// `attempt` is the claim generation. Every lease mutation and completion is fenced by it, so a
-/// worker whose lease expired cannot publish after another worker has reclaimed the same target.
+/// `claim_generation` fences every lease mutation and completion, so a worker whose lease expired
+/// cannot publish after another worker has reclaimed the same target. `failure_attempts` is kept
+/// separate so benign cancellation and lease recovery never consume the retry allowance.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClaimedReadinessWork {
     /// Exact desired target captured when the work was claimed.
     pub target: ReadinessTarget,
     /// Monotonic claim generation for this target's durable work row.
-    pub attempt: u32,
+    pub claim_generation: u32,
+    /// Retryable failures recorded before this claim began.
+    pub failure_attempts: u32,
     /// Current lease deadline captured by the claim operation.
     pub lease_expires_at: i64,
 }
@@ -276,8 +279,13 @@ impl ClaimedReadinessWork {
     }
 
     /// Monotonic generation used to fence stale workers.
-    pub fn attempt(&self) -> u32 {
-        self.attempt
+    pub fn claim_generation(&self) -> u32 {
+        self.claim_generation
+    }
+
+    /// Retryable failures recorded before this claim began.
+    pub fn failure_attempts(&self) -> u32 {
+        self.failure_attempts
     }
 
     /// Current lease deadline captured by the claim operation.
@@ -335,7 +343,7 @@ impl ReadinessRetryPolicy {
             })
     }
 
-    /// Maximum number of claims allowed before a retryable failure becomes terminal.
+    /// Maximum number of recorded retryable failures before work becomes terminal.
     pub fn max_attempts(self) -> u32 {
         self.max_attempts
     }

--- a/crates/wavecrate-library/src/sample_sources/readiness/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/model.rs
@@ -404,6 +404,8 @@ pub struct ReadinessWorkStats {
     pub retries_due: usize,
     /// Retryable failures waiting for their deadline.
     pub retries_waiting: usize,
+    /// Earliest persisted retry deadline that has not arrived yet.
+    pub earliest_retry_at: Option<i64>,
     /// Permanently failed rows.
     pub permanent_failures: usize,
     /// Unsupported rows.

--- a/crates/wavecrate-library/src/sample_sources/readiness/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/model.rs
@@ -255,6 +255,165 @@ impl ReadinessArtifact {
     }
 }
 
+/// One durably claimed readiness unit tied to the exact target observed at claim time.
+///
+/// `attempt` is the claim generation. Every lease mutation and completion is fenced by it, so a
+/// worker whose lease expired cannot publish after another worker has reclaimed the same target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClaimedReadinessWork {
+    /// Exact desired target captured when the work was claimed.
+    pub target: ReadinessTarget,
+    /// Monotonic claim generation for this target's durable work row.
+    pub attempt: u32,
+    /// Current lease deadline captured by the claim operation.
+    pub lease_expires_at: i64,
+}
+
+impl ClaimedReadinessWork {
+    /// Exact target owned by this claim generation.
+    pub fn target(&self) -> &ReadinessTarget {
+        &self.target
+    }
+
+    /// Monotonic generation used to fence stale workers.
+    pub fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    /// Current lease deadline captured by the claim operation.
+    pub fn lease_expires_at(&self) -> i64 {
+        self.lease_expires_at
+    }
+}
+
+/// Stable failure classes understood by readiness reconciliation and telemetry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessFailureClassification {
+    /// The operation may succeed after bounded backoff.
+    Retryable,
+    /// The exact target cannot complete without a content or product change.
+    Permanent,
+    /// The target's media or stage is not supported.
+    Unsupported,
+}
+
+impl ReadinessFailureClassification {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Retryable => "retryable",
+            Self::Permanent => "permanent",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Bounded exponential retry policy for readiness work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadinessRetryPolicy {
+    initial_delay_seconds: i64,
+    max_delay_seconds: i64,
+    max_attempts: u32,
+}
+
+impl ReadinessRetryPolicy {
+    /// Build a valid bounded policy.
+    ///
+    /// Returns `None` for zero/negative delays, an initial delay above the maximum, or zero
+    /// attempts.
+    pub fn new(
+        initial_delay_seconds: i64,
+        max_delay_seconds: i64,
+        max_attempts: u32,
+    ) -> Option<Self> {
+        (initial_delay_seconds > 0
+            && max_delay_seconds >= initial_delay_seconds
+            && max_attempts > 0)
+            .then_some(Self {
+                initial_delay_seconds,
+                max_delay_seconds,
+                max_attempts,
+            })
+    }
+
+    /// Maximum number of claims allowed before a retryable failure becomes terminal.
+    pub fn max_attempts(self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Delay for a failed claim attempt, saturating at the configured maximum.
+    pub fn delay_for_attempt(self, attempt: u32) -> i64 {
+        let exponent = attempt.saturating_sub(1).min(62);
+        self.initial_delay_seconds
+            .checked_mul(1_i64 << exponent)
+            .unwrap_or(i64::MAX)
+            .min(self.max_delay_seconds)
+    }
+}
+
+/// Outcome of a generation-fenced work-state mutation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessWorkMutationOutcome {
+    /// The claimed row still belonged to the caller and was updated.
+    Recorded,
+    /// The target changed, the lease expired, or a newer claim generation owns the row.
+    RejectedStale,
+}
+
+/// Outcome of renewing a claimed readiness lease.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessLeaseRenewalOutcome {
+    /// The claim remains current through the returned deadline.
+    Renewed {
+        /// Persisted lease deadline after renewal.
+        lease_expires_at: i64,
+    },
+    /// The target changed, the lease expired, or a newer claim generation owns the row.
+    RejectedStale,
+}
+
+/// Outcome of recording a readiness failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessFailureOutcome {
+    /// A retryable failure was scheduled at the returned deadline.
+    RetryScheduled {
+        /// Earliest time at which the exact target may be reclaimed.
+        retry_at: i64,
+    },
+    /// The worker explicitly classified the target as permanently failed.
+    Permanent,
+    /// The worker classified the target as unsupported.
+    Unsupported,
+    /// A retryable failure consumed the configured final attempt.
+    AttemptsExhausted,
+    /// The target changed, the lease expired, or a newer claim generation owns the row.
+    RejectedStale,
+}
+
+/// Current durable readiness queue state for telemetry.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReadinessWorkStats {
+    /// All readiness-managed work rows.
+    pub total: usize,
+    /// Immediately claimable pending rows.
+    pub pending: usize,
+    /// Rows with an unexpired lease.
+    pub running: usize,
+    /// Running rows whose lease has expired and may be recovered.
+    pub expired_leases: usize,
+    /// Retryable failures whose deadline has arrived.
+    pub retries_due: usize,
+    /// Retryable failures waiting for their deadline.
+    pub retries_waiting: usize,
+    /// Permanently failed rows.
+    pub permanent_failures: usize,
+    /// Unsupported rows.
+    pub unsupported: usize,
+    /// Pending rows most recently returned by explicit cancellation.
+    pub cancelled: usize,
+    /// Successfully completed rows retained for diagnostics.
+    pub completed: usize,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct ReadinessKey {
     pub(crate) source_id: String,

--- a/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
@@ -71,6 +71,11 @@ pub struct ReadinessDeficit {
     pub target: ReadinessTarget,
     /// Classification that made the target actionable.
     pub reason: ReadinessClassification,
+    /// Original durable work-row creation time, when this exact target has already been queued.
+    ///
+    /// A missing value means reconciliation discovered a new deficit that has not yet been
+    /// persisted. Coordinators should use their persistence timestamp for that first observation.
+    pub enqueued_at: Option<i64>,
 }
 
 /// Aggregate counts for one readiness stage.

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -5,11 +5,12 @@ mod work;
 
 pub use error::ReadinessError;
 pub use persistence::{
-    persist_readiness_deficits, publish_readiness_artifact, replace_readiness_targets,
+    persist_readiness_deficits, persist_readiness_deficits_with_cancel, publish_readiness_artifact,
+    replace_readiness_targets, replace_readiness_targets_with_cancel,
 };
-pub use reconcile::reconcile_readiness;
 #[cfg(test)]
 pub(crate) use reconcile::reconcile_readiness_with_hook;
+pub use reconcile::{reconcile_readiness, reconcile_readiness_with_cancel};
 pub use work::{
     cancel_readiness_work, claim_readiness_target, complete_readiness_work, fail_readiness_work,
     readiness_work_stats, release_readiness_work, renew_readiness_lease,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -1,6 +1,7 @@
 mod error;
 mod persistence;
 mod reconcile;
+mod work;
 
 pub use error::ReadinessError;
 pub use persistence::{
@@ -9,3 +10,7 @@ pub use persistence::{
 pub use reconcile::reconcile_readiness;
 #[cfg(test)]
 pub(crate) use reconcile::reconcile_readiness_with_hook;
+pub use work::{
+    cancel_readiness_work, claim_readiness_target, complete_readiness_work, fail_readiness_work,
+    readiness_work_stats, release_readiness_work, renew_readiness_lease,
+};

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
@@ -5,6 +5,9 @@ use super::super::model::{ReadinessScopeKind, ReadinessStage};
 /// Errors returned by the durable readiness contract.
 #[derive(Debug, Error)]
 pub enum ReadinessError {
+    /// The caller cancelled a potentially long readiness database operation.
+    #[error("Readiness operation cancelled")]
+    Cancelled,
     /// SQLite persistence or query failed.
     #[error("Readiness database operation failed: {0}")]
     Sql(#[from] rusqlite::Error),

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
@@ -131,7 +131,9 @@ pub enum ReadinessError {
         path: String,
     },
     /// Two current manifest paths claimed the same stable file identity.
-    #[error("Current source manifest has duplicate identity {identity}: {first_path}, {second_path}")]
+    #[error(
+        "Current source manifest has duplicate identity {identity}: {first_path}, {second_path}"
+    )]
     DuplicateManifestIdentity {
         /// Duplicated stable identity.
         identity: String,
@@ -162,4 +164,10 @@ pub enum ReadinessError {
     /// The read-only database predates the additive readiness schema.
     #[error("Source database does not contain the readiness schema")]
     SchemaUnavailable,
+    /// A lease must advance time by a positive bounded duration.
+    #[error("Readiness lease duration must be positive: {0}")]
+    InvalidLeaseDuration(i64),
+    /// A supplied timestamp and duration could not be represented durably.
+    #[error("Readiness timestamp overflow")]
+    TimestampOverflow,
 }

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
@@ -20,7 +23,55 @@ pub fn replace_readiness_targets(
     targets: &[ReadinessTarget],
     updated_at: i64,
 ) -> Result<(), ReadinessError> {
-    validate_targets(source_id, source_generation, targets)?;
+    replace_readiness_targets_inner(
+        connection,
+        source_id,
+        source_generation,
+        readiness_revision,
+        availability,
+        targets,
+        updated_at,
+        None,
+    )
+}
+
+/// Atomically replace desired readiness while honoring cancellation during large publications.
+#[allow(clippy::too_many_arguments)]
+pub fn replace_readiness_targets_with_cancel(
+    connection: &mut Connection,
+    source_id: &str,
+    source_generation: i64,
+    readiness_revision: i64,
+    availability: SourceAvailability,
+    targets: &[ReadinessTarget],
+    updated_at: i64,
+    cancel: &AtomicBool,
+) -> Result<(), ReadinessError> {
+    replace_readiness_targets_inner(
+        connection,
+        source_id,
+        source_generation,
+        readiness_revision,
+        availability,
+        targets,
+        updated_at,
+        Some(cancel),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn replace_readiness_targets_inner(
+    connection: &mut Connection,
+    source_id: &str,
+    source_generation: i64,
+    readiness_revision: i64,
+    availability: SourceAvailability,
+    targets: &[ReadinessTarget],
+    updated_at: i64,
+    cancel: Option<&AtomicBool>,
+) -> Result<(), ReadinessError> {
+    validate_targets(source_id, source_generation, targets, cancel)?;
+    cancellation_checkpoint(cancel)?;
     let tx = connection.transaction()?;
     let current_state = tx
         .query_row(
@@ -47,7 +98,8 @@ pub fn replace_readiness_targets(
             });
         }
     }
-    validate_manifest_membership(&tx, targets)?;
+    validate_manifest_membership(&tx, targets, cancel)?;
+    cancellation_checkpoint(cancel)?;
     tx.execute(
         "INSERT INTO source_readiness_sources (
             source_id, source_generation, readiness_revision, availability, updated_at
@@ -65,11 +117,13 @@ pub fn replace_readiness_targets(
             updated_at
         ],
     )?;
+    cancellation_checkpoint(cancel)?;
     tx.execute(
         "DELETE FROM source_readiness_targets WHERE source_id = ?1",
         [source_id],
     )?;
     for target in targets {
+        cancellation_checkpoint(cancel)?;
         insert_target(&tx, target, updated_at)?;
         if target.scope_kind == ReadinessScopeKind::File {
             refresh_work_metadata(&tx, target)?;
@@ -171,10 +225,31 @@ pub fn persist_readiness_deficits(
     deficits: &[ReadinessDeficit],
     created_at: i64,
 ) -> Result<usize, ReadinessError> {
+    persist_readiness_deficits_inner(connection, deficits, created_at, None)
+}
+
+/// Persist deficits while honoring cancellation; cancellation rolls back the current batch.
+pub fn persist_readiness_deficits_with_cancel(
+    connection: &mut Connection,
+    deficits: &[ReadinessDeficit],
+    created_at: i64,
+    cancel: &AtomicBool,
+) -> Result<usize, ReadinessError> {
+    persist_readiness_deficits_inner(connection, deficits, created_at, Some(cancel))
+}
+
+fn persist_readiness_deficits_inner(
+    connection: &mut Connection,
+    deficits: &[ReadinessDeficit],
+    created_at: i64,
+    cancel: Option<&AtomicBool>,
+) -> Result<usize, ReadinessError> {
+    cancellation_checkpoint(cancel)?;
     let mut unique = BTreeSet::new();
     let tx = connection.transaction()?;
     let mut changed = 0;
     for deficit in deficits {
+        cancellation_checkpoint(cancel)?;
         let target = &deficit.target;
         if !unique.insert((
             target.key(),
@@ -475,11 +550,13 @@ fn validate_targets(
     source_id: &str,
     source_generation: i64,
     targets: &[ReadinessTarget],
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), ReadinessError> {
     let mut keys = BTreeSet::new();
     let mut file_stages = BTreeMap::<String, BTreeSet<ReadinessStage>>::new();
     let mut has_similarity_layout = false;
     for target in targets {
+        cancellation_checkpoint(cancel)?;
         if target.source_id != source_id || target.source_generation != source_generation {
             return Err(ReadinessError::TargetGenerationMismatch {
                 source_id: source_id.to_string(),
@@ -558,6 +635,7 @@ fn validate_targets(
         }
     }
     for (scope_id, stages) in file_stages {
+        cancellation_checkpoint(cancel)?;
         for stage in [
             ReadinessStage::IndexedIdentity,
             ReadinessStage::PlaybackSummary,
@@ -581,12 +659,14 @@ fn validate_targets(
 fn validate_manifest_membership(
     tx: &Transaction<'_>,
     targets: &[ReadinessTarget],
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), ReadinessError> {
     let mut desired = BTreeMap::<String, String>::new();
     for target in targets.iter().filter(|target| {
         target.scope_kind == ReadinessScopeKind::File
             && target.eligibility != super::super::model::ReadinessEligibility::Deleted
     }) {
+        cancellation_checkpoint(cancel)?;
         let path = target
             .relative_path
             .as_deref()
@@ -617,6 +697,7 @@ fn validate_manifest_membership(
     })?;
     let mut manifest = BTreeMap::<String, String>::new();
     for row in rows {
+        cancellation_checkpoint(cancel)?;
         let (path, identity) = row?;
         let Some(identity) = identity.filter(|identity| !identity.trim().is_empty()) else {
             return Err(ReadinessError::ManifestIdentityUnavailable { path });
@@ -644,6 +725,7 @@ fn validate_manifest_membership(
         });
     }
     for (identity, expected) in manifest {
+        cancellation_checkpoint(cancel)?;
         let supplied = desired
             .get(&identity)
             .expect("identity sets were compared before paths");
@@ -656,6 +738,14 @@ fn validate_manifest_membership(
         }
     }
     Ok(())
+}
+
+fn cancellation_checkpoint(cancel: Option<&AtomicBool>) -> Result<(), ReadinessError> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+        Err(ReadinessError::Cancelled)
+    } else {
+        Ok(())
+    }
 }
 
 fn insert_target(

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use rusqlite::{Connection, OptionalExtension};
 
@@ -20,8 +23,27 @@ pub fn reconcile_readiness(
     source_id: &str,
     now: i64,
 ) -> Result<ReadinessSnapshot, ReadinessError> {
+    reconcile_readiness_inner(connection, source_id, now, None)
+}
+
+/// Compare desired readiness with persisted state while honoring cancellation during large scans.
+pub fn reconcile_readiness_with_cancel(
+    connection: &Connection,
+    source_id: &str,
+    now: i64,
+    cancel: &AtomicBool,
+) -> Result<ReadinessSnapshot, ReadinessError> {
+    reconcile_readiness_inner(connection, source_id, now, Some(cancel))
+}
+
+fn reconcile_readiness_inner(
+    connection: &Connection,
+    source_id: &str,
+    now: i64,
+    cancel: Option<&AtomicBool>,
+) -> Result<ReadinessSnapshot, ReadinessError> {
     let tx = connection.unchecked_transaction()?;
-    let snapshot = reconcile_readiness_snapshot(&tx, source_id, now, || {})?;
+    let snapshot = reconcile_readiness_snapshot(&tx, source_id, now, || {}, cancel)?;
     tx.commit()?;
     Ok(snapshot)
 }
@@ -34,7 +56,7 @@ pub(crate) fn reconcile_readiness_with_hook(
     after_source_state: impl FnOnce(),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     let tx = connection.unchecked_transaction()?;
-    let snapshot = reconcile_readiness_snapshot(&tx, source_id, now, after_source_state)?;
+    let snapshot = reconcile_readiness_snapshot(&tx, source_id, now, after_source_state, None)?;
     tx.commit()?;
     Ok(snapshot)
 }
@@ -44,7 +66,9 @@ fn reconcile_readiness_snapshot(
     source_id: &str,
     now: i64,
     after_source_state: impl FnOnce(),
+    cancel: Option<&AtomicBool>,
 ) -> Result<ReadinessSnapshot, ReadinessError> {
+    cancellation_checkpoint(cancel)?;
     if !readiness_schema_available(connection)? {
         return Err(ReadinessError::SchemaUnavailable);
     }
@@ -76,17 +100,18 @@ fn reconcile_readiness_snapshot(
         availability,
     };
     after_source_state();
-    let targets = load_targets(connection, source_id)?;
-    let artifacts = load_artifacts(connection, source_id)?;
-    let work = load_work(connection, source_id)?;
-    Ok(build_snapshot(
+    let targets = load_targets(connection, source_id, cancel)?;
+    let artifacts = load_artifacts(connection, source_id, cancel)?;
+    let work = load_work(connection, source_id, cancel)?;
+    build_snapshot(
         source_id,
         source_state,
         targets,
         artifacts,
         work,
         now,
-    ))
+        cancel,
+    )
 }
 
 fn readiness_schema_available(connection: &Connection) -> Result<bool, rusqlite::Error> {
@@ -134,6 +159,7 @@ struct StoredWork {
 fn load_targets(
     connection: &Connection,
     source_id: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<Vec<ReadinessTarget>, ReadinessError> {
     let mut statement = connection.prepare(
         "SELECT scope_kind, scope_id, relative_path, stage, required_version,
@@ -145,6 +171,7 @@ fn load_targets(
     let mut rows = statement.query([source_id])?;
     let mut targets = Vec::new();
     while let Some(row) = rows.next()? {
+        cancellation_checkpoint(cancel)?;
         targets.push(ReadinessTarget {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -163,6 +190,7 @@ fn load_targets(
 fn load_artifacts(
     connection: &Connection,
     source_id: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<BTreeMap<ReadinessKey, StoredArtifact>, ReadinessError> {
     let mut statement = connection.prepare(
         "SELECT scope_kind, scope_id, stage, artifact_version,
@@ -173,6 +201,7 @@ fn load_artifacts(
     let mut rows = statement.query([source_id])?;
     let mut artifacts = BTreeMap::new();
     while let Some(row) = rows.next()? {
+        cancellation_checkpoint(cancel)?;
         let key = ReadinessKey {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -194,6 +223,7 @@ fn load_artifacts(
 fn load_work(
     connection: &Connection,
     source_id: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<BTreeMap<ReadinessKey, StoredWork>, ReadinessError> {
     let mut statement = connection.prepare(
         "SELECT readiness_scope_kind, readiness_scope_id, readiness_stage, status,
@@ -206,6 +236,7 @@ fn load_work(
     let mut rows = statement.query([source_id])?;
     let mut work = BTreeMap::new();
     while let Some(row) = rows.next()? {
+        cancellation_checkpoint(cancel)?;
         let key = ReadinessKey {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -230,6 +261,14 @@ fn load_work(
     Ok(work)
 }
 
+fn cancellation_checkpoint(cancel: Option<&AtomicBool>) -> Result<(), ReadinessError> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+        Err(ReadinessError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
 fn build_snapshot(
     source_id: &str,
     source_state: StoredSourceState,
@@ -237,11 +276,13 @@ fn build_snapshot(
     artifacts: BTreeMap<ReadinessKey, StoredArtifact>,
     work: BTreeMap<ReadinessKey, StoredWork>,
     now: i64,
-) -> ReadinessSnapshot {
+    cancel: Option<&AtomicBool>,
+) -> Result<ReadinessSnapshot, ReadinessError> {
     let mut entries = Vec::with_capacity(targets.len());
     let mut deficits = Vec::new();
     let mut stage_counts = BTreeMap::new();
     for target in targets {
+        cancellation_checkpoint(cancel)?;
         let key = target.key();
         let classification = classify_target(
             &target,
@@ -264,7 +305,7 @@ fn build_snapshot(
         });
     }
     let activity = resolve_activity(&entries, &deficits, now);
-    ReadinessSnapshot {
+    Ok(ReadinessSnapshot {
         source_id: source_id.to_string(),
         source_generation: source_state.generation,
         readiness_revision: source_state.readiness_revision,
@@ -273,7 +314,7 @@ fn build_snapshot(
         deficits,
         stage_counts,
         activity,
-    }
+    })
 }
 
 fn resolve_activity(

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -128,6 +128,7 @@ struct StoredWork {
     failure_kind: Option<String>,
     last_error: Option<String>,
     lease_expires_at: Option<i64>,
+    created_at: i64,
 }
 
 fn load_targets(
@@ -197,7 +198,7 @@ fn load_work(
     let mut statement = connection.prepare(
         "SELECT readiness_scope_kind, readiness_scope_id, readiness_stage, status,
                 artifact_version, source_generation, content_generation, retry_at,
-                failure_kind, last_error, lease_expires_at
+                failure_kind, last_error, lease_expires_at, created_at
          FROM analysis_jobs
          WHERE source_id = ?1 AND readiness_managed = 1
          ORDER BY id",
@@ -222,6 +223,7 @@ fn load_work(
                 failure_kind: row.get(8)?,
                 last_error: row.get(9)?,
                 lease_expires_at: row.get(10)?,
+                created_at: row.get(11)?,
             },
         );
     }
@@ -253,6 +255,7 @@ fn build_snapshot(
             deficits.push(ReadinessDeficit {
                 target: target.clone(),
                 reason: classification.clone(),
+                enqueued_at: work.get(&key).map(|work| work.created_at),
             });
         }
         entries.push(ReadinessEntry {

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -23,8 +23,8 @@ pub fn claim_readiness_target(
     let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let candidate = tx
         .query_row(
-            "SELECT job.id, job.attempts, target.relative_path, target.source_generation,
-                    target.eligibility
+            "SELECT job.id, job.readiness_claim_generation, job.attempts,
+                    target.relative_path, target.source_generation, target.eligibility
              FROM source_readiness_targets AS target
              JOIN source_readiness_sources AS source
                ON source.source_id = target.source_id
@@ -87,26 +87,36 @@ pub fn claim_readiness_target(
                 Ok((
                     row.get::<_, i64>(0)?,
                     row.get::<_, i64>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
                 ))
             },
         )
         .optional()?;
-    let Some((job_id, stored_attempt, relative_path, source_generation, eligibility)) = candidate
+    let Some((
+        job_id,
+        stored_claim_generation,
+        stored_failure_attempts,
+        relative_path,
+        source_generation,
+        eligibility,
+    )) = candidate
     else {
         tx.commit()?;
         return Ok(None);
     };
-    let previous_attempt = decode_attempt(stored_attempt)?;
-    let attempt = previous_attempt
+    let previous_claim_generation =
+        decode_counter("readiness_claim_generation", stored_claim_generation)?;
+    let claim_generation = previous_claim_generation
         .checked_add(1)
         .ok_or(ReadinessError::TimestampOverflow)?;
+    let failure_attempts = decode_counter("attempts", stored_failure_attempts)?;
     let changed = tx.execute(
         "UPDATE analysis_jobs
          SET status = 'running',
-             attempts = ?1,
+             readiness_claim_generation = ?1,
              running_at = ?2,
              retry_at = NULL,
              failure_kind = NULL,
@@ -115,15 +125,15 @@ pub fn claim_readiness_target(
              relative_path = ?4,
              source_generation = ?5
          WHERE id = ?6
-           AND attempts = ?7",
+           AND readiness_claim_generation = ?7",
         params![
-            attempt,
+            claim_generation,
             now,
             lease_expires_at,
             relative_path.as_deref().unwrap_or(""),
             source_generation,
             job_id,
-            previous_attempt,
+            previous_claim_generation,
         ],
     )?;
     if changed != 1 {
@@ -144,7 +154,8 @@ pub fn claim_readiness_target(
     tx.commit()?;
     Ok(Some(ClaimedReadinessWork {
         target,
-        attempt,
+        claim_generation,
+        failure_attempts,
         lease_expires_at,
     }))
 }
@@ -163,7 +174,7 @@ pub fn renew_readiness_lease(
          SET lease_expires_at = MAX(lease_expires_at, ?1)
          WHERE status = 'running'
            AND lease_expires_at > ?2
-           AND attempts = ?3
+           AND readiness_claim_generation = ?3
            AND source_id = ?4
            AND readiness_managed = 1
            AND readiness_scope_kind = ?5
@@ -191,7 +202,7 @@ pub fn renew_readiness_lease(
         params![
             requested_deadline,
             now,
-            claim.attempt,
+            claim.claim_generation,
             claim.target.source_id,
             claim.target.scope_kind.as_str(),
             claim.target.scope_id,
@@ -214,7 +225,7 @@ pub fn renew_readiness_lease(
            AND readiness_scope_id = ?3
            AND readiness_stage = ?4
            AND status = 'running'
-           AND attempts = ?5
+           AND readiness_claim_generation = ?5
            AND artifact_version = ?6
            AND content_generation = ?7
            AND (?2 = 'file' OR source_generation = ?8)",
@@ -223,7 +234,7 @@ pub fn renew_readiness_lease(
             claim.target.scope_kind.as_str(),
             claim.target.scope_id,
             claim.target.stage.as_str(),
-            claim.attempt,
+            claim.claim_generation,
             claim.target.required_version,
             claim.target.content_generation,
             claim.target.source_generation,
@@ -247,6 +258,7 @@ pub fn complete_readiness_work(
         completed_at,
         "status = 'done', running_at = NULL, retry_at = NULL, failure_kind = NULL, \
          last_error = NULL, lease_expires_at = NULL",
+        None,
         None,
     )?;
     if changed != 1 {
@@ -288,9 +300,21 @@ pub fn fail_readiness_work(
     failed_at: i64,
     retry_policy: ReadinessRetryPolicy,
 ) -> Result<ReadinessFailureOutcome, ReadinessError> {
+    let failure_attempt = match classification {
+        ReadinessFailureClassification::Retryable => Some(
+            claim
+                .failure_attempts
+                .checked_add(1)
+                .ok_or(ReadinessError::TimestampOverflow)?,
+        ),
+        ReadinessFailureClassification::Permanent | ReadinessFailureClassification::Unsupported => {
+            None
+        }
+    };
     let (stored_classification, retry_at, outcome) = match classification {
         ReadinessFailureClassification::Retryable
-            if claim.attempt >= retry_policy.max_attempts() =>
+            if failure_attempt.expect("retryable failure attempt")
+                >= retry_policy.max_attempts() =>
         {
             (
                 ReadinessFailureClassification::Permanent,
@@ -299,8 +323,9 @@ pub fn fail_readiness_work(
             )
         }
         ReadinessFailureClassification::Retryable => {
+            let failure_attempt = failure_attempt.expect("retryable failure attempt");
             let retry_at = failed_at
-                .checked_add(retry_policy.delay_for_attempt(claim.attempt))
+                .checked_add(retry_policy.delay_for_attempt(failure_attempt))
                 .ok_or(ReadinessError::TimestampOverflow)?;
             (
                 classification,
@@ -327,6 +352,7 @@ pub fn fail_readiness_work(
             retry_at,
             normalized_reason(reason),
         )),
+        failure_attempt,
     )?;
     if changed != 1 {
         tx.rollback()?;
@@ -440,7 +466,7 @@ fn return_claim_to_pending(
             None,
         )
     };
-    let changed = finish_claim_update(&tx, claim, now, set_clause, extras)?;
+    let changed = finish_claim_update(&tx, claim, now, set_clause, extras, None)?;
     if changed != 1 {
         tx.rollback()?;
         return Ok(ReadinessWorkMutationOutcome::RejectedStale);
@@ -455,13 +481,15 @@ fn finish_claim_update(
     now: i64,
     set_clause: &str,
     extras: Option<(&str, Option<i64>, &str)>,
+    failure_attempt: Option<u32>,
 ) -> Result<usize, rusqlite::Error> {
     let sql = format!(
         "UPDATE analysis_jobs
-         SET {set_clause}
+         SET {set_clause},
+             attempts = COALESCE(?13, attempts)
          WHERE status = 'running'
            AND lease_expires_at > ?1
-           AND attempts = ?2
+           AND readiness_claim_generation = ?2
            AND source_id = ?3
            AND readiness_managed = 1
            AND readiness_scope_kind = ?4
@@ -487,40 +515,27 @@ fn finish_claim_update(
                  AND source.availability = 'active'
            )"
     );
-    if let Some((failure_kind, retry_at, reason)) = extras {
-        tx.execute(
-            &sql,
-            params![
-                now,
-                claim.attempt,
-                claim.target.source_id,
-                claim.target.scope_kind.as_str(),
-                claim.target.scope_id,
-                claim.target.stage.as_str(),
-                claim.target.required_version,
-                claim.target.content_generation,
-                claim.target.source_generation,
-                failure_kind,
-                retry_at,
-                reason,
-            ],
-        )
-    } else {
-        tx.execute(
-            &sql,
-            params![
-                now,
-                claim.attempt,
-                claim.target.source_id,
-                claim.target.scope_kind.as_str(),
-                claim.target.scope_id,
-                claim.target.stage.as_str(),
-                claim.target.required_version,
-                claim.target.content_generation,
-                claim.target.source_generation,
-            ],
-        )
-    }
+    let (failure_kind, retry_at, reason) = extras
+        .map(|(kind, retry_at, reason)| (Some(kind), retry_at, Some(reason)))
+        .unwrap_or((None, None, None));
+    tx.execute(
+        &sql,
+        params![
+            now,
+            claim.claim_generation,
+            claim.target.source_id,
+            claim.target.scope_kind.as_str(),
+            claim.target.scope_id,
+            claim.target.stage.as_str(),
+            claim.target.required_version,
+            claim.target.content_generation,
+            claim.target.source_generation,
+            failure_kind,
+            retry_at,
+            reason,
+            failure_attempt,
+        ],
+    )
 }
 
 fn lease_deadline(now: i64, duration_seconds: i64) -> Result<i64, ReadinessError> {
@@ -531,9 +546,9 @@ fn lease_deadline(now: i64, duration_seconds: i64) -> Result<i64, ReadinessError
         .ok_or(ReadinessError::TimestampOverflow)
 }
 
-fn decode_attempt(value: i64) -> Result<u32, ReadinessError> {
+fn decode_counter(field: &'static str, value: i64) -> Result<u32, ReadinessError> {
     u32::try_from(value).map_err(|_| ReadinessError::UnknownStoredValue {
-        field: "attempts",
+        field,
         value: value.to_string(),
     })
 }

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -1,0 +1,554 @@
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior, params};
+
+use super::super::model::{
+    ClaimedReadinessWork, ReadinessArtifact, ReadinessEligibility, ReadinessFailureClassification,
+    ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessTarget,
+    ReadinessWorkMutationOutcome, ReadinessWorkStats,
+};
+use super::super::snapshot::ArtifactPublishOutcome;
+use super::error::ReadinessError;
+
+/// Claim one exact desired target with a durable lease.
+///
+/// File targets remain claimable across unrelated source-generation changes when their stable
+/// identity, stage, artifact version, and content generation are unchanged. The returned target is
+/// always refreshed from the current desired-state row.
+pub fn claim_readiness_target(
+    connection: &mut Connection,
+    requested: &ReadinessTarget,
+    now: i64,
+    lease_duration_seconds: i64,
+) -> Result<Option<ClaimedReadinessWork>, ReadinessError> {
+    let lease_expires_at = lease_deadline(now, lease_duration_seconds)?;
+    let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let candidate = tx
+        .query_row(
+            "SELECT job.id, job.attempts, target.relative_path, target.source_generation,
+                    target.eligibility
+             FROM source_readiness_targets AS target
+             JOIN source_readiness_sources AS source
+               ON source.source_id = target.source_id
+              AND source.source_generation = target.source_generation
+             JOIN analysis_jobs AS job
+               ON job.source_id = target.source_id
+              AND job.readiness_managed = 1
+              AND job.readiness_scope_kind = target.scope_kind
+              AND job.readiness_scope_id = target.scope_id
+              AND job.readiness_stage = target.stage
+              AND job.artifact_version = target.required_version
+              AND job.content_generation = target.content_generation
+              AND (target.scope_kind = 'file' OR job.source_generation = target.source_generation)
+             WHERE target.source_id = ?1
+               AND target.scope_kind = ?2
+               AND target.scope_id = ?3
+               AND target.stage = ?4
+               AND target.required_version = ?5
+               AND target.content_generation = ?6
+               AND (?2 = 'file' OR target.source_generation = ?7)
+               AND target.eligibility = 'eligible'
+               AND source.availability = 'active'
+               AND (
+                    job.status = 'pending'
+                    OR (
+                        job.status = 'failed'
+                        AND (job.failure_kind IS NULL OR job.failure_kind = 'retryable')
+                        AND (job.retry_at IS NULL OR job.retry_at <= ?8)
+                    )
+                    OR (
+                        job.status = 'running'
+                        AND (job.lease_expires_at IS NULL OR job.lease_expires_at <= ?8)
+                    )
+               )
+               AND NOT EXISTS (
+                    SELECT 1
+                    FROM source_readiness_artifacts AS artifact
+                    WHERE artifact.source_id = target.source_id
+                      AND artifact.scope_kind = target.scope_kind
+                      AND artifact.scope_id = target.scope_id
+                      AND artifact.stage = target.stage
+                      AND artifact.artifact_version = target.required_version
+                      AND artifact.content_generation = target.content_generation
+                      AND (
+                          target.scope_kind = 'file'
+                          OR artifact.source_generation = target.source_generation
+                      )
+               )",
+            params![
+                requested.source_id,
+                requested.scope_kind.as_str(),
+                requested.scope_id,
+                requested.stage.as_str(),
+                requested.required_version,
+                requested.content_generation,
+                requested.source_generation,
+                now,
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((job_id, stored_attempt, relative_path, source_generation, eligibility)) = candidate
+    else {
+        tx.commit()?;
+        return Ok(None);
+    };
+    let previous_attempt = decode_attempt(stored_attempt)?;
+    let attempt = previous_attempt
+        .checked_add(1)
+        .ok_or(ReadinessError::TimestampOverflow)?;
+    let changed = tx.execute(
+        "UPDATE analysis_jobs
+         SET status = 'running',
+             attempts = ?1,
+             running_at = ?2,
+             retry_at = NULL,
+             failure_kind = NULL,
+             last_error = NULL,
+             lease_expires_at = ?3,
+             relative_path = ?4,
+             source_generation = ?5
+         WHERE id = ?6
+           AND attempts = ?7",
+        params![
+            attempt,
+            now,
+            lease_expires_at,
+            relative_path.as_deref().unwrap_or(""),
+            source_generation,
+            job_id,
+            previous_attempt,
+        ],
+    )?;
+    if changed != 1 {
+        tx.rollback()?;
+        return Ok(None);
+    }
+    let target = ReadinessTarget {
+        source_id: requested.source_id.clone(),
+        scope_kind: requested.scope_kind,
+        scope_id: requested.scope_id.clone(),
+        relative_path,
+        stage: requested.stage,
+        required_version: requested.required_version.clone(),
+        source_generation,
+        content_generation: requested.content_generation.clone(),
+        eligibility: decode_eligibility(eligibility)?,
+    };
+    tx.commit()?;
+    Ok(Some(ClaimedReadinessWork {
+        target,
+        attempt,
+        lease_expires_at,
+    }))
+}
+
+/// Renew an unexpired claim without changing its claim generation.
+pub fn renew_readiness_lease(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    now: i64,
+    lease_duration_seconds: i64,
+) -> Result<ReadinessLeaseRenewalOutcome, ReadinessError> {
+    let requested_deadline = lease_deadline(now, lease_duration_seconds)?;
+    let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let changed = tx.execute(
+        "UPDATE analysis_jobs
+         SET lease_expires_at = MAX(lease_expires_at, ?1)
+         WHERE status = 'running'
+           AND lease_expires_at > ?2
+           AND attempts = ?3
+           AND source_id = ?4
+           AND readiness_managed = 1
+           AND readiness_scope_kind = ?5
+           AND readiness_scope_id = ?6
+           AND readiness_stage = ?7
+           AND artifact_version = ?8
+           AND content_generation = ?9
+           AND (?5 = 'file' OR source_generation = ?10)
+           AND EXISTS (
+               SELECT 1
+               FROM source_readiness_targets AS target
+               JOIN source_readiness_sources AS source
+                 ON source.source_id = target.source_id
+                AND source.source_generation = target.source_generation
+               WHERE target.source_id = analysis_jobs.source_id
+                 AND target.scope_kind = analysis_jobs.readiness_scope_kind
+                 AND target.scope_id = analysis_jobs.readiness_scope_id
+                 AND target.stage = analysis_jobs.readiness_stage
+                 AND target.required_version = analysis_jobs.artifact_version
+                 AND target.content_generation = analysis_jobs.content_generation
+                 AND (?5 = 'file' OR target.source_generation = ?10)
+                 AND target.eligibility = 'eligible'
+                 AND source.availability = 'active'
+           )",
+        params![
+            requested_deadline,
+            now,
+            claim.attempt,
+            claim.target.source_id,
+            claim.target.scope_kind.as_str(),
+            claim.target.scope_id,
+            claim.target.stage.as_str(),
+            claim.target.required_version,
+            claim.target.content_generation,
+            claim.target.source_generation,
+        ],
+    )?;
+    if changed != 1 {
+        tx.rollback()?;
+        return Ok(ReadinessLeaseRenewalOutcome::RejectedStale);
+    }
+    let lease_expires_at = tx.query_row(
+        "SELECT lease_expires_at
+         FROM analysis_jobs
+         WHERE source_id = ?1
+           AND readiness_managed = 1
+           AND readiness_scope_kind = ?2
+           AND readiness_scope_id = ?3
+           AND readiness_stage = ?4
+           AND status = 'running'
+           AND attempts = ?5
+           AND artifact_version = ?6
+           AND content_generation = ?7
+           AND (?2 = 'file' OR source_generation = ?8)",
+        params![
+            claim.target.source_id,
+            claim.target.scope_kind.as_str(),
+            claim.target.scope_id,
+            claim.target.stage.as_str(),
+            claim.attempt,
+            claim.target.required_version,
+            claim.target.content_generation,
+            claim.target.source_generation,
+        ],
+        |row| row.get(0),
+    )?;
+    tx.commit()?;
+    Ok(ReadinessLeaseRenewalOutcome::Renewed { lease_expires_at })
+}
+
+/// Atomically publish the exact claimed artifact and mark its work row complete.
+pub fn complete_readiness_work(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    completed_at: i64,
+) -> Result<ArtifactPublishOutcome, ReadinessError> {
+    let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let changed = finish_claim_update(
+        &tx,
+        claim,
+        completed_at,
+        "status = 'done', running_at = NULL, retry_at = NULL, failure_kind = NULL, \
+         last_error = NULL, lease_expires_at = NULL",
+        None,
+    )?;
+    if changed != 1 {
+        tx.rollback()?;
+        return Ok(ArtifactPublishOutcome::RejectedStale);
+    }
+    let artifact = ReadinessArtifact::for_target(&claim.target, completed_at);
+    tx.execute(
+        "INSERT INTO source_readiness_artifacts (
+            source_id, scope_kind, scope_id, stage, artifact_version,
+            source_generation, content_generation, completed_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(source_id, scope_kind, scope_id, stage) DO UPDATE SET
+            artifact_version = excluded.artifact_version,
+            source_generation = excluded.source_generation,
+            content_generation = excluded.content_generation,
+            completed_at = excluded.completed_at",
+        params![
+            artifact.source_id,
+            artifact.scope_kind.as_str(),
+            artifact.scope_id,
+            artifact.stage.as_str(),
+            artifact.artifact_version,
+            artifact.source_generation,
+            artifact.content_generation,
+            artifact.completed_at,
+        ],
+    )?;
+    tx.commit()?;
+    Ok(ArtifactPublishOutcome::Recorded)
+}
+
+/// Record a classified failure, applying bounded backoff to retryable failures.
+pub fn fail_readiness_work(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    classification: ReadinessFailureClassification,
+    reason: &str,
+    failed_at: i64,
+    retry_policy: ReadinessRetryPolicy,
+) -> Result<ReadinessFailureOutcome, ReadinessError> {
+    let (stored_classification, retry_at, outcome) = match classification {
+        ReadinessFailureClassification::Retryable
+            if claim.attempt >= retry_policy.max_attempts() =>
+        {
+            (
+                ReadinessFailureClassification::Permanent,
+                None,
+                ReadinessFailureOutcome::AttemptsExhausted,
+            )
+        }
+        ReadinessFailureClassification::Retryable => {
+            let retry_at = failed_at
+                .checked_add(retry_policy.delay_for_attempt(claim.attempt))
+                .ok_or(ReadinessError::TimestampOverflow)?;
+            (
+                classification,
+                Some(retry_at),
+                ReadinessFailureOutcome::RetryScheduled { retry_at },
+            )
+        }
+        ReadinessFailureClassification::Permanent => {
+            (classification, None, ReadinessFailureOutcome::Permanent)
+        }
+        ReadinessFailureClassification::Unsupported => {
+            (classification, None, ReadinessFailureOutcome::Unsupported)
+        }
+    };
+    let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let changed = finish_claim_update(
+        &tx,
+        claim,
+        failed_at,
+        "status = 'failed', running_at = NULL, failure_kind = ?10, retry_at = ?11, \
+         last_error = ?12, lease_expires_at = NULL",
+        Some((
+            stored_classification.as_str(),
+            retry_at,
+            normalized_reason(reason),
+        )),
+    )?;
+    if changed != 1 {
+        tx.rollback()?;
+        return Ok(ReadinessFailureOutcome::RejectedStale);
+    }
+    tx.commit()?;
+    Ok(outcome)
+}
+
+/// Voluntarily release a current claim back to pending without deleting durable work.
+pub fn release_readiness_work(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    released_at: i64,
+) -> Result<ReadinessWorkMutationOutcome, ReadinessError> {
+    return_claim_to_pending(connection, claim, released_at, None)
+}
+
+/// Cancel in-flight execution back to pending while retaining a cancellation diagnostic.
+pub fn cancel_readiness_work(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    reason: &str,
+    cancelled_at: i64,
+) -> Result<ReadinessWorkMutationOutcome, ReadinessError> {
+    return_claim_to_pending(
+        connection,
+        claim,
+        cancelled_at,
+        Some(normalized_reason(reason)),
+    )
+}
+
+/// Read queue, retry, lease-recovery, cancellation, and terminal counts for telemetry.
+pub fn readiness_work_stats(
+    connection: &Connection,
+    now: i64,
+) -> Result<ReadinessWorkStats, ReadinessError> {
+    let values = connection.query_row(
+        "SELECT
+            COUNT(*),
+            SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'running' AND lease_expires_at > ?1 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'running' AND (
+                lease_expires_at IS NULL OR lease_expires_at <= ?1
+            ) THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+                AND (retry_at IS NULL OR retry_at <= ?1) THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+                AND retry_at > ?1 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'failed' AND failure_kind = 'permanent'
+                THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'failed' AND failure_kind = 'unsupported'
+                THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'pending' AND failure_kind = 'cancelled'
+                THEN 1 ELSE 0 END),
+            SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END)
+         FROM analysis_jobs
+         WHERE readiness_managed = 1",
+        [now],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<i64>>(1)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(2)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(3)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(6)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(7)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(8)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(9)?.unwrap_or(0),
+            ))
+        },
+    )?;
+    Ok(ReadinessWorkStats {
+        total: count(values.0),
+        pending: count(values.1),
+        running: count(values.2),
+        expired_leases: count(values.3),
+        retries_due: count(values.4),
+        retries_waiting: count(values.5),
+        permanent_failures: count(values.6),
+        unsupported: count(values.7),
+        cancelled: count(values.8),
+        completed: count(values.9),
+    })
+}
+
+fn return_claim_to_pending(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    now: i64,
+    cancellation_reason: Option<&str>,
+) -> Result<ReadinessWorkMutationOutcome, ReadinessError> {
+    let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let (set_clause, extras) = if let Some(reason) = cancellation_reason {
+        (
+            "status = 'pending', running_at = NULL, retry_at = NULL, \
+             failure_kind = ?10, last_error = ?12, lease_expires_at = NULL",
+            Some(("cancelled", None, reason)),
+        )
+    } else {
+        (
+            "status = 'pending', running_at = NULL, retry_at = NULL, \
+             failure_kind = NULL, last_error = NULL, lease_expires_at = NULL",
+            None,
+        )
+    };
+    let changed = finish_claim_update(&tx, claim, now, set_clause, extras)?;
+    if changed != 1 {
+        tx.rollback()?;
+        return Ok(ReadinessWorkMutationOutcome::RejectedStale);
+    }
+    tx.commit()?;
+    Ok(ReadinessWorkMutationOutcome::Recorded)
+}
+
+fn finish_claim_update(
+    tx: &Transaction<'_>,
+    claim: &ClaimedReadinessWork,
+    now: i64,
+    set_clause: &str,
+    extras: Option<(&str, Option<i64>, &str)>,
+) -> Result<usize, rusqlite::Error> {
+    let sql = format!(
+        "UPDATE analysis_jobs
+         SET {set_clause}
+         WHERE status = 'running'
+           AND lease_expires_at > ?1
+           AND attempts = ?2
+           AND source_id = ?3
+           AND readiness_managed = 1
+           AND readiness_scope_kind = ?4
+           AND readiness_scope_id = ?5
+           AND readiness_stage = ?6
+           AND artifact_version = ?7
+           AND content_generation = ?8
+           AND (?4 = 'file' OR source_generation = ?9)
+           AND EXISTS (
+               SELECT 1
+               FROM source_readiness_targets AS target
+               JOIN source_readiness_sources AS source
+                 ON source.source_id = target.source_id
+                AND source.source_generation = target.source_generation
+               WHERE target.source_id = analysis_jobs.source_id
+                 AND target.scope_kind = analysis_jobs.readiness_scope_kind
+                 AND target.scope_id = analysis_jobs.readiness_scope_id
+                 AND target.stage = analysis_jobs.readiness_stage
+                 AND target.required_version = analysis_jobs.artifact_version
+                 AND target.content_generation = analysis_jobs.content_generation
+                 AND (?4 = 'file' OR target.source_generation = ?9)
+                 AND target.eligibility = 'eligible'
+                 AND source.availability = 'active'
+           )"
+    );
+    if let Some((failure_kind, retry_at, reason)) = extras {
+        tx.execute(
+            &sql,
+            params![
+                now,
+                claim.attempt,
+                claim.target.source_id,
+                claim.target.scope_kind.as_str(),
+                claim.target.scope_id,
+                claim.target.stage.as_str(),
+                claim.target.required_version,
+                claim.target.content_generation,
+                claim.target.source_generation,
+                failure_kind,
+                retry_at,
+                reason,
+            ],
+        )
+    } else {
+        tx.execute(
+            &sql,
+            params![
+                now,
+                claim.attempt,
+                claim.target.source_id,
+                claim.target.scope_kind.as_str(),
+                claim.target.scope_id,
+                claim.target.stage.as_str(),
+                claim.target.required_version,
+                claim.target.content_generation,
+                claim.target.source_generation,
+            ],
+        )
+    }
+}
+
+fn lease_deadline(now: i64, duration_seconds: i64) -> Result<i64, ReadinessError> {
+    if duration_seconds <= 0 {
+        return Err(ReadinessError::InvalidLeaseDuration(duration_seconds));
+    }
+    now.checked_add(duration_seconds)
+        .ok_or(ReadinessError::TimestampOverflow)
+}
+
+fn decode_attempt(value: i64) -> Result<u32, ReadinessError> {
+    u32::try_from(value).map_err(|_| ReadinessError::UnknownStoredValue {
+        field: "attempts",
+        value: value.to_string(),
+    })
+}
+
+fn decode_eligibility(value: String) -> Result<ReadinessEligibility, ReadinessError> {
+    ReadinessEligibility::from_stored(&value).ok_or(ReadinessError::UnknownStoredValue {
+        field: "eligibility",
+        value,
+    })
+}
+
+fn normalized_reason(reason: &str) -> &str {
+    if reason.trim().is_empty() {
+        "readiness_work_failed"
+    } else {
+        reason
+    }
+}
+
+fn count(value: i64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -377,6 +377,8 @@ pub fn readiness_work_stats(
                 AND (retry_at IS NULL OR retry_at <= ?1) THEN 1 ELSE 0 END),
             SUM(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
                 AND retry_at > ?1 THEN 1 ELSE 0 END),
+            MIN(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+                AND retry_at > ?1 THEN retry_at ELSE NULL END),
             SUM(CASE WHEN status = 'failed' AND failure_kind = 'permanent'
                 THEN 1 ELSE 0 END),
             SUM(CASE WHEN status = 'failed' AND failure_kind = 'unsupported'
@@ -395,10 +397,11 @@ pub fn readiness_work_stats(
                 row.get::<_, Option<i64>>(3)?.unwrap_or(0),
                 row.get::<_, Option<i64>>(4)?.unwrap_or(0),
                 row.get::<_, Option<i64>>(5)?.unwrap_or(0),
-                row.get::<_, Option<i64>>(6)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(6)?,
                 row.get::<_, Option<i64>>(7)?.unwrap_or(0),
                 row.get::<_, Option<i64>>(8)?.unwrap_or(0),
                 row.get::<_, Option<i64>>(9)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(10)?.unwrap_or(0),
             ))
         },
     )?;
@@ -409,10 +412,11 @@ pub fn readiness_work_stats(
         expired_leases: count(values.3),
         retries_due: count(values.4),
         retries_waiting: count(values.5),
-        permanent_failures: count(values.6),
-        unsupported: count(values.7),
-        cancelled: count(values.8),
-        completed: count(values.9),
+        earliest_retry_at: values.6,
+        permanent_failures: count(values.7),
+        unsupported: count(values.8),
+        cancelled: count(values.9),
+        completed: count(values.10),
     })
 }
 

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/mod.rs
@@ -5,6 +5,7 @@ use crate::sample_sources::{SourceDatabase, SourceDatabaseConnectionRole};
 
 mod classification;
 mod persistence;
+mod work;
 
 const SOURCE_ID: &str = "source-a";
 

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -164,6 +164,12 @@ fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
             .retries_waiting,
         1
     );
+    assert_eq!(
+        readiness_work_stats(&connection, 4)
+            .expect("waiting deadline")
+            .earliest_retry_at,
+        Some(5)
+    );
 
     let second = claim_readiness_target(&mut connection, &target, 5, 100)
         .expect("claim second")

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -25,7 +25,8 @@ fn exact_target_claim_is_deduplicated_and_generation_fenced() {
         .expect("claim target")
         .expect("claim available");
     assert_eq!(claim.target, target);
-    assert_eq!(claim.attempt, 1);
+    assert_eq!(claim.claim_generation, 1);
+    assert_eq!(claim.failure_attempts, 0);
     assert_eq!(claim.lease_expires_at, 40);
     assert_eq!(
         claim_readiness_target(&mut connection, &target, 11, 30).expect("duplicate claim"),
@@ -59,7 +60,8 @@ fn expired_claim_is_recovered_after_restart_with_a_new_attempt() {
     let recovered = claim_readiness_target(&mut reopened, &target, 20, 10)
         .expect("recover claim")
         .expect("expired claim available");
-    assert_eq!(recovered.attempt, first.attempt + 1);
+    assert_eq!(recovered.claim_generation, first.claim_generation + 1);
+    assert_eq!(recovered.failure_attempts, 0);
     assert_eq!(recovered.lease_expires_at, 30);
     assert_eq!(
         complete_readiness_work(&mut reopened, &first, 21).expect("stale completion"),
@@ -174,7 +176,8 @@ fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
     let second = claim_readiness_target(&mut connection, &target, 5, 100)
         .expect("claim second")
         .expect("second available");
-    assert_eq!(second.attempt, 2);
+    assert_eq!(second.claim_generation, 2);
+    assert_eq!(second.failure_attempts, 1);
     assert_eq!(
         fail_readiness_work(
             &mut connection,
@@ -190,7 +193,8 @@ fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
     let third = claim_readiness_target(&mut connection, &target, 15, 100)
         .expect("claim third")
         .expect("third available");
-    assert_eq!(third.attempt, 3);
+    assert_eq!(third.claim_generation, 3);
+    assert_eq!(third.failure_attempts, 2);
     assert_eq!(
         fail_readiness_work(
             &mut connection,
@@ -276,7 +280,8 @@ fn release_and_cancel_return_claims_to_pending_without_deletion() {
     let second = claim_readiness_target(&mut connection, &target, 1, 100)
         .expect("claim second")
         .expect("second available");
-    assert_eq!(second.attempt, 2);
+    assert_eq!(second.claim_generation, 2);
+    assert_eq!(second.failure_attempts, 0);
     assert_eq!(
         cancel_readiness_work(&mut connection, &second, "shutdown", 2).expect("cancel claim"),
         ReadinessWorkMutationOutcome::Recorded
@@ -289,13 +294,67 @@ fn release_and_cancel_return_claims_to_pending_without_deletion() {
     let third = claim_readiness_target(&mut connection, &target, 2, 100)
         .expect("claim cancelled work")
         .expect("cancelled work available");
-    assert_eq!(third.attempt, 3);
+    assert_eq!(third.claim_generation, 3);
+    assert_eq!(third.failure_attempts, 0);
     assert_eq!(
         readiness_work_stats(&connection, 2)
             .expect("reclaimed stats")
             .cancelled,
         0
     );
+}
+
+#[test]
+fn benign_reclaims_do_not_consume_retry_backoff_attempts() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("cancel-retry", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 0);
+
+    for generation in 1..=10 {
+        let claim = claim_readiness_target(&mut connection, &target, generation, 100)
+            .expect("claim interruptible work")
+            .expect("work remains claimable");
+        assert_eq!(claim.claim_generation, generation as u32);
+        assert_eq!(claim.failure_attempts, 0);
+        assert_eq!(
+            cancel_readiness_work(&mut connection, &claim, "playback interruption", generation,)
+                .expect("cancel work"),
+            ReadinessWorkMutationOutcome::Recorded
+        );
+    }
+
+    let policy = ReadinessRetryPolicy::new(5, 20, 3).expect("valid retry policy");
+    for (now, expected_attempts, expected) in [
+        (
+            11,
+            0,
+            ReadinessFailureOutcome::RetryScheduled { retry_at: 16 },
+        ),
+        (
+            16,
+            1,
+            ReadinessFailureOutcome::RetryScheduled { retry_at: 26 },
+        ),
+        (26, 2, ReadinessFailureOutcome::AttemptsExhausted),
+    ] {
+        let claim = claim_readiness_target(&mut connection, &target, now, 100)
+            .expect("claim retryable work")
+            .expect("retry is due");
+        assert_eq!(claim.failure_attempts, expected_attempts);
+        assert_eq!(
+            fail_readiness_work(
+                &mut connection,
+                &claim,
+                ReadinessFailureClassification::Retryable,
+                "database busy",
+                now,
+                policy,
+            )
+            .expect("record retryable failure"),
+            expected
+        );
+    }
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -1,0 +1,323 @@
+use super::*;
+
+fn persist_target(connection: &mut Connection, target: &ReadinessTarget, now: i64) {
+    let snapshot = reconcile_readiness(connection, SOURCE_ID, now).expect("reconcile target");
+    let deficit = snapshot
+        .deficits
+        .iter()
+        .find(|deficit| {
+            deficit.target.scope_id == target.scope_id && deficit.target.stage == target.stage
+        })
+        .expect("target deficit")
+        .clone();
+    persist_readiness_deficits(connection, &[deficit], now).expect("persist target work");
+}
+
+#[test]
+fn exact_target_claim_is_deduplicated_and_generation_fenced() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("claimed", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 10);
+    persist_target(&mut connection, &target, 10);
+
+    let claim = claim_readiness_target(&mut connection, &target, 10, 30)
+        .expect("claim target")
+        .expect("claim available");
+    assert_eq!(claim.target, target);
+    assert_eq!(claim.attempt, 1);
+    assert_eq!(claim.lease_expires_at, 40);
+    assert_eq!(
+        claim_readiness_target(&mut connection, &target, 11, 30).expect("duplicate claim"),
+        None
+    );
+
+    let stats = readiness_work_stats(&connection, 11).expect("work stats");
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.running, 1);
+    assert_eq!(stats.pending, 0);
+}
+
+#[test]
+fn expired_claim_is_recovered_after_restart_with_a_new_attempt() {
+    let (root, mut connection) = open_fixture();
+    let target = file_target("restart", ReadinessStage::PlaybackSummary, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 10);
+    let first = claim_readiness_target(&mut connection, &target, 10, 10)
+        .expect("first claim")
+        .expect("first claim available");
+    drop(connection);
+
+    let mut reopened = SourceDatabase::open_connection(root.path()).expect("reopen source db");
+    assert_eq!(
+        claim_readiness_target(&mut reopened, &target, 19, 10).expect("lease still active"),
+        None
+    );
+    let expired = readiness_work_stats(&reopened, 20).expect("expired stats");
+    assert_eq!(expired.expired_leases, 1);
+    let recovered = claim_readiness_target(&mut reopened, &target, 20, 10)
+        .expect("recover claim")
+        .expect("expired claim available");
+    assert_eq!(recovered.attempt, first.attempt + 1);
+    assert_eq!(recovered.lease_expires_at, 30);
+    assert_eq!(
+        complete_readiness_work(&mut reopened, &first, 21).expect("stale completion"),
+        ArtifactPublishOutcome::RejectedStale
+    );
+}
+
+#[test]
+fn stale_completion_cannot_publish_over_a_changed_exact_target() {
+    let (_root, mut connection) = open_fixture();
+    let original = file_target("changed", ReadinessStage::EmbeddingAspects, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&original));
+    persist_target(&mut connection, &original, 0);
+    let stale_claim = claim_readiness_target(&mut connection, &original, 0, 100)
+        .expect("claim original")
+        .expect("original available");
+
+    let current = file_target("changed", ReadinessStage::EmbeddingAspects, 2);
+    replace(&mut connection, 2, std::slice::from_ref(&current));
+    persist_target(&mut connection, &current, 1);
+    assert_eq!(
+        complete_readiness_work(&mut connection, &stale_claim, 2).expect("reject stale completion"),
+        ArtifactPublishOutcome::RejectedStale
+    );
+
+    let current_claim = claim_readiness_target(&mut connection, &current, 2, 100)
+        .expect("claim current")
+        .expect("current available");
+    assert_eq!(
+        complete_readiness_work(&mut connection, &current_claim, 3).expect("complete current"),
+        ArtifactPublishOutcome::Recorded
+    );
+    assert!(
+        reconcile_readiness(&connection, SOURCE_ID, 4)
+            .expect("current snapshot")
+            .is_fully_ready()
+    );
+}
+
+#[test]
+fn file_completion_survives_unrelated_source_generation_changes() {
+    let (_root, mut connection) = open_fixture();
+    let original = file_target("stable", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&original));
+    persist_target(&mut connection, &original, 0);
+    let claim = claim_readiness_target(&mut connection, &original, 0, 100)
+        .expect("claim original")
+        .expect("original available");
+
+    let mut unchanged = original.clone();
+    unchanged.source_generation = 2;
+    unchanged.relative_path = Some("Renamed/stable.wav".to_string());
+    replace(&mut connection, 2, std::slice::from_ref(&unchanged));
+    assert_eq!(
+        complete_readiness_work(&mut connection, &claim, 1).expect("complete stable file"),
+        ArtifactPublishOutcome::Recorded
+    );
+    assert_eq!(
+        entry_for(
+            &reconcile_readiness(&connection, SOURCE_ID, 2).expect("reconcile renamed file"),
+            "stable",
+            ReadinessStage::AnalysisFeatures,
+        )
+        .classification,
+        ReadinessClassification::Current
+    );
+}
+
+#[test]
+fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("retry", ReadinessStage::PlaybackSummary, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 0);
+    let policy = ReadinessRetryPolicy::new(5, 20, 3).expect("valid retry policy");
+    assert_eq!(policy.delay_for_attempt(1), 5);
+    assert_eq!(policy.delay_for_attempt(2), 10);
+    assert_eq!(policy.delay_for_attempt(20), 20);
+
+    let first = claim_readiness_target(&mut connection, &target, 0, 100)
+        .expect("claim first")
+        .expect("first available");
+    assert_eq!(
+        fail_readiness_work(
+            &mut connection,
+            &first,
+            ReadinessFailureClassification::Retryable,
+            "database busy",
+            0,
+            policy,
+        )
+        .expect("fail first"),
+        ReadinessFailureOutcome::RetryScheduled { retry_at: 5 }
+    );
+    assert_eq!(
+        claim_readiness_target(&mut connection, &target, 4, 100).expect("retry not due"),
+        None
+    );
+    assert_eq!(
+        readiness_work_stats(&connection, 4)
+            .expect("waiting stats")
+            .retries_waiting,
+        1
+    );
+
+    let second = claim_readiness_target(&mut connection, &target, 5, 100)
+        .expect("claim second")
+        .expect("second available");
+    assert_eq!(second.attempt, 2);
+    assert_eq!(
+        fail_readiness_work(
+            &mut connection,
+            &second,
+            ReadinessFailureClassification::Retryable,
+            "database busy",
+            5,
+            policy,
+        )
+        .expect("fail second"),
+        ReadinessFailureOutcome::RetryScheduled { retry_at: 15 }
+    );
+    let third = claim_readiness_target(&mut connection, &target, 15, 100)
+        .expect("claim third")
+        .expect("third available");
+    assert_eq!(third.attempt, 3);
+    assert_eq!(
+        fail_readiness_work(
+            &mut connection,
+            &third,
+            ReadinessFailureClassification::Retryable,
+            "still busy",
+            15,
+            policy,
+        )
+        .expect("exhaust retries"),
+        ReadinessFailureOutcome::AttemptsExhausted
+    );
+    assert_eq!(
+        claim_readiness_target(&mut connection, &target, 1_000, 100).expect("terminal claim"),
+        None
+    );
+    let stats = readiness_work_stats(&connection, 1_000).expect("terminal stats");
+    assert_eq!(stats.permanent_failures, 1);
+    assert_eq!(stats.retries_due, 0);
+}
+
+#[test]
+fn explicit_failure_classifications_are_terminal_and_observable() {
+    let (_root, mut connection) = open_fixture();
+    let permanent = file_target("permanent", ReadinessStage::AnalysisFeatures, 1);
+    let unsupported = file_target("unsupported", ReadinessStage::EmbeddingAspects, 1);
+    replace(
+        &mut connection,
+        1,
+        &[permanent.clone(), unsupported.clone()],
+    );
+    persist_target(&mut connection, &permanent, 0);
+    persist_target(&mut connection, &unsupported, 0);
+    let policy = ReadinessRetryPolicy::new(1, 8, 3).expect("valid retry policy");
+
+    for (target, classification, expected) in [
+        (
+            &permanent,
+            ReadinessFailureClassification::Permanent,
+            ReadinessFailureOutcome::Permanent,
+        ),
+        (
+            &unsupported,
+            ReadinessFailureClassification::Unsupported,
+            ReadinessFailureOutcome::Unsupported,
+        ),
+    ] {
+        let claim = claim_readiness_target(&mut connection, target, 0, 100)
+            .expect("claim classified target")
+            .expect("classified target available");
+        assert_eq!(
+            fail_readiness_work(
+                &mut connection,
+                &claim,
+                classification,
+                "terminal",
+                0,
+                policy,
+            )
+            .expect("record classified failure"),
+            expected
+        );
+    }
+    let stats = readiness_work_stats(&connection, 1).expect("classification stats");
+    assert_eq!(stats.permanent_failures, 1);
+    assert_eq!(stats.unsupported, 1);
+}
+
+#[test]
+fn release_and_cancel_return_claims_to_pending_without_deletion() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("cancel", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 0);
+
+    let first = claim_readiness_target(&mut connection, &target, 0, 100)
+        .expect("claim first")
+        .expect("first available");
+    assert_eq!(
+        release_readiness_work(&mut connection, &first, 1).expect("release claim"),
+        ReadinessWorkMutationOutcome::Recorded
+    );
+    let second = claim_readiness_target(&mut connection, &target, 1, 100)
+        .expect("claim second")
+        .expect("second available");
+    assert_eq!(second.attempt, 2);
+    assert_eq!(
+        cancel_readiness_work(&mut connection, &second, "shutdown", 2).expect("cancel claim"),
+        ReadinessWorkMutationOutcome::Recorded
+    );
+    let cancelled = readiness_work_stats(&connection, 2).expect("cancel stats");
+    assert_eq!(cancelled.total, 1);
+    assert_eq!(cancelled.pending, 1);
+    assert_eq!(cancelled.cancelled, 1);
+
+    let third = claim_readiness_target(&mut connection, &target, 2, 100)
+        .expect("claim cancelled work")
+        .expect("cancelled work available");
+    assert_eq!(third.attempt, 3);
+    assert_eq!(
+        readiness_work_stats(&connection, 2)
+            .expect("reclaimed stats")
+            .cancelled,
+        0
+    );
+}
+
+#[test]
+fn lease_renewal_extends_only_the_current_unexpired_claim() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("renew", ReadinessStage::PlaybackSummary, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 0);
+    let claim = claim_readiness_target(&mut connection, &target, 0, 10)
+        .expect("claim target")
+        .expect("target available");
+
+    assert_eq!(
+        renew_readiness_lease(&mut connection, &claim, 5, 20).expect("renew lease"),
+        ReadinessLeaseRenewalOutcome::Renewed {
+            lease_expires_at: 25
+        }
+    );
+    assert_eq!(
+        claim_readiness_target(&mut connection, &target, 20, 10).expect("still leased"),
+        None
+    );
+    assert_eq!(
+        complete_readiness_work(&mut connection, &claim, 24).expect("complete renewed claim"),
+        ArtifactPublishOutcome::Recorded
+    );
+    assert_eq!(
+        renew_readiness_lease(&mut connection, &claim, 24, 20).expect("renew completed claim"),
+        ReadinessLeaseRenewalOutcome::RejectedStale
+    );
+}

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -10,7 +10,8 @@ pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
     complete_deferred_hashes, complete_deferred_rename_candidates,
-    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
+    sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -9,7 +9,7 @@ pub mod sample_sources;
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, complete_deferred_rename_candidates, hard_rescan, scan_in_background,
-    scan_once, scan_with_progress, schedule_deep_hash_scan,
+    complete_deferred_hashes, complete_deferred_rename_candidates, complete_pending_deep_hashes,
+    hard_rescan, scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
     schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -9,7 +9,8 @@ pub mod sample_sources;
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, complete_deferred_rename_candidates, complete_pending_deep_hashes,
-    hard_rescan, scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    complete_deferred_hashes, complete_deferred_rename_candidates,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
     schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -10,8 +10,9 @@ mod scan_walk;
 pub use scan::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
-    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -10,8 +10,8 @@ mod scan_walk;
 pub use scan::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -10,7 +10,8 @@ mod scan_walk;
 pub use scan::{
     ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
-    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,8 +7,9 @@ pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
     ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
-    scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,9 +7,10 @@ pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
     ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
-    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+    schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,9 +7,9 @@ pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
     ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
 };
 pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -57,7 +57,7 @@ fn scan(
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
     walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
-    db_sync_phase(db, &mut context)?;
+    db_sync_phase(db, &mut context, cancel)?;
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -110,6 +110,7 @@ pub fn complete_deferred_rename_candidates(
         None,
         &rename_candidates,
         super::super::scan_hash::DeferredHashScope::RenameCandidates,
+        None,
     )?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)
@@ -138,9 +139,30 @@ pub fn complete_deferred_hashes_with_cancel(
     } else {
         super::super::scan_hash::DeferredHashScope::RenameCandidates
     };
-    let deferred = super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates, scope)?;
+    let deferred =
+        super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates, scope, None)?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)
+}
+
+/// Complete a bounded batch of pending deep-content hashes without launching an unowned worker.
+///
+/// Long-lived runtimes should call this from their owned source-processing supervisor so hashing
+/// shares cancellation, resource budgets, shutdown, retry policy, and cross-source fairness with
+/// other source work. Proven rename candidates are always reconciled even when the hash budget is
+/// exhausted.
+pub fn complete_pending_deep_hashes(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+) -> Result<ScanStats, ScanError> {
+    super::super::scan_hash::deep_hash_scan(
+        db,
+        cancel,
+        &HashSet::new(),
+        super::super::scan_hash::DeferredHashScope::AllUnhashed,
+        Some(max_hashes),
+    )
 }
 
 /// Spawn a detached deep-hash pass to backfill content hashes after quick scans.
@@ -161,6 +183,7 @@ pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: 
                 None,
                 &HashSet::new(),
                 super::super::scan_hash::DeferredHashScope::AllUnhashed,
+                None,
             )?;
             Ok(())
         })();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -111,6 +111,7 @@ pub fn complete_deferred_rename_candidates(
         &rename_candidates,
         super::super::scan_hash::DeferredHashScope::RenameCandidates,
         None,
+        None,
     )?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)
@@ -140,16 +141,16 @@ pub fn complete_deferred_hashes_with_cancel(
         super::super::scan_hash::DeferredHashScope::RenameCandidates
     };
     let deferred =
-        super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates, scope, None)?;
+        super::super::scan_hash::deep_hash_scan(db, cancel, &rename_candidates, scope, None, None)?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)
 }
 
 /// Complete a bounded batch of pending deep-content hashes without launching an unowned worker.
 ///
-/// Long-lived runtimes should call this from their owned source-processing supervisor so hashing
-/// shares cancellation, resource budgets, shutdown, retry policy, and cross-source fairness with
-/// other source work. Proven rename candidates are always reconciled even when the hash budget is
+/// Explicit scan workflows may use this bounded batch helper. Long-lived runtimes should instead
+/// schedule [`complete_pending_deep_hash_for_path`] behind per-file durable work so failures cannot
+/// starve later paths. Proven rename candidates are always reconciled even when the hash budget is
 /// exhausted.
 pub fn complete_pending_deep_hashes(
     db: &SourceDatabase,
@@ -162,6 +163,26 @@ pub fn complete_pending_deep_hashes(
         &HashSet::new(),
         super::super::scan_hash::DeferredHashScope::AllUnhashed,
         Some(max_hashes),
+        None,
+    )
+}
+
+/// Complete the pending deep-content hash for one exact tracked source-relative path.
+///
+/// The caller owns scheduling, durable retry policy, cancellation, and resource budgets. Work for
+/// other paths is deliberately excluded so one failure cannot abort or starve a path-ordered batch.
+pub fn complete_pending_deep_hash_for_path(
+    db: &SourceDatabase,
+    relative_path: &std::path::Path,
+    cancel: Option<&AtomicBool>,
+) -> Result<ScanStats, ScanError> {
+    super::super::scan_hash::deep_hash_scan(
+        db,
+        cancel,
+        &HashSet::new(),
+        super::super::scan_hash::DeferredHashScope::AllUnhashed,
+        Some(1),
+        Some(relative_path),
     )
 }
 
@@ -183,6 +204,7 @@ pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: 
                 None,
                 &HashSet::new(),
                 super::super::scan_hash::DeferredHashScope::AllUnhashed,
+                None,
                 None,
             )?;
             Ok(())

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -91,7 +91,16 @@ pub fn complete_deferred_hashes(
 /// as possible destinations for a following watcher batch.
 pub fn complete_deferred_rename_candidates(
     db: &SourceDatabase,
+    stats: ScanStats,
+) -> Result<ScanStats, ScanError> {
+    complete_deferred_rename_candidates_with_cancel(db, stats, None)
+}
+
+/// Reconcile only proven rename destinations while honoring the owning runtime's cancellation.
+pub fn complete_deferred_rename_candidates_with_cancel(
+    db: &SourceDatabase,
     mut stats: ScanStats,
+    cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
     if db.list_pending_renames()?.is_empty() {
         return Ok(stats);
@@ -107,7 +116,7 @@ pub fn complete_deferred_rename_candidates(
         .collect::<HashSet<_>>();
     let deferred = super::super::scan_hash::deep_hash_scan(
         db,
-        None,
+        cancel,
         &rename_candidates,
         super::super::scan_hash::DeferredHashScope::RenameCandidates,
         None,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -464,7 +464,7 @@ fn scan_hashes_current_bytes_when_facts_are_preserved_after_discovery() {
 }
 
 #[test]
-fn cancellation_after_first_committed_batch_finishes_consistently() {
+fn cancellation_after_first_committed_batch_stops_at_a_resumable_checkpoint() {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     let dir = tempdir().unwrap();
@@ -474,15 +474,57 @@ fn cancellation_after_first_committed_batch_finishes_consistently() {
     let db = SourceDatabase::open(dir.path()).unwrap();
     let cancel = AtomicBool::new(false);
 
-    let stats = scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |count, _| {
+    let result = scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |count, _| {
         if count == 65 {
             cancel.store(true, Ordering::Relaxed);
         }
-    })
-    .expect("once a bounded batch commits, the scan must finish consistently");
+    });
 
-    assert_eq!(stats.total_files, 70);
+    assert!(matches!(result, Err(ScanError::Canceled)));
+    assert_eq!(db.count_files().unwrap(), 64);
+
+    cancel.store(false, Ordering::Relaxed);
+    let resumed = scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |_, _| {})
+        .expect("a later scan must resume from the partial checkpoint");
+    assert_eq!(resumed.total_files, 70);
     assert_eq!(db.count_files().unwrap(), 70);
+}
+
+#[test]
+fn cancellation_after_walk_skips_missing_reconciliation_and_completion_publish() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let dir = tempdir().unwrap();
+    for index in 0..70 {
+        std::fs::write(dir.path().join(format!("sample-{index:03}.wav")), b"x").unwrap();
+    }
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::remove_file(dir.path().join("sample-000.wav")).unwrap();
+    let cancel = AtomicBool::new(false);
+
+    let result = scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |count, _| {
+        if count == 69 {
+            cancel.store(true, Ordering::Relaxed);
+        }
+    });
+
+    assert!(matches!(result, Err(ScanError::Canceled)));
+    assert!(
+        db.entry_for_path(Path::new("sample-000.wav"))
+            .unwrap()
+            .is_some(),
+        "cancellation before database reconciliation must leave missing rows for the next sweep"
+    );
+
+    cancel.store(false, Ordering::Relaxed);
+    scan_with_progress(&db, ScanMode::Quick, Some(&cancel), &mut |_, _| {})
+        .expect("a later scan must finish missing-row reconciliation");
+    assert!(
+        db.entry_for_path(Path::new("sample-000.wav"))
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -286,6 +286,7 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         &rename_candidates(&["two.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(deep_stats.hashes_computed, 1);
@@ -403,6 +404,7 @@ fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
         &HashSet::new(),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
         None,
+        None,
     )
     .unwrap();
 
@@ -441,6 +443,7 @@ fn large_rename_reconciles_when_unchanged_duplicate_remains() {
         None,
         &rename_candidates(&["c.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
         None,
     )
     .unwrap();
@@ -497,6 +500,7 @@ fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
         None,
         &rename_candidates(&["new.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
         None,
     )
     .unwrap();
@@ -572,6 +576,7 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
         &rename_candidates(&["two.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(deep_stats.renames_reconciled, 1);
@@ -616,6 +621,7 @@ fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
         None,
         &rename_candidates(&["b.wav", "c.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
         None,
     )
     .unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -200,6 +200,44 @@ fn canceled_deferred_hashing_reports_cancellation_after_quick_scan_commit() {
 }
 
 #[test]
+fn canceled_rename_reconciliation_can_be_safely_requeued() {
+    let dir = tempdir().unwrap();
+    let old_path = dir.path().join("old.wav");
+    let new_path = dir.path().join("new.wav");
+    std::fs::write(&old_path, vec![3_u8; 9 * 1024 * 1024]).unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    std::fs::rename(&old_path, &new_path).unwrap();
+    let stats = scan_once(&db).unwrap();
+    let cancel = std::sync::atomic::AtomicBool::new(true);
+
+    let cancelled =
+        complete_deferred_rename_candidates_with_cancel(&db, stats.clone(), Some(&cancel));
+
+    assert!(matches!(cancelled, Err(ScanError::Canceled)));
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+
+    cancel.store(false, std::sync::atomic::Ordering::Release);
+    let completed =
+        complete_deferred_rename_candidates_with_cancel(&db, stats, Some(&cancel)).unwrap();
+    assert_eq!(completed.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+}
+
+#[test]
 fn candidate_completion_keeps_cold_large_import_hashing_deferred() {
     let dir = tempdir().unwrap();
     std::fs::write(dir.path().join("large.wav"), vec![0_u8; 9 * 1024 * 1024]).unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -285,6 +285,7 @@ fn large_rename_defers_identity_until_deep_hash_and_survives_restart() {
         None,
         &rename_candidates(&["two.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
     assert_eq!(deep_stats.hashes_computed, 1);
@@ -401,6 +402,7 @@ fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
         None,
         &HashSet::new(),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
 
@@ -439,6 +441,7 @@ fn large_rename_reconciles_when_unchanged_duplicate_remains() {
         None,
         &rename_candidates(&["c.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
     assert_eq!(deep.renames_reconciled, 1);
@@ -494,6 +497,7 @@ fn size_and_mtime_coincidence_never_transfers_identity_or_metadata() {
         None,
         &rename_candidates(&["new.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
 
@@ -567,6 +571,7 @@ fn deep_hash_scan_replays_pending_rename_metadata() {
         None,
         &rename_candidates(&["two.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
     assert_eq!(deep_stats.renames_reconciled, 1);
@@ -611,6 +616,7 @@ fn deep_hash_scan_uses_matching_facts_to_disambiguate_backfilled_duplicates() {
         None,
         &rename_candidates(&["b.wav", "c.wav"]),
         crate::sample_sources::scanner::scan_hash::DeferredHashScope::AllUnhashed,
+        None,
     )
     .unwrap();
     assert_eq!(deep.hashes_computed, 2);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::sample_sources::scanner::sync_paths;
+use crate::sample_sources::scanner::{sync_paths, sync_paths_with_progress};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[test]
 fn targeted_sync_updates_only_requested_file() {
@@ -123,4 +124,32 @@ fn targeted_sync_ignores_appledouble_sidecars() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("drums/kick.wav"));
+}
+
+#[test]
+fn targeted_sync_cancels_after_a_committed_batch_and_resumes_safely() {
+    let dir = tempdir().unwrap();
+    let drums = dir.path().join("drums");
+    std::fs::create_dir_all(&drums).unwrap();
+    for index in 0..70 {
+        std::fs::write(drums.join(format!("sample-{index:03}.wav")), b"x").unwrap();
+    }
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let cancel = AtomicBool::new(false);
+    let targets = [PathBuf::from("drums")];
+
+    let result = sync_paths_with_progress(&db, &targets, Some(&cancel), &mut |count, _| {
+        if count == 65 {
+            cancel.store(true, Ordering::Relaxed);
+        }
+    });
+
+    assert!(matches!(result, Err(ScanError::Canceled)));
+    assert_eq!(db.count_files().unwrap(), 64);
+
+    cancel.store(false, Ordering::Relaxed);
+    let resumed = sync_paths_with_progress(&db, &targets, Some(&cancel), &mut |_, _| {})
+        .expect("targeted sync must resume from the committed checkpoint");
+    assert_eq!(resumed.total_files, 70);
+    assert_eq!(db.count_files().unwrap(), 70);
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::scan::{ScanContext, ScanError, ScanMode};
@@ -10,12 +11,16 @@ const MISSING_BATCH_SIZE: usize = 64;
 pub(super) fn db_sync_phase(
     db: &SourceDatabase,
     context: &mut ScanContext,
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), ScanError> {
     let mut existing = std::mem::take(&mut context.existing)
         .into_values()
         .collect::<Vec<_>>()
         .into_iter();
     loop {
+        if cancel_requested(cancel) {
+            return Err(ScanError::Canceled);
+        }
         let chunk = existing
             .by_ref()
             .take(MISSING_BATCH_SIZE)
@@ -26,9 +31,15 @@ pub(super) fn db_sync_phase(
         let mut batch = db.write_batch()?;
         context.ensure_rename_candidate_generation(&mut batch)?;
         mark_missing(db, &mut batch, chunk, &mut context.stats, context.mode)?;
+        if cancel_requested(cancel) {
+            return Err(ScanError::Canceled);
+        }
         batch.commit()?;
     }
 
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
     if context.mode == ScanMode::Hard {
@@ -41,6 +52,13 @@ pub(super) fn db_sync_phase(
         .as_secs()
         .to_string();
     batch.set_metadata(META_LAST_SCAN_COMPLETED_AT, &timestamp)?;
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
     batch.commit()?;
     Ok(())
+}
+
+fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
+    cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -34,11 +34,14 @@ pub(super) fn deep_hash_scan(
     rename_candidates: &HashSet<PathBuf>,
     scope: DeferredHashScope,
     max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
-    let entries = if scope == DeferredHashScope::AllUnhashed && rename_candidates.is_empty() {
+    let entries = if let Some(exact_path) = exact_path {
+        db.entry_for_path(exact_path)?.into_iter().collect()
+    } else if scope == DeferredHashScope::AllUnhashed && rename_candidates.is_empty() {
         db.list_pending_hash_files(max_hashes.unwrap_or(usize::MAX))?
     } else {
         db.list_files()?
@@ -357,6 +360,7 @@ mod tests {
             &HashSet::new(),
             DeferredHashScope::AllUnhashed,
             None,
+            None,
         );
 
         assert!(matches!(result, Err(ScanError::Canceled)));
@@ -379,6 +383,7 @@ mod tests {
             &HashSet::new(),
             DeferredHashScope::AllUnhashed,
             Some(8),
+            None,
         )
         .expect("bounded hash pass");
 
@@ -390,6 +395,42 @@ mod tests {
                 .filter(|entry| entry.content_hash.is_some())
                 .count(),
             8
+        );
+    }
+
+    #[test]
+    fn deep_hash_scan_exact_path_does_not_process_earlier_pending_rows() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        for relative in [Path::new("a-first.wav"), Path::new("z-target.wav")] {
+            std::fs::write(dir.path().join(relative), [9_u8; 32]).expect("write wav");
+            db.upsert_file(relative, 32, 1).expect("insert pending row");
+        }
+
+        let stats = deep_hash_scan(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(Path::new("z-target.wav")),
+        )
+        .expect("targeted hash pass");
+
+        assert_eq!(stats.hashes_computed, 1);
+        assert!(
+            db.entry_for_path(Path::new("a-first.wav"))
+                .unwrap()
+                .unwrap()
+                .content_hash
+                .is_none()
+        );
+        assert!(
+            db.entry_for_path(Path::new("z-target.wav"))
+                .unwrap()
+                .unwrap()
+                .content_hash
+                .is_some()
         );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -33,6 +33,7 @@ pub(super) fn deep_hash_scan(
     cancel: Option<&AtomicBool>,
     rename_candidates: &HashSet<PathBuf>,
     scope: DeferredHashScope,
+    max_hashes: Option<usize>,
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
     let entries = db.list_files()?;
@@ -107,6 +108,12 @@ pub(super) fn deep_hash_scan(
             continue;
         }
         let was_unhashed = entry.content_hash.is_none();
+        if was_unhashed
+            && !is_rename_candidate
+            && max_hashes.is_some_and(|limit| stats.hashes_computed >= limit)
+        {
+            continue;
+        }
         let absolute = root.join(&entry.relative_path);
         if !is_supported_regular_audio_file(&absolute) {
             continue;
@@ -345,8 +352,40 @@ mod tests {
             Some(&cancel),
             &HashSet::new(),
             DeferredHashScope::AllUnhashed,
+            None,
         );
 
         assert!(matches!(result, Err(ScanError::Canceled)));
+    }
+
+    #[test]
+    fn deep_hash_scan_respects_non_rename_batch_limit() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        for index in 0..5 {
+            let relative = PathBuf::from(format!("pending-{index}.wav"));
+            std::fs::write(dir.path().join(&relative), [index as u8; 32]).expect("write wav");
+            db.upsert_file(&relative, 32, index)
+                .expect("insert pending row");
+        }
+
+        let stats = deep_hash_scan(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(2),
+        )
+        .expect("bounded hash pass");
+
+        assert_eq!(stats.hashes_computed, 2);
+        assert_eq!(
+            db.list_files()
+                .expect("list files")
+                .iter()
+                .filter(|entry| entry.content_hash.is_some())
+                .count(),
+            2
+        );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -36,13 +36,17 @@ pub(super) fn deep_hash_scan(
     max_hashes: Option<usize>,
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
-    let entries = db.list_files()?;
+    let mut rename_candidates = rename_candidates.clone();
+    rename_candidates.extend(db.list_pending_rename_destinations()?);
+    let entries = if scope == DeferredHashScope::AllUnhashed && rename_candidates.is_empty() {
+        db.list_pending_hash_files(max_hashes.unwrap_or(usize::MAX))?
+    } else {
+        db.list_files()?
+    };
     let mut entries_by_path: HashMap<PathBuf, WavEntry> = entries
         .into_iter()
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect();
-    let mut rename_candidates = rename_candidates.clone();
-    rename_candidates.extend(db.list_pending_rename_destinations()?);
     let has_unhashed_files = scope == DeferredHashScope::AllUnhashed
         && entries_by_path.values().any(|entry| {
             !entry.missing
@@ -359,10 +363,10 @@ mod tests {
     }
 
     #[test]
-    fn deep_hash_scan_respects_non_rename_batch_limit() {
+    fn deep_hash_scan_bounds_a_large_library_batch() {
         let dir = tempfile::tempdir().expect("temp source");
         let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
-        for index in 0..5 {
+        for index in 0..512 {
             let relative = PathBuf::from(format!("pending-{index}.wav"));
             std::fs::write(dir.path().join(&relative), [index as u8; 32]).expect("write wav");
             db.upsert_file(&relative, 32, index)
@@ -374,18 +378,18 @@ mod tests {
             None,
             &HashSet::new(),
             DeferredHashScope::AllUnhashed,
-            Some(2),
+            Some(8),
         )
         .expect("bounded hash pass");
 
-        assert_eq!(stats.hashes_computed, 2);
+        assert_eq!(stats.hashes_computed, 8);
         assert_eq!(
             db.list_files()
                 .expect("list files")
                 .iter()
                 .filter(|entry| entry.content_hash.is_some())
                 .count(),
-            2
+            8
         );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -39,8 +39,7 @@ pub fn sync_paths_with_progress(
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     for relative_path in targets.current_files {
-        if !committed
-            && let Some(cancel) = cancel
+        if let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
         {
             return Err(ScanError::Canceled);
@@ -67,27 +66,13 @@ pub fn sync_paths_with_progress(
         if prepared.len() == TARGET_PREPARE_BATCH_SIZE {
             let chunk =
                 std::mem::replace(&mut prepared, Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE));
-            committed |= apply_prepared_chunk(
-                db,
-                &root,
-                cancel.filter(|_| !committed),
-                &mut context,
-                chunk,
-                committed,
-            )?;
+            committed |= apply_prepared_chunk(db, &root, cancel, &mut context, chunk, committed)?;
         }
     }
     if !prepared.is_empty() {
-        let _ = apply_prepared_chunk(
-            db,
-            &root,
-            cancel.filter(|_| !committed),
-            &mut context,
-            prepared,
-            committed,
-        )?;
+        let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
     }
-    db_sync_phase(db, &mut context)?;
+    db_sync_phase(db, &mut context, cancel)?;
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -25,78 +25,58 @@ pub(super) fn walk_phase(
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
 ) -> Result<(), ScanError> {
-    // Before the first commit cancellation is rollback-safe. After a bounded
-    // batch commits, finish the scan so callers never receive `Canceled` for a
-    // partially applied source state.
+    // Each committed batch is a valid checkpoint. Cancellation may stop the scan between batches;
+    // the completion metadata and missing-row reconciliation are not published, so a later scan
+    // resumes from the durable partial index without presenting it as a complete generation.
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
-    visit_dir_with_cancel_check(
-        root,
-        &mut || cancel_requested(cancel, committed.get()),
-        &mut |path| {
-            if cancel_requested(cancel, committed.get()) {
-                return Err(ScanError::Canceled);
-            }
-            let mut prepared = match prepare_diff(root, path, context) {
-                Ok(prepared) => prepared,
-                Err(error) if committed.get() => {
-                    if let Ok(relative) = path.strip_prefix(root)
-                        && is_supported_scannable_audio_file(root, relative)
-                    {
-                        context.existing.remove(relative);
-                    }
-                    tracing::warn!(
-                        path = %path.display(),
-                        error = %error,
-                        "Skipping file that changed after an earlier scan batch committed"
-                    );
-                    return Ok(());
+    visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
+        if cancel_requested(cancel) {
+            return Err(ScanError::Canceled);
+        }
+        let mut prepared = match prepare_diff(root, path, context) {
+            Ok(prepared) => prepared,
+            Err(error) if committed.get() => {
+                if let Ok(relative) = path.strip_prefix(root)
+                    && is_supported_scannable_audio_file(root, relative)
+                {
+                    context.existing.remove(relative);
                 }
-                Err(error) => return Err(error),
-            };
-            context.stats.total_files += 1;
-            if let Some(on_progress) = on_progress.as_mut() {
-                on_progress(context.stats.total_files, path);
-            }
-            if !prepared.requires_apply {
-                let Some(refreshed) =
-                    refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
-                else {
-                    return Ok(());
-                };
-                prepared = refreshed;
-            }
-            if !prepared.requires_apply {
-                skip_noop(context, &prepared);
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "Skipping file that changed after an earlier scan batch committed"
+                );
                 return Ok(());
             }
-            pending.push(prepared);
-            if pending.len() == APPLY_BATCH_SIZE {
-                let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-                if apply_batch(
-                    db,
-                    root,
-                    cancel.filter(|_| !committed.get()),
-                    context,
-                    files,
-                    committed.get(),
-                )? {
-                    committed.set(true);
-                }
+            Err(error) => return Err(error),
+        };
+        context.stats.total_files += 1;
+        if let Some(on_progress) = on_progress.as_mut() {
+            on_progress(context.stats.total_files, path);
+        }
+        if !prepared.requires_apply {
+            let Some(refreshed) =
+                refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
+            else {
+                return Ok(());
+            };
+            prepared = refreshed;
+        }
+        if !prepared.requires_apply {
+            skip_noop(context, &prepared);
+            return Ok(());
+        }
+        pending.push(prepared);
+        if pending.len() == APPLY_BATCH_SIZE {
+            let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
+            if apply_batch(db, root, cancel, context, files, committed.get())? {
+                committed.set(true);
             }
-            Ok(())
-        },
-    )?;
-    if !pending.is_empty()
-        && apply_batch(
-            db,
-            root,
-            cancel.filter(|_| !committed.get()),
-            context,
-            pending,
-            committed.get(),
-        )?
-    {
+        }
+        Ok(())
+    })?;
+    if !pending.is_empty() && apply_batch(db, root, cancel, context, pending, committed.get())? {
         committed.set(true);
     }
     Ok(())
@@ -212,6 +192,7 @@ fn apply_batch(
         let relative_path = file.facts.relative.clone();
         let outcome = match prepare_for_apply(db, root, cancel, file) {
             Ok(outcome) => outcome,
+            Err(ScanError::Canceled) => return Err(ScanError::Canceled),
             Err(error) if tolerate_file_errors => {
                 skip_changed_or_unavailable(context, root, &relative_path);
                 tracing::warn!(
@@ -234,7 +215,7 @@ fn apply_batch(
     if ready.is_empty() {
         return Ok(false);
     }
-    if cancel_requested(cancel, false) {
+    if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
@@ -320,8 +301,8 @@ fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> 
         && current.file_identity == prepared.facts.file_identity
 }
 
-fn cancel_requested(cancel: Option<&AtomicBool>, committed: bool) -> bool {
-    !committed && cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
+fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
+    cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
 }
 
 #[cfg(test)]

--- a/src/app/controller/library/analysis_jobs/db/cleanup.rs
+++ b/src/app/controller/library/analysis_jobs/db/cleanup.rs
@@ -3,6 +3,15 @@ use super::telemetry;
 use rusqlite::{Connection, params};
 
 pub(crate) fn reset_running_to_pending(conn: &Connection) -> Result<usize, String> {
+    if conn
+        .is_readonly(rusqlite::MAIN_DB)
+        .map_err(|err| format!("Failed to inspect analysis database mode: {err}"))?
+    {
+        return Ok(0);
+    }
+    if !analysis_jobs_has_column(conn, "readiness_managed")? {
+        return Ok(0);
+    }
     progress_snapshot::ensure_all_progress_snapshot_rows(conn)?;
     let counts =
         progress_snapshot::running_counts_by_job_type(conn, "readiness_managed = 0", Vec::new())?;
@@ -34,6 +43,22 @@ pub(crate) fn reset_running_to_pending(conn: &Connection) -> Result<usize, Strin
     }
     progress_snapshot::apply_state_transitions(conn, transitions)?;
     Ok(changed)
+}
+
+fn analysis_jobs_has_column(conn: &Connection, column: &str) -> Result<bool, String> {
+    let mut statement = conn
+        .prepare("PRAGMA table_info(analysis_jobs)")
+        .map_err(|err| format!("Failed to inspect analysis job schema: {err}"))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|err| format!("Failed to inspect analysis job schema: {err}"))?;
+    for result in columns {
+        if result.map_err(|err| format!("Failed to inspect analysis job schema: {err}"))? == column
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 pub(crate) fn fail_stale_running_jobs(

--- a/src/app/controller/library/analysis_jobs/db/jobs.rs
+++ b/src/app/controller/library/analysis_jobs/db/jobs.rs
@@ -2,7 +2,7 @@ use super::progress_snapshot::{self, SnapshotJobState};
 use super::telemetry;
 use super::types::ClaimedJob;
 use crate::logging::{ActionDebugEvent, emit_action_debug_event};
-use rusqlite::{Connection, params, params_from_iter};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -138,6 +138,54 @@ pub(crate) fn claim_next_jobs(
         error: None,
     });
     Ok(jobs)
+}
+
+pub(crate) fn claim_job_by_id(
+    conn: &mut Connection,
+    source_root: &Path,
+    job_id: i64,
+) -> Result<Option<ClaimedJob>, String> {
+    let tx = telemetry::begin_immediate_transaction(conn, "analysis_claim_job_by_id")
+        .map_err(|err| format!("Failed to start analysis claim transaction: {err}"))?;
+    progress_snapshot::ensure_all_progress_snapshot_rows(&tx)?;
+    let before = progress_snapshot::job_state_by_id(&tx, job_id)?;
+    let running_at = now_epoch_seconds();
+    let claimed = tx
+        .query_row(
+            "UPDATE analysis_jobs
+             SET status = 'running', attempts = attempts + 1, running_at = ?2
+             WHERE id = ?1
+               AND status = 'pending'
+               AND readiness_managed = 0
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM analysis_jobs AS running
+                   WHERE running.sample_id = analysis_jobs.sample_id
+                     AND running.job_type = analysis_jobs.job_type
+                     AND running.status = 'running'
+                     AND running.id != analysis_jobs.id
+               )
+             RETURNING id, sample_id, content_hash, job_type",
+            params![job_id, running_at],
+            |row| {
+                Ok(ClaimedJob {
+                    id: row.get(0)?,
+                    sample_id: row.get(1)?,
+                    content_hash: row.get(2)?,
+                    job_type: row.get(3)?,
+                    source_root: source_root.to_path_buf(),
+                })
+            },
+        )
+        .optional()
+        .map_err(|err| format!("Failed to claim analysis job {job_id}: {err}"))?;
+    if claimed.is_some() {
+        let after = progress_snapshot::job_state_by_id(&tx, job_id)?;
+        progress_snapshot::apply_state_transitions(&tx, [(before, after)])?;
+    }
+    telemetry::commit_transaction(tx, "analysis_claim_job_by_id")
+        .map_err(|err| format!("Failed to commit analysis job claim: {err}"))?;
+    Ok(claimed)
 }
 
 pub(crate) fn mark_done(conn: &Connection, job_id: i64) -> Result<(), String> {

--- a/src/app/controller/library/analysis_jobs/db/jobs.rs
+++ b/src/app/controller/library/analysis_jobs/db/jobs.rs
@@ -237,6 +237,21 @@ pub(crate) fn mark_pending(conn: &Connection, job_id: i64) -> Result<(), String>
     Ok(())
 }
 
+pub(crate) fn mark_pending_if_running(conn: &Connection, job_id: i64) -> Result<(), String> {
+    progress_snapshot::ensure_all_progress_snapshot_rows(conn)?;
+    let before = progress_snapshot::job_state_by_id(conn, job_id)?;
+    conn.execute(
+        "UPDATE analysis_jobs
+         SET status = 'pending', running_at = NULL
+         WHERE id = ?1 AND status = 'running'",
+        params![job_id],
+    )
+    .map_err(|err| format!("Failed to release running analysis job: {err}"))?;
+    let after = progress_snapshot::job_state_by_id(conn, job_id)?;
+    progress_snapshot::apply_state_transitions(conn, [(before, after)])?;
+    Ok(())
+}
+
 pub(crate) fn touch_running_at(conn: &Connection, job_ids: &[i64]) -> Result<(), String> {
     if job_ids.is_empty() {
         return Ok(());

--- a/src/app/controller/library/analysis_jobs/db/mod.rs
+++ b/src/app/controller/library/analysis_jobs/db/mod.rs
@@ -57,9 +57,9 @@ pub(crate) use jobs::update_sample_bpm;
 #[cfg(test)]
 pub(crate) use jobs::update_sample_bpms;
 pub(crate) use jobs::{
-    SampleAnalysisState, claim_next_jobs, mark_done, mark_failed_with_reason, mark_pending,
-    sample_analysis_states, sample_content_hash, sample_ids_missing_duration, touch_running_at,
-    update_sample_bpms_in_tx,
+    SampleAnalysisState, claim_job_by_id, claim_next_jobs, mark_done, mark_failed_with_reason,
+    mark_pending, sample_analysis_states, sample_content_hash, sample_ids_missing_duration,
+    touch_running_at, update_sample_bpms_in_tx,
 };
 pub(crate) use progress::{
     current_embedding_backfill_progress, current_progress, current_running_jobs,

--- a/src/app/controller/library/analysis_jobs/db/mod.rs
+++ b/src/app/controller/library/analysis_jobs/db/mod.rs
@@ -58,8 +58,8 @@ pub(crate) use jobs::update_sample_bpm;
 pub(crate) use jobs::update_sample_bpms;
 pub(crate) use jobs::{
     SampleAnalysisState, claim_job_by_id, claim_next_jobs, mark_done, mark_failed_with_reason,
-    mark_pending, sample_analysis_states, sample_content_hash, sample_ids_missing_duration,
-    touch_running_at, update_sample_bpms_in_tx,
+    mark_pending, mark_pending_if_running, sample_analysis_states, sample_content_hash,
+    sample_ids_missing_duration, touch_running_at, update_sample_bpms_in_tx,
 };
 pub(crate) use progress::{
     current_embedding_backfill_progress, current_progress, current_running_jobs,

--- a/src/app/controller/library/analysis_jobs/db/tests/cleanup.rs
+++ b/src/app/controller/library/analysis_jobs/db/tests/cleanup.rs
@@ -24,6 +24,36 @@ fn reset_running_to_pending_updates_rows() {
 }
 
 #[test]
+fn reset_running_to_pending_skips_read_only_legacy_databases() {
+    let directory = tempfile::tempdir().unwrap();
+    let database_path = directory.path().join("legacy.sqlite3");
+    rusqlite::Connection::open(&database_path).unwrap();
+    let connection = rusqlite::Connection::open_with_flags(
+        database_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+
+    assert_eq!(reset_running_to_pending(&connection).unwrap(), 0);
+}
+
+#[test]
+fn reset_running_to_pending_skips_unmigrated_analysis_job_schema() {
+    let connection = rusqlite::Connection::open_in_memory().unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE analysis_jobs (
+                id INTEGER PRIMARY KEY,
+                job_type TEXT NOT NULL,
+                status TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+
+    assert_eq!(reset_running_to_pending(&connection).unwrap(), 0);
+}
+
+#[test]
 fn fail_stale_running_jobs_ignores_recent_claims() {
     let db = TestDb::new();
     db.insert_job(

--- a/src/app/controller/library/analysis_jobs/db/tests/jobs.rs
+++ b/src/app/controller/library/analysis_jobs/db/tests/jobs.rs
@@ -262,6 +262,50 @@ fn mark_done_clears_error_and_updates_status() {
 }
 
 #[test]
+fn release_by_id_only_returns_running_jobs_to_pending() {
+    let db = TestDb::new();
+    db.insert_job(JobRow::new("s::running.wav", "x", "running").with_attempts(1));
+    db.insert_job(JobRow::new("s::done.wav", "x", "done").with_attempts(1));
+    let running_id: i64 = db
+        .conn
+        .query_row(
+            "SELECT id FROM analysis_jobs WHERE sample_id = 's::running.wav'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let done_id: i64 = db
+        .conn
+        .query_row(
+            "SELECT id FROM analysis_jobs WHERE sample_id = 's::done.wav'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    mark_pending_if_running(&db.conn, running_id).unwrap();
+    mark_pending_if_running(&db.conn, done_id).unwrap();
+
+    let statuses = db
+        .conn
+        .prepare("SELECT sample_id, status FROM analysis_jobs ORDER BY sample_id")
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        statuses,
+        vec![
+            ("s::done.wav".to_string(), "done".to_string()),
+            ("s::running.wav".to_string(), "pending".to_string()),
+        ]
+    );
+}
+
+#[test]
 fn mark_failed_updates_status_and_error() {
     let db = TestDb::new();
     db.insert_job(JobRow::new("s::a.wav", "x", "running").with_attempts(1));

--- a/src/app/controller/library/analysis_jobs/mod.rs
+++ b/src/app/controller/library/analysis_jobs/mod.rs
@@ -97,6 +97,7 @@ pub(crate) fn run_claimed_job(
     max_analysis_duration_seconds: f32,
     analysis_sample_rate: u32,
     analysis_version: &str,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<(), String> {
     pool::job_execution::run_job(
         conn,
@@ -105,5 +106,6 @@ pub(crate) fn run_claimed_job(
         max_analysis_duration_seconds,
         analysis_sample_rate,
         analysis_version,
+        cancel,
     )
 }

--- a/src/app/controller/library/analysis_jobs/mod.rs
+++ b/src/app/controller/library/analysis_jobs/mod.rs
@@ -131,3 +131,43 @@ pub(crate) fn run_claimed_job_with_embedding_worker_limit(
         Some(embedding_worker_limit),
     )
 }
+
+pub(crate) fn run_readiness_feature_stage(
+    conn: &mut rusqlite::Connection,
+    source_root: &std::path::Path,
+    source_id: &str,
+    relative_path: &std::path::Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> Result<bool, String> {
+    pool::job_execution::run_feature_stage(
+        conn,
+        source_root,
+        source_id,
+        relative_path,
+        content_hash,
+        analysis_version,
+        cancel,
+    )
+}
+
+pub(crate) fn run_readiness_embedding_stage(
+    conn: &mut rusqlite::Connection,
+    source_root: &std::path::Path,
+    source_id: &str,
+    relative_path: &std::path::Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> Result<bool, String> {
+    pool::job_execution::run_embedding_stage(
+        conn,
+        source_root,
+        source_id,
+        relative_path,
+        content_hash,
+        analysis_version,
+        cancel,
+    )
+}

--- a/src/app/controller/library/analysis_jobs/mod.rs
+++ b/src/app/controller/library/analysis_jobs/mod.rs
@@ -109,3 +109,25 @@ pub(crate) fn run_claimed_job(
         cancel,
     )
 }
+
+pub(crate) fn run_claimed_job_with_embedding_worker_limit(
+    conn: &mut rusqlite::Connection,
+    job: &db::ClaimedJob,
+    use_cache: bool,
+    max_analysis_duration_seconds: f32,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
+    embedding_worker_limit: usize,
+) -> Result<(), String> {
+    pool::job_execution::run_job_with_embedding_worker_limit(
+        conn,
+        job,
+        use_cache,
+        max_analysis_duration_seconds,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+        Some(embedding_worker_limit),
+    )
+}

--- a/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/execution.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_claim/compute_worker/execution.rs
@@ -166,6 +166,7 @@ fn run_work_item(
                 settings.max_analysis_duration_seconds,
                 settings.analysis_sample_rate,
                 &settings.analysis_version,
+                None,
             );
             *immediate_job = Some((work.job, result));
             Ok(())
@@ -254,6 +255,7 @@ fn run_decoded_batch(
         max_analysis_duration_seconds: settings.max_analysis_duration_seconds,
         analysis_sample_rate: settings.analysis_sample_rate,
         analysis_version: settings.analysis_version.as_str(),
+        cancel: None,
     };
     let batch_outcomes = catch_unwind(AssertUnwindSafe(|| {
         super::super::super::job_execution::run_analysis_jobs_with_decoded_batch(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/analysis.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/analysis.rs
@@ -2,17 +2,30 @@ use crate::app::controller::library::analysis_jobs::db;
 
 use super::analysis_cache::{load_existing_embedding, lookup_cache_by_hash};
 use super::analysis_db::{
-    apply_cached_embedding, apply_cached_features_and_embedding, finalize_analysis_job,
-    update_metadata_for_skip,
+    apply_cached_embedding, apply_cached_features_and_embedding, finish_decoded_analysis_write,
+    persist_decoded_analysis_write, update_metadata_for_skip,
 };
 use super::analysis_decode::{DecodeOutcome, decode_for_analysis};
 use super::support::JobHeartbeat;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) struct AnalysisContext<'a> {
     pub(crate) use_cache: bool,
     pub(crate) max_analysis_duration_seconds: f32,
     pub(crate) analysis_sample_rate: u32,
     pub(crate) analysis_version: &'a str,
+    pub(crate) cancel: Option<&'a AtomicBool>,
+}
+
+fn checkpoint(context: &AnalysisContext<'_>) -> Result<(), String> {
+    if context
+        .cancel
+        .is_some_and(|cancel| cancel.load(Ordering::Acquire))
+    {
+        Err("Analysis job cancelled".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 pub(crate) fn run_analysis_job(
@@ -20,6 +33,7 @@ pub(crate) fn run_analysis_job(
     job: &db::ClaimedJob,
     context: &AnalysisContext<'_>,
 ) -> Result<(), String> {
+    checkpoint(context)?;
     let mut heartbeat = JobHeartbeat::new(std::time::Duration::from_secs(4));
     let job_ids = [job.id];
     heartbeat.touch_jobs(conn, &job_ids)?;
@@ -36,6 +50,7 @@ pub(crate) fn run_analysis_job(
         if let (Some(features), Some(embedding), Some(embedding_vec)) =
             (&cache.features, &cache.embedding, &cache.embedding_vec)
         {
+            checkpoint(context)?;
             apply_cached_features_and_embedding(
                 conn,
                 job,
@@ -49,6 +64,7 @@ pub(crate) fn run_analysis_job(
             return Ok(());
         }
         if let Some(embedding) = cache.embedding.as_ref() {
+            checkpoint(context)?;
             apply_cached_embedding(conn, job, embedding)?;
         }
     }
@@ -56,6 +72,7 @@ pub(crate) fn run_analysis_job(
     heartbeat.touch_jobs(conn, &job_ids)?;
     match decode_for_analysis(job, context)? {
         DecodeOutcome::Decoded(decoded) => {
+            checkpoint(context)?;
             heartbeat.touch_jobs(conn, &job_ids)?;
             run_analysis_job_with_decoded(conn, job, decoded, context)
         }
@@ -63,6 +80,7 @@ pub(crate) fn run_analysis_job(
             duration_seconds,
             sample_rate,
         } => {
+            checkpoint(context)?;
             heartbeat.touch_jobs(conn, &job_ids)?;
             update_metadata_for_skip(
                 conn,
@@ -81,19 +99,22 @@ pub(crate) fn run_analysis_job_with_decoded(
     decoded: wavecrate_analysis::AnalysisAudio,
     context: &AnalysisContext<'_>,
 ) -> Result<(), String> {
+    checkpoint(context)?;
     let needs_embedding_upsert = if context.use_cache {
         load_existing_embedding(conn, &job.sample_id)?.is_none()
     } else {
         true
     };
-    finalize_analysis_job(
-        conn,
+    let write = super::analysis_db::build_decoded_analysis_write(
         job,
         decoded,
         context.analysis_version,
         needs_embedding_upsert,
-        true,
-    )
+    )?;
+    checkpoint(context)?;
+    let persisted = persist_decoded_analysis_write(conn, Some(job.source_root.as_path()), &write)?;
+    checkpoint(context)?;
+    finish_decoded_analysis_write(conn, job, &write, persisted, true)
 }
 
 pub(crate) fn run_analysis_jobs_with_decoded_batch(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/analysis_db/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/analysis_db/mod.rs
@@ -3,8 +3,8 @@ mod persistence;
 mod planning;
 
 pub(crate) use persistence::{
-    apply_cached_embedding, apply_cached_features_and_embedding, finalize_analysis_job,
-    finish_decoded_analysis_write, persist_decoded_analysis_batch, update_metadata_for_skip,
+    apply_cached_embedding, apply_cached_features_and_embedding, finish_decoded_analysis_write,
+    persist_decoded_analysis_batch, persist_decoded_analysis_write, update_metadata_for_skip,
 };
 pub(crate) use planning::build_decoded_analysis_write;
 

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/analysis_db/persistence.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/analysis_db/persistence.rs
@@ -70,24 +70,6 @@ pub(crate) fn update_metadata_for_skip(
     )
 }
 
-pub(crate) fn finalize_analysis_job(
-    conn: &mut rusqlite::Connection,
-    job: &db::ClaimedJob,
-    decoded: wavecrate_analysis::AnalysisAudio,
-    analysis_version: &str,
-    needs_embedding_upsert: bool,
-    do_ann_upsert: bool,
-) -> Result<(), String> {
-    let write = super::build_decoded_analysis_write(
-        job,
-        decoded,
-        analysis_version,
-        needs_embedding_upsert,
-    )?;
-    let persisted = persist_decoded_analysis_write(conn, Some(job.source_root.as_path()), &write)?;
-    finish_decoded_analysis_write(conn, job, &write, persisted, do_ann_upsert)
-}
-
 /// Persist one decoded analysis result inside a single immediate transaction.
 pub(crate) fn persist_decoded_analysis_write(
     conn: &mut rusqlite::Connection,

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
@@ -1,6 +1,7 @@
 //! Embedding backfill job orchestration.
 
 use crate::app::controller::library::analysis_jobs::db;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::warn;
 
 mod model;
@@ -25,14 +26,23 @@ pub(crate) fn run_embedding_backfill_job(
     use_cache: bool,
     analysis_sample_rate: u32,
     analysis_version: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), String> {
+    checkpoint(cancel)?;
     let sample_ids = planning::parse_backfill_payload(job)?;
     if sample_ids.is_empty() {
         return Ok(());
     }
 
     let plan = planning::build_backfill_plan(conn, job, &sample_ids, use_cache, analysis_version)?;
-    finalize_backfill_job(conn, job, plan, analysis_sample_rate, analysis_version)
+    finalize_backfill_job(
+        conn,
+        job,
+        plan,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+    )
 }
 
 fn finalize_backfill_job(
@@ -41,17 +51,27 @@ fn finalize_backfill_job(
     plan: BackfillPlan,
     analysis_sample_rate: u32,
     analysis_version: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), String> {
     let BackfillPlan { ready, work } = plan;
-    let (computed, errors) = workers::run_embedding_workers(work, analysis_sample_rate);
+    let (computed, errors) = workers::run_embedding_workers(work, analysis_sample_rate, cancel);
+    checkpoint(cancel)?;
     let results = collect_results_for_write(ready, computed);
     if results.is_empty() {
         return finish_empty_backfill(errors);
     }
 
-    persistence::write_backfill_results(conn, job, &results, analysis_version)?;
+    persistence::write_backfill_results(conn, job, &results, analysis_version, cancel)?;
     log_worker_errors(&errors);
     Ok(())
+}
+
+fn checkpoint(cancel: Option<&AtomicBool>) -> Result<(), String> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+        Err("Embedding backfill cancelled".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 fn collect_results_for_write(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
@@ -28,6 +28,26 @@ pub(crate) fn run_embedding_backfill_job(
     analysis_version: &str,
     cancel: Option<&AtomicBool>,
 ) -> Result<(), String> {
+    run_embedding_backfill_job_with_worker_limit(
+        conn,
+        job,
+        use_cache,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+        None,
+    )
+}
+
+pub(crate) fn run_embedding_backfill_job_with_worker_limit(
+    conn: &mut rusqlite::Connection,
+    job: &db::ClaimedJob,
+    use_cache: bool,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: Option<&AtomicBool>,
+    worker_limit: Option<usize>,
+) -> Result<(), String> {
     checkpoint(cancel)?;
     let sample_ids = planning::parse_backfill_payload(job)?;
     if sample_ids.is_empty() {
@@ -42,6 +62,7 @@ pub(crate) fn run_embedding_backfill_job(
         analysis_sample_rate,
         analysis_version,
         cancel,
+        worker_limit,
     )
 }
 
@@ -52,9 +73,11 @@ fn finalize_backfill_job(
     analysis_sample_rate: u32,
     analysis_version: &str,
     cancel: Option<&AtomicBool>,
+    worker_limit: Option<usize>,
 ) -> Result<(), String> {
     let BackfillPlan { ready, work } = plan;
-    let (computed, errors) = workers::run_embedding_workers(work, analysis_sample_rate, cancel);
+    let (computed, errors) =
+        workers::run_embedding_workers(work, analysis_sample_rate, cancel, worker_limit);
     checkpoint(cancel)?;
     let results = collect_results_for_write(ready, computed);
     if results.is_empty() {

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/model.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/model.rs
@@ -19,6 +19,7 @@ pub(super) struct EmbeddingComputation {
 }
 
 /// Persistable embedding row for a specific sample id.
+#[derive(Clone)]
 pub(super) struct EmbeddingResult {
     pub(super) sample_id: String,
     pub(super) content_hash: String,

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/persistence.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/persistence.rs
@@ -4,6 +4,7 @@ use crate::app::controller::library::analysis_jobs::db;
 use crate::app::controller::library::analysis_jobs::db::telemetry;
 use crate::app::controller::library::analysis_jobs::pool::job_execution::support::now_epoch_seconds;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -17,9 +18,13 @@ pub(super) fn write_backfill_results(
     job: &db::ClaimedJob,
     results: &[EmbeddingResult],
     analysis_version: &str,
+    cancel: Option<&AtomicBool>,
 ) -> Result<(), String> {
     const INSERT_BATCH: usize = 128;
     for chunk in results.chunks(INSERT_BATCH) {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+            return Err("Embedding backfill cancelled before publication".to_string());
+        }
         retry_backfill_write_with(
             &job.source_root,
             "embedding_backfill_write",

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/persistence.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/persistence.rs
@@ -25,10 +25,14 @@ pub(super) fn write_backfill_results(
         if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
             return Err("Embedding backfill cancelled before publication".to_string());
         }
+        let mut persisted = Vec::new();
         retry_backfill_write_with(
             &job.source_root,
             "embedding_backfill_write",
-            || write_backfill_chunk(conn, chunk, analysis_version),
+            || {
+                persisted = write_backfill_chunk(conn, chunk, analysis_version)?;
+                Ok(())
+            },
             3,
             Duration::from_millis(50),
         )?;
@@ -36,7 +40,10 @@ pub(super) fn write_backfill_results(
             &job.source_root,
             crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
         );
-        if let Err(err) = update_ann_index_with_retry(conn, &job.source_root, chunk) {
+        if persisted.is_empty() {
+            continue;
+        }
+        if let Err(err) = update_ann_index_with_retry(conn, &job.source_root, &persisted) {
             let rebuild_result = handle_ann_update_failure(conn, job, &err);
             return Err(format_ann_update_error(err, rebuild_result));
         }
@@ -103,10 +110,16 @@ fn write_backfill_chunk(
     conn: &mut rusqlite::Connection,
     chunk: &[EmbeddingResult],
     analysis_version: &str,
-) -> Result<(), String> {
+) -> Result<Vec<EmbeddingResult>, String> {
     let tx = telemetry::begin_immediate_transaction(conn, "embedding_backfill_chunk")
         .map_err(|err| format!("Begin embedding backfill tx failed: {err}"))?;
+    let mut persisted = Vec::with_capacity(chunk.len());
     for result in chunk {
+        if db::sample_content_hash(&tx, &result.sample_id)?.as_deref()
+            != Some(result.content_hash.as_str())
+        {
+            continue;
+        }
         let embedding_blob = wavecrate_analysis::vector::encode_f32_le_blob(&result.embedding);
         db::upsert_embedding(
             &tx,
@@ -160,10 +173,11 @@ fn write_backfill_chunk(
                 created_at: result.created_at,
             },
         )?;
+        persisted.push(result.clone());
     }
     telemetry::commit_transaction(tx, "embedding_backfill_chunk")
         .map_err(|err| format!("Commit embedding backfill tx failed: {err}"))?;
-    Ok(())
+    Ok(persisted)
 }
 
 fn update_ann_index_with_retry(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/batching.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/batching.rs
@@ -4,6 +4,13 @@ use std::collections::VecDeque;
 use std::sync::mpsc::channel;
 
 #[test]
+fn embedding_worker_limit_caps_real_executor_fanout() {
+    assert_eq!(workers::bounded_worker_count_for_test(64, 1), 1);
+    assert_eq!(workers::bounded_worker_count_for_test(64, 3), 3);
+    assert_eq!(workers::bounded_worker_count_for_test(2, 8), 2);
+}
+
+#[test]
 fn drain_batch_caps_at_limit() {
     let mut queue = VecDeque::new();
     queue.push_back(make_work("a"));

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/persistence_rollback.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/persistence_rollback.rs
@@ -34,7 +34,8 @@ fn write_backfill_results_rolls_back_chunk_on_late_failure() {
         },
     ];
 
-    let err = persistence::write_backfill_results(&mut conn, &job, &results, "v1").unwrap_err();
+    let err =
+        persistence::write_backfill_results(&mut conn, &job, &results, "v1", None).unwrap_err();
 
     assert!(err.contains("synthetic backfill cache failure"));
     assert_eq!(count_rows(&conn, "embeddings"), 0);

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/persistence_rollback.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/persistence_rollback.rs
@@ -44,6 +44,28 @@ fn write_backfill_results_rolls_back_chunk_on_late_failure() {
     assert_eq!(count_rows(&conn, "analysis_cache_aspect_descriptors"), 0);
 }
 
+#[test]
+fn write_backfill_results_skips_stale_content_before_sql_and_ann_publication() {
+    let mut conn = conn_with_schema();
+    insert_sample(&conn, "s::stale.wav", "current-hash");
+    let temp = tempfile::TempDir::new().unwrap();
+    let job = make_job(&["s::stale.wav"], temp.path());
+    let results = vec![model::EmbeddingResult {
+        sample_id: "s::stale.wav".to_string(),
+        content_hash: "stale-hash".to_string(),
+        embedding: vec![0.0; wavecrate_analysis::similarity::SIMILARITY_DIM],
+        aspect_descriptors: dummy_aspects(),
+        created_at: 1,
+    }];
+
+    persistence::write_backfill_results(&mut conn, &job, &results, "v1", None).unwrap();
+
+    assert_eq!(count_rows(&conn, "embeddings"), 0);
+    assert_eq!(count_rows(&conn, "similarity_aspect_descriptors"), 0);
+    assert_eq!(count_rows(&conn, "analysis_cache_embeddings"), 0);
+    assert_eq!(count_rows(&conn, "analysis_cache_aspect_descriptors"), 0);
+}
+
 fn dummy_aspects() -> model::AspectDescriptorData {
     model::AspectDescriptorData {
         vec_blob: vec![0; wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DIM * 4],

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/workers.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/workers.rs
@@ -3,13 +3,19 @@
 use crate::app::controller::library::analysis_jobs::pool::job_execution::errors::ErrorCollector;
 use crate::app::controller::library::analysis_jobs::pool::job_execution::support::now_epoch_seconds;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex, mpsc::Receiver, mpsc::channel};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+    mpsc::Receiver,
+    mpsc::channel,
+};
 
 use super::model::{AspectDescriptorData, EmbeddingComputation, EmbeddingResult, EmbeddingWork};
 
 pub(super) fn run_embedding_workers(
     work: Vec<EmbeddingWork>,
     analysis_sample_rate: u32,
+    cancel: Option<&AtomicBool>,
 ) -> (Vec<EmbeddingComputation>, Vec<String>) {
     if work.is_empty() {
         return (Vec::new(), Vec::new());
@@ -22,7 +28,7 @@ pub(super) fn run_embedding_workers(
         for _ in 0..worker_count {
             let queue = Arc::clone(&queue);
             let tx = tx.clone();
-            scope.spawn(move || run_worker_loop(queue, tx, analysis_sample_rate));
+            scope.spawn(move || run_worker_loop(queue, tx, analysis_sample_rate, cancel));
         }
         drop(tx);
     });
@@ -86,14 +92,21 @@ fn run_worker_loop(
     queue: Arc<Mutex<VecDeque<EmbeddingWork>>>,
     tx: std::sync::mpsc::Sender<Result<EmbeddingComputation, String>>,
     analysis_sample_rate: u32,
+    cancel: Option<&AtomicBool>,
 ) {
     let batch_max = wavecrate_analysis::similarity::SIMILARITY_BATCH_MAX;
     loop {
+        if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+            break;
+        }
         let batch = next_batch(&queue, batch_max);
         if batch.is_empty() {
             break;
         }
         for work in batch {
+            if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+                return;
+            }
             let result = compute_embedding(work, analysis_sample_rate);
             let _ = tx.send(result);
         }

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/workers.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/workers.rs
@@ -16,11 +16,12 @@ pub(super) fn run_embedding_workers(
     work: Vec<EmbeddingWork>,
     analysis_sample_rate: u32,
     cancel: Option<&AtomicBool>,
+    worker_limit: Option<usize>,
 ) -> (Vec<EmbeddingComputation>, Vec<String>) {
     if work.is_empty() {
         return (Vec::new(), Vec::new());
     }
-    let worker_count = worker_count_for(&work);
+    let worker_count = worker_count_for(&work, worker_limit);
     let queue = Arc::new(Mutex::new(VecDeque::from(work)));
     let (tx, rx) = channel();
 
@@ -80,12 +81,20 @@ pub(super) fn collect_results(
     (results, errors.into_vec())
 }
 
-fn worker_count_for(work: &[EmbeddingWork]) -> usize {
-    std::thread::available_parallelism()
+fn worker_count_for(work: &[EmbeddingWork], worker_limit: Option<usize>) -> usize {
+    let available = std::thread::available_parallelism()
         .map(|n| n.get())
-        .unwrap_or(1)
-        .min(work.len())
-        .max(1)
+        .unwrap_or(1);
+    bounded_worker_count(available, work.len(), worker_limit)
+}
+
+fn bounded_worker_count(available: usize, work_items: usize, worker_limit: Option<usize>) -> usize {
+    worker_limit.unwrap_or(available).max(1).min(work_items)
+}
+
+#[cfg(test)]
+pub(super) fn bounded_worker_count_for_test(work_items: usize, worker_limit: usize) -> usize {
+    bounded_worker_count(usize::MAX, work_items, Some(worker_limit))
 }
 
 fn run_worker_loop(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
@@ -8,12 +8,14 @@ mod analysis_db;
 mod analysis_decode;
 mod backfill;
 mod errors;
+mod readiness;
 mod rebuild;
 mod status;
 mod support;
 
 #[cfg(not(test))]
 pub(crate) use analysis::{AnalysisContext, run_analysis_jobs_with_decoded_batch};
+pub(crate) use readiness::{run_embedding_stage, run_feature_stage};
 pub(crate) use status::update_job_status_with_retry;
 
 pub(crate) fn run_job(

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
@@ -23,6 +23,7 @@ pub(crate) fn run_job(
     max_analysis_duration_seconds: f32,
     analysis_sample_rate: u32,
     analysis_version: &str,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<(), String> {
     let started_at = Instant::now();
     let source = job.source_root.display().to_string();
@@ -33,6 +34,7 @@ pub(crate) fn run_job(
                 max_analysis_duration_seconds,
                 analysis_sample_rate,
                 analysis_version,
+                cancel,
             };
             analysis::run_analysis_job(conn, job, &context)
         }
@@ -42,6 +44,7 @@ pub(crate) fn run_job(
             use_cache,
             analysis_sample_rate,
             analysis_version,
+            cancel,
         ),
         db::REBUILD_INDEX_JOB_TYPE => rebuild::run_rebuild_index_job(conn, job),
         _ => Err(format!("Unknown job type: {}", job.job_type)),

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/mod.rs
@@ -25,6 +25,28 @@ pub(crate) fn run_job(
     analysis_version: &str,
     cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<(), String> {
+    run_job_with_embedding_worker_limit(
+        conn,
+        job,
+        use_cache,
+        max_analysis_duration_seconds,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+        None,
+    )
+}
+
+pub(crate) fn run_job_with_embedding_worker_limit(
+    conn: &mut rusqlite::Connection,
+    job: &db::ClaimedJob,
+    use_cache: bool,
+    max_analysis_duration_seconds: f32,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
+    embedding_worker_limit: Option<usize>,
+) -> Result<(), String> {
     let started_at = Instant::now();
     let source = job.source_root.display().to_string();
     let result = match job.job_type.as_str() {
@@ -38,13 +60,14 @@ pub(crate) fn run_job(
             };
             analysis::run_analysis_job(conn, job, &context)
         }
-        db::EMBEDDING_BACKFILL_JOB_TYPE => backfill::run_embedding_backfill_job(
+        db::EMBEDDING_BACKFILL_JOB_TYPE => backfill::run_embedding_backfill_job_with_worker_limit(
             conn,
             job,
             use_cache,
             analysis_sample_rate,
             analysis_version,
             cancel,
+            embedding_worker_limit,
         ),
         db::REBUILD_INDEX_JOB_TYPE => rebuild::run_rebuild_index_job(conn, job),
         _ => Err(format!("Unknown job type: {}", job.job_type)),

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
@@ -1,6 +1,8 @@
 //! Stage-specific execution reused by the native readiness supervisor.
 
 use std::{
+    fs::File,
+    io::Read,
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -26,12 +28,39 @@ pub(crate) fn run_feature_stage(
     analysis_version: &str,
     cancel: &AtomicBool,
 ) -> Result<bool, String> {
+    run_feature_stage_with_post_decode_hook(
+        conn,
+        source_root,
+        source_id,
+        relative_path,
+        content_hash,
+        analysis_version,
+        cancel,
+        || {},
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_feature_stage_with_post_decode_hook(
+    conn: &mut rusqlite::Connection,
+    source_root: &Path,
+    source_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+    post_decode_hook: impl FnOnce(),
+) -> Result<bool, String> {
     checkpoint(cancel, "feature analysis cancelled")?;
+    let absolute_path = source_root.join(relative_path);
     let sample_id = db::build_sample_id(source_id, relative_path);
     if !ensure_current_sample_row(conn, &sample_id, relative_path, content_hash, source_root)? {
         return Ok(false);
     }
     if db::sample_content_hash(conn, &sample_id)?.as_deref() != Some(content_hash) {
+        return Ok(false);
+    }
+    if !file_content_hash_matches(&absolute_path, content_hash, cancel)? {
         return Ok(false);
     }
     if let Some(cached) = db::cached_features_by_hash(
@@ -71,6 +100,7 @@ pub(crate) fn run_feature_stage(
             ));
         }
     };
+    post_decode_hook();
     checkpoint(cancel, "feature analysis cancelled before computation")?;
     let features = wavecrate_analysis::compute_feature_vector_v1_for_decoded_audio(&decoded)?;
     checkpoint(cancel, "feature analysis cancelled before publication")?;
@@ -78,10 +108,15 @@ pub(crate) fn run_feature_stage(
     let light_dsp_blob = wavecrate_analysis::light_dsp_from_features_v1(&features)
         .map(|values| wavecrate_analysis::vector::encode_f32_le_blob(&values));
     let rms = features.get(FEATURE_RMS_INDEX).copied();
+    if !file_content_hash_matches(&absolute_path, content_hash, cancel)? {
+        return Ok(false);
+    }
     let computed_at = now_epoch_seconds();
     let tx = db::telemetry::begin_immediate_transaction(conn, "readiness_feature_publish")
         .map_err(|error| format!("Failed to start readiness feature transaction: {error}"))?;
-    if db::sample_content_hash(&tx, &sample_id)?.as_deref() != Some(content_hash) {
+    if db::sample_content_hash(&tx, &sample_id)?.as_deref() != Some(content_hash)
+        || !manifest_content_hash_is_current(&tx, relative_path, content_hash)?
+    {
         db::telemetry::commit_transaction(tx, "readiness_feature_publish_stale")
             .map_err(|error| format!("Failed to commit stale feature skip: {error}"))?;
         return Ok(false);
@@ -127,6 +162,48 @@ pub(crate) fn run_feature_stage(
     );
     checkpoint(cancel, "feature analysis cancelled after publication")?;
     Ok(true)
+}
+
+fn file_content_hash_matches(
+    path: &Path,
+    claimed_hash: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    let mut file = File::open(path)
+        .map_err(|error| format!("Failed to open readiness input {}: {error}", path.display()))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        checkpoint(
+            cancel,
+            "feature analysis cancelled while verifying content hash",
+        )?;
+        let read = file.read(&mut buffer).map_err(|error| {
+            format!("Failed to hash readiness input {}: {error}", path.display())
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().to_hex().as_str() == claimed_hash)
+}
+
+fn manifest_content_hash_is_current(
+    conn: &rusqlite::Connection,
+    relative_path: &Path,
+    content_hash: &str,
+) -> Result<bool, String> {
+    let relative_path = relative_path.to_string_lossy().replace('\\', "/");
+    conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM wav_files
+            WHERE path = ?1 AND content_hash = ?2 AND missing = 0
+         )",
+        rusqlite::params![relative_path, content_hash],
+        |row| row.get(0),
+    )
+    .map_err(|error| format!("Failed to revalidate readiness sample manifest: {error}"))
 }
 
 fn materialize_cached_features(
@@ -280,5 +357,85 @@ fn checkpoint(cancel: &AtomicBool, reason: &'static str) -> Result<(), String> {
         Err(reason.to_string())
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sample_sources::{SampleSource, SourceDatabase, SourceId};
+
+    #[test]
+    fn feature_publication_rejects_file_mutated_while_stage_is_in_flight() {
+        let directory = tempfile::tempdir().expect("temporary readiness source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("feature-content-fence"),
+            directory.path().to_path_buf(),
+        );
+        let relative_path = Path::new("sample.wav");
+        let absolute_path = source.root.join(relative_path);
+        write_wav(&absolute_path, 440);
+        let original_bytes = std::fs::read(&absolute_path).expect("read original wav");
+        let original_hash = blake3::hash(&original_bytes).to_hex().to_string();
+        let metadata = std::fs::metadata(&absolute_path).expect("read original metadata");
+        let mut connection = SourceDatabase::open_connection(&source.root).expect("open source db");
+        connection
+            .execute(
+                "INSERT INTO wav_files (
+                    path, file_size, modified_ns, content_hash, extension, missing, file_identity
+                 ) VALUES (?1, ?2, 1, ?3, 'wav', 0, 'feature-content-fence-identity')",
+                rusqlite::params![
+                    relative_path.to_string_lossy(),
+                    i64::try_from(metadata.len()).expect("wav size fits i64"),
+                    original_hash,
+                ],
+            )
+            .expect("seed source manifest");
+        let cancel = AtomicBool::new(false);
+
+        let published = run_feature_stage_with_post_decode_hook(
+            &mut connection,
+            &source.root,
+            source.id.as_str(),
+            relative_path,
+            &original_hash,
+            wavecrate_analysis::analysis_version(),
+            &cancel,
+            || write_wav(&absolute_path, 880),
+        )
+        .expect("run fenced feature stage");
+
+        assert!(!published, "changed bytes must make the claim retryable");
+        let cached: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM analysis_cache_features WHERE content_hash = ?1",
+                [&original_hash],
+                |row| row.get(0),
+            )
+            .expect("count cached features");
+        assert_eq!(cached, 0, "changed bytes must not poison the content cache");
+        assert_ne!(
+            blake3::hash(&std::fs::read(&absolute_path).expect("read mutated wav"))
+                .to_hex()
+                .as_str(),
+            original_hash
+        );
+    }
+
+    fn write_wav(path: &Path, frequency_hz: usize) {
+        let sample_rate = 8_000_u32;
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create test wav");
+        for sample_index in 0..usize::try_from(sample_rate).expect("sample rate fits usize") {
+            let phase = sample_index as f32 * frequency_hz as f32 / sample_rate as f32;
+            let sample = ((phase * std::f32::consts::TAU).sin() * 12_000.0) as i16;
+            writer.write_sample(sample).expect("write wav sample");
+        }
+        writer.finalize().expect("finalize test wav");
     }
 }

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
@@ -1,0 +1,284 @@
+//! Stage-specific execution reused by the native readiness supervisor.
+
+use std::{
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use crate::app::controller::library::analysis_jobs::db;
+use rusqlite::OptionalExtension;
+
+use super::{
+    analysis::AnalysisContext,
+    analysis_decode::{self, DecodeOutcome},
+    backfill,
+    support::now_epoch_seconds,
+};
+
+const FEATURE_RMS_INDEX: usize = 2;
+
+pub(crate) fn run_feature_stage(
+    conn: &mut rusqlite::Connection,
+    source_root: &Path,
+    source_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    checkpoint(cancel, "feature analysis cancelled")?;
+    let sample_id = db::build_sample_id(source_id, relative_path);
+    if !ensure_current_sample_row(conn, &sample_id, relative_path, content_hash, source_root)? {
+        return Ok(false);
+    }
+    if db::sample_content_hash(conn, &sample_id)?.as_deref() != Some(content_hash) {
+        return Ok(false);
+    }
+    if let Some(cached) = db::cached_features_by_hash(
+        conn,
+        content_hash,
+        analysis_version,
+        wavecrate_analysis::vector::FEATURE_VERSION_V1,
+    )? {
+        return materialize_cached_features(
+            conn,
+            source_root,
+            &sample_id,
+            content_hash,
+            analysis_version,
+            &cached,
+        );
+    }
+    let job = db::ClaimedJob {
+        id: -1,
+        sample_id: sample_id.clone(),
+        content_hash: Some(content_hash.to_string()),
+        job_type: db::ANALYZE_SAMPLE_JOB_TYPE.to_string(),
+        source_root: source_root.to_path_buf(),
+    };
+    let context = AnalysisContext {
+        use_cache: true,
+        max_analysis_duration_seconds: f32::INFINITY,
+        analysis_sample_rate: wavecrate_analysis::ANALYSIS_SAMPLE_RATE,
+        analysis_version,
+        cancel: Some(cancel),
+    };
+    let decoded = match analysis_decode::decode_for_analysis(&job, &context)? {
+        DecodeOutcome::Decoded(decoded) => decoded,
+        DecodeOutcome::Skipped { .. } => {
+            return Err(String::from(
+                "feature analysis unexpectedly skipped an unbounded readiness target",
+            ));
+        }
+    };
+    checkpoint(cancel, "feature analysis cancelled before computation")?;
+    let features = wavecrate_analysis::compute_feature_vector_v1_for_decoded_audio(&decoded)?;
+    checkpoint(cancel, "feature analysis cancelled before publication")?;
+    let feature_blob = wavecrate_analysis::vector::encode_f32_le_blob(&features);
+    let light_dsp_blob = wavecrate_analysis::light_dsp_from_features_v1(&features)
+        .map(|values| wavecrate_analysis::vector::encode_f32_le_blob(&values));
+    let rms = features.get(FEATURE_RMS_INDEX).copied();
+    let computed_at = now_epoch_seconds();
+    let tx = db::telemetry::begin_immediate_transaction(conn, "readiness_feature_publish")
+        .map_err(|error| format!("Failed to start readiness feature transaction: {error}"))?;
+    if db::sample_content_hash(&tx, &sample_id)?.as_deref() != Some(content_hash) {
+        db::telemetry::commit_transaction(tx, "readiness_feature_publish_stale")
+            .map_err(|error| format!("Failed to commit stale feature skip: {error}"))?;
+        return Ok(false);
+    }
+    db::update_analysis_metadata(
+        &tx,
+        db::AnalysisMetadataUpdate {
+            sample_id: &sample_id,
+            content_hash: Some(content_hash),
+            duration_seconds: decoded.duration_seconds,
+            sr_used: decoded.sample_rate_used,
+            analysis_version,
+        },
+    )?;
+    db::upsert_analysis_features(
+        &tx,
+        &sample_id,
+        &feature_blob,
+        light_dsp_blob.as_deref(),
+        rms,
+        wavecrate_analysis::vector::FEATURE_VERSION_V1,
+        computed_at,
+    )?;
+    db::upsert_cached_features(
+        &tx,
+        db::CachedFeaturesUpsert {
+            content_hash,
+            analysis_version,
+            feat_version: wavecrate_analysis::vector::FEATURE_VERSION_V1,
+            vec_blob: &feature_blob,
+            light_dsp_blob: light_dsp_blob.as_deref(),
+            rms,
+            computed_at,
+            duration_seconds: decoded.duration_seconds,
+            sr_used: decoded.sample_rate_used,
+        },
+    )?;
+    db::telemetry::commit_transaction(tx, "readiness_feature_publish")
+        .map_err(|error| format!("Failed to commit readiness features: {error}"))?;
+    crate::sample_sources::SourceDatabase::maybe_checkpoint_wal(
+        source_root,
+        crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
+    );
+    checkpoint(cancel, "feature analysis cancelled after publication")?;
+    Ok(true)
+}
+
+fn materialize_cached_features(
+    conn: &mut rusqlite::Connection,
+    source_root: &Path,
+    sample_id: &str,
+    content_hash: &str,
+    analysis_version: &str,
+    cached: &db::CachedFeatures,
+) -> Result<bool, String> {
+    let tx = db::telemetry::begin_immediate_transaction(conn, "readiness_feature_cache_apply")
+        .map_err(|error| format!("Failed to start readiness feature cache transaction: {error}"))?;
+    if db::sample_content_hash(&tx, sample_id)?.as_deref() != Some(content_hash) {
+        db::telemetry::commit_transaction(tx, "readiness_feature_cache_stale")
+            .map_err(|error| format!("Failed to commit stale feature cache skip: {error}"))?;
+        return Ok(false);
+    }
+    db::update_analysis_metadata(
+        &tx,
+        db::AnalysisMetadataUpdate {
+            sample_id,
+            content_hash: Some(content_hash),
+            duration_seconds: cached.duration_seconds,
+            sr_used: cached.sr_used,
+            analysis_version,
+        },
+    )?;
+    db::upsert_analysis_features(
+        &tx,
+        sample_id,
+        &cached.vec_blob,
+        cached.light_dsp_blob.as_deref(),
+        cached.rms,
+        cached.feat_version,
+        cached.computed_at,
+    )?;
+    db::telemetry::commit_transaction(tx, "readiness_feature_cache_apply")
+        .map_err(|error| format!("Failed to commit cached readiness features: {error}"))?;
+    crate::sample_sources::SourceDatabase::maybe_checkpoint_wal(
+        source_root,
+        crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
+    );
+    Ok(true)
+}
+
+fn ensure_current_sample_row(
+    conn: &mut rusqlite::Connection,
+    sample_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    source_root: &Path,
+) -> Result<bool, String> {
+    let relative_path = relative_path.to_string_lossy().replace('\\', "/");
+    let manifest = conn
+        .query_row(
+            "SELECT file_size, modified_ns
+             FROM wav_files
+             WHERE path = ?1 AND content_hash = ?2 AND missing = 0",
+            rusqlite::params![relative_path, content_hash],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()
+        .map_err(|error| format!("Failed to read readiness sample manifest: {error}"))?;
+    let Some((size, modified_ns)) = manifest else {
+        return Ok(false);
+    };
+    let size = u64::try_from(size)
+        .map_err(|_| format!("Readiness sample has a negative file size: {relative_path}"))?;
+    let tx = db::telemetry::begin_immediate_transaction(conn, "readiness_sample_upsert")
+        .map_err(|error| format!("Failed to start readiness sample transaction: {error}"))?;
+    db::upsert_samples_in_tx(
+        &tx,
+        &[db::SampleMetadata {
+            sample_id: sample_id.to_string(),
+            content_hash: content_hash.to_string(),
+            size,
+            mtime_ns: modified_ns,
+        }],
+    )?;
+    db::telemetry::commit_transaction(tx, "readiness_sample_upsert")
+        .map_err(|error| format!("Failed to commit readiness sample metadata: {error}"))?;
+    crate::sample_sources::SourceDatabase::maybe_checkpoint_wal(
+        source_root,
+        crate::sample_sources::SourceDatabaseConnectionRole::JobWorker,
+    );
+    Ok(true)
+}
+
+pub(crate) fn run_embedding_stage(
+    conn: &mut rusqlite::Connection,
+    source_root: &Path,
+    source_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    checkpoint(cancel, "embedding analysis cancelled")?;
+    let sample_id = db::build_sample_id(source_id, relative_path);
+    if db::sample_content_hash(conn, &sample_id)?.as_deref() != Some(content_hash) {
+        return Ok(false);
+    }
+    if db::cached_features_by_hash(
+        conn,
+        content_hash,
+        analysis_version,
+        wavecrate_analysis::vector::FEATURE_VERSION_V1,
+    )?
+    .is_none()
+    {
+        return Ok(false);
+    }
+    let job = db::ClaimedJob {
+        id: -1,
+        sample_id: sample_id.clone(),
+        content_hash: Some(
+            serde_json::to_string(&[sample_id.as_str()]).map_err(|error| {
+                format!("Failed to encode readiness embedding payload: {error}")
+            })?,
+        ),
+        job_type: db::EMBEDDING_BACKFILL_JOB_TYPE.to_string(),
+        source_root: source_root.to_path_buf(),
+    };
+    backfill::run_embedding_backfill_job_with_worker_limit(
+        conn,
+        &job,
+        true,
+        wavecrate_analysis::ANALYSIS_SAMPLE_RATE,
+        analysis_version,
+        Some(cancel),
+        Some(1),
+    )?;
+    checkpoint(cancel, "embedding analysis cancelled after publication")?;
+    let embedding = db::cached_embedding_by_hash(
+        conn,
+        content_hash,
+        analysis_version,
+        wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+    )?;
+    let aspects = db::cached_aspect_descriptors_by_hash(
+        conn,
+        content_hash,
+        analysis_version,
+        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+    )?;
+    Ok(embedding.is_some() && aspects.is_some())
+}
+
+fn checkpoint(cancel: &AtomicBool, reason: &'static str) -> Result<(), String> {
+    if cancel.load(Ordering::Acquire) {
+        Err(reason.to_string())
+    } else {
+        Ok(())
+    }
+}

--- a/src/internal_analysis_jobs.rs
+++ b/src/internal_analysis_jobs.rs
@@ -137,6 +137,11 @@ pub fn release(conn: &Connection, job: &ClaimedAnalysisJob) -> Result<(), String
     analysis_jobs::db::mark_pending(conn, job.inner.id)
 }
 
+/// Return one exact claimed job to pending after its worker process is cancelled.
+pub fn release_job_by_id(conn: &Connection, job_id: i64) -> Result<(), String> {
+    analysis_jobs::db::mark_pending_if_running(conn, job_id)
+}
+
 /// Mark one claimed analysis job as failed.
 pub fn mark_failed_with_reason(
     conn: &Connection,

--- a/src/internal_analysis_jobs.rs
+++ b/src/internal_analysis_jobs.rs
@@ -1,6 +1,7 @@
 //! Hidden bridge for native-runtime analysis job execution.
 
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 
 use rusqlite::Connection;
 
@@ -30,6 +31,16 @@ pub fn claim_next_jobs(
     })
 }
 
+/// Claim one exact pending analysis job selected by the source supervisor.
+pub fn claim_job_by_id(
+    conn: &mut Connection,
+    source_root: &Path,
+    job_id: i64,
+) -> Result<Option<ClaimedAnalysisJob>, String> {
+    analysis_jobs::db::claim_job_by_id(conn, source_root, job_id)
+        .map(|job| job.map(|inner| ClaimedAnalysisJob { inner }))
+}
+
 /// Execute one claimed analysis job with the shared Wavecrate analysis executor.
 pub fn run_claimed_job(
     conn: &mut Connection,
@@ -38,6 +49,7 @@ pub fn run_claimed_job(
     max_analysis_duration_seconds: f32,
     analysis_sample_rate: u32,
     analysis_version: &str,
+    cancel: &AtomicBool,
 ) -> Result<(), String> {
     analysis_jobs::run_claimed_job(
         conn,
@@ -46,6 +58,7 @@ pub fn run_claimed_job(
         max_analysis_duration_seconds,
         analysis_sample_rate,
         analysis_version,
+        Some(cancel),
     )
 }
 

--- a/src/internal_analysis_jobs.rs
+++ b/src/internal_analysis_jobs.rs
@@ -85,6 +85,48 @@ pub fn run_claimed_job_with_embedding_worker_limit(
     )
 }
 
+/// Produce current feature artifacts for one readiness-owned file target.
+pub fn run_readiness_feature_stage(
+    conn: &mut Connection,
+    source_root: &Path,
+    source_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    analysis_jobs::run_readiness_feature_stage(
+        conn,
+        source_root,
+        source_id,
+        relative_path,
+        content_hash,
+        analysis_version,
+        cancel,
+    )
+}
+
+/// Produce current embedding, aspect, and ANN artifacts for one readiness-owned file target.
+pub fn run_readiness_embedding_stage(
+    conn: &mut Connection,
+    source_root: &Path,
+    source_id: &str,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    analysis_jobs::run_readiness_embedding_stage(
+        conn,
+        source_root,
+        source_id,
+        relative_path,
+        content_hash,
+        analysis_version,
+        cancel,
+    )
+}
+
 /// Mark one claimed analysis job as done.
 pub fn mark_done(conn: &Connection, job: &ClaimedAnalysisJob) -> Result<(), String> {
     analysis_jobs::db::mark_done(conn, job.inner.id)

--- a/src/internal_analysis_jobs.rs
+++ b/src/internal_analysis_jobs.rs
@@ -62,6 +62,29 @@ pub fn run_claimed_job(
     )
 }
 
+/// Execute one claimed job while bounding embedding worker fan-out to the reserved CPU permits.
+pub fn run_claimed_job_with_embedding_worker_limit(
+    conn: &mut Connection,
+    job: &ClaimedAnalysisJob,
+    use_cache: bool,
+    max_analysis_duration_seconds: f32,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+    embedding_worker_limit: usize,
+) -> Result<(), String> {
+    analysis_jobs::run_claimed_job_with_embedding_worker_limit(
+        conn,
+        &job.inner,
+        use_cache,
+        max_analysis_duration_seconds,
+        analysis_sample_rate,
+        analysis_version,
+        Some(cancel),
+        embedding_worker_limit,
+    )
+}
+
 /// Mark one claimed analysis job as done.
 pub fn mark_done(conn: &Connection, job: &ClaimedAnalysisJob) -> Result<(), String> {
     analysis_jobs::db::mark_done(conn, job.inner.id)

--- a/src/internal_analysis_jobs.rs
+++ b/src/internal_analysis_jobs.rs
@@ -54,6 +54,11 @@ pub fn mark_done(conn: &Connection, job: &ClaimedAnalysisJob) -> Result<(), Stri
     analysis_jobs::db::mark_done(conn, job.inner.id)
 }
 
+/// Return one claimed job to pending when its owning supervisor is cancelled.
+pub fn release(conn: &Connection, job: &ClaimedAnalysisJob) -> Result<(), String> {
+    analysis_jobs::db::mark_pending(conn, job.inner.id)
+}
+
 /// Mark one claimed analysis job as failed.
 pub fn mark_failed_with_reason(
     conn: &Connection,

--- a/src/native_app.rs
+++ b/src/native_app.rs
@@ -9,6 +9,7 @@ mod release_update;
 mod sample_identity_diagnostics;
 mod sample_library;
 mod shell;
+mod source_processing;
 mod starmap_audition_telemetry;
 #[cfg(test)]
 mod test_support;

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -379,6 +379,7 @@ pub(in crate::native_app) enum GuiMessage {
 pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) source_id: String,
     pub(in crate::native_app) changed_count: usize,
+    pub(in crate::native_app) cancelled: bool,
     pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,
 }
 

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -14,6 +14,7 @@ use crate::native_app::app::{
     ExtractedFilePlaybackType, FileMoveProgress, GuiMessage, NormalizationProgress,
     NormalizationQueueItem, PendingWaveformDestructiveEdit,
 };
+use crate::native_app::source_processing::SourceProcessingSupervisor;
 use crate::native_app::waveform::WaveformPreservedMarks;
 
 pub(in crate::native_app) struct BackgroundTaskState {
@@ -43,13 +44,22 @@ pub(in crate::native_app) struct BackgroundTaskState {
     pub(in crate::native_app) file_move_progress: Option<FileMoveProgress>,
     pub(in crate::native_app) progress_tick: f32,
     pub(in crate::native_app) frame_cadence: frame_ui::FrameCadenceMonitor,
+    pub(in crate::native_app) source_processing: SourceProcessingSupervisor,
 }
 
 impl BackgroundTaskState {
     pub(in crate::native_app) fn new(
         worker_sender: Sender<GuiMessage>,
         worker_receiver: Option<Receiver<GuiMessage>>,
+        sources: Vec<wavecrate::sample_sources::SampleSource>,
     ) -> Self {
+        #[cfg(not(test))]
+        let source_processing = SourceProcessingSupervisor::start(sources);
+        #[cfg(test)]
+        let source_processing = {
+            drop(sources);
+            SourceProcessingSupervisor::dormant()
+        };
         Self {
             worker_sender,
             worker_receiver,
@@ -76,6 +86,7 @@ impl BackgroundTaskState {
             file_move_progress: None,
             progress_tick: 0.0,
             frame_cadence: frame_ui::FrameCadenceMonitor::new(),
+            source_processing,
         }
     }
 
@@ -87,7 +98,7 @@ impl BackgroundTaskState {
 
     #[cfg(test)]
     pub(in crate::native_app) fn for_tests() -> Self {
-        Self::new(std::sync::mpsc::channel().0, None)
+        Self::new(std::sync::mpsc::channel().0, None, Vec::new())
     }
 }
 

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -1,3 +1,8 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
 use radiant::prelude as ui;
 
 use crate::native_app::sample_library::folder_browser::scan::{
@@ -15,17 +20,31 @@ pub(in crate::native_app) enum FolderScanWorkerEvent {
 pub(in crate::native_app) fn run_folder_scan_worker(
     request: FolderScanRequest,
     events: ui::BusinessEventSink<FolderScanWorkerEvent>,
+    cancel: Arc<AtomicBool>,
 ) -> PreparedFolderScanResult {
-    run_folder_scan_worker_with_emit(request, move |event| events.emit(event))
+    run_folder_scan_worker_with_emit_and_cancel(
+        request,
+        move |event| events.emit(event),
+        cancel.as_ref(),
+    )
 }
 
+#[cfg(test)]
 fn run_folder_scan_worker_with_emit(
     request: FolderScanRequest,
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
 ) -> PreparedFolderScanResult {
+    run_folder_scan_worker_with_emit_and_cancel(request, emit, &AtomicBool::new(false))
+}
+
+fn run_folder_scan_worker_with_emit_and_cancel(
+    request: FolderScanRequest,
+    emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
+    cancel: &AtomicBool,
+) -> PreparedFolderScanResult {
     let mut discovery_transport =
         FolderScanDiscoveryTransport::new(emit.clone(), request.task_id, request.source_id.clone());
-    let scan = scan::scan_source_with_progress(
+    let scan = scan::scan_source_with_progress_cancellable(
         request,
         |progress| {
             let _ = emit(FolderScanWorkerEvent::Progress(progress));
@@ -33,8 +52,11 @@ fn run_folder_scan_worker_with_emit(
         |event| {
             discovery_transport.push(event);
         },
+        cancel,
     );
-    discovery_transport.flush();
+    if !cancel.load(Ordering::Acquire) {
+        discovery_transport.flush();
+    }
     let audio_file_paths = scan.audio_file_paths();
     let scan_cache_update = prepare_folder_scan_cache_update(&scan);
     PreparedFolderScanResult {
@@ -87,13 +109,23 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, sync::mpsc};
+    use std::{
+        fs,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
+    };
 
     use crate::native_app::sample_library::folder_browser::scan::{
         FolderScanItem, FolderScanRequest, INDEX_PROGRESS_REPORT_INTERVAL,
     };
 
-    use super::{DISCOVERY_BATCH_SIZE, FolderScanWorkerEvent, run_folder_scan_worker_with_emit};
+    use super::{
+        DISCOVERY_BATCH_SIZE, FolderScanWorkerEvent, run_folder_scan_worker_with_emit,
+        run_folder_scan_worker_with_emit_and_cancel,
+    };
 
     fn temp_source_with_wavs(count: usize) -> tempfile::TempDir {
         let root = tempfile::tempdir().expect("source root");
@@ -194,5 +226,27 @@ mod tests {
             1 + file_count / INDEX_PROGRESS_REPORT_INTERVAL,
             "indexing progress must stay bounded so a large background scan cannot saturate the UI queue"
         );
+    }
+
+    #[test]
+    fn active_scan_stops_when_supervisor_cancels_its_permit() {
+        let file_count = DISCOVERY_BATCH_SIZE * 4;
+        let root = temp_source_with_wavs(file_count);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let callback_cancel = Arc::clone(&cancel);
+
+        let result = run_folder_scan_worker_with_emit_and_cancel(
+            scan_request(&root),
+            move |event| {
+                if matches!(event, FolderScanWorkerEvent::DiscoveryBatch(_)) {
+                    callback_cancel.store(true, Ordering::Release);
+                }
+                true
+            },
+            cancel.as_ref(),
+        );
+
+        assert!(result.scan.cancelled);
+        assert!(result.scan.file_count < file_count);
     }
 }

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -62,6 +62,10 @@ pub(in crate::native_app) enum SourceScanFinish {
     Stale {
         label: String,
     },
+    Cancelled {
+        source_id: String,
+        label: String,
+    },
 }
 
 impl SourceScanWorkflow {
@@ -322,6 +326,14 @@ impl SourceScanWorkflow {
         let folder_count = result.folder_count;
         let source_db_error = result.source_db_error.clone();
         let source_root_available = result.source_root_available;
+        if result.cancelled {
+            if browser.cancel_scan(&source_id, result.task_id) {
+                self.progress = None;
+                self.queue_required_refresh(source_id.clone());
+                return SourceScanFinish::Cancelled { source_id, label };
+            }
+            return SourceScanFinish::Stale { label };
+        }
         if browser.apply_scan_finished(result) {
             self.progress = None;
             SourceScanFinish::Applied {

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -94,6 +94,27 @@ fn pending_refresh_waits_for_active_scan() {
 }
 
 #[test]
+fn cancelled_scan_releases_ownership_and_requeues_the_source() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 22)
+        .expect("scan request");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let mut result = scan_source_with_progress(request, |_| {}, |_| {});
+    result.cancelled = true;
+
+    assert!(matches!(
+        workflow.finish_scan(&mut browser, result),
+        SourceScanFinish::Cancelled { .. }
+    ));
+    assert!(!workflow.active());
+    assert_eq!(workflow.next_pending_refresh_if_idle(), Some(source_id));
+}
+
+#[test]
 fn cached_source_selection_defers_reconcile_while_another_scan_is_active() {
     let first_root = temp_dir_with_wav();
     let second_root = temp_dir_with_wav();

--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::native_app::app::{
     NativeAppState, SampleBrowserDisplayMode, SampleNameViewMode, StarmapAuditionDragState,
@@ -209,6 +209,33 @@ pub(in crate::native_app) fn prepare_sample_browser_view(state: &mut NativeAppSt
             overscan_rows: SAMPLE_BROWSER_OVERSCAN_ROWS,
             guard_rows: SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
         });
+    let visible_paths = state
+        .library
+        .folder_browser
+        .prepared_visible_sample_file_ids_matching_tags(
+            &state.metadata.tags_by_file,
+            SAMPLE_BROWSER_PROJECTED_VIEWPORT_ROWS
+                + SAMPLE_BROWSER_OVERSCAN_ROWS
+                + SAMPLE_BROWSER_EDGE_CONTEXT_ROWS,
+        )
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|file_id| {
+            state
+                .library
+                .folder_browser
+                .sample_source_for_file_path(Path::new(&file_id))
+        })
+        .map(|(source, relative_path)| {
+            (
+                source.id.as_str().to_owned(),
+                relative_path.to_string_lossy().into_owned(),
+            )
+        });
+    state
+        .background
+        .source_processing
+        .set_visible_paths(visible_paths);
     if state.ui.chrome.sample_browser_display == SampleBrowserDisplayMode::Map {
         state
             .library

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -340,6 +340,17 @@ impl NativeAppState {
         autoplay: bool,
         started_at: Instant,
     ) {
+        if let Some((source, relative_path)) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(std::path::Path::new(&path))
+        {
+            self.background.source_processing.prioritize_path(
+                source.id.as_str(),
+                &relative_path.to_string_lossy(),
+                true,
+            );
+        }
         self.yield_sample_cache_warm_for_foreground_load(context);
         self.cancel_inflight_sample_load_preserving_early_playback_for(path.as_str());
         if self.start_memory_cached_sample(path.as_str(), autoplay, context, started_at) {

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -120,6 +120,7 @@ impl NativeAppState {
         _modifiers: PointerModifiers,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.begin_interactive_sample_load(path.as_str());
         let total_started_at = starmap_telemetry::stage_timer();
         let started_at = Instant::now();
         let previous_selection = self
@@ -340,17 +341,7 @@ impl NativeAppState {
         autoplay: bool,
         started_at: Instant,
     ) {
-        if let Some((source, relative_path)) = self
-            .library
-            .folder_browser
-            .sample_source_for_file_path(std::path::Path::new(&path))
-        {
-            self.background.source_processing.prioritize_path(
-                source.id.as_str(),
-                &relative_path.to_string_lossy(),
-                true,
-            );
-        }
+        self.begin_interactive_sample_load(path.as_str());
         self.yield_sample_cache_warm_for_foreground_load(context);
         self.cancel_inflight_sample_load_preserving_early_playback_for(path.as_str());
         if self.start_memory_cached_sample(path.as_str(), autoplay, context, started_at) {
@@ -383,6 +374,7 @@ impl NativeAppState {
         started_at: Instant,
         transient_navigation: bool,
     ) {
+        self.begin_interactive_sample_load(path.as_str());
         self.yield_sample_cache_warm_for_foreground_load(context);
         self.cancel_inflight_sample_load_preserving_early_playback_for(path.as_str());
         self.audio.pending_sample_playback = None;
@@ -446,6 +438,7 @@ impl NativeAppState {
         started_at: Instant,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.begin_interactive_sample_load(path.as_str());
         self.yield_sample_cache_warm_for_foreground_load(context);
         self.cancel_inflight_sample_load_preserving_early_playback_for(path.as_str());
         let request = SampleLoadPathValidationRequest::new(path, intent);
@@ -509,6 +502,7 @@ impl NativeAppState {
             );
             return;
         }
+        self.begin_interactive_sample_load(path.as_str());
         if self
             .audio
             .promote_sample_playback_session_to_waveform(path.as_str())
@@ -579,6 +573,23 @@ impl NativeAppState {
             "settled_full_playback_queued",
             SampleLoadStrategy::CacheThenDecode,
         );
+    }
+
+    fn begin_interactive_sample_load(&mut self, path: &str) {
+        self.background
+            .source_processing
+            .set_foreground_activity(true);
+        if let Some((source, relative_path)) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(Path::new(path))
+        {
+            self.background.source_processing.prioritize_path(
+                source.id.as_str(),
+                &relative_path.to_string_lossy(),
+                true,
+            );
+        }
     }
 
     pub(in crate::native_app) fn finish_sample_load_path_validation(

--- a/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
@@ -208,6 +208,11 @@ impl FolderBrowserState {
         else {
             return false;
         };
+        let selected_tree_owns_root = self.source.selected_source == source_id
+            && self.source.sources[source_index].root_folder.is_none();
+        if selected_tree_owns_root {
+            self.source.sources[source_index].root_folder = self.tree.folders.first().cloned();
+        }
         let root = self.source.sources[source_index].root.clone();
         let database_root = self.source.sources[source_index].database_root.clone();
         let mut changed = false;
@@ -221,6 +226,9 @@ impl FolderBrowserState {
         }
         if changed {
             self.after_source_tree_changed(source_id);
+        }
+        if selected_tree_owns_root {
+            self.source.sources[source_index].root_folder = None;
         }
         changed
     }

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -7,8 +7,10 @@ pub(in crate::native_app) use super::scan_types::{
 };
 #[cfg(test)]
 pub(in crate::native_app) use super::scanning::INDEX_PROGRESS_REPORT_INTERVAL;
+#[cfg(test)]
+pub(in crate::native_app) use super::scanning::scan_source_with_progress;
 pub(in crate::native_app) use super::scanning::{
-    refresh_folder_tree_only, scan_source_with_progress, verify_direct_folder,
+    refresh_folder_tree_only, scan_source_with_progress_cancellable, verify_direct_folder,
 };
 pub(in crate::native_app) use super::source_scan_cache::{
     FolderScanCacheUpdate, apply_folder_scan_cache_update, prepare_folder_scan_cache_update,

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -65,6 +65,7 @@ pub(in crate::native_app) struct FolderScanResult {
     pub(in crate::native_app) folder_count: usize,
     pub(in crate::native_app) source_db_error: Option<String>,
     pub(in crate::native_app) source_root_available: bool,
+    pub(in crate::native_app) cancelled: bool,
 }
 
 impl FolderScanResult {

--- a/src/native_app/sample_library/folder_browser/scanning.rs
+++ b/src/native_app/sample_library/folder_browser/scanning.rs
@@ -11,7 +11,9 @@ pub(in crate::native_app::sample_library::folder_browser) use metadata::refreshe
 pub(super) use metadata::{SourceMetadataMap, file_entry_for_source_path};
 #[cfg(test)]
 pub(in crate::native_app) use progress::INDEX_PROGRESS_REPORT_INTERVAL;
+#[cfg(test)]
 pub(in crate::native_app) use progress::scan_source_with_progress;
+pub(in crate::native_app) use progress::scan_source_with_progress_cancellable;
 pub(in crate::native_app) use traversal::refresh_folder_tree_only;
 pub(super) use traversal::{load_folder_at_path, load_source_snapshot, placeholder_folder};
 pub(in crate::native_app) use verification::verify_direct_folder;

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -104,15 +104,8 @@ fn sync_source_database(
         Ok(stats) => stats,
         Err(err) => return Some(format!("sync source index: {err}")),
     };
-    let completed = match scanner::complete_deferred_rename_candidates(&db, stats) {
-        Ok(completed) => completed,
-        Err(err) => return Some(format!("finish deferred rename hashing: {err}")),
-    };
-    if completed.hashes_pending > 0 {
-        scanner::schedule_deep_hash_scan_with_database_root(
-            request.root.clone(),
-            request.database_root.clone(),
-        );
+    if let Err(err) = scanner::complete_deferred_rename_candidates(&db, stats) {
+        return Some(format!("finish deferred rename hashing: {err}"));
     }
     None
 }

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -120,7 +120,9 @@ fn sync_source_database(
         Ok(stats) => stats,
         Err(err) => return Some(format!("sync source index: {err}")),
     };
-    if let Err(err) = scanner::complete_deferred_rename_candidates(&db, stats) {
+    if let Err(err) =
+        scanner::complete_deferred_rename_candidates_with_cancel(&db, stats, Some(cancel))
+    {
         return Some(format!("finish deferred rename hashing: {err}"));
     }
     None

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use super::{
     super::{
@@ -18,18 +21,28 @@ use wavecrate::sample_sources::{SourceDatabase, scanner};
 /// Publish at most one source-index progress update per bounded file batch.
 pub(in crate::native_app) const INDEX_PROGRESS_REPORT_INTERVAL: usize = 128;
 
+#[cfg(test)]
 pub(in crate::native_app) fn scan_source_with_progress(
+    request: FolderScanRequest,
+    progress: impl FnMut(FolderScanProgress),
+    discovered: impl FnMut(FolderScanDiscovery),
+) -> FolderScanResult {
+    scan_source_with_progress_cancellable(request, progress, discovered, &AtomicBool::new(false))
+}
+
+pub(in crate::native_app) fn scan_source_with_progress_cancellable(
     request: FolderScanRequest,
     mut progress: impl FnMut(FolderScanProgress),
     mut discovered: impl FnMut(FolderScanDiscovery),
+    cancel: &AtomicBool,
 ) -> FolderScanResult {
     let source_root_available = request.root.is_dir();
     let source_db_error = if source_root_available {
-        sync_source_database(&request, &mut progress)
+        sync_source_database(&request, &mut progress, cancel)
     } else {
         None
     };
-    let ratings = if source_root_available {
+    let ratings = if source_root_available && !cancel.load(Ordering::Acquire) {
         source_rating_map_with_rating_decay(
             &request.root,
             &request.database_root,
@@ -48,6 +61,7 @@ pub(in crate::native_app) fn scan_source_with_progress(
         },
         progress: &mut progress,
         discovered: &mut discovered,
+        cancel,
     };
     scan.report_initial();
     let folder = load_folder_with_progress(&request.root, &mut scan)
@@ -67,12 +81,14 @@ pub(in crate::native_app) fn scan_source_with_progress(
         folder_count,
         source_db_error,
         source_root_available,
+        cancelled: cancel.load(Ordering::Acquire),
     }
 }
 
 fn sync_source_database(
     request: &FolderScanRequest,
     progress: &mut impl FnMut(FolderScanProgress),
+    cancel: &AtomicBool,
 ) -> Option<String> {
     let db = match SourceDatabase::open_for_background_job_with_database_root(
         &request.root,
@@ -98,7 +114,7 @@ fn sync_source_database(
     let stats = match scanner::scan_with_progress(
         &db,
         scanner::ScanMode::Quick,
-        None,
+        Some(cancel),
         &mut sync_progress,
     ) {
         Ok(stats) => stats,
@@ -126,6 +142,7 @@ where
     counter: ScanProgressCounter,
     progress: &'a mut P,
     discovered: &'a mut D,
+    cancel: &'a AtomicBool,
 }
 
 impl<P, D> ScanProgressContext<'_, P, D>
@@ -201,6 +218,9 @@ where
     P: FnMut(FolderScanProgress),
     D: FnMut(FolderScanDiscovery),
 {
+    if scan.cancel.load(Ordering::Acquire) {
+        return None;
+    }
     let entries = read_sorted_entries(path)?;
     let parent_id = path_id(path);
     scan.record_folder_snapshot_start(&parent_id);
@@ -208,6 +228,9 @@ where
         .iter()
         .filter(|entry| entry.is_dir())
         .filter_map(|entry| {
+            if scan.cancel.load(Ordering::Acquire) {
+                return None;
+            }
             scan.record_folder(entry, &parent_id);
             load_folder_with_progress(entry, scan)
         })
@@ -216,10 +239,15 @@ where
         .iter()
         .filter(|entry| entry.is_file())
         .map(|entry| {
+            if scan.cancel.load(Ordering::Acquire) {
+                return None;
+            }
             let file = rated_file_entry(entry, &scan.request.root, &scan.ratings);
             scan.record_file(entry, &parent_id, file.clone());
-            file
+            Some(file)
         })
+        .take_while(Option::is_some)
+        .flatten()
         .collect::<Vec<_>>();
     Some(FolderEntry {
         id: path_id(path),

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -322,6 +322,22 @@ impl FolderBrowserState {
         true
     }
 
+    pub(in crate::native_app) fn cancel_scan(&mut self, source_id: &str, task_id: u64) -> bool {
+        let Some(source) = self
+            .source
+            .sources
+            .iter_mut()
+            .find(|source| source.id == source_id)
+        else {
+            return false;
+        };
+        if source.loading_task != Some(task_id) {
+            return false;
+        }
+        source.loading_task = None;
+        true
+    }
+
     pub(in crate::native_app) fn apply_folder_tree_refresh_result(
         &mut self,
         result: FolderTreeRefreshResult,

--- a/src/native_app/sample_library/folder_browser_actions/folder_tree.rs
+++ b/src/native_app/sample_library/folder_browser_actions/folder_tree.rs
@@ -18,6 +18,15 @@ impl NativeAppState {
     ) {
         let started_at = Instant::now();
         let source = folder_id.clone();
+        if let Some((sample_source, relative_path)) = self
+            .library
+            .folder_browser
+            .sample_source_for_file_path(std::path::Path::new(&folder_id))
+        {
+            self.background
+                .source_processing
+                .set_current_folder(sample_source.id.as_str(), &relative_path.to_string_lossy());
+        }
         self.library
             .folder_browser
             .apply_message(FolderBrowserMessage::ActivateFolder(folder_id, modifiers));

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -85,6 +85,13 @@ impl NativeAppState {
     ) {
         let source_id = result.source_id;
         let changed_count = result.changed_count;
+        if result.cancelled {
+            self.background
+                .source_processing
+                .wake_source(&source_id, "filesystem_sync_cancelled");
+            self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
+            return;
+        }
         match result.result {
             Ok(success) if success.renames_reconciled > 0 => {
                 if changed_count > 0 {
@@ -184,9 +191,28 @@ impl NativeAppState {
         else {
             return;
         };
+        let budget = self.background.source_processing.budget_handle();
         context.business().background("gui-source-db-sync").run(
             move |_| {
-                sync_source_database_paths(source_id, root, database_root, paths, changed_count)
+                let Some(permit) = budget.acquire_scan(&source_id) else {
+                    return SourceFilesystemSyncResult {
+                        source_id,
+                        changed_count,
+                        cancelled: true,
+                        result: Err(String::from("Source filesystem sync canceled")),
+                    };
+                };
+                let cancel = permit.cancel_token();
+                let result = sync_source_database_paths(
+                    source_id,
+                    root,
+                    database_root,
+                    paths,
+                    changed_count,
+                    cancel.as_ref(),
+                );
+                drop(permit);
+                result
             },
             GuiMessage::SourceFilesystemSyncFinished,
         );

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -43,7 +43,7 @@ impl NativeAppState {
                 self.queue_source_filesystem_sync(source_id.clone(), paths, changed_count, context);
                 if changed {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
-                    self.queue_source_prep(
+                    self.queue_source_prep_pending_commit(
                         source_id.clone(),
                         SourcePrepTrigger::FilesystemChanged,
                         context,
@@ -83,19 +83,32 @@ impl NativeAppState {
         result: SourceFilesystemSyncResult,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let source_id = result.source_id;
+        let changed_count = result.changed_count;
         match result.result {
             Ok(success) if success.renames_reconciled > 0 => {
-                self.queue_filesystem_source_refresh(result.source_id, Instant::now(), context);
+                if changed_count > 0 {
+                    self.background
+                        .source_processing
+                        .wake_source(&source_id, "filesystem_sync_commit");
+                }
+                self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
             }
-            Ok(_) => {}
+            Ok(_) => {
+                if changed_count > 0 {
+                    self.background
+                        .source_processing
+                        .wake_source(&source_id, "filesystem_sync_commit");
+                }
+            }
             Err(error) => {
                 tracing::warn!(
-                    source_id = %result.source_id,
-                    changed_count = result.changed_count,
+                    source_id = %source_id,
+                    changed_count,
                     error = %error,
                     "Failed to sync source database after filesystem change"
                 );
-                if result.source_id == self.library.folder_browser.selected_source_id() {
+                if source_id == self.library.folder_browser.selected_source_id() {
                     self.ui.status.sample = format!("Source sync failed: {error}");
                 }
             }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -17,13 +17,13 @@ pub(super) fn sync_source_database_paths(
             let stats = scanner::sync_paths(&db, &paths)
                 .map_err(|err| format!("sync source index: {err}"))?;
             let committed = stats.clone();
-            let completed = match scanner::complete_deferred_hashes(&db, stats) {
+            let completed = match scanner::complete_deferred_rename_candidates(&db, stats) {
                 Ok(completed) => completed,
                 Err(error) => {
                     tracing::warn!(
                         source_id,
                         error = %error,
-                        "Deferred source hashing failed after filesystem sync committed"
+                        "Deferred rename reconciliation failed after filesystem sync committed"
                     );
                     committed
                 }
@@ -79,6 +79,37 @@ mod tests {
                 .unwrap()
                 .tag,
             Rating::KEEP_1
+        );
+    }
+
+    #[test]
+    fn filesystem_sync_leaves_non_rename_hashing_for_the_supervisor() {
+        let root = tempfile::tempdir().expect("source root");
+        let fresh = root.path().join("fresh.wav");
+        std::fs::write(&fresh, vec![7_u8; 9 * 1024 * 1024]).expect("large wav");
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("fresh.wav")],
+            1,
+        );
+
+        assert_eq!(
+            result.result,
+            Ok(SourceFilesystemSyncSuccess {
+                renames_reconciled: 0
+            })
+        );
+        let db = SourceDatabase::open(root.path()).expect("source db");
+        assert!(
+            db.entry_for_path(Path::new("fresh.wav"))
+                .expect("read entry")
+                .expect("fresh entry")
+                .content_hash
+                .is_none(),
+            "ordinary deep hashing must remain queued for the supervisor"
         );
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use wavecrate::sample_sources::{SourceDatabase, scanner};
 
@@ -10,15 +13,22 @@ pub(super) fn sync_source_database_paths(
     database_root: PathBuf,
     paths: Vec<PathBuf>,
     changed_count: usize,
+    cancel: &AtomicBool,
 ) -> SourceFilesystemSyncResult {
     let result = SourceDatabase::open_for_background_job_with_database_root(&root, &database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            let stats = scanner::sync_paths(&db, &paths)
-                .map_err(|err| format!("sync source index: {err}"))?;
+            let stats =
+                scanner::sync_paths_with_progress(&db, &paths, Some(cancel), &mut |_, _| {})
+                    .map_err(|err| format!("sync source index: {err}"))?;
             let committed = stats.clone();
-            let completed = match scanner::complete_deferred_rename_candidates(&db, stats) {
+            let completed = match scanner::complete_deferred_rename_candidates_with_cancel(
+                &db,
+                stats,
+                Some(cancel),
+            ) {
                 Ok(completed) => completed,
+                Err(scanner::ScanError::Canceled) => committed,
                 Err(error) => {
                     tracing::warn!(
                         source_id,
@@ -35,13 +45,17 @@ pub(super) fn sync_source_database_paths(
     SourceFilesystemSyncResult {
         source_id,
         changed_count,
+        cancelled: cancel.load(Ordering::Acquire),
         result,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        sync::atomic::AtomicBool,
+    };
 
     use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
 
@@ -65,6 +79,7 @@ mod tests {
             root.path().to_path_buf(),
             vec![PathBuf::from("old.wav"), PathBuf::from("new.wav")],
             2,
+            &AtomicBool::new(false),
         );
 
         assert_eq!(
@@ -94,6 +109,7 @@ mod tests {
             root.path().to_path_buf(),
             vec![PathBuf::from("fresh.wav")],
             1,
+            &AtomicBool::new(false),
         );
 
         assert_eq!(
@@ -110,6 +126,32 @@ mod tests {
                 .content_hash
                 .is_none(),
             "ordinary deep hashing must remain queued for the supervisor"
+        );
+    }
+
+    #[test]
+    fn filesystem_sync_reports_lifecycle_cancellation_for_requeue() {
+        let root = tempfile::tempdir().expect("source root");
+        let fresh = root.path().join("fresh.wav");
+        std::fs::write(&fresh, b"fresh").expect("wav");
+        let cancel = AtomicBool::new(true);
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("fresh.wav")],
+            1,
+            &cancel,
+        );
+
+        assert!(result.cancelled);
+        assert!(result.result.is_err());
+        let db = SourceDatabase::open(root.path()).expect("source db");
+        assert!(
+            db.entry_for_path(Path::new("fresh.wav"))
+                .expect("read entry")
+                .is_none()
         );
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -28,6 +28,27 @@ impl NativeAppState {
         let started_at = Instant::now();
         let label = request.label.clone();
         let root = request.root.display().to_string();
+        let source = self
+            .library
+            .folder_browser
+            .configured_sample_sources()
+            .into_iter()
+            .find(|source| source.id.as_str() == request.source_id);
+        let admission = source
+            .ok_or_else(|| "Source is not present in the configured source set".to_string())
+            .and_then(|source| {
+                self.background
+                    .source_processing
+                    .register_source_for_scan(source)
+            });
+        if let Err(error) = admission {
+            tracing::error!(
+                target: "wavecrate::source_processing",
+                source_id = request.source_id.as_str(),
+                error,
+                "Folder scan will be cancelled because source admission could not be synchronized"
+            );
+        }
         self.library.start_folder_scan(&request);
         self.ui.status.sample = format!("Scanning source {}", request.label);
         tracing::info!(

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -44,10 +44,15 @@ impl NativeAppState {
             started_at,
             None,
         );
+        let budget = self.background.source_processing.budget_handle();
+        let source_id = request.source_id.clone();
         // Keep this stream fully ordered: discovery batches must not be
         // replaced by progress.
         context.business().background("gui-folder-scan").stream(
-            move |_context, events| run_folder_scan_worker(request, events),
+            move |_context, events| {
+                let _permit = budget.acquire_scan(&source_id);
+                run_folder_scan_worker(request, events)
+            },
             folder_scan_worker_event_message,
             GuiMessage::FolderScanFinished,
         );

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -50,8 +50,14 @@ impl NativeAppState {
         // replaced by progress.
         context.business().background("gui-folder-scan").stream(
             move |_context, events| {
-                let _permit = budget.acquire_scan(&source_id);
-                run_folder_scan_worker(request, events)
+                let Some(permit) = budget.acquire_scan(&source_id) else {
+                    let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+                    return run_folder_scan_worker(request, events, cancel);
+                };
+                let cancel = permit.cancel_token();
+                let result = run_folder_scan_worker(request, events, cancel);
+                drop(permit);
+                result
             },
             folder_scan_worker_event_message,
             GuiMessage::FolderScanFinished,
@@ -104,6 +110,20 @@ impl NativeAppState {
                     started_at,
                     None,
                 );
+            }
+            SourceScanFinish::Cancelled { source_id, label } => {
+                self.ui.status.sample = format!("Paused source scan for {label}");
+                emit_gui_action(
+                    "folder_browser.scan.finish",
+                    Some("folder_browser"),
+                    Some(&label),
+                    "cancelled",
+                    started_at,
+                    Some("source_processing_cancelled"),
+                );
+                self.background
+                    .source_processing
+                    .wake_source(&source_id, "external_scan_cancelled");
             }
         }
     }

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -14,8 +14,8 @@ use worker::{enqueue_similarity_prep_inner_with_cancel, resolve_similarity_prep_
 
 pub(in crate::native_app) use worker::{
     NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
-    reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
-    similarity_prep_needs_finalization,
+    reset_interrupted_similarity_prep_jobs, run_internal_similarity_finalizer_from_args,
+    run_similarity_prep_job, similarity_prep_needs_finalization,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -13,7 +13,7 @@ mod worker;
 use worker::{enqueue_similarity_prep_inner, resolve_similarity_prep_status};
 
 pub(in crate::native_app) use worker::{
-    NATIVE_SIMILARITY_UMAP_VERSION, finalize_similarity_prep_if_ready,
+    NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
     reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
     similarity_prep_needs_finalization,
 };

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -10,9 +10,11 @@ use crate::native_app::app::{
 };
 
 mod worker;
-use worker::{
-    drain_similarity_prep_jobs, enqueue_similarity_prep_inner, finalize_similarity_prep_if_ready,
-    resolve_similarity_prep_status,
+use worker::{enqueue_similarity_prep_inner, resolve_similarity_prep_status};
+
+pub(in crate::native_app) use worker::{
+    finalize_similarity_prep_if_ready, reset_interrupted_similarity_prep_jobs,
+    run_similarity_prep_job_batch, similarity_prep_needs_finalization,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -256,6 +258,9 @@ impl NativeAppState {
                 }
             }
         }
+        self.background
+            .source_processing
+            .wake_source(&result.source_id, "similarity_prep_commit");
         self.start_next_pending_similarity_prep(context);
     }
 
@@ -417,35 +422,7 @@ fn enqueue_similarity_prep(
         result: enqueue_similarity_prep_inner(
             &sample_source,
             trigger == SimilarityPrepTrigger::Automatic,
-        )
-        .and_then(|summary| finish_similarity_prep(summary, &sample_source, trigger)),
-    }
-}
-
-fn finish_similarity_prep(
-    mut summary: SimilarityPrepEnqueueSummary,
-    source: &SampleSource,
-    trigger: SimilarityPrepTrigger,
-) -> Result<SimilarityPrepEnqueueSummary, String> {
-    if !should_drain_similarity_prep_jobs(&summary, source, trigger)? {
-        return Ok(summary);
-    }
-    let drain = drain_similarity_prep_jobs(source)?;
-    summary.jobs_processed = drain.processed;
-    summary.jobs_failed = drain.failed;
-    summary.finalized |= finalize_similarity_prep_if_ready(source)?;
-    summary.status = resolve_similarity_prep_status(source)?;
-    Ok(summary)
-}
-
-fn should_drain_similarity_prep_jobs(
-    _summary: &SimilarityPrepEnqueueSummary,
-    _source: &SampleSource,
-    trigger: SimilarityPrepTrigger,
-) -> Result<bool, String> {
-    match trigger {
-        SimilarityPrepTrigger::UserRequested => Ok(true),
-        SimilarityPrepTrigger::Automatic => Ok(false),
+        ),
     }
 }
 

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -10,7 +10,7 @@ use crate::native_app::app::{
 };
 
 mod worker;
-use worker::{enqueue_similarity_prep_inner, resolve_similarity_prep_status};
+use worker::{enqueue_similarity_prep_inner_with_cancel, resolve_similarity_prep_status};
 
 pub(in crate::native_app) use worker::{
     NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
@@ -187,8 +187,22 @@ impl NativeAppState {
         } else if selected_source {
             self.library.similarity_prep.summary = None;
         }
+        let budget = self.background.source_processing.budget_handle();
         context.business().background("gui-similarity-prep").run(
-            move |_| enqueue_similarity_prep(source, trigger),
+            move |_| {
+                let source_id = source.id().as_str().to_string();
+                let Some(permit) = budget.acquire_scan(&source_id) else {
+                    return SimilarityPrepEnqueueResult {
+                        source_id,
+                        trigger,
+                        result: Err(String::from("Similarity preparation canceled")),
+                    };
+                };
+                let cancel = permit.cancel_token();
+                let result = enqueue_similarity_prep(source, trigger, Some(cancel.as_ref()));
+                drop(permit);
+                result
+            },
             GuiMessage::SimilarityPrepEnqueueFinished,
         );
     }
@@ -414,15 +428,17 @@ fn resolve_status_result(source: SimilarityPrepSource) -> SimilarityPrepStatusRe
 fn enqueue_similarity_prep(
     source: SimilarityPrepSource,
     trigger: SimilarityPrepTrigger,
+    cancel: Option<&std::sync::atomic::AtomicBool>,
 ) -> SimilarityPrepEnqueueResult {
     let source_id = source.id().as_str().to_string();
     let sample_source = source.sample_source();
     SimilarityPrepEnqueueResult {
         source_id,
         trigger,
-        result: enqueue_similarity_prep_inner(
+        result: enqueue_similarity_prep_inner_with_cancel(
             &sample_source,
             trigger == SimilarityPrepTrigger::Automatic,
+            cancel,
         ),
     }
 }

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -13,8 +13,9 @@ mod worker;
 use worker::{enqueue_similarity_prep_inner, resolve_similarity_prep_status};
 
 pub(in crate::native_app) use worker::{
-    finalize_similarity_prep_if_ready, reset_interrupted_similarity_prep_jobs,
-    run_similarity_prep_job_batch, similarity_prep_needs_finalization,
+    NATIVE_SIMILARITY_UMAP_VERSION, finalize_similarity_prep_if_ready,
+    reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
+    similarity_prep_needs_finalization,
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -3,8 +3,15 @@
 use std::{
     collections::HashSet,
     path::PathBuf,
+    process::Child,
     sync::atomic::{AtomicBool, Ordering},
     time::{Duration, Instant},
+};
+
+#[cfg(not(test))]
+use std::{
+    io::Read,
+    process::{Command, Stdio},
 };
 
 use wavecrate::sample_sources::config::{self, AnalysisSettings};
@@ -39,7 +46,10 @@ pub(in crate::native_app) struct SimilarityPrepJobDrainSummary {
     pub(in crate::native_app) failed: usize,
 }
 
-#[derive(Clone, Debug)]
+const INTERNAL_SIMILARITY_FINALIZER_ARG: &str = "--wavecrate-internal-similarity-finalizer-v1";
+const FINALIZER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub(in crate::native_app) enum SimilarityPublicationFence {
     Readiness {
         source_id: String,
@@ -224,7 +234,124 @@ pub(in crate::native_app) fn finalize_similarity_prep_if_ready(
     publication_fence: &SimilarityPublicationFence,
     cancel: &AtomicBool,
 ) -> Result<bool, String> {
-    finalize_if_ready(source, publication_fence, cancel)
+    #[cfg(test)]
+    {
+        return finalize_if_ready(source, publication_fence, cancel);
+    }
+    #[cfg(not(test))]
+    {
+        finalize_similarity_prep_in_child(source, publication_fence, cancel)
+    }
+}
+
+pub(in crate::native_app) fn run_internal_similarity_finalizer_from_args()
+-> Result<Option<bool>, String> {
+    let mut args = std::env::args();
+    let _executable = args.next();
+    if args.next().as_deref() != Some(INTERNAL_SIMILARITY_FINALIZER_ARG) {
+        return Ok(None);
+    }
+    let source_json = args
+        .next()
+        .ok_or_else(|| "Internal similarity finalizer is missing its source".to_string())?;
+    let fence_json = args.next().ok_or_else(|| {
+        "Internal similarity finalizer is missing its publication fence".to_string()
+    })?;
+    if args.next().is_some() {
+        return Err("Internal similarity finalizer received unexpected arguments".to_string());
+    }
+    let source = serde_json::from_str::<SampleSource>(&source_json)
+        .map_err(|error| format!("Decode internal similarity source failed: {error}"))?;
+    let publication_fence = serde_json::from_str::<SimilarityPublicationFence>(&fence_json)
+        .map_err(|error| format!("Decode internal similarity fence failed: {error}"))?;
+    let cancel = AtomicBool::new(false);
+    finalize_if_ready(&source, &publication_fence, &cancel).map(Some)
+}
+
+#[cfg(not(test))]
+fn finalize_similarity_prep_in_child(
+    source: &SampleSource,
+    publication_fence: &SimilarityPublicationFence,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("Resolve similarity finalizer executable failed: {error}"))?;
+    let source_json = serde_json::to_string(source)
+        .map_err(|error| format!("Encode internal similarity source failed: {error}"))?;
+    let fence_json = serde_json::to_string(publication_fence)
+        .map_err(|error| format!("Encode internal similarity fence failed: {error}"))?;
+    let child = Command::new(executable)
+        .arg(INTERNAL_SIMILARITY_FINALIZER_ARG)
+        .arg(source_json)
+        .arg(fence_json)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Start similarity finalizer process failed: {error}"))?;
+    let Some(mut child) = wait_for_cancellable_child(child, cancel)? else {
+        return Ok(false);
+    };
+    let mut stdout = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        pipe.read_to_string(&mut stdout)
+            .map_err(|error| format!("Read similarity finalizer result failed: {error}"))?;
+    }
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        pipe.read_to_string(&mut stderr)
+            .map_err(|error| format!("Read similarity finalizer error failed: {error}"))?;
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("Join similarity finalizer process failed: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "Similarity finalizer process failed with {status}: {}",
+            stderr.trim()
+        ));
+    }
+    serde_json::from_str::<bool>(stdout.trim())
+        .map_err(|error| format!("Decode similarity finalizer result failed: {error}"))
+}
+
+fn wait_for_cancellable_child(
+    mut child: Child,
+    cancel: &AtomicBool,
+) -> Result<Option<Child>, String> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            if let Err(error) = child.kill()
+                && child
+                    .try_wait()
+                    .map_err(|poll_error| {
+                        format!(
+                            "Cancel similarity finalizer process failed: {error}; poll failed: {poll_error}"
+                        )
+                    })?
+                    .is_none()
+            {
+                return Err(format!(
+                    "Cancel similarity finalizer process failed: {error}"
+                ));
+            }
+            child
+                .wait()
+                .map_err(|error| format!("Join cancelled similarity finalizer failed: {error}"))?;
+            return Ok(None);
+        }
+        if child
+            .try_wait()
+            .map_err(|error| format!("Poll similarity finalizer process failed: {error}"))?
+            .is_some()
+        {
+            return Ok(Some(child));
+        }
+        std::thread::sleep(FINALIZER_POLL_INTERVAL);
+    }
 }
 
 fn finalize_if_ready(

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::HashSet,
     path::PathBuf,
-    process::Child,
     sync::atomic::{AtomicBool, Ordering},
     time::{Duration, Instant},
 };
@@ -47,7 +46,6 @@ pub(in crate::native_app) struct SimilarityPrepJobDrainSummary {
 }
 
 const INTERNAL_SIMILARITY_FINALIZER_ARG: &str = "--wavecrate-internal-similarity-finalizer-v1";
-const FINALIZER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub(in crate::native_app) enum SimilarityPublicationFence {
@@ -292,7 +290,12 @@ fn finalize_similarity_prep_in_child(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| format!("Start similarity finalizer process failed: {error}"))?;
-    let Some(mut child) = wait_for_cancellable_child(child, cancel)? else {
+    let Some(mut child) = crate::native_app::source_processing::wait_for_cancellable_child(
+        child,
+        cancel,
+        "similarity finalizer",
+    )?
+    else {
         return Ok(false);
     };
     let mut stdout = String::new();
@@ -316,42 +319,6 @@ fn finalize_similarity_prep_in_child(
     }
     serde_json::from_str::<bool>(stdout.trim())
         .map_err(|error| format!("Decode similarity finalizer result failed: {error}"))
-}
-
-fn wait_for_cancellable_child(
-    mut child: Child,
-    cancel: &AtomicBool,
-) -> Result<Option<Child>, String> {
-    loop {
-        if cancel.load(Ordering::Acquire) {
-            if let Err(error) = child.kill()
-                && child
-                    .try_wait()
-                    .map_err(|poll_error| {
-                        format!(
-                            "Cancel similarity finalizer process failed: {error}; poll failed: {poll_error}"
-                        )
-                    })?
-                    .is_none()
-            {
-                return Err(format!(
-                    "Cancel similarity finalizer process failed: {error}"
-                ));
-            }
-            child
-                .wait()
-                .map_err(|error| format!("Join cancelled similarity finalizer failed: {error}"))?;
-            return Ok(None);
-        }
-        if child
-            .try_wait()
-            .map_err(|error| format!("Poll similarity finalizer process failed: {error}"))?
-            .is_some()
-        {
-            return Ok(Some(child));
-        }
-        std::thread::sleep(FINALIZER_POLL_INTERVAL);
-    }
 }
 
 fn finalize_if_ready(

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -10,7 +10,8 @@ use std::{
 use wavecrate::sample_sources::config::{self, AnalysisSettings};
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
-    db::{META_LAST_SCAN_COMPLETED_AT, META_LAST_SIMILARITY_PREP_SCAN_AT},
+    db::{META_LAST_SCAN_COMPLETED_AT, META_LAST_SIMILARITY_PREP_SCAN_AT, META_WAV_PATHS_REVISION},
+    readiness::{ReadinessScopeKind, ReadinessStage, ReadinessTarget},
     scanner::{self, ScanMode},
 };
 use wavecrate_analysis::{
@@ -36,6 +37,88 @@ const SIMILARITY_BUSY_RETRY_DELAY: Duration = Duration::from_millis(250);
 pub(in crate::native_app) struct SimilarityPrepJobDrainSummary {
     pub(in crate::native_app) processed: usize,
     pub(in crate::native_app) failed: usize,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::native_app) enum SimilarityPublicationFence {
+    Readiness {
+        source_id: String,
+        source_generation: i64,
+        membership_generation: String,
+        artifact_version: String,
+    },
+    LegacyPathsRevision(i64),
+}
+
+impl SimilarityPublicationFence {
+    pub(in crate::native_app) fn for_readiness_target(
+        target: &ReadinessTarget,
+    ) -> Result<Self, String> {
+        if target.scope_kind != ReadinessScopeKind::Source
+            || target.stage != ReadinessStage::SimilarityLayout
+        {
+            return Err("similarity publication requires a source-level layout target".to_string());
+        }
+        Ok(Self::Readiness {
+            source_id: target.source_id.clone(),
+            source_generation: target.source_generation,
+            membership_generation: target.content_generation.clone(),
+            artifact_version: target.required_version.clone(),
+        })
+    }
+
+    pub(in crate::native_app) fn legacy_paths_revision(revision: i64) -> Self {
+        Self::LegacyPathsRevision(revision)
+    }
+
+    fn is_current(&self, connection: &rusqlite::Connection) -> Result<bool, String> {
+        match self {
+            Self::Readiness {
+                source_id,
+                source_generation,
+                membership_generation,
+                artifact_version,
+            } => connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1
+                        FROM source_readiness_sources AS source
+                        JOIN source_readiness_targets AS target
+                          ON target.source_id = source.source_id
+                        WHERE source.source_id = ?1
+                          AND source.source_generation = ?2
+                          AND source.availability = 'active'
+                          AND target.scope_kind = 'source'
+                          AND target.scope_id = ?1
+                          AND target.stage = 'similarity_layout'
+                          AND target.required_version = ?3
+                          AND target.source_generation = ?2
+                          AND target.content_generation = ?4
+                          AND target.eligibility = 'eligible'
+                    )",
+                    rusqlite::params![
+                        source_id,
+                        source_generation,
+                        artifact_version,
+                        membership_generation,
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(|error| {
+                    format!("Validate similarity readiness generation failed: {error}")
+                }),
+            Self::LegacyPathsRevision(revision) => connection
+                .query_row(
+                    "SELECT COALESCE(
+                        (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1),
+                        0
+                    ) = ?2",
+                    rusqlite::params![META_WAV_PATHS_REVISION, revision],
+                    |row| row.get(0),
+                )
+                .map_err(|error| format!("Validate source paths revision failed: {error}")),
+        }
+    }
 }
 
 pub(super) fn enqueue_similarity_prep_inner(
@@ -114,12 +197,17 @@ fn is_transient_database_busy(error: &str) -> bool {
 
 pub(in crate::native_app) fn finalize_similarity_prep_if_ready(
     source: &SampleSource,
+    publication_fence: &SimilarityPublicationFence,
     cancel: &AtomicBool,
 ) -> Result<bool, String> {
-    finalize_if_ready(source, cancel)
+    finalize_if_ready(source, publication_fence, cancel)
 }
 
-fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool, String> {
+fn finalize_if_ready(
+    source: &SampleSource,
+    publication_fence: &SimilarityPublicationFence,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
     if cancel.load(Ordering::Acquire) {
         return Ok(false);
     }
@@ -128,8 +216,11 @@ fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool,
     }
     if current_similarity_sample_ids(source)?.is_empty() {
         if let Some(scan_completed_at) = read_source_scan_timestamp(source)? {
-            set_source_prep_timestamp(source, scan_completed_at)?;
-            return Ok(true);
+            return set_source_prep_timestamp_if_current(
+                source,
+                scan_completed_at,
+                publication_fence,
+            );
         }
         return Ok(false);
     }
@@ -137,14 +228,20 @@ fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool,
         return Ok(false);
     }
     let mut conn = open_source_db(source)?;
-    analysis::build_map_layout_with_cancel(
+    let fence = |connection: &rusqlite::Connection| publication_fence.is_current(connection);
+    if analysis::build_map_layout_with_cancel_and_publication_fence(
         &mut conn,
         SIMILARITY_MODEL_ID,
         NATIVE_SIMILARITY_UMAP_VERSION,
         0,
         0.95,
         cancel,
-    )?;
+        &fence,
+    )?
+    .is_none()
+    {
+        return Ok(false);
+    }
     if cancel.load(Ordering::Acquire) {
         return Ok(false);
     }
@@ -164,7 +261,7 @@ fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool,
     if layout_rows == 0 {
         return Ok(false);
     }
-    analysis::hdbscan::build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
+    if analysis::hdbscan::build_hdbscan_clusters_for_sample_id_prefix_with_cancel_and_publication_fence(
         &mut conn,
         SIMILARITY_MODEL_ID,
         analysis::hdbscan::HdbscanMethod::Umap,
@@ -176,16 +273,23 @@ fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool,
             allow_single_cluster: false,
         },
         cancel,
-    )?;
+        &fence,
+    )?
+    .is_none()
+    {
+        return Ok(false);
+    }
     if cancel.load(Ordering::Acquire) {
         return Ok(false);
     }
-    analysis::flush_ann_index(&conn)?;
+    if !analysis::flush_ann_index_with_publication_fence(&mut conn, &fence)? {
+        return Ok(false);
+    }
     if cancel.load(Ordering::Acquire) {
         return Ok(false);
     }
     if let Some(scan_completed_at) = read_source_scan_timestamp(source)? {
-        set_source_prep_timestamp(source, scan_completed_at)?;
+        return set_source_prep_timestamp_if_current(source, scan_completed_at, publication_fence);
     }
     Ok(true)
 }
@@ -373,8 +477,8 @@ fn ensure_source_database_scanned(source: &SampleSource) -> Result<(), String> {
     }
     let stats = scanner::scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {})
         .map_err(|err| format!("Sync source index failed: {err}"))?;
-    scanner::complete_deferred_hashes(&db, stats)
-        .map_err(|err| format!("Finish deferred source hashing failed: {err}"))?;
+    scanner::complete_deferred_rename_candidates(&db, stats)
+        .map_err(|err| format!("Finish deferred rename reconciliation failed: {err}"))?;
     Ok(())
 }
 
@@ -474,10 +578,37 @@ fn read_source_timestamp(source: &SampleSource, key: &str) -> Result<Option<i64>
         .transpose()
 }
 
-fn set_source_prep_timestamp(source: &SampleSource, value: i64) -> Result<(), String> {
-    let db = open_user_metadata_source_db(source).map_err(|err| err.to_string())?;
-    db.set_metadata(META_LAST_SIMILARITY_PREP_SCAN_AT, &value.to_string())
-        .map_err(|err| err.to_string())
+fn set_source_prep_timestamp_if_current(
+    source: &SampleSource,
+    value: i64,
+    publication_fence: &SimilarityPublicationFence,
+) -> Result<bool, String> {
+    let mut connection = open_source_db(source)?;
+    let tx = connection
+        .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+        .map_err(|error| format!("Start similarity completion transaction failed: {error}"))?;
+    if !publication_fence.is_current(&tx)? {
+        tx.rollback()
+            .map_err(|error| format!("Roll back stale similarity completion failed: {error}"))?;
+        return Ok(false);
+    }
+    tx.execute(
+        "INSERT INTO metadata (key, value)
+         VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![META_LAST_SIMILARITY_PREP_SCAN_AT, value.to_string()],
+    )
+    .map_err(|error| format!("Write similarity completion timestamp failed: {error}"))?;
+    tx.execute(
+        "INSERT INTO metadata (key, value)
+         VALUES ('revision', '1')
+         ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)",
+        [],
+    )
+    .map_err(|error| format!("Advance source metadata revision failed: {error}"))?;
+    tx.commit()
+        .map_err(|error| format!("Commit similarity completion failed: {error}"))?;
+    Ok(true)
 }
 
 fn source_has_embeddings(source: &SampleSource) -> Result<bool, String> {
@@ -841,14 +972,6 @@ pub(super) fn open_fast_source_db(source: &SampleSource) -> Result<SourceDatabas
         .database_root()
         .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
     SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
-        .map_err(|err| format!("Open source DB failed: {err}"))
-}
-
-fn open_user_metadata_source_db(source: &SampleSource) -> Result<SourceDatabase, String> {
-    let database_root = source
-        .database_root()
-        .map_err(|err| format!("Resolve source metadata location failed: {err}"))?;
-    SourceDatabase::open_for_user_metadata_write_with_database_root(&source.root, database_root)
         .map_err(|err| format!("Open source DB failed: {err}"))
 }
 

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -1,6 +1,9 @@
+#![cfg_attr(test, allow(dead_code))]
+
 use std::{
     collections::HashSet,
     path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
     time::{Duration, Instant},
 };
 
@@ -26,12 +29,11 @@ pub(in crate::native_app) use wavecrate::sample_sources::STARMAP_LAYOUT_UMAP_VER
 const NATIVE_SIMILARITY_CLUSTER_MIN_SIZE: usize = 10;
 const ANALYZE_SAMPLE_JOB_TYPE: &str = "wav_metadata_v1";
 const EMBEDDING_BACKFILL_JOB_TYPE: &str = "embedding_backfill_v1";
-const SIMILARITY_DRAIN_CLAIM_LIMIT: usize = 8;
 const SIMILARITY_BUSY_RETRY_ATTEMPTS: usize = 3;
 const SIMILARITY_BUSY_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(super) struct SimilarityPrepJobDrainSummary {
+pub(in crate::native_app) struct SimilarityPrepJobDrainSummary {
     pub(super) processed: usize,
     pub(super) failed: usize,
 }
@@ -65,14 +67,13 @@ fn enqueue_similarity_prep_once(
     }
     let analysis_inserted = enqueue_analysis_backfill(source)?;
     let embedding_inserted = enqueue_embedding_backfill(source)?;
-    let finalized = finalize_if_ready(source)?;
     let status = resolve_similarity_prep_status(source)?;
     Ok(SimilarityPrepEnqueueSummary {
         analysis_inserted,
         embedding_inserted,
         jobs_processed: 0,
         jobs_failed: 0,
-        finalized,
+        finalized: false,
         status,
     })
 }
@@ -111,7 +112,9 @@ fn is_transient_database_busy(error: &str) -> bool {
         || lowered.contains("sqlite_busy")
 }
 
-pub(super) fn finalize_similarity_prep_if_ready(source: &SampleSource) -> Result<bool, String> {
+pub(in crate::native_app) fn finalize_similarity_prep_if_ready(
+    source: &SampleSource,
+) -> Result<bool, String> {
     finalize_if_ready(source)
 }
 
@@ -172,42 +175,66 @@ fn finalize_if_ready(source: &SampleSource) -> Result<bool, String> {
     Ok(true)
 }
 
-pub(super) fn drain_similarity_prep_jobs(
+pub(in crate::native_app) fn reset_interrupted_similarity_prep_jobs(
     source: &SampleSource,
+) -> Result<usize, String> {
+    let conn = open_source_db(source)?;
+    wavecrate::internal_analysis_jobs::reset_running_to_pending(&conn)
+}
+
+pub(in crate::native_app) fn run_similarity_prep_job_batch(
+    source: &SampleSource,
+    limit: usize,
+    cancel: &AtomicBool,
 ) -> Result<SimilarityPrepJobDrainSummary, String> {
     let mut conn = open_source_db(source)?;
-    wavecrate::internal_analysis_jobs::reset_running_to_pending(&conn)?;
     let settings = load_analysis_settings();
     let runtime = SimilarityPrepJobRuntime::from_settings(&settings);
     let mut summary = SimilarityPrepJobDrainSummary::default();
-    loop {
-        let jobs = wavecrate::internal_analysis_jobs::claim_next_jobs(
+    let jobs = wavecrate::internal_analysis_jobs::claim_next_jobs(&mut conn, &source.root, limit)?;
+    for job in jobs {
+        if cancel.load(Ordering::Acquire) {
+            wavecrate::internal_analysis_jobs::release(&conn, &job)?;
+            continue;
+        }
+        let outcome = wavecrate::internal_analysis_jobs::run_claimed_job(
             &mut conn,
-            &source.root,
-            SIMILARITY_DRAIN_CLAIM_LIMIT,
-        )?;
-        if jobs.is_empty() {
-            break;
+            &job,
+            true,
+            runtime.max_analysis_duration_seconds,
+            runtime.analysis_sample_rate,
+            runtime.analysis_version.as_str(),
+        );
+        if let Err(error) = outcome.as_ref() {
+            summary.failed += 1;
+            wavecrate::internal_analysis_jobs::mark_failed_with_reason(&conn, &job, error)?;
+        } else {
+            wavecrate::internal_analysis_jobs::mark_done(&conn, &job)?;
         }
-        for job in jobs {
-            let outcome = wavecrate::internal_analysis_jobs::run_claimed_job(
-                &mut conn,
-                &job,
-                true,
-                runtime.max_analysis_duration_seconds,
-                runtime.analysis_sample_rate,
-                runtime.analysis_version.as_str(),
-            );
-            if let Err(error) = outcome.as_ref() {
-                summary.failed += 1;
-                wavecrate::internal_analysis_jobs::mark_failed_with_reason(&conn, &job, error)?;
-            } else {
-                wavecrate::internal_analysis_jobs::mark_done(&conn, &job)?;
-            }
-            summary.processed += 1;
-        }
+        summary.processed += 1;
     }
     Ok(summary)
+}
+
+#[cfg(test)]
+pub(in crate::native_app) fn similarity_prep_has_pending_jobs(
+    source: &SampleSource,
+) -> Result<bool, String> {
+    source_has_active_similarity_prep_jobs(source)
+}
+
+pub(in crate::native_app) fn similarity_prep_needs_finalization(
+    source: &SampleSource,
+) -> Result<bool, String> {
+    if source_has_active_similarity_prep_jobs(source)? {
+        return Ok(false);
+    }
+    if resolve_similarity_prep_status(source)? == NativeSimilarityPrepStatus::UpToDate {
+        return Ok(false);
+    }
+    Ok((read_source_scan_timestamp(source)?.is_some()
+        && current_similarity_sample_ids(source)?.is_empty())
+        || (source_has_embeddings(source)? && source_has_aspect_descriptors(source)?))
 }
 
 pub(super) fn source_has_active_similarity_prep_jobs(
@@ -287,7 +314,7 @@ fn ensure_source_database_scanned(source: &SampleSource) -> Result<(), String> {
     Ok(())
 }
 
-pub(super) fn resolve_similarity_prep_status(
+pub(in crate::native_app) fn resolve_similarity_prep_status(
     source: &SampleSource,
 ) -> Result<NativeSimilarityPrepStatus, String> {
     let facts = SimilarityPrepFacts {

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -433,7 +433,7 @@ fn finalize_if_ready(
     if cancel.load(Ordering::Acquire) {
         return Ok(false);
     }
-    if !analysis::flush_ann_index_with_publication_fence(&mut conn, &fence)? {
+    if !analysis::rebuild_ann_index_with_publication_fence(&mut conn, &fence)? {
         return Ok(false);
     }
     if cancel.load(Ordering::Acquire) {

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -114,11 +114,15 @@ fn is_transient_database_busy(error: &str) -> bool {
 
 pub(in crate::native_app) fn finalize_similarity_prep_if_ready(
     source: &SampleSource,
+    cancel: &AtomicBool,
 ) -> Result<bool, String> {
-    finalize_if_ready(source)
+    finalize_if_ready(source, cancel)
 }
 
-fn finalize_if_ready(source: &SampleSource) -> Result<bool, String> {
+fn finalize_if_ready(source: &SampleSource, cancel: &AtomicBool) -> Result<bool, String> {
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
     if source_has_active_similarity_prep_jobs(source)? {
         return Ok(false);
     }
@@ -133,13 +137,17 @@ fn finalize_if_ready(source: &SampleSource) -> Result<bool, String> {
         return Ok(false);
     }
     let mut conn = open_source_db(source)?;
-    analysis::build_map_layout(
+    analysis::build_map_layout_with_cancel(
         &mut conn,
         SIMILARITY_MODEL_ID,
         NATIVE_SIMILARITY_UMAP_VERSION,
         0,
         0.95,
+        cancel,
     )?;
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
     let sample_id_prefix = format!("{}::%", source.id.as_str());
     let layout_rows: i64 = conn
         .query_row(
@@ -156,7 +164,7 @@ fn finalize_if_ready(source: &SampleSource) -> Result<bool, String> {
     if layout_rows == 0 {
         return Ok(false);
     }
-    analysis::hdbscan::build_hdbscan_clusters_for_sample_id_prefix(
+    analysis::hdbscan::build_hdbscan_clusters_for_sample_id_prefix_with_cancel(
         &mut conn,
         SIMILARITY_MODEL_ID,
         analysis::hdbscan::HdbscanMethod::Umap,
@@ -167,8 +175,15 @@ fn finalize_if_ready(source: &SampleSource) -> Result<bool, String> {
             min_samples: None,
             allow_single_cluster: false,
         },
+        cancel,
     )?;
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
     analysis::flush_ann_index(&conn)?;
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
     if let Some(scan_completed_at) = read_source_scan_timestamp(source)? {
         set_source_prep_timestamp(source, scan_completed_at)?;
     }
@@ -182,6 +197,7 @@ pub(in crate::native_app) fn reset_interrupted_similarity_prep_jobs(
     wavecrate::internal_analysis_jobs::reset_running_to_pending(&conn)
 }
 
+#[cfg(test)]
 pub(in crate::native_app) fn run_similarity_prep_job_batch(
     source: &SampleSource,
     limit: usize,
@@ -204,6 +220,7 @@ pub(in crate::native_app) fn run_similarity_prep_job_batch(
             runtime.max_analysis_duration_seconds,
             runtime.analysis_sample_rate,
             runtime.analysis_version.as_str(),
+            cancel,
         );
         if let Err(error) = outcome.as_ref() {
             summary.failed += 1;
@@ -212,6 +229,51 @@ pub(in crate::native_app) fn run_similarity_prep_job_batch(
             wavecrate::internal_analysis_jobs::mark_done(&conn, &job)?;
         }
         summary.processed += 1;
+    }
+    Ok(summary)
+}
+
+pub(in crate::native_app) fn run_similarity_prep_job(
+    source: &SampleSource,
+    job_id: i64,
+    cancel: &AtomicBool,
+) -> Result<SimilarityPrepJobDrainSummary, String> {
+    let mut conn = open_source_db(source)?;
+    let settings = load_analysis_settings();
+    let runtime = SimilarityPrepJobRuntime::from_settings(&settings);
+    let Some(job) =
+        wavecrate::internal_analysis_jobs::claim_job_by_id(&mut conn, &source.root, job_id)?
+    else {
+        return Ok(SimilarityPrepJobDrainSummary::default());
+    };
+    if cancel.load(Ordering::Acquire) {
+        wavecrate::internal_analysis_jobs::release(&conn, &job)?;
+        return Ok(SimilarityPrepJobDrainSummary::default());
+    }
+    let outcome = wavecrate::internal_analysis_jobs::run_claimed_job(
+        &mut conn,
+        &job,
+        true,
+        runtime.max_analysis_duration_seconds,
+        runtime.analysis_sample_rate,
+        runtime.analysis_version.as_str(),
+        cancel,
+    );
+    if cancel.load(Ordering::Acquire) {
+        wavecrate::internal_analysis_jobs::release(&conn, &job)?;
+        return Ok(SimilarityPrepJobDrainSummary::default());
+    }
+    let mut summary = SimilarityPrepJobDrainSummary {
+        processed: 1,
+        failed: usize::from(outcome.is_err()),
+    };
+    if let Err(error) = outcome {
+        wavecrate::internal_analysis_jobs::mark_failed_with_reason(&conn, &job, &error)?;
+    } else {
+        wavecrate::internal_analysis_jobs::mark_done(&conn, &job)?;
+    }
+    if cancel.load(Ordering::Acquire) {
+        summary.processed = 0;
     }
     Ok(summary)
 }

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -34,8 +34,8 @@ const SIMILARITY_BUSY_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(in crate::native_app) struct SimilarityPrepJobDrainSummary {
-    pub(super) processed: usize,
-    pub(super) failed: usize,
+    pub(in crate::native_app) processed: usize,
+    pub(in crate::native_app) failed: usize,
 }
 
 pub(super) fn enqueue_similarity_prep_inner(
@@ -237,6 +237,7 @@ pub(in crate::native_app) fn run_similarity_prep_job(
     source: &SampleSource,
     job_id: i64,
     cancel: &AtomicBool,
+    embedding_worker_limit: usize,
 ) -> Result<SimilarityPrepJobDrainSummary, String> {
     let mut conn = open_source_db(source)?;
     let settings = load_analysis_settings();
@@ -250,7 +251,7 @@ pub(in crate::native_app) fn run_similarity_prep_job(
         wavecrate::internal_analysis_jobs::release(&conn, &job)?;
         return Ok(SimilarityPrepJobDrainSummary::default());
     }
-    let outcome = wavecrate::internal_analysis_jobs::run_claimed_job(
+    let outcome = wavecrate::internal_analysis_jobs::run_claimed_job_with_embedding_worker_limit(
         &mut conn,
         &job,
         true,
@@ -258,6 +259,7 @@ pub(in crate::native_app) fn run_similarity_prep_job(
         runtime.analysis_sample_rate,
         runtime.analysis_version.as_str(),
         cancel,
+        embedding_worker_limit,
     );
     if cancel.load(Ordering::Acquire) {
         wavecrate::internal_analysis_jobs::release(&conn, &job)?;

--- a/src/native_app/sample_library/similarity_prep/worker.rs
+++ b/src/native_app/sample_library/similarity_prep/worker.rs
@@ -121,18 +121,32 @@ impl SimilarityPublicationFence {
     }
 }
 
+#[cfg(test)]
 pub(super) fn enqueue_similarity_prep_inner(
     source: &SampleSource,
     automatic: bool,
 ) -> Result<SimilarityPrepEnqueueSummary, String> {
-    retry_similarity_prep_busy(source, || enqueue_similarity_prep_once(source, automatic))
+    enqueue_similarity_prep_inner_with_cancel(source, automatic, None)
+}
+
+pub(super) fn enqueue_similarity_prep_inner_with_cancel(
+    source: &SampleSource,
+    automatic: bool,
+    cancel: Option<&AtomicBool>,
+) -> Result<SimilarityPrepEnqueueSummary, String> {
+    retry_similarity_prep_busy(source, || {
+        enqueue_similarity_prep_once(source, automatic, cancel)
+    })
 }
 
 fn enqueue_similarity_prep_once(
     source: &SampleSource,
     automatic: bool,
+    cancel: Option<&AtomicBool>,
 ) -> Result<SimilarityPrepEnqueueSummary, String> {
-    ensure_source_database_scanned(source)?;
+    ensure_not_cancelled(cancel)?;
+    ensure_source_database_scanned(source, cancel)?;
+    ensure_not_cancelled(cancel)?;
     let initial_status = resolve_similarity_prep_status(source)?;
     if initial_status == NativeSimilarityPrepStatus::UpToDate
         || (automatic
@@ -149,7 +163,9 @@ fn enqueue_similarity_prep_once(
         });
     }
     let analysis_inserted = enqueue_analysis_backfill(source)?;
+    ensure_not_cancelled(cancel)?;
     let embedding_inserted = enqueue_embedding_backfill(source)?;
+    ensure_not_cancelled(cancel)?;
     let status = resolve_similarity_prep_status(source)?;
     Ok(SimilarityPrepEnqueueSummary {
         analysis_inserted,
@@ -159,6 +175,14 @@ fn enqueue_similarity_prep_once(
         finalized: false,
         status,
     })
+}
+
+fn ensure_not_cancelled(cancel: Option<&AtomicBool>) -> Result<(), String> {
+    if cancel.is_some_and(|cancel| cancel.load(Ordering::Acquire)) {
+        Err(String::from("Similarity preparation canceled"))
+    } else {
+        Ok(())
+    }
 }
 
 fn retry_similarity_prep_busy<T>(
@@ -466,7 +490,10 @@ fn load_analysis_settings() -> AnalysisSettings {
         .unwrap_or_default()
 }
 
-fn ensure_source_database_scanned(source: &SampleSource) -> Result<(), String> {
+fn ensure_source_database_scanned(
+    source: &SampleSource,
+    cancel: Option<&AtomicBool>,
+) -> Result<(), String> {
     let db = open_fast_source_db(source).map_err(|err| err.to_string())?;
     let has_scan_timestamp = db
         .get_metadata(META_LAST_SCAN_COMPLETED_AT)
@@ -475,9 +502,9 @@ fn ensure_source_database_scanned(source: &SampleSource) -> Result<(), String> {
     if has_scan_timestamp {
         return Ok(());
     }
-    let stats = scanner::scan_with_progress(&db, ScanMode::Quick, None, &mut |_, _| {})
+    let stats = scanner::scan_with_progress(&db, ScanMode::Quick, cancel, &mut |_, _| {})
         .map_err(|err| format!("Sync source index failed: {err}"))?;
-    scanner::complete_deferred_rename_candidates(&db, stats)
+    scanner::complete_deferred_rename_candidates_with_cancel(&db, stats, cancel)
         .map_err(|err| format!("Finish deferred rename reconciliation failed: {err}"))?;
     Ok(())
 }

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -142,8 +142,15 @@ fn native_similarity_prepare_skips_unchanged_unsupported_files() {
     assert_eq!(summary.status, NativeSimilarityPrepStatus::Outdated);
     assert!(similarity_prep_needs_finalization(&source).expect("finalization needed"));
     let cancel = AtomicBool::new(false);
+    let publication_fence = SimilarityPublicationFence::legacy_paths_revision(
+        open_fast_source_db(&source)
+            .expect("open source")
+            .get_wav_paths_revision()
+            .expect("paths revision") as i64,
+    );
     assert!(
-        finalize_similarity_prep_if_ready(&source, &cancel).expect("finalize unsupported source")
+        finalize_similarity_prep_if_ready(&source, &publication_fence, &cancel)
+            .expect("finalize unsupported source")
     );
     assert_eq!(
         resolve_similarity_prep_status(&source).expect("resolved status"),
@@ -172,6 +179,69 @@ fn native_similarity_prepare_retries_unsupported_files_after_content_changes() {
         count_jobs_by_type_and_status(&source, ANALYZE_SAMPLE_JOB_TYPE, "pending"),
         1
     );
+}
+
+#[test]
+fn stale_legacy_generation_rejects_similarity_completion_timestamp() {
+    let (_dir, source) = source_with_file("changed.wav");
+    let db = open_fast_source_db(&source).expect("open source");
+    let publication_fence = SimilarityPublicationFence::legacy_paths_revision(
+        db.get_wav_paths_revision().expect("paths revision") as i64,
+    );
+    db.upsert_file(std::path::Path::new("changed.wav"), 17, 23)
+        .expect("advance source generation");
+
+    assert!(
+        !set_source_prep_timestamp_if_current(&source, 123, &publication_fence)
+            .expect("reject stale completion")
+    );
+    assert_eq!(
+        read_source_prep_timestamp(&source).expect("prep timestamp"),
+        None
+    );
+}
+
+#[test]
+fn readiness_publication_fence_requires_exact_membership_generation() {
+    let (_dir, source) = source_with_file("readiness.wav");
+    let connection = open_source_db(&source).expect("open source");
+    connection
+        .execute(
+            "INSERT INTO source_readiness_sources (
+                source_id, source_generation, readiness_revision, availability, updated_at
+             ) VALUES (?1, 7, 1, 'active', 1)",
+            [source.id.as_str()],
+        )
+        .expect("insert readiness source");
+    connection
+        .execute(
+            "INSERT INTO source_readiness_targets (
+                source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                source_generation, content_generation, eligibility, updated_at
+             ) VALUES (?1, 'source', ?1, NULL, 'similarity_layout', ?2,
+                       7, 'members-v7', 'eligible', 1)",
+            rusqlite::params![source.id.as_str(), NATIVE_SIMILARITY_UMAP_VERSION],
+        )
+        .expect("insert readiness target");
+    let target = ReadinessTarget::source(
+        source.id.as_str(),
+        ReadinessStage::SimilarityLayout,
+        NATIVE_SIMILARITY_UMAP_VERSION,
+        7,
+        "members-v7",
+    );
+    let fence = SimilarityPublicationFence::for_readiness_target(&target).expect("build fence");
+
+    assert!(fence.is_current(&connection).expect("current fence"));
+    connection
+        .execute(
+            "UPDATE source_readiness_sources
+             SET source_generation = 8, readiness_revision = 2
+             WHERE source_id = ?1",
+            [source.id.as_str()],
+        )
+        .expect("advance readiness generation");
+    assert!(!fence.is_current(&connection).expect("stale fence"));
 }
 
 #[test]

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -2,6 +2,44 @@ use super::*;
 use wavecrate::sample_sources::{SourceId, db::META_LAST_SCAN_COMPLETED_AT};
 
 #[test]
+fn cancellable_finalizer_process_releases_promptly() {
+    let child = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .args([
+            "--exact",
+            "native_app::sample_library::similarity_prep::worker::tests::cancellable_child_helper_waits",
+            "--ignored",
+        ])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn cancellable finalizer helper");
+    let cancel = std::sync::Arc::new(AtomicBool::new(false));
+    let cancel_worker = std::sync::Arc::clone(&cancel);
+    let trigger = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(50));
+        cancel_worker.store(true, Ordering::Release);
+    });
+    let started_at = Instant::now();
+
+    let child = wait_for_cancellable_child(child, cancel.as_ref())
+        .expect("cancel finalizer child without error");
+
+    trigger.join().expect("join cancellation trigger");
+    assert!(child.is_none());
+    assert!(
+        started_at.elapsed() < Duration::from_secs(1),
+        "cancellation must promptly terminate the CPU-owning finalizer process"
+    );
+}
+
+#[test]
+#[ignore = "helper process for cancellable_finalizer_process_releases_promptly"]
+fn cancellable_child_helper_waits() {
+    std::thread::sleep(Duration::from_secs(30));
+}
+
+#[test]
 fn native_similarity_status_resolves_core_states() {
     assert_eq!(
         resolve_similarity_prep_facts(SimilarityPrepFacts {

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -22,8 +22,12 @@ fn cancellable_finalizer_process_releases_promptly() {
     });
     let started_at = Instant::now();
 
-    let child = wait_for_cancellable_child(child, cancel.as_ref())
-        .expect("cancel finalizer child without error");
+    let child = crate::native_app::source_processing::wait_for_cancellable_child(
+        child,
+        cancel.as_ref(),
+        "similarity finalizer",
+    )
+    .expect("cancel finalizer child without error");
 
     trigger.join().expect("join cancellation trigger");
     assert!(child.is_none());

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -92,6 +92,17 @@ fn native_similarity_prepare_enqueues_analysis_and_embedding_jobs() {
 }
 
 #[test]
+fn native_similarity_prepare_honors_supervisor_cancellation_before_writes() {
+    let (_dir, source) = source_with_file("cancelled.wav");
+    let cancel = AtomicBool::new(true);
+
+    let result = enqueue_similarity_prep_inner_with_cancel(&source, false, Some(&cancel));
+
+    assert_eq!(result, Err(String::from("Similarity preparation canceled")));
+    assert_eq!(count_jobs(&source), 0);
+}
+
+#[test]
 fn native_similarity_prepare_skips_current_analysis_artifacts() {
     let (_dir, source) = source_with_file("current.wav");
     seed_current_analysis_artifacts(&source, "current.wav");
@@ -252,7 +263,7 @@ fn automatic_native_similarity_finish_leaves_pending_jobs_for_background_process
     write_valid_wav_with_frequency(&dir.path().join("covered-b.wav"), 660.0);
     write_valid_wav_with_frequency(&dir.path().join("covered-c.wav"), 880.0);
     write_valid_wav_with_frequency(&dir.path().join("covered-d.wav"), 990.0);
-    ensure_source_database_scanned(&source).expect("scan source");
+    ensure_source_database_scanned(&source, None).expect("scan source");
     seed_similarity_artifacts_without_features(&source, "covered-a.wav");
     seed_similarity_artifacts_without_features(&source, "covered-b.wav");
     seed_similarity_artifacts_without_features(&source, "covered-c.wav");

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -141,7 +141,10 @@ fn native_similarity_prepare_skips_unchanged_unsupported_files() {
     assert_eq!(summary.embedding_inserted, 0);
     assert_eq!(summary.status, NativeSimilarityPrepStatus::Outdated);
     assert!(similarity_prep_needs_finalization(&source).expect("finalization needed"));
-    assert!(finalize_similarity_prep_if_ready(&source).expect("finalize unsupported source"));
+    let cancel = AtomicBool::new(false);
+    assert!(
+        finalize_similarity_prep_if_ready(&source, &cancel).expect("finalize unsupported source")
+    );
     assert_eq!(
         resolve_similarity_prep_status(&source).expect("resolved status"),
         NativeSimilarityPrepStatus::UpToDate

--- a/src/native_app/sample_library/similarity_prep/worker/tests.rs
+++ b/src/native_app/sample_library/similarity_prep/worker/tests.rs
@@ -139,7 +139,13 @@ fn native_similarity_prepare_skips_unchanged_unsupported_files() {
 
     assert_eq!(summary.analysis_inserted, 0);
     assert_eq!(summary.embedding_inserted, 0);
-    assert_eq!(summary.status, NativeSimilarityPrepStatus::UpToDate);
+    assert_eq!(summary.status, NativeSimilarityPrepStatus::Outdated);
+    assert!(similarity_prep_needs_finalization(&source).expect("finalization needed"));
+    assert!(finalize_similarity_prep_if_ready(&source).expect("finalize unsupported source"));
+    assert_eq!(
+        resolve_similarity_prep_status(&source).expect("resolved status"),
+        NativeSimilarityPrepStatus::UpToDate
+    );
     assert_eq!(count_jobs_by_status(&source, "failed"), 1);
 }
 
@@ -179,13 +185,7 @@ fn automatic_native_similarity_finish_leaves_pending_jobs_for_background_process
     seed_similarity_artifacts_without_features(&source, "covered-c.wav");
     seed_similarity_artifacts_without_features(&source, "covered-d.wav");
 
-    let summary = enqueue_similarity_prep_inner(&source, true).expect("automatic enqueue");
-    let finished = super::super::finish_similarity_prep(
-        summary,
-        &source,
-        super::super::SimilarityPrepTrigger::Automatic,
-    )
-    .expect("finish automatic prep");
+    let finished = enqueue_similarity_prep_inner(&source, true).expect("automatic enqueue");
 
     assert_eq!(finished.jobs_processed, 0);
     assert!(
@@ -210,16 +210,10 @@ fn automatic_native_similarity_finish_does_not_drain_pending_jobs_when_other_job
     enqueue_similarity_prep_inner(&source, false).expect("initial enqueue");
     seed_failed_analysis_job(&source, "failed.wav");
 
-    let summary = enqueue_similarity_prep_inner(&source, true).expect("automatic enqueue");
+    let finished = enqueue_similarity_prep_inner(&source, true).expect("automatic enqueue");
     let pending_before_finish = count_jobs_by_status(&source, "pending");
     let pending_analysis_before_finish =
         count_jobs_by_type_and_status(&source, ANALYZE_SAMPLE_JOB_TYPE, "pending");
-    let finished = super::super::finish_similarity_prep(
-        summary,
-        &source,
-        super::super::SimilarityPrepTrigger::Automatic,
-    )
-    .expect("finish automatic prep");
 
     assert_eq!(finished.jobs_processed, 0);
     assert_eq!(
@@ -255,13 +249,19 @@ fn native_similarity_prep_recognizes_transient_database_busy_errors() {
 }
 
 #[test]
-fn native_similarity_user_drain_processes_valid_wav_jobs() {
+fn native_similarity_supervisor_batches_process_valid_wav_jobs() {
     let config_base = tempfile::tempdir().expect("config base");
     let _config_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
     let (_dir, source) = source_with_valid_wav("valid.wav");
 
     let summary = enqueue_similarity_prep_inner(&source, false).expect("enqueue");
-    let drain = drain_similarity_prep_jobs(&source).expect("drain jobs");
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+    let mut drain = SimilarityPrepJobDrainSummary::default();
+    while similarity_prep_has_pending_jobs(&source).expect("pending jobs") {
+        let batch = run_similarity_prep_job_batch(&source, 1, &cancel).expect("run batch");
+        drain.processed += batch.processed;
+        drain.failed += batch.failed;
+    }
 
     assert_eq!(summary.analysis_inserted, 1);
     assert_eq!(summary.embedding_inserted, 1);

--- a/src/native_app/sample_library/source_prep.rs
+++ b/src/native_app/sample_library/source_prep.rs
@@ -55,8 +55,37 @@ impl NativeAppState {
         trigger: SourcePrepTrigger,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.queue_source_prep_inner(source_id, trigger, true, context);
+    }
+
+    pub(in crate::native_app) fn queue_source_prep_pending_commit(
+        &mut self,
+        source_id: String,
+        trigger: SourcePrepTrigger,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.queue_source_prep_inner(source_id, trigger, false, context);
+    }
+
+    fn queue_source_prep_inner(
+        &mut self,
+        source_id: String,
+        trigger: SourcePrepTrigger,
+        wake_supervisor: bool,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         let started_at = Instant::now();
         let selected_source = source_id == self.library.folder_browser.selected_source_id();
+        if wake_supervisor {
+            self.background
+                .source_processing
+                .wake_source(&source_id, trigger.action_label());
+        }
+        if selected_source {
+            self.background
+                .source_processing
+                .set_selected_source(Some(&source_id));
+        }
         self.schedule_persisted_metadata_tags_refresh_for_source(
             &source_id,
             trigger.force_metadata_refresh(),

--- a/src/native_app/shell/launch/mod.rs
+++ b/src/native_app/shell/launch/mod.rs
@@ -21,6 +21,12 @@ pub(in crate::native_app) use options::default_window_title;
 
 /// Run the default Radiant GUI application shell.
 pub(crate) fn run() -> Result<(), String> {
+    if let Some(finalized) =
+        crate::native_app::sample_library::similarity_prep::run_internal_similarity_finalizer_from_args()?
+    {
+        println!("{finalized}");
+        return Ok(());
+    }
     logging::install_panic_hook();
     let args = args::LaunchArgs::collect();
     let startup_started_at = Instant::now();

--- a/src/native_app/shell/launch/mod.rs
+++ b/src/native_app/shell/launch/mod.rs
@@ -21,6 +21,12 @@ pub(in crate::native_app) use options::default_window_title;
 
 /// Run the default Radiant GUI application shell.
 pub(crate) fn run() -> Result<(), String> {
+    if let Some(result_json) =
+        crate::native_app::source_processing::run_internal_source_analysis_from_args()?
+    {
+        println!("{result_json}");
+        return Ok(());
+    }
     if let Some(finalized) =
         crate::native_app::sample_library::similarity_prep::run_internal_similarity_finalizer_from_args()?
     {

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -82,9 +82,18 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn sync_source_watcher(&mut self) {
         let sources = self.library.folder_browser.configured_sample_sources();
-        self.background
+        if let Err(error) = self
+            .background
             .source_processing
-            .replace_sources(sources.clone());
+            .replace_sources(sources.clone())
+        {
+            tracing::error!(
+                target: "wavecrate::source_processing",
+                error,
+                "Configured sources remain unchanged because retirement fencing failed"
+            );
+            return;
+        }
         if sources.is_empty() {
             self.library.source_watcher = None;
             return;

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -38,7 +38,8 @@ impl NativeAppState {
                 worker_sender.clone(),
             )
         });
-        let background = BackgroundTaskState::new(worker_sender, Some(worker_receiver));
+        let background =
+            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone());
         let audio = AudioAppState::from_settings(&config.core);
         let startup = StartupState::new(
             startup_source_scan_pending,
@@ -81,6 +82,9 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn sync_source_watcher(&mut self) {
         let sources = self.library.folder_browser.configured_sample_sources();
+        self.background
+            .source_processing
+            .replace_sources(sources.clone());
         if sources.is_empty() {
             self.library.source_watcher = None;
             return;
@@ -126,6 +130,9 @@ impl NativeAppState {
         &mut self,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        self.background
+            .source_processing
+            .set_playback_active(self.playback_visual_activity_active());
         if !ui_frame_diagnostics_enabled() {
             self.waveform
                 .current
@@ -326,10 +333,12 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn shutdown(&mut self) -> Option<serde_json::Value> {
         let started_at = Instant::now();
+        let source_processing = self.background.source_processing.shutdown();
         crate::native_app::waveform::flush_background_waveform_cache_stores_for_shutdown();
         let elapsed = started_at.elapsed();
         Some(serde_json::json!({
             "waveform_cache_shutdown_flush_ms": duration_ms(elapsed),
+            "source_processing": source_processing,
         }))
     }
 }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -132,6 +132,9 @@ impl NativeAppState {
     ) {
         self.background
             .source_processing
+            .set_foreground_activity(self.waveform_sample_load_active());
+        self.background
+            .source_processing
             .set_playback_active(self.playback_visual_activity_active());
         if !ui_frame_diagnostics_enabled() {
             self.waveform

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -2,5 +2,9 @@
 
 mod scheduler;
 mod supervisor;
+mod worker;
 
 pub(in crate::native_app) use supervisor::SourceProcessingSupervisor;
+pub(in crate::native_app) use worker::{
+    run_internal_source_analysis_from_args, wait_for_cancellable_child,
+};

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -1,0 +1,6 @@
+//! Always-on, resource-bounded processing for configured sample sources.
+
+mod scheduler;
+mod supervisor;
+
+pub(in crate::native_app) use supervisor::SourceProcessingSupervisor;

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -1,0 +1,576 @@
+//! Deterministic priority, fairness, and resource-budget policy for native source work.
+#![cfg_attr(test, allow(dead_code))]
+
+use std::collections::{BTreeMap, BTreeSet};
+#[cfg(test)]
+use wavecrate::sample_sources::readiness::{ReadinessStage, ReadinessTarget};
+
+/// Execution lane used to cap work with similar resource pressure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProcessingLane {
+    Scan,
+    Hashing,
+    DecodeSummary,
+    FeatureAnalysis,
+    Embedding,
+    Finalization,
+    Cleanup,
+}
+
+impl ProcessingLane {
+    #[cfg(test)]
+    const ALL: [Self; 7] = [
+        Self::Scan,
+        Self::Hashing,
+        Self::DecodeSummary,
+        Self::FeatureAnalysis,
+        Self::Embedding,
+        Self::Finalization,
+        Self::Cleanup,
+    ];
+
+    #[cfg(test)]
+    pub(crate) fn for_readiness_stage(stage: ReadinessStage) -> Self {
+        match stage {
+            ReadinessStage::IndexedIdentity => Self::Hashing,
+            ReadinessStage::PlaybackSummary => Self::DecodeSummary,
+            ReadinessStage::AnalysisFeatures => Self::FeatureAnalysis,
+            ReadinessStage::EmbeddingAspects => Self::Embedding,
+            ReadinessStage::SimilarityLayout => Self::Finalization,
+        }
+    }
+
+    fn demand(self) -> ResourceUse {
+        match self {
+            Self::Scan | Self::Cleanup => ResourceUse::new(0, 1, 1),
+            Self::Hashing | Self::DecodeSummary => ResourceUse::new(1, 1, 1),
+            Self::FeatureAnalysis | Self::Embedding => ResourceUse::new(1, 0, 1),
+            Self::Finalization => ResourceUse::new(1, 1, 1),
+        }
+    }
+}
+
+/// CPU, IO, and SQLite writer capacity consumed by one work item.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ResourceUse {
+    pub(crate) cpu: usize,
+    pub(crate) io: usize,
+    pub(crate) database: usize,
+}
+
+impl ResourceUse {
+    const fn new(cpu: usize, io: usize, database: usize) -> Self {
+        Self { cpu, io, database }
+    }
+
+    fn fits_within(self, limit: Self) -> bool {
+        self.cpu <= limit.cpu && self.io <= limit.io && self.database <= limit.database
+    }
+
+    fn add(self, other: Self) -> Self {
+        Self::new(
+            self.cpu.saturating_add(other.cpu),
+            self.io.saturating_add(other.io),
+            self.database.saturating_add(other.database),
+        )
+    }
+
+    fn subtract(self, other: Self) -> Self {
+        Self::new(
+            self.cpu.saturating_sub(other.cpu),
+            self.io.saturating_sub(other.io),
+            self.database.saturating_sub(other.database),
+        )
+    }
+}
+
+/// Explicit global, per-source, and per-lane concurrency ceilings.
+#[derive(Clone, Debug)]
+pub(crate) struct ProcessingBudgets {
+    pub(crate) global: ResourceUse,
+    pub(crate) per_source: ResourceUse,
+    lane_limits: BTreeMap<ProcessingLane, usize>,
+}
+
+impl ProcessingBudgets {
+    #[cfg(test)]
+    pub(crate) fn for_tests(
+        global: ResourceUse,
+        per_source: ResourceUse,
+        lane_limit: usize,
+    ) -> Self {
+        Self {
+            global,
+            per_source,
+            lane_limits: ProcessingLane::ALL
+                .into_iter()
+                .map(|lane| (lane, lane_limit))
+                .collect(),
+        }
+    }
+
+    fn lane_limit(&self, lane: ProcessingLane) -> usize {
+        self.lane_limits.get(&lane).copied().unwrap_or(0)
+    }
+}
+
+impl Default for ProcessingBudgets {
+    fn default() -> Self {
+        let parallelism = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(2);
+        let cpu = parallelism.saturating_sub(2).max(1);
+        Self {
+            global: ResourceUse::new(cpu, 2, 1),
+            per_source: ResourceUse::new(1, 1, 1),
+            lane_limits: [
+                (ProcessingLane::Scan, 1),
+                (ProcessingLane::Hashing, 1),
+                (ProcessingLane::DecodeSummary, cpu.min(2)),
+                (ProcessingLane::FeatureAnalysis, cpu),
+                (ProcessingLane::Embedding, 1),
+                (ProcessingLane::Finalization, 1),
+                (ProcessingLane::Cleanup, 1),
+            ]
+            .into_iter()
+            .collect(),
+        }
+    }
+}
+
+/// Capacity reservation retained until one owned worker reports completion.
+#[derive(Clone, Debug)]
+pub(crate) struct BudgetPermit {
+    source_id: String,
+    lane: ProcessingLane,
+    demand: ResourceUse,
+}
+
+/// Mutable accounting for all in-flight supervisor work.
+#[derive(Debug)]
+pub(crate) struct BudgetTracker {
+    limits: ProcessingBudgets,
+    global: ResourceUse,
+    by_source: BTreeMap<String, ResourceUse>,
+    by_lane: BTreeMap<ProcessingLane, usize>,
+}
+
+impl BudgetTracker {
+    pub(crate) fn new(limits: ProcessingBudgets) -> Self {
+        Self {
+            limits,
+            global: ResourceUse::default(),
+            by_source: BTreeMap::new(),
+            by_lane: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn can_acquire(&self, source_id: &str, lane: ProcessingLane) -> bool {
+        let demand = lane.demand();
+        let global = self.global.add(demand);
+        let source = self
+            .by_source
+            .get(source_id)
+            .copied()
+            .unwrap_or_default()
+            .add(demand);
+        let lane_count = self.by_lane.get(&lane).copied().unwrap_or(0);
+        global.fits_within(self.limits.global)
+            && source.fits_within(self.limits.per_source)
+            && lane_count < self.limits.lane_limit(lane)
+    }
+
+    pub(crate) fn try_acquire(
+        &mut self,
+        source_id: &str,
+        lane: ProcessingLane,
+    ) -> Option<BudgetPermit> {
+        if !self.can_acquire(source_id, lane) {
+            return None;
+        }
+        let demand = lane.demand();
+        self.global = self.global.add(demand);
+        let source = self.by_source.entry(source_id.to_string()).or_default();
+        *source = source.add(demand);
+        *self.by_lane.entry(lane).or_default() += 1;
+        Some(BudgetPermit {
+            source_id: source_id.to_string(),
+            lane,
+            demand,
+        })
+    }
+
+    pub(crate) fn release(&mut self, permit: BudgetPermit) {
+        self.global = self.global.subtract(permit.demand);
+        if let Some(source) = self.by_source.get_mut(&permit.source_id) {
+            *source = source.subtract(permit.demand);
+            if *source == ResourceUse::default() {
+                self.by_source.remove(&permit.source_id);
+            }
+        }
+        if let Some(count) = self.by_lane.get_mut(&permit.lane) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.by_lane.remove(&permit.lane);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_global(&self) -> ResourceUse {
+        self.global
+    }
+}
+
+/// Stable key used by interaction context to raise already-authoritative work.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct PriorityKey {
+    pub(crate) source_id: String,
+    pub(crate) scope_id: String,
+}
+
+impl PriorityKey {
+    #[cfg(test)]
+    fn new(source_id: &str, scope_id: &str) -> Self {
+        Self {
+            source_id: source_id.to_string(),
+            scope_id: scope_id.to_string(),
+        }
+    }
+}
+
+/// Session-local priority hints. They never create durable work.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PriorityContext {
+    pub(crate) immediate: BTreeSet<PriorityKey>,
+    pub(crate) visible: BTreeSet<PriorityKey>,
+    pub(crate) immediate_paths: BTreeSet<(String, String)>,
+    pub(crate) visible_paths: BTreeSet<(String, String)>,
+    pub(crate) selected_source: Option<String>,
+    pub(crate) current_folder: Option<(String, String)>,
+}
+
+/// One durable or discovered source-processing unit eligible for scheduling.
+#[derive(Clone, Debug)]
+pub(crate) struct WorkCandidate {
+    pub(crate) source_id: String,
+    pub(crate) scope_id: String,
+    pub(crate) relative_path: Option<String>,
+    pub(crate) lane: ProcessingLane,
+    pub(crate) stage_rank: u8,
+    pub(crate) enqueued_at: i64,
+}
+
+impl WorkCandidate {
+    #[cfg(test)]
+    pub(crate) fn readiness(target: &ReadinessTarget, enqueued_at: i64) -> Self {
+        Self {
+            source_id: target.source_id.clone(),
+            scope_id: target.scope_id.clone(),
+            relative_path: target.relative_path.clone(),
+            lane: ProcessingLane::for_readiness_stage(target.stage),
+            stage_rank: stage_rank(target.stage),
+            enqueued_at,
+        }
+    }
+
+    pub(crate) fn source(
+        source_id: impl Into<String>,
+        lane: ProcessingLane,
+        stage_rank: u8,
+        enqueued_at: i64,
+    ) -> Self {
+        let source_id = source_id.into();
+        Self {
+            scope_id: source_id.clone(),
+            source_id,
+            relative_path: None,
+            lane,
+            stage_rank,
+            enqueued_at,
+        }
+    }
+}
+
+/// Weighted-fair scheduler that preserves interaction priority without starving other sources.
+#[derive(Debug, Default)]
+pub(crate) struct FairScheduler {
+    virtual_finish: BTreeMap<String, u64>,
+    paused: bool,
+}
+
+impl FairScheduler {
+    pub(crate) fn set_paused(&mut self, paused: bool) {
+        self.paused = paused;
+    }
+
+    pub(crate) fn choose(
+        &mut self,
+        candidates: &[WorkCandidate],
+        priority: &PriorityContext,
+        budgets: &BudgetTracker,
+    ) -> Option<usize> {
+        if self.paused {
+            return None;
+        }
+        let mut best_by_source = BTreeMap::<&str, usize>::new();
+        for (index, candidate) in candidates.iter().enumerate() {
+            if !budgets.can_acquire(&candidate.source_id, candidate.lane) {
+                continue;
+            }
+            best_by_source
+                .entry(candidate.source_id.as_str())
+                .and_modify(|current| {
+                    if candidate_order(candidate, &candidates[*current], priority).is_lt() {
+                        *current = index;
+                    }
+                })
+                .or_insert(index);
+        }
+        let selected = best_by_source
+            .into_iter()
+            .map(|(source_id, index)| {
+                let weight = priority_weight(&candidates[index], priority);
+                let increment = 48 / weight;
+                let finish = self
+                    .virtual_finish
+                    .get(source_id)
+                    .copied()
+                    .unwrap_or_default()
+                    .saturating_add(increment);
+                (finish, std::cmp::Reverse(weight), source_id, index)
+            })
+            .min()?;
+        self.virtual_finish
+            .insert(selected.2.to_string(), selected.0);
+        self.normalize_virtual_time();
+        Some(selected.3)
+    }
+
+    fn normalize_virtual_time(&mut self) {
+        let Some(minimum) = self.virtual_finish.values().copied().min() else {
+            return;
+        };
+        if minimum < 1_000_000 {
+            return;
+        }
+        for finish in self.virtual_finish.values_mut() {
+            *finish = finish.saturating_sub(minimum);
+        }
+    }
+}
+
+fn candidate_order(
+    left: &WorkCandidate,
+    right: &WorkCandidate,
+    priority: &PriorityContext,
+) -> std::cmp::Ordering {
+    std::cmp::Reverse(priority_weight(left, priority))
+        .cmp(&std::cmp::Reverse(priority_weight(right, priority)))
+        .then_with(|| left.stage_rank.cmp(&right.stage_rank))
+        .then_with(|| left.enqueued_at.cmp(&right.enqueued_at))
+        .then_with(|| left.scope_id.cmp(&right.scope_id))
+}
+
+fn priority_weight(candidate: &WorkCandidate, context: &PriorityContext) -> u64 {
+    let key = PriorityKey {
+        source_id: candidate.source_id.clone(),
+        scope_id: candidate.scope_id.clone(),
+    };
+    if context.immediate.contains(&key) {
+        return 48;
+    }
+    if candidate.relative_path.as_ref().is_some_and(|path| {
+        context
+            .immediate_paths
+            .contains(&(candidate.source_id.clone(), path.clone()))
+    }) {
+        return 48;
+    }
+    if context.visible.contains(&key) {
+        return 12;
+    }
+    if candidate.relative_path.as_ref().is_some_and(|path| {
+        context
+            .visible_paths
+            .contains(&(candidate.source_id.clone(), path.clone()))
+    }) {
+        return 12;
+    }
+    if context
+        .current_folder
+        .as_ref()
+        .is_some_and(|(source, folder)| {
+            source == &candidate.source_id
+                && candidate
+                    .relative_path
+                    .as_deref()
+                    .is_some_and(|path| path.starts_with(folder))
+        })
+    {
+        return 6;
+    }
+    if context.selected_source.as_deref() == Some(candidate.source_id.as_str()) {
+        return 3;
+    }
+    1
+}
+
+#[cfg(test)]
+fn stage_rank(stage: ReadinessStage) -> u8 {
+    match stage {
+        ReadinessStage::PlaybackSummary => 0,
+        ReadinessStage::IndexedIdentity => 1,
+        ReadinessStage::AnalysisFeatures => 2,
+        ReadinessStage::EmbeddingAspects => 3,
+        ReadinessStage::SimilarityLayout => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(source: &str, scope: &str, stage: ReadinessStage) -> ReadinessTarget {
+        if stage == ReadinessStage::SimilarityLayout {
+            ReadinessTarget::source(source, stage, "v1", 1, "members-v1")
+        } else {
+            ReadinessTarget::file(
+                source,
+                scope,
+                format!("folder/{scope}.wav"),
+                stage,
+                "v1",
+                1,
+                format!("content-{scope}"),
+            )
+        }
+    }
+
+    fn candidate(source: &str, scope: &str, stage: ReadinessStage) -> WorkCandidate {
+        WorkCandidate::readiness(&target(source, scope, stage), 10)
+    }
+
+    #[test]
+    fn immediate_and_visible_work_lead_without_starving_backlog_sources() {
+        let mut scheduler = FairScheduler::default();
+        let budgets = BudgetTracker::new(ProcessingBudgets::for_tests(
+            ResourceUse::new(10, 10, 10),
+            ResourceUse::new(10, 10, 10),
+            10,
+        ));
+        let candidates = [
+            candidate("active", "now", ReadinessStage::PlaybackSummary),
+            candidate("backlog", "old", ReadinessStage::AnalysisFeatures),
+        ];
+        let priority = PriorityContext {
+            immediate: [PriorityKey::new("active", "now")].into_iter().collect(),
+            ..PriorityContext::default()
+        };
+        let mut chosen_sources = Vec::new();
+        for _ in 0..60 {
+            let index = scheduler.choose(&candidates, &priority, &budgets).unwrap();
+            chosen_sources.push(candidates[index].source_id.as_str());
+        }
+        assert_eq!(chosen_sources[0], "active");
+        assert!(
+            chosen_sources[..10]
+                .iter()
+                .all(|source| *source == "active")
+        );
+        assert!(chosen_sources.contains(&"backlog"));
+    }
+
+    #[test]
+    fn current_folder_and_stage_order_prioritize_interactive_readiness() {
+        let mut scheduler = FairScheduler::default();
+        let budgets = BudgetTracker::new(ProcessingBudgets::for_tests(
+            ResourceUse::new(10, 10, 10),
+            ResourceUse::new(10, 10, 10),
+            10,
+        ));
+        let candidates = [
+            candidate("source", "analysis", ReadinessStage::AnalysisFeatures),
+            candidate("source", "playback", ReadinessStage::PlaybackSummary),
+        ];
+        let priority = PriorityContext {
+            current_folder: Some(("source".to_string(), "folder/".to_string())),
+            ..PriorityContext::default()
+        };
+        let index = scheduler.choose(&candidates, &priority, &budgets).unwrap();
+        assert_eq!(candidates[index].scope_id, "playback");
+    }
+
+    #[test]
+    fn budgets_cap_global_per_source_and_lane_usage() {
+        let limits =
+            ProcessingBudgets::for_tests(ResourceUse::new(2, 2, 2), ResourceUse::new(1, 1, 1), 1);
+        let mut tracker = BudgetTracker::new(limits);
+        let first = tracker
+            .try_acquire("one", ProcessingLane::DecodeSummary)
+            .expect("first permit");
+        assert!(
+            tracker
+                .try_acquire("one", ProcessingLane::FeatureAnalysis)
+                .is_none()
+        );
+        assert!(
+            tracker
+                .try_acquire("two", ProcessingLane::DecodeSummary)
+                .is_none()
+        );
+        let second = tracker
+            .try_acquire("two", ProcessingLane::FeatureAnalysis)
+            .expect("independent lane");
+        assert_eq!(tracker.current_global(), ResourceUse::new(2, 1, 2));
+        tracker.release(first);
+        tracker.release(second);
+        assert_eq!(tracker.current_global(), ResourceUse::default());
+    }
+
+    #[test]
+    fn pause_retains_the_same_pending_backlog_for_resume() {
+        let mut scheduler = FairScheduler::default();
+        let budgets = BudgetTracker::new(ProcessingBudgets::for_tests(
+            ResourceUse::new(2, 2, 2),
+            ResourceUse::new(1, 1, 1),
+            2,
+        ));
+        let candidates = [candidate(
+            "source",
+            "pending",
+            ReadinessStage::AnalysisFeatures,
+        )];
+        scheduler.set_paused(true);
+        assert!(
+            scheduler
+                .choose(&candidates, &PriorityContext::default(), &budgets)
+                .is_none()
+        );
+        scheduler.set_paused(false);
+        assert_eq!(
+            scheduler.choose(&candidates, &PriorityContext::default(), &budgets),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn stress_accounting_never_exceeds_resource_ceilings() {
+        let limits =
+            ProcessingBudgets::for_tests(ResourceUse::new(4, 3, 2), ResourceUse::new(2, 2, 1), 2);
+        let mut tracker = BudgetTracker::new(limits.clone());
+        let mut permits = Vec::new();
+        for index in 0..1_000 {
+            let source = format!("source-{}", index % 8);
+            let lane = ProcessingLane::ALL[index % ProcessingLane::ALL.len()];
+            if let Some(permit) = tracker.try_acquire(&source, lane) {
+                assert!(tracker.current_global().fits_within(limits.global));
+                permits.push(permit);
+            }
+        }
+        for permit in permits {
+            tracker.release(permit);
+        }
+        assert_eq!(tracker.current_global(), ResourceUse::default());
+    }
+}

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(test)]
 use wavecrate::sample_sources::readiness::{ReadinessStage, ReadinessTarget};
 
 /// Execution lane used to cap work with similar resource pressure.
@@ -29,7 +28,6 @@ impl ProcessingLane {
         Self::Cleanup,
     ];
 
-    #[cfg(test)]
     pub(crate) fn for_readiness_stage(stage: ReadinessStage) -> Self {
         match stage {
             ReadinessStage::IndexedIdentity => Self::Hashing,
@@ -44,7 +42,7 @@ impl ProcessingLane {
         match self {
             Self::Scan | Self::Cleanup => ResourceUse::new(0, 1, 1),
             Self::Hashing | Self::DecodeSummary => ResourceUse::new(1, 1, 1),
-            Self::FeatureAnalysis | Self::Embedding => ResourceUse::new(1, 0, 1),
+            Self::FeatureAnalysis | Self::Embedding => ResourceUse::new(1, 1, 1),
             Self::Finalization => ResourceUse::new(1, 1, 1),
         }
     }
@@ -262,7 +260,6 @@ pub(crate) struct WorkCandidate {
 }
 
 impl WorkCandidate {
-    #[cfg(test)]
     pub(crate) fn readiness(target: &ReadinessTarget, enqueued_at: i64) -> Self {
         Self {
             source_id: target.source_id.clone(),
@@ -285,6 +282,25 @@ impl WorkCandidate {
             scope_id: source_id.clone(),
             source_id,
             relative_path: None,
+            lane,
+            stage_rank,
+            enqueued_at,
+        }
+    }
+
+    pub(crate) fn file(
+        source_id: impl Into<String>,
+        relative_path: impl Into<String>,
+        lane: ProcessingLane,
+        stage_rank: u8,
+        enqueued_at: i64,
+    ) -> Self {
+        let source_id = source_id.into();
+        let relative_path = relative_path.into();
+        Self {
+            source_id,
+            scope_id: relative_path.clone(),
+            relative_path: Some(relative_path),
             lane,
             stage_rank,
             enqueued_at,
@@ -416,7 +432,6 @@ fn priority_weight(candidate: &WorkCandidate, context: &PriorityContext) -> u64 
     1
 }
 
-#[cfg(test)]
 fn stage_rank(stage: ReadinessStage) -> u8 {
     match stage {
         ReadinessStage::PlaybackSummary => 0,
@@ -522,7 +537,7 @@ mod tests {
         let second = tracker
             .try_acquire("two", ProcessingLane::FeatureAnalysis)
             .expect("independent lane");
-        assert_eq!(tracker.current_global(), ResourceUse::new(2, 1, 2));
+        assert_eq!(tracker.current_global(), ResourceUse::new(2, 2, 2));
         tracker.release(first);
         tracker.release(second);
         assert_eq!(tracker.current_global(), ResourceUse::default());

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -144,6 +144,12 @@ pub(crate) struct BudgetPermit {
     demand: ResourceUse,
 }
 
+impl BudgetPermit {
+    pub(crate) fn source_id(&self) -> &str {
+        &self.source_id
+    }
+}
+
 /// Mutable accounting for all in-flight supervisor work.
 #[derive(Debug)]
 pub(crate) struct BudgetTracker {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -783,6 +783,14 @@ fn discover_source_candidates(
     let source_id = source.id.as_str();
     let mut candidates = Vec::new();
     let mut stats = SourceDiscoveryStats::default();
+    if !source_processing_schema_available(&connection)? {
+        tracing::debug!(
+            target: "wavecrate::source_processing",
+            source_id,
+            "Source processing is unavailable until the read-only source database is migrated"
+        );
+        return Ok((candidates, stats));
+    }
     publish_current_readiness_targets(&mut connection, source_id, now)?;
     let readiness_source_exists: bool = connection
         .query_row(
@@ -901,6 +909,64 @@ fn discover_source_candidates(
         });
     }
     Ok((candidates, stats))
+}
+
+fn source_processing_schema_available(connection: &rusqlite::Connection) -> Result<bool, String> {
+    for (table, required_columns) in [
+        (
+            "wav_files",
+            &[
+                "path",
+                "file_identity",
+                "content_hash",
+                "file_size",
+                "modified_ns",
+                "missing",
+            ][..],
+        ),
+        (
+            "analysis_jobs",
+            &[
+                "id",
+                "relative_path",
+                "job_type",
+                "created_at",
+                "status",
+                "readiness_managed",
+            ][..],
+        ),
+        ("metadata", &["key", "value"][..]),
+    ] {
+        let pragma = format!("PRAGMA table_info({table})");
+        let mut statement = connection
+            .prepare(&pragma)
+            .map_err(|error| error.to_string())?;
+        let columns = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|error| error.to_string())?
+            .collect::<Result<std::collections::BTreeSet<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        if required_columns
+            .iter()
+            .any(|column| !columns.contains(*column))
+        {
+            return Ok(false);
+        }
+    }
+    connection
+        .query_row(
+            "SELECT COUNT(*) = 3
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name IN (
+                   'source_readiness_sources',
+                   'source_readiness_targets',
+                   'source_readiness_artifacts'
+               )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())
 }
 
 fn publish_current_readiness_targets(
@@ -1710,6 +1776,30 @@ mod tests {
         assert!(cached_waveform_file_audition_ready_exists(
             &source.root.join("ready.wav")
         ));
+    }
+
+    #[test]
+    fn legacy_source_schema_is_not_eligible_for_automatic_processing() {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE wav_files (
+                    path TEXT PRIMARY KEY,
+                    file_size INTEGER NOT NULL,
+                    modified_ns INTEGER NOT NULL
+                 );
+                 CREATE TABLE analysis_jobs (
+                    id INTEGER PRIMARY KEY,
+                    relative_path TEXT NOT NULL,
+                    job_type TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    status TEXT NOT NULL
+                 );
+                 CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+            )
+            .unwrap();
+
+        assert!(!source_processing_schema_available(&connection).unwrap());
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -23,7 +23,7 @@ use wavecrate::sample_sources::{
         fail_readiness_work, persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
         renew_readiness_lease, replace_readiness_targets,
     },
-    scanner::complete_pending_deep_hashes,
+    scanner::complete_pending_deep_hash_for_path,
 };
 
 use super::scheduler::{
@@ -39,7 +39,6 @@ use crate::native_app::waveform::{
 };
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
-const DEEP_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
 const READINESS_MAX_ATTEMPTS: u32 = 8;
@@ -462,7 +461,6 @@ struct SupervisorTelemetry {
 
 #[derive(Clone, Debug)]
 enum RuntimeTask {
-    DeepHash,
     LegacyAnalysis {
         job_id: i64,
     },
@@ -690,8 +688,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                 continue;
             }
             let should_refresh = match (&candidate.task, execution_outcome) {
-                (RuntimeTask::DeepHash, Some(ExecutionOutcome::Completed))
-                | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
+                (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
                 | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Failed))
                 | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Completed))
                 | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Retried { .. }))
@@ -826,24 +823,6 @@ fn discover_source_candidates(
         );
     }
 
-    let has_unhashed: bool = connection
-        .query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM wav_files
-                WHERE missing = 0 AND content_hash IS NULL
-                LIMIT 1
-             )",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(|error| error.to_string())?;
-    if has_unhashed {
-        candidates.push(RuntimeCandidate {
-            schedule: WorkCandidate::source(source_id, ProcessingLane::Hashing, 1, now),
-            source: source.clone(),
-            task: RuntimeTask::DeepHash,
-        });
-    }
     let legacy_jobs = {
         let mut statement = connection
             .prepare(
@@ -1153,26 +1132,6 @@ fn execute_candidate(
     cancel: &AtomicBool,
 ) -> Result<ExecutionOutcome, String> {
     let result = match &candidate.task {
-        RuntimeTask::DeepHash => {
-            let database_root = candidate
-                .source
-                .database_root()
-                .map_err(|error| error.to_string())?;
-            let db = SourceDatabase::open_for_background_job_with_database_root(
-                &candidate.source.root,
-                database_root,
-            )
-            .map_err(|error| error.to_string())?;
-            complete_pending_deep_hashes(&db, Some(cancel), DEEP_HASH_BATCH)
-                .map(|stats| {
-                    if stats.hashes_computed > 0 {
-                        ExecutionOutcome::Completed
-                    } else {
-                        ExecutionOutcome::NotClaimed
-                    }
-                })
-                .map_err(|error| error.to_string())
-        }
         RuntimeTask::LegacyAnalysis { job_id } => {
             run_similarity_prep_job(&candidate.source, *job_id, cancel, 1).map(|summary| {
                 if summary.processed == 0 {
@@ -1436,7 +1395,50 @@ fn run_readiness_stage(
                 )
                 .map_err(|error| error.to_string())?;
             Ok(if current {
-                ReadinessExecutionOutcome::Complete
+                let has_content_hash: bool = connection
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM wav_files
+                            WHERE file_identity = ?1 AND path = ?2 AND missing = 0
+                              AND content_hash IS NOT NULL AND content_hash != ''
+                        )",
+                        params![target.scope_id, relative_path],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?;
+                if !has_content_hash {
+                    let database_root =
+                        source.database_root().map_err(|error| error.to_string())?;
+                    let db = SourceDatabase::open_for_background_job_with_database_root(
+                        &source.root,
+                        database_root,
+                    )
+                    .map_err(|error| error.to_string())?;
+                    complete_pending_deep_hash_for_path(
+                        &db,
+                        std::path::Path::new(relative_path),
+                        Some(cancel),
+                    )
+                    .map_err(|error| error.to_string())?;
+                }
+                let hash_is_current: bool = connection
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM wav_files
+                            WHERE file_identity = ?1 AND path = ?2 AND missing = 0
+                              AND content_hash IS NOT NULL AND content_hash != ''
+                        )",
+                        params![target.scope_id, relative_path],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?;
+                if hash_is_current {
+                    ReadinessExecutionOutcome::Complete
+                } else {
+                    ReadinessExecutionOutcome::Retry(
+                        "indexed identity content hash is not durable yet",
+                    )
+                }
             } else {
                 ReadinessExecutionOutcome::Retry("indexed identity is not committed yet")
             })
@@ -1779,6 +1781,72 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_hash_path_backs_off_without_starving_later_files() {
+        let directory = tempfile::tempdir().expect("temporary hash source");
+        let good_path = directory.path().join("z-good.wav");
+        std::fs::write(&good_path, [7_u8; 64]).expect("write hashable sample");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("hash-fairness"),
+            directory.path().to_path_buf(),
+        );
+        let db = source.open_db().expect("open hash source database");
+        db.upsert_file(Path::new("a-unavailable.wav"), 64, 1)
+            .expect("insert unavailable hash row");
+        db.upsert_file(Path::new("z-good.wav"), 64, 1)
+            .expect("insert good hash row");
+        let database_root = source.database_root().expect("database root");
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open hash database");
+        connection
+            .execute_batch(
+                "UPDATE wav_files SET file_identity = 'identity-bad'
+                 WHERE path = 'a-unavailable.wav';
+                 UPDATE wav_files SET file_identity = 'identity-good'
+                 WHERE path = 'z-good.wav';",
+            )
+            .expect("assign hash identities");
+        drop(connection);
+
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+        wait_until(Duration::from_secs(10), || {
+            source
+                .open_db()
+                .expect("open hash source")
+                .entry_for_path(Path::new("z-good.wav"))
+                .expect("read good hash row")
+                .and_then(|entry| entry.content_hash)
+                .is_some()
+        });
+        assert_eq!(supervisor.shutdown()["joined"], true);
+
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("reopen hash database");
+        let failure: (String, Option<String>, Option<i64>, i64) = connection
+            .query_row(
+                "SELECT status, failure_kind, retry_at, attempts
+                 FROM analysis_jobs
+                 WHERE readiness_managed = 1
+                   AND readiness_stage = 'indexed_identity'
+                   AND relative_path = 'a-unavailable.wav'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("read durable hash failure");
+        assert_eq!(failure.0, "failed");
+        assert_eq!(failure.1.as_deref(), Some("retryable"));
+        assert!(failure.2.is_some());
+        assert_eq!(failure.3, 1);
+    }
+
+    #[test]
     fn legacy_source_schema_is_not_eligible_for_automatic_processing() {
         let connection = rusqlite::Connection::open_in_memory().unwrap();
         connection
@@ -2038,6 +2106,11 @@ mod tests {
         let db = source.open_db().expect("open source database");
         db.upsert_file(Path::new("pending.wav"), 64, 1)
             .expect("insert pending hash row");
+        let mut batch = db.write_batch().expect("open identity batch");
+        batch
+            .set_file_identity(Path::new("pending.wav"), Some(&format!("identity-{id}")))
+            .expect("assign pending identity");
+        batch.commit().expect("commit pending identity");
         (directory, source)
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -10,10 +10,15 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+use rusqlite::params;
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
-    readiness::{persist_readiness_deficits, readiness_work_stats, reconcile_readiness},
+    readiness::{
+        ClaimedReadinessWork, ReadinessFailureClassification, ReadinessRetryPolicy, ReadinessStage,
+        ReadinessTarget, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+        fail_readiness_work, persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
+    },
     scanner::complete_pending_deep_hashes,
 };
 
@@ -21,19 +26,65 @@ use super::scheduler::{
     BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane, WorkCandidate,
 };
 use crate::native_app::sample_library::similarity_prep::{
-    finalize_similarity_prep_if_ready, reset_interrupted_similarity_prep_jobs,
-    run_similarity_prep_job_batch, similarity_prep_needs_finalization,
+    NATIVE_SIMILARITY_UMAP_VERSION, finalize_similarity_prep_if_ready,
+    reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
+    similarity_prep_needs_finalization,
 };
+use crate::native_app::waveform::cached_waveform_file_playback_ready_exists;
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
-const LEGACY_ANALYSIS_BATCH: usize = 8;
 const DEEP_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
+const READINESS_LEASE_SECONDS: i64 = 5 * 60;
+const MAX_DISCOVERED_ANALYSIS_JOBS: i64 = 256;
 
 /// Owned runtime coordinator. All work is joined during shutdown and observes one cancel token.
 pub(in crate::native_app) struct SourceProcessingSupervisor {
     shared: Arc<Shared>,
     coordinator: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone)]
+pub(in crate::native_app) struct SourceProcessingBudgetHandle {
+    shared: Arc<Shared>,
+}
+
+pub(in crate::native_app) struct SourceProcessingBudgetPermit {
+    shared: Arc<Shared>,
+    permit: Option<super::scheduler::BudgetPermit>,
+}
+
+impl SourceProcessingBudgetHandle {
+    pub(in crate::native_app) fn acquire_scan(
+        &self,
+        source_id: &str,
+    ) -> SourceProcessingBudgetPermit {
+        let mut budgets = self.shared.budgets();
+        loop {
+            if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
+                return SourceProcessingBudgetPermit {
+                    shared: Arc::clone(&self.shared),
+                    permit: Some(permit),
+                };
+            }
+            budgets = self
+                .shared
+                .budget_wake
+                .wait(budgets)
+                .unwrap_or_else(|poison| poison.into_inner());
+        }
+    }
+}
+
+impl Drop for SourceProcessingBudgetPermit {
+    fn drop(&mut self) {
+        if let Some(permit) = self.permit.take() {
+            self.shared.budgets().release(permit);
+            self.shared.budget_wake.notify_all();
+            self.shared.control().wake("external_budget_released");
+            self.shared.wake.notify_one();
+        }
+    }
 }
 
 impl SourceProcessingSupervisor {
@@ -73,6 +124,12 @@ impl SourceProcessingSupervisor {
         control.priority.visible_paths.clear();
         control.wake("configured_sources_changed");
         self.shared.wake.notify_one();
+    }
+
+    pub(in crate::native_app) fn budget_handle(&self) -> SourceProcessingBudgetHandle {
+        SourceProcessingBudgetHandle {
+            shared: Arc::clone(&self.shared),
+        }
     }
 
     pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {
@@ -198,6 +255,8 @@ struct Shared {
     cancel: AtomicBool,
     work_cancel: AtomicBool,
     telemetry: Mutex<SupervisorTelemetry>,
+    budgets: Mutex<BudgetTracker>,
+    budget_wake: Condvar,
 }
 
 impl Shared {
@@ -215,6 +274,8 @@ impl Shared {
             cancel: AtomicBool::new(false),
             work_cancel: AtomicBool::new(false),
             telemetry: Mutex::new(SupervisorTelemetry::default()),
+            budgets: Mutex::new(BudgetTracker::new(ProcessingBudgets::default())),
+            budget_wake: Condvar::new(),
         }
     }
 
@@ -226,6 +287,12 @@ impl Shared {
 
     fn telemetry(&self) -> MutexGuard<'_, SupervisorTelemetry> {
         self.telemetry
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn budgets(&self) -> MutexGuard<'_, BudgetTracker> {
+        self.budgets
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
     }
@@ -262,11 +329,12 @@ struct SupervisorTelemetry {
     readiness_queue_depth: usize,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 enum RuntimeTask {
     DeepHash,
-    LegacyAnalysis,
+    LegacyAnalysis { job_id: i64 },
     FinalizeSimilarity,
+    Readiness(ReadinessTarget),
 }
 
 struct RuntimeCandidate {
@@ -278,7 +346,6 @@ struct RuntimeCandidate {
 fn run_coordinator(shared: Arc<Shared>) {
     let mut observed_generation = 0;
     let mut scheduler = FairScheduler::default();
-    let mut budgets = BudgetTracker::new(ProcessingBudgets::default());
     let mut reset_sources = BTreeMap::<String, bool>::new();
     loop {
         let (sources, priority, playback_active, generation, reason) = {
@@ -322,6 +389,12 @@ fn run_coordinator(shared: Arc<Shared>) {
         for source in &sources {
             let source_id = source.id.as_str().to_string();
             if !reset_sources.contains_key(&source_id) {
+                let Some(permit) = shared
+                    .budgets()
+                    .try_acquire(&source_id, ProcessingLane::Cleanup)
+                else {
+                    continue;
+                };
                 match reset_interrupted_similarity_prep_jobs(source) {
                     Ok(reset) => {
                         reset_sources.insert(source_id, true);
@@ -336,6 +409,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                     }
                     Err(error) => record_discovery_error(&shared, source, &error),
                 }
+                shared.budgets().release(permit);
+                shared.budget_wake.notify_all();
             }
         }
         reset_sources
@@ -366,14 +441,15 @@ fn run_coordinator(shared: Arc<Shared>) {
                 .iter()
                 .map(|candidate| candidate.schedule.clone())
                 .collect::<Vec<_>>();
-            let Some(index) = scheduler.choose(&schedules, &priority, &budgets) else {
+            let Some(index) = scheduler.choose(&schedules, &priority, &shared.budgets()) else {
                 let mut telemetry = shared.telemetry();
                 telemetry.contention = telemetry.contention.saturating_add(1);
                 break;
             };
             let candidate = candidates.swap_remove(index);
-            let Some(permit) =
-                budgets.try_acquire(&candidate.schedule.source_id, candidate.schedule.lane)
+            let Some(permit) = shared
+                .budgets()
+                .try_acquire(&candidate.schedule.source_id, candidate.schedule.lane)
             else {
                 let mut telemetry = shared.telemetry();
                 telemetry.contention = telemetry.contention.saturating_add(1);
@@ -384,7 +460,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                 telemetry.claimed = telemetry.claimed.saturating_add(1);
             }
             let result = execute_candidate(&candidate, &shared.work_cancel);
-            budgets.release(permit);
+            shared.budgets().release(permit);
+            shared.budget_wake.notify_all();
             let mut telemetry = shared.telemetry();
             match result {
                 _ if shared.work_cancel.load(Ordering::Acquire) => {
@@ -454,6 +531,12 @@ fn discover_candidates(
     let mut readiness_queue_depth = 0;
     let mut retries_due = 0;
     for source in sources {
+        let Some(permit) = shared
+            .budgets()
+            .try_acquire(source.id.as_str(), ProcessingLane::Cleanup)
+        else {
+            continue;
+        };
         match discover_source_candidates(source, now) {
             Ok((mut source_candidates, source_readiness_depth, source_retries_due)) => {
                 candidates.append(&mut source_candidates);
@@ -462,6 +545,8 @@ fn discover_candidates(
             }
             Err(error) => record_discovery_error(shared, source, &error),
         }
+        shared.budgets().release(permit);
+        shared.budget_wake.notify_all();
     }
     (candidates, retries_due, readiness_queue_depth)
 }
@@ -478,6 +563,7 @@ fn discover_source_candidates(
     )
     .map_err(|error| error.to_string())?;
     let source_id = source.id.as_str();
+    let mut candidates = Vec::new();
     let mut readiness_queue_depth = 0;
     let mut retries_due = 0;
     let readiness_source_exists: bool = connection
@@ -493,6 +579,11 @@ fn discover_source_candidates(
         persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
             .map_err(|error| error.to_string())?;
         readiness_queue_depth = snapshot.deficits.len();
+        candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
+            schedule: WorkCandidate::readiness(&deficit.target, now),
+            source: source.clone(),
+            task: RuntimeTask::Readiness(deficit.target.clone()),
+        }));
         let stats = readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
         retries_due = stats.retries_due;
         tracing::debug!(
@@ -507,7 +598,6 @@ fn discover_source_candidates(
         );
     }
 
-    let mut candidates = Vec::new();
     let has_unhashed: bool = connection
         .query_row(
             "SELECT EXISTS(
@@ -526,28 +616,48 @@ fn discover_source_candidates(
             task: RuntimeTask::DeepHash,
         });
     }
-    let legacy_analysis_created_at: Option<i64> = connection
-        .query_row(
-            "SELECT MIN(created_at) FROM analysis_jobs
-             WHERE readiness_managed = 0
-               AND status = 'pending'
-               AND job_type IN ('wav_metadata_v1', 'embedding_backfill_v1')",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(|error| error.to_string())?;
-    if let Some(created_at) = legacy_analysis_created_at {
+    let legacy_jobs = {
+        let mut statement = connection
+            .prepare(
+                "SELECT id, relative_path, job_type, created_at
+                 FROM analysis_jobs
+                 WHERE readiness_managed = 0
+                   AND status = 'pending'
+                   AND job_type IN ('wav_metadata_v1', 'embedding_backfill_v1')
+                 ORDER BY created_at, id
+                 LIMIT ?1",
+            )
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map([MAX_DISCOVERED_ANALYSIS_JOBS], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            })
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    for (job_id, relative_path, job_type, created_at) in legacy_jobs {
+        let lane = if job_type == "embedding_backfill_v1" {
+            ProcessingLane::Embedding
+        } else {
+            ProcessingLane::FeatureAnalysis
+        };
         candidates.push(RuntimeCandidate {
-            schedule: WorkCandidate::source(
-                source_id,
-                ProcessingLane::FeatureAnalysis,
-                2,
-                created_at,
-            ),
+            schedule: WorkCandidate::file(source_id, relative_path, lane, 2, created_at),
             source: source.clone(),
-            task: RuntimeTask::LegacyAnalysis,
+            task: RuntimeTask::LegacyAnalysis { job_id },
         });
-    } else if similarity_prep_needs_finalization(source)? {
+    }
+    if candidates
+        .iter()
+        .all(|candidate| !matches!(&candidate.task, RuntimeTask::LegacyAnalysis { .. }))
+        && similarity_prep_needs_finalization(source)?
+    {
         candidates.push(RuntimeCandidate {
             schedule: WorkCandidate::source(source_id, ProcessingLane::Finalization, 4, now),
             source: source.clone(),
@@ -558,7 +668,7 @@ fn discover_source_candidates(
 }
 
 fn execute_candidate(candidate: &RuntimeCandidate, cancel: &AtomicBool) -> Result<(), String> {
-    match candidate.task {
+    match &candidate.task {
         RuntimeTask::DeepHash => {
             let database_root = candidate
                 .source
@@ -573,12 +683,224 @@ fn execute_candidate(candidate: &RuntimeCandidate, cancel: &AtomicBool) -> Resul
                 .map(drop)
                 .map_err(|error| error.to_string())
         }
-        RuntimeTask::LegacyAnalysis => {
-            run_similarity_prep_job_batch(&candidate.source, LEGACY_ANALYSIS_BATCH, cancel)
-                .map(drop)
+        RuntimeTask::LegacyAnalysis { job_id } => {
+            run_similarity_prep_job(&candidate.source, *job_id, cancel).map(drop)
         }
         RuntimeTask::FinalizeSimilarity => {
-            finalize_similarity_prep_if_ready(&candidate.source).map(drop)
+            finalize_similarity_prep_if_ready(&candidate.source, cancel).map(drop)
+        }
+        RuntimeTask::Readiness(target) => {
+            execute_readiness_target(&candidate.source, target, cancel)
+        }
+    }
+}
+
+enum ReadinessExecutionOutcome {
+    Complete,
+    Retry(&'static str),
+    Permanent(&'static str),
+}
+
+fn execute_readiness_target(
+    source: &SampleSource,
+    target: &ReadinessTarget,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .map_err(|error| error.to_string())?;
+    let now = now_epoch_seconds();
+    let Some(claim) = claim_readiness_target(&mut connection, target, now, READINESS_LEASE_SECONDS)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+    if cancel.load(Ordering::Acquire) {
+        cancel_readiness_work(&mut connection, &claim, "runtime cancellation", now)
+            .map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+    let outcome = run_readiness_stage(source, &connection, &claim, cancel);
+    if cancel.load(Ordering::Acquire) {
+        cancel_readiness_work(
+            &mut connection,
+            &claim,
+            "runtime cancellation before readiness publication",
+            now_epoch_seconds(),
+        )
+        .map_err(|error| error.to_string())?;
+        return Ok(());
+    }
+    match outcome {
+        Ok(ReadinessExecutionOutcome::Complete) => {
+            let _outcome = complete_readiness_work(&mut connection, &claim, now_epoch_seconds())
+                .map_err(|error| error.to_string())?;
+            Ok(())
+        }
+        Ok(ReadinessExecutionOutcome::Retry(reason)) => {
+            let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
+                .expect("valid readiness retry policy");
+            fail_readiness_work(
+                &mut connection,
+                &claim,
+                ReadinessFailureClassification::Retryable,
+                reason,
+                now_epoch_seconds(),
+                policy,
+            )
+            .map(drop)
+            .map_err(|error| error.to_string())
+        }
+        Err(reason) => {
+            let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
+                .expect("valid readiness retry policy");
+            fail_readiness_work(
+                &mut connection,
+                &claim,
+                ReadinessFailureClassification::Retryable,
+                &reason,
+                now_epoch_seconds(),
+                policy,
+            )
+            .map(drop)
+            .map_err(|error| error.to_string())
+        }
+        Ok(ReadinessExecutionOutcome::Permanent(reason)) => {
+            let policy =
+                ReadinessRetryPolicy::new(5, 5 * 60, 1).expect("valid readiness terminal policy");
+            fail_readiness_work(
+                &mut connection,
+                &claim,
+                ReadinessFailureClassification::Permanent,
+                reason,
+                now_epoch_seconds(),
+                policy,
+            )
+            .map(drop)
+            .map_err(|error| error.to_string())
+        }
+    }
+}
+
+fn run_readiness_stage(
+    source: &SampleSource,
+    connection: &rusqlite::Connection,
+    claim: &ClaimedReadinessWork,
+    cancel: &AtomicBool,
+) -> Result<ReadinessExecutionOutcome, String> {
+    let target = claim.target();
+    match target.stage {
+        ReadinessStage::IndexedIdentity => {
+            let Some(relative_path) = target.relative_path.as_deref() else {
+                return Ok(ReadinessExecutionOutcome::Permanent(
+                    "indexed identity target has no relative path",
+                ));
+            };
+            let current: bool = connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM wav_files
+                        WHERE file_identity = ?1 AND path = ?2 AND missing = 0
+                    )",
+                    params![target.scope_id, relative_path],
+                    |row| row.get(0),
+                )
+                .map_err(|error| error.to_string())?;
+            Ok(if current {
+                ReadinessExecutionOutcome::Complete
+            } else {
+                ReadinessExecutionOutcome::Retry("indexed identity is not committed yet")
+            })
+        }
+        ReadinessStage::PlaybackSummary => {
+            let Some(relative_path) = target.relative_path.as_deref() else {
+                return Ok(ReadinessExecutionOutcome::Permanent(
+                    "playback summary target has no relative path",
+                ));
+            };
+            Ok(
+                if cached_waveform_file_playback_ready_exists(&source.root.join(relative_path)) {
+                    ReadinessExecutionOutcome::Complete
+                } else {
+                    ReadinessExecutionOutcome::Retry(
+                        "playback summary prerequisite is not durable yet",
+                    )
+                },
+            )
+        }
+        ReadinessStage::AnalysisFeatures => {
+            let current: bool = connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM analysis_cache_features
+                        WHERE content_hash = ?1 AND analysis_version = ?2
+                    )",
+                    params![target.content_generation, target.required_version],
+                    |row| row.get(0),
+                )
+                .map_err(|error| error.to_string())?;
+            Ok(if current {
+                ReadinessExecutionOutcome::Complete
+            } else {
+                ReadinessExecutionOutcome::Retry("analysis feature prerequisite is not durable yet")
+            })
+        }
+        ReadinessStage::EmbeddingAspects => {
+            let expected_version = format!(
+                "{}+{}",
+                wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+                wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+            );
+            if target.required_version != expected_version {
+                return Ok(ReadinessExecutionOutcome::Retry(
+                    "embedding executor version does not match target",
+                ));
+            }
+            let current: bool = connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM analysis_cache_embeddings
+                        WHERE content_hash = ?1 AND model_id = ?2
+                    ) AND EXISTS(
+                        SELECT 1 FROM analysis_cache_aspect_descriptors
+                        WHERE content_hash = ?1 AND model_id = ?3
+                    )",
+                    params![
+                        target.content_generation,
+                        wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+                        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(|error| error.to_string())?;
+            Ok(if current {
+                ReadinessExecutionOutcome::Complete
+            } else {
+                ReadinessExecutionOutcome::Retry("embedding prerequisite is not durable yet")
+            })
+        }
+        ReadinessStage::SimilarityLayout => {
+            if target.required_version != NATIVE_SIMILARITY_UMAP_VERSION {
+                return Ok(ReadinessExecutionOutcome::Retry(
+                    "similarity finalizer version does not match target",
+                ));
+            }
+            if cancel.load(Ordering::Acquire) {
+                return Ok(ReadinessExecutionOutcome::Retry(
+                    "similarity finalization cancelled",
+                ));
+            }
+            finalize_similarity_prep_if_ready(source, cancel).map(|finalized| {
+                if finalized {
+                    ReadinessExecutionOutcome::Complete
+                } else {
+                    ReadinessExecutionOutcome::Retry("similarity prerequisites are not durable yet")
+                }
+            })
         }
     }
 }
@@ -622,7 +944,10 @@ fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
 mod tests {
     use std::path::Path;
 
-    use wavecrate::sample_sources::SourceId;
+    use wavecrate::sample_sources::{
+        SourceId,
+        readiness::{ReadinessEligibility, SourceAvailability, replace_readiness_targets},
+    };
 
     use super::*;
 
@@ -651,6 +976,104 @@ mod tests {
 
         thread::sleep(Duration::from_millis(150));
         assert!(!source_is_hashed(&source));
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn production_supervisor_claims_and_completes_indexed_identity_readiness() {
+        let (_directory, source) = unhashed_source("readiness");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files SET file_identity = 'identity-1' WHERE path = 'pending.wav'",
+                [],
+            )
+            .expect("assign file identity");
+        let target = ReadinessTarget::file(
+            source.id.as_str(),
+            "identity-1",
+            "pending.wav",
+            ReadinessStage::IndexedIdentity,
+            "manifest-v1",
+            1,
+            "content-1",
+        );
+        let mut targets = vec![target.clone()];
+        for stage in [
+            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
+            ReadinessStage::EmbeddingAspects,
+        ] {
+            let mut terminal = target.clone();
+            terminal.stage = stage;
+            terminal.required_version = "unsupported-v1".to_string();
+            terminal.eligibility = ReadinessEligibility::Unsupported;
+            targets.push(terminal);
+        }
+        targets.push(
+            ReadinessTarget::source(
+                source.id.as_str(),
+                ReadinessStage::SimilarityLayout,
+                "layout-v1",
+                1,
+                "members-1",
+            )
+            .with_eligibility(ReadinessEligibility::Unsupported),
+        );
+        replace_readiness_targets(
+            &mut connection,
+            source.id.as_str(),
+            1,
+            1,
+            SourceAvailability::Active,
+            &targets,
+            now_epoch_seconds(),
+        )
+        .expect("publish readiness target");
+        drop(connection);
+
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+        wait_until(Duration::from_secs(3), || {
+            let database_root = source.database_root().expect("database root");
+            let connection = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            )
+            .expect("open readiness database");
+            connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM source_readiness_artifacts
+                        WHERE source_id = ?1 AND scope_id = 'identity-1'
+                          AND stage = 'indexed_identity'
+                    )",
+                    [source.id.as_str()],
+                    |row| row.get::<_, bool>(0),
+                )
+                .expect("read readiness artifact")
+        });
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn real_hash_execution_waits_for_shared_scan_database_budget() {
+        let (_directory, source) = unhashed_source("shared-budget");
+        let mut supervisor =
+            SourceProcessingSupervisor::start_with_playback_state(vec![source.clone()], true);
+        let permit = supervisor.budget_handle().acquire_scan(source.id.as_str());
+        supervisor.set_playback_active(false);
+        thread::sleep(Duration::from_millis(150));
+        assert!(!source_is_hashed(&source));
+
+        drop(permit);
+        wait_until(Duration::from_secs(3), || source_is_hashed(&source));
         assert_eq!(supervisor.shutdown()["joined"], true);
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -15,9 +15,12 @@ use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
     readiness::{
-        ClaimedReadinessWork, ReadinessFailureClassification, ReadinessRetryPolicy, ReadinessStage,
-        ReadinessTarget, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        fail_readiness_work, persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
+        ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessFailureClassification,
+        ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
+        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, cancel_readiness_work,
+        claim_readiness_target, complete_readiness_work, fail_readiness_work,
+        persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
+        renew_readiness_lease,
     },
     scanner::complete_pending_deep_hashes,
 };
@@ -230,6 +233,8 @@ impl SourceProcessingSupervisor {
             "claimed": telemetry.claimed,
             "completed": telemetry.completed,
             "failed": telemetry.failed,
+            "retried": telemetry.retried,
+            "stale": telemetry.stale,
             "cancelled": telemetry.cancelled,
             "contention": telemetry.contention,
             "max_queue_depth": telemetry.max_queue_depth,
@@ -320,6 +325,8 @@ struct SupervisorTelemetry {
     claimed: u64,
     completed: u64,
     failed: u64,
+    retried: u64,
+    stale: u64,
     cancelled: u64,
     contention: u64,
     max_queue_depth: usize,
@@ -343,21 +350,52 @@ struct RuntimeCandidate {
     task: RuntimeTask,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct SourceDiscoveryStats {
+    readiness_queue_depth: usize,
+    retries_due: usize,
+    earliest_retry_at: Option<i64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExecutionOutcome {
+    Completed,
+    Retried { retry_at: i64 },
+    Failed,
+    Stale,
+    Cancelled,
+    NotClaimed,
+}
+
+impl ExecutionOutcome {
+    fn was_claimed(self) -> bool {
+        !matches!(self, Self::NotClaimed)
+    }
+}
+
 fn run_coordinator(shared: Arc<Shared>) {
     let mut observed_generation = 0;
+    let mut next_retry_at = None;
     let mut scheduler = FairScheduler::default();
     let mut reset_sources = BTreeMap::<String, bool>::new();
     loop {
         let (sources, priority, playback_active, generation, reason) = {
             let mut control = shared.control();
             while !control.shutdown && control.wake_generation == observed_generation {
+                let wait_duration = coordinator_wait_duration(next_retry_at, now_epoch_seconds());
                 let (next, _) = shared
                     .wake
-                    .wait_timeout(control, SAFETY_SWEEP_INTERVAL)
+                    .wait_timeout(control, wait_duration)
                     .unwrap_or_else(|poison| poison.into_inner());
                 control = next;
                 if control.wake_generation == observed_generation {
-                    control.wake("periodic_safety_sweep");
+                    let retry_due =
+                        next_retry_at.is_some_and(|deadline| deadline <= now_epoch_seconds());
+                    control.wake(if retry_due {
+                        "retry_deadline"
+                    } else {
+                        "periodic_safety_sweep"
+                    });
                 }
             }
             if control.shutdown {
@@ -417,17 +455,18 @@ fn run_coordinator(shared: Arc<Shared>) {
             .retain(|source_id, _| sources.iter().any(|source| source.id.as_str() == source_id));
 
         let sweep_started = Instant::now();
-        let (mut candidates, retries_due, readiness_queue_depth) =
-            discover_candidates(&shared, &sources);
+        let (mut candidates, mut source_stats) = discover_candidates(&shared, &sources);
+        let discovered_stats = aggregate_source_stats(source_stats.values().copied());
+        next_retry_at = discovered_stats.earliest_retry_at;
         {
             let mut telemetry = shared.telemetry();
             telemetry.sweeps = telemetry.sweeps.saturating_add(1);
-            telemetry.queue_depth = candidates.len() + readiness_queue_depth;
+            telemetry.queue_depth = candidates.len();
             telemetry.max_queue_depth = telemetry.max_queue_depth.max(telemetry.queue_depth);
             telemetry.oldest_job_age_seconds =
                 oldest_job_age_seconds(&candidates, now_epoch_seconds());
-            telemetry.retries_due = retries_due;
-            telemetry.readiness_queue_depth = readiness_queue_depth;
+            telemetry.retries_due = discovered_stats.retries_due;
+            telemetry.readiness_queue_depth = discovered_stats.readiness_queue_depth;
         }
         while !candidates.is_empty() && !shared.cancel.load(Ordering::Acquire) {
             let control = shared.control();
@@ -455,25 +494,43 @@ fn run_coordinator(shared: Arc<Shared>) {
                 telemetry.contention = telemetry.contention.saturating_add(1);
                 break;
             };
-            {
-                let mut telemetry = shared.telemetry();
-                telemetry.claimed = telemetry.claimed.saturating_add(1);
-            }
             let result = execute_candidate(&candidate, &shared.work_cancel);
             shared.budgets().release(permit);
             shared.budget_wake.notify_all();
             let mut telemetry = shared.telemetry();
+            let mut execution_outcome = None;
             match result {
-                _ if shared.work_cancel.load(Ordering::Acquire) => {
-                    telemetry.cancelled = telemetry.cancelled.saturating_add(1);
-                    tracing::debug!(
-                        target: "wavecrate::source_processing",
-                        source_id = candidate.source.id.as_str(),
-                        task = ?candidate.task,
-                        "Source work yielded to playback or source reconfiguration"
-                    );
+                Ok(outcome) => {
+                    execution_outcome = Some(outcome);
+                    if outcome.was_claimed() {
+                        telemetry.claimed = telemetry.claimed.saturating_add(1);
+                    }
+                    match outcome {
+                        ExecutionOutcome::Completed => {
+                            telemetry.completed = telemetry.completed.saturating_add(1)
+                        }
+                        ExecutionOutcome::Retried { retry_at } => {
+                            telemetry.retried = telemetry.retried.saturating_add(1);
+                            if let Some(stats) = source_stats.get_mut(candidate.source.id.as_str())
+                            {
+                                stats.earliest_retry_at =
+                                    earliest_deadline(stats.earliest_retry_at, Some(retry_at));
+                            }
+                            let aggregate = aggregate_source_stats(source_stats.values().copied());
+                            next_retry_at = aggregate.earliest_retry_at;
+                        }
+                        ExecutionOutcome::Failed => {
+                            telemetry.failed = telemetry.failed.saturating_add(1)
+                        }
+                        ExecutionOutcome::Stale => {
+                            telemetry.stale = telemetry.stale.saturating_add(1)
+                        }
+                        ExecutionOutcome::Cancelled => {
+                            telemetry.cancelled = telemetry.cancelled.saturating_add(1)
+                        }
+                        ExecutionOutcome::NotClaimed => {}
+                    }
                 }
-                Ok(()) => telemetry.completed = telemetry.completed.saturating_add(1),
                 Err(error) if shared.cancel.load(Ordering::Acquire) => {
                     telemetry.cancelled = telemetry.cancelled.saturating_add(1);
                     tracing::debug!(
@@ -497,10 +554,40 @@ fn run_coordinator(shared: Arc<Shared>) {
                 }
             }
             drop(telemetry);
-            (candidates, _, _) = discover_candidates(&shared, &sources);
+            let source_id = candidate.source.id.as_str();
+            if candidates
+                .iter()
+                .any(|queued| queued.source.id.as_str() == source_id)
+            {
+                continue;
+            }
+            let should_refresh = match (&candidate.task, execution_outcome) {
+                (RuntimeTask::DeepHash, Some(ExecutionOutcome::Completed))
+                | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
+                | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Failed))
+                | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Completed))
+                | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Retried { .. }))
+                | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Failed)) => true,
+                _ => false,
+            };
+            if !should_refresh {
+                continue;
+            }
+            match discover_source_candidates(&candidate.source, now_epoch_seconds()) {
+                Ok((mut refreshed, refreshed_stats)) => {
+                    candidates.append(&mut refreshed);
+                    source_stats.insert(source_id.to_string(), refreshed_stats);
+                    let aggregate = aggregate_source_stats(source_stats.values().copied());
+                    next_retry_at = aggregate.earliest_retry_at;
+                    let mut telemetry = shared.telemetry();
+                    telemetry.retries_due = aggregate.retries_due;
+                    telemetry.readiness_queue_depth = aggregate.readiness_queue_depth;
+                }
+                Err(error) => record_discovery_error(&shared, &candidate.source, &error),
+            }
         }
         let mut telemetry = shared.telemetry();
-        telemetry.queue_depth = candidates.len() + telemetry.readiness_queue_depth;
+        telemetry.queue_depth = candidates.len();
         telemetry.oldest_job_age_seconds = oldest_job_age_seconds(&candidates, now_epoch_seconds());
         tracing::debug!(
             target: "wavecrate::source_processing",
@@ -513,6 +600,8 @@ fn run_coordinator(shared: Arc<Shared>) {
             claimed = telemetry.claimed,
             completed = telemetry.completed,
             failed = telemetry.failed,
+            retried = telemetry.retried,
+            stale = telemetry.stale,
             cancelled = telemetry.cancelled,
             contention = telemetry.contention,
             elapsed_ms = sweep_started.elapsed().as_secs_f64() * 1_000.0,
@@ -525,11 +614,13 @@ fn run_coordinator(shared: Arc<Shared>) {
 fn discover_candidates(
     shared: &Shared,
     sources: &[SampleSource],
-) -> (Vec<RuntimeCandidate>, usize, usize) {
+) -> (
+    Vec<RuntimeCandidate>,
+    BTreeMap<String, SourceDiscoveryStats>,
+) {
     let now = now_epoch_seconds();
     let mut candidates = Vec::new();
-    let mut readiness_queue_depth = 0;
-    let mut retries_due = 0;
+    let mut source_stats = BTreeMap::new();
     for source in sources {
         let Some(permit) = shared
             .budgets()
@@ -538,23 +629,22 @@ fn discover_candidates(
             continue;
         };
         match discover_source_candidates(source, now) {
-            Ok((mut source_candidates, source_readiness_depth, source_retries_due)) => {
+            Ok((mut source_candidates, stats)) => {
                 candidates.append(&mut source_candidates);
-                readiness_queue_depth += source_readiness_depth;
-                retries_due += source_retries_due;
+                source_stats.insert(source.id.as_str().to_string(), stats);
             }
             Err(error) => record_discovery_error(shared, source, &error),
         }
         shared.budgets().release(permit);
         shared.budget_wake.notify_all();
     }
-    (candidates, retries_due, readiness_queue_depth)
+    (candidates, source_stats)
 }
 
 fn discover_source_candidates(
     source: &SampleSource,
     now: i64,
-) -> Result<(Vec<RuntimeCandidate>, usize, usize), String> {
+) -> Result<(Vec<RuntimeCandidate>, SourceDiscoveryStats), String> {
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
@@ -564,8 +654,7 @@ fn discover_source_candidates(
     .map_err(|error| error.to_string())?;
     let source_id = source.id.as_str();
     let mut candidates = Vec::new();
-    let mut readiness_queue_depth = 0;
-    let mut retries_due = 0;
+    let mut stats = SourceDiscoveryStats::default();
     let readiness_source_exists: bool = connection
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
@@ -578,22 +667,24 @@ fn discover_source_candidates(
             reconcile_readiness(&connection, source_id, now).map_err(|error| error.to_string())?;
         persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
             .map_err(|error| error.to_string())?;
-        readiness_queue_depth = snapshot.deficits.len();
+        stats.readiness_queue_depth = snapshot.deficits.len();
         candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
             schedule: WorkCandidate::readiness(&deficit.target, now),
             source: source.clone(),
             task: RuntimeTask::Readiness(deficit.target.clone()),
         }));
-        let stats = readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
-        retries_due = stats.retries_due;
+        let work_stats =
+            readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
+        stats.retries_due = work_stats.retries_due;
+        stats.earliest_retry_at = work_stats.earliest_retry_at;
         tracing::debug!(
             target: "wavecrate::source_processing",
             source_id,
-            pending = stats.pending,
-            running = stats.running,
-            retries_due = stats.retries_due,
-            retries_waiting = stats.retries_waiting,
-            expired_leases = stats.expired_leases,
+            pending = work_stats.pending,
+            running = work_stats.running,
+            retries_due = work_stats.retries_due,
+            retries_waiting = work_stats.retries_waiting,
+            expired_leases = work_stats.expired_leases,
             "Readiness work reconciled"
         );
     }
@@ -664,11 +755,14 @@ fn discover_source_candidates(
             task: RuntimeTask::FinalizeSimilarity,
         });
     }
-    Ok((candidates, readiness_queue_depth, retries_due))
+    Ok((candidates, stats))
 }
 
-fn execute_candidate(candidate: &RuntimeCandidate, cancel: &AtomicBool) -> Result<(), String> {
-    match &candidate.task {
+fn execute_candidate(
+    candidate: &RuntimeCandidate,
+    cancel: &AtomicBool,
+) -> Result<ExecutionOutcome, String> {
+    let result = match &candidate.task {
         RuntimeTask::DeepHash => {
             let database_root = candidate
                 .source
@@ -680,18 +774,43 @@ fn execute_candidate(candidate: &RuntimeCandidate, cancel: &AtomicBool) -> Resul
             )
             .map_err(|error| error.to_string())?;
             complete_pending_deep_hashes(&db, Some(cancel), DEEP_HASH_BATCH)
-                .map(drop)
+                .map(|stats| {
+                    if stats.hashes_computed > 0 {
+                        ExecutionOutcome::Completed
+                    } else {
+                        ExecutionOutcome::NotClaimed
+                    }
+                })
                 .map_err(|error| error.to_string())
         }
         RuntimeTask::LegacyAnalysis { job_id } => {
-            run_similarity_prep_job(&candidate.source, *job_id, cancel).map(drop)
+            run_similarity_prep_job(&candidate.source, *job_id, cancel, 1).map(|summary| {
+                if summary.processed == 0 {
+                    ExecutionOutcome::NotClaimed
+                } else if summary.failed > 0 {
+                    ExecutionOutcome::Failed
+                } else {
+                    ExecutionOutcome::Completed
+                }
+            })
         }
         RuntimeTask::FinalizeSimilarity => {
-            finalize_similarity_prep_if_ready(&candidate.source, cancel).map(drop)
+            finalize_similarity_prep_if_ready(&candidate.source, cancel).map(|finalized| {
+                if finalized {
+                    ExecutionOutcome::Completed
+                } else {
+                    ExecutionOutcome::NotClaimed
+                }
+            })
         }
         RuntimeTask::Readiness(target) => {
             execute_readiness_target(&candidate.source, target, cancel)
         }
+    };
+    if cancel.load(Ordering::Acquire) {
+        Ok(ExecutionOutcome::Cancelled)
+    } else {
+        result
     }
 }
 
@@ -705,7 +824,7 @@ fn execute_readiness_target(
     source: &SampleSource,
     target: &ReadinessTarget,
     cancel: &AtomicBool,
-) -> Result<(), String> {
+) -> Result<ExecutionOutcome, String> {
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
@@ -717,34 +836,53 @@ fn execute_readiness_target(
     let Some(claim) = claim_readiness_target(&mut connection, target, now, READINESS_LEASE_SECONDS)
         .map_err(|error| error.to_string())?
     else {
-        return Ok(());
+        return Ok(ExecutionOutcome::NotClaimed);
     };
     if cancel.load(Ordering::Acquire) {
-        cancel_readiness_work(&mut connection, &claim, "runtime cancellation", now)
-            .map_err(|error| error.to_string())?;
-        return Ok(());
+        return cancel_claim(&mut connection, &claim, "runtime cancellation", now);
     }
-    let outcome = run_readiness_stage(source, &connection, &claim, cancel);
+    let (outcome, lease_stale) = match run_with_readiness_lease_heartbeat(
+        source,
+        &claim,
+        cancel,
+        READINESS_LEASE_SECONDS,
+        |lease_cancel| run_readiness_stage(source, &connection, &claim, lease_cancel),
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            let _ = cancel_readiness_work(
+                &mut connection,
+                &claim,
+                "readiness lease heartbeat failure",
+                now_epoch_seconds(),
+            );
+            return Err(error);
+        }
+    };
+    if lease_stale {
+        return Ok(ExecutionOutcome::Stale);
+    }
     if cancel.load(Ordering::Acquire) {
-        cancel_readiness_work(
+        return cancel_claim(
             &mut connection,
             &claim,
             "runtime cancellation before readiness publication",
             now_epoch_seconds(),
-        )
-        .map_err(|error| error.to_string())?;
-        return Ok(());
+        );
     }
     match outcome {
         Ok(ReadinessExecutionOutcome::Complete) => {
-            let _outcome = complete_readiness_work(&mut connection, &claim, now_epoch_seconds())
-                .map_err(|error| error.to_string())?;
-            Ok(())
+            match complete_readiness_work(&mut connection, &claim, now_epoch_seconds())
+                .map_err(|error| error.to_string())?
+            {
+                ArtifactPublishOutcome::Recorded => Ok(ExecutionOutcome::Completed),
+                ArtifactPublishOutcome::RejectedStale => Ok(ExecutionOutcome::Stale),
+            }
         }
         Ok(ReadinessExecutionOutcome::Retry(reason)) => {
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
                 .expect("valid readiness retry policy");
-            fail_readiness_work(
+            let outcome = fail_readiness_work(
                 &mut connection,
                 &claim,
                 ReadinessFailureClassification::Retryable,
@@ -752,13 +890,13 @@ fn execute_readiness_target(
                 now_epoch_seconds(),
                 policy,
             )
-            .map(drop)
-            .map_err(|error| error.to_string())
+            .map_err(|error| error.to_string())?;
+            Ok(execution_outcome_for_failure(outcome))
         }
         Err(reason) => {
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
                 .expect("valid readiness retry policy");
-            fail_readiness_work(
+            let outcome = fail_readiness_work(
                 &mut connection,
                 &claim,
                 ReadinessFailureClassification::Retryable,
@@ -766,13 +904,13 @@ fn execute_readiness_target(
                 now_epoch_seconds(),
                 policy,
             )
-            .map(drop)
-            .map_err(|error| error.to_string())
+            .map_err(|error| error.to_string())?;
+            Ok(execution_outcome_for_failure(outcome))
         }
         Ok(ReadinessExecutionOutcome::Permanent(reason)) => {
             let policy =
                 ReadinessRetryPolicy::new(5, 5 * 60, 1).expect("valid readiness terminal policy");
-            fail_readiness_work(
+            let outcome = fail_readiness_work(
                 &mut connection,
                 &claim,
                 ReadinessFailureClassification::Permanent,
@@ -780,10 +918,105 @@ fn execute_readiness_target(
                 now_epoch_seconds(),
                 policy,
             )
-            .map(drop)
-            .map_err(|error| error.to_string())
+            .map_err(|error| error.to_string())?;
+            Ok(execution_outcome_for_failure(outcome))
         }
     }
+}
+
+fn cancel_claim(
+    connection: &mut rusqlite::Connection,
+    claim: &ClaimedReadinessWork,
+    reason: &str,
+    now: i64,
+) -> Result<ExecutionOutcome, String> {
+    match cancel_readiness_work(connection, claim, reason, now)
+        .map_err(|error| error.to_string())?
+    {
+        ReadinessWorkMutationOutcome::Recorded => Ok(ExecutionOutcome::Cancelled),
+        ReadinessWorkMutationOutcome::RejectedStale => Ok(ExecutionOutcome::Stale),
+    }
+}
+
+fn execution_outcome_for_failure(outcome: ReadinessFailureOutcome) -> ExecutionOutcome {
+    match outcome {
+        ReadinessFailureOutcome::RetryScheduled { retry_at } => {
+            ExecutionOutcome::Retried { retry_at }
+        }
+        ReadinessFailureOutcome::RejectedStale => ExecutionOutcome::Stale,
+        ReadinessFailureOutcome::Permanent
+        | ReadinessFailureOutcome::Unsupported
+        | ReadinessFailureOutcome::AttemptsExhausted => ExecutionOutcome::Failed,
+    }
+}
+
+fn run_with_readiness_lease_heartbeat<T>(
+    source: &SampleSource,
+    claim: &ClaimedReadinessWork,
+    external_cancel: &AtomicBool,
+    lease_duration_seconds: i64,
+    execute: impl FnOnce(&AtomicBool) -> T,
+) -> Result<(T, bool), String> {
+    let local_cancel = AtomicBool::new(external_cancel.load(Ordering::Acquire));
+    let stop = AtomicBool::new(false);
+    let lease_stale = AtomicBool::new(false);
+    let heartbeat_error = Mutex::new(None::<String>);
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    let renew_interval = Duration::from_secs((lease_duration_seconds / 3).max(1) as u64);
+    let mut heartbeat_connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .map_err(|error| error.to_string())?;
+
+    let result = thread::scope(|scope| {
+        scope.spawn(|| {
+            let mut next_renewal = Instant::now() + renew_interval;
+            while !stop.load(Ordering::Acquire) {
+                if external_cancel.load(Ordering::Acquire) {
+                    local_cancel.store(true, Ordering::Release);
+                }
+                if Instant::now() >= next_renewal {
+                    match renew_readiness_lease(
+                        &mut heartbeat_connection,
+                        claim,
+                        now_epoch_seconds(),
+                        lease_duration_seconds,
+                    ) {
+                        Ok(ReadinessLeaseRenewalOutcome::Renewed { .. }) => {
+                            next_renewal = Instant::now() + renew_interval;
+                        }
+                        Ok(ReadinessLeaseRenewalOutcome::RejectedStale) => {
+                            lease_stale.store(true, Ordering::Release);
+                            local_cancel.store(true, Ordering::Release);
+                            return;
+                        }
+                        Err(error) => {
+                            *heartbeat_error
+                                .lock()
+                                .unwrap_or_else(|poison| poison.into_inner()) =
+                                Some(error.to_string());
+                            local_cancel.store(true, Ordering::Release);
+                            return;
+                        }
+                    }
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+        });
+        let result = execute(&local_cancel);
+        stop.store(true, Ordering::Release);
+        result
+    });
+    if let Some(error) = heartbeat_error
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .take()
+    {
+        return Err(format!("Readiness lease heartbeat failed: {error}"));
+    }
+    Ok((result, lease_stale.load(Ordering::Acquire)))
 }
 
 fn run_readiness_stage(
@@ -932,6 +1165,38 @@ fn now_epoch_seconds() -> i64 {
         .min(i64::MAX as u64) as i64
 }
 
+fn earliest_deadline(current: Option<i64>, candidate: Option<i64>) -> Option<i64> {
+    match (current, candidate) {
+        (Some(current), Some(candidate)) => Some(current.min(candidate)),
+        (Some(current), None) => Some(current),
+        (None, Some(candidate)) => Some(candidate),
+        (None, None) => None,
+    }
+}
+
+fn aggregate_source_stats(
+    stats: impl IntoIterator<Item = SourceDiscoveryStats>,
+) -> SourceDiscoveryStats {
+    stats
+        .into_iter()
+        .fold(SourceDiscoveryStats::default(), |mut aggregate, source| {
+            aggregate.readiness_queue_depth = aggregate
+                .readiness_queue_depth
+                .saturating_add(source.readiness_queue_depth);
+            aggregate.retries_due = aggregate.retries_due.saturating_add(source.retries_due);
+            aggregate.earliest_retry_at =
+                earliest_deadline(aggregate.earliest_retry_at, source.earliest_retry_at);
+            aggregate
+        })
+}
+
+fn coordinator_wait_duration(next_retry_at: Option<i64>, now: i64) -> Duration {
+    let retry_wait = next_retry_at.map_or(SAFETY_SWEEP_INTERVAL, |deadline| {
+        Duration::from_secs(deadline.saturating_sub(now).max(0) as u64)
+    });
+    SAFETY_SWEEP_INTERVAL.min(retry_wait)
+}
+
 fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
     candidates
         .iter()
@@ -991,7 +1256,9 @@ mod tests {
         .expect("open readiness database");
         connection
             .execute(
-                "UPDATE wav_files SET file_identity = 'identity-1' WHERE path = 'pending.wav'",
+                "UPDATE wav_files
+                 SET file_identity = 'identity-1', content_hash = 'content-1'
+                 WHERE path = 'pending.wav'",
                 [],
             )
             .expect("assign file identity");
@@ -1059,7 +1326,13 @@ mod tests {
                 )
                 .expect("read readiness artifact")
         });
-        assert_eq!(supervisor.shutdown()["joined"], true);
+        let report = supervisor.shutdown();
+        assert_eq!(report["joined"], true);
+        assert_eq!(report["claimed"], 1);
+        assert_eq!(report["completed"], 1);
+        assert_eq!(report["retried"], 0);
+        assert_eq!(report["stale"], 0);
+        assert_eq!(report["readiness_queue_depth"], 0);
     }
 
     #[test]
@@ -1075,6 +1348,117 @@ mod tests {
         drop(permit);
         wait_until(Duration::from_secs(3), || source_is_hashed(&source));
         assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn readiness_lease_heartbeat_keeps_long_claim_current() {
+        let (_directory, source) = unhashed_source("lease-heartbeat");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'identity-lease', content_hash = 'content-lease'
+                 WHERE path = 'pending.wav'",
+                [],
+            )
+            .expect("assign file identity");
+        let target = ReadinessTarget::file(
+            source.id.as_str(),
+            "identity-lease",
+            "pending.wav",
+            ReadinessStage::IndexedIdentity,
+            "manifest-v1",
+            1,
+            "content-lease",
+        );
+        let mut targets = vec![target.clone()];
+        for stage in [
+            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
+            ReadinessStage::EmbeddingAspects,
+        ] {
+            let mut terminal = target.clone();
+            terminal.stage = stage;
+            terminal.eligibility = ReadinessEligibility::Unsupported;
+            targets.push(terminal);
+        }
+        targets.push(
+            ReadinessTarget::source(
+                source.id.as_str(),
+                ReadinessStage::SimilarityLayout,
+                "layout-v1",
+                1,
+                "members-1",
+            )
+            .with_eligibility(ReadinessEligibility::Unsupported),
+        );
+        let now = now_epoch_seconds();
+        replace_readiness_targets(
+            &mut connection,
+            source.id.as_str(),
+            1,
+            1,
+            SourceAvailability::Active,
+            &targets,
+            now,
+        )
+        .expect("publish readiness targets");
+        let snapshot =
+            reconcile_readiness(&connection, source.id.as_str(), now).expect("reconcile readiness");
+        persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+            .expect("persist readiness work");
+        let claim = claim_readiness_target(&mut connection, &target, now, 2)
+            .expect("claim readiness")
+            .expect("claim available");
+        let cancel = AtomicBool::new(false);
+
+        let ((), stale) = run_with_readiness_lease_heartbeat(&source, &claim, &cancel, 2, |_| {
+            thread::sleep(Duration::from_millis(2_500))
+        })
+        .expect("run with heartbeat");
+
+        assert!(!stale);
+        assert_eq!(
+            complete_readiness_work(&mut connection, &claim, now_epoch_seconds())
+                .expect("complete renewed claim"),
+            ArtifactPublishOutcome::Recorded
+        );
+    }
+
+    #[test]
+    fn retry_deadline_shortens_coordinator_wait_deterministically() {
+        assert_eq!(
+            coordinator_wait_duration(Some(105), 100),
+            Duration::from_secs(5)
+        );
+        assert_eq!(coordinator_wait_duration(Some(100), 100), Duration::ZERO);
+        assert_eq!(
+            coordinator_wait_duration(Some(200), 100),
+            SAFETY_SWEEP_INTERVAL
+        );
+        assert_eq!(coordinator_wait_duration(None, 100), SAFETY_SWEEP_INTERVAL);
+    }
+
+    #[test]
+    fn durable_failure_outcomes_do_not_count_as_completion() {
+        assert_eq!(
+            execution_outcome_for_failure(ReadinessFailureOutcome::RetryScheduled { retry_at: 5 }),
+            ExecutionOutcome::Retried { retry_at: 5 }
+        );
+        assert_eq!(
+            execution_outcome_for_failure(ReadinessFailureOutcome::RejectedStale),
+            ExecutionOutcome::Stale
+        );
+        assert_eq!(
+            execution_outcome_for_failure(ReadinessFailureOutcome::Permanent),
+            ExecutionOutcome::Failed
+        );
     }
 
     fn unhashed_source(id: &str) -> (tempfile::TempDir, SampleSource) {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -226,9 +226,17 @@ impl Drop for SourceProcessingBudgetPermit {
             .remove(&self.registration_id);
         self.shared.external_scan_wake.notify_all();
         if let Some(permit) = self.permit.take() {
+            let source_id = permit.source_id().to_string();
             self.shared.budgets().release(permit);
             self.shared.budget_wake.notify_all();
-            self.shared.control().notify("external_budget_released");
+            let mut control = self.shared.control();
+            if control.source_is_active(&source_id) {
+                control.cancel_source_work(&source_id);
+                control.mark_source_dirty(&source_id, "external_source_work_committed");
+            } else {
+                control.notify("external_budget_released");
+            }
+            drop(control);
             self.shared.wake.notify_one();
         }
     }
@@ -2549,6 +2557,37 @@ mod tests {
         ));
         drop(control);
         drop(first_scan);
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn external_scan_release_invalidates_retained_source_generation() {
+        let (_directory, source) = unhashed_source("external-commit-generation");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
+        let retained_generation = {
+            let mut control = supervisor.shared.control();
+            control.dirty_sources.clear();
+            Arc::clone(&control.source_work_cancels[source.id.as_str()])
+        };
+        let permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("admit external source work");
+
+        drop(permit);
+
+        assert!(retained_generation.load(Ordering::Acquire));
+        let control = supervisor.shared.control();
+        assert!(control.dirty_sources.contains(source.id.as_str()));
+        assert!(!control.source_work_cancels[source.id.as_str()].load(Ordering::Acquire));
+        assert!(!Arc::ptr_eq(
+            &retained_generation,
+            &control.source_work_cancels[source.id.as_str()]
+        ));
+        drop(control);
         assert_eq!(supervisor.shutdown()["joined"], true);
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -34,12 +34,15 @@ use crate::native_app::sample_library::similarity_prep::{
     reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
     similarity_prep_needs_finalization,
 };
-use crate::native_app::waveform::cached_waveform_file_playback_ready_exists;
+use crate::native_app::waveform::{
+    cached_waveform_file_audition_ready_exists, ensure_persisted_playback_summary,
+};
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 const DEEP_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
+const READINESS_MAX_ATTEMPTS: u32 = 8;
 const MAX_DISCOVERED_ANALYSIS_JOBS: i64 = 256;
 const EXTERNAL_SCAN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const READINESS_MANIFEST_VERSION: &str = "source_manifest_v1";
@@ -1169,7 +1172,7 @@ fn execute_readiness_target(
         &claim,
         cancel,
         READINESS_LEASE_SECONDS,
-        |lease_cancel| run_readiness_stage(source, &connection, &claim, lease_cancel),
+        |lease_cancel| run_readiness_stage(source, &mut connection, &claim, lease_cancel),
     ) {
         Ok(result) => result,
         Err(error) => {
@@ -1203,7 +1206,7 @@ fn execute_readiness_target(
             }
         }
         Ok(ReadinessExecutionOutcome::Retry(reason)) => {
-            let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
+            let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");
             let outcome = fail_readiness_work(
                 &mut connection,
@@ -1217,7 +1220,7 @@ fn execute_readiness_target(
             Ok(execution_outcome_for_failure(outcome))
         }
         Err(reason) => {
-            let policy = ReadinessRetryPolicy::new(5, 5 * 60, u32::MAX)
+            let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");
             let outcome = fail_readiness_work(
                 &mut connection,
@@ -1344,7 +1347,7 @@ fn run_with_readiness_lease_heartbeat<T>(
 
 fn run_readiness_stage(
     source: &SampleSource,
-    connection: &rusqlite::Connection,
+    connection: &mut rusqlite::Connection,
     claim: &ClaimedReadinessWork,
     cancel: &AtomicBool,
 ) -> Result<ReadinessExecutionOutcome, String> {
@@ -1378,31 +1381,42 @@ fn run_readiness_stage(
                     "playback summary target has no relative path",
                 ));
             };
-            Ok(
-                if cached_waveform_file_playback_ready_exists(&source.root.join(relative_path)) {
+            let absolute_path = source.root.join(relative_path);
+            if !cached_waveform_file_audition_ready_exists(&absolute_path) {
+                ensure_persisted_playback_summary(absolute_path, cancel)?;
+            }
+            Ok(ReadinessExecutionOutcome::Complete)
+        }
+        ReadinessStage::AnalysisFeatures => {
+            let Some(relative_path) = target.relative_path.as_deref() else {
+                return Ok(ReadinessExecutionOutcome::Permanent(
+                    "analysis feature target has no relative path",
+                ));
+            };
+            if target.required_version != wavecrate_analysis::analysis_version() {
+                return Ok(ReadinessExecutionOutcome::Retry(
+                    "feature executor version does not match target",
+                ));
+            }
+            Ok(if analysis_features_are_current(connection, target)? {
+                ReadinessExecutionOutcome::Complete
+            } else {
+                let produced = wavecrate::internal_analysis_jobs::run_readiness_feature_stage(
+                    connection,
+                    &source.root,
+                    target.source_id.as_str(),
+                    std::path::Path::new(relative_path),
+                    target.content_generation.as_str(),
+                    target.required_version.as_str(),
+                    cancel,
+                )?;
+                if produced && analysis_features_are_current(connection, target)? {
                     ReadinessExecutionOutcome::Complete
                 } else {
                     ReadinessExecutionOutcome::Retry(
-                        "playback summary prerequisite is not durable yet",
+                        "analysis feature source generation is not current yet",
                     )
-                },
-            )
-        }
-        ReadinessStage::AnalysisFeatures => {
-            let current: bool = connection
-                .query_row(
-                    "SELECT EXISTS(
-                        SELECT 1 FROM analysis_cache_features
-                        WHERE content_hash = ?1 AND analysis_version = ?2
-                    )",
-                    params![target.content_generation, target.required_version],
-                    |row| row.get(0),
-                )
-                .map_err(|error| error.to_string())?;
-            Ok(if current {
-                ReadinessExecutionOutcome::Complete
-            } else {
-                ReadinessExecutionOutcome::Retry("analysis feature prerequisite is not durable yet")
+                }
             })
         }
         ReadinessStage::EmbeddingAspects => {
@@ -1416,27 +1430,30 @@ fn run_readiness_stage(
                     "embedding executor version does not match target",
                 ));
             }
-            let current: bool = connection
-                .query_row(
-                    "SELECT EXISTS(
-                        SELECT 1 FROM analysis_cache_embeddings
-                        WHERE content_hash = ?1 AND model_id = ?2
-                    ) AND EXISTS(
-                        SELECT 1 FROM analysis_cache_aspect_descriptors
-                        WHERE content_hash = ?1 AND model_id = ?3
-                    )",
-                    params![
-                        target.content_generation,
-                        wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
-                        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
-                    ],
-                    |row| row.get(0),
-                )
-                .map_err(|error| error.to_string())?;
-            Ok(if current {
+            let Some(relative_path) = target.relative_path.as_deref() else {
+                return Ok(ReadinessExecutionOutcome::Permanent(
+                    "embedding target has no relative path",
+                ));
+            };
+            Ok(if embedding_aspects_are_current(connection, target)? {
                 ReadinessExecutionOutcome::Complete
             } else {
-                ReadinessExecutionOutcome::Retry("embedding prerequisite is not durable yet")
+                let produced = wavecrate::internal_analysis_jobs::run_readiness_embedding_stage(
+                    connection,
+                    &source.root,
+                    target.source_id.as_str(),
+                    std::path::Path::new(relative_path),
+                    target.content_generation.as_str(),
+                    wavecrate_analysis::analysis_version(),
+                    cancel,
+                )?;
+                if produced && embedding_aspects_are_current(connection, target)? {
+                    ReadinessExecutionOutcome::Complete
+                } else {
+                    ReadinessExecutionOutcome::Retry(
+                        "embedding feature prerequisite is not durable yet",
+                    )
+                }
             })
         }
         ReadinessStage::SimilarityLayout => {
@@ -1460,6 +1477,85 @@ fn run_readiness_stage(
             })
         }
     }
+}
+
+fn analysis_features_are_current(
+    connection: &rusqlite::Connection,
+    target: &ReadinessTarget,
+) -> Result<bool, String> {
+    let Some(sample_id) = readiness_sample_id(target) else {
+        return Ok(false);
+    };
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM analysis_cache_features
+                WHERE content_hash = ?1 AND analysis_version = ?2
+            ) AND EXISTS(
+                SELECT 1
+                FROM samples AS sample
+                JOIN features AS feature ON feature.sample_id = sample.sample_id
+                WHERE sample.sample_id = ?3
+                  AND sample.content_hash = ?1
+                  AND sample.analysis_version = ?2
+                  AND feature.feat_version = ?4
+            )",
+            params![
+                target.content_generation,
+                target.required_version,
+                sample_id,
+                wavecrate_analysis::vector::FEATURE_VERSION_V1,
+            ],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())
+}
+
+fn embedding_aspects_are_current(
+    connection: &rusqlite::Connection,
+    target: &ReadinessTarget,
+) -> Result<bool, String> {
+    let Some(sample_id) = readiness_sample_id(target) else {
+        return Ok(false);
+    };
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM analysis_cache_embeddings
+                WHERE content_hash = ?1 AND analysis_version = ?2 AND model_id = ?3
+            ) AND EXISTS(
+                SELECT 1 FROM analysis_cache_aspect_descriptors
+                WHERE content_hash = ?1 AND analysis_version = ?2 AND model_id = ?4
+            ) AND EXISTS(
+                SELECT 1 FROM embeddings
+                WHERE sample_id = ?5 AND model_id = ?3 AND dim = ?6
+                  AND dtype = ?7 AND l2_normed = 1
+            ) AND EXISTS(
+                SELECT 1 FROM similarity_aspect_descriptors
+                WHERE sample_id = ?5 AND model_id = ?4 AND dim = ?8
+                  AND dtype = ?9 AND l2_normed = 1
+            )",
+            params![
+                target.content_generation,
+                wavecrate_analysis::analysis_version(),
+                wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+                wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+                sample_id,
+                wavecrate_analysis::similarity::SIMILARITY_DIM as i64,
+                wavecrate_analysis::similarity::SIMILARITY_DTYPE_F32,
+                wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DIM as i64,
+                wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DTYPE_F32,
+            ],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())
+}
+
+fn readiness_sample_id(target: &ReadinessTarget) -> Option<String> {
+    target
+        .relative_path
+        .as_deref()
+        .map(|relative_path| format!("{}::{}", target.source_id, relative_path.replace('\\', "/")))
 }
 
 fn record_discovery_error(shared: &Shared, source: &SampleSource, error: &str) {
@@ -1570,26 +1666,10 @@ mod tests {
 
     #[test]
     fn production_supervisor_publishes_claims_and_completes_readiness_without_manual_seed() {
-        let (_directory, source) = unhashed_source("readiness");
-        let database_root = source.database_root().expect("database root");
-        let connection = SourceDatabase::open_connection_with_role_and_database_root(
-            &source.root,
-            &database_root,
-            SourceDatabaseConnectionRole::JobWorker,
-        )
-        .expect("open readiness database");
-        connection
-            .execute(
-                "UPDATE wav_files
-                 SET file_identity = 'identity-1', content_hash = 'content-1'
-                 WHERE path = 'pending.wav'",
-                [],
-            )
-            .expect("assign file identity");
-        drop(connection);
+        let (_directory, source) = ready_analysis_source("readiness");
 
         let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
-        wait_until(Duration::from_secs(3), || {
+        wait_until(Duration::from_secs(10), || {
             let database_root = source.database_root().expect("database root");
             let connection = SourceDatabase::open_connection_with_role_and_database_root(
                 &source.root,
@@ -1599,8 +1679,7 @@ mod tests {
             .expect("open readiness database");
             connection
                 .query_row(
-                    "SELECT EXISTS(
-                        SELECT 1
+                    "SELECT COUNT(*) = 4
                         FROM source_readiness_sources AS source
                         JOIN source_readiness_targets AS target
                           ON target.source_id = source.source_id
@@ -1612,12 +1691,14 @@ mod tests {
                         WHERE source.source_id = ?1
                           AND source.availability = 'active'
                           AND target.scope_id = 'identity-1'
-                          AND target.stage = 'indexed_identity'
-                          AND target.required_version = ?2
+                          AND target.stage IN (
+                              'indexed_identity', 'playback_summary',
+                              'analysis_features', 'embedding_aspects'
+                          )
                           AND artifact.artifact_version = target.required_version
                           AND artifact.content_generation = target.content_generation
-                    )",
-                    params![source.id.as_str(), READINESS_MANIFEST_VERSION],
+                          AND artifact.source_generation = target.source_generation",
+                    params![source.id.as_str()],
                     |row| row.get::<_, bool>(0),
                 )
                 .expect("read readiness artifact")
@@ -1625,7 +1706,10 @@ mod tests {
         let report = supervisor.shutdown();
         assert_eq!(report["joined"], true);
         assert!(report["claimed"].as_u64().unwrap_or_default() >= 1);
-        assert!(report["completed"].as_u64().unwrap_or_default() >= 1);
+        assert!(report["completed"].as_u64().unwrap_or_default() >= 4);
+        assert!(cached_waveform_file_audition_ready_exists(
+            &source.root.join("ready.wav")
+        ));
     }
 
     #[test]
@@ -1864,6 +1948,47 @@ mod tests {
         let db = source.open_db().expect("open source database");
         db.upsert_file(Path::new("pending.wav"), 64, 1)
             .expect("insert pending hash row");
+        (directory, source)
+    }
+
+    fn ready_analysis_source(id: &str) -> (tempfile::TempDir, SampleSource) {
+        let directory = tempfile::tempdir().expect("temporary readiness source");
+        let path = directory.path().join("ready.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: wavecrate_analysis::ANALYSIS_SAMPLE_RATE,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).expect("create readiness wav");
+        for index in 0..4_096 {
+            let phase = index as f32 / 32.0;
+            writer
+                .write_sample((phase.sin() * i16::MAX as f32 * 0.25) as i16)
+                .expect("write readiness sample");
+        }
+        writer.finalize().expect("finalize readiness wav");
+        let size = path.metadata().expect("read readiness metadata").len();
+        let source =
+            SampleSource::new_with_id(SourceId::from_string(id), directory.path().to_path_buf());
+        let db = source.open_db().expect("open readiness source database");
+        db.upsert_file(Path::new("ready.wav"), size, 1)
+            .expect("insert readiness wav row");
+        let database_root = source.database_root().expect("database root");
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'identity-1', content_hash = 'content-1'
+                 WHERE path = 'ready.wav'",
+                [],
+            )
+            .expect("assign readiness identity");
         (directory, source)
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
@@ -72,8 +72,31 @@ struct ExternalScanRegistration {
 
 #[derive(Default)]
 struct ExternalScanState {
-    admissions: usize,
+    admissions: BTreeMap<u64, String>,
     registrations: BTreeMap<u64, ExternalScanRegistration>,
+}
+
+struct InFlightWorkGuard<'a> {
+    shared: &'a Shared,
+    source_id: String,
+}
+
+impl Drop for InFlightWorkGuard<'_> {
+    fn drop(&mut self) {
+        let mut in_flight = self
+            .shared
+            .in_flight_work
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(count) = in_flight.get_mut(&self.source_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                in_flight.remove(&self.source_id);
+            }
+        }
+        drop(in_flight);
+        self.shared.in_flight_wake.notify_all();
+    }
 }
 
 impl SourceProcessingBudgetHandle {
@@ -81,7 +104,7 @@ impl SourceProcessingBudgetHandle {
         &self,
         source_id: &str,
     ) -> Option<SourceProcessingBudgetPermit> {
-        let admission_cancel = {
+        let (admission_id, admission_cancel) = {
             let mut control = self.shared.control();
             while !control.shutdown
                 && control.sources.contains_key(source_id)
@@ -100,22 +123,27 @@ impl SourceProcessingBudgetHandle {
                 return None;
             }
             let admission_cancel = Arc::clone(&control.source_work_cancels[source_id]);
+            if admission_cancel.load(Ordering::Acquire) {
+                return None;
+            }
+            let admission_id = self
+                .shared
+                .next_external_scan_id
+                .fetch_add(1, Ordering::Relaxed);
             let mut external_scans = self.shared.external_scans();
-            external_scans.admissions = external_scans.admissions.saturating_add(1);
-            admission_cancel
+            external_scans
+                .admissions
+                .insert(admission_id, source_id.to_string());
+            (admission_id, admission_cancel)
         };
         loop {
             let mut budgets = self.shared.budgets();
             if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
                 drop(budgets);
-                let registration_id = self
-                    .shared
-                    .next_external_scan_id
-                    .fetch_add(1, Ordering::Relaxed);
                 let cancel = Arc::new(AtomicBool::new(false));
                 let control = self.shared.control();
                 let mut external_scans = self.shared.external_scans();
-                external_scans.admissions = external_scans.admissions.saturating_sub(1);
+                external_scans.admissions.remove(&admission_id);
                 if control.shutdown
                     || self.shared.cancel.load(Ordering::Acquire)
                     || !control.sources.contains_key(source_id)
@@ -130,7 +158,7 @@ impl SourceProcessingBudgetHandle {
                     return None;
                 }
                 external_scans.registrations.insert(
-                    registration_id,
+                    admission_id,
                     ExternalScanRegistration {
                         source_id: source_id.to_string(),
                         cancel: Arc::clone(&cancel),
@@ -142,7 +170,7 @@ impl SourceProcessingBudgetHandle {
                 let permit = SourceProcessingBudgetPermit {
                     shared: Arc::clone(&self.shared),
                     permit: Some(permit),
-                    registration_id,
+                    registration_id: admission_id,
                     cancel,
                 };
                 if permit.should_cancel_now() {
@@ -164,7 +192,7 @@ impl SourceProcessingBudgetHandle {
                 || admission_cancel.load(Ordering::Acquire);
             drop(control);
             if unavailable {
-                self.shared.finish_external_scan_admission();
+                self.shared.finish_external_scan_admission(admission_id);
                 return None;
             }
         }
@@ -233,11 +261,19 @@ impl SourceProcessingSupervisor {
         }
     }
 
-    pub(in crate::native_app) fn replace_sources(&self, sources: Vec<SampleSource>) {
+    pub(in crate::native_app) fn replace_sources(
+        &self,
+        sources: Vec<SampleSource>,
+    ) -> Result<(), String> {
+        let _replacement = self
+            .shared
+            .source_replacement
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         let sources = sources_by_id(sources);
-        let mut control = self.shared.control();
+        let control = self.shared.control();
         if source_maps_match(&control.sources, &sources) {
-            return;
+            return Ok(());
         }
         let changed_source_ids = control
             .sources
@@ -256,11 +292,47 @@ impl SourceProcessingSupervisor {
                 changed.then(|| source_id.clone())
             }))
             .collect::<std::collections::BTreeSet<_>>();
+        let retired_sources = changed_source_ids
+            .iter()
+            .filter_map(|source_id| control.sources.get(source_id).cloned())
+            .collect::<Vec<_>>();
         for source_id in &changed_source_ids {
             if let Some(cancel) = control.source_work_cancels.get(source_id) {
                 cancel.store(true, Ordering::Release);
             }
         }
+        drop(control);
+        self.shared.cancel_external_scans(|registration| {
+            changed_source_ids.contains(&registration.source_id)
+        });
+        self.shared.budget_wake.notify_all();
+        self.shared.wake.notify_all();
+        self.shared
+            .wait_for_external_scans_for_sources(&changed_source_ids);
+        self.shared.wait_for_in_flight_sources(&changed_source_ids);
+        for source in retired_sources {
+            if let Err(error) = fence_retired_source_readiness(&source) {
+                let mut control = self.shared.control();
+                for source_id in &changed_source_ids {
+                    if control.sources.contains_key(source_id) {
+                        control
+                            .source_work_cancels
+                            .insert(source_id.clone(), Arc::new(AtomicBool::new(false)));
+                        control.dirty_sources.insert(source_id.clone());
+                    }
+                }
+                control.notify("configured_sources_change_failed");
+                drop(control);
+                self.shared.budget_wake.notify_all();
+                self.shared.wake.notify_all();
+                return Err(format!(
+                    "Persist retired source readiness fence for {} failed: {error}",
+                    source.id
+                ));
+            }
+        }
+
+        let mut control = self.shared.control();
         let mut source_work_cancels = BTreeMap::new();
         for (source_id, source) in &sources {
             let cancel = control
@@ -320,14 +392,9 @@ impl SourceProcessingSupervisor {
         }
         control.notify("configured_sources_changed");
         drop(control);
-        self.shared.cancel_external_scans(|registration| {
-            changed_source_ids.contains(&registration.source_id)
-                || !retained_source_ids
-                    .iter()
-                    .any(|source_id| source_id == &registration.source_id)
-        });
         self.shared.budget_wake.notify_all();
         self.shared.wake.notify_all();
+        Ok(())
     }
 
     pub(in crate::native_app) fn budget_handle(&self) -> SourceProcessingBudgetHandle {
@@ -415,7 +482,7 @@ impl SourceProcessingSupervisor {
             if active {
                 control.notify("playback_pause");
             } else {
-                control.mark_all_sources_dirty("playback_resume");
+                control.notify("playback_resume");
             }
             drop(control);
             if active {
@@ -440,7 +507,7 @@ impl SourceProcessingSupervisor {
         if active {
             control.notify("foreground_activity_pause");
         } else {
-            control.mark_all_sources_dirty("foreground_activity_resume");
+            control.notify("foreground_activity_resume");
         }
         drop(control);
         if active {
@@ -499,6 +566,7 @@ impl Drop for SourceProcessingSupervisor {
 }
 
 struct Shared {
+    source_replacement: Mutex<()>,
     state: Mutex<ControlState>,
     wake: Condvar,
     cancel: AtomicBool,
@@ -508,6 +576,8 @@ struct Shared {
     external_scans: Mutex<ExternalScanState>,
     external_scan_wake: Condvar,
     next_external_scan_id: AtomicU64,
+    in_flight_work: Mutex<BTreeMap<String, usize>>,
+    in_flight_wake: Condvar,
 }
 
 impl Shared {
@@ -519,6 +589,7 @@ impl Shared {
             .collect();
         let dirty_sources = sources.keys().cloned().collect();
         Self {
+            source_replacement: Mutex::new(()),
             state: Mutex::new(ControlState {
                 sources,
                 source_work_cancels,
@@ -538,6 +609,8 @@ impl Shared {
             external_scans: Mutex::new(ExternalScanState::default()),
             external_scan_wake: Condvar::new(),
             next_external_scan_id: AtomicU64::new(1),
+            in_flight_work: Mutex::new(BTreeMap::new()),
+            in_flight_wake: Condvar::new(),
         }
     }
 
@@ -578,17 +651,78 @@ impl Shared {
         drop(
             self.external_scan_wake
                 .wait_while(registrations, |state| {
-                    state.admissions > 0 || !state.registrations.is_empty()
+                    !state.admissions.is_empty() || !state.registrations.is_empty()
                 })
                 .unwrap_or_else(|poison| poison.into_inner()),
         );
     }
 
-    fn finish_external_scan_admission(&self) {
+    fn wait_for_external_scans_for_sources(&self, source_ids: &BTreeSet<String>) {
+        let registrations = self.external_scans();
+        drop(
+            self.external_scan_wake
+                .wait_while(registrations, |state| {
+                    state
+                        .admissions
+                        .values()
+                        .any(|source_id| source_ids.contains(source_id))
+                        || state
+                            .registrations
+                            .values()
+                            .any(|registration| source_ids.contains(&registration.source_id))
+                })
+                .unwrap_or_else(|poison| poison.into_inner()),
+        );
+    }
+
+    fn finish_external_scan_admission(&self, admission_id: u64) {
         let mut external_scans = self.external_scans();
-        external_scans.admissions = external_scans.admissions.saturating_sub(1);
+        external_scans.admissions.remove(&admission_id);
         drop(external_scans);
         self.external_scan_wake.notify_all();
+    }
+
+    fn begin_in_flight_work<'a>(
+        &'a self,
+        source_id: &str,
+        expected_cancel: &Arc<AtomicBool>,
+    ) -> Option<InFlightWorkGuard<'a>> {
+        let control = self.control();
+        let current_cancel = control.source_work_cancels.get(source_id)?;
+        if control.shutdown
+            || control.processing_paused()
+            || !Arc::ptr_eq(current_cancel, expected_cancel)
+            || expected_cancel.load(Ordering::Acquire)
+        {
+            return None;
+        }
+        let mut in_flight = self
+            .in_flight_work
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        *in_flight.entry(source_id.to_string()).or_default() += 1;
+        drop(in_flight);
+        drop(control);
+        Some(InFlightWorkGuard {
+            shared: self,
+            source_id: source_id.to_string(),
+        })
+    }
+
+    fn wait_for_in_flight_sources(&self, source_ids: &BTreeSet<String>) {
+        let in_flight = self
+            .in_flight_work
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        drop(
+            self.in_flight_wake
+                .wait_while(in_flight, |work| {
+                    source_ids
+                        .iter()
+                        .any(|source_id| work.get(source_id).is_some_and(|count| *count > 0))
+                })
+                .unwrap_or_else(|poison| poison.into_inner()),
+        );
     }
 }
 
@@ -753,11 +887,17 @@ fn run_coordinator(shared: Arc<Shared>) {
             if control.shutdown {
                 break;
             }
+            let processing_paused = control.processing_paused();
+            let dirty_sources = if processing_paused {
+                BTreeSet::new()
+            } else {
+                std::mem::take(&mut control.dirty_sources)
+            };
             (
                 control.sources.values().cloned().collect::<Vec<_>>(),
-                std::mem::take(&mut control.dirty_sources),
+                dirty_sources,
                 control.source_work_cancels.clone(),
-                control.processing_paused(),
+                processing_paused,
                 control.wake_generation,
                 control.wake_reason,
             )
@@ -792,6 +932,17 @@ fn run_coordinator(shared: Arc<Shared>) {
                 else {
                     continue;
                 };
+                let Some(source_cancel) = source_work_cancels.get(&source_id) else {
+                    shared.budgets().release(permit);
+                    shared.budget_wake.notify_all();
+                    continue;
+                };
+                let Some(in_flight_work) = shared.begin_in_flight_work(&source_id, source_cancel)
+                else {
+                    shared.budgets().release(permit);
+                    shared.budget_wake.notify_all();
+                    continue;
+                };
                 match reset_interrupted_similarity_prep_jobs(source) {
                     Ok(reset) => {
                         reset_sources.insert(source_id, true);
@@ -806,6 +957,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                     }
                     Err(error) => record_discovery_error(&shared, source, &error),
                 }
+                drop(in_flight_work);
                 shared.budgets().release(permit);
                 shared.budget_wake.notify_all();
             }
@@ -823,7 +975,7 @@ fn run_coordinator(shared: Arc<Shared>) {
             source_stats.remove(source.id.as_str());
         }
         let (mut discovered, discovered_source_stats, deferred_discoveries) =
-            discover_candidates(&shared, &sources_to_discover);
+            discover_candidates(&shared, &sources_to_discover, &source_work_cancels);
         if !deferred_discoveries.is_empty() {
             shared.control().dirty_sources.extend(deferred_discoveries);
         }
@@ -873,7 +1025,16 @@ fn run_coordinator(shared: Arc<Shared>) {
                 shared.budget_wake.notify_all();
                 break;
             };
+            let Some(in_flight_work) =
+                shared.begin_in_flight_work(candidate.source.id.as_str(), candidate_cancel)
+            else {
+                shared.budgets().release(permit);
+                shared.budget_wake.notify_all();
+                candidates.push(candidate);
+                break;
+            };
             let result = execute_candidate(&candidate, candidate_cancel.as_ref());
+            drop(in_flight_work);
             shared.budgets().release(permit);
             shared.budget_wake.notify_all();
             let mut telemetry = shared.telemetry();
@@ -933,6 +1094,16 @@ fn run_coordinator(shared: Arc<Shared>) {
                 }
             }
             drop(telemetry);
+            let requeue_cancelled = matches!(execution_outcome, Some(ExecutionOutcome::Cancelled))
+                && {
+                    let control = shared.control();
+                    control.sources.contains_key(candidate.source.id.as_str())
+                        && !control.dirty_sources.contains(candidate.source.id.as_str())
+                };
+            if requeue_cancelled {
+                candidates.push(candidate);
+                continue;
+            }
             let source_id = candidate.source.id.as_str();
             if candidates
                 .iter()
@@ -984,6 +1155,7 @@ fn run_coordinator(shared: Arc<Shared>) {
 fn discover_candidates(
     shared: &Shared,
     sources: &[SampleSource],
+    source_work_cancels: &BTreeMap<String, Arc<AtomicBool>>,
 ) -> (
     Vec<RuntimeCandidate>,
     BTreeMap<String, SourceDiscoveryStats>,
@@ -1001,6 +1173,17 @@ fn discover_candidates(
             deferred.insert(source.id.as_str().to_string());
             continue;
         };
+        let Some(source_cancel) = source_work_cancels.get(source.id.as_str()) else {
+            shared.budgets().release(permit);
+            shared.budget_wake.notify_all();
+            continue;
+        };
+        let Some(in_flight_work) = shared.begin_in_flight_work(source.id.as_str(), source_cancel)
+        else {
+            shared.budgets().release(permit);
+            shared.budget_wake.notify_all();
+            continue;
+        };
         {
             let mut telemetry = shared.telemetry();
             telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
@@ -1012,6 +1195,7 @@ fn discover_candidates(
             }
             Err(error) => record_discovery_error(shared, source, &error),
         }
+        drop(in_flight_work);
         shared.budgets().release(permit);
         shared.budget_wake.notify_all();
     }
@@ -1217,6 +1401,53 @@ fn source_processing_schema_available(connection: &rusqlite::Connection) -> Resu
             |row| row.get(0),
         )
         .map_err(|error| error.to_string())
+}
+
+fn fence_retired_source_readiness(source: &SampleSource) -> Result<(), String> {
+    let database_path = source.db_path().map_err(|error| error.to_string())?;
+    if !database_path.exists() {
+        return Ok(());
+    }
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .map_err(|error| error.to_string())?;
+    if connection
+        .is_readonly(rusqlite::MAIN_DB)
+        .map_err(|error| error.to_string())?
+    {
+        return Ok(());
+    }
+    let readiness_source_table_exists = connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = 'source_readiness_sources'
+             )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if !readiness_source_table_exists {
+        return Ok(());
+    }
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| error.to_string())?;
+    transaction
+        .execute(
+            "UPDATE source_readiness_sources
+             SET availability = 'disabled',
+                 readiness_revision = readiness_revision + 1,
+                 updated_at = ?2
+             WHERE source_id = ?1 AND availability != 'disabled'",
+            params![source.id.as_str(), now_epoch_seconds()],
+        )
+        .map_err(|error| error.to_string())?;
+    transaction.commit().map_err(|error| error.to_string())
 }
 
 fn publish_current_readiness_targets(
@@ -1860,19 +2091,39 @@ fn embedding_aspects_are_current(
     connection
         .query_row(
             "SELECT EXISTS(
-                SELECT 1 FROM analysis_cache_embeddings
-                WHERE content_hash = ?1 AND analysis_version = ?2 AND model_id = ?3
-            ) AND EXISTS(
-                SELECT 1 FROM analysis_cache_aspect_descriptors
-                WHERE content_hash = ?1 AND analysis_version = ?2 AND model_id = ?4
-            ) AND EXISTS(
-                SELECT 1 FROM embeddings
-                WHERE sample_id = ?5 AND model_id = ?3 AND dim = ?6
-                  AND dtype = ?7 AND l2_normed = 1
-            ) AND EXISTS(
-                SELECT 1 FROM similarity_aspect_descriptors
-                WHERE sample_id = ?5 AND model_id = ?4 AND dim = ?8
-                  AND dtype = ?9 AND l2_normed = 1
+                SELECT 1
+                FROM samples AS sample
+                JOIN embeddings AS embedding
+                  ON embedding.sample_id = sample.sample_id
+                JOIN analysis_cache_embeddings AS cached_embedding
+                  ON cached_embedding.content_hash = sample.content_hash
+                 AND cached_embedding.analysis_version = ?2
+                 AND cached_embedding.model_id = ?3
+                JOIN similarity_aspect_descriptors AS aspects
+                  ON aspects.sample_id = sample.sample_id
+                JOIN analysis_cache_aspect_descriptors AS cached_aspects
+                  ON cached_aspects.content_hash = sample.content_hash
+                 AND cached_aspects.analysis_version = ?2
+                 AND cached_aspects.model_id = ?4
+                WHERE sample.sample_id = ?5
+                  AND sample.content_hash = ?1
+                  AND embedding.model_id = cached_embedding.model_id
+                  AND embedding.dim = cached_embedding.dim
+                  AND embedding.dtype = cached_embedding.dtype
+                  AND embedding.l2_normed = cached_embedding.l2_normed
+                  AND embedding.vec = cached_embedding.vec
+                  AND embedding.dim = ?6
+                  AND embedding.dtype = ?7
+                  AND embedding.l2_normed = 1
+                  AND aspects.model_id = cached_aspects.model_id
+                  AND aspects.dim = cached_aspects.dim
+                  AND aspects.dtype = cached_aspects.dtype
+                  AND aspects.l2_normed = cached_aspects.l2_normed
+                  AND aspects.valid_mask = cached_aspects.valid_mask
+                  AND aspects.vec = cached_aspects.vec
+                  AND aspects.dim = ?8
+                  AND aspects.dtype = ?9
+                  AND aspects.l2_normed = 1
             )",
             params![
                 target.content_generation,
@@ -2019,7 +2270,9 @@ mod tests {
         let (_directory, source) = unhashed_source("removed");
         let mut supervisor =
             SourceProcessingSupervisor::start_with_playback_state(vec![source.clone()], true);
-        supervisor.replace_sources(Vec::new());
+        supervisor
+            .replace_sources(Vec::new())
+            .expect("remove configured sources");
         supervisor.set_playback_active(false);
 
         thread::sleep(Duration::from_millis(150));
@@ -2032,7 +2285,9 @@ mod tests {
         let (_first_directory, first) = unhashed_source("first");
         let (_second_directory, second) = unhashed_source("second");
         let mut supervisor = SourceProcessingSupervisor::dormant();
-        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+        supervisor
+            .replace_sources(vec![first.clone(), second.clone()])
+            .expect("configure sources");
         let (first_generation, second_generation) = {
             let control = supervisor.shared.control();
             (
@@ -2067,7 +2322,9 @@ mod tests {
         let (_first_directory, first) = unhashed_source("refresh-first");
         let (_second_directory, second) = unhashed_source("refresh-second");
         let mut supervisor = SourceProcessingSupervisor::dormant();
-        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+        supervisor
+            .replace_sources(vec![first.clone(), second.clone()])
+            .expect("configure sources");
         let (first_generation, second_generation, wake_generation) = {
             let mut control = supervisor.shared.control();
             control.dirty_sources.clear();
@@ -2087,7 +2344,9 @@ mod tests {
             )
         };
 
-        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+        supervisor
+            .replace_sources(vec![first.clone(), second.clone()])
+            .expect("refresh identical sources");
 
         {
             let control = supervisor.shared.control();
@@ -2106,7 +2365,9 @@ mod tests {
         let replacement_directory = tempfile::tempdir().expect("replacement source root");
         let replacement =
             SampleSource::new_with_id(first.id.clone(), replacement_directory.path().to_path_buf());
-        supervisor.replace_sources(vec![replacement, second.clone()]);
+        supervisor
+            .replace_sources(vec![replacement, second.clone()])
+            .expect("replace changed source");
 
         assert!(first_generation.load(Ordering::Acquire));
         assert!(!second_generation.load(Ordering::Acquire));
@@ -2142,7 +2403,7 @@ mod tests {
         let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
         wait_until(Duration::from_secs(5), || {
             let telemetry = supervisor.shared.telemetry();
-            telemetry.source_discoveries >= 1 && telemetry.queue_depth == 0
+            telemetry.source_discoveries >= 2 && telemetry.queue_depth == 0
         });
         let discoveries_before = supervisor.shared.telemetry().source_discoveries;
 
@@ -2160,6 +2421,230 @@ mod tests {
             discoveries_before,
             "priority-only wakes must reschedule the retained batch without database discovery"
         );
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn playback_and_foreground_resumes_reuse_the_retained_source_snapshot() {
+        let directory = tempfile::tempdir().expect("resume source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("resume-cache"),
+            directory.path().to_path_buf(),
+        );
+        source.open_db().expect("create resume source database");
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source]);
+        wait_until(Duration::from_secs(5), || {
+            let telemetry = supervisor.shared.telemetry();
+            telemetry.source_discoveries >= 2 && telemetry.queue_depth == 0
+        });
+        let discoveries_before = supervisor.shared.telemetry().source_discoveries;
+
+        for _ in 0..64 {
+            supervisor.set_playback_active(true);
+            supervisor.set_playback_active(false);
+            supervisor.set_foreground_activity(true);
+            supervisor.set_foreground_activity(false);
+        }
+        thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(
+            supervisor.shared.telemetry().source_discoveries,
+            discoveries_before,
+            "resume must reuse retained candidates instead of restarting manifest discovery"
+        );
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn embedding_readiness_rejects_rows_from_the_previous_content_generation() {
+        let (_directory, source) = ready_analysis_source("embedding-generation");
+        let database_root = source.database_root().expect("database root");
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open embedding database");
+        let sample_id = format!("{}::ready.wav", source.id);
+        let embedding_dim = wavecrate_analysis::similarity::SIMILARITY_DIM as i64;
+        let aspect_dim = wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DIM as i64;
+        let embedding_a = vec![1_u8, 2, 3, 4];
+        let embedding_b = vec![5_u8, 6, 7, 8];
+        let aspects_a = vec![9_u8, 10, 11, 12];
+        let aspects_b = vec![13_u8, 14, 15, 16];
+        connection
+            .execute(
+                "INSERT INTO samples (sample_id, content_hash, size, mtime_ns)
+                 VALUES (?1, 'content-a', 1, 1)",
+                [&sample_id],
+            )
+            .expect("insert sample");
+        for (content_hash, embedding, aspects) in [
+            ("content-a", embedding_a.as_slice(), aspects_a.as_slice()),
+            ("content-b", embedding_b.as_slice(), aspects_b.as_slice()),
+        ] {
+            connection
+                .execute(
+                    "INSERT INTO analysis_cache_embeddings (
+                        content_hash, analysis_version, model_id, dim, dtype,
+                        l2_normed, vec, created_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, 1)",
+                    params![
+                        content_hash,
+                        wavecrate_analysis::analysis_version(),
+                        wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+                        embedding_dim,
+                        wavecrate_analysis::similarity::SIMILARITY_DTYPE_F32,
+                        embedding,
+                    ],
+                )
+                .expect("insert cached embedding");
+            connection
+                .execute(
+                    "INSERT INTO analysis_cache_aspect_descriptors (
+                        content_hash, analysis_version, model_id, dim, dtype,
+                        l2_normed, valid_mask, vec, created_at
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, 1, 7, ?6, 1)",
+                    params![
+                        content_hash,
+                        wavecrate_analysis::analysis_version(),
+                        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+                        aspect_dim,
+                        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DTYPE_F32,
+                        aspects,
+                    ],
+                )
+                .expect("insert cached aspects");
+        }
+        connection
+            .execute(
+                "INSERT INTO embeddings (
+                    sample_id, model_id, dim, dtype, l2_normed, vec, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, 1, ?5, 1)",
+                params![
+                    sample_id,
+                    wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+                    embedding_dim,
+                    wavecrate_analysis::similarity::SIMILARITY_DTYPE_F32,
+                    embedding_a,
+                ],
+            )
+            .expect("insert materialized embedding");
+        connection
+            .execute(
+                "INSERT INTO similarity_aspect_descriptors (
+                    sample_id, model_id, dim, dtype, l2_normed, valid_mask, vec, created_at
+                 ) VALUES (?1, ?2, ?3, ?4, 1, 7, ?5, 1)",
+                params![
+                    sample_id,
+                    wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+                    aspect_dim,
+                    wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DTYPE_F32,
+                    aspects_a,
+                ],
+            )
+            .expect("insert materialized aspects");
+        connection
+            .execute(
+                "UPDATE samples SET content_hash = 'content-b' WHERE sample_id = ?1",
+                [&sample_id],
+            )
+            .expect("advance sample content");
+        let target = ReadinessTarget::file(
+            source.id.as_str(),
+            "identity-1",
+            "ready.wav",
+            ReadinessStage::EmbeddingAspects,
+            "embedding-v1",
+            1,
+            "content-b",
+        );
+
+        assert!(!embedding_aspects_are_current(&connection, &target).unwrap());
+
+        connection
+            .execute(
+                "UPDATE embeddings SET vec = ?2 WHERE sample_id = ?1",
+                params![sample_id, embedding_b],
+            )
+            .expect("materialize current embedding");
+        connection
+            .execute(
+                "UPDATE similarity_aspect_descriptors SET vec = ?2 WHERE sample_id = ?1",
+                params![sample_id, aspects_b],
+            )
+            .expect("materialize current aspects");
+        assert!(embedding_aspects_are_current(&connection, &target).unwrap());
+    }
+
+    #[test]
+    fn source_removal_joins_in_flight_publication_before_disabling_readiness() {
+        let (_directory, source) = unhashed_source("retired-fence");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'retired-identity', content_hash = 'retired-content'
+                 WHERE path = 'pending.wav'",
+                [],
+            )
+            .expect("assign readiness identity");
+        publish_current_readiness_targets(&mut connection, source.id.as_str(), 1)
+            .expect("publish readiness targets");
+        drop(connection);
+
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
+        let generation = {
+            let control = supervisor.shared.control();
+            Arc::clone(&control.source_work_cancels[source.id.as_str()])
+        };
+        let in_flight = supervisor
+            .shared
+            .begin_in_flight_work(source.id.as_str(), &generation)
+            .expect("register in-flight source publication");
+        let (removed, removal_finished) = std::sync::mpsc::channel();
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                supervisor
+                    .replace_sources(Vec::new())
+                    .expect("remove configured source");
+                removed.send(()).expect("report source removal");
+            });
+            assert!(
+                removal_finished
+                    .recv_timeout(Duration::from_millis(50))
+                    .is_err(),
+                "source removal must join active publication before returning"
+            );
+            drop(in_flight);
+            removal_finished
+                .recv_timeout(Duration::from_secs(2))
+                .expect("source removal completes after publication joins");
+        });
+
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("reopen readiness database");
+        let availability: String = connection
+            .query_row(
+                "SELECT availability FROM source_readiness_sources WHERE source_id = ?1",
+                [source.id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("read retired source readiness");
+        assert_eq!(availability, "disabled");
         assert_eq!(supervisor.shutdown()["joined"], true);
     }
 
@@ -2221,7 +2706,9 @@ mod tests {
     fn shutdown_waits_for_external_scan_admissions_and_rejects_late_permits() {
         let (_directory, source) = unhashed_source("admission-race");
         let mut supervisor = SourceProcessingSupervisor::dormant();
-        supervisor.replace_sources(vec![source.clone()]);
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
         let handle = supervisor.budget_handle();
         let first = handle
             .acquire_scan(source.id.as_str())
@@ -2231,7 +2718,7 @@ mod tests {
         let source_id = source.id.to_string();
         let waiting = thread::spawn(move || waiting_handle.acquire_scan(&source_id).is_none());
         wait_until(Duration::from_secs(2), || {
-            supervisor.shared.external_scans().admissions == 1
+            supervisor.shared.external_scans().admissions.len() == 1
         });
 
         let shutdown = thread::spawn(move || supervisor.shutdown());
@@ -2250,7 +2737,9 @@ mod tests {
     fn foreground_activity_cancels_in_flight_work_without_reviving_old_generations() {
         let (_directory, source) = unhashed_source("foreground");
         let mut supervisor = SourceProcessingSupervisor::dormant();
-        supervisor.replace_sources(vec![source.clone()]);
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
         let source_generation = {
             let control = supervisor.shared.control();
             Arc::clone(&control.source_work_cancels[source.id.as_str()])
@@ -2471,7 +2960,9 @@ mod tests {
     fn external_scan_tokens_cancel_for_playback_removal_and_shutdown() {
         let (_directory, source) = unhashed_source("external-cancel");
         let mut supervisor = SourceProcessingSupervisor::dormant();
-        supervisor.replace_sources(vec![source.clone()]);
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
 
         let playback_permit = supervisor
             .budget_handle()
@@ -2489,11 +2980,22 @@ mod tests {
             .acquire_scan(source.id.as_str())
             .expect("acquire removal permit");
         let removal_cancel = removal_permit.cancel_token();
-        supervisor.replace_sources(Vec::new());
+        let removal_cancel_for_releaser = Arc::clone(&removal_cancel);
+        let releaser = thread::spawn(move || {
+            while !removal_cancel_for_releaser.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            drop(removal_permit);
+        });
+        supervisor
+            .replace_sources(Vec::new())
+            .expect("remove configured source");
+        releaser.join().expect("join removal scan releaser");
         assert!(removal_cancel.load(Ordering::Acquire));
-        drop(removal_permit);
 
-        supervisor.replace_sources(vec![source.clone()]);
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("restore configured source");
         let shutdown_permit = supervisor
             .budget_handle()
             .acquire_scan(source.id.as_str())

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -397,6 +397,46 @@ impl SourceProcessingSupervisor {
         Ok(())
     }
 
+    /// Admit a newly configured source before its first external scan starts.
+    ///
+    /// This deliberately only grows the configured set. Full replacement may
+    /// fence retired sources and wait for their in-flight work, so it must not
+    /// run from the UI scan-launch path.
+    pub(in crate::native_app) fn register_source_for_scan(
+        &self,
+        source: SampleSource,
+    ) -> Result<(), String> {
+        let _replacement = match self.shared.source_replacement.try_lock() {
+            Ok(replacement) => replacement,
+            Err(std::sync::TryLockError::Poisoned(poison)) => poison.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => {
+                return Err("Configured sources are currently being replaced".to_string());
+            }
+        };
+        let source_id = source.id.as_str().to_string();
+        let mut control = self.shared.control();
+        if control.shutdown || self.shared.cancel.load(Ordering::Acquire) {
+            return Err("Source processing supervisor is shutting down".to_string());
+        }
+        if let Some(current) = control.sources.get(&source_id) {
+            return source_descriptors_match(current, &source)
+                .then_some(())
+                .ok_or_else(|| {
+                    format!("Source {source_id} is already registered with a different descriptor")
+                });
+        }
+
+        control.sources.insert(source_id.clone(), source);
+        control
+            .source_work_cancels
+            .insert(source_id.clone(), Arc::new(AtomicBool::new(false)));
+        control.mark_source_dirty(&source_id, "source_registered_for_scan");
+        drop(control);
+        self.shared.budget_wake.notify_all();
+        self.shared.wake.notify_one();
+        Ok(())
+    }
+
     pub(in crate::native_app) fn budget_handle(&self) -> SourceProcessingBudgetHandle {
         SourceProcessingBudgetHandle {
             shared: Arc::clone(&self.shared),
@@ -2424,6 +2464,54 @@ mod tests {
         ));
         drop(control);
         drop(first_scan);
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn scan_registration_only_adds_absent_matching_sources() {
+        let (_directory, source) = unhashed_source("scan-registration");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+
+        supervisor
+            .register_source_for_scan(source.clone())
+            .expect("register source before first scan");
+        supervisor
+            .register_source_for_scan(source.clone())
+            .expect("matching registration is idempotent");
+        let permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("newly registered source admits scan work");
+
+        let replacement_directory = tempfile::tempdir().expect("replacement source root");
+        let replacement = SampleSource::new_with_id(
+            source.id.clone(),
+            replacement_directory.path().to_path_buf(),
+        );
+        assert!(
+            supervisor.register_source_for_scan(replacement).is_err(),
+            "scan registration must not replace an authoritative descriptor"
+        );
+        let control = supervisor.shared.control();
+        assert!(source_descriptors_match(
+            &control.sources[source.id.as_str()],
+            &source
+        ));
+        drop(control);
+        drop(permit);
+
+        let replacement = supervisor
+            .shared
+            .source_replacement
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        assert_eq!(
+            supervisor
+                .register_source_for_scan(source.clone())
+                .expect_err("scan registration must not wait for source replacement"),
+            "Configured sources are currently being replaced"
+        );
+        drop(replacement);
         assert_eq!(supervisor.shutdown()["joined"], true);
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -1,0 +1,689 @@
+#![cfg_attr(test, allow(dead_code))]
+
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc, Condvar, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+use wavecrate::sample_sources::{
+    SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
+    readiness::{persist_readiness_deficits, readiness_work_stats, reconcile_readiness},
+    scanner::complete_pending_deep_hashes,
+};
+
+use super::scheduler::{
+    BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane, WorkCandidate,
+};
+use crate::native_app::sample_library::similarity_prep::{
+    finalize_similarity_prep_if_ready, reset_interrupted_similarity_prep_jobs,
+    run_similarity_prep_job_batch, similarity_prep_needs_finalization,
+};
+
+const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+const LEGACY_ANALYSIS_BATCH: usize = 8;
+const DEEP_HASH_BATCH: usize = 8;
+const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
+
+/// Owned runtime coordinator. All work is joined during shutdown and observes one cancel token.
+pub(in crate::native_app) struct SourceProcessingSupervisor {
+    shared: Arc<Shared>,
+    coordinator: Option<JoinHandle<()>>,
+}
+
+impl SourceProcessingSupervisor {
+    pub(in crate::native_app) fn start(sources: Vec<SampleSource>) -> Self {
+        Self::start_with_playback_state(sources, false)
+    }
+
+    fn start_with_playback_state(sources: Vec<SampleSource>, playback_active: bool) -> Self {
+        let shared = Arc::new(Shared::new(sources));
+        shared.control().playback_active = playback_active;
+        let thread_shared = Arc::clone(&shared);
+        let coordinator = thread::Builder::new()
+            .name(String::from("wavecrate-source-supervisor"))
+            .spawn(move || run_coordinator(thread_shared))
+            .expect("spawn source processing supervisor");
+        Self {
+            shared,
+            coordinator: Some(coordinator),
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn dormant() -> Self {
+        Self {
+            shared: Arc::new(Shared::new(Vec::new())),
+            coordinator: None,
+        }
+    }
+
+    pub(in crate::native_app) fn replace_sources(&self, sources: Vec<SampleSource>) {
+        self.shared.work_cancel.store(true, Ordering::Release);
+        let mut control = self.shared.control();
+        control.sources = sources_by_id(sources);
+        control.priority.immediate.clear();
+        control.priority.visible.clear();
+        control.priority.immediate_paths.clear();
+        control.priority.visible_paths.clear();
+        control.wake("configured_sources_changed");
+        self.shared.wake.notify_one();
+    }
+
+    pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {
+        let mut control = self.shared.control();
+        if control.sources.contains_key(source_id) {
+            self.shared.work_cancel.store(true, Ordering::Release);
+            control.wake(reason);
+            self.shared.wake.notify_one();
+        }
+    }
+
+    pub(in crate::native_app) fn set_selected_source(&self, source_id: Option<&str>) {
+        let mut control = self.shared.control();
+        let selected = source_id.map(str::to_string);
+        if control.priority.selected_source != selected {
+            control.priority.selected_source = selected;
+            control.wake("selected_source_changed");
+            self.shared.wake.notify_one();
+        }
+    }
+
+    pub(in crate::native_app) fn prioritize_path(
+        &self,
+        source_id: &str,
+        relative_path: &str,
+        immediate: bool,
+    ) {
+        let mut control = self.shared.control();
+        let key = (source_id.to_string(), relative_path.to_string());
+        let priorities = if immediate {
+            control.priority.immediate_paths.clear();
+            &mut control.priority.immediate_paths
+        } else {
+            &mut control.priority.visible_paths
+        };
+        if priorities.insert(key) {
+            control.wake("interactive_path_priority");
+            self.shared.wake.notify_one();
+        }
+    }
+
+    pub(in crate::native_app) fn set_visible_paths<I>(&self, paths: I)
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let visible_paths = paths.into_iter().take(MAX_VISIBLE_PRIORITY_PATHS).collect();
+        let mut control = self.shared.control();
+        if control.priority.visible_paths != visible_paths {
+            control.priority.visible_paths = visible_paths;
+            control.wake("visible_paths_changed");
+            self.shared.wake.notify_one();
+        }
+    }
+
+    pub(in crate::native_app) fn set_current_folder(&self, source_id: &str, relative_path: &str) {
+        let mut control = self.shared.control();
+        let current = Some((source_id.to_string(), relative_path.to_string()));
+        if control.priority.current_folder != current {
+            control.priority.current_folder = current;
+            control.wake("current_folder_changed");
+            self.shared.wake.notify_one();
+        }
+    }
+
+    pub(in crate::native_app) fn set_playback_active(&self, active: bool) {
+        let mut control = self.shared.control();
+        if control.playback_active != active {
+            control.playback_active = active;
+            self.shared.work_cancel.store(active, Ordering::Release);
+            control.wake(if active {
+                "playback_pause"
+            } else {
+                "playback_resume"
+            });
+            self.shared.wake.notify_all();
+        }
+    }
+
+    pub(in crate::native_app) fn shutdown(&mut self) -> Value {
+        let started_at = Instant::now();
+        self.shared.cancel.store(true, Ordering::Release);
+        self.shared.work_cancel.store(true, Ordering::Release);
+        {
+            let mut control = self.shared.control();
+            control.shutdown = true;
+            control.wake("shutdown");
+        }
+        self.shared.wake.notify_all();
+        let joined = self
+            .coordinator
+            .take()
+            .is_none_or(|coordinator| coordinator.join().is_ok());
+        let telemetry = self.shared.telemetry();
+        serde_json::json!({
+            "joined": joined,
+            "elapsed_ms": started_at.elapsed().as_secs_f64() * 1_000.0,
+            "sweeps": telemetry.sweeps,
+            "claimed": telemetry.claimed,
+            "completed": telemetry.completed,
+            "failed": telemetry.failed,
+            "cancelled": telemetry.cancelled,
+            "contention": telemetry.contention,
+            "max_queue_depth": telemetry.max_queue_depth,
+            "queue_depth": telemetry.queue_depth,
+            "oldest_job_age_seconds": telemetry.oldest_job_age_seconds,
+            "retries_due": telemetry.retries_due,
+            "readiness_queue_depth": telemetry.readiness_queue_depth,
+        })
+    }
+}
+
+impl Drop for SourceProcessingSupervisor {
+    fn drop(&mut self) {
+        if self.coordinator.is_some() {
+            let _ = self.shutdown();
+        }
+    }
+}
+
+struct Shared {
+    state: Mutex<ControlState>,
+    wake: Condvar,
+    cancel: AtomicBool,
+    work_cancel: AtomicBool,
+    telemetry: Mutex<SupervisorTelemetry>,
+}
+
+impl Shared {
+    fn new(sources: Vec<SampleSource>) -> Self {
+        Self {
+            state: Mutex::new(ControlState {
+                sources: sources_by_id(sources),
+                wake_generation: 1,
+                wake_reason: "startup",
+                playback_active: false,
+                shutdown: false,
+                priority: PriorityContext::default(),
+            }),
+            wake: Condvar::new(),
+            cancel: AtomicBool::new(false),
+            work_cancel: AtomicBool::new(false),
+            telemetry: Mutex::new(SupervisorTelemetry::default()),
+        }
+    }
+
+    fn control(&self) -> MutexGuard<'_, ControlState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn telemetry(&self) -> MutexGuard<'_, SupervisorTelemetry> {
+        self.telemetry
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+}
+
+struct ControlState {
+    sources: BTreeMap<String, SampleSource>,
+    wake_generation: u64,
+    wake_reason: &'static str,
+    playback_active: bool,
+    shutdown: bool,
+    priority: PriorityContext,
+}
+
+impl ControlState {
+    fn wake(&mut self, reason: &'static str) {
+        self.wake_generation = self.wake_generation.wrapping_add(1);
+        self.wake_reason = reason;
+    }
+}
+
+#[derive(Default)]
+struct SupervisorTelemetry {
+    sweeps: u64,
+    claimed: u64,
+    completed: u64,
+    failed: u64,
+    cancelled: u64,
+    contention: u64,
+    max_queue_depth: usize,
+    queue_depth: usize,
+    oldest_job_age_seconds: u64,
+    retries_due: usize,
+    readiness_queue_depth: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RuntimeTask {
+    DeepHash,
+    LegacyAnalysis,
+    FinalizeSimilarity,
+}
+
+struct RuntimeCandidate {
+    schedule: WorkCandidate,
+    source: SampleSource,
+    task: RuntimeTask,
+}
+
+fn run_coordinator(shared: Arc<Shared>) {
+    let mut observed_generation = 0;
+    let mut scheduler = FairScheduler::default();
+    let mut budgets = BudgetTracker::new(ProcessingBudgets::default());
+    let mut reset_sources = BTreeMap::<String, bool>::new();
+    loop {
+        let (sources, priority, playback_active, generation, reason) = {
+            let mut control = shared.control();
+            while !control.shutdown && control.wake_generation == observed_generation {
+                let (next, _) = shared
+                    .wake
+                    .wait_timeout(control, SAFETY_SWEEP_INTERVAL)
+                    .unwrap_or_else(|poison| poison.into_inner());
+                control = next;
+                if control.wake_generation == observed_generation {
+                    control.wake("periodic_safety_sweep");
+                }
+            }
+            if control.shutdown {
+                break;
+            }
+            if !control.playback_active {
+                shared.work_cancel.store(false, Ordering::Release);
+            }
+            (
+                control.sources.values().cloned().collect::<Vec<_>>(),
+                control.priority.clone(),
+                control.playback_active,
+                control.wake_generation,
+                control.wake_reason,
+            )
+        };
+        observed_generation = generation;
+        scheduler.set_paused(playback_active);
+        if playback_active {
+            tracing::debug!(
+                target: "wavecrate::source_processing",
+                event = "source_processing.paused",
+                reason,
+                "Source processing paused for playback"
+            );
+            continue;
+        }
+
+        for source in &sources {
+            let source_id = source.id.as_str().to_string();
+            if !reset_sources.contains_key(&source_id) {
+                match reset_interrupted_similarity_prep_jobs(source) {
+                    Ok(reset) => {
+                        reset_sources.insert(source_id, true);
+                        if reset > 0 {
+                            tracing::info!(
+                                target: "wavecrate::source_processing",
+                                source_id = source.id.as_str(),
+                                reset,
+                                "Recovered interrupted source jobs"
+                            );
+                        }
+                    }
+                    Err(error) => record_discovery_error(&shared, source, &error),
+                }
+            }
+        }
+        reset_sources
+            .retain(|source_id, _| sources.iter().any(|source| source.id.as_str() == source_id));
+
+        let sweep_started = Instant::now();
+        let (mut candidates, retries_due, readiness_queue_depth) =
+            discover_candidates(&shared, &sources);
+        {
+            let mut telemetry = shared.telemetry();
+            telemetry.sweeps = telemetry.sweeps.saturating_add(1);
+            telemetry.queue_depth = candidates.len() + readiness_queue_depth;
+            telemetry.max_queue_depth = telemetry.max_queue_depth.max(telemetry.queue_depth);
+            telemetry.oldest_job_age_seconds =
+                oldest_job_age_seconds(&candidates, now_epoch_seconds());
+            telemetry.retries_due = retries_due;
+            telemetry.readiness_queue_depth = readiness_queue_depth;
+        }
+        while !candidates.is_empty() && !shared.cancel.load(Ordering::Acquire) {
+            let control = shared.control();
+            let interrupted =
+                control.playback_active || control.wake_generation != observed_generation;
+            drop(control);
+            if interrupted {
+                break;
+            }
+            let schedules = candidates
+                .iter()
+                .map(|candidate| candidate.schedule.clone())
+                .collect::<Vec<_>>();
+            let Some(index) = scheduler.choose(&schedules, &priority, &budgets) else {
+                let mut telemetry = shared.telemetry();
+                telemetry.contention = telemetry.contention.saturating_add(1);
+                break;
+            };
+            let candidate = candidates.swap_remove(index);
+            let Some(permit) =
+                budgets.try_acquire(&candidate.schedule.source_id, candidate.schedule.lane)
+            else {
+                let mut telemetry = shared.telemetry();
+                telemetry.contention = telemetry.contention.saturating_add(1);
+                break;
+            };
+            {
+                let mut telemetry = shared.telemetry();
+                telemetry.claimed = telemetry.claimed.saturating_add(1);
+            }
+            let result = execute_candidate(&candidate, &shared.work_cancel);
+            budgets.release(permit);
+            let mut telemetry = shared.telemetry();
+            match result {
+                _ if shared.work_cancel.load(Ordering::Acquire) => {
+                    telemetry.cancelled = telemetry.cancelled.saturating_add(1);
+                    tracing::debug!(
+                        target: "wavecrate::source_processing",
+                        source_id = candidate.source.id.as_str(),
+                        task = ?candidate.task,
+                        "Source work yielded to playback or source reconfiguration"
+                    );
+                }
+                Ok(()) => telemetry.completed = telemetry.completed.saturating_add(1),
+                Err(error) if shared.cancel.load(Ordering::Acquire) => {
+                    telemetry.cancelled = telemetry.cancelled.saturating_add(1);
+                    tracing::debug!(
+                        target: "wavecrate::source_processing",
+                        source_id = candidate.source.id.as_str(),
+                        task = ?candidate.task,
+                        error,
+                        "Source work cancelled"
+                    );
+                }
+                Err(error) => {
+                    telemetry.failed = telemetry.failed.saturating_add(1);
+                    tracing::warn!(
+                        target: "wavecrate::source_processing",
+                        source_id = candidate.source.id.as_str(),
+                        task = ?candidate.task,
+                        error,
+                        "Source work failed"
+                    );
+                    break;
+                }
+            }
+            drop(telemetry);
+            (candidates, _, _) = discover_candidates(&shared, &sources);
+        }
+        let mut telemetry = shared.telemetry();
+        telemetry.queue_depth = candidates.len() + telemetry.readiness_queue_depth;
+        telemetry.oldest_job_age_seconds = oldest_job_age_seconds(&candidates, now_epoch_seconds());
+        tracing::debug!(
+            target: "wavecrate::source_processing",
+            event = "source_processing.sweep",
+            reason,
+            source_count = sources.len(),
+            queued = telemetry.queue_depth,
+            oldest_job_age_seconds = telemetry.oldest_job_age_seconds,
+            retries_due = telemetry.retries_due,
+            claimed = telemetry.claimed,
+            completed = telemetry.completed,
+            failed = telemetry.failed,
+            cancelled = telemetry.cancelled,
+            contention = telemetry.contention,
+            elapsed_ms = sweep_started.elapsed().as_secs_f64() * 1_000.0,
+            "Source processing sweep complete"
+        );
+        drop(telemetry);
+    }
+}
+
+fn discover_candidates(
+    shared: &Shared,
+    sources: &[SampleSource],
+) -> (Vec<RuntimeCandidate>, usize, usize) {
+    let now = now_epoch_seconds();
+    let mut candidates = Vec::new();
+    let mut readiness_queue_depth = 0;
+    let mut retries_due = 0;
+    for source in sources {
+        match discover_source_candidates(source, now) {
+            Ok((mut source_candidates, source_readiness_depth, source_retries_due)) => {
+                candidates.append(&mut source_candidates);
+                readiness_queue_depth += source_readiness_depth;
+                retries_due += source_retries_due;
+            }
+            Err(error) => record_discovery_error(shared, source, &error),
+        }
+    }
+    (candidates, retries_due, readiness_queue_depth)
+}
+
+fn discover_source_candidates(
+    source: &SampleSource,
+    now: i64,
+) -> Result<(Vec<RuntimeCandidate>, usize, usize), String> {
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .map_err(|error| error.to_string())?;
+    let source_id = source.id.as_str();
+    let mut readiness_queue_depth = 0;
+    let mut retries_due = 0;
+    let readiness_source_exists: bool = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
+            [source_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if readiness_source_exists {
+        let snapshot =
+            reconcile_readiness(&connection, source_id, now).map_err(|error| error.to_string())?;
+        persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+            .map_err(|error| error.to_string())?;
+        readiness_queue_depth = snapshot.deficits.len();
+        let stats = readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
+        retries_due = stats.retries_due;
+        tracing::debug!(
+            target: "wavecrate::source_processing",
+            source_id,
+            pending = stats.pending,
+            running = stats.running,
+            retries_due = stats.retries_due,
+            retries_waiting = stats.retries_waiting,
+            expired_leases = stats.expired_leases,
+            "Readiness work reconciled"
+        );
+    }
+
+    let mut candidates = Vec::new();
+    let has_unhashed: bool = connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM wav_files
+                WHERE missing = 0 AND content_hash IS NULL
+                LIMIT 1
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if has_unhashed {
+        candidates.push(RuntimeCandidate {
+            schedule: WorkCandidate::source(source_id, ProcessingLane::Hashing, 1, now),
+            source: source.clone(),
+            task: RuntimeTask::DeepHash,
+        });
+    }
+    let legacy_analysis_created_at: Option<i64> = connection
+        .query_row(
+            "SELECT MIN(created_at) FROM analysis_jobs
+             WHERE readiness_managed = 0
+               AND status = 'pending'
+               AND job_type IN ('wav_metadata_v1', 'embedding_backfill_v1')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if let Some(created_at) = legacy_analysis_created_at {
+        candidates.push(RuntimeCandidate {
+            schedule: WorkCandidate::source(
+                source_id,
+                ProcessingLane::FeatureAnalysis,
+                2,
+                created_at,
+            ),
+            source: source.clone(),
+            task: RuntimeTask::LegacyAnalysis,
+        });
+    } else if similarity_prep_needs_finalization(source)? {
+        candidates.push(RuntimeCandidate {
+            schedule: WorkCandidate::source(source_id, ProcessingLane::Finalization, 4, now),
+            source: source.clone(),
+            task: RuntimeTask::FinalizeSimilarity,
+        });
+    }
+    Ok((candidates, readiness_queue_depth, retries_due))
+}
+
+fn execute_candidate(candidate: &RuntimeCandidate, cancel: &AtomicBool) -> Result<(), String> {
+    match candidate.task {
+        RuntimeTask::DeepHash => {
+            let database_root = candidate
+                .source
+                .database_root()
+                .map_err(|error| error.to_string())?;
+            let db = SourceDatabase::open_for_background_job_with_database_root(
+                &candidate.source.root,
+                database_root,
+            )
+            .map_err(|error| error.to_string())?;
+            complete_pending_deep_hashes(&db, Some(cancel), DEEP_HASH_BATCH)
+                .map(drop)
+                .map_err(|error| error.to_string())
+        }
+        RuntimeTask::LegacyAnalysis => {
+            run_similarity_prep_job_batch(&candidate.source, LEGACY_ANALYSIS_BATCH, cancel)
+                .map(drop)
+        }
+        RuntimeTask::FinalizeSimilarity => {
+            finalize_similarity_prep_if_ready(&candidate.source).map(drop)
+        }
+    }
+}
+
+fn record_discovery_error(shared: &Shared, source: &SampleSource, error: &str) {
+    let mut telemetry = shared.telemetry();
+    telemetry.failed = telemetry.failed.saturating_add(1);
+    drop(telemetry);
+    tracing::warn!(
+        target: "wavecrate::source_processing",
+        source_id = source.id.as_str(),
+        error,
+        "Source processing discovery failed"
+    );
+}
+
+fn sources_by_id(sources: Vec<SampleSource>) -> BTreeMap<String, SampleSource> {
+    sources
+        .into_iter()
+        .map(|source| (source.id.as_str().to_string(), source))
+        .collect()
+}
+
+fn now_epoch_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .min(i64::MAX as u64) as i64
+}
+
+fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
+    candidates
+        .iter()
+        .map(|candidate| now.saturating_sub(candidate.schedule.enqueued_at) as u64)
+        .max()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use wavecrate::sample_sources::SourceId;
+
+    use super::*;
+
+    #[test]
+    fn playback_pause_retains_hash_backlog_until_resume_and_shutdown_joins() {
+        let (_directory, source) = unhashed_source("paused");
+        let mut supervisor =
+            SourceProcessingSupervisor::start_with_playback_state(vec![source.clone()], true);
+
+        thread::sleep(Duration::from_millis(100));
+        assert!(!source_is_hashed(&source));
+
+        supervisor.set_playback_active(false);
+        wait_until(Duration::from_secs(3), || source_is_hashed(&source));
+        let report = supervisor.shutdown();
+        assert_eq!(report["joined"], true);
+    }
+
+    #[test]
+    fn removing_a_source_cancels_its_unstarted_backlog() {
+        let (_directory, source) = unhashed_source("removed");
+        let mut supervisor =
+            SourceProcessingSupervisor::start_with_playback_state(vec![source.clone()], true);
+        supervisor.replace_sources(Vec::new());
+        supervisor.set_playback_active(false);
+
+        thread::sleep(Duration::from_millis(150));
+        assert!(!source_is_hashed(&source));
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    fn unhashed_source(id: &str) -> (tempfile::TempDir, SampleSource) {
+        let directory = tempfile::tempdir().expect("temporary source");
+        let path = directory.path().join("pending.wav");
+        std::fs::write(&path, [1_u8; 64]).expect("write sample bytes");
+        let source =
+            SampleSource::new_with_id(SourceId::from_string(id), directory.path().to_path_buf());
+        let db = source.open_db().expect("open source database");
+        db.upsert_file(Path::new("pending.wav"), 64, 1)
+            .expect("insert pending hash row");
+        (directory, source)
+    }
+
+    fn source_is_hashed(source: &SampleSource) -> bool {
+        source
+            .open_db()
+            .expect("open source database")
+            .entry_for_path(Path::new("pending.wav"))
+            .expect("read pending file")
+            .and_then(|entry| entry.content_hash)
+            .is_some()
+    }
+
+    fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if condition() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(condition(), "condition did not become true before timeout");
+    }
+}

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -107,7 +107,7 @@ impl SourceProcessingBudgetHandle {
         let (admission_id, admission_cancel) = {
             let mut control = self.shared.control();
             while !control.shutdown
-                && control.sources.contains_key(source_id)
+                && control.source_is_active(source_id)
                 && control.processing_paused()
             {
                 control = self
@@ -118,7 +118,7 @@ impl SourceProcessingBudgetHandle {
             }
             if control.shutdown
                 || self.shared.cancel.load(Ordering::Acquire)
-                || !control.sources.contains_key(source_id)
+                || !control.source_is_active(source_id)
             {
                 return None;
             }
@@ -146,7 +146,7 @@ impl SourceProcessingBudgetHandle {
                 external_scans.admissions.remove(&admission_id);
                 if control.shutdown
                     || self.shared.cancel.load(Ordering::Acquire)
-                    || !control.sources.contains_key(source_id)
+                    || !control.source_is_active(source_id)
                     || control.processing_paused()
                     || admission_cancel.load(Ordering::Acquire)
                 {
@@ -187,7 +187,7 @@ impl SourceProcessingBudgetHandle {
             let control = self.shared.control();
             let unavailable = control.shutdown
                 || self.shared.cancel.load(Ordering::Acquire)
-                || !control.sources.contains_key(source_id)
+                || !control.source_is_active(source_id)
                 || control.processing_paused()
                 || admission_cancel.load(Ordering::Acquire);
             drop(control);
@@ -214,7 +214,7 @@ impl SourceProcessingBudgetPermit {
             || self
                 .permit
                 .as_ref()
-                .is_some_and(|permit| !control.sources.contains_key(permit.source_id()))
+                .is_some_and(|permit| !control.source_is_active(permit.source_id()))
     }
 }
 
@@ -271,8 +271,16 @@ impl SourceProcessingSupervisor {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
         let sources = sources_by_id(sources);
-        let control = self.shared.control();
+        let mut control = self.shared.control();
         if source_maps_match(&control.sources, &sources) {
+            if !control.quarantined_sources.is_empty() {
+                control.quarantined_sources.clear();
+                control.reset_source_work_tokens();
+                control.mark_all_sources_dirty("configured_sources_reactivated");
+                drop(control);
+                self.shared.budget_wake.notify_all();
+                self.shared.wake.notify_all();
+            }
             return Ok(());
         }
         let changed_source_ids = control
@@ -314,14 +322,15 @@ impl SourceProcessingSupervisor {
             if let Err(error) = fence_retired_source_readiness(&source) {
                 let mut control = self.shared.control();
                 for source_id in &changed_source_ids {
-                    if control.sources.contains_key(source_id) {
-                        control
-                            .source_work_cancels
-                            .insert(source_id.clone(), Arc::new(AtomicBool::new(false)));
-                        control.dirty_sources.insert(source_id.clone());
+                    if let Some(cancel) = control.source_work_cancels.get(source_id) {
+                        cancel.store(true, Ordering::Release);
                     }
+                    if control.sources.contains_key(source_id) {
+                        control.quarantined_sources.insert(source_id.clone());
+                    }
+                    control.dirty_sources.remove(source_id);
                 }
-                control.notify("configured_sources_change_failed");
+                control.notify("configured_sources_retirement_quarantined");
                 drop(control);
                 self.shared.budget_wake.notify_all();
                 self.shared.wake.notify_all();
@@ -346,6 +355,7 @@ impl SourceProcessingSupervisor {
         }
         control.sources = sources;
         control.source_work_cancels = source_work_cancels;
+        control.quarantined_sources.clear();
         let retained_source_ids = control.sources.keys().cloned().collect::<BTreeSet<_>>();
         control
             .dirty_sources
@@ -419,11 +429,21 @@ impl SourceProcessingSupervisor {
             return Err("Source processing supervisor is shutting down".to_string());
         }
         if let Some(current) = control.sources.get(&source_id) {
-            return source_descriptors_match(current, &source)
-                .then_some(())
-                .ok_or_else(|| {
-                    format!("Source {source_id} is already registered with a different descriptor")
-                });
+            if !source_descriptors_match(current, &source) {
+                return Err(format!(
+                    "Source {source_id} is already registered with a different descriptor"
+                ));
+            }
+            if control.quarantined_sources.remove(&source_id) {
+                control
+                    .source_work_cancels
+                    .insert(source_id.clone(), Arc::new(AtomicBool::new(false)));
+                control.mark_source_dirty(&source_id, "source_scan_registration_reactivated");
+                drop(control);
+                self.shared.budget_wake.notify_all();
+                self.shared.wake.notify_one();
+            }
+            return Ok(());
         }
 
         control.sources.insert(source_id.clone(), source);
@@ -445,7 +465,7 @@ impl SourceProcessingSupervisor {
 
     pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {
         let mut control = self.shared.control();
-        if !control.sources.contains_key(source_id) {
+        if !control.source_is_active(source_id) {
             return;
         }
         control.cancel_source_work(source_id);
@@ -634,6 +654,7 @@ impl Shared {
                 sources,
                 source_work_cancels,
                 dirty_sources,
+                quarantined_sources: BTreeSet::new(),
                 wake_generation: 1,
                 wake_reason: "startup",
                 playback_active: false,
@@ -731,6 +752,7 @@ impl Shared {
         let current_cancel = control.source_work_cancels.get(source_id)?;
         if control.shutdown
             || control.processing_paused()
+            || !control.source_is_active(source_id)
             || !Arc::ptr_eq(current_cancel, expected_cancel)
             || expected_cancel.load(Ordering::Acquire)
         {
@@ -770,6 +792,7 @@ struct ControlState {
     sources: BTreeMap<String, SampleSource>,
     source_work_cancels: BTreeMap<String, Arc<AtomicBool>>,
     dirty_sources: BTreeSet<String>,
+    quarantined_sources: BTreeSet<String>,
     wake_generation: u64,
     wake_reason: &'static str,
     playback_active: bool,
@@ -779,20 +802,29 @@ struct ControlState {
 }
 
 impl ControlState {
+    fn source_is_active(&self, source_id: &str) -> bool {
+        self.sources.contains_key(source_id) && !self.quarantined_sources.contains(source_id)
+    }
+
     fn notify(&mut self, reason: &'static str) {
         self.wake_generation = self.wake_generation.wrapping_add(1);
         self.wake_reason = reason;
     }
 
     fn mark_source_dirty(&mut self, source_id: &str, reason: &'static str) {
-        if self.sources.contains_key(source_id) {
+        if self.source_is_active(source_id) {
             self.dirty_sources.insert(source_id.to_string());
             self.notify(reason);
         }
     }
 
     fn mark_all_sources_dirty(&mut self, reason: &'static str) {
-        self.dirty_sources.extend(self.sources.keys().cloned());
+        self.dirty_sources.extend(
+            self.sources
+                .keys()
+                .filter(|source_id| !self.quarantined_sources.contains(*source_id))
+                .cloned(),
+        );
         self.notify(reason);
     }
 
@@ -803,7 +835,9 @@ impl ControlState {
     fn cancel_source_work(&mut self, source_id: &str) {
         if let Some(cancel) = self.source_work_cancels.get_mut(source_id) {
             cancel.store(true, Ordering::Release);
-            *cancel = Arc::new(AtomicBool::new(false));
+            if !self.quarantined_sources.contains(source_id) {
+                *cancel = Arc::new(AtomicBool::new(false));
+            }
         }
     }
 
@@ -817,7 +851,10 @@ impl ControlState {
         self.source_work_cancels = self
             .sources
             .keys()
-            .map(|source_id| (source_id.clone(), Arc::new(AtomicBool::new(false))))
+            .map(|source_id| {
+                let cancelled = self.quarantined_sources.contains(source_id);
+                (source_id.clone(), Arc::new(AtomicBool::new(cancelled)))
+            })
             .collect();
     }
 }
@@ -939,7 +976,12 @@ fn run_coordinator(shared: Arc<Shared>) {
                 std::mem::take(&mut control.dirty_sources)
             };
             (
-                control.sources.values().cloned().collect::<Vec<_>>(),
+                control
+                    .sources
+                    .iter()
+                    .filter(|(source_id, _)| control.source_is_active(source_id))
+                    .map(|(_, source)| source.clone())
+                    .collect::<Vec<_>>(),
                 dirty_sources,
                 control.source_work_cancels.clone(),
                 processing_paused,
@@ -1142,7 +1184,7 @@ fn run_coordinator(shared: Arc<Shared>) {
             let requeue_cancelled = matches!(execution_outcome, Some(ExecutionOutcome::Cancelled))
                 && {
                     let control = shared.control();
-                    control.sources.contains_key(candidate.source.id.as_str())
+                    control.source_is_active(candidate.source.id.as_str())
                         && !control.dirty_sources.contains(candidate.source.id.as_str())
                 };
             if requeue_cancelled {
@@ -2427,6 +2469,49 @@ mod tests {
 
         thread::sleep(Duration::from_millis(150));
         assert!(!source_is_hashed(&source));
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn failed_retirement_fence_quarantines_source_until_retry_succeeds() {
+        let (_directory, source) = unhashed_source("retirement-fence-failure");
+        let database_path = source.db_path().expect("source database path");
+        std::fs::remove_file(&database_path).expect("remove source database");
+        std::fs::create_dir(&database_path).expect("replace database with invalid directory");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor
+            .replace_sources(vec![source.clone()])
+            .expect("configure source");
+
+        assert!(
+            supervisor.replace_sources(Vec::new()).is_err(),
+            "invalid database path must fail persistent retirement fencing"
+        );
+        supervisor.wake_source(source.id.as_str(), "late_watcher_event");
+        supervisor.set_playback_active(true);
+        supervisor.set_playback_active(false);
+
+        let control = supervisor.shared.control();
+        assert!(control.quarantined_sources.contains(source.id.as_str()));
+        assert!(!control.dirty_sources.contains(source.id.as_str()));
+        assert!(control.source_work_cancels[source.id.as_str()].load(Ordering::Acquire));
+        drop(control);
+        assert!(
+            supervisor
+                .budget_handle()
+                .acquire_scan(source.id.as_str())
+                .is_none(),
+            "quarantined retirement must reject late external scans"
+        );
+
+        std::fs::remove_dir(&database_path).expect("repair invalid database path");
+        supervisor
+            .replace_sources(Vec::new())
+            .expect("retry retirement fence");
+        let control = supervisor.shared.control();
+        assert!(!control.sources.contains_key(source.id.as_str()));
+        assert!(control.quarantined_sources.is_empty());
+        drop(control);
         assert_eq!(supervisor.shutdown()["joined"], true);
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -20,8 +20,9 @@ use wavecrate::sample_sources::{
         ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
         ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability,
         cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        fail_readiness_work, persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
-        renew_readiness_lease, replace_readiness_targets,
+        fail_readiness_work, persist_readiness_deficits_with_cancel, readiness_work_stats,
+        reconcile_readiness_with_cancel, renew_readiness_lease,
+        replace_readiness_targets_with_cancel,
     },
     scanner::complete_pending_deep_hash_for_path,
 };
@@ -823,6 +824,11 @@ struct SourceDiscoveryStats {
     earliest_retry_at: Option<i64>,
 }
 
+enum Cancellable<T> {
+    Completed(T),
+    Cancelled,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ExecutionOutcome {
     Completed,
@@ -1187,10 +1193,13 @@ fn discover_candidates(
             let mut telemetry = shared.telemetry();
             telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
         }
-        match discover_source_candidates(source, now) {
-            Ok((mut source_candidates, stats)) => {
+        match discover_source_candidates(source, now, source_cancel) {
+            Ok(Cancellable::Completed((mut source_candidates, stats))) => {
                 candidates.append(&mut source_candidates);
                 source_stats.insert(source.id.as_str().to_string(), stats);
+            }
+            Ok(Cancellable::Cancelled) => {
+                deferred.insert(source.id.as_str().to_string());
             }
             Err(error) => record_discovery_error(shared, source, &error),
         }
@@ -1204,7 +1213,11 @@ fn discover_candidates(
 fn discover_source_candidates(
     source: &SampleSource,
     now: i64,
-) -> Result<(Vec<RuntimeCandidate>, SourceDiscoveryStats), String> {
+    cancel: &AtomicBool,
+) -> Result<Cancellable<(Vec<RuntimeCandidate>, SourceDiscoveryStats)>, String> {
+    if cancelled(cancel) {
+        return Ok(Cancellable::Cancelled);
+    }
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
@@ -1212,14 +1225,15 @@ fn discover_source_candidates(
         SourceDatabaseConnectionRole::JobWorker,
     )
     .map_err(|error| error.to_string())?;
-    discover_source_candidates_with_connection(source, &mut connection, now)
+    discover_source_candidates_with_connection(source, &mut connection, now, cancel)
 }
 
 fn discover_source_candidates_with_connection(
     source: &SampleSource,
     connection: &mut rusqlite::Connection,
     now: i64,
-) -> Result<(Vec<RuntimeCandidate>, SourceDiscoveryStats), String> {
+    cancel: &AtomicBool,
+) -> Result<Cancellable<(Vec<RuntimeCandidate>, SourceDiscoveryStats)>, String> {
     let source_id = source.id.as_str();
     let mut candidates = Vec::new();
     let mut stats = SourceDiscoveryStats::default();
@@ -1232,7 +1246,7 @@ fn discover_source_candidates_with_connection(
             source_id,
             "Source processing is disabled for a read-only source database"
         );
-        return Ok((candidates, stats));
+        return Ok(Cancellable::Completed((candidates, stats)));
     }
     if !source_processing_schema_available(&connection)? {
         tracing::debug!(
@@ -1240,9 +1254,17 @@ fn discover_source_candidates_with_connection(
             source_id,
             "Source processing is unavailable until the read-only source database is migrated"
         );
-        return Ok((candidates, stats));
+        return Ok(Cancellable::Completed((candidates, stats)));
     }
-    publish_current_readiness_targets(connection, source_id, now)?;
+    if matches!(
+        publish_current_readiness_targets_with_cancel(connection, source_id, now, cancel)?,
+        Cancellable::Cancelled
+    ) {
+        return Ok(Cancellable::Cancelled);
+    }
+    if cancelled(cancel) {
+        return Ok(Cancellable::Cancelled);
+    }
     let readiness_source_exists: bool = connection
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
@@ -1251,10 +1273,20 @@ fn discover_source_candidates_with_connection(
         )
         .map_err(|error| error.to_string())?;
     if readiness_source_exists {
-        let snapshot =
-            reconcile_readiness(&connection, source_id, now).map_err(|error| error.to_string())?;
-        persist_readiness_deficits(connection, &snapshot.deficits, now)
-            .map_err(|error| error.to_string())?;
+        let snapshot = match reconcile_readiness_with_cancel(&connection, source_id, now, cancel) {
+            Ok(snapshot) => snapshot,
+            Err(wavecrate::sample_sources::readiness::ReadinessError::Cancelled) => {
+                return Ok(Cancellable::Cancelled);
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        match persist_readiness_deficits_with_cancel(connection, &snapshot.deficits, now, cancel) {
+            Ok(_) => {}
+            Err(wavecrate::sample_sources::readiness::ReadinessError::Cancelled) => {
+                return Ok(Cancellable::Cancelled);
+            }
+            Err(error) => return Err(error.to_string()),
+        }
         stats.readiness_queue_depth = snapshot.deficits.len();
         candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
             schedule: WorkCandidate::readiness(&deficit.target, deficit.enqueued_at.unwrap_or(now)),
@@ -1303,6 +1335,9 @@ fn discover_source_candidates_with_connection(
             .map_err(|error| error.to_string())?
     };
     for (job_id, relative_path, job_type, created_at) in legacy_jobs {
+        if cancelled(cancel) {
+            return Ok(Cancellable::Cancelled);
+        }
         let lane = if job_type == "embedding_backfill_v1" {
             ProcessingLane::Embedding
         } else {
@@ -1341,7 +1376,11 @@ fn discover_source_candidates_with_connection(
             },
         });
     }
-    Ok((candidates, stats))
+    if cancelled(cancel) {
+        Ok(Cancellable::Cancelled)
+    } else {
+        Ok(Cancellable::Completed((candidates, stats)))
+    }
 }
 
 fn source_processing_schema_available(connection: &rusqlite::Connection) -> Result<bool, String> {
@@ -1449,11 +1488,45 @@ fn fence_retired_source_readiness(source: &SampleSource) -> Result<(), String> {
     transaction.commit().map_err(|error| error.to_string())
 }
 
+#[cfg(test)]
 fn publish_current_readiness_targets(
     connection: &mut rusqlite::Connection,
     source_id: &str,
     now: i64,
 ) -> Result<bool, String> {
+    let cancel = AtomicBool::new(false);
+    match publish_current_readiness_targets_with_cancel(connection, source_id, now, &cancel)? {
+        Cancellable::Completed(changed) => Ok(changed),
+        Cancellable::Cancelled => unreachable!("an uncancelled publication cannot be cancelled"),
+    }
+}
+
+fn publish_current_readiness_targets_with_cancel(
+    connection: &mut rusqlite::Connection,
+    source_id: &str,
+    now: i64,
+    cancel: &AtomicBool,
+) -> Result<Cancellable<bool>, String> {
+    publish_current_readiness_targets_with_cancel_and_checkpoint(
+        connection,
+        source_id,
+        now,
+        cancel,
+        &mut || {},
+    )
+}
+
+fn publish_current_readiness_targets_with_cancel_and_checkpoint(
+    connection: &mut rusqlite::Connection,
+    source_id: &str,
+    now: i64,
+    cancel: &AtomicBool,
+    checkpoint: &mut impl FnMut(),
+) -> Result<Cancellable<bool>, String> {
+    checkpoint();
+    if cancelled(cancel) {
+        return Ok(Cancellable::Cancelled);
+    }
     let rows = {
         let mut statement = connection
             .prepare(
@@ -1463,28 +1536,37 @@ fn publish_current_readiness_targets(
                  ORDER BY path",
             )
             .map_err(|error| error.to_string())?;
-        statement
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, i64>(4)?,
-                ))
-            })
-            .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| error.to_string())?
+        let mut query = statement.query([]).map_err(|error| error.to_string())?;
+        let mut rows = Vec::new();
+        while let Some(row) = query.next().map_err(|error| error.to_string())? {
+            checkpoint();
+            if cancelled(cancel) {
+                return Ok(Cancellable::Cancelled);
+            }
+            rows.push((
+                row.get::<_, String>(0).map_err(|error| error.to_string())?,
+                row.get::<_, Option<String>>(1)
+                    .map_err(|error| error.to_string())?,
+                row.get::<_, Option<String>>(2)
+                    .map_err(|error| error.to_string())?,
+                row.get::<_, i64>(3).map_err(|error| error.to_string())?,
+                row.get::<_, i64>(4).map_err(|error| error.to_string())?,
+            ));
+        }
+        rows
     };
     let mut manifest = Vec::with_capacity(rows.len());
     for (path, identity, content_hash, file_size, modified_ns) in rows {
+        checkpoint();
+        if cancelled(cancel) {
+            return Ok(Cancellable::Cancelled);
+        }
         if !wavecrate_library::sample_sources::is_supported_audio(std::path::Path::new(&path)) {
             continue;
         }
         let Some(identity) = identity.filter(|value| !value.trim().is_empty()) else {
             mark_readiness_temporarily_unavailable(connection, source_id, now)?;
-            return Ok(false);
+            return Ok(Cancellable::Completed(false));
         };
         let content_hash = content_hash
             .filter(|value| !value.trim().is_empty())
@@ -1509,6 +1591,10 @@ fn publish_current_readiness_targets(
     let mut membership = blake3::Hasher::new();
     let mut targets = Vec::with_capacity(manifest.len().saturating_mul(4).saturating_add(1));
     for (path, identity, content_hash) in &manifest {
+        checkpoint();
+        if cancelled(cancel) {
+            return Ok(Cancellable::Cancelled);
+        }
         membership.update(identity.as_bytes());
         membership.update(&[0]);
         membership.update(content_hash.as_bytes());
@@ -1541,7 +1627,10 @@ fn publish_current_readiness_targets(
         source_generation,
         membership_generation,
     ));
-    let target_fingerprint = readiness_target_fingerprint(&targets);
+    let Some(target_fingerprint) = readiness_target_fingerprint_with_cancel(&targets, cancel)
+    else {
+        return Ok(Cancellable::Cancelled);
+    };
     let current_fingerprint = connection
         .query_row(
             "SELECT value FROM metadata WHERE key = ?1",
@@ -1566,12 +1655,12 @@ fn publish_current_readiness_targets(
                 *generation == source_generation && availability == "active"
             })
     {
-        return Ok(false);
+        return Ok(Cancellable::Completed(false));
     }
     let readiness_revision = current_source
         .map(|(_, revision, _)| revision.saturating_add(1))
         .unwrap_or(1);
-    replace_readiness_targets(
+    match replace_readiness_targets_with_cancel(
         connection,
         source_id,
         source_generation,
@@ -1579,8 +1668,17 @@ fn publish_current_readiness_targets(
         SourceAvailability::Active,
         &targets,
         now,
-    )
-    .map_err(|error| error.to_string())?;
+        cancel,
+    ) {
+        Ok(()) => {}
+        Err(wavecrate::sample_sources::readiness::ReadinessError::Cancelled) => {
+            return Ok(Cancellable::Cancelled);
+        }
+        Err(error) => return Err(error.to_string()),
+    }
+    if cancelled(cancel) {
+        return Ok(Cancellable::Cancelled);
+    }
     connection
         .execute(
             "INSERT INTO metadata (key, value) VALUES (?1, ?2)
@@ -1588,7 +1686,11 @@ fn publish_current_readiness_targets(
             params![META_READINESS_TARGET_FINGERPRINT, target_fingerprint],
         )
         .map_err(|error| error.to_string())?;
-    Ok(true)
+    Ok(Cancellable::Completed(true))
+}
+
+fn cancelled(cancel: &AtomicBool) -> bool {
+    cancel.load(Ordering::Acquire)
 }
 
 fn mark_readiness_temporarily_unavailable(
@@ -1609,9 +1711,15 @@ fn mark_readiness_temporarily_unavailable(
     Ok(())
 }
 
-fn readiness_target_fingerprint(targets: &[ReadinessTarget]) -> String {
+fn readiness_target_fingerprint_with_cancel(
+    targets: &[ReadinessTarget],
+    cancel: &AtomicBool,
+) -> Option<String> {
     let mut hash = blake3::Hasher::new();
     for target in targets {
+        if cancelled(cancel) {
+            return None;
+        }
         hash.update(target.source_id.as_bytes());
         hash.update(&[0]);
         hash.update(target.scope_id.as_bytes());
@@ -1625,7 +1733,7 @@ fn readiness_target_fingerprint(targets: &[ReadinessTarget]) -> String {
         hash.update(target.content_generation.as_bytes());
         hash.update(&[0xff]);
     }
-    hash.finalize().to_hex().to_string()
+    Some(hash.finalize().to_hex().to_string())
 }
 
 fn execute_candidate(
@@ -2244,7 +2352,10 @@ mod tests {
 
     use wavecrate::sample_sources::{
         SourceId,
-        readiness::{ReadinessEligibility, SourceAvailability, replace_readiness_targets},
+        readiness::{
+            ReadinessEligibility, SourceAvailability, persist_readiness_deficits,
+            reconcile_readiness, replace_readiness_targets,
+        },
     };
 
     use super::*;
@@ -2688,8 +2799,12 @@ mod tests {
         drop(connection);
 
         let started_at = Instant::now();
-        let (candidates, stats) =
-            discover_source_candidates(&source, 100).expect("discover large source");
+        let cancel = AtomicBool::new(false);
+        let Cancellable::Completed((candidates, stats)) =
+            discover_source_candidates(&source, 100, &cancel).expect("discover large source")
+        else {
+            panic!("large source discovery unexpectedly cancelled");
+        };
         let elapsed = started_at.elapsed();
 
         assert_eq!(candidates.len(), FILE_COUNT * 4 + 1);
@@ -2698,6 +2813,99 @@ mod tests {
             "large_source_discovery file_count={FILE_COUNT} candidate_count={} elapsed_ms={:.3}",
             candidates.len(),
             elapsed.as_secs_f64() * 1_000.0,
+        );
+    }
+
+    #[test]
+    fn large_source_discovery_cancels_mid_manifest_and_resumes_cleanly() {
+        const FILE_COUNT: usize = 512;
+        let directory = tempfile::tempdir().expect("large cancellation source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("large-discovery-cancel"),
+            directory.path().to_path_buf(),
+        );
+        source
+            .open_db()
+            .expect("create cancellation source database");
+        let database_root = source.database_root().expect("cancellation database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open cancellation database");
+        let transaction = connection.transaction().expect("start cancellation seed");
+        {
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO wav_files (
+                        path, file_size, modified_ns, file_identity, content_hash, missing,
+                        extension
+                     ) VALUES (?1, 1024, 1, ?2, ?3, 0, 'wav')",
+                )
+                .expect("prepare cancellation seed");
+            for index in 0..FILE_COUNT {
+                insert
+                    .execute(params![
+                        format!("cancel/sample-{index:05}.wav"),
+                        format!("cancel-identity-{index:05}"),
+                        format!("cancel-content-{index:05}"),
+                    ])
+                    .expect("insert cancellation row");
+            }
+        }
+        transaction.commit().expect("commit cancellation seed");
+
+        let cancel = AtomicBool::new(false);
+        let mut checkpoints = 0_usize;
+        let started_at = Instant::now();
+        let cancelled_outcome = publish_current_readiness_targets_with_cancel_and_checkpoint(
+            &mut connection,
+            source.id.as_str(),
+            100,
+            &cancel,
+            &mut || {
+                checkpoints += 1;
+                if checkpoints == 128 {
+                    cancel.store(true, Ordering::Release);
+                }
+            },
+        )
+        .expect("cancel manifest discovery");
+
+        assert!(matches!(cancelled_outcome, Cancellable::Cancelled));
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_readiness_targets WHERE source_id = ?1",
+                    [source.id.as_str()],
+                    |row| row.get::<_, i64>(0),
+                )
+                .expect("count cancelled readiness targets"),
+            0,
+            "cancelled discovery must not publish a partial desired state"
+        );
+
+        cancel.store(false, Ordering::Release);
+        assert!(
+            publish_current_readiness_targets_with_cancel(
+                &mut connection,
+                source.id.as_str(),
+                101,
+                &cancel,
+            )
+            .is_ok_and(|outcome| matches!(outcome, Cancellable::Completed(true)))
+        );
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM source_readiness_targets WHERE source_id = ?1",
+                    [source.id.as_str()],
+                    |row| row.get::<_, i64>(0),
+                )
+                .expect("count resumed readiness targets"),
+            i64::try_from(FILE_COUNT * 4 + 1).expect("target count fits i64")
         );
     }
 
@@ -2782,9 +2990,13 @@ mod tests {
         assert!(connection.is_readonly(rusqlite::MAIN_DB).unwrap());
         let counts_before = discovery_durable_counts(&connection);
 
-        let (candidates, stats) =
-            discover_source_candidates_with_connection(&source, &mut connection, 100)
-                .expect("skip read-only source processing");
+        let cancel = AtomicBool::new(false);
+        let Cancellable::Completed((candidates, stats)) =
+            discover_source_candidates_with_connection(&source, &mut connection, 100, &cancel)
+                .expect("skip read-only source processing")
+        else {
+            panic!("read-only discovery unexpectedly cancelled");
+        };
 
         assert!(candidates.is_empty());
         assert_eq!(stats.readiness_queue_depth, 0);
@@ -2798,12 +3010,13 @@ mod tests {
         let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
         wait_until(Duration::from_secs(10), || {
             let database_root = source.database_root().expect("database root");
-            let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            let Ok(connection) = SourceDatabase::open_connection_with_role_and_database_root(
                 &source.root,
                 &database_root,
                 SourceDatabaseConnectionRole::JobWorker,
-            )
-            .expect("open readiness database");
+            ) else {
+                return false;
+            };
             connection
                 .query_row(
                     "SELECT COUNT(*) = 4
@@ -2828,7 +3041,7 @@ mod tests {
                     params![source.id.as_str()],
                     |row| row.get::<_, bool>(0),
                 )
-                .expect("read readiness artifact")
+                .unwrap_or(false)
         });
         let report = supervisor.shutdown();
         assert_eq!(report["joined"], true);
@@ -3044,7 +3257,12 @@ mod tests {
             .expect("persist deficits");
         drop(connection);
 
-        let (candidates, _) = discover_source_candidates(&source, 250).expect("rediscover work");
+        let cancel = AtomicBool::new(false);
+        let Cancellable::Completed((candidates, _)) =
+            discover_source_candidates(&source, 250, &cancel).expect("rediscover work")
+        else {
+            panic!("source rediscovery unexpectedly cancelled");
+        };
         let readiness = candidates
             .iter()
             .filter(|candidate| matches!(candidate.task, RuntimeTask::Readiness(_)))
@@ -3215,6 +3433,9 @@ mod tests {
         }
         writer.finalize().expect("finalize readiness wav");
         let size = path.metadata().expect("read readiness metadata").len();
+        let content_hash = blake3::hash(&std::fs::read(&path).expect("read readiness wav"))
+            .to_hex()
+            .to_string();
         let source =
             SampleSource::new_with_id(SourceId::from_string(id), directory.path().to_path_buf());
         let db = source.open_db().expect("open readiness source database");
@@ -3230,9 +3451,9 @@ mod tests {
         connection
             .execute(
                 "UPDATE wav_files
-                 SET file_identity = 'identity-1', content_hash = 'content-1'
+                 SET file_identity = 'identity-1', content_hash = ?1
                  WHERE path = 'ready.wav'",
-                [],
+                [&content_hash],
             )
             .expect("assign readiness identity");
         (directory, source)

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::{
         Arc, Condvar, Mutex, MutexGuard,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -70,12 +70,18 @@ struct ExternalScanRegistration {
     cancel: Arc<AtomicBool>,
 }
 
+#[derive(Default)]
+struct ExternalScanState {
+    admissions: usize,
+    registrations: BTreeMap<u64, ExternalScanRegistration>,
+}
+
 impl SourceProcessingBudgetHandle {
     pub(in crate::native_app) fn acquire_scan(
         &self,
         source_id: &str,
     ) -> Option<SourceProcessingBudgetPermit> {
-        loop {
+        let admission_cancel = {
             let mut control = self.shared.control();
             while !control.shutdown
                 && control.sources.contains_key(source_id)
@@ -93,7 +99,12 @@ impl SourceProcessingBudgetHandle {
             {
                 return None;
             }
-            drop(control);
+            let admission_cancel = Arc::clone(&control.source_work_cancels[source_id]);
+            let mut external_scans = self.shared.external_scans();
+            external_scans.admissions = external_scans.admissions.saturating_add(1);
+            admission_cancel
+        };
+        loop {
             let mut budgets = self.shared.budgets();
             if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
                 drop(budgets);
@@ -102,13 +113,32 @@ impl SourceProcessingBudgetHandle {
                     .next_external_scan_id
                     .fetch_add(1, Ordering::Relaxed);
                 let cancel = Arc::new(AtomicBool::new(false));
-                self.shared.external_scans().insert(
+                let control = self.shared.control();
+                let mut external_scans = self.shared.external_scans();
+                external_scans.admissions = external_scans.admissions.saturating_sub(1);
+                if control.shutdown
+                    || self.shared.cancel.load(Ordering::Acquire)
+                    || !control.sources.contains_key(source_id)
+                    || control.processing_paused()
+                    || admission_cancel.load(Ordering::Acquire)
+                {
+                    drop(external_scans);
+                    drop(control);
+                    self.shared.external_scan_wake.notify_all();
+                    self.shared.budgets().release(permit);
+                    self.shared.budget_wake.notify_all();
+                    return None;
+                }
+                external_scans.registrations.insert(
                     registration_id,
                     ExternalScanRegistration {
                         source_id: source_id.to_string(),
                         cancel: Arc::clone(&cancel),
                     },
                 );
+                drop(external_scans);
+                drop(control);
+                self.shared.external_scan_wake.notify_all();
                 let permit = SourceProcessingBudgetPermit {
                     shared: Arc::clone(&self.shared),
                     permit: Some(permit),
@@ -126,6 +156,17 @@ impl SourceProcessingBudgetHandle {
                     .wait(budgets)
                     .unwrap_or_else(|poison| poison.into_inner()),
             );
+            let control = self.shared.control();
+            let unavailable = control.shutdown
+                || self.shared.cancel.load(Ordering::Acquire)
+                || !control.sources.contains_key(source_id)
+                || control.processing_paused()
+                || admission_cancel.load(Ordering::Acquire);
+            drop(control);
+            if unavailable {
+                self.shared.finish_external_scan_admission();
+                return None;
+            }
         }
     }
 }
@@ -151,12 +192,15 @@ impl SourceProcessingBudgetPermit {
 
 impl Drop for SourceProcessingBudgetPermit {
     fn drop(&mut self) {
-        self.shared.external_scans().remove(&self.registration_id);
+        self.shared
+            .external_scans()
+            .registrations
+            .remove(&self.registration_id);
         self.shared.external_scan_wake.notify_all();
         if let Some(permit) = self.permit.take() {
             self.shared.budgets().release(permit);
             self.shared.budget_wake.notify_all();
-            self.shared.control().wake("external_budget_released");
+            self.shared.control().notify("external_budget_released");
             self.shared.wake.notify_one();
         }
     }
@@ -190,21 +234,97 @@ impl SourceProcessingSupervisor {
     }
 
     pub(in crate::native_app) fn replace_sources(&self, sources: Vec<SampleSource>) {
+        let sources = sources_by_id(sources);
         let mut control = self.shared.control();
-        control.cancel_all_source_work();
-        control.sources = sources_by_id(sources);
-        control.reset_source_work_tokens();
-        let retained_source_ids = control.sources.keys().cloned().collect::<Vec<_>>();
-        control.priority.immediate.clear();
-        control.priority.visible.clear();
-        control.priority.immediate_paths.clear();
-        control.priority.visible_paths.clear();
-        control.wake("configured_sources_changed");
+        if source_maps_match(&control.sources, &sources) {
+            return;
+        }
+        let changed_source_ids = control
+            .sources
+            .iter()
+            .filter_map(|(source_id, current)| {
+                let changed = sources
+                    .get(source_id)
+                    .is_none_or(|replacement| !source_descriptors_match(current, replacement));
+                changed.then(|| source_id.clone())
+            })
+            .chain(sources.iter().filter_map(|(source_id, replacement)| {
+                let changed = control
+                    .sources
+                    .get(source_id)
+                    .is_none_or(|current| !source_descriptors_match(current, replacement));
+                changed.then(|| source_id.clone())
+            }))
+            .collect::<std::collections::BTreeSet<_>>();
+        for source_id in &changed_source_ids {
+            if let Some(cancel) = control.source_work_cancels.get(source_id) {
+                cancel.store(true, Ordering::Release);
+            }
+        }
+        let mut source_work_cancels = BTreeMap::new();
+        for (source_id, source) in &sources {
+            let cancel = control
+                .sources
+                .get(source_id)
+                .filter(|current| source_descriptors_match(current, source))
+                .and_then(|_| control.source_work_cancels.get(source_id))
+                .cloned()
+                .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+            source_work_cancels.insert(source_id.clone(), cancel);
+        }
+        control.sources = sources;
+        control.source_work_cancels = source_work_cancels;
+        let retained_source_ids = control.sources.keys().cloned().collect::<BTreeSet<_>>();
+        control
+            .dirty_sources
+            .retain(|source_id| retained_source_ids.contains(source_id));
+        control.dirty_sources.extend(
+            changed_source_ids
+                .iter()
+                .filter(|source_id| retained_source_ids.contains(*source_id))
+                .cloned(),
+        );
+        control.priority.immediate.retain(|priority| {
+            retained_source_ids.contains(&priority.source_id)
+                && !changed_source_ids.contains(&priority.source_id)
+        });
+        control.priority.visible.retain(|priority| {
+            retained_source_ids.contains(&priority.source_id)
+                && !changed_source_ids.contains(&priority.source_id)
+        });
+        control.priority.immediate_paths.retain(|(source_id, _)| {
+            retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
+        });
+        control.priority.visible_paths.retain(|(source_id, _)| {
+            retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
+        });
+        if control
+            .priority
+            .selected_source
+            .as_ref()
+            .is_some_and(|source_id| {
+                !retained_source_ids.contains(source_id) || changed_source_ids.contains(source_id)
+            })
+        {
+            control.priority.selected_source = None;
+        }
+        if control
+            .priority
+            .current_folder
+            .as_ref()
+            .is_some_and(|(source_id, _)| {
+                !retained_source_ids.contains(source_id) || changed_source_ids.contains(source_id)
+            })
+        {
+            control.priority.current_folder = None;
+        }
+        control.notify("configured_sources_changed");
         drop(control);
         self.shared.cancel_external_scans(|registration| {
-            !retained_source_ids
-                .iter()
-                .any(|source_id| source_id == &registration.source_id)
+            changed_source_ids.contains(&registration.source_id)
+                || !retained_source_ids
+                    .iter()
+                    .any(|source_id| source_id == &registration.source_id)
         });
         self.shared.budget_wake.notify_all();
         self.shared.wake.notify_all();
@@ -222,7 +342,7 @@ impl SourceProcessingSupervisor {
             return;
         }
         control.cancel_source_work(source_id);
-        control.wake(reason);
+        control.mark_source_dirty(source_id, reason);
         drop(control);
         self.shared
             .cancel_external_scans(|registration| registration.source_id == source_id);
@@ -235,7 +355,7 @@ impl SourceProcessingSupervisor {
         let selected = source_id.map(str::to_string);
         if control.priority.selected_source != selected {
             control.priority.selected_source = selected;
-            control.wake("selected_source_changed");
+            control.notify("selected_source_changed");
             self.shared.wake.notify_one();
         }
     }
@@ -255,7 +375,7 @@ impl SourceProcessingSupervisor {
             &mut control.priority.visible_paths
         };
         if priorities.insert(key) {
-            control.wake("interactive_path_priority");
+            control.notify("interactive_path_priority");
             self.shared.wake.notify_one();
         }
     }
@@ -268,7 +388,7 @@ impl SourceProcessingSupervisor {
         let mut control = self.shared.control();
         if control.priority.visible_paths != visible_paths {
             control.priority.visible_paths = visible_paths;
-            control.wake("visible_paths_changed");
+            control.notify("visible_paths_changed");
             self.shared.wake.notify_one();
         }
     }
@@ -278,7 +398,7 @@ impl SourceProcessingSupervisor {
         let current = Some((source_id.to_string(), relative_path.to_string()));
         if control.priority.current_folder != current {
             control.priority.current_folder = current;
-            control.wake("current_folder_changed");
+            control.notify("current_folder_changed");
             self.shared.wake.notify_one();
         }
     }
@@ -292,11 +412,11 @@ impl SourceProcessingSupervisor {
             } else if !control.foreground_active {
                 control.reset_source_work_tokens();
             }
-            control.wake(if active {
-                "playback_pause"
+            if active {
+                control.notify("playback_pause");
             } else {
-                "playback_resume"
-            });
+                control.mark_all_sources_dirty("playback_resume");
+            }
             drop(control);
             if active {
                 self.shared.cancel_external_scans(|_| true);
@@ -317,11 +437,11 @@ impl SourceProcessingSupervisor {
         } else if !control.playback_active {
             control.reset_source_work_tokens();
         }
-        control.wake(if active {
-            "foreground_activity_pause"
+        if active {
+            control.notify("foreground_activity_pause");
         } else {
-            "foreground_activity_resume"
-        });
+            control.mark_all_sources_dirty("foreground_activity_resume");
+        }
         drop(control);
         if active {
             self.shared.cancel_external_scans(|_| true);
@@ -338,7 +458,7 @@ impl SourceProcessingSupervisor {
             let mut control = self.shared.control();
             control.cancel_all_source_work();
             control.shutdown = true;
-            control.wake("shutdown");
+            control.notify("shutdown");
         }
         self.shared.wake.notify_all();
         self.shared.budget_wake.notify_all();
@@ -365,6 +485,7 @@ impl SourceProcessingSupervisor {
             "oldest_job_age_seconds": telemetry.oldest_job_age_seconds,
             "retries_due": telemetry.retries_due,
             "readiness_queue_depth": telemetry.readiness_queue_depth,
+            "source_discoveries": telemetry.source_discoveries,
         })
     }
 }
@@ -384,7 +505,7 @@ struct Shared {
     telemetry: Mutex<SupervisorTelemetry>,
     budgets: Mutex<BudgetTracker>,
     budget_wake: Condvar,
-    external_scans: Mutex<BTreeMap<u64, ExternalScanRegistration>>,
+    external_scans: Mutex<ExternalScanState>,
     external_scan_wake: Condvar,
     next_external_scan_id: AtomicU64,
 }
@@ -396,10 +517,12 @@ impl Shared {
             .keys()
             .map(|source_id| (source_id.clone(), Arc::new(AtomicBool::new(false))))
             .collect();
+        let dirty_sources = sources.keys().cloned().collect();
         Self {
             state: Mutex::new(ControlState {
                 sources,
                 source_work_cancels,
+                dirty_sources,
                 wake_generation: 1,
                 wake_reason: "startup",
                 playback_active: false,
@@ -412,7 +535,7 @@ impl Shared {
             telemetry: Mutex::new(SupervisorTelemetry::default()),
             budgets: Mutex::new(BudgetTracker::new(ProcessingBudgets::default())),
             budget_wake: Condvar::new(),
-            external_scans: Mutex::new(BTreeMap::new()),
+            external_scans: Mutex::new(ExternalScanState::default()),
             external_scan_wake: Condvar::new(),
             next_external_scan_id: AtomicU64::new(1),
         }
@@ -436,14 +559,14 @@ impl Shared {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
-    fn external_scans(&self) -> MutexGuard<'_, BTreeMap<u64, ExternalScanRegistration>> {
+    fn external_scans(&self) -> MutexGuard<'_, ExternalScanState> {
         self.external_scans
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
     fn cancel_external_scans(&self, should_cancel: impl Fn(&ExternalScanRegistration) -> bool) {
-        for registration in self.external_scans().values() {
+        for registration in self.external_scans().registrations.values() {
             if should_cancel(registration) {
                 registration.cancel.store(true, Ordering::Release);
             }
@@ -454,15 +577,25 @@ impl Shared {
         let registrations = self.external_scans();
         drop(
             self.external_scan_wake
-                .wait_while(registrations, |registrations| !registrations.is_empty())
+                .wait_while(registrations, |state| {
+                    state.admissions > 0 || !state.registrations.is_empty()
+                })
                 .unwrap_or_else(|poison| poison.into_inner()),
         );
+    }
+
+    fn finish_external_scan_admission(&self) {
+        let mut external_scans = self.external_scans();
+        external_scans.admissions = external_scans.admissions.saturating_sub(1);
+        drop(external_scans);
+        self.external_scan_wake.notify_all();
     }
 }
 
 struct ControlState {
     sources: BTreeMap<String, SampleSource>,
     source_work_cancels: BTreeMap<String, Arc<AtomicBool>>,
+    dirty_sources: BTreeSet<String>,
     wake_generation: u64,
     wake_reason: &'static str,
     playback_active: bool,
@@ -472,9 +605,21 @@ struct ControlState {
 }
 
 impl ControlState {
-    fn wake(&mut self, reason: &'static str) {
+    fn notify(&mut self, reason: &'static str) {
         self.wake_generation = self.wake_generation.wrapping_add(1);
         self.wake_reason = reason;
+    }
+
+    fn mark_source_dirty(&mut self, source_id: &str, reason: &'static str) {
+        if self.sources.contains_key(source_id) {
+            self.dirty_sources.insert(source_id.to_string());
+            self.notify(reason);
+        }
+    }
+
+    fn mark_all_sources_dirty(&mut self, reason: &'static str) {
+        self.dirty_sources.extend(self.sources.keys().cloned());
+        self.notify(reason);
     }
 
     fn processing_paused(&self) -> bool {
@@ -518,6 +663,7 @@ struct SupervisorTelemetry {
     oldest_job_age_seconds: u64,
     retries_due: usize,
     readiness_queue_depth: usize,
+    source_discoveries: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -563,26 +709,45 @@ impl ExecutionOutcome {
 fn run_coordinator(shared: Arc<Shared>) {
     let mut observed_generation = 0;
     let mut next_retry_at = None;
+    let mut next_safety_sweep_at = Instant::now() + SAFETY_SWEEP_INTERVAL;
     let mut scheduler = FairScheduler::default();
     let mut reset_sources = BTreeMap::<String, bool>::new();
+    let mut candidates = Vec::<RuntimeCandidate>::new();
+    let mut source_stats = BTreeMap::<String, SourceDiscoveryStats>::new();
     loop {
-        let (sources, source_work_cancels, priority, processing_paused, generation, reason) = {
+        let (sources, dirty_sources, source_work_cancels, processing_paused, generation, reason) = {
             let mut control = shared.control();
             while !control.shutdown && control.wake_generation == observed_generation {
-                let wait_duration = coordinator_wait_duration(next_retry_at, now_epoch_seconds());
+                let wait_duration = coordinator_wait_duration(
+                    next_retry_at,
+                    now_epoch_seconds(),
+                    next_safety_sweep_at.saturating_duration_since(Instant::now()),
+                );
                 let (next, _) = shared
                     .wake
                     .wait_timeout(control, wait_duration)
                     .unwrap_or_else(|poison| poison.into_inner());
                 control = next;
                 if control.wake_generation == observed_generation {
-                    let retry_due =
-                        next_retry_at.is_some_and(|deadline| deadline <= now_epoch_seconds());
-                    control.wake(if retry_due {
-                        "retry_deadline"
+                    let now = now_epoch_seconds();
+                    if Instant::now() >= next_safety_sweep_at {
+                        control.mark_all_sources_dirty("periodic_safety_sweep");
+                        next_safety_sweep_at = Instant::now() + SAFETY_SWEEP_INTERVAL;
                     } else {
-                        "periodic_safety_sweep"
-                    });
+                        let due_sources = source_stats
+                            .iter()
+                            .filter_map(|(source_id, stats)| {
+                                stats
+                                    .earliest_retry_at
+                                    .is_some_and(|deadline| deadline <= now)
+                                    .then(|| source_id.clone())
+                            })
+                            .collect::<Vec<_>>();
+                        for source_id in due_sources {
+                            control.dirty_sources.insert(source_id);
+                        }
+                        control.notify("retry_deadline");
+                    }
                 }
             }
             if control.shutdown {
@@ -590,8 +755,8 @@ fn run_coordinator(shared: Arc<Shared>) {
             }
             (
                 control.sources.values().cloned().collect::<Vec<_>>(),
+                std::mem::take(&mut control.dirty_sources),
                 control.source_work_cancels.clone(),
-                control.priority.clone(),
                 control.processing_paused(),
                 control.wake_generation,
                 control.wake_reason,
@@ -599,6 +764,15 @@ fn run_coordinator(shared: Arc<Shared>) {
         };
         observed_generation = generation;
         scheduler.set_paused(processing_paused);
+        let configured_source_ids = sources
+            .iter()
+            .map(|source| source.id.as_str().to_string())
+            .collect::<BTreeSet<_>>();
+        candidates.retain(|candidate| {
+            configured_source_ids.contains(candidate.source.id.as_str())
+                && !dirty_sources.contains(candidate.source.id.as_str())
+        });
+        source_stats.retain(|source_id, _| configured_source_ids.contains(source_id));
         if processing_paused {
             tracing::debug!(
                 target: "wavecrate::source_processing",
@@ -640,7 +814,21 @@ fn run_coordinator(shared: Arc<Shared>) {
             .retain(|source_id, _| sources.iter().any(|source| source.id.as_str() == source_id));
 
         let sweep_started = Instant::now();
-        let (mut candidates, mut source_stats) = discover_candidates(&shared, &sources);
+        let sources_to_discover = sources
+            .iter()
+            .filter(|source| dirty_sources.contains(source.id.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        for source in &sources_to_discover {
+            source_stats.remove(source.id.as_str());
+        }
+        let (mut discovered, discovered_source_stats, deferred_discoveries) =
+            discover_candidates(&shared, &sources_to_discover);
+        if !deferred_discoveries.is_empty() {
+            shared.control().dirty_sources.extend(deferred_discoveries);
+        }
+        candidates.append(&mut discovered);
+        source_stats.extend(discovered_source_stats);
         let discovered_stats = aggregate_source_stats(source_stats.values().copied());
         next_retry_at = discovered_stats.earliest_retry_at;
         {
@@ -655,8 +843,8 @@ fn run_coordinator(shared: Arc<Shared>) {
         }
         while !candidates.is_empty() && !shared.cancel.load(Ordering::Acquire) {
             let control = shared.control();
-            let interrupted =
-                control.processing_paused() || control.wake_generation != observed_generation;
+            let interrupted = control.processing_paused() || !control.dirty_sources.is_empty();
+            let priority = control.priority.clone();
             drop(control);
             if interrupted {
                 break;
@@ -763,18 +951,10 @@ fn run_coordinator(shared: Arc<Shared>) {
             if !should_refresh {
                 continue;
             }
-            match discover_source_candidates(&candidate.source, now_epoch_seconds()) {
-                Ok((mut refreshed, refreshed_stats)) => {
-                    candidates.append(&mut refreshed);
-                    source_stats.insert(source_id.to_string(), refreshed_stats);
-                    let aggregate = aggregate_source_stats(source_stats.values().copied());
-                    next_retry_at = aggregate.earliest_retry_at;
-                    let mut telemetry = shared.telemetry();
-                    telemetry.retries_due = aggregate.retries_due;
-                    telemetry.readiness_queue_depth = aggregate.readiness_queue_depth;
-                }
-                Err(error) => record_discovery_error(&shared, &candidate.source, &error),
-            }
+            shared
+                .control()
+                .mark_source_dirty(source_id, "source_stage_progress");
+            break;
         }
         let mut telemetry = shared.telemetry();
         telemetry.queue_depth = candidates.len();
@@ -807,17 +987,24 @@ fn discover_candidates(
 ) -> (
     Vec<RuntimeCandidate>,
     BTreeMap<String, SourceDiscoveryStats>,
+    BTreeSet<String>,
 ) {
     let now = now_epoch_seconds();
     let mut candidates = Vec::new();
     let mut source_stats = BTreeMap::new();
+    let mut deferred = BTreeSet::new();
     for source in sources {
         let Some(permit) = shared
             .budgets()
             .try_acquire(source.id.as_str(), ProcessingLane::Cleanup)
         else {
+            deferred.insert(source.id.as_str().to_string());
             continue;
         };
+        {
+            let mut telemetry = shared.telemetry();
+            telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
+        }
         match discover_source_candidates(source, now) {
             Ok((mut source_candidates, stats)) => {
                 candidates.append(&mut source_candidates);
@@ -828,7 +1015,7 @@ fn discover_candidates(
         shared.budgets().release(permit);
         shared.budget_wake.notify_all();
     }
-    (candidates, source_stats)
+    (candidates, source_stats, deferred)
 }
 
 fn discover_source_candidates(
@@ -1729,6 +1916,26 @@ fn sources_by_id(sources: Vec<SampleSource>) -> BTreeMap<String, SampleSource> {
         .collect()
 }
 
+fn source_maps_match(
+    current: &BTreeMap<String, SampleSource>,
+    replacement: &BTreeMap<String, SampleSource>,
+) -> bool {
+    current.len() == replacement.len()
+        && current.iter().all(|(source_id, source)| {
+            replacement
+                .get(source_id)
+                .is_some_and(|other| source_descriptors_match(source, other))
+        })
+}
+
+fn source_descriptors_match(left: &SampleSource, right: &SampleSource) -> bool {
+    left.id == right.id
+        && left.root == right.root
+        && left.role == right.role
+        && left.metadata_storage == right.metadata_storage
+        && left.primary_import_folder == right.primary_import_folder
+}
+
 fn now_epoch_seconds() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1762,11 +1969,15 @@ fn aggregate_source_stats(
         })
 }
 
-fn coordinator_wait_duration(next_retry_at: Option<i64>, now: i64) -> Duration {
-    let retry_wait = next_retry_at.map_or(SAFETY_SWEEP_INTERVAL, |deadline| {
+fn coordinator_wait_duration(
+    next_retry_at: Option<i64>,
+    now: i64,
+    safety_wait: Duration,
+) -> Duration {
+    let retry_wait = next_retry_at.map_or(safety_wait, |deadline| {
         Duration::from_secs(deadline.saturating_sub(now).max(0) as u64)
     });
-    SAFETY_SWEEP_INTERVAL.min(retry_wait)
+    safety_wait.min(retry_wait)
 }
 
 fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
@@ -1849,6 +2060,190 @@ mod tests {
         drop(control);
         drop(first_scan);
         assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn identical_source_refresh_is_a_noop_and_descriptor_changes_are_source_local() {
+        let (_first_directory, first) = unhashed_source("refresh-first");
+        let (_second_directory, second) = unhashed_source("refresh-second");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+        let (first_generation, second_generation, wake_generation) = {
+            let mut control = supervisor.shared.control();
+            control.dirty_sources.clear();
+            control
+                .priority
+                .immediate_paths
+                .insert((first.id.to_string(), "first.wav".to_string()));
+            control
+                .priority
+                .immediate_paths
+                .insert((second.id.to_string(), "second.wav".to_string()));
+            control.priority.selected_source = Some(second.id.to_string());
+            (
+                Arc::clone(&control.source_work_cancels[first.id.as_str()]),
+                Arc::clone(&control.source_work_cancels[second.id.as_str()]),
+                control.wake_generation,
+            )
+        };
+
+        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+
+        {
+            let control = supervisor.shared.control();
+            assert_eq!(control.wake_generation, wake_generation);
+            assert!(control.dirty_sources.is_empty());
+            assert!(Arc::ptr_eq(
+                &first_generation,
+                &control.source_work_cancels[first.id.as_str()]
+            ));
+            assert!(Arc::ptr_eq(
+                &second_generation,
+                &control.source_work_cancels[second.id.as_str()]
+            ));
+        }
+
+        let replacement_directory = tempfile::tempdir().expect("replacement source root");
+        let replacement =
+            SampleSource::new_with_id(first.id.clone(), replacement_directory.path().to_path_buf());
+        supervisor.replace_sources(vec![replacement, second.clone()]);
+
+        assert!(first_generation.load(Ordering::Acquire));
+        assert!(!second_generation.load(Ordering::Acquire));
+        let control = supervisor.shared.control();
+        assert_eq!(
+            control.dirty_sources,
+            BTreeSet::from([first.id.to_string()])
+        );
+        assert!(Arc::ptr_eq(
+            &second_generation,
+            &control.source_work_cancels[second.id.as_str()]
+        ));
+        assert_eq!(
+            control.priority.immediate_paths,
+            BTreeSet::from([(second.id.to_string(), "second.wav".to_string())])
+        );
+        assert_eq!(
+            control.priority.selected_source.as_deref(),
+            Some(second.id.as_str())
+        );
+        drop(control);
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn priority_only_wakes_reuse_candidates_without_source_rediscovery() {
+        let directory = tempfile::tempdir().expect("priority source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("priority-cache"),
+            directory.path().to_path_buf(),
+        );
+        source.open_db().expect("create priority source database");
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+        wait_until(Duration::from_secs(5), || {
+            let telemetry = supervisor.shared.telemetry();
+            telemetry.source_discoveries >= 1 && telemetry.queue_depth == 0
+        });
+        let discoveries_before = supervisor.shared.telemetry().source_discoveries;
+
+        for index in 0..128 {
+            supervisor.prioritize_path(
+                source.id.as_str(),
+                format!("visible/sample-{index}.wav").as_str(),
+                true,
+            );
+        }
+        thread::sleep(Duration::from_millis(150));
+
+        assert_eq!(
+            supervisor.shared.telemetry().source_discoveries,
+            discoveries_before,
+            "priority-only wakes must reschedule the retained batch without database discovery"
+        );
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    #[ignore = "representative 10k-file source discovery profile"]
+    fn profile_large_source_discovery_baseline() {
+        const FILE_COUNT: usize = 10_000;
+        let directory = tempfile::tempdir().expect("large profile source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("large-discovery-profile"),
+            directory.path().to_path_buf(),
+        );
+        source.open_db().expect("create profile source database");
+        let database_root = source.database_root().expect("profile database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open profile database");
+        let transaction = connection.transaction().expect("start profile seed");
+        {
+            let mut insert = transaction
+                .prepare(
+                    "INSERT INTO wav_files (
+                        path, file_size, modified_ns, file_identity, content_hash, missing,
+                        extension
+                     ) VALUES (?1, 1024, 1, ?2, ?3, 0, 'wav')",
+                )
+                .expect("prepare profile insert");
+            for index in 0..FILE_COUNT {
+                insert
+                    .execute(params![
+                        format!("profile/sample-{index:05}.wav"),
+                        format!("identity-{index:05}"),
+                        format!("content-{index:05}"),
+                    ])
+                    .expect("insert profile row");
+            }
+        }
+        transaction.commit().expect("commit profile seed");
+        drop(connection);
+
+        let started_at = Instant::now();
+        let (candidates, stats) =
+            discover_source_candidates(&source, 100).expect("discover large source");
+        let elapsed = started_at.elapsed();
+
+        assert_eq!(candidates.len(), FILE_COUNT * 4 + 1);
+        assert_eq!(stats.readiness_queue_depth, FILE_COUNT * 4 + 1);
+        eprintln!(
+            "large_source_discovery file_count={FILE_COUNT} candidate_count={} elapsed_ms={:.3}",
+            candidates.len(),
+            elapsed.as_secs_f64() * 1_000.0,
+        );
+    }
+
+    #[test]
+    fn shutdown_waits_for_external_scan_admissions_and_rejects_late_permits() {
+        let (_directory, source) = unhashed_source("admission-race");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor.replace_sources(vec![source.clone()]);
+        let handle = supervisor.budget_handle();
+        let first = handle
+            .acquire_scan(source.id.as_str())
+            .expect("reserve the only scan lane");
+        let first_cancel = first.cancel_token();
+        let waiting_handle = handle.clone();
+        let source_id = source.id.to_string();
+        let waiting = thread::spawn(move || waiting_handle.acquire_scan(&source_id).is_none());
+        wait_until(Duration::from_secs(2), || {
+            supervisor.shared.external_scans().admissions == 1
+        });
+
+        let shutdown = thread::spawn(move || supervisor.shutdown());
+        wait_until(Duration::from_secs(2), || {
+            first_cancel.load(Ordering::Acquire)
+        });
+        drop(first);
+
+        assert!(waiting.join().expect("join waiting admission"));
+        let report = shutdown.join().expect("join supervisor shutdown");
+        assert_eq!(report["joined"], true);
+        assert_eq!(report["external_scans_joined"], true);
     }
 
     #[test]
@@ -2246,15 +2641,26 @@ mod tests {
     #[test]
     fn retry_deadline_shortens_coordinator_wait_deterministically() {
         assert_eq!(
-            coordinator_wait_duration(Some(105), 100),
+            coordinator_wait_duration(Some(105), 100, SAFETY_SWEEP_INTERVAL),
             Duration::from_secs(5)
         );
-        assert_eq!(coordinator_wait_duration(Some(100), 100), Duration::ZERO);
         assert_eq!(
-            coordinator_wait_duration(Some(200), 100),
+            coordinator_wait_duration(Some(100), 100, SAFETY_SWEEP_INTERVAL),
+            Duration::ZERO
+        );
+        assert_eq!(
+            coordinator_wait_duration(Some(200), 100, SAFETY_SWEEP_INTERVAL),
             SAFETY_SWEEP_INTERVAL
         );
-        assert_eq!(coordinator_wait_duration(None, 100), SAFETY_SWEEP_INTERVAL);
+        assert_eq!(
+            coordinator_wait_duration(None, 100, SAFETY_SWEEP_INTERVAL),
+            SAFETY_SWEEP_INTERVAL
+        );
+        assert_eq!(
+            coordinator_wait_duration(None, 100, Duration::from_secs(3)),
+            Duration::from_secs(3),
+            "priority wakes must preserve the remaining absolute safety-sweep deadline"
+        );
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -4,23 +4,24 @@ use std::{
     collections::BTreeMap,
     sync::{
         Arc, Condvar, Mutex, MutexGuard,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
+    db::META_WAV_PATHS_REVISION,
     readiness::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessFailureClassification,
         ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
-        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, cancel_readiness_work,
-        claim_readiness_target, complete_readiness_work, fail_readiness_work,
-        persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
-        renew_readiness_lease,
+        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability,
+        cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+        fail_readiness_work, persist_readiness_deficits, readiness_work_stats, reconcile_readiness,
+        renew_readiness_lease, replace_readiness_targets,
     },
     scanner::complete_pending_deep_hashes,
 };
@@ -40,6 +41,10 @@ const DEEP_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
 const MAX_DISCOVERED_ANALYSIS_JOBS: i64 = 256;
+const EXTERNAL_SCAN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const READINESS_MANIFEST_VERSION: &str = "source_manifest_v1";
+const READINESS_PLAYBACK_VERSION: &str = "waveform_cache_v4";
+const META_READINESS_TARGET_FINGERPRINT: &str = "readiness_target_fingerprint_v1";
 
 /// Owned runtime coordinator. All work is joined during shutdown and observes one cancel token.
 pub(in crate::native_app) struct SourceProcessingSupervisor {
@@ -55,32 +60,98 @@ pub(in crate::native_app) struct SourceProcessingBudgetHandle {
 pub(in crate::native_app) struct SourceProcessingBudgetPermit {
     shared: Arc<Shared>,
     permit: Option<super::scheduler::BudgetPermit>,
+    registration_id: u64,
+    cancel: Arc<AtomicBool>,
+}
+
+struct ExternalScanRegistration {
+    source_id: String,
+    cancel: Arc<AtomicBool>,
 }
 
 impl SourceProcessingBudgetHandle {
     pub(in crate::native_app) fn acquire_scan(
         &self,
         source_id: &str,
-    ) -> SourceProcessingBudgetPermit {
-        let mut budgets = self.shared.budgets();
+    ) -> Option<SourceProcessingBudgetPermit> {
         loop {
+            let mut control = self.shared.control();
+            while !control.shutdown
+                && control.sources.contains_key(source_id)
+                && control.playback_active
+            {
+                control = self
+                    .shared
+                    .wake
+                    .wait(control)
+                    .unwrap_or_else(|poison| poison.into_inner());
+            }
+            if control.shutdown
+                || self.shared.cancel.load(Ordering::Acquire)
+                || !control.sources.contains_key(source_id)
+            {
+                return None;
+            }
+            drop(control);
+            let mut budgets = self.shared.budgets();
             if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
-                return SourceProcessingBudgetPermit {
+                drop(budgets);
+                let registration_id = self
+                    .shared
+                    .next_external_scan_id
+                    .fetch_add(1, Ordering::Relaxed);
+                let cancel = Arc::new(AtomicBool::new(false));
+                self.shared.external_scans().insert(
+                    registration_id,
+                    ExternalScanRegistration {
+                        source_id: source_id.to_string(),
+                        cancel: Arc::clone(&cancel),
+                    },
+                );
+                let permit = SourceProcessingBudgetPermit {
                     shared: Arc::clone(&self.shared),
                     permit: Some(permit),
+                    registration_id,
+                    cancel,
                 };
+                if permit.should_cancel_now() {
+                    permit.cancel.store(true, Ordering::Release);
+                }
+                return Some(permit);
             }
-            budgets = self
-                .shared
-                .budget_wake
-                .wait(budgets)
-                .unwrap_or_else(|poison| poison.into_inner());
+            drop(
+                self.shared
+                    .budget_wake
+                    .wait(budgets)
+                    .unwrap_or_else(|poison| poison.into_inner()),
+            );
         }
+    }
+}
+
+impl SourceProcessingBudgetPermit {
+    pub(in crate::native_app) fn cancel_token(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+
+    fn should_cancel_now(&self) -> bool {
+        if self.shared.cancel.load(Ordering::Acquire) {
+            return true;
+        }
+        let control = self.shared.control();
+        control.shutdown
+            || control.playback_active
+            || self
+                .permit
+                .as_ref()
+                .is_some_and(|permit| !control.sources.contains_key(permit.source_id()))
     }
 }
 
 impl Drop for SourceProcessingBudgetPermit {
     fn drop(&mut self) {
+        self.shared.external_scans().remove(&self.registration_id);
+        self.shared.external_scan_wake.notify_all();
         if let Some(permit) = self.permit.take() {
             self.shared.budgets().release(permit);
             self.shared.budget_wake.notify_all();
@@ -121,12 +192,20 @@ impl SourceProcessingSupervisor {
         self.shared.work_cancel.store(true, Ordering::Release);
         let mut control = self.shared.control();
         control.sources = sources_by_id(sources);
+        let retained_source_ids = control.sources.keys().cloned().collect::<Vec<_>>();
         control.priority.immediate.clear();
         control.priority.visible.clear();
         control.priority.immediate_paths.clear();
         control.priority.visible_paths.clear();
         control.wake("configured_sources_changed");
-        self.shared.wake.notify_one();
+        drop(control);
+        self.shared.cancel_external_scans(|registration| {
+            !retained_source_ids
+                .iter()
+                .any(|source_id| source_id == &registration.source_id)
+        });
+        self.shared.budget_wake.notify_all();
+        self.shared.wake.notify_all();
     }
 
     pub(in crate::native_app) fn budget_handle(&self) -> SourceProcessingBudgetHandle {
@@ -207,6 +286,11 @@ impl SourceProcessingSupervisor {
             } else {
                 "playback_resume"
             });
+            drop(control);
+            if active {
+                self.shared.cancel_external_scans(|_| true);
+            }
+            self.shared.budget_wake.notify_all();
             self.shared.wake.notify_all();
         }
     }
@@ -215,19 +299,25 @@ impl SourceProcessingSupervisor {
         let started_at = Instant::now();
         self.shared.cancel.store(true, Ordering::Release);
         self.shared.work_cancel.store(true, Ordering::Release);
+        self.shared.cancel_external_scans(|_| true);
         {
             let mut control = self.shared.control();
             control.shutdown = true;
             control.wake("shutdown");
         }
         self.shared.wake.notify_all();
+        self.shared.budget_wake.notify_all();
         let joined = self
             .coordinator
             .take()
             .is_none_or(|coordinator| coordinator.join().is_ok());
+        let external_scans_joined = self
+            .shared
+            .wait_for_external_scans(EXTERNAL_SCAN_SHUTDOWN_TIMEOUT);
         let telemetry = self.shared.telemetry();
         serde_json::json!({
             "joined": joined,
+            "external_scans_joined": external_scans_joined,
             "elapsed_ms": started_at.elapsed().as_secs_f64() * 1_000.0,
             "sweeps": telemetry.sweeps,
             "claimed": telemetry.claimed,
@@ -262,6 +352,9 @@ struct Shared {
     telemetry: Mutex<SupervisorTelemetry>,
     budgets: Mutex<BudgetTracker>,
     budget_wake: Condvar,
+    external_scans: Mutex<BTreeMap<u64, ExternalScanRegistration>>,
+    external_scan_wake: Condvar,
+    next_external_scan_id: AtomicU64,
 }
 
 impl Shared {
@@ -281,6 +374,9 @@ impl Shared {
             telemetry: Mutex::new(SupervisorTelemetry::default()),
             budgets: Mutex::new(BudgetTracker::new(ProcessingBudgets::default())),
             budget_wake: Condvar::new(),
+            external_scans: Mutex::new(BTreeMap::new()),
+            external_scan_wake: Condvar::new(),
+            next_external_scan_id: AtomicU64::new(1),
         }
     }
 
@@ -300,6 +396,31 @@ impl Shared {
         self.budgets
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn external_scans(&self) -> MutexGuard<'_, BTreeMap<u64, ExternalScanRegistration>> {
+        self.external_scans
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn cancel_external_scans(&self, should_cancel: impl Fn(&ExternalScanRegistration) -> bool) {
+        for registration in self.external_scans().values() {
+            if should_cancel(registration) {
+                registration.cancel.store(true, Ordering::Release);
+            }
+        }
+    }
+
+    fn wait_for_external_scans(&self, timeout: Duration) -> bool {
+        let registrations = self.external_scans();
+        let (registrations, _) = self
+            .external_scan_wake
+            .wait_timeout_while(registrations, timeout, |registrations| {
+                !registrations.is_empty()
+            })
+            .unwrap_or_else(|poison| poison.into_inner());
+        registrations.is_empty()
     }
 }
 
@@ -659,6 +780,7 @@ fn discover_source_candidates(
     let source_id = source.id.as_str();
     let mut candidates = Vec::new();
     let mut stats = SourceDiscoveryStats::default();
+    publish_current_readiness_targets(&mut connection, source_id, now)?;
     let readiness_source_exists: bool = connection
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
@@ -673,7 +795,7 @@ fn discover_source_candidates(
             .map_err(|error| error.to_string())?;
         stats.readiness_queue_depth = snapshot.deficits.len();
         candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
-            schedule: WorkCandidate::readiness(&deficit.target, now),
+            schedule: WorkCandidate::readiness(&deficit.target, deficit.enqueued_at.unwrap_or(now)),
             source: source.clone(),
             task: RuntimeTask::Readiness(deficit.target.clone()),
         }));
@@ -776,6 +898,185 @@ fn discover_source_candidates(
         });
     }
     Ok((candidates, stats))
+}
+
+fn publish_current_readiness_targets(
+    connection: &mut rusqlite::Connection,
+    source_id: &str,
+    now: i64,
+) -> Result<bool, String> {
+    let rows = {
+        let mut statement = connection
+            .prepare(
+                "SELECT path, file_identity, content_hash, file_size, modified_ns
+                 FROM wav_files
+                 WHERE missing = 0
+                 ORDER BY path",
+            )
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    let mut manifest = Vec::with_capacity(rows.len());
+    for (path, identity, content_hash, file_size, modified_ns) in rows {
+        if !wavecrate_library::sample_sources::is_supported_audio(std::path::Path::new(&path)) {
+            continue;
+        }
+        let Some(identity) = identity.filter(|value| !value.trim().is_empty()) else {
+            mark_readiness_temporarily_unavailable(connection, source_id, now)?;
+            return Ok(false);
+        };
+        let content_hash = content_hash
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| format!("pending-{identity}-{file_size}-{modified_ns}"));
+        manifest.push((path, identity, content_hash));
+    }
+    let source_generation = connection
+        .query_row(
+            "SELECT COALESCE(
+                (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1),
+                0
+             )",
+            [META_WAV_PATHS_REVISION],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    let embedding_version = format!(
+        "{}+{}",
+        wavecrate_analysis::similarity::SIMILARITY_MODEL_ID,
+        wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+    );
+    let mut membership = blake3::Hasher::new();
+    let mut targets = Vec::with_capacity(manifest.len().saturating_mul(4).saturating_add(1));
+    for (path, identity, content_hash) in &manifest {
+        membership.update(identity.as_bytes());
+        membership.update(&[0]);
+        membership.update(content_hash.as_bytes());
+        membership.update(&[0xff]);
+        for (stage, version) in [
+            (ReadinessStage::IndexedIdentity, READINESS_MANIFEST_VERSION),
+            (ReadinessStage::PlaybackSummary, READINESS_PLAYBACK_VERSION),
+            (
+                ReadinessStage::AnalysisFeatures,
+                wavecrate_analysis::analysis_version(),
+            ),
+            (ReadinessStage::EmbeddingAspects, embedding_version.as_str()),
+        ] {
+            targets.push(ReadinessTarget::file(
+                source_id,
+                identity,
+                path,
+                stage,
+                version,
+                source_generation,
+                content_hash,
+            ));
+        }
+    }
+    let membership_generation = membership.finalize().to_hex().to_string();
+    targets.push(ReadinessTarget::source(
+        source_id,
+        ReadinessStage::SimilarityLayout,
+        NATIVE_SIMILARITY_UMAP_VERSION,
+        source_generation,
+        membership_generation,
+    ));
+    let target_fingerprint = readiness_target_fingerprint(&targets);
+    let current_fingerprint = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [META_READINESS_TARGET_FINGERPRINT],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let current_source: Option<(i64, i64, String)> = connection
+        .query_row(
+            "SELECT source_generation, readiness_revision, availability
+             FROM source_readiness_sources WHERE source_id = ?1",
+            [source_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    if current_fingerprint.as_deref() == Some(target_fingerprint.as_str())
+        && current_source
+            .as_ref()
+            .is_some_and(|(generation, _, availability)| {
+                *generation == source_generation && availability == "active"
+            })
+    {
+        return Ok(false);
+    }
+    let readiness_revision = current_source
+        .map(|(_, revision, _)| revision.saturating_add(1))
+        .unwrap_or(1);
+    replace_readiness_targets(
+        connection,
+        source_id,
+        source_generation,
+        readiness_revision,
+        SourceAvailability::Active,
+        &targets,
+        now,
+    )
+    .map_err(|error| error.to_string())?;
+    connection
+        .execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![META_READINESS_TARGET_FINGERPRINT, target_fingerprint],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(true)
+}
+
+fn mark_readiness_temporarily_unavailable(
+    connection: &rusqlite::Connection,
+    source_id: &str,
+    now: i64,
+) -> Result<(), String> {
+    connection
+        .execute(
+            "UPDATE source_readiness_sources
+             SET availability = 'offline',
+                 readiness_revision = readiness_revision + 1,
+                 updated_at = ?2
+             WHERE source_id = ?1 AND availability != 'offline'",
+            params![source_id, now],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn readiness_target_fingerprint(targets: &[ReadinessTarget]) -> String {
+    let mut hash = blake3::Hasher::new();
+    for target in targets {
+        hash.update(target.source_id.as_bytes());
+        hash.update(&[0]);
+        hash.update(target.scope_id.as_bytes());
+        hash.update(&[0]);
+        hash.update(format!("{:?}", target.stage).as_bytes());
+        hash.update(&[0]);
+        hash.update(target.required_version.as_bytes());
+        hash.update(&[0]);
+        hash.update(target.source_generation.to_string().as_bytes());
+        hash.update(&[0]);
+        hash.update(target.content_generation.as_bytes());
+        hash.update(&[0xff]);
+    }
+    hash.finalize().to_hex().to_string()
 }
 
 fn execute_candidate(
@@ -1249,7 +1550,7 @@ mod tests {
         assert!(!source_is_hashed(&source));
 
         supervisor.set_playback_active(false);
-        wait_until(Duration::from_secs(3), || source_is_hashed(&source));
+        wait_until(Duration::from_secs(10), || source_is_hashed(&source));
         let report = supervisor.shutdown();
         assert_eq!(report["joined"], true);
     }
@@ -1268,10 +1569,10 @@ mod tests {
     }
 
     #[test]
-    fn production_supervisor_claims_and_completes_indexed_identity_readiness() {
+    fn production_supervisor_publishes_claims_and_completes_readiness_without_manual_seed() {
         let (_directory, source) = unhashed_source("readiness");
         let database_root = source.database_root().expect("database root");
-        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
             &source.root,
             &database_root,
             SourceDatabaseConnectionRole::JobWorker,
@@ -1285,47 +1586,6 @@ mod tests {
                 [],
             )
             .expect("assign file identity");
-        let target = ReadinessTarget::file(
-            source.id.as_str(),
-            "identity-1",
-            "pending.wav",
-            ReadinessStage::IndexedIdentity,
-            "manifest-v1",
-            1,
-            "content-1",
-        );
-        let mut targets = vec![target.clone()];
-        for stage in [
-            ReadinessStage::PlaybackSummary,
-            ReadinessStage::AnalysisFeatures,
-            ReadinessStage::EmbeddingAspects,
-        ] {
-            let mut terminal = target.clone();
-            terminal.stage = stage;
-            terminal.required_version = "unsupported-v1".to_string();
-            terminal.eligibility = ReadinessEligibility::Unsupported;
-            targets.push(terminal);
-        }
-        targets.push(
-            ReadinessTarget::source(
-                source.id.as_str(),
-                ReadinessStage::SimilarityLayout,
-                "layout-v1",
-                1,
-                "members-1",
-            )
-            .with_eligibility(ReadinessEligibility::Unsupported),
-        );
-        replace_readiness_targets(
-            &mut connection,
-            source.id.as_str(),
-            1,
-            1,
-            SourceAvailability::Active,
-            &targets,
-            now_epoch_seconds(),
-        )
-        .expect("publish readiness target");
         drop(connection);
 
         let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
@@ -1340,37 +1600,148 @@ mod tests {
             connection
                 .query_row(
                     "SELECT EXISTS(
-                        SELECT 1 FROM source_readiness_artifacts
-                        WHERE source_id = ?1 AND scope_id = 'identity-1'
-                          AND stage = 'indexed_identity'
+                        SELECT 1
+                        FROM source_readiness_sources AS source
+                        JOIN source_readiness_targets AS target
+                          ON target.source_id = source.source_id
+                        JOIN source_readiness_artifacts AS artifact
+                          ON artifact.source_id = target.source_id
+                         AND artifact.scope_kind = target.scope_kind
+                         AND artifact.scope_id = target.scope_id
+                         AND artifact.stage = target.stage
+                        WHERE source.source_id = ?1
+                          AND source.availability = 'active'
+                          AND target.scope_id = 'identity-1'
+                          AND target.stage = 'indexed_identity'
+                          AND target.required_version = ?2
+                          AND artifact.artifact_version = target.required_version
+                          AND artifact.content_generation = target.content_generation
                     )",
-                    [source.id.as_str()],
+                    params![source.id.as_str(), READINESS_MANIFEST_VERSION],
                     |row| row.get::<_, bool>(0),
                 )
                 .expect("read readiness artifact")
         });
         let report = supervisor.shutdown();
         assert_eq!(report["joined"], true);
-        assert_eq!(report["claimed"], 1);
-        assert_eq!(report["completed"], 1);
-        assert_eq!(report["retried"], 0);
-        assert_eq!(report["stale"], 0);
-        assert_eq!(report["readiness_queue_depth"], 0);
+        assert!(report["claimed"].as_u64().unwrap_or_default() >= 1);
+        assert!(report["completed"].as_u64().unwrap_or_default() >= 1);
     }
 
     #[test]
     fn real_hash_execution_waits_for_shared_scan_database_budget() {
         let (_directory, source) = unhashed_source("shared-budget");
-        let mut supervisor =
-            SourceProcessingSupervisor::start_with_playback_state(vec![source.clone()], true);
-        let permit = supervisor.budget_handle().acquire_scan(source.id.as_str());
-        supervisor.set_playback_active(false);
+        let shared = Arc::new(Shared::new(vec![source.clone()]));
+        let permit = SourceProcessingBudgetHandle {
+            shared: Arc::clone(&shared),
+        }
+        .acquire_scan(source.id.as_str())
+        .expect("acquire external scan budget");
+        let coordinator_shared = Arc::clone(&shared);
+        let coordinator = thread::Builder::new()
+            .name(String::from("wavecrate-source-supervisor-test"))
+            .spawn(move || run_coordinator(coordinator_shared))
+            .expect("spawn source processing supervisor");
+        let mut supervisor = SourceProcessingSupervisor {
+            shared,
+            coordinator: Some(coordinator),
+        };
         thread::sleep(Duration::from_millis(150));
         assert!(!source_is_hashed(&source));
 
         drop(permit);
         wait_until(Duration::from_secs(3), || source_is_hashed(&source));
         assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn external_scan_tokens_cancel_for_playback_removal_and_shutdown() {
+        let (_directory, source) = unhashed_source("external-cancel");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor.replace_sources(vec![source.clone()]);
+
+        let playback_permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("acquire playback permit");
+        let playback_cancel = playback_permit.cancel_token();
+        assert!(!playback_cancel.load(Ordering::Acquire));
+        supervisor.set_playback_active(true);
+        assert!(playback_cancel.load(Ordering::Acquire));
+        drop(playback_permit);
+
+        supervisor.set_playback_active(false);
+        let removal_permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("acquire removal permit");
+        let removal_cancel = removal_permit.cancel_token();
+        supervisor.replace_sources(Vec::new());
+        assert!(removal_cancel.load(Ordering::Acquire));
+        drop(removal_permit);
+
+        supervisor.replace_sources(vec![source.clone()]);
+        let shutdown_permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("acquire shutdown permit");
+        let shutdown_cancel = shutdown_permit.cancel_token();
+        let release_cancel = Arc::clone(&shutdown_cancel);
+        let releaser = thread::spawn(move || {
+            while !release_cancel.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            drop(shutdown_permit);
+        });
+        let wake_generation = supervisor.shared.control().wake_generation;
+        let report = supervisor.shutdown();
+        releaser.join().expect("join external scan releaser");
+        assert_eq!(report["joined"], true);
+        assert_eq!(report["external_scans_joined"], true);
+        assert!(shutdown_cancel.load(Ordering::Acquire));
+        assert!(supervisor.shared.control().wake_generation > wake_generation);
+    }
+
+    #[test]
+    fn readiness_candidates_preserve_durable_queue_creation_time() {
+        let (_directory, source) = unhashed_source("queue-age");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'queue-identity', content_hash = 'queue-content'
+                 WHERE path = 'pending.wav'",
+                [],
+            )
+            .expect("assign queue identity");
+        assert!(
+            publish_current_readiness_targets(&mut connection, source.id.as_str(), 100)
+                .expect("publish current targets")
+        );
+        let snapshot =
+            reconcile_readiness(&connection, source.id.as_str(), 100).expect("reconcile targets");
+        persist_readiness_deficits(&mut connection, &snapshot.deficits, 100)
+            .expect("persist deficits");
+        drop(connection);
+
+        let (candidates, _) = discover_source_candidates(&source, 250).expect("rediscover work");
+        let readiness = candidates
+            .iter()
+            .filter(|candidate| matches!(candidate.task, RuntimeTask::Readiness(_)))
+            .collect::<Vec<_>>();
+        assert!(!readiness.is_empty());
+        assert!(
+            readiness
+                .iter()
+                .all(|candidate| candidate.schedule.enqueued_at == 100)
+        );
+        assert_eq!(oldest_job_age_seconds(&candidates, 250), 150);
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -31,8 +31,7 @@ use super::scheduler::{
 };
 use crate::native_app::sample_library::similarity_prep::{
     NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
-    reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
-    similarity_prep_needs_finalization,
+    reset_interrupted_similarity_prep_jobs, similarity_prep_needs_finalization,
 };
 use crate::native_app::waveform::{
     cached_waveform_file_audition_ready_exists, ensure_persisted_playback_summary,
@@ -1635,15 +1634,17 @@ fn execute_candidate(
 ) -> Result<ExecutionOutcome, String> {
     let result = match &candidate.task {
         RuntimeTask::LegacyAnalysis { job_id } => {
-            run_similarity_prep_job(&candidate.source, *job_id, cancel, 1).map(|summary| {
-                if summary.processed == 0 {
-                    ExecutionOutcome::NotClaimed
-                } else if summary.failed > 0 {
-                    ExecutionOutcome::Failed
-                } else {
-                    ExecutionOutcome::Completed
-                }
-            })
+            super::worker::run_legacy_job(&candidate.source, *job_id, 1, cancel).map(
+                |(processed, failed)| {
+                    if processed == 0 {
+                        ExecutionOutcome::NotClaimed
+                    } else if failed > 0 {
+                        ExecutionOutcome::Failed
+                    } else {
+                        ExecutionOutcome::Completed
+                    }
+                },
+            )
         }
         RuntimeTask::FinalizeSimilarity { publication_fence } => {
             finalize_similarity_prep_if_ready(&candidate.source, publication_fence, cancel).map(
@@ -1971,10 +1972,9 @@ fn run_readiness_stage(
             Ok(if analysis_features_are_current(connection, target)? {
                 ReadinessExecutionOutcome::Complete
             } else {
-                let produced = wavecrate::internal_analysis_jobs::run_readiness_feature_stage(
+                let produced = super::worker::run_readiness_feature_stage(
                     connection,
-                    &source.root,
-                    target.source_id.as_str(),
+                    source,
                     std::path::Path::new(relative_path),
                     target.content_generation.as_str(),
                     target.required_version.as_str(),
@@ -2008,10 +2008,9 @@ fn run_readiness_stage(
             Ok(if embedding_aspects_are_current(connection, target)? {
                 ReadinessExecutionOutcome::Complete
             } else {
-                let produced = wavecrate::internal_analysis_jobs::run_readiness_embedding_stage(
+                let produced = super::worker::run_readiness_embedding_stage(
                     connection,
-                    &source.root,
-                    target.source_id.as_str(),
+                    source,
                     std::path::Path::new(relative_path),
                     target.content_generation.as_str(),
                     wavecrate_analysis::analysis_version(),

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -29,7 +29,7 @@ use super::scheduler::{
     BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane, WorkCandidate,
 };
 use crate::native_app::sample_library::similarity_prep::{
-    NATIVE_SIMILARITY_UMAP_VERSION, finalize_similarity_prep_if_ready,
+    NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
     reset_interrupted_similarity_prep_jobs, run_similarity_prep_job,
     similarity_prep_needs_finalization,
 };
@@ -339,8 +339,12 @@ struct SupervisorTelemetry {
 #[derive(Clone, Debug)]
 enum RuntimeTask {
     DeepHash,
-    LegacyAnalysis { job_id: i64 },
-    FinalizeSimilarity,
+    LegacyAnalysis {
+        job_id: i64,
+    },
+    FinalizeSimilarity {
+        publication_fence: SimilarityPublicationFence,
+    },
     Readiness(ReadinessTarget),
 }
 
@@ -744,15 +748,31 @@ fn discover_source_candidates(
             task: RuntimeTask::LegacyAnalysis { job_id },
         });
     }
-    if candidates
-        .iter()
-        .all(|candidate| !matches!(&candidate.task, RuntimeTask::LegacyAnalysis { .. }))
+    if !readiness_source_exists
+        && candidates
+            .iter()
+            .all(|candidate| !matches!(&candidate.task, RuntimeTask::LegacyAnalysis { .. }))
         && similarity_prep_needs_finalization(source)?
     {
+        let paths_revision = connection
+            .query_row(
+                "SELECT COALESCE(
+                    (SELECT CAST(value AS INTEGER) FROM metadata
+                     WHERE key = 'wav_paths_revision_v1'),
+                    0
+                )",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|error| error.to_string())?;
         candidates.push(RuntimeCandidate {
             schedule: WorkCandidate::source(source_id, ProcessingLane::Finalization, 4, now),
             source: source.clone(),
-            task: RuntimeTask::FinalizeSimilarity,
+            task: RuntimeTask::FinalizeSimilarity {
+                publication_fence: SimilarityPublicationFence::legacy_paths_revision(
+                    paths_revision,
+                ),
+            },
         });
     }
     Ok((candidates, stats))
@@ -794,14 +814,16 @@ fn execute_candidate(
                 }
             })
         }
-        RuntimeTask::FinalizeSimilarity => {
-            finalize_similarity_prep_if_ready(&candidate.source, cancel).map(|finalized| {
-                if finalized {
-                    ExecutionOutcome::Completed
-                } else {
-                    ExecutionOutcome::NotClaimed
-                }
-            })
+        RuntimeTask::FinalizeSimilarity { publication_fence } => {
+            finalize_similarity_prep_if_ready(&candidate.source, publication_fence, cancel).map(
+                |finalized| {
+                    if finalized {
+                        ExecutionOutcome::Completed
+                    } else {
+                        ExecutionOutcome::NotClaimed
+                    }
+                },
+            )
         }
         RuntimeTask::Readiness(target) => {
             execute_readiness_target(&candidate.source, target, cancel)
@@ -1127,7 +1149,8 @@ fn run_readiness_stage(
                     "similarity finalization cancelled",
                 ));
             }
-            finalize_similarity_prep_if_ready(source, cancel).map(|finalized| {
+            let publication_fence = SimilarityPublicationFence::for_readiness_target(target)?;
+            finalize_similarity_prep_if_ready(source, &publication_fence, cancel).map(|finalized| {
                 if finalized {
                     ReadinessExecutionOutcome::Complete
                 } else {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -43,7 +43,6 @@ const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
 const READINESS_MAX_ATTEMPTS: u32 = 8;
 const MAX_DISCOVERED_ANALYSIS_JOBS: i64 = 256;
-const EXTERNAL_SCAN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const READINESS_MANIFEST_VERSION: &str = "source_manifest_v1";
 const READINESS_PLAYBACK_VERSION: &str = "waveform_cache_v4";
 const META_READINESS_TARGET_FINGERPRINT: &str = "readiness_target_fingerprint_v1";
@@ -80,7 +79,7 @@ impl SourceProcessingBudgetHandle {
             let mut control = self.shared.control();
             while !control.shutdown
                 && control.sources.contains_key(source_id)
-                && control.playback_active
+                && control.processing_paused()
             {
                 control = self
                     .shared
@@ -142,7 +141,7 @@ impl SourceProcessingBudgetPermit {
         }
         let control = self.shared.control();
         control.shutdown
-            || control.playback_active
+            || control.processing_paused()
             || self
                 .permit
                 .as_ref()
@@ -191,9 +190,10 @@ impl SourceProcessingSupervisor {
     }
 
     pub(in crate::native_app) fn replace_sources(&self, sources: Vec<SampleSource>) {
-        self.shared.work_cancel.store(true, Ordering::Release);
         let mut control = self.shared.control();
+        control.cancel_all_source_work();
         control.sources = sources_by_id(sources);
+        control.reset_source_work_tokens();
         let retained_source_ids = control.sources.keys().cloned().collect::<Vec<_>>();
         control.priority.immediate.clear();
         control.priority.visible.clear();
@@ -218,11 +218,16 @@ impl SourceProcessingSupervisor {
 
     pub(in crate::native_app) fn wake_source(&self, source_id: &str, reason: &'static str) {
         let mut control = self.shared.control();
-        if control.sources.contains_key(source_id) {
-            self.shared.work_cancel.store(true, Ordering::Release);
-            control.wake(reason);
-            self.shared.wake.notify_one();
+        if !control.sources.contains_key(source_id) {
+            return;
         }
+        control.cancel_source_work(source_id);
+        control.wake(reason);
+        drop(control);
+        self.shared
+            .cancel_external_scans(|registration| registration.source_id == source_id);
+        self.shared.budget_wake.notify_all();
+        self.shared.wake.notify_one();
     }
 
     pub(in crate::native_app) fn set_selected_source(&self, source_id: Option<&str>) {
@@ -282,7 +287,11 @@ impl SourceProcessingSupervisor {
         let mut control = self.shared.control();
         if control.playback_active != active {
             control.playback_active = active;
-            self.shared.work_cancel.store(active, Ordering::Release);
+            if active {
+                control.cancel_all_source_work();
+            } else if !control.foreground_active {
+                control.reset_source_work_tokens();
+            }
             control.wake(if active {
                 "playback_pause"
             } else {
@@ -297,13 +306,37 @@ impl SourceProcessingSupervisor {
         }
     }
 
+    pub(in crate::native_app) fn set_foreground_activity(&self, active: bool) {
+        let mut control = self.shared.control();
+        if control.foreground_active == active {
+            return;
+        }
+        control.foreground_active = active;
+        if active {
+            control.cancel_all_source_work();
+        } else if !control.playback_active {
+            control.reset_source_work_tokens();
+        }
+        control.wake(if active {
+            "foreground_activity_pause"
+        } else {
+            "foreground_activity_resume"
+        });
+        drop(control);
+        if active {
+            self.shared.cancel_external_scans(|_| true);
+        }
+        self.shared.budget_wake.notify_all();
+        self.shared.wake.notify_all();
+    }
+
     pub(in crate::native_app) fn shutdown(&mut self) -> Value {
         let started_at = Instant::now();
         self.shared.cancel.store(true, Ordering::Release);
-        self.shared.work_cancel.store(true, Ordering::Release);
         self.shared.cancel_external_scans(|_| true);
         {
             let mut control = self.shared.control();
+            control.cancel_all_source_work();
             control.shutdown = true;
             control.wake("shutdown");
         }
@@ -313,13 +346,11 @@ impl SourceProcessingSupervisor {
             .coordinator
             .take()
             .is_none_or(|coordinator| coordinator.join().is_ok());
-        let external_scans_joined = self
-            .shared
-            .wait_for_external_scans(EXTERNAL_SCAN_SHUTDOWN_TIMEOUT);
+        self.shared.wait_for_external_scans();
         let telemetry = self.shared.telemetry();
         serde_json::json!({
             "joined": joined,
-            "external_scans_joined": external_scans_joined,
+            "external_scans_joined": true,
             "elapsed_ms": started_at.elapsed().as_secs_f64() * 1_000.0,
             "sweeps": telemetry.sweeps,
             "claimed": telemetry.claimed,
@@ -350,7 +381,6 @@ struct Shared {
     state: Mutex<ControlState>,
     wake: Condvar,
     cancel: AtomicBool,
-    work_cancel: AtomicBool,
     telemetry: Mutex<SupervisorTelemetry>,
     budgets: Mutex<BudgetTracker>,
     budget_wake: Condvar,
@@ -361,18 +391,24 @@ struct Shared {
 
 impl Shared {
     fn new(sources: Vec<SampleSource>) -> Self {
+        let sources = sources_by_id(sources);
+        let source_work_cancels = sources
+            .keys()
+            .map(|source_id| (source_id.clone(), Arc::new(AtomicBool::new(false))))
+            .collect();
         Self {
             state: Mutex::new(ControlState {
-                sources: sources_by_id(sources),
+                sources,
+                source_work_cancels,
                 wake_generation: 1,
                 wake_reason: "startup",
                 playback_active: false,
+                foreground_active: false,
                 shutdown: false,
                 priority: PriorityContext::default(),
             }),
             wake: Condvar::new(),
             cancel: AtomicBool::new(false),
-            work_cancel: AtomicBool::new(false),
             telemetry: Mutex::new(SupervisorTelemetry::default()),
             budgets: Mutex::new(BudgetTracker::new(ProcessingBudgets::default())),
             budget_wake: Condvar::new(),
@@ -414,23 +450,23 @@ impl Shared {
         }
     }
 
-    fn wait_for_external_scans(&self, timeout: Duration) -> bool {
+    fn wait_for_external_scans(&self) {
         let registrations = self.external_scans();
-        let (registrations, _) = self
-            .external_scan_wake
-            .wait_timeout_while(registrations, timeout, |registrations| {
-                !registrations.is_empty()
-            })
-            .unwrap_or_else(|poison| poison.into_inner());
-        registrations.is_empty()
+        drop(
+            self.external_scan_wake
+                .wait_while(registrations, |registrations| !registrations.is_empty())
+                .unwrap_or_else(|poison| poison.into_inner()),
+        );
     }
 }
 
 struct ControlState {
     sources: BTreeMap<String, SampleSource>,
+    source_work_cancels: BTreeMap<String, Arc<AtomicBool>>,
     wake_generation: u64,
     wake_reason: &'static str,
     playback_active: bool,
+    foreground_active: bool,
     shutdown: bool,
     priority: PriorityContext,
 }
@@ -439,6 +475,31 @@ impl ControlState {
     fn wake(&mut self, reason: &'static str) {
         self.wake_generation = self.wake_generation.wrapping_add(1);
         self.wake_reason = reason;
+    }
+
+    fn processing_paused(&self) -> bool {
+        self.playback_active || self.foreground_active
+    }
+
+    fn cancel_source_work(&mut self, source_id: &str) {
+        if let Some(cancel) = self.source_work_cancels.get_mut(source_id) {
+            cancel.store(true, Ordering::Release);
+            *cancel = Arc::new(AtomicBool::new(false));
+        }
+    }
+
+    fn cancel_all_source_work(&mut self) {
+        for cancel in self.source_work_cancels.values() {
+            cancel.store(true, Ordering::Release);
+        }
+    }
+
+    fn reset_source_work_tokens(&mut self) {
+        self.source_work_cancels = self
+            .sources
+            .keys()
+            .map(|source_id| (source_id.clone(), Arc::new(AtomicBool::new(false))))
+            .collect();
     }
 }
 
@@ -505,7 +566,7 @@ fn run_coordinator(shared: Arc<Shared>) {
     let mut scheduler = FairScheduler::default();
     let mut reset_sources = BTreeMap::<String, bool>::new();
     loop {
-        let (sources, priority, playback_active, generation, reason) = {
+        let (sources, source_work_cancels, priority, processing_paused, generation, reason) = {
             let mut control = shared.control();
             while !control.shutdown && control.wake_generation == observed_generation {
                 let wait_duration = coordinator_wait_duration(next_retry_at, now_epoch_seconds());
@@ -527,20 +588,18 @@ fn run_coordinator(shared: Arc<Shared>) {
             if control.shutdown {
                 break;
             }
-            if !control.playback_active {
-                shared.work_cancel.store(false, Ordering::Release);
-            }
             (
                 control.sources.values().cloned().collect::<Vec<_>>(),
+                control.source_work_cancels.clone(),
                 control.priority.clone(),
-                control.playback_active,
+                control.processing_paused(),
                 control.wake_generation,
                 control.wake_reason,
             )
         };
         observed_generation = generation;
-        scheduler.set_paused(playback_active);
-        if playback_active {
+        scheduler.set_paused(processing_paused);
+        if processing_paused {
             tracing::debug!(
                 target: "wavecrate::source_processing",
                 event = "source_processing.paused",
@@ -597,7 +656,7 @@ fn run_coordinator(shared: Arc<Shared>) {
         while !candidates.is_empty() && !shared.cancel.load(Ordering::Acquire) {
             let control = shared.control();
             let interrupted =
-                control.playback_active || control.wake_generation != observed_generation;
+                control.processing_paused() || control.wake_generation != observed_generation;
             drop(control);
             if interrupted {
                 break;
@@ -620,7 +679,13 @@ fn run_coordinator(shared: Arc<Shared>) {
                 telemetry.contention = telemetry.contention.saturating_add(1);
                 break;
             };
-            let result = execute_candidate(&candidate, &shared.work_cancel);
+            let Some(candidate_cancel) = source_work_cancels.get(candidate.source.id.as_str())
+            else {
+                shared.budgets().release(permit);
+                shared.budget_wake.notify_all();
+                break;
+            };
+            let result = execute_candidate(&candidate, candidate_cancel.as_ref());
             shared.budgets().release(permit);
             shared.budget_wake.notify_all();
             let mut telemetry = shared.telemetry();
@@ -777,9 +842,28 @@ fn discover_source_candidates(
         SourceDatabaseConnectionRole::JobWorker,
     )
     .map_err(|error| error.to_string())?;
+    discover_source_candidates_with_connection(source, &mut connection, now)
+}
+
+fn discover_source_candidates_with_connection(
+    source: &SampleSource,
+    connection: &mut rusqlite::Connection,
+    now: i64,
+) -> Result<(Vec<RuntimeCandidate>, SourceDiscoveryStats), String> {
     let source_id = source.id.as_str();
     let mut candidates = Vec::new();
     let mut stats = SourceDiscoveryStats::default();
+    if connection
+        .is_readonly(rusqlite::MAIN_DB)
+        .map_err(|error| error.to_string())?
+    {
+        tracing::debug!(
+            target: "wavecrate::source_processing",
+            source_id,
+            "Source processing is disabled for a read-only source database"
+        );
+        return Ok((candidates, stats));
+    }
     if !source_processing_schema_available(&connection)? {
         tracing::debug!(
             target: "wavecrate::source_processing",
@@ -788,7 +872,7 @@ fn discover_source_candidates(
         );
         return Ok((candidates, stats));
     }
-    publish_current_readiness_targets(&mut connection, source_id, now)?;
+    publish_current_readiness_targets(connection, source_id, now)?;
     let readiness_source_exists: bool = connection
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
@@ -799,7 +883,7 @@ fn discover_source_candidates(
     if readiness_source_exists {
         let snapshot =
             reconcile_readiness(&connection, source_id, now).map_err(|error| error.to_string())?;
-        persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+        persist_readiness_deficits(connection, &snapshot.deficits, now)
             .map_err(|error| error.to_string())?;
         stats.readiness_queue_depth = snapshot.deficits.len();
         candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
@@ -1733,6 +1817,98 @@ mod tests {
     }
 
     #[test]
+    fn source_wakes_cancel_only_that_sources_in_flight_generation() {
+        let (_first_directory, first) = unhashed_source("first");
+        let (_second_directory, second) = unhashed_source("second");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor.replace_sources(vec![first.clone(), second.clone()]);
+        let (first_generation, second_generation) = {
+            let control = supervisor.shared.control();
+            (
+                Arc::clone(&control.source_work_cancels[first.id.as_str()]),
+                Arc::clone(&control.source_work_cancels[second.id.as_str()]),
+            )
+        };
+        let first_scan = supervisor
+            .budget_handle()
+            .acquire_scan(first.id.as_str())
+            .expect("acquire first-source scan permit");
+        let first_scan_generation = first_scan.cancel_token();
+
+        supervisor.wake_source(first.id.as_str(), "test_source_wake");
+
+        assert!(first_generation.load(Ordering::Acquire));
+        assert!(first_scan_generation.load(Ordering::Acquire));
+        assert!(!second_generation.load(Ordering::Acquire));
+        let control = supervisor.shared.control();
+        assert!(!control.source_work_cancels[first.id.as_str()].load(Ordering::Acquire));
+        assert!(Arc::ptr_eq(
+            &second_generation,
+            &control.source_work_cancels[second.id.as_str()]
+        ));
+        drop(control);
+        drop(first_scan);
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn foreground_activity_cancels_in_flight_work_without_reviving_old_generations() {
+        let (_directory, source) = unhashed_source("foreground");
+        let mut supervisor = SourceProcessingSupervisor::dormant();
+        supervisor.replace_sources(vec![source.clone()]);
+        let source_generation = {
+            let control = supervisor.shared.control();
+            Arc::clone(&control.source_work_cancels[source.id.as_str()])
+        };
+        let scan_permit = supervisor
+            .budget_handle()
+            .acquire_scan(source.id.as_str())
+            .expect("acquire external scan permit");
+        let scan_generation = scan_permit.cancel_token();
+
+        supervisor.set_foreground_activity(true);
+
+        assert!(source_generation.load(Ordering::Acquire));
+        assert!(scan_generation.load(Ordering::Acquire));
+        assert!(supervisor.shared.control().processing_paused());
+        drop(scan_permit);
+
+        supervisor.set_foreground_activity(false);
+
+        assert!(
+            source_generation.load(Ordering::Acquire),
+            "resuming must not clear a token held by an interrupted worker"
+        );
+        let control = supervisor.shared.control();
+        assert!(!control.processing_paused());
+        assert!(!control.source_work_cancels[source.id.as_str()].load(Ordering::Acquire));
+        drop(control);
+        assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn read_only_discovery_does_not_publish_or_mutate_work() {
+        let (_directory, source) = ready_analysis_source("read-only-discovery");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::UiRead,
+        )
+        .expect("open read-only source database");
+        assert!(connection.is_readonly(rusqlite::MAIN_DB).unwrap());
+        let counts_before = discovery_durable_counts(&connection);
+
+        let (candidates, stats) =
+            discover_source_candidates_with_connection(&source, &mut connection, 100)
+                .expect("skip read-only source processing");
+
+        assert!(candidates.is_empty());
+        assert_eq!(stats.readiness_queue_depth, 0);
+        assert_eq!(discovery_durable_counts(&connection), counts_before);
+    }
+
+    #[test]
     fn production_supervisor_publishes_claims_and_completes_readiness_without_manual_seed() {
         let (_directory, source) = ready_analysis_source("readiness");
 
@@ -2163,6 +2339,19 @@ mod tests {
             .expect("read pending file")
             .and_then(|entry| entry.content_hash)
             .is_some()
+    }
+
+    fn discovery_durable_counts(connection: &rusqlite::Connection) -> (i64, i64, i64) {
+        connection
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM source_readiness_targets),
+                    (SELECT COUNT(*) FROM analysis_jobs),
+                    (SELECT COUNT(*) FROM metadata WHERE key = ?1)",
+                [META_READINESS_TARGET_FINGERPRINT],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read durable discovery counts")
     }
 
     fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {

--- a/src/native_app/source_processing/worker.rs
+++ b/src/native_app/source_processing/worker.rs
@@ -1,0 +1,312 @@
+//! Killable process boundary for supervisor-owned decode, DSP, and embedding work.
+
+mod child_process;
+
+pub(in crate::native_app) use child_process::wait_for_cancellable_child;
+
+use std::{path::Path, sync::atomic::AtomicBool};
+
+#[cfg(not(test))]
+use std::{
+    io::Read,
+    process::{Command, Stdio},
+};
+
+use serde::{Deserialize, Serialize};
+use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceDatabaseConnectionRole};
+
+const INTERNAL_SOURCE_ANALYSIS_ARG: &str = "--wavecrate-internal-source-analysis-v1";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum SourceAnalysisTask {
+    ReadinessFeature {
+        relative_path: String,
+        content_hash: String,
+        analysis_version: String,
+    },
+    ReadinessEmbedding {
+        relative_path: String,
+        content_hash: String,
+        analysis_version: String,
+    },
+    LegacyJob {
+        job_id: i64,
+        embedding_worker_limit: usize,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SourceAnalysisRequest {
+    source: SampleSource,
+    task: SourceAnalysisTask,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+struct SourceAnalysisResult {
+    produced: bool,
+    processed: usize,
+    failed: usize,
+}
+
+pub(super) fn run_readiness_feature_stage(
+    connection: &mut rusqlite::Connection,
+    source: &SampleSource,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    #[cfg(test)]
+    {
+        wavecrate::internal_analysis_jobs::run_readiness_feature_stage(
+            connection,
+            &source.root,
+            source.id.as_str(),
+            relative_path,
+            content_hash,
+            analysis_version,
+            cancel,
+        )
+    }
+    #[cfg(not(test))]
+    {
+        let _ = connection;
+        let request = SourceAnalysisRequest {
+            source: source.clone(),
+            task: SourceAnalysisTask::ReadinessFeature {
+                relative_path: relative_path.to_string_lossy().replace('\\', "/"),
+                content_hash: content_hash.to_string(),
+                analysis_version: analysis_version.to_string(),
+            },
+        };
+        run_request_in_child(&request, cancel)
+            .map(|result| result.is_some_and(|result| result.produced))
+    }
+}
+
+pub(super) fn run_readiness_embedding_stage(
+    connection: &mut rusqlite::Connection,
+    source: &SampleSource,
+    relative_path: &Path,
+    content_hash: &str,
+    analysis_version: &str,
+    cancel: &AtomicBool,
+) -> Result<bool, String> {
+    #[cfg(test)]
+    {
+        wavecrate::internal_analysis_jobs::run_readiness_embedding_stage(
+            connection,
+            &source.root,
+            source.id.as_str(),
+            relative_path,
+            content_hash,
+            analysis_version,
+            cancel,
+        )
+    }
+    #[cfg(not(test))]
+    {
+        let _ = connection;
+        let request = SourceAnalysisRequest {
+            source: source.clone(),
+            task: SourceAnalysisTask::ReadinessEmbedding {
+                relative_path: relative_path.to_string_lossy().replace('\\', "/"),
+                content_hash: content_hash.to_string(),
+                analysis_version: analysis_version.to_string(),
+            },
+        };
+        run_request_in_child(&request, cancel)
+            .map(|result| result.is_some_and(|result| result.produced))
+    }
+}
+
+pub(super) fn run_legacy_job(
+    source: &SampleSource,
+    job_id: i64,
+    embedding_worker_limit: usize,
+    cancel: &AtomicBool,
+) -> Result<(usize, usize), String> {
+    #[cfg(test)]
+    {
+        let summary = crate::native_app::sample_library::similarity_prep::run_similarity_prep_job(
+            source,
+            job_id,
+            cancel,
+            embedding_worker_limit,
+        )?;
+        Ok((summary.processed, summary.failed))
+    }
+    #[cfg(not(test))]
+    {
+        let request = SourceAnalysisRequest {
+            source: source.clone(),
+            task: SourceAnalysisTask::LegacyJob {
+                job_id,
+                embedding_worker_limit,
+            },
+        };
+        let result = match run_request_in_child(&request, cancel) {
+            Ok(result) => result,
+            Err(error) => {
+                reset_legacy_job(source, job_id)?;
+                return Err(error);
+            }
+        };
+        let Some(result) = result else {
+            reset_legacy_job(source, job_id)?;
+            return Ok((0, 0));
+        };
+        Ok((result.processed, result.failed))
+    }
+}
+
+pub(in crate::native_app) fn run_internal_source_analysis_from_args()
+-> Result<Option<String>, String> {
+    let mut args = std::env::args();
+    let _executable = args.next();
+    if args.next().as_deref() != Some(INTERNAL_SOURCE_ANALYSIS_ARG) {
+        return Ok(None);
+    }
+    let request_json = args
+        .next()
+        .ok_or_else(|| "Internal source analysis is missing its request".to_string())?;
+    if args.next().is_some() {
+        return Err("Internal source analysis received unexpected arguments".to_string());
+    }
+    let request = serde_json::from_str::<SourceAnalysisRequest>(&request_json)
+        .map_err(|error| format!("Decode internal source analysis request failed: {error}"))?;
+    let result = execute_request(&request)?;
+    serde_json::to_string(&result)
+        .map(Some)
+        .map_err(|error| format!("Encode internal source analysis result failed: {error}"))
+}
+
+fn execute_request(request: &SourceAnalysisRequest) -> Result<SourceAnalysisResult, String> {
+    let cancel = AtomicBool::new(false);
+    match &request.task {
+        SourceAnalysisTask::ReadinessFeature {
+            relative_path,
+            content_hash,
+            analysis_version,
+        } => {
+            let mut connection = open_source_connection(&request.source)?;
+            let produced = wavecrate::internal_analysis_jobs::run_readiness_feature_stage(
+                &mut connection,
+                &request.source.root,
+                request.source.id.as_str(),
+                Path::new(relative_path),
+                content_hash,
+                analysis_version,
+                &cancel,
+            )?;
+            Ok(SourceAnalysisResult {
+                produced,
+                processed: usize::from(produced),
+                failed: 0,
+            })
+        }
+        SourceAnalysisTask::ReadinessEmbedding {
+            relative_path,
+            content_hash,
+            analysis_version,
+        } => {
+            let mut connection = open_source_connection(&request.source)?;
+            let produced = wavecrate::internal_analysis_jobs::run_readiness_embedding_stage(
+                &mut connection,
+                &request.source.root,
+                request.source.id.as_str(),
+                Path::new(relative_path),
+                content_hash,
+                analysis_version,
+                &cancel,
+            )?;
+            Ok(SourceAnalysisResult {
+                produced,
+                processed: usize::from(produced),
+                failed: 0,
+            })
+        }
+        SourceAnalysisTask::LegacyJob {
+            job_id,
+            embedding_worker_limit,
+        } => {
+            let summary =
+                crate::native_app::sample_library::similarity_prep::run_similarity_prep_job(
+                    &request.source,
+                    *job_id,
+                    &cancel,
+                    *embedding_worker_limit,
+                )?;
+            Ok(SourceAnalysisResult {
+                produced: summary.processed > 0 && summary.failed == 0,
+                processed: summary.processed,
+                failed: summary.failed,
+            })
+        }
+    }
+}
+
+fn open_source_connection(source: &SampleSource) -> Result<rusqlite::Connection, String> {
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(test))]
+fn reset_legacy_job(source: &SampleSource, job_id: i64) -> Result<(), String> {
+    let connection = open_source_connection(source)?;
+    wavecrate::internal_analysis_jobs::release_job_by_id(&connection, job_id)
+}
+
+#[cfg(not(test))]
+fn run_request_in_child(
+    request: &SourceAnalysisRequest,
+    cancel: &AtomicBool,
+) -> Result<Option<SourceAnalysisResult>, String> {
+    if cancel.load(std::sync::atomic::Ordering::Acquire) {
+        return Ok(None);
+    }
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("Resolve source analysis executable failed: {error}"))?;
+    let request_json = serde_json::to_string(request)
+        .map_err(|error| format!("Encode internal source analysis request failed: {error}"))?;
+    let child = Command::new(executable)
+        .arg(INTERNAL_SOURCE_ANALYSIS_ARG)
+        .arg(request_json)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("Start source analysis process failed: {error}"))?;
+    let Some(mut child) =
+        child_process::wait_for_cancellable_child(child, cancel, "source analysis")?
+    else {
+        return Ok(None);
+    };
+    let mut stdout = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        pipe.read_to_string(&mut stdout)
+            .map_err(|error| format!("Read source analysis result failed: {error}"))?;
+    }
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        pipe.read_to_string(&mut stderr)
+            .map_err(|error| format!("Read source analysis error failed: {error}"))?;
+    }
+    let status = child
+        .wait()
+        .map_err(|error| format!("Join source analysis process failed: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "Source analysis process failed with {status}: {}",
+            stderr.trim()
+        ));
+    }
+    serde_json::from_str::<SourceAnalysisResult>(stdout.trim())
+        .map(Some)
+        .map_err(|error| format!("Decode source analysis result failed: {error}"))
+}

--- a/src/native_app/source_processing/worker/child_process.rs
+++ b/src/native_app/source_processing/worker/child_process.rs
@@ -1,0 +1,44 @@
+//! Shared cancellation and join policy for CPU-owning native child processes.
+
+use std::{
+    process::Child,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(in crate::native_app) fn wait_for_cancellable_child(
+    mut child: Child,
+    cancel: &AtomicBool,
+    operation: &str,
+) -> Result<Option<Child>, String> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            if let Err(error) = child.kill()
+                && child
+                    .try_wait()
+                    .map_err(|poll_error| {
+                        format!(
+                            "Cancel {operation} process failed: {error}; poll failed: {poll_error}"
+                        )
+                    })?
+                    .is_none()
+            {
+                return Err(format!("Cancel {operation} process failed: {error}"));
+            }
+            child
+                .wait()
+                .map_err(|error| format!("Join cancelled {operation} failed: {error}"))?;
+            return Ok(None);
+        }
+        if child
+            .try_wait()
+            .map_err(|error| format!("Poll {operation} process failed: {error}"))?
+            .is_some()
+        {
+            return Ok(Some(child));
+        }
+        std::thread::sleep(CHILD_POLL_INTERVAL);
+    }
+}

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -1,6 +1,39 @@
 use super::*;
 
 #[test]
+fn adding_source_after_startup_registers_it_before_scan_admission_and_finish() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let mut state = gui_state_for_span_tests();
+    let request = state
+        .library
+        .folder_browser
+        .begin_add_source_path(source_root.path().to_path_buf(), 101)
+        .expect("new source requests scan");
+    let source_id = request.source_id.clone();
+    let request_for_worker = request.clone();
+    let mut context = ui::UiUpdateContext::default();
+
+    state.launch_folder_scan(request, &mut context);
+
+    let permit = state
+        .background
+        .source_processing
+        .budget_handle()
+        .acquire_scan(&source_id)
+        .expect("newly added source must be admitted before its first scan");
+    let result = crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+        request_for_worker,
+        |_| {},
+        |_| {},
+    );
+    drop(permit);
+    state.finish_folder_scan(result, &mut context);
+
+    assert!(state.library.folder_browser.selected_source_loaded());
+    assert!(state.library.folder_progress().is_none());
+}
+
+#[test]
 fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
     let source_root = tempfile::tempdir().expect("source root");
     let drums = source_root.path().join("drums");

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -54,7 +54,6 @@ mod audio_file;
 #[cfg(test)]
 pub(in crate::native_app) use audio_file::PersistedPlaybackCacheFile;
 pub(super) use audio_file::WaveformFile;
-#[cfg(test)]
 pub(in crate::native_app) use audio_file::cached_waveform_file_playback_ready_exists;
 #[cfg(test)]
 pub(super) use audio_file::store_cached_waveform_file_for_tests;

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -54,6 +54,7 @@ mod audio_file;
 #[cfg(test)]
 pub(in crate::native_app) use audio_file::PersistedPlaybackCacheFile;
 pub(super) use audio_file::WaveformFile;
+#[cfg(test)]
 pub(in crate::native_app) use audio_file::cached_waveform_file_playback_ready_exists;
 #[cfg(test)]
 pub(super) use audio_file::store_cached_waveform_file_for_tests;
@@ -62,13 +63,13 @@ pub(super) use audio_file::store_summary_only_cached_waveform_file_for_tests;
 pub(in crate::native_app) use audio_file::{
     InstantWaveformPreview, InstantWaveformPreviewTier, PersistedPlaybackDescriptor,
     PreviewAuditionClip, WaveformPlaybackReady, cached_waveform_file_audition_ready_exists,
-    cached_waveform_file_exists, decode_wav_preview_clip, file_backed_wav_playback_descriptor,
-    flush_background_waveform_cache_stores_for_shutdown, instant_waveform_head_preview_from_clip,
-    invalidate_persisted_waveform_cache_path, invalidate_persisted_waveform_cache_paths,
-    load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
-    load_wav_detail_summary, mark_cached_waveform_file_source_warm_attempted,
-    remap_persisted_waveform_cache_after_move, should_use_file_backed_wav_decode,
-    should_use_file_backed_wav_decode_for_entry,
+    cached_waveform_file_exists, decode_wav_preview_clip, ensure_persisted_playback_summary,
+    file_backed_wav_playback_descriptor, flush_background_waveform_cache_stores_for_shutdown,
+    instant_waveform_head_preview_from_clip, invalidate_persisted_waveform_cache_path,
+    invalidate_persisted_waveform_cache_paths, load_cached_waveform_file_for_playback,
+    load_cached_waveform_playback_descriptor_sidecar, load_wav_detail_summary,
+    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
+    should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
 };
 #[cfg(test)]
 pub(super) use audio_file::{

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -20,6 +20,7 @@ mod wav_summary_builder;
 mod wav_summary_hound;
 mod waveform_cache;
 
+#[cfg(test)]
 pub(in crate::native_app) use cache_facade::cached_waveform_file_playback_ready_exists;
 pub(in crate::native_app) use cache_facade::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
@@ -58,8 +59,8 @@ pub(super) use loader::load_waveform_file;
 #[cfg(test)]
 pub(super) use loader::load_waveform_file_with_progress_cancel_and_playback_ready;
 pub(in crate::native_app) use loader::{
-    file_backed_wav_playback_descriptor, should_use_file_backed_wav_decode,
-    should_use_file_backed_wav_decode_for_entry,
+    ensure_persisted_playback_summary, file_backed_wav_playback_descriptor,
+    should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
 };
 pub(super) use loader::{
     is_wav_path, load_waveform_file_for_foreground_audition,

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -20,7 +20,6 @@ mod wav_summary_builder;
 mod wav_summary_hound;
 mod waveform_cache;
 
-#[cfg(test)]
 pub(in crate::native_app) use cache_facade::cached_waveform_file_playback_ready_exists;
 pub(in crate::native_app) use cache_facade::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,

--- a/src/native_app/waveform/audio_file/cache_facade.rs
+++ b/src/native_app/waveform/audio_file/cache_facade.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 pub(in crate::native_app) use super::waveform_cache::cached_waveform_file_playback_ready_exists;
 pub(in crate::native_app) use super::waveform_cache::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,

--- a/src/native_app/waveform/audio_file/cache_facade.rs
+++ b/src/native_app/waveform/audio_file/cache_facade.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 pub(in crate::native_app) use super::waveform_cache::cached_waveform_file_playback_ready_exists;
 pub(in crate::native_app) use super::waveform_cache::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,

--- a/src/native_app/waveform/audio_file/loader.rs
+++ b/src/native_app/waveform/audio_file/loader.rs
@@ -54,6 +54,39 @@ pub(in crate::native_app::waveform) fn load_waveform_file_with_progress_and_canc
     load_waveform_file_with_progress_cancel_and_playback_ready(path, progress, cancelled, |_| {})
 }
 
+pub(in crate::native_app) fn ensure_persisted_playback_summary(
+    path: PathBuf,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> Result<(), String> {
+    use std::sync::atomic::Ordering;
+
+    if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
+        return Ok(());
+    }
+    let file = load_waveform_file_with_progress_cancel_playback_ready_and_cache_policy(
+        path.clone(),
+        |_| {},
+        || cancel.load(Ordering::Acquire),
+        |_| {},
+        true,
+        false,
+        PlaybackReadyCachePolicy::Allow,
+        FileBackedWavPolicy::AllowSummary,
+    )?;
+    if cancel.load(Ordering::Acquire) {
+        return Err(String::from("waveform summary cancelled"));
+    }
+    waveform_cache::persist_cached_waveform_file(&file)?;
+    if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
+        Ok(())
+    } else {
+        Err(format!(
+            "waveform cache did not publish an audition-ready summary: {}",
+            path.display()
+        ))
+    }
+}
+
 pub(in crate::native_app::waveform) fn load_waveform_file_with_progress_cancel_and_playback_ready(
     path: PathBuf,
     progress: impl Fn(f32),

--- a/src/native_app/waveform/audio_file/waveform_cache.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache.rs
@@ -11,6 +11,7 @@ pub(in crate::native_app) use playback_load::{
     load_cached_waveform_file_for_playback, load_cached_waveform_file_summary,
     load_cached_waveform_playback_descriptor_sidecar,
 };
+#[cfg(test)]
 pub(in crate::native_app) use read::cached_waveform_file_playback_ready_exists;
 #[cfg(test)]
 pub(in crate::native_app) use read::cached_waveform_file_source_ready_exists;
@@ -20,6 +21,7 @@ pub(in crate::native_app) use read::{
 };
 pub(in crate::native_app) use remap::remap_persisted_waveform_cache_after_move;
 pub(in crate::native_app) use store_queue::flush_background_waveform_cache_stores_for_shutdown;
+pub(super) use store_queue::persist_cached_waveform_file;
 #[cfg(test)]
 pub(super) use store_queue::store_cached_waveform_file;
 pub(super) use store_queue::store_cached_waveform_file_in_background;

--- a/src/native_app/waveform/audio_file/waveform_cache.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache.rs
@@ -11,7 +11,6 @@ pub(in crate::native_app) use playback_load::{
     load_cached_waveform_file_for_playback, load_cached_waveform_file_summary,
     load_cached_waveform_playback_descriptor_sidecar,
 };
-#[cfg(test)]
 pub(in crate::native_app) use read::cached_waveform_file_playback_ready_exists;
 #[cfg(test)]
 pub(in crate::native_app) use read::cached_waveform_file_source_ready_exists;

--- a/src/native_app/waveform/audio_file/waveform_cache/read.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/read.rs
@@ -120,7 +120,6 @@ fn cached_waveform_file_v3_exists(path: &Path, identity: &CacheIdentity) -> bool
     cache_path_for_identity(path, identity).is_ok_and(|path| path.is_file())
 }
 
-#[cfg(test)]
 pub(in crate::native_app) fn cached_waveform_file_playback_ready_exists(path: &Path) -> bool {
     let Ok(identity) = CacheIdentity::for_path(path) else {
         return false;

--- a/src/native_app/waveform/audio_file/waveform_cache/read.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/read.rs
@@ -120,6 +120,7 @@ fn cached_waveform_file_v3_exists(path: &Path, identity: &CacheIdentity) -> bool
     cache_path_for_identity(path, identity).is_ok_and(|path| path.is_file())
 }
 
+#[cfg(test)]
 pub(in crate::native_app) fn cached_waveform_file_playback_ready_exists(path: &Path) -> bool {
     let Ok(identity) = CacheIdentity::for_path(path) else {
         return false;

--- a/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
@@ -7,10 +7,10 @@ use std::{
 };
 
 use super::{
-    identity::{cache_path_for_identity, CacheIdentity},
-    invalidation::current_path_generation,
-    write::store_cached_waveform_file_now,
     BACKGROUND_STORE_SHUTDOWN_WAIT,
+    identity::{CacheIdentity, cache_path_for_identity},
+    invalidation::current_path_generation,
+    write::{StoreWriteOutcome, store_cached_waveform_file_now as write_cached_waveform_file_now},
 };
 use crate::native_app::waveform::audio_file::WaveformFile;
 use diagnostics::{log_slow_cache_shutdown_flush, log_store_completion};
@@ -24,10 +24,28 @@ static BACKGROUND_STORE_QUEUE: LazyLock<Arc<BackgroundStoreQueue>> =
 
 #[cfg(test)]
 pub(in crate::native_app::waveform::audio_file) fn store_cached_waveform_file(file: &WaveformFile) {
-    let Some(job) = CachedWaveformStoreJob::new(file) else {
-        return;
-    };
-    let _ = store_cached_waveform_file_now(job);
+    let _ = persist_cached_waveform_file(file);
+}
+
+pub(in crate::native_app::waveform::audio_file) fn persist_cached_waveform_file(
+    file: &WaveformFile,
+) -> Result<(), String> {
+    let job = CachedWaveformStoreJob::new(file).ok_or_else(|| {
+        format!(
+            "waveform cache input identity is unavailable: {}",
+            file.path.display()
+        )
+    })?;
+    let outcome = write_cached_waveform_file_now(job);
+    let kind = outcome.kind();
+    if matches!(outcome, StoreWriteOutcome::Completed(_)) && !outcome.report().has_failures() {
+        Ok(())
+    } else {
+        Err(format!(
+            "waveform cache persistence failed for {}: {kind}",
+            file.path.display()
+        ))
+    }
 }
 
 pub(in crate::native_app::waveform::audio_file) fn store_cached_waveform_file_in_background(
@@ -166,7 +184,7 @@ impl BackgroundStoreQueue {
         loop {
             let job = self.next_job();
             let cache_path = job.cache_path.clone();
-            let outcome = store_cached_waveform_file_now(job);
+            let outcome = write_cached_waveform_file_now(job);
             log_store_completion(&cache_path, outcome);
             self.finish_job(&cache_path);
         }

--- a/src/native_app/waveform_edits/completion.rs
+++ b/src/native_app/waveform_edits/completion.rs
@@ -101,6 +101,9 @@ impl NativeAppState {
                 Instant::now(),
             );
         }
+        self.background
+            .source_processing
+            .wake_source(&applied.source_id, "waveform_edit_commit");
         self.register_destructive_edit_transaction(active.request.prompt.edit, applied);
 
         let label = sample_path_label(&active.request.absolute_path);

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -23,9 +23,9 @@ pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
         complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-        complete_deferred_rename_candidates, hard_rescan, scan_in_background, scan_once,
-        scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
-        sync_paths, sync_paths_with_progress,
+        complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
+        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -23,9 +23,10 @@ pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
         complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-        complete_deferred_rename_candidates, complete_pending_deep_hashes, hard_rescan,
-        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+        complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
+        complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once,
+        scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
+        sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -23,10 +23,10 @@ pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
         complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-        complete_deferred_rename_candidates, complete_pending_deep_hash_for_path,
-        complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once,
-        scan_with_progress, schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root,
-        sync_paths, sync_paths_with_progress,
+        complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+        complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
+        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -865,6 +865,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "source watcher worker",
         ),
         (
+            "src/native_app/source_processing/supervisor.rs",
+            "owned source processing supervisor worker boundary",
+        ),
+        (
             "src/native_app/sample_library/trash_actions/movement.rs",
             "trash movement worker",
         ),

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -869,6 +869,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "owned source processing supervisor worker boundary",
         ),
         (
+            "src/native_app/source_processing/worker",
+            "owned source analysis worker process boundary",
+        ),
+        (
             "src/native_app/sample_library/trash_actions/movement.rs",
             "trash movement worker",
         ),

--- a/tests/source_analysis_process.rs
+++ b/tests/source_analysis_process.rs
@@ -124,7 +124,10 @@ impl SourceAnalysisFixture {
         write_test_wav(&absolute_path, duration_seconds, sample_rate);
         let metadata = std::fs::metadata(&absolute_path).expect("read wav metadata");
         let file_identity = format!("identity-{source_id}");
-        let content_hash = format!("content-{source_id}");
+        let content_hash =
+            blake3::hash(&std::fs::read(&absolute_path).expect("read wav for content hash"))
+                .to_hex()
+                .to_string();
         let connection = SourceDatabase::open_connection(directory.path()).expect("open source db");
         connection
             .execute(

--- a/tests/source_analysis_process.rs
+++ b/tests/source_analysis_process.rs
@@ -1,0 +1,267 @@
+//! Process-boundary coverage for cancellable native source analysis.
+
+use std::{
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use rusqlite::params;
+use serde_json::{Value, json};
+use wavecrate::sample_sources::{
+    SampleSource, SourceDatabase, SourceId,
+    readiness::{
+        ReadinessEligibility, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
+        SourceAvailability, cancel_readiness_work, claim_readiness_target,
+        persist_readiness_deficits, reconcile_readiness, replace_readiness_targets,
+    },
+};
+
+const INTERNAL_SOURCE_ANALYSIS_ARG: &str = "--wavecrate-internal-source-analysis-v1";
+const SOURCE_GENERATION: i64 = 1;
+
+#[test]
+fn internal_feature_and_embedding_workers_complete_without_starting_the_gui() {
+    let fixture = SourceAnalysisFixture::new("process-analysis-complete", "short.wav", 2, 8_000);
+
+    let feature = run_internal_analysis(&fixture.feature_request());
+    assert_eq!(feature["produced"], true);
+
+    let embedding = run_internal_analysis(&fixture.embedding_request());
+    assert_eq!(embedding["produced"], true);
+}
+
+#[test]
+fn long_running_feature_worker_is_killable_and_its_claim_is_reclaimable() {
+    let mut fixture = SourceAnalysisFixture::new("process-analysis-cancel", "long.wav", 300, 8_000);
+    let target = fixture.install_feature_readiness_target();
+    let claim = claim_readiness_target(&mut fixture.connection, &target, 10, 300)
+        .expect("claim long-running feature target")
+        .expect("feature target should be pending");
+
+    let request_json = serde_json::to_string(&fixture.feature_request()).expect("encode request");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wavecrate"))
+        .arg(INTERNAL_SOURCE_ANALYSIS_ARG)
+        .arg(request_json)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start long-running feature worker");
+
+    thread::sleep(Duration::from_millis(150));
+    assert!(
+        child.try_wait().expect("poll feature worker").is_none(),
+        "the long-running feature worker completed before cancellation could be exercised"
+    );
+
+    let cancellation_started = Instant::now();
+    child.kill().expect("terminate feature worker");
+    let status = child.wait().expect("join terminated feature worker");
+    assert!(
+        !status.success(),
+        "terminated worker unexpectedly succeeded"
+    );
+    assert!(
+        cancellation_started.elapsed() < Duration::from_secs(1),
+        "terminating and joining the feature worker took {:?}",
+        cancellation_started.elapsed()
+    );
+
+    assert_eq!(
+        cancel_readiness_work(
+            &mut fixture.connection,
+            &claim,
+            "test playback preemption",
+            11,
+        )
+        .expect("release cancelled readiness claim"),
+        ReadinessWorkMutationOutcome::Recorded
+    );
+    assert!(
+        claim_readiness_target(&mut fixture.connection, &target, 12, 300)
+            .expect("reclaim cancelled feature target")
+            .is_some(),
+        "cancelled readiness work should be immediately reclaimable"
+    );
+    assert_eq!(
+        fixture
+            .connection
+            .query_row(
+                "SELECT COUNT(*) FROM source_readiness_artifacts
+                 WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'analysis_features'",
+                params![fixture.source.id.as_str(), fixture.file_identity],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("read feature readiness artifacts"),
+        0,
+        "a killed worker must not publish readiness completion"
+    );
+}
+
+struct SourceAnalysisFixture {
+    _directory: tempfile::TempDir,
+    source: SampleSource,
+    connection: rusqlite::Connection,
+    relative_path: String,
+    file_identity: String,
+    content_hash: String,
+}
+
+impl SourceAnalysisFixture {
+    fn new(
+        source_id: &str,
+        relative_path: &str,
+        duration_seconds: usize,
+        sample_rate: u32,
+    ) -> Self {
+        let directory = tempfile::tempdir().expect("temporary analysis source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string(source_id),
+            directory.path().to_path_buf(),
+        );
+        let absolute_path = directory.path().join(relative_path);
+        write_test_wav(&absolute_path, duration_seconds, sample_rate);
+        let metadata = std::fs::metadata(&absolute_path).expect("read wav metadata");
+        let file_identity = format!("identity-{source_id}");
+        let content_hash = format!("content-{source_id}");
+        let connection = SourceDatabase::open_connection(directory.path()).expect("open source db");
+        connection
+            .execute(
+                "INSERT INTO wav_files (
+                    path, file_size, modified_ns, content_hash, extension, missing, file_identity
+                 ) VALUES (?1, ?2, 1, ?3, 'wav', 0, ?4)",
+                params![
+                    relative_path,
+                    i64::try_from(metadata.len()).expect("wav size fits i64"),
+                    content_hash,
+                    file_identity,
+                ],
+            )
+            .expect("seed wav manifest");
+        Self {
+            _directory: directory,
+            source,
+            connection,
+            relative_path: relative_path.to_string(),
+            file_identity,
+            content_hash,
+        }
+    }
+
+    fn feature_request(&self) -> Value {
+        json!({
+            "source": self.source,
+            "task": {
+                "ReadinessFeature": {
+                    "relative_path": self.relative_path,
+                    "content_hash": self.content_hash,
+                    "analysis_version": wavecrate_analysis::analysis_version(),
+                }
+            }
+        })
+    }
+
+    fn embedding_request(&self) -> Value {
+        json!({
+            "source": self.source,
+            "task": {
+                "ReadinessEmbedding": {
+                    "relative_path": self.relative_path,
+                    "content_hash": self.content_hash,
+                    "analysis_version": wavecrate_analysis::analysis_version(),
+                }
+            }
+        })
+    }
+
+    fn install_feature_readiness_target(&mut self) -> ReadinessTarget {
+        let feature_target = ReadinessTarget::file(
+            self.source.id.as_str(),
+            self.file_identity.as_str(),
+            self.relative_path.as_str(),
+            ReadinessStage::AnalysisFeatures,
+            wavecrate_analysis::analysis_version(),
+            SOURCE_GENERATION,
+            self.content_hash.as_str(),
+        );
+        let mut targets = Vec::new();
+        for stage in [
+            ReadinessStage::IndexedIdentity,
+            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
+            ReadinessStage::EmbeddingAspects,
+        ] {
+            let mut target = feature_target.clone();
+            target.stage = stage;
+            if stage != ReadinessStage::AnalysisFeatures {
+                target.required_version = "test-unsupported-v1".to_string();
+                target.eligibility = ReadinessEligibility::Unsupported;
+            }
+            targets.push(target);
+        }
+        targets.push(
+            ReadinessTarget::source(
+                self.source.id.as_str(),
+                ReadinessStage::SimilarityLayout,
+                "test-unsupported-v1",
+                SOURCE_GENERATION,
+                "test-membership-v1",
+            )
+            .with_eligibility(ReadinessEligibility::Unsupported),
+        );
+        replace_readiness_targets(
+            &mut self.connection,
+            self.source.id.as_str(),
+            SOURCE_GENERATION,
+            1,
+            SourceAvailability::Active,
+            &targets,
+            1,
+        )
+        .expect("install readiness targets");
+        let snapshot = reconcile_readiness(&self.connection, self.source.id.as_str(), 2)
+            .expect("reconcile feature readiness");
+        assert_eq!(snapshot.deficits.len(), 1);
+        assert_eq!(
+            persist_readiness_deficits(&mut self.connection, &snapshot.deficits, 2)
+                .expect("persist feature readiness deficit"),
+            1
+        );
+        feature_target
+    }
+}
+
+fn run_internal_analysis(request: &Value) -> Value {
+    let request_json = serde_json::to_string(request).expect("encode analysis request");
+    let output = Command::new(env!("CARGO_BIN_EXE_wavecrate"))
+        .arg(INTERNAL_SOURCE_ANALYSIS_ARG)
+        .arg(request_json)
+        .output()
+        .expect("run internal source analysis process");
+    assert!(
+        output.status.success(),
+        "internal source analysis failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("decode internal source analysis result")
+}
+
+fn write_test_wav(path: &std::path::Path, duration_seconds: usize, sample_rate: u32) {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).expect("create test wav");
+    let sample_count = duration_seconds
+        .checked_mul(usize::try_from(sample_rate).expect("sample rate fits usize"))
+        .expect("sample count fits usize");
+    for sample_index in 0..sample_count {
+        let phase = (sample_index % 200) as f32 / 200.0;
+        let sample = ((phase * std::f32::consts::TAU).sin() * 16_000.0) as i16;
+        writer.write_sample(sample).expect("write test sample");
+    }
+    writer.finalize().expect("finalize test wav");
+}

--- a/tests/source_finalizer_process.rs
+++ b/tests/source_finalizer_process.rs
@@ -1,0 +1,45 @@
+//! Process-boundary coverage for cancellable native similarity finalization.
+
+use std::process::Command;
+
+use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId};
+
+#[test]
+fn internal_similarity_finalizer_runs_to_completion_without_starting_the_gui() {
+    let directory = tempfile::tempdir().expect("temporary similarity source");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("process-finalizer"),
+        directory.path().to_path_buf(),
+    );
+    let database =
+        SourceDatabase::open_for_source_write(directory.path()).expect("create source database");
+    database
+        .set_metadata("last_scan_completed_at", "100")
+        .expect("seed completed scan timestamp");
+    drop(database);
+    let source_json = serde_json::to_string(&source).expect("encode source descriptor");
+    let fence_json = r#"{"LegacyPathsRevision":0}"#;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wavecrate"))
+        .arg("--wavecrate-internal-similarity-finalizer-v1")
+        .arg(source_json)
+        .arg(fence_json)
+        .output()
+        .expect("run internal finalizer process");
+
+    assert!(
+        output.status.success(),
+        "internal finalizer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "true");
+    assert_eq!(
+        source
+            .open_db()
+            .expect("reopen finalized source")
+            .get_metadata("last_similarity_prep_scan_at")
+            .expect("read finalizer timestamp")
+            .as_deref(),
+        Some("100")
+    );
+}


### PR DESCRIPTION
## Scope

- Add one owned native source-processing supervisor with startup, committed-source, mutation, artifact/retry sweep, playback, foreground sample-load, source-removal, and shutdown lifecycle integration.
- Add durable readiness claims with generation fencing, leases, restart recovery, bounded exponential backoff, failure classification, cancellation, and telemetry.
- Add explicit global, per-source, and per-lane CPU/IO/database budgets plus weighted-fair interaction priorities for immediate samples, visible rows, current folder, and selected source.
- Route deep hashing through durable per-file readiness jobs and similarity analysis/finalization through bounded supervisor work, removing native detached/manual convergence paths.
- Keep read-only source databases physically immutable and skip supervisor discovery writes in sandbox/read-only operation.

## Definition of Done

- [x] The production native runtime owns one durable background processing supervisor.
- [x] Work discovery and retry recovery are restart-safe and source-local.
- [x] CPU, IO, and database work are explicitly capped globally, per source, and per processing lane.
- [x] Interactive requests preempt active background work; playback and foreground loading pause/cancel work for later resume.
- [x] Full and targeted scans honor cancellation at resumable committed checkpoints and through final reconciliation.
- [x] Shutdown joins the owned coordinator, all CPU-owning child processes, and all admitted/registered external scans; source removal prevents late work.
- [x] Queue depth, age, retry, failure, cancellation, contention, discovery, and throughput telemetry are exposed.
- [x] Deep hashing and similarity processing no longer depend on detached or synchronous manual drains.
- [x] Failed paths back off durably without starving later files.
- [x] Read-only runtime mode cannot mutate source databases.
- [x] Sources added after supervisor startup are admitted before their first scan without blocking the UI path or replacing authoritative descriptors.

## Validation

Exact head: `dbe8e2479256a55d5240384e6f67ffe12805a915`

- `CARGO_BUILD_JOBS=1 cargo test -p wavecrate --lib -- --skip prepare_auto_rename_requests_logs_looped_provenance --skip rating_previous_random_history_entry_restores_waveform_for_replacement`
  - 1,917 passed, 20 ignored, 2 established skips, 0 failed
- `cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests -- --test-threads=1`
  - 24 passed, 1 opt-in 10k-file profile ignored, 0 failed
  - includes deterministic mid-manifest cancellation, failure-atomic rollback, clean resume, and non-blocking first-scan source admission, and fail-closed retirement quarantine\/retry, and external-commit candidate generation fencing
- `cargo test -p wavecrate --bin wavecrate native_app::tests::config_sources::scan_handoff -- --nocapture`
  - 2 passed, 0 failed
  - includes add-after-startup launch, budget admission, scan, and finish
- `CARGO_BUILD_JOBS=1 cargo test -p wavecrate-library readiness --no-fail-fast`
  - 37 passed, 0 failed
  - cancellable target replacement, reconciliation, and deficit persistence retain atomic transaction boundaries
- `CARGO_BUILD_JOBS=1 cargo test --test source_analysis_process --no-fail-fast`
  - 2 passed, 0 failed
  - feature and embedding workers complete without GUI startup; a real 300-second feature worker remains killable and reclaimable
- `cargo test --lib feature_publication_rejects_file_mutated_while_stage_is_in_flight --no-fail-fast`
  - 1 passed; changed filesystem bytes are rejected before cache/artifact publication under the claimed hash
- Non-blocking architecture checks
  - Radiant app/runtime guardrails: 19 passed
  - `cargo test --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis -- --nocapture`: 1 passed
- `CARGO_BUILD_JOBS=1 bash scripts/perf.sh guard`
  - all scenario p95 values within warning limits
- `CARGO_BUILD_JOBS=1 cargo build --release --bin wavecrate`
  - debug binary SHA-256: `ab63e2b781a2c551bf21b6b447d14e1ca5ff78b5c1b1e653b2b6e8880927d68e`
  - release binary SHA-256: `e8ef61076aff1c08a481b3eba80bf795dfc4fda8a2dd43f5490133298644e62c`
- `bash scripts/run.sh sandbox --temp`
  - optimized binary launched in the read-only sandbox and shut down with Ctrl-C without a panic
- `git diff --check`
  - passed; worktree clean and local/remote/PR heads match

Validation notes:

- `cargo check -p wavecrate --tests --bins` stalled twice in a sleeping local rustc metadata process. The same changed crates compiled and linked successfully in focused tests, the complete Wavecrate library lane, the production process tests, the perf build, and the optimized release build.
- Initial parallel supervisor reruns exposed existing timing-sensitive resume and heartbeat assertions. Each passed in isolation, and the deterministic single-thread complete supervisor lane above passed cleanly.

## Risk profiles

- ordinary
- persistence / restart recovery
- performance
- realtime audio / playback-sensitive
- process execution boundary

## Known limitations

- The opt-in `cargo test --release` profile cannot currently compile because pre-existing playback-history tests call debug-only source-DB counters. The production optimized application builds and launches successfully; debug profile evidence is recorded above.

User review is required before merge.

Linear: https://linear.app/boostnlvp/issue/OPT-1178