### PR TITLE
OPT-1182: Make playback and waveform readiness converge automatically

### DIFF
--- a/crates/wavecrate-analysis/src/analysis/similarity_artifacts.rs
+++ b/crates/wavecrate-analysis/src/analysis/similarity_artifacts.rs
@@ -806,7 +806,10 @@ mod tests {
                 .expect("seed current readiness job");
             connection
                 .execute(
-                    "INSERT INTO source_readiness_artifacts VALUES
+                    "INSERT INTO source_readiness_artifacts (
+                         source_id, scope_kind, scope_id, stage, artifact_version,
+                         source_generation, content_generation
+                     ) VALUES
                      ('source', 'file', ?1, 'embedding_aspects', 'v1', 1, 'content-v1')",
                     [identity],
                 )
@@ -825,7 +828,10 @@ mod tests {
             .expect("seed obsolete readiness job");
         connection
             .execute(
-                "INSERT INTO source_readiness_artifacts VALUES
+                "INSERT INTO source_readiness_artifacts (
+                     source_id, scope_kind, scope_id, stage, artifact_version,
+                     source_generation, content_generation
+                 ) VALUES
                  ('source', 'file', 'deleted-identity', 'embedding_aspects',
                   'v1', 1, 'deleted-content')",
                 [],

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -127,10 +127,12 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         source_id TEXT NOT NULL,
         scope_kind TEXT NOT NULL,
         scope_id TEXT NOT NULL,
+        relative_path TEXT,
         stage TEXT NOT NULL,
         artifact_version TEXT NOT NULL CHECK(length(trim(artifact_version)) > 0),
         source_generation INTEGER NOT NULL,
         content_generation TEXT NOT NULL CHECK(length(trim(content_generation)) > 0),
+        artifact_ref TEXT,
         completed_at INTEGER NOT NULL,
         CHECK (
             (stage = 'similarity_layout' AND scope_kind = 'source')

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/analysis_jobs.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/analysis_jobs.rs
@@ -110,10 +110,12 @@ pub(super) fn ensure_source_readiness_schema(connection: &Connection) -> Result<
                 source_id TEXT NOT NULL,
                 scope_kind TEXT NOT NULL,
                 scope_id TEXT NOT NULL,
+                relative_path TEXT,
                 stage TEXT NOT NULL,
                 artifact_version TEXT NOT NULL CHECK(length(trim(artifact_version)) > 0),
                 source_generation INTEGER NOT NULL,
                 content_generation TEXT NOT NULL CHECK(length(trim(content_generation)) > 0),
+                artifact_ref TEXT,
                 completed_at INTEGER NOT NULL,
                 CHECK (
                     (stage = 'similarity_layout' AND scope_kind = 'source')
@@ -146,6 +148,19 @@ pub(super) fn ensure_source_readiness_schema(connection: &Connection) -> Result<
                 [],
             )
             .map_err(map_sql_error)?;
+    }
+    let artifact_columns = table_columns(connection, "source_readiness_artifacts")?;
+    for (column, definition) in [("relative_path", "TEXT"), ("artifact_ref", "TEXT")] {
+        if !artifact_columns.contains(column) {
+            connection
+                .execute(
+                    &format!(
+                        "ALTER TABLE source_readiness_artifacts ADD COLUMN {column} {definition}"
+                    ),
+                    [],
+                )
+                .map_err(map_sql_error)?;
+        }
     }
     Ok(())
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -315,6 +315,17 @@ fn readiness_schema_repairs_current_stamped_analysis_storage() {
             source_generation INTEGER NOT NULL,
             availability TEXT NOT NULL,
             updated_at INTEGER NOT NULL
+        ) WITHOUT ROWID;
+        CREATE TABLE source_readiness_artifacts (
+            source_id TEXT NOT NULL,
+            scope_kind TEXT NOT NULL,
+            scope_id TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            artifact_version TEXT NOT NULL,
+            source_generation INTEGER NOT NULL,
+            content_generation TEXT NOT NULL,
+            completed_at INTEGER NOT NULL,
+            PRIMARY KEY (source_id, scope_kind, scope_id, stage)
         ) WITHOUT ROWID;",
     )
     .unwrap();
@@ -329,6 +340,9 @@ fn readiness_schema_repairs_current_stamped_analysis_storage() {
     assert!(job_columns.contains("lease_expires_at"));
     let source_columns = table_columns(&conn, "source_readiness_sources").unwrap();
     assert!(source_columns.contains("readiness_revision"));
+    let artifact_columns = table_columns(&conn, "source_readiness_artifacts").unwrap();
+    assert!(artifact_columns.contains("relative_path"));
+    assert!(artifact_columns.contains("artifact_ref"));
     for table in [
         "source_readiness_sources",
         "source_readiness_targets",

--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -22,10 +22,11 @@ pub use snapshot::{
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
     ReadinessError, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-    fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits,
-    persist_readiness_deficits_with_cancel, publish_readiness_artifact, readiness_work_stats,
-    reconcile_readiness, reconcile_readiness_with_cancel, release_readiness_work,
-    renew_readiness_lease, replace_readiness_targets, replace_readiness_targets_with_cancel,
+    complete_readiness_work_with_artifact_ref, fail_readiness_work, invalidate_readiness_artifact,
+    persist_readiness_deficits, persist_readiness_deficits_with_cancel, publish_readiness_artifact,
+    readiness_work_stats, reconcile_readiness, reconcile_readiness_with_cancel,
+    release_readiness_work, renew_readiness_lease, replace_readiness_targets,
+    replace_readiness_targets_with_cancel,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -13,6 +13,7 @@ pub use persistence::{
 pub(crate) use reconcile::reconcile_readiness_with_hook;
 pub use reconcile::{reconcile_readiness, reconcile_readiness_with_cancel};
 pub use work::{
-    cancel_readiness_work, claim_readiness_target, complete_readiness_work, fail_readiness_work,
-    readiness_work_stats, release_readiness_work, renew_readiness_lease,
+    cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+    complete_readiness_work_with_artifact_ref, fail_readiness_work, readiness_work_stats,
+    release_readiness_work, renew_readiness_lease,
 };

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/error.rs
@@ -79,6 +79,16 @@ pub enum ReadinessError {
         /// Readiness stage requiring the version.
         stage: ReadinessStage,
     },
+    /// A cache-backed artifact omitted its durable reverse-ownership reference.
+    #[error("Readiness artifact reference must be non-empty for {source_id}:{scope_id}:{stage:?}")]
+    InvalidArtifactReference {
+        /// Source identity.
+        source_id: String,
+        /// File or source scope identity.
+        scope_id: String,
+        /// Readiness stage requiring the reference.
+        stage: ReadinessStage,
+    },
     /// A stage was assigned to the wrong durable ownership scope.
     #[error("Invalid readiness scope {scope_kind:?} for {source_id}:{scope_id}:{stage:?}")]
     InvalidStageScope {

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -190,16 +190,20 @@ pub fn publish_readiness_artifact(
             source_id,
             scope_kind,
             scope_id,
+            relative_path,
             stage,
             artifact_version,
             source_generation,
             content_generation,
+            artifact_ref,
             completed_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ) VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, NULL, ?8)
          ON CONFLICT(source_id, scope_kind, scope_id, stage) DO UPDATE SET
+            relative_path = NULL,
             artifact_version = excluded.artifact_version,
             source_generation = excluded.source_generation,
             content_generation = excluded.content_generation,
+            artifact_ref = NULL,
             completed_at = excluded.completed_at",
         params![
             artifact.source_id,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -251,6 +251,35 @@ pub fn complete_readiness_work(
     claim: &ClaimedReadinessWork,
     completed_at: i64,
 ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+    complete_readiness_work_inner(connection, claim, completed_at, None)
+}
+
+/// Atomically publish a cache-backed artifact reference and mark its exact work row complete.
+///
+/// The reference is stored beside the source/path/content generations so later reconciliation can
+/// retire the exact app-global payload after edits, moves, deletion, or cache pruning.
+pub fn complete_readiness_work_with_artifact_ref(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    completed_at: i64,
+    artifact_ref: &str,
+) -> Result<ArtifactPublishOutcome, ReadinessError> {
+    if artifact_ref.trim().is_empty() {
+        return Err(ReadinessError::InvalidArtifactReference {
+            source_id: claim.target.source_id.clone(),
+            scope_id: claim.target.scope_id.clone(),
+            stage: claim.target.stage,
+        });
+    }
+    complete_readiness_work_inner(connection, claim, completed_at, Some(artifact_ref))
+}
+
+fn complete_readiness_work_inner(
+    connection: &mut Connection,
+    claim: &ClaimedReadinessWork,
+    completed_at: i64,
+    artifact_ref: Option<&str>,
+) -> Result<ArtifactPublishOutcome, ReadinessError> {
     let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let changed = finish_claim_update(
         &tx,
@@ -268,22 +297,26 @@ pub fn complete_readiness_work(
     let artifact = ReadinessArtifact::for_target(&claim.target, completed_at);
     tx.execute(
         "INSERT INTO source_readiness_artifacts (
-            source_id, scope_kind, scope_id, stage, artifact_version,
-            source_generation, content_generation, completed_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            source_id, scope_kind, scope_id, relative_path, stage, artifact_version,
+            source_generation, content_generation, artifact_ref, completed_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
          ON CONFLICT(source_id, scope_kind, scope_id, stage) DO UPDATE SET
+            relative_path = excluded.relative_path,
             artifact_version = excluded.artifact_version,
             source_generation = excluded.source_generation,
             content_generation = excluded.content_generation,
+            artifact_ref = excluded.artifact_ref,
             completed_at = excluded.completed_at",
         params![
             artifact.source_id,
             artifact.scope_kind.as_str(),
             artifact.scope_id,
+            claim.target.relative_path,
             artifact.stage.as_str(),
             artifact.artifact_version,
             artifact.source_generation,
             artifact.content_generation,
+            artifact_ref,
             artifact.completed_at,
         ],
     )?;

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -118,6 +118,81 @@ fn stale_completion_cannot_publish_over_a_changed_exact_target() {
 }
 
 #[test]
+fn cache_backed_completion_persists_exact_reverse_ownership_atomically() {
+    let (_root, mut connection) = open_fixture();
+    let target = file_target("owned", ReadinessStage::PlaybackSummary, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&target));
+    persist_target(&mut connection, &target, 10);
+    let claim = claim_readiness_target(&mut connection, &target, 10, 100)
+        .expect("claim cache-backed target")
+        .expect("cache-backed target available");
+
+    assert_eq!(
+        complete_readiness_work_with_artifact_ref(
+            &mut connection,
+            &claim,
+            11,
+            "/app-cache/owned.wfc",
+        )
+        .expect("complete cache-backed target"),
+        ArtifactPublishOutcome::Recorded
+    );
+    let stored = connection
+        .query_row(
+            "SELECT relative_path, artifact_ref, content_generation
+             FROM source_readiness_artifacts
+             WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'playback_summary'",
+            rusqlite::params![SOURCE_ID, target.scope_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .expect("read reverse ownership");
+    assert_eq!(stored.0, target.relative_path.as_deref().unwrap());
+    assert_eq!(stored.1, "/app-cache/owned.wfc");
+    assert_eq!(stored.2, target.content_generation);
+}
+
+#[test]
+fn stale_cache_backed_completion_cannot_replace_current_ownership() {
+    let (_root, mut connection) = open_fixture();
+    let original = file_target("owned-stale", ReadinessStage::PlaybackSummary, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&original));
+    persist_target(&mut connection, &original, 10);
+    let stale_claim = claim_readiness_target(&mut connection, &original, 10, 100)
+        .expect("claim original target")
+        .expect("original target available");
+
+    let current = file_target("owned-stale", ReadinessStage::PlaybackSummary, 2);
+    replace(&mut connection, 2, std::slice::from_ref(&current));
+    assert_eq!(
+        complete_readiness_work_with_artifact_ref(
+            &mut connection,
+            &stale_claim,
+            11,
+            "/app-cache/stale.wfc",
+        )
+        .expect("reject stale cache-backed target"),
+        ArtifactPublishOutcome::RejectedStale
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT COUNT(*) FROM source_readiness_artifacts
+                 WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'playback_summary'",
+                rusqlite::params![SOURCE_ID, original.scope_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("count stale ownership"),
+        0
+    );
+}
+
+#[test]
 fn file_completion_survives_unrelated_source_generation_changes() {
     let (_root, mut connection) = open_fixture();
     let original = file_target("stable", ReadinessStage::AnalysisFeatures, 1);

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -316,6 +316,8 @@ Every enabled, available source should converge automatically in background work
 
 The source-local database is the authoritative durable coordination boundary. It should store desired versioned readiness targets, exact artifact completion generations, source availability, and readiness-owned work metadata. Readiness work must reuse the existing source-local persistent analysis/job storage rather than introducing an unrelated queue format. App-global cache payloads may remain app-global, but their source/file identity, artifact version, and completion generation must be projected into the source readiness contract.
 
+Playback-summary completions must also persist the current source-relative path and exact app-global cache reference beside those generations. That record is the reverse-ownership manifest: reconciliation uses it to retire a replaced or deleted identity after the old filesystem metadata is gone, remap reusable payloads on path-only moves, and invalidate readiness when disk-budget pruning removes a payload. Cache-backed readiness completion and its ownership reference publish under the same generation fence; a rejected, cancelled, or otherwise stale completion must remove its unpublished cache payload rather than repopulating an obsolete entry.
+
 For every current eligible file, the readiness stages are:
 
 1. the committed source index contains the current file identity and content generation;
@@ -1231,6 +1233,8 @@ Scan progress should expose queued, active, completed, skipped, failed, and canc
 Waveform and playback-readiness cache/pre-cache progress should be visible both globally and per item. The bottom status bar should include a compact background-job progress bar for scanning, indexing, and cache preparation work. The visible progress bar should represent one current job at a time rather than combining unrelated concurrent job types into a misleading aggregate. If several job types are active, the visible status-bar job should prefer foreground/current-selection work first, active-folder work second, and source-wide background work after that. The indicator should show successive job progress as queued jobs run, so a sequence of small background jobs can appear as repeated fills while broader queue counts live in the details popover.
 
 The status-bar background-job indicator should provide a direct way to pause and resume non-critical background work such as pre-caching. This may be a small pause/resume button on the indicator, a click target, or a right-click context menu. Pausing background work should not cancel the currently selected foreground file load, prevent selected-file loading from starting, or block urgent user-requested work. The pause is session-local, should not auto-resume because the user is idle, and should reset to enabled on the next application launch.
+
+Playback and foreground source loading may cooperatively cancel the current low-priority cache batch, but cancellation is a pause boundary rather than queue deletion. Every unprocessed path from planning, persisted-cache hydration, or source warming must return to the retained backlog and resume after foreground activity ends.
 
 Background scan, indexing, and pre-cache jobs should continue while Wavecrate is minimized unless the user manually pauses them, the operating system suspends the process, or the app is shutting down.
 

--- a/src/native_app/app/cache.rs
+++ b/src/native_app/app/cache.rs
@@ -77,6 +77,7 @@ pub(in crate::native_app) struct WaveformCacheEntry {
 #[derive(Clone, Debug)]
 pub(in crate::native_app) struct WaveformCacheWarmResult {
     pub(in crate::native_app) loaded: Vec<(PathBuf, Arc<WaveformFile>)>,
+    pub(in crate::native_app) deferred: Vec<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -100,10 +101,12 @@ pub(in crate::native_app) struct WaveformCacheIndicatorRefreshResult {
 
 impl PartialEq for WaveformCacheWarmResult {
     fn eq(&self, other: &Self) -> bool {
-        self.loaded
-            .iter()
-            .map(|(path, _)| path)
-            .eq(other.loaded.iter().map(|(path, _)| path))
+        self.deferred == other.deferred
+            && self
+                .loaded
+                .iter()
+                .map(|(path, _)| path)
+                .eq(other.loaded.iter().map(|(path, _)| path))
     }
 }
 

--- a/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/active_folder_warm.rs
@@ -151,7 +151,13 @@ impl NativeAppState {
         };
         self.waveform.cache.active_folder_warm_plan_cancel = None;
         if result.cancelled {
-            self.waveform.cache.clear_active_folder_warm_job();
+            if result.pending.is_empty() {
+                self.waveform.cache.clear_active_folder_warm_job();
+            } else {
+                self.waveform
+                    .cache
+                    .start_active_folder_warm_decode_queue(result.folder_id, result.pending);
+            }
             return;
         }
         for path in result.playback_ready {
@@ -333,13 +339,13 @@ impl NativeAppState {
         if let Some(token) = self.waveform.cache.active_folder_warm_cancel.take() {
             token.cancel();
         }
-        self.waveform.cache.clear_active_folder_warm_job();
         if running {
             return;
         }
         if let Some(key) = self.waveform.cache.active_folder_warm_key.take() {
             self.waveform.cache.active_folder_warm_tasks.cancel(&key);
         }
+        self.waveform.cache.clear_active_folder_warm_current();
     }
 
     fn reschedule_active_folder_cache_warm_delay(

--- a/src/native_app/audio/sample_load_actions/cache/persisted_warm.rs
+++ b/src/native_app/audio/sample_load_actions/cache/persisted_warm.rs
@@ -69,6 +69,9 @@ impl NativeAppState {
         };
         self.waveform.cache.warm_key = None;
         self.waveform.cache.warm_cancel = None;
+        for path in result.deferred.iter().rev() {
+            self.waveform.cache.warm_pending.push_front(path.clone());
+        }
         self.apply_waveform_cache_warm_result(result);
         log_slow_cache_phase(
             "browser.sample_cache.warm_finish",

--- a/src/native_app/audio/sample_load_actions/cache/workers.rs
+++ b/src/native_app/audio/sample_load_actions/cache/workers.rs
@@ -34,18 +34,20 @@ pub(in crate::native_app) fn warm_persisted_waveform_cache(
     paths: Vec<PathBuf>,
     is_cancelled: impl Fn() -> bool,
 ) -> WaveformCacheWarmResult {
-    let loaded = paths
-        .into_iter()
-        .filter_map(|path| {
-            if is_cancelled() {
-                return None;
-            }
-            load_cached_waveform_file_for_playback(path.clone())
-                .map(Arc::new)
-                .map(|file| (path, file))
-        })
-        .collect();
-    WaveformCacheWarmResult { loaded }
+    let mut paths = paths.into_iter();
+    let mut loaded = Vec::new();
+    let mut deferred = Vec::new();
+    while let Some(path) = paths.next() {
+        if is_cancelled() {
+            deferred.push(path);
+            deferred.extend(paths);
+            break;
+        }
+        if let Some(file) = load_cached_waveform_file_for_playback(path.clone()) {
+            loaded.push((path, Arc::new(file)));
+        }
+    }
+    WaveformCacheWarmResult { loaded, deferred }
 }
 
 #[cfg(test)]
@@ -77,10 +79,12 @@ pub(in crate::native_app) fn plan_active_folder_waveform_cache_warm_with_progres
     );
     let playback_ready = Vec::new();
     let mut pending = Vec::new();
-    for (index, path) in paths.into_iter().enumerate() {
+    let mut paths = paths.into_iter().enumerate();
+    while let Some((index, path)) = paths.next() {
         let checked = index.saturating_add(1);
         if is_cancelled() {
             pending.push(path);
+            pending.extend(paths.map(|(_, path)| path));
             return ActiveFolderCacheWarmPlanResult {
                 folder_id,
                 playback_ready,
@@ -267,6 +271,32 @@ fn report_active_folder_cache_progress(
         stage,
         cached,
     });
+}
+
+#[cfg(test)]
+mod cancellation_tests {
+    use super::*;
+
+    #[test]
+    fn persisted_hydration_cancellation_returns_the_complete_unfinished_batch() {
+        let paths = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
+
+        let result = warm_persisted_waveform_cache(paths.clone(), || true);
+
+        assert!(result.loaded.is_empty());
+        assert_eq!(result.deferred, paths);
+    }
+
+    #[test]
+    fn source_warm_planning_cancellation_returns_the_complete_unfinished_plan() {
+        let paths = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
+        let request = ActiveFolderCacheWarmRequest::new(String::from("source"), paths.clone());
+
+        let result = plan_active_folder_waveform_cache_warm(request, || true);
+
+        assert!(result.cancelled);
+        assert_eq!(result.pending, paths);
+    }
 }
 
 pub(super) fn probe_persisted_waveform_cache_indicators(

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -21,7 +21,8 @@ use wavecrate::sample_sources::{
         ReadinessFailureClassification, ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome,
         ReadinessRetryPolicy, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
         SourceAvailability, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
+        complete_readiness_work_with_artifact_ref, fail_readiness_work,
+        invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
         readiness_work_stats, reconcile_readiness_with_cancel, release_readiness_work,
         renew_readiness_lease, replace_readiness_targets_with_cancel,
     },
@@ -40,7 +41,9 @@ use crate::native_app::sample_library::similarity_artifacts::{
     native_similarity_artifact_version, reset_interrupted_readiness_jobs,
 };
 use crate::native_app::waveform::{
-    cached_waveform_file_audition_ready_exists, ensure_persisted_playback_summary,
+    ensure_persisted_playback_summary, invalidate_persisted_waveform_cache_path,
+    invalidate_persisted_waveform_cache_ref, persisted_waveform_cache_ref_is_current,
+    remap_persisted_waveform_cache_ref_after_move,
 };
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
@@ -52,7 +55,7 @@ const MAX_VISIBLE_PRIORITY_PATHS: usize = 128;
 const READINESS_LEASE_SECONDS: i64 = 5 * 60;
 const READINESS_MAX_ATTEMPTS: u32 = 8;
 const READINESS_MANIFEST_VERSION: &str = "source_manifest_v1";
-const READINESS_PLAYBACK_VERSION: &str = "waveform_cache_v4";
+const READINESS_PLAYBACK_VERSION: &str = "waveform_cache_v5_owned";
 const META_READINESS_TARGET_FINGERPRINT: &str = "readiness_target_fingerprint_v1";
 
 /// Owned runtime coordinator. All work is joined during shutdown and observes one cancel token.
@@ -1841,6 +1844,12 @@ fn discover_source_candidates_with_connection(
     ) {
         return Ok(Cancellable::Cancelled);
     }
+    if matches!(
+        reconcile_playback_cache_ownership(source, connection, cancel)?,
+        Cancellable::Cancelled
+    ) {
+        return Ok(Cancellable::Cancelled);
+    }
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);
     }
@@ -1954,6 +1963,19 @@ fn source_processing_schema_available(connection: &rusqlite::Connection) -> Resu
             ][..],
         ),
         ("metadata", &["key", "value"][..]),
+        (
+            "source_readiness_artifacts",
+            &[
+                "source_id",
+                "scope_kind",
+                "scope_id",
+                "relative_path",
+                "stage",
+                "artifact_version",
+                "content_generation",
+                "artifact_ref",
+            ][..],
+        ),
     ] {
         let pragma = format!("PRAGMA table_info({table})");
         let mut statement = connection
@@ -2264,6 +2286,209 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
     Ok(Cancellable::Completed(true))
 }
 
+#[derive(Debug)]
+struct PlaybackCacheOwnershipRow {
+    scope_id: String,
+    artifact_relative_path: Option<String>,
+    artifact_version: String,
+    artifact_content_generation: String,
+    artifact_ref: Option<String>,
+    target_relative_path: Option<String>,
+    target_version: Option<String>,
+    target_content_generation: Option<String>,
+    target_eligibility: Option<String>,
+}
+
+/// Reconcile source-owned playback artifact rows with their exact app-global cache payloads.
+///
+/// The source database is the durable reverse index. This pass runs on startup and every committed
+/// source wake, so changed/deleted identities can retire their old cache keys even after the old
+/// filesystem metadata is gone. Path-only moves remap reusable payloads without decoding again.
+fn reconcile_playback_cache_ownership(
+    source: &SampleSource,
+    connection: &mut rusqlite::Connection,
+    cancel: &AtomicBool,
+) -> Result<Cancellable<usize>, String> {
+    let rows = {
+        let mut statement = connection
+            .prepare(
+                "SELECT artifact.scope_id,
+                        artifact.relative_path,
+                        artifact.artifact_version,
+                        artifact.content_generation,
+                        artifact.artifact_ref,
+                        target.relative_path,
+                        target.required_version,
+                        target.content_generation,
+                        target.eligibility
+                 FROM source_readiness_artifacts AS artifact
+                 LEFT JOIN source_readiness_targets AS target
+                   ON target.source_id = artifact.source_id
+                  AND target.scope_kind = artifact.scope_kind
+                  AND target.scope_id = artifact.scope_id
+                  AND target.stage = artifact.stage
+                 WHERE artifact.source_id = ?1
+                   AND artifact.scope_kind = 'file'
+                   AND artifact.stage = 'playback_summary'
+                 ORDER BY artifact.scope_id",
+            )
+            .map_err(|error| error.to_string())?;
+        statement
+            .query_map([source.id.as_str()], |row| {
+                Ok(PlaybackCacheOwnershipRow {
+                    scope_id: row.get(0)?,
+                    artifact_relative_path: row.get(1)?,
+                    artifact_version: row.get(2)?,
+                    artifact_content_generation: row.get(3)?,
+                    artifact_ref: row.get(4)?,
+                    target_relative_path: row.get(5)?,
+                    target_version: row.get(6)?,
+                    target_content_generation: row.get(7)?,
+                    target_eligibility: row.get(8)?,
+                })
+            })
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?
+    };
+    let mut changed = 0_usize;
+    for row in rows {
+        if cancelled(cancel) {
+            return Ok(Cancellable::Cancelled);
+        }
+        let target_matches = row.target_version.as_deref() == Some(row.artifact_version.as_str())
+            && row.target_content_generation.as_deref()
+                == Some(row.artifact_content_generation.as_str())
+            && row.target_eligibility.as_deref() == Some("eligible");
+        let Some(cache_ref) = row.artifact_ref.as_deref().map(std::path::Path::new) else {
+            changed = changed.saturating_add(delete_playback_cache_ownership_row(
+                connection,
+                source.id.as_str(),
+                &row,
+            )?);
+            continue;
+        };
+        if !target_matches {
+            invalidate_playback_cache_owner(source, &row);
+            changed = changed.saturating_add(delete_playback_cache_ownership_row(
+                connection,
+                source.id.as_str(),
+                &row,
+            )?);
+            continue;
+        }
+        let (Some(artifact_relative_path), Some(target_relative_path)) = (
+            row.artifact_relative_path.as_deref(),
+            row.target_relative_path.as_deref(),
+        ) else {
+            invalidate_playback_cache_owner(source, &row);
+            changed = changed.saturating_add(delete_playback_cache_ownership_row(
+                connection,
+                source.id.as_str(),
+                &row,
+            )?);
+            continue;
+        };
+        let target_path = source.root.join(target_relative_path);
+        if artifact_relative_path == target_relative_path
+            && persisted_waveform_cache_ref_is_current(&target_path, cache_ref)
+        {
+            continue;
+        }
+        if artifact_relative_path != target_relative_path {
+            let artifact_path = source.root.join(artifact_relative_path);
+            invalidate_persisted_waveform_cache_path(&artifact_path);
+            if let Some(remapped_ref) = remap_persisted_waveform_cache_ref_after_move(
+                cache_ref,
+                &artifact_path,
+                &target_path,
+            ) {
+                let updated = connection
+                    .execute(
+                        "UPDATE source_readiness_artifacts AS artifact
+                         SET relative_path = ?1, artifact_ref = ?2
+                         WHERE artifact.source_id = ?3
+                           AND artifact.scope_kind = 'file'
+                           AND artifact.scope_id = ?4
+                           AND artifact.stage = 'playback_summary'
+                           AND artifact.artifact_version = ?5
+                           AND artifact.content_generation = ?6
+                           AND artifact.artifact_ref IS ?7
+                           AND EXISTS (
+                               SELECT 1 FROM source_readiness_targets AS target
+                               WHERE target.source_id = artifact.source_id
+                                 AND target.scope_kind = artifact.scope_kind
+                                 AND target.scope_id = artifact.scope_id
+                                 AND target.stage = artifact.stage
+                                 AND target.relative_path = ?1
+                                 AND target.required_version = artifact.artifact_version
+                                 AND target.content_generation = artifact.content_generation
+                                 AND target.eligibility = 'eligible'
+                           )",
+                        params![
+                            target_relative_path,
+                            remapped_ref.to_string_lossy(),
+                            source.id.as_str(),
+                            row.scope_id,
+                            row.artifact_version,
+                            row.artifact_content_generation,
+                            row.artifact_ref,
+                        ],
+                    )
+                    .map_err(|error| error.to_string())?;
+                if updated == 1 {
+                    changed = changed.saturating_add(1);
+                    continue;
+                }
+                invalidate_persisted_waveform_cache_ref(&remapped_ref);
+            }
+        } else {
+            invalidate_playback_cache_owner(source, &row);
+        }
+        changed = changed.saturating_add(delete_playback_cache_ownership_row(
+            connection,
+            source.id.as_str(),
+            &row,
+        )?);
+    }
+    Ok(Cancellable::Completed(changed))
+}
+
+fn invalidate_playback_cache_owner(source: &SampleSource, row: &PlaybackCacheOwnershipRow) {
+    if let Some(relative_path) = row.artifact_relative_path.as_deref() {
+        invalidate_persisted_waveform_cache_path(&source.root.join(relative_path));
+    }
+    if let Some(cache_ref) = row.artifact_ref.as_deref() {
+        invalidate_persisted_waveform_cache_ref(std::path::Path::new(cache_ref));
+    }
+}
+
+fn delete_playback_cache_ownership_row(
+    connection: &rusqlite::Connection,
+    source_id: &str,
+    row: &PlaybackCacheOwnershipRow,
+) -> Result<usize, String> {
+    connection
+        .execute(
+            "DELETE FROM source_readiness_artifacts
+             WHERE source_id = ?1
+               AND scope_kind = 'file'
+               AND scope_id = ?2
+               AND stage = 'playback_summary'
+               AND artifact_version = ?3
+               AND content_generation = ?4
+               AND artifact_ref IS ?5",
+            params![
+                source_id,
+                row.scope_id,
+                row.artifact_version,
+                row.artifact_content_generation,
+                row.artifact_ref,
+            ],
+        )
+        .map_err(|error| error.to_string())
+}
+
 fn readiness_unsupported_content_generations(
     connection: &rusqlite::Connection,
     source_id: &str,
@@ -2471,7 +2696,7 @@ fn execute_candidate(
 }
 
 enum ReadinessExecutionOutcome {
-    Complete,
+    Complete(Option<std::path::PathBuf>),
     Retry(&'static str),
     Permanent(&'static str),
     Unsupported(&'static str),
@@ -2518,9 +2743,11 @@ fn execute_readiness_target(
         }
     };
     if lease_stale {
+        cleanup_unpublished_readiness_output(&outcome);
         return Ok(ExecutionOutcome::Stale);
     }
     if cancel.load(Ordering::Acquire) {
+        cleanup_unpublished_readiness_output(&outcome);
         return cancel_claim(
             &mut connection,
             &claim,
@@ -2529,12 +2756,33 @@ fn execute_readiness_target(
         );
     }
     match outcome {
-        Ok(ReadinessExecutionOutcome::Complete) => {
-            match complete_readiness_work(&mut connection, &claim, now_epoch_seconds())
-                .map_err(|error| error.to_string())?
-            {
+        Ok(ReadinessExecutionOutcome::Complete(artifact_ref)) => {
+            let completed = match artifact_ref.as_deref() {
+                Some(artifact_ref) => complete_readiness_work_with_artifact_ref(
+                    &mut connection,
+                    &claim,
+                    now_epoch_seconds(),
+                    &artifact_ref.to_string_lossy(),
+                ),
+                None => complete_readiness_work(&mut connection, &claim, now_epoch_seconds()),
+            };
+            let completed = match completed {
+                Ok(completed) => completed,
+                Err(error) => {
+                    if let Some(artifact_ref) = artifact_ref.as_deref() {
+                        invalidate_persisted_waveform_cache_ref(artifact_ref);
+                    }
+                    return Err(error.to_string());
+                }
+            };
+            match completed {
                 ArtifactPublishOutcome::Recorded => Ok(ExecutionOutcome::Completed),
-                ArtifactPublishOutcome::RejectedStale => Ok(ExecutionOutcome::Stale),
+                ArtifactPublishOutcome::RejectedStale => {
+                    if let Some(artifact_ref) = artifact_ref.as_deref() {
+                        invalidate_persisted_waveform_cache_ref(artifact_ref);
+                    }
+                    Ok(ExecutionOutcome::Stale)
+                }
             }
         }
         Ok(ReadinessExecutionOutcome::Retry(reason)) => {
@@ -2604,6 +2852,12 @@ fn execute_readiness_target(
                 ReadinessWorkMutationOutcome::RejectedStale => Ok(ExecutionOutcome::Stale),
             }
         }
+    }
+}
+
+fn cleanup_unpublished_readiness_output(outcome: &Result<ReadinessExecutionOutcome, String>) {
+    if let Ok(ReadinessExecutionOutcome::Complete(Some(artifact_ref))) = outcome {
+        invalidate_persisted_waveform_cache_ref(artifact_ref);
     }
 }
 
@@ -2877,7 +3131,7 @@ fn run_readiness_stage(
                     .flatten()
                     .filter(|content_hash| !content_hash.is_empty());
                 if committed_content_hash.as_deref() == Some(target.content_generation.as_str()) {
-                    ReadinessExecutionOutcome::Complete
+                    ReadinessExecutionOutcome::Complete(None)
                 } else if committed_content_hash.is_some() {
                     ReadinessExecutionOutcome::PrerequisiteInvalidated
                 } else {
@@ -2899,10 +3153,14 @@ fn run_readiness_stage(
                 ));
             };
             let absolute_path = source.root.join(relative_path);
-            if !cached_waveform_file_audition_ready_exists(&absolute_path) {
-                ensure_persisted_playback_summary(absolute_path, cancel)?;
+            // A claimed deficit has no exact current cache owner. Do not hydrate an unowned v4
+            // payload using only size/mtime; erase that key first so this generation produces a
+            // cache that can be committed atomically with its durable v5 ownership reference.
+            if !prepare_playback_cache_generation(connection, target, &absolute_path)? {
+                return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated);
             }
-            Ok(ReadinessExecutionOutcome::Complete)
+            let cache_ref = ensure_persisted_playback_summary(absolute_path, cancel)?;
+            Ok(ReadinessExecutionOutcome::Complete(Some(cache_ref)))
         }
         ReadinessStage::AnalysisFeatures => {
             if target.content_generation.starts_with("pending-") {
@@ -2924,7 +3182,7 @@ fn run_readiness_stage(
                 ));
             }
             if analysis_features_are_current(connection, target)? {
-                return Ok(ReadinessExecutionOutcome::Complete);
+                return Ok(ReadinessExecutionOutcome::Complete(None));
             }
             let produced = super::worker::run_readiness_feature_stage(
                 connection,
@@ -2935,7 +3193,7 @@ fn run_readiness_stage(
                 cancel,
             )?;
             if produced && analysis_features_are_current(connection, target)? {
-                return Ok(ReadinessExecutionOutcome::Complete);
+                return Ok(ReadinessExecutionOutcome::Complete(None));
             }
             if !produced {
                 reconcile_stale_analysis_input(
@@ -2992,7 +3250,7 @@ fn run_readiness_stage(
                 return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated);
             }
             Ok(if embedding_aspects_are_current(connection, target)? {
-                ReadinessExecutionOutcome::Complete
+                ReadinessExecutionOutcome::Complete(None)
             } else {
                 let produced = super::worker::run_readiness_embedding_stage(
                     connection,
@@ -3003,7 +3261,7 @@ fn run_readiness_stage(
                     cancel,
                 )?;
                 if produced && embedding_aspects_are_current(connection, target)? {
-                    ReadinessExecutionOutcome::Complete
+                    ReadinessExecutionOutcome::Complete(None)
                 } else {
                     ReadinessExecutionOutcome::Retry(
                         "embedding feature prerequisite is not durable yet",
@@ -3026,7 +3284,7 @@ fn run_readiness_stage(
             finalize_similarity_artifacts_if_ready(source, &publication_fence, cancel).map(
                 |finalized| {
                     if finalized {
-                        ReadinessExecutionOutcome::Complete
+                        ReadinessExecutionOutcome::Complete(None)
                     } else {
                         ReadinessExecutionOutcome::PrerequisiteInvalidated
                     }
@@ -3034,6 +3292,51 @@ fn run_readiness_stage(
             )
         }
     }
+}
+
+fn prepare_playback_cache_generation(
+    connection: &mut rusqlite::Connection,
+    target: &ReadinessTarget,
+    absolute_path: &std::path::Path,
+) -> Result<bool, String> {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| error.to_string())?;
+    let current = transaction
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1
+                FROM source_readiness_sources AS source
+                JOIN source_readiness_targets AS target
+                  ON target.source_id = source.source_id
+                 AND target.source_generation = source.source_generation
+                WHERE target.source_id = ?1
+                  AND target.scope_kind = 'file'
+                  AND target.scope_id = ?2
+                  AND target.relative_path = ?3
+                  AND target.stage = 'playback_summary'
+                  AND target.required_version = ?4
+                  AND target.content_generation = ?5
+                  AND target.eligibility = 'eligible'
+                  AND source.availability = 'active'
+            )",
+            params![
+                target.source_id,
+                target.scope_id,
+                target.relative_path,
+                target.required_version,
+                target.content_generation,
+            ],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if !current {
+        transaction.rollback().map_err(|error| error.to_string())?;
+        return Ok(false);
+    }
+    invalidate_persisted_waveform_cache_path(absolute_path);
+    transaction.commit().map_err(|error| error.to_string())?;
+    Ok(true)
 }
 
 fn readiness_stage_is_unsupported(
@@ -3296,6 +3599,8 @@ fn oldest_job_age_seconds(candidates: &[RuntimeCandidate], now: i64) -> u64 {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+
+    use crate::native_app::waveform::cached_waveform_file_audition_ready_exists;
 
     use wavecrate::sample_sources::{
         SourceId,
@@ -4806,6 +5111,14 @@ mod tests {
                           AND artifact.artifact_version = target.required_version
                           AND artifact.content_generation = target.content_generation
                           AND (
+                              target.stage != 'playback_summary'
+                              OR (
+                                  artifact.relative_path = target.relative_path
+                                  AND artifact.artifact_ref IS NOT NULL
+                                  AND length(trim(artifact.artifact_ref)) > 0
+                              )
+                          )
+                          AND (
                               target.scope_kind = 'file'
                               OR artifact.source_generation = target.source_generation
                           )
@@ -4838,6 +5151,90 @@ mod tests {
         assert!(cached_waveform_file_audition_ready_exists(
             &source.root.join("ready.wav")
         ));
+        let database_root = source.database_root().expect("database root");
+        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("open converged readiness database");
+        let cache_ref = connection
+            .query_row(
+                "SELECT artifact_ref
+                 FROM source_readiness_artifacts
+                 WHERE source_id = ?1 AND stage = 'playback_summary'",
+                [source.id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("read playback ownership reference");
+        assert!(std::path::Path::new(&cache_ref).is_file());
+        assert!(
+            !std::path::Path::new(&cache_ref)
+                .with_extension("pcm")
+                .exists(),
+            "large-file readiness should remain file-backed without persisted decoded PCM"
+        );
+    }
+
+    #[test]
+    fn committed_delete_retires_exact_owned_playback_cache_without_old_file_metadata() {
+        let (_directory, source) = ready_analysis_source("playback-delete");
+        let mut supervisor = SourceProcessingSupervisor::start(vec![source.clone()]);
+        let database_root = source.database_root().expect("database root");
+        let mut owned_cache_ref = None::<std::path::PathBuf>;
+        wait_until(Duration::from_secs(15), || {
+            let Ok(connection) = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            ) else {
+                return false;
+            };
+            owned_cache_ref = connection
+                .query_row(
+                    "SELECT artifact_ref
+                     FROM source_readiness_artifacts
+                     WHERE source_id = ?1
+                       AND stage = 'playback_summary'
+                       AND artifact_ref IS NOT NULL",
+                    [source.id.as_str()],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .ok()
+                .flatten()
+                .map(std::path::PathBuf::from);
+            owned_cache_ref.as_ref().is_some_and(|path| path.is_file())
+        });
+        let owned_cache_ref = owned_cache_ref.expect("owned playback cache ref");
+
+        std::fs::remove_file(source.root.join("ready.wav")).expect("delete source sample");
+        let db = source.open_db().expect("open source after delete");
+        wavecrate::sample_sources::scanner::sync_paths(&db, &[PathBuf::from("ready.wav")])
+            .expect("commit source deletion");
+        supervisor.wake_source(source.id.as_str(), "test_committed_delete");
+
+        wait_until(Duration::from_secs(10), || {
+            let Ok(connection) = SourceDatabase::open_connection_with_role_and_database_root(
+                &source.root,
+                &database_root,
+                SourceDatabaseConnectionRole::JobWorker,
+            ) else {
+                return false;
+            };
+            let ownership_removed = connection
+                .query_row(
+                    "SELECT COUNT(*) = 0
+                     FROM source_readiness_artifacts
+                     WHERE source_id = ?1 AND stage = 'playback_summary'",
+                    [source.id.as_str()],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap_or(false);
+            ownership_removed && !owned_cache_ref.exists()
+        });
+        let report = supervisor.shutdown();
+        assert_eq!(report["joined"], true);
     }
 
     #[test]

--- a/src/native_app/tests/waveform_playback/active_folder_cache.rs
+++ b/src/native_app/tests/waveform_playback/active_folder_cache.rs
@@ -308,7 +308,7 @@ fn active_folder_cache_warm_tracks_worker_progress() {
                 running_ticket,
                 source_root.path().display().to_string(),
                 Vec::new(),
-                vec![second],
+                vec![second.clone()],
                 1,
                 true,
                 false,
@@ -940,7 +940,7 @@ fn active_folder_cache_warm_does_not_chain_batches_while_playing() {
                 running_ticket,
                 source_root.path().display().to_string(),
                 Vec::new(),
-                vec![second],
+                vec![second.clone()],
                 1,
                 true,
                 false,
@@ -981,7 +981,7 @@ fn active_folder_cache_warm_does_not_chain_batches_while_playing() {
 }
 
 #[test]
-fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediately() {
+fn running_active_folder_cache_warm_pause_for_playback_preserves_and_resumes_backlog() {
     let source_root = tempfile::tempdir().expect("source root");
     let folder = source_root.path().join("large-folder");
     fs::create_dir_all(&folder).expect("create folder");
@@ -1033,19 +1033,12 @@ fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediate
         "running warm task should stay tracked until its cancellation completion arrives"
     );
     assert!(
-        state.waveform.cache.active_folder_warm_folder_id.is_none(),
-        "playback pause should clear source-cache progress immediately"
+        state.waveform.cache.active_folder_warm_folder_id.is_some(),
+        "playback pause should retain the durable source-cache job"
     );
     assert!(
         state.waveform.cache.active_folder_warm_pending.is_empty(),
-        "playback pause should abandon deferred source-cache work immediately"
-    );
-
-    let before = state.capture_frame_surface_inputs();
-    state.advance_frame(&mut ui::UiUpdateContext::default());
-    assert!(
-        state.frame_can_use_paint_only_since(before),
-        "a cancelled running source-cache warm must not force playback surface frames"
+        "the running batch returns its deferred paths through cancellation completion"
     );
 
     state.apply_message(
@@ -1054,7 +1047,7 @@ fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediate
                 running_ticket,
                 source_root.path().display().to_string(),
                 Vec::new(),
-                vec![second],
+                vec![second.clone()],
                 1,
                 true,
                 true,
@@ -1067,8 +1060,20 @@ fn running_active_folder_cache_warm_pause_for_playback_clears_progress_immediate
         "cancelled warm completion should retire the tracked running task"
     );
     assert!(
-        state.waveform.cache.active_folder_warm_pending.is_empty(),
-        "cancelled warm completion should not repopulate abandoned playback-time work"
+        state
+            .waveform
+            .cache
+            .active_folder_warm_pending
+            .iter()
+            .any(|path| path == &second),
+        "cancelled warm completion should restore unfinished playback-time work"
+    );
+
+    state.waveform.current.stop_playback();
+    state.maybe_start_active_folder_cache_warm(&mut context);
+    assert!(
+        active_folder_cache_warm_ticket(&state).is_some(),
+        "the preserved backlog should resume once playback stops"
     );
 }
 

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -66,10 +66,12 @@ pub(in crate::native_app) use audio_file::{
     cached_waveform_file_exists, decode_wav_preview_clip, ensure_persisted_playback_summary,
     file_backed_wav_playback_descriptor, flush_background_waveform_cache_stores_for_shutdown,
     instant_waveform_head_preview_from_clip, invalidate_persisted_waveform_cache_path,
-    invalidate_persisted_waveform_cache_paths, load_cached_waveform_file_for_playback,
-    load_cached_waveform_playback_descriptor_sidecar, load_wav_detail_summary,
-    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
-    should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
+    invalidate_persisted_waveform_cache_paths, invalidate_persisted_waveform_cache_ref,
+    load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
+    load_wav_detail_summary, mark_cached_waveform_file_source_warm_attempted,
+    persisted_waveform_cache_ref_is_current, remap_persisted_waveform_cache_after_move,
+    remap_persisted_waveform_cache_ref_after_move, should_use_file_backed_wav_decode,
+    should_use_file_backed_wav_decode_for_entry,
 };
 #[cfg(test)]
 pub(super) use audio_file::{

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -25,9 +25,10 @@ pub(in crate::native_app) use cache_facade::cached_waveform_file_playback_ready_
 pub(in crate::native_app) use cache_facade::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
     flush_background_waveform_cache_stores_for_shutdown, invalidate_persisted_waveform_cache_path,
-    invalidate_persisted_waveform_cache_paths, load_cached_waveform_file_for_playback,
-    load_cached_waveform_playback_descriptor_sidecar,
-    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
+    invalidate_persisted_waveform_cache_paths, invalidate_persisted_waveform_cache_ref,
+    load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
+    mark_cached_waveform_file_source_warm_attempted, persisted_waveform_cache_ref_is_current,
+    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
 };
 #[cfg(test)]
 pub(in crate::native_app) use cache_facade::{

--- a/src/native_app/waveform/audio_file/cache_facade.rs
+++ b/src/native_app/waveform/audio_file/cache_facade.rs
@@ -3,9 +3,10 @@ pub(in crate::native_app) use super::waveform_cache::cached_waveform_file_playba
 pub(in crate::native_app) use super::waveform_cache::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
     flush_background_waveform_cache_stores_for_shutdown, invalidate_persisted_waveform_cache_path,
-    invalidate_persisted_waveform_cache_paths, load_cached_waveform_file_for_playback,
-    load_cached_waveform_playback_descriptor_sidecar,
-    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
+    invalidate_persisted_waveform_cache_paths, invalidate_persisted_waveform_cache_ref,
+    load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
+    mark_cached_waveform_file_source_warm_attempted, persisted_waveform_cache_ref_is_current,
+    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
 };
 
 #[cfg(test)]

--- a/src/native_app/waveform/audio_file/loader.rs
+++ b/src/native_app/waveform/audio_file/loader.rs
@@ -57,11 +57,16 @@ pub(in crate::native_app::waveform) fn load_waveform_file_with_progress_and_canc
 pub(in crate::native_app) fn ensure_persisted_playback_summary(
     path: PathBuf,
     cancel: &std::sync::atomic::AtomicBool,
-) -> Result<(), String> {
+) -> Result<PathBuf, String> {
     use std::sync::atomic::Ordering;
 
     if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
-        return Ok(());
+        return waveform_cache::persisted_waveform_cache_ref(&path).ok_or_else(|| {
+            format!(
+                "waveform cache reference is unavailable: {}",
+                path.display()
+            )
+        });
     }
     let file = load_waveform_file_with_progress_cancel_playback_ready_and_cache_policy(
         path.clone(),
@@ -78,7 +83,12 @@ pub(in crate::native_app) fn ensure_persisted_playback_summary(
     }
     waveform_cache::persist_cached_waveform_file(&file)?;
     if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
-        Ok(())
+        waveform_cache::persisted_waveform_cache_ref(&path).ok_or_else(|| {
+            format!(
+                "waveform cache reference is unavailable after persistence: {}",
+                path.display()
+            )
+        })
     } else {
         Err(format!(
             "waveform cache did not publish an audition-ready summary: {}",

--- a/src/native_app/waveform/audio_file/waveform_cache.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache.rs
@@ -6,6 +6,7 @@ use format::CACHE_FORMAT_VERSION;
 use identity::CacheIdentity;
 pub(in crate::native_app) use invalidation::{
     invalidate_persisted_waveform_cache_path, invalidate_persisted_waveform_cache_paths,
+    invalidate_persisted_waveform_cache_ref,
 };
 pub(in crate::native_app) use playback_load::{
     load_cached_waveform_file_for_playback, load_cached_waveform_file_summary,
@@ -19,7 +20,9 @@ use read::read_cached_waveform_file;
 pub(in crate::native_app) use read::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
 };
-pub(in crate::native_app) use remap::remap_persisted_waveform_cache_after_move;
+pub(in crate::native_app) use remap::{
+    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
+};
 pub(in crate::native_app) use store_queue::flush_background_waveform_cache_stores_for_shutdown;
 pub(super) use store_queue::persist_cached_waveform_file;
 #[cfg(test)]
@@ -44,6 +47,20 @@ const GIB: usize = 1024 * 1024 * 1024;
 pub(super) const MAX_PERSISTED_PLAYBACK_SAMPLE_BYTES: usize = 8 * GIB;
 pub(super) const MAX_PERSISTED_WAVEFORM_CACHE_BYTES: u64 = 64 * GIB as u64;
 pub(super) const BACKGROUND_STORE_SHUTDOWN_WAIT: Duration = Duration::from_secs(30);
+
+pub(in crate::native_app) fn persisted_waveform_cache_ref(
+    path: &std::path::Path,
+) -> Option<PathBuf> {
+    identity::cache_path_for_current_file(path).ok()
+}
+
+pub(in crate::native_app) fn persisted_waveform_cache_ref_is_current(
+    path: &std::path::Path,
+    cache_ref: &std::path::Path,
+) -> bool {
+    identity::cache_path_for_current_file(path).is_ok_and(|current| current == cache_ref)
+        && read::cached_waveform_file_audition_ready_exists(path)
+}
 
 pub(super) fn load_cached_waveform_file(
     path: PathBuf,

--- a/src/native_app/waveform/audio_file/waveform_cache/identity.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/identity.rs
@@ -43,6 +43,21 @@ pub(super) fn cache_path_for_identity(
     Ok(dir.join(format!("{:016x}.wfc", hasher.finish())))
 }
 
+pub(super) fn cache_path_for_current_file(path: &Path) -> Result<PathBuf, String> {
+    let identity = CacheIdentity::for_path(path)?;
+    cache_path_for_identity(path, &identity)
+}
+
+pub(super) fn cache_ref_is_managed(cache_ref: &Path) -> bool {
+    let Ok(cache_dir) = wavecrate::app_dirs::waveform_cache_dir() else {
+        return false;
+    };
+    cache_ref.parent() == Some(cache_dir.as_path())
+        && cache_ref
+            .extension()
+            .is_some_and(|extension| extension == "wfc")
+}
+
 pub(super) fn playback_ready_marker_path(cache_path: &Path) -> PathBuf {
     cache_path.with_extension("ready")
 }

--- a/src/native_app/waveform/audio_file/waveform_cache/invalidation.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/invalidation.rs
@@ -27,6 +27,16 @@ pub(in crate::native_app) fn invalidate_persisted_waveform_cache_paths(paths: &[
     }
 }
 
+/// Remove one exact cache payload and every companion without consulting the source file.
+///
+/// This is the reverse-ownership cleanup path used after the source file was replaced or deleted
+/// and its old metadata can no longer be reconstructed from disk.
+pub(in crate::native_app) fn invalidate_persisted_waveform_cache_ref(cache_ref: &Path) {
+    if super::identity::cache_ref_is_managed(cache_ref) {
+        cleanup_cache_artifacts(cache_ref);
+    }
+}
+
 pub(super) fn current_path_generation(path: &Path) -> u64 {
     CACHE_PATH_GENERATIONS
         .lock()

--- a/src/native_app/waveform/audio_file/waveform_cache/prune.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/prune.rs
@@ -6,6 +6,7 @@ use std::{
 
 use super::identity::{
     playback_descriptor_path, playback_ready_marker_path, playback_sidecar_path,
+    source_warm_marker_path,
 };
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -59,10 +60,9 @@ pub(super) fn prune_waveform_cache_dir(
             }
             continue;
         }
-        if path
-            .extension()
-            .is_some_and(|extension| extension == "ready")
-        {
+        if path.extension().is_some_and(|extension| {
+            extension == "ready" || extension == "playback" || extension == "source-ready"
+        }) {
             if !path.with_extension("wfc").is_file() {
                 if fs::remove_file(path).is_ok() {
                     outcome.orphan_marker_removed += 1;
@@ -125,6 +125,9 @@ pub(super) fn prune_waveform_cache_dir(
                 outcome.companion_remove_failed += 1;
             }
             if remove_if_exists(playback_sidecar_path(&entry.path)).is_err() {
+                outcome.companion_remove_failed += 1;
+            }
+            if remove_if_exists(source_warm_marker_path(&entry.path)).is_err() {
                 outcome.companion_remove_failed += 1;
             }
             total_bytes = total_bytes.saturating_sub(entry.len);

--- a/src/native_app/waveform/audio_file/waveform_cache/read.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/read.rs
@@ -204,6 +204,20 @@ pub(super) fn read_cached_waveform_file(
     outcome.into_hit()
 }
 
+pub(super) fn read_cached_waveform_file_at_ref(
+    source_path: &Path,
+    cache_ref: &Path,
+) -> Option<CachedWaveformFile> {
+    let outcome = read_cache_file(
+        source_path,
+        cache_ref.to_path_buf(),
+        "browser.sample_cache.owned_metadata_read",
+        "browser.sample_cache.owned_metadata_deserialize",
+    );
+    outcome.log_if_unusable(source_path, CACHE_FORMAT_VERSION);
+    outcome.into_hit()
+}
+
 pub(super) fn read_cached_waveform_file_outcome(
     path: &Path,
     identity: &CacheIdentity,

--- a/src/native_app/waveform/audio_file/waveform_cache/remap.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/remap.rs
@@ -10,7 +10,6 @@ use super::{
         playback_ready_marker_path, playback_sidecar_path, playback_sidecar_valid,
         source_warm_marker_path,
     },
-    read::read_cached_waveform_file,
     write::{
         mark_source_warm_ready_for_cache_path, update_playback_ready_marker,
         write_playback_descriptor_sidecar,
@@ -43,6 +42,35 @@ pub(in crate::native_app) fn remap_persisted_waveform_cache_after_move(
     }
 }
 
+/// Remap an exact reverse-owned cache payload after a committed path-only move.
+///
+/// Unlike the legacy path-only entrypoint, this remains usable after the old source path has
+/// disappeared because the caller supplies the previously persisted cache reference.
+pub(in crate::native_app) fn remap_persisted_waveform_cache_ref_after_move(
+    old_cache_ref: &Path,
+    old_path: &Path,
+    new_path: &Path,
+) -> Option<PathBuf> {
+    if !super::identity::cache_ref_is_managed(old_cache_ref) || !new_path.is_file() {
+        return None;
+    }
+    match remap_file_from_cache_ref(old_cache_ref, old_path, new_path) {
+        Ok(cache_ref) => cache_ref,
+        Err(err) => {
+            tracing::debug!(
+                target: "wavecrate::debug::sample_cache",
+                event = "browser.sample_cache.owned_move_remap_failed",
+                old_cache_ref = %old_cache_ref.display(),
+                old_path = %old_path.display(),
+                new_path = %new_path.display(),
+                error = %err,
+                "Reverse-owned waveform cache could not be remapped after file move"
+            );
+            None
+        }
+    }
+}
+
 fn remap_directory(old_dir: &Path, new_dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(new_dir) else {
         return 0;
@@ -69,15 +97,29 @@ fn remap_file(old_path: &Path, new_path: &Path) -> Result<bool, String> {
     if !old_cache_path.is_file() {
         return Ok(false);
     }
-    let Some(cached) = read_cached_waveform_file(old_path, &identity) else {
-        return Ok(false);
+    remap_file_from_cache_ref(&old_cache_path, old_path, new_path)
+        .map(|cache_ref| cache_ref.is_some())
+}
+
+fn remap_file_from_cache_ref(
+    old_cache_path: &Path,
+    old_path: &Path,
+    new_path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    if !old_cache_path.is_file() {
+        return Ok(None);
+    }
+    let identity = CacheIdentity::for_path(new_path)?;
+    let Some(cached) = super::read::read_cached_waveform_file_at_ref(old_path, old_cache_path)
+    else {
+        return Ok(None);
     };
     let new_cache_path = cache_path_for_identity(new_path, &identity)?;
     let Some(mut moved_cache) = cached
         .clone()
         .into_moved_path(old_path, new_path, &identity)
     else {
-        return Ok(false);
+        return Ok(None);
     };
 
     let sidecar_paths = valid_playback_sidecar_paths(&cached, &old_cache_path, &new_cache_path);
@@ -107,7 +149,7 @@ fn remap_file(old_path: &Path, new_path: &Path) -> Result<bool, String> {
         let _ = update_playback_ready_marker(&new_cache_path, false);
     }
     cleanup_old_cache_artifacts(&old_cache_path);
-    Ok(true)
+    Ok(Some(new_cache_path))
 }
 
 fn valid_playback_sidecar_paths(

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/identity_staleness.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/identity_staleness.rs
@@ -79,6 +79,50 @@ fn invalidating_path_removes_current_persisted_playback_cache() {
 }
 
 #[test]
+fn reverse_owned_invalidation_removes_cache_after_source_file_is_deleted() {
+    let _guard = waveform_cache_test_guard();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("deleted.wav");
+    fs::write(&path, [1_u8, 2, 3, 4]).expect("write sample");
+    let mut file = waveform_file_from_mono_samples(
+        path.clone(),
+        Arc::from([1_u8, 2, 3, 4]),
+        48_000,
+        1,
+        vec![0.0, 0.5, -0.5, 0.25],
+    );
+    file.playback_samples = Some(Arc::from(vec![0.0, 0.5, -0.5, 0.25]));
+    store_cached_waveform_file(&file);
+    let cache_ref = persisted_waveform_cache_ref(&path).expect("cache reference");
+    let descriptor = playback_descriptor_path(&cache_ref);
+    let sidecar = playback_sidecar_path(&cache_ref);
+    assert!(cache_ref.is_file());
+    assert!(descriptor.is_file());
+    assert!(sidecar.is_file());
+
+    fs::remove_file(&path).expect("delete source file");
+    invalidate_persisted_waveform_cache_ref(&cache_ref);
+
+    assert!(!cache_ref.exists());
+    assert!(!descriptor.exists());
+    assert!(!sidecar.exists());
+    assert!(!playback_ready_marker_path(&cache_ref).exists());
+    assert!(!source_warm_marker_path(&cache_ref).exists());
+}
+
+#[test]
+fn reverse_owned_invalidation_refuses_paths_outside_the_managed_cache_directory() {
+    let _guard = waveform_cache_test_guard();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let outside = dir.path().join("outside.wfc");
+    fs::write(&outside, [1_u8, 2, 3, 4]).expect("write outside payload");
+
+    invalidate_persisted_waveform_cache_ref(&outside);
+
+    assert!(outside.is_file());
+}
+
+#[test]
 fn invalidating_path_makes_existing_store_job_stale() {
     let _guard = waveform_cache_test_guard();
     let dir = tempfile::tempdir().expect("tempdir");

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/prune_behavior.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/prune_behavior.rs
@@ -9,10 +9,14 @@ fn waveform_cache_prune_removes_old_payloads_and_stale_temps() {
     let pinned_path = dir.path().join("pinned.wfc");
     let temp_path = dir.path().join("stale.tmp");
     let old_sidecar = playback_sidecar_path(&old_path);
+    let old_source_ready = source_warm_marker_path(&old_path);
+    let pinned_source_ready = source_warm_marker_path(&pinned_path);
     fs::write(&old_path, [0_u8; 4]).expect("write old cache");
     fs::write(&old_sidecar, [9_u8; 8]).expect("write old sidecar");
+    fs::write(&old_source_ready, []).expect("write old source-ready marker");
     fs::write(&newer_path, [1_u8; 4]).expect("write newer cache");
     fs::write(&pinned_path, [2_u8; 4]).expect("write pinned cache");
+    fs::write(&pinned_source_ready, []).expect("write pinned source-ready marker");
     fs::write(&temp_path, [3_u8; 4]).expect("write temp cache");
 
     set_file_modified_seconds(&old_path, 10);
@@ -23,9 +27,11 @@ fn waveform_cache_prune_removes_old_payloads_and_stale_temps() {
 
     assert!(!old_path.exists());
     assert!(!old_sidecar.exists());
+    assert!(!old_source_ready.exists());
     assert!(!temp_path.exists());
     assert!(newer_path.exists());
     assert!(pinned_path.exists());
+    assert!(pinned_source_ready.exists());
     assert_eq!(prune.stale_temp_removed, 1);
     assert_eq!(prune.cache_removed, 1);
     assert_eq!(prune.companion_remove_failed, 0);

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/remap_behavior.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/remap_behavior.rs
@@ -34,6 +34,37 @@ fn persisted_waveform_cache_remaps_playback_sidecar_after_file_move() {
 }
 
 #[test]
+fn reverse_owned_cache_ref_remaps_after_old_source_path_disappears() {
+    let _guard = waveform_cache_test_guard();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let old_path = dir.path().join("owned-old.wav");
+    let new_path = dir.path().join("owned-new.wav");
+    fs::write(&old_path, [1_u8, 2, 3, 4]).expect("write sample");
+    let mut file = waveform_file_from_mono_samples(
+        old_path.clone(),
+        Arc::from([1_u8, 2, 3, 4]),
+        48_000,
+        1,
+        vec![0.0, 0.5, -0.5, 0.25],
+    );
+    file.playback_samples = Some(Arc::from(vec![0.0, 0.5, -0.5, 0.25]));
+    store_cached_waveform_file(&file);
+    let old_cache_ref = persisted_waveform_cache_ref(&old_path).expect("old cache reference");
+
+    fs::rename(&old_path, &new_path).expect("move sample");
+    let new_cache_ref =
+        remap_persisted_waveform_cache_ref_after_move(&old_cache_ref, &old_path, &new_path)
+            .expect("remap reverse-owned cache");
+
+    assert!(!old_cache_ref.exists());
+    assert!(new_cache_ref.is_file());
+    assert!(persisted_waveform_cache_ref_is_current(
+        &new_path,
+        &new_cache_ref
+    ));
+}
+
+#[test]
 fn persisted_waveform_cache_remaps_source_ready_summary_after_file_move() {
     let _guard = waveform_cache_test_guard();
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Goal

Make every eligible current source file converge automatically to bounded playback and waveform readiness, without requiring Process Source and without losing unfinished warming work when playback begins.

## Scope and non-goals

- Publish playback-summary readiness through the existing automatic source-processing supervisor.
- Store source-relative path and exact app-global cache reference atomically with readiness completion.
- Reconcile owned cache references after edits, deletion, path-only moves, restart, and cache pruning.
- Preserve and resume cancelled persisted-cache and active-folder warm batches across playback/interactive yielding.
- Keep long WAVs file-backed; decoded PCM remains optional and bounded.
- Extend cache pruning to remove all companions while preserving pinned entries.
- No playback-quality changes, eager whole-library PCM decode, or source-removal workflow expansion.

## Definition of Done

- [x] Missing/stale playback readiness is discovered automatically from the current durable source manifest.
- [x] Requested/visible/folder/source priority and fair background scheduling continue through the supervisor.
- [x] Playback and foreground work pause/yield background warming and resume the retained backlog.
- [x] Playback cache ownership records source, relative path, content generation, artifact version, and exact cache reference under one completion fence.
- [x] Deleted/replaced identities retire exact stale cache payloads without old filesystem metadata.
- [x] Path-only moves remap reusable cache payloads after the old path disappears.
- [x] Pruned payloads invalidate readiness and converge again; pinned cache entries remain protected.
- [x] Long-file readiness stays summary/file-backed without a persisted PCM sidecar.

## Validation

- `cargo check -p wavecrate --all-targets` — passed
- `cargo test -p wavecrate-library sample_sources::readiness` — 40 passed
- `cargo test -p wavecrate-library sample_sources::db::schema::migrations::tests` — 7 passed
- `cargo test -p wavecrate-analysis similarity_artifacts` — 6 passed
- `cargo test -p wavecrate --bin wavecrate cancellation_tests` — 2 passed
- `cargo test -p wavecrate --bin wavecrate running_active_folder_cache_warm_pause_for_playback_preserves_and_resumes_backlog` — passed
- `cargo test -p wavecrate --bin wavecrate waveform_cache::tests` — 26 passed
- `cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests:: -- --test-threads=1` — 48 passed, 1 ignored
- `cargo test -p wavecrate --bin wavecrate committed_file_mutations` — 14 passed
- `cargo test -p wavecrate --bin wavecrate source_watcher` — 17 passed
- `bash scripts/ci.sh agent` — passed, including non-blocking architecture checks, Radiant 1,650 tests, and Wavecrate 1,855 tests
- `cargo test -p wavecrate --bin wavecrate profile_large_source_discovery_baseline -- --ignored --nocapture --test-threads=1` — passed for 10,000 files / 40,001 candidates (debug profile)

## Known limitations

None.

User approval is required before merge.

Linear: OPT-1182