### PR TITLE
OPT-1198 Block similarity finalization until prerequisites converge

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
@@ -136,6 +136,34 @@ pub struct ReadinessSnapshot {
 }
 
 impl ReadinessSnapshot {
+    /// Whether the exact target's upstream durable artifacts are current.
+    ///
+    /// File-scoped stages are independently schedulable. Source-level similarity publication
+    /// depends on every eligible identity, analysis, and embedding target in the same source
+    /// generation, so it must stay parked until those exact artifacts have converged.
+    pub fn prerequisites_are_current(&self, target: &ReadinessTarget) -> bool {
+        if target.stage != ReadinessStage::SimilarityLayout {
+            return true;
+        }
+        target.source_id == self.source_id
+            && target.source_generation == self.source_generation
+            && self
+                .entries
+                .iter()
+                .filter(|entry| {
+                    entry.target.source_id == target.source_id
+                        && entry.target.source_generation == target.source_generation
+                        && matches!(
+                            entry.target.stage,
+                            ReadinessStage::IndexedIdentity
+                                | ReadinessStage::AnalysisFeatures
+                                | ReadinessStage::EmbeddingAspects
+                        )
+                        && entry.target.eligibility == ReadinessEligibility::Eligible
+                })
+                .all(|entry| entry.classification == ReadinessClassification::Current)
+    }
+
     /// Whether the coordinator has no immediately actionable deficit.
     pub fn is_idle(&self) -> bool {
         self.activity == ReadinessActivity::Idle

--- a/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
-use super::model::{ReadinessEligibility, ReadinessStage, ReadinessTarget, SourceAvailability};
+use super::model::{
+    ReadinessEligibility, ReadinessScopeKind, ReadinessStage, ReadinessTarget, SourceAvailability,
+};
 
 /// Authoritative classification for one target at one reconciliation instant.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -153,6 +155,7 @@ impl ReadinessSnapshot {
                 .filter(|entry| {
                     entry.target.source_id == target.source_id
                         && entry.target.source_generation == target.source_generation
+                        && entry.target.scope_kind == ReadinessScopeKind::File
                         && matches!(
                             entry.target.stage,
                             ReadinessStage::IndexedIdentity

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -59,6 +59,34 @@ pub fn claim_readiness_target(
                         AND (job.lease_expires_at IS NULL OR job.lease_expires_at <= ?8)
                     )
                )
+               AND (
+                    target.stage <> 'similarity_layout'
+                    OR NOT EXISTS (
+                        SELECT 1
+                        FROM source_readiness_targets AS prerequisite
+                        WHERE prerequisite.source_id = target.source_id
+                          AND prerequisite.source_generation = target.source_generation
+                          AND prerequisite.scope_kind = 'file'
+                          AND prerequisite.stage IN (
+                              'indexed_identity',
+                              'analysis_features',
+                              'embedding_aspects'
+                          )
+                          AND prerequisite.eligibility = 'eligible'
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM source_readiness_artifacts AS prerequisite_artifact
+                              WHERE prerequisite_artifact.source_id = prerequisite.source_id
+                                AND prerequisite_artifact.scope_kind = prerequisite.scope_kind
+                                AND prerequisite_artifact.scope_id = prerequisite.scope_id
+                                AND prerequisite_artifact.stage = prerequisite.stage
+                                AND prerequisite_artifact.artifact_version =
+                                    prerequisite.required_version
+                                AND prerequisite_artifact.content_generation =
+                                    prerequisite.content_generation
+                          )
+                    )
+               )
                AND NOT EXISTS (
                     SELECT 1
                     FROM source_readiness_artifacts AS artifact

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -308,6 +308,164 @@ fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
 }
 
 #[test]
+fn similarity_layout_waits_for_delayed_embeddings_without_hot_reclaiming() {
+    const FILE_COUNT: usize = 19;
+    const DELAYED_EMBEDDINGS: usize = 4;
+    const NOW: i64 = 100;
+    const RETRY_AT: i64 = 180;
+
+    let (_root, mut connection) = open_fixture();
+    let mut targets = Vec::with_capacity(FILE_COUNT * 4 + 1);
+    for index in 0..FILE_COUNT {
+        let identity = format!("sample-{index:02}");
+        for stage in [
+            ReadinessStage::IndexedIdentity,
+            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
+            ReadinessStage::EmbeddingAspects,
+        ] {
+            targets.push(file_target(&identity, stage, 1));
+        }
+    }
+    let layout = ReadinessTarget::source(
+        SOURCE_ID,
+        ReadinessStage::SimilarityLayout,
+        "layout-v1",
+        1,
+        "membership-v1",
+    );
+    targets.push(layout.clone());
+    replace(&mut connection, 1, &targets);
+
+    let initial = reconcile_readiness(&connection, SOURCE_ID, NOW).expect("initial snapshot");
+    assert_eq!(initial.deficits.len(), FILE_COUNT * 4 + 1);
+    persist_readiness_deficits(&mut connection, &initial.deficits, NOW)
+        .expect("persist exact readiness queue");
+
+    let retry_policy =
+        ReadinessRetryPolicy::new(RETRY_AT - NOW, RETRY_AT - NOW, 3).expect("retry policy");
+    let mut delayed = Vec::new();
+    for target in targets
+        .iter()
+        .filter(|target| target.stage != ReadinessStage::SimilarityLayout)
+    {
+        let claim = claim_readiness_target(&mut connection, target, NOW, 100)
+            .expect("claim file readiness")
+            .expect("file readiness available");
+        let embedding_index = target
+            .scope_id
+            .strip_prefix("sample-")
+            .and_then(|value| value.parse::<usize>().ok());
+        if target.stage == ReadinessStage::EmbeddingAspects
+            && embedding_index.is_some_and(|index| index >= FILE_COUNT - DELAYED_EMBEDDINGS)
+        {
+            assert_eq!(
+                fail_readiness_work(
+                    &mut connection,
+                    &claim,
+                    ReadinessFailureClassification::Retryable,
+                    "embedding feature prerequisite is not durable yet",
+                    NOW,
+                    retry_policy,
+                )
+                .expect("delay embedding"),
+                ReadinessFailureOutcome::RetryScheduled { retry_at: RETRY_AT }
+            );
+            delayed.push(target.clone());
+        } else {
+            assert_eq!(
+                complete_readiness_work(&mut connection, &claim, NOW)
+                    .expect("complete file readiness"),
+                ArtifactPublishOutcome::Recorded
+            );
+        }
+    }
+    assert_eq!(delayed.len(), DELAYED_EMBEDDINGS);
+
+    let waiting =
+        reconcile_readiness(&connection, SOURCE_ID, NOW + 1).expect("waiting similarity snapshot");
+    assert_eq!(waiting.deficits.len(), 1);
+    assert_eq!(waiting.deficits[0].target, layout);
+    assert!(!waiting.prerequisites_are_current(&layout));
+    let stats = readiness_work_stats(&connection, NOW + 1).expect("72 of 77 stats");
+    assert_eq!(stats.completed, 72);
+    assert_eq!(stats.total, 77);
+    assert_eq!(stats.pending, 1);
+    assert_eq!(stats.retries_waiting, DELAYED_EMBEDDINGS);
+    assert_eq!(stats.earliest_retry_at, Some(RETRY_AT));
+    assert_eq!(
+        claim_readiness_target(&mut connection, &layout, NOW + 1, 100)
+            .expect("blocked layout claim"),
+        None
+    );
+
+    let retry_due =
+        reconcile_readiness(&connection, SOURCE_ID, RETRY_AT).expect("retry-due snapshot");
+    assert_eq!(retry_due.deficits.len(), DELAYED_EMBEDDINGS + 1);
+    assert_eq!(
+        retry_due
+            .deficits
+            .iter()
+            .filter(|deficit| retry_due.prerequisites_are_current(&deficit.target))
+            .count(),
+        DELAYED_EMBEDDINGS
+    );
+    for target in &delayed {
+        let claim = claim_readiness_target(&mut connection, target, RETRY_AT, 100)
+            .expect("claim delayed embedding")
+            .expect("delayed embedding is due");
+        assert_eq!(
+            complete_readiness_work(&mut connection, &claim, RETRY_AT)
+                .expect("complete delayed embedding"),
+            ArtifactPublishOutcome::Recorded
+        );
+    }
+
+    let analysis = targets
+        .iter()
+        .find(|target| {
+            target.scope_id == "sample-00" && target.stage == ReadinessStage::AnalysisFeatures
+        })
+        .expect("analysis prerequisite");
+    connection
+        .execute(
+            "DELETE FROM source_readiness_artifacts
+             WHERE source_id = ?1
+               AND scope_kind = 'file'
+               AND scope_id = ?2
+               AND stage = 'analysis_features'",
+            rusqlite::params![analysis.source_id, analysis.scope_id],
+        )
+        .expect("remove one analysis prerequisite");
+    let inconsistent = reconcile_readiness(&connection, SOURCE_ID, RETRY_AT + 1)
+        .expect("inconsistent prerequisite snapshot");
+    assert!(!inconsistent.prerequisites_are_current(&layout));
+    assert_eq!(
+        claim_readiness_target(&mut connection, &layout, RETRY_AT + 1, 100)
+            .expect("analysis-blocked layout claim"),
+        None
+    );
+    assert_eq!(
+        publish_readiness_artifact(
+            &mut connection,
+            &ReadinessArtifact::for_target(analysis, RETRY_AT + 1),
+        )
+        .expect("restore analysis prerequisite"),
+        ArtifactPublishOutcome::Recorded
+    );
+
+    let ready =
+        reconcile_readiness(&connection, SOURCE_ID, RETRY_AT + 2).expect("layout-ready snapshot");
+    assert_eq!(ready.deficits.len(), 1);
+    assert!(ready.prerequisites_are_current(&layout));
+    assert!(
+        claim_readiness_target(&mut connection, &layout, RETRY_AT + 2, 100)
+            .expect("claim unblocked layout")
+            .is_some()
+    );
+}
+
+#[test]
 fn explicit_failure_classifications_are_terminal_and_observable() {
     let (_root, mut connection) = open_fixture();
     let permanent = file_target("permanent", ReadinessStage::AnalysisFeatures, 1);

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -1139,6 +1139,7 @@ struct RuntimeCandidate {
 #[derive(Clone, Copy, Debug, Default)]
 struct SourceDiscoveryStats {
     readiness_queue_depth: usize,
+    prerequisites_blocked: usize,
     retries_due: usize,
     earliest_retry_at: Option<i64>,
     progress_completed: usize,
@@ -1217,10 +1218,15 @@ fn run_coordinator(shared: Arc<Shared>) {
                     next_safety_sweep_at.saturating_duration_since(Instant::now()),
                     control.processing_paused(),
                 );
-                if progress_visible && !wait_duration.is_zero() {
+                if progress_visible
+                    && !wait_duration.is_zero()
+                    && !source_stats
+                        .values()
+                        .any(|stats| stats.prerequisites_blocked > 0)
+                {
                     // Keep feedback stable across immediate coordinator handoffs. Only clear it
                     // when the coordinator is genuinely about to sleep with no newly published
-                    // work waiting to be handled.
+                    // work or prerequisite retry waiting to be handled.
                     publish_source_processing_finished(&shared);
                     progress_visible = false;
                     active_progress_source = None;
@@ -1632,6 +1638,17 @@ fn run_coordinator(shared: Arc<Shared>) {
         {
             last_similarity_refresh_publish_at = Some(Instant::now());
         }
+        if candidates.is_empty()
+            && publish_source_processing_prerequisite_wait(
+                &shared,
+                &source_lifecycle_generations,
+                &source_stats,
+            )
+        {
+            progress_visible = true;
+            active_progress_source = None;
+            last_progress_publish_at = Some(Instant::now());
+        }
         let mut telemetry = shared.telemetry();
         telemetry.queue_depth = candidates.len();
         telemetry.oldest_job_age_seconds = oldest_job_age_seconds(&candidates, now_epoch_seconds());
@@ -1926,6 +1943,63 @@ fn publish_source_processing_finished(shared: &Shared) {
     ));
 }
 
+fn publish_source_processing_prerequisite_wait(
+    shared: &Shared,
+    lifecycle_generations: &BTreeMap<String, u64>,
+    source_stats: &BTreeMap<String, SourceDiscoveryStats>,
+) -> bool {
+    let Some((source_id, stats)) = source_stats
+        .iter()
+        .filter(|(_, stats)| stats.prerequisites_blocked > 0)
+        .min_by_key(|(_, stats)| stats.earliest_retry_at.unwrap_or(i64::MAX))
+    else {
+        return false;
+    };
+    let Some(lifecycle_generation) = lifecycle_generations.get(source_id).copied() else {
+        return false;
+    };
+    let control = shared.control();
+    if control.processing_paused()
+        || !control.source_is_active(source_id)
+        || control.source_lifecycle_generations.get(source_id) != Some(&lifecycle_generation)
+    {
+        return false;
+    }
+    drop(control);
+    let Some(worker_sender) = shared.worker_sender.as_ref() else {
+        return false;
+    };
+    let (stage, detail) = match stats.earliest_retry_at {
+        Some(retry_at) => {
+            let retry_in = retry_at.saturating_sub(now_epoch_seconds());
+            (
+                String::from("Waiting for prerequisites"),
+                if retry_in <= 1 {
+                    String::from("Prerequisite retry is due")
+                } else {
+                    format!("Retrying prerequisites in {retry_in}s")
+                },
+            )
+        }
+        None => (
+            String::from("Blocked by prerequisites"),
+            String::from("Similarity finalization is waiting for durable prerequisites"),
+        ),
+    };
+    let _ = worker_sender.send(GuiMessage::SourceProcessingProgress(
+        SourceProcessingProgress {
+            source_id: source_id.clone(),
+            lifecycle_generation,
+            active: true,
+            completed: stats.progress_completed,
+            total: stats.progress_total,
+            stage,
+            detail,
+        },
+    ));
+    true
+}
+
 fn publish_source_processing_pausing(shared: &Shared, detail: &str) {
     let Some(worker_sender) = shared.worker_sender.as_ref() else {
         return;
@@ -2217,6 +2291,10 @@ fn discover_source_candidates_with_connection(
             .filter(|deficit| snapshot.prerequisites_are_current(&deficit.target))
             .collect::<Vec<_>>();
         stats.readiness_queue_depth = schedulable_deficits.len();
+        stats.prerequisites_blocked = snapshot
+            .deficits
+            .len()
+            .saturating_sub(schedulable_deficits.len());
         candidates.extend(schedulable_deficits.iter().map(|deficit| RuntimeCandidate {
             schedule: WorkCandidate::readiness(&deficit.target, deficit.enqueued_at.unwrap_or(now)),
             source: source.clone(),
@@ -2240,10 +2318,7 @@ fn discover_source_candidates_with_connection(
             retries_due = work_stats.retries_due,
             retries_waiting = work_stats.retries_waiting,
             expired_leases = work_stats.expired_leases,
-            prerequisites_blocked = snapshot
-                .deficits
-                .len()
-                .saturating_sub(schedulable_deficits.len()),
+            prerequisites_blocked = stats.prerequisites_blocked,
             "Readiness work reconciled"
         );
     }
@@ -4146,6 +4221,9 @@ fn aggregate_source_stats(
             aggregate.readiness_queue_depth = aggregate
                 .readiness_queue_depth
                 .saturating_add(source.readiness_queue_depth);
+            aggregate.prerequisites_blocked = aggregate
+                .prerequisites_blocked
+                .saturating_add(source.prerequisites_blocked);
             aggregate.retries_due = aggregate.retries_due.saturating_add(source.retries_due);
             aggregate.earliest_retry_at =
                 earliest_deadline(aggregate.earliest_retry_at, source.earliest_retry_at);
@@ -5680,6 +5758,50 @@ mod tests {
         assert_eq!(progress.total, 9_985);
         assert_eq!(progress.stage, "Preparing similarity");
         assert_eq!(progress.detail, "drums/kick.wav");
+    }
+
+    #[test]
+    fn prerequisite_wait_feedback_preserves_determinate_progress_without_claiming_activity() {
+        let directory = tempfile::tempdir().expect("waiting source");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("waiting-source"),
+            directory.path().to_path_buf(),
+        );
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let shared = Shared::new(vec![source.clone()], Some(sender));
+        let lifecycle_generation = shared.control().source_lifecycle_generations["waiting-source"];
+        let lifecycle_generations =
+            BTreeMap::from([(String::from("waiting-source"), lifecycle_generation)]);
+        let source_stats = BTreeMap::from([(
+            String::from("waiting-source"),
+            SourceDiscoveryStats {
+                prerequisites_blocked: 1,
+                earliest_retry_at: Some(now_epoch_seconds().saturating_add(60)),
+                progress_completed: 72,
+                progress_total: 77,
+                ..SourceDiscoveryStats::default()
+            },
+        )]);
+
+        assert!(publish_source_processing_prerequisite_wait(
+            &shared,
+            &lifecycle_generations,
+            &source_stats,
+        ));
+
+        let GuiMessage::SourceProcessingProgress(progress) = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("prerequisite wait message")
+        else {
+            panic!("unexpected supervisor GUI message");
+        };
+        assert!(progress.active);
+        assert_eq!(progress.source_id, "waiting-source");
+        assert_eq!(progress.lifecycle_generation, lifecycle_generation);
+        assert_eq!(progress.completed, 72);
+        assert_eq!(progress.total, 77);
+        assert_eq!(progress.stage, "Waiting for prerequisites");
+        assert!(progress.detail.starts_with("Retrying prerequisites in "));
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -19,12 +19,12 @@ use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole, SourceMetadataStorage,
     db::{META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION},
     readiness::{
-        ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessEligibility,
-        ReadinessFailureClassification, ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome,
-        ReadinessRetryPolicy, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
-        SourceAvailability, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        complete_readiness_work_with_artifact_ref, fail_readiness_work,
-        invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
+        ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessClassification,
+        ReadinessEligibility, ReadinessFailureClassification, ReadinessFailureOutcome,
+        ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessSnapshot, ReadinessStage,
+        ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability, cancel_readiness_work,
+        claim_readiness_target, complete_readiness_work, complete_readiness_work_with_artifact_ref,
+        fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
         readiness_work_stats, reconcile_readiness_with_cancel, release_readiness_work,
         renew_readiness_lease, replace_readiness_targets_with_cancel,
     },
@@ -1140,6 +1140,7 @@ struct RuntimeCandidate {
 struct SourceDiscoveryStats {
     readiness_queue_depth: usize,
     prerequisites_blocked: usize,
+    prerequisite_retry_at: Option<i64>,
     retries_due: usize,
     earliest_retry_at: Option<i64>,
     progress_completed: usize,
@@ -1951,7 +1952,7 @@ fn publish_source_processing_prerequisite_wait(
     let Some((source_id, stats)) = source_stats
         .iter()
         .filter(|(_, stats)| stats.prerequisites_blocked > 0)
-        .min_by_key(|(_, stats)| stats.earliest_retry_at.unwrap_or(i64::MAX))
+        .min_by_key(|(_, stats)| stats.prerequisite_retry_at.unwrap_or(i64::MAX))
     else {
         return false;
     };
@@ -1969,7 +1970,7 @@ fn publish_source_processing_prerequisite_wait(
     let Some(worker_sender) = shared.worker_sender.as_ref() else {
         return false;
     };
-    let (stage, detail) = match stats.earliest_retry_at {
+    let (stage, detail) = match stats.prerequisite_retry_at {
         Some(retry_at) => {
             let retry_in = retry_at.saturating_sub(now_epoch_seconds());
             (
@@ -2070,6 +2071,44 @@ fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String)
         .map(str::to_string)
         .unwrap_or_else(|| String::from("Finalizing source"));
     (stage, detail)
+}
+
+fn similarity_prerequisite_blocker_stats(snapshot: &ReadinessSnapshot) -> (usize, Option<i64>) {
+    let Some(layout) = snapshot.entries.iter().find(|entry| {
+        entry.target.stage == ReadinessStage::SimilarityLayout
+            && entry.target.eligibility == ReadinessEligibility::Eligible
+            && entry.classification != ReadinessClassification::Current
+            && !snapshot.prerequisites_are_current(&entry.target)
+    }) else {
+        return (0, None);
+    };
+    let mut blocked = 0_usize;
+    let mut all_retryable = true;
+    let mut earliest_retry_at = None;
+    for entry in snapshot.entries.iter().filter(|entry| {
+        entry.target.source_id == layout.target.source_id
+            && entry.target.source_generation == layout.target.source_generation
+            && entry.target.eligibility == ReadinessEligibility::Eligible
+            && matches!(
+                entry.target.stage,
+                ReadinessStage::IndexedIdentity
+                    | ReadinessStage::AnalysisFeatures
+                    | ReadinessStage::EmbeddingAspects
+            )
+            && entry.classification != ReadinessClassification::Current
+    }) {
+        blocked = blocked.saturating_add(1);
+        match entry.classification {
+            ReadinessClassification::RetryableFailure { retry_at, .. } => {
+                earliest_retry_at = earliest_deadline(earliest_retry_at, Some(retry_at));
+            }
+            _ => all_retryable = false,
+        }
+    }
+    (
+        blocked,
+        all_retryable.then_some(earliest_retry_at).flatten(),
+    )
 }
 
 fn scheduler_candidate_indices(
@@ -2291,10 +2330,8 @@ fn discover_source_candidates_with_connection(
             .filter(|deficit| snapshot.prerequisites_are_current(&deficit.target))
             .collect::<Vec<_>>();
         stats.readiness_queue_depth = schedulable_deficits.len();
-        stats.prerequisites_blocked = snapshot
-            .deficits
-            .len()
-            .saturating_sub(schedulable_deficits.len());
+        (stats.prerequisites_blocked, stats.prerequisite_retry_at) =
+            similarity_prerequisite_blocker_stats(&snapshot);
         candidates.extend(schedulable_deficits.iter().map(|deficit| RuntimeCandidate {
             schedule: WorkCandidate::readiness(&deficit.target, deficit.enqueued_at.unwrap_or(now)),
             source: source.clone(),
@@ -5772,7 +5809,7 @@ mod tests {
         let lifecycle_generation = shared.control().source_lifecycle_generations["waiting-source"];
         let lifecycle_generations =
             BTreeMap::from([(String::from("waiting-source"), lifecycle_generation)]);
-        let source_stats = BTreeMap::from([(
+        let mut source_stats = BTreeMap::from([(
             String::from("waiting-source"),
             SourceDiscoveryStats {
                 prerequisites_blocked: 1,
@@ -5791,7 +5828,7 @@ mod tests {
 
         let GuiMessage::SourceProcessingProgress(progress) = receiver
             .recv_timeout(Duration::from_secs(1))
-            .expect("prerequisite wait message")
+            .expect("blocked prerequisite message")
         else {
             panic!("unexpected supervisor GUI message");
         };
@@ -5800,8 +5837,104 @@ mod tests {
         assert_eq!(progress.lifecycle_generation, lifecycle_generation);
         assert_eq!(progress.completed, 72);
         assert_eq!(progress.total, 77);
+        assert_eq!(progress.stage, "Blocked by prerequisites");
+        assert_eq!(
+            progress.detail,
+            "Similarity finalization is waiting for durable prerequisites"
+        );
+
+        source_stats
+            .get_mut("waiting-source")
+            .expect("waiting source stats")
+            .prerequisite_retry_at = Some(now_epoch_seconds().saturating_add(60));
+        assert!(publish_source_processing_prerequisite_wait(
+            &shared,
+            &lifecycle_generations,
+            &source_stats,
+        ));
+        let GuiMessage::SourceProcessingProgress(progress) = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("retrying prerequisite message")
+        else {
+            panic!("unexpected supervisor GUI message");
+        };
         assert_eq!(progress.stage, "Waiting for prerequisites");
         assert!(progress.detail.starts_with("Retrying prerequisites in "));
+    }
+
+    #[test]
+    fn similarity_blocker_state_ignores_unrelated_retry_deadlines() {
+        let source_id = "dependency-specific-retry";
+        let layout = ReadinessTarget::source(
+            source_id,
+            ReadinessStage::SimilarityLayout,
+            "layout-v1",
+            1,
+            "membership-v1",
+        );
+        let file_target = |stage| {
+            ReadinessTarget::file(
+                source_id,
+                "identity-1",
+                "kick.wav",
+                stage,
+                "v1",
+                1,
+                "content-1",
+            )
+        };
+        let mut snapshot = ReadinessSnapshot {
+            source_id: source_id.to_string(),
+            source_generation: 1,
+            readiness_revision: 1,
+            availability: SourceAvailability::Active,
+            entries: vec![
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: layout,
+                    classification: ReadinessClassification::Pending,
+                },
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: file_target(ReadinessStage::IndexedIdentity),
+                    classification: ReadinessClassification::Current,
+                },
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: file_target(ReadinessStage::AnalysisFeatures),
+                    classification: ReadinessClassification::Current,
+                },
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: file_target(ReadinessStage::EmbeddingAspects),
+                    classification: ReadinessClassification::PermanentFailure {
+                        reason: String::from("embedding failed permanently"),
+                    },
+                },
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: file_target(ReadinessStage::PlaybackSummary),
+                    classification: ReadinessClassification::RetryableFailure {
+                        retry_at: 200,
+                        reason: String::from("unrelated playback retry"),
+                    },
+                },
+            ],
+            deficits: Vec::new(),
+            stage_counts: BTreeMap::new(),
+            activity: wavecrate::sample_sources::readiness::ReadinessActivity::Idle,
+        };
+
+        assert_eq!(similarity_prerequisite_blocker_stats(&snapshot), (1, None));
+
+        snapshot
+            .entries
+            .iter_mut()
+            .find(|entry| entry.target.stage == ReadinessStage::EmbeddingAspects)
+            .expect("embedding blocker")
+            .classification = ReadinessClassification::RetryableFailure {
+            retry_at: 300,
+            reason: String::from("embedding retry"),
+        };
+        assert_eq!(
+            similarity_prerequisite_blocker_stats(&snapshot),
+            (1, Some(300))
+        );
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -21,10 +21,11 @@ use wavecrate::sample_sources::{
     readiness::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessClassification,
         ReadinessEligibility, ReadinessFailureClassification, ReadinessFailureOutcome,
-        ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessSnapshot, ReadinessStage,
-        ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability, cancel_readiness_work,
-        claim_readiness_target, complete_readiness_work, complete_readiness_work_with_artifact_ref,
-        fail_readiness_work, invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
+        ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessScopeKind, ReadinessSnapshot,
+        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability,
+        cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+        complete_readiness_work_with_artifact_ref, fail_readiness_work,
+        invalidate_readiness_artifact, persist_readiness_deficits_with_cancel,
         readiness_work_stats, reconcile_readiness_with_cancel, release_readiness_work,
         renew_readiness_lease, replace_readiness_targets_with_cancel,
     },
@@ -2088,6 +2089,7 @@ fn similarity_prerequisite_blocker_stats(snapshot: &ReadinessSnapshot) -> (usize
     for entry in snapshot.entries.iter().filter(|entry| {
         entry.target.source_id == layout.target.source_id
             && entry.target.source_generation == layout.target.source_generation
+            && entry.target.scope_kind == ReadinessScopeKind::File
             && entry.target.eligibility == ReadinessEligibility::Eligible
             && matches!(
                 entry.target.stage,
@@ -5863,7 +5865,7 @@ mod tests {
     }
 
     #[test]
-    fn similarity_blocker_state_ignores_unrelated_retry_deadlines() {
+    fn similarity_blocker_state_ignores_unrelated_retries_and_non_file_targets() {
         let source_id = "dependency-specific-retry";
         let layout = ReadinessTarget::source(
             source_id,
@@ -5890,7 +5892,7 @@ mod tests {
             availability: SourceAvailability::Active,
             entries: vec![
                 wavecrate::sample_sources::readiness::ReadinessEntry {
-                    target: layout,
+                    target: layout.clone(),
                     classification: ReadinessClassification::Pending,
                 },
                 wavecrate::sample_sources::readiness::ReadinessEntry {
@@ -5914,6 +5916,16 @@ mod tests {
                         reason: String::from("unrelated playback retry"),
                     },
                 },
+                wavecrate::sample_sources::readiness::ReadinessEntry {
+                    target: ReadinessTarget::source(
+                        source_id,
+                        ReadinessStage::AnalysisFeatures,
+                        "malformed-source-analysis-v1",
+                        1,
+                        "malformed-source-analysis-generation",
+                    ),
+                    classification: ReadinessClassification::Pending,
+                },
             ],
             deficits: Vec::new(),
             stage_counts: BTreeMap::new(),
@@ -5935,6 +5947,15 @@ mod tests {
             similarity_prerequisite_blocker_stats(&snapshot),
             (1, Some(300))
         );
+
+        snapshot
+            .entries
+            .iter_mut()
+            .find(|entry| entry.target.stage == ReadinessStage::EmbeddingAspects)
+            .expect("embedding blocker")
+            .classification = ReadinessClassification::Current;
+        assert!(snapshot.prerequisites_are_current(&layout));
+        assert_eq!(similarity_prerequisite_blocker_stats(&snapshot), (0, None));
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -2211,8 +2211,13 @@ fn discover_source_candidates_with_connection(
             }
             Err(error) => return Err(error.to_string()),
         }
-        stats.readiness_queue_depth = snapshot.deficits.len();
-        candidates.extend(snapshot.deficits.iter().map(|deficit| RuntimeCandidate {
+        let schedulable_deficits = snapshot
+            .deficits
+            .iter()
+            .filter(|deficit| snapshot.prerequisites_are_current(&deficit.target))
+            .collect::<Vec<_>>();
+        stats.readiness_queue_depth = schedulable_deficits.len();
+        candidates.extend(schedulable_deficits.iter().map(|deficit| RuntimeCandidate {
             schedule: WorkCandidate::readiness(&deficit.target, deficit.enqueued_at.unwrap_or(now)),
             source: source.clone(),
             task: RuntimeTask::Readiness(deficit.target.clone()),
@@ -2235,6 +2240,10 @@ fn discover_source_candidates_with_connection(
             retries_due = work_stats.retries_due,
             retries_waiting = work_stats.retries_waiting,
             expired_leases = work_stats.expired_leases,
+            prerequisites_blocked = snapshot
+                .deficits
+                .len()
+                .saturating_sub(schedulable_deficits.len()),
             "Readiness work reconciled"
         );
     }
@@ -6410,6 +6419,14 @@ mod tests {
             readiness
                 .iter()
                 .all(|candidate| candidate.schedule.enqueued_at == 100)
+        );
+        assert!(
+            readiness.iter().all(|candidate| !matches!(
+                candidate.task,
+                RuntimeTask::Readiness(ref target)
+                    if target.stage == ReadinessStage::SimilarityLayout
+            )),
+            "similarity layout must stay parked behind the pending embedding target"
         );
         assert_eq!(oldest_job_age_seconds(&candidates, 250), 150);
     }


### PR DESCRIPTION
## Goal

Prevent source processing from hot-looping the similarity finalizer while exact file-level prerequisites are delayed or missing, and show that blocked state truthfully in the source-processing surface.

Linear: OPT-1198

## Scope and non-goals

- Keep the full determinate readiness queue, including the source-level layout target.
- Schedule similarity layout only after every eligible indexed-identity, analysis-feature, and embedding/aspect artifact is exact and current.
- Repeat the prerequisite fence inside the transactional durable claim so races cannot launch stale finalization work.
- Preserve source-wide wake deadlines while deriving waiting/blocked feedback only from the prerequisites that actually fence similarity layout.
- Automatically admit layout work after prerequisites converge.
- Project parked finalization as Waiting for prerequisites or Blocked by prerequisites while retaining determinate progress.
- Add an exact 19-file, 72-of-77 regression that proves delayed embeddings do not hot-reclaim layout work.
- Non-goal: change retry policy, finalizer algorithms, source lifecycle cancellation, or retained source data.

## Definition of Done

- The 72/77 state with four delayed embeddings retains all 77 progress targets without spawning or reclaiming the layout finalizer.
- Only due prerequisite jobs are schedulable while layout is parked.
- Missing durable identity, analysis, or embedding artifacts reject a layout claim transactionally.
- The job-details surface distinguishes retryable prerequisites from terminal/non-retry blockers without borrowing unrelated source retry deadlines.
- Layout becomes claimable automatically after exact prerequisites complete.
- Existing source removal, retry, recovery, and progress behavior remains passing.

## Validation

- cargo test -p wavecrate-library — 216 passed.
- cargo test -p wavecrate --no-default-features --bin wavecrate native_app::source_processing::supervisor::tests:: -- --test-threads=1 — 55 passed, 1 intentionally ignored profile test.
- Exact 72/77 delayed-embedding and auto-resume regression — passed.
- Dependency-specific feedback regression with permanent embedding plus unrelated playback retry — passed as Blocked, not Waiting.
- bash scripts/ci.sh smoke — passed.
- bash scripts/build.sh --release — passed; fresh ad-hoc signed Wavecrate OPT-1198.app produced and codesign verification passed.
- git diff origin/main...HEAD --check — passed.
- Initial repository preflight passed guardrails and non-blocking checks, then hit the existing unrelated facade guardrail violations on main in app_core/test-support. This diff does not touch those paths.

## Known limitations

- I did not restart Wavecrate against the user’s retained inbox database because that would resume and mutate the live source-processing queue. The exact observed 19-file, 72/77 durable state is reproduced deterministically in the regression test.

User approval is required before merge.