### PR TITLE
Enforce typed readiness persistence boundary

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -21,18 +21,17 @@ pub use snapshot::{
 #[cfg(test)]
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
-    ReadinessCompatibilityCleanup, ReadinessError, ReadinessSourceState, ReadinessStore,
-    ReadinessTargetPublication,
+    ReadinessCompatibilityCleanup, ReadinessEmbeddingArtifactTarget, ReadinessError,
+    ReadinessSimilarityManifest, ReadinessSimilarityManifestRequest,
+    ReadinessSimilarityManifestRow, ReadinessSimilarityPayloadContract, ReadinessSourceState,
+    ReadinessStore, ReadinessTargetPublication, ReadinessView,
 };
 #[cfg(test)]
-pub use store::{
+pub(crate) use store::{
     cancel_readiness_work, claim_readiness_target, complete_readiness_work,
     complete_readiness_work_with_artifact_ref, fail_readiness_work, invalidate_readiness_artifact,
-    persist_readiness_deficits, persist_readiness_deficits_with_cancel,
-    persist_readiness_deficits_with_cancel_and_progress, publish_readiness_artifact,
-    readiness_work_stats, reconcile_readiness, reconcile_readiness_with_cancel,
-    reconcile_readiness_with_cancel_and_progress, release_readiness_work, renew_readiness_lease,
-    replace_readiness_targets, replace_readiness_targets_with_cancel,
+    persist_readiness_deficits, publish_readiness_artifact, readiness_work_stats,
+    reconcile_readiness, release_readiness_work, renew_readiness_lease, replace_readiness_targets,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -21,7 +21,12 @@ pub use snapshot::{
 #[cfg(test)]
 pub(crate) use store::reconcile_readiness_with_hook;
 pub use store::{
-    ReadinessError, cancel_readiness_work, claim_readiness_target, complete_readiness_work,
+    ReadinessCompatibilityCleanup, ReadinessError, ReadinessSourceState, ReadinessStore,
+    ReadinessTargetPublication,
+};
+#[cfg(test)]
+pub use store::{
+    cancel_readiness_work, claim_readiness_target, complete_readiness_work,
     complete_readiness_work_with_artifact_ref, fail_readiness_work, invalidate_readiness_artifact,
     persist_readiness_deficits, persist_readiness_deficits_with_cancel,
     persist_readiness_deficits_with_cancel_and_progress, publish_readiness_artifact,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -4,6 +4,530 @@ mod reconcile;
 mod work;
 
 pub use error::ReadinessError;
+use std::{collections::BTreeSet, sync::atomic::AtomicBool};
+
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+
+use super::{
+    ClaimedReadinessWork, ReadinessArtifact, ReadinessDeficit, ReadinessFailureClassification,
+    ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessSnapshot,
+    ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, ReadinessWorkStats,
+    SourceAvailability,
+};
+use crate::sample_sources::readiness::ArtifactPublishOutcome;
+
+/// Typed request for atomically publishing a source's complete desired readiness set.
+///
+/// Keeping the publication inputs together makes the generation, revision, availability, and
+/// target set one durable operation instead of a convention spread across native orchestration.
+#[derive(Debug)]
+pub struct ReadinessTargetPublication<'a> {
+    source_id: &'a str,
+    source_generation: i64,
+    readiness_revision: i64,
+    availability: SourceAvailability,
+    targets: &'a [ReadinessTarget],
+    updated_at: i64,
+}
+
+impl<'a> ReadinessTargetPublication<'a> {
+    /// Build one complete readiness publication for a source generation.
+    pub fn new(
+        source_id: &'a str,
+        source_generation: i64,
+        readiness_revision: i64,
+        availability: SourceAvailability,
+        targets: &'a [ReadinessTarget],
+        updated_at: i64,
+    ) -> Self {
+        Self {
+            source_id,
+            source_generation,
+            readiness_revision,
+            availability,
+            targets,
+            updated_at,
+        }
+    }
+}
+
+/// The only production persistence boundary for durable source readiness.
+///
+/// The repository borrows one source-database connection, owns readiness transactions, and
+/// exposes domain operations rather than readiness table access.
+pub struct ReadinessStore<'connection> {
+    connection: &'connection mut Connection,
+}
+
+/// The result of an idempotent compatibility cleanup after its transaction commits.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ReadinessCompatibilityCleanup {
+    /// Number of obsolete readiness rows removed.
+    pub changed: usize,
+    /// Cache payloads no longer referenced by the retired readiness rows.
+    pub retired_artifact_refs: Vec<String>,
+}
+
+/// Durable readiness publication state for one configured source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadinessSourceState {
+    /// Last accepted manifest generation.
+    pub source_generation: i64,
+    /// Last accepted readiness publication revision.
+    pub readiness_revision: i64,
+    /// Current processing availability.
+    pub availability: SourceAvailability,
+}
+
+impl<'connection> ReadinessStore<'connection> {
+    /// Bind readiness persistence to one caller-selected source database connection.
+    pub fn new(connection: &'connection mut Connection) -> Self {
+        Self { connection }
+    }
+
+    /// Atomically publish one complete, validated target generation.
+    pub fn publish_targets(
+        &mut self,
+        publication: &ReadinessTargetPublication<'_>,
+    ) -> Result<(), ReadinessError> {
+        persistence::replace_readiness_targets_inner(
+            self.connection,
+            publication.source_id,
+            publication.source_generation,
+            publication.readiness_revision,
+            publication.availability,
+            publication.targets,
+            publication.updated_at,
+            None,
+        )
+    }
+
+    /// Publish targets while rolling back if cancellation is observed.
+    pub fn publish_targets_with_cancel(
+        &mut self,
+        publication: &ReadinessTargetPublication<'_>,
+        cancel: &AtomicBool,
+    ) -> Result<(), ReadinessError> {
+        persistence::replace_readiness_targets_inner(
+            self.connection,
+            publication.source_id,
+            publication.source_generation,
+            publication.readiness_revision,
+            publication.availability,
+            publication.targets,
+            publication.updated_at,
+            Some(cancel),
+        )
+    }
+
+    /// Classify durable readiness for one source at a point in time.
+    pub fn reconcile(
+        &mut self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut || {})
+    }
+
+    /// Reconcile a source while reporting checkpoints and honoring cancellation.
+    pub fn reconcile_with_cancel_and_progress(
+        &mut self,
+        source_id: &str,
+        now: i64,
+        cancel: &AtomicBool,
+        progress: &mut dyn FnMut(),
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        reconcile::reconcile_readiness_inner(
+            self.connection,
+            source_id,
+            now,
+            Some(cancel),
+            progress,
+        )
+    }
+
+    /// Atomically enqueue actionable deficits.
+    pub fn persist_deficits(
+        &mut self,
+        deficits: &[ReadinessDeficit],
+        created_at: i64,
+    ) -> Result<usize, ReadinessError> {
+        persistence::persist_readiness_deficits_inner(
+            self.connection,
+            deficits,
+            created_at,
+            None,
+            &mut || {},
+        )
+    }
+
+    /// Enqueue deficits with cancellation-safe progress reporting.
+    pub fn persist_deficits_with_cancel_and_progress(
+        &mut self,
+        deficits: &[ReadinessDeficit],
+        created_at: i64,
+        cancel: &AtomicBool,
+        progress: &mut dyn FnMut(),
+    ) -> Result<usize, ReadinessError> {
+        persistence::persist_readiness_deficits_inner(
+            self.connection,
+            deficits,
+            created_at,
+            Some(cancel),
+            progress,
+        )
+    }
+
+    /// Claim one current target under a durable lease.
+    pub fn claim(
+        &mut self,
+        target: &ReadinessTarget,
+        now: i64,
+        lease_duration_seconds: i64,
+    ) -> Result<Option<ClaimedReadinessWork>, ReadinessError> {
+        work::claim_readiness_target(self.connection, target, now, lease_duration_seconds)
+    }
+    /// Renew an active claim without changing its generation.
+    pub fn renew_lease(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        now: i64,
+        lease_duration_seconds: i64,
+    ) -> Result<ReadinessLeaseRenewalOutcome, ReadinessError> {
+        work::renew_readiness_lease(self.connection, claim, now, lease_duration_seconds)
+    }
+    /// Publish a claimed completion without an external artifact reference.
+    pub fn complete(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        completed_at: i64,
+    ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+        work::complete_readiness_work(self.connection, claim, completed_at)
+    }
+    /// Publish a claimed completion with its durable artifact reference.
+    pub fn complete_with_artifact_ref(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        completed_at: i64,
+        artifact_ref: &str,
+    ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+        work::complete_readiness_work_with_artifact_ref(
+            self.connection,
+            claim,
+            completed_at,
+            artifact_ref,
+        )
+    }
+    /// Record a classified failure for a current claim.
+    pub fn fail(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        classification: ReadinessFailureClassification,
+        reason: &str,
+        failed_at: i64,
+        retry_policy: ReadinessRetryPolicy,
+    ) -> Result<ReadinessFailureOutcome, ReadinessError> {
+        work::fail_readiness_work(
+            self.connection,
+            claim,
+            classification,
+            reason,
+            failed_at,
+            retry_policy,
+        )
+    }
+    /// Return a current claim to pending work.
+    pub fn release(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        released_at: i64,
+    ) -> Result<ReadinessWorkMutationOutcome, ReadinessError> {
+        work::release_readiness_work(self.connection, claim, released_at)
+    }
+    /// Return a current claim to pending work with a cancellation diagnostic.
+    pub fn cancel(
+        &mut self,
+        claim: &ClaimedReadinessWork,
+        reason: &str,
+        cancelled_at: i64,
+    ) -> Result<ReadinessWorkMutationOutcome, ReadinessError> {
+        work::cancel_readiness_work(self.connection, claim, reason, cancelled_at)
+    }
+    /// Invalidate an exact artifact only when its target remains current.
+    pub fn invalidate_artifact(
+        &mut self,
+        target: &ReadinessTarget,
+    ) -> Result<bool, ReadinessError> {
+        persistence::invalidate_readiness_artifact(self.connection, target)
+    }
+    /// Load queue and lease-recovery telemetry for the current durable work set.
+    pub fn work_stats(&mut self, now: i64) -> Result<ReadinessWorkStats, ReadinessError> {
+        work::readiness_work_stats(self.connection, now)
+    }
+    /// Publish an independently produced artifact if its target is still current.
+    pub fn publish_artifact(
+        &mut self,
+        artifact: &ReadinessArtifact,
+    ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+        persistence::publish_readiness_artifact(self.connection, artifact)
+    }
+
+    /// Whether the readiness schema required for source processing is present.
+    pub fn schema_available(&mut self) -> Result<bool, ReadinessError> {
+        self.connection.query_row(
+            "SELECT COUNT(*) = 3 FROM sqlite_master WHERE type = 'table' AND name IN ('source_readiness_sources', 'source_readiness_targets', 'source_readiness_artifacts')",
+            [], |row| row.get(0),
+        ).map_err(Into::into)
+    }
+
+    /// Whether the source database has every readiness-owned table and work column.
+    pub fn processing_schema_available(&mut self) -> Result<bool, ReadinessError> {
+        for (table, columns) in [
+            (
+                "analysis_jobs",
+                &[
+                    "id",
+                    "relative_path",
+                    "job_type",
+                    "created_at",
+                    "status",
+                    "readiness_managed",
+                ][..],
+            ),
+            (
+                "source_readiness_artifacts",
+                &[
+                    "source_id",
+                    "scope_kind",
+                    "scope_id",
+                    "relative_path",
+                    "stage",
+                    "artifact_version",
+                    "content_generation",
+                    "artifact_ref",
+                ][..],
+            ),
+        ] {
+            let pragma = format!("PRAGMA table_info({table})");
+            let mut statement = self.connection.prepare(&pragma)?;
+            let found = statement
+                .query_map([], |row| row.get::<_, String>(1))?
+                .collect::<Result<BTreeSet<_>, _>>()?;
+            if columns.iter().any(|column| !found.contains(*column)) {
+                return Ok(false);
+            }
+        }
+        self.schema_available()
+    }
+
+    /// Whether one source has durable readiness state.
+    pub fn source_exists(&mut self, source_id: &str) -> Result<bool, ReadinessError> {
+        self.connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
+                [source_id],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
+    }
+
+    /// Load the state required to decide whether a complete target publication is still current.
+    pub fn source_state(
+        &mut self,
+        source_id: &str,
+    ) -> Result<Option<ReadinessSourceState>, ReadinessError> {
+        self.connection.query_row(
+            "SELECT source_generation, readiness_revision, availability FROM source_readiness_sources WHERE source_id = ?1",
+            [source_id],
+            |row| {
+                let availability = row.get::<_, String>(2)?;
+                let availability = SourceAvailability::from_stored(&availability).ok_or_else(|| rusqlite::Error::InvalidQuery)?;
+                Ok(ReadinessSourceState { source_generation: row.get(0)?, readiness_revision: row.get(1)?, availability })
+            },
+        ).optional().map_err(Into::into)
+    }
+
+    /// Mark a source offline without modifying its generation or target set.
+    pub fn mark_temporarily_unavailable(
+        &mut self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<(), ReadinessError> {
+        self.connection.execute(
+            "UPDATE source_readiness_sources SET availability = 'offline', readiness_revision = readiness_revision + 1, updated_at = ?2 WHERE source_id = ?1 AND availability != 'offline'",
+            params![source_id, now],
+        )?;
+        Ok(())
+    }
+
+    /// Drop queued readiness work for files that are still being actively recorded.
+    pub fn defer_active_recordings(
+        &mut self,
+        scope_ids: &BTreeSet<String>,
+    ) -> Result<(), ReadinessError> {
+        for scope_id in scope_ids {
+            self.connection.execute(
+                "DELETE FROM analysis_jobs WHERE readiness_managed = 1 AND readiness_scope_id = ?1 AND status != 'running'",
+                [scope_id],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Remove obsolete jobs from the retired, non-readiness similarity pipeline.
+    pub fn prune_legacy_similarity_jobs(&mut self) -> Result<usize, ReadinessError> {
+        let removed = self.connection.execute(
+            "DELETE FROM analysis_jobs WHERE readiness_managed = 0 AND job_type IN ('wav_metadata_v1', 'embedding_backfill_v1', 'rebuild_index_v1')", [],
+        )?;
+        self.connection.execute(
+            "DELETE FROM analysis_job_progress_snapshots WHERE job_type IN ('wav_metadata_v1', 'embedding_backfill_v1', 'rebuild_index_v1')", [],
+        )?;
+        Ok(removed)
+    }
+
+    /// Return file content generations that have durably failed as unsupported.
+    pub fn unsupported_content_generations(
+        &mut self,
+        source_id: &str,
+    ) -> Result<BTreeSet<(String, String)>, ReadinessError> {
+        let mut statement = self.connection.prepare(
+            "SELECT DISTINCT readiness_scope_id, content_generation FROM analysis_jobs WHERE source_id = ?1 AND readiness_managed = 1 AND readiness_scope_kind = 'file' AND status = 'failed' AND failure_kind = 'unsupported' AND readiness_scope_id IS NOT NULL AND content_generation IS NOT NULL",
+        )?;
+        statement
+            .query_map([source_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<BTreeSet<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Check whether a prerequisite stage is terminally unsupported for a file generation.
+    pub fn stage_is_unsupported(
+        &mut self,
+        target: &ReadinessTarget,
+        stage: ReadinessStage,
+    ) -> Result<bool, ReadinessError> {
+        self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM analysis_jobs WHERE readiness_managed = 1 AND source_id = ?1 AND readiness_scope_kind = 'file' AND readiness_scope_id = ?2 AND readiness_stage = ?3 AND content_generation = ?4 AND status = 'failed' AND failure_kind = 'unsupported')",
+            params![target.source_id, target.scope_id, stage.as_str(), target.content_generation], |row| row.get(0),
+        ).map_err(Into::into)
+    }
+
+    /// Upgrade deterministic legacy decode failures to the terminal unsupported classification.
+    pub fn reclassify_known_unsupported_failures(
+        &mut self,
+        is_unsupported: impl Fn(&str) -> bool,
+    ) -> Result<usize, ReadinessError> {
+        let failures = {
+            let mut statement = self.connection.prepare(
+                "SELECT id, COALESCE(last_error, '') FROM analysis_jobs WHERE readiness_managed = 1 AND status = 'failed' AND failure_kind IN ('retryable', 'permanent')",
+            )?;
+            statement
+                .query_map([], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        let tx = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let mut changed = 0;
+        for id in failures
+            .into_iter()
+            .filter_map(|(id, error)| is_unsupported(&error).then_some(id))
+        {
+            changed += tx.execute(
+                "UPDATE analysis_jobs SET failure_kind = 'unsupported', retry_at = NULL WHERE id = ?1 AND readiness_managed = 1 AND status = 'failed' AND failure_kind IN ('retryable', 'permanent')", [id],
+            )?;
+        }
+        changed += tx.execute(
+            "UPDATE analysis_jobs AS dependent SET failure_kind = 'unsupported', retry_at = NULL WHERE dependent.readiness_managed = 1 AND dependent.status = 'failed' AND dependent.failure_kind IN ('retryable', 'permanent') AND dependent.readiness_stage = 'embedding_aspects' AND dependent.last_error = 'embedding feature prerequisite is not durable yet' AND EXISTS (SELECT 1 FROM analysis_jobs AS prerequisite WHERE prerequisite.readiness_managed = 1 AND prerequisite.source_id = dependent.source_id AND prerequisite.readiness_scope_kind = dependent.readiness_scope_kind AND prerequisite.readiness_scope_id = dependent.readiness_scope_id AND prerequisite.readiness_stage = 'analysis_features' AND prerequisite.content_generation = dependent.content_generation AND prerequisite.status = 'failed' AND prerequisite.failure_kind = 'unsupported')", [],
+        )?;
+        tx.commit()?;
+        Ok(changed)
+    }
+
+    /// Retire rows belonging to the removed playback-summary stage, atomically collecting cache refs.
+    pub fn retire_legacy_playback(
+        &mut self,
+        source_id: &str,
+    ) -> Result<ReadinessCompatibilityCleanup, ReadinessError> {
+        let tx = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let refs = {
+            let mut statement = tx.prepare("SELECT artifact_ref FROM source_readiness_artifacts WHERE source_id = ?1 AND stage = 'playback_summary' AND artifact_ref IS NOT NULL AND length(trim(artifact_ref)) > 0")?;
+            statement
+                .query_map([source_id], |row| row.get::<_, String>(0))?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        let mut changed = tx.execute("DELETE FROM analysis_jobs WHERE source_id = ?1 AND readiness_managed = 1 AND readiness_stage = 'playback_summary'", [source_id])?;
+        changed += tx.execute("DELETE FROM source_readiness_artifacts WHERE source_id = ?1 AND stage = 'playback_summary'", [source_id])?;
+        changed += tx.execute("DELETE FROM source_readiness_targets WHERE source_id = ?1 AND stage = 'playback_summary'", [source_id])?;
+        tx.commit()?;
+        Ok(ReadinessCompatibilityCleanup {
+            changed,
+            retired_artifact_refs: refs,
+        })
+    }
+
+    /// Disable a retired source and delete all readiness-owned work, retaining cache cleanup data.
+    pub fn retire_source(
+        &mut self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessCompatibilityCleanup, ReadinessError> {
+        let tx = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let refs = {
+            let mut statement = tx.prepare("SELECT artifact_ref FROM source_readiness_artifacts WHERE source_id = ?1 AND stage = 'playback_summary' AND artifact_ref IS NOT NULL AND length(trim(artifact_ref)) > 0")?;
+            statement
+                .query_map([source_id], |row| row.get::<_, String>(0))?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        tx.execute("UPDATE source_readiness_sources SET availability = 'disabled', readiness_revision = readiness_revision + 1, updated_at = ?2 WHERE source_id = ?1 AND availability != 'disabled'", params![source_id, now])?;
+        let mut changed = tx.execute(
+            "DELETE FROM analysis_jobs WHERE source_id = ?1 AND readiness_managed = 1",
+            [source_id],
+        )?;
+        changed += tx.execute("DELETE FROM source_readiness_artifacts WHERE source_id = ?1 AND stage = 'playback_summary'", [source_id])?;
+        changed += tx.execute("DELETE FROM source_readiness_targets WHERE source_id = ?1 AND stage = 'playback_summary'", [source_id])?;
+        tx.commit()?;
+        Ok(ReadinessCompatibilityCleanup {
+            changed,
+            retired_artifact_refs: refs,
+        })
+    }
+
+    /// Return legacy playback cache references for bounded app-global cache collection.
+    pub fn legacy_playback_artifact_refs(&mut self) -> Result<Vec<String>, ReadinessError> {
+        if !self.schema_available()? {
+            return Ok(Vec::new());
+        }
+        let mut statement = self.connection.prepare(
+            "SELECT artifact_ref FROM source_readiness_artifacts WHERE stage = 'playback_summary' AND artifact_ref IS NOT NULL AND length(trim(artifact_ref)) > 0",
+        )?;
+        statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Check legacy playback cache ownership without exposing the artifact table to callers.
+    pub fn legacy_playback_artifact_ref_is_owned(
+        &mut self,
+        artifact_ref: &str,
+    ) -> Result<bool, ReadinessError> {
+        if !self.schema_available()? {
+            return Ok(false);
+        }
+        self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM source_readiness_artifacts WHERE stage = 'playback_summary' AND artifact_ref = ?1)",
+            [artifact_ref], |row| row.get(0),
+        ).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
 pub use persistence::{
     invalidate_readiness_artifact, persist_readiness_deficits,
     persist_readiness_deficits_with_cancel, persist_readiness_deficits_with_cancel_and_progress,
@@ -11,10 +535,12 @@ pub use persistence::{
 };
 #[cfg(test)]
 pub(crate) use reconcile::reconcile_readiness_with_hook;
+#[cfg(test)]
 pub use reconcile::{
     reconcile_readiness, reconcile_readiness_with_cancel,
     reconcile_readiness_with_cancel_and_progress,
 };
+#[cfg(test)]
 pub use work::{
     cancel_readiness_work, claim_readiness_target, complete_readiness_work,
     complete_readiness_work_with_artifact_ref, fail_readiness_work, readiness_work_stats,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -1,10 +1,18 @@
 mod error;
 mod persistence;
 mod reconcile;
+mod similarity;
+mod view;
 mod work;
 
 pub use error::ReadinessError;
+pub use similarity::{
+    ReadinessEmbeddingArtifactTarget, ReadinessSimilarityManifest,
+    ReadinessSimilarityManifestRequest, ReadinessSimilarityManifestRow,
+    ReadinessSimilarityPayloadContract,
+};
 use std::{collections::BTreeSet, sync::atomic::AtomicBool};
+pub use view::ReadinessView;
 
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
@@ -264,6 +272,7 @@ impl<'connection> ReadinessStore<'connection> {
     pub fn work_stats(&mut self, now: i64) -> Result<ReadinessWorkStats, ReadinessError> {
         work::readiness_work_stats(self.connection, now)
     }
+
     /// Publish an independently produced artifact if its target is still current.
     pub fn publish_artifact(
         &mut self,
@@ -405,10 +414,7 @@ impl<'connection> ReadinessStore<'connection> {
         target: &ReadinessTarget,
         stage: ReadinessStage,
     ) -> Result<bool, ReadinessError> {
-        self.connection.query_row(
-            "SELECT EXISTS(SELECT 1 FROM analysis_jobs WHERE readiness_managed = 1 AND source_id = ?1 AND readiness_scope_kind = 'file' AND readiness_scope_id = ?2 AND readiness_stage = ?3 AND content_generation = ?4 AND status = 'failed' AND failure_kind = 'unsupported')",
-            params![target.source_id, target.scope_id, stage.as_str(), target.content_generation], |row| row.get(0),
-        ).map_err(Into::into)
+        ReadinessView::new(self.connection).stage_is_unsupported(target, stage)
     }
 
     /// Upgrade deterministic legacy decode failures to the terminal unsupported classification.
@@ -525,23 +531,24 @@ impl<'connection> ReadinessStore<'connection> {
             [artifact_ref], |row| row.get(0),
         ).map_err(Into::into)
     }
+
+    /// Reset interrupted readiness claims so recovery can claim them again.
+    pub fn reset_interrupted_work(&mut self) -> Result<usize, ReadinessError> {
+        self.connection.execute("UPDATE analysis_jobs SET status = 'pending', running_at = NULL, lease_expires_at = NULL WHERE status = 'running' AND readiness_managed = 1", []).map_err(Into::into)
+    }
 }
 
 #[cfg(test)]
-pub use persistence::{
-    invalidate_readiness_artifact, persist_readiness_deficits,
-    persist_readiness_deficits_with_cancel, persist_readiness_deficits_with_cancel_and_progress,
-    publish_readiness_artifact, replace_readiness_targets, replace_readiness_targets_with_cancel,
+pub(crate) use persistence::{
+    invalidate_readiness_artifact, persist_readiness_deficits, publish_readiness_artifact,
+    replace_readiness_targets,
 };
+#[cfg(test)]
+pub(crate) use reconcile::reconcile_readiness;
 #[cfg(test)]
 pub(crate) use reconcile::reconcile_readiness_with_hook;
 #[cfg(test)]
-pub use reconcile::{
-    reconcile_readiness, reconcile_readiness_with_cancel,
-    reconcile_readiness_with_cancel_and_progress,
-};
-#[cfg(test)]
-pub use work::{
+pub(crate) use work::{
     cancel_readiness_work, claim_readiness_target, complete_readiness_work,
     complete_readiness_work_with_artifact_ref, fail_readiness_work, readiness_work_stats,
     release_readiness_work, renew_readiness_lease,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -14,6 +14,7 @@ use super::super::{
 use super::error::ReadinessError;
 
 /// Atomically replace the complete desired readiness set for one source generation.
+#[cfg(test)]
 pub fn replace_readiness_targets(
     connection: &mut Connection,
     source_id: &str,
@@ -37,6 +38,7 @@ pub fn replace_readiness_targets(
 
 /// Atomically replace desired readiness while honoring cancellation during large publications.
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub fn replace_readiness_targets_with_cancel(
     connection: &mut Connection,
     source_id: &str,
@@ -60,7 +62,7 @@ pub fn replace_readiness_targets_with_cancel(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn replace_readiness_targets_inner(
+pub(super) fn replace_readiness_targets_inner(
     connection: &mut Connection,
     source_id: &str,
     source_generation: i64,
@@ -155,7 +157,7 @@ fn replace_readiness_targets_inner(
 }
 
 /// Publish a completion only when its version and generations still match the desired target.
-pub fn publish_readiness_artifact(
+pub(crate) fn publish_readiness_artifact(
     connection: &mut Connection,
     artifact: &ReadinessArtifact,
 ) -> Result<ArtifactPublishOutcome, ReadinessError> {
@@ -245,7 +247,7 @@ pub fn publish_readiness_artifact(
 ///
 /// The desired target must still match the supplied generation and version. This fence prevents
 /// a stale worker from invalidating a replacement artifact published for newer content.
-pub fn invalidate_readiness_artifact(
+pub(crate) fn invalidate_readiness_artifact(
     connection: &mut Connection,
     target: &ReadinessTarget,
 ) -> Result<bool, ReadinessError> {
@@ -291,6 +293,7 @@ pub fn invalidate_readiness_artifact(
 ///
 /// These rows are readiness-managed so the legacy analysis claimant ignores them. OPT-1178's
 /// supervisor can claim them through the unified readiness contract.
+#[cfg(test)]
 pub fn persist_readiness_deficits(
     connection: &mut Connection,
     deficits: &[ReadinessDeficit],
@@ -300,6 +303,7 @@ pub fn persist_readiness_deficits(
 }
 
 /// Persist deficits while honoring cancellation; cancellation rolls back the current batch.
+#[cfg(test)]
 pub fn persist_readiness_deficits_with_cancel(
     connection: &mut Connection,
     deficits: &[ReadinessDeficit],
@@ -310,6 +314,7 @@ pub fn persist_readiness_deficits_with_cancel(
 }
 
 /// Persist deficits while reporting each completed queue-reconciliation step.
+#[cfg(test)]
 pub fn persist_readiness_deficits_with_cancel_and_progress(
     connection: &mut Connection,
     deficits: &[ReadinessDeficit],
@@ -320,7 +325,7 @@ pub fn persist_readiness_deficits_with_cancel_and_progress(
     persist_readiness_deficits_inner(connection, deficits, created_at, Some(cancel), progress)
 }
 
-fn persist_readiness_deficits_inner(
+pub(super) fn persist_readiness_deficits_inner(
     connection: &mut Connection,
     deficits: &[ReadinessDeficit],
     created_at: i64,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -36,31 +36,6 @@ pub fn replace_readiness_targets(
     )
 }
 
-/// Atomically replace desired readiness while honoring cancellation during large publications.
-#[allow(clippy::too_many_arguments)]
-#[cfg(test)]
-pub fn replace_readiness_targets_with_cancel(
-    connection: &mut Connection,
-    source_id: &str,
-    source_generation: i64,
-    readiness_revision: i64,
-    availability: SourceAvailability,
-    targets: &[ReadinessTarget],
-    updated_at: i64,
-    cancel: &AtomicBool,
-) -> Result<(), ReadinessError> {
-    replace_readiness_targets_inner(
-        connection,
-        source_id,
-        source_generation,
-        readiness_revision,
-        availability,
-        targets,
-        updated_at,
-        Some(cancel),
-    )
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(super) fn replace_readiness_targets_inner(
     connection: &mut Connection,
@@ -300,29 +275,6 @@ pub fn persist_readiness_deficits(
     created_at: i64,
 ) -> Result<usize, ReadinessError> {
     persist_readiness_deficits_inner(connection, deficits, created_at, None, &mut || {})
-}
-
-/// Persist deficits while honoring cancellation; cancellation rolls back the current batch.
-#[cfg(test)]
-pub fn persist_readiness_deficits_with_cancel(
-    connection: &mut Connection,
-    deficits: &[ReadinessDeficit],
-    created_at: i64,
-    cancel: &AtomicBool,
-) -> Result<usize, ReadinessError> {
-    persist_readiness_deficits_inner(connection, deficits, created_at, Some(cancel), &mut || {})
-}
-
-/// Persist deficits while reporting each completed queue-reconciliation step.
-#[cfg(test)]
-pub fn persist_readiness_deficits_with_cancel_and_progress(
-    connection: &mut Connection,
-    deficits: &[ReadinessDeficit],
-    created_at: i64,
-    cancel: &AtomicBool,
-    progress: &mut dyn FnMut(),
-) -> Result<usize, ReadinessError> {
-    persist_readiness_deficits_inner(connection, deficits, created_at, Some(cancel), progress)
 }
 
 pub(super) fn persist_readiness_deficits_inner(

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -27,29 +27,6 @@ pub fn reconcile_readiness(
     reconcile_readiness_inner(connection, source_id, now, None, &mut || {})
 }
 
-/// Compare desired readiness with persisted state while honoring cancellation during large scans.
-#[cfg(test)]
-pub fn reconcile_readiness_with_cancel(
-    connection: &Connection,
-    source_id: &str,
-    now: i64,
-    cancel: &AtomicBool,
-) -> Result<ReadinessSnapshot, ReadinessError> {
-    reconcile_readiness_inner(connection, source_id, now, Some(cancel), &mut || {})
-}
-
-/// Compare desired readiness with persisted state while reporting completed reconciliation steps.
-#[cfg(test)]
-pub fn reconcile_readiness_with_cancel_and_progress(
-    connection: &Connection,
-    source_id: &str,
-    now: i64,
-    cancel: &AtomicBool,
-    progress: &mut dyn FnMut(),
-) -> Result<ReadinessSnapshot, ReadinessError> {
-    reconcile_readiness_inner(connection, source_id, now, Some(cancel), progress)
-}
-
 pub(super) fn reconcile_readiness_inner(
     connection: &Connection,
     source_id: &str,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -18,6 +18,7 @@ use super::super::{
 use super::error::ReadinessError;
 
 /// Compare desired readiness with persisted artifacts and work without mutating the database.
+#[cfg(test)]
 pub fn reconcile_readiness(
     connection: &Connection,
     source_id: &str,
@@ -27,6 +28,7 @@ pub fn reconcile_readiness(
 }
 
 /// Compare desired readiness with persisted state while honoring cancellation during large scans.
+#[cfg(test)]
 pub fn reconcile_readiness_with_cancel(
     connection: &Connection,
     source_id: &str,
@@ -37,6 +39,7 @@ pub fn reconcile_readiness_with_cancel(
 }
 
 /// Compare desired readiness with persisted state while reporting completed reconciliation steps.
+#[cfg(test)]
 pub fn reconcile_readiness_with_cancel_and_progress(
     connection: &Connection,
     source_id: &str,
@@ -47,7 +50,7 @@ pub fn reconcile_readiness_with_cancel_and_progress(
     reconcile_readiness_inner(connection, source_id, now, Some(cancel), progress)
 }
 
-fn reconcile_readiness_inner(
+pub(super) fn reconcile_readiness_inner(
     connection: &Connection,
     source_id: &str,
     now: i64,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/similarity.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/similarity.rs
@@ -1,0 +1,264 @@
+use rusqlite::params;
+
+use super::{ReadinessError, ReadinessStore, ReadinessView};
+
+/// One current embedding artifact selected for similarity publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessEmbeddingArtifactTarget {
+    /// Stable file identity.
+    pub scope_id: String,
+    /// Current source-relative path.
+    pub relative_path: String,
+    /// Required embedding contract version.
+    pub required_version: String,
+    /// Source generation.
+    pub source_generation: i64,
+    /// Exact content generation.
+    pub content_generation: String,
+}
+
+/// Analysis payload contract required for an exact similarity publication.
+#[derive(Clone, Copy, Debug)]
+pub struct ReadinessSimilarityPayloadContract<'a> {
+    analysis_version: &'a str,
+    embedding_model_id: &'a str,
+    feature_version: i64,
+    embedding_dim: i64,
+    embedding_dtype: &'a str,
+    aspect_model_id: &'a str,
+    aspect_dim: i64,
+    aspect_dtype: &'a str,
+}
+
+impl<'a> ReadinessSimilarityPayloadContract<'a> {
+    /// Build the exact analysis contract required by a similarity publisher.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        analysis_version: &'a str,
+        embedding_model_id: &'a str,
+        feature_version: i64,
+        embedding_dim: i64,
+        embedding_dtype: &'a str,
+        aspect_model_id: &'a str,
+        aspect_dim: i64,
+        aspect_dtype: &'a str,
+    ) -> Self {
+        Self {
+            analysis_version,
+            embedding_model_id,
+            feature_version,
+            embedding_dim,
+            embedding_dtype,
+            aspect_model_id,
+            aspect_dim,
+            aspect_dtype,
+        }
+    }
+}
+
+/// Typed request for the exact embedding payloads owned by one readiness generation.
+#[derive(Clone, Copy, Debug)]
+pub struct ReadinessSimilarityManifestRequest<'a> {
+    source_id: &'a str,
+    source_generation: i64,
+    contract: ReadinessSimilarityPayloadContract<'a>,
+}
+
+impl<'a> ReadinessSimilarityManifestRequest<'a> {
+    /// Bind an analysis payload contract to one source generation.
+    pub fn new(
+        source_id: &'a str,
+        source_generation: i64,
+        contract: ReadinessSimilarityPayloadContract<'a>,
+    ) -> Self {
+        Self {
+            source_id,
+            source_generation,
+            contract,
+        }
+    }
+}
+
+/// One exact embedding payload selected through the readiness publication fence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessSimilarityManifestRow {
+    /// Stable file identity used in the membership generation.
+    pub scope_id: String,
+    /// Current source-relative path.
+    pub relative_path: String,
+    /// Exact content generation.
+    pub content_generation: String,
+    /// Stored embedding dimension.
+    pub embedding_dim: i64,
+    /// Stored little-endian embedding payload.
+    pub embedding: Vec<u8>,
+}
+
+/// Complete readiness-owned selection for exact similarity publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessSimilarityManifest {
+    /// Number of eligible embedding targets in the desired readiness set.
+    pub target_count: usize,
+    /// Targets whose readiness artifact and analysis payload are both exact.
+    pub rows: Vec<ReadinessSimilarityManifestRow>,
+}
+
+impl ReadinessStore<'_> {
+    /// Check the exact source-level similarity publication fence against durable readiness state.
+    pub fn similarity_publication_is_current(
+        &mut self,
+        source_id: &str,
+        source_generation: i64,
+        artifact_version: &str,
+        membership_generation: &str,
+        manifest_generation: i64,
+    ) -> Result<bool, ReadinessError> {
+        ReadinessView::new(self.connection).similarity_publication_is_current(
+            source_id,
+            source_generation,
+            artifact_version,
+            membership_generation,
+            manifest_generation,
+        )
+    }
+
+    /// Whether indexed file targets still await a committed content generation.
+    pub fn has_pending_file_content(&mut self, source_id: &str) -> Result<bool, ReadinessError> {
+        self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM source_readiness_targets WHERE source_id = ?1 AND scope_kind = 'file' AND stage = 'indexed_identity' AND content_generation LIKE 'pending-%')",
+            [source_id],
+            |row| row.get(0),
+        ).map_err(Into::into)
+    }
+
+    /// Load current embedding artifact targets for a similarity generation.
+    pub fn embedding_artifact_targets(
+        &mut self,
+        source_id: &str,
+        source_generation: i64,
+    ) -> Result<Vec<ReadinessEmbeddingArtifactTarget>, ReadinessError> {
+        let mut statement = self.connection.prepare(
+            "SELECT target.scope_id, target.relative_path, target.required_version, target.source_generation, target.content_generation FROM source_readiness_targets AS target JOIN source_readiness_artifacts AS artifact ON artifact.source_id = target.source_id AND artifact.scope_kind = target.scope_kind AND artifact.scope_id = target.scope_id AND artifact.stage = target.stage AND artifact.artifact_version = target.required_version AND artifact.content_generation = target.content_generation WHERE target.source_id = ?1 AND target.scope_kind = 'file' AND target.stage = 'embedding_aspects' AND target.source_generation = ?2 AND target.eligibility = 'eligible'",
+        )?;
+        statement
+            .query_map(params![source_id, source_generation], |row| {
+                Ok(ReadinessEmbeddingArtifactTarget {
+                    scope_id: row.get(0)?,
+                    relative_path: row.get(1)?,
+                    required_version: row.get(2)?,
+                    source_generation: row.get(3)?,
+                    content_generation: row.get(4)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Select exact similarity payloads through current targets and artifacts.
+    pub fn similarity_manifest(
+        &mut self,
+        request: ReadinessSimilarityManifestRequest<'_>,
+    ) -> Result<ReadinessSimilarityManifest, ReadinessError> {
+        let target_count = self.connection.query_row(
+            "SELECT COUNT(*)
+             FROM source_readiness_targets
+             WHERE source_id = ?1
+               AND scope_kind = 'file'
+               AND stage = 'embedding_aspects'
+               AND eligibility = 'eligible'",
+            [request.source_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let mut statement = self.connection.prepare(
+            "SELECT target.scope_id, target.relative_path, target.content_generation,
+                    embedding.dim, embedding.vec
+             FROM source_readiness_targets AS target
+             JOIN source_readiness_artifacts AS artifact
+               ON artifact.source_id = target.source_id
+              AND artifact.scope_kind = target.scope_kind
+              AND artifact.scope_id = target.scope_id
+              AND artifact.stage = target.stage
+              AND artifact.artifact_version = target.required_version
+              AND artifact.content_generation = target.content_generation
+             JOIN samples AS sample
+               ON sample.sample_id = target.source_id || '::' || target.relative_path
+              AND sample.content_hash = target.content_generation
+              AND sample.analysis_version = ?4
+             JOIN features AS feature
+               ON feature.sample_id = sample.sample_id
+             JOIN analysis_cache_features AS cached_feature
+               ON cached_feature.content_hash = target.content_generation
+              AND cached_feature.analysis_version = ?4
+              AND cached_feature.feat_version = feature.feat_version
+              AND cached_feature.vec_blob = feature.vec_blob
+              AND cached_feature.light_dsp_blob IS feature.light_dsp_blob
+              AND cached_feature.rms IS feature.rms
+             JOIN embeddings AS embedding
+               ON embedding.sample_id = sample.sample_id
+              AND embedding.model_id = ?3
+             JOIN analysis_cache_embeddings AS cached_embedding
+               ON cached_embedding.content_hash = target.content_generation
+              AND cached_embedding.analysis_version = ?4
+              AND cached_embedding.model_id = embedding.model_id
+              AND cached_embedding.dim = embedding.dim
+              AND cached_embedding.dtype = embedding.dtype
+              AND cached_embedding.l2_normed = embedding.l2_normed
+              AND cached_embedding.vec = embedding.vec
+             JOIN similarity_aspect_descriptors AS aspects
+               ON aspects.sample_id = sample.sample_id
+              AND aspects.model_id = ?5
+             JOIN analysis_cache_aspect_descriptors AS cached_aspects
+               ON cached_aspects.content_hash = target.content_generation
+              AND cached_aspects.analysis_version = ?4
+              AND cached_aspects.model_id = aspects.model_id
+              AND cached_aspects.dim = aspects.dim
+              AND cached_aspects.dtype = aspects.dtype
+              AND cached_aspects.l2_normed = aspects.l2_normed
+              AND cached_aspects.valid_mask = aspects.valid_mask
+              AND cached_aspects.vec = aspects.vec
+             WHERE target.source_id = ?1
+               AND target.scope_kind = 'file'
+               AND target.stage = 'embedding_aspects'
+               AND target.source_generation = ?2
+               AND target.eligibility = 'eligible'
+               AND feature.feat_version = ?6
+               AND embedding.dim = ?7
+               AND embedding.dtype = ?8
+               AND embedding.l2_normed = 1
+               AND aspects.dim = ?9
+               AND aspects.dtype = ?10
+               AND aspects.l2_normed = 1
+             ORDER BY target.relative_path",
+        )?;
+        let contract = request.contract;
+        let rows = statement
+            .query_map(
+                params![
+                    request.source_id,
+                    request.source_generation,
+                    contract.embedding_model_id,
+                    contract.analysis_version,
+                    contract.aspect_model_id,
+                    contract.feature_version,
+                    contract.embedding_dim,
+                    contract.embedding_dtype,
+                    contract.aspect_dim,
+                    contract.aspect_dtype,
+                ],
+                |row| {
+                    Ok(ReadinessSimilarityManifestRow {
+                        scope_id: row.get(0)?,
+                        relative_path: row.get(1)?,
+                        content_generation: row.get(2)?,
+                        embedding_dim: row.get(3)?,
+                        embedding: row.get(4)?,
+                    })
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ReadinessSimilarityManifest {
+            target_count: usize::try_from(target_count).unwrap_or(usize::MAX),
+            rows,
+        })
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
@@ -1,0 +1,80 @@
+use std::sync::atomic::AtomicBool;
+
+use rusqlite::{Connection, params};
+
+use super::{ReadinessError, reconcile, work};
+use crate::sample_sources::readiness::{
+    ReadinessSnapshot, ReadinessStage, ReadinessTarget, ReadinessWorkStats,
+};
+
+/// Read-only half of the typed readiness persistence boundary.
+pub struct ReadinessView<'connection> {
+    connection: &'connection Connection,
+}
+
+impl<'connection> ReadinessView<'connection> {
+    /// Bind readiness queries to one caller-selected source database connection.
+    pub fn new(connection: &'connection Connection) -> Self {
+        Self { connection }
+    }
+
+    /// Classify durable readiness for one source at a point in time.
+    pub fn reconcile(
+        &self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut || {})
+    }
+
+    /// Reconcile with cancellation-safe progress reporting.
+    pub fn reconcile_with_cancel_and_progress(
+        &self,
+        source_id: &str,
+        now: i64,
+        cancel: &AtomicBool,
+        progress: &mut dyn FnMut(),
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        reconcile::reconcile_readiness_inner(
+            self.connection,
+            source_id,
+            now,
+            Some(cancel),
+            progress,
+        )
+    }
+
+    /// Read queue and lease-recovery telemetry.
+    pub fn work_stats(&self, now: i64) -> Result<ReadinessWorkStats, ReadinessError> {
+        work::readiness_work_stats(self.connection, now)
+    }
+
+    /// Check whether a prerequisite stage is terminally unsupported.
+    pub fn stage_is_unsupported(
+        &self,
+        target: &ReadinessTarget,
+        stage: ReadinessStage,
+    ) -> Result<bool, ReadinessError> {
+        self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM analysis_jobs WHERE readiness_managed = 1 AND source_id = ?1 AND readiness_scope_kind = 'file' AND readiness_scope_id = ?2 AND readiness_stage = ?3 AND content_generation = ?4 AND status = 'failed' AND failure_kind = 'unsupported')",
+            params![target.source_id, target.scope_id, stage.as_str(), target.content_generation],
+            |row| row.get(0),
+        ).map_err(Into::into)
+    }
+
+    /// Check the exact source-level similarity publication fence.
+    pub fn similarity_publication_is_current(
+        &self,
+        source_id: &str,
+        source_generation: i64,
+        artifact_version: &str,
+        membership_generation: &str,
+        manifest_generation: i64,
+    ) -> Result<bool, ReadinessError> {
+        self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM source_readiness_sources AS source JOIN source_readiness_targets AS target ON target.source_id = source.source_id WHERE source.source_id = ?1 AND source.source_generation = ?2 AND source.availability = 'active' AND target.scope_kind = 'source' AND target.scope_id = ?1 AND target.stage = 'similarity_layout' AND target.required_version = ?3 AND target.source_generation = ?2 AND target.content_generation = ?4 AND target.eligibility = 'eligible' AND ?5 = ?2)",
+            params![source_id, source_generation, artifact_version, membership_generation, manifest_generation],
+            |row| row.get(0),
+        ).map_err(Into::into)
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -13,7 +13,7 @@ use super::error::ReadinessError;
 /// File targets remain claimable across unrelated source-generation changes when their stable
 /// identity, stage, artifact version, and content generation are unchanged. The returned target is
 /// always refreshed from the current desired-state row.
-pub fn claim_readiness_target(
+pub(crate) fn claim_readiness_target(
     connection: &mut Connection,
     requested: &ReadinessTarget,
     now: i64,
@@ -189,7 +189,7 @@ pub fn claim_readiness_target(
 }
 
 /// Renew an unexpired claim without changing its claim generation.
-pub fn renew_readiness_lease(
+pub(crate) fn renew_readiness_lease(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     now: i64,
@@ -274,7 +274,7 @@ pub fn renew_readiness_lease(
 }
 
 /// Atomically publish the exact claimed artifact and mark its work row complete.
-pub fn complete_readiness_work(
+pub(crate) fn complete_readiness_work(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     completed_at: i64,
@@ -286,7 +286,7 @@ pub fn complete_readiness_work(
 ///
 /// The reference is stored beside the source/path/content generations so later reconciliation can
 /// retire the exact app-global payload after edits, moves, deletion, or cache pruning.
-pub fn complete_readiness_work_with_artifact_ref(
+pub(crate) fn complete_readiness_work_with_artifact_ref(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     completed_at: i64,
@@ -353,7 +353,7 @@ fn complete_readiness_work_inner(
 }
 
 /// Record a classified failure, applying bounded backoff to retryable failures.
-pub fn fail_readiness_work(
+pub(crate) fn fail_readiness_work(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     classification: ReadinessFailureClassification,
@@ -424,7 +424,7 @@ pub fn fail_readiness_work(
 }
 
 /// Voluntarily release a current claim back to pending without deleting durable work.
-pub fn release_readiness_work(
+pub(crate) fn release_readiness_work(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     released_at: i64,
@@ -433,7 +433,7 @@ pub fn release_readiness_work(
 }
 
 /// Cancel in-flight execution back to pending while retaining a cancellation diagnostic.
-pub fn cancel_readiness_work(
+pub(crate) fn cancel_readiness_work(
     connection: &mut Connection,
     claim: &ClaimedReadinessWork,
     reason: &str,
@@ -448,7 +448,7 @@ pub fn cancel_readiness_work(
 }
 
 /// Read queue, retry, lease-recovery, cancellation, and terminal counts for telemetry.
-pub fn readiness_work_stats(
+pub(crate) fn readiness_work_stats(
     connection: &Connection,
     now: i64,
 ) -> Result<ReadinessWorkStats, ReadinessError> {

--- a/scripts/internal/check/check_non_blocking_architecture.sh
+++ b/scripts/internal/check/check_non_blocking_architecture.sh
@@ -53,4 +53,13 @@ run_step "Wavecrate app-facing blocking guardrail" \
 run_step "Wavecrate strict slow-handler diagnostics harness" \
   cargo test -p wavecrate --no-default-features rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow
 
+run_step "Wavecrate readiness persistence boundary" \
+  bash -c '
+    production_source="$(sed -n \"1,/^#\[cfg(test)\]/p\" src/native_app/source_processing/supervisor.rs)"
+    if printf "%s\\n" "$production_source" | rg -n "source_readiness_(sources|targets|artifacts)|analysis_jobs|readiness_managed"; then
+      echo "[non_blocking_architecture] native source processing must use ReadinessStore for readiness persistence" >&2
+      exit 1
+    fi
+  '
+
 echo "[non_blocking_architecture] OK"

--- a/scripts/internal/check/check_non_blocking_architecture.sh
+++ b/scripts/internal/check/check_non_blocking_architecture.sh
@@ -55,8 +55,12 @@ run_step "Wavecrate strict slow-handler diagnostics harness" \
 
 run_step "Wavecrate readiness persistence boundary" \
   bash -c '
-    production_source="$(sed -n \"1,/^#\[cfg(test)\]/p\" src/native_app/source_processing/supervisor.rs)"
-    if printf "%s\\n" "$production_source" | rg -n "source_readiness_(sources|targets|artifacts)|analysis_jobs|readiness_managed"; then
+    set -euo pipefail
+    supervisor_source="$(sed "/^mod tests {/q" src/native_app/source_processing/supervisor.rs)"
+    similarity_source="$(cat src/native_app/sample_library/similarity_artifacts/worker.rs)"
+    production_source="${supervisor_source}
+${similarity_source}"
+    if printf "%s\\n" "$production_source" | rg -n "source_readiness_(sources|targets|artifacts)|(^|[^[:alnum:]_])analysis_jobs([^[:alnum:]_]|$)|readiness_managed"; then
       echo "[non_blocking_architecture] native source processing must use ReadinessStore for readiness persistence" >&2
       exit 1
     fi

--- a/src/native_app/sample_library/similarity_artifacts/worker.rs
+++ b/src/native_app/sample_library/similarity_artifacts/worker.rs
@@ -14,9 +14,7 @@ use std::{
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
     db::META_WAV_PATHS_REVISION,
-    readiness::{
-        ReadinessScopeKind, ReadinessStage, ReadinessTarget, invalidate_readiness_artifact,
-    },
+    readiness::{ReadinessScopeKind, ReadinessStage, ReadinessStore, ReadinessTarget},
 };
 use wavecrate_analysis::{
     self as analysis,
@@ -484,9 +482,11 @@ fn invalidate_incomplete_embedding_artifacts(
             generation,
             content_generation,
         );
-        invalidate_readiness_artifact(connection, &target).map_err(|error| {
-            format!("Invalidate incomplete similarity artifact failed: {error}")
-        })?;
+        ReadinessStore::new(connection)
+            .invalidate_artifact(&target)
+            .map_err(|error| {
+                format!("Invalidate incomplete similarity artifact failed: {error}")
+            })?;
     }
     Ok(())
 }

--- a/src/native_app/sample_library/similarity_artifacts/worker.rs
+++ b/src/native_app/sample_library/similarity_artifacts/worker.rs
@@ -14,7 +14,10 @@ use std::{
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole,
     db::META_WAV_PATHS_REVISION,
-    readiness::{ReadinessScopeKind, ReadinessStage, ReadinessStore, ReadinessTarget},
+    readiness::{
+        ReadinessScopeKind, ReadinessSimilarityManifestRequest, ReadinessSimilarityPayloadContract,
+        ReadinessStage, ReadinessStore, ReadinessTarget, ReadinessView,
+    },
 };
 use wavecrate_analysis::{
     self as analysis,
@@ -65,36 +68,20 @@ impl SimilarityPublicationFence {
     }
 
     fn is_current(&self, connection: &rusqlite::Connection) -> Result<bool, String> {
-        connection
+        let manifest_generation = connection
             .query_row(
-                "SELECT EXISTS(
-                    SELECT 1
-                    FROM source_readiness_sources AS source
-                    JOIN source_readiness_targets AS target
-                      ON target.source_id = source.source_id
-                    WHERE source.source_id = ?1
-                      AND source.source_generation = ?2
-                      AND source.availability = 'active'
-                      AND target.scope_kind = 'source'
-                      AND target.scope_id = ?1
-                      AND target.stage = 'similarity_layout'
-                      AND target.required_version = ?3
-                      AND target.source_generation = ?2
-                      AND target.content_generation = ?4
-                      AND target.eligibility = 'eligible'
-                      AND COALESCE(
-                          (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?5),
-                          0
-                      ) = ?2
-                )",
-                rusqlite::params![
-                    self.source_id,
-                    self.source_generation,
-                    self.artifact_version,
-                    self.membership_generation,
-                    META_WAV_PATHS_REVISION,
-                ],
+                "SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1), 0)",
+                [META_WAV_PATHS_REVISION],
                 |row| row.get(0),
+            )
+            .map_err(|error| format!("Read manifest revision failed: {error}"))?;
+        ReadinessView::new(connection)
+            .similarity_publication_is_current(
+                &self.source_id,
+                self.source_generation,
+                &self.artifact_version,
+                &self.membership_generation,
+                manifest_generation,
             )
             .map_err(|error| format!("Validate similarity readiness generation failed: {error}"))
     }
@@ -226,18 +213,8 @@ fn finalize_exact_readiness_similarity(
     if !publication_fence.is_current(&connection)? {
         return Ok(false);
     }
-    let pending_content_identities: bool = connection
-        .query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM source_readiness_targets
-                WHERE source_id = ?1
-                  AND scope_kind = 'file'
-                  AND stage = 'indexed_identity'
-                  AND content_generation LIKE 'pending-%'
-             )",
-            [source_id],
-            |row| row.get(0),
-        )
+    let pending_content_identities = ReadinessStore::new(&mut connection)
+        .has_pending_file_content(source_id)
         .map_err(|error| format!("Check deferred similarity identities failed: {error}"))?;
     if pending_content_identities {
         return Ok(false);
@@ -288,132 +265,47 @@ fn exact_similarity_manifest(
     source_generation: i64,
     expected_membership_generation: &str,
 ) -> Result<Option<Vec<analysis::ExactSimilarityManifestEntry>>, String> {
-    let target_count: i64 = connection
-        .query_row(
-            "SELECT COUNT(*)
-             FROM source_readiness_targets
-             WHERE source_id = ?1
-               AND scope_kind = 'file'
-               AND stage = 'embedding_aspects'
-               AND eligibility = 'eligible'",
-            [source_id],
-            |row| row.get(0),
-        )
-        .map_err(|error| format!("Count exact similarity targets failed: {error}"))?;
-    let mut statement = connection
-        .prepare(
-            "SELECT target.scope_id, target.relative_path, target.content_generation,
-                    embedding.dim, embedding.vec
-             FROM source_readiness_targets AS target
-             JOIN source_readiness_artifacts AS artifact
-               ON artifact.source_id = target.source_id
-              AND artifact.scope_kind = target.scope_kind
-              AND artifact.scope_id = target.scope_id
-              AND artifact.stage = target.stage
-              AND artifact.artifact_version = target.required_version
-              AND artifact.content_generation = target.content_generation
-             JOIN samples AS sample
-               ON sample.sample_id = target.source_id || '::' || target.relative_path
-              AND sample.content_hash = target.content_generation
-              AND sample.analysis_version = ?4
-             JOIN features AS feature
-               ON feature.sample_id = sample.sample_id
-             JOIN analysis_cache_features AS cached_feature
-               ON cached_feature.content_hash = target.content_generation
-              AND cached_feature.analysis_version = ?4
-              AND cached_feature.feat_version = feature.feat_version
-              AND cached_feature.vec_blob = feature.vec_blob
-              AND cached_feature.light_dsp_blob IS feature.light_dsp_blob
-              AND cached_feature.rms IS feature.rms
-             JOIN embeddings AS embedding
-               ON embedding.sample_id = sample.sample_id
-              AND embedding.model_id = ?3
-             JOIN analysis_cache_embeddings AS cached_embedding
-               ON cached_embedding.content_hash = target.content_generation
-              AND cached_embedding.analysis_version = ?4
-              AND cached_embedding.model_id = embedding.model_id
-              AND cached_embedding.dim = embedding.dim
-              AND cached_embedding.dtype = embedding.dtype
-              AND cached_embedding.l2_normed = embedding.l2_normed
-              AND cached_embedding.vec = embedding.vec
-             JOIN similarity_aspect_descriptors AS aspects
-               ON aspects.sample_id = sample.sample_id
-              AND aspects.model_id = ?5
-             JOIN analysis_cache_aspect_descriptors AS cached_aspects
-               ON cached_aspects.content_hash = target.content_generation
-              AND cached_aspects.analysis_version = ?4
-              AND cached_aspects.model_id = aspects.model_id
-              AND cached_aspects.dim = aspects.dim
-              AND cached_aspects.dtype = aspects.dtype
-              AND cached_aspects.l2_normed = aspects.l2_normed
-              AND cached_aspects.valid_mask = aspects.valid_mask
-              AND cached_aspects.vec = aspects.vec
-             WHERE target.source_id = ?1
-               AND target.scope_kind = 'file'
-               AND target.stage = 'embedding_aspects'
-              AND target.source_generation = ?2
-              AND target.eligibility = 'eligible'
-              AND feature.feat_version = ?6
-              AND embedding.dim = ?7
-              AND embedding.dtype = ?8
-              AND embedding.l2_normed = 1
-              AND aspects.dim = ?9
-              AND aspects.dtype = ?10
-              AND aspects.l2_normed = 1
-             ORDER BY target.relative_path",
-        )
-        .map_err(|error| format!("Prepare exact similarity manifest failed: {error}"))?;
-    let rows = statement
-        .query_map(
-            rusqlite::params![
-                source_id,
-                source_generation,
-                SIMILARITY_MODEL_ID,
-                wavecrate_analysis::analysis_version(),
-                ASPECT_DESCRIPTOR_MODEL_ID,
-                wavecrate_analysis::vector::FEATURE_VERSION_V1,
-                wavecrate_analysis::similarity::SIMILARITY_DIM as i64,
-                wavecrate_analysis::similarity::SIMILARITY_DTYPE_F32,
-                ASPECT_DESCRIPTOR_DIM as i64,
-                ASPECT_DESCRIPTOR_DTYPE_F32,
-            ],
-            |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, Vec<u8>>(4)?,
-                ))
-            },
-        )
+    let contract = ReadinessSimilarityPayloadContract::new(
+        wavecrate_analysis::analysis_version(),
+        SIMILARITY_MODEL_ID,
+        wavecrate_analysis::vector::FEATURE_VERSION_V1,
+        wavecrate_analysis::similarity::SIMILARITY_DIM as i64,
+        wavecrate_analysis::similarity::SIMILARITY_DTYPE_F32,
+        ASPECT_DESCRIPTOR_MODEL_ID,
+        ASPECT_DESCRIPTOR_DIM as i64,
+        ASPECT_DESCRIPTOR_DTYPE_F32,
+    );
+    let selection = ReadinessStore::new(connection)
+        .similarity_manifest(ReadinessSimilarityManifestRequest::new(
+            source_id,
+            source_generation,
+            contract,
+        ))
         .map_err(|error| format!("Query exact similarity manifest failed: {error}"))?;
     let mut membership = blake3::Hasher::new();
     let mut manifest = Vec::new();
     let mut valid_identities = HashSet::new();
-    for row in rows {
-        let (identity, relative_path, content_generation, dim, vector) =
-            row.map_err(|error| format!("Decode exact similarity manifest failed: {error}"))?;
-        membership.update(identity.as_bytes());
+    for row in selection.rows {
+        membership.update(row.scope_id.as_bytes());
         membership.update(&[0]);
-        membership.update(content_generation.as_bytes());
+        membership.update(row.content_generation.as_bytes());
         membership.update(&[0xff]);
-        valid_identities.insert(identity);
-        let embedding = analysis::decode_f32_le_blob(&vector)?;
-        if embedding.len() != usize::try_from(dim).unwrap_or_default()
+        valid_identities.insert(row.scope_id);
+        let embedding = analysis::decode_f32_le_blob(&row.embedding)?;
+        if embedding.len() != usize::try_from(row.embedding_dim).unwrap_or_default()
             || embedding.len() != wavecrate_analysis::similarity::SIMILARITY_DIM
         {
             return Err(format!(
-                "Invalid exact similarity embedding for {relative_path}"
+                "Invalid exact similarity embedding for {}",
+                row.relative_path
             ));
         }
         manifest.push(analysis::ExactSimilarityManifestEntry {
-            sample_id: format!("{source_id}::{}", relative_path.replace('\\', "/")),
+            sample_id: format!("{source_id}::{}", row.relative_path.replace('\\', "/")),
             embedding,
         });
     }
-    drop(statement);
-    if i64::try_from(manifest.len()).unwrap_or(i64::MAX) != target_count {
+    if manifest.len() != selection.target_count {
         invalidate_incomplete_embedding_artifacts(
             connection,
             source_id,
@@ -435,52 +327,21 @@ fn invalidate_incomplete_embedding_artifacts(
     source_generation: i64,
     valid_identities: &HashSet<String>,
 ) -> Result<(), String> {
-    let artifact_targets = {
-        let mut statement = connection
-            .prepare(
-                "SELECT target.scope_id, target.relative_path, target.required_version,
-                        target.source_generation, target.content_generation
-                 FROM source_readiness_targets AS target
-                 JOIN source_readiness_artifacts AS artifact
-                   ON artifact.source_id = target.source_id
-                  AND artifact.scope_kind = target.scope_kind
-                  AND artifact.scope_id = target.scope_id
-                  AND artifact.stage = target.stage
-                  AND artifact.artifact_version = target.required_version
-                  AND artifact.content_generation = target.content_generation
-                 WHERE target.source_id = ?1
-                   AND target.scope_kind = 'file'
-                   AND target.stage = 'embedding_aspects'
-                   AND target.source_generation = ?2
-                   AND target.eligibility = 'eligible'",
-            )
-            .map_err(|error| format!("Prepare incomplete similarity artifacts failed: {error}"))?;
-        statement
-            .query_map(rusqlite::params![source_id, source_generation], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
-                    row.get::<_, String>(4)?,
-                ))
-            })
-            .map_err(|error| format!("Query incomplete similarity artifacts failed: {error}"))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| format!("Decode incomplete similarity artifacts failed: {error}"))?
-    };
-    for (identity, relative_path, version, generation, content_generation) in artifact_targets {
-        if valid_identities.contains(&identity) {
+    let artifact_targets = ReadinessStore::new(connection)
+        .embedding_artifact_targets(source_id, source_generation)
+        .map_err(|error| format!("Query incomplete similarity artifacts failed: {error}"))?;
+    for artifact in artifact_targets {
+        if valid_identities.contains(&artifact.scope_id) {
             continue;
         }
         let target = ReadinessTarget::file(
             source_id,
-            identity,
-            relative_path,
+            artifact.scope_id,
+            artifact.relative_path,
             ReadinessStage::EmbeddingAspects,
-            version,
-            generation,
-            content_generation,
+            artifact.required_version,
+            artifact.source_generation,
+            artifact.content_generation,
         );
         ReadinessStore::new(connection)
             .invalidate_artifact(&target)
@@ -494,17 +355,10 @@ fn invalidate_incomplete_embedding_artifacts(
 pub(in crate::native_app) fn reset_interrupted_readiness_jobs(
     source: &SampleSource,
 ) -> Result<usize, String> {
-    let conn = open_source_db(source)?;
-    conn.execute(
-        "UPDATE analysis_jobs
-         SET status = 'pending',
-             running_at = NULL,
-             lease_expires_at = NULL
-         WHERE status = 'running'
-           AND readiness_managed = 1",
-        [],
-    )
-    .map_err(|error| format!("Reset interrupted readiness jobs failed: {error}"))
+    let mut conn = open_source_db(source)?;
+    ReadinessStore::new(&mut conn)
+        .reset_interrupted_work()
+        .map_err(|error| format!("Reset interrupted readiness jobs failed: {error}"))
 }
 
 pub(super) fn open_source_db(source: &SampleSource) -> Result<rusqlite::Connection, String> {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -4697,12 +4697,114 @@ mod tests {
     use wavecrate::sample_sources::{
         SourceId,
         readiness::{
-            ReadinessArtifact, ReadinessEligibility, ReadinessStore, ReadinessTargetPublication,
-            SourceAvailability,
+            ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessArtifact, ReadinessDeficit,
+            ReadinessEligibility, ReadinessError, ReadinessSnapshot, ReadinessStore,
+            ReadinessTargetPublication, ReadinessView, ReadinessWorkStats, SourceAvailability,
         },
     };
 
     use super::*;
+
+    fn reconcile_readiness(
+        connection: &rusqlite::Connection,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        ReadinessView::new(connection).reconcile(source_id, now)
+    }
+
+    fn reconcile_readiness_with_cancel_and_progress(
+        connection: &rusqlite::Connection,
+        source_id: &str,
+        now: i64,
+        cancel: &AtomicBool,
+        progress: &mut dyn FnMut(),
+    ) -> Result<ReadinessSnapshot, ReadinessError> {
+        ReadinessView::new(connection)
+            .reconcile_with_cancel_and_progress(source_id, now, cancel, progress)
+    }
+
+    fn persist_readiness_deficits(
+        connection: &mut rusqlite::Connection,
+        deficits: &[ReadinessDeficit],
+        created_at: i64,
+    ) -> Result<usize, ReadinessError> {
+        ReadinessStore::new(connection).persist_deficits(deficits, created_at)
+    }
+
+    fn publish_readiness_artifact(
+        connection: &mut rusqlite::Connection,
+        artifact: &ReadinessArtifact,
+    ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+        ReadinessStore::new(connection).publish_artifact(artifact)
+    }
+
+    fn readiness_work_stats(
+        connection: &rusqlite::Connection,
+        now: i64,
+    ) -> Result<ReadinessWorkStats, ReadinessError> {
+        ReadinessView::new(connection).work_stats(now)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn replace_readiness_targets(
+        connection: &mut rusqlite::Connection,
+        source_id: &str,
+        source_generation: i64,
+        readiness_revision: i64,
+        availability: SourceAvailability,
+        targets: &[ReadinessTarget],
+        updated_at: i64,
+    ) -> Result<(), ReadinessError> {
+        ReadinessStore::new(connection).publish_targets(&ReadinessTargetPublication::new(
+            source_id,
+            source_generation,
+            readiness_revision,
+            availability,
+            targets,
+            updated_at,
+        ))
+    }
+
+    fn claim_readiness_target(
+        connection: &mut rusqlite::Connection,
+        target: &ReadinessTarget,
+        now: i64,
+        lease_duration_seconds: i64,
+    ) -> Result<Option<ClaimedReadinessWork>, ReadinessError> {
+        ReadinessStore::new(connection).claim(target, now, lease_duration_seconds)
+    }
+
+    fn complete_readiness_work(
+        connection: &mut rusqlite::Connection,
+        claim: &ClaimedReadinessWork,
+        completed_at: i64,
+    ) -> Result<ArtifactPublishOutcome, ReadinessError> {
+        ReadinessStore::new(connection).complete(claim, completed_at)
+    }
+
+    fn reclassify_known_unsupported_audio_failures(
+        connection: &mut rusqlite::Connection,
+    ) -> Result<usize, String> {
+        ReadinessStore::new(connection)
+            .reclassify_known_unsupported_failures(is_known_unsupported_audio_failure)
+            .map_err(|error| error.to_string())
+    }
+
+    fn readiness_stage_is_unsupported(
+        connection: &rusqlite::Connection,
+        target: &ReadinessTarget,
+        stage: &str,
+    ) -> Result<bool, String> {
+        let stage = match stage {
+            "analysis_features" => ReadinessStage::AnalysisFeatures,
+            "embedding_aspects" => ReadinessStage::EmbeddingAspects,
+            _ => return Ok(false),
+        };
+        ReadinessView::new(connection)
+            .stage_is_unsupported(target, stage)
+            .map_err(|error| error.to_string())
+    }
 
     #[test]
     fn retired_jobs_are_pruned_and_only_readiness_jobs_are_recovered() {
@@ -4713,7 +4815,7 @@ mod tests {
         );
         source.open_db().expect("create source database");
         let database_root = source.database_root().expect("database root");
-        let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
             &source.root,
             &database_root,
             SourceDatabaseConnectionRole::JobWorker,
@@ -4760,7 +4862,9 @@ mod tests {
         );
 
         assert_eq!(
-            prune_legacy_similarity_jobs(&connection).expect("prune retired jobs"),
+            ReadinessStore::new(&mut connection)
+                .prune_legacy_similarity_jobs()
+                .expect("prune retired jobs"),
             1
         );
         assert_eq!(
@@ -7559,7 +7663,7 @@ mod tests {
 
     #[test]
     fn legacy_source_schema_is_not_eligible_for_automatic_processing() {
-        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
         connection
             .execute_batch(
                 "CREATE TABLE wav_files (
@@ -7578,7 +7682,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(!source_processing_schema_available(&connection).unwrap());
+        assert!(!source_processing_schema_available(&mut connection).unwrap());
     }
 
     #[test]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -13,7 +13,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::{OptionalExtension, TransactionBehavior, params};
+use rusqlite::{OptionalExtension, params};
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole, SourceMetadataStorage,
@@ -22,12 +22,8 @@ use wavecrate::sample_sources::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessClassification,
         ReadinessEligibility, ReadinessFailureClassification, ReadinessFailureOutcome,
         ReadinessLeaseRenewalOutcome, ReadinessRetryPolicy, ReadinessScopeKind, ReadinessSnapshot,
-        ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome, SourceAvailability,
-        cancel_readiness_work, claim_readiness_target, complete_readiness_work,
-        complete_readiness_work_with_artifact_ref, fail_readiness_work,
-        invalidate_readiness_artifact, persist_readiness_deficits_with_cancel_and_progress,
-        readiness_work_stats, reconcile_readiness_with_cancel_and_progress, renew_readiness_lease,
-        replace_readiness_targets_with_cancel,
+        ReadinessStage, ReadinessStore, ReadinessTarget, ReadinessTargetPublication,
+        ReadinessWorkMutationOutcome, SourceAvailability,
     },
     scanner::{
         ScanError, audit_source_and_record_with_progress, complete_pending_deep_hash_for_path,
@@ -2683,13 +2679,15 @@ fn discover_source_candidates_with_progress(
     let database_root = source.database_root().map_err(|error| error.to_string())?;
     if !source.root.is_dir() {
         if database_root != source.root && database_root.is_dir() {
-            let connection = SourceDatabase::open_unavailable_source_metadata_connection(
+            let mut connection = SourceDatabase::open_unavailable_source_metadata_connection(
                 &database_root,
                 SourceDatabaseConnectionRole::JobWorker,
             )
             .map_err(|error| error.to_string())?;
-            if source_processing_schema_available(&connection)? {
-                mark_readiness_temporarily_unavailable(&connection, source.id.as_str(), now)?;
+            if source_processing_schema_available(&mut connection)? {
+                ReadinessStore::new(&mut connection)
+                    .mark_temporarily_unavailable(source.id.as_str(), now)
+                    .map_err(|error| error.to_string())?;
             }
         }
         return Ok(Cancellable::Completed((
@@ -2754,7 +2752,7 @@ fn discover_source_candidates_with_connection_and_progress(
         );
         return Ok(Cancellable::Completed((candidates, stats)));
     }
-    if !source_processing_schema_available(&connection)? {
+    if !source_processing_schema_available(connection)? {
         tracing::debug!(
             target: "wavecrate::source_processing",
             source_id,
@@ -2762,7 +2760,9 @@ fn discover_source_candidates_with_connection_and_progress(
         );
         return Ok(Cancellable::Completed((candidates, stats)));
     }
-    let pruned_legacy_jobs = prune_legacy_similarity_jobs(connection)?;
+    let pruned_legacy_jobs = ReadinessStore::new(connection)
+        .prune_legacy_similarity_jobs()
+        .map_err(|error| format!("Prune retired similarity jobs failed: {error}"))?;
     if pruned_legacy_jobs > 0 {
         tracing::info!(
             target: "wavecrate::source_processing",
@@ -2827,15 +2827,13 @@ fn discover_source_candidates_with_connection_and_progress(
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);
     }
-    let readiness_source_exists: bool = connection
-        .query_row(
-            "SELECT EXISTS(SELECT 1 FROM source_readiness_sources WHERE source_id = ?1)",
-            [source_id],
-            |row| row.get(0),
-        )
+    let readiness_source_exists = ReadinessStore::new(connection)
+        .source_exists(source_id)
         .map_err(|error| error.to_string())?;
     if readiness_source_exists {
-        let reclassified = reclassify_known_unsupported_audio_failures(connection)?;
+        let reclassified = ReadinessStore::new(connection)
+            .reclassify_known_unsupported_failures(is_known_unsupported_audio_failure)
+            .map_err(|error| error.to_string())?;
         if reclassified > 0 {
             tracing::info!(
                 target: "wavecrate::source_processing",
@@ -2844,8 +2842,7 @@ fn discover_source_candidates_with_connection_and_progress(
                 "Reclassified deterministic audio decode failures as unsupported"
             );
         }
-        let snapshot = match reconcile_readiness_with_cancel_and_progress(
-            &connection,
+        let snapshot = match ReadinessStore::new(connection).reconcile_with_cancel_and_progress(
             source_id,
             now,
             cancel,
@@ -2871,8 +2868,7 @@ fn discover_source_candidates_with_connection_and_progress(
             })
             .cloned()
             .collect::<Vec<_>>();
-        match persist_readiness_deficits_with_cancel_and_progress(
-            connection,
+        match ReadinessStore::new(connection).persist_deficits_with_cancel_and_progress(
             &persistable_deficits,
             now,
             cancel,
@@ -2887,7 +2883,9 @@ fn discover_source_candidates_with_connection_and_progress(
             }
             Err(error) => return Err(error.to_string()),
         }
-        park_active_recording_jobs(connection, &active_recordings.scope_ids)?;
+        ReadinessStore::new(connection)
+            .defer_active_recordings(&active_recordings.scope_ids)
+            .map_err(|error| error.to_string())?;
         let schedulable_deficits = persistable_deficits
             .iter()
             .filter(|deficit| snapshot.prerequisites_are_current(&deficit.target))
@@ -2900,8 +2898,9 @@ fn discover_source_candidates_with_connection_and_progress(
             source: source.clone(),
             task: RuntimeTask::Readiness(deficit.target.clone()),
         }));
-        let work_stats =
-            readiness_work_stats(&connection, now).map_err(|error| error.to_string())?;
+        let work_stats = ReadinessStore::new(connection)
+            .work_stats(now)
+            .map_err(|error| error.to_string())?;
         stats.progress_total = work_stats.total;
         stats.progress_completed = work_stats
             .completed
@@ -2987,44 +2986,9 @@ fn active_recording_deferrals(
     Ok(deferrals)
 }
 
-fn park_active_recording_jobs(
-    connection: &rusqlite::Connection,
-    scope_ids: &BTreeSet<String>,
-) -> Result<(), String> {
-    for scope_id in scope_ids {
-        connection
-            .execute(
-                "DELETE FROM analysis_jobs
-                 WHERE readiness_managed = 1
-                   AND readiness_scope_id = ?1
-                   AND status != 'running'",
-                [scope_id],
-            )
-            .map_err(|error| error.to_string())?;
-    }
-    Ok(())
-}
-
-fn prune_legacy_similarity_jobs(connection: &rusqlite::Connection) -> Result<usize, String> {
-    let removed = connection
-        .execute(
-            "DELETE FROM analysis_jobs
-             WHERE readiness_managed = 0
-               AND job_type IN ('wav_metadata_v1', 'embedding_backfill_v1', 'rebuild_index_v1')",
-            [],
-        )
-        .map_err(|error| format!("Prune retired similarity jobs failed: {error}"))?;
-    connection
-        .execute(
-            "DELETE FROM analysis_job_progress_snapshots
-             WHERE job_type IN ('wav_metadata_v1', 'embedding_backfill_v1', 'rebuild_index_v1')",
-            [],
-        )
-        .map_err(|error| format!("Prune retired similarity progress failed: {error}"))?;
-    Ok(removed)
-}
-
-fn source_processing_schema_available(connection: &rusqlite::Connection) -> Result<bool, String> {
+fn source_processing_schema_available(
+    connection: &mut rusqlite::Connection,
+) -> Result<bool, String> {
     for (table, required_columns) in [
         (
             "wav_files",
@@ -3037,31 +3001,7 @@ fn source_processing_schema_available(connection: &rusqlite::Connection) -> Resu
                 "missing",
             ][..],
         ),
-        (
-            "analysis_jobs",
-            &[
-                "id",
-                "relative_path",
-                "job_type",
-                "created_at",
-                "status",
-                "readiness_managed",
-            ][..],
-        ),
         ("metadata", &["key", "value"][..]),
-        (
-            "source_readiness_artifacts",
-            &[
-                "source_id",
-                "scope_kind",
-                "scope_id",
-                "relative_path",
-                "stage",
-                "artifact_version",
-                "content_generation",
-                "artifact_ref",
-            ][..],
-        ),
     ] {
         let pragma = format!("PRAGMA table_info({table})");
         let mut statement = connection
@@ -3079,19 +3019,8 @@ fn source_processing_schema_available(connection: &rusqlite::Connection) -> Resu
             return Ok(false);
         }
     }
-    connection
-        .query_row(
-            "SELECT COUNT(*) = 3
-             FROM sqlite_master
-             WHERE type = 'table'
-               AND name IN (
-                   'source_readiness_sources',
-                   'source_readiness_targets',
-                   'source_readiness_artifacts'
-               )",
-            [],
-            |row| row.get(0),
-        )
+    ReadinessStore::new(connection)
+        .processing_schema_available()
         .map_err(|error| error.to_string())
 }
 
@@ -3128,75 +3057,19 @@ pub(super) fn retire_source_derived_state(
             database_path.display()
         ));
     }
-    let readiness_source_table_exists = connection
-        .query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM sqlite_master
-                WHERE type = 'table' AND name = 'source_readiness_sources'
-             )",
-            [],
-            |row| row.get::<_, bool>(0),
-        )
-        .map_err(|error| error.to_string())?;
-    if !readiness_source_table_exists {
+    if !ReadinessStore::new(&mut connection)
+        .schema_available()
+        .map_err(|error| error.to_string())?
+    {
         return Ok(SourceRetirementOutcome::Retired {
             retired_cache_refs: 0,
         });
     }
-    let transaction = connection
-        .transaction_with_behavior(TransactionBehavior::Immediate)
+    let cleanup = ReadinessStore::new(&mut connection)
+        .retire_source(source.id.as_str(), now_epoch_seconds())
         .map_err(|error| error.to_string())?;
-    let cache_refs = {
-        let mut statement = transaction
-            .prepare(
-                "SELECT artifact_ref
-                 FROM source_readiness_artifacts
-                 WHERE source_id = ?1
-                   AND stage = 'playback_summary'
-                   AND artifact_ref IS NOT NULL
-                   AND length(trim(artifact_ref)) > 0",
-            )
-            .map_err(|error| error.to_string())?;
-        statement
-            .query_map([source.id.as_str()], |row| row.get::<_, String>(0))
-            .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| error.to_string())?
-    };
-    transaction
-        .execute(
-            "UPDATE source_readiness_sources
-             SET availability = 'disabled',
-                 readiness_revision = readiness_revision + 1,
-                 updated_at = ?2
-             WHERE source_id = ?1 AND availability != 'disabled'",
-            params![source.id.as_str(), now_epoch_seconds()],
-        )
-        .map_err(|error| error.to_string())?;
-    transaction
-        .execute(
-            "DELETE FROM analysis_jobs
-             WHERE source_id = ?1 AND readiness_managed = 1",
-            [source.id.as_str()],
-        )
-        .map_err(|error| error.to_string())?;
-    transaction
-        .execute(
-            "DELETE FROM source_readiness_artifacts
-             WHERE source_id = ?1 AND stage = 'playback_summary'",
-            [source.id.as_str()],
-        )
-        .map_err(|error| error.to_string())?;
-    transaction
-        .execute(
-            "DELETE FROM source_readiness_targets
-             WHERE source_id = ?1 AND stage = 'playback_summary'",
-            [source.id.as_str()],
-        )
-        .map_err(|error| error.to_string())?;
-    transaction.commit().map_err(|error| error.to_string())?;
     let mut invalidated = 0;
-    for cache_ref in &cache_refs {
+    for cache_ref in &cleanup.retired_artifact_refs {
         match retained_waveform_cache_ref_is_owned(cache_ref) {
             Ok(false) => {
                 invalidate_persisted_waveform_cache_ref(std::path::Path::new(cache_ref));
@@ -3239,24 +3112,14 @@ fn retained_waveform_cache_ref_is_owned(cache_ref: &str) -> Result<bool, String>
                 database_path.display()
             ));
         }
-        let connection = rusqlite::Connection::open_with_flags(
+        let mut connection = rusqlite::Connection::open_with_flags(
             &database_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
         .map_err(|error| error.to_string())?;
-        let owned = connection
-            .query_row(
-                "SELECT EXISTS(
-                    SELECT 1
-                    FROM source_readiness_artifacts
-                    WHERE stage = 'playback_summary' AND artifact_ref = ?1
-                 )",
-                [cache_ref],
-                |row| row.get::<_, bool>(0),
-            )
-            .optional()
-            .map_err(|error| error.to_string())?
-            .unwrap_or(false);
+        let owned = ReadinessStore::new(&mut connection)
+            .legacy_playback_artifact_ref_is_owned(cache_ref)
+            .map_err(|error| error.to_string())?;
         if owned {
             return Ok(true);
         }
@@ -3282,37 +3145,13 @@ fn prune_unreferenced_waveform_cache() -> Result<usize, String> {
                 database_path.display()
             ));
         }
-        let connection = rusqlite::Connection::open_with_flags(
+        let mut connection = rusqlite::Connection::open_with_flags(
             &database_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
         .map_err(|error| format!("open retained cache manifest: {error}"))?;
-        let manifest_exists = connection
-            .query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM sqlite_master
-                    WHERE type = 'table' AND name = 'source_readiness_artifacts'
-                 )",
-                [],
-                |row| row.get::<_, bool>(0),
-            )
-            .map_err(|error| error.to_string())?;
-        if !manifest_exists {
-            continue;
-        }
-        let mut statement = connection
-            .prepare(
-                "SELECT artifact_ref
-                 FROM source_readiness_artifacts
-                 WHERE stage = 'playback_summary'
-                   AND artifact_ref IS NOT NULL
-                   AND length(trim(artifact_ref)) > 0",
-            )
-            .map_err(|error| error.to_string())?;
-        let refs = statement
-            .query_map([], |row| row.get::<_, String>(0))
-            .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
+        let refs = ReadinessStore::new(&mut connection)
+            .legacy_playback_artifact_refs()
             .map_err(|error| error.to_string())?;
         referenced.extend(refs.into_iter().map(PathBuf::from));
     }
@@ -3437,7 +3276,9 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
         }
         rows
     };
-    let unsupported_generations = readiness_unsupported_content_generations(connection, source_id)?;
+    let unsupported_generations = ReadinessStore::new(connection)
+        .unsupported_content_generations(source_id)
+        .map_err(|error| error.to_string())?;
     let mut manifest = Vec::with_capacity(rows.len());
     for (path, identity, content_hash, file_size, modified_ns) in rows {
         checkpoint();
@@ -3448,7 +3289,9 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
             continue;
         }
         let Some(identity) = identity.filter(|value| !value.trim().is_empty()) else {
-            mark_readiness_temporarily_unavailable(connection, source_id, now)?;
+            ReadinessStore::new(connection)
+                .mark_temporarily_unavailable(source_id, now)
+                .map_err(|error| error.to_string())?;
             return Ok(Cancellable::Completed(false));
         };
         let content_hash = content_hash.filter(|value| !value.trim().is_empty());
@@ -3541,37 +3384,29 @@ fn publish_current_readiness_targets_with_cancel_and_checkpoint(
         )
         .optional()
         .map_err(|error| error.to_string())?;
-    let current_source: Option<(i64, i64, String)> = connection
-        .query_row(
-            "SELECT source_generation, readiness_revision, availability
-             FROM source_readiness_sources WHERE source_id = ?1",
-            [source_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .optional()
+    let current_source = ReadinessStore::new(connection)
+        .source_state(source_id)
         .map_err(|error| error.to_string())?;
     if current_fingerprint.as_deref() == Some(target_fingerprint.as_str())
-        && current_source
-            .as_ref()
-            .is_some_and(|(generation, _, availability)| {
-                *generation == source_generation && availability == "active"
-            })
+        && current_source.as_ref().is_some_and(|state| {
+            state.source_generation == source_generation
+                && state.availability == SourceAvailability::Active
+        })
     {
         return Ok(Cancellable::Completed(false));
     }
     let readiness_revision = current_source
-        .map(|(_, revision, _)| revision.saturating_add(1))
+        .map(|state| state.readiness_revision.saturating_add(1))
         .unwrap_or(1);
-    match replace_readiness_targets_with_cancel(
-        connection,
+    let publication = ReadinessTargetPublication::new(
         source_id,
         source_generation,
         readiness_revision,
         SourceAvailability::Active,
         &targets,
         now,
-        cancel,
-    ) {
+    );
+    match ReadinessStore::new(connection).publish_targets_with_cancel(&publication, cancel) {
         Ok(()) => {}
         Err(wavecrate::sample_sources::readiness::ReadinessError::Cancelled) => {
             return Ok(Cancellable::Cancelled);
@@ -3622,83 +3457,12 @@ fn retire_legacy_playback_readiness_with_post_commit_hook(
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);
     }
-    let has_legacy_rows = connection
-        .query_row(
-            "SELECT EXISTS (
-                 SELECT 1
-                 FROM source_readiness_targets
-                 WHERE source_id = ?1 AND stage = 'playback_summary'
-                 UNION ALL
-                 SELECT 1
-                 FROM source_readiness_artifacts
-                 WHERE source_id = ?1 AND stage = 'playback_summary'
-                 UNION ALL
-                 SELECT 1
-                 FROM analysis_jobs
-                 WHERE source_id = ?1
-                   AND readiness_managed = 1
-                   AND readiness_stage = 'playback_summary'
-             )",
-            [source.id.as_str()],
-            |row| row.get::<_, bool>(0),
-        )
+    let cleanup = ReadinessStore::new(connection)
+        .retire_legacy_playback(source.id.as_str())
         .map_err(|error| error.to_string())?;
-    if !has_legacy_rows {
-        return Ok(Cancellable::Completed(0));
-    }
-    let cache_refs = {
-        let mut statement = connection
-            .prepare(
-                "SELECT artifact_ref
-                 FROM source_readiness_artifacts
-                 WHERE source_id = ?1
-                   AND stage = 'playback_summary'
-                   AND artifact_ref IS NOT NULL
-                   AND length(trim(artifact_ref)) > 0",
-            )
-            .map_err(|error| error.to_string())?;
-        statement
-            .query_map([source.id.as_str()], |row| row.get::<_, String>(0))
-            .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| error.to_string())?
-    };
-    let transaction = connection
-        .transaction_with_behavior(TransactionBehavior::Immediate)
-        .map_err(|error| error.to_string())?;
-    let mut changed = transaction
-        .execute(
-            "DELETE FROM analysis_jobs
-             WHERE source_id = ?1
-               AND readiness_managed = 1
-               AND readiness_stage = 'playback_summary'",
-            [source.id.as_str()],
-        )
-        .map_err(|error| error.to_string())?;
-    changed = changed.saturating_add(
-        transaction
-            .execute(
-                "DELETE FROM source_readiness_artifacts
-             WHERE source_id = ?1
-               AND stage = 'playback_summary'",
-                [source.id.as_str()],
-            )
-            .map_err(|error| error.to_string())?,
-    );
-    changed = changed.saturating_add(
-        transaction
-            .execute(
-                "DELETE FROM source_readiness_targets
-             WHERE source_id = ?1
-               AND stage = 'playback_summary'",
-                [source.id.as_str()],
-            )
-            .map_err(|error| error.to_string())?,
-    );
-    transaction.commit().map_err(|error| error.to_string())?;
     post_commit();
 
-    for cache_ref in cache_refs {
+    for cache_ref in cleanup.retired_artifact_refs {
         match retained_waveform_cache_ref_is_owned(&cache_ref) {
             Ok(false) => invalidate_persisted_waveform_cache_ref(std::path::Path::new(&cache_ref)),
             Ok(true) => {}
@@ -3711,53 +3475,11 @@ fn retire_legacy_playback_readiness_with_post_commit_hook(
             ),
         }
     }
-    Ok(Cancellable::Completed(changed))
-}
-
-fn readiness_unsupported_content_generations(
-    connection: &rusqlite::Connection,
-    source_id: &str,
-) -> Result<BTreeSet<(String, String)>, String> {
-    let mut statement = connection
-        .prepare(
-            "SELECT DISTINCT readiness_scope_id, content_generation
-             FROM analysis_jobs
-             WHERE source_id = ?1
-               AND readiness_managed = 1
-               AND readiness_scope_kind = 'file'
-               AND status = 'failed'
-               AND failure_kind = 'unsupported'
-               AND readiness_scope_id IS NOT NULL
-               AND content_generation IS NOT NULL",
-        )
-        .map_err(|error| error.to_string())?;
-    statement
-        .query_map([source_id], |row| Ok((row.get(0)?, row.get(1)?)))
-        .map_err(|error| error.to_string())?
-        .collect::<Result<BTreeSet<_>, _>>()
-        .map_err(|error| error.to_string())
+    Ok(Cancellable::Completed(cleanup.changed))
 }
 
 fn cancelled(cancel: &AtomicBool) -> bool {
     cancel.load(Ordering::Acquire)
-}
-
-fn mark_readiness_temporarily_unavailable(
-    connection: &rusqlite::Connection,
-    source_id: &str,
-    now: i64,
-) -> Result<(), String> {
-    connection
-        .execute(
-            "UPDATE source_readiness_sources
-             SET availability = 'offline',
-                 readiness_revision = readiness_revision + 1,
-                 updated_at = ?2
-             WHERE source_id = ?1 AND availability != 'offline'",
-            params![source_id, now],
-        )
-        .map_err(|error| error.to_string())?;
-    Ok(())
 }
 
 fn readiness_target_fingerprint_with_cancel(
@@ -3991,7 +3713,8 @@ fn execute_synthetic_candidate_for_profile(
         .get_mut(source_id)
         .expect("synthetic source connection was inserted");
     let now = now_epoch_seconds();
-    let Some(claim) = claim_readiness_target(connection, target, now, READINESS_LEASE_SECONDS)
+    let Some(claim) = ReadinessStore::new(connection)
+        .claim(target, now, READINESS_LEASE_SECONDS)
         .map_err(|error| error.to_string())?
     else {
         return Ok(ExecutionOutcome::NotClaimed);
@@ -3999,7 +3722,8 @@ fn execute_synthetic_candidate_for_profile(
     if cancel.load(Ordering::Acquire) {
         return cancel_claim(connection, &claim, "profile cancellation", now);
     }
-    match complete_readiness_work(connection, &claim, now_epoch_seconds())
+    match ReadinessStore::new(connection)
+        .complete(&claim, now_epoch_seconds())
         .map_err(|error| error.to_string())?
     {
         ArtifactPublishOutcome::Recorded => Ok(ExecutionOutcome::Completed),
@@ -4028,7 +3752,8 @@ fn execute_readiness_target(
     )
     .map_err(|error| error.to_string())?;
     let now = now_epoch_seconds();
-    let Some(claim) = claim_readiness_target(&mut connection, target, now, READINESS_LEASE_SECONDS)
+    let Some(claim) = ReadinessStore::new(&mut connection)
+        .claim(target, now, READINESS_LEASE_SECONDS)
         .map_err(|error| error.to_string())?
     else {
         return Ok(ExecutionOutcome::NotClaimed);
@@ -4045,8 +3770,7 @@ fn execute_readiness_target(
     ) {
         Ok(result) => result,
         Err(error) => {
-            let _ = cancel_readiness_work(
-                &mut connection,
+            let _ = ReadinessStore::new(&mut connection).cancel(
                 &claim,
                 "readiness lease heartbeat failure",
                 now_epoch_seconds(),
@@ -4070,13 +3794,13 @@ fn execute_readiness_target(
     match outcome {
         Ok(ReadinessExecutionOutcome::Complete(artifact_ref)) => {
             let completed = match artifact_ref.as_deref() {
-                Some(artifact_ref) => complete_readiness_work_with_artifact_ref(
-                    &mut connection,
-                    &claim,
-                    now_epoch_seconds(),
-                    &artifact_ref.to_string_lossy(),
-                ),
-                None => complete_readiness_work(&mut connection, &claim, now_epoch_seconds()),
+                Some(artifact_ref) => ReadinessStore::new(&mut connection)
+                    .complete_with_artifact_ref(
+                        &claim,
+                        now_epoch_seconds(),
+                        &artifact_ref.to_string_lossy(),
+                    ),
+                None => ReadinessStore::new(&mut connection).complete(&claim, now_epoch_seconds()),
             };
             let completed = match completed {
                 Ok(completed) => completed,
@@ -4100,58 +3824,52 @@ fn execute_readiness_target(
         Ok(ReadinessExecutionOutcome::Retry(reason)) => {
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");
-            let outcome = fail_readiness_work(
-                &mut connection,
-                &claim,
-                ReadinessFailureClassification::Retryable,
-                reason,
-                now_epoch_seconds(),
-                policy,
-            )
-            .map_err(|error| error.to_string())?;
+            let outcome = ReadinessStore::new(&mut connection)
+                .fail(
+                    &claim,
+                    ReadinessFailureClassification::Retryable,
+                    reason,
+                    now_epoch_seconds(),
+                    policy,
+                )
+                .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
         Err(reason) => {
             let classification = readiness_failure_classification(&reason);
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");
-            let outcome = fail_readiness_work(
-                &mut connection,
-                &claim,
-                classification,
-                &reason,
-                now_epoch_seconds(),
-                policy,
-            )
-            .map_err(|error| error.to_string())?;
+            let outcome = ReadinessStore::new(&mut connection)
+                .fail(&claim, classification, &reason, now_epoch_seconds(), policy)
+                .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
         Ok(ReadinessExecutionOutcome::Permanent(reason)) => {
             let policy =
                 ReadinessRetryPolicy::new(5, 5 * 60, 1).expect("valid readiness terminal policy");
-            let outcome = fail_readiness_work(
-                &mut connection,
-                &claim,
-                ReadinessFailureClassification::Permanent,
-                reason,
-                now_epoch_seconds(),
-                policy,
-            )
-            .map_err(|error| error.to_string())?;
+            let outcome = ReadinessStore::new(&mut connection)
+                .fail(
+                    &claim,
+                    ReadinessFailureClassification::Permanent,
+                    reason,
+                    now_epoch_seconds(),
+                    policy,
+                )
+                .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
         Ok(ReadinessExecutionOutcome::Unsupported(reason)) => {
             let policy =
                 ReadinessRetryPolicy::new(5, 5 * 60, 1).expect("valid readiness terminal policy");
-            let outcome = fail_readiness_work(
-                &mut connection,
-                &claim,
-                ReadinessFailureClassification::Unsupported,
-                reason,
-                now_epoch_seconds(),
-                policy,
-            )
-            .map_err(|error| error.to_string())?;
+            let outcome = ReadinessStore::new(&mut connection)
+                .fail(
+                    &claim,
+                    ReadinessFailureClassification::Unsupported,
+                    reason,
+                    now_epoch_seconds(),
+                    policy,
+                )
+                .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
         Ok(ReadinessExecutionOutcome::PrerequisiteInvalidated(reason)) => {
@@ -4161,15 +3879,15 @@ fn execute_readiness_target(
                 READINESS_MAX_ATTEMPTS,
             )
             .expect("valid prerequisite invalidation retry policy");
-            match fail_readiness_work(
-                &mut connection,
-                &claim,
-                ReadinessFailureClassification::Retryable,
-                reason,
-                now_epoch_seconds(),
-                policy,
-            )
-            .map_err(|error| error.to_string())?
+            match ReadinessStore::new(&mut connection)
+                .fail(
+                    &claim,
+                    ReadinessFailureClassification::Retryable,
+                    reason,
+                    now_epoch_seconds(),
+                    policy,
+                )
+                .map_err(|error| error.to_string())?
             {
                 ReadinessFailureOutcome::RetryScheduled { retry_at } => {
                     Ok(ExecutionOutcome::PrerequisiteInvalidated { retry_at, reason })
@@ -4206,91 +3924,14 @@ fn is_known_unsupported_audio_failure(reason: &str) -> bool {
         || reason.contains("no suitable format reader found")
 }
 
-fn reclassify_known_unsupported_audio_failures(
-    connection: &mut rusqlite::Connection,
-) -> Result<usize, String> {
-    let legacy_terminal_failures = {
-        let mut statement = connection
-            .prepare(
-                "SELECT id, COALESCE(last_error, '')
-                 FROM analysis_jobs
-                 WHERE readiness_managed = 1
-                   AND status = 'failed'
-                   AND failure_kind IN ('retryable', 'permanent')",
-            )
-            .map_err(|error| error.to_string())?;
-        statement
-            .query_map([], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-            })
-            .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| error.to_string())?
-    };
-    let unsupported_ids = legacy_terminal_failures
-        .into_iter()
-        .filter_map(|(id, error)| is_known_unsupported_audio_failure(&error).then_some(id))
-        .collect::<Vec<_>>();
-    let transaction = connection
-        .transaction_with_behavior(TransactionBehavior::Immediate)
-        .map_err(|error| error.to_string())?;
-    let mut reclassified = 0_usize;
-    for id in unsupported_ids {
-        reclassified = reclassified.saturating_add(
-            transaction
-                .execute(
-                    "UPDATE analysis_jobs
-                     SET failure_kind = 'unsupported', retry_at = NULL
-                     WHERE id = ?1
-                       AND readiness_managed = 1
-                       AND status = 'failed'
-                       AND failure_kind IN ('retryable', 'permanent')",
-                    [id],
-                )
-                .map_err(|error| error.to_string())?,
-        );
-    }
-    reclassified = reclassified.saturating_add(
-        transaction
-            .execute(
-                "UPDATE analysis_jobs AS dependent
-                 SET failure_kind = 'unsupported', retry_at = NULL
-                 WHERE dependent.readiness_managed = 1
-                   AND dependent.status = 'failed'
-                   AND dependent.failure_kind IN ('retryable', 'permanent')
-                   AND dependent.readiness_stage = 'embedding_aspects'
-                   AND dependent.last_error =
-                       'embedding feature prerequisite is not durable yet'
-                   AND EXISTS(
-                       SELECT 1
-                       FROM analysis_jobs AS prerequisite
-                       WHERE prerequisite.readiness_managed = 1
-                         AND prerequisite.source_id = dependent.source_id
-                         AND prerequisite.readiness_scope_kind =
-                             dependent.readiness_scope_kind
-                         AND prerequisite.readiness_scope_id =
-                             dependent.readiness_scope_id
-                         AND prerequisite.readiness_stage = 'analysis_features'
-                         AND prerequisite.content_generation =
-                             dependent.content_generation
-                         AND prerequisite.status = 'failed'
-                         AND prerequisite.failure_kind = 'unsupported'
-                   )",
-                [],
-            )
-            .map_err(|error| error.to_string())?,
-    );
-    transaction.commit().map_err(|error| error.to_string())?;
-    Ok(reclassified)
-}
-
 fn cancel_claim(
     connection: &mut rusqlite::Connection,
     claim: &ClaimedReadinessWork,
     reason: &str,
     now: i64,
 ) -> Result<ExecutionOutcome, String> {
-    match cancel_readiness_work(connection, claim, reason, now)
+    match ReadinessStore::new(connection)
+        .cancel(claim, reason, now)
         .map_err(|error| error.to_string())?
     {
         ReadinessWorkMutationOutcome::Recorded => Ok(ExecutionOutcome::Cancelled),
@@ -4338,8 +3979,7 @@ fn run_with_readiness_lease_heartbeat<T>(
                     local_cancel.store(true, Ordering::Release);
                 }
                 if Instant::now() >= next_renewal {
-                    match renew_readiness_lease(
-                        &mut heartbeat_connection,
+                    match ReadinessStore::new(&mut heartbeat_connection).renew_lease(
                         claim,
                         now_epoch_seconds(),
                         lease_duration_seconds,
@@ -4530,7 +4170,8 @@ fn run_readiness_stage(
             analysis_target.stage = ReadinessStage::AnalysisFeatures;
             analysis_target.required_version = wavecrate_analysis::analysis_version().to_string();
             if !analysis_features_are_current(connection, &analysis_target)? {
-                if invalidate_readiness_artifact(connection, &analysis_target)
+                if ReadinessStore::new(connection)
+                    .invalidate_artifact(&analysis_target)
                     .map_err(|error| error.to_string())?
                 {
                     tracing::warn!(
@@ -4592,32 +4233,17 @@ fn run_readiness_stage(
 }
 
 fn readiness_stage_is_unsupported(
-    connection: &rusqlite::Connection,
+    connection: &mut rusqlite::Connection,
     target: &ReadinessTarget,
     stage: &str,
 ) -> Result<bool, String> {
-    connection
-        .query_row(
-            "SELECT EXISTS(
-                SELECT 1
-                FROM analysis_jobs
-                WHERE readiness_managed = 1
-                  AND source_id = ?1
-                  AND readiness_scope_kind = 'file'
-                  AND readiness_scope_id = ?2
-                  AND readiness_stage = ?3
-                  AND content_generation = ?4
-                  AND status = 'failed'
-                  AND failure_kind = 'unsupported'
-            )",
-            params![
-                target.source_id,
-                target.scope_id,
-                stage,
-                target.content_generation
-            ],
-            |row| row.get(0),
-        )
+    let stage = match stage {
+        "analysis_features" => ReadinessStage::AnalysisFeatures,
+        "embedding_aspects" => ReadinessStage::EmbeddingAspects,
+        _ => return Ok(false),
+    };
+    ReadinessStore::new(connection)
+        .stage_is_unsupported(target, stage)
         .map_err(|error| error.to_string())
 }
 
@@ -5071,9 +4697,8 @@ mod tests {
     use wavecrate::sample_sources::{
         SourceId,
         readiness::{
-            ReadinessArtifact, ReadinessEligibility, SourceAvailability,
-            persist_readiness_deficits, publish_readiness_artifact, readiness_work_stats,
-            reconcile_readiness, replace_readiness_targets,
+            ReadinessArtifact, ReadinessEligibility, ReadinessStore, ReadinessTargetPublication,
+            SourceAvailability,
         },
     };
 

--- a/src/test_support/source_processing_liveness/diagnostics.rs
+++ b/src/test_support/source_processing_liveness/diagnostics.rs
@@ -243,8 +243,10 @@ fn durable_job_diagnostics(connection: &Connection) -> rusqlite::Result<DurableJ
 }
 
 pub(super) fn readiness_snapshot(source: &SampleSource) -> Option<ReadinessSnapshot> {
-    let connection = open_connection(source).ok()?;
-    reconcile_readiness(&connection, source.id.as_str(), now_epoch_seconds()).ok()
+    let mut connection = open_connection(source).ok()?;
+    ReadinessStore::new(&mut connection)
+        .reconcile(source.id.as_str(), now_epoch_seconds())
+        .ok()
 }
 
 pub(super) fn open_connection(source: &SampleSource) -> Result<Connection, String> {

--- a/src/test_support/source_processing_liveness/mod.rs
+++ b/src/test_support/source_processing_liveness/mod.rs
@@ -14,7 +14,7 @@ use wavecrate::sample_sources::{
     db::{META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION},
     readiness::{
         ReadinessActivity, ReadinessClassification, ReadinessSnapshot, ReadinessStage,
-        SourceAvailability, reconcile_readiness,
+        ReadinessStore, SourceAvailability,
     },
     scanner::audit_source_and_record,
 };

--- a/src/test_support/source_processing_liveness/scenarios.rs
+++ b/src/test_support/source_processing_liveness/scenarios.rs
@@ -14,7 +14,8 @@ fn liveness_oracle_rejects_actionable_deficits_without_observable_runtime_work()
     let mut connection = open_connection(&source).expect("open liveness oracle connection");
     publish_current_readiness_targets(&mut connection, source.id.as_str(), now_epoch_seconds())
         .expect("publish liveness oracle targets");
-    let snapshot = reconcile_readiness(&connection, source.id.as_str(), now_epoch_seconds())
+    let snapshot = ReadinessStore::new(&mut connection)
+        .reconcile(source.id.as_str(), now_epoch_seconds())
         .expect("reconcile liveness oracle");
     assert!(!snapshot.deficits.is_empty());
 
@@ -76,7 +77,8 @@ fn unrelated_source_queue_does_not_mask_silent_idle_source() {
     let mut connection = open_connection(&first).expect("open first connection");
     publish_current_readiness_targets(&mut connection, first.id.as_str(), now_epoch_seconds())
         .expect("publish first targets");
-    let snapshot = reconcile_readiness(&connection, first.id.as_str(), now_epoch_seconds())
+    let snapshot = ReadinessStore::new(&mut connection)
+        .reconcile(first.id.as_str(), now_epoch_seconds())
         .expect("reconcile first source");
     assert!(!snapshot.deficits.is_empty());
 

--- a/tests/source_analysis_process.rs
+++ b/tests/source_analysis_process.rs
@@ -11,9 +11,8 @@ use serde_json::{Value, json};
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceId,
     readiness::{
-        ReadinessEligibility, ReadinessStage, ReadinessTarget, ReadinessWorkMutationOutcome,
-        SourceAvailability, cancel_readiness_work, claim_readiness_target,
-        persist_readiness_deficits, reconcile_readiness, replace_readiness_targets,
+        ReadinessEligibility, ReadinessStage, ReadinessStore, ReadinessTarget,
+        ReadinessTargetPublication, ReadinessWorkMutationOutcome, SourceAvailability,
     },
 };
 
@@ -35,7 +34,8 @@ fn internal_feature_and_embedding_workers_complete_without_starting_the_gui() {
 fn long_running_feature_worker_is_killable_and_its_claim_is_reclaimable() {
     let mut fixture = SourceAnalysisFixture::new("process-analysis-cancel", "long.wav", 300, 8_000);
     let target = fixture.install_feature_readiness_target();
-    let claim = claim_readiness_target(&mut fixture.connection, &target, 10, 300)
+    let claim = ReadinessStore::new(&mut fixture.connection)
+        .claim(&target, 10, 300)
         .expect("claim long-running feature target")
         .expect("feature target should be pending");
 
@@ -69,17 +69,14 @@ fn long_running_feature_worker_is_killable_and_its_claim_is_reclaimable() {
     );
 
     assert_eq!(
-        cancel_readiness_work(
-            &mut fixture.connection,
-            &claim,
-            "test playback preemption",
-            11,
-        )
-        .expect("release cancelled readiness claim"),
+        ReadinessStore::new(&mut fixture.connection)
+            .cancel(&claim, "test playback preemption", 11,)
+            .expect("release cancelled readiness claim"),
         ReadinessWorkMutationOutcome::Recorded
     );
     assert!(
-        claim_readiness_target(&mut fixture.connection, &target, 12, 300)
+        ReadinessStore::new(&mut fixture.connection)
+            .claim(&target, 12, 300)
             .expect("reclaim cancelled feature target")
             .is_some(),
         "cancelled readiness work should be immediately reclaimable"
@@ -212,21 +209,23 @@ impl SourceAnalysisFixture {
             )
             .with_eligibility(ReadinessEligibility::Unsupported),
         );
-        replace_readiness_targets(
-            &mut self.connection,
-            self.source.id.as_str(),
-            SOURCE_GENERATION,
-            1,
-            SourceAvailability::Active,
-            &targets,
-            1,
-        )
-        .expect("install readiness targets");
-        let snapshot = reconcile_readiness(&self.connection, self.source.id.as_str(), 2)
+        ReadinessStore::new(&mut self.connection)
+            .publish_targets(&ReadinessTargetPublication::new(
+                self.source.id.as_str(),
+                SOURCE_GENERATION,
+                1,
+                SourceAvailability::Active,
+                &targets,
+                1,
+            ))
+            .expect("install readiness targets");
+        let snapshot = ReadinessStore::new(&mut self.connection)
+            .reconcile(self.source.id.as_str(), 2)
             .expect("reconcile feature readiness");
         assert_eq!(snapshot.deficits.len(), 1);
         assert_eq!(
-            persist_readiness_deficits(&mut self.connection, &snapshot.deficits, 2)
+            ReadinessStore::new(&mut self.connection)
+                .persist_deficits(&snapshot.deficits, 2)
                 .expect("persist feature readiness deficit"),
             1
         );


### PR DESCRIPTION
## Goal
Enforce a typed persistence boundary for durable source readiness.

## Scope
- Add `ReadinessStore`, `ReadinessView`, and typed publication/query requests.
- Move native source-processing and similarity-finalizer readiness persistence, recovery, selection, and compatibility cleanup behind the store.
- Add a static architecture guard against native readiness-table SQL in both production orchestration paths.

## Non-goals
- Redesign source-manifest metadata queries that are not owned by readiness.
- Change readiness scheduling or similarity publication semantics.

## Definition of Done
Production source processing uses typed readiness operations; readiness generation, lease, classification, recovery, artifact selection, and publication invariants remain store-owned. The architecture guard rejects direct readiness-table SQL in the supervisor and similarity worker.

## Validation
- `cargo check -p wavecrate --bin wavecrate` — passed
- `cargo test -p wavecrate-library sample_sources::readiness::tests` — 42 passed
- `cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests` — 77 passed, 1 profiling test ignored
- `cargo test -p wavecrate --test source_finalizer_process` — 1 passed
- `bash scripts/check.sh non-blocking-architecture` — passed
- `bash scripts/ci.sh smoke` — passed
- `cargo fmt --check` and `git diff --check` — passed

## Known limitations
None.

User approval is required before merge.