### PR TITLE
OPT-1204: Reconcile the playback readiness contract

### DIFF
--- a/crates/reson/src/player/playback.rs
+++ b/crates/reson/src/player/playback.rs
@@ -399,40 +399,40 @@ impl AudioPlayer {
             );
             Box::new(editable)
         } else {
-            let source: Box<dyn Source<Item = f32> + Send> =
-                if let Some(samples) = self.playback_samples.as_ref().cloned() {
-                    let playback_span =
-                        PlaybackSpanHandle::from_plan_with_metronome(&plan, metronome);
-                    let source = SpanSamplesSource::new(
-                        channels,
-                        sample_rate,
-                        samples,
-                        playback_span.clone(),
-                        SpanSamplesMode::OneShot,
-                        plan.start_sample(),
-                    )
-                    .with_edge_fade(self.anti_clip_fade());
-                    active_playback_span = Some(playback_span);
-                    Box::new(source)
-                } else {
-                    let lazy_source = span_source_for_audio_source(self.audio_source()?, &plan)?;
-                    let mut async_source = AsyncSource::with_buffer_seconds(
-                        lazy_source,
-                        self.stream_policy.buffer_seconds,
-                    );
-                    async_source.prefill_for_duration(
-                        self.stream_policy.prefill_duration,
-                        self.stream_policy.prefill_timeout,
-                    );
-                    let source = async_source
-                        .take_samples(plan.sample_count() as usize)
-                        .buffered();
-                    Box::new(StaticSpanEdgeFadeSource::new(
-                        source,
-                        &plan,
-                        self.anti_clip_fade(),
-                    ))
-                };
+            let source: Box<dyn Source<Item = f32> + Send> = if let Some(samples) =
+                self.playback_samples.as_ref().cloned()
+            {
+                let playback_span = PlaybackSpanHandle::from_plan_with_metronome(&plan, metronome);
+                let source = SpanSamplesSource::new(
+                    channels,
+                    sample_rate,
+                    samples,
+                    playback_span.clone(),
+                    SpanSamplesMode::OneShot,
+                    plan.start_sample(),
+                )
+                .with_edge_fade(self.anti_clip_fade());
+                active_playback_span = Some(playback_span);
+                Box::new(source)
+            } else {
+                let lazy_source = span_source_for_audio_source(self.audio_source()?, &plan)?;
+                let mut async_source = AsyncSource::with_buffer_seconds(
+                    lazy_source,
+                    self.stream_policy.buffer_seconds,
+                );
+                async_source.prefill_for_duration(
+                    self.stream_policy.prefill_duration,
+                    self.stream_policy.prefill_timeout,
+                );
+                let source = async_source
+                    .take_samples(plan.sample_count() as usize)
+                    .buffered();
+                Box::new(StaticSpanEdgeFadeSource::new(
+                    source,
+                    &plan,
+                    self.anti_clip_fade(),
+                ))
+            };
             let editable =
                 EditFadeSource::new(source, self.edit_fade_handle.clone(), plan.start_seconds());
             Box::new(editable)

--- a/crates/wavecrate-library/src/sample_sources/readiness/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/model.rs
@@ -3,8 +3,6 @@
 pub enum ReadinessStage {
     /// The source manifest contains the current file identity.
     IndexedIdentity,
-    /// A bounded playback descriptor and compact waveform summary are current.
-    PlaybackSummary,
     /// Versioned analysis features are current.
     AnalysisFeatures,
     /// Versioned similarity embedding and aspect descriptors are current.
@@ -14,9 +12,8 @@ pub enum ReadinessStage {
 }
 
 impl ReadinessStage {
-    pub(crate) const ALL: [Self; 5] = [
+    pub(crate) const ALL: [Self; 4] = [
         Self::IndexedIdentity,
-        Self::PlaybackSummary,
         Self::AnalysisFeatures,
         Self::EmbeddingAspects,
         Self::SimilarityLayout,
@@ -25,7 +22,6 @@ impl ReadinessStage {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::IndexedIdentity => "indexed_identity",
-            Self::PlaybackSummary => "playback_summary",
             Self::AnalysisFeatures => "analysis_features",
             Self::EmbeddingAspects => "embedding_aspects",
             Self::SimilarityLayout => "similarity_layout",
@@ -39,7 +35,6 @@ impl ReadinessStage {
     pub(crate) fn job_type(self) -> &'static str {
         match self {
             Self::IndexedIdentity => "readiness_indexed_identity_v1",
-            Self::PlaybackSummary => "readiness_playback_summary_v1",
             Self::AnalysisFeatures => "readiness_analysis_features_v1",
             Self::EmbeddingAspects => "readiness_embedding_aspects_v1",
             Self::SimilarityLayout => "readiness_similarity_layout_v1",

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -182,6 +182,7 @@ fn load_targets(
                 source_generation, content_generation, eligibility
          FROM source_readiness_targets
          WHERE source_id = ?1
+           AND stage != 'playback_summary'
          ORDER BY scope_kind, scope_id, stage",
     )?;
     let mut rows = statement.query([source_id])?;
@@ -214,7 +215,8 @@ fn load_artifacts(
         "SELECT scope_kind, scope_id, stage, artifact_version,
                 source_generation, content_generation
          FROM source_readiness_artifacts
-         WHERE source_id = ?1",
+         WHERE source_id = ?1
+           AND stage != 'playback_summary'",
     )?;
     let mut rows = statement.query([source_id])?;
     let mut artifacts = BTreeMap::new();
@@ -250,7 +252,9 @@ fn load_work(
                 artifact_version, source_generation, content_generation, retry_at,
                 failure_kind, last_error, lease_expires_at, created_at
          FROM analysis_jobs
-         WHERE source_id = ?1 AND readiness_managed = 1
+         WHERE source_id = ?1
+           AND readiness_managed = 1
+           AND readiness_stage != 'playback_summary'
          ORDER BY id",
     )?;
     let mut rows = statement.query([source_id])?;

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/classification.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/classification.rs
@@ -5,7 +5,7 @@ use super::*;
 #[test]
 fn readiness_classifies_missing_pending_current_and_stale_generations() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("one", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("one", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
 
     let missing = reconcile_readiness(&connection, SOURCE_ID, 100).expect("missing snapshot");
@@ -13,7 +13,7 @@ fn readiness_classifies_missing_pending_current_and_stale_generations() {
     assert!(!missing.is_idle());
     assert_eq!(missing.deficits.len(), 1);
     assert_eq!(
-        entry_for(&missing, "one", ReadinessStage::PlaybackSummary).classification,
+        entry_for(&missing, "one", ReadinessStage::AnalysisFeatures).classification,
         ReadinessClassification::Pending
     );
 
@@ -27,17 +27,17 @@ fn readiness_classifies_missing_pending_current_and_stale_generations() {
     );
     let current = reconcile_readiness(&connection, SOURCE_ID, 102).expect("current snapshot");
     assert_eq!(
-        entry_for(&current, "one", ReadinessStage::PlaybackSummary).classification,
+        entry_for(&current, "one", ReadinessStage::AnalysisFeatures).classification,
         ReadinessClassification::Current
     );
     assert!(current.is_idle());
     assert!(current.is_fully_ready());
 
-    let changed = file_target("one", ReadinessStage::PlaybackSummary, 2);
+    let changed = file_target("one", ReadinessStage::AnalysisFeatures, 2);
     replace(&mut connection, 2, std::slice::from_ref(&changed));
     let stale = reconcile_readiness(&connection, SOURCE_ID, 103).expect("stale snapshot");
     assert_eq!(
-        entry_for(&stale, "one", ReadinessStage::PlaybackSummary).classification,
+        entry_for(&stale, "one", ReadinessStage::AnalysisFeatures).classification,
         ReadinessClassification::StaleByGeneration
     );
     assert_eq!(stale.deficits.len(), 1);
@@ -47,10 +47,10 @@ fn readiness_classifies_missing_pending_current_and_stale_generations() {
 #[test]
 fn reconciliation_reads_one_snapshot_during_concurrent_publication() {
     let (root, mut connection) = open_fixture();
-    let generation_one = file_target("one", ReadinessStage::PlaybackSummary, 1);
+    let generation_one = file_target("one", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&generation_one));
     let mut writer = SourceDatabase::open_connection(root.path()).expect("writer connection");
-    let generation_two = file_target("two", ReadinessStage::PlaybackSummary, 2);
+    let generation_two = file_target("two", ReadinessStage::AnalysisFeatures, 2);
 
     let snapshot = reconcile_readiness_with_hook(&connection, SOURCE_ID, 10, || {
         replace(&mut writer, 2, std::slice::from_ref(&generation_two));
@@ -58,9 +58,9 @@ fn reconciliation_reads_one_snapshot_during_concurrent_publication() {
     .expect("consistent snapshot");
     assert_eq!(snapshot.source_generation, 1);
     assert_eq!(snapshot.readiness_revision, 101);
-    assert_eq!(snapshot.entries.len(), 5);
+    assert_eq!(snapshot.entries.len(), 4);
     assert_eq!(
-        entry_for(&snapshot, "one", ReadinessStage::PlaybackSummary)
+        entry_for(&snapshot, "one", ReadinessStage::AnalysisFeatures)
             .target
             .source_generation,
         1
@@ -69,9 +69,9 @@ fn reconciliation_reads_one_snapshot_during_concurrent_publication() {
     let current = reconcile_readiness(&connection, SOURCE_ID, 11).expect("current snapshot");
     assert_eq!(current.source_generation, 2);
     assert_eq!(current.readiness_revision, 102);
-    assert_eq!(current.entries.len(), 5);
+    assert_eq!(current.entries.len(), 4);
     assert_eq!(
-        entry_for(&current, "two", ReadinessStage::PlaybackSummary)
+        entry_for(&current, "two", ReadinessStage::AnalysisFeatures)
             .target
             .scope_id,
         "two"
@@ -236,7 +236,7 @@ fn persisted_work_deduplicates_and_survives_restart() {
 #[test]
 fn overlapping_manifest_snapshots_preserve_unchanged_file_lease() {
     let (_root, mut connection) = open_fixture();
-    let original = file_target("leased", ReadinessStage::PlaybackSummary, 1);
+    let original = file_target("leased", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&original));
     let original_snapshot =
         reconcile_readiness(&connection, SOURCE_ID, 10).expect("original snapshot");
@@ -279,11 +279,11 @@ fn overlapping_manifest_snapshots_preserve_unchanged_file_lease() {
 #[test]
 fn stale_content_deficit_cannot_reset_newer_running_work() {
     let (_root, mut connection) = open_fixture();
-    let original = file_target("changed", ReadinessStage::PlaybackSummary, 1);
+    let original = file_target("changed", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&original));
     let stale_snapshot = reconcile_readiness(&connection, SOURCE_ID, 10).expect("stale snapshot");
 
-    let current = file_target("changed", ReadinessStage::PlaybackSummary, 2);
+    let current = file_target("changed", ReadinessStage::AnalysisFeatures, 2);
     replace(&mut connection, 2, std::slice::from_ref(&current));
     let current_snapshot =
         reconcile_readiness(&connection, SOURCE_ID, 11).expect("current snapshot");
@@ -391,7 +391,7 @@ fn path_only_rename_refreshes_running_work_without_losing_lease() {
 #[test]
 fn running_lease_expiry_becomes_an_actionable_retry() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("leased", ReadinessStage::PlaybackSummary, 2);
+    let target = file_target("leased", ReadinessStage::AnalysisFeatures, 2);
     replace(&mut connection, 2, std::slice::from_ref(&target));
     let pending = reconcile_readiness(&connection, SOURCE_ID, 10).expect("pending snapshot");
     persist_readiness_deficits(&mut connection, &pending.deficits, 10).expect("persist work");
@@ -407,7 +407,7 @@ fn running_lease_expiry_becomes_an_actionable_retry() {
     let running = reconcile_readiness(&connection, SOURCE_ID, 49).expect("running snapshot");
     assert_eq!(running.activity, ReadinessActivity::Running);
     assert_eq!(
-        entry_for(&running, "leased", ReadinessStage::PlaybackSummary).classification,
+        entry_for(&running, "leased", ReadinessStage::AnalysisFeatures).classification,
         ReadinessClassification::Running {
             lease_expires_at: 50
         }
@@ -418,7 +418,7 @@ fn running_lease_expiry_becomes_an_actionable_retry() {
     assert_eq!(expired.activity, ReadinessActivity::Actionable);
     assert_eq!(expired.deficits.len(), 1);
     assert_eq!(
-        entry_for(&expired, "leased", ReadinessStage::PlaybackSummary).classification,
+        entry_for(&expired, "leased", ReadinessStage::AnalysisFeatures).classification,
         ReadinessClassification::RetryableFailure {
             retry_at: 50,
             reason: "lease_expired".to_string(),
@@ -448,7 +448,7 @@ fn future_retry_waits_and_terminal_states_do_not_spin() {
         file_target("retry", ReadinessStage::AnalysisFeatures, 3),
         file_target("permanent", ReadinessStage::AnalysisFeatures, 3),
         file_target("unsupported", ReadinessStage::EmbeddingAspects, 3),
-        file_target("deleted", ReadinessStage::PlaybackSummary, 3)
+        file_target("deleted", ReadinessStage::AnalysisFeatures, 3)
             .with_eligibility(ReadinessEligibility::Deleted),
     ];
     replace(&mut connection, 3, &targets);

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
@@ -100,7 +100,7 @@ fn target_replacement_is_failure_atomic() {
 #[test]
 fn stale_same_generation_publication_cannot_reactivate_disabled_source() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("guarded", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("guarded", ReadinessStage::AnalysisFeatures, 1);
     let complete = complete_targets(1, std::slice::from_ref(&target));
     sync_manifest(&connection, &complete);
     replace_readiness_targets(
@@ -294,7 +294,7 @@ fn invalid_stage_scope_pairings_are_rejected() {
 
     let invalid_source = ReadinessTarget::source(
         SOURCE_ID,
-        ReadinessStage::PlaybackSummary,
+        ReadinessStage::AnalysisFeatures,
         "v1",
         1,
         "membership-v1",
@@ -547,7 +547,7 @@ fn desired_targets_must_match_authoritative_manifest_paths_one_to_one() {
 #[test]
 fn delayed_deficit_cannot_enqueue_after_disable_or_delete() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("inactive", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("inactive", ReadinessStage::AnalysisFeatures, 1);
     let complete = complete_targets(1, std::slice::from_ref(&target));
     sync_manifest(&connection, &complete);
     replace_readiness_targets(
@@ -609,7 +609,7 @@ fn delayed_deficit_cannot_enqueue_after_disable_or_delete() {
 #[test]
 fn delayed_deficit_cannot_recreate_completed_work() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("completed", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("completed", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
     let pending = reconcile_readiness(&connection, SOURCE_ID, 10).expect("pending snapshot");
     publish_readiness_artifact(&mut connection, &ReadinessArtifact::for_target(&target, 11))
@@ -706,32 +706,94 @@ fn delayed_deficit_preserves_terminal_failure_and_future_retry() {
 #[test]
 fn target_replacement_prunes_removed_legacy_playback_work() {
     let (_root, mut connection) = open_fixture();
-    let legacy = file_target("legacy-playback", ReadinessStage::PlaybackSummary, 1);
-    replace(&mut connection, 1, std::slice::from_ref(&legacy));
-    let pending = reconcile_readiness(&connection, SOURCE_ID, 10).expect("legacy snapshot");
+    let current = file_target("legacy-playback", ReadinessStage::AnalysisFeatures, 1);
+    replace(&mut connection, 1, std::slice::from_ref(&current));
+    let pending = reconcile_readiness(&connection, SOURCE_ID, 10).expect("current snapshot");
     persist_readiness_deficits(&mut connection, &pending.deficits, 10)
-        .expect("persist legacy playback work");
+        .expect("persist current work");
+    connection
+        .execute(
+            "INSERT INTO source_readiness_targets (
+                source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                source_generation, content_generation, eligibility, updated_at
+             )
+             SELECT source_id, scope_kind, scope_id, relative_path, 'playback_summary',
+                    'legacy-playback-v1', source_generation, content_generation,
+                    eligibility, updated_at
+             FROM source_readiness_targets
+             WHERE source_id = ?1
+               AND scope_id = 'legacy-playback'
+               AND stage = 'analysis_features'",
+            [SOURCE_ID],
+        )
+        .expect("seed legacy playback target");
+    connection
+        .execute(
+            "UPDATE analysis_jobs
+             SET job_type = 'readiness_playback_summary_v1',
+                 readiness_stage = 'playback_summary'
+             WHERE source_id = ?1
+               AND readiness_scope_id = 'legacy-playback'
+               AND readiness_stage = 'analysis_features'",
+            [SOURCE_ID],
+        )
+        .expect("seed legacy playback work");
 
-    let current = file_target("legacy-playback", ReadinessStage::AnalysisFeatures, 2);
-    replace(&mut connection, 2, &[current]);
+    let replacement = file_target("legacy-playback", ReadinessStage::AnalysisFeatures, 2);
+    replace(&mut connection, 2, &[replacement]);
 
-    let playback_jobs: i64 = connection
+    let playback_rows: i64 = connection
         .query_row(
-            "SELECT COUNT(*)
-             FROM analysis_jobs
-             WHERE readiness_managed = 1 AND readiness_stage = 'playback_summary'",
-            [],
+            "SELECT
+                (SELECT COUNT(*) FROM source_readiness_targets
+                 WHERE source_id = ?1 AND stage = 'playback_summary')
+              + (SELECT COUNT(*) FROM analysis_jobs
+                 WHERE source_id = ?1
+                   AND readiness_managed = 1
+                   AND readiness_stage = 'playback_summary')",
+            [SOURCE_ID],
             |row| row.get(0),
         )
-        .expect("count removed playback jobs");
-    assert_eq!(playback_jobs, 0);
+        .expect("count removed legacy playback rows");
+    assert_eq!(playback_rows, 0);
 }
 
 #[test]
-fn read_only_reconciliation_never_enqueues_work() {
+fn read_only_reconciliation_ignores_legacy_playback_rows_without_enqueuing() {
     let (root, mut connection) = open_fixture();
-    let target = file_target("read-only", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("read-only", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, &[target]);
+    connection
+        .execute(
+            "INSERT INTO source_readiness_targets (
+                source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                source_generation, content_generation, eligibility, updated_at
+             )
+             SELECT source_id, scope_kind, scope_id, relative_path, 'playback_summary',
+                    'legacy-playback-v1', source_generation, content_generation,
+                    eligibility, updated_at
+             FROM source_readiness_targets
+             WHERE source_id = ?1
+               AND scope_id = 'read-only'
+               AND stage = 'analysis_features'",
+            [SOURCE_ID],
+        )
+        .expect("seed legacy read-only target");
+    connection
+        .execute(
+            "INSERT INTO source_readiness_artifacts (
+                source_id, scope_kind, scope_id, relative_path, stage, artifact_version,
+                source_generation, content_generation, completed_at
+             )
+             SELECT source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                    source_generation, content_generation, updated_at
+             FROM source_readiness_targets
+             WHERE source_id = ?1
+               AND scope_id = 'read-only'
+               AND stage = 'playback_summary'",
+            [SOURCE_ID],
+        )
+        .expect("seed legacy read-only artifact");
     drop(connection);
     let read_only = SourceDatabase::open_connection_with_role(
         root.path(),
@@ -741,6 +803,7 @@ fn read_only_reconciliation_never_enqueues_work() {
 
     let snapshot = reconcile_readiness(&read_only, SOURCE_ID, 2).expect("read snapshot");
     assert_eq!(snapshot.deficits.len(), 1);
+    assert_eq!(snapshot.entries.len(), 4);
     let jobs: i64 = read_only
         .query_row("SELECT COUNT(*) FROM analysis_jobs", [], |row| row.get(0))
         .expect("count jobs");

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/work.rs
@@ -58,7 +58,7 @@ fn work_stats_exclude_jobs_for_identities_no_longer_in_the_current_manifest() {
 #[test]
 fn expired_claim_is_recovered_after_restart_with_a_new_attempt() {
     let (root, mut connection) = open_fixture();
-    let target = file_target("restart", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("restart", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
     persist_target(&mut connection, &target, 10);
     let first = claim_readiness_target(&mut connection, &target, 10, 10)
@@ -118,9 +118,9 @@ fn stale_completion_cannot_publish_over_a_changed_exact_target() {
 }
 
 #[test]
-fn cache_backed_completion_persists_exact_reverse_ownership_atomically() {
+fn completion_persists_an_exact_artifact_reference_atomically() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("owned", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("owned", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
     persist_target(&mut connection, &target, 10);
     let claim = claim_readiness_target(&mut connection, &target, 10, 100)
@@ -141,7 +141,7 @@ fn cache_backed_completion_persists_exact_reverse_ownership_atomically() {
         .query_row(
             "SELECT relative_path, artifact_ref, content_generation
              FROM source_readiness_artifacts
-             WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'playback_summary'",
+             WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'analysis_features'",
             rusqlite::params![SOURCE_ID, target.scope_id],
             |row| {
                 Ok((
@@ -158,16 +158,16 @@ fn cache_backed_completion_persists_exact_reverse_ownership_atomically() {
 }
 
 #[test]
-fn stale_cache_backed_completion_cannot_replace_current_ownership() {
+fn stale_completion_cannot_replace_a_current_artifact_reference() {
     let (_root, mut connection) = open_fixture();
-    let original = file_target("owned-stale", ReadinessStage::PlaybackSummary, 1);
+    let original = file_target("owned-stale", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&original));
     persist_target(&mut connection, &original, 10);
     let stale_claim = claim_readiness_target(&mut connection, &original, 10, 100)
         .expect("claim original target")
         .expect("original target available");
 
-    let current = file_target("owned-stale", ReadinessStage::PlaybackSummary, 2);
+    let current = file_target("owned-stale", ReadinessStage::AnalysisFeatures, 2);
     replace(&mut connection, 2, std::slice::from_ref(&current));
     assert_eq!(
         complete_readiness_work_with_artifact_ref(
@@ -183,7 +183,7 @@ fn stale_cache_backed_completion_cannot_replace_current_ownership() {
         connection
             .query_row(
                 "SELECT COUNT(*) FROM source_readiness_artifacts
-                 WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'playback_summary'",
+                 WHERE source_id = ?1 AND scope_id = ?2 AND stage = 'analysis_features'",
                 rusqlite::params![SOURCE_ID, original.scope_id],
                 |row| row.get::<_, i64>(0),
             )
@@ -224,7 +224,7 @@ fn file_completion_survives_unrelated_source_generation_changes() {
 #[test]
 fn retry_backoff_is_bounded_and_exhaustion_becomes_terminal() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("retry", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("retry", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
     persist_target(&mut connection, &target, 0);
     let policy = ReadinessRetryPolicy::new(5, 20, 3).expect("valid retry policy");
@@ -315,12 +315,11 @@ fn similarity_layout_waits_for_delayed_embeddings_without_hot_reclaiming() {
     const RETRY_AT: i64 = 180;
 
     let (_root, mut connection) = open_fixture();
-    let mut targets = Vec::with_capacity(FILE_COUNT * 4 + 1);
+    let mut targets = Vec::with_capacity(FILE_COUNT * 3 + 1);
     for index in 0..FILE_COUNT {
         let identity = format!("sample-{index:02}");
         for stage in [
             ReadinessStage::IndexedIdentity,
-            ReadinessStage::PlaybackSummary,
             ReadinessStage::AnalysisFeatures,
             ReadinessStage::EmbeddingAspects,
         ] {
@@ -338,7 +337,7 @@ fn similarity_layout_waits_for_delayed_embeddings_without_hot_reclaiming() {
     replace(&mut connection, 1, &targets);
 
     let initial = reconcile_readiness(&connection, SOURCE_ID, NOW).expect("initial snapshot");
-    assert_eq!(initial.deficits.len(), FILE_COUNT * 4 + 1);
+    assert_eq!(initial.deficits.len(), FILE_COUNT * 3 + 1);
     persist_readiness_deficits(&mut connection, &initial.deficits, NOW)
         .expect("persist exact readiness queue");
 
@@ -387,9 +386,9 @@ fn similarity_layout_waits_for_delayed_embeddings_without_hot_reclaiming() {
     assert_eq!(waiting.deficits.len(), 1);
     assert_eq!(waiting.deficits[0].target, layout);
     assert!(!waiting.prerequisites_are_current(&layout));
-    let stats = readiness_work_stats(&connection, NOW + 1).expect("72 of 77 stats");
-    assert_eq!(stats.completed, 72);
-    assert_eq!(stats.total, 77);
+    let stats = readiness_work_stats(&connection, NOW + 1).expect("53 of 58 stats");
+    assert_eq!(stats.completed, 53);
+    assert_eq!(stats.total, 58);
     assert_eq!(stats.pending, 1);
     assert_eq!(stats.retries_waiting, DELAYED_EMBEDDINGS);
     assert_eq!(stats.earliest_retry_at, Some(RETRY_AT));
@@ -609,7 +608,7 @@ fn benign_reclaims_do_not_consume_retry_backoff_attempts() {
 #[test]
 fn lease_renewal_extends_only_the_current_unexpired_claim() {
     let (_root, mut connection) = open_fixture();
-    let target = file_target("renew", ReadinessStage::PlaybackSummary, 1);
+    let target = file_target("renew", ReadinessStage::AnalysisFeatures, 1);
     replace(&mut connection, 1, std::slice::from_ref(&target));
     persist_target(&mut connection, &target, 0);
     let claim = claim_readiness_target(&mut connection, &target, 0, 10)

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -316,6 +316,8 @@ Every enabled, available source should converge automatically in background work
 
 The source-local database is the authoritative durable coordination boundary. It should store desired versioned readiness targets, exact artifact completion generations, source availability, and readiness-owned work metadata. Readiness work must reuse the existing source-local persistent analysis/job storage rather than introducing an unrelated queue format. App-global cache payloads remain rebuildable performance aids outside this readiness contract: compact waveform or browser caches may be missing, stale, or evicted without making an otherwise complete source unready.
 
+Playback and waveform cache work remains automatic, bounded, attributable to exact source-file identity, invalidatable after content changes, and subordinate to foreground audition. Its separate cache lifecycle owns stale-completion rejection, path move/remap, delete, pruning, and source-retirement cleanup. It must not publish a `playback_summary` desired target or completion artifact, and legacy rows from builds that did so must be ignored by read-only reconciliation and retired on the next writable source-processing pass.
+
 Configured source lifecycles also carry a runtime epoch distinct from the durable source identity. Removing or replacing a descriptor cancels that exact epoch, immediately closes new admission, purges its queued UI/readiness work, and lets the control-plane transition return without waiting for scans, hashing, finalization, or cleanup. Late work may not publish after its epoch is retired. A replacement that shares the same source database waits for the old epoch to drain before new processing admission; destructive retirement is suppressed when that database has already been re-added.
 
 Source retirement keeps the audio folder, authoritative source database, source manifest, reusable analysis/similarity artifacts, and safe content-addressed analysis caches. It releases source-owned in-memory playback/preview/browser state and asynchronously removes readiness-managed jobs and unshared managed cache payloads. The source descriptor registry retains role, metadata-storage policy, and primary-import settings so protected/AppData sources rehydrate safely; corrupt present descriptor values fail closed. Cleanup is idempotent, retryable after unavailable/read-only storage, recovered from retained inactive descriptors at startup, and bounded so removal never waits for database maintenance or cache garbage collection.
@@ -326,6 +328,8 @@ For every current eligible file, the readiness stages are:
 2. the required analysis feature version is current;
 3. the required embedding model and aspect-descriptor version are current; and
 4. the source-level similarity membership, ANN/index, layout, and cluster generation covers exactly the current eligible identities.
+
+This is exactly three file-scoped targets per current eligible file plus one source-scoped similarity target. Playback-cache residency is not a fifth readiness stage.
 
 Each target and completion must carry the committed source generation, a non-empty file content generation or source-membership generation, and the stage's artifact-contract version. Desired-state publications also carry a per-source monotonic readiness revision; a writer whose revision is not newer than the persisted revision is stale even when its source generation is equal, so delayed lifecycle writers cannot reactivate an offline or disabled source. The source generation is a publication and diagnostic fence, not a blanket invalidation token for file-scoped artifacts: an unchanged stable file identity remains current across unrelated manifest changes when its stage version and stage-relevant content/path generation still match. Source-scoped similarity work must additionally match the current source generation and membership generation. A late completion may publish only when the values relevant to its scope still match the current desired target. Timestamps, total row counts, source-prep markers, or the existence of some artifacts are diagnostic inputs only; they must never make a source look ready when a current eligible identity lacks an exact artifact or when stale/deleted identities are still the only covered rows.
 
@@ -346,7 +350,8 @@ categories is silently idle and must fail with generation, stage, job,
 lease/retry, watcher-health, active-work, and resource diagnostics. Restart,
 external and internal churn, watcher overflow/loss, playback, source
 disappearance/reappearance, removal/re-add, stale completion, terminal inputs,
-and exact removal of obsolete similarity/playback membership belong in this
+exact removal of obsolete similarity membership, and legacy playback-readiness
+retirement belong in this
 proof. Large-library throughput and browser/frame responsiveness remain an
 explicit calibrated lane rather than an unbounded normal-CI soak.
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -241,7 +241,7 @@ inherit a real-time soak:
   mutation, closed-app restart audit, root disappearance/reappearance, and
   source remove/re-add:
   `cargo test -p wavecrate --bin wavecrate source_processing_liveness_harness_converges_restart_churn_and_root_recovery -- --ignored --nocapture`
-- 10,000-file / 40,001-target calibrated source-processing profile:
+- 10,000-file / 30,001-target calibrated source-processing profile:
   `cargo test -p wavecrate --bin wavecrate profile_source_processing_churn_under_playback_and_browser_priority -- --ignored --nocapture`
 - full mutation and watcher family coverage:
   `cargo test -p wavecrate --bin wavecrate committed_file_mutations`
@@ -271,7 +271,7 @@ classifications, durable job status/lease/retry state, active runtime work,
 watcher stimulus/root health, and supervisor resource counters. The calibrated
 profile enforces these source-processing budgets in debug test builds:
 
-- materialize 40,001 exact targets from 10,000 files within 180 seconds;
+- materialize 30,001 exact targets from 10,000 files within 180 seconds;
 - sustain at least 200 materialized candidates per second;
 - keep browser-priority update p99 at or below 10 ms while playback pauses
   processing;

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -64,7 +64,7 @@ fn create_commits_revision_and_invalidates_file_readiness() {
     assert!(
         event
             .invalidated_stages
-            .contains(&ReadinessStage::PlaybackSummary)
+            .contains(&ReadinessStage::IndexedIdentity)
     );
     assert!(event.changes[0].before_content_identity.is_none());
     assert!(event.changes[0].after_content_identity.is_some());

--- a/src/native_app/source_processing/scheduler.rs
+++ b/src/native_app/source_processing/scheduler.rs
@@ -9,7 +9,6 @@ use wavecrate::sample_sources::readiness::{ReadinessStage, ReadinessTarget};
 pub(crate) enum ProcessingLane {
     Scan,
     Hashing,
-    DecodeSummary,
     FeatureAnalysis,
     Embedding,
     Finalization,
@@ -18,10 +17,9 @@ pub(crate) enum ProcessingLane {
 
 impl ProcessingLane {
     #[cfg(test)]
-    const ALL: [Self; 7] = [
+    const ALL: [Self; 6] = [
         Self::Scan,
         Self::Hashing,
-        Self::DecodeSummary,
         Self::FeatureAnalysis,
         Self::Embedding,
         Self::Finalization,
@@ -31,7 +29,6 @@ impl ProcessingLane {
     pub(crate) fn for_readiness_stage(stage: ReadinessStage) -> Self {
         match stage {
             ReadinessStage::IndexedIdentity => Self::Hashing,
-            ReadinessStage::PlaybackSummary => Self::DecodeSummary,
             ReadinessStage::AnalysisFeatures => Self::FeatureAnalysis,
             ReadinessStage::EmbeddingAspects => Self::Embedding,
             ReadinessStage::SimilarityLayout => Self::Finalization,
@@ -41,7 +38,7 @@ impl ProcessingLane {
     fn demand(self) -> ResourceUse {
         match self {
             Self::Scan | Self::Cleanup => ResourceUse::new(0, 1, 1),
-            Self::Hashing | Self::DecodeSummary => ResourceUse::new(1, 1, 1),
+            Self::Hashing => ResourceUse::new(1, 1, 1),
             Self::FeatureAnalysis | Self::Embedding => ResourceUse::new(1, 1, 1),
             Self::Finalization => ResourceUse::new(1, 1, 1),
         }
@@ -124,7 +121,6 @@ impl Default for ProcessingBudgets {
             lane_limits: [
                 (ProcessingLane::Scan, 1),
                 (ProcessingLane::Hashing, 1),
-                (ProcessingLane::DecodeSummary, cpu.min(2)),
                 (ProcessingLane::FeatureAnalysis, cpu),
                 (ProcessingLane::Embedding, 1),
                 (ProcessingLane::Finalization, 1),
@@ -442,10 +438,9 @@ fn priority_weight(candidate: &WorkCandidate, context: &PriorityContext) -> u64 
 fn stage_rank(stage: ReadinessStage) -> u8 {
     match stage {
         ReadinessStage::IndexedIdentity => 0,
-        ReadinessStage::PlaybackSummary => 1,
-        ReadinessStage::AnalysisFeatures => 2,
-        ReadinessStage::EmbeddingAspects => 3,
-        ReadinessStage::SimilarityLayout => 4,
+        ReadinessStage::AnalysisFeatures => 1,
+        ReadinessStage::EmbeddingAspects => 2,
+        ReadinessStage::SimilarityLayout => 3,
     }
 }
 
@@ -482,7 +477,7 @@ mod tests {
             10,
         ));
         let mut candidates = vec![
-            candidate("active", "now", ReadinessStage::PlaybackSummary),
+            candidate("active", "now", ReadinessStage::IndexedIdentity),
             candidate("active", "next", ReadinessStage::AnalysisFeatures),
             candidate("backlog", "old", ReadinessStage::AnalysisFeatures),
         ];
@@ -517,14 +512,14 @@ mod tests {
         ));
         let candidates = [
             candidate("source", "analysis", ReadinessStage::AnalysisFeatures),
-            candidate("source", "playback", ReadinessStage::PlaybackSummary),
+            candidate("source", "identity", ReadinessStage::IndexedIdentity),
         ];
         let priority = PriorityContext {
             current_folder: Some(("source".to_string(), "folder/".to_string())),
             ..PriorityContext::default()
         };
         let index = scheduler.choose(&candidates, &priority, &budgets).unwrap();
-        assert_eq!(candidates[index].scope_id, "playback");
+        assert_eq!(candidates[index].scope_id, "identity");
     }
 
     #[test]
@@ -536,7 +531,7 @@ mod tests {
             10,
         ));
         let candidates = [
-            candidate("source", "sample", ReadinessStage::PlaybackSummary),
+            candidate("source", "sample", ReadinessStage::AnalysisFeatures),
             candidate("source", "sample", ReadinessStage::IndexedIdentity),
         ];
 
@@ -553,7 +548,7 @@ mod tests {
             ProcessingBudgets::for_tests(ResourceUse::new(2, 2, 2), ResourceUse::new(1, 1, 1), 1);
         let mut tracker = BudgetTracker::new(limits);
         let first = tracker
-            .try_acquire("one", ProcessingLane::DecodeSummary)
+            .try_acquire("one", ProcessingLane::Hashing)
             .expect("first permit");
         assert!(
             tracker
@@ -562,7 +557,7 @@ mod tests {
         );
         assert!(
             tracker
-                .try_acquire("two", ProcessingLane::DecodeSummary)
+                .try_acquire("two", ProcessingLane::Hashing)
                 .is_none()
         );
         let second = tracker
@@ -581,15 +576,15 @@ mod tests {
             ProcessingBudgets::for_tests(ResourceUse::new(2, 2, 2), ResourceUse::new(1, 1, 1), 2);
         let mut budgets = BudgetTracker::new(limits);
         let candidates = [
-            candidate("active", "first", ReadinessStage::PlaybackSummary),
-            candidate("backlog", "other", ReadinessStage::PlaybackSummary),
+            candidate("active", "first", ReadinessStage::AnalysisFeatures),
+            candidate("backlog", "other", ReadinessStage::AnalysisFeatures),
         ];
         let chosen = scheduler
             .choose(&candidates, &PriorityContext::default(), &budgets)
             .expect("select active source");
         assert_eq!(candidates[chosen].source_id, "active");
         let permit = budgets
-            .try_acquire("active", ProcessingLane::DecodeSummary)
+            .try_acquire("active", ProcessingLane::FeatureAnalysis)
             .expect("occupy active-source budget");
 
         assert_eq!(
@@ -612,7 +607,7 @@ mod tests {
         let active = [candidate(
             "active",
             "first",
-            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
         )];
         assert_eq!(
             scheduler.choose(&active, &PriorityContext::default(), &budgets),
@@ -621,7 +616,7 @@ mod tests {
         let backlog = [candidate(
             "backlog",
             "other",
-            ReadinessStage::PlaybackSummary,
+            ReadinessStage::AnalysisFeatures,
         )];
         assert_eq!(
             scheduler.choose(&backlog, &PriorityContext::default(), &budgets),

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -3610,6 +3610,15 @@ fn retire_legacy_playback_readiness(
     connection: &mut rusqlite::Connection,
     cancel: &AtomicBool,
 ) -> Result<Cancellable<usize>, String> {
+    retire_legacy_playback_readiness_with_post_commit_hook(source, connection, cancel, || {})
+}
+
+fn retire_legacy_playback_readiness_with_post_commit_hook(
+    source: &SampleSource,
+    connection: &mut rusqlite::Connection,
+    cancel: &AtomicBool,
+    post_commit: impl FnOnce(),
+) -> Result<Cancellable<usize>, String> {
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);
     }
@@ -3687,11 +3696,9 @@ fn retire_legacy_playback_readiness(
             .map_err(|error| error.to_string())?,
     );
     transaction.commit().map_err(|error| error.to_string())?;
+    post_commit();
 
     for cache_ref in cache_refs {
-        if cancelled(cancel) {
-            break;
-        }
         match retained_waveform_cache_ref_is_owned(&cache_ref) {
             Ok(false) => invalidate_persisted_waveform_cache_ref(std::path::Path::new(&cache_ref)),
             Ok(true) => {}
@@ -7645,6 +7652,64 @@ mod tests {
     }
 
     #[test]
+    fn post_commit_cancellation_still_retires_every_legacy_cache_ref() {
+        let (_directory, source) = ready_analysis_source("legacy-playback-cancellation");
+        let database_root = source.database_root().expect("database root");
+        let (first_cache_ref, now) = seed_legacy_playback_artifact(&source);
+        let second_cache_ref = seed_managed_legacy_cache_ref(&source, "second", now);
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+            &source.root,
+            &database_root,
+            SourceDatabaseConnectionRole::JobWorker,
+        )
+        .expect("reopen source with multiple legacy playback rows");
+        connection
+            .execute(
+                "INSERT INTO source_readiness_targets (
+                    source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                    source_generation, content_generation, eligibility, updated_at
+                 )
+                 SELECT source_id, scope_kind, 'legacy-second', 'legacy-second.wav', stage,
+                        required_version, source_generation, content_generation, eligibility,
+                        updated_at
+                 FROM source_readiness_targets
+                 WHERE source_id = ?1 AND stage = 'playback_summary'",
+                [source.id.as_str()],
+            )
+            .expect("seed second legacy playback target");
+        connection
+            .execute(
+                "INSERT INTO source_readiness_artifacts (
+                    source_id, scope_kind, scope_id, relative_path, stage, artifact_version,
+                    source_generation, content_generation, artifact_ref, completed_at
+                 )
+                 SELECT source_id, scope_kind, scope_id, relative_path, stage, required_version,
+                        source_generation, content_generation, ?2, ?3
+                 FROM source_readiness_targets
+                 WHERE source_id = ?1
+                   AND scope_id = 'legacy-second'
+                   AND stage = 'playback_summary'",
+                params![source.id.as_str(), second_cache_ref.to_string_lossy(), now],
+            )
+            .expect("seed second legacy playback artifact");
+
+        let cancel = AtomicBool::new(false);
+        assert!(matches!(
+            retire_legacy_playback_readiness_with_post_commit_hook(
+                &source,
+                &mut connection,
+                &cancel,
+                || cancel.store(true, Ordering::Release),
+            )
+            .expect("retire every captured legacy playback reference"),
+            Cancellable::Completed(4)
+        ));
+        assert!(cancelled(&cancel));
+        assert!(!first_cache_ref.exists());
+        assert!(!second_cache_ref.exists());
+    }
+
+    #[test]
     fn legacy_playback_cache_owner_is_retired_after_committed_delete() {
         let (_directory, source) = ready_analysis_source("playback-delete");
         let database_root = source.database_root().expect("database root");
@@ -8990,12 +9055,7 @@ mod tests {
         .expect("open legacy playback database");
         publish_current_readiness_targets(&mut connection, source.id.as_str(), now)
             .expect("publish current target matrix");
-        let cache_directory =
-            wavecrate::app_dirs::waveform_cache_dir().expect("resolve waveform cache directory");
-        std::fs::create_dir_all(&cache_directory).expect("create waveform cache directory");
-        let cache_ref =
-            cache_directory.join(format!("legacy-playback-{}-{now}.wfc", source.id.as_str()));
-        std::fs::write(&cache_ref, b"legacy playback cache").expect("seed legacy playback cache");
+        let cache_ref = seed_managed_legacy_cache_ref(source, "first", now);
         connection
             .execute(
                 "INSERT INTO source_readiness_targets (
@@ -9024,6 +9084,22 @@ mod tests {
             )
             .expect("seed legacy playback artifact");
         (cache_ref, now)
+    }
+
+    fn seed_managed_legacy_cache_ref(
+        source: &SampleSource,
+        label: &str,
+        now: i64,
+    ) -> std::path::PathBuf {
+        let cache_directory =
+            wavecrate::app_dirs::waveform_cache_dir().expect("resolve waveform cache directory");
+        std::fs::create_dir_all(&cache_directory).expect("create waveform cache directory");
+        let cache_ref = cache_directory.join(format!(
+            "legacy-playback-{}-{label}-{now}.wfc",
+            source.id.as_str()
+        ));
+        std::fs::write(&cache_ref, b"legacy playback cache").expect("seed legacy playback cache");
+        cache_ref
     }
 
     fn source_is_hashed(source: &SampleSource) -> bool {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -43,11 +43,7 @@ use crate::native_app::sample_library::similarity_artifacts::{
     SimilarityPublicationFence, finalize_similarity_artifacts_if_ready,
     native_similarity_artifact_version, reset_interrupted_readiness_jobs,
 };
-use crate::native_app::waveform::{
-    ensure_persisted_playback_summary, invalidate_persisted_waveform_cache_path,
-    invalidate_persisted_waveform_cache_ref, persisted_waveform_cache_ref_is_current,
-    remap_persisted_waveform_cache_ref_after_move,
-};
+use crate::native_app::waveform::invalidate_persisted_waveform_cache_ref;
 
 const SAFETY_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 const PROGRESS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
@@ -2512,7 +2508,6 @@ fn runtime_task_progress_detail(task: &RuntimeTask) -> (&'static str, String) {
 fn readiness_progress_detail(target: &ReadinessTarget) -> (&'static str, String) {
     let stage = match target.stage {
         ReadinessStage::IndexedIdentity => "Indexing files",
-        ReadinessStage::PlaybackSummary => "Preparing playback",
         ReadinessStage::AnalysisFeatures => "Analyzing audio",
         ReadinessStage::EmbeddingAspects => "Preparing similarity",
         ReadinessStage::SimilarityLayout => "Building similarity layout",
@@ -2809,6 +2804,13 @@ fn discover_source_candidates_with_connection_and_progress(
             task: RuntimeTask::ManifestAudit,
         });
     }
+    progress("Retiring legacy playback readiness", work_units);
+    if matches!(
+        retire_legacy_playback_readiness(source, connection, cancel)?,
+        Cancellable::Cancelled
+    ) {
+        return Ok(Cancellable::Cancelled);
+    }
     let target_publication = publish_current_readiness_targets_with_cancel_and_checkpoint(
         connection,
         source_id,
@@ -2820,13 +2822,6 @@ fn discover_source_candidates_with_connection_and_progress(
         },
     )?;
     if matches!(target_publication, Cancellable::Cancelled) {
-        return Ok(Cancellable::Cancelled);
-    }
-    progress("Checking playback-cache ownership", work_units);
-    if matches!(
-        reconcile_playback_cache_ownership(source, connection, cancel)?,
-        Cancellable::Cancelled
-    ) {
         return Ok(Cancellable::Cancelled);
     }
     if cancelled(cancel) {
@@ -3604,256 +3599,112 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
     Ok(Cancellable::Completed(true))
 }
 
-#[derive(Debug)]
-struct PlaybackCacheOwnershipRow {
-    scope_id: String,
-    artifact_relative_path: Option<String>,
-    artifact_version: String,
-    artifact_content_generation: String,
-    artifact_ref: Option<String>,
-    target_relative_path: Option<String>,
-    target_version: Option<String>,
-    target_content_generation: Option<String>,
-    target_eligibility: Option<String>,
-}
-
-/// Reconcile source-owned playback artifact rows with their app-global cache payloads.
+/// Retire rows written by the removed durable playback-summary readiness stage.
 ///
-/// The source database is the durable reverse index. This pass runs on startup and every committed
-/// source wake, so changed/deleted identities can retire their old cache keys even after the old
-/// filesystem metadata is gone. Path-only moves remap reusable payloads without decoding again.
-///
-/// Cache residency is deliberately not a readiness invariant: the app-global waveform cache is
-/// bounded and may evict a successfully prepared payload. In that case the durable artifact remains
-/// current, its stale cache reference is cleared, and playback may repopulate the cache on demand.
-/// Treating budget eviction as a readiness deficit would make source processing loop forever once
-/// the cache reaches its limit.
-fn reconcile_playback_cache_ownership(
+/// Current waveform and playback caches are managed by the independent cache lifecycle. This
+/// compatibility pass exists only so writable source databases from older builds cannot keep stale
+/// readiness work or reverse-ownership rows alive. Read-only reconciliation filters the same legacy
+/// stage without mutating it.
+fn retire_legacy_playback_readiness(
     source: &SampleSource,
     connection: &mut rusqlite::Connection,
     cancel: &AtomicBool,
 ) -> Result<Cancellable<usize>, String> {
-    let rows = {
+    if cancelled(cancel) {
+        return Ok(Cancellable::Cancelled);
+    }
+    let has_legacy_rows = connection
+        .query_row(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM source_readiness_targets
+                 WHERE source_id = ?1 AND stage = 'playback_summary'
+                 UNION ALL
+                 SELECT 1
+                 FROM source_readiness_artifacts
+                 WHERE source_id = ?1 AND stage = 'playback_summary'
+                 UNION ALL
+                 SELECT 1
+                 FROM analysis_jobs
+                 WHERE source_id = ?1
+                   AND readiness_managed = 1
+                   AND readiness_stage = 'playback_summary'
+             )",
+            [source.id.as_str()],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if !has_legacy_rows {
+        return Ok(Cancellable::Completed(0));
+    }
+    let cache_refs = {
         let mut statement = connection
             .prepare(
-                "SELECT artifact.scope_id,
-                        artifact.relative_path,
-                        artifact.artifact_version,
-                        artifact.content_generation,
-                        artifact.artifact_ref,
-                        target.relative_path,
-                        target.required_version,
-                        target.content_generation,
-                        target.eligibility
-                 FROM source_readiness_artifacts AS artifact
-                 LEFT JOIN source_readiness_targets AS target
-                   ON target.source_id = artifact.source_id
-                  AND target.scope_kind = artifact.scope_kind
-                  AND target.scope_id = artifact.scope_id
-                  AND target.stage = artifact.stage
-                 WHERE artifact.source_id = ?1
-                   AND artifact.scope_kind = 'file'
-                   AND artifact.stage = 'playback_summary'
-                 ORDER BY artifact.scope_id",
+                "SELECT artifact_ref
+                 FROM source_readiness_artifacts
+                 WHERE source_id = ?1
+                   AND stage = 'playback_summary'
+                   AND artifact_ref IS NOT NULL
+                   AND length(trim(artifact_ref)) > 0",
             )
             .map_err(|error| error.to_string())?;
         statement
-            .query_map([source.id.as_str()], |row| {
-                Ok(PlaybackCacheOwnershipRow {
-                    scope_id: row.get(0)?,
-                    artifact_relative_path: row.get(1)?,
-                    artifact_version: row.get(2)?,
-                    artifact_content_generation: row.get(3)?,
-                    artifact_ref: row.get(4)?,
-                    target_relative_path: row.get(5)?,
-                    target_version: row.get(6)?,
-                    target_content_generation: row.get(7)?,
-                    target_eligibility: row.get(8)?,
-                })
-            })
+            .query_map([source.id.as_str()], |row| row.get::<_, String>(0))
             .map_err(|error| error.to_string())?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|error| error.to_string())?
     };
-    let mut changed = 0_usize;
-    for row in rows {
+    let transaction = connection
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|error| error.to_string())?;
+    let mut changed = transaction
+        .execute(
+            "DELETE FROM analysis_jobs
+             WHERE source_id = ?1
+               AND readiness_managed = 1
+               AND readiness_stage = 'playback_summary'",
+            [source.id.as_str()],
+        )
+        .map_err(|error| error.to_string())?;
+    changed = changed.saturating_add(
+        transaction
+            .execute(
+                "DELETE FROM source_readiness_artifacts
+             WHERE source_id = ?1
+               AND stage = 'playback_summary'",
+                [source.id.as_str()],
+            )
+            .map_err(|error| error.to_string())?,
+    );
+    changed = changed.saturating_add(
+        transaction
+            .execute(
+                "DELETE FROM source_readiness_targets
+             WHERE source_id = ?1
+               AND stage = 'playback_summary'",
+                [source.id.as_str()],
+            )
+            .map_err(|error| error.to_string())?,
+    );
+    transaction.commit().map_err(|error| error.to_string())?;
+
+    for cache_ref in cache_refs {
         if cancelled(cancel) {
-            return Ok(Cancellable::Cancelled);
+            break;
         }
-        let target_matches = row.target_version.as_deref() == Some(row.artifact_version.as_str())
-            && row.target_content_generation.as_deref()
-                == Some(row.artifact_content_generation.as_str())
-            && row.target_eligibility.as_deref() == Some("eligible");
-        if !target_matches {
-            invalidate_playback_cache_owner(source, &row);
-            changed = changed.saturating_add(delete_playback_cache_ownership_row(
-                connection,
-                source.id.as_str(),
-                &row,
-            )?);
-            continue;
-        }
-        let Some(target_relative_path) = row.target_relative_path.as_deref() else {
-            invalidate_playback_cache_owner(source, &row);
-            changed = changed.saturating_add(delete_playback_cache_ownership_row(
-                connection,
-                source.id.as_str(),
-                &row,
-            )?);
-            continue;
-        };
-        let target_path = source.root.join(target_relative_path);
-        let Some(cache_ref) = row.artifact_ref.as_deref().map(std::path::Path::new) else {
-            if row.artifact_relative_path.as_deref() == Some(target_relative_path) {
-                continue;
-            }
-            changed = changed.saturating_add(update_playback_cache_ownership_row(
-                connection,
-                source.id.as_str(),
-                &row,
-                target_relative_path,
-                None,
-            )?);
-            continue;
-        };
-        if row.artifact_relative_path.as_deref() == Some(target_relative_path) {
-            if persisted_waveform_cache_ref_is_current(&target_path, cache_ref) {
-                continue;
-            }
-            invalidate_persisted_waveform_cache_ref(cache_ref);
-            changed = changed.saturating_add(update_playback_cache_ownership_row(
-                connection,
-                source.id.as_str(),
-                &row,
-                target_relative_path,
-                None,
-            )?);
-            continue;
-        }
-        if let Some(artifact_relative_path) = row.artifact_relative_path.as_deref() {
-            let artifact_path = source.root.join(artifact_relative_path);
-            invalidate_persisted_waveform_cache_path(&artifact_path);
-            if let Some(remapped_ref) = remap_persisted_waveform_cache_ref_after_move(
+        match retained_waveform_cache_ref_is_owned(&cache_ref) {
+            Ok(false) => invalidate_persisted_waveform_cache_ref(std::path::Path::new(&cache_ref)),
+            Ok(true) => {}
+            Err(error) => tracing::warn!(
+                target: "wavecrate::source_processing",
+                source_id = source.id.as_str(),
                 cache_ref,
-                &artifact_path,
-                &target_path,
-            ) {
-                let updated = connection
-                    .execute(
-                        "UPDATE source_readiness_artifacts AS artifact
-                         SET relative_path = ?1, artifact_ref = ?2
-                         WHERE artifact.source_id = ?3
-                           AND artifact.scope_kind = 'file'
-                           AND artifact.scope_id = ?4
-                           AND artifact.stage = 'playback_summary'
-                           AND artifact.artifact_version = ?5
-                           AND artifact.content_generation = ?6
-                           AND artifact.artifact_ref IS ?7
-                           AND EXISTS (
-                               SELECT 1 FROM source_readiness_targets AS target
-                               WHERE target.source_id = artifact.source_id
-                                 AND target.scope_kind = artifact.scope_kind
-                                 AND target.scope_id = artifact.scope_id
-                                 AND target.stage = artifact.stage
-                                 AND target.relative_path = ?1
-                                 AND target.required_version = artifact.artifact_version
-                                 AND target.content_generation = artifact.content_generation
-                                 AND target.eligibility = 'eligible'
-                           )",
-                        params![
-                            target_relative_path,
-                            remapped_ref.to_string_lossy(),
-                            source.id.as_str(),
-                            row.scope_id,
-                            row.artifact_version,
-                            row.artifact_content_generation,
-                            row.artifact_ref,
-                        ],
-                    )
-                    .map_err(|error| error.to_string())?;
-                if updated == 1 {
-                    changed = changed.saturating_add(1);
-                    continue;
-                }
-                invalidate_persisted_waveform_cache_ref(&remapped_ref);
-            }
+                error,
+                "Legacy playback cache ownership could not be proven; payload was preserved"
+            ),
         }
-        invalidate_persisted_waveform_cache_ref(cache_ref);
-        changed = changed.saturating_add(update_playback_cache_ownership_row(
-            connection,
-            source.id.as_str(),
-            &row,
-            target_relative_path,
-            None,
-        )?);
     }
     Ok(Cancellable::Completed(changed))
-}
-
-fn update_playback_cache_ownership_row(
-    connection: &rusqlite::Connection,
-    source_id: &str,
-    row: &PlaybackCacheOwnershipRow,
-    relative_path: &str,
-    artifact_ref: Option<&std::path::Path>,
-) -> Result<usize, String> {
-    connection
-        .execute(
-            "UPDATE source_readiness_artifacts
-             SET relative_path = ?1, artifact_ref = ?2
-             WHERE source_id = ?3
-               AND scope_kind = 'file'
-               AND scope_id = ?4
-               AND stage = 'playback_summary'
-               AND artifact_version = ?5
-               AND content_generation = ?6
-               AND artifact_ref IS ?7",
-            params![
-                relative_path,
-                artifact_ref.map(|path| path.to_string_lossy().into_owned()),
-                source_id,
-                row.scope_id,
-                row.artifact_version,
-                row.artifact_content_generation,
-                row.artifact_ref,
-            ],
-        )
-        .map_err(|error| error.to_string())
-}
-
-fn invalidate_playback_cache_owner(source: &SampleSource, row: &PlaybackCacheOwnershipRow) {
-    if let Some(relative_path) = row.artifact_relative_path.as_deref() {
-        invalidate_persisted_waveform_cache_path(&source.root.join(relative_path));
-    }
-    if let Some(cache_ref) = row.artifact_ref.as_deref() {
-        invalidate_persisted_waveform_cache_ref(std::path::Path::new(cache_ref));
-    }
-}
-
-fn delete_playback_cache_ownership_row(
-    connection: &rusqlite::Connection,
-    source_id: &str,
-    row: &PlaybackCacheOwnershipRow,
-) -> Result<usize, String> {
-    connection
-        .execute(
-            "DELETE FROM source_readiness_artifacts
-             WHERE source_id = ?1
-               AND scope_kind = 'file'
-               AND scope_id = ?2
-               AND stage = 'playback_summary'
-               AND artifact_version = ?3
-               AND content_generation = ?4
-               AND artifact_ref IS ?5",
-            params![
-                source_id,
-                row.scope_id,
-                row.artifact_version,
-                row.artifact_content_generation,
-                row.artifact_ref,
-            ],
-        )
-        .map_err(|error| error.to_string())
 }
 
 fn readiness_unsupported_content_generations(
@@ -4598,29 +4449,6 @@ fn run_readiness_stage(
                 ReadinessExecutionOutcome::Retry("indexed identity is not committed yet")
             })
         }
-        ReadinessStage::PlaybackSummary => {
-            if target.content_generation.starts_with("pending-") {
-                return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated(
-                    "playback target is waiting for a committed content generation",
-                ));
-            }
-            let Some(relative_path) = target.relative_path.as_deref() else {
-                return Ok(ReadinessExecutionOutcome::Permanent(
-                    "playback summary target has no relative path",
-                ));
-            };
-            let absolute_path = source.root.join(relative_path);
-            // A claimed deficit has no exact current cache owner. Do not hydrate an unowned v4
-            // payload using only size/mtime; erase that key first so this generation produces a
-            // cache that can be committed atomically with its durable v5 ownership reference.
-            if !prepare_playback_cache_generation(connection, target, &absolute_path)? {
-                return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated(
-                    "playback source fingerprint changed before cache publication",
-                ));
-            }
-            let cache_ref = ensure_persisted_playback_summary(absolute_path, cancel)?;
-            Ok(ReadinessExecutionOutcome::Complete(Some(cache_ref)))
-        }
         ReadinessStage::AnalysisFeatures => {
             if target.content_generation.starts_with("pending-") {
                 return Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated(
@@ -4754,51 +4582,6 @@ fn run_readiness_stage(
             )
         }
     }
-}
-
-fn prepare_playback_cache_generation(
-    connection: &mut rusqlite::Connection,
-    target: &ReadinessTarget,
-    absolute_path: &std::path::Path,
-) -> Result<bool, String> {
-    let transaction = connection
-        .transaction_with_behavior(TransactionBehavior::Immediate)
-        .map_err(|error| error.to_string())?;
-    let current = transaction
-        .query_row(
-            "SELECT EXISTS(
-                SELECT 1
-                FROM source_readiness_sources AS source
-                JOIN source_readiness_targets AS target
-                  ON target.source_id = source.source_id
-                 AND target.source_generation = source.source_generation
-                WHERE target.source_id = ?1
-                  AND target.scope_kind = 'file'
-                  AND target.scope_id = ?2
-                  AND target.relative_path = ?3
-                  AND target.stage = 'playback_summary'
-                  AND target.required_version = ?4
-                  AND target.content_generation = ?5
-                  AND target.eligibility = 'eligible'
-                  AND source.availability = 'active'
-            )",
-            params![
-                target.source_id,
-                target.scope_id,
-                target.relative_path,
-                target.required_version,
-                target.content_generation,
-            ],
-            |row| row.get::<_, bool>(0),
-        )
-        .map_err(|error| error.to_string())?;
-    if !current {
-        transaction.rollback().map_err(|error| error.to_string())?;
-        return Ok(false);
-    }
-    invalidate_persisted_waveform_cache_path(absolute_path);
-    transaction.commit().map_err(|error| error.to_string())?;
-    Ok(true)
 }
 
 fn readiness_stage_is_unsupported(
@@ -6569,10 +6352,11 @@ mod tests {
         };
         let elapsed = started_at.elapsed();
 
-        assert_eq!(candidates.len(), FILE_COUNT * 4);
-        assert_eq!(stats.readiness_queue_depth, FILE_COUNT * 4);
+        assert_eq!(candidates.len(), FILE_COUNT * 3);
+        assert_eq!(stats.readiness_queue_depth, FILE_COUNT * 3);
         assert_eq!(
-            stats.prerequisites_blocked, 1,
+            stats.prerequisites_blocked,
+            FILE_COUNT * 3,
             "the source-wide similarity layout must remain parked until file embeddings converge"
         );
         eprintln!(
@@ -7347,10 +7131,14 @@ mod tests {
                     },
                 },
                 wavecrate::sample_sources::readiness::ReadinessEntry {
-                    target: file_target(ReadinessStage::PlaybackSummary),
+                    target: {
+                        let mut target = file_target(ReadinessStage::AnalysisFeatures);
+                        target.source_id = String::from("unrelated-source");
+                        target
+                    },
                     classification: ReadinessClassification::RetryableFailure {
                         retry_at: 200,
-                        reason: String::from("unrelated playback retry"),
+                        reason: String::from("unrelated source retry"),
                     },
                 },
                 wavecrate::sample_sources::readiness::ReadinessEntry {
@@ -7805,45 +7593,17 @@ mod tests {
     }
 
     #[test]
-    fn budget_evicted_playback_cache_does_not_requeue_completed_source_work() {
-        let (_directory, source) = ready_analysis_source("playback-budget-eviction");
+    fn legacy_playback_readiness_is_retired_without_requeueing_source_work() {
+        let (_directory, source) = ready_analysis_source("legacy-playback-retirement");
         let database_root = source.database_root().expect("database root");
-        let (cache_ref, completed_at) = seed_legacy_playback_artifact(&source);
-
-        invalidate_persisted_waveform_cache_ref(&cache_ref);
-        assert!(
-            !cache_ref.exists(),
-            "fixture should model bounded-cache eviction"
-        );
+        let (cache_ref, _) = seed_legacy_playback_artifact(&source);
 
         let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
             &source.root,
             &database_root,
             SourceDatabaseConnectionRole::JobWorker,
         )
-        .expect("reopen source after cache eviction");
-        assert!(matches!(
-            reconcile_playback_cache_ownership(&source, &mut connection, &AtomicBool::new(false))
-                .expect("reconcile evicted cache ownership"),
-            Cancellable::Completed(1)
-        ));
-
-        let (artifact_ref, persisted_completed_at) = connection
-            .query_row(
-                "SELECT artifact_ref, completed_at
-                 FROM source_readiness_artifacts
-                 WHERE source_id = ?1 AND stage = 'playback_summary'",
-                [source.id.as_str()],
-                |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?)),
-            )
-            .expect("read preserved playback artifact");
-        assert_eq!(artifact_ref, None);
-        assert_eq!(persisted_completed_at, completed_at);
-        assert!(matches!(
-            reconcile_playback_cache_ownership(&source, &mut connection, &AtomicBool::new(false))
-                .expect("repeat cache-ownership reconciliation"),
-            Cancellable::Completed(0)
-        ));
+        .expect("reopen source with legacy playback rows");
 
         let snapshot = reconcile_readiness_with_cancel_and_progress(
             &connection,
@@ -7852,24 +7612,40 @@ mod tests {
             &AtomicBool::new(false),
             &mut || {},
         )
-        .expect("reconcile source readiness after cache eviction");
-        let playback = snapshot
-            .entries
-            .iter()
-            .find(|entry| entry.target.stage == ReadinessStage::PlaybackSummary)
-            .expect("playback readiness entry");
-        assert_eq!(playback.classification, ReadinessClassification::Current);
-        assert!(
-            snapshot
-                .deficits
-                .iter()
-                .all(|deficit| deficit.target.stage != ReadinessStage::PlaybackSummary),
-            "bounded-cache eviction must not recreate completed playback work"
-        );
+        .expect("ignore legacy playback rows during reconciliation");
+        assert_eq!(snapshot.entries.len(), 4);
+
+        assert!(matches!(
+            retire_legacy_playback_readiness(&source, &mut connection, &AtomicBool::new(false))
+                .expect("retire legacy playback readiness"),
+            Cancellable::Completed(2)
+        ));
+        let playback_rows = connection
+            .query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM source_readiness_targets
+                     WHERE source_id = ?1 AND stage = 'playback_summary')
+                  + (SELECT COUNT(*) FROM source_readiness_artifacts
+                     WHERE source_id = ?1 AND stage = 'playback_summary')
+                  + (SELECT COUNT(*) FROM analysis_jobs
+                     WHERE source_id = ?1
+                       AND readiness_managed = 1
+                       AND readiness_stage = 'playback_summary')",
+                [source.id.as_str()],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("count retired playback rows");
+        assert_eq!(playback_rows, 0);
+        assert!(!cache_ref.exists());
+        assert!(matches!(
+            retire_legacy_playback_readiness(&source, &mut connection, &AtomicBool::new(false))
+                .expect("repeat legacy retirement"),
+            Cancellable::Completed(0)
+        ));
     }
 
     #[test]
-    fn committed_delete_retires_exact_owned_playback_cache_without_old_file_metadata() {
+    fn legacy_playback_cache_owner_is_retired_after_committed_delete() {
         let (_directory, source) = ready_analysis_source("playback-delete");
         let database_root = source.database_root().expect("database root");
         let (owned_cache_ref, _) = seed_legacy_playback_artifact(&source);
@@ -8623,7 +8399,6 @@ mod tests {
         );
         let mut targets = vec![target.clone()];
         for stage in [
-            ReadinessStage::PlaybackSummary,
             ReadinessStage::AnalysisFeatures,
             ReadinessStage::EmbeddingAspects,
         ] {
@@ -8711,11 +8486,11 @@ mod tests {
             1,
             "pending-identity",
         ));
-        let mut playback_task = indexed.clone();
-        let RuntimeTask::Readiness(playback_target) = &mut playback_task else {
+        let mut analysis_task = indexed.clone();
+        let RuntimeTask::Readiness(analysis_target) = &mut analysis_task else {
             unreachable!();
         };
-        playback_target.stage = ReadinessStage::PlaybackSummary;
+        analysis_target.stage = ReadinessStage::AnalysisFeatures;
 
         assert_eq!(
             candidate_invalidation_scope(&indexed, Some(ExecutionOutcome::Retried { retry_at: 5 })),
@@ -8737,7 +8512,7 @@ mod tests {
             "recording an already exact indexed identity must preserve same-generation dependents"
         );
         assert_eq!(
-            candidate_invalidation_scope(&playback_task, Some(ExecutionOutcome::Completed)),
+            candidate_invalidation_scope(&analysis_task, Some(ExecutionOutcome::Completed)),
             CandidateInvalidationScope::None
         );
         assert_eq!(
@@ -9215,11 +8990,12 @@ mod tests {
         .expect("open legacy playback database");
         publish_current_readiness_targets(&mut connection, source.id.as_str(), now)
             .expect("publish current target matrix");
-        let cache_ref = ensure_persisted_playback_summary(
-            source.root.join("ready.wav"),
-            &AtomicBool::new(false),
-        )
-        .expect("seed legacy playback cache");
+        let cache_directory =
+            wavecrate::app_dirs::waveform_cache_dir().expect("resolve waveform cache directory");
+        std::fs::create_dir_all(&cache_directory).expect("create waveform cache directory");
+        let cache_ref =
+            cache_directory.join(format!("legacy-playback-{}-{now}.wfc", source.id.as_str()));
+        std::fs::write(&cache_ref, b"legacy playback cache").expect("seed legacy playback cache");
         connection
             .execute(
                 "INSERT INTO source_readiness_targets (

--- a/src/native_app/starmap_audition_telemetry.rs
+++ b/src/native_app/starmap_audition_telemetry.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicU64, Ordering},
         OnceLock,
+        atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -65,13 +65,12 @@ pub(super) use audio_file::store_summary_only_cached_waveform_file_for_tests;
 pub(in crate::native_app) use audio_file::{
     InstantWaveformPreview, InstantWaveformPreviewTier, PersistedPlaybackDescriptor,
     PreviewAuditionClip, WaveformPlaybackReady, cached_waveform_file_audition_ready_exists,
-    cached_waveform_file_exists, decode_wav_preview_clip, ensure_persisted_playback_summary,
+    cached_waveform_file_exists, decode_wav_preview_clip,
     flush_background_waveform_cache_stores_for_shutdown, instant_waveform_head_preview_from_clip,
     invalidate_persisted_waveform_cache_path, invalidate_persisted_waveform_cache_paths,
     invalidate_persisted_waveform_cache_ref, load_cached_waveform_file_for_playback,
     load_cached_waveform_playback_descriptor_sidecar, load_wav_detail_summary,
-    mark_cached_waveform_file_source_warm_attempted, persisted_waveform_cache_ref_is_current,
-    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
+    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
     should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
 };
 #[cfg(test)]

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -27,8 +27,7 @@ pub(in crate::native_app) use cache_facade::{
     flush_background_waveform_cache_stores_for_shutdown, invalidate_persisted_waveform_cache_path,
     invalidate_persisted_waveform_cache_paths, invalidate_persisted_waveform_cache_ref,
     load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
-    mark_cached_waveform_file_source_warm_attempted, persisted_waveform_cache_ref_is_current,
-    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
+    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
 };
 #[cfg(test)]
 pub(in crate::native_app) use cache_facade::{
@@ -61,14 +60,13 @@ pub(in crate::native_app) use loader::file_backed_wav_playback_descriptor;
 pub(super) use loader::load_waveform_file;
 #[cfg(test)]
 pub(super) use loader::load_waveform_file_with_progress_cancel_and_playback_ready;
-pub(in crate::native_app) use loader::{
-    ensure_persisted_playback_summary, should_use_file_backed_wav_decode,
-    should_use_file_backed_wav_decode_for_entry,
-};
 pub(super) use loader::{
     is_wav_path, load_waveform_file_for_foreground_audition,
     load_waveform_file_for_instant_audition_display,
     load_waveform_file_for_looped_foreground_audition, load_waveform_file_with_progress_and_cancel,
+};
+pub(in crate::native_app) use loader::{
+    should_use_file_backed_wav_decode, should_use_file_backed_wav_decode_for_entry,
 };
 pub(in crate::native_app) use model::{
     PersistedPlaybackCacheFile, PersistedPlaybackDescriptor, WaveformFile, WaveformPlaybackReady,

--- a/src/native_app/waveform/audio_file/cache_facade.rs
+++ b/src/native_app/waveform/audio_file/cache_facade.rs
@@ -5,8 +5,7 @@ pub(in crate::native_app) use super::waveform_cache::{
     flush_background_waveform_cache_stores_for_shutdown, invalidate_persisted_waveform_cache_path,
     invalidate_persisted_waveform_cache_paths, invalidate_persisted_waveform_cache_ref,
     load_cached_waveform_file_for_playback, load_cached_waveform_playback_descriptor_sidecar,
-    mark_cached_waveform_file_source_warm_attempted, persisted_waveform_cache_ref_is_current,
-    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
+    mark_cached_waveform_file_source_warm_attempted, remap_persisted_waveform_cache_after_move,
 };
 
 #[cfg(test)]

--- a/src/native_app/waveform/audio_file/loader.rs
+++ b/src/native_app/waveform/audio_file/loader.rs
@@ -50,49 +50,6 @@ pub(in crate::native_app::waveform) fn load_waveform_file_with_progress_and_canc
     load_waveform_file_with_progress_cancel_and_playback_ready(path, progress, cancelled, |_| {})
 }
 
-pub(in crate::native_app) fn ensure_persisted_playback_summary(
-    path: PathBuf,
-    cancel: &std::sync::atomic::AtomicBool,
-) -> Result<PathBuf, String> {
-    use std::sync::atomic::Ordering;
-
-    if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
-        return waveform_cache::persisted_waveform_cache_ref(&path).ok_or_else(|| {
-            format!(
-                "waveform cache reference is unavailable: {}",
-                path.display()
-            )
-        });
-    }
-    let file = load_waveform_file_with_progress_cancel_playback_ready_and_cache_policy(
-        path.clone(),
-        |_| {},
-        || cancel.load(Ordering::Acquire),
-        |_| {},
-        true,
-        false,
-        PlaybackReadyCachePolicy::Allow,
-        FileBackedWavPolicy::AllowSummary,
-    )?;
-    if cancel.load(Ordering::Acquire) {
-        return Err(String::from("waveform summary cancelled"));
-    }
-    waveform_cache::persist_cached_waveform_file(&file)?;
-    if waveform_cache::cached_waveform_file_audition_ready_exists(&path) {
-        waveform_cache::persisted_waveform_cache_ref(&path).ok_or_else(|| {
-            format!(
-                "waveform cache reference is unavailable after persistence: {}",
-                path.display()
-            )
-        })
-    } else {
-        Err(format!(
-            "waveform cache did not publish an audition-ready summary: {}",
-            path.display()
-        ))
-    }
-}
-
 pub(in crate::native_app::waveform) fn load_waveform_file_with_progress_cancel_and_playback_ready(
     path: PathBuf,
     progress: impl Fn(f32),

--- a/src/native_app/waveform/audio_file/waveform_cache.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache.rs
@@ -20,11 +20,8 @@ use read::read_cached_waveform_file;
 pub(in crate::native_app) use read::{
     cached_waveform_file_audition_ready_exists, cached_waveform_file_exists,
 };
-pub(in crate::native_app) use remap::{
-    remap_persisted_waveform_cache_after_move, remap_persisted_waveform_cache_ref_after_move,
-};
+pub(in crate::native_app) use remap::remap_persisted_waveform_cache_after_move;
 pub(in crate::native_app) use store_queue::flush_background_waveform_cache_stores_for_shutdown;
-pub(super) use store_queue::persist_cached_waveform_file;
 #[cfg(test)]
 pub(super) use store_queue::store_cached_waveform_file;
 pub(super) use store_queue::store_cached_waveform_file_in_background;
@@ -49,18 +46,11 @@ pub(super) const MAX_PERSISTED_PLAYBACK_SAMPLE_BYTES: usize = 8 * GIB;
 pub(super) const MAX_PERSISTED_WAVEFORM_CACHE_BYTES: u64 = 2 * GIB as u64;
 pub(super) const BACKGROUND_STORE_SHUTDOWN_WAIT: Duration = Duration::from_secs(30);
 
+#[cfg(test)]
 pub(in crate::native_app) fn persisted_waveform_cache_ref(
     path: &std::path::Path,
 ) -> Option<PathBuf> {
     identity::cache_path_for_current_file(path).ok()
-}
-
-pub(in crate::native_app) fn persisted_waveform_cache_ref_is_current(
-    path: &std::path::Path,
-    cache_ref: &std::path::Path,
-) -> bool {
-    identity::cache_path_for_current_file(path).is_ok_and(|current| current == cache_ref)
-        && read::cached_waveform_file_audition_ready_exists(path)
 }
 
 pub(super) fn load_cached_waveform_file(

--- a/src/native_app/waveform/audio_file/waveform_cache/identity.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/identity.rs
@@ -43,6 +43,7 @@ pub(super) fn cache_path_for_identity(
     Ok(dir.join(format!("{:016x}.wfc", hasher.finish())))
 }
 
+#[cfg(test)]
 pub(super) fn cache_path_for_current_file(path: &Path) -> Result<PathBuf, String> {
     let identity = CacheIdentity::for_path(path)?;
     cache_path_for_identity(path, &identity)

--- a/src/native_app/waveform/audio_file/waveform_cache/remap.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/remap.rs
@@ -42,35 +42,6 @@ pub(in crate::native_app) fn remap_persisted_waveform_cache_after_move(
     }
 }
 
-/// Remap an exact reverse-owned cache payload after a committed path-only move.
-///
-/// Unlike the legacy path-only entrypoint, this remains usable after the old source path has
-/// disappeared because the caller supplies the previously persisted cache reference.
-pub(in crate::native_app) fn remap_persisted_waveform_cache_ref_after_move(
-    old_cache_ref: &Path,
-    old_path: &Path,
-    new_path: &Path,
-) -> Option<PathBuf> {
-    if !super::identity::cache_ref_is_managed(old_cache_ref) || !new_path.is_file() {
-        return None;
-    }
-    match remap_file_from_cache_ref(old_cache_ref, old_path, new_path) {
-        Ok(cache_ref) => cache_ref,
-        Err(err) => {
-            tracing::debug!(
-                target: "wavecrate::debug::sample_cache",
-                event = "browser.sample_cache.owned_move_remap_failed",
-                old_cache_ref = %old_cache_ref.display(),
-                old_path = %old_path.display(),
-                new_path = %new_path.display(),
-                error = %err,
-                "Reverse-owned waveform cache could not be remapped after file move"
-            );
-            None
-        }
-    }
-}
-
 fn remap_directory(old_dir: &Path, new_dir: &Path) -> usize {
     let Ok(entries) = fs::read_dir(new_dir) else {
         return 0;

--- a/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/store_queue.rs
@@ -6,11 +6,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(test)]
+use super::write::StoreWriteOutcome;
 use super::{
     BACKGROUND_STORE_SHUTDOWN_WAIT,
     identity::{CacheIdentity, cache_path_for_identity},
     invalidation::current_path_generation,
-    write::{StoreWriteOutcome, store_cached_waveform_file_now as write_cached_waveform_file_now},
+    write::store_cached_waveform_file_now as write_cached_waveform_file_now,
 };
 use crate::native_app::waveform::audio_file::WaveformFile;
 use diagnostics::{log_slow_cache_shutdown_flush, log_store_completion};
@@ -27,6 +29,7 @@ pub(in crate::native_app::waveform::audio_file) fn store_cached_waveform_file(fi
     let _ = persist_cached_waveform_file(file);
 }
 
+#[cfg(test)]
 pub(in crate::native_app::waveform::audio_file) fn persist_cached_waveform_file(
     file: &WaveformFile,
 ) -> Result<(), String> {

--- a/src/native_app/waveform/audio_file/waveform_cache/tests/remap_behavior.rs
+++ b/src/native_app/waveform/audio_file/waveform_cache/tests/remap_behavior.rs
@@ -34,37 +34,6 @@ fn persisted_waveform_cache_remaps_summary_without_playback_sidecar_after_file_m
 }
 
 #[test]
-fn reverse_owned_cache_ref_remaps_after_old_source_path_disappears() {
-    let _guard = waveform_cache_test_guard();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let old_path = dir.path().join("owned-old.wav");
-    let new_path = dir.path().join("owned-new.wav");
-    fs::write(&old_path, [1_u8, 2, 3, 4]).expect("write sample");
-    let mut file = waveform_file_from_mono_samples(
-        old_path.clone(),
-        Arc::from([1_u8, 2, 3, 4]),
-        48_000,
-        1,
-        vec![0.0, 0.5, -0.5, 0.25],
-    );
-    file.playback_samples = Some(Arc::from(vec![0.0, 0.5, -0.5, 0.25]));
-    store_cached_waveform_file(&file);
-    let old_cache_ref = persisted_waveform_cache_ref(&old_path).expect("old cache reference");
-
-    fs::rename(&old_path, &new_path).expect("move sample");
-    let new_cache_ref =
-        remap_persisted_waveform_cache_ref_after_move(&old_cache_ref, &old_path, &new_path)
-            .expect("remap reverse-owned cache");
-
-    assert!(!old_cache_ref.exists());
-    assert!(new_cache_ref.is_file());
-    assert!(persisted_waveform_cache_ref_is_current(
-        &new_path,
-        &new_cache_ref
-    ));
-}
-
-#[test]
 fn persisted_waveform_cache_remaps_source_ready_summary_after_file_move() {
     let _guard = waveform_cache_test_guard();
     let dir = tempfile::tempdir().expect("tempdir");

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -305,8 +305,11 @@ fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_st
         .expect("serialize existing changelog"),
     )
     .expect("write existing changelog");
-    fs::write(&release_log, "# Wavecrate 19.1.0\n\n- Repaired stable body\n")
-        .expect("write current log");
+    fs::write(
+        &release_log,
+        "# Wavecrate 19.1.0\n\n- Repaired stable body\n",
+    )
+    .expect("write current log");
 
     run_success(
         Command::new("python3")

--- a/tests/source_analysis_process.rs
+++ b/tests/source_analysis_process.rs
@@ -191,7 +191,6 @@ impl SourceAnalysisFixture {
         let mut targets = Vec::new();
         for stage in [
             ReadinessStage::IndexedIdentity,
-            ReadinessStage::PlaybackSummary,
             ReadinessStage::AnalysisFeatures,
             ReadinessStage::EmbeddingAspects,
         ] {


### PR DESCRIPTION
## Goal

Reconcile Wavecrate source readiness with the production contract after playback-cache residency stopped being a durable source-processing target.

## Scope and non-goals

- Define durable readiness as three file-scoped stages plus one source-scoped similarity stage.
- Remove playback-summary scheduling, execution, progress, and durable model variants.
- Ignore legacy playback rows during read-only reconciliation and retire legacy targets, artifacts, jobs, and unshared managed cache payloads during writable processing.
- Keep automatic waveform/playback cache ownership in its existing bounded cache lifecycle, including stale fencing, remap, invalidation, pruning, and source retirement.
- Update durable product/test documentation and exact 10,000-file counts to 30,001 targets.
- Include the user-requested rustfmt-only Wavecrate cleanup and repin Radiant to its pushed formatting commit `3939fe95`.
- Non-goal: change cache size policy, foreground audition semantics, or calibrated performance budgets.

## Definition of Done

- Every eligible file publishes exactly indexed identity, analysis features, and embedding/aspects readiness targets.
- Every active source publishes exactly one similarity-layout target.
- No current playback-summary target, artifact, job, scheduler lane, or executor path remains.
- Legacy playback rows cannot affect read-only readiness and are retired safely on writable processing without deleting cache payloads still referenced by another retained source database.
- The 10,000-file discovery baseline asserts 30,000 runnable file targets and 30,001 total durable targets.
- Playback cache behavior remains covered independently of durable readiness.

## Validation

- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate-library sample_sources::readiness::tests` — passed, 42/42.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests` — passed, 77/77 with the explicit 10k profile ignored; includes post-commit cancellation coverage for multiple legacy cache references.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate --bin wavecrate native_app::waveform::audio_file::waveform_cache::tests` — passed, 25/25.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate --test source_analysis_process` — passed, 2/2.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate --bin wavecrate profile_large_source_discovery_baseline -- --ignored --nocapture` — passed: 10,000 files, 30,000 runnable candidates, 68.6 s.
- `bash scripts/check.sh mdbook` — passed.
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt1204-target CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=4 bash scripts/ci.sh smoke` — passed from an isolated target after the shared target twice left `rustc` sleeping at 0% CPU.
- `cargo fmt --all -- --check`, `git diff --check`, and stale playback/count grep — passed.
- Radiant `cargo fmt --all -- --check` — passed before `3939fe95` was pushed to `main`.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wavecrate --bin wavecrate profile_source_processing_churn_under_playback_and_browser_priority -- --ignored --nocapture` — attempted twice; see Known limitations.

## Known limitations

- On this currently loaded workstation, the calibrated 10,000-file churn profile made steady error-free progress but missed its unchanged 900-second drain budget twice: 16,692/30,001 and 16,753/30,001 completed, with zero failures, retries, stale completions, cancellations, or reported contention. The historical calibration is 353 candidates/s; these runs were about 18.6 candidates/s. The budget was intentionally not weakened. This exact-head environment limitation needs a clean performance host rerun before merge confidence is complete.

User approval is required before merge.

Linear: OPT-1204