### PR TITLE
OPT-1202: Keep source processing pulse cadence stable during playback

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -25,8 +25,7 @@ const SOURCE_ROW_OUTLINE_INSET: f32 = 0.5;
 const SOURCE_ROW_OUTLINE_WIDTH: f32 = 1.0;
 const SOURCE_ROW_OUTLINE_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 30);
 const SOURCE_PROCESSING_MARKER_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 151, 72, 230);
-const SOURCE_PROCESSING_FILL_MIN_ALPHA: u8 = 48;
-const SOURCE_PROCESSING_FILL_MAX_ALPHA: u8 = 112;
+const SOURCE_PROCESSING_FILL_ALPHA: u8 = 48;
 const SOURCE_PROCESSING_HOVER_ALPHA_BOOST: u8 = 24;
 const SOURCE_ADD_BUTTON_TOOLTIP: &str = "Add source";
 
@@ -61,7 +60,7 @@ pub(super) fn source_row(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
     let row = if source.protected_source_error_flash {
         row.dense_chrome_palette(source_protected_error_palette())
     } else if source.processing {
-        row.dense_chrome_palette(source_processing_palette(source.processing_pulse))
+        row.dense_chrome_palette(source_processing_palette())
     } else {
         row
     };
@@ -183,22 +182,15 @@ fn source_processing_marker() -> ui::DenseRowMarkerStyle {
     )
 }
 
-fn source_processing_palette(progress_tick: f32) -> ui::DenseRowPalette {
-    let fill =
-        SOURCE_PROCESSING_MARKER_COLOR.with_alpha(source_processing_fill_alpha(progress_tick));
+fn source_processing_palette() -> ui::DenseRowPalette {
+    // Keep the retained row stable. The cadence-independent pulse is painted by the
+    // app transient overlay from its monotonic animation time.
+    let fill = SOURCE_PROCESSING_MARKER_COLOR.with_alpha(SOURCE_PROCESSING_FILL_ALPHA);
     let hovered = fill.with_alpha(fill.a.saturating_add(SOURCE_PROCESSING_HOVER_ALPHA_BOOST));
     ui::DenseRowPalette::new()
         .selected(fill)
         .selected_hovered(hovered)
         .interaction_fills(hovered, hovered)
-}
-
-fn source_processing_fill_alpha(progress_tick: f32) -> u8 {
-    let phase = progress_tick.rem_euclid(1.0);
-    let triangle = 1.0 - (phase.mul_add(2.0, -1.0)).abs();
-    let alpha = f32::from(SOURCE_PROCESSING_FILL_MIN_ALPHA)
-        + triangle * f32::from(SOURCE_PROCESSING_FILL_MAX_ALPHA - SOURCE_PROCESSING_FILL_MIN_ALPHA);
-    alpha.round() as u8
 }
 
 fn source_protected_error_palette() -> ui::DenseRowPalette {
@@ -248,8 +240,8 @@ pub(super) fn source_processing_marker_color_for_tests() -> ui::Rgba8 {
 }
 
 #[cfg(test)]
-pub(super) fn source_processing_fill_for_tests(progress_tick: f32) -> ui::Rgba8 {
-    SOURCE_PROCESSING_MARKER_COLOR.with_alpha(source_processing_fill_alpha(progress_tick))
+pub(super) fn source_processing_fill_for_tests() -> ui::Rgba8 {
+    SOURCE_PROCESSING_MARKER_COLOR.with_alpha(SOURCE_PROCESSING_FILL_ALPHA)
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -149,7 +149,6 @@ fn source_row_routes_drop_to_source_root() {
         selected: false,
         scanning: false,
         processing: false,
-        processing_pulse: 0.0,
         missing: false,
         protected_source_error_flash: false,
         drag_active: true,
@@ -203,11 +202,10 @@ fn processing_source_row_keeps_actions_enabled_and_paints_activity_marker() {
     let mut model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let row = model.rows.first_mut().expect("source row");
     row.processing = true;
-    row.processing_pulse = 0.5;
     let frame = source_row(row)
         .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
 
-    let pulse_fill = source_processing_fill_for_tests(row.processing_pulse);
+    let pulse_fill = source_processing_fill_for_tests();
     assert!(
         frame
             .paint_plan
@@ -227,40 +225,6 @@ fn processing_source_row_keeps_actions_enabled_and_paints_activity_marker() {
             FolderBrowserMessage::SelectSource(source.id.clone())
         )),
         "processing must never lock source interaction"
-    );
-}
-
-#[test]
-fn processing_source_idle_highlight_changes_with_progress_tick() {
-    let source = test_source("source-processing-pulse");
-    let state = FolderBrowserState::from_sources_deferred(vec![source.clone()], source.id.clone());
-    let mut model = SourceSelectorViewModel::from_folder_browser(&state, false);
-    let row = model.rows.first_mut().expect("source row");
-    row.processing = true;
-
-    row.processing_pulse = 0.0;
-    let dim_frame = source_row(row)
-        .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
-    row.processing_pulse = 0.5;
-    let bright_frame = source_row(row)
-        .view_frame_at_size_with_default_theme(ui::Vector2::new(180.0, SOURCE_ROW_HEIGHT));
-
-    let dim = source_processing_fill_for_tests(0.0);
-    let bright = source_processing_fill_for_tests(0.5);
-    assert_ne!(dim, bright);
-    assert!(
-        dim_frame
-            .paint_plan
-            .fill_rects()
-            .any(|fill| fill.color == dim),
-        "idle processing row should paint the dim pulse frame"
-    );
-    assert!(
-        bright_frame
-            .paint_plan
-            .fill_rects()
-            .any(|fill| fill.color == bright),
-        "idle processing row should paint the bright pulse frame"
     );
 }
 

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -41,7 +41,6 @@ pub(in crate::native_app) struct SourceRowViewModel {
     pub(in crate::native_app) selected: bool,
     pub(in crate::native_app) scanning: bool,
     pub(in crate::native_app) processing: bool,
-    pub(in crate::native_app) processing_pulse: f32,
     pub(in crate::native_app) missing: bool,
     pub(in crate::native_app) protected_source_error_flash: bool,
     pub(in crate::native_app) drag_active: bool,
@@ -189,7 +188,6 @@ impl LibrarySidebarViewModel {
                     .as_ref()
                     .filter(|progress| progress.active && progress.source_row_active)
                     .map(|progress| progress.source_id.as_str()),
-                state.background.progress_tick,
                 state
                     .library
                     .folder_progress()
@@ -214,20 +212,13 @@ impl SourceSelectorViewModel {
         folder_browser: &FolderBrowserState,
         help_tooltips_enabled: bool,
     ) -> Self {
-        Self::from_folder_browser_with_processing(
-            folder_browser,
-            help_tooltips_enabled,
-            None,
-            0.0,
-            None,
-        )
+        Self::from_folder_browser_with_processing(folder_browser, help_tooltips_enabled, None, None)
     }
 
     fn from_folder_browser_with_processing(
         folder_browser: &FolderBrowserState,
         help_tooltips_enabled: bool,
         processing_source_id: Option<&str>,
-        processing_pulse: f32,
         scanning_source_id: Option<&str>,
     ) -> Self {
         let selected_source_id = folder_browser.selected_source_id();
@@ -240,7 +231,6 @@ impl SourceSelectorViewModel {
                     selected_source_id,
                     folder_browser,
                     processing_source_id,
-                    processing_pulse,
                     scanning_source_id,
                 )
             })
@@ -261,7 +251,6 @@ impl SourceRowViewModel {
         selected_source_id: &str,
         folder_browser: &FolderBrowserState,
         processing_source_id: Option<&str>,
-        processing_pulse: f32,
         scanning_source_id: Option<&str>,
     ) -> Self {
         Self {
@@ -271,7 +260,6 @@ impl SourceRowViewModel {
             selected: selected_source_id == source.id,
             scanning: scanning_source_id == Some(source.id.as_str()),
             processing: processing_source_id == Some(source.id.as_str()),
-            processing_pulse,
             missing: source.is_missing(),
             protected_source_error_flash: folder_browser
                 .source_protected_error_flash_active(&source.id),

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -518,6 +518,68 @@ fn source_processing_activity_moves_in_transient_overlay_without_input() {
 }
 
 #[test]
+fn source_processing_source_pulse_uses_animation_time_not_frame_count() {
+    let (mut state, _source_root, _selected_file) =
+        native_app_state_with_temp_sample("processing-pulse.wav");
+    let source_id = state
+        .library
+        .folder_browser
+        .selected_source_id()
+        .to_string();
+    state.background.source_processing_progress = Some(
+        crate::native_app::test_support::state::SourceProcessingProgress {
+            source_id,
+            lifecycle_generation: 0,
+            active: true,
+            source_row_active: true,
+            completed: 3,
+            total: 10,
+            stage: String::from("Analyzing audio"),
+            detail: String::from("processing-pulse.wav"),
+        },
+    );
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+
+    let pulse_alpha = |runtime: &mut NativeRuntimeForTests, animation_time| {
+        let mut primitives = Vec::new();
+        runtime
+            .bridge_mut()
+            .state_mut()
+            .paint_source_processing_source_pulse(
+                TransientOverlayContext::new(
+                    &frame.paint_plan,
+                    Vector2::new(900.0, 620.0),
+                    animation_time,
+                ),
+                &mut primitives,
+            );
+        primitives
+            .iter()
+            .filter_map(|primitive| primitive.fill_rect())
+            .next()
+            .expect("source processing pulse fill")
+            .color
+            .a
+    };
+
+    let initial = pulse_alpha(&mut runtime, Duration::ZERO);
+    runtime.bridge_mut().state_mut().background.progress_tick = 0.5;
+    let after_frame_count_change = pulse_alpha(&mut runtime, Duration::ZERO);
+    let later = pulse_alpha(&mut runtime, Duration::from_millis(250));
+
+    assert_eq!(
+        after_frame_count_change, initial,
+        "playback frame cadence must not change the pulse phase"
+    );
+    assert_ne!(
+        later, initial,
+        "the pulse must advance from monotonic animation time"
+    );
+}
+
+#[test]
 fn manifest_maintenance_does_not_paint_source_row_pulse_overlay() {
     let (mut state, _source_root, _selected_file) =
         native_app_state_with_temp_sample("maintenance.wav");


### PR DESCRIPTION
## Goal

Keep the active source-processing row pulse at the same visible rate whether audio playback is idle or active.

## Scope and non-goals

- Replace the retained source row's frame-count-driven pulse with a stable base highlight.
- Keep the existing monotonic-animation-time transient overlay as the single pulse clock.
- Preserve the processing marker, row actions, and manifest-maintenance suppression.
- Add regression coverage proving frame-count tick changes do not change pulse phase.
- Non-goals: source-processing scheduling, playback/audio behavior, and unrelated progress animations.

## Definition of Done

- The source-processing pulse advances from elapsed animation time rather than UI frame count.
- Playback frame cadence cannot speed up the source-row pulse.
- The processing row remains visibly highlighted and interactive.
- Manifest maintenance still does not pulse a source row.
- Focused tests, the standard agent gate, and a freshly built signed-app smoke are green.

## Validation

- `cargo test -p wavecrate --bin wavecrate source_processing_source_pulse_uses_animation_time_not_frame_count` — passed (1 test).
- `cargo test -p wavecrate --bin wavecrate processing_source_row_keeps_actions_enabled_and_paints_activity_marker` — passed (1 test).
- `cargo test -p wavecrate --bin wavecrate manifest_maintenance_does_not_paint_source_row_pulse_overlay` — passed (1 test).
- `bash scripts/ci.sh smoke` — passed.
- `bash scripts/ci.sh agent` — passed: 1,650 Radiant tests, 50 app-runtime API tests, and 1,856 Wavecrate tests; 20 intentional ignores.
- `cargo fmt --all --check` and `git diff --check` — passed.
- `bash scripts/build.sh --release` — built and signed `target/app-bundles/opt1202/Wavecrate OPT-1202.app`.
- Signed-app runtime smoke — source processing remained visible while playback was active and after stopping playback; user confirmed the pulse now appears correct.

## Known limitations

None.

User approval is required before merge.
