### PR TITLE
Wavecrate: target architecture guardrail test binaries directly

### DIFF
--- a/scripts/internal/check/check_non_blocking_architecture.ps1
+++ b/scripts/internal/check/check_non_blocking_architecture.ps1
@@ -47,7 +47,7 @@ try {
   Enable-WavecrateCargoCache
 
   Invoke-NativeStep -Label "Radiant synthetic blocking-token fixture" -Command {
-    Invoke-WavecrateCargo test --manifest-path vendor/radiant/Cargo.toml guardrail_reports_file_line_and_guidance_for_blocking_tokens
+    Invoke-WavecrateCargo test --manifest-path vendor/radiant/Cargo.toml --lib guardrail_reports_file_line_and_guidance_for_blocking_tokens
   }
 
   Invoke-NativeStep -Label "Radiant app/runtime/example guardrails" -Command {
@@ -55,11 +55,11 @@ try {
   }
 
   Invoke-NativeStep -Label "Wavecrate app-facing blocking guardrail" -Command {
-    Invoke-WavecrateCargo test --package wavecrate --no-default-features native_app_ui_update_paths_do_not_call_blocking_business_apis
+    Invoke-WavecrateCargo test --package wavecrate --no-default-features --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis
   }
 
   Invoke-NativeStep -Label "Wavecrate strict slow-handler diagnostics harness" -Command {
-    Invoke-WavecrateCargo test --package wavecrate --no-default-features rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow
+    Invoke-WavecrateCargo test --package wavecrate --no-default-features --lib rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow
   }
 
   Invoke-NativeStep -Label "Wavecrate readiness persistence boundary" -Command {

--- a/scripts/internal/check/check_non_blocking_architecture.sh
+++ b/scripts/internal/check/check_non_blocking_architecture.sh
@@ -42,16 +42,16 @@ run_step() {
 }
 
 run_step "Radiant synthetic blocking-token fixture" \
-  cargo test --manifest-path vendor/radiant/Cargo.toml guardrail_reports_file_line_and_guidance_for_blocking_tokens
+  cargo test --manifest-path vendor/radiant/Cargo.toml --lib guardrail_reports_file_line_and_guidance_for_blocking_tokens
 
 run_step "Radiant app/runtime/example guardrails" \
   cargo test --manifest-path vendor/radiant/Cargo.toml --test generic_surface_guardrails source_quality::runtime::commands_and_app
 
 run_step "Wavecrate app-facing blocking guardrail" \
-  cargo test -p wavecrate --no-default-features native_app_ui_update_paths_do_not_call_blocking_business_apis
+  cargo test -p wavecrate --no-default-features --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis
 
 run_step "Wavecrate strict slow-handler diagnostics harness" \
-  cargo test -p wavecrate --no-default-features rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow
+  cargo test -p wavecrate --no-default-features --lib rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow
 
 run_step "Wavecrate readiness persistence boundary" \
   bash -c '

--- a/scripts/internal/data/validation_contract.json
+++ b/scripts/internal/data/validation_contract.json
@@ -93,6 +93,36 @@
         "fragment": "./scripts/check.sh non-blocking-architecture"
       },
       {
+        "label": "PowerShell architecture guardrail targets the Radiant library fixture",
+        "path": "scripts/internal/check/check_non_blocking_architecture.ps1",
+        "fragment": "test --manifest-path vendor/radiant/Cargo.toml --lib guardrail_reports_file_line_and_guidance_for_blocking_tokens"
+      },
+      {
+        "label": "Bash architecture guardrail targets the Radiant library fixture",
+        "path": "scripts/internal/check/check_non_blocking_architecture.sh",
+        "fragment": "test --manifest-path vendor/radiant/Cargo.toml --lib guardrail_reports_file_line_and_guidance_for_blocking_tokens"
+      },
+      {
+        "label": "PowerShell architecture guardrail targets the GUI boundary test",
+        "path": "scripts/internal/check/check_non_blocking_architecture.ps1",
+        "fragment": "test --package wavecrate --no-default-features --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis"
+      },
+      {
+        "label": "Bash architecture guardrail targets the GUI boundary test",
+        "path": "scripts/internal/check/check_non_blocking_architecture.sh",
+        "fragment": "test -p wavecrate --no-default-features --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis"
+      },
+      {
+        "label": "PowerShell architecture guardrail targets the Wavecrate library harness",
+        "path": "scripts/internal/check/check_non_blocking_architecture.ps1",
+        "fragment": "test --package wavecrate --no-default-features --lib rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow"
+      },
+      {
+        "label": "Bash architecture guardrail targets the Wavecrate library harness",
+        "path": "scripts/internal/check/check_non_blocking_architecture.sh",
+        "fragment": "test -p wavecrate --no-default-features --lib rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow"
+      },
+      {
         "label": "PowerShell ci agent requires readiness executor boundary guardrails",
         "path": "scripts/internal/ci/ci_agent.ps1",
         "fragment": "scripts/check.ps1\") readiness-executor-boundary"


### PR DESCRIPTION
## Goal

Make the required non-blocking architecture lane launch only the Cargo test targets that own its focused assertions.

Linear: OPT-1218

## Scope and non-goals

- Target the Radiant synthetic fixture with `--lib`.
- Target the Wavecrate app-facing assertion with `--test gui_boundary`.
- Target the Wavecrate slow-handler assertion with `--lib`.
- Preserve `--no-default-features`, failure behavior, static architecture scans, CI wiring, and Bash/PowerShell parity.
- Pin all six Bash/PowerShell selector fragments in the existing deterministic script guardrail contract.
- Do not change production architecture, allowlists, Cargo caching, or broader preflight ownership.

The issue suggested `--bin wavecrate` for the slow-handler test, but current target enumeration proves that binary runs zero matching tests. The test is owned by Wavecrate's library target, so this PR uses `--lib` to preserve the intended assertion.

## Definition of Done

- [x] Each focused command launches exactly one owning test binary.
- [x] Each intended test executes exactly once.
- [x] Deterministic script coverage requires the selectors in both Bash and PowerShell.
- [x] A synthetic blocking violation still fails the targeted lane with precise diagnostics.
- [x] Warm-build evidence shows materially fewer launched binaries and lower wall time.
- [x] The architecture and script guardrail lanes pass.
- [x] The full agent lane result is calibrated against detached `main`.

## Validation

Exact commit: `92bdd66bf8bfb628be8dc14b38d68d9d963892a5`

- `cargo test --manifest-path vendor/radiant/Cargo.toml --lib guardrail_reports_file_line_and_guidance_for_blocking_tokens` — one binary, one test passed.
- `cargo test -p wavecrate --no-default-features --test gui_boundary native_app_ui_update_paths_do_not_call_blocking_business_apis` — one binary, one test passed.
- `cargo test -p wavecrate --no-default-features --lib rapid_navigation_harness_keeps_ui_responsive_while_business_work_is_slow` — one binary, one test passed.
- Temporary synthetic `std::thread::sleep` in a scanned native-app file — targeted GUI command exited 101 and reported the exact file, line, token, and offloading guidance; fixture removed afterward.
- `bash scripts/internal/check/check_non_blocking_architecture.sh` — passed; four total intended test binaries launched.
- `bash scripts/internal/check/check_script_guardrails.sh` — passed, including all six new selector assertions.
- `bash scripts/ci.sh agent` — optimized architecture lane, 1,650 Radiant library tests, 50 Radiant runtime API tests, and five legacy-controller integration tests passed. The Wavecrate library phase then reproduced the current baseline result: 3,692 passed, 51 failed, 23 ignored.
- Detached `main` ran the exact same Wavecrate library command and reproduced exactly 3,692 passed, 51 failed, and 23 ignored, confirming those failures are independent of this script-only diff.

Warm architecture-lane comparison on the same build artifacts:

| | Before | After | Change |
| --- | ---: | ---: | ---: |
| Launched test binaries | 41 | 4 | -90.2% |
| Wall time | 1.45 s | 1.17 s | -19.3% |

## Known limitations

- PowerShell was not installed on this macOS host, so PowerShell parity is enforced by the same deterministic required-fragment contract rather than a local PowerShell execution.
- The unrelated 51-test Wavecrate library baseline remains outside this PR.

User approval is required before merge.
