### PR TITLE
OPT-1179: Make source discovery revisioned and self-healing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ likely to miss important reasoning.
    - macOS/Linux/WSL: `bash scripts/doctor.sh`
 
 ## Golden Commands
+- Build a testable macOS app bundle:
+  - macOS: `bash scripts/build.sh --release`
 - Bootstrap:
   - Windows PowerShell: `powershell -ExecutionPolicy Bypass -File scripts/bootstrap.ps1`
   - macOS/Linux/WSL: `bash scripts/bootstrap.sh`

--- a/crates/wavecrate-library/src/filesystem_identity.rs
+++ b/crates/wavecrate-library/src/filesystem_identity.rs
@@ -12,6 +12,47 @@ pub fn stable_filesystem_identity(path: &Path, metadata: &fs::Metadata) -> Optio
     stable_filesystem_identity_impl(path, metadata)
 }
 
+/// Return whether two persisted identities describe the same filesystem object.
+///
+/// Version 2 added creation time so reused inode/file-index values no longer alias a
+/// replacement. During migration, a legacy identity can still be matched to its v2 form
+/// by the platform object fields that were available in v1.
+pub fn same_filesystem_object_identity(previous: &str, current: &str) -> bool {
+    if previous == current {
+        return true;
+    }
+    legacy_identity_parts(previous)
+        .zip(version_2_identity_parts(current))
+        .is_some_and(|(previous, current)| previous == current)
+        || version_2_identity_parts(previous)
+            .zip(legacy_identity_parts(current))
+            .is_some_and(|(previous, current)| previous == current)
+}
+
+fn legacy_identity_parts(identity: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = identity.split(':');
+    let platform = parts.next()?;
+    if !matches!(platform, "unix" | "windows") {
+        return None;
+    }
+    let first = parts.next()?;
+    let second = parts.next()?;
+    parts.next().is_none().then_some((platform, first, second))
+}
+
+fn version_2_identity_parts(identity: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = identity.split(':');
+    let platform = match parts.next()? {
+        "unix-v2" => "unix",
+        "windows-v2" => "windows",
+        _ => return None,
+    };
+    let first = parts.next()?;
+    let second = parts.next()?;
+    let _creation_time = parts.next()?;
+    parts.next().is_none().then_some((platform, first, second))
+}
+
 #[cfg(unix)]
 fn stable_filesystem_identity_impl(_path: &Path, metadata: &fs::Metadata) -> Option<String> {
     use std::os::unix::fs::MetadataExt;
@@ -105,5 +146,25 @@ mod tests {
             stable_filesystem_identity(&renamed, &renamed_metadata).expect("read renamed identity");
 
         assert_eq!(original_identity, renamed_identity);
+    }
+
+    #[test]
+    fn legacy_identity_matches_its_version_2_upgrade_only() {
+        assert!(same_filesystem_object_identity(
+            "unix:10:20",
+            "unix-v2:10:20:30"
+        ));
+        assert!(same_filesystem_object_identity(
+            "windows-v2:10:20:30",
+            "windows:10:20"
+        ));
+        assert!(!same_filesystem_object_identity(
+            "unix-v2:10:20:30",
+            "unix-v2:10:20:31"
+        ));
+        assert!(!same_filesystem_object_identity(
+            "unix:10:20",
+            "windows-v2:10:20:30"
+        ));
     }
 }

--- a/crates/wavecrate-library/src/filesystem_identity.rs
+++ b/crates/wavecrate-library/src/filesystem_identity.rs
@@ -12,45 +12,14 @@ pub fn stable_filesystem_identity(path: &Path, metadata: &fs::Metadata) -> Optio
     stable_filesystem_identity_impl(path, metadata)
 }
 
-/// Return whether two persisted identities describe the same filesystem object.
+/// Return a platform marker that changes when the filesystem object is mutated.
 ///
-/// Version 2 added creation time so reused inode/file-index values no longer alias a
-/// replacement. During migration, a legacy identity can still be matched to its v2 form
-/// by the platform object fields that were available in v1.
-pub fn same_filesystem_object_identity(previous: &str, current: &str) -> bool {
-    if previous == current {
-        return true;
-    }
-    legacy_identity_parts(previous)
-        .zip(version_2_identity_parts(current))
-        .is_some_and(|(previous, current)| previous == current)
-        || version_2_identity_parts(previous)
-            .zip(legacy_identity_parts(current))
-            .is_some_and(|(previous, current)| previous == current)
-}
-
-fn legacy_identity_parts(identity: &str) -> Option<(&str, &str, &str)> {
-    let mut parts = identity.split(':');
-    let platform = parts.next()?;
-    if !matches!(platform, "unix" | "windows") {
-        return None;
-    }
-    let first = parts.next()?;
-    let second = parts.next()?;
-    parts.next().is_none().then_some((platform, first, second))
-}
-
-fn version_2_identity_parts(identity: &str) -> Option<(&str, &str, &str)> {
-    let mut parts = identity.split(':');
-    let platform = match parts.next()? {
-        "unix-v2" => "unix",
-        "windows-v2" => "windows",
-        _ => return None,
-    };
-    let first = parts.next()?;
-    let second = parts.next()?;
-    let _creation_time = parts.next()?;
-    parts.next().is_none().then_some((platform, first, second))
+/// This is intentionally separate from modified time because callers use it to fence
+/// content reads even when another process restores the user-visible modified time.
+/// Unsupported filesystems and lookup failures return `None`; callers must not treat a
+/// missing marker as proof that a content snapshot remained stable.
+pub fn filesystem_change_marker(path: &Path, metadata: &fs::Metadata) -> Option<String> {
+    filesystem_change_marker_impl(path, metadata)
 }
 
 #[cfg(unix)]
@@ -63,10 +32,21 @@ fn stable_filesystem_identity_impl(_path: &Path, metadata: &fs::Metadata) -> Opt
     // distinguishes a replacement that inherits the same device/inode pair.
     let created = metadata.created().ok()?.duration_since(UNIX_EPOCH).ok()?;
     Some(format!(
-        "unix-v2:{}:{}:{}",
+        "unix:{}:{}:{}",
         metadata.dev(),
         metadata.ino(),
         created.as_nanos()
+    ))
+}
+
+#[cfg(unix)]
+fn filesystem_change_marker_impl(_path: &Path, metadata: &fs::Metadata) -> Option<String> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(format!(
+        "unix:{}:{}",
+        metadata.ctime(),
+        metadata.ctime_nsec()
     ))
 }
 
@@ -97,13 +77,51 @@ fn stable_filesystem_identity_impl(path: &Path, metadata: &fs::Metadata) -> Opti
     let creation_time = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
         | u64::from(information.ftCreationTime.dwLowDateTime);
     Some(format!(
-        "windows-v2:{}:{}:{}",
+        "windows:{}:{}:{}",
         information.dwVolumeSerialNumber, file_index, creation_time
     ))
 }
 
+#[cfg(windows)]
+fn filesystem_change_marker_impl(path: &Path, metadata: &fs::Metadata) -> Option<String> {
+    use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{
+            FILE_BASIC_INFO, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
+            FILE_SHARE_READ, FILE_SHARE_WRITE, FileBasicInfo, GetFileInformationByHandleEx,
+        },
+    };
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .access_mode(FILE_READ_ATTRIBUTES.0)
+        .share_mode((FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0);
+    if metadata.file_type().is_symlink() {
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT.0);
+    }
+
+    let file = options.open(path).ok()?;
+    let mut information = FILE_BASIC_INFO::default();
+    unsafe {
+        GetFileInformationByHandleEx(
+            HANDLE(file.as_raw_handle()),
+            FileBasicInfo,
+            (&mut information as *mut FILE_BASIC_INFO).cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    }
+    .ok()?;
+    (information.ChangeTime != 0).then(|| format!("windows:{}", information.ChangeTime))
+}
+
 #[cfg(not(any(unix, windows)))]
 fn stable_filesystem_identity_impl(_path: &Path, _metadata: &fs::Metadata) -> Option<String> {
+    None
+}
+
+#[cfg(not(any(unix, windows)))]
+fn filesystem_change_marker_impl(_path: &Path, _metadata: &fs::Metadata) -> Option<String> {
     None
 }
 
@@ -146,25 +164,5 @@ mod tests {
             stable_filesystem_identity(&renamed, &renamed_metadata).expect("read renamed identity");
 
         assert_eq!(original_identity, renamed_identity);
-    }
-
-    #[test]
-    fn legacy_identity_matches_its_version_2_upgrade_only() {
-        assert!(same_filesystem_object_identity(
-            "unix:10:20",
-            "unix-v2:10:20:30"
-        ));
-        assert!(same_filesystem_object_identity(
-            "windows-v2:10:20:30",
-            "windows:10:20"
-        ));
-        assert!(!same_filesystem_object_identity(
-            "unix-v2:10:20:30",
-            "unix-v2:10:20:31"
-        ));
-        assert!(!same_filesystem_object_identity(
-            "unix:10:20",
-            "windows-v2:10:20:30"
-        ));
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -419,6 +419,20 @@ impl SourceDatabase {
         Ok(db.into_connection())
     }
 
+    /// Open an external metadata database while its audio source root is unavailable.
+    ///
+    /// This is intentionally limited to callers that already resolved a separate, existing
+    /// metadata root. Treating that directory as the operational root avoids recreating or
+    /// validating the absent audio directory while still applying the requested connection role.
+    pub fn open_unavailable_source_metadata_connection(
+        database_root: impl AsRef<Path>,
+        role: SourceDatabaseConnectionRole,
+    ) -> Result<Connection, SourceDbError> {
+        let database_root = database_root.as_ref();
+        let db = Self::open_with_role_and_database_root(database_root, database_root, role)?;
+        Ok(db.into_connection())
+    }
+
     /// Return the path to the root folder backing this database.
     pub fn root(&self) -> &Path {
         &self.root

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -41,7 +41,10 @@ pub use open_profiles::SourceDatabaseConnectionRole;
 /// Metadata retained for a pruned row so later scans can recover rename state.
 pub use pending_renames::PendingRenameEntry;
 pub use rename_metadata::RenameMetadataSnapshot;
-pub use types::{Rating, SampleCollection, SampleSoundType, SourceTag, SourceTagUsage, WavEntry};
+pub use types::{
+    Rating, SampleCollection, SampleSoundType, SourceManifestEntry, SourceTag, SourceTagUsage,
+    WavEntry,
+};
 pub use util::normalize_relative_path;
 pub use write::{
     SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
@@ -54,6 +57,8 @@ pub const DB_FILE_NAME: &str = ".wavecrate.db";
 pub const LEGACY_DB_FILE_NAME: &str = ".wavecrate_samples.db";
 /// Metadata key for the last completed scan timestamp.
 pub const META_LAST_SCAN_COMPLETED_AT: &str = "last_scan_completed_at";
+/// Metadata key storing the last completed periodic source-manifest audit timestamp.
+pub const META_LAST_MANIFEST_AUDIT_AT: &str = "last_manifest_audit_at_v1";
 /// Metadata key for the last similarity-prep scan timestamp.
 pub const META_LAST_SIMILARITY_PREP_SCAN_AT: &str = "last_similarity_prep_scan_at";
 /// Metadata key storing the last data revision cleaned by deferred maintenance.

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -1,5 +1,8 @@
-use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use rusqlite::{Connection, Transaction};
 use std::fmt;
@@ -102,6 +105,7 @@ pub struct SourceWriteBatch<'conn> {
     tx: Transaction<'conn>,
     db_path: PathBuf,
     paths_revision_dirty: bool,
+    manifest_touched_paths: BTreeSet<PathBuf>,
     telemetry_label: &'static str,
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/open.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open.rs
@@ -88,8 +88,15 @@ fn open_source_database_with_flags(
         return Err(SourceDbError::InvalidRoot(root.to_path_buf()));
     }
 
-    let db_path = paths::prepare_writable_db_path(database_root)?;
-    util::create_parent_if_needed(&db_path)?;
+    let database_is_embedded = database_root == root;
+    let db_path = if database_is_embedded {
+        paths::prepare_writable_db_path_in_existing_root(database_root)?
+    } else {
+        paths::prepare_writable_db_path(database_root)?
+    };
+    if !database_is_embedded {
+        util::create_parent_if_needed(&db_path)?;
+    }
     let connect_started = std::time::Instant::now();
     let connection = match Connection::open_with_flags(&db_path, open_flags) {
         Ok(connection) => {

--- a/crates/wavecrate-library/src/sample_sources/db/open/paths.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open/paths.rs
@@ -29,6 +29,20 @@ pub(super) fn read_only_db_path(database_root: &Path) -> Result<Option<PathBuf>,
 
 pub(super) fn prepare_writable_db_path(database_root: &Path) -> Result<PathBuf, SourceDbError> {
     let policy = SourceDbPathPolicy::for_writable(database_root)?;
+    prepare_writable_db_path_with_policy(database_root, &policy)
+}
+
+pub(super) fn prepare_writable_db_path_in_existing_root(
+    database_root: &Path,
+) -> Result<PathBuf, SourceDbError> {
+    let policy = SourceDbPathPolicy::from_existing_root(database_root)?;
+    prepare_writable_db_path_with_policy(database_root, &policy)
+}
+
+fn prepare_writable_db_path_with_policy(
+    database_root: &Path,
+    policy: &SourceDbPathPolicy,
+) -> Result<PathBuf, SourceDbError> {
     let db_path = database_root.join(DB_FILE_NAME);
     if policy.regular_file_status(&db_path)? == PathStatus::RegularFile {
         policy.validate_sidecars(&db_path)?;

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use rusqlite::Params;
+use rusqlite::{OptionalExtension, Params};
 
 use super::super::super::util::map_sql_error;
 use super::super::super::{Rating, SourceDatabase, SourceDbError, SourceManifestEntry, WavEntry};
@@ -50,6 +50,60 @@ fn count_rows(db: &SourceDatabase, extra_predicate: &str) -> Result<usize, Sourc
 }
 
 impl SourceDatabase {
+    /// Fetch the committed live source manifest and revision from one SQLite read snapshot.
+    pub fn manifest_snapshot_with_revision(
+        &self,
+    ) -> Result<(u64, Vec<SourceManifestEntry>), SourceDbError> {
+        let filter = wav_file_supported_audio_filter(self)?;
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = transaction
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default();
+        let sql = format!(
+            "SELECT path, file_identity, content_hash, file_size, modified_ns
+             FROM wav_files
+             WHERE {filter} AND missing = 0
+             ORDER BY path ASC"
+        );
+        let entries = {
+            let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+            let rows = statement
+                .query_map([], |row| {
+                    let Some(relative_path) = decode_path_row(
+                        row,
+                        "Skipping source manifest row with invalid relative path",
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    Ok(Some(SourceManifestEntry {
+                        relative_path,
+                        file_identity: row.get(1)?,
+                        content_hash: row.get(2)?,
+                        file_size: row.get::<_, i64>(3)?.max(0) as u64,
+                        modified_ns: row.get(4)?,
+                    }))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?;
+            rows.into_iter().flatten().collect()
+        };
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok((revision, entries))
+    }
+
     /// Fetch the committed live source manifest in deterministic path order.
     pub fn list_manifest_entries(&self) -> Result<Vec<SourceManifestEntry>, SourceDbError> {
         let filter = wav_file_supported_audio_filter(self)?;

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use rusqlite::Params;
 
 use super::super::super::util::map_sql_error;
-use super::super::super::{Rating, SourceDatabase, SourceDbError, WavEntry};
+use super::super::super::{Rating, SourceDatabase, SourceDbError, SourceManifestEntry, WavEntry};
 use super::super::decode::{
     decode_path_row, decode_wav_entry_row, wav_file_has_column, wav_file_select_columns,
     wav_file_supported_audio_filter,
@@ -50,6 +50,39 @@ fn count_rows(db: &SourceDatabase, extra_predicate: &str) -> Result<usize, Sourc
 }
 
 impl SourceDatabase {
+    /// Fetch the committed live source manifest in deterministic path order.
+    pub fn list_manifest_entries(&self) -> Result<Vec<SourceManifestEntry>, SourceDbError> {
+        let filter = wav_file_supported_audio_filter(self)?;
+        let sql = format!(
+            "SELECT path, file_identity, content_hash, file_size, modified_ns
+             FROM wav_files
+             WHERE {filter} AND missing = 0
+             ORDER BY path ASC"
+        );
+        let mut statement = self.connection.prepare(&sql).map_err(map_sql_error)?;
+        let rows = statement
+            .query_map([], |row| {
+                let Some(relative_path) = decode_path_row(
+                    row,
+                    "Skipping source manifest row with invalid relative path",
+                )?
+                else {
+                    return Ok(None);
+                };
+                Ok(Some(SourceManifestEntry {
+                    relative_path,
+                    file_identity: row.get(1)?,
+                    content_hash: row.get(2)?,
+                    file_size: row.get::<_, i64>(3)?.max(0) as u64,
+                    modified_ns: row.get(4)?,
+                }))
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        Ok(rows.into_iter().flatten().collect())
+    }
+
     /// Fetch all tracked wav files for this source.
     pub fn list_files(&self) -> Result<Vec<WavEntry>, SourceDbError> {
         let filter = wav_file_supported_audio_filter(self)?;

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -9,6 +9,14 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS source_manifest_audit_state (
+        singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+        started_at INTEGER NOT NULL,
+        checked_files INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS source_manifest_audit_seen (
+        path TEXT PRIMARY KEY
+    ) WITHOUT ROWID;
     CREATE TABLE IF NOT EXISTS wav_files (
         path TEXT PRIMARY KEY,
         file_size INTEGER NOT NULL,

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -29,6 +29,7 @@ use self::tag_catalog::{backfill_tag_catalog, ensure_tag_catalog_schema};
 /// Apply additive column migrations needed by older source databases.
 pub(super) fn apply_optional_migrations(connection: &Connection) -> Result<(), SourceDbError> {
     apply_structural_migrations(connection)?;
+    migrate_canonical_file_identities(connection)?;
     backfill_tag_catalog(connection)?;
     Ok(())
 }
@@ -82,6 +83,50 @@ fn ensure_collection_membership_schema(connection: &Connection) -> Result<(), So
             SELECT path, collection
             FROM wav_files
             WHERE collection IS NOT NULL;",
+        )
+        .map_err(map_sql_error)?;
+    Ok(())
+}
+
+fn migrate_canonical_file_identities(connection: &Connection) -> Result<(), SourceDbError> {
+    for table in ["wav_files", "pending_wav_renames"] {
+        if !table_columns(connection, table)?.contains("file_identity") {
+            continue;
+        }
+        let sql = format!(
+            "UPDATE {table}
+             SET file_identity = CASE
+                 WHEN file_identity LIKE 'unix-v2:%'
+                     THEN 'unix:' || substr(file_identity, length('unix-v2:') + 1)
+                 WHEN file_identity LIKE 'windows-v2:%'
+                     THEN 'windows:' || substr(file_identity, length('windows-v2:') + 1)
+                 WHEN (
+                     file_identity LIKE 'unix:%'
+                     OR file_identity LIKE 'windows:%'
+                 ) AND (
+                     length(file_identity) - length(replace(file_identity, ':', ''))
+                 ) = 3
+                     THEN file_identity
+                 ELSE NULL
+             END
+             WHERE file_identity IS NOT NULL"
+        );
+        connection.execute(&sql, []).map_err(map_sql_error)?;
+    }
+    // Readiness rows are derived from the manifest. Rebuilding them is both
+    // simpler and safer than rewriting identity-bearing keys in place: mixed
+    // experimental/canonical databases may already contain both spellings,
+    // making an UPDATE collide with their uniqueness constraints. Existing
+    // durable analysis artifacts are deliberately preserved and will be
+    // rediscovered under the canonical identities.
+    connection
+        .execute_batch(
+            "DELETE FROM analysis_jobs WHERE readiness_managed = 1;
+             DELETE FROM source_readiness_targets;
+             DELETE FROM source_readiness_artifacts;
+             DELETE FROM source_readiness_sources;
+             DELETE FROM metadata
+             WHERE key = 'readiness_target_fingerprint_v1';",
         )
         .map_err(map_sql_error)?;
     Ok(())

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -80,6 +80,165 @@ fn wav_file_migration_adds_stable_file_identity_column() {
 }
 
 #[test]
+fn canonical_identity_migration_rebuilds_derived_readiness_state() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            file_identity TEXT
+        );
+        CREATE TABLE pending_wav_renames (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            content_hash TEXT,
+            tag INTEGER NOT NULL,
+            looped INTEGER NOT NULL,
+            locked INTEGER NOT NULL,
+            last_played_at INTEGER,
+            file_identity TEXT
+        );
+        CREATE TABLE source_readiness_targets (
+            source_id TEXT NOT NULL,
+            scope_kind TEXT NOT NULL,
+            scope_id TEXT NOT NULL
+        );
+        CREATE TABLE source_readiness_artifacts (
+            source_id TEXT NOT NULL,
+            scope_kind TEXT NOT NULL,
+            scope_id TEXT NOT NULL
+        );
+        CREATE TABLE source_readiness_sources (
+            source_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE analysis_jobs (
+            id INTEGER PRIMARY KEY,
+            sample_id TEXT NOT NULL,
+            readiness_managed INTEGER NOT NULL,
+            readiness_scope_kind TEXT,
+            readiness_scope_id TEXT
+        );
+        INSERT INTO wav_files (path, file_size, modified_ns, file_identity) VALUES
+            ('unix-v2.wav', 1, 1, 'unix-v2:10:20:30'),
+            ('windows-v2.wav', 1, 1, 'windows-v2:40:50:60'),
+            ('canonical.wav', 1, 1, 'unix:70:80:90'),
+            ('obsolete.wav', 1, 1, 'unix:100:110');
+        INSERT INTO pending_wav_renames (
+            path, file_size, modified_ns, content_hash, tag, looped, locked,
+            last_played_at, file_identity
+        ) VALUES (
+            'pending.wav', 1, 1, NULL, 0, 0, 0, NULL, 'windows:120:130'
+        );
+        INSERT INTO source_readiness_targets VALUES
+            ('source', 'file', 'unix-v2:10:20:30'),
+            ('source', 'file', 'unix:100:110');
+        INSERT INTO source_readiness_artifacts VALUES
+            ('source', 'file', 'windows-v2:40:50:60'),
+            ('source', 'file', 'windows:120:130');
+        INSERT INTO analysis_jobs VALUES
+            (1, 'unix-v2:10:20:30', 1, 'file', 'unix-v2:10:20:30'),
+            (2, 'manual-job', 0, NULL, NULL);
+        INSERT INTO source_readiness_sources VALUES ('source');
+        INSERT INTO metadata VALUES ('readiness_target_fingerprint_v1', 'stale');
+        INSERT INTO metadata VALUES ('unrelated', 'preserved');",
+    )
+    .unwrap();
+
+    migrate_canonical_file_identities(&conn).unwrap();
+
+    let identities = conn
+        .prepare("SELECT path, file_identity FROM wav_files ORDER BY path")
+        .unwrap()
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        identities,
+        vec![
+            (
+                String::from("canonical.wav"),
+                Some(String::from("unix:70:80:90")),
+            ),
+            (String::from("obsolete.wav"), None),
+            (
+                String::from("unix-v2.wav"),
+                Some(String::from("unix:10:20:30")),
+            ),
+            (
+                String::from("windows-v2.wav"),
+                Some(String::from("windows:40:50:60")),
+            ),
+        ]
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT file_identity FROM pending_wav_renames WHERE path = 'pending.wav'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap(),
+        None
+    );
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM source_readiness_targets", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM source_readiness_artifacts",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        conn.query_row("SELECT sample_id FROM analysis_jobs", [], |row| row
+            .get::<_, String>(0),)
+            .unwrap(),
+        "manual-job"
+    );
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM source_readiness_sources", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT value FROM metadata WHERE key = 'unrelated'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap(),
+        "preserved"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM metadata
+             WHERE key = 'readiness_target_fingerprint_v1'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0
+    );
+}
+
+#[test]
 fn collection_membership_schema_backfills_legacy_collection_column() {
     let conn = Connection::open_in_memory().unwrap();
     conn.execute_batch(

--- a/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use migrations::table_columns;
 /// A matching stamp means the file has already passed the full schema-assurance
 /// path once. Current-stamped opens still run low-cost additive table/column
 /// repairs, but they skip index rebuilds and deferred cleanup work.
-pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 6;
+pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 8;
 
 /// Apply the full source-database schema, including deferred cleanup work.
 pub(super) fn apply_schema(connection: &Connection) -> Result<SchemaApplyOutcome, SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -265,6 +265,21 @@ pub struct WavEntry {
     pub tag_named: bool,
 }
 
+/// Authoritative identity facts for one live source-manifest row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceManifestEntry {
+    /// File path relative to the source root.
+    pub relative_path: PathBuf,
+    /// Stable filesystem-object identity when the platform provides one.
+    pub file_identity: Option<String>,
+    /// Full content hash when deep hashing has completed.
+    pub content_hash: Option<String>,
+    /// File size in bytes.
+    pub file_size: u64,
+    /// Last modified timestamp in epoch nanoseconds.
+    pub modified_ns: i64,
+}
+
 /// One normal library tag stored in a source database.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceTag {

--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -3,6 +3,7 @@ mod collections;
 mod command;
 mod database;
 mod event;
+mod manifest_audit;
 mod mutation;
 mod paths;
 mod scan_queries;

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -164,6 +164,8 @@ impl<'conn> SourceWriteBatch<'conn> {
         relative_path: &Path,
         file_identity: Option<&str>,
     ) -> Result<(), SourceDbError> {
+        self.manifest_touched_paths
+            .insert(relative_path.to_path_buf());
         match file_identity {
             Some(identity) => update_path_text_statement(
                 &self.tx,
@@ -189,6 +191,8 @@ impl<'conn> SourceWriteBatch<'conn> {
         missing: bool,
     ) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.manifest_touched_paths
+            .insert(relative_path.to_path_buf());
         self.clear_pending_rename_for_live_path(relative_path)?;
         execute_wav_upsert(
             &self.tx,
@@ -270,6 +274,8 @@ impl<'conn> SourceWriteBatch<'conn> {
         relative_path: &Path,
         missing: bool,
     ) -> Result<(), SourceDbError> {
+        self.manifest_touched_paths
+            .insert(relative_path.to_path_buf());
         update_flag_statement(&self.tx, UPDATE_MISSING_SQL, relative_path, missing)
     }
 

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -175,6 +175,7 @@ impl SourceDatabase {
             tx,
             db_path: self.db_path.clone(),
             paths_revision_dirty: false,
+            manifest_touched_paths: std::collections::BTreeSet::new(),
             telemetry_label: self.telemetry_label,
         })
     }

--- a/crates/wavecrate-library/src/sample_sources/db/write/manifest_audit.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/manifest_audit.rs
@@ -1,0 +1,154 @@
+use std::path::PathBuf;
+
+use rusqlite::{Transaction, TransactionBehavior, params};
+
+use super::super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
+use super::super::{META_LAST_MANIFEST_AUDIT_AT, SourceDatabase, SourceDbError, SourceWriteBatch};
+
+impl SourceDatabase {
+    /// Start a durable manifest-audit cycle or recover the paths already checked by an
+    /// interrupted cycle.
+    ///
+    /// Audit bookkeeping deliberately does not advance the source revision: it is private scan
+    /// progress, not a committed manifest mutation.
+    pub fn begin_or_resume_manifest_audit(
+        &self,
+        started_at: i64,
+    ) -> Result<Vec<PathBuf>, SourceDbError> {
+        let transaction =
+            Transaction::new_unchecked(&self.connection, TransactionBehavior::Immediate)
+                .map_err(map_sql_error)?;
+        transaction
+            .execute(
+                "INSERT OR IGNORE INTO source_manifest_audit_state (
+                    singleton, started_at, checked_files
+                 ) VALUES (1, ?1, 0)",
+                [started_at],
+            )
+            .map_err(map_sql_error)?;
+        let raw_paths = {
+            let mut statement = transaction
+                .prepare("SELECT path FROM source_manifest_audit_seen ORDER BY path ASC")
+                .map_err(map_sql_error)?;
+            statement
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        };
+        transaction.commit().map_err(map_sql_error)?;
+        Ok(raw_paths
+            .into_iter()
+            .filter_map(|path| match parse_relative_path_from_db(&path) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        path,
+                        "Skipping invalid durable manifest-audit checkpoint path"
+                    );
+                    None
+                }
+            })
+            .collect())
+    }
+
+    /// Durably checkpoint paths completed by the current manifest-audit cycle.
+    pub fn checkpoint_manifest_audit_paths(&self, paths: &[PathBuf]) -> Result<(), SourceDbError> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+        let transaction =
+            Transaction::new_unchecked(&self.connection, TransactionBehavior::Immediate)
+                .map_err(map_sql_error)?;
+        {
+            let mut insert = transaction
+                .prepare("INSERT OR IGNORE INTO source_manifest_audit_seen (path) VALUES (?1)")
+                .map_err(map_sql_error)?;
+            for path in paths {
+                let normalized = normalize_relative_path(path)?;
+                insert.execute([normalized]).map_err(map_sql_error)?;
+            }
+        }
+        transaction
+            .execute(
+                "UPDATE source_manifest_audit_state
+                 SET checked_files = (
+                     SELECT COUNT(*) FROM source_manifest_audit_seen
+                 )
+                 WHERE singleton = 1",
+                [],
+            )
+            .map_err(map_sql_error)?;
+        transaction.commit().map_err(map_sql_error)?;
+        Ok(())
+    }
+}
+
+impl SourceWriteBatch<'_> {
+    /// Finish a complete manifest-audit cycle in the same transaction that publishes its
+    /// completion timestamp.
+    pub fn complete_manifest_audit(&mut self, completed_at: i64) -> Result<(), SourceDbError> {
+        self.set_metadata(META_LAST_MANIFEST_AUDIT_AT, &completed_at.to_string())?;
+        self.tx
+            .execute("DELETE FROM source_manifest_audit_seen", [])
+            .map_err(map_sql_error)?;
+        self.tx
+            .execute(
+                "DELETE FROM source_manifest_audit_state WHERE singleton = ?1",
+                params![1],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn interrupted_manifest_audit_recovers_only_durable_checked_paths() {
+        let directory = tempfile::tempdir().expect("source");
+        let database = SourceDatabase::open(directory.path()).expect("database");
+
+        assert!(
+            database
+                .begin_or_resume_manifest_audit(10)
+                .expect("begin audit")
+                .is_empty()
+        );
+        database
+            .checkpoint_manifest_audit_paths(&[
+                Path::new("a.wav").to_path_buf(),
+                Path::new("nested/b.wav").to_path_buf(),
+            ])
+            .expect("checkpoint audit");
+
+        assert_eq!(
+            database
+                .begin_or_resume_manifest_audit(20)
+                .expect("resume audit"),
+            vec![PathBuf::from("a.wav"), PathBuf::from("nested/b.wav")]
+        );
+
+        let mut batch = database.write_batch().expect("completion batch");
+        batch.complete_manifest_audit(30).expect("complete audit");
+        batch.commit().expect("commit completion");
+
+        assert!(
+            database
+                .begin_or_resume_manifest_audit(40)
+                .expect("new audit")
+                .is_empty()
+        );
+        assert_eq!(
+            database
+                .get_metadata(META_LAST_MANIFEST_AUDIT_AT)
+                .expect("audit metadata")
+                .as_deref(),
+            Some("30")
+        );
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
@@ -9,6 +9,8 @@ impl SourceWriteBatch<'_> {
     /// Remove a wav row within the batch.
     pub fn remove_file(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.manifest_touched_paths
+            .insert(relative_path.to_path_buf());
         delete_path_statement(&self.tx, relative_path)
     }
 
@@ -19,6 +21,10 @@ impl SourceWriteBatch<'_> {
         new_relative_path: &Path,
     ) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.manifest_touched_paths
+            .insert(old_relative_path.to_path_buf());
+        self.manifest_touched_paths
+            .insert(new_relative_path.to_path_buf());
         self.clear_pending_rename(old_relative_path)?;
         self.clear_pending_rename(new_relative_path)?;
         remap_wav_file_path_statement(&self.tx, old_relative_path, new_relative_path)

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -37,32 +37,48 @@ impl SourceWriteBatch<'_> {
         Ok(snapshot)
     }
 
-    /// Commit the batch and return its exact revision plus only manifest paths touched by it.
+    /// Commit the batch and return its exact revision plus manifest state owned by that revision.
     ///
-    /// This keeps chunked scans linear while allowing callers to maintain the authoritative
-    /// manifest incrementally. Each optional row is read from the committing transaction after
-    /// the revision bump; `None` means the touched path is absent from the live manifest.
+    /// When the caller's cached revision is current, the second tuple element contains only
+    /// touched paths and the optional full snapshot is `None`, keeping chunked scans linear. When
+    /// another writer has advanced the manifest, the touched-path list is empty and the optional
+    /// full snapshot is captured inside this committing transaction before the write lock is
+    /// released.
     pub fn commit_with_manifest_changes(
         self,
-    ) -> Result<(u64, Vec<(PathBuf, Option<SourceManifestEntry>)>), SourceDbError> {
+        expected_previous_revision: u64,
+    ) -> Result<
+        (
+            u64,
+            Vec<(PathBuf, Option<SourceManifestEntry>)>,
+            Option<Vec<SourceManifestEntry>>,
+        ),
+        SourceDbError,
+    > {
         self.prepare_commit()?;
         let revision = manifest_revision(&self.tx)?;
-        let changes = self
-            .manifest_touched_paths
-            .iter()
-            .map(|path| {
-                let normalized = PathBuf::from(normalize_relative_path(path)?);
-                let entry = manifest_entry_for_path(&self.tx, &normalized)?;
-                Ok((normalized, entry))
-            })
-            .collect::<Result<Vec<_>, SourceDbError>>()?;
+        let (changes, snapshot) = if revision == expected_previous_revision.saturating_add(1) {
+            let changes = self
+                .manifest_touched_paths
+                .iter()
+                .map(|path| {
+                    let normalized = PathBuf::from(normalize_relative_path(path)?);
+                    let entry = manifest_entry_for_path(&self.tx, &normalized)?;
+                    Ok((normalized, entry))
+                })
+                .collect::<Result<Vec<_>, SourceDbError>>()?;
+            (changes, None)
+        } else {
+            let (_, snapshot) = manifest_snapshot(&self.tx)?;
+            (Vec::new(), Some(snapshot))
+        };
         self.tx.commit().map_err(map_sql_error)?;
         crate::sqlite_wal::maybe_checkpoint_database_file(
             &self.db_path,
             "source_db",
             self.telemetry_label,
         );
-        Ok((revision, changes))
+        Ok((revision, changes, snapshot))
     }
 
     fn prepare_commit(&self) -> Result<(), SourceDbError> {
@@ -219,6 +235,7 @@ mod tests {
             .upsert_file(Path::new("untouched.wav"), 6, 20)
             .expect("insert untouched file");
 
+        let expected_previous_revision = database.get_revision().expect("previous revision");
         let mut batch = database.write_batch().expect("manifest batch");
         batch
             .set_missing(Path::new("removed.wav"), true)
@@ -226,11 +243,12 @@ mod tests {
         batch
             .upsert_file_with_hash(Path::new("created.wav"), 7, 30, "created-hash")
             .expect("insert created file");
-        let (revision, changes) = batch
-            .commit_with_manifest_changes()
+        let (revision, changes, snapshot) = batch
+            .commit_with_manifest_changes(expected_previous_revision)
             .expect("commit manifest changes");
 
         assert_eq!(revision, database.get_revision().expect("current revision"));
+        assert!(snapshot.is_none());
         assert_eq!(changes.len(), 2);
         assert_eq!(
             changes[0],
@@ -252,15 +270,17 @@ mod tests {
     fn commit_manifest_changes_normalizes_windows_separator_paths() {
         let directory = tempfile::tempdir().expect("source root");
         let database = SourceDatabase::open(directory.path()).expect("source database");
+        let expected_previous_revision = database.get_revision().expect("previous revision");
         let mut batch = database.write_batch().expect("manifest batch");
         batch
             .upsert_file_with_hash(Path::new(r"nested\kick.wav"), 7, 30, "kick-hash")
             .expect("insert nested file");
 
-        let (_revision, changes) = batch
-            .commit_with_manifest_changes()
+        let (_revision, changes, snapshot) = batch
+            .commit_with_manifest_changes(expected_previous_revision)
             .expect("commit manifest changes");
 
+        assert!(snapshot.is_none());
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].0, Path::new("nested/kick.wav"));
         assert_eq!(

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -37,6 +37,30 @@ impl SourceWriteBatch<'_> {
         Ok(snapshot)
     }
 
+    /// Commit the batch and return its exact revision plus only manifest paths touched by it.
+    ///
+    /// This keeps chunked scans linear while allowing callers to maintain the authoritative
+    /// manifest incrementally. Each optional row is read from the committing transaction after
+    /// the revision bump; `None` means the touched path is absent from the live manifest.
+    pub fn commit_with_manifest_changes(
+        self,
+    ) -> Result<(u64, Vec<(PathBuf, Option<SourceManifestEntry>)>), SourceDbError> {
+        self.prepare_commit()?;
+        let revision = manifest_revision(&self.tx)?;
+        let changes = self
+            .manifest_touched_paths
+            .iter()
+            .map(|path| Ok((path.clone(), manifest_entry_for_path(&self.tx, path)?)))
+            .collect::<Result<Vec<_>, SourceDbError>>()?;
+        self.tx.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(
+            &self.db_path,
+            "source_db",
+            self.telemetry_label,
+        );
+        Ok((revision, changes))
+    }
+
     fn prepare_commit(&self) -> Result<(), SourceDbError> {
         SourceDatabase::bump_revision(&self.tx)?;
         if self.paths_revision_dirty {
@@ -49,17 +73,7 @@ impl SourceWriteBatch<'_> {
 fn manifest_snapshot(
     connection: &rusqlite::Connection,
 ) -> Result<(u64, Vec<SourceManifestEntry>), SourceDbError> {
-    let revision = connection
-        .query_row(
-            "SELECT value FROM metadata WHERE key = 'revision'",
-            [],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()
-        .map_err(map_sql_error)?
-        .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
-        .transpose()?
-        .unwrap_or_default();
+    let revision = manifest_revision(connection)?;
     let filter = crate::sample_sources::supported_audio_where_clause();
     let sql = format!(
         "SELECT path, file_identity, content_hash, file_size, modified_ns
@@ -111,6 +125,56 @@ fn manifest_snapshot(
     Ok((revision, entries))
 }
 
+fn manifest_revision(connection: &rusqlite::Connection) -> Result<u64, SourceDbError> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = 'revision'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_sql_error)?
+        .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+        .transpose()
+        .map(|revision| revision.unwrap_or_default())
+}
+
+fn manifest_entry_for_path(
+    connection: &rusqlite::Connection,
+    relative_path: &std::path::Path,
+) -> Result<Option<SourceManifestEntry>, SourceDbError> {
+    let raw_path = relative_path.to_string_lossy();
+    let row = connection
+        .query_row(
+            "SELECT path, file_identity, content_hash, file_size, modified_ns
+             FROM wav_files
+             WHERE path = ?1 AND missing = 0",
+            [raw_path.as_ref()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(map_sql_error)?;
+    let Some((raw_path, file_identity, content_hash, file_size, modified_ns)) = row else {
+        return Ok(None);
+    };
+    let normalized = normalize_relative_path(std::path::Path::new(&raw_path))?;
+    Ok(Some(SourceManifestEntry {
+        relative_path: PathBuf::from(normalized),
+        file_identity,
+        content_hash,
+        file_size: file_size.max(0) as u64,
+        modified_ns,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -138,5 +202,45 @@ mod tests {
         assert_eq!(committed_manifest.len(), 1);
         assert_eq!(committed_manifest[0].relative_path, Path::new("first.wav"));
         assert!(database.get_revision().expect("current revision") > committed_revision);
+    }
+
+    #[test]
+    fn commit_manifest_changes_reports_only_touched_live_rows() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database = SourceDatabase::open(directory.path()).expect("source database");
+        database
+            .upsert_file(Path::new("removed.wav"), 5, 10)
+            .expect("insert removed file");
+        database
+            .upsert_file(Path::new("untouched.wav"), 6, 20)
+            .expect("insert untouched file");
+
+        let mut batch = database.write_batch().expect("manifest batch");
+        batch
+            .set_missing(Path::new("removed.wav"), true)
+            .expect("mark file missing");
+        batch
+            .upsert_file_with_hash(Path::new("created.wav"), 7, 30, "created-hash")
+            .expect("insert created file");
+        let (revision, changes) = batch
+            .commit_with_manifest_changes()
+            .expect("commit manifest changes");
+
+        assert_eq!(revision, database.get_revision().expect("current revision"));
+        assert_eq!(changes.len(), 2);
+        assert_eq!(
+            changes[0],
+            (
+                PathBuf::from("created.wav"),
+                Some(SourceManifestEntry {
+                    relative_path: PathBuf::from("created.wav"),
+                    file_identity: None,
+                    content_hash: Some(String::from("created-hash")),
+                    file_size: 7,
+                    modified_ns: 30,
+                })
+            )
+        );
+        assert_eq!(changes[1], (PathBuf::from("removed.wav"), None));
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -50,7 +50,11 @@ impl SourceWriteBatch<'_> {
         let changes = self
             .manifest_touched_paths
             .iter()
-            .map(|path| Ok((path.clone(), manifest_entry_for_path(&self.tx, path)?)))
+            .map(|path| {
+                let normalized = PathBuf::from(normalize_relative_path(path)?);
+                let entry = manifest_entry_for_path(&self.tx, &normalized)?;
+                Ok((normalized, entry))
+            })
             .collect::<Result<Vec<_>, SourceDbError>>()?;
         self.tx.commit().map_err(map_sql_error)?;
         crate::sqlite_wal::maybe_checkpoint_database_file(
@@ -242,5 +246,29 @@ mod tests {
             )
         );
         assert_eq!(changes[1], (PathBuf::from("removed.wav"), None));
+    }
+
+    #[test]
+    fn commit_manifest_changes_normalizes_windows_separator_paths() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database = SourceDatabase::open(directory.path()).expect("source database");
+        let mut batch = database.write_batch().expect("manifest batch");
+        batch
+            .upsert_file_with_hash(Path::new(r"nested\kick.wav"), 7, 30, "kick-hash")
+            .expect("insert nested file");
+
+        let (_revision, changes) = batch
+            .commit_with_manifest_changes()
+            .expect("commit manifest changes");
+
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].0, Path::new("nested/kick.wav"));
+        assert_eq!(
+            changes[0]
+                .1
+                .as_ref()
+                .map(|entry| entry.relative_path.as_path()),
+            Some(Path::new("nested/kick.wav"))
+        );
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -1,13 +1,14 @@
-use super::super::util::map_sql_error;
-use super::super::{SourceDatabase, SourceDbError, SourceWriteBatch};
+use std::path::PathBuf;
+
+use rusqlite::OptionalExtension;
+
+use super::super::util::{map_sql_error, normalize_relative_path};
+use super::super::{SourceDatabase, SourceDbError, SourceManifestEntry, SourceWriteBatch};
 
 impl SourceWriteBatch<'_> {
     /// Commit all batched operations atomically.
     pub fn commit(self) -> Result<(), SourceDbError> {
-        SourceDatabase::bump_revision(&self.tx)?;
-        if self.paths_revision_dirty {
-            SourceDatabase::bump_wav_paths_revision(&self.tx)?;
-        }
+        self.prepare_commit()?;
         self.tx.commit().map_err(map_sql_error)?;
         crate::sqlite_wal::maybe_checkpoint_database_file(
             &self.db_path,
@@ -15,5 +16,127 @@ impl SourceWriteBatch<'_> {
             self.telemetry_label,
         );
         Ok(())
+    }
+
+    /// Commit the batch and return the manifest snapshot owned by that exact revision.
+    ///
+    /// The snapshot is read from the active write transaction after its revision bump and before
+    /// `COMMIT`. A later writer therefore cannot advance the returned revision or alter the
+    /// returned manifest between the authoritative mutation and delta publication.
+    pub fn commit_with_manifest_snapshot(
+        self,
+    ) -> Result<(u64, Vec<SourceManifestEntry>), SourceDbError> {
+        self.prepare_commit()?;
+        let snapshot = manifest_snapshot(&self.tx)?;
+        self.tx.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(
+            &self.db_path,
+            "source_db",
+            self.telemetry_label,
+        );
+        Ok(snapshot)
+    }
+
+    fn prepare_commit(&self) -> Result<(), SourceDbError> {
+        SourceDatabase::bump_revision(&self.tx)?;
+        if self.paths_revision_dirty {
+            SourceDatabase::bump_wav_paths_revision(&self.tx)?;
+        }
+        Ok(())
+    }
+}
+
+fn manifest_snapshot(
+    connection: &rusqlite::Connection,
+) -> Result<(u64, Vec<SourceManifestEntry>), SourceDbError> {
+    let revision = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = 'revision'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_sql_error)?
+        .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+        .transpose()?
+        .unwrap_or_default();
+    let filter = crate::sample_sources::supported_audio_where_clause();
+    let sql = format!(
+        "SELECT path, file_identity, content_hash, file_size, modified_ns
+         FROM wav_files
+         WHERE {filter} AND missing = 0
+         ORDER BY path ASC"
+    );
+    let raw_entries = {
+        let mut statement = connection.prepare(&sql).map_err(map_sql_error)?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get(4)?,
+                ))
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?
+    };
+    let entries = raw_entries
+        .into_iter()
+        .filter_map(
+            |(raw_path, file_identity, content_hash, file_size, modified_ns)| {
+                let normalized = match normalize_relative_path(std::path::Path::new(&raw_path)) {
+                    Ok(normalized) => normalized,
+                    Err(error) => {
+                        tracing::warn!(
+                            path = raw_path,
+                            %error,
+                            "Skipping source manifest row with invalid relative path"
+                        );
+                        return None;
+                    }
+                };
+                Some(SourceManifestEntry {
+                    relative_path: PathBuf::from(normalized),
+                    file_identity,
+                    content_hash,
+                    file_size: file_size.max(0) as u64,
+                    modified_ns,
+                })
+            },
+        )
+        .collect();
+    Ok((revision, entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn commit_snapshot_stays_bound_to_its_own_revision() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database = SourceDatabase::open(directory.path()).expect("source database");
+        let mut first = database.write_batch().expect("first batch");
+        first
+            .upsert_file_with_hash(Path::new("first.wav"), 5, 10, "first-hash")
+            .expect("insert first file");
+        let (committed_revision, committed_manifest) = first
+            .commit_with_manifest_snapshot()
+            .expect("commit first manifest");
+
+        let mut second = database.write_batch().expect("second batch");
+        second
+            .upsert_file_with_hash(Path::new("second.wav"), 6, 20, "second-hash")
+            .expect("insert second file");
+        second.commit().expect("commit second manifest");
+
+        assert_eq!(committed_manifest.len(), 1);
+        assert_eq!(committed_manifest[0].relative_path, Path::new("first.wav"));
+        assert!(database.get_revision().expect("current revision") > committed_revision);
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/library.rs
+++ b/crates/wavecrate-library/src/sample_sources/library.rs
@@ -118,6 +118,23 @@ pub fn upsert_harvest_file(
     result
 }
 
+/// Insert or refresh multiple harvest rows in one transaction without changing workflow state.
+pub fn upsert_harvest_files(identities: &[HarvestFileIdentity]) -> Result<(), LibraryError> {
+    if identities.is_empty() {
+        return Ok(());
+    }
+    let started_at = Instant::now();
+    let _guard = lock_library();
+    let mut db = LibraryDatabase::open()?;
+    let result = db.upsert_harvest_files(identities);
+    record_library_db_event(
+        "library.harvest.upsert_files",
+        started_at,
+        result.as_ref().map(|_| ()),
+    );
+    result
+}
+
 /// Mark a harvest file as seen unless it is already in a later/manual state.
 pub fn mark_harvest_seen(
     identity: &HarvestFileIdentity,

--- a/crates/wavecrate-library/src/sample_sources/library/harvest.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/harvest.rs
@@ -278,6 +278,18 @@ impl LibraryDatabase {
             .ok_or_else(|| rusqlite::Error::QueryReturnedNoRows.into())
     }
 
+    pub(super) fn upsert_harvest_files(
+        &mut self,
+        identities: &[HarvestFileIdentity],
+    ) -> Result<(), LibraryError> {
+        let now = now_unix_seconds();
+        let tx = self.connection.transaction().map_err(map_sql_error)?;
+        for identity in identities {
+            upsert_harvest_file_on_transaction(&tx, identity, now)?;
+        }
+        tx.commit().map_err(map_sql_error)
+    }
+
     pub(super) fn advance_harvest_state(
         &self,
         identity: &HarvestFileIdentity,

--- a/crates/wavecrate-library/src/sample_sources/library/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/library/tests.rs
@@ -298,6 +298,26 @@ fn harvest_state_auto_transitions_only_move_forward() {
 }
 
 #[test]
+fn harvest_file_batch_upsert_persists_every_identity() {
+    let temp = tempdir().unwrap();
+    with_config_home(temp.path(), || {
+        let first = harvest_identity("source-a", "drums/kick.wav");
+        let second = harvest_identity("source-a", "drums/snare.wav");
+
+        upsert_harvest_files(&[first.clone(), second.clone()]).unwrap();
+
+        assert_eq!(
+            harvest_file(&first.key).unwrap().unwrap().file_size,
+            first.file_size
+        );
+        assert_eq!(
+            harvest_file(&second.key).unwrap().unwrap().content_hash,
+            second.content_hash
+        );
+    });
+}
+
+#[test]
 fn manual_harvest_reset_returns_file_to_new_queue() {
     let temp = tempdir().unwrap();
     with_config_home(temp.path(), || {

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -17,8 +17,8 @@ pub use audio_support::{
 pub use db::normalize_relative_path;
 pub use db::{
     DB_FILE_NAME, Rating, SampleCollection, SourceCollectionWrite, SourceContentHashWrite,
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceTag,
-    SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
+    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite,
+    SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -22,10 +22,10 @@ pub use snapshot::{
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
     ReadinessError, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-    fail_readiness_work, persist_readiness_deficits, persist_readiness_deficits_with_cancel,
-    publish_readiness_artifact, readiness_work_stats, reconcile_readiness,
-    reconcile_readiness_with_cancel, release_readiness_work, renew_readiness_lease,
-    replace_readiness_targets, replace_readiness_targets_with_cancel,
+    fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits,
+    persist_readiness_deficits_with_cancel, publish_readiness_artifact, readiness_work_stats,
+    reconcile_readiness, reconcile_readiness_with_cancel, release_readiness_work,
+    renew_readiness_lease, replace_readiness_targets, replace_readiness_targets_with_cancel,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -5,8 +5,9 @@ mod work;
 
 pub use error::ReadinessError;
 pub use persistence::{
-    persist_readiness_deficits, persist_readiness_deficits_with_cancel, publish_readiness_artifact,
-    replace_readiness_targets, replace_readiness_targets_with_cancel,
+    invalidate_readiness_artifact, persist_readiness_deficits,
+    persist_readiness_deficits_with_cancel, publish_readiness_artifact, replace_readiness_targets,
+    replace_readiness_targets_with_cancel,
 };
 #[cfg(test)]
 pub(crate) use reconcile::reconcile_readiness_with_hook;

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -216,6 +216,52 @@ pub fn publish_readiness_artifact(
     Ok(ArtifactPublishOutcome::Recorded)
 }
 
+/// Remove an exact artifact whose backing payload has been proven missing or corrupt.
+///
+/// The desired target must still match the supplied generation and version. This fence prevents
+/// a stale worker from invalidating a replacement artifact published for newer content.
+pub fn invalidate_readiness_artifact(
+    connection: &mut Connection,
+    target: &ReadinessTarget,
+) -> Result<bool, ReadinessError> {
+    let changed = connection.execute(
+        "DELETE FROM source_readiness_artifacts AS artifact
+         WHERE artifact.source_id = ?1
+           AND artifact.scope_kind = ?2
+           AND artifact.scope_id = ?3
+           AND artifact.stage = ?4
+           AND artifact.artifact_version = ?5
+           AND artifact.content_generation = ?6
+           AND (?2 = 'file' OR artifact.source_generation = ?7)
+           AND EXISTS (
+               SELECT 1
+               FROM source_readiness_sources AS source
+               JOIN source_readiness_targets AS target
+                 ON target.source_id = source.source_id
+                AND target.source_generation = source.source_generation
+               WHERE target.source_id = artifact.source_id
+                 AND target.scope_kind = artifact.scope_kind
+                 AND target.scope_id = artifact.scope_id
+                 AND target.stage = artifact.stage
+                 AND target.required_version = artifact.artifact_version
+                 AND target.content_generation = artifact.content_generation
+                 AND (?2 = 'file' OR target.source_generation = ?7)
+                 AND target.eligibility = 'eligible'
+                 AND source.availability = 'active'
+           )",
+        params![
+            target.source_id,
+            target.scope_kind.as_str(),
+            target.scope_id,
+            target.stage.as_str(),
+            target.required_version,
+            target.content_generation,
+            target.source_generation,
+        ],
+    )?;
+    Ok(changed == 1)
+}
+
 /// Persist actionable deficits into the existing source-local analysis job table.
 ///
 /// These rows are readiness-managed so the legacy analysis claimant ignores them. OPT-1178's

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -412,8 +412,24 @@ pub fn readiness_work_stats(
             SUM(CASE WHEN status = 'pending' AND failure_kind = 'cancelled'
                 THEN 1 ELSE 0 END),
             SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END)
-         FROM analysis_jobs
-         WHERE readiness_managed = 1",
+         FROM analysis_jobs AS job
+         JOIN source_readiness_targets AS target
+           ON target.source_id = job.source_id
+          AND target.scope_kind = job.readiness_scope_kind
+          AND target.scope_id = job.readiness_scope_id
+          AND target.stage = job.readiness_stage
+          AND target.required_version = job.artifact_version
+          AND target.content_generation = job.content_generation
+         JOIN source_readiness_sources AS source
+           ON source.source_id = target.source_id
+          AND source.source_generation = target.source_generation
+         WHERE job.readiness_managed = 1
+           AND target.eligibility = 'eligible'
+           AND source.availability = 'active'
+           AND (
+               target.scope_kind = 'file'
+               OR job.source_generation = target.source_generation
+           )",
         [now],
         |row| {
             Ok((

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
@@ -30,6 +30,34 @@ fn stale_completion_cannot_overwrite_a_new_generation() {
 }
 
 #[test]
+fn invalidation_is_fenced_to_the_exact_current_artifact() {
+    let (_root, mut connection) = open_fixture();
+    let current = file_target("repair", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&current));
+    publish_readiness_artifact(
+        &mut connection,
+        &ReadinessArtifact::for_target(&current, 10),
+    )
+    .expect("publish current artifact");
+
+    let mut stale = current.clone();
+    stale.content_generation = String::from("stale-content");
+    assert!(
+        !invalidate_readiness_artifact(&mut connection, &stale).expect("reject stale invalidation")
+    );
+    assert!(
+        invalidate_readiness_artifact(&mut connection, &current)
+            .expect("invalidate current artifact")
+    );
+
+    let snapshot = reconcile_readiness(&connection, SOURCE_ID, 11).expect("reconcile invalidation");
+    assert_eq!(
+        entry_for(&snapshot, "repair", ReadinessStage::AnalysisFeatures).classification,
+        ReadinessClassification::Pending
+    );
+}
+
+#[test]
 fn target_replacement_is_failure_atomic() {
     let (_root, mut connection) = open_fixture();
     let original = file_target("original", ReadinessStage::IndexedIdentity, 1);

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -40,6 +40,22 @@ fn exact_target_claim_is_deduplicated_and_generation_fenced() {
 }
 
 #[test]
+fn work_stats_exclude_jobs_for_identities_no_longer_in_the_current_manifest() {
+    let (_root, mut connection) = open_fixture();
+    let stale = file_target("stale", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&stale));
+    persist_target(&mut connection, &stale, 10);
+
+    let current = file_target("current", ReadinessStage::AnalysisFeatures, 2);
+    replace(&mut connection, 2, std::slice::from_ref(&current));
+    persist_target(&mut connection, &current, 20);
+
+    let stats = readiness_work_stats(&connection, 20).expect("current work stats");
+    assert_eq!(stats.total, 1);
+    assert_eq!(stats.pending, 1);
+}
+
+#[test]
 fn expired_claim_is_recovered_after_restart_with_a_new_attempt() {
     let (root, mut connection) = open_fixture();
     let target = file_target("restart", ReadinessStage::PlaybackSummary, 1);

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -8,10 +8,10 @@ pub mod sample_sources;
 
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
-    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, complete_deferred_rename_candidates,
+    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
+    audit_source_and_record, complete_deferred_hashes, complete_deferred_rename_candidates,
     complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
     complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    schedule_deep_hash_scan, schedule_deep_hash_scan_with_database_root, sync_paths,
-    sync_paths_with_progress,
+    sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -10,8 +10,8 @@ pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
     RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-    audit_source_and_record, complete_deferred_hashes, complete_deferred_rename_candidates,
-    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
-    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
-    sync_paths, sync_paths_with_progress,
+    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
+    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/mod.rs
@@ -16,7 +16,10 @@ pub mod library {
 }
 
 pub use scan_state::ScanTracker;
-pub use scanner::{ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample};
+pub use scanner::{
+    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+};
 pub(crate) use wavecrate_library::sample_sources::is_supported_audio;
 pub use wavecrate_library::sample_sources::normalize_relative_path;
 pub use wavecrate_library::sample_sources::{

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -1,0 +1,265 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use wavecrate_library::sample_sources::{SourceDatabase, SourceManifestEntry};
+
+use super::scan::{
+    CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity, ScanError, ScanStats,
+};
+
+pub(super) fn capture_manifest(
+    database: &SourceDatabase,
+) -> Result<Vec<SourceManifestEntry>, ScanError> {
+    database.list_manifest_entries().map_err(ScanError::from)
+}
+
+pub(super) fn publish_committed_delta(
+    database: &SourceDatabase,
+    stats: &mut ScanStats,
+    before: Vec<SourceManifestEntry>,
+) -> Result<(), ScanError> {
+    let after = capture_manifest(database)?;
+    let revision = database.get_revision()?;
+    stats.committed_delta = build_committed_delta(&before, &after, revision);
+    stats.manifest_before = before;
+    stats.manifest_after = after;
+    Ok(())
+}
+
+pub(super) fn build_committed_delta(
+    before: &[SourceManifestEntry],
+    after: &[SourceManifestEntry],
+    revision: u64,
+) -> CommittedSourceDelta {
+    let mut matched_before = BTreeSet::new();
+    let mut matched_after = BTreeSet::new();
+    let mut matches = Vec::new();
+
+    match_unique(
+        before,
+        after,
+        |entry| normalized(entry.file_identity.as_deref()),
+        &mut matched_before,
+        &mut matched_after,
+        &mut matches,
+    );
+    match_unique(
+        before,
+        after,
+        |entry| {
+            normalized(entry.file_identity.as_deref())
+                .is_none()
+                .then(|| entry.relative_path.to_string_lossy().into_owned())
+        },
+        &mut matched_before,
+        &mut matched_after,
+        &mut matches,
+    );
+    match_unique(
+        before,
+        after,
+        |entry| {
+            normalized(entry.file_identity.as_deref())
+                .is_none()
+                .then(|| normalized(entry.content_hash.as_deref()))
+                .flatten()
+        },
+        &mut matched_before,
+        &mut matched_after,
+        &mut matches,
+    );
+
+    let mut delta = CommittedSourceDelta {
+        revision,
+        ..CommittedSourceDelta::default()
+    };
+    for (before_index, after_index) in matches {
+        let previous = &before[before_index];
+        let current = &after[after_index];
+        let identity = stable_identity(current, Some(previous));
+        let generation = content_generation(current);
+        if previous.relative_path != current.relative_path {
+            delta.moved.push(MovedManifestIdentity {
+                identity: identity.clone(),
+                old_relative_path: previous.relative_path.clone(),
+                new_relative_path: current.relative_path.clone(),
+                content_generation: generation.clone(),
+            });
+        }
+        if content_generation(previous) != generation {
+            delta.changed.push(ManifestIdentityDelta {
+                identity,
+                relative_path: current.relative_path.clone(),
+                content_generation: generation,
+            });
+        }
+    }
+    for (index, entry) in after.iter().enumerate() {
+        if !matched_after.contains(&index) {
+            delta.created.push(identity_delta(entry, None));
+        }
+    }
+    for (index, entry) in before.iter().enumerate() {
+        if !matched_before.contains(&index) {
+            delta.deleted.push(identity_delta(entry, None));
+        }
+    }
+    delta
+        .created
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    delta
+        .changed
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    delta.moved.sort_by(|left, right| {
+        left.old_relative_path
+            .cmp(&right.old_relative_path)
+            .then_with(|| left.new_relative_path.cmp(&right.new_relative_path))
+    });
+    delta
+        .deleted
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    delta
+}
+
+fn match_unique(
+    before: &[SourceManifestEntry],
+    after: &[SourceManifestEntry],
+    key: impl Fn(&SourceManifestEntry) -> Option<String>,
+    matched_before: &mut BTreeSet<usize>,
+    matched_after: &mut BTreeSet<usize>,
+    matches: &mut Vec<(usize, usize)>,
+) {
+    let before_by_key = unique_indexes(before, &key, matched_before);
+    let after_by_key = unique_indexes(after, &key, matched_after);
+    for (value, before_index) in before_by_key {
+        let Some(after_index) = after_by_key.get(&value).copied() else {
+            continue;
+        };
+        matched_before.insert(before_index);
+        matched_after.insert(after_index);
+        matches.push((before_index, after_index));
+    }
+}
+
+fn unique_indexes(
+    entries: &[SourceManifestEntry],
+    key: &impl Fn(&SourceManifestEntry) -> Option<String>,
+    already_matched: &BTreeSet<usize>,
+) -> BTreeMap<String, usize> {
+    let mut indexes = BTreeMap::new();
+    let mut duplicates = BTreeSet::new();
+    for (index, entry) in entries.iter().enumerate() {
+        if already_matched.contains(&index) {
+            continue;
+        }
+        let Some(value) = key(entry) else {
+            continue;
+        };
+        if indexes.insert(value.clone(), index).is_some() {
+            duplicates.insert(value);
+        }
+    }
+    indexes.retain(|value, _| !duplicates.contains(value));
+    indexes
+}
+
+fn normalized(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn identity_delta(
+    entry: &SourceManifestEntry,
+    previous: Option<&SourceManifestEntry>,
+) -> ManifestIdentityDelta {
+    ManifestIdentityDelta {
+        identity: stable_identity(entry, previous),
+        relative_path: entry.relative_path.clone(),
+        content_generation: content_generation(entry),
+    }
+}
+
+fn stable_identity(entry: &SourceManifestEntry, previous: Option<&SourceManifestEntry>) -> String {
+    normalized(entry.file_identity.as_deref())
+        .or_else(|| previous.and_then(|entry| normalized(entry.file_identity.as_deref())))
+        .map(|identity| format!("file:{identity}"))
+        .or_else(|| {
+            normalized(entry.content_hash.as_deref())
+                .map(|content_hash| format!("hash:{content_hash}"))
+        })
+        .unwrap_or_else(|| format!("path:{}", entry.relative_path.display()))
+}
+
+fn content_generation(entry: &SourceManifestEntry) -> String {
+    normalized(entry.content_hash.as_deref()).unwrap_or_else(|| {
+        format!(
+            "pending:{}:{}:{}",
+            normalized(entry.file_identity.as_deref())
+                .unwrap_or_else(|| entry.relative_path.display().to_string()),
+            entry.file_size,
+            entry.modified_ns,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::build_committed_delta;
+    use wavecrate_library::sample_sources::SourceManifestEntry;
+
+    fn entry(
+        path: &str,
+        identity: &str,
+        hash: Option<&str>,
+        size: u64,
+        modified: i64,
+    ) -> SourceManifestEntry {
+        SourceManifestEntry {
+            relative_path: PathBuf::from(path),
+            file_identity: Some(identity.to_string()),
+            content_hash: hash.map(str::to_string),
+            file_size: size,
+            modified_ns: modified,
+        }
+    }
+
+    #[test]
+    fn committed_delta_classifies_create_change_move_and_delete() {
+        let before = vec![
+            entry("changed.wav", "changed", Some("old"), 4, 1),
+            entry("old.wav", "moved", Some("same"), 4, 1),
+            entry("deleted.wav", "deleted", Some("gone"), 4, 1),
+        ];
+        let after = vec![
+            entry("changed.wav", "changed", Some("new"), 4, 1),
+            entry("new.wav", "moved", Some("same"), 4, 1),
+            entry("created.wav", "created", None, 4, 1),
+        ];
+
+        let delta = build_committed_delta(&before, &after, 17);
+
+        assert_eq!(delta.revision, 17);
+        assert_eq!(delta.created.len(), 1);
+        assert_eq!(delta.changed.len(), 1);
+        assert_eq!(delta.moved.len(), 1);
+        assert_eq!(delta.deleted.len(), 1);
+        assert_eq!(delta.moved[0].old_relative_path, PathBuf::from("old.wav"));
+        assert_eq!(delta.moved[0].new_relative_path, PathBuf::from("new.wav"));
+    }
+
+    #[test]
+    fn same_path_identity_replacement_retires_the_old_identity() {
+        let before = vec![entry("same.wav", "old-file", Some("same"), 4, 1)];
+        let after = vec![entry("same.wav", "new-file", Some("same"), 4, 1)];
+
+        let delta = build_committed_delta(&before, &after, 18);
+
+        assert_eq!(delta.created.len(), 1);
+        assert_eq!(delta.deleted.len(), 1);
+        assert!(delta.changed.is_empty());
+        assert!(delta.moved.is_empty());
+    }
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -17,8 +17,7 @@ pub(super) fn publish_committed_delta(
     stats: &mut ScanStats,
     before: Vec<SourceManifestEntry>,
 ) -> Result<(), ScanError> {
-    let after = capture_manifest(database)?;
-    let revision = database.get_revision()?;
+    let (revision, after) = database.manifest_snapshot_with_revision()?;
     stats.committed_delta = build_committed_delta(&before, &after, revision);
     stats.manifest_before = before;
     stats.manifest_after = after;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -40,6 +40,13 @@ pub(super) fn build_committed_delta(
         &mut matched_after,
         &mut matches,
     );
+    match_same_path_and_identity(
+        before,
+        after,
+        &mut matched_before,
+        &mut matched_after,
+        &mut matches,
+    );
     match_unique(
         before,
         after,
@@ -116,6 +123,42 @@ pub(super) fn build_committed_delta(
         .deleted
         .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     delta
+}
+
+fn match_same_path_and_identity(
+    before: &[SourceManifestEntry],
+    after: &[SourceManifestEntry],
+    matched_before: &mut BTreeSet<usize>,
+    matched_after: &mut BTreeSet<usize>,
+    matches: &mut Vec<(usize, usize)>,
+) {
+    let after_by_path = after
+        .iter()
+        .enumerate()
+        .filter(|(index, entry)| {
+            !matched_after.contains(index) && normalized(entry.file_identity.as_deref()).is_some()
+        })
+        .map(|(index, entry)| (entry.relative_path.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    for (before_index, previous) in before.iter().enumerate() {
+        if matched_before.contains(&before_index) {
+            continue;
+        }
+        let Some(previous_identity) = normalized(previous.file_identity.as_deref()) else {
+            continue;
+        };
+        let Some(after_index) = after_by_path.get(&previous.relative_path).copied() else {
+            continue;
+        };
+        if normalized(after[after_index].file_identity.as_deref()).as_deref()
+            != Some(previous_identity.as_str())
+        {
+            continue;
+        }
+        matched_before.insert(before_index);
+        matched_after.insert(after_index);
+        matches.push((before_index, after_index));
+    }
 }
 
 fn match_unique(
@@ -259,5 +302,19 @@ mod tests {
         assert_eq!(delta.deleted.len(), 1);
         assert!(delta.changed.is_empty());
         assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn unchanged_duplicate_filesystem_identities_are_matched_by_path() {
+        let before = vec![
+            entry("first.wav", "shared-inode", Some("same"), 4, 1),
+            entry("second.wav", "shared-inode", Some("same"), 4, 1),
+        ];
+        let after = before.clone();
+
+        let delta = build_committed_delta(&before, &after, 19);
+
+        assert!(delta.is_empty());
+        assert_eq!(delta.revision, 19);
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use wavecrate_library::filesystem_identity::same_filesystem_object_identity;
 use wavecrate_library::sample_sources::{SourceDatabase, SourceManifestEntry};
 
 use super::scan::{
@@ -10,6 +11,14 @@ pub(super) fn capture_manifest(
     database: &SourceDatabase,
 ) -> Result<Vec<SourceManifestEntry>, ScanError> {
     database.list_manifest_entries().map_err(ScanError::from)
+}
+
+pub(super) fn capture_manifest_with_revision(
+    database: &SourceDatabase,
+) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+    database
+        .manifest_snapshot_with_revision()
+        .map_err(ScanError::from)
 }
 
 pub(super) fn publish_committed_delta(
@@ -41,6 +50,13 @@ pub(super) fn build_committed_delta(
         &mut matches,
     );
     match_same_path_and_identity(
+        before,
+        after,
+        &mut matched_before,
+        &mut matched_after,
+        &mut matches,
+    );
+    match_same_path_with_missing_identity(
         before,
         after,
         &mut matched_before,
@@ -95,6 +111,8 @@ pub(super) fn build_committed_delta(
                 identity,
                 relative_path: current.relative_path.clone(),
                 content_generation: generation,
+                source_metadata_changed: previous.file_size != current.file_size
+                    || previous.modified_ns != current.modified_ns,
             });
         }
     }
@@ -125,6 +143,38 @@ pub(super) fn build_committed_delta(
     delta
 }
 
+fn match_same_path_with_missing_identity(
+    before: &[SourceManifestEntry],
+    after: &[SourceManifestEntry],
+    matched_before: &mut BTreeSet<usize>,
+    matched_after: &mut BTreeSet<usize>,
+    matches: &mut Vec<(usize, usize)>,
+) {
+    let after_by_path = after
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !matched_after.contains(index))
+        .map(|(index, entry)| (entry.relative_path.clone(), index))
+        .collect::<BTreeMap<_, _>>();
+    for (before_index, previous) in before.iter().enumerate() {
+        if matched_before.contains(&before_index) {
+            continue;
+        }
+        let Some(after_index) = after_by_path.get(&previous.relative_path).copied() else {
+            continue;
+        };
+        let current = &after[after_index];
+        if normalized(previous.file_identity.as_deref()).is_some()
+            && normalized(current.file_identity.as_deref()).is_some()
+        {
+            continue;
+        }
+        matched_before.insert(before_index);
+        matched_after.insert(after_index);
+        matches.push((before_index, after_index));
+    }
+}
+
 fn match_same_path_and_identity(
     before: &[SourceManifestEntry],
     after: &[SourceManifestEntry],
@@ -150,9 +200,10 @@ fn match_same_path_and_identity(
         let Some(after_index) = after_by_path.get(&previous.relative_path).copied() else {
             continue;
         };
-        if normalized(after[after_index].file_identity.as_deref()).as_deref()
-            != Some(previous_identity.as_str())
-        {
+        let Some(current_identity) = normalized(after[after_index].file_identity.as_deref()) else {
+            continue;
+        };
+        if !same_filesystem_object_identity(&previous_identity, &current_identity) {
             continue;
         }
         matched_before.insert(before_index);
@@ -218,6 +269,7 @@ fn identity_delta(
         identity: stable_identity(entry, previous),
         relative_path: entry.relative_path.clone(),
         content_generation: content_generation(entry),
+        source_metadata_changed: true,
     }
 }
 
@@ -316,5 +368,35 @@ mod tests {
 
         assert!(delta.is_empty());
         assert_eq!(delta.revision, 19);
+    }
+
+    #[test]
+    fn same_path_identity_version_upgrade_is_not_create_delete_churn() {
+        let before = vec![entry("same.wav", "unix:10:20", Some("same"), 4, 1)];
+        let after = vec![entry("same.wav", "unix-v2:10:20:30", Some("same"), 4, 1)];
+
+        let delta = build_committed_delta(&before, &after, 20);
+
+        assert!(delta.is_empty());
+        assert_eq!(delta.revision, 20);
+    }
+
+    #[test]
+    fn materializing_identity_and_hash_at_same_path_is_a_change() {
+        let before = vec![SourceManifestEntry {
+            relative_path: PathBuf::from("same.wav"),
+            file_identity: None,
+            content_hash: None,
+            file_size: 4,
+            modified_ns: 1,
+        }];
+        let after = vec![entry("same.wav", "materialized", Some("hash"), 4, 1)];
+
+        let delta = build_committed_delta(&before, &after, 20);
+
+        assert!(delta.created.is_empty());
+        assert_eq!(delta.changed.len(), 1);
+        assert!(delta.moved.is_empty());
+        assert!(delta.deleted.is_empty());
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use wavecrate_library::filesystem_identity::same_filesystem_object_identity;
 use wavecrate_library::sample_sources::{SourceDatabase, SourceManifestEntry};
 
 use super::scan::{
@@ -203,7 +202,7 @@ fn match_same_path_and_identity(
         let Some(current_identity) = normalized(after[after_index].file_identity.as_deref()) else {
             continue;
         };
-        if !same_filesystem_object_identity(&previous_identity, &current_identity) {
+        if previous_identity != current_identity {
             continue;
         }
         matched_before.insert(before_index);
@@ -368,17 +367,6 @@ mod tests {
 
         assert!(delta.is_empty());
         assert_eq!(delta.revision, 19);
-    }
-
-    #[test]
-    fn same_path_identity_version_upgrade_is_not_create_delete_churn() {
-        let before = vec![entry("same.wav", "unix:10:20", Some("same"), 4, 1)];
-        let after = vec![entry("same.wav", "unix-v2:10:20:30", Some("same"), 4, 1)];
-
-        let delta = build_committed_delta(&before, &after, 20);
-
-        assert!(delta.is_empty());
-        assert_eq!(delta.revision, 20);
     }
 
     #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -13,15 +13,14 @@ pub(super) fn capture_manifest(
 }
 
 pub(super) fn publish_committed_delta(
-    database: &SourceDatabase,
     stats: &mut ScanStats,
     before: Vec<SourceManifestEntry>,
-) -> Result<(), ScanError> {
-    let (revision, after) = database.manifest_snapshot_with_revision()?;
+    committed_snapshot: (u64, Vec<SourceManifestEntry>),
+) {
+    let (revision, after) = committed_snapshot;
     stats.committed_delta = build_committed_delta(&before, &after, revision);
     stats.manifest_before = before;
     stats.manifest_after = after;
-    Ok(())
 }
 
 pub(super) fn build_committed_delta(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -11,9 +11,9 @@ mod scan_walk;
 pub use scan::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
     RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-    audit_source_and_record, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
-    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress,
+    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
+    complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
+    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -1,3 +1,4 @@
+mod manifest;
 mod scan;
 mod scan_db_sync;
 mod scan_diff;
@@ -8,11 +9,11 @@ mod scan_paths;
 mod scan_walk;
 
 pub use scan::{
-    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-    complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
+    audit_source_and_record, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
     complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    scan_in_background, scan_once, scan_with_progress,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -168,11 +168,25 @@ impl ScanContext {
 
     pub(in crate::sample_sources::scanner) fn commit_batch(
         &mut self,
-        db: &SourceDatabase,
         batch: SourceWriteBatch<'_>,
     ) -> Result<u64, ScanError> {
-        let (revision, changes) = batch.commit_with_manifest_changes()?;
-        let revision = if revision == self.committed_manifest_revision.saturating_add(1) {
+        self.commit_batch_with_post_commit_hook(batch, || {})
+    }
+
+    fn commit_batch_with_post_commit_hook(
+        &mut self,
+        batch: SourceWriteBatch<'_>,
+        post_commit_hook: impl FnOnce(),
+    ) -> Result<u64, ScanError> {
+        let (revision, changes, snapshot) =
+            batch.commit_with_manifest_changes(self.committed_manifest_revision)?;
+        post_commit_hook();
+        if let Some(snapshot) = snapshot {
+            self.committed_manifest = snapshot
+                .into_iter()
+                .map(|entry| (entry.relative_path.clone(), entry))
+                .collect();
+        } else {
             for (path, entry) in changes {
                 if let Some(entry) = entry {
                     self.committed_manifest.insert(path, entry);
@@ -180,15 +194,7 @@ impl ScanContext {
                     self.committed_manifest.remove(&path);
                 }
             }
-            revision
-        } else {
-            let (snapshot_revision, snapshot) = db.manifest_snapshot_with_revision()?;
-            self.committed_manifest = snapshot
-                .into_iter()
-                .map(|entry| (entry.relative_path.clone(), entry))
-                .collect();
-            snapshot_revision
-        };
+        }
         self.committed_manifest_revision = revision;
         self.last_committed_revision = Some(revision);
         Ok(revision)
@@ -245,7 +251,13 @@ mod tests {
             .upsert_file_with_hash(Path::new("scan.wav"), 3, 3, "scan")
             .expect("scan row");
         let revision = context
-            .commit_batch(&database, scan_batch)
+            .commit_batch_with_post_commit_hook(scan_batch, || {
+                let mut later_batch = database.write_batch().expect("later batch");
+                later_batch
+                    .upsert_file_with_hash(Path::new("later.wav"), 4, 4, "later")
+                    .expect("later row");
+                later_batch.commit().expect("commit later writer");
+            })
             .expect("commit scan batch");
         let (_revision, snapshot) = context.committed_snapshot(revision);
         let paths = snapshot
@@ -253,7 +265,7 @@ mod tests {
             .map(|entry| entry.relative_path)
             .collect::<Vec<_>>();
 
-        assert_eq!(revision, database.get_revision().expect("current revision"));
+        assert!(revision < database.get_revision().expect("current revision"));
         assert_eq!(
             paths,
             vec![

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
@@ -12,25 +12,35 @@ pub(crate) struct ScanContext {
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
     pub(crate) rename_candidate_generation: Option<u64>,
-    pub(crate) last_committed_snapshot: Option<(u64, Vec<SourceManifestEntry>)>,
+    committed_manifest: BTreeMap<PathBuf, SourceManifestEntry>,
+    pub(crate) last_committed_revision: Option<u64>,
 }
 
 impl ScanContext {
-    pub(super) fn new(db: &SourceDatabase, mode: ScanMode) -> Result<Self, ScanError> {
+    pub(super) fn new(
+        db: &SourceDatabase,
+        mode: ScanMode,
+        manifest: Vec<SourceManifestEntry>,
+    ) -> Result<Self, ScanError> {
         let existing = index_existing(db)?;
-        Ok(Self::from_existing(existing, mode))
+        Ok(Self::from_existing(existing, mode, manifest))
     }
 
     pub(in crate::sample_sources::scanner) fn from_existing(
         existing: HashMap<PathBuf, WavEntry>,
         mode: ScanMode,
+        manifest: Vec<SourceManifestEntry>,
     ) -> Self {
         Self {
             existing,
             stats: ScanStats::default(),
             mode,
             rename_candidate_generation: None,
-            last_committed_snapshot: None,
+            committed_manifest: manifest
+                .into_iter()
+                .map(|entry| (entry.relative_path.clone(), entry))
+                .collect(),
+            last_committed_revision: None,
         }
     }
 
@@ -53,10 +63,27 @@ impl ScanContext {
     pub(in crate::sample_sources::scanner) fn commit_batch(
         &mut self,
         batch: SourceWriteBatch<'_>,
-    ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
-        let snapshot = batch.commit_with_manifest_snapshot()?;
-        self.last_committed_snapshot = Some(snapshot.clone());
-        Ok(snapshot)
+    ) -> Result<u64, ScanError> {
+        let (revision, changes) = batch.commit_with_manifest_changes()?;
+        for (path, entry) in changes {
+            if let Some(entry) = entry {
+                self.committed_manifest.insert(path, entry);
+            } else {
+                self.committed_manifest.remove(&path);
+            }
+        }
+        self.last_committed_revision = Some(revision);
+        Ok(revision)
+    }
+
+    pub(in crate::sample_sources::scanner) fn committed_snapshot(
+        &self,
+        revision: u64,
+    ) -> (u64, Vec<SourceManifestEntry>) {
+        (
+            revision,
+            self.committed_manifest.values().cloned().collect(),
+        )
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
+use wavecrate_library::sample_sources::SourceManifestEntry;
 
 use super::{ScanError, ScanMode, ScanStats};
 
@@ -11,6 +12,7 @@ pub(crate) struct ScanContext {
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
     pub(crate) rename_candidate_generation: Option<u64>,
+    pub(crate) last_committed_snapshot: Option<(u64, Vec<SourceManifestEntry>)>,
 }
 
 impl ScanContext {
@@ -28,6 +30,7 @@ impl ScanContext {
             stats: ScanStats::default(),
             mode,
             rename_candidate_generation: None,
+            last_committed_snapshot: None,
         }
     }
 
@@ -45,6 +48,15 @@ impl ScanContext {
         };
         self.rename_candidate_generation = Some(generation);
         Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn commit_batch(
+        &mut self,
+        batch: SourceWriteBatch<'_>,
+    ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+        let snapshot = batch.commit_with_manifest_snapshot()?;
+        self.last_committed_snapshot = Some(snapshot.clone());
+        Ok(snapshot)
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -13,6 +13,7 @@ pub(crate) struct ScanContext {
     pub(crate) mode: ScanMode,
     pub(crate) rename_candidate_generation: Option<u64>,
     committed_manifest: BTreeMap<PathBuf, SourceManifestEntry>,
+    committed_manifest_revision: u64,
     pub(crate) last_committed_revision: Option<u64>,
 }
 
@@ -20,15 +21,22 @@ impl ScanContext {
     pub(super) fn new(
         db: &SourceDatabase,
         mode: ScanMode,
+        manifest_revision: u64,
         manifest: Vec<SourceManifestEntry>,
     ) -> Result<Self, ScanError> {
         let existing = index_existing(db)?;
-        Ok(Self::from_existing(existing, mode, manifest))
+        Ok(Self::from_existing(
+            existing,
+            mode,
+            manifest_revision,
+            manifest,
+        ))
     }
 
     pub(in crate::sample_sources::scanner) fn from_existing(
         existing: HashMap<PathBuf, WavEntry>,
         mode: ScanMode,
+        manifest_revision: u64,
         manifest: Vec<SourceManifestEntry>,
     ) -> Self {
         Self {
@@ -40,6 +48,7 @@ impl ScanContext {
                 .into_iter()
                 .map(|entry| (entry.relative_path.clone(), entry))
                 .collect(),
+            committed_manifest_revision: manifest_revision,
             last_committed_revision: None,
         }
     }
@@ -60,18 +69,39 @@ impl ScanContext {
         Ok(())
     }
 
+    pub(in crate::sample_sources::scanner) fn committed_file_identity(
+        &self,
+        relative_path: &std::path::Path,
+    ) -> Option<&str> {
+        self.committed_manifest
+            .get(relative_path)
+            .and_then(|entry| entry.file_identity.as_deref())
+    }
+
     pub(in crate::sample_sources::scanner) fn commit_batch(
         &mut self,
+        db: &SourceDatabase,
         batch: SourceWriteBatch<'_>,
     ) -> Result<u64, ScanError> {
         let (revision, changes) = batch.commit_with_manifest_changes()?;
-        for (path, entry) in changes {
-            if let Some(entry) = entry {
-                self.committed_manifest.insert(path, entry);
-            } else {
-                self.committed_manifest.remove(&path);
+        let revision = if revision == self.committed_manifest_revision.saturating_add(1) {
+            for (path, entry) in changes {
+                if let Some(entry) = entry {
+                    self.committed_manifest.insert(path, entry);
+                } else {
+                    self.committed_manifest.remove(&path);
+                }
             }
-        }
+            revision
+        } else {
+            let (snapshot_revision, snapshot) = db.manifest_snapshot_with_revision()?;
+            self.committed_manifest = snapshot
+                .into_iter()
+                .map(|entry| (entry.relative_path.clone(), entry))
+                .collect();
+            snapshot_revision
+        };
+        self.committed_manifest_revision = revision;
         self.last_committed_revision = Some(revision);
         Ok(revision)
     }
@@ -93,4 +123,56 @@ fn index_existing(db: &SourceDatabase) -> Result<HashMap<PathBuf, WavEntry>, Sca
         .into_iter()
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn interleaved_manifest_writer_forces_exact_committed_resnapshot() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database = SourceDatabase::open(directory.path()).expect("source database");
+        let mut initial_batch = database.write_batch().expect("initial batch");
+        initial_batch
+            .upsert_file_with_hash(Path::new("initial.wav"), 1, 1, "initial")
+            .expect("initial row");
+        initial_batch.commit().expect("commit initial row");
+        let (manifest_revision, manifest) = database
+            .manifest_snapshot_with_revision()
+            .expect("initial manifest");
+        let existing = index_existing(&database).expect("existing rows");
+        let mut context =
+            ScanContext::from_existing(existing, ScanMode::Quick, manifest_revision, manifest);
+
+        let mut external_batch = database.write_batch().expect("external batch");
+        external_batch
+            .upsert_file_with_hash(Path::new("external.wav"), 2, 2, "external")
+            .expect("interleaved writer");
+        external_batch.commit().expect("commit interleaved writer");
+        let mut scan_batch = database.write_batch().expect("scan batch");
+        scan_batch
+            .upsert_file_with_hash(Path::new("scan.wav"), 3, 3, "scan")
+            .expect("scan row");
+        let revision = context
+            .commit_batch(&database, scan_batch)
+            .expect("commit scan batch");
+        let (_revision, snapshot) = context.committed_snapshot(revision);
+        let paths = snapshot
+            .into_iter()
+            .map(|entry| entry.relative_path)
+            .collect::<Vec<_>>();
+
+        assert_eq!(revision, database.get_revision().expect("current revision"));
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("external.wav"),
+                PathBuf::from("initial.wav"),
+                PathBuf::from("scan.wav"),
+            ]
+        );
+    }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
@@ -15,6 +15,13 @@ pub(crate) struct ScanContext {
     committed_manifest: BTreeMap<PathBuf, SourceManifestEntry>,
     committed_manifest_revision: u64,
     pub(crate) last_committed_revision: Option<u64>,
+    manifest_audit: Option<ManifestAuditCheckpoint>,
+}
+
+struct ManifestAuditCheckpoint {
+    previously_checked: HashSet<PathBuf>,
+    pending: Vec<PathBuf>,
+    expected_total: usize,
 }
 
 impl ScanContext {
@@ -50,7 +57,88 @@ impl ScanContext {
                 .collect(),
             committed_manifest_revision: manifest_revision,
             last_committed_revision: None,
+            manifest_audit: None,
         }
+    }
+
+    pub(in crate::sample_sources::scanner) fn resume_manifest_audit(
+        &mut self,
+        db: &SourceDatabase,
+        started_at: i64,
+    ) -> Result<(), ScanError> {
+        let previously_checked = db
+            .begin_or_resume_manifest_audit(started_at)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+        self.stats.total_files = previously_checked.len();
+        self.manifest_audit = Some(ManifestAuditCheckpoint {
+            expected_total: self.committed_manifest.len().max(previously_checked.len()),
+            previously_checked,
+            pending: Vec::new(),
+        });
+        Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn manifest_audit_progress(
+        &self,
+    ) -> Option<(usize, usize)> {
+        self.manifest_audit.as_ref().map(|audit| {
+            (
+                self.stats.total_files,
+                audit.expected_total.max(self.stats.total_files),
+            )
+        })
+    }
+
+    pub(in crate::sample_sources::scanner) fn skip_previously_audited_path(
+        &mut self,
+        relative_path: &std::path::Path,
+    ) -> bool {
+        let already_checked = self
+            .manifest_audit
+            .as_ref()
+            .is_some_and(|audit| audit.previously_checked.contains(relative_path));
+        if already_checked {
+            self.existing.remove(relative_path);
+        }
+        already_checked
+    }
+
+    pub(in crate::sample_sources::scanner) fn record_manifest_audit_paths(
+        &mut self,
+        db: &SourceDatabase,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<(), ScanError> {
+        let Some(audit) = self.manifest_audit.as_mut() else {
+            return Ok(());
+        };
+        for path in paths {
+            if audit.previously_checked.insert(path.clone()) {
+                audit.pending.push(path);
+                self.stats.total_files = self.stats.total_files.saturating_add(1);
+            }
+        }
+        if audit.pending.len() >= 64 {
+            db.checkpoint_manifest_audit_paths(&audit.pending)?;
+            audit.pending.clear();
+        }
+        Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn flush_manifest_audit_checkpoint(
+        &mut self,
+        db: &SourceDatabase,
+    ) -> Result<(), ScanError> {
+        let Some(audit) = self.manifest_audit.as_mut() else {
+            return Ok(());
+        };
+        db.checkpoint_manifest_audit_paths(&audit.pending)?;
+        audit.pending.clear();
+        Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn resumable_manifest_audit_active(&self) -> bool {
+        self.manifest_audit.is_some()
     }
 
     pub(in crate::sample_sources::scanner) fn ensure_rename_candidate_generation(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 use crate::sample_sources::SourceDbError;
 
+use super::ScanStats;
+
 /// Errors that can occur while scanning a source folder.
 #[derive(Debug, Error)]
 pub enum ScanError {
@@ -13,6 +15,14 @@ pub enum ScanError {
     /// Scan was canceled by the caller.
     #[error("Scan canceled")]
     Canceled,
+    /// A source revision committed before later work stopped.
+    #[error("Scan incomplete after committed checkpoint: {error}")]
+    Incomplete {
+        /// Authoritative checkpoint that callers must publish before retrying.
+        committed: Box<ScanStats>,
+        /// Error that stopped the remaining work.
+        error: String,
+    },
     /// Failed to read a file or directory.
     #[error("Failed to read {path}: {source}")]
     Io {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -5,6 +5,8 @@ mod stats;
 
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
+#[cfg(test)]
+pub(crate) use runner::audit_source_and_record_with_post_scan_hook;
 pub use runner::{
     ScanMode, audit_source, audit_source_and_record, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -6,13 +6,15 @@ mod stats;
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
-    ScanMode, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
-    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-    schedule_deep_hash_scan_with_database_root,
+    ScanMode, audit_source, audit_source_and_record, complete_deferred_hashes,
+    complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
+    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
 };
-pub use stats::{ChangedSample, RenamedSample, ScanStats, UpdatedSample};
+pub use stats::{
+    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+    RenamedSample, ScanStats, UpdatedSample,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -9,10 +9,11 @@ pub use errors::ScanError;
 pub(crate) use runner::audit_source_and_record_with_post_scan_hook;
 pub(crate) use runner::finish_scan_result;
 pub use runner::{
-    ScanMode, audit_source, audit_source_and_record, complete_deferred_hashes,
-    complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
-    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
-    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    ScanMode, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
+    complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress,
 };
 pub use stats::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 #[cfg(test)]
 pub(crate) use runner::audit_source_and_record_with_post_scan_hook;
+pub(crate) use runner::finish_scan_result;
 pub use runner::{
     ScanMode, audit_source, audit_source_and_record, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -44,9 +44,6 @@ pub fn audit_source(
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
-    if stats.is_incomplete() {
-        return Ok(stats);
-    }
     merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None),
@@ -75,9 +72,6 @@ fn audit_source_and_record_after_scan(
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
-    if stats.is_incomplete() {
-        return Ok(stats);
-    }
     after_scan();
     merge_audit_verification(
         &mut stats,
@@ -108,6 +102,10 @@ fn merge_audit_verification(
                 revision = stats.committed_delta.revision,
                 "Publishing committed manifest repair before retrying incomplete content audit"
             );
+            return Err(ScanError::Incomplete {
+                committed: Box::new(std::mem::take(stats)),
+                error: error.to_string(),
+            });
         }
         Err(error) => return Err(error),
     }
@@ -133,7 +131,7 @@ fn scan(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let manifest_before = super::super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
-    let mut context = ScanContext::new(db, mode)?;
+    let mut context = ScanContext::new(db, mode, manifest_before.clone())?;
     let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context)
         .and_then(|()| db_sync_phase(db, &mut context, cancel));
     finish_scan_result(manifest_before, context, result)
@@ -160,16 +158,19 @@ pub(crate) fn finish_scan_result(
             Ok(context.stats)
         }
         Err(error) => {
-            let Some(committed_snapshot) = context.last_committed_snapshot.take() else {
+            let Some(committed_revision) = context.last_committed_revision else {
                 return Err(error);
             };
+            let committed_snapshot = context.committed_snapshot(committed_revision);
             super::super::manifest::publish_committed_delta(
                 &mut context.stats,
                 manifest_before,
                 committed_snapshot,
             );
-            context.stats.incomplete_error = Some(error.to_string());
-            Ok(context.stats)
+            Err(ScanError::Incomplete {
+                committed: Box::new(context.stats),
+                error: error.to_string(),
+            })
         }
     }
 }
@@ -215,9 +216,6 @@ pub fn complete_deferred_rename_candidates_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
-    if stats.is_incomplete() {
-        return Ok(stats);
-    }
     if db.list_pending_renames()?.is_empty() {
         return Ok(stats);
     }
@@ -248,9 +246,6 @@ pub fn complete_deferred_hashes_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
-    if stats.is_incomplete() {
-        return Ok(stats);
-    }
     let persisted_candidates = db.list_pending_rename_destinations()?;
     if stats.hashes_pending == 0
         && stats.rename_candidate_paths.is_empty()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -28,13 +28,13 @@ pub enum ScanMode {
 /// Recursively scan the source root, syncing supported audio files into the database.
 /// Returns counts of added/updated/removed rows.
 pub fn scan_once(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
-    scan(db, ScanMode::Quick, None, None)
+    scan(db, ScanMode::Quick, None, None, None)
 }
 
 /// Rescan the entire source, pruning rows for files that no longer exist and
 /// clearing any unmatched pending rename rows left over from prior quick scans.
 pub fn hard_rescan(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
-    scan(db, ScanMode::Hard, None, None)
+    scan(db, ScanMode::Hard, None, None, None)
 }
 
 /// Reconcile the full source manifest and verify a bounded rotating content batch.
@@ -43,7 +43,7 @@ pub fn audit_source(
     cancel: Option<&AtomicBool>,
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    let mut stats = scan(db, ScanMode::Quick, cancel, None, None)?;
     merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None),
@@ -61,7 +61,25 @@ pub fn audit_source_and_record(
     max_hashes: usize,
     completed_at: i64,
 ) -> Result<ScanStats, ScanError> {
-    audit_source_and_record_after_scan(db, cancel, max_hashes, completed_at, || {})
+    audit_source_and_record_with_progress(db, cancel, max_hashes, completed_at, &mut |_, _| {})
+}
+
+/// Reconcile and durably record a resumable source audit while publishing checked-file progress.
+pub fn audit_source_and_record_with_progress(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+    on_progress: &mut impl FnMut(usize, &Path),
+) -> Result<ScanStats, ScanError> {
+    audit_source_and_record_after_scan(
+        db,
+        cancel,
+        max_hashes,
+        completed_at,
+        Some(on_progress),
+        || {},
+    )
 }
 
 fn audit_source_and_record_after_scan(
@@ -69,9 +87,10 @@ fn audit_source_and_record_after_scan(
     cancel: Option<&AtomicBool>,
     max_hashes: usize,
     completed_at: i64,
+    on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    let mut stats = scan(db, ScanMode::Quick, cancel, on_progress, Some(completed_at))?;
     after_scan();
     merge_audit_verification(
         &mut stats,
@@ -87,7 +106,7 @@ pub(crate) fn audit_source_and_record_with_post_scan_hook(
     completed_at: i64,
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
-    audit_source_and_record_after_scan(db, cancel, max_hashes, completed_at, after_scan)
+    audit_source_and_record_after_scan(db, cancel, max_hashes, completed_at, None, after_scan)
 }
 
 fn merge_audit_verification(
@@ -119,7 +138,7 @@ pub fn scan_with_progress(
     cancel: Option<&AtomicBool>,
     on_progress: &mut impl FnMut(usize, &Path),
 ) -> Result<ScanStats, ScanError> {
-    scan(db, mode, cancel, Some(on_progress))
+    scan(db, mode, cancel, Some(on_progress), None)
 }
 
 fn scan(
@@ -127,12 +146,22 @@ fn scan(
     mode: ScanMode,
     cancel: Option<&AtomicBool>,
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
+    manifest_audit_started_at: Option<i64>,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
     let (manifest_revision, manifest_before) =
         super::super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode, manifest_revision, manifest_before.clone())?;
+    if let Some(started_at) = manifest_audit_started_at {
+        context.resume_manifest_audit(db, started_at)?;
+        if let Some((checked, _expected)) = context.manifest_audit_progress()
+            && checked > 0
+            && let Some(on_progress) = on_progress.as_mut()
+        {
+            on_progress(checked, &root);
+        }
+    }
     let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context)
         .and_then(|()| db_sync_phase(db, &mut context, cancel));
     finish_scan_result(manifest_before, context, result)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -44,6 +44,9 @@ pub fn audit_source(
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    if stats.is_incomplete() {
+        return Ok(stats);
+    }
     merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None),
@@ -72,6 +75,9 @@ fn audit_source_and_record_after_scan(
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    if stats.is_incomplete() {
+        return Ok(stats);
+    }
     after_scan();
     merge_audit_verification(
         &mut stats,
@@ -128,14 +134,44 @@ fn scan(
     let manifest_before = super::super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
-    walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
-    let committed_snapshot = db_sync_phase(db, &mut context, cancel)?;
-    super::super::manifest::publish_committed_delta(
-        &mut context.stats,
-        manifest_before,
-        committed_snapshot,
-    );
-    Ok(context.stats)
+    let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context)
+        .and_then(|()| db_sync_phase(db, &mut context, cancel));
+    finish_scan_result(manifest_before, context, result)
+}
+
+pub(crate) fn finish_scan_result(
+    manifest_before: Vec<wavecrate_library::sample_sources::SourceManifestEntry>,
+    mut context: ScanContext,
+    result: Result<
+        (
+            u64,
+            Vec<wavecrate_library::sample_sources::SourceManifestEntry>,
+        ),
+        ScanError,
+    >,
+) -> Result<ScanStats, ScanError> {
+    match result {
+        Ok(committed_snapshot) => {
+            super::super::manifest::publish_committed_delta(
+                &mut context.stats,
+                manifest_before,
+                committed_snapshot,
+            );
+            Ok(context.stats)
+        }
+        Err(error) => {
+            let Some(committed_snapshot) = context.last_committed_snapshot.take() else {
+                return Err(error);
+            };
+            super::super::manifest::publish_committed_delta(
+                &mut context.stats,
+                manifest_before,
+                committed_snapshot,
+            );
+            context.stats.incomplete_error = Some(error.to_string());
+            Ok(context.stats)
+        }
+    }
 }
 
 /// Spawn a background thread that opens the source database and performs one scan.
@@ -179,6 +215,9 @@ pub fn complete_deferred_rename_candidates_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
+    if stats.is_incomplete() {
+        return Ok(stats);
+    }
     if db.list_pending_renames()?.is_empty() {
         return Ok(stats);
     }
@@ -209,6 +248,9 @@ pub fn complete_deferred_hashes_with_cancel(
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
 ) -> Result<ScanStats, ScanError> {
+    if stats.is_incomplete() {
+        return Ok(stats);
+    }
     let persisted_candidates = db.list_pending_rename_destinations()?;
     if stats.hashes_pending == 0
         && stats.rename_candidate_paths.is_empty()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -96,7 +96,7 @@ fn merge_audit_verification(
 ) -> Result<ScanStats, ScanError> {
     match verification {
         Ok(verified) => stats.merge_deferred_hashes(verified),
-        Err(error) if !stats.committed_delta.is_empty() => {
+        Err(error) if stats.committed_delta.revision > 0 => {
             tracing::warn!(
                 %error,
                 revision = stats.committed_delta.revision,
@@ -129,9 +129,10 @@ fn scan(
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
-    let manifest_before = super::super::manifest::capture_manifest(db)?;
+    let (manifest_revision, manifest_before) =
+        super::super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
-    let mut context = ScanContext::new(db, mode, manifest_before.clone())?;
+    let mut context = ScanContext::new(db, mode, manifest_revision, manifest_before.clone())?;
     let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context)
         .and_then(|()| db_sync_phase(db, &mut context, cancel));
     finish_scan_result(manifest_before, context, result)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -44,23 +44,68 @@ pub fn audit_source(
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
-    let verified = super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None)?;
-    stats.merge_deferred_hashes(verified);
-    Ok(stats)
+    merge_audit_verification(
+        &mut stats,
+        super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None),
+    )
 }
 
-/// Reconcile a source audit and durably record its completion in the same final revision.
+/// Reconcile a source audit and, after successful content verification, durably record completion
+/// in the same final revision.
+///
+/// A manifest repair committed before verification fails is still returned for publication. In
+/// that case the completion timestamp remains unchanged so the unfinished audit stays due.
 pub fn audit_source_and_record(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
     max_hashes: usize,
     completed_at: i64,
 ) -> Result<ScanStats, ScanError> {
+    audit_source_and_record_after_scan(db, cancel, max_hashes, completed_at, || {})
+}
+
+fn audit_source_and_record_after_scan(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+    after_scan: impl FnOnce(),
+) -> Result<ScanStats, ScanError> {
     let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
-    let verified =
-        super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, Some(completed_at))?;
-    stats.merge_deferred_hashes(verified);
-    Ok(stats)
+    after_scan();
+    merge_audit_verification(
+        &mut stats,
+        super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, Some(completed_at)),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn audit_source_and_record_with_post_scan_hook(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+    after_scan: impl FnOnce(),
+) -> Result<ScanStats, ScanError> {
+    audit_source_and_record_after_scan(db, cancel, max_hashes, completed_at, after_scan)
+}
+
+fn merge_audit_verification(
+    stats: &mut ScanStats,
+    verification: Result<ScanStats, ScanError>,
+) -> Result<ScanStats, ScanError> {
+    match verification {
+        Ok(verified) => stats.merge_deferred_hashes(verified),
+        Err(error) if !stats.committed_delta.is_empty() => {
+            tracing::warn!(
+                %error,
+                revision = stats.committed_delta.revision,
+                "Publishing committed manifest repair before retrying incomplete content audit"
+            );
+        }
+        Err(error) => return Err(error),
+    }
+    Ok(std::mem::take(stats))
 }
 
 /// Scan with a progress callback, optionally honoring a cancel flag.
@@ -84,8 +129,12 @@ fn scan(
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
     walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
-    db_sync_phase(db, &mut context, cancel)?;
-    super::super::manifest::publish_committed_delta(db, &mut context.stats, manifest_before)?;
+    let committed_snapshot = db_sync_phase(db, &mut context, cancel)?;
+    super::super::manifest::publish_committed_delta(
+        &mut context.stats,
+        manifest_before,
+        committed_snapshot,
+    );
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -37,6 +37,32 @@ pub fn hard_rescan(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
     scan(db, ScanMode::Hard, None, None)
 }
 
+/// Reconcile the full source manifest and verify a bounded rotating content batch.
+pub fn audit_source(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+) -> Result<ScanStats, ScanError> {
+    let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    let verified = super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, None)?;
+    stats.merge_deferred_hashes(verified);
+    Ok(stats)
+}
+
+/// Reconcile a source audit and durably record its completion in the same final revision.
+pub fn audit_source_and_record(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+) -> Result<ScanStats, ScanError> {
+    let mut stats = scan(db, ScanMode::Quick, cancel, None)?;
+    let verified =
+        super::super::scan_hash::verify_content_batch(db, cancel, max_hashes, Some(completed_at))?;
+    stats.merge_deferred_hashes(verified);
+    Ok(stats)
+}
+
 /// Scan with a progress callback, optionally honoring a cancel flag.
 pub fn scan_with_progress(
     db: &SourceDatabase,
@@ -54,10 +80,12 @@ fn scan(
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
+    let manifest_before = super::super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
     let mut context = ScanContext::new(db, mode)?;
     walk_phase(db, &root, cancel, &mut on_progress, &mut context)?;
     db_sync_phase(db, &mut context, cancel)?;
+    super::super::manifest::publish_committed_delta(db, &mut context.stats, manifest_before)?;
     Ok(context.stats)
 }
 
@@ -193,33 +221,4 @@ pub fn complete_pending_deep_hash_for_path(
         Some(1),
         Some(relative_path),
     )
-}
-
-/// Spawn a detached deep-hash pass to backfill content hashes after quick scans.
-///
-/// This keeps incremental scans responsive by moving full hashing and rename
-/// reconciliation for large files to a best-effort background worker.
-pub fn schedule_deep_hash_scan(root: PathBuf) {
-    schedule_deep_hash_scan_with_database_root(root.clone(), root);
-}
-
-/// Spawn a detached deep-hash pass using a separate database root.
-pub fn schedule_deep_hash_scan_with_database_root(root: PathBuf, database_root: PathBuf) {
-    thread::spawn(move || {
-        let result = (|| -> Result<(), ScanError> {
-            let db = SourceDatabase::open_for_scan_with_database_root(root, database_root)?;
-            let _ = super::super::scan_hash::deep_hash_scan(
-                &db,
-                None,
-                &HashSet::new(),
-                super::super::scan_hash::DeferredHashScope::AllUnhashed,
-                None,
-                None,
-            )?;
-            Ok(())
-        })();
-        if let Err(err) = result {
-            tracing::warn!("Deferred deep-hash scan failed: {err}");
-        }
-    });
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -7,6 +7,11 @@ use wavecrate_library::sample_sources::SourceManifestEntry;
 pub struct ScanStats {
     /// Authoritative identity delta observed at the final committed source revision.
     pub committed_delta: CommittedSourceDelta,
+    /// Error that stopped this scan after an earlier source revision committed.
+    ///
+    /// The committed delta remains authoritative and must be published before the caller retries
+    /// the unfinished scan.
+    pub incomplete_error: Option<String>,
     /// Number of newly discovered files.
     pub added: usize,
     /// Number of files updated in-place.
@@ -39,6 +44,11 @@ pub struct ScanStats {
 }
 
 impl ScanStats {
+    /// Whether work stopped after publishing the latest committed checkpoint.
+    pub fn is_incomplete(&self) -> bool {
+        self.incomplete_error.is_some()
+    }
+
     pub(super) fn merge_deferred_hashes(&mut self, mut deferred: Self) {
         self.hashes_computed += deferred.hashes_computed;
         self.hashes_pending = self.hashes_pending.saturating_sub(deferred.hashes_computed);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -1,8 +1,12 @@
 use std::path::PathBuf;
 
+use wavecrate_library::sample_sources::SourceManifestEntry;
+
 /// Summary of a scan run.
 #[derive(Debug, Default, Clone)]
 pub struct ScanStats {
+    /// Authoritative identity delta observed at the final committed source revision.
+    pub committed_delta: CommittedSourceDelta,
     /// Number of newly discovered files.
     pub added: usize,
     /// Number of files updated in-place.
@@ -28,6 +32,10 @@ pub struct ScanStats {
     /// Newly inserted paths from this scan that are eligible as rename destinations.
     #[doc(hidden)]
     pub rename_candidate_paths: Vec<PathBuf>,
+    #[doc(hidden)]
+    pub manifest_before: Vec<SourceManifestEntry>,
+    #[doc(hidden)]
+    pub manifest_after: Vec<SourceManifestEntry>,
 }
 
 impl ScanStats {
@@ -38,10 +46,67 @@ impl ScanStats {
         self.updated_samples.append(&mut deferred.updated_samples);
         self.renamed_samples.append(&mut deferred.renamed_samples);
         self.changed_samples.append(&mut deferred.changed_samples);
+        if !deferred.manifest_after.is_empty() || deferred.committed_delta.revision > 0 {
+            self.manifest_after = deferred.manifest_after;
+            self.committed_delta = super::super::manifest::build_committed_delta(
+                &self.manifest_before,
+                &self.manifest_after,
+                deferred.committed_delta.revision,
+            );
+        }
     }
 
     pub(crate) fn record_rename_candidate(&mut self, path: PathBuf) {
         self.rename_candidate_paths.push(path);
+    }
+}
+
+/// One current or retired identity in a committed source-manifest delta.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestIdentityDelta {
+    /// Stable identity used to fence downstream work.
+    pub identity: String,
+    /// Source-relative path at this revision.
+    pub relative_path: PathBuf,
+    /// Full hash or explicit pending generation for this identity.
+    pub content_generation: String,
+}
+
+/// One identity whose committed source-relative path changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MovedManifestIdentity {
+    /// Stable identity used to fence downstream work.
+    pub identity: String,
+    /// Previous source-relative path.
+    pub old_relative_path: PathBuf,
+    /// Current source-relative path.
+    pub new_relative_path: PathBuf,
+    /// Current full hash or explicit pending generation.
+    pub content_generation: String,
+}
+
+/// Structured source-manifest delta published only after the authoritative commit.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CommittedSourceDelta {
+    /// Monotonic committed source-path revision.
+    pub revision: u64,
+    /// Identities newly present at this revision.
+    pub created: Vec<ManifestIdentityDelta>,
+    /// Identities whose content generation changed at this revision.
+    pub changed: Vec<ManifestIdentityDelta>,
+    /// Identities whose path changed without losing stable ownership.
+    pub moved: Vec<MovedManifestIdentity>,
+    /// Identities no longer present at this revision.
+    pub deleted: Vec<ManifestIdentityDelta>,
+}
+
+impl CommittedSourceDelta {
+    /// Return true when the committed manifest did not change.
+    pub fn is_empty(&self) -> bool {
+        self.created.is_empty()
+            && self.changed.is_empty()
+            && self.moved.is_empty()
+            && self.deleted.is_empty()
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -70,6 +70,8 @@ pub struct ManifestIdentityDelta {
     pub relative_path: PathBuf,
     /// Full hash or explicit pending generation for this identity.
     pub content_generation: String,
+    /// Whether source-visible size or modification metadata changed.
+    pub source_metadata_changed: bool,
 }
 
 /// One identity whose committed source-relative path changed.

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -7,11 +7,6 @@ use wavecrate_library::sample_sources::SourceManifestEntry;
 pub struct ScanStats {
     /// Authoritative identity delta observed at the final committed source revision.
     pub committed_delta: CommittedSourceDelta,
-    /// Error that stopped this scan after an earlier source revision committed.
-    ///
-    /// The committed delta remains authoritative and must be published before the caller retries
-    /// the unfinished scan.
-    pub incomplete_error: Option<String>,
     /// Number of newly discovered files.
     pub added: usize,
     /// Number of files updated in-place.
@@ -44,11 +39,6 @@ pub struct ScanStats {
 }
 
 impl ScanStats {
-    /// Whether work stopped after publishing the latest committed checkpoint.
-    pub fn is_incomplete(&self) -> bool {
-        self.incomplete_error.is_some()
-    }
-
     pub(super) fn merge_deferred_hashes(&mut self, mut deferred: Self) {
         self.hashes_computed += deferred.hashes_computed;
         self.hashes_pending = self.hashes_pending.saturating_sub(deferred.hashes_computed);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -595,6 +595,31 @@ fn bounded_manifest_audit_repairs_same_size_closed_app_edit() {
 }
 
 #[test]
+fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    std::fs::write(dir.path().join("missed.wav"), b"missed watcher event").unwrap();
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+
+    let stats = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
+        cancel.store(true, std::sync::atomic::Ordering::Release)
+    })
+    .unwrap();
+
+    assert_eq!(stats.committed_delta.created.len(), 1);
+    assert_eq!(
+        stats.committed_delta.created[0].relative_path,
+        Path::new("missed.wav")
+    );
+    assert!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .is_none(),
+        "incomplete verification must remain due for retry"
+    );
+}
+
+#[test]
 fn skipped_existing_file_is_not_used_as_a_rename_source() {
     let dir = tempdir().unwrap();
     let hidden = dir.path().join(".hidden");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -480,7 +480,10 @@ fn cancellation_after_first_committed_batch_stops_at_a_resumable_checkpoint() {
         }
     });
 
-    assert!(matches!(result, Err(ScanError::Canceled)));
+    let partial = result.expect("return the committed walk checkpoint before cancellation");
+    assert_eq!(partial.committed_delta.created.len(), 64);
+    assert!(partial.committed_delta.revision > 0);
+    assert_eq!(partial.incomplete_error.as_deref(), Some("Scan canceled"));
     assert_eq!(db.count_files().unwrap(), 64);
 
     cancel.store(false, Ordering::Relaxed);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -60,10 +60,10 @@ fn scan_skips_analysis_when_hash_unchanged() {
 }
 
 #[test]
-fn scan_backfills_missing_identity_for_unchanged_legacy_row() {
+fn scan_backfills_missing_identity_for_unchanged_row() {
     let dir = tempdir().unwrap();
-    let relative = Path::new("legacy.wav");
-    std::fs::write(dir.path().join(relative), b"legacy").unwrap();
+    let relative = Path::new("missing-identity.wav");
+    std::fs::write(dir.path().join(relative), b"sample").unwrap();
     let db = SourceDatabase::open(dir.path()).unwrap();
     scan_once(&db).unwrap();
     let original = db.list_manifest_entries().unwrap().remove(0);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -60,6 +60,29 @@ fn scan_skips_analysis_when_hash_unchanged() {
 }
 
 #[test]
+fn scan_backfills_missing_identity_for_unchanged_legacy_row() {
+    let dir = tempdir().unwrap();
+    let relative = Path::new("legacy.wav");
+    std::fs::write(dir.path().join(relative), b"legacy").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let original = db.list_manifest_entries().unwrap().remove(0);
+    assert!(original.file_identity.is_some());
+
+    let mut batch = db.write_batch().unwrap();
+    batch.set_file_identity(relative, None).unwrap();
+    batch.commit().unwrap();
+
+    let stats = scan_once(&db).unwrap();
+    let repaired = db.list_manifest_entries().unwrap().remove(0);
+
+    assert_eq!(repaired.content_hash, original.content_hash);
+    assert!(repaired.file_identity.is_some());
+    assert!(stats.committed_delta.created.is_empty());
+    assert!(stats.committed_delta.deleted.is_empty());
+}
+
+#[test]
 fn scan_adds_duplicate_content_when_original_path_still_exists() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");
@@ -627,6 +650,30 @@ fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled()
             .is_none(),
         "incomplete verification must remain due for retry"
     );
+}
+
+#[test]
+fn manifest_audit_publishes_unchanged_committed_revision_when_verification_is_cancelled() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("known.wav"), b"known").unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+
+    let result = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
+        cancel.store(true, std::sync::atomic::Ordering::Release)
+    });
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("cancelled verification must return the committed unchanged checkpoint");
+    };
+
+    assert_eq!(error, "Scan canceled");
+    assert!(committed.committed_delta.is_empty());
+    assert_eq!(
+        committed.committed_delta.revision,
+        db.get_revision().unwrap()
+    );
+    assert!(committed.committed_delta.revision > 0);
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -556,6 +556,45 @@ fn unchanged_large_scan_only_commits_completion_metadata() {
 }
 
 #[test]
+fn bounded_manifest_audit_repairs_same_size_closed_app_edit() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("same.wav");
+    std::fs::write(&path, b"one").unwrap();
+    let original_modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let original_hash = db
+        .entry_for_path(Path::new("same.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    std::fs::write(&path, b"two").unwrap();
+    let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    let stats = audit_source_and_record(&db, None, 8, 1_234).unwrap();
+    let current_hash = db
+        .entry_for_path(Path::new("same.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    assert_ne!(current_hash, original_hash);
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert_eq!(stats.hashes_computed, 1);
+    assert_eq!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .as_deref(),
+        Some("1234")
+    );
+    assert_eq!(stats.committed_delta.revision, db.get_revision().unwrap());
+}
+
+#[test]
 fn skipped_existing_file_is_not_used_as_a_rename_source() {
     let dir = tempdir().unwrap();
     let hidden = dir.path().join(".hidden");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -480,10 +480,13 @@ fn cancellation_after_first_committed_batch_stops_at_a_resumable_checkpoint() {
         }
     });
 
-    let partial = result.expect("return the committed walk checkpoint before cancellation");
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("cancellation after a commit must return the checkpoint outcome");
+    };
+    let partial = *committed;
     assert_eq!(partial.committed_delta.created.len(), 64);
     assert!(partial.committed_delta.revision > 0);
-    assert_eq!(partial.incomplete_error.as_deref(), Some("Scan canceled"));
+    assert_eq!(error, "Scan canceled");
     assert_eq!(db.count_files().unwrap(), 64);
 
     cancel.store(false, Ordering::Relaxed);
@@ -604,11 +607,15 @@ fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled()
     std::fs::write(dir.path().join("missed.wav"), b"missed watcher event").unwrap();
     let cancel = std::sync::atomic::AtomicBool::new(false);
 
-    let stats = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
+    let result = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
         cancel.store(true, std::sync::atomic::Ordering::Release)
-    })
-    .unwrap();
+    });
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("cancelled verification must return the committed manifest repair");
+    };
+    let stats = *committed;
 
+    assert_eq!(error, "Scan canceled");
     assert_eq!(stats.committed_delta.created.len(), 1);
     assert_eq!(
         stats.committed_delta.created[0].relative_path,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -520,6 +520,58 @@ fn cancellation_after_first_committed_batch_stops_at_a_resumable_checkpoint() {
 }
 
 #[test]
+fn interrupted_manifest_audit_resumes_checked_paths_and_finishes_deletion_reconciliation() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let dir = tempdir().unwrap();
+    for index in 0..70 {
+        std::fs::write(dir.path().join(format!("sample-{index:03}.wav")), b"x").unwrap();
+    }
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let cancel = AtomicBool::new(false);
+
+    let first =
+        audit_source_and_record_with_progress(&db, Some(&cancel), 0, 100, &mut |checked, _| {
+            if checked >= 64 {
+                cancel.store(true, Ordering::Release);
+            }
+        });
+    assert!(matches!(first, Err(ScanError::Incomplete { .. })));
+    let checked = db
+        .begin_or_resume_manifest_audit(101)
+        .expect("load durable audit checkpoint");
+    assert_eq!(checked.len(), 64);
+
+    std::fs::remove_file(dir.path().join(&checked[0])).unwrap();
+    cancel.store(false, Ordering::Release);
+    let mut resumed_progress = Vec::new();
+    let resumed =
+        audit_source_and_record_with_progress(&db, Some(&cancel), 0, 200, &mut |checked, _| {
+            resumed_progress.push(checked)
+        })
+        .expect("resume interrupted manifest audit");
+
+    assert_eq!(resumed_progress.first().copied(), Some(64));
+    assert_eq!(resumed.total_files, 70);
+    assert!(
+        db.entry_for_path(&checked[0]).unwrap().is_none(),
+        "a path deleted after its checkpoint must still be reconciled at cycle completion"
+    );
+    assert!(
+        db.begin_or_resume_manifest_audit(201)
+            .expect("new audit cycle")
+            .is_empty(),
+        "completed audit must clear its durable checkpoint"
+    );
+    assert_eq!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .as_deref(),
+        Some("200")
+    );
+}
+
+#[test]
 fn cancellation_after_walk_skips_missing_reconciliation_and_completion_publish() {
     use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -185,6 +185,25 @@ fn quick_scan_defers_hash_for_large_file() {
 }
 
 #[test]
+fn owned_deferred_hash_publishes_a_new_committed_content_generation() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("large.wav");
+    std::fs::write(&file_path, vec![0u8; 9 * 1024 * 1024]).unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    let initial = scan_once(&db).unwrap();
+
+    let completed = complete_pending_deep_hash_for_path(&db, Path::new("large.wav"), None)
+        .expect("owned deferred hash completion");
+
+    assert!(completed.committed_delta.revision > initial.committed_delta.revision);
+    assert_eq!(completed.committed_delta.changed.len(), 1);
+    assert_eq!(
+        completed.committed_delta.changed[0].relative_path,
+        Path::new("large.wav")
+    );
+}
+
+#[test]
 fn canceled_deferred_hashing_reports_cancellation_after_quick_scan_commit() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("large.wav");
@@ -423,7 +442,7 @@ fn copy_delete_before_initial_hash_does_not_transfer_identity() {
 }
 
 #[test]
-fn detached_deep_hash_uses_persisted_quick_scan_destinations() {
+fn owned_deep_hash_uses_persisted_quick_scan_destinations() {
     let dir = tempdir().unwrap();
     let old = dir.path().join("old.wav");
     let new = dir.path().join("new.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -214,7 +214,10 @@ fn targeted_sync_cancels_after_a_committed_batch_and_resumes_safely() {
         }
     });
 
-    assert!(matches!(result, Err(ScanError::Canceled)));
+    let partial = result.expect("return the targeted checkpoint before cancellation");
+    assert_eq!(partial.committed_delta.created.len(), 64);
+    assert!(partial.committed_delta.revision > 0);
+    assert_eq!(partial.incomplete_error.as_deref(), Some("Scan canceled"));
     assert_eq!(db.count_files().unwrap(), 64);
 
     cancel.store(false, Ordering::Relaxed);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -18,6 +18,74 @@ fn targeted_sync_updates_only_requested_file() {
     assert_eq!(stats.updated, 1);
     assert_eq!(stats.content_changed, 1);
     assert_eq!(db.list_files().unwrap().len(), 2);
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert!(stats.committed_delta.revision > 0);
+}
+
+#[test]
+fn targeted_sync_detects_same_size_edit_with_restored_mtime() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("same.wav");
+    std::fs::write(&path, b"one").unwrap();
+    let original_modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let original_hash = db
+        .entry_for_path(Path::new("same.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    std::fs::write(&path, b"two").unwrap();
+    let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    let stats = sync_paths(&db, &[PathBuf::from("same.wav")]).unwrap();
+    let current_hash = db
+        .entry_for_path(Path::new("same.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    assert_ne!(current_hash, original_hash);
+    assert_eq!(stats.content_changed, 1);
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert!(stats.committed_delta.created.is_empty());
+}
+
+#[test]
+fn targeted_sync_exactly_hashes_an_existing_large_file_edit() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("large.wav");
+    std::fs::write(&path, vec![1_u8; 9 * 1024 * 1024]).unwrap();
+    let original_modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let db = SourceDatabase::open(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    complete_pending_deep_hash_for_path(&db, Path::new("large.wav"), None).unwrap();
+    let original_hash = db
+        .entry_for_path(Path::new("large.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    std::fs::write(&path, vec![2_u8; 9 * 1024 * 1024]).unwrap();
+    let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+        .unwrap();
+    let stats = sync_paths(&db, &[PathBuf::from("large.wav")]).unwrap();
+    let current_hash = db
+        .entry_for_path(Path::new("large.wav"))
+        .unwrap()
+        .unwrap()
+        .content_hash
+        .unwrap();
+
+    assert_ne!(current_hash, original_hash);
+    assert_eq!(stats.committed_delta.changed.len(), 1);
+    assert_eq!(stats.hashes_pending, 0);
 }
 
 #[test]
@@ -36,6 +104,7 @@ fn targeted_sync_hides_confirmed_missing_file() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("two.wav"));
+    assert_eq!(stats.committed_delta.deleted.len(), 1);
 }
 
 #[test]
@@ -75,6 +144,7 @@ fn targeted_sync_adds_new_file_inside_requested_folder() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("drums/kick.wav"));
+    assert_eq!(stats.committed_delta.created.len(), 1);
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -214,10 +214,13 @@ fn targeted_sync_cancels_after_a_committed_batch_and_resumes_safely() {
         }
     });
 
-    let partial = result.expect("return the targeted checkpoint before cancellation");
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("targeted cancellation must return the committed checkpoint outcome");
+    };
+    let partial = *committed;
     assert_eq!(partial.committed_delta.created.len(), 64);
     assert!(partial.committed_delta.revision > 0);
-    assert_eq!(partial.incomplete_error.as_deref(), Some("Scan canceled"));
+    assert_eq!(error, "Scan canceled");
     assert_eq!(db.count_files().unwrap(), 64);
 
     cancel.store(false, Ordering::Relaxed);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -56,7 +56,8 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    context.commit_batch(batch)
+    let revision = context.commit_batch(batch)?;
+    Ok(context.committed_snapshot(revision))
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -35,7 +35,7 @@ pub(super) fn db_sync_phase(
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
-        context.commit_batch(db, batch)?;
+        context.commit_batch(batch)?;
     }
 
     if cancel_requested(cancel) {
@@ -56,7 +56,7 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    let revision = context.commit_batch(db, batch)?;
+    let revision = context.commit_batch(batch)?;
     Ok(context.committed_snapshot(revision))
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -5,6 +5,7 @@ use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::mark_missing;
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT;
+use crate::sample_sources::db::SourceManifestEntry;
 
 const MISSING_BATCH_SIZE: usize = 64;
 
@@ -12,7 +13,7 @@ pub(super) fn db_sync_phase(
     db: &SourceDatabase,
     context: &mut ScanContext,
     cancel: Option<&AtomicBool>,
-) -> Result<(), ScanError> {
+) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
     let mut existing = std::mem::take(&mut context.existing)
         .into_values()
         .collect::<Vec<_>>()
@@ -55,8 +56,9 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    batch.commit()?;
-    Ok(())
+    batch
+        .commit_with_manifest_snapshot()
+        .map_err(ScanError::from)
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -35,7 +35,7 @@ pub(super) fn db_sync_phase(
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
-        context.commit_batch(batch)?;
+        context.commit_batch(db, batch)?;
     }
 
     if cancel_requested(cancel) {
@@ -56,7 +56,7 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    let revision = context.commit_batch(batch)?;
+    let revision = context.commit_batch(db, batch)?;
     Ok(context.committed_snapshot(revision))
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -35,7 +35,7 @@ pub(super) fn db_sync_phase(
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
-        batch.commit()?;
+        context.commit_batch(batch)?;
     }
 
     if cancel_requested(cancel) {
@@ -56,9 +56,7 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    batch
-        .commit_with_manifest_snapshot()
-        .map_err(ScanError::from)
+    context.commit_batch(batch)
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -50,17 +50,21 @@ pub(super) fn apply_diff(
 ) -> Result<(), ScanError> {
     let PreparedFile {
         facts,
-        hash_required: _,
+        hash_required,
         needs_hash: _,
         requires_apply: _,
         content_hash,
     } = prepared;
     let path = facts.relative.clone();
-    let should_hash = should_compute_full_hash(context.mode, facts.size);
+    let should_hash = hash_required;
     let _ = context.existing.remove(&path);
     let existing = db.entry_for_path(&path)?;
     match existing {
-        Some(entry) if entry.file_size == facts.size && entry.modified_ns == facts.modified_ns => {
+        Some(entry)
+            if context.mode != ScanMode::Targeted
+                && entry.file_size == facts.size
+                && entry.modified_ns == facts.modified_ns =>
+        {
             if entry.missing {
                 batch.set_missing(&path, false)?;
             }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -18,6 +18,7 @@ pub(super) struct PreparedFile {
     pub(super) hash_required: bool,
     pub(super) needs_hash: bool,
     pub(super) requires_apply: bool,
+    pub(super) identity_replaced: bool,
     pub(super) content_hash: Option<String>,
 }
 
@@ -53,6 +54,7 @@ pub(super) fn apply_diff(
         hash_required,
         needs_hash: _,
         requires_apply: _,
+        identity_replaced,
         content_hash,
     } = prepared;
     let path = facts.relative.clone();
@@ -63,7 +65,8 @@ pub(super) fn apply_diff(
         Some(entry)
             if context.mode != ScanMode::Targeted
                 && entry.file_size == facts.size
-                && entry.modified_ns == facts.modified_ns =>
+                && entry.modified_ns == facts.modified_ns
+                && !identity_replaced =>
         {
             if entry.missing {
                 batch.set_missing(&path, false)?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -2,7 +2,6 @@ use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
 use super::scan_fs::read_facts;
 use std::path::Path;
-use wavecrate_library::filesystem_identity::same_filesystem_object_identity;
 
 pub(super) fn prepare_diff(
     root: &Path,
@@ -24,7 +23,7 @@ pub(super) fn prepare_diff(
         observed_identity.is_some_and(|identity| persisted_identity != Some(identity));
     let identity_replaced = persisted_identity
         .zip(observed_identity)
-        .is_some_and(|(previous, current)| !same_filesystem_object_identity(previous, current));
+        .is_some_and(|(previous, current)| previous != current);
     let force_targeted_verification = context.mode == ScanMode::Targeted;
     let hash_required = should_compute_full_hash(context.mode, facts.size)
         || (force_targeted_verification && existing.is_some());

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -2,6 +2,7 @@ use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
 use super::scan_fs::read_facts;
 use std::path::Path;
+use wavecrate_library::filesystem_identity::same_filesystem_object_identity;
 
 pub(super) fn prepare_diff(
     root: &Path,
@@ -10,6 +11,20 @@ pub(super) fn prepare_diff(
 ) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
     let existing = context.existing.get(&facts.relative);
+    let persisted_identity = context
+        .committed_file_identity(&facts.relative)
+        .map(str::trim)
+        .filter(|identity| !identity.is_empty());
+    let observed_identity = facts
+        .file_identity
+        .as_deref()
+        .map(str::trim)
+        .filter(|identity| !identity.is_empty());
+    let identity_requires_update =
+        observed_identity.is_some_and(|identity| persisted_identity != Some(identity));
+    let identity_replaced = persisted_identity
+        .zip(observed_identity)
+        .is_some_and(|(previous, current)| !same_filesystem_object_identity(previous, current));
     let force_targeted_verification = context.mode == ScanMode::Targeted;
     let hash_required = should_compute_full_hash(context.mode, facts.size)
         || (force_targeted_verification && existing.is_some());
@@ -19,6 +34,7 @@ pub(super) fn prepare_diff(
                 || entry.file_size != facts.size
                 || entry.modified_ns != facts.modified_ns
                 || entry.content_hash.is_none()
+                || identity_replaced
         });
     let requires_apply = existing.is_none_or(|entry| {
         force_targeted_verification
@@ -26,12 +42,14 @@ pub(super) fn prepare_diff(
             || entry.modified_ns != facts.modified_ns
             || entry.missing
             || (entry.content_hash.is_none() && needs_hash)
+            || identity_requires_update
     });
     Ok(PreparedFile {
         facts,
         hash_required,
         needs_hash,
         requires_apply,
+        identity_replaced,
         content_hash: None,
     })
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -1,4 +1,4 @@
-use super::scan::{ScanContext, ScanError};
+use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
 use super::scan_fs::read_facts;
 use std::path::Path;
@@ -9,15 +9,20 @@ pub(super) fn prepare_diff(
     context: &ScanContext,
 ) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
-    let hash_required = should_compute_full_hash(context.mode, facts.size);
+    let existing = context.existing.get(&facts.relative);
+    let force_targeted_verification = context.mode == ScanMode::Targeted;
+    let hash_required = should_compute_full_hash(context.mode, facts.size)
+        || (force_targeted_verification && existing.is_some());
     let needs_hash = hash_required
-        && context.existing.get(&facts.relative).is_none_or(|entry| {
-            entry.file_size != facts.size
+        && existing.is_none_or(|entry| {
+            force_targeted_verification
+                || entry.file_size != facts.size
                 || entry.modified_ns != facts.modified_ns
                 || entry.content_hash.is_none()
         });
-    let requires_apply = context.existing.get(&facts.relative).is_none_or(|entry| {
-        entry.file_size != facts.size
+    let requires_apply = existing.is_none_or(|entry| {
+        force_targeted_verification
+            || entry.file_size != facts.size
             || entry.modified_ns != facts.modified_ns
             || entry.missing
             || (entry.content_hash.is_none() && needs_hash)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -19,6 +19,19 @@ pub(super) struct FileFacts {
     pub(super) size: u64,
     pub(super) modified_ns: i64,
     pub(super) file_identity: Option<String>,
+    change_marker: Option<(i64, i64)>,
+}
+
+impl FileFacts {
+    pub(super) fn same_file_facts(&self, other: &Self) -> bool {
+        self.size == other.size
+            && self.modified_ns == other.modified_ns
+            && self.file_identity == other.file_identity
+    }
+
+    pub(super) fn same_content_snapshot(&self, other: &Self) -> bool {
+        self.same_file_facts(other) && self.change_marker == other.change_marker
+    }
 }
 
 pub(super) fn ensure_root_dir(db: &SourceDatabase) -> Result<PathBuf, ScanError> {
@@ -120,7 +133,20 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
         size: meta.len(),
         modified_ns,
         file_identity: stable_filesystem_identity(path, &meta),
+        change_marker: metadata_change_marker(&meta),
     })
+}
+
+#[cfg(unix)]
+fn metadata_change_marker(metadata: &fs::Metadata) -> Option<(i64, i64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some((metadata.ctime(), metadata.ctime_nsec()))
+}
+
+#[cfg(not(unix))]
+fn metadata_change_marker(_metadata: &fs::Metadata) -> Option<(i64, i64)> {
+    None
 }
 
 pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -7,7 +7,9 @@ use std::{
 };
 
 use tracing::warn;
-use wavecrate_library::filesystem_identity::stable_filesystem_identity;
+use wavecrate_library::filesystem_identity::{
+    filesystem_change_marker, stable_filesystem_identity,
+};
 
 use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
@@ -19,7 +21,7 @@ pub(super) struct FileFacts {
     pub(super) size: u64,
     pub(super) modified_ns: i64,
     pub(super) file_identity: Option<String>,
-    change_marker: Option<(i64, i64)>,
+    change_marker: Option<String>,
 }
 
 impl FileFacts {
@@ -30,7 +32,12 @@ impl FileFacts {
     }
 
     pub(super) fn same_content_snapshot(&self, other: &Self) -> bool {
-        self.same_file_facts(other) && self.change_marker == other.change_marker
+        self.same_file_facts(other)
+            && self
+                .change_marker
+                .as_ref()
+                .zip(other.change_marker.as_ref())
+                .is_some_and(|(before, after)| before == after)
     }
 }
 
@@ -133,20 +140,8 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
         size: meta.len(),
         modified_ns,
         file_identity: stable_filesystem_identity(path, &meta),
-        change_marker: metadata_change_marker(&meta),
+        change_marker: filesystem_change_marker(path, &meta),
     })
-}
-
-#[cfg(unix)]
-fn metadata_change_marker(metadata: &fs::Metadata) -> Option<(i64, i64)> {
-    use std::os::unix::fs::MetadataExt;
-
-    Some((metadata.ctime(), metadata.ctime_nsec()))
-}
-
-#[cfg(not(unix))]
-fn metadata_change_marker(_metadata: &fs::Metadata) -> Option<(i64, i64)> {
-    None
 }
 
 pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
@@ -274,5 +269,18 @@ mod tests {
             Some(cancel.as_ref()),
         );
         assert!(matches!(result, Err(ScanError::Canceled)));
+    }
+
+    #[test]
+    fn missing_change_markers_never_prove_a_stable_snapshot() {
+        let facts = FileFacts {
+            relative: PathBuf::from("sample.wav"),
+            size: 32,
+            modified_ns: 1,
+            file_identity: Some(String::from("identity")),
+            change_marker: None,
+        };
+
+        assert!(!facts.same_content_snapshot(&facts));
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::sample_sources::db::{PendingRenameEntry, SourceWriteBatch, WavEntry};
 use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
-use super::scan::{RenamedSample, ScanError, ScanStats};
+use super::scan::{ChangedSample, RenamedSample, ScanError, ScanStats, UpdatedSample};
 use super::scan_fs::{compute_content_hash, ensure_root_dir, read_facts};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -15,6 +15,112 @@ struct HashBackfill {
     modified_ns: i64,
     content_hash: String,
     file_identity: Option<String>,
+}
+
+const META_CONTENT_AUDIT_CURSOR: &str = "source_content_audit_cursor_v1";
+
+fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
+    cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
+}
+
+pub(super) fn verify_content_batch(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    audit_completed_at: Option<i64>,
+) -> Result<ScanStats, ScanError> {
+    let manifest_before = super::manifest::capture_manifest(db)?;
+    let root = ensure_root_dir(db)?;
+    let entries = db.list_manifest_entries()?;
+    let cursor = db
+        .get_metadata(META_CONTENT_AUDIT_CURSOR)?
+        .unwrap_or_default();
+    let start = entries
+        .iter()
+        .position(|entry| entry.relative_path.to_string_lossy().as_ref() > cursor.as_str())
+        .unwrap_or(0);
+    let selected = entries
+        .iter()
+        .cycle()
+        .skip(start)
+        .take(max_hashes.min(entries.len()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut stats = ScanStats::default();
+    let mut verified = Vec::new();
+    for entry in &selected {
+        if cancel_requested(cancel) {
+            return Err(ScanError::Canceled);
+        }
+        let absolute = root.join(&entry.relative_path);
+        if !is_supported_regular_audio_file(&absolute) {
+            continue;
+        }
+        let before_hash = read_facts(&root, &absolute)?;
+        let content_hash = compute_content_hash(&absolute, cancel)?;
+        let after_hash = read_facts(&root, &absolute)?;
+        if before_hash.size != after_hash.size
+            || before_hash.modified_ns != after_hash.modified_ns
+            || before_hash.file_identity != after_hash.file_identity
+        {
+            continue;
+        }
+        verified.push((entry.clone(), after_hash, content_hash));
+        stats.hashes_computed += 1;
+    }
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
+    if !selected.is_empty() || audit_completed_at.is_some() {
+        let mut batch = db.write_batch()?;
+        for (previous, facts, content_hash) in &verified {
+            if previous.content_hash.as_deref() == Some(content_hash.as_str())
+                && previous.file_size == facts.size
+                && previous.modified_ns == facts.modified_ns
+                && previous.file_identity == facts.file_identity
+            {
+                continue;
+            }
+            batch.upsert_file_with_hash(
+                &previous.relative_path,
+                facts.size,
+                facts.modified_ns,
+                content_hash,
+            )?;
+            batch.set_file_identity(&previous.relative_path, facts.file_identity.as_deref())?;
+            stats.updated += 1;
+            stats.updated_samples.push(UpdatedSample {
+                relative_path: previous.relative_path.clone(),
+                file_size: facts.size,
+                modified_ns: facts.modified_ns,
+                content_hash: Some(content_hash.clone()),
+            });
+            if previous.content_hash.as_deref() != Some(content_hash.as_str()) {
+                stats.content_changed += 1;
+                stats.changed_samples.push(ChangedSample {
+                    relative_path: previous.relative_path.clone(),
+                    file_size: facts.size,
+                    modified_ns: facts.modified_ns,
+                    content_hash: content_hash.clone(),
+                });
+            }
+        }
+        if let Some(last) = selected.last() {
+            batch.set_metadata(
+                META_CONTENT_AUDIT_CURSOR,
+                last.relative_path.to_string_lossy().as_ref(),
+            )?;
+        }
+        if let Some(completed_at) = audit_completed_at {
+            batch.set_metadata(
+                crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT,
+                &completed_at.to_string(),
+            )?;
+        }
+        batch.commit()?;
+    }
+    super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
+    Ok(stats)
 }
 
 fn is_supported_regular_audio_file(path: &std::path::Path) -> bool {
@@ -36,6 +142,7 @@ pub(super) fn deep_hash_scan(
     max_hashes: Option<usize>,
     exact_path: Option<&std::path::Path>,
 ) -> Result<ScanStats, ScanError> {
+    let manifest_before = super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
@@ -57,7 +164,9 @@ pub(super) fn deep_hash_scan(
                 && root.join(&entry.relative_path).is_file()
         });
     if !has_unhashed_files && rename_candidates.is_empty() {
-        return Ok(ScanStats::default());
+        let mut stats = ScanStats::default();
+        super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
+        return Ok(stats);
     }
     let pending_entries = db.list_pending_renames()?;
     let mut stats = ScanStats::default();
@@ -203,6 +312,7 @@ pub(super) fn deep_hash_scan(
     stats.renamed_samples = renamed_samples;
 
     batch.commit()?;
+    super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
     Ok(stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -117,10 +117,7 @@ pub(super) fn verify_content_batch(
             )?;
         }
         if let Some(completed_at) = audit_completed_at {
-            batch.set_metadata(
-                crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT,
-                &completed_at.to_string(),
-            )?;
+            batch.complete_manifest_audit(completed_at)?;
         }
         batch.commit_with_manifest_snapshot()?
     } else {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -78,6 +78,14 @@ pub(super) fn verify_content_batch(
             {
                 continue;
             }
+            if previous.file_identity != facts.file_identity {
+                tracing::debug!(
+                    path = %previous.relative_path.display(),
+                    previous_identity = ?previous.file_identity,
+                    current_identity = ?facts.file_identity,
+                    "Source content audit refreshed filesystem identity"
+                );
+            }
             batch.upsert_file_with_hash(
                 &previous.relative_path,
                 facts.size,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -71,7 +71,7 @@ pub(super) fn verify_content_batch(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    if !selected.is_empty() || audit_completed_at.is_some() {
+    let committed_snapshot = if !selected.is_empty() || audit_completed_at.is_some() {
         let mut batch = db.write_batch()?;
         for (previous, facts, content_hash) in &verified {
             if previous.content_hash.as_deref() == Some(content_hash.as_str())
@@ -117,9 +117,11 @@ pub(super) fn verify_content_batch(
                 &completed_at.to_string(),
             )?;
         }
-        batch.commit()?;
-    }
-    super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
+        batch.commit_with_manifest_snapshot()?
+    } else {
+        db.manifest_snapshot_with_revision()?
+    };
+    super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
     Ok(stats)
 }
 
@@ -165,7 +167,8 @@ pub(super) fn deep_hash_scan(
         });
     if !has_unhashed_files && rename_candidates.is_empty() {
         let mut stats = ScanStats::default();
-        super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
+        let committed_snapshot = db.manifest_snapshot_with_revision()?;
+        super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
         return Ok(stats);
     }
     let pending_entries = db.list_pending_renames()?;
@@ -311,8 +314,8 @@ pub(super) fn deep_hash_scan(
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
 
-    batch.commit()?;
-    super::manifest::publish_committed_delta(db, &mut stats, manifest_before)?;
+    let committed_snapshot = batch.commit_with_manifest_snapshot()?;
+    super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
     Ok(stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -583,6 +583,10 @@ mod tests {
         let relative = Path::new("changing.wav");
         let absolute = dir.path().join(relative);
         std::fs::write(&absolute, [1_u8; 32]).expect("write initial wav");
+        let original_modified = std::fs::metadata(&absolute)
+            .expect("read initial metadata")
+            .modified()
+            .expect("read initial modified time");
         let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
         db.upsert_file(relative, 32, 1).expect("insert pending row");
 
@@ -593,7 +597,15 @@ mod tests {
             DeferredHashScope::AllUnhashed,
             Some(1),
             Some(relative),
-            |path| std::fs::write(path, [2_u8; 32]).expect("mutate during hashing"),
+            |path| {
+                std::fs::write(path, [2_u8; 32]).expect("mutate during hashing");
+                let file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(path)
+                    .expect("reopen mutated wav");
+                file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+                    .expect("restore modified time");
+            },
         )
         .expect("defer unstable hash");
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -59,10 +59,7 @@ pub(super) fn verify_content_batch(
         let before_hash = read_facts(&root, &absolute)?;
         let content_hash = compute_content_hash(&absolute, cancel)?;
         let after_hash = read_facts(&root, &absolute)?;
-        if before_hash.size != after_hash.size
-            || before_hash.modified_ns != after_hash.modified_ns
-            || before_hash.file_identity != after_hash.file_identity
-        {
+        if !before_hash.same_content_snapshot(&after_hash) {
             continue;
         }
         verified.push((entry.clone(), after_hash, content_hash));
@@ -143,6 +140,26 @@ pub(super) fn deep_hash_scan(
     scope: DeferredHashScope,
     max_hashes: Option<usize>,
     exact_path: Option<&std::path::Path>,
+) -> Result<ScanStats, ScanError> {
+    deep_hash_scan_with_post_hash_hook(
+        db,
+        cancel,
+        rename_candidates,
+        scope,
+        max_hashes,
+        exact_path,
+        |_| {},
+    )
+}
+
+fn deep_hash_scan_with_post_hash_hook(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
+    max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
+    mut post_hash: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
     let manifest_before = super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
@@ -239,15 +256,20 @@ pub(super) fn deep_hash_scan(
         }
         let facts = read_facts(&root, &absolute)?;
         let hash = compute_content_hash(&absolute, cancel)?;
+        post_hash(&absolute);
+        let after_hash = read_facts(&root, &absolute)?;
+        if !facts.same_content_snapshot(&after_hash) {
+            continue;
+        }
         hash_backfills.push(HashBackfill {
             relative_path: entry.relative_path.clone(),
-            file_size: facts.size,
-            modified_ns: facts.modified_ns,
+            file_size: after_hash.size,
+            modified_ns: after_hash.modified_ns,
             content_hash: hash.clone(),
-            file_identity: facts.file_identity,
+            file_identity: after_hash.file_identity,
         });
-        entry.file_size = facts.size;
-        entry.modified_ns = facts.modified_ns;
+        entry.file_size = after_hash.size;
+        entry.modified_ns = after_hash.modified_ns;
         entry.content_hash = Some(hash.clone());
         present_by_hash
             .entry(hash)
@@ -544,6 +566,37 @@ mod tests {
                 .unwrap()
                 .content_hash
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn deep_hash_scan_does_not_commit_a_file_mutated_during_hashing() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let relative = Path::new("changing.wav");
+        let absolute = dir.path().join(relative);
+        std::fs::write(&absolute, [1_u8; 32]).expect("write initial wav");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(relative, 32, 1).expect("insert pending row");
+
+        let stats = deep_hash_scan_with_post_hash_hook(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(relative),
+            |path| std::fs::write(path, [2_u8; 32]).expect("mutate during hashing"),
+        )
+        .expect("defer unstable hash");
+
+        assert_eq!(stats.hashes_computed, 0);
+        assert!(
+            db.entry_for_path(relative)
+                .expect("read pending row")
+                .expect("pending row")
+                .content_hash
+                .is_none(),
+            "an unstable read must remain pending for a later hash pass"
         );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -33,12 +33,13 @@ pub fn sync_paths_with_progress(
     cancel: Option<&AtomicBool>,
     on_progress: &mut impl FnMut(usize, &Path),
 ) -> Result<ScanStats, ScanError> {
-    let manifest_before = super::manifest::capture_manifest(db)?;
+    let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(
         targets.existing,
         ScanMode::Targeted,
+        manifest_revision,
         manifest_before.clone(),
     );
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -39,47 +39,45 @@ pub fn sync_paths_with_progress(
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
-    for relative_path in targets.current_files {
-        if let Some(cancel) = cancel
-            && cancel.load(Ordering::Relaxed)
-        {
-            return Err(ScanError::Canceled);
-        }
-        let absolute = root.join(&relative_path);
-        let prepared_file = match prepare_diff(&root, &absolute, &context) {
-            Ok(prepared) => prepared,
-            Err(error) if committed => {
-                if absolute.exists() {
-                    context.existing.remove(&relative_path);
-                }
-                tracing::warn!(
-                    path = %absolute.display(),
-                    error = %error,
-                    "Skipping targeted file after an earlier chunk committed"
-                );
-                continue;
+    let result = (|| {
+        for relative_path in targets.current_files {
+            if let Some(cancel) = cancel
+                && cancel.load(Ordering::Relaxed)
+            {
+                return Err(ScanError::Canceled);
             }
-            Err(error) => return Err(error),
-        };
-        prepared.push(prepared_file);
-        context.stats.total_files += 1;
-        on_progress(context.stats.total_files, &absolute);
-        if prepared.len() == TARGET_PREPARE_BATCH_SIZE {
-            let chunk =
-                std::mem::replace(&mut prepared, Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE));
-            committed |= apply_prepared_chunk(db, &root, cancel, &mut context, chunk, committed)?;
+            let absolute = root.join(&relative_path);
+            let prepared_file = match prepare_diff(&root, &absolute, &context) {
+                Ok(prepared) => prepared,
+                Err(error) if committed => {
+                    if absolute.exists() {
+                        context.existing.remove(&relative_path);
+                    }
+                    tracing::warn!(
+                        path = %absolute.display(),
+                        error = %error,
+                        "Skipping targeted file after an earlier chunk committed"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            prepared.push(prepared_file);
+            context.stats.total_files += 1;
+            on_progress(context.stats.total_files, &absolute);
+            if prepared.len() == TARGET_PREPARE_BATCH_SIZE {
+                let chunk =
+                    std::mem::replace(&mut prepared, Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE));
+                committed |=
+                    apply_prepared_chunk(db, &root, cancel, &mut context, chunk, committed)?;
+            }
         }
-    }
-    if !prepared.is_empty() {
-        let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
-    }
-    let committed_snapshot = db_sync_phase(db, &mut context, cancel)?;
-    super::manifest::publish_committed_delta(
-        &mut context.stats,
-        manifest_before,
-        committed_snapshot,
-    );
-    Ok(context.stats)
+        if !prepared.is_empty() {
+            let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
+        }
+        db_sync_phase(db, &mut context, cancel)
+    })();
+    super::scan::finish_scan_result(manifest_before, context, result)
 }
 
 struct TargetedScanTargets {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -33,6 +33,7 @@ pub fn sync_paths_with_progress(
     cancel: Option<&AtomicBool>,
     on_progress: &mut impl FnMut(usize, &Path),
 ) -> Result<ScanStats, ScanError> {
+    let manifest_before = super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
     let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
@@ -73,6 +74,7 @@ pub fn sync_paths_with_progress(
         let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
     }
     db_sync_phase(db, &mut context, cancel)?;
+    super::manifest::publish_committed_delta(db, &mut context.stats, manifest_before)?;
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -73,8 +73,12 @@ pub fn sync_paths_with_progress(
     if !prepared.is_empty() {
         let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
     }
-    db_sync_phase(db, &mut context, cancel)?;
-    super::manifest::publish_committed_delta(db, &mut context.stats, manifest_before)?;
+    let committed_snapshot = db_sync_phase(db, &mut context, cancel)?;
+    super::manifest::publish_committed_delta(
+        &mut context.stats,
+        manifest_before,
+        committed_snapshot,
+    );
     Ok(context.stats)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -36,7 +36,11 @@ pub fn sync_paths_with_progress(
     let manifest_before = super::manifest::capture_manifest(db)?;
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
-    let mut context = ScanContext::from_existing(targets.existing, ScanMode::Targeted);
+    let mut context = ScanContext::from_existing(
+        targets.existing,
+        ScanMode::Targeted,
+        manifest_before.clone(),
+    );
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     let result = (|| {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -233,7 +233,7 @@ fn apply_batch(
         }
         apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
     }
-    batch.commit()?;
+    context.commit_batch(batch)?;
     Ok(true)
 }
 
@@ -296,9 +296,7 @@ fn prepare_for_apply(
 }
 
 fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
-    current.size == prepared.facts.size
-        && current.modified_ns == prepared.facts.modified_ns
-        && current.file_identity == prepared.facts.file_identity
+    current.same_file_facts(&prepared.facts)
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -233,7 +233,7 @@ fn apply_batch(
         }
         apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
     }
-    context.commit_batch(batch)?;
+    context.commit_batch(db, batch)?;
     Ok(true)
 }
 
@@ -351,6 +351,7 @@ mod tests {
             hash_required: true,
             needs_hash: false,
             requires_apply: true,
+            identity_replaced: false,
             content_hash: None,
         };
 
@@ -374,6 +375,7 @@ mod tests {
         let mut context = ScanContext::from_existing(
             HashMap::from([(Path::new("one.wav").to_path_buf(), entry)]),
             ScanMode::Quick,
+            db.get_revision().unwrap(),
             db.list_manifest_entries().unwrap(),
         );
         let prepared = prepare_diff(dir.path(), &file_path, &context).unwrap();
@@ -403,6 +405,7 @@ mod tests {
             hash_required: true,
             needs_hash: true,
             requires_apply: true,
+            identity_replaced: false,
             content_hash: None,
         };
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -276,7 +276,7 @@ fn apply_batch(
         apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
         audited_paths.push(relative_path);
     }
-    context.commit_batch(db, batch)?;
+    context.commit_batch(batch)?;
     Ok(ApplyBatchOutcome {
         committed: true,
         audited_paths,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -34,6 +34,13 @@ pub(super) fn walk_phase(
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
+        let relative_path = path
+            .strip_prefix(root)
+            .map(Path::to_path_buf)
+            .map_err(|_| ScanError::InvalidRoot(path.to_path_buf()))?;
+        if context.skip_previously_audited_path(&relative_path) {
+            return Ok(());
+        }
         let mut prepared = match prepare_diff(root, path, context) {
             Ok(prepared) => prepared,
             Err(error) if committed.get() => {
@@ -51,9 +58,11 @@ pub(super) fn walk_phase(
             }
             Err(error) => return Err(error),
         };
-        context.stats.total_files += 1;
-        if let Some(on_progress) = on_progress.as_mut() {
-            on_progress(context.stats.total_files, path);
+        if !context.resumable_manifest_audit_active() {
+            context.stats.total_files += 1;
+            if let Some(on_progress) = on_progress.as_mut() {
+                on_progress(context.stats.total_files, path);
+            }
         }
         if !prepared.requires_apply {
             let Some(refreshed) =
@@ -65,21 +74,52 @@ pub(super) fn walk_phase(
         }
         if !prepared.requires_apply {
             skip_noop(context, &prepared);
+            context.record_manifest_audit_paths(db, [relative_path])?;
+            publish_manifest_audit_progress(context, root, path, on_progress);
             return Ok(());
         }
         pending.push(prepared);
         if pending.len() == APPLY_BATCH_SIZE {
             let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-            if apply_batch(db, root, cancel, context, files, committed.get())? {
+            let outcome = apply_batch(db, root, cancel, context, files, committed.get())?;
+            if outcome.committed {
                 committed.set(true);
+            }
+            let last_path = outcome.audited_paths.last().cloned();
+            context.record_manifest_audit_paths(db, outcome.audited_paths)?;
+            if let Some(last_path) = last_path {
+                publish_manifest_audit_progress(context, root, &root.join(last_path), on_progress);
             }
         }
         Ok(())
     })?;
-    if !pending.is_empty() && apply_batch(db, root, cancel, context, pending, committed.get())? {
-        committed.set(true);
+    if !pending.is_empty() {
+        let outcome = apply_batch(db, root, cancel, context, pending, committed.get())?;
+        if outcome.committed {
+            committed.set(true);
+        }
+        let last_path = outcome.audited_paths.last().cloned();
+        context.record_manifest_audit_paths(db, outcome.audited_paths)?;
+        if let Some(last_path) = last_path {
+            publish_manifest_audit_progress(context, root, &root.join(last_path), on_progress);
+        }
     }
+    context.flush_manifest_audit_checkpoint(db)?;
     Ok(())
+}
+
+fn publish_manifest_audit_progress(
+    context: &ScanContext,
+    root: &Path,
+    path: &Path,
+    on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
+) {
+    let Some((checked, _expected)) = context.manifest_audit_progress() else {
+        return;
+    };
+    if let Some(on_progress) = on_progress.as_mut() {
+        on_progress(checked, path.strip_prefix(root).unwrap_or(path));
+    }
 }
 
 pub(super) fn apply_prepared_chunk(
@@ -110,6 +150,7 @@ pub(super) fn apply_prepared_chunk(
         return Ok(false);
     }
     apply_batch(db, root, cancel, context, pending, tolerate_file_errors)
+        .map(|outcome| outcome.committed)
 }
 
 fn refresh_noop_preparation_or_skip(
@@ -186,7 +227,7 @@ fn apply_batch(
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
-) -> Result<bool, ScanError> {
+) -> Result<ApplyBatchOutcome, ScanError> {
     let mut ready = Vec::with_capacity(prepared.len());
     for file in prepared {
         let relative_path = file.facts.relative.clone();
@@ -213,7 +254,7 @@ fn apply_batch(
         }
     }
     if ready.is_empty() {
-        return Ok(false);
+        return Ok(ApplyBatchOutcome::default());
     }
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
@@ -221,6 +262,7 @@ fn apply_batch(
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
     let mut rename_candidates = RenameCandidateCache::default();
+    let mut audited_paths = Vec::with_capacity(ready.len());
     for file in ready {
         let relative_path = file.facts.relative.clone();
         let absolute = root.join(&relative_path);
@@ -232,9 +274,19 @@ fn apply_batch(
             }
         }
         apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
+        audited_paths.push(relative_path);
     }
     context.commit_batch(db, batch)?;
-    Ok(true)
+    Ok(ApplyBatchOutcome {
+        committed: true,
+        audited_paths,
+    })
+}
+
+#[derive(Default)]
+struct ApplyBatchOutcome {
+    committed: bool,
+    audited_paths: Vec<std::path::PathBuf>,
 }
 
 fn skip_changed_or_unavailable(context: &mut ScanContext, root: &Path, relative_path: &Path) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -225,7 +225,7 @@ fn apply_batch(
         let relative_path = file.facts.relative.clone();
         let absolute = root.join(&relative_path);
         match read_facts(root, &absolute) {
-            Ok(current) if facts_match(&file, &current) => {}
+            Ok(current) if prepared_still_current(&file, &current) => {}
             _ => {
                 skip_changed_or_unavailable(context, root, &relative_path);
                 continue;
@@ -253,7 +253,17 @@ fn prepare_for_apply(
     db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
+    prepared: PreparedFile,
+) -> Result<PrepareForApply, ScanError> {
+    prepare_for_apply_with_post_hash_hook(db, root, cancel, prepared, |_| {})
+}
+
+fn prepare_for_apply_with_post_hash_hook(
+    db: &SourceDatabase,
+    root: &Path,
+    cancel: Option<&AtomicBool>,
     mut prepared: PreparedFile,
+    mut post_hash: impl FnMut(&Path),
 ) -> Result<PrepareForApply, ScanError> {
     let absolute = root.join(&prepared.facts.relative);
     if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
@@ -277,7 +287,9 @@ fn prepare_for_apply(
                 || entry.content_hash.is_none()
         });
     if prepared.hash_required && (prepared.needs_hash || current_needs_hash) {
+        prepared.facts = before_hash;
         prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
+        post_hash(&absolute);
         let Ok(after_hash) = read_facts(root, &absolute) else {
             return Ok(if absolute.exists() {
                 PrepareForApply::Skip
@@ -288,7 +300,7 @@ fn prepare_for_apply(
         if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
             return Ok(PrepareForApply::Gone);
         }
-        if !facts_match(&prepared, &after_hash) {
+        if !prepared.facts.same_content_snapshot(&after_hash) {
             return Ok(PrepareForApply::Skip);
         }
     }
@@ -299,13 +311,24 @@ fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> 
     current.same_file_facts(&prepared.facts)
 }
 
+fn prepared_still_current(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
+    if prepared.content_hash.is_some() {
+        current.same_content_snapshot(&prepared.facts)
+    } else {
+        facts_match(prepared, current)
+    }
+}
+
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
     cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{PrepareForApply, prepare_for_apply, refresh_noop_preparation_or_skip};
+    use super::{
+        PrepareForApply, prepare_for_apply, prepare_for_apply_with_post_hash_hook,
+        refresh_noop_preparation_or_skip,
+    };
     use crate::sample_sources::SourceDatabase;
     use crate::sample_sources::scanner::scan::{ScanContext, ScanMode, scan_once};
     use crate::sample_sources::scanner::scan_diff::PreparedFile;
@@ -351,6 +374,7 @@ mod tests {
         let mut context = ScanContext::from_existing(
             HashMap::from([(Path::new("one.wav").to_path_buf(), entry)]),
             ScanMode::Quick,
+            db.list_manifest_entries().unwrap(),
         );
         let prepared = prepare_diff(dir.path(), &file_path, &context).unwrap();
         assert!(!prepared.requires_apply);
@@ -365,5 +389,29 @@ mod tests {
                 .unwrap();
 
         assert!(refreshed.is_none());
+    }
+
+    #[test]
+    fn targeted_hash_preparation_rejects_mutation_during_hashing() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("one.wav");
+        std::fs::write(&file_path, [1_u8; 32]).unwrap();
+        let db = SourceDatabase::open(dir.path()).unwrap();
+        db.upsert_file(Path::new("one.wav"), 32, 1).unwrap();
+        let prepared = PreparedFile {
+            facts: read_facts(dir.path(), &file_path).unwrap(),
+            hash_required: true,
+            needs_hash: true,
+            requires_apply: true,
+            content_hash: None,
+        };
+
+        let outcome =
+            prepare_for_apply_with_post_hash_hook(&db, dir.path(), None, prepared, |path| {
+                std::fs::write(path, [2_u8; 32]).unwrap()
+            })
+            .unwrap();
+
+        assert!(matches!(outcome, PrepareForApply::Skip));
     }
 }

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1210,9 +1210,11 @@ The watcher should cover ordinary source-folder changes, including:
 - audio files overwritten or modified by another application
 - source database files changed, locked, or unavailable
 
-File-watch events should be debounced and reconciled through the same source database rules as manual scans. The UI may show a short scanning/reconciling state while Wavecrate validates the change, but it should not wait for a full source rescan before showing obvious additions, removals, folder changes, or stale/missing states.
+File-watch events are bounded, debounced hints and must be reconciled through the same source database rules as manual scans. Targeted sync, full scans, and deferred hashing publish a monotonic committed source revision plus structured created, changed, moved, and deleted identity deltas. Browser projection and readiness reconciliation may update only after that authoritative commit. The UI may show a short scanning/reconciling state while Wavecrate validates the change, but it should not wait for a full source rescan before showing committed additions, removals, folder changes, or stale/missing states.
 
-If a burst of external changes is too large for immediate precise updates, Wavecrate should degrade into an incremental background rescan of the affected folder subtree while keeping the current browser usable and clearly indicating that reconciliation is in progress.
+Watcher ingress and per-source path accumulation must remain bounded. Events should coalesce by source and path; overflow, watcher restart, or irreducibly uncertain targeted sync must degrade to an authoritative background source scan while keeping the current browser usable and clearly indicating that reconciliation is in progress. Watch roots must be re-established with bounded backoff after runtime failure, and missing roots must be detected and reconciled when they disappear or reappear.
+
+Watcher delivery is not the correctness boundary. While Wavecrate is running, the source-processing coordinator should periodically audit each active source manifest and a bounded rotating content sample so closed-app changes, dropped events, and same-size in-place edits eventually repair themselves without high-frequency polling or UI-thread filesystem work.
 
 When a file disappears, Wavecrate should retain metadata as unavailable state until reconciliation determines whether it was moved, renamed, deleted, or temporarily inaccessible. The UI should distinguish missing, unavailable, unsupported, and failed-to-scan files.
 
@@ -2612,7 +2614,7 @@ Durability rules:
 
 `src/app/controller/library/analysis_backfill.rs` owns explicit controller analysis requests, while the durable source-readiness reconciler owns automatic lifecycle catch-up. Sample addition, destructive audio-content edits, user-requested reanalysis, and explicit similarity repair may still request analysis directly through the controller boundary.
 
-Committed scan completion, watcher/auto-sync reconciliation, internal rename/move/edit completion, deferred maintenance, startup catch-up, and artifact-version changes must publish or refresh desired readiness and wake the coordinator. A wakeup is not permission to recompute every artifact: the reconciler compares exact identity, version, and generation state and emits only real deficits. A path-only rename may require playback/cache ownership repair while leaving content-derived analysis current.
+Committed scan completion, watcher/auto-sync reconciliation, internal rename/move/edit completion, deferred hash completion, periodic source audit, startup catch-up, and artifact-version changes must publish or refresh desired readiness and wake the coordinator. Discovery-side wakeups occur only after the source transaction publishes its committed revision and structured identity delta. A wakeup is not permission to recompute every artifact: the reconciler compares exact identity, version, and generation state and emits only real deficits. A path-only rename may require playback/cache ownership repair while leaving content-derived analysis current.
 
 Similarity browsing, row rendering, source selection, folder activation, status reads, and other UI/read-path resolution must not enqueue work directly. They may observe readiness and raise priority for already-authoritative deficits. When trigger behavior changes, update this contract and route lifecycle call sites through the coordinator rather than adding a hidden enqueue path.
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -378,6 +378,13 @@ shapes by projecting safe defaults or avoiding missing optional tables.
 
 ### Debug log workflow
 
+On macOS, build manual-test binaries with `bash scripts/build.sh --release`.
+The helper emits a branch-specific, ad-hoc-signed app under
+`target/app-bundles/` and prints both its Launch Services identity and launch
+command. Use that app name for UI automation; launching `target/release/wavecrate`
+directly does not register a distinct macOS application and can cause automation
+to fall back to an installed Wavecrate bundle.
+
 Use this when reproducing a release/manual bug that needs the richer
 per-launch diagnostics trail.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,8 @@ is the checked inventory for public entrypoints, compatibility wrappers, and
 dispatcher maps. These are the public entrypoints people should run directly:
 
 - `bootstrap.{sh,ps1}`: set up the repo and install hooks.
+- `build.sh`: build Wavecrate and create a uniquely identified, ad-hoc-signed
+  macOS app bundle that can be targeted independently by UI automation.
 - repo-root `run.{sh,ps1}`: compatibility wrappers for `cargo run`.
 - `run.ps1 logs debug-overlays` or `run.ps1 logs debug-layout`: convenience
   aliases for `cargo run -- --log` with debug layout overlays shown. The

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$script_dir/internal/build/build_app.sh" "$@"

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -21,6 +21,11 @@
       "windows_supported": false
     },
     {
+      "path": "scripts/build.sh",
+      "role": "Build Wavecrate and create a uniquely targetable macOS development app bundle.",
+      "windows_supported": false
+    },
+    {
       "path": "scripts/check.ps1",
       "role": "Focused guardrails and reporting helpers.",
       "windows_supported": true

--- a/scripts/internal/build/build_app.sh
+++ b/scripts/internal/build/build_app.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+# Build Wavecrate and, on macOS, wrap the exact binary in a uniquely identified
+# app bundle that Launch Services and accessibility automation can address.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PROFILE="release"
+VARIANT=""
+SKIP_BUILD=0
+CARGO_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build.sh [--release|--debug] [--variant <name>] [--no-build] [-- <cargo args>]
+
+Builds the Wavecrate binary. On macOS, the exact binary is also copied into a
+branch-specific app bundle under target/app-bundles so Launch Services and UI
+automation do not fall back to an installed Wavecrate build.
+
+Options:
+  --release         Build the optimized release profile (default).
+  --debug           Build the debug profile.
+  --variant <name>  Override the app suffix, for example OPT-1179.
+  --no-build        Re-bundle the existing profile binary without invoking Cargo.
+  --                 Pass the remaining arguments to cargo build.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --release) PROFILE="release" ;;
+    --debug) PROFILE="debug" ;;
+    --variant)
+      shift
+      (( $# > 0 )) || { echo "[build][error] --variant requires a value" >&2; exit 2; }
+      VARIANT="$1"
+      ;;
+    --no-build) SKIP_BUILD=1 ;;
+    --help|-h) usage; exit 0 ;;
+    --)
+      shift
+      CARGO_ARGS+=("$@")
+      break
+      ;;
+    *)
+      echo "[build][error] unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+cd "$ROOT_DIR"
+
+if (( SKIP_BUILD == 0 )); then
+  cargo_command=(cargo build --bin wavecrate)
+  if [[ "$PROFILE" == "release" ]]; then
+    cargo_command+=(--release)
+  fi
+  if (( ${#CARGO_ARGS[@]} > 0 )); then
+    cargo_command+=("${CARGO_ARGS[@]}")
+  fi
+  printf '[build]'
+  printf ' %q' "${cargo_command[@]}"
+  printf '\n'
+  "${cargo_command[@]}"
+fi
+
+profile_dir="$PROFILE"
+binary_path="${CARGO_TARGET_DIR:-$ROOT_DIR/target}/${profile_dir}/wavecrate"
+[[ -x "$binary_path" ]] || {
+  echo "[build][error] Wavecrate binary not found at $binary_path" >&2
+  exit 1
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "[build] binary=$binary_path"
+  exit 0
+fi
+
+if [[ -z "$VARIANT" ]]; then
+  branch="$(git branch --show-current 2>/dev/null || true)"
+  if [[ "$branch" =~ ([Oo][Pp][Tt]-[0-9]+) ]]; then
+    VARIANT="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')"
+  elif [[ -n "$branch" ]]; then
+    VARIANT="$(printf '%s' "$branch" | tr -cs '[:alnum:]' '-' | sed 's/^-//; s/-$//' | cut -c1-40)"
+  else
+    VARIANT="detached-$(git rev-parse --short HEAD)"
+  fi
+fi
+
+VARIANT="$(printf '%s' "$VARIANT" | tr -cs '[:alnum:]' '-' | sed 's/^-//; s/-$//' | cut -c1-40)"
+[[ -n "$VARIANT" ]] || {
+  echo "[build][error] app variant must contain at least one letter or number" >&2
+  exit 2
+}
+
+identifier_suffix="$(printf '%s' "$VARIANT" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')"
+display_name="Wavecrate $VARIANT"
+bundle_identifier="org.portalsurfer.wavecrate.dev.$identifier_suffix"
+bundle_root="$ROOT_DIR/target/app-bundles/$identifier_suffix"
+bundle_path="$bundle_root/$display_name.app"
+contents_path="$bundle_path/Contents"
+executable_path="$contents_path/MacOS/wavecrate"
+info_path="$contents_path/Info.plist"
+
+mkdir -p "$contents_path/MacOS"
+install -m 755 "$binary_path" "$executable_path"
+
+package_version="$(awk '
+  /^\[package\][[:space:]]*$/ { in_package = 1; next }
+  in_package && /^\[/ { exit }
+  in_package && /^[[:space:]]*version[[:space:]]*=/ {
+    gsub(/"/, "", $3)
+    print $3
+    exit
+  }
+' Cargo.toml)"
+bundle_version="$(git rev-list --count HEAD)"
+
+cat > "$info_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>$display_name</string>
+  <key>CFBundleExecutable</key>
+  <string>wavecrate</string>
+  <key>CFBundleIdentifier</key>
+  <string>$bundle_identifier</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$display_name</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$package_version</string>
+  <key>CFBundleVersion</key>
+  <string>$bundle_version</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+plutil -lint "$info_path" >/dev/null
+codesign --force --deep --sign - "$bundle_path" >/dev/null
+codesign --verify --deep --strict "$bundle_path"
+
+echo "[build] binary=$binary_path"
+echo "[build] app=$bundle_path"
+echo "[build] bundle_id=$bundle_identifier"
+echo "[build] computer_use_app=$display_name"
+echo "[build] launch: open -na '$bundle_path' --args --log"

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_embedding_backfill_job(
     analysis_version: &str,
     cancel: Option<&AtomicBool>,
 ) -> Result<(), String> {
-    run_embedding_backfill_job_with_worker_limit(
+    run_embedding_backfill_job_with_options(
         conn,
         job,
         use_cache,
@@ -36,6 +36,7 @@ pub(crate) fn run_embedding_backfill_job(
         analysis_version,
         cancel,
         None,
+        false,
     )
 }
 
@@ -48,13 +49,67 @@ pub(crate) fn run_embedding_backfill_job_with_worker_limit(
     cancel: Option<&AtomicBool>,
     worker_limit: Option<usize>,
 ) -> Result<(), String> {
+    run_embedding_backfill_job_with_options(
+        conn,
+        job,
+        use_cache,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+        worker_limit,
+        false,
+    )
+}
+
+pub(crate) fn run_readiness_embedding_backfill_job_with_worker_limit(
+    conn: &mut rusqlite::Connection,
+    job: &db::ClaimedJob,
+    use_cache: bool,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: Option<&AtomicBool>,
+    worker_limit: Option<usize>,
+) -> Result<(), String> {
+    run_embedding_backfill_job_with_options(
+        conn,
+        job,
+        use_cache,
+        analysis_sample_rate,
+        analysis_version,
+        cancel,
+        worker_limit,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_embedding_backfill_job_with_options(
+    conn: &mut rusqlite::Connection,
+    job: &db::ClaimedJob,
+    use_cache: bool,
+    analysis_sample_rate: u32,
+    analysis_version: &str,
+    cancel: Option<&AtomicBool>,
+    worker_limit: Option<usize>,
+    require_cache_materialization: bool,
+) -> Result<(), String> {
     checkpoint(cancel)?;
     let sample_ids = planning::parse_backfill_payload(job)?;
     if sample_ids.is_empty() {
         return Ok(());
     }
 
-    let plan = planning::build_backfill_plan(conn, job, &sample_ids, use_cache, analysis_version)?;
+    let plan = if require_cache_materialization {
+        planning::build_readiness_backfill_plan(
+            conn,
+            job,
+            &sample_ids,
+            use_cache,
+            analysis_version,
+        )?
+    } else {
+        planning::build_backfill_plan(conn, job, &sample_ids, use_cache, analysis_version)?
+    };
     finalize_backfill_job(
         conn,
         job,

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/planning.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/planning.rs
@@ -29,6 +29,27 @@ pub(super) fn build_backfill_plan(
     use_cache: bool,
     analysis_version: &str,
 ) -> Result<BackfillPlan, String> {
+    build_backfill_plan_inner(conn, job, sample_ids, use_cache, analysis_version, false)
+}
+
+pub(super) fn build_readiness_backfill_plan(
+    conn: &rusqlite::Connection,
+    job: &db::ClaimedJob,
+    sample_ids: &[String],
+    use_cache: bool,
+    analysis_version: &str,
+) -> Result<BackfillPlan, String> {
+    build_backfill_plan_inner(conn, job, sample_ids, use_cache, analysis_version, true)
+}
+
+fn build_backfill_plan_inner(
+    conn: &rusqlite::Connection,
+    job: &db::ClaimedJob,
+    sample_ids: &[String],
+    use_cache: bool,
+    analysis_version: &str,
+    require_cache_materialization: bool,
+) -> Result<BackfillPlan, String> {
     let mut state = BackfillPlanState {
         use_cache,
         analysis_version,
@@ -46,7 +67,15 @@ pub(super) fn build_backfill_plan(
         )?
         .is_some();
         let has_aspects = sample_has_current_aspect_descriptors(conn, sample_id)?;
-        if has_embedding && has_aspects {
+        let cache_is_current = if require_cache_materialization {
+            let Some(content_hash) = db::sample_content_hash(conn, sample_id)? else {
+                continue;
+            };
+            cached_embedding_data(conn, &content_hash, analysis_version)?.is_some()
+        } else {
+            true
+        };
+        if has_embedding && has_aspects && cache_is_current {
             continue;
         }
         plan_sample(conn, job, sample_id, &mut state)?;

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/planning.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/backfill/tests/planning.rs
@@ -57,6 +57,25 @@ fn plan_derives_missing_aspects_from_current_features_without_work() {
 }
 
 #[test]
+fn readiness_plan_materializes_missing_cache_for_current_sample_outputs() {
+    let conn = conn_with_schema();
+    insert_sample(&conn, "s::a.wav", "hash-a");
+    insert_current_embedding(&conn, "s::a.wav");
+    insert_current_aspects(&conn, "s::a.wav");
+    insert_current_features(&conn, "s::a.wav");
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let job = make_job(&["s::a.wav"], temp.path());
+    let plan =
+        planning::build_readiness_backfill_plan(&conn, &job, &["s::a.wav".to_string()], true, "v1")
+            .expect("readiness plan");
+
+    assert!(plan.work.is_empty());
+    assert_eq!(plan.ready.len(), 1);
+    assert_eq!(plan.ready[0].sample_id, "s::a.wav");
+}
+
+#[test]
 fn plan_builds_work_when_cache_misses() {
     let conn = conn_with_schema();
     insert_sample(&conn, "s::a.wav", "hash-a");
@@ -123,6 +142,29 @@ fn insert_current_features(conn: &rusqlite::Connection, sample_id: &str) {
             (sample_id, feat_version, vec_blob, light_dsp_blob, rms, computed_at)
          VALUES (?1, ?2, ?3, NULL, 0.5, 9)",
         params![sample_id, wavecrate_analysis::FEATURE_VERSION_V1, blob],
+    )
+    .unwrap();
+}
+
+fn insert_current_aspects(conn: &rusqlite::Connection, sample_id: &str) {
+    let mut features = vec![0.0_f32; wavecrate_analysis::FEATURE_VECTOR_LEN_V1];
+    for (index, value) in features.iter_mut().enumerate() {
+        *value = index as f32 + 1.0;
+    }
+    let aspects = wavecrate_analysis::aspects::aspect_descriptors_from_features_v1(&features)
+        .expect("aspects");
+    let blob = wavecrate_analysis::vector::encode_f32_le_blob(aspects.packed());
+    conn.execute(
+        "INSERT INTO similarity_aspect_descriptors
+            (sample_id, model_id, dim, dtype, l2_normed, valid_mask, vec, created_at)
+         VALUES (?1, ?2, ?3, 'f32', 1, ?4, ?5, 7)",
+        params![
+            sample_id,
+            wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_MODEL_ID,
+            wavecrate_analysis::aspects::ASPECT_DESCRIPTOR_DIM as i64,
+            aspects.valid_mask() as i64,
+            blob,
+        ],
     )
     .unwrap();
 }

--- a/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
+++ b/src/app/controller/library/analysis_jobs/pool/job_execution/readiness.rs
@@ -327,7 +327,7 @@ pub(crate) fn run_embedding_stage(
         job_type: db::EMBEDDING_BACKFILL_JOB_TYPE.to_string(),
         source_root: source_root.to_path_buf(),
     };
-    backfill::run_embedding_backfill_job_with_worker_limit(
+    backfill::run_readiness_embedding_backfill_job_with_worker_limit(
         conn,
         &job,
         true,

--- a/src/app/controller/library/background_jobs/scan.rs
+++ b/src/app/controller/library/background_jobs/scan.rs
@@ -35,6 +35,17 @@ pub(crate) fn handle_scan_finished(controller: &mut AppController, result: ScanR
             is_auto,
             stats,
         ),
+        Err(crate::sample_sources::scanner::ScanError::Incomplete { committed, error }) => {
+            handle_incomplete_scan(
+                controller,
+                &result.source_id,
+                label,
+                is_selected_source,
+                result.mode,
+                *committed,
+                &error,
+            );
+        }
         Err(crate::sample_sources::scanner::ScanError::Canceled) => {
             clear_scan_progress_if_active(controller);
             handle_scan_failure(
@@ -75,6 +86,10 @@ fn handle_successful_scan(
         .as_ref()
         .is_some_and(|state| state.source_id == *source_id);
 
+    if !apply_selected_source_scan_deltas(controller, source_id, is_selected_source, &stats) {
+        invalidate_scan_caches(controller, source_id, is_selected_source);
+    }
+
     report_successful_scan_status(
         controller,
         label,
@@ -83,9 +98,6 @@ fn handle_successful_scan(
         scan_changed,
         &stats,
     );
-    if !apply_selected_source_scan_deltas(controller, source_id, is_selected_source, &stats) {
-        invalidate_scan_caches(controller, source_id, is_selected_source);
-    }
     if is_selected_source {
         controller.refresh_selected_source_similarity_prep_status();
     }
@@ -104,6 +116,28 @@ fn handle_successful_scan(
         controller.handle_similarity_scan_finished(source_id);
     }
     clear_scan_progress_if_active(controller);
+}
+
+fn handle_incomplete_scan(
+    controller: &mut AppController,
+    source_id: &SourceId,
+    label: &str,
+    is_selected_source: bool,
+    mode: ScanMode,
+    stats: ScanStats,
+    error: &str,
+) {
+    if !apply_selected_source_scan_deltas(controller, source_id, is_selected_source, &stats) {
+        invalidate_scan_caches(controller, source_id, is_selected_source);
+    }
+    if is_selected_source {
+        controller.set_background_status(
+            format!("{label} committed a checkpoint; retrying incomplete work: {error}"),
+            StatusTone::Info,
+        );
+    }
+    clear_scan_progress_if_active(controller);
+    controller.request_incomplete_scan_retry(source_id, mode);
 }
 
 fn report_successful_scan_status(

--- a/src/app/controller/library/scans.rs
+++ b/src/app/controller/library/scans.rs
@@ -21,7 +21,7 @@ impl AppController {
         else {
             return;
         };
-        self.request_scan_for_source(&source, mode, ScanKind::Auto);
+        self.request_scan_for_source(&source, incomplete_retry_mode(mode), ScanKind::Auto);
     }
 
     /// Trigger a quick sync (incremental scan) of the selected source.
@@ -97,12 +97,26 @@ impl AppController {
     }
 }
 
+fn incomplete_retry_mode(mode: ScanMode) -> ScanMode {
+    match mode {
+        ScanMode::Targeted => ScanMode::Quick,
+        mode => mode,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app::controller::jobs::JobMessage;
     use crate::app::controller::test_support::dummy_controller;
     use std::path::PathBuf;
+
+    #[test]
+    fn incomplete_targeted_retry_promotes_to_authoritative_quick_scan() {
+        assert_eq!(incomplete_retry_mode(ScanMode::Targeted), ScanMode::Quick);
+        assert_eq!(incomplete_retry_mode(ScanMode::Quick), ScanMode::Quick);
+        assert_eq!(incomplete_retry_mode(ScanMode::Hard), ScanMode::Hard);
+    }
 
     #[test]
     fn auto_sync_due_respects_interval() {

--- a/src/app/controller/library/scans.rs
+++ b/src/app/controller/library/scans.rs
@@ -11,6 +11,19 @@ mod worker;
 const WATCHER_SYNC_INTERVAL: Duration = Duration::from_secs(2);
 
 impl AppController {
+    pub(crate) fn request_incomplete_scan_retry(&mut self, source_id: &SourceId, mode: ScanMode) {
+        let Some(source) = self
+            .library
+            .sources
+            .iter()
+            .find(|source| &source.id == source_id)
+            .cloned()
+        else {
+            return;
+        };
+        self.request_scan_for_source(&source, mode, ScanKind::Auto);
+    }
+
     /// Trigger a quick sync (incremental scan) of the selected source.
     pub fn request_quick_sync(&mut self) {
         self.request_scan_with_mode(ScanMode::Quick, ScanKind::Manual);

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -16,8 +16,8 @@ use crate::native_app::app::{
     ActiveFolderCacheWarmProgress, ActiveFolderCacheWarmResult, AppSettingsTab,
     AudioOpenTaskCompletion, FileMoveProgress, NormalizationProgress, NormalizationResult,
     PreviewAuditionResult, PreviewAuditionWarmResult, SampleLoadPathValidation, SampleLoadResult,
-    SamplePlaybackReady, StarmapViewportChange, WaveformCacheIndicatorRefreshResult,
-    WaveformCacheWarmResult,
+    SamplePlaybackReady, SourceProcessingProgress, StarmapViewportChange,
+    WaveformCacheIndicatorRefreshResult, WaveformCacheWarmResult,
 };
 use crate::native_app::audio::playback_history::{
     LastPlayedPersistRequest, LastPlayedPersistResult,
@@ -178,6 +178,10 @@ pub(in crate::native_app) enum GuiMessage {
     SimilarityPrepStatusResolved(SimilarityPrepStatusResult),
     SimilarityPrepEnqueueFinished(SimilarityPrepEnqueueResult),
     SimilarityScoresResolved(SimilarityScoresResult),
+    SimilarityReadinessAdvanced {
+        source_id: String,
+    },
+    SourceProcessingProgress(SourceProcessingProgress),
     Settings(SettingsMessage),
     Metadata(MetadataMessage),
     FocusLoadedFile,

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -78,6 +78,7 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         paths: Vec<PathBuf>,
         overflowed: bool,
+        source_root_available: bool,
     },
     SourceFilesystemSyncFinished(SourceFilesystemSyncResult),
     SourceManifestAuditCommitted {
@@ -390,6 +391,7 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) renames_reconciled: usize,
+    pub(in crate::native_app) incomplete_error: Option<String>,
     pub(in crate::native_app) committed_delta:
         wavecrate::sample_sources::scanner::CommittedSourceDelta,
 }

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -80,6 +80,10 @@ pub(in crate::native_app) enum GuiMessage {
         overflowed: bool,
     },
     SourceFilesystemSyncFinished(SourceFilesystemSyncResult),
+    SourceManifestAuditCommitted {
+        source_id: String,
+        committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta,
+    },
     NormalizationProgress(NormalizationProgress),
     NormalizationFinished(NormalizationResult),
     SelectSampleWithModifiers {

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -386,6 +386,8 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) renames_reconciled: usize,
+    pub(in crate::native_app) committed_delta:
+        wavecrate::sample_sources::scanner::CommittedSourceDelta,
 }
 
 #[derive(Clone, Debug)]

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -24,7 +24,7 @@ pub(in crate::native_app) use message::{
 };
 pub(in crate::native_app) use progress::{
     FileMoveProgress, NormalizationFailure, NormalizationHarvestDerivation, NormalizationProgress,
-    NormalizationQueueItem, NormalizationResult,
+    NormalizationQueueItem, NormalizationResult, SourceProcessingProgress,
 };
 pub(in crate::native_app) use settings::{
     AppSettingsTab, AudioSettingsDropdown, SampleNameViewMode,

--- a/src/native_app/app/progress.rs
+++ b/src/native_app/app/progress.rs
@@ -40,6 +40,17 @@ pub(in crate::native_app) struct FileMoveProgress {
     pub(in crate::native_app) detail: String,
 }
 
+/// Durable source-readiness work currently advancing in the background.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct SourceProcessingProgress {
+    pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) active: bool,
+    pub(in crate::native_app) completed: usize,
+    pub(in crate::native_app) total: usize,
+    pub(in crate::native_app) stage: String,
+    pub(in crate::native_app) detail: String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct NormalizationFailure {
     pub(in crate::native_app) path: PathBuf,

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -12,7 +12,7 @@ use wavecrate::audio::AudioPlayer;
 
 use crate::native_app::app::{
     ExtractedFilePlaybackType, FileMoveProgress, GuiMessage, NormalizationProgress,
-    NormalizationQueueItem, PendingWaveformDestructiveEdit,
+    NormalizationQueueItem, PendingWaveformDestructiveEdit, SourceProcessingProgress,
 };
 use crate::native_app::source_processing::SourceProcessingSupervisor;
 use crate::native_app::waveform::WaveformPreservedMarks;
@@ -42,6 +42,7 @@ pub(in crate::native_app) struct BackgroundTaskState {
     pub(in crate::native_app) normalization_active_paths: HashSet<PathBuf>,
     pub(in crate::native_app) normalization_queue: VecDeque<NormalizationQueueItem>,
     pub(in crate::native_app) file_move_progress: Option<FileMoveProgress>,
+    pub(in crate::native_app) source_processing_progress: Option<SourceProcessingProgress>,
     pub(in crate::native_app) progress_tick: f32,
     pub(in crate::native_app) frame_cadence: frame_ui::FrameCadenceMonitor,
     pub(in crate::native_app) source_processing: SourceProcessingSupervisor,
@@ -85,6 +86,7 @@ impl BackgroundTaskState {
             normalization_active_paths: HashSet::new(),
             normalization_queue: VecDeque::new(),
             file_move_progress: None,
+            source_processing_progress: None,
             progress_tick: 0.0,
             frame_cadence: frame_ui::FrameCadenceMonitor::new(),
             source_processing,

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -54,7 +54,8 @@ impl BackgroundTaskState {
         sources: Vec<wavecrate::sample_sources::SampleSource>,
     ) -> Self {
         #[cfg(not(test))]
-        let source_processing = SourceProcessingSupervisor::start(sources);
+        let source_processing =
+            SourceProcessingSupervisor::start_with_worker_sender(sources, worker_sender.clone());
         #[cfg(test)]
         let source_processing = {
             drop(sources);

--- a/src/native_app/app/state/library.rs
+++ b/src/native_app/app/state/library.rs
@@ -113,12 +113,14 @@ impl LibraryAppState {
         source_id: String,
         paths: &[std::path::PathBuf],
         overflowed: bool,
+        source_root_available: bool,
     ) -> SourceFilesystemChangePlan {
         self.source_scan.plan_filesystem_change(
             &mut self.folder_browser,
             source_id,
             paths,
             overflowed,
+            source_root_available,
         )
     }
 

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -142,12 +142,22 @@ impl SourceScanWorkflow {
                 self.remove_pending_refresh(&id);
                 return SourceSelectionRequest::Settled;
             }
-            self.queue_pending_selection(id);
-            return if browser.selected_source_loaded() {
-                SourceSelectionRequest::Settled
-            } else {
-                SourceSelectionRequest::Deferred
-            };
+            if browser.selected_source_loaded() {
+                // The cached tree is already authoritative enough to satisfy
+                // this selection. Do not turn a click made during another
+                // source's scan into a later full refresh.
+                self.clear_pending_selection(&id);
+                return SourceSelectionRequest::Settled;
+            }
+            self.queue_selected_required_refresh(id);
+            return SourceSelectionRequest::Deferred;
+        }
+        if !browser.select_source_without_scan(id.clone()) {
+            return SourceSelectionRequest::Settled;
+        }
+        if browser.source_is_missing(&id) || browser.selected_source_loaded() {
+            self.clear_pending_selection(&id);
+            return SourceSelectionRequest::Settled;
         }
         browser
             .begin_select_source(id, task_id)
@@ -264,10 +274,6 @@ impl SourceScanWorkflow {
         }
         self.queue_required_refresh(source_id.clone());
         SourceRefreshRequest::Deferred { source_id }
-    }
-
-    fn queue_pending_selection(&mut self, source_id: String) {
-        self.queue_pending_refresh(source_id, true, false);
     }
 
     fn queue_required_refresh(&mut self, source_id: String) {

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -210,8 +210,11 @@ impl SourceScanWorkflow {
         source_id: String,
         paths: &[PathBuf],
         overflowed: bool,
+        source_root_available: bool,
     ) -> SourceFilesystemChangePlan {
-        let Some(source_missing) = browser.refresh_source_availability_from_disk(&source_id) else {
+        let Some(source_missing) =
+            browser.apply_observed_source_availability(&source_id, source_root_available)
+        else {
             self.remove_pending_refresh(&source_id);
             return SourceFilesystemChangePlan::IgnoredSourceMissing { source_id };
         };

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -25,10 +25,9 @@ pub(in crate::native_app) enum SourceFilesystemChangePlan {
     IgnoredSourceMissing {
         source_id: String,
     },
-    Patched {
+    SyncPaths {
         source_id: String,
         changed_count: usize,
-        changed: bool,
     },
     DeferredAlreadyRunning {
         source_id: String,
@@ -221,11 +220,9 @@ impl SourceScanWorkflow {
             return SourceFilesystemChangePlan::IgnoredSourceMissing { source_id };
         }
         if !overflowed && !paths.is_empty() {
-            let changed = browser.refresh_filesystem_paths(&source_id, paths);
-            return SourceFilesystemChangePlan::Patched {
+            return SourceFilesystemChangePlan::SyncPaths {
                 source_id,
                 changed_count: paths.len(),
-                changed,
             };
         }
         if self.active() {

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -573,6 +573,39 @@ fn active_source_click_preserves_required_filesystem_refresh() {
 }
 
 #[test]
+fn targeted_watcher_hint_does_not_patch_browser_before_commit() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 125)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+    fs::remove_file(root.path().join("sample.wav")).expect("remove sample");
+
+    assert!(matches!(
+        workflow.plan_filesystem_change(
+            &mut browser,
+            source_id,
+            &[PathBuf::from("sample.wav")],
+            false,
+        ),
+        SourceFilesystemChangePlan::SyncPaths {
+            changed_count: 1,
+            ..
+        }
+    ));
+    assert_eq!(
+        browser.selected_audio_files().len(),
+        1,
+        "the watcher path is only a hint until the source database commit completes"
+    );
+}
+
+#[test]
 fn switching_away_parks_live_discoveries_from_an_active_scan() {
     let first = temp_dir_with_wav();
     let second = temp_dir_with_wav();

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -115,7 +115,7 @@ fn cancelled_scan_releases_ownership_and_requeues_the_source() {
 }
 
 #[test]
-fn cached_source_selection_defers_reconcile_while_another_scan_is_active() {
+fn cached_source_selection_does_not_queue_refresh_while_another_scan_is_active() {
     let first_root = temp_dir_with_wav();
     let second_root = temp_dir_with_wav();
     let mut browser = FolderBrowserState::load_default();
@@ -158,7 +158,7 @@ fn cached_source_selection_defers_reconcile_while_another_scan_is_active() {
     ));
     assert_eq!(browser.selected_source_id(), second_id);
     assert!(browser.selected_source_loaded());
-    assert!(workflow.pending_refresh_contains_for_tests(&second_id));
+    assert!(!workflow.pending_refresh_contains_for_tests(&second_id));
     let second_visible = browser
         .selected_audio_files()
         .into_iter()
@@ -191,7 +191,30 @@ fn cached_source_selection_defers_reconcile_while_another_scan_is_active() {
         workflow.finish_scan(&mut browser, active_result),
         SourceScanFinish::Applied { .. }
     ));
-    assert_eq!(workflow.next_pending_refresh_if_idle(), Some(second_id));
+    assert_eq!(workflow.next_pending_refresh_if_idle(), None);
+}
+
+#[test]
+fn cached_source_selection_does_not_rescan_when_idle() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 37)
+        .expect("initial source scan");
+    let source_id = request.source_id.clone();
+    workflow.start_scan(&request);
+    let result = scan_source_with_progress(request, |_| {}, |_| {});
+    workflow.finish_scan(&mut browser, result);
+
+    assert!(matches!(
+        workflow.begin_select_source(&mut browser, source_id.clone(), 38),
+        SourceSelectionRequest::Settled
+    ));
+    assert_eq!(browser.selected_source_id(), source_id);
+    assert!(browser.selected_source_loaded());
+    assert!(!workflow.active());
+    assert_eq!(workflow.next_pending_refresh_if_idle(), None);
 }
 
 #[test]
@@ -423,7 +446,7 @@ fn deferred_selection_is_refreshed_before_newer_watcher_work() {
     let selected_source = String::from("selected-source");
     let watcher_source = String::from("watcher-source");
 
-    workflow.queue_pending_selection(selected_source.clone());
+    workflow.queue_selected_required_refresh(selected_source.clone());
     workflow.queue_required_refresh(watcher_source.clone());
 
     assert_eq!(
@@ -650,10 +673,9 @@ fn switching_away_parks_live_discoveries_from_an_active_scan() {
     let second_result = scan_source_with_progress(second_request, |_| {}, |_| {});
     workflow.finish_scan(&mut browser, second_result);
 
-    let active = workflow.begin_select_source(&mut browser, first_id.clone(), 132);
-    let SourceSelectionRequest::Queued(active) = active else {
-        panic!("first source rescan should queue");
-    };
+    let active = workflow
+        .begin_source_scan(&mut browser, first_id.clone(), 132)
+        .expect("first source rescan");
     workflow.start_scan(&active);
     let mut batches = Vec::new();
     let _result = scan_source_with_progress(active, |_| {}, |batch| batches.push(batch));

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -78,7 +78,7 @@ fn pending_refresh_waits_for_active_scan() {
     let source_id = request.source_id.clone();
     workflow.start_scan(&request);
 
-    let plan = workflow.plan_filesystem_change(&mut browser, source_id.clone(), &[], true);
+    let plan = workflow.plan_filesystem_change(&mut browser, source_id.clone(), &[], true, true);
 
     assert!(matches!(
         plan,
@@ -561,7 +561,7 @@ fn active_source_click_preserves_required_filesystem_refresh() {
     let source_id = active.source_id.clone();
     workflow.start_scan(&active);
     assert!(matches!(
-        workflow.plan_filesystem_change(&mut browser, source_id.clone(), &[], true),
+        workflow.plan_filesystem_change(&mut browser, source_id.clone(), &[], true, true),
         SourceFilesystemChangePlan::DeferredAlreadyRunning { .. }
     ));
 
@@ -570,6 +570,29 @@ fn active_source_click_preserves_required_filesystem_refresh() {
         SourceSelectionRequest::Settled
     ));
     assert!(workflow.pending_refresh_contains_for_tests(&source_id));
+}
+
+#[test]
+fn filesystem_change_uses_watcher_root_observation_without_probing_disk() {
+    let root = temp_dir_with_wav();
+    let mut browser = FolderBrowserState::load_default();
+    let mut workflow = SourceScanWorkflow::new();
+    let request = workflow
+        .begin_add_source_path(&mut browser, root.path().to_path_buf(), 124)
+        .expect("source scan");
+    let source_id = request.source_id.clone();
+
+    let plan = workflow.plan_filesystem_change(&mut browser, source_id.clone(), &[], true, false);
+
+    assert!(matches!(
+        plan,
+        SourceFilesystemChangePlan::IgnoredSourceMissing { .. }
+    ));
+    assert!(browser.source_is_missing(&source_id));
+    assert!(
+        root.path().is_dir(),
+        "the test root remains present on disk"
+    );
 }
 
 #[test]
@@ -592,6 +615,7 @@ fn targeted_watcher_hint_does_not_patch_browser_before_commit() {
             source_id,
             &[PathBuf::from("sample.wav")],
             false,
+            true,
         ),
         SourceFilesystemChangePlan::SyncPaths {
             changed_count: 1,

--- a/src/native_app/app_chrome/scene.rs
+++ b/src/native_app/app_chrome/scene.rs
@@ -39,6 +39,7 @@ fn paint_app_transient_overlay(
     primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
 ) {
     state.paint_waveform_transient_overlay(context, primitives);
+    state.paint_source_processing_activity_overlay(context, primitives);
     paint_starmap_active_audition_overlay(state, context, primitives);
 }
 

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -15,7 +15,13 @@ use crate::native_app::app_chrome::modals;
 #[cfg(test)]
 use crate::native_app::app_chrome::view_models::status_bar::WorkerProgressViewModel;
 use crate::native_app::app_chrome::view_models::status_bar::{StatusBarViewModel, StatusSeverity};
+use crate::native_app::ui::ids::{
+    JOB_DETAILS_CURRENT_ROW_ID_BASE, WORKER_PROGRESS_ACTIVITY_OVERLAY_ID, WORKER_PROGRESS_ROOT_ID,
+};
+use radiant::gui::feedback::horizontal_progress_activity_rect;
 use radiant::prelude as ui;
+use radiant::runtime::{PaintPrimitive, SurfaceNode, TransientOverlayContext, WidgetPaint};
+use radiant::widgets::{TextWidget, WidgetSizing};
 
 const STATUS_BAR_HEIGHT: f32 = 30.0;
 const STATUS_BAR_SEGMENT_HEIGHT: f32 = 20.0;
@@ -23,7 +29,16 @@ const STATUS_BAR_LEFT_WIDTH: f32 = 120.0;
 const STATUS_BAR_SPACING: f32 = 8.0;
 const STATUS_BAR_PADDING_X: f32 = 12.0;
 const STATUS_BAR_PADDING_Y: f32 = 4.0;
+const JOB_DETAILS_WIDTH: f32 = 680.0;
+const JOB_DETAILS_HEIGHT: f32 = 212.0;
+const JOB_DETAILS_ROW_HEIGHT: f32 = 20.0;
+const JOB_DETAILS_TOOLTIP_THRESHOLD: usize = 72;
 const SOURCE_MISSING_STATUS_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 112, 86, 230);
+const SOURCE_PROCESSING_ACTIVITY_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 198, 116, 220);
+const SOURCE_PROCESSING_ACTIVITY_HEIGHT: f32 = 2.0;
+const SOURCE_PROCESSING_ACTIVITY_CYCLES_PER_SECOND: f32 = 2.1;
+const SOURCE_PROCESSING_ACTIVITY_SEGMENT_FRACTION: f32 = 0.24;
+const SOURCE_PROCESSING_ACTIVITY_MIN_WIDTH: f32 = 18.0;
 
 pub(in crate::native_app) fn bottom_status_area(state: &NativeAppState) -> ui::View<GuiMessage> {
     bottom_status_bar(StatusBarViewModel::from_app_state(state))
@@ -43,6 +58,54 @@ pub(in crate::native_app) fn bottom_status_bar(model: StatusBarViewModel) -> ui:
     .padding_y(STATUS_BAR_PADDING_Y)
     .fill_width()
     .height(STATUS_BAR_HEIGHT)
+}
+
+impl NativeAppState {
+    pub(in crate::native_app) fn source_processing_activity_overlay_visible(&self) -> bool {
+        self.library.folder_progress().is_none()
+            && self.background.normalization_progress.is_none()
+            && self.background.file_move_progress.is_none()
+            && self.waveform.cache.active_folder_warm_folder_id.is_none()
+            && self.background.source_processing_progress.is_some()
+    }
+
+    pub(in crate::native_app) fn paint_source_processing_activity_overlay(
+        &mut self,
+        context: TransientOverlayContext<'_>,
+        primitives: &mut Vec<PaintPrimitive>,
+    ) {
+        if !self.source_processing_activity_overlay_visible() {
+            return;
+        }
+        let Some(bounds) = context
+            .plan
+            .first_widget_rect_by_priority([WORKER_PROGRESS_ROOT_ID])
+        else {
+            return;
+        };
+        let height = bounds.height().min(SOURCE_PROCESSING_ACTIVITY_HEIGHT);
+        if height <= 0.0 {
+            return;
+        }
+        let y = bounds.min.y + (bounds.height() - height) * 0.5;
+        let track = ui::Rect::from_min_max(
+            ui::Point::new(bounds.min.x, y),
+            ui::Point::new(bounds.max.x, y + height),
+        );
+        let position = (context.animation_time.as_secs_f32()
+            * SOURCE_PROCESSING_ACTIVITY_CYCLES_PER_SECOND)
+            .fract();
+        let Some(activity) = horizontal_progress_activity_rect(
+            track,
+            position,
+            SOURCE_PROCESSING_ACTIVITY_SEGMENT_FRACTION,
+            SOURCE_PROCESSING_ACTIVITY_MIN_WIDTH,
+        ) else {
+            return;
+        };
+        WidgetPaint::new(primitives, WORKER_PROGRESS_ACTIVITY_OVERLAY_ID)
+            .push_visible_fill_rect(activity, SOURCE_PROCESSING_ACTIVITY_COLOR);
+    }
 }
 
 fn status_segment(label: impl Into<ui::TextContent>) -> ui::View<GuiMessage> {
@@ -104,21 +167,28 @@ pub(in crate::native_app) fn job_details_popover(
 fn job_details_popover_from_projection(
     projection: JobDetailsPopoverProjection,
 ) -> ui::View<GuiMessage> {
-    let content = ui::column(
-        projection
-            .rows
-            .into_iter()
-            .map(|row| ui::text_line(row, 20.0))
-            .collect::<Vec<_>>(),
-    )
-    .spacing(5.0)
-    .fill_width();
+    let [kind, source, progress, current] = projection.rows;
+    let mut rows = vec![
+        ui::text_line(kind, JOB_DETAILS_ROW_HEIGHT),
+        ui::text_line(source, JOB_DETAILS_ROW_HEIGHT),
+        ui::text_line(progress, JOB_DETAILS_ROW_HEIGHT),
+    ];
+    let current = current
+        .strip_prefix("Current: ")
+        .unwrap_or(current.as_str());
+    rows.extend(
+        current
+            .split(" | ")
+            .enumerate()
+            .map(job_details_current_row),
+    );
+    let content = ui::column(rows).spacing(5.0).fill_width();
     radiant::application::closeable_dialog_layer_from_parts(
         radiant::application::DialogLayerParts::new(
             projection.title,
             content,
             ui::WidgetTone::Neutral,
-            ui::Vector2::new(300.0, 132.0),
+            ui::Vector2::new(JOB_DETAILS_WIDTH, JOB_DETAILS_HEIGHT),
         )
         .horizontal(ui::LayerHorizontalAnchor::End)
         .vertical(ui::LayerVerticalAnchor::End)
@@ -128,10 +198,61 @@ fn job_details_popover_from_projection(
     .key(identity::JOB_DETAILS_POPOVER_KEY)
 }
 
+fn job_details_current_row((index, full_part): (usize, &str)) -> ui::View<GuiMessage> {
+    let compact_part = if index == 0 {
+        full_part.to_string()
+    } else {
+        compact_job_detail(full_part)
+    };
+    let display = if index == 0 {
+        format!("Current: {compact_part}")
+    } else {
+        format!("         {compact_part}")
+    };
+    let full = if index == 0 {
+        format!("Current: {full_part}")
+    } else {
+        full_part.to_string()
+    };
+    let show_tooltip = display != full || full.chars().count() > JOB_DETAILS_TOOLTIP_THRESHOLD;
+    if show_tooltip {
+        let mut row = TextWidget::new(
+            JOB_DETAILS_CURRENT_ROW_ID_BASE + index as u64,
+            display,
+            WidgetSizing::new(
+                ui::Vector2::new(1.0, JOB_DETAILS_ROW_HEIGHT),
+                ui::Vector2::new(JOB_DETAILS_WIDTH - 48.0, JOB_DETAILS_ROW_HEIGHT),
+            ),
+        );
+        row.common = row.common.with_pointer_focus();
+        row.common.tooltip = Some(full);
+        ui::View::from(SurfaceNode::static_widget(row))
+    } else {
+        ui::text_line(display, JOB_DETAILS_ROW_HEIGHT)
+            .truncate()
+            .id(JOB_DETAILS_CURRENT_ROW_ID_BASE + index as u64)
+    }
+}
+
+fn compact_job_detail(detail: &str) -> String {
+    let Some((label, value)) = detail.split_once(": ") else {
+        return detail.to_string();
+    };
+    let Some(file_name) = value
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|file_name| !file_name.is_empty() && *file_name != value)
+    else {
+        return detail.to_string();
+    };
+    format!("{label}: {file_name}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use radiant::prelude::IntoView;
+    use radiant::runtime::{DeclarativeOwnedRuntimeBridge, Event, SurfaceRuntime};
     use std::sync::Arc;
 
     #[test]
@@ -164,5 +285,101 @@ mod tests {
 
         assert_eq!(run.text.as_str(), label.as_ref());
         assert!(!run.text.is_static());
+    }
+
+    #[test]
+    fn job_details_popover_keeps_all_current_work_inside_dialog() {
+        let current =
+            "Current: Analyzing audio | samples: long/path/to/current-file.wav | 2 sources active";
+        let viewport = ui::Vector2::new(540.0, 260.0);
+        let frame = job_details_popover_from_projection(JobDetailsPopoverProjection {
+            title: "Job Details",
+            rows: [
+                String::from("Type: Source processing"),
+                String::from("Source: Multiple sources"),
+                String::from("Progress: 61/200"),
+                String::from(current),
+            ],
+        })
+        .view_frame_at_size_with_default_theme(viewport);
+        let current_run = frame
+            .paint_plan
+            .first_text_run("         2 sources active")
+            .expect("final current work detail should paint");
+        let dialog_bottom = viewport.y - 38.0;
+
+        assert!(
+            current_run.rect.max.y <= dialog_bottom,
+            "current work row must remain inside the bottom-anchored dialog"
+        );
+    }
+
+    #[test]
+    fn job_details_compacts_long_paths_and_keeps_the_full_value_in_a_tooltip() {
+        let full_path =
+            "Projects: OLD/#sounddesign/master-recordings/2026/#sounddesign-long-recording.wav";
+        let row = job_details_current_row((1, full_path));
+        let surface = row.into_surface();
+        let widget = surface
+            .find_widget(JOB_DETAILS_CURRENT_ROW_ID_BASE + 1)
+            .expect("current work row should be addressable");
+
+        assert_eq!(
+            widget.widget_object().common().tooltip.as_deref(),
+            Some(full_path)
+        );
+        assert_eq!(
+            widget.widget_object().common().focus,
+            radiant::widgets::FocusBehavior::Pointer
+        );
+        let frame = surface.frame_at_size_with_default_theme(ui::Vector2::new(680.0, 30.0));
+        assert!(
+            frame
+                .paint_plan
+                .contains_text("         Projects: #sounddesign-long-recording.wav")
+        );
+        assert!(!frame.paint_plan.contains_text(full_path));
+    }
+
+    #[test]
+    fn compact_job_detail_handles_windows_paths() {
+        assert_eq!(
+            compact_job_detail(r"samples: drums\processed\kick.wav"),
+            "samples: kick.wav"
+        );
+    }
+
+    #[test]
+    fn compact_job_detail_paints_wrapped_tooltip_when_hovered() {
+        let full_path = "Projects: old/recording.wav";
+        let compact = "         Projects: recording.wav";
+        let bridge = DeclarativeOwnedRuntimeBridge::new(
+            (),
+            |_| {
+                radiant::runtime::UiSurface::new(
+                    job_details_current_row((1, full_path)).into_node(),
+                )
+            },
+            |_, _: GuiMessage| {},
+        );
+        let mut runtime = SurfaceRuntime::new(bridge, ui::Vector2::new(680.0, 80.0));
+        let initial = runtime.frame_with_default_theme();
+        let compact_rect = initial
+            .paint_plan
+            .first_text_run(compact)
+            .expect("compact path should paint")
+            .rect;
+
+        runtime.dispatch_event(Event::PointerMove {
+            position: compact_rect.center(),
+        });
+
+        assert!(
+            runtime
+                .frame_with_default_theme()
+                .paint_plan
+                .contains_text(full_path),
+            "hovering the compact path should paint its complete value"
+        );
     }
 }

--- a/src/native_app/app_chrome/status_bar.rs
+++ b/src/native_app/app_chrome/status_bar.rs
@@ -2,10 +2,15 @@ mod identity;
 mod progress_bar;
 mod projection;
 
+#[cfg(test)]
+use self::projection::job_details_popover_projection;
 use self::projection::{
-    JobDetailsPopoverProjection, bottom_status_bar_projection, job_details_popover_projection,
+    JobDetailsPopoverProjection, bottom_status_bar_projection,
+    job_details_popover_projection_from_model,
 };
-use crate::native_app::app::{FolderScanProgress, GuiMessage, NativeAppState};
+#[cfg(test)]
+use crate::native_app::app::FolderScanProgress;
+use crate::native_app::app::{GuiMessage, NativeAppState};
 use crate::native_app::app_chrome::modals;
 #[cfg(test)]
 use crate::native_app::app_chrome::view_models::status_bar::WorkerProgressViewModel;
@@ -69,10 +74,13 @@ fn status_bar_overlays(state: &NativeAppState) -> ui::Overlays<GuiMessage> {
 }
 
 fn job_details_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessage>> {
-    if state.ui.chrome.job_details_open
-        && let Some(progress) = state.library.folder_progress()
-    {
-        return Some(job_details_popover(progress));
+    if state.ui.chrome.job_details_open {
+        let model = StatusBarViewModel::from_app_state(state);
+        if let Some(details) = model.job_details {
+            return Some(job_details_popover_from_projection(
+                job_details_popover_projection_from_model(details),
+            ));
+        }
     }
 
     None
@@ -86,6 +94,7 @@ fn transaction_list_overlay(state: &NativeAppState) -> Option<ui::View<GuiMessag
         .then(|| modals::transaction_list(state))
 }
 
+#[cfg(test)]
 pub(in crate::native_app) fn job_details_popover(
     progress: &FolderScanProgress,
 ) -> ui::View<GuiMessage> {
@@ -132,6 +141,7 @@ mod tests {
             status_text: String::from("Source missing | Ready"),
             status_severity: StatusSeverity::Warning,
             worker_progress: None,
+            job_details: None,
             progress_tick: 0.0,
         })
         .view_frame_at_size_with_default_theme(ui::Vector2::new(520.0, STATUS_BAR_HEIGHT));

--- a/src/native_app/app_chrome/status_bar/identity.rs
+++ b/src/native_app/app_chrome/status_bar/identity.rs
@@ -1,4 +1,3 @@
-pub(super) const WORKER_PROGRESS_ROOT_KEY: &str = "bottom-status-progress-bar";
 pub(super) const WORKER_PROGRESS_OVERALL_KEY: &str = "bottom-status-progress-overall";
 pub(super) const WORKER_PROGRESS_ACTIVE_KEY: &str = "bottom-status-progress-active";
 pub(super) const WORKER_PROGRESS_ACTIVITY_HIGHLIGHT_KEY: &str =
@@ -11,8 +10,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn worker_progress_keys_keep_root_and_layers_distinct() {
-        assert_eq!(WORKER_PROGRESS_ROOT_KEY, "bottom-status-progress-bar");
+    fn worker_progress_layer_keys_remain_distinct() {
         assert_ne!(WORKER_PROGRESS_OVERALL_KEY, WORKER_PROGRESS_ACTIVE_KEY);
         assert_ne!(
             WORKER_PROGRESS_ACTIVITY_HIGHLIGHT_KEY,

--- a/src/native_app/app_chrome/status_bar/progress_bar.rs
+++ b/src/native_app/app_chrome/status_bar/progress_bar.rs
@@ -28,10 +28,10 @@ pub(super) fn worker_progress_bar_from_projection(
                 .width(WORKER_PROGRESS_TRACK_WIDTH)
                 .height(WORKER_PROGRESS_HEIGHT)
         }
-        WorkerProgressBarContentProjection::SourceCache {
+        WorkerProgressBarContentProjection::Layered {
             overall,
             current_fraction,
-        } => source_cache_worker_progress(overall, current_fraction, projection.progress_tick),
+        } => layered_worker_progress(overall, current_fraction, projection.progress_tick),
     }
 }
 
@@ -46,7 +46,7 @@ pub(super) fn worker_progress_bar(
     ))
 }
 
-fn source_cache_worker_progress(
+fn layered_worker_progress(
     overall: ui::ProgressSnapshot,
     current_fraction: Option<f32>,
     progress_tick: f32,
@@ -56,7 +56,7 @@ fn source_cache_worker_progress(
             .key(identity::WORKER_PROGRESS_OVERALL_KEY)
             .width(WORKER_PROGRESS_TRACK_WIDTH)
             .height(OVERALL_PROGRESS_HEIGHT),
-        active_cache_progress_bar(current_fraction, progress_tick)
+        active_worker_activity_bar(current_fraction, progress_tick)
             .key(identity::WORKER_PROGRESS_ACTIVE_KEY)
             .width(WORKER_PROGRESS_TRACK_WIDTH)
             .height(ACTIVE_PROGRESS_HEIGHT),
@@ -81,7 +81,7 @@ fn overall_progress_bar(
         .message(GuiMessage::ToggleJobDetails)
 }
 
-fn active_cache_progress_bar(
+fn active_worker_activity_bar(
     current_fraction: Option<f32>,
     progress_tick: f32,
 ) -> ui::View<GuiMessage> {

--- a/src/native_app/app_chrome/status_bar/progress_bar.rs
+++ b/src/native_app/app_chrome/status_bar/progress_bar.rs
@@ -1,6 +1,7 @@
 use crate::native_app::app::GuiMessage;
 #[cfg(test)]
 use crate::native_app::app_chrome::view_models::status_bar::WorkerProgressViewModel;
+use crate::native_app::ui::ids::WORKER_PROGRESS_ROOT_ID;
 use radiant::prelude as ui;
 
 use super::identity;
@@ -22,19 +23,19 @@ pub(super) fn worker_progress_bar_from_projection(
         WorkerProgressBarContentProjection::Hidden => {
             ui::empty().width(0.0).height(WORKER_PROGRESS_HEIGHT)
         }
-        WorkerProgressBarContentProjection::Activity => {
-            overall_progress_bar(ui::ProgressSnapshot::new(0, 0), projection.progress_tick)
-                .key(identity::WORKER_PROGRESS_ROOT_KEY)
+        WorkerProgressBarContentProjection::Activity => source_processing_activity_track()
+            .id(WORKER_PROGRESS_ROOT_ID)
+            .width(WORKER_PROGRESS_TRACK_WIDTH)
+            .height(WORKER_PROGRESS_HEIGHT),
+        WorkerProgressBarContentProjection::OverallWithActivity { progress } => {
+            overall_progress_bar(progress, projection.progress_tick)
+                .id(WORKER_PROGRESS_ROOT_ID)
                 .width(WORKER_PROGRESS_TRACK_WIDTH)
                 .height(WORKER_PROGRESS_HEIGHT)
         }
-        WorkerProgressBarContentProjection::OverallWithActivity { progress } => {
-            overall_progress_with_activity(progress, projection.progress_tick)
-                .key(identity::WORKER_PROGRESS_ROOT_KEY)
-        }
         WorkerProgressBarContentProjection::Overall { progress } => {
             overall_progress_bar(progress, projection.progress_tick)
-                .key(identity::WORKER_PROGRESS_ROOT_KEY)
+                .id(WORKER_PROGRESS_ROOT_ID)
                 .width(WORKER_PROGRESS_TRACK_WIDTH)
                 .height(WORKER_PROGRESS_HEIGHT)
         }
@@ -43,29 +44,6 @@ pub(super) fn worker_progress_bar_from_projection(
             current_fraction,
         } => layered_worker_progress(overall, current_fraction, projection.progress_tick),
     }
-}
-
-fn overall_progress_with_activity(
-    progress: ui::ProgressSnapshot,
-    progress_tick: f32,
-) -> ui::View<GuiMessage> {
-    ui::stack([
-        overall_progress_bar(progress, progress_tick)
-            .width(WORKER_PROGRESS_TRACK_WIDTH)
-            .height(WORKER_PROGRESS_HEIGHT),
-        ui::indeterminate_progress_bar(progress_tick)
-            .colors(
-                ui::Rgba8::new(0, 0, 0, 0),
-                ui::Rgba8::new(255, 198, 116, 220),
-            )
-            .max_track_height(2.0)
-            .activatable()
-            .message(GuiMessage::ToggleJobDetails)
-            .width(WORKER_PROGRESS_TRACK_WIDTH)
-            .height(WORKER_PROGRESS_HEIGHT),
-    ])
-    .width(WORKER_PROGRESS_TRACK_WIDTH)
-    .height(WORKER_PROGRESS_HEIGHT)
 }
 
 #[cfg(test)]
@@ -95,7 +73,7 @@ fn layered_worker_progress(
             .height(ACTIVE_PROGRESS_HEIGHT),
     ])
     .spacing(1.0)
-    .key(identity::WORKER_PROGRESS_ROOT_KEY)
+    .id(WORKER_PROGRESS_ROOT_ID)
     .width(WORKER_PROGRESS_TRACK_WIDTH)
     .height(SOURCE_CACHE_PROGRESS_HEIGHT)
 }
@@ -105,6 +83,17 @@ fn overall_progress_bar(
     progress_tick: f32,
 ) -> ui::View<GuiMessage> {
     ui::progress_bar_for_snapshot(progress, progress_tick)
+        .colors(
+            ui::Rgba8::new(48, 50, 51, 210),
+            ui::Rgba8::new(255, 112, 86, 210),
+        )
+        .max_track_height(OVERALL_TRACK_HEIGHT)
+        .activatable()
+        .message(GuiMessage::ToggleJobDetails)
+}
+
+fn source_processing_activity_track() -> ui::View<GuiMessage> {
+    ui::determinate_progress_bar(0.0)
         .colors(
             ui::Rgba8::new(48, 50, 51, 210),
             ui::Rgba8::new(255, 112, 86, 210),

--- a/src/native_app/app_chrome/status_bar/progress_bar.rs
+++ b/src/native_app/app_chrome/status_bar/progress_bar.rs
@@ -22,6 +22,16 @@ pub(super) fn worker_progress_bar_from_projection(
         WorkerProgressBarContentProjection::Hidden => {
             ui::empty().width(0.0).height(WORKER_PROGRESS_HEIGHT)
         }
+        WorkerProgressBarContentProjection::Activity => {
+            overall_progress_bar(ui::ProgressSnapshot::new(0, 0), projection.progress_tick)
+                .key(identity::WORKER_PROGRESS_ROOT_KEY)
+                .width(WORKER_PROGRESS_TRACK_WIDTH)
+                .height(WORKER_PROGRESS_HEIGHT)
+        }
+        WorkerProgressBarContentProjection::OverallWithActivity { progress } => {
+            overall_progress_with_activity(progress, projection.progress_tick)
+                .key(identity::WORKER_PROGRESS_ROOT_KEY)
+        }
         WorkerProgressBarContentProjection::Overall { progress } => {
             overall_progress_bar(progress, projection.progress_tick)
                 .key(identity::WORKER_PROGRESS_ROOT_KEY)
@@ -33,6 +43,29 @@ pub(super) fn worker_progress_bar_from_projection(
             current_fraction,
         } => layered_worker_progress(overall, current_fraction, projection.progress_tick),
     }
+}
+
+fn overall_progress_with_activity(
+    progress: ui::ProgressSnapshot,
+    progress_tick: f32,
+) -> ui::View<GuiMessage> {
+    ui::stack([
+        overall_progress_bar(progress, progress_tick)
+            .width(WORKER_PROGRESS_TRACK_WIDTH)
+            .height(WORKER_PROGRESS_HEIGHT),
+        ui::indeterminate_progress_bar(progress_tick)
+            .colors(
+                ui::Rgba8::new(0, 0, 0, 0),
+                ui::Rgba8::new(255, 198, 116, 220),
+            )
+            .max_track_height(2.0)
+            .activatable()
+            .message(GuiMessage::ToggleJobDetails)
+            .width(WORKER_PROGRESS_TRACK_WIDTH)
+            .height(WORKER_PROGRESS_HEIGHT),
+    ])
+    .width(WORKER_PROGRESS_TRACK_WIDTH)
+    .height(WORKER_PROGRESS_HEIGHT)
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/status_bar/projection.rs
+++ b/src/native_app/app_chrome/status_bar/projection.rs
@@ -22,6 +22,10 @@ pub(super) struct WorkerProgressBarProjection {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum WorkerProgressBarContentProjection {
     Hidden,
+    Activity,
+    OverallWithActivity {
+        progress: ui::ProgressSnapshot,
+    },
     Overall {
         progress: ui::ProgressSnapshot,
     },
@@ -65,7 +69,13 @@ impl WorkerProgressBarProjection {
 
 impl WorkerProgressBarContentProjection {
     fn from_worker_progress(progress: WorkerProgressViewModel) -> Self {
+        if progress.compact_activity && progress.total == 0 {
+            return Self::Activity;
+        }
         let snapshot = ui::ProgressSnapshot::new(progress.completed, progress.total);
+        if progress.compact_activity {
+            return Self::OverallWithActivity { progress: snapshot };
+        }
         if progress.active_animation {
             return Self::Layered {
                 overall: snapshot,
@@ -132,6 +142,7 @@ mod tests {
                 total: 10,
                 current_fraction: Some(0.5),
                 active_animation: false,
+                compact_activity: false,
             }),
             0.25,
         );
@@ -153,6 +164,7 @@ mod tests {
                 total: 10,
                 current_fraction: Some(0.5),
                 active_animation: true,
+                compact_activity: false,
             }),
             0.25,
         );
@@ -162,6 +174,46 @@ mod tests {
             WorkerProgressBarContentProjection::Layered {
                 overall: ui::ProgressSnapshot::new(3, 10),
                 current_fraction: Some(0.5),
+            }
+        );
+    }
+
+    #[test]
+    fn worker_progress_projection_uses_compact_activity_for_unmeasured_work() {
+        let projection = WorkerProgressBarProjection::from_progress(
+            Some(WorkerProgressViewModel {
+                completed: 0,
+                total: 0,
+                current_fraction: None,
+                active_animation: false,
+                compact_activity: true,
+            }),
+            0.25,
+        );
+
+        assert_eq!(
+            projection.content,
+            WorkerProgressBarContentProjection::Activity
+        );
+    }
+
+    #[test]
+    fn worker_progress_projection_keeps_activity_visible_with_measured_work() {
+        let projection = WorkerProgressBarProjection::from_progress(
+            Some(WorkerProgressViewModel {
+                completed: 3,
+                total: 10,
+                current_fraction: None,
+                active_animation: false,
+                compact_activity: true,
+            }),
+            0.25,
+        );
+
+        assert_eq!(
+            projection.content,
+            WorkerProgressBarContentProjection::OverallWithActivity {
+                progress: ui::ProgressSnapshot::new(3, 10),
             }
         );
     }

--- a/src/native_app/app_chrome/status_bar/projection.rs
+++ b/src/native_app/app_chrome/status_bar/projection.rs
@@ -1,6 +1,7 @@
+#[cfg(test)]
 use crate::native_app::app::FolderScanProgress;
 use crate::native_app::app_chrome::view_models::status_bar::{
-    StatusBarViewModel, StatusSeverity, WorkerProgressViewModel,
+    JobDetailsViewModel, StatusBarViewModel, StatusSeverity, WorkerProgressViewModel,
 };
 use radiant::prelude as ui;
 
@@ -24,7 +25,7 @@ pub(super) enum WorkerProgressBarContentProjection {
     Overall {
         progress: ui::ProgressSnapshot,
     },
-    SourceCache {
+    Layered {
         overall: ui::ProgressSnapshot,
         current_fraction: Option<f32>,
     },
@@ -66,7 +67,7 @@ impl WorkerProgressBarContentProjection {
     fn from_worker_progress(progress: WorkerProgressViewModel) -> Self {
         let snapshot = ui::ProgressSnapshot::new(progress.completed, progress.total);
         if progress.active_animation {
-            return Self::SourceCache {
+            return Self::Layered {
                 overall: snapshot,
                 current_fraction: progress.current_fraction,
             };
@@ -75,36 +76,24 @@ impl WorkerProgressBarContentProjection {
     }
 }
 
+#[cfg(test)]
 pub(super) fn job_details_popover_projection(
     progress: &FolderScanProgress,
 ) -> JobDetailsPopoverProjection {
-    let total_label = progress_count_label(progress.completed, progress.total, "found");
-    let detail = if progress.detail.is_empty() {
-        "Waiting for next item".to_string()
-    } else {
-        progress.detail.clone()
-    };
+    job_details_popover_projection_from_model(JobDetailsViewModel::from_folder_progress(progress))
+}
+
+pub(super) fn job_details_popover_projection_from_model(
+    model: JobDetailsViewModel,
+) -> JobDetailsPopoverProjection {
     JobDetailsPopoverProjection {
         title: "Job Details",
-        rows: [
-            format!("Type: {}", progress.phase),
-            format!("Source: {}", progress.label),
-            format!("Progress: {total_label}"),
-            format!("Current: {detail}"),
-        ],
+        rows: model.rows,
     }
 }
 
 fn selected_sample_count_label(count: usize) -> String {
     format!("{count} sample{}", if count == 1 { "" } else { "s" })
-}
-
-fn progress_count_label(completed: usize, total: usize, indeterminate_suffix: &str) -> String {
-    if total == 0 {
-        format!("{completed} {indeterminate_suffix}")
-    } else {
-        format!("{}/{}", completed.min(total), total)
-    }
 }
 
 #[cfg(test)]
@@ -157,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_progress_projection_uses_source_cache_mode_for_active_animation() {
+    fn worker_progress_projection_uses_layered_mode_for_active_animation() {
         let projection = WorkerProgressBarProjection::from_progress(
             Some(WorkerProgressViewModel {
                 completed: 3,
@@ -170,7 +159,7 @@ mod tests {
 
         assert_eq!(
             projection.content,
-            WorkerProgressBarContentProjection::SourceCache {
+            WorkerProgressBarContentProjection::Layered {
                 overall: ui::ProgressSnapshot::new(3, 10),
                 current_fraction: Some(0.5),
             }
@@ -230,6 +219,7 @@ mod tests {
             status_text: "Ready".to_string(),
             status_severity: StatusSeverity::Normal,
             worker_progress: None,
+            job_details: None,
             progress_tick: 0.0,
         })
     }

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -1,7 +1,6 @@
 use crate::native_app::app::{
     FileMoveProgress, FolderScanProgress, NativeAppState, NormalizationProgress,
 };
-use radiant::prelude as ui;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(in crate::native_app) struct StatusBarViewModel {
@@ -9,6 +8,7 @@ pub(in crate::native_app) struct StatusBarViewModel {
     pub(in crate::native_app) status_text: String,
     pub(in crate::native_app) status_severity: StatusSeverity,
     pub(in crate::native_app) worker_progress: Option<WorkerProgressViewModel>,
+    pub(in crate::native_app) job_details: Option<JobDetailsViewModel>,
     pub(in crate::native_app) progress_tick: f32,
 }
 
@@ -20,11 +20,13 @@ pub(in crate::native_app) enum StatusSeverity {
 
 impl StatusBarViewModel {
     pub(in crate::native_app) fn from_app_state(state: &NativeAppState) -> Self {
+        let worker = active_worker(state);
         Self {
             selected_sample_count: state.library.folder_browser.selected_audio_file_count(),
             status_text: bottom_status_text(state),
-            status_severity: bottom_status_severity(state),
-            worker_progress: active_worker_progress(state),
+            status_severity: bottom_status_severity(state, worker.is_some()),
+            worker_progress: worker.as_ref().map(|worker| worker.progress),
+            job_details: worker.map(|worker| worker.details),
             progress_tick: state.background.progress_tick,
         }
     }
@@ -38,69 +40,17 @@ pub(in crate::native_app) struct WorkerProgressViewModel {
     pub(in crate::native_app) active_animation: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct JobDetailsViewModel {
+    pub(in crate::native_app) rows: [String; 4],
+}
+
+struct ActiveWorkerViewModel {
+    progress: WorkerProgressViewModel,
+    details: JobDetailsViewModel,
+}
+
 fn bottom_status_text(state: &NativeAppState) -> String {
-    if let Some(progress) = state.library.folder_progress() {
-        let counters = ui::ProgressSnapshot::new(progress.completed, progress.total);
-        return if counters.is_indeterminate() {
-            format!(
-                "{} {} | {}",
-                progress.phase,
-                progress.label,
-                counters.count_label("items found")
-            )
-        } else {
-            format!(
-                "{} {} | {} | {}",
-                progress.phase,
-                progress.label,
-                counters.count_label("items found"),
-                progress.detail
-            )
-        };
-    }
-    if let Some(progress) = state.background.normalization_progress.as_ref() {
-        let counters = ui::ProgressSnapshot::new(progress.completed, progress.total);
-        let queue = normalization_queue_status(progress.queued);
-        return if counters.is_indeterminate() {
-            format!(
-                "Normalizing {} | {}{}",
-                progress.label, progress.detail, queue
-            )
-        } else {
-            format!(
-                "Normalizing {} | {} | {}{}",
-                progress.label,
-                counters.count_label("items found"),
-                progress.detail,
-                queue
-            )
-        };
-    }
-    if let Some(progress) = state.background.file_move_progress.as_ref() {
-        let counters = ui::ProgressSnapshot::new(progress.completed, progress.total);
-        return if counters.is_indeterminate() {
-            format!("{} | {}", progress.label, progress.detail)
-        } else {
-            format!(
-                "{} | {} | {}",
-                progress.label,
-                counters.count_label("items"),
-                progress.detail
-            )
-        };
-    }
-    if let Some(progress) = WorkerProgressViewModel::from_source_cache_warm(state) {
-        if state
-            .waveform
-            .cache
-            .active_folder_warm_plan_task
-            .active()
-            .is_some()
-        {
-            return source_cache_plan_status_text(state, progress);
-        }
-        return source_cache_warm_status_text(state, progress);
-    }
     let status = state.ui.status.sample.clone();
     match state.library.folder_browser.selected_source_status_label() {
         Some(source_status) if source_status.starts_with(&status) => source_status,
@@ -111,8 +61,8 @@ fn bottom_status_text(state: &NativeAppState) -> String {
     }
 }
 
-fn bottom_status_severity(state: &NativeAppState) -> StatusSeverity {
-    if active_worker_progress(state).is_none()
+fn bottom_status_severity(state: &NativeAppState, worker_active: bool) -> StatusSeverity {
+    if !worker_active
         && state
             .library
             .folder_browser
@@ -124,38 +74,43 @@ fn bottom_status_severity(state: &NativeAppState) -> StatusSeverity {
     }
 }
 
-fn normalization_queue_status(queued: usize) -> String {
-    if queued == 0 {
-        String::new()
-    } else {
-        format!(" | {queued} queued")
+fn active_worker(state: &NativeAppState) -> Option<ActiveWorkerViewModel> {
+    if let Some(progress) = state.library.folder_progress() {
+        return Some(ActiveWorkerViewModel {
+            progress: WorkerProgressViewModel::from_folder_progress(progress),
+            details: JobDetailsViewModel::from_folder_progress(progress),
+        });
     }
-}
-
-fn active_worker_progress(state: &NativeAppState) -> Option<WorkerProgressViewModel> {
+    if let Some(progress) = state.background.normalization_progress.as_ref() {
+        return Some(ActiveWorkerViewModel {
+            progress: WorkerProgressViewModel::from_normalization_progress(progress),
+            details: JobDetailsViewModel::from_normalization_progress(progress),
+        });
+    }
+    if let Some(progress) = state.background.file_move_progress.as_ref() {
+        return Some(ActiveWorkerViewModel {
+            progress: WorkerProgressViewModel::from_file_move_progress(progress),
+            details: JobDetailsViewModel::from_file_move_progress(progress),
+        });
+    }
+    if let Some(progress) = WorkerProgressViewModel::from_source_cache_warm(state) {
+        return Some(ActiveWorkerViewModel {
+            progress,
+            details: JobDetailsViewModel::from_source_cache_warm(state),
+        });
+    }
     state
-        .library
-        .folder_progress()
-        .map(WorkerProgressViewModel::from_folder_progress)
-        .or_else(|| {
-            state
-                .background
-                .normalization_progress
-                .as_ref()
-                .map(WorkerProgressViewModel::from_normalization_progress)
+        .background
+        .source_processing_progress
+        .as_ref()
+        .map(|source_progress| ActiveWorkerViewModel {
+            progress: WorkerProgressViewModel::from_source_processing(source_progress),
+            details: JobDetailsViewModel::from_source_processing(state, source_progress),
         })
-        .or_else(|| {
-            state
-                .background
-                .file_move_progress
-                .as_ref()
-                .map(WorkerProgressViewModel::from_file_move_progress)
-        })
-        .or_else(|| WorkerProgressViewModel::from_source_cache_warm(state))
 }
 
 impl WorkerProgressViewModel {
-    fn from_folder_progress(progress: &FolderScanProgress) -> Self {
+    pub(in crate::native_app) fn from_folder_progress(progress: &FolderScanProgress) -> Self {
         Self {
             completed: progress.completed,
             total: progress.total,
@@ -195,86 +150,165 @@ impl WorkerProgressViewModel {
                 active_animation: true,
             })
     }
+
+    fn from_source_processing(progress: &crate::native_app::app::SourceProcessingProgress) -> Self {
+        Self {
+            completed: progress.completed,
+            total: progress.total,
+            current_fraction: None,
+            active_animation: true,
+        }
+    }
 }
 
-fn source_cache_warm_status_text(
-    state: &NativeAppState,
-    progress: WorkerProgressViewModel,
-) -> String {
-    let counters = ui::ProgressSnapshot::new(progress.completed, progress.total);
-    let detail = state
-        .waveform
-        .cache
-        .active_folder_warm_current
-        .as_ref()
-        .and_then(|path| path.file_name())
-        .map(|name| name.to_string_lossy().to_string());
-    let stage = state
-        .waveform
-        .cache
-        .active_folder_warm_current_stage
-        .map(|stage| {
-            let percent = (state
-                .waveform
-                .cache
-                .active_folder_warm_current_progress
-                .clamp(0.0, 1.0)
-                * 100.0)
+impl JobDetailsViewModel {
+    pub(in crate::native_app) fn from_folder_progress(progress: &FolderScanProgress) -> Self {
+        Self {
+            rows: job_rows(
+                progress.phase.as_str(),
+                progress.label.as_str(),
+                progress.completed,
+                progress.total,
+                progress.detail.as_str(),
+                "found",
+            ),
+        }
+    }
+
+    fn from_normalization_progress(progress: &NormalizationProgress) -> Self {
+        let detail = if progress.queued == 0 {
+            progress.detail.clone()
+        } else {
+            format!("{} | {} queued", progress.detail, progress.queued)
+        };
+        Self {
+            rows: job_rows(
+                "Normalization",
+                progress.label.as_str(),
+                progress.work_completed,
+                progress.work_total,
+                detail.as_str(),
+                "processed",
+            ),
+        }
+    }
+
+    fn from_file_move_progress(progress: &FileMoveProgress) -> Self {
+        Self {
+            rows: job_rows(
+                "File operation",
+                progress.label.as_str(),
+                progress.completed,
+                progress.total,
+                progress.detail.as_str(),
+                "processed",
+            ),
+        }
+    }
+
+    fn from_source_cache_warm(state: &NativeAppState) -> Self {
+        let cache = &state.waveform.cache;
+        let checking = cache.active_folder_warm_plan_task.active().is_some();
+        let path = cache
+            .active_folder_warm_current
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let stage = cache.active_folder_warm_current_stage.map(|stage| {
+            let percent = (cache.active_folder_warm_current_progress.clamp(0.0, 1.0) * 100.0)
                 .round() as usize;
             format!("{} {percent}%", stage.label())
         });
-    match (stage, detail) {
-        (Some(stage), Some(detail)) => format!(
-            "Caching source samples | {} | {} | {}",
-            counters.count_label("cached"),
-            stage,
-            detail
-        ),
-        (None, Some(detail)) => format!(
-            "Caching source samples | {} | {}",
-            counters.count_label("cached"),
-            detail
-        ),
-        (Some(stage), None) => format!(
-            "Caching source samples | {} | {}",
-            counters.count_label("cached"),
-            stage
-        ),
-        (None, None) => format!(
-            "Caching source samples | {}",
-            counters.count_label("cached")
-        ),
+        let detail = match (stage, path.is_empty()) {
+            (Some(stage), false) => format!("{stage} | {path}"),
+            (Some(stage), true) => stage,
+            (None, false) => path,
+            (None, true) => String::new(),
+        };
+        Self {
+            rows: job_rows(
+                if checking {
+                    "Cache check"
+                } else {
+                    "Waveform cache"
+                },
+                selected_source_label(state).as_str(),
+                cache.active_folder_warm_completed,
+                cache.active_folder_warm_total,
+                detail.as_str(),
+                if checking { "checked" } else { "cached" },
+            ),
+        }
+    }
+
+    fn from_source_processing(
+        state: &NativeAppState,
+        progress: &crate::native_app::app::SourceProcessingProgress,
+    ) -> Self {
+        let current = if progress.detail.is_empty() {
+            progress.stage.clone()
+        } else {
+            format!("{} | {}", progress.stage, progress.detail)
+        };
+        let source = state
+            .library
+            .folder_browser
+            .source_label(progress.source_id.as_str())
+            .unwrap_or(progress.source_id.as_str());
+        Self {
+            rows: if progress.total == 0 {
+                [
+                    String::from("Type: Source processing"),
+                    format!("Source: {source}"),
+                    String::from("Progress: Discovering work"),
+                    format!("Current: {current}"),
+                ]
+            } else {
+                job_rows(
+                    "Source processing",
+                    source,
+                    progress.completed,
+                    progress.total,
+                    current.as_str(),
+                    "processed",
+                )
+            },
+        }
     }
 }
 
-fn source_cache_plan_status_text(
-    state: &NativeAppState,
-    progress: WorkerProgressViewModel,
-) -> String {
-    let counters = ui::ProgressSnapshot::new(progress.completed, progress.total);
-    let detail = state
-        .waveform
-        .cache
-        .active_folder_warm_current
-        .as_ref()
-        .and_then(|path| path.file_name())
-        .map(|name| name.to_string_lossy().to_string());
-    let percent = (state
-        .waveform
-        .cache
-        .active_folder_warm_current_progress
-        .clamp(0.0, 1.0)
-        * 100.0)
-        .round() as usize;
-    match detail {
-        Some(detail) => format!(
-            "Checking source samples | {} | {percent}% | {}",
-            counters.count_label("checked"),
-            detail
-        ),
-        None => format!(
-            "Checking source samples | {}",
-            counters.count_label("checked")
-        ),
-    }
+fn selected_source_label(state: &NativeAppState) -> String {
+    let source_id = state.library.folder_browser.selected_source_id();
+    state
+        .library
+        .folder_browser
+        .source_label(source_id)
+        .unwrap_or(source_id)
+        .to_string()
+}
+
+fn job_rows(
+    kind: &str,
+    source: &str,
+    completed: usize,
+    total: usize,
+    detail: &str,
+    indeterminate_suffix: &str,
+) -> [String; 4] {
+    let progress = if total == 0 {
+        format!("{completed} {indeterminate_suffix}")
+    } else {
+        format!("{}/{}", completed.min(total), total)
+    };
+    let detail = if detail.is_empty() {
+        "Waiting for next item"
+    } else {
+        detail
+    };
+    [
+        format!("Type: {kind}"),
+        format!("Source: {source}"),
+        format!("Progress: {progress}"),
+        format!("Current: {detail}"),
+    ]
 }

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -270,10 +270,15 @@ impl JobDetailsViewModel {
         };
         Self {
             rows: if progress.total == 0 {
+                let progress_label = if progress.stage == "Checking pending work" {
+                    "Progress: Counting pending jobs"
+                } else {
+                    "Progress: Active (total not available)"
+                };
                 [
                     String::from("Type: Source processing"),
                     format!("Source: {source}"),
-                    String::from("Status: Active"),
+                    String::from(progress_label),
                     format!("Current: {current}"),
                 ]
             } else {

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -156,7 +156,11 @@ impl WorkerProgressViewModel {
             completed: progress.completed,
             total: progress.total,
             current_fraction: None,
-            active_animation: true,
+            // Source processing has no independently measurable current-item fraction. Use one
+            // determinate track when totals are known and let the shared progress primitive
+            // animate that same track when totals are unknown. A second indeterminate strip can
+            // clip down to an ambiguous edge sliver at the end of its animation cycle.
+            active_animation: false,
         }
     }
 }

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -38,6 +38,7 @@ pub(in crate::native_app) struct WorkerProgressViewModel {
     pub(in crate::native_app) total: usize,
     pub(in crate::native_app) current_fraction: Option<f32>,
     pub(in crate::native_app) active_animation: bool,
+    pub(in crate::native_app) compact_activity: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -116,6 +117,7 @@ impl WorkerProgressViewModel {
             total: progress.total,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     }
 
@@ -125,6 +127,7 @@ impl WorkerProgressViewModel {
             total: progress.work_total,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     }
 
@@ -134,6 +137,7 @@ impl WorkerProgressViewModel {
             total: progress.total,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     }
 
@@ -148,6 +152,7 @@ impl WorkerProgressViewModel {
                     .as_ref()
                     .map(|_| cache.active_folder_warm_current_progress.clamp(0.0, 1.0)),
                 active_animation: true,
+                compact_activity: false,
             })
     }
 
@@ -157,10 +162,10 @@ impl WorkerProgressViewModel {
             total: progress.total,
             current_fraction: None,
             // Source processing has no independently measurable current-item fraction. Use one
-            // determinate track when totals are known and let the shared progress primitive
-            // animate that same track when totals are unknown. A second indeterminate strip can
-            // clip down to an ambiguous edge sliver at the end of its animation cycle.
+            // determinate track when totals are known and a compact activity indicator when they
+            // are not, so discovery cannot look like a frozen determinate bar.
             active_animation: false,
+            compact_activity: true,
         }
     }
 }
@@ -254,17 +259,21 @@ impl JobDetailsViewModel {
         } else {
             format!("{} | {}", progress.stage, progress.detail)
         };
-        let source = state
-            .library
-            .folder_browser
-            .source_label(progress.source_id.as_str())
-            .unwrap_or(progress.source_id.as_str());
+        let source = if progress.source_id.is_empty() {
+            "Multiple sources"
+        } else {
+            state
+                .library
+                .folder_browser
+                .source_label(progress.source_id.as_str())
+                .unwrap_or(progress.source_id.as_str())
+        };
         Self {
             rows: if progress.total == 0 {
                 [
                     String::from("Type: Source processing"),
                     format!("Source: {source}"),
-                    String::from("Progress: Discovering work"),
+                    String::from("Status: Active"),
                     format!("Current: {current}"),
                 ]
             } else {

--- a/src/native_app/audio/playback/progress/waveform_publish.rs
+++ b/src/native_app/audio/playback/progress/waveform_publish.rs
@@ -83,6 +83,7 @@ impl NativeAppState {
         !self.chrome_overlay_suppresses_waveform_transient_overlay()
             && (self.playback_visual_activity_active()
                 || self.waveform.load.label.is_some()
+                || self.source_processing_activity_overlay_visible()
                 || self.active_starmap_audition_file_id().is_some())
     }
 

--- a/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/candidate_queries.rs
@@ -182,11 +182,28 @@ impl FolderBrowserState {
         if selected.is_empty() {
             return Vec::new();
         }
-        self.loaded_source_audio_files()
-            .into_iter()
-            .filter(|file| selected.contains(&file.id))
+        let wanted = selected.iter().map(String::as_str).collect();
+        let mut files_by_id = HashMap::with_capacity(selected.len());
+        for folder in self.loaded_source_root_folders() {
+            super::super::sample_queries::traversal::collect_audio_files_matching_ids(
+                folder,
+                &wanted,
+                &mut files_by_id,
+            );
+            if files_by_id.len() == wanted.len() {
+                break;
+            }
+        }
+        let mut files = files_by_id
+            .into_values()
             .filter(|file| !file.is_missing())
-            .collect()
+            .collect::<Vec<_>>();
+        // Preserve the established visible-order contract without sorting every loaded source
+        // file just to materialize the usually one-item active selection. This path is rebuilt
+        // every UI frame by the metadata sidebar, so an active similarity anchor otherwise turns
+        // a constant-time selection query into a full-library similarity sort.
+        self.sort_files(&mut files);
+        files
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/sample_queries.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries.rs
@@ -19,7 +19,7 @@ mod collection;
 mod filters;
 mod ordering;
 mod subtree;
-mod traversal;
+pub(super) mod traversal;
 
 impl FolderBrowserState {
     pub(super) fn active_name_filter(&self) -> &str {
@@ -631,7 +631,7 @@ impl FolderBrowserState {
         files
     }
 
-    fn loaded_source_root_folders(&self) -> Vec<&FolderEntry> {
+    pub(super) fn loaded_source_root_folders(&self) -> Vec<&FolderEntry> {
         let mut folders = self
             .source
             .sources

--- a/src/native_app/sample_library/folder_browser/sample_queries/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries/traversal.rs
@@ -29,7 +29,9 @@ pub(super) fn collect_collection_audio_files<'a>(
     }
 }
 
-pub(super) fn collect_audio_files_matching_ids<'a>(
+pub(in crate::native_app::sample_library::folder_browser) fn collect_audio_files_matching_ids<
+    'a,
+>(
     folder: &'a FolderEntry,
     wanted: &HashSet<&str>,
     files_by_id: &mut HashMap<&'a str, &'a FileEntry>,

--- a/src/native_app/sample_library/folder_browser/source_management/catalog.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/catalog.rs
@@ -97,6 +97,19 @@ impl FolderBrowserState {
         Some(source.refresh_availability_from_disk().is_missing())
     }
 
+    pub(in crate::native_app) fn apply_observed_source_availability(
+        &mut self,
+        source_id: &str,
+        available: bool,
+    ) -> Option<bool> {
+        let source = self
+            .source
+            .sources
+            .iter_mut()
+            .find(|source| source.id == source_id)?;
+        Some(source.apply_observed_availability(available).is_missing())
+    }
+
     pub(in crate::native_app) fn source_roots(
         &self,
         source_id: &str,

--- a/src/native_app/sample_library/folder_browser/source_management/catalog.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/catalog.rs
@@ -36,6 +36,14 @@ impl FolderBrowserState {
         self.source.selected_source.as_str()
     }
 
+    pub(in crate::native_app) fn source_label(&self, source_id: &str) -> Option<&str> {
+        self.source
+            .sources
+            .iter()
+            .find(|source| source.id == source_id)
+            .map(|source| source.label.as_str())
+    }
+
     pub(in crate::native_app) fn configured_sample_sources(&self) -> Vec<SampleSource> {
         self.source
             .sources

--- a/src/native_app/sample_library/folder_browser/state_types.rs
+++ b/src/native_app/sample_library/folder_browser/state_types.rs
@@ -118,6 +118,15 @@ impl SourceEntry {
         self.availability
     }
 
+    pub(super) fn apply_observed_availability(&mut self, available: bool) -> SourceAvailability {
+        self.availability = if available {
+            SourceAvailability::Available
+        } else {
+            SourceAvailability::Missing
+        };
+        self.availability
+    }
+
     pub(super) fn mark_available(&mut self) {
         self.availability = SourceAvailability::Available;
     }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -15,13 +15,16 @@ impl NativeAppState {
         source_id: String,
         paths: Vec<PathBuf>,
         overflowed: bool,
+        source_root_available: bool,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
-        match self
-            .library
-            .plan_filesystem_change(source_id, &paths, overflowed)
-        {
+        match self.library.plan_filesystem_change(
+            source_id,
+            &paths,
+            overflowed,
+            source_root_available,
+        ) {
             SourceFilesystemChangePlan::IgnoredSourceMissing { source_id } => {
                 self.background
                     .source_processing
@@ -86,16 +89,10 @@ impl NativeAppState {
             );
             return;
         }
-        if result.cancelled {
-            self.background
-                .source_processing
-                .wake_source(&source_id, "filesystem_sync_cancelled");
-            self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
-            return;
-        }
         match result.result {
             Ok(success) => {
                 let renames_reconciled = success.renames_reconciled;
+                let incomplete_error = success.incomplete_error;
                 let delta = success.committed_delta;
                 tracing::info!(
                     source_id = %source_id,
@@ -114,6 +111,11 @@ impl NativeAppState {
                         SourcePrepTrigger::FilesystemChanged,
                         context,
                     );
+                }
+                if result.cancelled || incomplete_error.is_some() {
+                    self.background
+                        .source_processing
+                        .wake_source(&source_id, "filesystem_sync_incomplete_after_commit");
                 }
                 self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
             }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -104,7 +104,7 @@ impl NativeAppState {
                     renames_reconciled,
                     "Committed filesystem source delta"
                 );
-                if !delta.is_empty() {
+                if !delta.is_empty() && incomplete_error.is_none() {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
                     self.queue_source_prep(
                         source_id.clone(),

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::Instant};
+use std::{collections::BTreeSet, path::PathBuf, time::Instant};
 
 use radiant::prelude as ui;
 
@@ -23,9 +23,16 @@ impl NativeAppState {
             .plan_filesystem_change(source_id, &paths, overflowed)
         {
             SourceFilesystemChangePlan::IgnoredSourceMissing { source_id } => {
+                self.background
+                    .source_processing
+                    .wake_source(&source_id, "source_root_availability_changed");
                 if source_id == self.library.folder_browser.selected_source_id() {
                     self.ui.status.sample = String::from("Source missing");
                 }
+                self.persist_user_configuration(
+                    "folder_browser.source.availability_changed",
+                    started_at,
+                );
                 emit_gui_action(
                     "folder_browser.source.filesystem_change",
                     Some("sources"),
@@ -35,29 +42,16 @@ impl NativeAppState {
                     Some("source_not_found"),
                 );
             }
-            SourceFilesystemChangePlan::Patched {
+            SourceFilesystemChangePlan::SyncPaths {
                 source_id,
                 changed_count,
-                changed,
             } => {
                 self.queue_source_filesystem_sync(source_id.clone(), paths, changed_count, context);
-                if changed {
-                    self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
-                    self.queue_source_prep_pending_commit(
-                        source_id.clone(),
-                        SourcePrepTrigger::FilesystemChanged,
-                        context,
-                    );
-                    self.persist_user_configuration(
-                        "folder_browser.source.filesystem_patch",
-                        started_at,
-                    );
-                }
                 emit_gui_action(
                     "folder_browser.source.filesystem_change",
                     Some("sources"),
                     Some(&source_id),
-                    "patched",
+                    "sync_queued",
                     started_at,
                     None,
                 );
@@ -85,6 +79,13 @@ impl NativeAppState {
     ) {
         let source_id = result.source_id;
         let changed_count = result.changed_count;
+        if !self.library.folder_browser.source_exists(&source_id) {
+            tracing::debug!(
+                source_id = %source_id,
+                "Ignoring stale filesystem sync completion for removed source"
+            );
+            return;
+        }
         if result.cancelled {
             self.background
                 .source_processing
@@ -93,19 +94,38 @@ impl NativeAppState {
             return;
         }
         match result.result {
-            Ok(success) if success.renames_reconciled > 0 => {
-                if changed_count > 0 {
-                    self.background
-                        .source_processing
-                        .wake_source(&source_id, "filesystem_sync_commit");
+            Ok(success) => {
+                let renames_reconciled = success.renames_reconciled;
+                let delta = success.committed_delta;
+                if delta.is_empty() {
+                    return;
                 }
-                self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
-            }
-            Ok(_) => {
-                if changed_count > 0 {
-                    self.background
-                        .source_processing
-                        .wake_source(&source_id, "filesystem_sync_commit");
+                let projection_paths = committed_delta_paths(&delta);
+                tracing::info!(
+                    source_id = %source_id,
+                    revision = delta.revision,
+                    created = delta.created.len(),
+                    changed = delta.changed.len(),
+                    moved = delta.moved.len(),
+                    deleted = delta.deleted.len(),
+                    renames_reconciled,
+                    "Committed filesystem source delta"
+                );
+                self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
+                self.queue_source_prep(
+                    source_id.clone(),
+                    SourcePrepTrigger::FilesystemChanged,
+                    context,
+                );
+                if self
+                    .library
+                    .folder_browser
+                    .refresh_filesystem_paths(&source_id, &projection_paths)
+                {
+                    self.persist_user_configuration(
+                        "folder_browser.source.filesystem_commit",
+                        Instant::now(),
+                    );
                 }
             }
             Err(error) => {
@@ -118,6 +138,7 @@ impl NativeAppState {
                 if source_id == self.library.folder_browser.selected_source_id() {
                     self.ui.status.sample = format!("Source sync failed: {error}");
                 }
+                self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
             }
         }
     }
@@ -217,4 +238,29 @@ impl NativeAppState {
             GuiMessage::SourceFilesystemSyncFinished,
         );
     }
+}
+
+fn committed_delta_paths(
+    delta: &wavecrate::sample_sources::scanner::CommittedSourceDelta,
+) -> Vec<PathBuf> {
+    delta
+        .created
+        .iter()
+        .chain(&delta.changed)
+        .map(|identity| identity.relative_path.clone())
+        .chain(delta.moved.iter().flat_map(|identity| {
+            [
+                identity.old_relative_path.clone(),
+                identity.new_relative_path.clone(),
+            ]
+        }))
+        .chain(
+            delta
+                .deleted
+                .iter()
+                .map(|identity| identity.relative_path.clone()),
+        )
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, path::PathBuf, time::Instant};
+use std::{path::PathBuf, time::Instant};
 
 use radiant::prelude as ui;
 
@@ -97,10 +97,6 @@ impl NativeAppState {
             Ok(success) => {
                 let renames_reconciled = success.renames_reconciled;
                 let delta = success.committed_delta;
-                if delta.is_empty() {
-                    return;
-                }
-                let projection_paths = committed_delta_paths(&delta);
                 tracing::info!(
                     source_id = %source_id,
                     revision = delta.revision,
@@ -111,22 +107,15 @@ impl NativeAppState {
                     renames_reconciled,
                     "Committed filesystem source delta"
                 );
-                self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
-                self.queue_source_prep(
-                    source_id.clone(),
-                    SourcePrepTrigger::FilesystemChanged,
-                    context,
-                );
-                if self
-                    .library
-                    .folder_browser
-                    .refresh_filesystem_paths(&source_id, &projection_paths)
-                {
-                    self.persist_user_configuration(
-                        "folder_browser.source.filesystem_commit",
-                        Instant::now(),
+                if !delta.is_empty() {
+                    self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
+                    self.queue_source_prep(
+                        source_id.clone(),
+                        SourcePrepTrigger::FilesystemChanged,
+                        context,
                     );
                 }
+                self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
             }
             Err(error) => {
                 tracing::warn!(
@@ -141,6 +130,27 @@ impl NativeAppState {
                 self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
             }
         }
+    }
+
+    pub(in crate::native_app) fn finish_source_manifest_audit(
+        &mut self,
+        source_id: String,
+        committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        if committed_delta.is_empty() || !self.library.folder_browser.source_exists(&source_id) {
+            return;
+        }
+        tracing::info!(
+            source_id = %source_id,
+            revision = committed_delta.revision,
+            created = committed_delta.created.len(),
+            changed = committed_delta.changed.len(),
+            moved = committed_delta.moved.len(),
+            deleted = committed_delta.deleted.len(),
+            "Refreshing browser projection after periodic source audit"
+        );
+        self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
     }
 
     pub(in crate::native_app) fn maybe_run_pending_source_refresh(
@@ -238,29 +248,4 @@ impl NativeAppState {
             GuiMessage::SourceFilesystemSyncFinished,
         );
     }
-}
-
-fn committed_delta_paths(
-    delta: &wavecrate::sample_sources::scanner::CommittedSourceDelta,
-) -> Vec<PathBuf> {
-    delta
-        .created
-        .iter()
-        .chain(&delta.changed)
-        .map(|identity| identity.relative_path.clone())
-        .chain(delta.moved.iter().flat_map(|identity| {
-            [
-                identity.old_relative_path.clone(),
-                identity.new_relative_path.clone(),
-            ]
-        }))
-        .chain(
-            delta
-                .deleted
-                .iter()
-                .map(|identity| identity.relative_path.clone()),
-        )
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -143,6 +143,17 @@ impl NativeAppState {
         if committed_delta.is_empty() || !self.library.folder_browser.source_exists(&source_id) {
             return;
         }
+        self.background
+            .source_processing
+            .wake_source(&source_id, "manifest_audit_committed");
+        if !manifest_delta_requires_browser_refresh(&committed_delta) {
+            tracing::debug!(
+                source_id = %source_id,
+                revision = committed_delta.revision,
+                "Skipping filesystem rescan for content-generation-only audit delta"
+            );
+            return;
+        }
         tracing::info!(
             source_id = %source_id,
             revision = committed_delta.revision,
@@ -249,5 +260,57 @@ impl NativeAppState {
             },
             GuiMessage::SourceFilesystemSyncFinished,
         );
+    }
+}
+
+fn manifest_delta_requires_browser_refresh(
+    delta: &wavecrate::sample_sources::scanner::CommittedSourceDelta,
+) -> bool {
+    !delta.created.is_empty()
+        || !delta.moved.is_empty()
+        || !delta.deleted.is_empty()
+        || delta
+            .changed
+            .iter()
+            .any(|change| change.source_metadata_changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::manifest_delta_requires_browser_refresh;
+    use wavecrate::sample_sources::scanner::{CommittedSourceDelta, ManifestIdentityDelta};
+
+    #[test]
+    fn content_generation_only_audit_does_not_queue_filesystem_rescan() {
+        let delta = CommittedSourceDelta {
+            revision: 7,
+            changed: vec![ManifestIdentityDelta {
+                identity: String::from("file-id"),
+                relative_path: PathBuf::from("sample.wav"),
+                content_generation: String::from("hash"),
+                source_metadata_changed: false,
+            }],
+            ..CommittedSourceDelta::default()
+        };
+
+        assert!(!manifest_delta_requires_browser_refresh(&delta));
+    }
+
+    #[test]
+    fn source_metadata_change_requires_browser_refresh() {
+        let delta = CommittedSourceDelta {
+            revision: 8,
+            changed: vec![ManifestIdentityDelta {
+                identity: String::from("file-id"),
+                relative_path: PathBuf::from("sample.wav"),
+                content_generation: String::from("new-hash"),
+                source_metadata_changed: true,
+            }],
+            ..CommittedSourceDelta::default()
+        };
+
+        assert!(manifest_delta_requires_browser_refresh(&delta));
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -62,6 +62,7 @@ fn sync_source_database_paths_once(
         .and_then(|db| {
             let stats = scanner::sync_paths_with_progress(&db, paths, Some(cancel), &mut |_, _| {})
                 .map_err(|err| format!("sync source index: {err}"))?;
+            let incomplete_error = stats.incomplete_error.clone();
             let committed = stats.clone();
             let completed = match scanner::complete_deferred_rename_candidates_with_cancel(
                 &db,
@@ -81,6 +82,7 @@ fn sync_source_database_paths_once(
             };
             Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: completed.renames_reconciled,
+                incomplete_error,
                 committed_delta: completed.committed_delta,
             })
         })

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -60,24 +60,33 @@ fn sync_source_database_paths_once(
     SourceDatabase::open_for_background_job_with_database_root(root, database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            let stats = scanner::sync_paths_with_progress(&db, paths, Some(cancel), &mut |_, _| {})
-                .map_err(|err| format!("sync source index: {err}"))?;
-            let incomplete_error = stats.incomplete_error.clone();
+            let (stats, mut incomplete_error) =
+                match scanner::sync_paths_with_progress(&db, paths, Some(cancel), &mut |_, _| {}) {
+                    Ok(stats) => (stats, None),
+                    Err(scanner::ScanError::Incomplete { committed, error }) => {
+                        (*committed, Some(error))
+                    }
+                    Err(error) => return Err(format!("sync source index: {error}")),
+                };
             let committed = stats.clone();
-            let completed = match scanner::complete_deferred_rename_candidates_with_cancel(
-                &db,
-                stats,
-                Some(cancel),
-            ) {
-                Ok(completed) => completed,
-                Err(scanner::ScanError::Canceled) => committed,
-                Err(error) => {
-                    tracing::warn!(
-                        source_id,
-                        error = %error,
-                        "Deferred rename reconciliation failed after filesystem sync committed"
-                    );
-                    committed
+            let completed = if incomplete_error.is_some() {
+                committed
+            } else {
+                match scanner::complete_deferred_rename_candidates_with_cancel(
+                    &db,
+                    stats,
+                    Some(cancel),
+                ) {
+                    Ok(completed) => completed,
+                    Err(error) => {
+                        incomplete_error = Some(error.to_string());
+                        tracing::warn!(
+                            source_id,
+                            error = %error,
+                            "Deferred rename reconciliation failed after filesystem sync committed"
+                        );
+                        committed
+                    }
                 }
             };
             Ok(SourceFilesystemSyncSuccess {

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -1,11 +1,17 @@
 use std::{
     path::PathBuf,
     sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::Duration,
 };
 
 use wavecrate::sample_sources::{SourceDatabase, scanner};
 
 use crate::native_app::app::{SourceFilesystemSyncResult, SourceFilesystemSyncSuccess};
+
+const MAX_SYNC_ATTEMPTS: usize = 3;
+const SYNC_RETRY_DELAYS: [Duration; MAX_SYNC_ATTEMPTS - 1] =
+    [Duration::from_millis(50), Duration::from_millis(200)];
 
 pub(super) fn sync_source_database_paths(
     source_id: String,
@@ -15,12 +21,47 @@ pub(super) fn sync_source_database_paths(
     changed_count: usize,
     cancel: &AtomicBool,
 ) -> SourceFilesystemSyncResult {
-    let result = SourceDatabase::open_for_background_job_with_database_root(&root, &database_root)
+    let mut result = Err(String::from("Source filesystem sync did not run"));
+    for attempt in 0..MAX_SYNC_ATTEMPTS {
+        result = sync_source_database_paths_once(&source_id, &root, &database_root, &paths, cancel);
+        if result.is_ok() || cancel.load(Ordering::Acquire) {
+            break;
+        }
+        let Some(delay) = SYNC_RETRY_DELAYS.get(attempt).copied() else {
+            break;
+        };
+        tracing::warn!(
+            source_id,
+            attempt = attempt + 1,
+            max_attempts = MAX_SYNC_ATTEMPTS,
+            delay_ms = delay.as_millis(),
+            error = %result.as_ref().expect_err("failed attempt"),
+            "Retrying targeted source sync"
+        );
+        if !wait_for_retry(cancel, delay) {
+            break;
+        }
+    }
+    SourceFilesystemSyncResult {
+        source_id,
+        changed_count,
+        cancelled: cancel.load(Ordering::Acquire),
+        result,
+    }
+}
+
+fn sync_source_database_paths_once(
+    source_id: &str,
+    root: &std::path::Path,
+    database_root: &std::path::Path,
+    paths: &[PathBuf],
+    cancel: &AtomicBool,
+) -> Result<SourceFilesystemSyncSuccess, String> {
+    SourceDatabase::open_for_background_job_with_database_root(root, database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            let stats =
-                scanner::sync_paths_with_progress(&db, &paths, Some(cancel), &mut |_, _| {})
-                    .map_err(|err| format!("sync source index: {err}"))?;
+            let stats = scanner::sync_paths_with_progress(&db, paths, Some(cancel), &mut |_, _| {})
+                .map_err(|err| format!("sync source index: {err}"))?;
             let committed = stats.clone();
             let completed = match scanner::complete_deferred_rename_candidates_with_cancel(
                 &db,
@@ -40,14 +81,20 @@ pub(super) fn sync_source_database_paths(
             };
             Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: completed.renames_reconciled,
+                committed_delta: completed.committed_delta,
             })
-        });
-    SourceFilesystemSyncResult {
-        source_id,
-        changed_count,
-        cancelled: cancel.load(Ordering::Acquire),
-        result,
+        })
+}
+
+fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {
+    let deadline = std::time::Instant::now() + delay;
+    while std::time::Instant::now() < deadline {
+        if cancel.load(Ordering::Acquire) {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(10));
     }
+    true
 }
 
 #[cfg(test)]
@@ -59,7 +106,7 @@ mod tests {
 
     use wavecrate::sample_sources::{Rating, SourceDatabase, scanner};
 
-    use super::{SourceFilesystemSyncSuccess, sync_source_database_paths};
+    use super::sync_source_database_paths;
 
     #[test]
     fn filesystem_sync_returns_deferred_rename_results_for_refresh() {
@@ -82,12 +129,9 @@ mod tests {
             &AtomicBool::new(false),
         );
 
-        assert_eq!(
-            result.result,
-            Ok(SourceFilesystemSyncSuccess {
-                renames_reconciled: 1
-            })
-        );
+        let success = result.result.expect("sync result");
+        assert_eq!(success.renames_reconciled, 1);
+        assert_eq!(success.committed_delta.moved.len(), 1);
         assert_eq!(
             db.entry_for_path(Path::new("new.wav"))
                 .unwrap()
@@ -112,12 +156,9 @@ mod tests {
             &AtomicBool::new(false),
         );
 
-        assert_eq!(
-            result.result,
-            Ok(SourceFilesystemSyncSuccess {
-                renames_reconciled: 0
-            })
-        );
+        let success = result.result.expect("sync result");
+        assert_eq!(success.renames_reconciled, 0);
+        assert_eq!(success.committed_delta.created.len(), 1);
         let db = SourceDatabase::open(root.path()).expect("source db");
         assert!(
             db.entry_for_path(Path::new("fresh.wav"))
@@ -153,5 +194,33 @@ mod tests {
                 .expect("read entry")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn filesystem_sync_retries_a_transient_database_root_failure() {
+        let root = tempfile::tempdir().expect("source root");
+        std::fs::write(root.path().join("fresh.wav"), b"fresh").expect("wav");
+        let database_parent = tempfile::tempdir().expect("database parent");
+        let database_root = database_parent.path().join("source-db");
+        std::fs::write(&database_root, b"temporarily blocked").expect("block database root");
+        let repaired_root = database_root.clone();
+        let repair = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(75));
+            std::fs::remove_file(&repaired_root).expect("remove transient blocker");
+            std::fs::create_dir(&repaired_root).expect("repair database root");
+        });
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            database_root,
+            vec![PathBuf::from("fresh.wav")],
+            1,
+            &AtomicBool::new(false),
+        );
+        repair.join().expect("repair worker");
+
+        let success = result.result.expect("transient sync should converge");
+        assert_eq!(success.committed_delta.created.len(), 1);
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
+};
 
 use wavecrate::sample_sources::{
     HarvestFileIdentity, HarvestFileKey, SampleSource,
@@ -47,11 +50,7 @@ pub(super) fn persist_folder_scan_maintenance(
     let scan_cache_error =
         apply_folder_scan_cache_update(request.scan_cache_update, request.scan_cache_revision)
             .err();
-    let harvest_errors = request
-        .audio_file_paths
-        .iter()
-        .filter_map(|path| persist_harvest_discovery(&request.sources, path).err())
-        .collect();
+    let harvest_errors = persist_harvest_discoveries(&request.sources, &request.audio_file_paths);
     FolderScanMaintenanceResult {
         config_error,
         scan_cache_error,
@@ -73,32 +72,55 @@ fn persist_config_revision(
     }
 }
 
-fn persist_harvest_discovery(sources: &[SampleSource], path: &Path) -> Result<(), String> {
-    let Some((source, relative_path)) = sources
-        .iter()
-        .filter_map(|source| {
-            path.strip_prefix(&source.root)
-                .ok()
-                .map(|relative| (source, relative.to_path_buf()))
-        })
-        .max_by_key(|(source, _)| source.root.components().count())
-    else {
-        return Ok(());
-    };
-    let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(path);
-    let entry = source
-        .open_db()
-        .ok()
-        .and_then(|db| db.entry_for_path(&relative_path).ok().flatten());
-    let identity = HarvestFileIdentity {
-        key: HarvestFileKey::new(source.id.clone(), relative_path),
-        file_size: file_size.or_else(|| entry.as_ref().map(|entry| entry.file_size)),
-        modified_ns: modified_ns.or_else(|| entry.as_ref().map(|entry| entry.modified_ns)),
-        content_hash: entry.and_then(|entry| entry.content_hash),
-    };
-    library::upsert_harvest_file(&identity)
-        .map(|_| ())
-        .map_err(|error| format!("record harvest discovery {}: {error}", path.display()))
+fn persist_harvest_discoveries(sources: &[SampleSource], paths: &[PathBuf]) -> Vec<String> {
+    let mut paths_by_source = BTreeMap::<usize, Vec<(&Path, PathBuf)>>::new();
+    for path in paths {
+        let Some((source_index, relative_path)) = sources
+            .iter()
+            .enumerate()
+            .filter_map(|(index, source)| {
+                path.strip_prefix(&source.root)
+                    .ok()
+                    .map(|relative| (index, relative.to_path_buf()))
+            })
+            .max_by_key(|(index, _)| sources[*index].root.components().count())
+        else {
+            continue;
+        };
+        paths_by_source
+            .entry(source_index)
+            .or_default()
+            .push((path.as_path(), relative_path));
+    }
+
+    let mut identities = Vec::with_capacity(paths.len());
+    for (source_index, source_paths) in paths_by_source {
+        let source = &sources[source_index];
+        let manifest = source
+            .open_db()
+            .ok()
+            .and_then(|db| db.list_manifest_entries().ok())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|entry| (entry.relative_path.clone(), entry))
+            .collect::<HashMap<_, _>>();
+        identities.extend(source_paths.into_iter().map(|(path, relative_path)| {
+            let (file_size, modified_ns) = harvest_file_ops::file_identity_metadata(path);
+            let entry = manifest.get(&relative_path);
+            HarvestFileIdentity {
+                key: HarvestFileKey::new(source.id.clone(), relative_path),
+                file_size: file_size.or_else(|| entry.map(|entry| entry.file_size)),
+                modified_ns: modified_ns.or_else(|| entry.map(|entry| entry.modified_ns)),
+                content_hash: entry.and_then(|entry| entry.content_hash.clone()),
+            }
+        }));
+    }
+
+    library::upsert_harvest_files(&identities)
+        .err()
+        .map(|error| format!("record {} harvest discoveries: {error}", identities.len()))
+        .into_iter()
+        .collect()
 }
 
 #[cfg(test)]
@@ -107,8 +129,29 @@ mod tests {
 
     #[test]
     fn discovery_outside_configured_sources_is_a_noop() {
-        let result = persist_harvest_discovery(&[], Path::new("/tmp/outside.wav"));
-        assert_eq!(result, Ok(()));
+        let errors = persist_harvest_discoveries(&[], &[PathBuf::from("/tmp/outside.wav")]);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn discovery_batch_opens_each_source_database_once() {
+        let config = tempfile::tempdir().unwrap();
+        let _guard = wavecrate::app_dirs::ConfigBaseGuard::set(config.path().to_path_buf());
+        let root = tempfile::tempdir().unwrap();
+        let first = root.path().join("first.wav");
+        let second = root.path().join("second.wav");
+        std::fs::write(&first, b"first").unwrap();
+        std::fs::write(&second, b"second").unwrap();
+        let source = SampleSource::new(root.path().to_path_buf());
+        wavecrate::sample_sources::db::test_reset_source_db_open_total_count(root.path());
+
+        let errors = persist_harvest_discoveries(&[source], &[first, second]);
+
+        assert!(errors.is_empty());
+        assert_eq!(
+            wavecrate::sample_sources::db::test_source_db_open_total_count(root.path()),
+            1
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_scan_actions/progress.rs
+++ b/src/native_app/sample_library/folder_scan_actions/progress.rs
@@ -11,12 +11,10 @@ impl NativeAppState {
         progress: FolderScanProgress,
     ) {
         let started_at = Instant::now();
+        let label = progress.label.clone();
+        let phase = progress.phase.clone();
         if self.library.apply_folder_scan_progress(progress) {
-            let phase = self
-                .library
-                .folder_progress()
-                .map(|progress| progress.phase.clone())
-                .unwrap_or_default();
+            self.ui.status.sample = format!("{phase} source {label}");
             emit_gui_action(
                 "folder_browser.scan.progress",
                 Some("folder_browser"),

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -50,7 +50,7 @@ impl NativeAppState {
             );
         }
         self.library.start_folder_scan(&request);
-        self.ui.status.sample = format!("Scanning source {}", request.label);
+        self.ui.status.sample = format!("Queued source scan for {}", request.label);
         tracing::info!(
             source = label,
             root = root,

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -237,6 +237,9 @@ impl NativeAppState {
             return;
         }
         if let Some(error) = scan.source_db_error {
+            self.background
+                .source_processing
+                .wake_source(&scan.source_id, "folder_scan_index_incomplete");
             self.ui.status.sample = format!(
                 "Loaded source {}: {} files in {} folders, but indexing failed: {error}",
                 scan.label, scan.file_count, scan.folder_count

--- a/src/native_app/sample_library/similarity_prep.rs
+++ b/src/native_app/sample_library/similarity_prep.rs
@@ -25,6 +25,8 @@ pub(in crate::native_app) struct NativeSimilarityPrepState {
     pub(in crate::native_app) running_source_id: Option<String>,
     pub(in crate::native_app) pending_source_ids: VecDeque<String>,
     pub(in crate::native_app) summary: Option<String>,
+    pub(in crate::native_app) readiness_score_refresh_running: bool,
+    pub(in crate::native_app) readiness_score_refresh_pending: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -149,19 +151,19 @@ impl NativeAppState {
     pub(in crate::native_app) fn prepare_similarity_for_anchor_path(
         &mut self,
         file_id: &str,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
+        _context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        let Some((source, _)) = self
+        let Some((source, relative_path)) = self
             .library
             .folder_browser
             .sample_source_for_file_path(Path::new(file_id))
         else {
             return;
         };
-        self.queue_similarity_prep_for_source(
-            SimilarityPrepSource { source },
-            SimilarityPrepTrigger::Automatic,
-            context,
+        self.background.source_processing.prioritize_path(
+            source.id.as_str(),
+            &relative_path.to_string_lossy(),
+            true,
         );
     }
 

--- a/src/native_app/sample_library/similarity_scores.rs
+++ b/src/native_app/sample_library/similarity_scores.rs
@@ -90,8 +90,10 @@ impl NativeAppState {
     pub(in crate::native_app) fn finish_similarity_scores(
         &mut self,
         result: SimilarityScoresResult,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if self.library.folder_browser.similarity_anchor_id() != Some(result.anchor_id.as_str()) {
+            self.finish_readiness_score_refresh(context);
             return;
         }
         match result.result {
@@ -106,32 +108,38 @@ impl NativeAppState {
                         scores.scores_by_file,
                         scores.aspect_scores_by_file,
                     );
-                self.ui.status.sample = format!(
-                    "Resolved {count} similar sample{}",
-                    if count == 1 { "" } else { "s" }
-                );
+                let total = self
+                    .library
+                    .folder_browser
+                    .selected_audio_files_matching_tags(&self.metadata.tags_by_file)
+                    .len();
+                let remaining = total.saturating_sub(count.saturating_add(1));
+                self.ui.status.sample = if remaining == 0 {
+                    format!(
+                        "Resolved {count} similar sample{}",
+                        if count == 1 { "" } else { "s" }
+                    )
+                } else {
+                    format!("Resolved {count} similar samples")
+                };
             }
             Err(error) => {
-                if similarity_artifacts_missing_error(&error)
-                    && self.similarity_prep_active_for_anchor(result.anchor_id.as_str())
-                {
-                    self.ui.status.sample = format!(
-                        "Preparing similarity for {}",
-                        sample_path_label(result.anchor_id.as_str())
+                if similarity_artifacts_missing_error(&error) {
+                    self.ui.status.sample = String::from("Similarity data not ready yet");
+                } else {
+                    self.ui.status.sample = format!("Similarity scores unavailable: {error}");
+                    emit_gui_action(
+                        "browser.similarity_scores.resolve",
+                        Some("browser"),
+                        Some(result.anchor_id.as_str()),
+                        "error",
+                        std::time::Instant::now(),
+                        Some(&error),
                     );
-                    return;
                 }
-                self.ui.status.sample = format!("Similarity scores unavailable: {error}");
-                emit_gui_action(
-                    "browser.similarity_scores.resolve",
-                    Some("browser"),
-                    Some(result.anchor_id.as_str()),
-                    "error",
-                    std::time::Instant::now(),
-                    Some(&error),
-                );
             }
         }
+        self.finish_readiness_score_refresh(context);
     }
 
     fn prepare_similarity_scores_request(
@@ -213,25 +221,49 @@ impl NativeAppState {
         scores
     }
 
-    fn similarity_prep_active_for_anchor(&self, anchor_id: &str) -> bool {
+    pub(in crate::native_app) fn finish_similarity_readiness_advanced(
+        &mut self,
+        source_id: String,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let Some(anchor_id) = self
+            .library
+            .folder_browser
+            .similarity_anchor_id()
+            .map(str::to_owned)
+        else {
+            return;
+        };
         let Some((source, _)) = self
             .library
             .folder_browser
-            .sample_source_for_file_path(Path::new(anchor_id))
+            .sample_source_for_file_path(Path::new(&anchor_id))
         else {
-            return false;
+            return;
         };
-        self.library
-            .similarity_prep
-            .running_source_id
-            .as_deref()
-            .is_some_and(|running| running == source.id.as_str())
-            || self
-                .library
-                .similarity_prep
-                .pending_source_ids
-                .iter()
-                .any(|pending| pending == source.id.as_str())
+        if source.id.as_str() != source_id {
+            return;
+        }
+        if self.library.similarity_prep.readiness_score_refresh_running {
+            self.library.similarity_prep.readiness_score_refresh_pending = true;
+            return;
+        }
+        self.library.similarity_prep.readiness_score_refresh_running = true;
+        self.queue_similarity_score_resolution(anchor_id, context);
+    }
+
+    fn finish_readiness_score_refresh(&mut self, context: &mut ui::UiUpdateContext<GuiMessage>) {
+        if !self.library.similarity_prep.readiness_score_refresh_running {
+            return;
+        }
+        self.library.similarity_prep.readiness_score_refresh_running = false;
+        if !std::mem::take(&mut self.library.similarity_prep.readiness_score_refresh_pending) {
+            return;
+        }
+        self.library.similarity_prep.readiness_score_refresh_running = true;
+        if !self.queue_active_similarity_score_resolution(context) {
+            self.library.similarity_prep.readiness_score_refresh_running = false;
+        }
     }
 }
 
@@ -243,8 +275,32 @@ fn resolve_similarity_scores(request: SimilarityScoresRequest) -> SimilarityScor
     let anchor_id = request.anchor_id.clone();
     SimilarityScoresResult {
         anchor_id,
-        result: resolve_similarity_scores_inner(&request),
+        result: resolve_similarity_scores_with_busy_retry(&request),
     }
+}
+
+fn resolve_similarity_scores_with_busy_retry(
+    request: &SimilarityScoresRequest,
+) -> Result<SimilarityScoresPayload, String> {
+    const MAX_ATTEMPTS: usize = 3;
+    for attempt in 0..MAX_ATTEMPTS {
+        match resolve_similarity_scores_inner(request) {
+            Err(error) if attempt + 1 < MAX_ATTEMPTS && similarity_database_is_busy(&error) => {
+                std::thread::sleep(std::time::Duration::from_millis(
+                    50_u64.saturating_mul(1_u64 << attempt),
+                ));
+            }
+            result => return result,
+        }
+    }
+    unreachable!("bounded similarity score retry returns from every attempt")
+}
+
+fn similarity_database_is_busy(error: &str) -> bool {
+    let error = error.to_ascii_lowercase();
+    error.contains("database is busy")
+        || error.contains("database is locked")
+        || error.contains("please retry")
 }
 
 fn resolve_similarity_scores_inner(

--- a/src/native_app/sample_library/source_prep.rs
+++ b/src/native_app/sample_library/source_prep.rs
@@ -55,32 +55,11 @@ impl NativeAppState {
         trigger: SourcePrepTrigger,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        self.queue_source_prep_inner(source_id, trigger, true, context);
-    }
-
-    pub(in crate::native_app) fn queue_source_prep_pending_commit(
-        &mut self,
-        source_id: String,
-        trigger: SourcePrepTrigger,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
-    ) {
-        self.queue_source_prep_inner(source_id, trigger, false, context);
-    }
-
-    fn queue_source_prep_inner(
-        &mut self,
-        source_id: String,
-        trigger: SourcePrepTrigger,
-        wake_supervisor: bool,
-        context: &mut ui::UiUpdateContext<GuiMessage>,
-    ) {
         let started_at = Instant::now();
         let selected_source = source_id == self.library.folder_browser.selected_source_id();
-        if wake_supervisor {
-            self.background
-                .source_processing
-                .wake_source(&source_id, trigger.action_label());
-        }
+        self.background
+            .source_processing
+            .wake_source(&source_id, trigger.action_label());
         if selected_source {
             self.background
                 .source_processing

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -10,6 +10,11 @@ mod state;
 const WATCHER_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const SOURCE_CHANGE_DEBOUNCE: Duration = Duration::from_millis(400);
 const MAX_PENDING_PATHS_PER_SOURCE: usize = 512;
+const WATCHER_EVENT_QUEUE_CAPACITY: usize = 256;
+const WATCHER_RESTART_MIN: Duration = Duration::from_secs(1);
+const WATCHER_RESTART_MAX: Duration = Duration::from_secs(60);
+const ROOT_REFRESH_AVAILABLE: Duration = Duration::from_secs(10);
+const ROOT_REFRESH_UNAVAILABLE: Duration = Duration::from_secs(30);
 
 pub(in crate::native_app) use handle::GuiSourceWatcherHandle;
 

--- a/src/native_app/sample_library/source_watcher/classification.rs
+++ b/src/native_app/sample_library/source_watcher/classification.rs
@@ -8,8 +8,19 @@ pub(super) fn event_triggers_source_refresh(event: &Event) -> bool {
     )
 }
 
+pub(super) fn retain_source_refresh_candidates(event: &mut Event) -> bool {
+    if !event_triggers_source_refresh(event) {
+        return false;
+    }
+    event
+        .paths
+        .retain(|path| path_is_source_refresh_candidate(path, event.kind));
+    !event.paths.is_empty()
+}
+
 pub(super) fn path_is_source_refresh_candidate(path: &Path, kind: EventKind) -> bool {
     if is_wavecrate_metadata_file(path)
+        || is_wavecrate_transient_analysis_path(path)
         || wavecrate_library::sample_sources::is_apple_double_sidecar(path)
     {
         return false;
@@ -18,6 +29,20 @@ pub(super) fn path_is_source_refresh_candidate(path: &Path, kind: EventKind) -> 
         || path_has_supported_audio_extension(path)
         || path.extension().is_none()
         || path.is_dir()
+}
+
+fn is_wavecrate_transient_analysis_path(path: &Path) -> bool {
+    path.components().any(|component| {
+        let name = component.as_os_str().to_string_lossy();
+        is_tempfile_name(&name, "ann_container") || is_tempfile_name(&name, "ann_dump")
+    })
+}
+
+fn is_tempfile_name(name: &str, prefix: &str) -> bool {
+    let Some(suffix) = name.strip_prefix(prefix) else {
+        return false;
+    };
+    suffix.len() == 6 && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 fn path_has_supported_audio_extension(path: &Path) -> bool {

--- a/src/native_app/sample_library/source_watcher/debounce.rs
+++ b/src/native_app/sample_library/source_watcher/debounce.rs
@@ -43,4 +43,5 @@ pub(super) struct GuiSourceWatchEvent {
     pub(super) source_id: String,
     pub(super) paths: Vec<PathBuf>,
     pub(super) overflowed: bool,
+    pub(super) source_root_available: bool,
 }

--- a/src/native_app/sample_library/source_watcher/debounce.rs
+++ b/src/native_app/sample_library/source_watcher/debounce.rs
@@ -21,6 +21,9 @@ impl PendingGuiSourceWatch {
     }
 
     pub(super) fn add_path(&mut self, path: Option<PathBuf>) {
+        if self.overflowed {
+            return;
+        }
         let Some(path) = path else {
             self.overflowed = true;
             self.paths.clear();

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -96,10 +96,10 @@ fn run_source_watcher(
                 Err(TrySendError::Disconnected(_)) => {}
             }) {
                 Ok(mut restarted) => {
-                    state.reset_watches(now);
                     let (unavailable, watch_failed) =
-                        state.refresh_watched_roots(&mut restarted, now);
+                        state.refresh_watched_roots(&mut restarted, now, false);
                     if watch_failed {
+                        state.reset_watches(now);
                         next_restart = now + restart_delay;
                         restart_delay = doubled_backoff(restart_delay);
                     } else {
@@ -129,7 +129,8 @@ fn run_source_watcher(
         if let Some(active_watcher) = watcher.as_mut()
             && now >= next_root_refresh
         {
-            let (unavailable, watch_failed) = state.refresh_watched_roots(active_watcher, now);
+            let (unavailable, watch_failed) =
+                state.refresh_watched_roots(active_watcher, now, true);
             root_refresh_failed = watch_failed;
             if !watch_failed {
                 next_root_refresh = now

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -178,6 +178,7 @@ fn run_source_watcher(
                 source_id: event.source_id,
                 paths: event.paths,
                 overflowed: event.overflowed,
+                source_root_available: event.source_root_available,
             });
         }
     }

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use wavecrate::sample_sources::SampleSource;
 
-use super::classification::event_triggers_source_refresh;
+use super::classification::retain_source_refresh_candidates;
 use super::state::GuiSourceWatchState;
 use super::{
     ROOT_REFRESH_AVAILABLE, ROOT_REFRESH_UNAVAILABLE, SOURCE_CHANGE_DEBOUNCE,
@@ -88,12 +88,23 @@ fn run_source_watcher(
         if watcher.is_none() && now >= next_restart {
             let callback_tx = event_tx.clone();
             let callback_overflowed = Arc::clone(&ingress_overflowed);
-            match notify::recommended_watcher(move |event| match callback_tx.try_send(event) {
-                Ok(()) => {}
-                Err(TrySendError::Full(_)) => {
-                    callback_overflowed.store(true, Ordering::Release);
+            match notify::recommended_watcher(move |event| {
+                let event = match event {
+                    Ok(mut event) => {
+                        if !retain_source_refresh_candidates(&mut event) {
+                            return;
+                        }
+                        Ok(event)
+                    }
+                    Err(error) => Err(error),
+                };
+                match callback_tx.try_send(event) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_)) => {
+                        callback_overflowed.store(true, Ordering::Release);
+                    }
+                    Err(TrySendError::Disconnected(_)) => {}
                 }
-                Err(TrySendError::Disconnected(_)) => {}
             }) {
                 Ok(mut restarted) => {
                     let (unavailable, watch_failed) =
@@ -149,6 +160,7 @@ fn run_source_watcher(
         }
 
         if ingress_overflowed.swap(false, Ordering::AcqRel) {
+            tracing::warn!("GUI source watcher event queue overflowed; reconciling every source");
             state.mark_all_overflowed(now);
         }
 
@@ -156,10 +168,7 @@ fn run_source_watcher(
         while let Ok(event) = event_rx.try_recv() {
             let event: notify::Result<Event> = event;
             match event {
-                Ok(event) if event_triggers_source_refresh(&event) => {
-                    state.collect_event(&event, Instant::now());
-                }
-                Ok(_) => {}
+                Ok(event) => state.collect_event(&event, Instant::now()),
                 Err(error) => {
                     tracing::warn!("GUI source watcher error: {error}");
                     watcher_failed = true;
@@ -175,6 +184,13 @@ fn run_source_watcher(
         }
 
         for event in state.drain_ready_sources(now, SOURCE_CHANGE_DEBOUNCE) {
+            tracing::debug!(
+                source_id = %event.source_id,
+                overflowed = event.overflowed,
+                source_root_available = event.source_root_available,
+                paths = ?event.paths,
+                "Publishing debounced GUI source watcher event"
+            );
             let _ = message_tx.send(GuiMessage::SourceFilesystemChanged {
                 source_id: event.source_id,
                 paths: event.paths,

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -1,14 +1,21 @@
 use notify::Event;
 use std::{
-    sync::mpsc::{Receiver, Sender},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, Sender, TrySendError},
+    },
     thread,
-    time::Instant,
+    time::{Duration, Instant},
 };
 use wavecrate::sample_sources::SampleSource;
 
 use super::classification::event_triggers_source_refresh;
 use super::state::GuiSourceWatchState;
-use super::{SOURCE_CHANGE_DEBOUNCE, WATCHER_POLL_INTERVAL};
+use super::{
+    ROOT_REFRESH_AVAILABLE, ROOT_REFRESH_UNAVAILABLE, SOURCE_CHANGE_DEBOUNCE,
+    WATCHER_EVENT_QUEUE_CAPACITY, WATCHER_POLL_INTERVAL, WATCHER_RESTART_MAX, WATCHER_RESTART_MIN,
+};
 use crate::native_app::app::GuiMessage;
 
 #[derive(Debug)]
@@ -57,29 +64,94 @@ fn run_source_watcher(
     message_tx: Sender<GuiMessage>,
     initial_sources: Vec<SampleSource>,
 ) {
-    let (event_tx, event_rx) = std::sync::mpsc::channel();
-    let mut watcher = match notify::recommended_watcher(move |event| {
-        let _ = event_tx.send(event);
-    }) {
-        Ok(watcher) => watcher,
-        Err(error) => {
-            tracing::warn!("Failed to initialize GUI source watcher: {error}");
-            return;
-        }
-    };
+    let (event_tx, event_rx) = std::sync::mpsc::sync_channel(WATCHER_EVENT_QUEUE_CAPACITY);
+    let ingress_overflowed = Arc::new(AtomicBool::new(false));
+    let mut watcher = None;
     let mut state = GuiSourceWatchState::default();
-    state.replace_sources(initial_sources, &mut watcher);
+    state.set_sources(initial_sources);
+    let mut next_restart = Instant::now();
+    let mut restart_delay = WATCHER_RESTART_MIN;
+    let mut next_root_refresh = Instant::now();
 
     loop {
         match command_rx.recv_timeout(WATCHER_POLL_INTERVAL) {
             Ok(GuiSourceWatchCommand::ReplaceSources(sources)) => {
-                state.replace_sources(sources, &mut watcher);
+                state.set_sources(sources);
+                next_root_refresh = Instant::now();
             }
             Ok(GuiSourceWatchCommand::Shutdown) => break,
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
 
+        let now = Instant::now();
+        if watcher.is_none() && now >= next_restart {
+            let callback_tx = event_tx.clone();
+            let callback_overflowed = Arc::clone(&ingress_overflowed);
+            match notify::recommended_watcher(move |event| match callback_tx.try_send(event) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    callback_overflowed.store(true, Ordering::Release);
+                }
+                Err(TrySendError::Disconnected(_)) => {}
+            }) {
+                Ok(mut restarted) => {
+                    state.reset_watches(now);
+                    let (unavailable, watch_failed) =
+                        state.refresh_watched_roots(&mut restarted, now);
+                    if watch_failed {
+                        next_restart = now + restart_delay;
+                        restart_delay = doubled_backoff(restart_delay);
+                    } else {
+                        watcher = Some(restarted);
+                        restart_delay = WATCHER_RESTART_MIN;
+                        next_root_refresh = now
+                            + if unavailable {
+                                ROOT_REFRESH_UNAVAILABLE
+                            } else {
+                                ROOT_REFRESH_AVAILABLE
+                            };
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        retry_ms = restart_delay.as_millis(),
+                        "Failed to initialize GUI source watcher: {error}"
+                    );
+                    state.mark_all_overflowed(now);
+                    next_restart = now + restart_delay;
+                    restart_delay = doubled_backoff(restart_delay);
+                }
+            }
+        }
+
+        let mut root_refresh_failed = false;
+        if let Some(active_watcher) = watcher.as_mut()
+            && now >= next_root_refresh
+        {
+            let (unavailable, watch_failed) = state.refresh_watched_roots(active_watcher, now);
+            root_refresh_failed = watch_failed;
+            if !watch_failed {
+                next_root_refresh = now
+                    + if unavailable {
+                        ROOT_REFRESH_UNAVAILABLE
+                    } else {
+                        ROOT_REFRESH_AVAILABLE
+                    };
+            }
+        }
+        if root_refresh_failed {
+            watcher = None;
+            state.reset_watches(now);
+            next_restart = now + restart_delay;
+            restart_delay = doubled_backoff(restart_delay);
+        }
+
+        if ingress_overflowed.swap(false, Ordering::AcqRel) {
+            state.mark_all_overflowed(now);
+        }
+
+        let mut watcher_failed = false;
         while let Ok(event) = event_rx.try_recv() {
             let event: notify::Result<Event> = event;
             match event {
@@ -89,11 +161,19 @@ fn run_source_watcher(
                 Ok(_) => {}
                 Err(error) => {
                     tracing::warn!("GUI source watcher error: {error}");
+                    watcher_failed = true;
                 }
             }
         }
 
-        for event in state.drain_ready_sources(Instant::now(), SOURCE_CHANGE_DEBOUNCE) {
+        if watcher_failed {
+            watcher = None;
+            state.reset_watches(now);
+            next_restart = now + restart_delay;
+            restart_delay = doubled_backoff(restart_delay);
+        }
+
+        for event in state.drain_ready_sources(now, SOURCE_CHANGE_DEBOUNCE) {
             let _ = message_tx.send(GuiMessage::SourceFilesystemChanged {
                 source_id: event.source_id,
                 paths: event.paths,
@@ -101,4 +181,8 @@ fn run_source_watcher(
             });
         }
     }
+}
+
+pub(super) fn doubled_backoff(current: Duration) -> Duration {
+    current.saturating_mul(2).min(WATCHER_RESTART_MAX)
 }

--- a/src/native_app/sample_library/source_watcher/roots.rs
+++ b/src/native_app/sample_library/source_watcher/roots.rs
@@ -2,17 +2,25 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::{collections::HashSet, path::PathBuf};
 use wavecrate::sample_sources::SampleSource;
 
+pub(super) struct RootWatchUpdate {
+    pub(super) changed_roots: Vec<PathBuf>,
+    pub(super) has_unavailable_roots: bool,
+    pub(super) watch_failed: bool,
+}
+
 pub(super) fn update_watched_roots(
     watcher: &mut RecommendedWatcher,
     watched_roots: &mut HashSet<PathBuf>,
     sources: &[SampleSource],
-) {
+) -> RootWatchUpdate {
     let desired = sources
         .iter()
         .map(|source| source.root.clone())
         .filter(|root| root.is_dir())
         .collect::<HashSet<_>>();
 
+    let mut changed_roots = Vec::new();
+    let mut watch_failed = false;
     for root in watched_roots
         .difference(&desired)
         .cloned()
@@ -25,6 +33,7 @@ pub(super) fn update_watched_roots(
             );
         }
         watched_roots.remove(&root);
+        changed_roots.push(root);
     }
 
     for root in desired
@@ -37,8 +46,16 @@ pub(super) fn update_watched_roots(
                 "Failed to watch GUI source root {}: {error}",
                 root.display()
             );
+            changed_roots.push(root);
+            watch_failed = true;
             continue;
         }
-        watched_roots.insert(root);
+        watched_roots.insert(root.clone());
+        changed_roots.push(root);
+    }
+    RootWatchUpdate {
+        changed_roots,
+        has_unavailable_roots: sources.iter().any(|source| !source.root.is_dir()),
+        watch_failed,
     }
 }

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -9,7 +9,7 @@ use wavecrate::sample_sources::SampleSource;
 use super::classification::path_is_source_refresh_candidate;
 use super::debounce::{GuiSourceWatchEvent, PendingGuiSourceWatch};
 use super::path_mapping::{source_for_path, source_relative_path};
-use super::roots::update_watched_roots;
+use super::roots::{RootWatchUpdate, update_watched_roots};
 
 #[derive(Default)]
 pub(super) struct GuiSourceWatchState {
@@ -34,17 +34,29 @@ impl GuiSourceWatchState {
         &mut self,
         watcher: &mut RecommendedWatcher,
         now: Instant,
+        reconcile_changed_roots: bool,
     ) -> (bool, bool) {
         let update = update_watched_roots(watcher, &mut self.watched_roots, &self.sources);
-        for root in update.changed_roots {
-            let affected = self
-                .sources
-                .iter()
-                .filter(|source| source.root == root)
-                .map(|source| source.id.as_str().to_string())
-                .collect::<Vec<_>>();
-            for source_id in affected {
-                self.mark_source_overflowed(&source_id, now);
+        self.apply_root_watch_update(update, now, reconcile_changed_roots)
+    }
+
+    pub(super) fn apply_root_watch_update(
+        &mut self,
+        update: RootWatchUpdate,
+        now: Instant,
+        reconcile_changed_roots: bool,
+    ) -> (bool, bool) {
+        if reconcile_changed_roots {
+            for root in update.changed_roots {
+                let affected = self
+                    .sources
+                    .iter()
+                    .filter(|source| source.root == root)
+                    .map(|source| source.id.as_str().to_string())
+                    .collect::<Vec<_>>();
+                for source_id in affected {
+                    self.mark_source_overflowed(&source_id, now);
+                }
             }
         }
         (update.has_unavailable_roots, update.watch_failed)

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -83,6 +83,19 @@ impl GuiSourceWatchState {
                 continue;
             }
             if let Some(source) = source_for_path(&self.sources, path) {
+                // FSEvents may coalesce writes to `.wavecrate.db`, its WAL, or related source
+                // metadata into an event for the watched root itself. Re-scanning that live root
+                // would write the database again and create a self-sustaining watcher loop.
+                // Root disappearance/reappearance is observed independently by the periodic root
+                // refresh; child paths still retain normal low-latency watcher behavior.
+                if path == &source.root && source.root.is_dir() {
+                    tracing::debug!(
+                        source_id = source.id.as_str(),
+                        kind = ?event.kind,
+                        "Ignoring coalesced live-root watcher event"
+                    );
+                    continue;
+                }
                 self.pending
                     .entry(source.id.as_str().to_string())
                     .and_modify(|pending| {

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -19,12 +19,7 @@ pub(super) struct GuiSourceWatchState {
 }
 
 impl GuiSourceWatchState {
-    pub(super) fn replace_sources(
-        &mut self,
-        sources: Vec<SampleSource>,
-        watcher: &mut RecommendedWatcher,
-    ) {
-        update_watched_roots(watcher, &mut self.watched_roots, &sources);
+    pub(super) fn set_sources(&mut self, sources: Vec<SampleSource>) {
         self.sources = sources;
         let allowed = self
             .sources
@@ -33,6 +28,53 @@ impl GuiSourceWatchState {
             .collect::<HashSet<_>>();
         self.pending
             .retain(|source_id, _| allowed.contains(source_id));
+    }
+
+    pub(super) fn refresh_watched_roots(
+        &mut self,
+        watcher: &mut RecommendedWatcher,
+        now: Instant,
+    ) -> (bool, bool) {
+        let update = update_watched_roots(watcher, &mut self.watched_roots, &self.sources);
+        for root in update.changed_roots {
+            let affected = self
+                .sources
+                .iter()
+                .filter(|source| source.root == root)
+                .map(|source| source.id.as_str().to_string())
+                .collect::<Vec<_>>();
+            for source_id in affected {
+                self.mark_source_overflowed(&source_id, now);
+            }
+        }
+        (update.has_unavailable_roots, update.watch_failed)
+    }
+
+    pub(super) fn reset_watches(&mut self, now: Instant) {
+        self.watched_roots.clear();
+        self.mark_all_overflowed(now);
+    }
+
+    pub(super) fn mark_all_overflowed(&mut self, now: Instant) {
+        let source_ids = self
+            .sources
+            .iter()
+            .map(|source| source.id.as_str().to_string())
+            .collect::<Vec<_>>();
+        for source_id in source_ids {
+            self.mark_source_overflowed(&source_id, now);
+        }
+    }
+
+    fn mark_source_overflowed(&mut self, source_id: &str, now: Instant) {
+        self.pending
+            .entry(source_id.to_string())
+            .and_modify(|pending| {
+                pending.last_event = now;
+                pending.overflowed = true;
+                pending.paths.clear();
+            })
+            .or_insert_with(|| PendingGuiSourceWatch::new(now, None));
     }
 
     pub(super) fn collect_event(&mut self, event: &Event, now: Instant) {

--- a/src/native_app/sample_library/source_watcher/state.rs
+++ b/src/native_app/sample_library/source_watcher/state.rs
@@ -107,10 +107,17 @@ impl GuiSourceWatchState {
             .filter(|&(_source_id, pending)| {
                 now.saturating_duration_since(pending.last_event) >= debounce
             })
-            .map(|(source_id, pending)| GuiSourceWatchEvent {
-                source_id: source_id.clone(),
-                paths: pending.paths.iter().cloned().collect(),
-                overflowed: pending.overflowed,
+            .filter_map(|(source_id, pending)| {
+                let source = self
+                    .sources
+                    .iter()
+                    .find(|source| source.id.as_str() == source_id)?;
+                Some(GuiSourceWatchEvent {
+                    source_id: source_id.clone(),
+                    paths: pending.paths.iter().cloned().collect(),
+                    overflowed: pending.overflowed,
+                    source_root_available: source.root.is_dir(),
+                })
             })
             .collect::<Vec<_>>();
         for event in &ready {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -139,6 +139,30 @@ fn debounce_drain_reports_root_availability_from_the_watcher_thread() {
 }
 
 #[test]
+fn live_root_events_do_not_feed_database_writes_back_into_scans() {
+    let root = tempfile::tempdir().expect("source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("source_id::root-event"),
+        root.path().to_path_buf(),
+    );
+    let mut state = GuiSourceWatchState {
+        sources: vec![source],
+        ..Default::default()
+    };
+
+    state.collect_event(
+        &Event {
+            kind: EventKind::Modify(notify::event::ModifyKind::Any),
+            paths: vec![root.path().to_path_buf()],
+            attrs: Default::default(),
+        },
+        Instant::now(),
+    );
+
+    assert!(state.pending.is_empty());
+}
+
+#[test]
 fn path_churn_is_bounded_and_escalates_to_full_refresh() {
     let root = PathBuf::from(r"C:\samples");
     let source =

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -110,6 +110,35 @@ fn debounce_drain_waits_until_source_is_ready() {
 }
 
 #[test]
+fn debounce_drain_reports_root_availability_from_the_watcher_thread() {
+    let root = tempfile::tempdir().expect("source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("source_id::availability"),
+        root.path().to_path_buf(),
+    );
+    let mut state = GuiSourceWatchState {
+        sources: vec![source],
+        ..Default::default()
+    };
+    let started = Instant::now();
+
+    state.mark_all_overflowed(started);
+    let ready = state.drain_ready_sources(
+        started + super::SOURCE_CHANGE_DEBOUNCE,
+        super::SOURCE_CHANGE_DEBOUNCE,
+    );
+    assert!(ready[0].source_root_available);
+
+    std::fs::remove_dir_all(root.path()).expect("remove source root");
+    state.mark_all_overflowed(started + super::SOURCE_CHANGE_DEBOUNCE);
+    let ready = state.drain_ready_sources(
+        started + super::SOURCE_CHANGE_DEBOUNCE * 2,
+        super::SOURCE_CHANGE_DEBOUNCE,
+    );
+    assert!(!ready[0].source_root_available);
+}
+
+#[test]
 fn path_churn_is_bounded_and_escalates_to_full_refresh() {
     let root = PathBuf::from(r"C:\samples");
     let source =

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -1,5 +1,6 @@
 use super::classification::path_is_source_refresh_candidate;
 use super::handle::doubled_backoff;
+use super::roots::RootWatchUpdate;
 use super::state::GuiSourceWatchState;
 use notify::{Event, EventKind, event::RemoveKind};
 use std::{path::PathBuf, time::Instant};
@@ -160,6 +161,61 @@ fn live_root_events_do_not_feed_database_writes_back_into_scans() {
     );
 
     assert!(state.pending.is_empty());
+}
+
+#[test]
+fn initial_watch_registration_does_not_queue_full_source_refresh() {
+    let root = tempfile::tempdir().expect("source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("source_id::initial-watch"),
+        root.path().to_path_buf(),
+    );
+    let mut state = GuiSourceWatchState {
+        sources: vec![source],
+        ..Default::default()
+    };
+    let (_unavailable, failed) = state.apply_root_watch_update(
+        RootWatchUpdate {
+            changed_roots: vec![root.path().to_path_buf()],
+            has_unavailable_roots: false,
+            watch_failed: false,
+        },
+        Instant::now(),
+        false,
+    );
+
+    assert!(!failed);
+    assert!(state.pending.is_empty());
+}
+
+#[test]
+fn later_watch_registration_queues_authoritative_source_refresh() {
+    let root = tempfile::tempdir().expect("source root");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("source_id::reappeared-watch"),
+        root.path().to_path_buf(),
+    );
+    let mut state = GuiSourceWatchState {
+        sources: vec![source],
+        ..Default::default()
+    };
+    let (_unavailable, failed) = state.apply_root_watch_update(
+        RootWatchUpdate {
+            changed_roots: vec![root.path().to_path_buf()],
+            has_unavailable_roots: false,
+            watch_failed: false,
+        },
+        Instant::now(),
+        true,
+    );
+
+    assert!(!failed);
+    assert!(
+        state
+            .pending
+            .get("source_id::reappeared-watch")
+            .is_some_and(|pending| pending.overflowed)
+    );
 }
 
 #[test]

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -1,4 +1,5 @@
 use super::classification::path_is_source_refresh_candidate;
+use super::handle::doubled_backoff;
 use super::state::GuiSourceWatchState;
 use notify::{Event, EventKind, event::RemoveKind};
 use std::{path::PathBuf, time::Instant};
@@ -106,4 +107,70 @@ fn debounce_drain_waits_until_source_is_ready() {
     assert_eq!(ready[0].source_id, "source_id::samples");
     assert_eq!(ready[0].paths, vec![PathBuf::from("kick.wav")]);
     assert!(!ready[0].overflowed);
+}
+
+#[test]
+fn path_churn_is_bounded_and_escalates_to_full_refresh() {
+    let root = PathBuf::from(r"C:\samples");
+    let source =
+        SampleSource::new_with_id(SourceId::from_string("source_id::samples"), root.clone());
+    let mut state = GuiSourceWatchState {
+        sources: vec![source],
+        ..Default::default()
+    };
+    let started = Instant::now();
+    for index in 0..=super::MAX_PENDING_PATHS_PER_SOURCE {
+        state.collect_event(
+            &Event {
+                kind: EventKind::Create(notify::event::CreateKind::File),
+                paths: vec![root.join(format!("sample-{index}.wav"))],
+                attrs: Default::default(),
+            },
+            started,
+        );
+    }
+
+    let pending = state.pending.get("source_id::samples").unwrap();
+    assert!(pending.overflowed);
+    assert!(pending.paths.is_empty());
+}
+
+#[test]
+fn watcher_restart_marks_every_source_for_authoritative_refresh() {
+    let first = SampleSource::new_with_id(
+        SourceId::from_string("source_id::first"),
+        PathBuf::from(r"C:\first"),
+    );
+    let second = SampleSource::new_with_id(
+        SourceId::from_string("source_id::second"),
+        PathBuf::from(r"C:\second"),
+    );
+    let mut state = GuiSourceWatchState {
+        sources: vec![first, second],
+        ..Default::default()
+    };
+    let started = Instant::now();
+
+    state.mark_all_overflowed(started);
+    let mut ready = state.drain_ready_sources(
+        started + super::SOURCE_CHANGE_DEBOUNCE,
+        super::SOURCE_CHANGE_DEBOUNCE,
+    );
+    ready.sort_by(|left, right| left.source_id.cmp(&right.source_id));
+
+    assert_eq!(ready.len(), 2);
+    assert!(ready.iter().all(|event| event.overflowed));
+    assert!(ready.iter().all(|event| event.paths.is_empty()));
+}
+
+#[test]
+fn watcher_restart_backoff_is_bounded() {
+    assert_eq!(
+        doubled_backoff(super::WATCHER_RESTART_MIN),
+        super::WATCHER_RESTART_MIN * 2
+    );
+    assert_eq!(
+        doubled_backoff(super::WATCHER_RESTART_MAX),
+        super::WATCHER_RESTART_MAX
+    );
 }

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -1,4 +1,4 @@
-use super::classification::path_is_source_refresh_candidate;
+use super::classification::{path_is_source_refresh_candidate, retain_source_refresh_candidates};
 use super::handle::doubled_backoff;
 use super::roots::RootWatchUpdate;
 use super::state::GuiSourceWatchState;
@@ -40,6 +40,32 @@ fn wavecrate_metadata_files_do_not_trigger_source_refresh() {
 }
 
 #[test]
+fn metadata_event_storm_is_filtered_before_the_bounded_watcher_queue() {
+    let root = PathBuf::from(r"C:\samples");
+    let mut event = Event {
+        kind: EventKind::Modify(notify::event::ModifyKind::Data(
+            notify::event::DataChange::Any,
+        )),
+        paths: vec![
+            root.join(wavecrate::sample_sources::db::DB_FILE_NAME),
+            root.join(format!(
+                "{}-wal",
+                wavecrate::sample_sources::db::DB_FILE_NAME
+            )),
+            root.join("kick.wav"),
+        ],
+        attrs: Default::default(),
+    };
+
+    assert!(retain_source_refresh_candidates(&mut event));
+    assert_eq!(event.paths, vec![root.join("kick.wav")]);
+
+    event.paths = vec![root.join(wavecrate::sample_sources::db::DB_FILE_NAME)];
+    assert!(!retain_source_refresh_candidates(&mut event));
+    assert!(event.paths.is_empty());
+}
+
+#[test]
 fn apple_double_sidecars_do_not_trigger_source_refresh() {
     let root = PathBuf::from(r"C:\samples");
     assert!(!path_is_source_refresh_candidate(
@@ -51,6 +77,30 @@ fn apple_double_sidecars_do_not_trigger_source_refresh() {
     assert!(!path_is_source_refresh_candidate(
         &root.join("drums").join("._snare.wav"),
         EventKind::Create(notify::event::CreateKind::File),
+    ));
+}
+
+#[test]
+fn transient_ann_persistence_artifacts_do_not_trigger_source_refresh() {
+    let root = PathBuf::from(r"C:\samples");
+    for path in [
+        root.join("ann_containerMqsFy3"),
+        root.join("ann_dumpJgi2JJ"),
+        root.join("ann_dumpJgi2JJ").join("ann_dump.hnsw.data"),
+        root.join("ann_dumpJgi2JJ").join("ann_dump.hnsw.graph"),
+    ] {
+        assert!(!path_is_source_refresh_candidate(
+            &path,
+            EventKind::Create(notify::event::CreateKind::Any),
+        ));
+    }
+    assert!(path_is_source_refresh_candidate(
+        &root.join("ann_dump.wav"),
+        EventKind::Create(notify::event::CreateKind::File),
+    ));
+    assert!(path_is_source_refresh_candidate(
+        &root.join("ann_dump_samples"),
+        EventKind::Create(notify::event::CreateKind::Folder),
     ));
 }
 

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -162,6 +162,7 @@ impl NativeAppState {
             if self.library.folder_scan_active()
                 || self.background.file_move_progress.is_some()
                 || self.waveform.cache.active_folder_warm_folder_id.is_some()
+                || self.background.source_processing_progress.is_some()
             {
                 self.background.progress_tick = (self.background.progress_tick + 0.035) % 1.0;
             }
@@ -202,6 +203,7 @@ impl NativeAppState {
         if self.library.folder_scan_active()
             || self.background.file_move_progress.is_some()
             || self.waveform.cache.active_folder_warm_folder_id.is_some()
+            || self.background.source_processing_progress.is_some()
         {
             self.background.progress_tick = (self.background.progress_tick + 0.035) % 1.0;
         }

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -76,6 +76,8 @@ impl NativeAppState {
             | GuiMessage::SimilarityPrepStatusResolved(_)
             | GuiMessage::SimilarityPrepEnqueueFinished(_)
             | GuiMessage::SimilarityScoresResolved(_)
+            | GuiMessage::SimilarityReadinessAdvanced { .. }
+            | GuiMessage::SourceProcessingProgress(_)
             | GuiMessage::FolderScanProgress(_)
             | GuiMessage::FolderScanDiscoveryBatch(_)
             | GuiMessage::FolderScanFinished(_)
@@ -324,6 +326,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",
         GuiMessage::SourceFilesystemSyncFinished(_) => "SourceFilesystemSyncFinished",
         GuiMessage::SourceManifestAuditCommitted { .. } => "SourceManifestAuditCommitted",
+        GuiMessage::SourceProcessingProgress(_) => "SourceProcessingProgress",
         GuiMessage::NormalizationProgress(_) => "NormalizationProgress",
         GuiMessage::NormalizationFinished(_) => "NormalizationFinished",
         GuiMessage::Waveform(_) => "Waveform",

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -84,6 +84,7 @@ impl NativeAppState {
             | GuiMessage::SelectedFolderVerifyFinished(_)
             | GuiMessage::SourceFilesystemChanged { .. }
             | GuiMessage::SourceFilesystemSyncFinished(_)
+            | GuiMessage::SourceManifestAuditCommitted { .. }
             | GuiMessage::NormalizationProgress(_)
             | GuiMessage::NormalizationFinished(_)
             | GuiMessage::SelectSampleWithModifiers { .. }
@@ -322,6 +323,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::SelectedFolderVerifyFinished(_) => "SelectedFolderVerifyFinished",
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",
         GuiMessage::SourceFilesystemSyncFinished(_) => "SourceFilesystemSyncFinished",
+        GuiMessage::SourceManifestAuditCommitted { .. } => "SourceManifestAuditCommitted",
         GuiMessage::NormalizationProgress(_) => "NormalizationProgress",
         GuiMessage::NormalizationFinished(_) => "NormalizationFinished",
         GuiMessage::Waveform(_) => "Waveform",

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -57,6 +57,7 @@ impl NativeAppState {
                 } else {
                     self.background.source_processing_progress = Some(progress);
                 }
+                context.repaint(ui::RepaintScope::Projection);
             }
             GuiMessage::FolderScanProgress(progress) => {
                 self.apply_folder_scan_progress(progress);

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -67,8 +67,15 @@ impl NativeAppState {
                 source_id,
                 paths,
                 overflowed,
+                source_root_available,
             } => {
-                self.refresh_source_after_filesystem_change(source_id, paths, overflowed, context);
+                self.refresh_source_after_filesystem_change(
+                    source_id,
+                    paths,
+                    overflowed,
+                    source_root_available,
+                    context,
+                );
             }
             GuiMessage::SourceFilesystemSyncFinished(result) => {
                 self.finish_source_filesystem_sync(result, context);

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -73,6 +73,12 @@ impl NativeAppState {
             GuiMessage::SourceFilesystemSyncFinished(result) => {
                 self.finish_source_filesystem_sync(result, context);
             }
+            GuiMessage::SourceManifestAuditCommitted {
+                source_id,
+                committed_delta,
+            } => {
+                self.finish_source_manifest_audit(source_id, committed_delta, context);
+            }
             GuiMessage::NormalizationProgress(progress) => {
                 self.apply_normalization_progress(progress);
             }

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -45,7 +45,18 @@ impl NativeAppState {
                 self.finish_similarity_prep_enqueue(result, context);
             }
             GuiMessage::SimilarityScoresResolved(result) => {
-                self.finish_similarity_scores(result);
+                self.finish_similarity_scores(result, context);
+            }
+            GuiMessage::SimilarityReadinessAdvanced { source_id } => {
+                self.finish_similarity_readiness_advanced(source_id, context);
+            }
+            GuiMessage::SourceProcessingProgress(progress) => {
+                if !progress.active {
+                    self.background.source_processing_progress = None;
+                    self.ui.chrome.job_details_open = false;
+                } else {
+                    self.background.source_processing_progress = Some(progress);
+                }
             }
             GuiMessage::FolderScanProgress(progress) => {
                 self.apply_folder_scan_progress(progress);

--- a/src/native_app/shell/message_dispatch/chrome.rs
+++ b/src/native_app/shell/message_dispatch/chrome.rs
@@ -1,6 +1,7 @@
 use radiant::prelude as ui;
 
 use crate::native_app::app::{GuiMessage, NativeAppState};
+use crate::native_app::app_chrome::view_models::status_bar::StatusBarViewModel;
 use crate::native_app::waveform::{SimilarSectionsResult, execute_similar_sections_scan};
 
 impl NativeAppState {
@@ -11,8 +12,10 @@ impl NativeAppState {
     ) {
         match message {
             GuiMessage::ToggleJobDetails => {
-                self.ui.chrome.job_details_open =
-                    self.library.folder_scan_active() && !self.ui.chrome.job_details_open;
+                let job_active = StatusBarViewModel::from_app_state(self)
+                    .job_details
+                    .is_some();
+                self.ui.chrome.job_details_open = job_active && !self.ui.chrome.job_details_open;
             }
             GuiMessage::CloseJobDetails => {
                 self.ui.chrome.job_details_open = false;

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -66,6 +66,30 @@ fn source_processing_progress_opens_the_shared_job_details_popover() {
 }
 
 #[test]
+fn source_processing_progress_refreshes_the_retained_details_projection() {
+    let mut state = NativeAppStateFixture::default().build();
+    let mut context = ui::UiUpdateContext::default();
+
+    state.apply_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 4,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("snare.wav"),
+        }),
+        &mut context,
+    );
+
+    assert_eq!(
+        context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::Projection),
+        "background progress must refresh retained text and counters without user input"
+    );
+}
+
+#[test]
 fn idle_map_frame_reuses_prepared_sample_browser_projection() {
     let (_root, mut state, _sample_id) = prepared_map_state("idle-map-frame.wav");
     let prepared = state

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -30,6 +30,42 @@ fn frame_messages_use_frame_budget_slow_threshold() {
 }
 
 #[test]
+fn source_processing_progress_opens_the_shared_job_details_popover() {
+    let mut state = NativeAppStateFixture::default().build();
+    state.background.source_processing_progress =
+        Some(crate::native_app::app::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 3,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("kick.wav"),
+        });
+
+    state.apply_message(
+        GuiMessage::ToggleJobDetails,
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(state.ui.chrome.job_details_open);
+
+    state.apply_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: false,
+            completed: 10,
+            total: 10,
+            stage: String::from("Building similarity layout"),
+            detail: String::from("Finalizing source"),
+        }),
+        &mut ui::UiUpdateContext::default(),
+    );
+
+    assert!(state.background.source_processing_progress.is_none());
+    assert!(!state.ui.chrome.job_details_open);
+}
+
+#[test]
 fn idle_map_frame_reuses_prepared_sample_browser_projection() {
     let (_root, mut state, _sample_id) = prepared_map_state("idle-map-frame.wav");
     let prepared = state

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -318,10 +318,12 @@ impl WorkCandidate {
     }
 }
 
-/// Weighted-fair scheduler that preserves interaction priority without starving other sources.
+/// Source-queued scheduler that chooses a source fairly, then drains its runnable work before
+/// moving to another source.
 #[derive(Debug, Default)]
 pub(crate) struct FairScheduler {
     virtual_finish: BTreeMap<String, u64>,
+    active_source: Option<String>,
     paused: bool,
 }
 
@@ -353,6 +355,12 @@ impl FairScheduler {
                 })
                 .or_insert(index);
         }
+        if let Some(active_source) = self.active_source.as_deref()
+            && let Some(index) = best_by_source.remove(active_source)
+        {
+            return Some(index);
+        }
+        self.active_source = None;
         let selected = best_by_source
             .into_iter()
             .map(|(source_id, index)| {
@@ -367,6 +375,7 @@ impl FairScheduler {
                 (finish, std::cmp::Reverse(weight), source_id, index)
             })
             .min()?;
+        self.active_source = Some(selected.2.to_string());
         self.virtual_finish
             .insert(selected.2.to_string(), selected.0);
         self.normalize_virtual_time();
@@ -477,33 +486,37 @@ mod tests {
     }
 
     #[test]
-    fn immediate_and_visible_work_lead_without_starving_backlog_sources() {
+    fn selected_source_is_drained_before_the_queue_advances() {
         let mut scheduler = FairScheduler::default();
         let budgets = BudgetTracker::new(ProcessingBudgets::for_tests(
             ResourceUse::new(10, 10, 10),
             ResourceUse::new(10, 10, 10),
             10,
         ));
-        let candidates = [
+        let mut candidates = vec![
             candidate("active", "now", ReadinessStage::PlaybackSummary),
+            candidate("active", "next", ReadinessStage::AnalysisFeatures),
             candidate("backlog", "old", ReadinessStage::AnalysisFeatures),
         ];
         let priority = PriorityContext {
             immediate: [PriorityKey::new("active", "now")].into_iter().collect(),
             ..PriorityContext::default()
         };
-        let mut chosen_sources = Vec::new();
-        for _ in 0..60 {
+        let mut chosen = Vec::new();
+        while !candidates.is_empty() {
             let index = scheduler.choose(&candidates, &priority, &budgets).unwrap();
-            chosen_sources.push(candidates[index].source_id.as_str());
+            let candidate = candidates.remove(index);
+            chosen.push((candidate.source_id, candidate.scope_id));
         }
-        assert_eq!(chosen_sources[0], "active");
-        assert!(
-            chosen_sources[..10]
-                .iter()
-                .all(|source| *source == "active")
+
+        assert_eq!(
+            chosen,
+            vec![
+                (String::from("active"), String::from("now")),
+                (String::from("active"), String::from("next")),
+                (String::from("backlog"), String::from("old")),
+            ]
         );
-        assert!(chosen_sources.contains(&"backlog"));
     }
 
     #[test]

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -157,7 +157,6 @@ pub(crate) struct BudgetTracker {
     global: ResourceUse,
     by_source: BTreeMap<String, ResourceUse>,
     by_lane: BTreeMap<ProcessingLane, usize>,
-    by_source_lane: BTreeMap<(String, ProcessingLane), usize>,
 }
 
 impl BudgetTracker {
@@ -167,7 +166,6 @@ impl BudgetTracker {
             global: ResourceUse::default(),
             by_source: BTreeMap::new(),
             by_lane: BTreeMap::new(),
-            by_source_lane: BTreeMap::new(),
         }
     }
 
@@ -199,10 +197,6 @@ impl BudgetTracker {
         let source = self.by_source.entry(source_id.to_string()).or_default();
         *source = source.add(demand);
         *self.by_lane.entry(lane).or_default() += 1;
-        *self
-            .by_source_lane
-            .entry((source_id.to_string(), lane))
-            .or_default() += 1;
         Some(BudgetPermit {
             source_id: source_id.to_string(),
             lane,
@@ -224,22 +218,10 @@ impl BudgetTracker {
                 self.by_lane.remove(&permit.lane);
             }
         }
-        let source_lane = (permit.source_id.clone(), permit.lane);
-        if let Some(count) = self.by_source_lane.get_mut(&source_lane) {
-            *count = count.saturating_sub(1);
-            if *count == 0 {
-                self.by_source_lane.remove(&source_lane);
-            }
-        }
     }
 
-    pub(crate) fn active_sources_for_lane(&self, lane: ProcessingLane) -> BTreeSet<String> {
-        self.by_source_lane
-            .keys()
-            .filter_map(|(source_id, active_lane)| {
-                (*active_lane == lane).then(|| source_id.clone())
-            })
-            .collect()
+    pub(crate) fn active_sources(&self) -> BTreeSet<String> {
+        self.by_source.keys().cloned().collect()
     }
 
     #[cfg(test)]

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -157,6 +157,7 @@ pub(crate) struct BudgetTracker {
     global: ResourceUse,
     by_source: BTreeMap<String, ResourceUse>,
     by_lane: BTreeMap<ProcessingLane, usize>,
+    by_source_lane: BTreeMap<(String, ProcessingLane), usize>,
 }
 
 impl BudgetTracker {
@@ -166,6 +167,7 @@ impl BudgetTracker {
             global: ResourceUse::default(),
             by_source: BTreeMap::new(),
             by_lane: BTreeMap::new(),
+            by_source_lane: BTreeMap::new(),
         }
     }
 
@@ -197,6 +199,10 @@ impl BudgetTracker {
         let source = self.by_source.entry(source_id.to_string()).or_default();
         *source = source.add(demand);
         *self.by_lane.entry(lane).or_default() += 1;
+        *self
+            .by_source_lane
+            .entry((source_id.to_string(), lane))
+            .or_default() += 1;
         Some(BudgetPermit {
             source_id: source_id.to_string(),
             lane,
@@ -218,6 +224,22 @@ impl BudgetTracker {
                 self.by_lane.remove(&permit.lane);
             }
         }
+        let source_lane = (permit.source_id.clone(), permit.lane);
+        if let Some(count) = self.by_source_lane.get_mut(&source_lane) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.by_source_lane.remove(&source_lane);
+            }
+        }
+    }
+
+    pub(crate) fn active_sources_for_lane(&self, lane: ProcessingLane) -> BTreeSet<String> {
+        self.by_source_lane
+            .keys()
+            .filter_map(|(source_id, active_lane)| {
+                (*active_lane == lane).then(|| source_id.clone())
+            })
+            .collect()
     }
 
     #[cfg(test)]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -131,7 +131,7 @@ impl SourceProcessingBudgetHandle {
         // coordinator could acquire the scan lane after we inspected it but before it observed the
         // foreground reservation.
         let budgets = self.shared.budgets();
-        let active_scan_sources = budgets.active_sources_for_lane(ProcessingLane::Scan);
+        let active_sources = budgets.active_sources();
         let (admission_id, admission_cancel) = {
             let mut control = self.shared.control();
             if control.shutdown
@@ -141,17 +141,17 @@ impl SourceProcessingBudgetHandle {
             {
                 return None;
             }
-            for active_source_id in active_scan_sources {
+            for active_source_id in active_sources {
                 tracing::info!(
                     target: "wavecrate::source_processing",
                     source_id,
                     preempted_source_id = active_source_id.as_str(),
-                    "Foreground source scan admission is reserving the occupied scan lane"
+                    "Foreground source scan admission is reserving occupied processing capacity"
                 );
                 control.cancel_source_work(&active_source_id);
                 control.mark_source_dirty(
                     &active_source_id,
-                    "foreground_scan_preempted_background_scan",
+                    "foreground_scan_preempted_background_work",
                 );
             }
             let admission_cancel = Arc::clone(&control.source_work_cancels[source_id]);
@@ -1156,6 +1156,11 @@ fn run_coordinator(shared: Arc<Shared>) {
             }
             let external_scan_admitted = shared.has_external_scan_admission();
             let eligible_indices = scheduler_candidate_indices(&candidates, external_scan_admitted);
+            if eligible_indices.is_empty() {
+                let mut telemetry = shared.telemetry();
+                telemetry.contention = telemetry.contention.saturating_add(1);
+                break;
+            }
             let schedules = eligible_indices
                 .iter()
                 .map(|index| candidates[*index].schedule.clone())
@@ -1274,6 +1279,7 @@ fn run_coordinator(shared: Arc<Shared>) {
             }
             let should_refresh = match (&candidate.task, execution_outcome) {
                 (RuntimeTask::ManifestAudit, Some(ExecutionOutcome::Completed))
+                | (RuntimeTask::ManifestAudit, Some(ExecutionOutcome::Failed))
                 | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
                 | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Failed))
                 | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Completed))
@@ -1321,10 +1327,7 @@ fn scheduler_candidate_indices(
     candidates
         .iter()
         .enumerate()
-        .filter_map(|(index, candidate)| {
-            (!(external_scan_admitted && candidate.schedule.lane == ProcessingLane::Scan))
-                .then_some(index)
-        })
+        .filter_map(|(index, _candidate)| (!external_scan_admitted).then_some(index))
         .collect()
 }
 
@@ -1392,8 +1395,7 @@ fn discover_source_candidates(
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     if !source.root.is_dir() {
         if database_root != source.root && database_root.is_dir() {
-            let connection = SourceDatabase::open_connection_with_role_and_database_root(
-                &source.root,
+            let connection = SourceDatabase::open_unavailable_source_metadata_connection(
                 &database_root,
                 SourceDatabaseConnectionRole::JobWorker,
             )
@@ -1974,6 +1976,7 @@ fn execute_candidate(
                 completed_at,
             )
             .map_err(|error| error.to_string())?;
+            let incomplete_error = outcome.incomplete_error.clone();
             tracing::debug!(
                 target: "wavecrate::source_processing",
                 source_id = candidate.source.id.as_str(),
@@ -1994,6 +1997,14 @@ fn execute_candidate(
             }
             if cancel.load(Ordering::Acquire) {
                 Ok(ExecutionOutcome::Cancelled)
+            } else if let Some(error) = incomplete_error {
+                tracing::warn!(
+                    target: "wavecrate::source_processing",
+                    source_id = candidate.source.id.as_str(),
+                    error,
+                    "Manifest audit published a committed checkpoint and remains due"
+                );
+                Ok(ExecutionOutcome::Failed)
             } else {
                 Ok(ExecutionOutcome::Completed)
             }
@@ -3320,7 +3331,7 @@ mod tests {
     }
 
     #[test]
-    fn foreground_scan_admission_preempts_the_background_scan_lane() {
+    fn foreground_scan_admission_preempts_incompatible_background_work() {
         let (_first_directory, first) = unhashed_source("background-holder");
         let (_second_directory, second) = unhashed_source("foreground-waiter");
         let shared = Arc::new(Shared::new(vec![first.clone(), second.clone()], None));
@@ -3330,8 +3341,8 @@ mod tests {
         };
         let background_permit = shared
             .budgets()
-            .try_acquire(first.id.as_str(), ProcessingLane::Scan)
-            .expect("reserve scan lane for background work");
+            .try_acquire(first.id.as_str(), ProcessingLane::Hashing)
+            .expect("reserve database capacity for background hashing");
         let waiting_shared = Arc::clone(&shared);
         let foreground_source_id = second.id.to_string();
         let waiting = thread::spawn(move || {
@@ -3364,7 +3375,7 @@ mod tests {
     }
 
     #[test]
-    fn foreground_scan_admission_reserves_scan_candidates_only() {
+    fn foreground_scan_admission_reserves_all_processing_capacity() {
         let (_directory, source) = unhashed_source("foreground-reservation");
         let candidates = vec![
             RuntimeCandidate {
@@ -3380,7 +3391,7 @@ mod tests {
         ];
 
         assert_eq!(scheduler_candidate_indices(&candidates, false), vec![0, 1]);
-        assert_eq!(scheduler_candidate_indices(&candidates, true), vec![1]);
+        assert!(scheduler_candidate_indices(&candidates, true).is_empty());
     }
 
     #[test]
@@ -3486,13 +3497,29 @@ mod tests {
     }
 
     #[test]
-    fn missing_source_discovery_does_not_recreate_the_source_root() {
+    fn missing_source_discovery_updates_external_metadata_without_recreating_audio_root() {
         let parent = tempfile::tempdir().expect("missing source parent");
         let root = parent.path().join("source");
         std::fs::create_dir(&root).expect("create source root");
         let source =
-            SampleSource::new_with_id(SourceId::from_string("missing-source"), root.clone());
-        source.open_db().expect("create source database");
+            SampleSource::new_with_id(SourceId::from_string("missing-source"), root.clone())
+                .protected();
+        let database_root = source.database_root().expect("external metadata root");
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("create external source database");
+        connection
+            .execute(
+                "INSERT INTO source_readiness_sources (
+                    source_id, source_generation, readiness_revision, availability, updated_at
+                 ) VALUES (?1, 1, 1, 'active', 1)",
+                [source.id.as_str()],
+            )
+            .expect("publish active source readiness");
+        drop(connection);
         std::fs::remove_dir_all(&root).expect("remove source root");
         let cancel = AtomicBool::new(false);
 
@@ -3507,6 +3534,19 @@ mod tests {
             !root.exists(),
             "discovery must not recreate a missing source"
         );
+        let connection = SourceDatabase::open_unavailable_source_metadata_connection(
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("reopen external source metadata");
+        let availability: String = connection
+            .query_row(
+                "SELECT availability FROM source_readiness_sources WHERE source_id = ?1",
+                [source.id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("read missing source availability");
+        assert_eq!(availability, "offline");
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -5,6 +5,7 @@ use std::{
     sync::{
         Arc, Condvar, Mutex, MutexGuard,
         atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc::Sender,
     },
     thread::{self, JoinHandle},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -30,6 +31,7 @@ use wavecrate::sample_sources::{
 use super::scheduler::{
     BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane, WorkCandidate,
 };
+use crate::native_app::app::GuiMessage;
 use crate::native_app::sample_library::similarity_prep::{
     NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
     reset_interrupted_similarity_prep_jobs, similarity_prep_needs_finalization,
@@ -245,12 +247,29 @@ impl Drop for SourceProcessingBudgetPermit {
 }
 
 impl SourceProcessingSupervisor {
+    #[cfg(test)]
     pub(in crate::native_app) fn start(sources: Vec<SampleSource>) -> Self {
         Self::start_with_playback_state(sources, false)
     }
 
+    pub(in crate::native_app) fn start_with_worker_sender(
+        sources: Vec<SampleSource>,
+        worker_sender: Sender<GuiMessage>,
+    ) -> Self {
+        Self::start_with_playback_state_and_sender(sources, false, Some(worker_sender))
+    }
+
+    #[cfg(test)]
     fn start_with_playback_state(sources: Vec<SampleSource>, playback_active: bool) -> Self {
-        let shared = Arc::new(Shared::new(sources));
+        Self::start_with_playback_state_and_sender(sources, playback_active, None)
+    }
+
+    fn start_with_playback_state_and_sender(
+        sources: Vec<SampleSource>,
+        playback_active: bool,
+        worker_sender: Option<Sender<GuiMessage>>,
+    ) -> Self {
+        let shared = Arc::new(Shared::new(sources, worker_sender));
         shared.control().playback_active = playback_active;
         let thread_shared = Arc::clone(&shared);
         let coordinator = thread::Builder::new()
@@ -266,7 +285,7 @@ impl SourceProcessingSupervisor {
     #[cfg(test)]
     pub(in crate::native_app) fn dormant() -> Self {
         Self {
-            shared: Arc::new(Shared::new(Vec::new())),
+            shared: Arc::new(Shared::new(Vec::new(), None)),
             coordinator: None,
         }
     }
@@ -648,10 +667,11 @@ struct Shared {
     next_external_scan_id: AtomicU64,
     in_flight_work: Mutex<BTreeMap<String, usize>>,
     in_flight_wake: Condvar,
+    worker_sender: Option<Sender<GuiMessage>>,
 }
 
 impl Shared {
-    fn new(sources: Vec<SampleSource>) -> Self {
+    fn new(sources: Vec<SampleSource>, worker_sender: Option<Sender<GuiMessage>>) -> Self {
         let sources = sources_by_id(sources);
         let source_work_cancels = sources
             .keys()
@@ -682,6 +702,7 @@ impl Shared {
             next_external_scan_id: AtomicU64::new(1),
             in_flight_work: Mutex::new(BTreeMap::new()),
             in_flight_wake: Condvar::new(),
+            worker_sender,
         }
     }
 
@@ -1131,7 +1152,11 @@ fn run_coordinator(shared: Arc<Shared>) {
                 candidates.push(candidate);
                 break;
             };
-            let result = execute_candidate(&candidate, candidate_cancel.as_ref());
+            let result = execute_candidate(
+                &candidate,
+                candidate_cancel.as_ref(),
+                shared.worker_sender.as_ref(),
+            );
             drop(in_flight_work);
             shared.budgets().release(permit);
             shared.budget_wake.notify_all();
@@ -1867,6 +1892,7 @@ fn readiness_target_fingerprint_with_cancel(
 fn execute_candidate(
     candidate: &RuntimeCandidate,
     cancel: &AtomicBool,
+    worker_sender: Option<&Sender<GuiMessage>>,
 ) -> Result<ExecutionOutcome, String> {
     let result = match &candidate.task {
         RuntimeTask::ManifestAudit => {
@@ -1900,6 +1926,14 @@ fn execute_candidate(
                     deleted = outcome.committed_delta.deleted.len(),
                     "Periodic source manifest audit committed"
                 );
+                if !outcome.committed_delta.is_empty()
+                    && let Some(worker_sender) = worker_sender
+                {
+                    let _ = worker_sender.send(GuiMessage::SourceManifestAuditCommitted {
+                        source_id: candidate.source.id.as_str().to_string(),
+                        committed_delta: outcome.committed_delta,
+                    });
+                }
                 Ok(ExecutionOutcome::Completed)
             }
         }
@@ -3351,6 +3385,52 @@ mod tests {
     }
 
     #[test]
+    fn periodic_manifest_audit_wakes_browser_projection_after_committed_repair() {
+        let directory = tempfile::tempdir().expect("manifest audit source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("audit-browser-wake"),
+            directory.path().to_path_buf(),
+        );
+        source.open_db().expect("create source database");
+        std::fs::write(directory.path().join("missed.wav"), [7_u8; 32])
+            .expect("write missed watcher file");
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        let candidate = RuntimeCandidate {
+            schedule: WorkCandidate::source(
+                source.id.as_str(),
+                ProcessingLane::Scan,
+                0,
+                now_epoch_seconds(),
+            ),
+            source,
+            task: RuntimeTask::ManifestAudit,
+        };
+        assert_eq!(
+            execute_candidate(&candidate, &AtomicBool::new(false), Some(&sender))
+                .expect("execute manifest audit"),
+            ExecutionOutcome::Completed
+        );
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("audit should publish a browser projection wake");
+        let GuiMessage::SourceManifestAuditCommitted {
+            source_id,
+            committed_delta,
+        } = message
+        else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+
+        assert_eq!(source_id, "audit-browser-wake");
+        assert_eq!(committed_delta.created.len(), 1);
+        assert_eq!(
+            committed_delta.created[0].relative_path,
+            Path::new("missed.wav")
+        );
+    }
+
+    #[test]
     fn production_supervisor_publishes_claims_and_completes_readiness_without_manual_seed() {
         let (_directory, source) = ready_analysis_source("readiness");
 
@@ -3377,7 +3457,6 @@ mod tests {
                          AND artifact.stage = target.stage
                         WHERE source.source_id = ?1
                           AND source.availability = 'active'
-                          AND target.scope_id = 'identity-1'
                           AND target.stage IN (
                               'indexed_identity', 'playback_summary',
                               'analysis_features', 'embedding_aspects'
@@ -3432,13 +3511,37 @@ mod tests {
 
         let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
         wait_until(Duration::from_secs(10), || {
-            source
+            let good_hashed = source
                 .open_db()
                 .expect("open hash source")
                 .entry_for_path(Path::new("z-good.wav"))
                 .expect("read good hash row")
                 .and_then(|entry| entry.content_hash)
-                .is_some()
+                .is_some();
+            let failure_recorded = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            )
+            .ok()
+            .and_then(|connection| {
+                connection
+                    .query_row(
+                        "SELECT status
+                         FROM analysis_jobs
+                         WHERE readiness_managed = 1
+                           AND readiness_stage = 'indexed_identity'
+                           AND relative_path = 'a-unavailable.wav'",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .ok()
+                    .flatten()
+            })
+            .as_deref()
+                == Some("failed");
+            good_hashed && failure_recorded
         });
         assert_eq!(supervisor.shutdown()["joined"], true);
 
@@ -3492,7 +3595,7 @@ mod tests {
     #[test]
     fn real_hash_execution_waits_for_shared_scan_database_budget() {
         let (_directory, source) = unhashed_source("shared-budget");
-        let shared = Arc::new(Shared::new(vec![source.clone()]));
+        let shared = Arc::new(Shared::new(vec![source.clone()], None));
         let permit = SourceProcessingBudgetHandle {
             shared: Arc::clone(&shared),
         }

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -108,7 +108,7 @@ impl SourceProcessingBudgetHandle {
         &self,
         source_id: &str,
     ) -> Option<SourceProcessingBudgetPermit> {
-        let (admission_id, admission_cancel) = {
+        {
             let mut control = self.shared.control();
             while !control.shutdown
                 && control.source_is_active(source_id)
@@ -126,6 +126,34 @@ impl SourceProcessingBudgetHandle {
             {
                 return None;
             }
+        }
+        // Hold the budget lock through admission publication. This closes the race where the
+        // coordinator could acquire the scan lane after we inspected it but before it observed the
+        // foreground reservation.
+        let budgets = self.shared.budgets();
+        let active_scan_sources = budgets.active_sources_for_lane(ProcessingLane::Scan);
+        let (admission_id, admission_cancel) = {
+            let mut control = self.shared.control();
+            if control.shutdown
+                || self.shared.cancel.load(Ordering::Acquire)
+                || !control.source_is_active(source_id)
+                || control.processing_paused()
+            {
+                return None;
+            }
+            for active_source_id in active_scan_sources {
+                tracing::info!(
+                    target: "wavecrate::source_processing",
+                    source_id,
+                    preempted_source_id = active_source_id.as_str(),
+                    "Foreground source scan admission is reserving the occupied scan lane"
+                );
+                control.cancel_source_work(&active_source_id);
+                control.mark_source_dirty(
+                    &active_source_id,
+                    "foreground_scan_preempted_background_scan",
+                );
+            }
             let admission_cancel = Arc::clone(&control.source_work_cancels[source_id]);
             if admission_cancel.load(Ordering::Acquire) {
                 return None;
@@ -140,6 +168,8 @@ impl SourceProcessingBudgetHandle {
                 .insert(admission_id, source_id.to_string());
             (admission_id, admission_cancel)
         };
+        drop(budgets);
+        self.shared.wake.notify_one();
         loop {
             let mut budgets = self.shared.budgets();
             if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
@@ -730,6 +760,10 @@ impl Shared {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
+    fn has_external_scan_admission(&self) -> bool {
+        !self.external_scans().admissions.is_empty()
+    }
+
     fn cancel_external_scans(&self, should_cancel: impl Fn(&ExternalScanRegistration) -> bool) {
         for registration in self.external_scans().registrations.values() {
             if should_cancel(registration) {
@@ -1120,15 +1154,19 @@ fn run_coordinator(shared: Arc<Shared>) {
             if interrupted {
                 break;
             }
-            let schedules = candidates
+            let external_scan_admitted = shared.has_external_scan_admission();
+            let eligible_indices = scheduler_candidate_indices(&candidates, external_scan_admitted);
+            let schedules = eligible_indices
                 .iter()
-                .map(|candidate| candidate.schedule.clone())
+                .map(|index| candidates[*index].schedule.clone())
                 .collect::<Vec<_>>();
-            let Some(index) = scheduler.choose(&schedules, &priority, &shared.budgets()) else {
+            let Some(schedule_index) = scheduler.choose(&schedules, &priority, &shared.budgets())
+            else {
                 let mut telemetry = shared.telemetry();
                 telemetry.contention = telemetry.contention.saturating_add(1);
                 break;
             };
+            let index = eligible_indices[schedule_index];
             let candidate = candidates.swap_remove(index);
             let Some(permit) = shared
                 .budgets()
@@ -1274,6 +1312,20 @@ fn run_coordinator(shared: Arc<Shared>) {
         );
         drop(telemetry);
     }
+}
+
+fn scheduler_candidate_indices(
+    candidates: &[RuntimeCandidate],
+    external_scan_admitted: bool,
+) -> Vec<usize> {
+    candidates
+        .iter()
+        .enumerate()
+        .filter_map(|(index, candidate)| {
+            (!(external_scan_admitted && candidate.schedule.lane == ProcessingLane::Scan))
+                .then_some(index)
+        })
+        .collect()
 }
 
 fn discover_candidates(
@@ -3265,6 +3317,70 @@ mod tests {
         let report = shutdown.join().expect("join supervisor shutdown");
         assert_eq!(report["joined"], true);
         assert_eq!(report["external_scans_joined"], true);
+    }
+
+    #[test]
+    fn foreground_scan_admission_preempts_the_background_scan_lane() {
+        let (_first_directory, first) = unhashed_source("background-holder");
+        let (_second_directory, second) = unhashed_source("foreground-waiter");
+        let shared = Arc::new(Shared::new(vec![first.clone(), second.clone()], None));
+        let background_cancel = {
+            let control = shared.control();
+            Arc::clone(&control.source_work_cancels[first.id.as_str()])
+        };
+        let background_permit = shared
+            .budgets()
+            .try_acquire(first.id.as_str(), ProcessingLane::Scan)
+            .expect("reserve scan lane for background work");
+        let waiting_shared = Arc::clone(&shared);
+        let foreground_source_id = second.id.to_string();
+        let waiting = thread::spawn(move || {
+            SourceProcessingBudgetHandle {
+                shared: waiting_shared,
+            }
+            .acquire_scan(&foreground_source_id)
+        });
+
+        wait_until(Duration::from_secs(2), || {
+            background_cancel.load(Ordering::Acquire)
+                && shared.external_scans().admissions.len() == 1
+        });
+        shared.budgets().release(background_permit);
+        shared.budget_wake.notify_all();
+
+        let foreground_permit = waiting
+            .join()
+            .expect("join foreground admission")
+            .expect("foreground scan acquires released lane");
+        assert_eq!(
+            foreground_permit
+                .permit
+                .as_ref()
+                .expect("owned budget permit")
+                .source_id(),
+            second.id.as_str()
+        );
+        drop(foreground_permit);
+    }
+
+    #[test]
+    fn foreground_scan_admission_reserves_scan_candidates_only() {
+        let (_directory, source) = unhashed_source("foreground-reservation");
+        let candidates = vec![
+            RuntimeCandidate {
+                schedule: WorkCandidate::source(source.id.as_str(), ProcessingLane::Scan, 0, 0),
+                source: source.clone(),
+                task: RuntimeTask::ManifestAudit,
+            },
+            RuntimeCandidate {
+                schedule: WorkCandidate::source(source.id.as_str(), ProcessingLane::Hashing, 0, 0),
+                source,
+                task: RuntimeTask::ManifestAudit,
+            },
+        ];
+
+        assert_eq!(scheduler_candidate_indices(&candidates, false), vec![0, 1]);
+        assert_eq!(scheduler_candidate_indices(&candidates, true), vec![1]);
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -25,7 +25,10 @@ use wavecrate::sample_sources::{
         reconcile_readiness_with_cancel, renew_readiness_lease,
         replace_readiness_targets_with_cancel,
     },
-    scanner::{ScanError, audit_source_and_record, complete_pending_deep_hash_for_path},
+    scanner::{
+        ScanError, audit_source_and_record, complete_pending_deep_hash_for_path,
+        sync_paths_with_progress,
+    },
 };
 
 use super::scheduler::{
@@ -2718,25 +2721,33 @@ fn run_readiness_stage(
                     "feature executor version does not match target",
                 ));
             }
-            Ok(if analysis_features_are_current(connection, target)? {
-                ReadinessExecutionOutcome::Complete
-            } else {
-                let produced = super::worker::run_readiness_feature_stage(
-                    connection,
+            if analysis_features_are_current(connection, target)? {
+                return Ok(ReadinessExecutionOutcome::Complete);
+            }
+            let produced = super::worker::run_readiness_feature_stage(
+                connection,
+                source,
+                std::path::Path::new(relative_path),
+                target.content_generation.as_str(),
+                target.required_version.as_str(),
+                cancel,
+            )?;
+            if produced && analysis_features_are_current(connection, target)? {
+                return Ok(ReadinessExecutionOutcome::Complete);
+            }
+            if !produced {
+                reconcile_stale_analysis_input(
                     source,
                     std::path::Path::new(relative_path),
-                    target.content_generation.as_str(),
-                    target.required_version.as_str(),
                     cancel,
                 )?;
-                if produced && analysis_features_are_current(connection, target)? {
-                    ReadinessExecutionOutcome::Complete
-                } else {
-                    ReadinessExecutionOutcome::Retry(
-                        "analysis feature source generation is not current yet",
-                    )
-                }
-            })
+                return Ok(ReadinessExecutionOutcome::Retry(
+                    "analysis input changed; targeted source reconciliation committed",
+                ));
+            }
+            Ok(ReadinessExecutionOutcome::Retry(
+                "analysis feature publication is not durable yet",
+            ))
         }
         ReadinessStage::EmbeddingAspects => {
             let expected_version = format!(
@@ -2795,6 +2806,33 @@ fn run_readiness_stage(
             })
         }
     }
+}
+
+fn reconcile_stale_analysis_input(
+    source: &SampleSource,
+    relative_path: &std::path::Path,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    let db =
+        SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
+            .map_err(|error| error.to_string())?;
+    let stats = sync_paths_with_progress(
+        &db,
+        &[relative_path.to_path_buf()],
+        Some(cancel),
+        &mut |_, _| {},
+    )
+    .map_err(|error| error.to_string())?;
+    tracing::info!(
+        target: "wavecrate::source_processing",
+        source_id = source.id.as_str(),
+        path = %relative_path.display(),
+        revision = stats.committed_delta.revision,
+        changed = stats.committed_delta.changed.len(),
+        "Reconciled stale analysis input against the source manifest"
+    );
+    Ok(())
 }
 
 fn analysis_features_are_current(
@@ -4327,6 +4365,77 @@ mod tests {
         assert!(cached_waveform_file_audition_ready_exists(
             &source.root.join("ready.wav")
         ));
+    }
+
+    #[test]
+    fn stale_analysis_hash_triggers_targeted_reconciliation_and_converges() {
+        let (_directory, source) = ready_analysis_source("stale-analysis-input");
+        let relative = Path::new("ready.wav");
+        let db = source.open_db().expect("open stale analysis source");
+        wavecrate::sample_sources::scanner::sync_paths(&db, &[relative.to_path_buf()])
+            .expect("normalize source manifest");
+        db.set_metadata(
+            META_LAST_MANIFEST_AUDIT_AT,
+            &now_epoch_seconds().to_string(),
+        )
+        .expect("defer periodic audit");
+
+        let path = source.root.join(relative);
+        let original_modified = std::fs::metadata(&path)
+            .expect("read original metadata")
+            .modified()
+            .expect("read original modified time");
+        let mut bytes = std::fs::read(&path).expect("read readiness wav");
+        let last = bytes.last_mut().expect("readiness wav has audio data");
+        *last ^= 0x01;
+        std::fs::write(&path, &bytes).expect("mutate readiness wav");
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("reopen mutated readiness wav");
+        file.set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            .expect("restore readiness modified time");
+        let current_hash = blake3::hash(&bytes).to_hex().to_string();
+
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+        wait_until(Duration::from_secs(15), || {
+            let manifest_is_current = source
+                .open_db()
+                .ok()
+                .and_then(|db| db.entry_for_path(relative).ok().flatten())
+                .and_then(|entry| entry.content_hash)
+                .as_deref()
+                == Some(current_hash.as_str());
+            if !manifest_is_current {
+                return false;
+            }
+            let database_root = source.database_root().expect("database root");
+            let Ok(connection) = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            ) else {
+                return false;
+            };
+            let sample_id = format!("{}::ready.wav", source.id);
+            connection
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1
+                        FROM samples AS sample
+                        JOIN features AS feature ON feature.sample_id = sample.sample_id
+                        JOIN embeddings AS embedding ON embedding.sample_id = sample.sample_id
+                        JOIN similarity_aspect_descriptors AS aspects
+                          ON aspects.sample_id = sample.sample_id
+                        WHERE sample.sample_id = ?1
+                          AND sample.content_hash = ?2
+                    )",
+                    params![sample_id, current_hash],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap_or(false)
+        });
+        assert_eq!(supervisor.shutdown()["joined"], true);
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -17,16 +17,16 @@ use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
     db::{META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION},
     readiness::{
-        ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessFailureClassification,
-        ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
-        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability,
-        cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        fail_readiness_work, persist_readiness_deficits_with_cancel, readiness_work_stats,
-        reconcile_readiness_with_cancel, renew_readiness_lease,
-        replace_readiness_targets_with_cancel,
+        ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessEligibility,
+        ReadinessFailureClassification, ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome,
+        ReadinessRetryPolicy, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
+        SourceAvailability, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+        fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
+        readiness_work_stats, reconcile_readiness_with_cancel, release_readiness_work,
+        renew_readiness_lease, replace_readiness_targets_with_cancel,
     },
     scanner::{
-        ScanError, audit_source_and_record, complete_pending_deep_hash_for_path,
+        ScanError, audit_source_and_record_with_progress, complete_pending_deep_hash_for_path,
         sync_paths_with_progress,
     },
 };
@@ -46,7 +46,7 @@ use crate::native_app::waveform::{
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 const PROGRESS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const SIMILARITY_SCORE_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-const MANIFEST_AUDIT_INTERVAL_SECONDS: i64 = 5 * 60;
+const MANIFEST_AUDIT_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 const MANIFEST_AUDIT_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
@@ -994,6 +994,7 @@ enum ExecutionOutcome {
     Completed,
     Retried { retry_at: i64 },
     Failed,
+    PrerequisiteInvalidated,
     Stale,
     Cancelled,
     NotClaimed,
@@ -1179,7 +1180,11 @@ fn run_coordinator(shared: Arc<Shared>) {
             .filter(|source| dirty_sources.contains(source.id.as_str()))
             .cloned()
             .collect::<Vec<_>>();
-        if !sources_to_discover.is_empty() {
+        if publish_source_processing_discovery_if_needed(
+            &shared,
+            &sources_to_discover,
+            progress_visible,
+        ) {
             progress_visible = true;
         }
         for source in &sources_to_discover {
@@ -1230,11 +1235,6 @@ fn run_coordinator(shared: Arc<Shared>) {
                 break;
             };
             let index = eligible_indices[schedule_index];
-            let active_source_count = candidates
-                .iter()
-                .map(|candidate| candidate.source.id.as_str())
-                .collect::<BTreeSet<_>>()
-                .len();
             let candidate = candidates.swap_remove(index);
             let Some(permit) = shared
                 .budgets()
@@ -1260,14 +1260,7 @@ fn run_coordinator(shared: Arc<Shared>) {
             };
             let progress_publish_due = last_progress_publish_at
                 .is_none_or(|published_at| published_at.elapsed() >= PROGRESS_REFRESH_INTERVAL);
-            if active_source_count > 1 {
-                if active_progress_source.as_deref() != Some("") || progress_publish_due {
-                    publish_multi_source_processing_activity(&shared, active_source_count);
-                    active_progress_source = Some(String::new());
-                    last_progress_publish_at = Some(Instant::now());
-                    progress_visible = true;
-                }
-            } else if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
+            if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
                 || !matches!(&candidate.task, RuntimeTask::Readiness(_))
                 || progress_publish_due)
                 && let Some(progress) = source_stats.get(candidate.source.id.as_str()).copied()
@@ -1312,7 +1305,6 @@ fn run_coordinator(shared: Arc<Shared>) {
                                     &mut source_stats,
                                     candidate.source.id.as_str(),
                                 )
-                                && active_source_count == 1
                                 && progress_refresh_due(last_progress_publish_at)
                             {
                                 let progress = stable_source_progress(
@@ -1342,7 +1334,6 @@ fn run_coordinator(shared: Arc<Shared>) {
                                     &mut source_stats,
                                     candidate.source.id.as_str(),
                                 )
-                                && active_source_count == 1
                                 && progress_refresh_due(last_progress_publish_at)
                             {
                                 let progress = stable_source_progress(
@@ -1354,6 +1345,13 @@ fn run_coordinator(shared: Arc<Shared>) {
                                 last_progress_publish_at = Some(Instant::now());
                                 progress_visible = true;
                             }
+                        }
+                        ExecutionOutcome::PrerequisiteInvalidated => {
+                            telemetry.stale = telemetry.stale.saturating_add(1);
+                            shared.control().mark_source_dirty(
+                                candidate.source.id.as_str(),
+                                "readiness_prerequisite_invalidated",
+                            );
                         }
                         ExecutionOutcome::Stale => {
                             telemetry.stale = telemetry.stale.saturating_add(1)
@@ -1491,34 +1489,12 @@ fn publish_source_processing_progress(
     let Some(worker_sender) = shared.worker_sender.as_ref() else {
         return;
     };
-    let (stage, detail, completed, total) = match &candidate.task {
-        RuntimeTask::Readiness(target) => {
-            let (stage, detail) = readiness_progress_detail(target);
-            (
-                stage,
-                detail,
-                stats.progress_completed,
-                stats.progress_total,
-            )
-        }
-        RuntimeTask::ManifestAudit => (
-            "Scanning source changes",
-            String::from("Checking the source manifest"),
-            0,
-            0,
-        ),
-        RuntimeTask::LegacyAnalysis { .. } => (
-            "Migrating analysis",
-            String::from("Preparing legacy source data"),
-            0,
-            0,
-        ),
-        RuntimeTask::FinalizeSimilarity { .. } => (
-            "Finalizing similarity",
-            String::from("Publishing the source layout"),
-            0,
-            0,
-        ),
+    let (stage, detail) = runtime_task_progress_detail(&candidate.task);
+    let (completed, total) = match &candidate.task {
+        RuntimeTask::Readiness(_) => (stats.progress_completed, stats.progress_total),
+        RuntimeTask::ManifestAudit
+        | RuntimeTask::LegacyAnalysis { .. }
+        | RuntimeTask::FinalizeSimilarity { .. } => (0, 0),
     };
     let (completed, total) = if total > 0 && completed < total {
         (completed, total)
@@ -1554,10 +1530,26 @@ fn publish_source_processing_discovery(shared: &Shared, source: &SampleSource) {
             active: true,
             completed: 0,
             total: 0,
-            stage: String::from("Inspecting source jobs"),
-            detail: String::from("Discovering background work"),
+            stage: String::from("Checking pending work"),
+            detail: String::from("Counting unfinished analysis, similarity, and indexing jobs"),
         },
     ));
+}
+
+fn publish_source_processing_discovery_if_needed(
+    shared: &Shared,
+    sources: &[SampleSource],
+    progress_visible: bool,
+) -> bool {
+    if progress_visible || sources.is_empty() {
+        return false;
+    }
+    if sources.len() == 1 {
+        publish_source_processing_discovery(shared, &sources[0]);
+    } else {
+        publish_multi_source_processing_activity(shared, sources.len());
+    }
+    true
 }
 
 fn publish_multi_source_processing_activity(shared: &Shared, source_count: usize) {
@@ -1633,12 +1625,33 @@ fn stable_source_progress(
     observed: SourceDiscoveryStats,
 ) -> SourceDiscoveryStats {
     let stable = displayed.entry(source_id.to_string()).or_insert(observed);
-    stable.progress_total = stable.progress_total.max(observed.progress_total);
+    if stable.progress_total != observed.progress_total {
+        *stable = observed;
+        return *stable;
+    }
     stable.progress_completed = stable
         .progress_completed
         .max(observed.progress_completed)
         .min(stable.progress_total);
     *stable
+}
+
+fn runtime_task_progress_detail(task: &RuntimeTask) -> (&'static str, String) {
+    match task {
+        RuntimeTask::Readiness(target) => readiness_progress_detail(target),
+        RuntimeTask::ManifestAudit => (
+            "Scanning source changes",
+            String::from("Checking the source manifest"),
+        ),
+        RuntimeTask::LegacyAnalysis { .. } => (
+            "Migrating analysis",
+            String::from("Preparing legacy source data"),
+        ),
+        RuntimeTask::FinalizeSimilarity { .. } => (
+            "Finalizing similarity",
+            String::from("Publishing the source layout"),
+        ),
+    }
 }
 
 fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String) {
@@ -1652,8 +1665,8 @@ fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String)
     let detail = target
         .relative_path
         .as_deref()
-        .unwrap_or("Finalizing source")
-        .to_string();
+        .map(str::to_string)
+        .unwrap_or_else(|| String::from("Finalizing source"));
     (stage, detail)
 }
 
@@ -1678,7 +1691,6 @@ fn discover_candidates(
     BTreeSet<String>,
 ) {
     let now = now_epoch_seconds();
-    let source_count = sources.len();
     let mut candidates = Vec::new();
     let mut source_stats = BTreeMap::new();
     let mut deferred = BTreeSet::new();
@@ -1704,11 +1716,6 @@ fn discover_candidates(
         {
             let mut telemetry = shared.telemetry();
             telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
-        }
-        if source_count > 1 {
-            publish_multi_source_processing_activity(shared, source_count);
-        } else {
-            publish_source_processing_discovery(shared, source);
         }
         match discover_source_candidates(source, now, source_cancel) {
             Ok(Cancellable::Completed((mut source_candidates, stats))) => {
@@ -1805,6 +1812,8 @@ fn discover_source_candidates_with_connection(
                 SELECT 1 FROM wav_files
                 WHERE missing = 0
                   AND (file_identity IS NULL OR TRIM(file_identity) = '')
+                  AND path NOT GLOB '._*'
+                  AND path NOT GLOB '*/._*'
              )",
             [],
             |row| row.get(0),
@@ -1836,6 +1845,15 @@ fn discover_source_candidates_with_connection(
         )
         .map_err(|error| error.to_string())?;
     if readiness_source_exists {
+        let reclassified = reclassify_known_unsupported_audio_failures(connection)?;
+        if reclassified > 0 {
+            tracing::info!(
+                target: "wavecrate::source_processing",
+                source_id,
+                reclassified,
+                "Reclassified deterministic audio decode failures as unsupported"
+            );
+        }
         let snapshot = match reconcile_readiness_with_cancel(&connection, source_id, now, cancel) {
             Ok(snapshot) => snapshot,
             Err(wavecrate::sample_sources::readiness::ReadinessError::Cancelled) => {
@@ -2140,7 +2158,7 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
         let content_hash = content_hash
             .filter(|value| !value.trim().is_empty())
             .unwrap_or_else(|| format!("pending-{identity}-{file_size}-{modified_ns}"));
-        manifest.push((path, identity, content_hash));
+        manifest.push((path, identity, content_hash, file_size));
     }
     let source_generation = connection
         .query_row(
@@ -2159,15 +2177,18 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
     );
     let mut membership = blake3::Hasher::new();
     let mut targets = Vec::with_capacity(manifest.len().saturating_mul(4).saturating_add(1));
-    for (path, identity, content_hash) in &manifest {
+    for (path, identity, content_hash, file_size) in &manifest {
         checkpoint();
         if cancelled(cancel) {
             return Ok(Cancellable::Cancelled);
         }
-        membership.update(identity.as_bytes());
-        membership.update(&[0]);
-        membership.update(content_hash.as_bytes());
-        membership.update(&[0xff]);
+        let analyzable = *file_size > 0;
+        if analyzable {
+            membership.update(identity.as_bytes());
+            membership.update(&[0]);
+            membership.update(content_hash.as_bytes());
+            membership.update(&[0xff]);
+        }
         for (stage, version) in [
             (ReadinessStage::IndexedIdentity, READINESS_MANIFEST_VERSION),
             (ReadinessStage::PlaybackSummary, READINESS_PLAYBACK_VERSION),
@@ -2177,7 +2198,7 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
             ),
             (ReadinessStage::EmbeddingAspects, embedding_version.as_str()),
         ] {
-            targets.push(ReadinessTarget::file(
+            let mut target = ReadinessTarget::file(
                 source_id,
                 identity,
                 path,
@@ -2185,7 +2206,11 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
                 version,
                 source_generation,
                 content_hash,
-            ));
+            );
+            if !analyzable && stage != ReadinessStage::IndexedIdentity {
+                target = target.with_eligibility(ReadinessEligibility::Unsupported);
+            }
+            targets.push(target);
         }
     }
     let membership_generation = membership.finalize().to_hex().to_string();
@@ -2300,6 +2325,13 @@ fn readiness_target_fingerprint_with_cancel(
         hash.update(target.source_generation.to_string().as_bytes());
         hash.update(&[0]);
         hash.update(target.content_generation.as_bytes());
+        hash.update(&[0]);
+        let eligibility: &[u8] = match target.eligibility {
+            ReadinessEligibility::Eligible => b"eligible",
+            ReadinessEligibility::Unsupported => b"unsupported",
+            ReadinessEligibility::Deleted => b"deleted",
+        };
+        hash.update(eligibility);
         hash.update(&[0xff]);
     }
     Some(hash.finalize().to_hex().to_string())
@@ -2331,11 +2363,48 @@ fn execute_candidate(
             )
             .map_err(|error| error.to_string())?;
             let completed_at = now_epoch_seconds();
-            let (outcome, incomplete_error) = match audit_source_and_record(
+            let expected_files = database
+                .list_manifest_entries()
+                .map_err(|error| error.to_string())?
+                .len();
+            let source_id = candidate.source.id.as_str().to_string();
+            let source_root = candidate.source.root.clone();
+            let mut last_progress_publish_at = None::<Instant>;
+            let mut publish_progress = |checked: usize, path: &std::path::Path| {
+                let publish_due = last_progress_publish_at.is_none_or(|published_at| {
+                    published_at.elapsed() >= Duration::from_millis(250)
+                });
+                if !publish_due {
+                    return;
+                }
+                let Some(worker_sender) = worker_sender else {
+                    return;
+                };
+                let relative = path.strip_prefix(&source_root).unwrap_or(path);
+                let source_detail = if relative.as_os_str().is_empty() {
+                    format!("Resumed after {checked} checked files")
+                } else {
+                    format!("Checked {checked} files | {}", relative.display())
+                };
+                let total = expected_files.max(checked);
+                let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+                    SourceProcessingProgress {
+                        source_id: source_id.clone(),
+                        active: true,
+                        completed: checked.min(total),
+                        total,
+                        stage: String::from("Scanning source changes"),
+                        detail: source_detail,
+                    },
+                ));
+                last_progress_publish_at = Some(Instant::now());
+            };
+            let (outcome, incomplete_error) = match audit_source_and_record_with_progress(
                 &database,
                 Some(cancel),
                 MANIFEST_AUDIT_HASH_BATCH,
                 completed_at,
+                &mut publish_progress,
             ) {
                 Ok(outcome) => (outcome, None),
                 Err(ScanError::Incomplete { committed, error }) => (*committed, Some(error)),
@@ -2424,6 +2493,8 @@ enum ReadinessExecutionOutcome {
     Complete,
     Retry(&'static str),
     Permanent(&'static str),
+    Unsupported(&'static str),
+    PrerequisiteInvalidated,
 }
 
 fn execute_readiness_target(
@@ -2500,12 +2571,13 @@ fn execute_readiness_target(
             Ok(execution_outcome_for_failure(outcome))
         }
         Err(reason) => {
+            let classification = readiness_failure_classification(&reason);
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");
             let outcome = fail_readiness_work(
                 &mut connection,
                 &claim,
-                ReadinessFailureClassification::Retryable,
+                classification,
                 &reason,
                 now_epoch_seconds(),
                 policy,
@@ -2527,7 +2599,143 @@ fn execute_readiness_target(
             .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
+        Ok(ReadinessExecutionOutcome::Unsupported(reason)) => {
+            let policy =
+                ReadinessRetryPolicy::new(5, 5 * 60, 1).expect("valid readiness terminal policy");
+            let outcome = fail_readiness_work(
+                &mut connection,
+                &claim,
+                ReadinessFailureClassification::Unsupported,
+                reason,
+                now_epoch_seconds(),
+                policy,
+            )
+            .map_err(|error| error.to_string())?;
+            Ok(execution_outcome_for_failure(outcome))
+        }
+        Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated) => {
+            match release_readiness_work(&mut connection, &claim, now_epoch_seconds())
+                .map_err(|error| error.to_string())?
+            {
+                ReadinessWorkMutationOutcome::Recorded => {
+                    Ok(ExecutionOutcome::PrerequisiteInvalidated)
+                }
+                ReadinessWorkMutationOutcome::RejectedStale => Ok(ExecutionOutcome::Stale),
+            }
+        }
     }
+}
+
+fn readiness_failure_classification(reason: &str) -> ReadinessFailureClassification {
+    if is_known_unsupported_audio_failure(reason) {
+        ReadinessFailureClassification::Unsupported
+    } else {
+        ReadinessFailureClassification::Retryable
+    }
+}
+
+fn is_known_unsupported_audio_failure(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    reason.contains("failed to decode audio file:")
+        || reason.contains("audio decode failed for")
+        || reason.contains("audio file contains no complete frames")
+        || reason.contains("unsupported codec")
+        || reason.contains("no suitable format reader found")
+}
+
+fn reclassify_known_unsupported_audio_failures(
+    connection: &mut rusqlite::Connection,
+) -> Result<usize, String> {
+    let legacy_terminal_failures = {
+        let mut statement = connection
+            .prepare(
+                "SELECT id, COALESCE(last_error, '')
+                 FROM analysis_jobs
+                 WHERE readiness_managed = 1
+                   AND status = 'failed'
+                   AND failure_kind IN ('retryable', 'permanent')",
+            )
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    let unsupported_ids = legacy_terminal_failures
+        .into_iter()
+        .filter_map(|(id, error)| is_known_unsupported_audio_failure(&error).then_some(id))
+        .collect::<Vec<_>>();
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| error.to_string())?;
+    let mut reclassified = 0_usize;
+    for id in unsupported_ids {
+        reclassified = reclassified.saturating_add(
+            transaction
+                .execute(
+                    "UPDATE analysis_jobs
+                     SET failure_kind = 'unsupported', retry_at = NULL
+                     WHERE id = ?1
+                       AND readiness_managed = 1
+                       AND status = 'failed'
+                       AND failure_kind IN ('retryable', 'permanent')",
+                    [id],
+                )
+                .map_err(|error| error.to_string())?,
+        );
+    }
+    reclassified = reclassified.saturating_add(
+        transaction
+            .execute(
+                "UPDATE analysis_jobs AS dependent
+                 SET failure_kind = 'unsupported', retry_at = NULL
+                 WHERE dependent.readiness_managed = 1
+                   AND dependent.status = 'failed'
+                   AND dependent.failure_kind IN ('retryable', 'permanent')
+                   AND dependent.readiness_stage = 'embedding_aspects'
+                   AND dependent.last_error =
+                       'embedding feature prerequisite is not durable yet'
+                   AND EXISTS(
+                       SELECT 1
+                       FROM analysis_jobs AS prerequisite
+                       WHERE prerequisite.readiness_managed = 1
+                         AND prerequisite.source_id = dependent.source_id
+                         AND prerequisite.readiness_scope_kind =
+                             dependent.readiness_scope_kind
+                         AND prerequisite.readiness_scope_id =
+                             dependent.readiness_scope_id
+                         AND prerequisite.readiness_stage = 'analysis_features'
+                         AND prerequisite.content_generation =
+                             dependent.content_generation
+                         AND prerequisite.status = 'failed'
+                         AND prerequisite.failure_kind = 'unsupported'
+                   )",
+                [],
+            )
+            .map_err(|error| error.to_string())?,
+    );
+    reclassified = reclassified.saturating_add(
+        transaction
+            .execute(
+                "UPDATE analysis_jobs
+                 SET failure_kind = 'retryable',
+                     attempts = 0,
+                     retry_at = NULL
+                 WHERE readiness_managed = 1
+                   AND status = 'failed'
+                   AND failure_kind = 'permanent'
+                   AND readiness_stage = 'embedding_aspects'
+                   AND last_error =
+                       'embedding feature prerequisite is not durable yet'",
+                [],
+            )
+            .map_err(|error| error.to_string())?,
+    );
+    transaction.commit().map_err(|error| error.to_string())?;
+    Ok(reclassified)
 }
 
 fn cancel_claim(
@@ -2716,6 +2924,11 @@ fn run_readiness_stage(
                     "analysis feature target has no relative path",
                 ));
             };
+            if readiness_stage_is_unsupported(connection, target, "playback_summary")? {
+                return Ok(ReadinessExecutionOutcome::Unsupported(
+                    "playback prerequisite is unsupported for this content generation",
+                ));
+            }
             if target.required_version != wavecrate_analysis::analysis_version() {
                 return Ok(ReadinessExecutionOutcome::Retry(
                     "feature executor version does not match target",
@@ -2765,6 +2978,27 @@ fn run_readiness_stage(
                     "embedding target has no relative path",
                 ));
             };
+            if readiness_stage_is_unsupported(connection, target, "analysis_features")? {
+                return Ok(ReadinessExecutionOutcome::Unsupported(
+                    "analysis prerequisite is unsupported for this content generation",
+                ));
+            }
+            let mut analysis_target = target.clone();
+            analysis_target.stage = ReadinessStage::AnalysisFeatures;
+            analysis_target.required_version = wavecrate_analysis::analysis_version().to_string();
+            if !analysis_features_are_current(connection, &analysis_target)? {
+                if invalidate_readiness_artifact(connection, &analysis_target)
+                    .map_err(|error| error.to_string())?
+                {
+                    tracing::warn!(
+                        target: "wavecrate::source_processing",
+                        source_id = target.source_id,
+                        scope_id = target.scope_id,
+                        "Invalidated an analysis readiness marker whose payload was missing"
+                    );
+                }
+                return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated);
+            }
             Ok(if embedding_aspects_are_current(connection, target)? {
                 ReadinessExecutionOutcome::Complete
             } else {
@@ -2806,6 +3040,36 @@ fn run_readiness_stage(
             })
         }
     }
+}
+
+fn readiness_stage_is_unsupported(
+    connection: &rusqlite::Connection,
+    target: &ReadinessTarget,
+    stage: &str,
+) -> Result<bool, String> {
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1
+                FROM analysis_jobs
+                WHERE readiness_managed = 1
+                  AND source_id = ?1
+                  AND readiness_scope_kind = 'file'
+                  AND readiness_scope_id = ?2
+                  AND readiness_stage = ?3
+                  AND content_generation = ?4
+                  AND status = 'failed'
+                  AND failure_kind = 'unsupported'
+            )",
+            params![
+                target.source_id,
+                target.scope_id,
+                stage,
+                target.content_generation
+            ],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())
 }
 
 fn reconcile_stale_analysis_input(
@@ -3037,12 +3301,13 @@ fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use wavecrate::sample_sources::{
         SourceId,
         readiness::{
-            ReadinessEligibility, SourceAvailability, persist_readiness_deficits,
+            ReadinessArtifact, ReadinessEligibility, SourceAvailability,
+            persist_readiness_deficits, publish_readiness_artifact, readiness_work_stats,
             reconcile_readiness, replace_readiness_targets,
         },
     };
@@ -3152,6 +3417,39 @@ mod tests {
         publish_source_processing_discovery(&supervisor.shared, &source);
         assert!(receiver.try_recv().is_err());
         assert_eq!(supervisor.shutdown()["joined"], true);
+    }
+
+    #[test]
+    fn repeated_discovery_keeps_existing_processing_feedback_stable() {
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("stable-discovery"),
+            PathBuf::from("/library/samples"),
+        );
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let shared = Shared::new(vec![source.clone()], Some(sender));
+
+        assert!(publish_source_processing_discovery_if_needed(
+            &shared,
+            std::slice::from_ref(&source),
+            false,
+        ));
+        let GuiMessage::SourceProcessingProgress(progress) = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("initial discovery feedback")
+        else {
+            panic!("unexpected supervisor GUI message");
+        };
+        assert_eq!(progress.stage, "Checking pending work");
+
+        assert!(!publish_source_processing_discovery_if_needed(
+            &shared,
+            &[source],
+            true,
+        ));
+        assert!(
+            receiver.try_recv().is_err(),
+            "an immediate rediscovery must not overwrite visible execution progress"
+        );
     }
 
     #[test]
@@ -4037,6 +4335,34 @@ mod tests {
     }
 
     #[test]
+    fn appledouble_sidecars_do_not_keep_manifest_audits_permanently_due() {
+        let directory = tempfile::tempdir().expect("AppleDouble source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("appledouble-audit"),
+            directory.path().to_path_buf(),
+        );
+        let db = source.open_db().expect("open AppleDouble source");
+        db.upsert_file(Path::new("folder/._sidecar.wav"), 4_096, 1)
+            .expect("seed legacy AppleDouble row");
+        db.set_metadata(META_LAST_MANIFEST_AUDIT_AT, "100")
+            .expect("record recent audit");
+        let cancel = AtomicBool::new(false);
+
+        let Cancellable::Completed((candidates, _)) =
+            discover_source_candidates(&source, 100, &cancel)
+                .expect("discover source with ignored AppleDouble row")
+        else {
+            panic!("AppleDouble source discovery unexpectedly cancelled");
+        };
+
+        assert!(
+            candidates
+                .iter()
+                .all(|candidate| !matches!(candidate.task, RuntimeTask::ManifestAudit))
+        );
+    }
+
+    #[test]
     fn missing_source_discovery_updates_external_metadata_without_recreating_audio_root() {
         let parent = tempfile::tempdir().expect("missing source parent");
         let root = parent.path().join("source");
@@ -4274,6 +4600,35 @@ mod tests {
     }
 
     #[test]
+    fn visible_source_progress_starts_a_coherent_snapshot_when_total_changes() {
+        let mut displayed = BTreeMap::new();
+        let inflated = stable_source_progress(
+            &mut displayed,
+            "projects",
+            SourceDiscoveryStats {
+                progress_completed: 44_029,
+                progress_total: 46_678,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+        let current = stable_source_progress(
+            &mut displayed,
+            "projects",
+            SourceDiscoveryStats {
+                progress_completed: 9_766,
+                progress_total: 9_985,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+
+        assert_eq!(inflated.progress_completed, 44_029);
+        assert_eq!(inflated.progress_total, 46_678);
+        assert_eq!(current.progress_completed, 9_766);
+        assert_eq!(current.progress_total, 9_985);
+        assert!(current.progress_completed <= current.progress_total);
+    }
+
+    #[test]
     fn periodic_manifest_audit_wakes_browser_projection_after_committed_repair() {
         let directory = tempfile::tempdir().expect("manifest audit source");
         let source = SampleSource::new_with_id(
@@ -4300,18 +4655,31 @@ mod tests {
                 .expect("execute manifest audit"),
             ExecutionOutcome::Completed
         );
-        let message = receiver
-            .recv_timeout(Duration::from_secs(1))
+        let messages = receiver.try_iter().collect::<Vec<_>>();
+        let progress = messages
+            .iter()
+            .find_map(|message| match message {
+                GuiMessage::SourceProcessingProgress(progress) => Some(progress),
+                _ => None,
+            })
+            .expect("audit should publish checked-file progress");
+        let (source_id, committed_delta) = messages
+            .iter()
+            .find_map(|message| match message {
+                GuiMessage::SourceManifestAuditCommitted {
+                    source_id,
+                    committed_delta,
+                } => Some((source_id, committed_delta)),
+                _ => None,
+            })
             .expect("audit should publish a browser projection wake");
-        let GuiMessage::SourceManifestAuditCommitted {
-            source_id,
-            committed_delta,
-        } = message
-        else {
-            panic!("unexpected supervisor GUI message: {message:?}");
-        };
 
         assert_eq!(source_id, "audit-browser-wake");
+        assert_eq!(progress.source_id, "audit-browser-wake");
+        assert_eq!(progress.completed, 1);
+        assert_eq!(progress.total, 1);
+        assert_eq!(progress.stage, "Scanning source changes");
+        assert!(progress.detail.contains("Checked 1 files"));
         assert_eq!(committed_delta.created.len(), 1);
         assert_eq!(
             committed_delta.created[0].relative_path,
@@ -4698,6 +5066,169 @@ mod tests {
     }
 
     #[test]
+    fn zero_byte_audio_is_terminally_non_analyzable_and_never_enters_the_work_queue() {
+        let directory = tempfile::tempdir().expect("zero-byte source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("zero-byte-source"),
+            directory.path().to_path_buf(),
+        );
+        let db = source.open_db().expect("open zero-byte source");
+        db.upsert_file(Path::new("empty.wav"), 0, 1)
+            .expect("insert zero-byte manifest row");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'zero-byte-identity',
+                     content_hash = 'zero-byte-content'
+                 WHERE path = 'empty.wav'",
+                [],
+            )
+            .expect("assign zero-byte identity");
+
+        assert!(
+            publish_current_readiness_targets(&mut connection, source.id.as_str(), 100)
+                .expect("publish zero-byte targets")
+        );
+        let targets = {
+            let mut statement = connection
+                .prepare(
+                    "SELECT stage, eligibility
+                     FROM source_readiness_targets
+                     WHERE source_id = ?1 AND scope_id = 'zero-byte-identity'
+                     ORDER BY stage",
+                )
+                .expect("prepare zero-byte targets");
+            statement
+                .query_map([source.id.as_str()], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .expect("query zero-byte targets")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("collect zero-byte targets")
+        };
+        assert_eq!(
+            targets,
+            vec![
+                (
+                    String::from("analysis_features"),
+                    String::from("unsupported")
+                ),
+                (
+                    String::from("embedding_aspects"),
+                    String::from("unsupported")
+                ),
+                (String::from("indexed_identity"), String::from("eligible")),
+                (
+                    String::from("playback_summary"),
+                    String::from("unsupported")
+                ),
+            ]
+        );
+
+        let snapshot = reconcile_readiness(&connection, source.id.as_str(), 100)
+            .expect("reconcile zero-byte targets");
+        persist_readiness_deficits(&mut connection, &snapshot.deficits, 100)
+            .expect("persist zero-byte deficits");
+        let queued_non_analyzable: i64 = connection
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM analysis_jobs
+                 WHERE readiness_scope_id = 'zero-byte-identity'
+                   AND readiness_stage IN (
+                       'playback_summary', 'analysis_features', 'embedding_aspects'
+                   )",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count zero-byte readiness work");
+        assert_eq!(queued_non_analyzable, 0);
+    }
+
+    #[test]
+    fn missing_analysis_payload_requeues_its_prerequisite_without_consuming_a_retry() {
+        let (_directory, source) = unhashed_source("missing-analysis-payload");
+        let database_root = source.database_root().expect("database root");
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open readiness database");
+        connection
+            .execute(
+                "UPDATE wav_files
+                 SET file_identity = 'missing-payload-identity',
+                     content_hash = 'missing-payload-content'
+                 WHERE path = 'pending.wav'",
+                [],
+            )
+            .expect("assign readiness identity");
+        let now = now_epoch_seconds();
+        assert!(
+            publish_current_readiness_targets(&mut connection, source.id.as_str(), now)
+                .expect("publish current targets")
+        );
+        let snapshot =
+            reconcile_readiness(&connection, source.id.as_str(), now).expect("reconcile targets");
+        persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+            .expect("persist readiness work");
+        let analysis = snapshot
+            .entries
+            .iter()
+            .find(|entry| entry.target.stage == ReadinessStage::AnalysisFeatures)
+            .expect("analysis target")
+            .target
+            .clone();
+        let embedding = snapshot
+            .entries
+            .iter()
+            .find(|entry| entry.target.stage == ReadinessStage::EmbeddingAspects)
+            .expect("embedding target")
+            .target
+            .clone();
+        assert_eq!(
+            publish_readiness_artifact(
+                &mut connection,
+                &ReadinessArtifact::for_target(&analysis, now),
+            )
+            .expect("publish inconsistent analysis marker"),
+            ArtifactPublishOutcome::Recorded
+        );
+        drop(connection);
+
+        let outcome = execute_readiness_target(&source, &embedding, &AtomicBool::new(false))
+            .expect("repair inconsistent prerequisite");
+        assert_eq!(outcome, ExecutionOutcome::PrerequisiteInvalidated);
+
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("reopen readiness database");
+        let repaired =
+            reconcile_readiness(&connection, source.id.as_str(), now + 1).expect("repair snapshot");
+        let repaired_analysis = repaired
+            .entries
+            .iter()
+            .find(|entry| entry.target.stage == ReadinessStage::AnalysisFeatures)
+            .expect("repaired analysis target");
+        assert_ne!(
+            repaired_analysis.classification,
+            wavecrate::sample_sources::readiness::ReadinessClassification::Current
+        );
+        let stats = readiness_work_stats(&connection, now + 1).expect("repaired work stats");
+        assert_eq!(stats.cancelled, 0);
+    }
+
+    #[test]
     fn readiness_lease_heartbeat_keeps_long_claim_current() {
         let (_directory, source) = unhashed_source("lease-heartbeat");
         let database_root = source.database_root().expect("database root");
@@ -4821,6 +5352,143 @@ mod tests {
         assert_eq!(
             execution_outcome_for_failure(ReadinessFailureOutcome::Permanent),
             ExecutionOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn deterministic_audio_decode_failures_are_not_retried() {
+        for reason in [
+            "failed to decode audio file: Invalid wav: no RIFF tag found",
+            "Source analysis process failed: Audio decode failed for bad.wav",
+            "audio file contains no complete frames",
+            "source analysis process failed: unsupported codec",
+            "Symphonia probe failed: no suitable format reader found",
+        ] {
+            assert_eq!(
+                readiness_failure_classification(reason),
+                ReadinessFailureClassification::Unsupported,
+                "{reason}"
+            );
+        }
+        assert_eq!(
+            readiness_failure_classification("database is locked"),
+            ReadinessFailureClassification::Retryable
+        );
+        assert_eq!(
+            readiness_failure_classification("failed to read audio file: permission denied"),
+            ReadinessFailureClassification::Retryable
+        );
+    }
+
+    #[test]
+    fn discovery_self_heals_existing_unsupported_audio_retries() {
+        let mut connection = rusqlite::Connection::open_in_memory().expect("open test database");
+        connection
+            .execute_batch(
+                "CREATE TABLE analysis_jobs (
+                    id INTEGER PRIMARY KEY,
+                    source_id TEXT NOT NULL,
+                    readiness_managed INTEGER NOT NULL,
+                    readiness_scope_kind TEXT,
+                    readiness_scope_id TEXT,
+                    readiness_stage TEXT,
+                    content_generation TEXT,
+                    status TEXT NOT NULL,
+                    attempts INTEGER NOT NULL,
+                    failure_kind TEXT,
+                    retry_at INTEGER,
+                    last_error TEXT
+                );
+                INSERT INTO analysis_jobs VALUES
+                    (1, 'source', 1, 'file', 'bad-audio', 'analysis_features', 'hash',
+                        'failed', 3, 'retryable', 500,
+                        'failed to decode audio file: Invalid wav'),
+                    (2, 'source', 1, 'file', 'transient', 'analysis_features', 'hash',
+                        'failed', 3, 'retryable', 500, 'database is locked'),
+                    (3, 'source', 1, 'file', 'pending', 'analysis_features', 'hash',
+                        'pending', 0, NULL, NULL, NULL),
+                    (4, 'source', 0, 'file', 'legacy', 'analysis_features', 'hash',
+                        'failed', 3, 'retryable', 500, 'unsupported codec'),
+                    (5, 'source', 1, 'file', 'bad-audio', 'embedding_aspects', 'hash',
+                        'failed', 3, 'retryable', 500,
+                        'embedding feature prerequisite is not durable yet'),
+                    (6, 'source', 1, 'file', 'missing-payload', 'embedding_aspects', 'hash',
+                        'failed', 8, 'permanent', NULL,
+                        'embedding feature prerequisite is not durable yet'),
+                    (7, 'source', 1, 'file', 'legacy-permanent', 'analysis_features', 'hash',
+                        'failed', 8, 'permanent', NULL,
+                        'Audio decode failed for empty.wav: no suitable format reader found');",
+            )
+            .expect("seed readiness failures");
+
+        assert_eq!(
+            reclassify_known_unsupported_audio_failures(&mut connection)
+                .expect("reclassify unsupported failures"),
+            4
+        );
+        let first = connection
+            .query_row(
+                "SELECT failure_kind, retry_at FROM analysis_jobs WHERE id = 1",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+            )
+            .expect("read reclassified failure");
+        assert_eq!(first, (String::from("unsupported"), None));
+        let second = connection
+            .query_row(
+                "SELECT failure_kind, retry_at FROM analysis_jobs WHERE id = 2",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+            )
+            .expect("read retryable failure");
+        assert_eq!(second, (String::from("retryable"), Some(500)));
+        let dependent = connection
+            .query_row(
+                "SELECT failure_kind, retry_at FROM analysis_jobs WHERE id = 5",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+            )
+            .expect("read unsupported dependent failure");
+        assert_eq!(dependent, (String::from("unsupported"), None));
+        let legacy_permanent = connection
+            .query_row(
+                "SELECT failure_kind, retry_at FROM analysis_jobs WHERE id = 7",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+            )
+            .expect("read legacy permanent failure");
+        assert_eq!(legacy_permanent, (String::from("unsupported"), None));
+        let repaired = connection
+            .query_row(
+                "SELECT failure_kind, attempts, retry_at FROM analysis_jobs WHERE id = 6",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .expect("read repaired prerequisite failure");
+        assert_eq!(repaired, (String::from("retryable"), 0, None));
+        let target = ReadinessTarget::file(
+            "source",
+            "bad-audio",
+            "bad.wav",
+            ReadinessStage::EmbeddingAspects,
+            "embedding-v1",
+            1,
+            "hash",
+        );
+        assert!(
+            readiness_stage_is_unsupported(&connection, &target, "analysis_features")
+                .expect("read unsupported prerequisite")
+        );
+        assert_eq!(
+            reclassify_known_unsupported_audio_failures(&mut connection)
+                .expect("reclassification is idempotent"),
+            0
         );
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -41,6 +41,7 @@ use crate::native_app::waveform::{
 };
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+const PROGRESS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const MANIFEST_AUDIT_INTERVAL_SECONDS: i64 = 5 * 60;
 const MANIFEST_AUDIT_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
@@ -595,6 +596,7 @@ impl SourceProcessingSupervisor {
             control.playback_active = active;
             if active {
                 control.cancel_all_source_work();
+                control.pause_feedback_pending = true;
             } else if !control.foreground_active {
                 control.reset_source_work_tokens();
             }
@@ -602,6 +604,9 @@ impl SourceProcessingSupervisor {
                 control.notify("playback_pause");
             } else {
                 control.notify("playback_resume");
+            }
+            if active {
+                publish_source_processing_pausing(&self.shared, "Waiting for playback");
             }
             drop(control);
             if active {
@@ -620,6 +625,7 @@ impl SourceProcessingSupervisor {
         control.foreground_active = active;
         if active {
             control.cancel_all_source_work();
+            control.pause_feedback_pending = true;
         } else if !control.playback_active {
             control.reset_source_work_tokens();
         }
@@ -627,6 +633,9 @@ impl SourceProcessingSupervisor {
             control.notify("foreground_activity_pause");
         } else {
             control.notify("foreground_activity_resume");
+        }
+        if active {
+            publish_source_processing_pausing(&self.shared, "Waiting for source loading");
         }
         drop(control);
         if active {
@@ -719,6 +728,7 @@ impl Shared {
                 wake_reason: "startup",
                 playback_active: false,
                 foreground_active: false,
+                pause_feedback_pending: false,
                 shutdown: false,
                 priority: PriorityContext::default(),
             }),
@@ -862,6 +872,7 @@ struct ControlState {
     wake_reason: &'static str,
     playback_active: bool,
     foreground_active: bool,
+    pause_feedback_pending: bool,
     shutdown: bool,
     priority: PriorityContext,
 }
@@ -999,14 +1010,25 @@ fn run_coordinator(shared: Arc<Shared>) {
     let mut candidates = Vec::<RuntimeCandidate>::new();
     let mut source_stats = BTreeMap::<String, SourceDiscoveryStats>::new();
     let mut active_progress_source = None::<String>;
+    let mut last_progress_publish_at = None::<Instant>;
+    let mut progress_visible = false;
     loop {
-        let (sources, dirty_sources, source_work_cancels, processing_paused, generation, reason) = {
+        let (
+            sources,
+            dirty_sources,
+            source_work_cancels,
+            processing_paused,
+            pause_feedback_pending,
+            generation,
+            reason,
+        ) = {
             let mut control = shared.control();
             while !control.shutdown && control.wake_generation == observed_generation {
                 let wait_duration = coordinator_wait_duration(
                     next_retry_at,
                     now_epoch_seconds(),
                     next_safety_sweep_at.saturating_duration_since(Instant::now()),
+                    control.processing_paused(),
                 );
                 let (next, _) = shared
                     .wake
@@ -1039,6 +1061,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                 break;
             }
             let processing_paused = control.processing_paused();
+            let pause_feedback_pending = std::mem::take(&mut control.pause_feedback_pending);
             let dirty_sources = if processing_paused {
                 BTreeSet::new()
             } else {
@@ -1054,6 +1077,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                 dirty_sources,
                 control.source_work_cancels.clone(),
                 processing_paused,
+                pause_feedback_pending,
                 control.wake_generation,
                 control.wake_reason,
             )
@@ -1069,6 +1093,15 @@ fn run_coordinator(shared: Arc<Shared>) {
                 && !dirty_sources.contains(candidate.source.id.as_str())
         });
         source_stats.retain(|source_id, _| configured_source_ids.contains(source_id));
+        if pause_feedback_pending {
+            // The pause may already have resumed by the time a long-running database
+            // checkpoint returns. Acknowledge the latched transition here so rapid foreground
+            // activity cannot leave stale pausing feedback behind.
+            publish_source_processing_finished(&shared);
+            progress_visible = false;
+            active_progress_source = None;
+            last_progress_publish_at = None;
+        }
         if processing_paused {
             tracing::debug!(
                 target: "wavecrate::source_processing",
@@ -1127,6 +1160,9 @@ fn run_coordinator(shared: Arc<Shared>) {
             .filter(|source| dirty_sources.contains(source.id.as_str()))
             .cloned()
             .collect::<Vec<_>>();
+        if !sources_to_discover.is_empty() {
+            progress_visible = true;
+        }
         for source in &sources_to_discover {
             source_stats.remove(source.id.as_str());
         }
@@ -1138,11 +1174,11 @@ fn run_coordinator(shared: Arc<Shared>) {
         candidates.append(&mut discovered);
         source_stats.extend(discovered_source_stats);
         let discovered_stats = aggregate_source_stats(source_stats.values().copied());
-        if candidates.is_empty()
-            && discovered_stats.progress_completed >= discovered_stats.progress_total
-        {
+        if candidates.is_empty() && progress_visible {
             publish_source_processing_finished(&shared);
+            progress_visible = false;
             active_progress_source = None;
+            last_progress_publish_at = None;
         }
         next_retry_at = discovered_stats.earliest_retry_at;
         {
@@ -1182,8 +1218,11 @@ fn run_coordinator(shared: Arc<Shared>) {
             };
             let index = eligible_indices[schedule_index];
             let candidate = candidates.swap_remove(index);
+            let progress_refresh_due = last_progress_publish_at
+                .is_none_or(|published_at| published_at.elapsed() >= PROGRESS_REFRESH_INTERVAL);
             if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
-                || !matches!(&candidate.task, RuntimeTask::Readiness(_)))
+                || !matches!(&candidate.task, RuntimeTask::Readiness(_))
+                || progress_refresh_due)
                 && source_stats.contains_key(candidate.source.id.as_str())
             {
                 publish_source_processing_progress(
@@ -1192,6 +1231,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                     aggregate_source_stats(source_stats.values().copied()),
                 );
                 active_progress_source = Some(candidate.source.id.as_str().to_string());
+                last_progress_publish_at = Some(Instant::now());
+                progress_visible = true;
             }
             let Some(permit) = shared
                 .budgets()
@@ -1250,6 +1291,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                                 )
                             {
                                 publish_source_processing_progress(&shared, &candidate, progress);
+                                last_progress_publish_at = Some(Instant::now());
+                                progress_visible = true;
                             }
                         }
                         ExecutionOutcome::Retried { retry_at } => {
@@ -1271,6 +1314,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                                 )
                             {
                                 publish_source_processing_progress(&shared, &candidate, progress);
+                                last_progress_publish_at = Some(Instant::now());
+                                progress_visible = true;
                             }
                         }
                         ExecutionOutcome::Stale => {
@@ -1340,6 +1385,12 @@ fn run_coordinator(shared: Arc<Shared>) {
                 .mark_source_dirty(source_id, "source_stage_progress");
             break;
         }
+        if candidates.is_empty() && progress_visible {
+            publish_source_processing_finished(&shared);
+            progress_visible = false;
+            active_progress_source = None;
+            last_progress_publish_at = None;
+        }
         let mut telemetry = shared.telemetry();
         telemetry.queue_depth = candidates.len();
         telemetry.oldest_job_age_seconds = oldest_job_age_seconds(&candidates, now_epoch_seconds());
@@ -1370,6 +1421,10 @@ fn publish_source_processing_progress(
     candidate: &RuntimeCandidate,
     stats: SourceDiscoveryStats,
 ) {
+    let control = shared.control();
+    if control.processing_paused() {
+        return;
+    }
     let Some(worker_sender) = shared.worker_sender.as_ref() else {
         return;
     };
@@ -1415,6 +1470,10 @@ fn publish_source_processing_progress(
 }
 
 fn publish_source_processing_discovery(shared: &Shared, source: &SampleSource) {
+    let control = shared.control();
+    if control.processing_paused() {
+        return;
+    }
     let Some(worker_sender) = shared.worker_sender.as_ref() else {
         return;
     };
@@ -1442,6 +1501,22 @@ fn publish_source_processing_finished(shared: &Shared) {
             total: 0,
             stage: String::new(),
             detail: String::new(),
+        },
+    ));
+}
+
+fn publish_source_processing_pausing(shared: &Shared, detail: &str) {
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return;
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: String::new(),
+            active: true,
+            completed: 0,
+            total: 0,
+            stage: String::from("Pausing source processing"),
+            detail: detail.to_string(),
         },
     ));
 }
@@ -2793,7 +2868,11 @@ fn coordinator_wait_duration(
     next_retry_at: Option<i64>,
     now: i64,
     safety_wait: Duration,
+    processing_paused: bool,
 ) -> Duration {
+    if processing_paused {
+        return safety_wait;
+    }
     let retry_wait = next_retry_at.map_or(safety_wait, |deadline| {
         Duration::from_secs(deadline.saturating_sub(now).max(0) as u64)
     });
@@ -2835,6 +2914,96 @@ mod tests {
         wait_until(Duration::from_secs(10), || source_is_hashed(&source));
         let report = supervisor.shutdown();
         assert_eq!(report["joined"], true);
+    }
+
+    #[test]
+    fn playback_pause_reports_transition_and_fences_source_processing_feedback() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut supervisor = SourceProcessingSupervisor::start_with_playback_state_and_sender(
+            Vec::new(),
+            false,
+            Some(sender),
+        );
+
+        supervisor.set_playback_active(true);
+
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("playback pause cleanup");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(progress.active);
+        assert_eq!(progress.stage, "Pausing source processing");
+        assert_eq!(progress.detail, "Waiting for playback");
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("playback pause acknowledgement");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(!progress.active);
+
+        supervisor.set_playback_active(false);
+        supervisor.set_foreground_activity(true);
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("foreground activity cleanup");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(progress.active);
+        assert_eq!(progress.stage, "Pausing source processing");
+        assert_eq!(progress.detail, "Waiting for source loading");
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("foreground activity pause acknowledgement");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(!progress.active);
+
+        supervisor.set_foreground_activity(false);
+        supervisor.set_foreground_activity(true);
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("rapid foreground pause transition");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(progress.active);
+        supervisor.set_foreground_activity(false);
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("rapid foreground pause acknowledgement");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert!(!progress.active);
+
+        supervisor.set_playback_active(true);
+        for expectation in ["final pause transition", "final pause acknowledgement"] {
+            let message = receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect(expectation);
+            let GuiMessage::SourceProcessingProgress(progress) = message else {
+                panic!("unexpected supervisor GUI message: {message:?}");
+            };
+            if expectation == "final pause transition" {
+                assert!(progress.active);
+            } else {
+                assert!(!progress.active);
+            }
+        }
+
+        let directory = tempfile::tempdir().expect("paused discovery source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("paused-discovery"),
+            directory.path().to_path_buf(),
+        );
+        publish_source_processing_discovery(&supervisor.shared, &source);
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(supervisor.shutdown()["joined"], true);
     }
 
     #[test]
@@ -4279,25 +4448,30 @@ mod tests {
     #[test]
     fn retry_deadline_shortens_coordinator_wait_deterministically() {
         assert_eq!(
-            coordinator_wait_duration(Some(105), 100, SAFETY_SWEEP_INTERVAL),
+            coordinator_wait_duration(Some(105), 100, SAFETY_SWEEP_INTERVAL, false),
             Duration::from_secs(5)
         );
         assert_eq!(
-            coordinator_wait_duration(Some(100), 100, SAFETY_SWEEP_INTERVAL),
+            coordinator_wait_duration(Some(100), 100, SAFETY_SWEEP_INTERVAL, false),
             Duration::ZERO
         );
         assert_eq!(
-            coordinator_wait_duration(Some(200), 100, SAFETY_SWEEP_INTERVAL),
+            coordinator_wait_duration(Some(200), 100, SAFETY_SWEEP_INTERVAL, false),
             SAFETY_SWEEP_INTERVAL
         );
         assert_eq!(
-            coordinator_wait_duration(None, 100, SAFETY_SWEEP_INTERVAL),
+            coordinator_wait_duration(None, 100, SAFETY_SWEEP_INTERVAL, false),
             SAFETY_SWEEP_INTERVAL
         );
         assert_eq!(
-            coordinator_wait_duration(None, 100, Duration::from_secs(3)),
+            coordinator_wait_duration(None, 100, Duration::from_secs(3), false),
             Duration::from_secs(3),
             "priority wakes must preserve the remaining absolute safety-sweep deadline"
+        );
+        assert_eq!(
+            coordinator_wait_duration(Some(100), 100, SAFETY_SWEEP_INTERVAL, true),
+            SAFETY_SWEEP_INTERVAL,
+            "paused processing must not spin on an already-due retry deadline"
         );
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -25,7 +25,7 @@ use wavecrate::sample_sources::{
         reconcile_readiness_with_cancel, renew_readiness_lease,
         replace_readiness_targets_with_cancel,
     },
-    scanner::{audit_source_and_record, complete_pending_deep_hash_for_path},
+    scanner::{ScanError, audit_source_and_record, complete_pending_deep_hash_for_path},
 };
 
 use super::scheduler::{
@@ -1969,14 +1969,16 @@ fn execute_candidate(
             )
             .map_err(|error| error.to_string())?;
             let completed_at = now_epoch_seconds();
-            let outcome = audit_source_and_record(
+            let (outcome, incomplete_error) = match audit_source_and_record(
                 &database,
                 Some(cancel),
                 MANIFEST_AUDIT_HASH_BATCH,
                 completed_at,
-            )
-            .map_err(|error| error.to_string())?;
-            let incomplete_error = outcome.incomplete_error.clone();
+            ) {
+                Ok(outcome) => (outcome, None),
+                Err(ScanError::Incomplete { committed, error }) => (*committed, Some(error)),
+                Err(error) => return Err(error.to_string()),
+            };
             tracing::debug!(
                 target: "wavecrate::source_processing",
                 source_id = candidate.source.id.as_str(),

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -1900,6 +1900,15 @@ fn execute_candidate(
                 .source
                 .database_root()
                 .map_err(|error| error.to_string())?;
+            if !candidate.source.root.is_dir() {
+                tracing::info!(
+                    target: "wavecrate::source_processing",
+                    source_id = candidate.source.id.as_str(),
+                    root = %candidate.source.root.display(),
+                    "Skipping manifest audit because the source root became unavailable"
+                );
+                return Ok(ExecutionOutcome::Cancelled);
+            }
             let database = SourceDatabase::open_for_background_job_with_database_root(
                 &candidate.source.root,
                 database_root,
@@ -1913,27 +1922,27 @@ fn execute_candidate(
                 completed_at,
             )
             .map_err(|error| error.to_string())?;
+            tracing::debug!(
+                target: "wavecrate::source_processing",
+                source_id = candidate.source.id.as_str(),
+                revision = outcome.committed_delta.revision,
+                created = outcome.committed_delta.created.len(),
+                changed = outcome.committed_delta.changed.len(),
+                moved = outcome.committed_delta.moved.len(),
+                deleted = outcome.committed_delta.deleted.len(),
+                "Periodic source manifest audit committed"
+            );
+            if !outcome.committed_delta.is_empty()
+                && let Some(worker_sender) = worker_sender
+            {
+                let _ = worker_sender.send(GuiMessage::SourceManifestAuditCommitted {
+                    source_id: candidate.source.id.as_str().to_string(),
+                    committed_delta: outcome.committed_delta,
+                });
+            }
             if cancel.load(Ordering::Acquire) {
                 Ok(ExecutionOutcome::Cancelled)
             } else {
-                tracing::debug!(
-                    target: "wavecrate::source_processing",
-                    source_id = candidate.source.id.as_str(),
-                    revision = outcome.committed_delta.revision,
-                    created = outcome.committed_delta.created.len(),
-                    changed = outcome.committed_delta.changed.len(),
-                    moved = outcome.committed_delta.moved.len(),
-                    deleted = outcome.committed_delta.deleted.len(),
-                    "Periodic source manifest audit committed"
-                );
-                if !outcome.committed_delta.is_empty()
-                    && let Some(worker_sender) = worker_sender
-                {
-                    let _ = worker_sender.send(GuiMessage::SourceManifestAuditCommitted {
-                        source_id: candidate.source.id.as_str().to_string(),
-                        committed_delta: outcome.committed_delta,
-                    });
-                }
                 Ok(ExecutionOutcome::Completed)
             }
         }
@@ -3381,6 +3390,39 @@ mod tests {
         assert!(
             !root.exists(),
             "discovery must not recreate a missing source"
+        );
+    }
+
+    #[test]
+    fn scheduled_manifest_audit_does_not_recreate_source_removed_after_discovery() {
+        let parent = tempfile::tempdir().expect("missing source parent");
+        let root = parent.path().join("source");
+        std::fs::create_dir(&root).expect("create source root");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("removed-after-discovery"),
+            root.clone(),
+        );
+        source.open_db().expect("create source database");
+        let candidate = RuntimeCandidate {
+            schedule: WorkCandidate::source(
+                source.id.as_str(),
+                ProcessingLane::Scan,
+                0,
+                now_epoch_seconds(),
+            ),
+            source,
+            task: RuntimeTask::ManifestAudit,
+        };
+        std::fs::remove_dir_all(&root).expect("remove source after scheduling");
+
+        assert_eq!(
+            execute_candidate(&candidate, &AtomicBool::new(false), None)
+                .expect("unavailable audit is cancelled"),
+            ExecutionOutcome::Cancelled
+        );
+        assert!(
+            !root.exists(),
+            "executing stale scheduled work must not recreate the source"
         );
     }
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -31,7 +31,7 @@ use wavecrate::sample_sources::{
 use super::scheduler::{
     BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane, WorkCandidate,
 };
-use crate::native_app::app::GuiMessage;
+use crate::native_app::app::{GuiMessage, SourceProcessingProgress};
 use crate::native_app::sample_library::similarity_prep::{
     NATIVE_SIMILARITY_UMAP_VERSION, SimilarityPublicationFence, finalize_similarity_prep_if_ready,
     reset_interrupted_similarity_prep_jobs, similarity_prep_needs_finalization,
@@ -965,6 +965,8 @@ struct SourceDiscoveryStats {
     readiness_queue_depth: usize,
     retries_due: usize,
     earliest_retry_at: Option<i64>,
+    progress_completed: usize,
+    progress_total: usize,
 }
 
 enum Cancellable<T> {
@@ -996,6 +998,7 @@ fn run_coordinator(shared: Arc<Shared>) {
     let mut reset_sources = BTreeMap::<String, bool>::new();
     let mut candidates = Vec::<RuntimeCandidate>::new();
     let mut source_stats = BTreeMap::<String, SourceDiscoveryStats>::new();
+    let mut active_progress_source = None::<String>;
     loop {
         let (sources, dirty_sources, source_work_cancels, processing_paused, generation, reason) = {
             let mut control = shared.control();
@@ -1135,6 +1138,12 @@ fn run_coordinator(shared: Arc<Shared>) {
         candidates.append(&mut discovered);
         source_stats.extend(discovered_source_stats);
         let discovered_stats = aggregate_source_stats(source_stats.values().copied());
+        if candidates.is_empty()
+            && discovered_stats.progress_completed >= discovered_stats.progress_total
+        {
+            publish_source_processing_finished(&shared);
+            active_progress_source = None;
+        }
         next_retry_at = discovered_stats.earliest_retry_at;
         {
             let mut telemetry = shared.telemetry();
@@ -1173,6 +1182,17 @@ fn run_coordinator(shared: Arc<Shared>) {
             };
             let index = eligible_indices[schedule_index];
             let candidate = candidates.swap_remove(index);
+            if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
+                || !matches!(&candidate.task, RuntimeTask::Readiness(_)))
+                && source_stats.contains_key(candidate.source.id.as_str())
+            {
+                publish_source_processing_progress(
+                    &shared,
+                    &candidate,
+                    aggregate_source_stats(source_stats.values().copied()),
+                );
+                active_progress_source = Some(candidate.source.id.as_str().to_string());
+            }
             let Some(permit) = shared
                 .budgets()
                 .try_acquire(&candidate.schedule.source_id, candidate.schedule.lane)
@@ -1208,12 +1228,29 @@ fn run_coordinator(shared: Arc<Shared>) {
             match result {
                 Ok(outcome) => {
                     execution_outcome = Some(outcome);
+                    if outcome == ExecutionOutcome::Completed
+                        && let RuntimeTask::Readiness(target) = &candidate.task
+                        && target.stage == ReadinessStage::EmbeddingAspects
+                        && let Some(worker_sender) = shared.worker_sender.as_ref()
+                    {
+                        let _ = worker_sender.send(GuiMessage::SimilarityReadinessAdvanced {
+                            source_id: target.source_id.clone(),
+                        });
+                    }
                     if outcome.was_claimed() {
                         telemetry.claimed = telemetry.claimed.saturating_add(1);
                     }
                     match outcome {
                         ExecutionOutcome::Completed => {
-                            telemetry.completed = telemetry.completed.saturating_add(1)
+                            telemetry.completed = telemetry.completed.saturating_add(1);
+                            if matches!(&candidate.task, RuntimeTask::Readiness(_))
+                                && let Some(progress) = advance_source_progress(
+                                    &mut source_stats,
+                                    candidate.source.id.as_str(),
+                                )
+                            {
+                                publish_source_processing_progress(&shared, &candidate, progress);
+                            }
                         }
                         ExecutionOutcome::Retried { retry_at } => {
                             telemetry.retried = telemetry.retried.saturating_add(1);
@@ -1226,7 +1263,15 @@ fn run_coordinator(shared: Arc<Shared>) {
                             next_retry_at = aggregate.earliest_retry_at;
                         }
                         ExecutionOutcome::Failed => {
-                            telemetry.failed = telemetry.failed.saturating_add(1)
+                            telemetry.failed = telemetry.failed.saturating_add(1);
+                            if matches!(&candidate.task, RuntimeTask::Readiness(_))
+                                && let Some(progress) = advance_source_progress(
+                                    &mut source_stats,
+                                    candidate.source.id.as_str(),
+                                )
+                            {
+                                publish_source_processing_progress(&shared, &candidate, progress);
+                            }
                         }
                         ExecutionOutcome::Stale => {
                             telemetry.stale = telemetry.stale.saturating_add(1)
@@ -1320,6 +1365,115 @@ fn run_coordinator(shared: Arc<Shared>) {
     }
 }
 
+fn publish_source_processing_progress(
+    shared: &Shared,
+    candidate: &RuntimeCandidate,
+    stats: SourceDiscoveryStats,
+) {
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return;
+    };
+    let (stage, detail, completed, total) = match &candidate.task {
+        RuntimeTask::Readiness(target) => {
+            let (stage, detail) = readiness_progress_detail(target);
+            (
+                stage,
+                detail,
+                stats.progress_completed,
+                stats.progress_total,
+            )
+        }
+        RuntimeTask::ManifestAudit => (
+            "Scanning source changes",
+            String::from("Checking the source manifest"),
+            0,
+            0,
+        ),
+        RuntimeTask::LegacyAnalysis { .. } => (
+            "Migrating analysis",
+            String::from("Preparing legacy source data"),
+            0,
+            0,
+        ),
+        RuntimeTask::FinalizeSimilarity { .. } => (
+            "Finalizing similarity",
+            String::from("Publishing the source layout"),
+            0,
+            0,
+        ),
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: candidate.source.id.as_str().to_string(),
+            active: total == 0 || completed < total,
+            completed,
+            total,
+            stage: stage.to_string(),
+            detail,
+        },
+    ));
+}
+
+fn publish_source_processing_discovery(shared: &Shared, source: &SampleSource) {
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return;
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: source.id.as_str().to_string(),
+            active: true,
+            completed: 0,
+            total: 0,
+            stage: String::from("Inspecting source jobs"),
+            detail: String::from("Discovering background work"),
+        },
+    ));
+}
+
+fn publish_source_processing_finished(shared: &Shared) {
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return;
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: String::new(),
+            active: false,
+            completed: 0,
+            total: 0,
+            stage: String::new(),
+            detail: String::new(),
+        },
+    ));
+}
+
+fn advance_source_progress(
+    source_stats: &mut BTreeMap<String, SourceDiscoveryStats>,
+    source_id: &str,
+) -> Option<SourceDiscoveryStats> {
+    let stats = source_stats.get_mut(source_id)?;
+    stats.progress_completed = stats
+        .progress_completed
+        .saturating_add(1)
+        .min(stats.progress_total);
+    Some(aggregate_source_stats(source_stats.values().copied()))
+}
+
+fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String) {
+    let stage = match target.stage {
+        ReadinessStage::IndexedIdentity => "Indexing files",
+        ReadinessStage::PlaybackSummary => "Preparing playback",
+        ReadinessStage::AnalysisFeatures => "Analyzing audio",
+        ReadinessStage::EmbeddingAspects => "Preparing similarity",
+        ReadinessStage::SimilarityLayout => "Building similarity layout",
+    };
+    let detail = target
+        .relative_path
+        .as_deref()
+        .unwrap_or("Finalizing source")
+        .to_string();
+    (stage, detail)
+}
+
 fn scheduler_candidate_indices(
     candidates: &[RuntimeCandidate],
     external_scan_admitted: bool,
@@ -1367,6 +1521,7 @@ fn discover_candidates(
             let mut telemetry = shared.telemetry();
             telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
         }
+        publish_source_processing_discovery(shared, source);
         match discover_source_candidates(source, now, source_cancel) {
             Ok(Cancellable::Completed((mut source_candidates, stats))) => {
                 candidates.append(&mut source_candidates);
@@ -1456,7 +1611,20 @@ fn discover_source_candidates_with_connection(
         .map_err(|error| error.to_string())?
         .and_then(|value| value.parse::<i64>().ok())
         .unwrap_or_default();
-    if now.saturating_sub(last_manifest_audit_at) >= MANIFEST_AUDIT_INTERVAL_SECONDS {
+    let manifest_identity_repair_due: bool = connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM wav_files
+                WHERE missing = 0
+                  AND (file_identity IS NULL OR TRIM(file_identity) = '')
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if manifest_identity_repair_due
+        || now.saturating_sub(last_manifest_audit_at) >= MANIFEST_AUDIT_INTERVAL_SECONDS
+    {
         candidates.push(RuntimeCandidate {
             schedule: WorkCandidate::source(source_id, ProcessingLane::Scan, 0, now),
             source: source.clone(),
@@ -1502,6 +1670,12 @@ fn discover_source_candidates_with_connection(
         }));
         let work_stats =
             readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
+        stats.progress_total = work_stats.total;
+        stats.progress_completed = work_stats
+            .completed
+            .saturating_add(work_stats.permanent_failures)
+            .saturating_add(work_stats.unsupported)
+            .min(stats.progress_total);
         stats.retries_due = work_stats.retries_due;
         stats.earliest_retry_at = work_stats.earliest_retry_at;
         tracing::debug!(
@@ -1984,9 +2158,21 @@ fn execute_candidate(
                 source_id = candidate.source.id.as_str(),
                 revision = outcome.committed_delta.revision,
                 created = outcome.committed_delta.created.len(),
+                created_paths = ?outcome
+                    .committed_delta
+                    .created
+                    .iter()
+                    .map(|identity| identity.relative_path.as_path())
+                    .collect::<Vec<_>>(),
                 changed = outcome.committed_delta.changed.len(),
                 moved = outcome.committed_delta.moved.len(),
                 deleted = outcome.committed_delta.deleted.len(),
+                deleted_paths = ?outcome
+                    .committed_delta
+                    .deleted
+                    .iter()
+                    .map(|identity| identity.relative_path.as_path())
+                    .collect::<Vec<_>>(),
                 "Periodic source manifest audit committed"
             );
             if !outcome.committed_delta.is_empty()
@@ -2593,6 +2779,12 @@ fn aggregate_source_stats(
             aggregate.retries_due = aggregate.retries_due.saturating_add(source.retries_due);
             aggregate.earliest_retry_at =
                 earliest_deadline(aggregate.earliest_retry_at, source.earliest_retry_at);
+            aggregate.progress_completed = aggregate
+                .progress_completed
+                .saturating_add(source.progress_completed);
+            aggregate.progress_total = aggregate
+                .progress_total
+                .saturating_add(source.progress_total);
             aggregate
         })
 }
@@ -3499,6 +3691,35 @@ mod tests {
     }
 
     #[test]
+    fn missing_manifest_identity_schedules_self_healing_audit_even_when_recent() {
+        let (_directory, source) = unhashed_source("manifest-identity-repair");
+        let db = source
+            .open_db()
+            .expect("open manifest identity repair source");
+        let mut batch = db.write_batch().expect("open missing identity batch");
+        batch
+            .set_file_identity(Path::new("pending.wav"), None)
+            .expect("clear manifest identity");
+        batch.commit().expect("commit missing manifest identity");
+        db.set_metadata(META_LAST_MANIFEST_AUDIT_AT, "100")
+            .expect("record recent audit");
+        let cancel = AtomicBool::new(false);
+
+        let Cancellable::Completed((candidates, _)) =
+            discover_source_candidates(&source, 100, &cancel)
+                .expect("discover manifest identity repair")
+        else {
+            panic!("manifest identity repair discovery unexpectedly cancelled");
+        };
+
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| matches!(candidate.task, RuntimeTask::ManifestAudit))
+        );
+    }
+
+    #[test]
     fn missing_source_discovery_updates_external_metadata_without_recreating_audio_root() {
         let parent = tempfile::tempdir().expect("missing source parent");
         let root = parent.path().join("source");
@@ -3582,6 +3803,54 @@ mod tests {
             !root.exists(),
             "executing stale scheduled work must not recreate the source"
         );
+    }
+
+    #[test]
+    fn readiness_progress_publishes_determinate_source_job_feedback() {
+        let directory = tempfile::tempdir().expect("progress source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("progress-source"),
+            directory.path().to_path_buf(),
+        );
+        let target = ReadinessTarget::file(
+            source.id.as_str(),
+            "identity-1",
+            "drums/kick.wav",
+            ReadinessStage::EmbeddingAspects,
+            "embedding-v1",
+            1,
+            "content-1",
+        );
+        let candidate = RuntimeCandidate {
+            schedule: WorkCandidate::readiness(&target, 1),
+            source: source.clone(),
+            task: RuntimeTask::Readiness(target),
+        };
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let shared = Shared::new(vec![source], Some(sender));
+
+        publish_source_processing_progress(
+            &shared,
+            &candidate,
+            SourceDiscoveryStats {
+                progress_completed: 313,
+                progress_total: 9_985,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+
+        let message = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("progress message");
+        let GuiMessage::SourceProcessingProgress(progress) = message else {
+            panic!("unexpected supervisor GUI message: {message:?}");
+        };
+        assert_eq!(progress.source_id, "progress-source");
+        assert!(progress.active);
+        assert_eq!(progress.completed, 313);
+        assert_eq!(progress.total, 9_985);
+        assert_eq!(progress.stage, "Preparing similarity");
+        assert_eq!(progress.detail, "drums/kick.wav");
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -997,13 +997,22 @@ enum ExecutionOutcome {
     PrerequisiteInvalidated,
     Stale,
     Cancelled,
+    Parked,
     NotClaimed,
 }
 
 impl ExecutionOutcome {
     fn was_claimed(self) -> bool {
-        !matches!(self, Self::NotClaimed)
+        !matches!(self, Self::Parked | Self::NotClaimed)
     }
+}
+
+fn should_requeue_cancelled(
+    outcome: Option<ExecutionOutcome>,
+    source_active: bool,
+    source_dirty: bool,
+) -> bool {
+    matches!(outcome, Some(ExecutionOutcome::Cancelled)) && source_active && !source_dirty
 }
 
 fn run_coordinator(shared: Arc<Shared>) {
@@ -1359,6 +1368,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                         ExecutionOutcome::Cancelled => {
                             telemetry.cancelled = telemetry.cancelled.saturating_add(1)
                         }
+                        ExecutionOutcome::Parked => {}
                         ExecutionOutcome::NotClaimed => {}
                     }
                 }
@@ -1393,12 +1403,14 @@ fn run_coordinator(shared: Arc<Shared>) {
             ) {
                 last_similarity_refresh_publish_at = Some(Instant::now());
             }
-            let requeue_cancelled = matches!(execution_outcome, Some(ExecutionOutcome::Cancelled))
-                && {
-                    let control = shared.control();
-                    control.source_is_active(candidate.source.id.as_str())
-                        && !control.dirty_sources.contains(candidate.source.id.as_str())
-                };
+            let requeue_cancelled = {
+                let control = shared.control();
+                should_requeue_cancelled(
+                    execution_outcome,
+                    control.source_is_active(candidate.source.id.as_str()),
+                    control.dirty_sources.contains(candidate.source.id.as_str()),
+                )
+            };
             if requeue_cancelled {
                 candidates.push(candidate);
                 continue;
@@ -2355,7 +2367,7 @@ fn execute_candidate(
                     root = %candidate.source.root.display(),
                     "Skipping manifest audit because the source root became unavailable"
                 );
-                return Ok(ExecutionOutcome::Cancelled);
+                return Ok(ExecutionOutcome::Parked);
             }
             let database = SourceDatabase::open_for_background_job_with_database_root(
                 &candidate.source.root,
@@ -4439,8 +4451,12 @@ mod tests {
 
         assert_eq!(
             execute_candidate(&candidate, &AtomicBool::new(false), None)
-                .expect("unavailable audit is cancelled"),
-            ExecutionOutcome::Cancelled
+                .expect("unavailable audit is parked"),
+            ExecutionOutcome::Parked
+        );
+        assert!(
+            !should_requeue_cancelled(Some(ExecutionOutcome::Parked), true, false),
+            "unavailable roots must wait for a later availability or safety wake"
         );
         assert!(
             !root.exists(),

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -14,7 +14,7 @@ use rusqlite::{OptionalExtension, TransactionBehavior, params};
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
-    db::META_WAV_PATHS_REVISION,
+    db::{META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION},
     readiness::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessFailureClassification,
         ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy,
@@ -24,7 +24,7 @@ use wavecrate::sample_sources::{
         reconcile_readiness_with_cancel, renew_readiness_lease,
         replace_readiness_targets_with_cancel,
     },
-    scanner::complete_pending_deep_hash_for_path,
+    scanner::{audit_source_and_record, complete_pending_deep_hash_for_path},
 };
 
 use super::scheduler::{
@@ -39,6 +39,8 @@ use crate::native_app::waveform::{
 };
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+const MANIFEST_AUDIT_INTERVAL_SECONDS: i64 = 5 * 60;
+const MANIFEST_AUDIT_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
 const READINESS_MAX_ATTEMPTS: u32 = 8;
@@ -887,6 +889,7 @@ struct SupervisorTelemetry {
 
 #[derive(Clone, Debug)]
 enum RuntimeTask {
+    ManifestAudit,
     LegacyAnalysis {
         job_id: i64,
     },
@@ -1207,7 +1210,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                 continue;
             }
             let should_refresh = match (&candidate.task, execution_outcome) {
-                (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
+                (RuntimeTask::ManifestAudit, Some(ExecutionOutcome::Completed))
+                | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Completed))
                 | (RuntimeTask::LegacyAnalysis { .. }, Some(ExecutionOutcome::Failed))
                 | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Completed))
                 | (RuntimeTask::Readiness(_), Some(ExecutionOutcome::Retried { .. }))
@@ -1309,6 +1313,23 @@ fn discover_source_candidates(
         return Ok(Cancellable::Cancelled);
     }
     let database_root = source.database_root().map_err(|error| error.to_string())?;
+    if !source.root.is_dir() {
+        if database_root != source.root && database_root.is_dir() {
+            let connection = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            )
+            .map_err(|error| error.to_string())?;
+            if source_processing_schema_available(&connection)? {
+                mark_readiness_temporarily_unavailable(&connection, source.id.as_str(), now)?;
+            }
+        }
+        return Ok(Cancellable::Completed((
+            Vec::new(),
+            SourceDiscoveryStats::default(),
+        )));
+    }
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
         &database_root,
@@ -1345,6 +1366,23 @@ fn discover_source_candidates_with_connection(
             "Source processing is unavailable until the read-only source database is migrated"
         );
         return Ok(Cancellable::Completed((candidates, stats)));
+    }
+    let last_manifest_audit_at = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [META_LAST_MANIFEST_AUDIT_AT],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default();
+    if now.saturating_sub(last_manifest_audit_at) >= MANIFEST_AUDIT_INTERVAL_SECONDS {
+        candidates.push(RuntimeCandidate {
+            schedule: WorkCandidate::source(source_id, ProcessingLane::Scan, 0, now),
+            source: source.clone(),
+            task: RuntimeTask::ManifestAudit,
+        });
     }
     if matches!(
         publish_current_readiness_targets_with_cancel(connection, source_id, now, cancel)?,
@@ -1831,6 +1869,40 @@ fn execute_candidate(
     cancel: &AtomicBool,
 ) -> Result<ExecutionOutcome, String> {
     let result = match &candidate.task {
+        RuntimeTask::ManifestAudit => {
+            let database_root = candidate
+                .source
+                .database_root()
+                .map_err(|error| error.to_string())?;
+            let database = SourceDatabase::open_for_background_job_with_database_root(
+                &candidate.source.root,
+                database_root,
+            )
+            .map_err(|error| error.to_string())?;
+            let completed_at = now_epoch_seconds();
+            let outcome = audit_source_and_record(
+                &database,
+                Some(cancel),
+                MANIFEST_AUDIT_HASH_BATCH,
+                completed_at,
+            )
+            .map_err(|error| error.to_string())?;
+            if cancel.load(Ordering::Acquire) {
+                Ok(ExecutionOutcome::Cancelled)
+            } else {
+                tracing::debug!(
+                    target: "wavecrate::source_processing",
+                    source_id = candidate.source.id.as_str(),
+                    revision = outcome.committed_delta.revision,
+                    created = outcome.committed_delta.created.len(),
+                    changed = outcome.committed_delta.changed.len(),
+                    moved = outcome.committed_delta.moved.len(),
+                    deleted = outcome.committed_delta.deleted.len(),
+                    "Periodic source manifest audit committed"
+                );
+                Ok(ExecutionOutcome::Completed)
+            }
+        }
         RuntimeTask::LegacyAnalysis { job_id } => {
             super::worker::run_legacy_job(&candidate.source, *job_id, 1, cancel).map(
                 |(processed, failed)| {
@@ -3213,6 +3285,69 @@ mod tests {
         assert!(candidates.is_empty());
         assert_eq!(stats.readiness_queue_depth, 0);
         assert_eq!(discovery_durable_counts(&connection), counts_before);
+    }
+
+    #[test]
+    fn manifest_audit_is_scheduled_only_when_the_active_source_is_due() {
+        let directory = tempfile::tempdir().expect("manifest audit source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("manifest-audit"),
+            directory.path().to_path_buf(),
+        );
+        let db = source.open_db().expect("open manifest audit source");
+        let cancel = AtomicBool::new(false);
+
+        let Cancellable::Completed((due, _)) =
+            discover_source_candidates(&source, MANIFEST_AUDIT_INTERVAL_SECONDS, &cancel)
+                .expect("discover due manifest audit")
+        else {
+            panic!("manifest audit discovery unexpectedly cancelled");
+        };
+        assert!(
+            due.iter()
+                .any(|candidate| matches!(candidate.task, RuntimeTask::ManifestAudit))
+        );
+
+        db.set_metadata(
+            META_LAST_MANIFEST_AUDIT_AT,
+            &MANIFEST_AUDIT_INTERVAL_SECONDS.to_string(),
+        )
+        .expect("record manifest audit");
+        let Cancellable::Completed((not_due, _)) =
+            discover_source_candidates(&source, MANIFEST_AUDIT_INTERVAL_SECONDS * 2 - 1, &cancel)
+                .expect("discover recent manifest audit")
+        else {
+            panic!("manifest audit discovery unexpectedly cancelled");
+        };
+        assert!(
+            not_due
+                .iter()
+                .all(|candidate| !matches!(candidate.task, RuntimeTask::ManifestAudit))
+        );
+    }
+
+    #[test]
+    fn missing_source_discovery_does_not_recreate_the_source_root() {
+        let parent = tempfile::tempdir().expect("missing source parent");
+        let root = parent.path().join("source");
+        std::fs::create_dir(&root).expect("create source root");
+        let source =
+            SampleSource::new_with_id(SourceId::from_string("missing-source"), root.clone());
+        source.open_db().expect("create source database");
+        std::fs::remove_dir_all(&root).expect("remove source root");
+        let cancel = AtomicBool::new(false);
+
+        let Cancellable::Completed((candidates, _)) =
+            discover_source_candidates(&source, 100, &cancel).expect("discover unavailable source")
+        else {
+            panic!("missing source discovery unexpectedly cancelled");
+        };
+
+        assert!(candidates.is_empty());
+        assert!(
+            !root.exists(),
+            "discovery must not recreate a missing source"
+        );
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -42,6 +42,7 @@ use crate::native_app::waveform::{
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 const PROGRESS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const SIMILARITY_SCORE_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 const MANIFEST_AUDIT_INTERVAL_SECONDS: i64 = 5 * 60;
 const MANIFEST_AUDIT_HASH_BATCH: usize = 8;
 const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
@@ -1009,8 +1010,11 @@ fn run_coordinator(shared: Arc<Shared>) {
     let mut reset_sources = BTreeMap::<String, bool>::new();
     let mut candidates = Vec::<RuntimeCandidate>::new();
     let mut source_stats = BTreeMap::<String, SourceDiscoveryStats>::new();
+    let mut displayed_source_stats = BTreeMap::<String, SourceDiscoveryStats>::new();
     let mut active_progress_source = None::<String>;
     let mut last_progress_publish_at = None::<Instant>;
+    let mut pending_similarity_refresh_sources = BTreeSet::<String>::new();
+    let mut last_similarity_refresh_publish_at = None::<Instant>;
     let mut progress_visible = false;
     loop {
         let (
@@ -1030,6 +1034,16 @@ fn run_coordinator(shared: Arc<Shared>) {
                     next_safety_sweep_at.saturating_duration_since(Instant::now()),
                     control.processing_paused(),
                 );
+                if progress_visible && !wait_duration.is_zero() {
+                    // Keep feedback stable across immediate coordinator handoffs. Only clear it
+                    // when the coordinator is genuinely about to sleep with no newly published
+                    // work waiting to be handled.
+                    publish_source_processing_finished(&shared);
+                    progress_visible = false;
+                    active_progress_source = None;
+                    last_progress_publish_at = None;
+                    displayed_source_stats.clear();
+                }
                 let (next, _) = shared
                     .wake
                     .wait_timeout(control, wait_duration)
@@ -1093,6 +1107,7 @@ fn run_coordinator(shared: Arc<Shared>) {
                 && !dirty_sources.contains(candidate.source.id.as_str())
         });
         source_stats.retain(|source_id, _| configured_source_ids.contains(source_id));
+        displayed_source_stats.retain(|source_id, _| configured_source_ids.contains(source_id));
         if pause_feedback_pending {
             // The pause may already have resumed by the time a long-running database
             // checkpoint returns. Acknowledge the latched transition here so rapid foreground
@@ -1101,6 +1116,7 @@ fn run_coordinator(shared: Arc<Shared>) {
             progress_visible = false;
             active_progress_source = None;
             last_progress_publish_at = None;
+            displayed_source_stats.clear();
         }
         if processing_paused {
             tracing::debug!(
@@ -1174,12 +1190,6 @@ fn run_coordinator(shared: Arc<Shared>) {
         candidates.append(&mut discovered);
         source_stats.extend(discovered_source_stats);
         let discovered_stats = aggregate_source_stats(source_stats.values().copied());
-        if candidates.is_empty() && progress_visible {
-            publish_source_processing_finished(&shared);
-            progress_visible = false;
-            active_progress_source = None;
-            last_progress_publish_at = None;
-        }
         next_retry_at = discovered_stats.earliest_retry_at;
         {
             let mut telemetry = shared.telemetry();
@@ -1217,23 +1227,12 @@ fn run_coordinator(shared: Arc<Shared>) {
                 break;
             };
             let index = eligible_indices[schedule_index];
+            let active_source_count = candidates
+                .iter()
+                .map(|candidate| candidate.source.id.as_str())
+                .collect::<BTreeSet<_>>()
+                .len();
             let candidate = candidates.swap_remove(index);
-            let progress_refresh_due = last_progress_publish_at
-                .is_none_or(|published_at| published_at.elapsed() >= PROGRESS_REFRESH_INTERVAL);
-            if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
-                || !matches!(&candidate.task, RuntimeTask::Readiness(_))
-                || progress_refresh_due)
-                && source_stats.contains_key(candidate.source.id.as_str())
-            {
-                publish_source_processing_progress(
-                    &shared,
-                    &candidate,
-                    aggregate_source_stats(source_stats.values().copied()),
-                );
-                active_progress_source = Some(candidate.source.id.as_str().to_string());
-                last_progress_publish_at = Some(Instant::now());
-                progress_visible = true;
-            }
             let Some(permit) = shared
                 .budgets()
                 .try_acquire(&candidate.schedule.source_id, candidate.schedule.lane)
@@ -1256,6 +1255,30 @@ fn run_coordinator(shared: Arc<Shared>) {
                 candidates.push(candidate);
                 break;
             };
+            let progress_publish_due = last_progress_publish_at
+                .is_none_or(|published_at| published_at.elapsed() >= PROGRESS_REFRESH_INTERVAL);
+            if active_source_count > 1 {
+                if active_progress_source.as_deref() != Some("") || progress_publish_due {
+                    publish_multi_source_processing_activity(&shared, active_source_count);
+                    active_progress_source = Some(String::new());
+                    last_progress_publish_at = Some(Instant::now());
+                    progress_visible = true;
+                }
+            } else if (active_progress_source.as_deref() != Some(candidate.source.id.as_str())
+                || !matches!(&candidate.task, RuntimeTask::Readiness(_))
+                || progress_publish_due)
+                && let Some(progress) = source_stats.get(candidate.source.id.as_str()).copied()
+            {
+                let progress = stable_source_progress(
+                    &mut displayed_source_stats,
+                    candidate.source.id.as_str(),
+                    progress,
+                );
+                publish_source_processing_progress(&shared, &candidate, progress);
+                active_progress_source = Some(candidate.source.id.as_str().to_string());
+                last_progress_publish_at = Some(Instant::now());
+                progress_visible = true;
+            }
             let result = execute_candidate(
                 &candidate,
                 candidate_cancel.as_ref(),
@@ -1272,11 +1295,8 @@ fn run_coordinator(shared: Arc<Shared>) {
                     if outcome == ExecutionOutcome::Completed
                         && let RuntimeTask::Readiness(target) = &candidate.task
                         && target.stage == ReadinessStage::EmbeddingAspects
-                        && let Some(worker_sender) = shared.worker_sender.as_ref()
                     {
-                        let _ = worker_sender.send(GuiMessage::SimilarityReadinessAdvanced {
-                            source_id: target.source_id.clone(),
-                        });
+                        pending_similarity_refresh_sources.insert(target.source_id.clone());
                     }
                     if outcome.was_claimed() {
                         telemetry.claimed = telemetry.claimed.saturating_add(1);
@@ -1289,7 +1309,14 @@ fn run_coordinator(shared: Arc<Shared>) {
                                     &mut source_stats,
                                     candidate.source.id.as_str(),
                                 )
+                                && active_source_count == 1
+                                && progress_refresh_due(last_progress_publish_at)
                             {
+                                let progress = stable_source_progress(
+                                    &mut displayed_source_stats,
+                                    candidate.source.id.as_str(),
+                                    progress,
+                                );
                                 publish_source_processing_progress(&shared, &candidate, progress);
                                 last_progress_publish_at = Some(Instant::now());
                                 progress_visible = true;
@@ -1312,7 +1339,14 @@ fn run_coordinator(shared: Arc<Shared>) {
                                     &mut source_stats,
                                     candidate.source.id.as_str(),
                                 )
+                                && active_source_count == 1
+                                && progress_refresh_due(last_progress_publish_at)
                             {
+                                let progress = stable_source_progress(
+                                    &mut displayed_source_stats,
+                                    candidate.source.id.as_str(),
+                                    progress,
+                                );
                                 publish_source_processing_progress(&shared, &candidate, progress);
                                 last_progress_publish_at = Some(Instant::now());
                                 progress_visible = true;
@@ -1350,6 +1384,14 @@ fn run_coordinator(shared: Arc<Shared>) {
                 }
             }
             drop(telemetry);
+            if last_similarity_refresh_publish_at.is_none_or(|published_at| {
+                published_at.elapsed() >= SIMILARITY_SCORE_REFRESH_INTERVAL
+            }) && publish_similarity_readiness_refreshes(
+                &shared,
+                &mut pending_similarity_refresh_sources,
+            ) {
+                last_similarity_refresh_publish_at = Some(Instant::now());
+            }
             let requeue_cancelled = matches!(execution_outcome, Some(ExecutionOutcome::Cancelled))
                 && {
                     let control = shared.control();
@@ -1385,11 +1427,9 @@ fn run_coordinator(shared: Arc<Shared>) {
                 .mark_source_dirty(source_id, "source_stage_progress");
             break;
         }
-        if candidates.is_empty() && progress_visible {
-            publish_source_processing_finished(&shared);
-            progress_visible = false;
-            active_progress_source = None;
-            last_progress_publish_at = None;
+        if publish_similarity_readiness_refreshes(&shared, &mut pending_similarity_refresh_sources)
+        {
+            last_similarity_refresh_publish_at = Some(Instant::now());
         }
         let mut telemetry = shared.telemetry();
         telemetry.queue_depth = candidates.len();
@@ -1414,6 +1454,26 @@ fn run_coordinator(shared: Arc<Shared>) {
         );
         drop(telemetry);
     }
+}
+
+fn progress_refresh_due(last_publish_at: Option<Instant>) -> bool {
+    last_publish_at.is_none_or(|published_at| published_at.elapsed() >= PROGRESS_REFRESH_INTERVAL)
+}
+
+fn publish_similarity_readiness_refreshes(
+    shared: &Shared,
+    pending_source_ids: &mut BTreeSet<String>,
+) -> bool {
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return false;
+    };
+    if pending_source_ids.is_empty() {
+        return false;
+    }
+    for source_id in std::mem::take(pending_source_ids) {
+        let _ = worker_sender.send(GuiMessage::SimilarityReadinessAdvanced { source_id });
+    }
+    true
 }
 
 fn publish_source_processing_progress(
@@ -1457,10 +1517,18 @@ fn publish_source_processing_progress(
             0,
         ),
     };
+    let (completed, total) = if total > 0 && completed < total {
+        (completed, total)
+    } else {
+        // A claimed candidate is active even when discovery counters have reached their current
+        // boundary. Keep showing activity until the coordinator actually becomes idle instead of
+        // publishing a false completion while the candidate is still executing.
+        (0, 0)
+    };
     let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
         SourceProcessingProgress {
             source_id: candidate.source.id.as_str().to_string(),
-            active: total == 0 || completed < total,
+            active: true,
             completed,
             total,
             stage: stage.to_string(),
@@ -1485,6 +1553,29 @@ fn publish_source_processing_discovery(shared: &Shared, source: &SampleSource) {
             total: 0,
             stage: String::from("Inspecting source jobs"),
             detail: String::from("Discovering background work"),
+        },
+    ));
+}
+
+fn publish_multi_source_processing_activity(shared: &Shared, source_count: usize) {
+    let control = shared.control();
+    if control.processing_paused() {
+        return;
+    }
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return;
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: String::new(),
+            active: true,
+            completed: 0,
+            total: 0,
+            stage: String::from("Processing source libraries"),
+            detail: format!(
+                "Advancing {source_count} source{}",
+                if source_count == 1 { "" } else { "s" }
+            ),
         },
     ));
 }
@@ -1530,7 +1621,21 @@ fn advance_source_progress(
         .progress_completed
         .saturating_add(1)
         .min(stats.progress_total);
-    Some(aggregate_source_stats(source_stats.values().copied()))
+    Some(*stats)
+}
+
+fn stable_source_progress(
+    displayed: &mut BTreeMap<String, SourceDiscoveryStats>,
+    source_id: &str,
+    observed: SourceDiscoveryStats,
+) -> SourceDiscoveryStats {
+    let stable = displayed.entry(source_id.to_string()).or_insert(observed);
+    stable.progress_total = stable.progress_total.max(observed.progress_total);
+    stable.progress_completed = stable
+        .progress_completed
+        .max(observed.progress_completed)
+        .min(stable.progress_total);
+    *stable
 }
 
 fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String) {
@@ -1570,6 +1675,7 @@ fn discover_candidates(
     BTreeSet<String>,
 ) {
     let now = now_epoch_seconds();
+    let source_count = sources.len();
     let mut candidates = Vec::new();
     let mut source_stats = BTreeMap::new();
     let mut deferred = BTreeSet::new();
@@ -1596,7 +1702,11 @@ fn discover_candidates(
             let mut telemetry = shared.telemetry();
             telemetry.source_discoveries = telemetry.source_discoveries.saturating_add(1);
         }
-        publish_source_processing_discovery(shared, source);
+        if source_count > 1 {
+            publish_multi_source_processing_activity(shared, source_count);
+        } else {
+            publish_source_processing_discovery(shared, source);
+        }
         match discover_source_candidates(source, now, source_cancel) {
             Ok(Cancellable::Completed((mut source_candidates, stats))) => {
                 candidates.append(&mut source_candidates);
@@ -4023,6 +4133,109 @@ mod tests {
     }
 
     #[test]
+    fn executing_candidate_remains_active_at_discovery_counter_boundary() {
+        let directory = tempfile::tempdir().expect("progress source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("boundary-source"),
+            directory.path().to_path_buf(),
+        );
+        let target = ReadinessTarget::file(
+            source.id.as_str(),
+            "identity-1",
+            "drums/kick.wav",
+            ReadinessStage::AnalysisFeatures,
+            "analysis-v1",
+            1,
+            "content-1",
+        );
+        let candidate = RuntimeCandidate {
+            schedule: WorkCandidate::readiness(&target, 1),
+            source: source.clone(),
+            task: RuntimeTask::Readiness(target),
+        };
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let shared = Shared::new(vec![source], Some(sender));
+
+        publish_source_processing_progress(
+            &shared,
+            &candidate,
+            SourceDiscoveryStats {
+                progress_completed: 25_000,
+                progress_total: 25_000,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+
+        let GuiMessage::SourceProcessingProgress(progress) = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("progress message")
+        else {
+            panic!("unexpected supervisor GUI message");
+        };
+        assert!(progress.active);
+        assert_eq!(progress.completed, 0);
+        assert_eq!(progress.total, 0);
+        assert_eq!(progress.stage, "Analyzing audio");
+    }
+
+    #[test]
+    fn readiness_progress_counts_remain_scoped_to_the_reported_source() {
+        let mut source_stats = BTreeMap::from([
+            (
+                String::from("first"),
+                SourceDiscoveryStats {
+                    progress_completed: 25_000,
+                    progress_total: 26_000,
+                    ..SourceDiscoveryStats::default()
+                },
+            ),
+            (
+                String::from("second"),
+                SourceDiscoveryStats {
+                    progress_completed: 24_000,
+                    progress_total: 25_000,
+                    ..SourceDiscoveryStats::default()
+                },
+            ),
+        ]);
+
+        let progress = advance_source_progress(&mut source_stats, "first")
+            .expect("first source progress advances");
+
+        assert_eq!(progress.progress_completed, 25_001);
+        assert_eq!(progress.progress_total, 26_000);
+        assert_eq!(source_stats["second"].progress_completed, 24_000);
+        assert_eq!(source_stats["second"].progress_total, 25_000);
+    }
+
+    #[test]
+    fn visible_source_progress_does_not_regress_across_rediscovery() {
+        let mut displayed = BTreeMap::new();
+        let first = stable_source_progress(
+            &mut displayed,
+            "projects",
+            SourceDiscoveryStats {
+                progress_completed: 15_888,
+                progress_total: 19_969,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+        let rediscovered = stable_source_progress(
+            &mut displayed,
+            "projects",
+            SourceDiscoveryStats {
+                progress_completed: 15_747,
+                progress_total: 19_969,
+                ..SourceDiscoveryStats::default()
+            },
+        );
+
+        assert_eq!(first.progress_completed, 15_888);
+        assert_eq!(rediscovered.progress_completed, 15_888);
+        assert_eq!(rediscovered.progress_total, 19_969);
+    }
+
+    #[test]
     fn periodic_manifest_audit_wakes_browser_projection_after_committed_repair() {
         let directory = tempfile::tempdir().expect("manifest audit source");
         let source = SampleSource::new_with_id(
@@ -4233,7 +4446,8 @@ mod tests {
     #[test]
     fn real_hash_execution_waits_for_shared_scan_database_budget() {
         let (_directory, source) = unhashed_source("shared-budget");
-        let shared = Arc::new(Shared::new(vec![source.clone()], None));
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let shared = Arc::new(Shared::new(vec![source.clone()], Some(sender)));
         let permit = SourceProcessingBudgetHandle {
             shared: Arc::clone(&shared),
         }
@@ -4250,6 +4464,16 @@ mod tests {
         };
         thread::sleep(Duration::from_millis(150));
         assert!(!source_is_hashed(&source));
+        assert!(
+            receiver.try_iter().all(|message| matches!(
+                message,
+                GuiMessage::SourceProcessingProgress(SourceProcessingProgress {
+                    active: false,
+                    ..
+                })
+            )),
+            "queued work must not publish active progress while foreground admission owns the lane"
+        );
 
         drop(permit);
         wait_until(Duration::from_secs(3), || source_is_hashed(&source));

--- a/src/native_app/test_support/state.rs
+++ b/src/native_app/test_support/state.rs
@@ -4,8 +4,8 @@ pub(in crate::native_app) use crate::native_app::app::{
     DEFAULT_VOLUME, FileMoveProgress, GuiMessage, LibraryAppState, MetadataAppState,
     MetadataMessage, NativeAppState, NativeFileDropHover, NormalizationProgress, SampleLoadResult,
     SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackReady, SamplePlaybackRequest,
-    SettingsAppState, StartupState, StatusState, UiAppState, WaveformAppState,
-    default_gui_shortcuts, format_sample_rate_label, shortcut_help_bindings,
+    SettingsAppState, SourceProcessingProgress, StartupState, StatusState, UiAppState,
+    WaveformAppState, default_gui_shortcuts, format_sample_rate_label, shortcut_help_bindings,
     shortcut_help_sections, view,
 };
 use crate::native_app::sample_library::folder_browser::view_contract::DEFAULT_FOLDER_WIDTH;

--- a/src/native_app/test_support/status_bar.rs
+++ b/src/native_app/test_support/status_bar.rs
@@ -9,6 +9,7 @@ pub(in crate::native_app) struct WorkerProgressProjection {
     pub(in crate::native_app) total: usize,
     pub(in crate::native_app) current_fraction: Option<f32>,
     pub(in crate::native_app) active_animation: bool,
+    pub(in crate::native_app) compact_activity: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -46,6 +47,7 @@ pub(in crate::native_app) fn status_bar_projection(state: &NativeAppState) -> St
                 total: progress.total,
                 current_fraction: progress.current_fraction,
                 active_animation: progress.active_animation,
+                compact_activity: progress.compact_activity,
             }),
         job_details: model.job_details.map(|details| details.rows),
     }

--- a/src/native_app/test_support/status_bar.rs
+++ b/src/native_app/test_support/status_bar.rs
@@ -16,6 +16,7 @@ pub(in crate::native_app) struct StatusBarProjection {
     pub(in crate::native_app) selected_sample_count: usize,
     pub(in crate::native_app) status_text: String,
     pub(in crate::native_app) worker_progress: Option<WorkerProgressProjection>,
+    pub(in crate::native_app) job_details: Option<[String; 4]>,
 }
 
 pub(in crate::native_app) fn bottom_status_bar(state: &NativeAppState) -> ui::View<GuiMessage> {
@@ -46,5 +47,6 @@ pub(in crate::native_app) fn status_bar_projection(state: &NativeAppState) -> St
                 current_fraction: progress.current_fraction,
                 active_animation: progress.active_animation,
             }),
+        job_details: model.job_details.map(|details| details.rows),
     }
 }

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -332,16 +332,29 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             .into_iter()
             .map(|file| file.name.clone())
             .collect::<Vec<_>>(),
-        vec!["keep.wav"],
-        "bounded filesystem patch should remove deleted sample from the visible list immediately"
+        vec!["keep.wav", "stale.wav"],
+        "watcher hints must not patch the visible tree before the source transaction commits"
     );
     let sync_finished =
         run_named_perform(context.into_command(), "gui-source-db-sync").expect("db sync command");
-    state.apply_message(sync_finished, &mut ui::UiUpdateContext::default());
+    let mut post_commit = ui::UiUpdateContext::default();
+    state.apply_message(sync_finished, &mut post_commit);
 
     let rows = db.list_files().expect("synced rows");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, std::path::Path::new("keep.wav"));
+    assert!(state.library.folder_progress().is_none());
+    assert_eq!(
+        state
+            .library
+            .folder_browser
+            .selected_audio_files()
+            .into_iter()
+            .map(|file| file.name.clone())
+            .collect::<Vec<_>>(),
+        vec!["keep.wav"],
+        "the browser projection should refresh only from committed source state"
+    );
 }
 
 fn run_named_perform(

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -343,7 +343,36 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
     let rows = db.list_files().expect("synced rows");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, std::path::Path::new("keep.wav"));
-    assert!(state.library.folder_progress().is_none());
+    let refresh_task = state
+        .library
+        .folder_progress()
+        .expect("post-commit projection refresh should run in the background")
+        .task_id;
+    assert_eq!(
+        state
+            .library
+            .folder_browser
+            .selected_audio_files()
+            .into_iter()
+            .map(|file| file.name.clone())
+            .collect::<Vec<_>>(),
+        vec!["keep.wav", "stale.wav"],
+        "the UI thread must retain owned projection data while background refresh runs"
+    );
+    let refreshed =
+        crate::native_app::sample_library::folder_browser::scan::scan_source_with_progress(
+            crate::native_app::sample_library::folder_browser::scan::FolderScanRequest {
+                task_id: refresh_task,
+                source_id,
+                label: String::from("source"),
+                root: source_root.path().to_path_buf(),
+                database_root: source_root.path().to_path_buf(),
+                rating_decay_weeks: crate::native_app::sample_library::folder_browser::scan::FolderScanRequest::default_rating_decay_weeks(),
+            },
+            |_| {},
+            |_| {},
+        );
+    state.finish_folder_scan(refreshed, &mut ui::UiUpdateContext::default());
     assert_eq!(
         state
             .library
@@ -353,7 +382,7 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             .map(|file| file.name.clone())
             .collect::<Vec<_>>(),
         vec!["keep.wav"],
-        "the browser projection should refresh only from committed source state"
+        "the browser projection should refresh only from committed background state"
     );
 }
 

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -270,6 +270,7 @@ fn source_filesystem_change_queues_refresh_without_clearing_loaded_tree() {
             source_id: source_id.clone(),
             paths: Vec::new(),
             overflowed: true,
+            source_root_available: true,
         },
         &mut context,
     );
@@ -320,6 +321,7 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             source_id: source_id.clone(),
             paths: vec![PathBuf::from("stale.wav")],
             overflowed: false,
+            source_root_available: true,
         },
         &mut context,
     );

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -60,7 +60,7 @@ fn context_source_refresh_queues_scan_without_clearing_loaded_tree() {
         visible_before,
         "refresh should keep the current cached tree visible while the scan runs"
     );
-    assert!(state.ui.status.sample.contains("Scanning source"));
+    assert!(state.ui.status.sample.contains("Queued source scan"));
 }
 
 #[test]

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -53,13 +53,20 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
     );
     state.finish_folder_scan(result, &mut ui::UiUpdateContext::default());
     let mut context = ui::UiUpdateContext::default();
-    state.refresh_source_after_filesystem_change(source_id.clone(), Vec::new(), true, &mut context);
+    state.refresh_source_after_filesystem_change(
+        source_id.clone(),
+        Vec::new(),
+        true,
+        true,
+        &mut context,
+    );
 
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::SourceFilesystemChanged {
             source_id: source_id.clone(),
             paths: Vec::new(),
             overflowed: true,
+            source_root_available: true,
         },
         &mut context,
     );

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -437,10 +437,11 @@ fn sample_browser_similarity_anchor_resolves_production_scores() {
             .similarity_display_strength_for_file(missing_id.as_str())
             .is_none()
     );
+    assert_eq!(state.ui.status.sample, "Resolved 2 similar samples");
 }
 
 #[test]
-fn sample_browser_similarity_anchor_queues_missing_artifacts_before_scoring() {
+fn sample_browser_similarity_anchor_delegates_missing_artifacts_to_readiness_worker() {
     let mut state = crate::native_app::tests::gui_state_for_span_tests();
     let source_root = tempfile::tempdir().expect("source root");
     let drums = source_root.path().join("drums");
@@ -478,21 +479,19 @@ fn sample_browser_similarity_anchor_queues_missing_artifacts_before_scoring() {
         &mut context,
     );
 
-    assert_eq!(
-        state.library.similarity_prep.running_source_id.as_deref(),
-        Some(SIMILARITY_TEST_SOURCE_ID)
-    );
+    assert!(state.library.similarity_prep.running_source_id.is_none());
     super::super::run_command_for_tests(&mut state, context.into_command());
 
     assert!(!state.library.similarity_prep.running);
     assert_eq!(
         source_jobs_by_status(source_root.path(), "wav_metadata_v1", "pending"),
-        2,
-        "automatic anchor prep should queue waveform metadata work without draining it inline"
+        0,
+        "anchor activation must not launch the competing legacy whole-source prep queue"
     );
-    assert!(
-        source_jobs_by_status(source_root.path(), "embedding_backfill_v1", "pending") >= 1,
-        "automatic anchor prep should queue embedding work without blocking the UI path"
+    assert_eq!(
+        source_jobs_by_status(source_root.path(), "embedding_backfill_v1", "pending"),
+        0,
+        "the revisioned readiness worker owns embedding generation"
     );
     assert_eq!(source_artifact_rows(source_root.path(), "embeddings"), 0);
     assert_eq!(
@@ -512,8 +511,9 @@ fn sample_browser_similarity_anchor_queues_missing_artifacts_before_scoring() {
             .folder_browser
             .similarity_display_strength_for_file(near_id.as_str()),
         None,
-        "anchor activation must wait for background prep before resolving missing similarity artifacts"
+        "anchor activation must wait for readiness before resolving missing similarity artifacts"
     );
+    assert_eq!(state.ui.status.sample, "Similarity data not ready yet");
 }
 
 #[test]

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -74,6 +74,7 @@ fn bottom_status_progress_bar_paints_without_text_chrome() {
 #[test]
 fn bottom_status_bar_reports_normalization_progress() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.background.normalization_progress = Some(
         crate::native_app::test_support::state::NormalizationProgress {
             task_id: 9,
@@ -89,16 +90,14 @@ fn bottom_status_bar_reports_normalization_progress() {
     let frame = crate::native_app::test_support::status_bar::bottom_status_bar(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(720.0, 30.0));
 
-    assert!(
-        frame
-            .paint_plan
-            .contains_text("Normalizing 2 samples | 1/2 | snare.wav")
-    );
+    assert!(frame.paint_plan.contains_text("Ready"));
+    assert!(!frame.paint_plan.contains_text("Normalizing 2 samples"));
 }
 
 #[test]
 fn bottom_status_bar_reports_queued_normalization_tasks() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.background.normalization_progress = Some(
         crate::native_app::test_support::state::NormalizationProgress {
             task_id: 9,
@@ -114,10 +113,11 @@ fn bottom_status_bar_reports_queued_normalization_tasks() {
     let frame = crate::native_app::test_support::status_bar::bottom_status_bar(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(720.0, 30.0));
 
-    assert!(
-        frame
-            .paint_plan
-            .contains_text("Normalizing 1 sample | 0/1 | kick.wav | 2 queued")
+    assert!(frame.paint_plan.contains_text("Ready"));
+    let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
+    assert_eq!(
+        model.job_details.expect("normalization details")[3],
+        "Current: kick.wav | 2 queued"
     );
 }
 
@@ -181,6 +181,25 @@ fn source_cache_warm_advances_activity_tick_on_frame() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_total = 10;
+
+    state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
+
+    assert_eq!(state.background.progress_tick, 0.035);
+}
+
+#[test]
+fn source_processing_advances_activity_tick_on_frame() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 3,
+            total: 10,
+            stage: String::from("Analyzing audio"),
+            detail: String::from("kick.wav"),
+        },
+    );
 
     state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
 
@@ -259,7 +278,7 @@ fn status_bar_view_model_prioritizes_active_worker_progress() {
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
     assert_eq!(model.selected_sample_count, 0);
-    assert_eq!(model.status_text, "Scanning Assets | 2/5 | kick.wav");
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -272,8 +291,61 @@ fn status_bar_view_model_prioritizes_active_worker_progress() {
 }
 
 #[test]
+fn status_bar_routes_source_processing_through_worker_progress_and_job_details() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let source_id = state
+        .library
+        .folder_browser
+        .selected_source_id()
+        .to_string();
+    let source_label = state
+        .library
+        .folder_browser
+        .source_label(source_id.as_str())
+        .expect("selected source label")
+        .to_string();
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id,
+            active: true,
+            completed: 313,
+            total: 9_985,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("017/bounce/kick.wav"),
+        },
+    );
+
+    let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
+
+    assert_eq!(
+        model.worker_progress.expect("worker progress"),
+        crate::native_app::test_support::status_bar::WorkerProgressProjection {
+            completed: 313,
+            total: 9_985,
+            current_fraction: None,
+            active_animation: true,
+        }
+    );
+    assert_eq!(
+        model.job_details.expect("job details"),
+        [
+            String::from("Type: Source processing"),
+            format!("Source: {source_label}"),
+            String::from("Progress: 313/9985"),
+            String::from("Current: Preparing similarity | 017/bounce/kick.wav"),
+        ]
+    );
+}
+
+#[test]
 fn status_bar_view_model_uses_normalization_work_progress_for_worker_bar() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.background.normalization_progress = Some(
         crate::native_app::test_support::state::NormalizationProgress {
             task_id: 9,
@@ -289,10 +361,7 @@ fn status_bar_view_model_uses_normalization_work_progress_for_worker_bar() {
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
-    assert_eq!(
-        model.status_text,
-        "Normalizing 1 sample | 0/1 | kick.wav | Writing"
-    );
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -307,6 +376,7 @@ fn status_bar_view_model_uses_normalization_work_progress_for_worker_bar() {
 #[test]
 fn status_bar_view_model_reports_file_move_progress() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.background.file_move_progress =
         Some(crate::native_app::test_support::state::FileMoveProgress {
             task_id: 11,
@@ -318,10 +388,7 @@ fn status_bar_view_model_reports_file_move_progress() {
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
-    assert_eq!(
-        model.status_text,
-        "Moving 3 files | 2/4 | Updating metadata"
-    );
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -336,6 +403,7 @@ fn status_bar_view_model_reports_file_move_progress() {
 #[test]
 fn status_bar_view_model_reports_source_cache_warm_progress() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_completed = 3;
     state.waveform.cache.active_folder_warm_total = 10;
@@ -343,10 +411,7 @@ fn status_bar_view_model_reports_source_cache_warm_progress() {
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
-    assert_eq!(
-        model.status_text,
-        "Caching source samples | 3/10 | kick-01.wav"
-    );
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -361,6 +426,7 @@ fn status_bar_view_model_reports_source_cache_warm_progress() {
 #[test]
 fn status_bar_view_model_reports_source_cache_plan_progress() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.waveform.cache.active_folder_warm_plan_task.begin();
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_completed = 42;
@@ -372,10 +438,7 @@ fn status_bar_view_model_reports_source_cache_plan_progress() {
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
-    assert_eq!(
-        model.status_text,
-        "Checking source samples | 42/100 | 42% | plan-target.wav"
-    );
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -388,7 +451,7 @@ fn status_bar_view_model_reports_source_cache_plan_progress() {
 }
 
 #[test]
-fn status_bar_view_model_restores_source_cache_progress_after_playback_status() {
+fn status_bar_view_model_preserves_playback_status_while_source_cache_progress_runs() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.ui.status.sample = String::from("Playing kick.wav");
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
@@ -401,15 +464,10 @@ fn status_bar_view_model_restores_source_cache_progress_after_playback_status() 
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
+    assert_eq!(model.status_text, "Playing kick.wav");
     assert!(
-        model.status_text.contains("Caching source samples | 3/10"),
-        "worker status should reclaim the status bar after transient playback text: {}",
-        model.status_text
-    );
-    assert!(
-        model.status_text.contains("decoding 51%"),
-        "worker status should keep per-file progress visible: {}",
-        model.status_text
+        model.job_details.expect("cache details")[3].contains("decoding 51%"),
+        "job details should retain per-file cache progress"
     );
     assert_eq!(
         model.worker_progress.expect("worker progress"),
@@ -425,6 +483,7 @@ fn status_bar_view_model_restores_source_cache_progress_after_playback_status() 
 #[test]
 fn status_bar_view_model_keeps_normalization_priority_over_source_cache_warm() {
     let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.status.sample = String::from("Ready");
     state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
     state.waveform.cache.active_folder_warm_completed = 3;
     state.waveform.cache.active_folder_warm_total = 10;
@@ -443,10 +502,7 @@ fn status_bar_view_model_keeps_normalization_priority_over_source_cache_warm() {
 
     let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
 
-    assert_eq!(
-        model.status_text,
-        "Normalizing 1 sample | 0/1 | kick.wav | Writing"
-    );
+    assert_eq!(model.status_text, "Ready");
     assert_eq!(
         model.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -207,7 +207,7 @@ fn source_processing_advances_activity_tick_on_frame() {
 }
 
 #[test]
-fn source_processing_uses_one_unambiguous_progress_track() {
+fn source_processing_keeps_measured_progress_and_activity_on_one_track() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.background.source_processing_progress = Some(
         crate::native_app::test_support::state::SourceProcessingProgress {
@@ -223,8 +223,49 @@ fn source_processing_uses_one_unambiguous_progress_track() {
     let frame = crate::native_app::test_support::status_bar::worker_progress_bar(&state)
         .view_frame_at_size_with_default_theme(Vector2::new(180.0, 10.0));
 
-    assert_eq!(frame.paint_plan.fill_rects().count(), 2);
+    assert_eq!(
+        frame.paint_plan.fill_rects().count(),
+        4,
+        "the determinate track and moving activity highlight share one stacked surface"
+    );
     assert_eq!(frame.paint_plan.stroke_rects().count(), 0);
+}
+
+#[test]
+fn source_processing_discovery_uses_compact_activity_feedback() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id: String::new(),
+            active: true,
+            completed: 0,
+            total: 0,
+            stage: String::from("Processing source libraries"),
+            detail: String::from("Advancing 2 sources"),
+        },
+    );
+
+    let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
+
+    assert_eq!(
+        model.worker_progress.expect("worker activity"),
+        crate::native_app::test_support::status_bar::WorkerProgressProjection {
+            completed: 0,
+            total: 0,
+            current_fraction: None,
+            active_animation: false,
+            compact_activity: true,
+        }
+    );
+    assert_eq!(
+        model.job_details.expect("activity details"),
+        [
+            String::from("Type: Source processing"),
+            String::from("Source: Multiple sources"),
+            String::from("Status: Active"),
+            String::from("Current: Processing source libraries | Advancing 2 sources"),
+        ]
+    );
 }
 
 #[test]
@@ -307,6 +348,7 @@ fn status_bar_view_model_prioritizes_active_worker_progress() {
             total: 5,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     );
 }
@@ -350,6 +392,7 @@ fn status_bar_routes_source_processing_through_worker_progress_and_job_details()
             total: 9_985,
             current_fraction: None,
             active_animation: false,
+            compact_activity: true,
         }
     );
     assert_eq!(
@@ -390,6 +433,7 @@ fn status_bar_view_model_uses_normalization_work_progress_for_worker_bar() {
             total: 1_000,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     );
 }
@@ -417,6 +461,7 @@ fn status_bar_view_model_reports_file_move_progress() {
             total: 4,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     );
 }
@@ -440,6 +485,7 @@ fn status_bar_view_model_reports_source_cache_warm_progress() {
             total: 10,
             current_fraction: Some(0.0),
             active_animation: true,
+            compact_activity: false,
         }
     );
 }
@@ -467,6 +513,7 @@ fn status_bar_view_model_reports_source_cache_plan_progress() {
             total: 100,
             current_fraction: Some(0.42),
             active_animation: true,
+            compact_activity: false,
         }
     );
 }
@@ -497,6 +544,7 @@ fn status_bar_view_model_preserves_playback_status_while_source_cache_progress_r
             total: 10,
             current_fraction: Some(0.51),
             active_animation: true,
+            compact_activity: false,
         }
     );
 }
@@ -531,6 +579,7 @@ fn status_bar_view_model_keeps_normalization_priority_over_source_cache_warm() {
             total: 1_000,
             current_fraction: None,
             active_animation: false,
+            compact_activity: false,
         }
     );
 }

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -207,6 +207,27 @@ fn source_processing_advances_activity_tick_on_frame() {
 }
 
 #[test]
+fn source_processing_uses_one_unambiguous_progress_track() {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 20_625,
+            total: 40_658,
+            stage: String::from("Analyzing audio"),
+            detail: String::from("kick.wav"),
+        },
+    );
+
+    let frame = crate::native_app::test_support::status_bar::worker_progress_bar(&state)
+        .view_frame_at_size_with_default_theme(Vector2::new(180.0, 10.0));
+
+    assert_eq!(frame.paint_plan.fill_rects().count(), 2);
+    assert_eq!(frame.paint_plan.stroke_rects().count(), 0);
+}
+
+#[test]
 fn normalization_progress_does_not_advance_activity_tick_on_frame() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.background.normalization_progress = Some(
@@ -328,7 +349,7 @@ fn status_bar_routes_source_processing_through_worker_progress_and_job_details()
             completed: 313,
             total: 9_985,
             current_fraction: None,
-            active_animation: true,
+            active_animation: false,
         }
     );
     assert_eq!(

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -225,8 +225,8 @@ fn source_processing_keeps_measured_progress_and_activity_on_one_track() {
 
     assert_eq!(
         frame.paint_plan.fill_rects().count(),
-        4,
-        "the determinate track and moving activity highlight share one stacked surface"
+        2,
+        "source processing keeps only the determinate track in retained paint"
     );
     assert_eq!(frame.paint_plan.stroke_rects().count(), 0);
 }
@@ -262,7 +262,7 @@ fn source_processing_discovery_uses_compact_activity_feedback() {
         [
             String::from("Type: Source processing"),
             String::from("Source: Multiple sources"),
-            String::from("Status: Active"),
+            String::from("Progress: Active (total not available)"),
             String::from("Current: Processing source libraries | Advancing 2 sources"),
         ]
     );

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -427,6 +427,93 @@ fn scene_source_cache_frame_uses_projection_repaint_scope() {
 }
 
 #[test]
+fn scene_source_processing_frame_uses_paint_only_repaint_scope() {
+    let mut state = gui_state_for_span_tests();
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 3,
+            total: 10,
+            stage: String::from("Analyzing audio"),
+            detail: String::from("kick.wav"),
+        },
+    );
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(|state, message, _context| {
+            if message == GuiMessage::Frame {
+                state.advance_frame(&mut radiant::prelude::UiUpdateContext::default());
+            }
+        })
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+
+    assert!(runtime.host_animation_activity().needs_frame_message());
+    assert!(runtime.host_queue_animation_frame());
+    let command = runtime
+        .bridge_mut()
+        .update(crate::native_app::test_support::state::GuiMessage::Frame);
+
+    assert_eq!(
+        command.repaint_scope(),
+        Some(RepaintScope::PaintOnly),
+        "source-processing animation must not rebuild the full library projection"
+    );
+}
+
+#[test]
+fn source_processing_activity_moves_in_transient_overlay_without_input() {
+    let mut state = gui_state_for_span_tests();
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id: String::from("source"),
+            active: true,
+            completed: 3,
+            total: 10,
+            stage: String::from("Analyzing audio"),
+            detail: String::from("kick.wav"),
+        },
+    );
+    assert!(state.should_paint_app_transient_overlay());
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+
+    let activity_x = |runtime: &mut NativeRuntimeForTests, animation_time| {
+        let mut primitives = Vec::new();
+        runtime
+            .bridge_mut()
+            .state_mut()
+            .paint_source_processing_activity_overlay(
+                TransientOverlayContext::new(
+                    &frame.paint_plan,
+                    Vector2::new(900.0, 620.0),
+                    animation_time,
+                ),
+                &mut primitives,
+            );
+        primitives
+            .iter()
+            .filter_map(|primitive| primitive.fill_rect())
+            .next()
+            .expect("source processing activity fill")
+            .rect
+            .center()
+            .x
+    };
+
+    let first_x = activity_x(&mut runtime, Duration::ZERO);
+    let later_x = activity_x(&mut runtime, Duration::from_millis(250));
+
+    assert!(
+        later_x > first_x,
+        "paint-only source activity must advance from animation time"
+    );
+}
+
+#[test]
 fn scene_installs_playback_cursor_transient_overlay() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.start_playback(0.25);

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -140,6 +140,7 @@ fn active_folder_cache_plan_is_visible_before_decode_batches_start() {
             total: 2,
             current_fraction: None,
             active_animation: true,
+            compact_activity: false,
         }
     );
 
@@ -172,6 +173,7 @@ fn active_folder_cache_plan_is_visible_before_decode_batches_start() {
             total: 2,
             current_fraction: Some(0.5),
             active_animation: true,
+            compact_activity: false,
         }
     );
 }

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -130,8 +130,8 @@ fn active_folder_cache_plan_is_visible_before_decode_batches_start() {
 
     let status = crate::native_app::test_support::status_bar::status_bar_projection(&state);
     assert_eq!(
-        status.status_text, "Checking source samples | 0/2",
-        "starting source prep should show cache-plan progress immediately"
+        status.job_details.expect("cache plan details")[2],
+        "Progress: 0/2"
     );
     assert_eq!(
         status.worker_progress.expect("worker progress"),
@@ -161,10 +161,10 @@ fn active_folder_cache_plan_is_visible_before_decode_batches_start() {
     );
 
     let status = crate::native_app::test_support::status_bar::status_bar_projection(&state);
-    assert_eq!(
-        status.status_text,
-        "Checking source samples | 1/2 | 50% | first.wav"
-    );
+    let details = status.job_details.expect("cache plan details");
+    assert_eq!(details[2], "Progress: 1/2");
+    assert!(details[3].contains("checking 50%"));
+    assert!(details[3].contains("first.wav"));
     assert_eq!(
         status.worker_progress.expect("worker progress"),
         crate::native_app::test_support::status_bar::WorkerProgressProjection {
@@ -688,10 +688,8 @@ fn sample_selection_pauses_running_active_folder_cache_warm_without_hiding_progr
     );
     let status = crate::native_app::test_support::status_bar::status_bar_projection(&state);
     assert!(
-        status
-            .status_text
-            .starts_with("Caching source samples | 0/2"),
-        "cache progress should remain visible instead of being replaced by the sample load status: {}",
+        !status.status_text.starts_with("Caching source samples"),
+        "background work belongs in the progress control, not status text: {}",
         status.status_text
     );
     assert!(

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -33,6 +33,7 @@ const TOOLBAR: WidgetIdNamespace = WidgetIdNamespace::new(32_100);
 const FOLDER_FILTERS: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_4600);
 const SAMPLE_BROWSER_HEADER: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_4800);
 const COLLECTIONS: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_4c00);
+const STATUS_BAR: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_5000);
 const SOURCES: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_5300);
 const METADATA_TAGS: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_5440);
 const HARVEST_FAMILY: WidgetIdNamespace = WidgetIdNamespace::new(0x5743_0000_0000_5800);
@@ -78,6 +79,9 @@ pub(in crate::native_app) const GENERAL_SETTINGS_BUTTON_ID: u64 = AUDIO_SETTINGS
 pub(in crate::native_app) const RELEASE_UPDATE_BUTTON_ID: u64 = AUDIO_SETTINGS.id(120);
 
 pub(in crate::native_app) const TRANSACTION_LIST_MODAL_ID: u64 = TRANSACTION_HISTORY.id(0);
+pub(in crate::native_app) const WORKER_PROGRESS_ROOT_ID: u64 = STATUS_BAR.id(0);
+pub(in crate::native_app) const WORKER_PROGRESS_ACTIVITY_OVERLAY_ID: u64 = STATUS_BAR.id(1);
+pub(in crate::native_app) const JOB_DETAILS_CURRENT_ROW_ID_BASE: u64 = STATUS_BAR.id(10);
 
 pub(in crate::native_app) const TOOLBAR_FOCUS_LOADED_ID: u64 = TOOLBAR.id(0);
 pub(in crate::native_app) const TOOLBAR_LOOP_ID: u64 = TOOLBAR.id(1);

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -23,10 +23,11 @@ pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
         RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-        audit_source_and_record, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
-        complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
-        complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-        scan_in_background, scan_once, scan_with_progress, sync_paths, sync_paths_with_progress,
+        audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
+        complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
+        complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+        complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once,
+        scan_with_progress, sync_paths, sync_paths_with_progress,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -59,6 +59,7 @@ pub mod library {
         harvest_parents_for_child, load, lookup_source_id_for_root, mark_harvest_seen,
         mark_harvest_touched, open_connection, record_harvest_derivation, remap_harvest_file_key,
         remap_harvest_file_prefix, save, set_harvest_state, upsert_harvest_file,
+        upsert_harvest_files,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -21,12 +21,12 @@ pub mod scan_state {
 /// Source scanning logic.
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
-        ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
-        complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+        ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+        RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
+        audit_source_and_record, complete_deferred_hashes, complete_deferred_hashes_with_cancel,
         complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
         complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-        scan_in_background, scan_once, scan_with_progress, schedule_deep_hash_scan,
-        schedule_deep_hash_scan_with_database_root, sync_paths, sync_paths_with_progress,
+        scan_in_background, scan_once, scan_with_progress, sync_paths, sync_paths_with_progress,
     };
 }
 
@@ -34,7 +34,7 @@ pub mod scanner {
 pub mod db {
     pub use wavecrate_library::sample_sources::db::{
         DB_FILE_NAME, LEGACY_DB_FILE_NAME, META_DEFERRED_MAINTENANCE_REVISION,
-        META_DEFERRED_MAINTENANCE_SCHEMA, META_LAST_SCAN_COMPLETED_AT,
+        META_DEFERRED_MAINTENANCE_SCHEMA, META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT,
         META_LAST_SIMILARITY_PREP_SCAN_AT, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
         SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceCollectionWrite,
         SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
@@ -92,5 +92,6 @@ pub use wavecrate_library::sample_sources::{
 };
 pub use wavecrate_scan::sample_sources::ScanTracker;
 pub use wavecrate_scan::sample_sources::{
-    ChangedSample, RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+    ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
+    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
 };


### PR DESCRIPTION
## Goal

Make source discovery authoritative, ordered, and self-healing so downstream readiness never starts from pre-commit watcher hints and missed filesystem events eventually converge.

## Scope and non-goals

- Publish a monotonic committed source revision with structured created, changed, moved, and deleted identity deltas from full scans, targeted sync, deferred hashing, and audits.
- Refresh browser projection and wake readiness only after the authoritative source transaction commits.
- Exactly hash existing targeted files, including same-size/mtime-preserving edits, while keeping new large-file hashing owned by the source-processing supervisor.
- Use one canonical creation-fenced filesystem identity format. A one-time migration removes obsolete identity shapes, converts the experimental v2 prefix, and rebuilds derived readiness state from the canonical manifest.
- Track revisioned readiness work through restart, refresh similarity results as embeddings commit, and route discovery plus processing feedback through the shared bottom-right job indicator.
- Bound watcher ingress and per-source path churn; restart failed watches with capped backoff and escalate overflow or uncertainty to authoritative scans.
- Ignore source-database and ANN temporary-file watcher noise.
- Retry targeted sync transient failures, ignore stale completions for removed sources, and avoid recreating missing source roots.
- Periodically reconcile active manifests and a rotating bounded content batch.
- Reserve shared processing capacity for admitted foreground folder scans by cancelling and requeueing incompatible lower-priority supervisor work.
- Return and publish the exact latest committed checkpoint if a later scan phase fails or is cancelled, then keep incomplete work due for retry.
- Batch harvest persistence by owning source and transaction.
- Provide a branch-specific, signed macOS development app bundle so the exact local build can be targeted independently by UI automation.
- No changes to embedding models, similarity scoring policy, playback behavior, or classification policy.

## Definition of Done

- Every discovery commit returns its exact committed revision and deterministic identity delta, including intermediate checkpoints before later cancellation.
- Targeted watcher hints cannot mutate the browser or schedule prep before commit.
- Same-size edits and identity replacements invalidate the correct generations.
- Deferred hash completion uses a platform change marker as a stable-read fence, publishes a later committed revision, and is re-reconciled by the supervisor.
- Missing identities self-heal; obsolete identity encodings are removed by the one-time canonical migration and current filesystem facts are republished.
- An analysis job that discovers stale source content triggers exact-path source reconciliation, then retries against the committed content generation.
- Watcher overflow, restart, missing/reappearing roots, and transient sync errors converge without UI-thread filesystem work.
- Successful initial watch installation does not enqueue a full scan of every source.
- External metadata remains writable for readiness availability updates while the audio root is missing.
- Periodic audits repair changes missed while Wavecrate is closed or watcher delivery is lost.
- A foreground folder scan cannot remain indefinitely at zero behind incompatible background processing.
- Background discovery is immediately visible as indeterminate activity. Source processing uses a stable one-source-at-a-time queue: each source retains source-scoped stage, file, and completed/total feedback until its runnable work drains, then the queue advances. Idle state removes the indicator entirely.
- Processing text no longer displaces the normal footer status.
- A local macOS build produces a uniquely identified app that Computer Use can address without launching the installed Wavecrate bundle.

## Validation

Current head `ba6522e12`:

- `cargo test -p wavecrate-library --lib -- --test-threads=1` — 210 passed.
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` — 91 passed.
- `cargo test -p wavecrate-library commit_manifest_changes -- --test-threads=1` — 2 passed.
- `cargo test -p wavecrate-scan interleaved_manifest_writer_forces_exact_committed_resnapshot -- --test-threads=1` — passed; a later writer in the former post-commit readback window cannot contaminate the published checkpoint.
- `cargo test --bin wavecrate scheduled_manifest_audit_does_not_recreate_source_removed_after_discovery -- --test-threads=1` — passed; a missing root is parked and is not immediately requeued.
- `cargo test --bin wavecrate native_app::source_processing::scheduler::tests -- --test-threads=1` — 5 passed at the preceding exact source-processing head.
- `cargo test --bin wavecrate manifest_audit -- --test-threads=1` — 4 passed at the preceding exact source-processing head.
- `cargo test --bin wavecrate source_processing_ -- --test-threads=1` — 10 passed at the preceding exact source-processing head.
- Focused zero-byte terminal-classification and legacy unsupported-failure recovery regressions passed.
- `cargo test --bin wavecrate stale_analysis_hash_triggers_targeted_reconciliation_and_converges -- --nocapture` — passed.
- `git diff --check` — passed.
- `bash scripts/build.sh --release --variant OPT-1179` — passed at `ba6522e12` and re-signed `Wavecrate OPT-1179.app` with bundle ID `org.portalsurfer.wavecrate.dev.opt1179`.
- The broader serial supervisor suite advanced through 31 tests before the existing `real_hash_execution_waits_for_shared_scan_database_budget` panic-cleanup hang; sampling showed the test process waiting in `wait_for_external_scans`, outside the changed commit/publication and parked-root paths.
- Windows cross-target checking was attempted, but this macOS host lacks `ml64.exe` and the Windows C runtime required by native dependencies; no Rust diagnostic was reached.

Live exact-bundle validation:

- The previously colliding source database migrated from experimental schema 7 to schema 8 without retry or uniqueness errors. Derived readiness rows were republished from the canonical manifest while durable analysis caches remained intact.
- The two non-empty `gwge3` WAVs reconciled to their actual BLAKE3 content hashes, and each now has a 732-byte embedding, a 1544-byte similarity aspect descriptor, and four durable completed readiness stages.
- In the active similarity view those two rows left the N/A tail. The remaining five N/A rows are genuine 0-byte WAV files; the footer reported 7,226 resolved similar samples.
- The source queue drained `samples`, advanced to `inbox`, returned only when a new `samples` prerequisite became runnable, and then reached true idle with the progress surface removed; source names no longer flickered between individual work items.
- A prior active-anchor profile reduced the bad-state roughly 96% CPU loop to roughly 13-16% idle and 6-13% during continuing multi-source work.
- Durable audit restart validation interrupted `samples` after a committed checkpoint and relaunched at 6,885/7,232 instead of zero. Completed checkpoints are cleared atomically with the audit timestamp, and the normal full-audit cadence is now 24 hours.
- Legacy AppleDouble `._*.wav` rows no longer make identity repair permanently due; the live source stopped immediately re-enqueueing full audits.
- A live 0-byte WAV that previously held similarity progress at 28,918/28,929 is now published as terminally unsupported for playback, analysis, and embedding. The queue retired it, advanced to the next source, and reached idle.
- At `ba6522e12`, the signed b6630 app remained idle with no progress indicator through a complete 30-second safety sweep. Only one OPT-1179 process was running, at about 8.1% CPU.

## Known limitations

A pre-migration file renamed while Wavecrate was closed cannot retain move classification if its database only contained an obsolete two-field identity. It is reconciled safely as delete/create; all current and future identities use the canonical creation-fenced format.

User approval is required before merge.
