### PR TITLE
Remove post-merge hooks

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -35,13 +35,13 @@ Use the lightest lane that still gives trustworthy coverage for the change.
 `scripts/agent.sh preflight` / `scripts/agent.sh request` and their PowerShell
 equivalents own the full agent preflight, including Cargo-backed architecture
 checks. Concurrent full-preflight invocations for the same repository coalesce
-to one owner and report the shared result. `post-merge` and branch-changing
-`post-checkout` hooks deliberately run only `run_agent_hook_checks.sh`: bounded
+to one owner and report the shared result. Branch-changing `post-checkout`
+hooks deliberately run only `run_agent_hook_checks.sh`: bounded
 repository-state checks that preserve reviewed-head validation evidence during
 merge cleanup.
 
 Run `bash scripts/internal/agent/test_agent_preflight_coordination.sh` to
-exercise hook installation, merge/checkout ownership, concurrent coalescing,
+exercise hook installation, checkout ownership, concurrent coalescing,
 and stale-lock recovery without invoking Cargo.
 
 ## Validation and release lane contract

--- a/scripts/internal/agent/install_agent_preflight_hooks.sh
+++ b/scripts/internal/agent/install_agent_preflight_hooks.sh
@@ -5,11 +5,11 @@
 # branch/source updates.
 #
 # Hooks installed for wavecrate:
-# - post-merge / post-checkout: run bounded repository-state checks
+# - post-checkout: run bounded repository-state checks
 # - pre-commit / pre-push: verify local `main` tracks `origin/main`; feature branches are allowed for PR work
 #
 # Hooks installed for vendor/radiant:
-# - post-merge / post-checkout / pre-commit / pre-push: fail unless radiant uses
+# - post-checkout / pre-commit / pre-push: fail unless radiant uses
 #   local `main` tracking `origin/main`
 #
 # To temporarily disable hook execution, set WAVECRATE_SKIP_AGENT_PREFLIGHT_HOOK=1.
@@ -88,30 +88,21 @@ write_hook() {
   chmod +x "$target"
 }
 
+remove_managed_hook() {
+  local hook_dir="$1"
+  local hook_name="$2"
+  local sentinel="$3"
+  local target="$hook_dir/$hook_name"
+
+  if [[ -f "$target" ]] && grep -q "$sentinel" "$target" 2>/dev/null; then
+    rm -f -- "$target"
+    echo "[agent_hook_install] Removed deprecated managed hook: $target"
+  fi
+}
+
 ROOT_HOOK_DIR="$(git rev-parse --git-common-dir)/hooks"
 ensure_hook_dir "$ROOT_HOOK_DIR"
-
-write_hook "$ROOT_HOOK_DIR" "post-merge" "run_agent_hook_checks.sh" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [[ "${WAVECRATE_SKIP_AGENT_PREFLIGHT_HOOK:-0}" == "1" ]]; then
-  exit 0
-fi
-
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-if [[ -z "$repo_root" ]]; then
-  exit 0
-fi
-
-hook_checks="$repo_root/scripts/internal/agent/run_agent_hook_checks.sh"
-if [[ -x "$hook_checks" ]]; then
-  "$hook_checks" --event post-merge
-else
-  echo "[agent_preflight_hook] ERROR: missing $hook_checks" >&2
-  exit 1
-fi
-EOF
+remove_managed_hook "$ROOT_HOOK_DIR" "post-merge" "run_agent_hook_checks.sh"
 
 write_hook "$ROOT_HOOK_DIR" "post-checkout" "run_agent_hook_checks.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -188,8 +179,9 @@ RADIANT_HOOK_DIR=""
 if git -C "$RADIANT_DIR" rev-parse --git-common-dir >/dev/null 2>&1; then
   RADIANT_HOOK_DIR="$(git -C "$RADIANT_DIR" rev-parse --git-common-dir)/hooks"
   ensure_hook_dir "$RADIANT_HOOK_DIR"
+  remove_managed_hook "$RADIANT_HOOK_DIR" "post-merge" "vendor/radiant must use local 'main'"
 
-  for hook_name in post-merge post-checkout pre-commit pre-push; do
+  for hook_name in post-checkout pre-commit pre-push; do
     write_hook "$RADIANT_HOOK_DIR" "$hook_name" "vendor/radiant must use local 'main'" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -233,12 +225,10 @@ EOF
 fi
 
 echo "[agent_hook_install] Installed hooks:"
-echo "[agent_hook_install]   - $ROOT_HOOK_DIR/post-merge"
 echo "[agent_hook_install]   - $ROOT_HOOK_DIR/post-checkout"
 echo "[agent_hook_install]   - $ROOT_HOOK_DIR/pre-commit"
 echo "[agent_hook_install]   - $ROOT_HOOK_DIR/pre-push"
 if [[ -n "$RADIANT_HOOK_DIR" ]]; then
-  echo "[agent_hook_install]   - $RADIANT_HOOK_DIR/post-merge"
   echo "[agent_hook_install]   - $RADIANT_HOOK_DIR/post-checkout"
   echo "[agent_hook_install]   - $RADIANT_HOOK_DIR/pre-commit"
   echo "[agent_hook_install]   - $RADIANT_HOOK_DIR/pre-push"

--- a/scripts/internal/agent/run_agent_hook_checks.sh
+++ b/scripts/internal/agent/run_agent_hook_checks.sh
@@ -13,7 +13,7 @@ cd "$ROOT_DIR"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/internal/agent/run_agent_hook_checks.sh --event <post-merge|post-checkout>
+Usage: scripts/internal/agent/run_agent_hook_checks.sh --event post-checkout
 
 Run cheap repository-state checks for a Git hook. This command intentionally
 does not run the full Cargo-backed agent preflight.
@@ -45,10 +45,10 @@ while (( $# > 0 )); do
 done
 
 case "$EVENT" in
-  post-merge|post-checkout)
+  post-checkout)
     ;;
   *)
-    echo "[agent_hook_checks] --event must be post-merge or post-checkout." >&2
+    echo "[agent_hook_checks] --event must be post-checkout." >&2
     exit 2
     ;;
 esac

--- a/scripts/internal/agent/test_agent_preflight_coordination.sh
+++ b/scripts/internal/agent/test_agent_preflight_coordination.sh
@@ -53,11 +53,32 @@ git init --bare "$REMOTE_DIR" >/dev/null
 git -C "$REPO_DIR" remote add origin "$REMOTE_DIR"
 WAVECRATE_SKIP_AGENT_PREFLIGHT_HOOK=1 git -C "$REPO_DIR" push -u origin main >/dev/null
 
+RADIANT_SOURCE_DIR="$FIXTURE_DIR/radiant-source"
+RADIANT_REMOTE_DIR="$FIXTURE_DIR/radiant-remote.git"
+git init --initial-branch=main "$RADIANT_SOURCE_DIR" >/dev/null
+git -C "$RADIANT_SOURCE_DIR" config user.email agent-test@example.invalid
+git -C "$RADIANT_SOURCE_DIR" config user.name agent-test
+touch "$RADIANT_SOURCE_DIR/README.md"
+git -C "$RADIANT_SOURCE_DIR" add README.md
+git -C "$RADIANT_SOURCE_DIR" commit -m fixture >/dev/null
+git init --bare --initial-branch=main "$RADIANT_REMOTE_DIR" >/dev/null
+git -C "$RADIANT_SOURCE_DIR" remote add origin "$RADIANT_REMOTE_DIR"
+git -C "$RADIANT_SOURCE_DIR" push -u origin main >/dev/null
+git -c protocol.file.allow=always -C "$REPO_DIR" \
+  submodule add "$RADIANT_REMOTE_DIR" vendor/radiant >/dev/null
+RADIANT_REPO_DIR="$REPO_DIR/vendor/radiant"
+RADIANT_HOOK_DIR="$(git -C "$RADIANT_REPO_DIR" rev-parse --git-common-dir)/hooks"
+
 cat > "$REPO_DIR/.git/hooks/post-merge" <<'EOF'
 #!/usr/bin/env bash
 # run_agent_hook_checks.sh
 EOF
 chmod +x "$REPO_DIR/.git/hooks/post-merge"
+cat > "$RADIANT_HOOK_DIR/post-merge" <<'EOF'
+#!/usr/bin/env bash
+# vendor/radiant must use local 'main'
+EOF
+chmod +x "$RADIANT_HOOK_DIR/post-merge"
 
 HOOK_COUNT="$FIXTURE_DIR/hook-count"
 FULL_COUNT="$FIXTURE_DIR/full-count"
@@ -88,7 +109,15 @@ for hook in post-checkout pre-commit pre-push; do
   fi
 done
 if [[ -e "$REPO_DIR/.git/hooks/post-merge" ]]; then
-  fail "installer did not remove the deprecated managed post-merge hook"
+  fail "installer did not remove the deprecated managed root post-merge hook"
+fi
+for hook in post-checkout pre-commit pre-push; do
+  if [[ ! -x "$RADIANT_HOOK_DIR/$hook" ]]; then
+    fail "installer did not create executable Radiant $hook hook"
+  fi
+done
+if [[ -e "$RADIANT_HOOK_DIR/post-merge" ]]; then
+  fail "installer did not remove the deprecated managed Radiant post-merge hook"
 fi
 
 # Automatic and explicit checkouts each run only the cheap hook state check.

--- a/scripts/internal/agent/test_agent_preflight_coordination.sh
+++ b/scripts/internal/agent/test_agent_preflight_coordination.sh
@@ -53,6 +53,12 @@ git init --bare "$REMOTE_DIR" >/dev/null
 git -C "$REPO_DIR" remote add origin "$REMOTE_DIR"
 WAVECRATE_SKIP_AGENT_PREFLIGHT_HOOK=1 git -C "$REPO_DIR" push -u origin main >/dev/null
 
+cat > "$REPO_DIR/.git/hooks/post-merge" <<'EOF'
+#!/usr/bin/env bash
+# run_agent_hook_checks.sh
+EOF
+chmod +x "$REPO_DIR/.git/hooks/post-merge"
+
 HOOK_COUNT="$FIXTURE_DIR/hook-count"
 FULL_COUNT="$FIXTURE_DIR/full-count"
 FAKE_HOOK_CHECK="$FIXTURE_DIR/fake-hook-check"
@@ -76,30 +82,30 @@ chmod +x "$FAKE_HOOK_CHECK" "$FAKE_FULL_CHECK"
 
 (cd "$REPO_DIR" && ./scripts/internal/agent/install_agent_preflight_hooks.sh --force) >/dev/null
 
-for hook in post-merge post-checkout pre-commit pre-push; do
+for hook in post-checkout pre-commit pre-push; do
   if [[ ! -x "$REPO_DIR/.git/hooks/$hook" ]]; then
     fail "installer did not create executable $hook hook"
   fi
 done
+if [[ -e "$REPO_DIR/.git/hooks/post-merge" ]]; then
+  fail "installer did not remove the deprecated managed post-merge hook"
+fi
 
-# A merge, automatic checkout, and explicit checkout each run only the cheap
-# hook state check. None may launch the full preflight command.
-(cd "$REPO_DIR" && WAVECRATE_AGENT_HOOK_CHECK_COMMAND="$FAKE_HOOK_CHECK" \
-  WAVECRATE_AGENT_CI_CHECKS_COMMAND="$FAKE_FULL_CHECK" \
-  .git/hooks/post-merge)
+# Automatic and explicit checkouts each run only the cheap hook state check.
+# Neither may launch the full preflight command.
 (cd "$REPO_DIR" && WAVECRATE_AGENT_HOOK_CHECK_COMMAND="$FAKE_HOOK_CHECK" \
   WAVECRATE_AGENT_CI_CHECKS_COMMAND="$FAKE_FULL_CHECK" \
   .git/hooks/post-checkout before after 1)
 (cd "$REPO_DIR" && WAVECRATE_AGENT_HOOK_CHECK_COMMAND="$FAKE_HOOK_CHECK" \
   WAVECRATE_AGENT_CI_CHECKS_COMMAND="$FAKE_FULL_CHECK" \
   .git/hooks/post-checkout after after 1)
-expect_file_count "$HOOK_COUNT" 3
+expect_file_count "$HOOK_COUNT" 2
 expect_file_count "$FULL_COUNT" 0
 
 # Pre-commit and pre-push retain their branch-policy ownership.
 (cd "$REPO_DIR" && WAVECRATE_AGENT_HOOK_CHECK_COMMAND="$FAKE_HOOK_CHECK" .git/hooks/pre-commit)
 (cd "$REPO_DIR" && WAVECRATE_AGENT_HOOK_CHECK_COMMAND="$FAKE_HOOK_CHECK" .git/hooks/pre-push)
-expect_file_count "$HOOK_COUNT" 5
+expect_file_count "$HOOK_COUNT" 4
 
 # Two concurrent explicit full-preflight requests coalesce to one owner.
 STATE_DIR="$FIXTURE_DIR/preflight-state"


### PR DESCRIPTION
## Goal

Remove Wavecrate-managed post-merge Git hooks so merge operations never trigger repository checks.

## Scope and non-goals

- Stop installing root and `vendor/radiant` post-merge hooks.
- Remove legacy managed post-merge hooks when the installer runs.
- Restrict bounded hook checks to branch-changing post-checkout events.
- Update regression coverage and workflow documentation.
- Keep post-checkout, pre-commit, and pre-push hooks unchanged.
- Do not change Codex memories or application/runtime behavior.

## Definition of Done

- No active post-merge hook remains in the local Wavecrate or Radiant Git directories.
- The installer does not create root or Radiant post-merge hooks.
- Re-running the installer removes legacy managed post-merge hooks.
- Hook coordination coverage passes with no Cargo-backed validation started from Git hooks.

## Validation

- `git diff --check` — passed
- `bash -n scripts/internal/agent/install_agent_preflight_hooks.sh scripts/internal/agent/run_agent_hook_checks.sh scripts/internal/agent/test_agent_preflight_coordination.sh` — passed
- `bash scripts/internal/agent/test_agent_preflight_coordination.sh` — passed (`[agent_preflight_test] OK`)
- Verified no `post-merge*` file exists in the Git hook directories for Wavecrate, `vendor/radiant`, or Audiodev.

## Known limitations

None.

User approval is required before merge.
