### PR TITLE
OPT-1211 Replace SourcePrepTrigger with explicit processing intents

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -351,6 +351,8 @@ Reconciliation compares desired targets with persisted artifacts and readiness-o
 
 Detection and execution stay off UI, render, and latency-sensitive read paths. UI and read paths may observe a side-effect-free readiness snapshot and request priority, repair, or retry, but they must not discover a missing artifact by directly enqueueing hidden work. Lifecycle writers publish committed desired generations and wake the background coordinator only after their authoritative transaction succeeds.
 
+Native source-preparation callers declare orthogonal intents for readiness wake or reanalysis, source priority, persisted-metadata projection, waveform-cache projection, cache warming, and user feedback. Source selection, folder activation, verified startup, scan completion, committed filesystem mutation, watcher reconciliation, and explicit `Process Source` each request only their required effects; descriptive telemetry reasons never select policy. The source-processing supervisor remains the sole owner of readiness convergence.
+
 The readiness contract must be protected by a deterministic native-runtime
 liveness oracle over real temporary sources. The oracle observes committed
 manifest/readiness generations and the supervisor's durable/runtime state

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -15,7 +15,10 @@ use crate::native_app::sample_library::folder_browser::BrowserListingRevealReaso
 use crate::native_app::sample_library::folder_browser::commands::{
     FileMoveConflictCompletion, FolderMoveRequest, FolderMoveSuccess, RenameCommitCompletion,
 };
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
 
 #[cfg(test)]
 mod tests;
@@ -29,6 +32,17 @@ use worker::{
     build_source_requests, capture_expected_filesystem_state, merge_file_mutation_failures,
     mutation_completion_is_stale_or_duplicate, reconcile_file_mutation_requests,
 };
+
+pub(in crate::native_app) const COMMITTED_MUTATION_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::InvalidateAndRequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const COMMITTED_MUTATION_PREP_REASON: &str = "filesystem_changed";
 
 #[cfg(test)]
 pub(in crate::native_app) fn reconcile_file_mutation_for_liveness_test(
@@ -543,7 +557,8 @@ impl NativeAppState {
             // reconciler. It deliberately happens after the source DB and browser projection.
             self.queue_source_prep(
                 event.source_id,
-                SourcePrepTrigger::FilesystemChanged,
+                COMMITTED_MUTATION_PREP_INTENTS,
+                COMMITTED_MUTATION_PREP_REASON,
                 context,
             );
         }

--- a/src/native_app/sample_library/folder_browser_actions.rs
+++ b/src/native_app/sample_library/folder_browser_actions.rs
@@ -5,7 +5,15 @@ mod layout;
 mod navigation;
 mod source;
 
+#[cfg(test)]
+pub(in crate::native_app) use folder_tree::{
+    FOLDER_ACTIVATION_PREP_INTENTS, FOLDER_ACTIVATION_PREP_REASON,
+};
 pub(in crate::native_app) use navigation::file_navigation_reveal_direction;
+#[cfg(test)]
+pub(in crate::native_app) use source::{
+    SOURCE_SELECTION_PREP_INTENTS, SOURCE_SELECTION_PREP_REASON,
+};
 
 use radiant::prelude as ui;
 

--- a/src/native_app/sample_library/folder_browser_actions/folder_tree.rs
+++ b/src/native_app/sample_library/folder_browser_actions/folder_tree.rs
@@ -7,7 +7,21 @@ use crate::native_app::sample_library::folder_browser::commands::FolderBrowserMe
 use crate::native_app::sample_library::folder_browser::view_contract::{
     FOLDER_TREE_EDGE_CONTEXT_ROWS, FOLDER_TREE_OVERSCAN_ROWS, FOLDER_TREE_PROJECTED_VIEWPORT_ROWS,
 };
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
+
+pub(in crate::native_app) const FOLDER_ACTIVATION_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::IfNotLoaded,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const FOLDER_ACTIVATION_PREP_REASON: &str = "folder_activated";
 
 impl NativeAppState {
     pub(super) fn activate_folder_browser_folder(
@@ -31,7 +45,11 @@ impl NativeAppState {
             .folder_browser
             .apply_message(FolderBrowserMessage::ActivateFolder(folder_id, modifiers));
         self.queue_selected_folder_verify_after_activation(context);
-        self.queue_selected_source_prep(SourcePrepTrigger::FolderActivated, context);
+        self.queue_selected_source_prep(
+            FOLDER_ACTIVATION_PREP_INTENTS,
+            FOLDER_ACTIVATION_PREP_REASON,
+            context,
+        );
         emit_gui_action(
             "folder_browser.activate_folder",
             Some("folder_browser"),

--- a/src/native_app/sample_library/folder_browser_actions/source.rs
+++ b/src/native_app/sample_library/folder_browser_actions/source.rs
@@ -2,7 +2,21 @@ use radiant::prelude as ui;
 use std::time::Instant;
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
+
+pub(in crate::native_app) const SOURCE_SELECTION_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::IfNotLoaded,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const SOURCE_SELECTION_PREP_REASON: &str = "source_selected";
 
 impl NativeAppState {
     pub(super) fn select_folder_browser_source(
@@ -17,7 +31,11 @@ impl NativeAppState {
         self.select_source(id, context);
         log_select_source_phase("select_source", selection_started_at);
         let prep_started_at = Instant::now();
-        self.queue_selected_source_prep(SourcePrepTrigger::SourceSelected, context);
+        self.queue_selected_source_prep(
+            SOURCE_SELECTION_PREP_INTENTS,
+            SOURCE_SELECTION_PREP_REASON,
+            context,
+        );
         log_select_source_phase("queue_selected_source_prep", prep_started_at);
         emit_gui_action(
             "folder_browser.select_source",

--- a/src/native_app/sample_library/folder_scan_actions.rs
+++ b/src/native_app/sample_library/folder_scan_actions.rs
@@ -7,5 +7,17 @@ mod source_commands;
 mod task_ids;
 mod worker;
 
+#[cfg(test)]
+pub(in crate::native_app) use filesystem_refresh::{
+    FILESYSTEM_SYNC_PREP_INTENTS, FILESYSTEM_SYNC_PREP_REASON,
+};
 pub(in crate::native_app) use filesystem_refresh_worker::sync_source_database_paths;
 pub(in crate::native_app) use maintenance::FolderScanMaintenanceResult;
+#[cfg(test)]
+pub(in crate::native_app) use source_commands::{
+    PROCESS_SOURCE_PREP_INTENTS, PROCESS_SOURCE_PREP_REASON,
+};
+#[cfg(test)]
+pub(in crate::native_app) use worker::{
+    SOURCE_SCAN_COMPLETION_PREP_INTENTS, SOURCE_SCAN_COMPLETION_PREP_REASON,
+};

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -7,8 +7,22 @@ use crate::native_app::app::{
     SourceRefreshRequest, emit_gui_action,
 };
 use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::sync_source_database_paths;
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
 use crate::native_app::source_processing::manifest_delta_requires_browser_refresh;
+
+pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::InvalidateAndRequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_REASON: &str = "filesystem_changed";
 
 impl NativeAppState {
     pub(in crate::native_app) fn refresh_source_after_filesystem_change(
@@ -124,7 +138,8 @@ impl NativeAppState {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
                     self.queue_source_prep(
                         source_id.clone(),
-                        SourcePrepTrigger::FilesystemChanged,
+                        FILESYSTEM_SYNC_PREP_INTENTS,
+                        FILESYSTEM_SYNC_PREP_REASON,
                         context,
                     );
                 }

--- a/src/native_app/sample_library/folder_scan_actions/source_commands.rs
+++ b/src/native_app/sample_library/folder_scan_actions/source_commands.rs
@@ -3,7 +3,21 @@ use std::time::Instant;
 use radiant::prelude as ui;
 
 use crate::native_app::app::{GuiMessage, NativeAppState, SourceSelectionRequest, emit_gui_action};
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
+
+pub(in crate::native_app) const PROCESS_SOURCE_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::Reanalyze,
+        priority: SourcePriorityIntent::PromoteSource,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::SelectedFolderOrSource,
+        feedback: SourceFeedbackIntent::QueuedIfCacheWarmNotScheduled,
+    };
+pub(in crate::native_app) const PROCESS_SOURCE_PREP_REASON: &str = "user_requested";
 
 impl NativeAppState {
     pub(in crate::native_app) fn select_source(
@@ -183,7 +197,12 @@ impl NativeAppState {
             );
             return;
         }
-        self.queue_source_prep(source_id.clone(), SourcePrepTrigger::UserRequested, context);
+        self.queue_source_prep(
+            source_id.clone(),
+            PROCESS_SOURCE_PREP_INTENTS,
+            PROCESS_SOURCE_PREP_REASON,
+            context,
+        );
         emit_gui_action(
             "folder_browser.source.process",
             Some("sources"),

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -10,13 +10,27 @@ use crate::native_app::{
     sample_library::folder_browser::scan::{
         FolderScanRequest, PreparedFolderScanResult, reserve_source_scan_cache_revision,
     },
-    sample_library::source_prep::SourcePrepTrigger,
+    sample_library::source_prep::{
+        CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+        SourcePrepIntents, SourcePriorityIntent,
+    },
 };
 use wavecrate::sample_sources::config::{AppConfig, reserve_save_revision};
 
 use super::maintenance::{
     FolderScanMaintenanceRequest, FolderScanMaintenanceResult, persist_folder_scan_maintenance,
 };
+
+pub(in crate::native_app) const SOURCE_SCAN_COMPLETION_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const SOURCE_SCAN_COMPLETION_PREP_REASON: &str = "source_scan_finished";
 
 impl NativeAppState {
     pub(in crate::native_app) fn launch_folder_scan(
@@ -313,7 +327,8 @@ impl NativeAppState {
             );
             self.queue_source_prep(
                 scan.source_id.clone(),
-                SourcePrepTrigger::SourceScanFinished,
+                SOURCE_SCAN_COMPLETION_PREP_INTENTS,
+                SOURCE_SCAN_COMPLETION_PREP_REASON,
                 context,
             );
         }

--- a/src/native_app/sample_library/folder_startup_verify_actions.rs
+++ b/src/native_app/sample_library/folder_startup_verify_actions.rs
@@ -3,7 +3,21 @@ use std::time::Instant;
 
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 use crate::native_app::sample_library::folder_browser::scan;
-use crate::native_app::sample_library::source_prep::SourcePrepTrigger;
+use crate::native_app::sample_library::source_prep::{
+    CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+    SourcePrepIntents, SourcePriorityIntent,
+};
+
+pub(in crate::native_app) const VERIFIED_FOLDER_MUTATION_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::InvalidateAndRequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const VERIFIED_FOLDER_MUTATION_PREP_REASON: &str = "filesystem_changed";
 
 impl NativeAppState {
     pub(in crate::native_app) fn maybe_startup_visible_folder_verify(
@@ -99,7 +113,8 @@ impl NativeAppState {
         if changed {
             self.queue_source_prep(
                 source_id.clone(),
-                SourcePrepTrigger::FilesystemChanged,
+                VERIFIED_FOLDER_MUTATION_PREP_INTENTS,
+                VERIFIED_FOLDER_MUTATION_PREP_REASON,
                 context,
             );
             self.persist_user_configuration(action, started_at);

--- a/src/native_app/sample_library/folder_tree_refresh_actions.rs
+++ b/src/native_app/sample_library/folder_tree_refresh_actions.rs
@@ -3,8 +3,25 @@ use std::time::Instant;
 
 use crate::native_app::{
     app::{GuiMessage, NativeAppState, emit_gui_action},
-    sample_library::{folder_browser::scan, source_prep::SourcePrepTrigger},
+    sample_library::{
+        folder_browser::scan,
+        source_prep::{
+            CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+            SourcePrepIntents, SourcePriorityIntent,
+        },
+    },
 };
+
+pub(in crate::native_app) const VERIFIED_SOURCE_PREP_INTENTS: SourcePrepIntents =
+    SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::IfNotLoaded,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+pub(in crate::native_app) const VERIFIED_SOURCE_PREP_REASON: &str = "source_verified";
 
 impl NativeAppState {
     pub(in crate::native_app) fn queue_selected_source_folder_tree_refresh(
@@ -64,7 +81,8 @@ impl NativeAppState {
         }
         self.queue_source_prep(
             source_id.clone(),
-            SourcePrepTrigger::SourceVerified,
+            VERIFIED_SOURCE_PREP_INTENTS,
+            VERIFIED_SOURCE_PREP_REASON,
             context,
         );
         emit_gui_action(

--- a/src/native_app/sample_library/source_prep.rs
+++ b/src/native_app/sample_library/source_prep.rs
@@ -5,106 +5,278 @@ use radiant::prelude as ui;
 use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(in crate::native_app) enum SourcePrepTrigger {
-    UserRequested,
-    SourceSelected,
-    FolderActivated,
-    SourceVerified,
-    SourceScanFinished,
-    FilesystemChanged,
+pub(in crate::native_app) enum ReadinessIntent {
+    RequestConvergence,
+    InvalidateAndRequestConvergence,
+    Reanalyze,
 }
 
-impl SourcePrepTrigger {
-    fn action_label(self) -> &'static str {
-        match self {
-            Self::UserRequested => "user_requested",
-            Self::SourceSelected => "source_selected",
-            Self::FolderActivated => "folder_activated",
-            Self::SourceVerified => "source_verified",
-            Self::SourceScanFinished => "source_scan_finished",
-            Self::FilesystemChanged => "filesystem_changed",
-        }
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum SourcePriorityIntent {
+    PromoteIfSelected,
+    PromoteSource,
+}
 
-    fn schedules_source_cache_warm(self) -> bool {
-        matches!(self, Self::UserRequested)
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum MetadataRefreshIntent {
+    IfNotLoaded,
+    Force,
+}
 
-    fn force_metadata_refresh(self) -> bool {
-        matches!(
-            self,
-            Self::UserRequested | Self::SourceScanFinished | Self::FilesystemChanged
-        )
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum CacheWarmIntent {
+    Preserve,
+    SelectedFolderOrSource,
+}
 
-    fn invalidates_running_source_work(self) -> bool {
-        matches!(self, Self::FilesystemChanged)
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum SourceFeedbackIntent {
+    Preserve,
+    QueuedIfCacheWarmNotScheduled,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct SourcePrepIntents {
+    pub(in crate::native_app) readiness: ReadinessIntent,
+    pub(in crate::native_app) priority: SourcePriorityIntent,
+    pub(in crate::native_app) metadata_refresh: MetadataRefreshIntent,
+    pub(in crate::native_app) refresh_waveform_cache_projection_if_selected: bool,
+    pub(in crate::native_app) cache_warm: CacheWarmIntent,
+    pub(in crate::native_app) feedback: SourceFeedbackIntent,
 }
 
 impl NativeAppState {
     pub(in crate::native_app) fn queue_selected_source_prep(
         &mut self,
-        trigger: SourcePrepTrigger,
+        intents: SourcePrepIntents,
+        reason: &'static str,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let source_id = self.library.folder_browser.selected_source_id().to_string();
-        self.queue_source_prep(source_id, trigger, context);
+        self.queue_source_prep(source_id, intents, reason, context);
     }
 
     pub(in crate::native_app) fn queue_source_prep(
         &mut self,
         source_id: String,
-        trigger: SourcePrepTrigger,
+        intents: SourcePrepIntents,
+        reason: &'static str,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
         let selected_source = source_id == self.library.folder_browser.selected_source_id();
-        if trigger == SourcePrepTrigger::UserRequested {
-            self.background
+        match intents.priority {
+            SourcePriorityIntent::PromoteIfSelected if selected_source => self
+                .background
                 .source_processing
-                .request_source_reanalysis(&source_id, trigger.action_label());
-        } else if trigger.invalidates_running_source_work() {
-            self.background
+                .set_selected_source(Some(&source_id)),
+            SourcePriorityIntent::PromoteSource => self
+                .background
                 .source_processing
-                .wake_source(&source_id, trigger.action_label());
-        } else {
-            self.background
-                .source_processing
-                .request_source_processing(&source_id, trigger.action_label());
+                .set_selected_source(Some(&source_id)),
+            SourcePriorityIntent::PromoteIfSelected => {}
         }
-        if selected_source {
-            self.background
+        match intents.readiness {
+            ReadinessIntent::RequestConvergence => self
+                .background
                 .source_processing
-                .set_selected_source(Some(&source_id));
+                .request_source_processing(&source_id, reason),
+            ReadinessIntent::InvalidateAndRequestConvergence => self
+                .background
+                .source_processing
+                .wake_source(&source_id, reason),
+            ReadinessIntent::Reanalyze => self
+                .background
+                .source_processing
+                .request_source_reanalysis(&source_id, reason),
         }
         self.schedule_persisted_metadata_tags_refresh_for_source(
             &source_id,
-            trigger.force_metadata_refresh(),
+            intents.metadata_refresh == MetadataRefreshIntent::Force,
             context,
         );
-        if selected_source {
+        if selected_source && intents.refresh_waveform_cache_projection_if_selected {
             self.schedule_persisted_waveform_cache_indicator_refresh(context);
         }
-        let cache_scheduled = if trigger.schedules_source_cache_warm() {
-            if selected_source {
+        let cache_scheduled = match intents.cache_warm {
+            CacheWarmIntent::Preserve => false,
+            CacheWarmIntent::SelectedFolderOrSource if selected_source => {
                 self.schedule_active_folder_cache_warm(context)
-            } else {
+            }
+            CacheWarmIntent::SelectedFolderOrSource => {
                 self.schedule_source_cache_warm(&source_id, context)
             }
-        } else {
-            false
         };
-        if trigger == SourcePrepTrigger::UserRequested && !cache_scheduled {
+        if intents.feedback == SourceFeedbackIntent::QueuedIfCacheWarmNotScheduled
+            && !cache_scheduled
+        {
             self.ui.status.sample = String::from("Source processing queued");
         }
         emit_gui_action(
             "source_prep.queue",
             Some("background"),
             Some(&source_id),
-            trigger.action_label(),
+            reason,
             started_at,
             None,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
+        SourcePrepIntents, SourcePriorityIntent,
+    };
+    use crate::native_app::sample_library::{
+        committed_file_mutations::{
+            COMMITTED_MUTATION_PREP_INTENTS, COMMITTED_MUTATION_PREP_REASON,
+        },
+        folder_browser_actions::{
+            FOLDER_ACTIVATION_PREP_INTENTS, FOLDER_ACTIVATION_PREP_REASON,
+            SOURCE_SELECTION_PREP_INTENTS, SOURCE_SELECTION_PREP_REASON,
+        },
+        folder_scan_actions::{
+            FILESYSTEM_SYNC_PREP_INTENTS, FILESYSTEM_SYNC_PREP_REASON, PROCESS_SOURCE_PREP_INTENTS,
+            PROCESS_SOURCE_PREP_REASON, SOURCE_SCAN_COMPLETION_PREP_INTENTS,
+            SOURCE_SCAN_COMPLETION_PREP_REASON,
+        },
+        folder_startup_verify_actions::{
+            VERIFIED_FOLDER_MUTATION_PREP_INTENTS, VERIFIED_FOLDER_MUTATION_PREP_REASON,
+        },
+        folder_tree_refresh_actions::{VERIFIED_SOURCE_PREP_INTENTS, VERIFIED_SOURCE_PREP_REASON},
+    };
+
+    const PASSIVE_SELECTION: SourcePrepIntents = SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::IfNotLoaded,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+    const SCAN_COMPLETION: SourcePrepIntents = SourcePrepIntents {
+        readiness: ReadinessIntent::RequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+    const FILESYSTEM_MUTATION: SourcePrepIntents = SourcePrepIntents {
+        readiness: ReadinessIntent::InvalidateAndRequestConvergence,
+        priority: SourcePriorityIntent::PromoteIfSelected,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::Preserve,
+        feedback: SourceFeedbackIntent::Preserve,
+    };
+    const EXPLICIT_PROCESS_SOURCE: SourcePrepIntents = SourcePrepIntents {
+        readiness: ReadinessIntent::Reanalyze,
+        priority: SourcePriorityIntent::PromoteSource,
+        metadata_refresh: MetadataRefreshIntent::Force,
+        refresh_waveform_cache_projection_if_selected: true,
+        cache_warm: CacheWarmIntent::SelectedFolderOrSource,
+        feedback: SourceFeedbackIntent::QueuedIfCacheWarmNotScheduled,
+    };
+
+    #[test]
+    fn call_site_matrix_declares_exact_source_prep_effects() {
+        let scenarios = [
+            (
+                "source selection",
+                SOURCE_SELECTION_PREP_INTENTS,
+                SOURCE_SELECTION_PREP_REASON,
+                PASSIVE_SELECTION,
+                "source_selected",
+            ),
+            (
+                "folder activation",
+                FOLDER_ACTIVATION_PREP_INTENTS,
+                FOLDER_ACTIVATION_PREP_REASON,
+                PASSIVE_SELECTION,
+                "folder_activated",
+            ),
+            (
+                "verified startup",
+                VERIFIED_SOURCE_PREP_INTENTS,
+                VERIFIED_SOURCE_PREP_REASON,
+                PASSIVE_SELECTION,
+                "source_verified",
+            ),
+            (
+                "scan completion",
+                SOURCE_SCAN_COMPLETION_PREP_INTENTS,
+                SOURCE_SCAN_COMPLETION_PREP_REASON,
+                SCAN_COMPLETION,
+                "source_scan_finished",
+            ),
+            (
+                "verified folder mutation",
+                VERIFIED_FOLDER_MUTATION_PREP_INTENTS,
+                VERIFIED_FOLDER_MUTATION_PREP_REASON,
+                FILESYSTEM_MUTATION,
+                "filesystem_changed",
+            ),
+            (
+                "external filesystem sync",
+                FILESYSTEM_SYNC_PREP_INTENTS,
+                FILESYSTEM_SYNC_PREP_REASON,
+                FILESYSTEM_MUTATION,
+                "filesystem_changed",
+            ),
+            (
+                "committed Wavecrate mutation",
+                COMMITTED_MUTATION_PREP_INTENTS,
+                COMMITTED_MUTATION_PREP_REASON,
+                FILESYSTEM_MUTATION,
+                "filesystem_changed",
+            ),
+            (
+                "explicit Process Source",
+                PROCESS_SOURCE_PREP_INTENTS,
+                PROCESS_SOURCE_PREP_REASON,
+                EXPLICIT_PROCESS_SOURCE,
+                "user_requested",
+            ),
+        ];
+
+        for (scenario, actual_intents, actual_reason, expected_intents, expected_reason) in
+            scenarios
+        {
+            assert_eq!(
+                actual_intents, expected_intents,
+                "{scenario} must request exactly its documented effects"
+            );
+            assert_eq!(
+                actual_reason, expected_reason,
+                "{scenario} must retain its descriptive telemetry reason"
+            );
+        }
+    }
+
+    #[test]
+    fn descriptive_reasons_are_independent_from_effect_policy() {
+        assert_ne!(
+            SOURCE_SELECTION_PREP_REASON, FOLDER_ACTIVATION_PREP_REASON,
+            "distinct events retain distinct telemetry reasons"
+        );
+        assert_eq!(
+            SOURCE_SELECTION_PREP_INTENTS, FOLDER_ACTIVATION_PREP_INTENTS,
+            "different reasons may deliberately request identical effects"
+        );
+        assert_eq!(
+            VERIFIED_FOLDER_MUTATION_PREP_REASON,
+            FILESYSTEM_SYNC_PREP_REASON
+        );
+        assert_eq!(
+            VERIFIED_FOLDER_MUTATION_PREP_INTENTS, FILESYSTEM_SYNC_PREP_INTENTS,
+            "shared reason text does not hide caller-owned policy"
+        );
+        assert_ne!(
+            SOURCE_SELECTION_PREP_INTENTS, SOURCE_SCAN_COMPLETION_PREP_INTENTS,
+            "metadata refresh policy is explicit even when readiness policy matches"
         );
     }
 }

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -851,7 +851,6 @@ impl SourceProcessingSupervisor {
         control
             .force_reanalysis_sources
             .insert(source_id.to_string());
-        control.priority.selected_source = Some(source_id.to_string());
         control.mark_source_dirty(source_id, reason);
         drop(control);
         self.shared
@@ -885,6 +884,11 @@ impl SourceProcessingSupervisor {
             control.notify("selected_source_changed");
             self.shared.wake.notify_one();
         }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn selected_source_priority_for_tests(&self) -> Option<String> {
+        self.shared.control().priority.selected_source.clone()
     }
 
     pub(in crate::native_app) fn prioritize_path(
@@ -5807,7 +5811,7 @@ mod tests {
     }
 
     #[test]
-    fn explicit_reanalysis_cancels_current_work_and_prioritizes_the_source() {
+    fn explicit_reanalysis_cancels_current_work_without_implicit_priority() {
         let (_directory, source) = unhashed_source("explicit-reanalysis-request");
         let mut supervisor = SourceProcessingSupervisor::dormant();
         supervisor
@@ -5835,10 +5839,7 @@ mod tests {
                 .force_reanalysis_sources
                 .contains(source.id.as_str())
         );
-        assert_eq!(
-            control.priority.selected_source.as_deref(),
-            Some(source.id.as_str())
-        );
+        assert_eq!(control.priority.selected_source, None);
         assert!(
             !control.source_work_cancels[source.id.as_str()].load(Ordering::Acquire),
             "the replacement generation must be available for the reanalysis run"

--- a/src/native_app/tests/browser_context_menu.rs
+++ b/src/native_app/tests/browser_context_menu.rs
@@ -937,6 +937,15 @@ fn source_context_menu_processes_context_source_without_selecting_it() {
         first_source_id
     );
     assert_eq!(
+        state
+            .background
+            .source_processing
+            .selected_source_priority_for_tests()
+            .as_deref(),
+        Some(second_source_id.as_str()),
+        "explicit Process Source must promote its context source without changing UI selection"
+    );
+    assert_eq!(
         state.waveform.cache.active_folder_warm_folder_id.as_deref(),
         Some(second_root.path().to_string_lossy().as_ref())
     );

--- a/src/native_app/tests/metadata_tag_tests/input/persistence.rs
+++ b/src/native_app/tests/metadata_tag_tests/input/persistence.rs
@@ -102,7 +102,8 @@ fn source_prep_loads_persisted_metadata_tags_in_background() {
     let mut context = ui::UiUpdateContext::default();
 
     state.queue_selected_source_prep(
-        crate::native_app::sample_library::source_prep::SourcePrepTrigger::SourceSelected,
+        crate::native_app::sample_library::folder_browser_actions::SOURCE_SELECTION_PREP_INTENTS,
+        crate::native_app::sample_library::folder_browser_actions::SOURCE_SELECTION_PREP_REASON,
         &mut context,
     );
 

--- a/src/native_app/tests/sample_browser/similarity.rs
+++ b/src/native_app/tests/sample_browser/similarity.rs
@@ -612,7 +612,8 @@ fn source_selection_ui_path_does_not_directly_enqueue_heavy_readiness_work() {
     let mut context = radiant::prelude::UiUpdateContext::default();
 
     state.queue_selected_source_prep(
-        crate::native_app::sample_library::source_prep::SourcePrepTrigger::SourceSelected,
+        crate::native_app::sample_library::folder_browser_actions::SOURCE_SELECTION_PREP_INTENTS,
+        crate::native_app::sample_library::folder_browser_actions::SOURCE_SELECTION_PREP_REASON,
         &mut context,
     );
 


### PR DESCRIPTION
## Goal

Replace the event-shaped `SourcePrepTrigger` catch-all with explicit, orthogonal source-processing intents so each caller requests only the readiness, priority, projection, cache-warm, and feedback effects it owns.

Linear: OPT-1211

## Scope and non-goals

- Introduce explicit intents for readiness convergence/reanalysis, source priority, metadata refresh, waveform-cache projection refresh, cache warming, and user feedback.
- Migrate source selection, folder activation, verified startup, scan completion, filesystem sync, committed Wavecrate mutations, and explicit Process Source.
- Keep descriptive telemetry reasons separate from execution policy.
- Remove the supervisor's hidden `reanalysis => selected priority` coupling; explicit Process Source promotes its context source before waking reanalysis.
- Document the durable boundary in `docs/TARGET.md`.
- Preserve readiness convergence behavior, watcher/committed-mutation invalidation, status copy, and the existing cache design.
- Do not introduce a second Process Source pipeline or change readiness completeness rules.

## Definition of Done

- [x] `SourcePrepTrigger` and equivalent event catch-alls are absent.
- [x] Every production caller declares an explicit effect set adjacent to the call site.
- [x] Reason strings are descriptive only and never select behavior.
- [x] An exact-effects matrix covers source selection, folder activation, verified startup, scan completion, filesystem mutation, committed mutation, and explicit Process Source, including forbidden effects.
- [x] The source-processing supervisor remains the sole owner of convergence.
- [x] Process Source explicitly promotes its context source without changing UI selection.

## Validation

- `cargo test -p wavecrate --lib source_prep` — 4 passed.
- `cargo test -p wavecrate --lib explicit_reanalysis_cancels_current_work_without_implicit_priority` — 1 passed.
- `cargo test -p wavecrate --lib source_selection_ui_path_does_not_directly_enqueue_heavy_readiness_work` — 1 passed.
- `cargo test -p wavecrate --lib folder_activation_` — 2 passed.
- `cargo test -p wavecrate --lib source_filesystem_change_queues_refresh_without_clearing_loaded_tree` — 1 passed.
- `cargo test -p wavecrate --lib source_context_menu_processes_context_source_without_selecting_it` — 1 passed.
- `cargo test -p wavecrate --lib native_app::sample_library::committed_file_mutations::tests` — 14 passed.
- `cargo test -p wavecrate --bin wavecrate native_app::sample_library` — passed; 0 tests after native coverage moved to the library target.
- `cargo check -p wavecrate --tests --bins` — passed.
- `bash scripts/ci.sh smoke` — passed.
- `bash scripts/build.sh --release` — passed; fresh signed development app bundle produced.
- Exact-head real-app sandbox smoke — passed: source-a/source-b selection, explicit Process Source, and external watcher mutation (`external-2.wav`) all refreshed correctly.

## Known limitations

The broader `cargo test -p wavecrate --lib native_app::sample_library` baseline completed 406/408 tests. Two unchanged, unrelated tests fail on `origin/main`: `root_facade_exports_only_stable_entrypoints` (stale expected exports) and `starmap_projection_marks_cold_long_wavs_as_preview_candidates` (the short zero-byte fixture is also classified cold). Neither failing file is changed by this PR. The required project smoke gate passes.

User approval is required before merge.