### PR TITLE
OPT-1216: migrate GUI startup automation to native runtime

### DIFF
--- a/crates/wavecrate-library/src/app_dirs.rs
+++ b/crates/wavecrate-library/src/app_dirs.rs
@@ -14,7 +14,7 @@ mod resolution;
 mod state;
 
 pub use error::AppDirError;
-pub use overrides::ConfigBaseGuard;
+pub use overrides::{AppRootGuard, ConfigBaseGuard};
 pub use paths::{
     clear_rebuildable_cache_payloads, handoff_staging_dir, logs_dir, rebuildable_cache_root_dir,
     waveform_cache_dir,

--- a/crates/wavecrate-library/src/app_dirs/overrides.rs
+++ b/crates/wavecrate-library/src/app_dirs/overrides.rs
@@ -2,7 +2,44 @@
 
 use std::path::PathBuf;
 
-use super::state::{APP_ROOT_OVERRIDE, SCOPED_APP_ROOT_OVERRIDE, TEST_CONFIG_OVERRIDE};
+use super::{
+    AppDirError,
+    state::{APP_ROOT_OVERRIDE, SCOPED_APP_ROOT_OVERRIDE, TEST_CONFIG_OVERRIDE},
+};
+
+/// Guard that pins application-root resolution on the current thread.
+///
+/// Runtime owners use this to propagate an already-resolved persistence root
+/// into child threads without changing process-wide environment variables.
+pub struct AppRootGuard {
+    previous: Option<PathBuf>,
+}
+
+impl AppRootGuard {
+    /// Override the application root for the lifetime of the current-thread guard.
+    pub fn set(path: PathBuf) -> Result<Self, AppDirError> {
+        std::fs::create_dir_all(&path).map_err(|source| AppDirError::CreateDir {
+            path: path.clone(),
+            source,
+        })?;
+        let previous = SCOPED_APP_ROOT_OVERRIDE.with(|override_path| {
+            let mut slot = override_path.borrow_mut();
+            let previous = slot.clone();
+            *slot = Some(path);
+            previous
+        });
+        Ok(Self { previous })
+    }
+}
+
+impl Drop for AppRootGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        SCOPED_APP_ROOT_OVERRIDE.with(|override_path| {
+            *override_path.borrow_mut() = previous;
+        });
+    }
+}
 
 /// Guard that sets a temporary config base path for tests and restores the prior value.
 pub struct ConfigBaseGuard {

--- a/crates/wavecrate-library/src/app_dirs/tests.rs
+++ b/crates/wavecrate-library/src/app_dirs/tests.rs
@@ -128,6 +128,23 @@ fn automated_profile_guard_uses_canonical_mode() {
 }
 
 #[test]
+fn app_root_guard_pins_child_thread_to_resolved_runtime_root() {
+    let _lock = app_dirs_test_lock();
+    let parent = tempdir().unwrap();
+    let runtime_root = parent.path().join("native-runtime-root");
+    let expected = runtime_root.clone();
+
+    let observed = std::thread::spawn(move || {
+        let _guard = AppRootGuard::set(runtime_root).expect("pin worker app root");
+        app_root_dir().expect("resolve worker app root")
+    })
+    .join()
+    .expect("join app-root worker");
+
+    assert_eq!(observed, expected);
+}
+
+#[test]
 fn rejects_invalid_profile_names() {
     let _lock = app_dirs_test_lock();
     let base = tempdir().unwrap();

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -441,10 +441,12 @@ Enables deterministic GUI test mode for the main app binary.
 
 - `WAVECRATE_GUI_TEST_FIXTURE`
 Selects the GUI fixture used in GUI test mode. The default is
-`isolated-startup`, which keeps automated runs on a dedicated non-live
-profile. Use `live` only when you explicitly want GUI validation to exercise
-the real persisted startup profile. The legacy `default` tag is accepted only
- as an alias for `isolated-startup`.
+`isolated-startup`, which captures the production native app composition on a
+temporary config base using the dedicated non-live `automated-tests` profile.
+Use `live` only when you explicitly want GUI validation to exercise the real
+persisted startup profile. The legacy `default` tag is accepted only as an alias
+for `isolated-startup`. Named deterministic fixtures remain retained-controller
+compatibility tools and are not product-startup certification.
 
 ## Logging
 

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2599,18 +2599,34 @@ Behavioral coverage anchor: `src/app_core/ui_bridge/tests.rs`.
 
 ### GUI Test Platform
 
-The GUI test platform has four layers:
+The GUI test platform has two explicitly separated runtime families:
 
-1. host action catalog in `src/app_core/actions/**`
-2. semantic automation snapshots emitted by runtime/test projection helpers
-3. deterministic GUI test mode and artifact emission
-4. in-process scenario runner and `tools/gui-test-cli`
+1. product certification for `live`, `isolated-startup`, and the legacy
+   `default` alias lowers `NativeAppState` through the same Radiant runtime
+   bridge, subscriptions, message reducer, and shutdown hook as the desktop
+   executable;
+2. named deterministic fixtures remain retained-controller compatibility
+   coverage until equivalent native fixture builders exist.
+
+The product-native path owns startup and persistence certification. Named
+controller fixtures must never be treated as proof of production startup or
+background-worker composition. Architecture guardrails reject attempts to
+route live/startup fixtures back through `new_ui_bridge` or controller startup.
 
 The important contract is semantic stability:
 
 * target controls by stable node IDs and action IDs
 * prefer semantic automation over screenshot matching when possible
-* correlate GUI artifacts through the existing runtime/test projection helpers instead of inventing a separate reporting format
+* emit both native and compatibility snapshots through Radiant's backend-neutral
+  automation schema
+* record the fixture runtime and observable worker composition in artifacts so
+  product certification proves one native watcher/readiness supervisor and no
+  legacy analysis pool
+* keep automated startup on an isolated temporary config base using the
+  `automated-tests` profile; only the explicit `live` tag may resolve the live
+  profile
+* complete native captures through the real shutdown hook and retain its
+  machine-readable artifact
 
 Current development loops:
 

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -362,12 +362,20 @@ runtime dependency.
 Use for semantic GUI contracts and CLI scenarios.
 
 - Automated GUI runs default to the isolated `isolated-startup` fixture, which
-  exercises persisted startup against the dedicated `automated-tests`
-  persistence profile.
+  exercises the production `NativeAppState`/Radiant composition against a
+  temporary config base using the dedicated `automated-tests` persistence
+  profile.
 - Use the `live` GUI fixture only for deliberate manual validation against the
-  real persisted startup profile.
+  real persisted startup profile. It uses the same native composition as the
+  product executable and is the only GUI fixture allowed to resolve live state.
 - Treat `default` only as a legacy alias for `isolated-startup`; it is not a
   separate live-profile mode.
+- Named fixtures such as `browser`, `waveform`, and `map` remain explicitly
+  legacy-controller compatibility coverage. They do not certify native startup
+  or background-worker ownership.
+- Native startup artifacts identify `fixture_runtime: native-app`, report native
+  watcher/readiness-supervisor counts, report zero legacy analysis pools, and
+  include the native shutdown artifact.
 
 - Browser preview/commit flicker regressions:
   - targeted controller checks: `cargo test browser_focus_transition`
@@ -396,10 +404,12 @@ sample-source persistence, or GUI fixture profile selection.
 - regression anchors:
   - `cargo test app_core::controller::tests::persistence_boundary::`
   - `cargo test gui_test::`
+  - `cargo test native_app::automation::tests::startup_capture_uses_native_workers_and_shutdown_hook`
 - wrapper coverage:
   - `powershell -ExecutionPolicy Bypass -File scripts/gui.ps1 contract`
-    now includes the persistence-boundary regression that snapshots the live
-    `library.db` bytes before and after an isolated controller run
+    includes the native-startup regression that snapshots live configuration
+    bytes before and after an isolated native-runtime run, plus the retained
+    controller `library.db` boundary checks
   - `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 agent`
     still covers the same regression through `cargo test -p wavecrate --lib`
 

--- a/scripts/internal/check/check_native_app_boundary.ps1
+++ b/scripts/internal/check/check_native_app_boundary.ps1
@@ -63,6 +63,8 @@ Push-Location $rootDir
 try {
   $violations = New-Object System.Collections.Generic.List[string]
   $ambiguousModules = @("browser", "context_menu", "library_browser", "widgets")
+  $nativeGuiFixturePath = Join-Path $rootDir "src/gui_test/fixtures.rs"
+  $nativeGuiRunnerPath = Join-Path $rootDir "src/gui_test/runner/mod.rs"
 
   foreach ($file in Get-ChildItem -LiteralPath (Join-Path $rootDir "src/native_app") -Recurse -File -Filter "*.rs") {
     $repoPath = Convert-ToRepoPath -Path $file.FullName
@@ -98,10 +100,31 @@ try {
     }
   }
 
+  if (Test-Path -LiteralPath $nativeGuiFixturePath) {
+    $lineNumber = 0
+    foreach ($line in Get-Content -LiteralPath $nativeGuiFixturePath) {
+      $lineNumber++
+      if ($line -match '\b(?:new_ui_bridge|build_ui_app_controller|start_analysis_runtime)\s*\(') {
+        $violations.Add(("src/gui_test/fixtures.rs:{0}: product startup fixtures must not construct the legacy UI bridge: {1}" -f $lineNumber, $line.Trim()))
+      }
+    }
+  }
+
+  if (Test-Path -LiteralPath $nativeGuiRunnerPath) {
+    $nativeGuiRunner = Get-Content -LiteralPath $nativeGuiRunnerPath -Raw
+    if (-not $nativeGuiRunner.Contains("capture_native_startup_bundle")) {
+      $violations.Add("src/gui_test/runner/mod.rs: live and isolated-startup capture must route through the product-native harness")
+    }
+    if (-not $nativeGuiRunner.Contains("crate::native_app::automation::capture_startup")) {
+      $violations.Add("src/gui_test/runner/mod.rs: product startup certification must use NativeAppState automation")
+    }
+  }
+
   if ($violations.Count -gt 0) {
     Write-Host "[native_app_boundary] Native app boundary violations detected:"
     Write-Host "[native_app_boundary] app_chrome is the view-composition layer; product/domain modules must depend on messages, view models, or domain APIs instead."
     Write-Host "[native_app_boundary] Root native-app module names must describe durable ownership, not generic widgets. See docs/TARGET.md native app module map."
+    Write-Host "[native_app_boundary] Live and isolated-startup GUI certification must use the production native app composition."
     foreach ($violation in ($violations | Sort-Object)) {
       Write-Host (" - {0}" -f $violation)
     }

--- a/scripts/internal/check/check_native_app_boundary.sh
+++ b/scripts/internal/check/check_native_app_boundary.sh
@@ -34,6 +34,8 @@ done
 violations=()
 domain_roots=(audio metadata sample_library waveform workflows)
 ambiguous_modules=(browser context_menu library_browser widgets)
+native_gui_fixture_file="src/gui_test/fixtures.rs"
+native_gui_runner_file="src/gui_test/runner/mod.rs"
 
 is_domain_native_app_path() {
   local path="$1"
@@ -78,10 +80,26 @@ for module_name in "${ambiguous_modules[@]}"; do
   fi
 done
 
+if [[ -f "$native_gui_fixture_file" ]]; then
+  while IFS=: read -r line_number line_text; do
+    violations+=("$native_gui_fixture_file:$line_number: product startup fixtures must not construct the legacy UI bridge: ${line_text#"${line_text%%[![:space:]]*}"}")
+  done < <(grep -nE '\b(new_ui_bridge|build_ui_app_controller|start_analysis_runtime)[[:space:]]*\(' "$native_gui_fixture_file" || true)
+fi
+
+if [[ -f "$native_gui_runner_file" ]]; then
+  if ! grep -q 'capture_native_startup_bundle' "$native_gui_runner_file"; then
+    violations+=("$native_gui_runner_file: live and isolated-startup capture must route through the product-native harness")
+  fi
+  if ! grep -q 'crate::native_app::automation::capture_startup' "$native_gui_runner_file"; then
+    violations+=("$native_gui_runner_file: product startup certification must use NativeAppState automation")
+  fi
+fi
+
 if (( ${#violations[@]} > 0 )); then
   echo "[native_app_boundary] Native app boundary violations detected:"
   echo "[native_app_boundary] app_chrome is the view-composition layer; product/domain modules must depend on messages, view models, or domain APIs instead."
   echo "[native_app_boundary] Root native-app module names must describe durable ownership, not generic widgets. See docs/TARGET.md native app module map."
+  echo "[native_app_boundary] Live and isolated-startup GUI certification must use the production native app composition."
   printf '%s\n' "${violations[@]}" | sort | sed 's/^/ - /'
   exit 1
 fi

--- a/scripts/internal/gui/run_gui_suite.ps1
+++ b/scripts/internal/gui/run_gui_suite.ps1
@@ -21,6 +21,22 @@ if ($artifactDir) {
 Write-Host "[gui-suite] cargo run -p gui-test-cli -- snapshot $ArtifactPath"
 cargo run -p gui-test-cli -- snapshot $ArtifactPath
 if ($LASTEXITCODE -ne 0) { throw "gui snapshot export failed" }
+$nativeArtifact = Get-Content -LiteralPath $ArtifactPath -Raw | ConvertFrom-Json
+if ($nativeArtifact.fixture_runtime -ne "native-app") {
+    throw "gui snapshot export did not use the native app runtime"
+}
+if ($nativeArtifact.runtime_composition.native_source_watchers -ne 1) {
+    throw "gui snapshot export did not start exactly one native source watcher"
+}
+if ($nativeArtifact.runtime_composition.native_readiness_supervisors -ne 1) {
+    throw "gui snapshot export did not start exactly one native readiness supervisor"
+}
+if ($nativeArtifact.runtime_composition.legacy_analysis_pools -ne 0) {
+    throw "gui snapshot export started a legacy analysis pool"
+}
+if ($nativeArtifact.shutdown_artifact.source_processing.joined -ne $true) {
+    throw "gui snapshot export did not complete native source-processing shutdown"
+}
 
 Write-Host "[gui-suite] cargo run -p gui-test-cli -- run-scenario-pack contract-smoke $ScenarioPackOutputDir"
 cargo run -p gui-test-cli -- run-scenario-pack contract-smoke $ScenarioPackOutputDir

--- a/src/app_core/ui_bridge/gui_test.rs
+++ b/src/app_core/ui_bridge/gui_test.rs
@@ -4,8 +4,9 @@ use crate::app_core::actions::NativeUiAction;
 use crate::{
     app_core::actions::NativeAppModel,
     gui_test::{
-        GuiTestArtifactBundle, GuiTestModeConfig, build_model_summary, catalog_report,
-        trace_event_for_action, write_artifact_bundle,
+        GuiFixtureRuntime, GuiTestArtifactBundle, GuiTestModeConfig, build_model_summary,
+        catalog_report, legacy_automation_snapshot_to_radiant, trace_event_for_action,
+        write_artifact_bundle,
     },
     native_runtime::capture_gui_automation_snapshot,
 };
@@ -52,7 +53,7 @@ impl BridgeGuiTestRecorder {
 
     fn write_bundle(&self, model: &NativeAppModel, failure_summary: Option<String>) {
         let bundle = GuiTestArtifactBundle {
-            schema_version: 1,
+            schema_version: 2,
             scenario_name: self.config.scenario_name.clone(),
             fixture_tag: self.config.fixture_tag.clone(),
             run_id: self.config.run_id.clone(),
@@ -61,7 +62,12 @@ impl BridgeGuiTestRecorder {
                 .run_manifest_path
                 .as_ref()
                 .map(|path| path.to_string_lossy().into_owned()),
-            automation_snapshot: capture_gui_automation_snapshot(self.config.viewport_f32(), model),
+            fixture_runtime: GuiFixtureRuntime::LegacyController,
+            runtime_composition: None,
+            shutdown_artifact: None,
+            automation_snapshot: legacy_automation_snapshot_to_radiant(
+                capture_gui_automation_snapshot(self.config.viewport_f32(), model),
+            ),
             action_trace: self.action_trace.clone(),
             model_summary: build_model_summary(model),
             action_catalog: catalog_report(),

--- a/src/gui_test/artifacts.rs
+++ b/src/gui_test/artifacts.rs
@@ -1,8 +1,11 @@
 //! Machine-readable GUI test artifacts shared by the CLI, bridge, and docs.
 
 use crate::app_core::actions::{
-    GUI_ACTION_CATALOG, GuiActionCatalogEntry, NativeAppModel, NativeGuiAutomationSnapshot,
-    NativeUiAction, action_catalog_entry,
+    GUI_ACTION_CATALOG, GuiActionCatalogEntry, NativeAppModel, NativeAutomationNodeSnapshot,
+    NativeAutomationRole, NativeGuiAutomationSnapshot, NativeUiAction, action_catalog_entry,
+};
+use radiant::gui::automation::{
+    AutomationNodeSemantics, AutomationNodeSnapshot, AutomationRole, GuiAutomationSnapshot,
 };
 use serde::Serialize;
 use std::{
@@ -56,6 +59,27 @@ pub struct GuiModelSummary {
     pub update_status: String,
 }
 
+/// Runtime family that produced one GUI test artifact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GuiFixtureRuntime {
+    /// Production `NativeAppState` lowered through the Radiant host boundary.
+    NativeApp,
+    /// Retained `AppController` compatibility fixture.
+    LegacyController,
+}
+
+/// Observable worker ownership for one GUI fixture runtime.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct GuiRuntimeComposition {
+    /// Number of native filesystem watcher coordinators.
+    pub native_source_watchers: usize,
+    /// Number of native readiness supervisors.
+    pub native_readiness_supervisors: usize,
+    /// Number of retained controller analysis pools.
+    pub legacy_analysis_pools: usize,
+}
+
 /// Timing sample for one named GUI scenario step.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct GuiStepTimingSample {
@@ -78,8 +102,14 @@ pub struct GuiTestArtifactBundle {
     pub run_id: Option<String>,
     /// Runtime manifest path associated with the bundle, when any.
     pub run_manifest_path: Option<String>,
+    /// Runtime family that produced the artifact.
+    pub fixture_runtime: GuiFixtureRuntime,
+    /// Observable background-worker ownership, when the runtime exposes it.
+    pub runtime_composition: Option<GuiRuntimeComposition>,
+    /// Artifact returned by the fixture runtime's shutdown hook.
+    pub shutdown_artifact: Option<serde_json::Value>,
     /// Latest semantic automation snapshot.
-    pub automation_snapshot: NativeGuiAutomationSnapshot,
+    pub automation_snapshot: GuiAutomationSnapshot,
     /// Recorded action trace.
     pub action_trace: Vec<GuiActionTraceEvent>,
     /// Compact projected-model summary.
@@ -111,6 +141,114 @@ pub fn build_model_summary(model: &NativeAppModel) -> GuiModelSummary {
         progress_visible: model.progress_overlay.visible,
         update_status: format!("{:?}", model.update.status),
     }
+}
+
+/// Build a compact summary from the production native automation tree.
+pub(crate) fn build_native_model_summary(snapshot: &GuiAutomationSnapshot) -> GuiModelSummary {
+    let mut nodes = Vec::new();
+    collect_nodes(&snapshot.root, &mut nodes);
+    let selected_rows = nodes
+        .iter()
+        .filter(|node| node.role == AutomationRole::Row && node.selected)
+        .count();
+    let visible_rows = nodes
+        .iter()
+        .filter(|node| node.role == AutomationRole::Row)
+        .count();
+    let waveform_loaded_label = nodes
+        .iter()
+        .find(|node| node.role == AutomationRole::TimelineRegion)
+        .and_then(|node| node.label.clone().or_else(|| node.value.clone()));
+
+    GuiModelSummary {
+        title: String::from("Wavecrate"),
+        focus_context: String::from("NativeApp"),
+        browser_visible_count: visible_rows,
+        browser_selected_count: selected_rows,
+        browser_view_start_row: 0,
+        browser_autoscroll: false,
+        waveform_loaded_label,
+        prompt_visible: nodes.iter().any(|node| node.role == AutomationRole::Dialog),
+        options_visible: nodes.iter().any(|node| {
+            node.role == AutomationRole::Panel
+                && node
+                    .label
+                    .as_deref()
+                    .is_some_and(|label| label.contains("Settings"))
+        }),
+        progress_visible: nodes.iter().any(|node| {
+            node.role == AutomationRole::Readout
+                && node
+                    .label
+                    .as_deref()
+                    .is_some_and(|label| label.contains("progress"))
+        }),
+        update_status: String::from("Native"),
+    }
+}
+
+fn collect_nodes<'a>(
+    node: &'a AutomationNodeSnapshot,
+    nodes: &mut Vec<&'a AutomationNodeSnapshot>,
+) {
+    nodes.push(node);
+    for child in &node.children {
+        collect_nodes(child, nodes);
+    }
+}
+
+pub(crate) fn legacy_automation_snapshot_to_radiant(
+    snapshot: NativeGuiAutomationSnapshot,
+) -> GuiAutomationSnapshot {
+    GuiAutomationSnapshot {
+        schema_version: snapshot.schema_version,
+        viewport_width: snapshot.viewport_width,
+        viewport_height: snapshot.viewport_height,
+        root: legacy_automation_node_to_radiant(snapshot.root),
+    }
+}
+
+fn legacy_automation_node_to_radiant(node: NativeAutomationNodeSnapshot) -> AutomationNodeSnapshot {
+    let semantics = AutomationNodeSemantics::new(match node.role {
+        NativeAutomationRole::Root => AutomationRole::Root,
+        NativeAutomationRole::Group => AutomationRole::Group,
+        NativeAutomationRole::Panel => AutomationRole::Panel,
+        NativeAutomationRole::Toolbar => AutomationRole::Toolbar,
+        NativeAutomationRole::TabList => AutomationRole::TabList,
+        NativeAutomationRole::Tab => AutomationRole::Tab,
+        NativeAutomationRole::Button => AutomationRole::Button,
+        NativeAutomationRole::SearchField => AutomationRole::SearchField,
+        NativeAutomationRole::Slider => AutomationRole::Slider,
+        NativeAutomationRole::Row => AutomationRole::Row,
+        NativeAutomationRole::Table => AutomationRole::Table,
+        NativeAutomationRole::WaveformRegion => AutomationRole::TimelineRegion,
+        NativeAutomationRole::MapCanvas => AutomationRole::SpatialCanvas,
+        NativeAutomationRole::MapPoint => AutomationRole::SpatialPoint,
+        NativeAutomationRole::Readout => AutomationRole::Readout,
+        NativeAutomationRole::Dialog => AutomationRole::Dialog,
+    });
+    let semantics = match node.label.as_ref() {
+        Some(label) => semantics.with_label(label),
+        None => semantics,
+    };
+    let mut semantics = match node.value.as_ref() {
+        Some(value) => semantics.with_value_text(value),
+        None => semantics,
+    };
+    semantics.disabled = !node.enabled;
+    semantics.selected = node.selected;
+    semantics.metadata = node.metadata.clone();
+    let mut converted = AutomationNodeSnapshot::from_semantics(node.id, node.bounds, semantics);
+    converted.enabled = node.enabled;
+    converted.selected = node.selected;
+    converted.available_actions = node.available_actions;
+    converted.metadata = node.metadata;
+    converted.children = node
+        .children
+        .into_iter()
+        .map(legacy_automation_node_to_radiant)
+        .collect();
+    converted
 }
 
 /// Write one artifact bundle as pretty JSON, creating parent directories as needed.

--- a/src/gui_test/automation.rs
+++ b/src/gui_test/automation.rs
@@ -1,6 +1,6 @@
 //! Shared automation-snapshot lookup helpers for scenario assertions.
 
-use crate::app_core::actions::{NativeAutomationNodeSnapshot, NativeGuiAutomationSnapshot};
+use radiant::gui::automation::{AutomationNodeSnapshot, GuiAutomationSnapshot};
 use serde::Serialize;
 use std::{fs, path::Path};
 
@@ -33,15 +33,15 @@ pub struct GuiAutomationTarget {
 
 /// Find one semantic automation node by stable id.
 pub(crate) fn find_automation_node<'a>(
-    snapshot: &'a NativeGuiAutomationSnapshot,
+    snapshot: &'a GuiAutomationSnapshot,
     node_id: &str,
-) -> Option<&'a NativeAutomationNodeSnapshot> {
+) -> Option<&'a AutomationNodeSnapshot> {
     find_node_recursive(&snapshot.root, node_id)
 }
 
 /// Resolve one semantic automation target from a full snapshot.
 pub fn resolve_automation_target(
-    snapshot: &NativeGuiAutomationSnapshot,
+    snapshot: &GuiAutomationSnapshot,
     node_id: &str,
 ) -> Result<GuiAutomationTarget, String> {
     let node = find_automation_node(snapshot, node_id)
@@ -68,7 +68,7 @@ pub fn resolve_automation_target(
 /// Read a full automation snapshot from one GUI artifact bundle file.
 pub fn read_automation_snapshot_from_artifact(
     artifact_path: &Path,
-) -> Result<NativeGuiAutomationSnapshot, String> {
+) -> Result<GuiAutomationSnapshot, String> {
     let json = fs::read_to_string(artifact_path)
         .map_err(|err| format!("read GUI artifact {}: {err}", artifact_path.display()))?;
     let value: serde_json::Value = serde_json::from_str(&json)
@@ -88,9 +88,9 @@ pub fn read_automation_snapshot_from_artifact(
 }
 
 fn find_node_recursive<'a>(
-    node: &'a NativeAutomationNodeSnapshot,
+    node: &'a AutomationNodeSnapshot,
     node_id: &str,
-) -> Option<&'a NativeAutomationNodeSnapshot> {
+) -> Option<&'a AutomationNodeSnapshot> {
     if node.id.0 == node_id {
         return Some(node);
     }
@@ -102,49 +102,89 @@ fn find_node_recursive<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_core::actions::NativeAutomationBounds as AutomationBounds;
-    use crate::app_core::actions::{
-        NativeAutomationNodeId, NativeAutomationNodeSnapshot, NativeAutomationRole,
-        NativeGuiAutomationSnapshot,
+    use crate::{
+        app_dirs::{ConfigBaseGuard, PersistenceProfileGuard},
+        gui_test::{GuiFixtureRuntime, GuiTestModeConfig, capture_default_bundle},
+        sample_sources::config::{AppConfig, AppSettingsCore, config_path, save},
     };
-    use crate::gui_test::capture_default_bundle;
-    use std::collections::BTreeMap;
+    use radiant::gui::automation::{
+        AutomationBounds, AutomationNodeId, AutomationNodeSemantics, AutomationNodeSnapshot,
+        AutomationRole, GuiAutomationSnapshot,
+    };
     use tempfile::tempdir;
 
-    fn sample_snapshot() -> NativeGuiAutomationSnapshot {
-        NativeGuiAutomationSnapshot {
+    fn sample_snapshot() -> GuiAutomationSnapshot {
+        GuiAutomationSnapshot {
             schema_version: 1,
             viewport_width: 400,
             viewport_height: 200,
-            root: NativeAutomationNodeSnapshot {
-                id: NativeAutomationNodeId::new("shell.root"),
-                role: NativeAutomationRole::Root,
-                label: Some(String::from("Root")),
-                bounds: AutomationBounds {
+            root: AutomationNodeSnapshot::from_semantics(
+                AutomationNodeId::new("shell.root"),
+                AutomationBounds {
                     x: 0.0,
                     y: 0.0,
                     width: 400.0,
                     height: 200.0,
                 },
-                value: None,
-                enabled: true,
-                selected: false,
-                available_actions: Vec::new(),
-                metadata: BTreeMap::new(),
-                children: Vec::new(),
-            },
+                AutomationNodeSemantics::new(AutomationRole::Root).with_label("Root"),
+            ),
         }
     }
 
     #[test]
     fn resolve_target_uses_window_relative_center() {
-        let bundle =
-            capture_default_bundle(&crate::gui_test::GuiTestModeConfig::default()).expect("bundle");
-        let target = resolve_automation_target(&bundle.automation_snapshot, "shell.root")
-            .expect("root target");
+        let live_base = tempdir().expect("live config base");
+        let _base_guard = ConfigBaseGuard::set(live_base.path().to_path_buf());
+        let _live_guard = PersistenceProfileGuard::live();
+        save(&AppConfig {
+            sources: Vec::new(),
+            core: AppSettingsCore {
+                volume: 0.314,
+                ..AppSettingsCore::default()
+            },
+        })
+        .expect("seed live sentinel config");
+        let live_config_path = config_path().expect("live config path");
+        let live_before = std::fs::read(&live_config_path).expect("read live config");
+
+        let bundle = capture_default_bundle(&GuiTestModeConfig::default()).expect("bundle");
+
+        assert_eq!(bundle.fixture_runtime, GuiFixtureRuntime::NativeApp);
+        assert_eq!(
+            bundle
+                .runtime_composition
+                .expect("native runtime composition"),
+            crate::gui_test::GuiRuntimeComposition {
+                native_source_watchers: 1,
+                native_readiness_supervisors: 1,
+                legacy_analysis_pools: 0,
+            }
+        );
+        assert_eq!(
+            bundle
+                .shutdown_artifact
+                .as_ref()
+                .and_then(|artifact| artifact["source_processing"]["joined"].as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            std::fs::read(live_config_path).expect("re-read live config"),
+            live_before,
+            "isolated native automation must not mutate the live profile"
+        );
+        let target_id = bundle
+            .automation_snapshot
+            .root
+            .automation_targets()
+            .into_iter()
+            .find(|target| !target.bounds.is_empty())
+            .map(|target| target.id.0)
+            .expect("visible native automation target");
+        let target = resolve_automation_target(&bundle.automation_snapshot, &target_id)
+            .expect("visible target");
         assert!(target.center_x > 0.0);
         assert!(target.center_y > 0.0);
-        assert_eq!(target.node_id, "shell.root");
+        assert_eq!(target.node_id, target_id);
     }
 
     #[test]

--- a/src/gui_test/fixtures.rs
+++ b/src/gui_test/fixtures.rs
@@ -7,9 +7,8 @@ use crate::{
             NativeSegmentRevisions, NativeUiAction,
         },
         gui_fixtures::build_named_gui_fixture_controller,
-        ui_bridge::{WavecrateUiBridge, new_ui_bridge, new_ui_bridge_with_controller},
+        ui_bridge::{WavecrateUiBridge, new_ui_bridge_with_controller},
     },
-    app_dirs::PersistenceProfileGuard,
     gui_test::{
         GuiTestModeConfig, canonical_gui_test_fixture_tag, gui_test_fixture_uses_isolated_startup,
         gui_test_fixture_uses_live_profile,
@@ -27,7 +26,6 @@ use tempfile::TempDir;
 /// delegating all bridge behavior to `WavecrateUiBridge`.
 pub struct GuiFixtureBridge {
     bridge: WavecrateUiBridge,
-    _profile_guard: Option<PersistenceProfileGuard>,
     _sandbox_guards: Vec<TempDir>,
     shutdown_emitted: bool,
 }
@@ -35,36 +33,16 @@ pub struct GuiFixtureBridge {
 impl GuiFixtureBridge {
     /// Build one bridge for the requested fixture tag and viewport.
     ///
-    /// The `live` fixture uses the normal persisted startup path. The canonical
-    /// `isolated-startup` fixture exercises persisted startup against the
-    /// dedicated automated-validation profile. The legacy `default` tag remains a
-    /// compatibility alias for `isolated-startup`. Named controller fixtures
-    /// use deterministic seeded controllers without touching user data.
+    /// Product-native `live` and `isolated-startup` fixtures are owned by the
+    /// native runner. This compatibility bridge accepts only named seeded
+    /// fixtures and never certifies product startup.
     pub fn new_with_viewport(fixture_tag: &str, viewport: [u32; 2]) -> Result<Self, String> {
-        if gui_test_fixture_uses_live_profile(fixture_tag) {
-            let bridge = new_ui_bridge(
-                WaveformRenderer::new(viewport[0].max(320), viewport[1].max(180)),
-                None,
-            )?;
-            return Ok(Self {
-                bridge,
-                _profile_guard: None,
-                _sandbox_guards: Vec::new(),
-                shutdown_emitted: false,
-            });
-        }
-        if gui_test_fixture_uses_isolated_startup(fixture_tag) {
-            let profile_guard = PersistenceProfileGuard::automated();
-            let bridge = new_ui_bridge(
-                WaveformRenderer::new(viewport[0].max(320), viewport[1].max(180)),
-                None,
-            )?;
-            return Ok(Self {
-                bridge,
-                _profile_guard: Some(profile_guard),
-                _sandbox_guards: Vec::new(),
-                shutdown_emitted: false,
-            });
+        if gui_test_fixture_uses_live_profile(fixture_tag)
+            || gui_test_fixture_uses_isolated_startup(fixture_tag)
+        {
+            return Err(format!(
+                "fixture {fixture_tag} is owned by the product-native GUI harness"
+            ));
         }
         let bundle = build_named_gui_fixture_controller(
             WaveformRenderer::new(viewport[0].max(320), viewport[1].max(180)),
@@ -72,7 +50,6 @@ impl GuiFixtureBridge {
         )?;
         Ok(Self {
             bridge: new_ui_bridge_with_controller(bundle.controller),
-            _profile_guard: None,
             _sandbox_guards: bundle.sandbox_guards,
             shutdown_emitted: false,
         })
@@ -199,23 +176,21 @@ mod tests {
 
     #[test]
     #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
-    fn default_fixture_alias_matches_isolated_startup_behavior() {
-        let default_bridge = GuiFixtureBridge::new("default").expect("default fixture bridge");
-        let isolated_bridge = GuiFixtureBridge::new(GUI_TEST_ISOLATED_STARTUP_FIXTURE_TAG)
-            .expect("isolated startup bridge");
-        assert_eq!(
-            default_bridge._profile_guard.is_some(),
-            isolated_bridge._profile_guard.is_some()
-        );
-        assert!(default_bridge._sandbox_guards.is_empty());
-        assert!(isolated_bridge._sandbox_guards.is_empty());
+    fn product_startup_fixtures_are_rejected_by_legacy_bridge() {
+        let default_error = GuiFixtureBridge::new("default")
+            .err()
+            .expect("default is native");
+        let isolated_error = GuiFixtureBridge::new(GUI_TEST_ISOLATED_STARTUP_FIXTURE_TAG)
+            .err()
+            .expect("isolated startup is native");
+        assert!(default_error.contains("product-native"));
+        assert!(isolated_error.contains("product-native"));
     }
 
     #[test]
     #[ignore = "runs through scripts/gui.ps1 contract; fixture-backed smoke is too expensive for the default lib test lane"]
     fn named_fixtures_stay_controller_backed() {
         let bridge = GuiFixtureBridge::new("browser").expect("browser fixture bridge");
-        assert!(bridge._profile_guard.is_none());
         assert!(!bridge._sandbox_guards.is_empty());
     }
 }

--- a/src/gui_test/mod.rs
+++ b/src/gui_test/mod.rs
@@ -11,8 +11,8 @@ mod scenario;
 mod shell_automation;
 
 pub use self::artifacts::{
-    GuiActionTraceEvent, GuiModelSummary, GuiStepTimingSample, GuiTestArtifactBundle,
-    build_model_summary, write_artifact_bundle,
+    GuiActionTraceEvent, GuiFixtureRuntime, GuiModelSummary, GuiRuntimeComposition,
+    GuiStepTimingSample, GuiTestArtifactBundle, build_model_summary, write_artifact_bundle,
 };
 pub use self::automation::{
     GuiAutomationTarget, read_automation_snapshot_from_artifact, resolve_automation_target,
@@ -27,7 +27,10 @@ pub use self::packs::{GuiScenarioPack, gui_scenario_pack};
 pub use self::runner::{capture_default_bundle, dispatch_action_bundle, run_scenario};
 pub use self::scenario::{GuiAssertion, GuiScenario, GuiScenarioStep};
 
-pub(crate) use self::artifacts::{catalog_report, trace_event_for_action};
+pub(crate) use self::artifacts::{
+    build_native_model_summary, catalog_report, legacy_automation_snapshot_to_radiant,
+    trace_event_for_action,
+};
 pub(crate) use self::automation::find_automation_node;
 #[cfg(test)]
 pub(crate) use self::runner::run_scenario_batch;

--- a/src/gui_test/runner/assertions.rs
+++ b/src/gui_test/runner/assertions.rs
@@ -1,13 +1,14 @@
 //! Semantic assertion helpers for the in-process GUI scenario runner.
 
 use crate::{
-    app_core::actions::{NativeGuiAutomationSnapshot, action_catalog_entry_by_id},
+    app_core::actions::action_catalog_entry_by_id,
     gui_test::{GuiActionTraceEvent, GuiAssertion, find_automation_node},
 };
+use radiant::gui::automation::GuiAutomationSnapshot;
 
 /// Evaluate one semantic GUI assertion against the latest snapshot and action trace.
 pub(super) fn assert_scenario_state(
-    snapshot: &NativeGuiAutomationSnapshot,
+    snapshot: &GuiAutomationSnapshot,
     trace: &[GuiActionTraceEvent],
     assertion: &GuiAssertion,
 ) -> Result<(), String> {

--- a/src/gui_test/runner/bundle.rs
+++ b/src/gui_test/runner/bundle.rs
@@ -1,12 +1,10 @@
 //! Bundle capture helpers for the in-process GUI scenario runner.
 
 use crate::{
-    app_core::actions::{
-        GUI_ACTION_CATALOG, NativeAppBridge, NativeAppModel, NativeGuiAutomationSnapshot,
-    },
+    app_core::actions::{GUI_ACTION_CATALOG, NativeAppBridge, NativeAppModel},
     gui_test::{
-        GuiActionTraceEvent, GuiStepTimingSample, GuiTestArtifactBundle, GuiTestModeConfig,
-        build_model_summary,
+        GuiActionTraceEvent, GuiFixtureRuntime, GuiStepTimingSample, GuiTestArtifactBundle,
+        GuiTestModeConfig, build_model_summary, legacy_automation_snapshot_to_radiant,
     },
     native_runtime::capture_gui_automation_snapshot,
 };
@@ -22,7 +20,7 @@ pub(super) fn snapshot_bundle(
     let projected_model = bridge.project_model();
     let model = NativeAppModel::from(projected_model.as_ref().clone());
     GuiTestArtifactBundle {
-        schema_version: 1,
+        schema_version: 2,
         scenario_name: config.scenario_name.clone(),
         fixture_tag: config.fixture_tag.clone(),
         run_id: config.run_id.clone(),
@@ -30,7 +28,12 @@ pub(super) fn snapshot_bundle(
             .run_manifest_path
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned()),
-        automation_snapshot: capture_gui_automation_snapshot(config.viewport_f32(), &model),
+        fixture_runtime: GuiFixtureRuntime::LegacyController,
+        runtime_composition: None,
+        shutdown_artifact: None,
+        automation_snapshot: legacy_automation_snapshot_to_radiant(
+            capture_gui_automation_snapshot(config.viewport_f32(), &model),
+        ),
         action_trace: trace,
         model_summary: build_model_summary(&model),
         action_catalog: GUI_ACTION_CATALOG.to_vec(),
@@ -45,8 +48,11 @@ pub(super) fn snapshot_bundle(
 pub(super) fn current_snapshot(
     config: &GuiTestModeConfig,
     bridge: &mut impl NativeAppBridge,
-) -> NativeGuiAutomationSnapshot {
+) -> radiant::gui::automation::GuiAutomationSnapshot {
     let projected_model = bridge.project_model();
     let model = NativeAppModel::from(projected_model.as_ref().clone());
-    capture_gui_automation_snapshot(config.viewport_f32(), &model)
+    legacy_automation_snapshot_to_radiant(capture_gui_automation_snapshot(
+        config.viewport_f32(),
+        &model,
+    ))
 }

--- a/src/gui_test/runner/mod.rs
+++ b/src/gui_test/runner/mod.rs
@@ -10,7 +10,16 @@ use super::{
 };
 use crate::{
     app_core::actions::{GuiDispatchPolicy, NativeUiAction, action_catalog_entry},
-    gui_test::{GuiFixtureBridge, trace_event_for_action},
+    app_dirs::{ConfigBaseGuard, PersistenceProfileGuard},
+    gui_test::{
+        GuiFixtureBridge, GuiFixtureRuntime, GuiRuntimeComposition, build_native_model_summary,
+        gui_test_fixture_uses_isolated_startup, gui_test_fixture_uses_live_profile,
+        trace_event_for_action,
+    },
+    sample_sources::{
+        SampleSource,
+        config::{AppConfig, AppSettingsCore},
+    },
 };
 use std::{
     thread,
@@ -24,6 +33,9 @@ const SCENARIO_ASSERT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Capture a deterministic automation bundle from the default bridge fixture.
 pub fn capture_default_bundle(config: &GuiTestModeConfig) -> Result<GuiTestArtifactBundle, String> {
+    if fixture_uses_native_app(&config.fixture_tag) {
+        return capture_native_startup_bundle(config);
+    }
     let mut bridge = make_bridge_for_fixture(&config.fixture_tag, config.viewport)?;
     Ok(snapshot_bundle(
         config,
@@ -40,6 +52,7 @@ pub fn dispatch_action_bundle(
     action: NativeUiAction,
 ) -> Result<GuiTestArtifactBundle, String> {
     ensure_public_dispatch_action(&action)?;
+    ensure_legacy_fixture_for_controller_actions(&config.fixture_tag)?;
     let mut bridge = make_bridge_for_fixture(&config.fixture_tag, config.viewport)?;
     let started = Instant::now();
     bridge.reduce_action(action.clone());
@@ -57,8 +70,83 @@ pub fn run_scenario(
     config: &GuiTestModeConfig,
     scenario: &GuiScenario,
 ) -> Result<GuiTestArtifactBundle, String> {
+    ensure_legacy_fixture_for_controller_actions(&scenario.fixture_tag)?;
     let mut bridge = make_bridge_for_fixture(&scenario.fixture_tag, config.viewport)?;
     run_scenario_with_bridge(config, scenario, &mut bridge)
+}
+
+fn fixture_uses_native_app(fixture_tag: &str) -> bool {
+    gui_test_fixture_uses_live_profile(fixture_tag)
+        || gui_test_fixture_uses_isolated_startup(fixture_tag)
+}
+
+fn ensure_legacy_fixture_for_controller_actions(fixture_tag: &str) -> Result<(), String> {
+    if !fixture_uses_native_app(fixture_tag) {
+        return Ok(());
+    }
+    Err(format!(
+        "fixture {fixture_tag} is product-native and does not accept retained controller actions; use a named legacy fixture for NativeUiAction scenarios"
+    ))
+}
+
+fn capture_native_startup_bundle(
+    config: &GuiTestModeConfig,
+) -> Result<GuiTestArtifactBundle, String> {
+    if gui_test_fixture_uses_live_profile(&config.fixture_tag) {
+        let _profile_guard = PersistenceProfileGuard::live();
+        return native_bundle_from_capture(
+            config,
+            crate::native_app::automation::capture_startup(config.viewport)?,
+        );
+    }
+
+    let config_base = tempfile::tempdir()
+        .map_err(|err| format!("create isolated native GUI config base: {err}"))?;
+    let source_root = tempfile::tempdir()
+        .map_err(|err| format!("create isolated native GUI source root: {err}"))?;
+    let _base_guard = ConfigBaseGuard::set(config_base.path().to_path_buf());
+    let _profile_guard = PersistenceProfileGuard::automated();
+    crate::sample_sources::config::save(&AppConfig {
+        sources: vec![SampleSource::new(source_root.path().to_path_buf())],
+        core: AppSettingsCore::default(),
+    })
+    .map_err(|err| format!("seed isolated native GUI profile: {err}"))?;
+    native_bundle_from_capture(
+        config,
+        crate::native_app::automation::capture_startup(config.viewport)?,
+    )
+}
+
+fn native_bundle_from_capture(
+    config: &GuiTestModeConfig,
+    capture: crate::native_app::automation::NativeAutomationCapture,
+) -> Result<GuiTestArtifactBundle, String> {
+    let model_summary = build_native_model_summary(&capture.automation_snapshot);
+    Ok(GuiTestArtifactBundle {
+        schema_version: 2,
+        scenario_name: config.scenario_name.clone(),
+        fixture_tag: config.fixture_tag.clone(),
+        run_id: config.run_id.clone(),
+        run_manifest_path: config
+            .run_manifest_path
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned()),
+        fixture_runtime: GuiFixtureRuntime::NativeApp,
+        runtime_composition: Some(GuiRuntimeComposition {
+            native_source_watchers: capture.runtime_composition.source_watcher_count,
+            native_readiness_supervisors: capture.runtime_composition.readiness_supervisor_count,
+            legacy_analysis_pools: capture.runtime_composition.legacy_analysis_pool_count,
+        }),
+        shutdown_artifact: capture.shutdown_artifact,
+        automation_snapshot: capture.automation_snapshot,
+        action_trace: Vec::new(),
+        model_summary,
+        action_catalog: Vec::new(),
+        screenshot_before_failure: None,
+        screenshot_after_failure: None,
+        failure_summary: None,
+        step_timings_ms: Vec::new(),
+    })
 }
 
 /// Run a sequence of scenarios against one shared fixture bridge.

--- a/src/gui_test/runner/tests.rs
+++ b/src/gui_test/runner/tests.rs
@@ -1,12 +1,11 @@
 use super::assertions::assert_scenario_state;
 use super::*;
-use crate::app_core::actions::NativeAutomationBounds as AutomationBounds;
-use crate::app_core::actions::{
-    GUI_ACTION_CATALOG, NativeAutomationNodeId, NativeAutomationNodeSnapshot, NativeAutomationRole,
-    NativeGuiAutomationSnapshot,
-};
+use crate::app_core::actions::GUI_ACTION_CATALOG;
 use crate::gui_test::{GuiActionTraceEvent, GuiAssertion, GuiScenario, GuiScenarioStep};
-use std::collections::BTreeMap;
+use radiant::gui::automation::{
+    AutomationBounds, AutomationNodeId, AutomationNodeSemantics, AutomationNodeSnapshot,
+    AutomationRole, GuiAutomationSnapshot,
+};
 
 mod action_parity;
 
@@ -17,47 +16,40 @@ fn deterministic_test_config(fixture_tag: &str) -> GuiTestModeConfig {
     }
 }
 
-fn snapshot_with_child() -> NativeGuiAutomationSnapshot {
-    NativeGuiAutomationSnapshot {
+fn snapshot_with_child() -> GuiAutomationSnapshot {
+    let mut child_semantics = AutomationNodeSemantics::new(AutomationRole::SearchField)
+        .with_label("Search")
+        .with_value_text("kick search");
+    child_semantics.selected = true;
+    child_semantics
+        .metadata
+        .insert(String::from("placeholder"), String::from("Search samples"));
+    let mut child = AutomationNodeSnapshot::from_semantics(
+        AutomationNodeId::new("browser.search"),
+        AutomationBounds {
+            x: 20.0,
+            y: 30.0,
+            width: 200.0,
+            height: 30.0,
+        },
+        child_semantics,
+    );
+    child.available_actions = vec![String::from("browser.search.commit")];
+    GuiAutomationSnapshot {
         schema_version: 1,
         viewport_width: 800,
         viewport_height: 600,
-        root: NativeAutomationNodeSnapshot {
-            id: NativeAutomationNodeId::new("shell.root"),
-            role: NativeAutomationRole::Root,
-            label: Some(String::from("Root")),
-            bounds: AutomationBounds {
+        root: AutomationNodeSnapshot::from_semantics(
+            AutomationNodeId::new("shell.root"),
+            AutomationBounds {
                 x: 0.0,
                 y: 0.0,
                 width: 800.0,
                 height: 600.0,
             },
-            value: None,
-            enabled: true,
-            selected: false,
-            available_actions: Vec::new(),
-            metadata: BTreeMap::new(),
-            children: vec![NativeAutomationNodeSnapshot {
-                id: NativeAutomationNodeId::new("browser.search"),
-                role: NativeAutomationRole::SearchField,
-                label: Some(String::from("Search")),
-                bounds: AutomationBounds {
-                    x: 20.0,
-                    y: 30.0,
-                    width: 200.0,
-                    height: 30.0,
-                },
-                value: Some(String::from("kick search")),
-                enabled: true,
-                selected: true,
-                available_actions: vec![String::from("browser.search.commit")],
-                metadata: BTreeMap::from([(
-                    String::from("placeholder"),
-                    String::from("Search samples"),
-                )]),
-                children: Vec::new(),
-            }],
-        },
+            AutomationNodeSemantics::new(AutomationRole::Root).with_label("Root"),
+        )
+        .with_children(vec![child]),
     }
 }
 
@@ -71,7 +63,7 @@ fn trace_with_action(action_id: &str, handled: bool) -> Vec<GuiActionTraceEvent>
 }
 
 fn collect_advertised_actions<'a>(
-    node: &'a NativeAutomationNodeSnapshot,
+    node: &'a AutomationNodeSnapshot,
     actions: &mut Vec<(&'a str, &'a str)>,
 ) {
     for action_id in &node.available_actions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Library exports for reuse in benchmarks and tests.
 extern crate alloc;
+extern crate self as wavecrate;
 /// Retained controller internals used only by compatibility tests and tools.
 #[cfg(any(test, feature = "legacy-controller"))]
 #[allow(dead_code)]
@@ -34,6 +35,8 @@ mod http_client;
 pub mod issue_gateway;
 /// Logging setup helpers.
 pub mod logging;
+/// Production Radiant application composition and native GUI behavior.
+pub mod native_app;
 /// Shared runtime host glue that starts native `radiant` hosts.
 ///
 /// The runtime boundary only adapts launch options and forwards lifecycle/error

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,15 @@
     windows_subsystem = "windows"
 )]
 
-mod native_app;
-
 fn main() -> Result<(), String> {
-    native_app::run()
+    wavecrate::native_app::run()
+}
+
+#[cfg(test)]
+mod native_app {
+    #[test]
+    fn production_entrypoint_is_library_owned() {
+        let entrypoint: fn() -> Result<(), String> = wavecrate::native_app::run;
+        let _ = entrypoint;
+    }
 }

--- a/src/native_app.rs
+++ b/src/native_app.rs
@@ -3,6 +3,8 @@
 mod app;
 mod app_chrome;
 mod audio;
+#[cfg(any(test, feature = "legacy-controller"))]
+pub(crate) mod automation;
 mod metadata;
 mod protected_source_feedback;
 mod release_update;
@@ -20,7 +22,7 @@ mod waveform_edit_effects;
 mod waveform_edits;
 mod workflows;
 
-pub(crate) use shell::run;
+pub use shell::run;
 
 #[cfg(test)]
 mod tests;

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -30,7 +30,6 @@ pub(in crate::native_app) use progress::{
 pub(in crate::native_app) use settings::{
     AppSettingsTab, AudioSettingsDropdown, SampleNameViewMode,
 };
-#[cfg(not(test))]
 pub(in crate::native_app) use source_processing_events::GuiSourceProcessingEventSink;
 #[cfg(test)]
 pub(in crate::native_app) use state::DEFAULT_VOLUME;

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -10,7 +10,6 @@ use std::{
 use radiant::{gui::frame as frame_ui, prelude as ui};
 use wavecrate::audio::AudioPlayer;
 
-#[cfg(not(test))]
 use crate::native_app::app::GuiSourceProcessingEventSink;
 use crate::native_app::app::{
     ExtractedFilePlaybackType, FileMoveProgress, GuiMessage, NormalizationProgress,
@@ -58,15 +57,40 @@ impl BackgroundTaskState {
         sources: Vec<wavecrate::sample_sources::SampleSource>,
     ) -> Self {
         #[cfg(not(test))]
-        let source_processing = SourceProcessingSupervisor::start_with_event_sink(
-            sources,
-            GuiSourceProcessingEventSink::new(worker_sender.clone()),
-        );
+        let source_processing = Self::start_source_processing(&worker_sender, sources);
         #[cfg(test)]
         let source_processing = {
             drop(sources);
             SourceProcessingSupervisor::dormant()
         };
+        Self::with_source_processing(worker_sender, worker_receiver, source_processing)
+    }
+
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn new_runtime(
+        worker_sender: Sender<GuiMessage>,
+        worker_receiver: Option<Receiver<GuiMessage>>,
+        sources: Vec<wavecrate::sample_sources::SampleSource>,
+    ) -> Self {
+        let source_processing = Self::start_source_processing(&worker_sender, sources);
+        Self::with_source_processing(worker_sender, worker_receiver, source_processing)
+    }
+
+    fn start_source_processing(
+        worker_sender: &Sender<GuiMessage>,
+        sources: Vec<wavecrate::sample_sources::SampleSource>,
+    ) -> SourceProcessingSupervisor {
+        SourceProcessingSupervisor::start_with_event_sink(
+            sources,
+            GuiSourceProcessingEventSink::new(worker_sender.clone()),
+        )
+    }
+
+    fn with_source_processing(
+        worker_sender: Sender<GuiMessage>,
+        worker_receiver: Option<Receiver<GuiMessage>>,
+        source_processing: SourceProcessingSupervisor,
+    ) -> Self {
         let source_lifecycle_generations = source_processing.lifecycle_generations();
         Self {
             worker_sender,

--- a/src/native_app/automation.rs
+++ b/src/native_app/automation.rs
@@ -1,0 +1,108 @@
+//! Product-composition GUI automation harness for startup certification.
+
+use std::{sync::Arc, time::Duration};
+
+use radiant::{
+    gui::{automation::GuiAutomationSnapshot, repaint::RepaintSignal},
+    layout::Vector2,
+    runtime::SurfaceRuntime,
+};
+use serde::Serialize;
+
+use crate::native_app::{
+    app::NativeAppState, app_chrome::view_models::sample_browser::prepare_sample_browser_view,
+    shell::native_app_runtime_bridge,
+};
+
+/// Observable worker composition started by one native app state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct NativeRuntimeComposition {
+    /// Number of native filesystem watcher coordinators owned by the state.
+    pub(crate) source_watcher_count: usize,
+    /// Number of native readiness supervisors owned by the state.
+    pub(crate) readiness_supervisor_count: usize,
+    /// Number of retained controller analysis pools started by the state.
+    pub(crate) legacy_analysis_pool_count: usize,
+}
+
+/// Product-native startup artifact captured through Radiant's runtime boundary.
+pub(crate) struct NativeAutomationCapture {
+    /// Backend-neutral semantic snapshot projected by the real native view.
+    pub(crate) automation_snapshot: GuiAutomationSnapshot,
+    /// Background runtime composition observed before shutdown.
+    pub(crate) runtime_composition: NativeRuntimeComposition,
+    /// Artifact returned by the real native shutdown hook.
+    pub(crate) shutdown_artifact: Option<serde_json::Value>,
+}
+
+/// Capture one product-native startup without opening a desktop window.
+pub(crate) fn capture_startup(viewport: [u32; 2]) -> Result<NativeAutomationCapture, String> {
+    let mut state = NativeAppState::load_for_automation()?;
+    state.wait_for_source_watcher_ready(Duration::from_secs(30))?;
+    let runtime_composition = state.automation_runtime_composition();
+    prepare_sample_browser_view(&mut state);
+
+    let bridge = native_app_runtime_bridge(state);
+    let mut runtime =
+        SurfaceRuntime::new(bridge, Vector2::new(viewport[0] as f32, viewport[1] as f32));
+    runtime.host_install_repaint_signal(Arc::new(NoopRepaintSignal));
+    let _ = runtime.drain_runtime_messages();
+    let automation_snapshot = runtime.automation_snapshot();
+    let shutdown_artifact = runtime.host_on_runtime_exit();
+
+    Ok(NativeAutomationCapture {
+        automation_snapshot,
+        runtime_composition,
+        shutdown_artifact,
+    })
+}
+
+struct NoopRepaintSignal;
+
+impl RepaintSignal for NoopRepaintSignal {
+    fn request_repaint(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_dirs::{ConfigBaseGuard, PersistenceProfileGuard};
+    use crate::sample_sources::{
+        SampleSource,
+        config::{AppConfig, AppSettingsCore, save},
+    };
+    use tempfile::tempdir;
+
+    #[test]
+    fn startup_capture_uses_native_workers_and_shutdown_hook() {
+        let config_base = tempdir().expect("config base");
+        let source_root = tempdir().expect("source root");
+        let _base_guard = ConfigBaseGuard::set(config_base.path().to_path_buf());
+        let _profile_guard = PersistenceProfileGuard::automated();
+        save(&AppConfig {
+            sources: vec![SampleSource::new(source_root.path().to_path_buf())],
+            core: AppSettingsCore::default(),
+        })
+        .expect("seed isolated startup profile");
+
+        let capture = capture_startup([960, 540]).expect("native startup capture");
+
+        assert_eq!(
+            capture.runtime_composition,
+            NativeRuntimeComposition {
+                source_watcher_count: 1,
+                readiness_supervisor_count: 1,
+                legacy_analysis_pool_count: 0,
+            }
+        );
+        assert_eq!(capture.automation_snapshot.viewport_width, 960);
+        assert_eq!(capture.automation_snapshot.viewport_height, 540);
+        assert_eq!(
+            capture
+                .shutdown_artifact
+                .as_ref()
+                .and_then(|artifact| artifact["source_processing"]["joined"].as_bool()),
+            Some(true)
+        );
+    }
+}

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -306,14 +306,20 @@ impl GuiSourceWatcherHandle {
             .send(GuiSourceWatchCommand::InjectPaths(paths));
     }
 
-    #[cfg(test)]
-    pub(in crate::native_app) fn wait_until_ready_for_tests(&self) {
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn wait_until_ready(&self, timeout: Duration) -> Result<(), String> {
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         self.command_tx
             .send(GuiSourceWatchCommand::AwaitReady(ready_tx))
-            .expect("request source watcher readiness");
+            .map_err(|_| String::from("request source watcher readiness"))?;
         ready_rx
-            .recv_timeout(Duration::from_secs(30))
+            .recv_timeout(timeout)
+            .map_err(|_| String::from("source watcher did not become ready"))
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn wait_until_ready_for_tests(&self) {
+        self.wait_until_ready(Duration::from_secs(30))
             .expect("source watcher should become ready");
     }
 }
@@ -342,7 +348,7 @@ enum GuiSourceWatchCommand {
     ForceRestart,
     #[cfg(test)]
     ForceRootRefresh,
-    #[cfg(test)]
+    #[cfg(any(test, feature = "legacy-controller"))]
     AwaitReady(Sender<()>),
     #[cfg(test)]
     InjectPaths(Vec<std::path::PathBuf>),
@@ -370,7 +376,7 @@ fn run_source_watcher(
     let mut next_root_refresh = Instant::now();
     let mut root_identity_recovery = RootIdentityRecovery::default();
     let mut watcher_has_been_ready = false;
-    #[cfg(test)]
+    #[cfg(any(test, feature = "legacy-controller"))]
     let mut readiness_waiters = Vec::<Sender<()>>::new();
 
     loop {
@@ -416,7 +422,7 @@ fn run_source_watcher(
             Ok(GuiSourceWatchCommand::ForceRootRefresh) => {
                 next_root_refresh = Instant::now();
             }
-            #[cfg(test)]
+            #[cfg(any(test, feature = "legacy-controller"))]
             Ok(GuiSourceWatchCommand::AwaitReady(ready_tx)) => {
                 readiness_waiters.push(ready_tx);
             }
@@ -640,7 +646,7 @@ fn run_source_watcher(
                 }
             }
         }
-        #[cfg(test)]
+        #[cfg(any(test, feature = "legacy-controller"))]
         if watcher.is_some() {
             for ready in readiness_waiters.drain(..) {
                 let _ = ready.send(());

--- a/src/native_app/shell.rs
+++ b/src/native_app/shell.rs
@@ -7,7 +7,9 @@ pub(in crate::native_app) mod message_dispatch;
 pub(in crate::native_app) mod shortcuts;
 
 pub(in crate::native_app) use launch::emit_gui_action;
-pub(crate) use launch::run;
+#[cfg(any(test, feature = "legacy-controller"))]
+pub(in crate::native_app) use launch::native_app_runtime_bridge;
+pub use launch::run;
 #[cfg(test)]
 pub(in crate::native_app) use launch::{
     DEBUG_LAYOUT_ARG, DEBUG_LAYOUT_SHORT_ARG, DEBUG_OVERLAYS_ARG, debug_layout_requested,

--- a/src/native_app/shell/launch/mod.rs
+++ b/src/native_app/shell/launch/mod.rs
@@ -18,9 +18,11 @@ pub(in crate::native_app) use args::{
 pub(in crate::native_app) use logging::emit_gui_action;
 #[cfg(test)]
 pub(in crate::native_app) use options::default_window_title;
+#[cfg(any(test, feature = "legacy-controller"))]
+pub(in crate::native_app) use radiant_runtime::native_app_runtime_bridge;
 
 /// Run the default Radiant GUI application shell.
-pub(crate) fn run() -> Result<(), String> {
+pub fn run() -> Result<(), String> {
     if let Some(result_json) =
         crate::native_app::source_processing::run_internal_source_analysis_from_args()?
     {

--- a/src/native_app/shell/launch/radiant_runtime.rs
+++ b/src/native_app/shell/launch/radiant_runtime.rs
@@ -2,7 +2,7 @@ use std::panic::{self, AssertUnwindSafe};
 
 use radiant::runtime::NativeRunOptions;
 
-use crate::native_app::app::{NativeAppState, view};
+use crate::native_app::app::{GuiMessage, NativeAppState, view};
 use crate::native_app::app_chrome::settings;
 use crate::native_app::app_chrome::view_models::sample_browser::prepare_sample_browser_view;
 use crate::native_app::audio::playback::playhead_frame_diagnostics_observer_enabled;
@@ -13,23 +13,29 @@ pub(super) fn run_catching_unwind(
 ) -> Result<Result<(), String>, Box<dyn std::any::Any + Send>> {
     panic::catch_unwind(AssertUnwindSafe(|| {
         prepare_sample_browser_view(&mut state);
-        let app = radiant::app(state)
-            .options(options)
-            .view(view)
-            .subscriptions(NativeAppState::worker_subscription)
-            .auxiliary_windows(settings::auxiliary_windows)
-            .on_native_file_open(|state, open, context| {
-                state.open_audio_documents(open.paths, context);
-            });
-        let app = if playhead_frame_diagnostics_observer_enabled() {
-            app.on_native_frame_diagnostics(|state, diagnostics| {
-                state.observe_playhead_native_frame_diagnostics(diagnostics);
-            })
-        } else {
-            app
-        };
-        app.on_shutdown(NativeAppState::shutdown)
-            .handle_message(NativeAppState::handle_message)
-            .run()
+        radiant::runtime::run_native_vello_runtime(options, native_app_runtime_bridge(state))
     }))
+}
+
+/// Lower the production app composition into Radiant's backend-neutral host boundary.
+pub(in crate::native_app) fn native_app_runtime_bridge(
+    state: NativeAppState,
+) -> impl radiant::runtime::RuntimeBridge<GuiMessage> {
+    let app = radiant::app(state)
+        .view(view)
+        .subscriptions(NativeAppState::worker_subscription)
+        .auxiliary_windows(settings::auxiliary_windows)
+        .on_native_file_open(|state, open, context| {
+            state.open_audio_documents(open.paths, context);
+        });
+    let app = if playhead_frame_diagnostics_observer_enabled() {
+        app.on_native_frame_diagnostics(|state, diagnostics| {
+            state.observe_playhead_native_frame_diagnostics(diagnostics);
+        })
+    } else {
+        app
+    };
+    app.on_shutdown(NativeAppState::shutdown)
+        .handle_message(NativeAppState::handle_message)
+        .into_bridge()
 }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -19,6 +19,17 @@ const UI_FRAME_CADENCE: frame_ui::FrameCadenceConfig =
 
 impl NativeAppState {
     pub(in crate::native_app) fn load_default() -> Result<Self, String> {
+        Self::load_default_with_runtime_background(cfg!(not(test)))
+    }
+
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn load_for_automation() -> Result<Self, String> {
+        Self::load_default_with_runtime_background(true)
+    }
+
+    fn load_default_with_runtime_background(
+        start_runtime_background: bool,
+    ) -> Result<Self, String> {
         let started_at = Instant::now();
         let config = wavecrate::sample_sources::config::load_or_default()
             .map_err(|err| format!("load app configuration: {err}"))?;
@@ -38,8 +49,21 @@ impl NativeAppState {
                 worker_sender.clone(),
             )
         });
-        let background =
-            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone());
+        #[cfg(any(test, feature = "legacy-controller"))]
+        let background = if start_runtime_background {
+            BackgroundTaskState::new_runtime(
+                worker_sender,
+                Some(worker_receiver),
+                config.sources.clone(),
+            )
+        } else {
+            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone())
+        };
+        #[cfg(not(any(test, feature = "legacy-controller")))]
+        let background = {
+            let _ = start_runtime_background;
+            BackgroundTaskState::new(worker_sender, Some(worker_receiver), config.sources.clone())
+        };
         let audio = AudioAppState::from_settings(&config.core);
         let startup = StartupState::new(
             startup_source_scan_pending,
@@ -78,6 +102,28 @@ impl NativeAppState {
             None,
         );
         Ok(state)
+    }
+
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn automation_runtime_composition(
+        &self,
+    ) -> crate::native_app::automation::NativeRuntimeComposition {
+        crate::native_app::automation::NativeRuntimeComposition {
+            source_watcher_count: usize::from(self.library.source_watcher.is_some()),
+            readiness_supervisor_count: usize::from(self.background.source_processing.is_running()),
+            legacy_analysis_pool_count: 0,
+        }
+    }
+
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn wait_for_source_watcher_ready(
+        &self,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        match self.library.source_watcher.as_ref() {
+            Some(watcher) => watcher.wait_until_ready(timeout),
+            None => Ok(()),
+        }
     }
 
     pub(in crate::native_app) fn sync_source_watcher(&mut self) {

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -412,6 +412,11 @@ impl Drop for SourceProcessingBudgetPermit {
     }
 }
 
+fn install_worker_app_root(app_root: PathBuf) -> wavecrate::app_dirs::AppRootGuard {
+    wavecrate::app_dirs::AppRootGuard::set(app_root)
+        .expect("source-processing worker should inherit the resolved persistence root")
+}
+
 impl SourceProcessingSupervisor {
     #[cfg(test)]
     pub(in crate::native_app) fn start(sources: Vec<SampleSource>) -> Self {
@@ -445,20 +450,30 @@ impl SourceProcessingSupervisor {
         event_sink: Option<Arc<dyn SourceProcessingEventSink>>,
         synthetic_test_execution: bool,
     ) -> Self {
+        let app_root = wavecrate::app_dirs::app_root_dir()
+            .expect("source-processing supervisor should resolve its persistence root");
         let shared = Arc::new(Shared::new(sources, event_sink));
         shared.control().playback_active = playback_active;
         shared
             .synthetic_test_execution
             .store(synthetic_test_execution, Ordering::Release);
         let thread_shared = Arc::clone(&shared);
+        let coordinator_app_root = app_root.clone();
         let coordinator = thread::Builder::new()
             .name(String::from("wavecrate-source-supervisor"))
-            .spawn(move || run_coordinator(thread_shared))
+            .spawn(move || {
+                let _app_root_guard = install_worker_app_root(coordinator_app_root);
+                run_coordinator(thread_shared);
+            })
             .expect("spawn source processing supervisor");
         let retirement_shared = Arc::clone(&shared);
+        let retirement_app_root = app_root;
         let retirement_worker = thread::Builder::new()
             .name(String::from("wavecrate-source-retirement"))
-            .spawn(move || run_retirement_worker(retirement_shared))
+            .spawn(move || {
+                let _app_root_guard = install_worker_app_root(retirement_app_root);
+                run_retirement_worker(retirement_shared);
+            })
             .expect("spawn source retirement worker");
         Self {
             shared,
@@ -474,6 +489,11 @@ impl SourceProcessingSupervisor {
             coordinator: None,
             retirement_worker: None,
         }
+    }
+
+    #[cfg(any(test, feature = "legacy-controller"))]
+    pub(in crate::native_app) fn is_running(&self) -> bool {
+        self.coordinator.is_some() && self.retirement_worker.is_some()
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Goal

Make `live`, `isolated-startup`, and the legacy `default` alias certify the same `NativeAppState` + Radiant runtime composition as the Wavecrate executable, without starting the retained `AppController` processing runtime.

## Scope

- Extract the production Radiant runtime bridge and reuse it for backend-neutral native automation capture.
- Route live and isolated startup snapshots through `NativeAppState`, native subscriptions/message dispatch, and the real shutdown hook.
- Emit Radiant automation snapshots plus fixture-runtime, worker-composition, and shutdown evidence in GUI artifacts.
- Keep named deterministic fixtures explicitly legacy-controller-only for compatibility scenarios.
- Propagate the resolved persistence root into native supervisor worker threads and add isolated/live boundary regression coverage.
- Extend native-app architecture checks and the GUI suite to enforce the runtime boundary and 1 watcher / 1 readiness supervisor / 0 legacy pool contract.

Non-goals: migrating every named controller fixture, redesigning visible GUI behavior, or making ordinary automation use the live profile.

## Definition of Done

- [x] Live/isolated startup use the production native app bridge.
- [x] Product certification records exactly one native watcher, one readiness supervisor, and no legacy analysis pool.
- [x] Named deterministic fixtures are labeled legacy-only and excluded from native startup certification.
- [x] Isolated automation cannot mutate live source configuration.
- [x] Native startup, source selection, mutation, progress, playback, persistence, and shutdown coverage remains in the native suite, with product-composition startup evidence added here.
- [x] Architecture checks reject legacy startup bridge construction in product fixture routing.
- [x] Native GUI artifact and retained scenario lanes pass.
- [x] Legacy controller startup remains behind the existing `legacy-controller`/test feature boundary.

## Validation

- `cargo test -p wavecrate --lib gui_test` — 17 passed, 11 intentionally ignored
- `cargo test -p wavecrate --lib gui_test::fixtures::tests -- --ignored --nocapture` — 2 passed
- `cargo test -p wavecrate --lib gui_test::runner::tests -- --ignored --nocapture` — 8 passed
- `cargo test -p wavecrate --lib native_app::automation::tests::startup_capture_uses_native_workers_and_shutdown_hook -- --exact` — passed
- `cargo test -p wavecrate --bin wavecrate native_app` — passed
- `cargo test -p wavecrate-library app_root_guard_pins_child_thread_to_resolved_runtime_root` — passed
- `cargo check -p wavecrate --lib --features legacy-controller` — passed
- `bash scripts/internal/check/check_native_app_boundary.sh` — passed
- `cargo run -p gui-test-cli -- snapshot <temp>` plus artifact assertions — native-app, 1 watcher, 1 supervisor, 0 legacy pools, joined shutdown
- `cargo run -p gui-test-cli -- run-scenario-pack contract-smoke <temp>` — 11 artifacts
- `bash scripts/ci.sh smoke` — passed

## Known limitations

- Explicit `live` capture was not run because it intentionally operates on the user's real persisted profile and requires deliberate operator validation.
- `bash scripts/agent.sh request` reaches and passes the OPT-1216-specific architecture/non-blocking checks, then fails `check_wavecrate_facades.sh`; the same facade guard fails unchanged `origin/main` at `b7c4544d0` with pre-existing OPT-529/OPT-541 and legacy app-core crossings.
- PowerShell wrapper execution was unavailable on this macOS host; its underlying Cargo and CLI lanes were run directly.

User approval is required before merge.

Linear: OPT-1216