### PR TITLE
OPT-1188: Load Starmap during playback

### DIFF
--- a/src/native_app/shell/message_dispatch/frame.rs
+++ b/src/native_app/shell/message_dispatch/frame.rs
@@ -26,6 +26,7 @@ impl NativeAppState {
         let revision_guard = self.begin_frame_surface_revision_tracking();
         if self.playback_visual_activity_active() {
             self.pause_background_work_for_playback_frame();
+            self.maybe_start_starmap_layout_load(context);
             self.flush_pending_play_selection_playback_retarget();
             self.advance_frame(context);
             self.finish_frame_surface_revision_tracking(revision_guard);

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -275,6 +275,40 @@ fn idle_map_frame_reuses_prepared_sample_browser_projection() {
 }
 
 #[test]
+fn playback_frame_starts_pending_starmap_layout_load() {
+    let root = tempfile::tempdir().expect("source root");
+    let sample = root.path().join("playing-map-load.wav");
+    fs::write(&sample, [0_u8; 8]).expect("write sample");
+    let sample_id = sample.to_string_lossy().into_owned();
+    let mut state = NativeAppStateFixture::default()
+        .with_folder_browser(FolderBrowserState::from_root(root.path().to_path_buf()))
+        .build();
+    state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    prepare_sample_browser_view(&mut state);
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_id,
+        "loaded_sample",
+    );
+    assert!(state.playback_visual_activity_active());
+    let mut context = ui::UiUpdateContext::default();
+
+    state.handle_message(GuiMessage::Frame, &mut context);
+
+    assert!(
+        state.playback_visual_activity_active(),
+        "loading the starmap must not interrupt active playback"
+    );
+    assert_eq!(
+        context
+            .into_command()
+            .business_task_priority("gui-starmap-layout-load"),
+        Some(ui::TaskPriority::Idle),
+        "opening the starmap during playback must not defer its layout until transport stops"
+    );
+}
+
+#[test]
 fn map_frame_rebuilds_projection_when_copy_flash_expires() {
     let (_root, mut state, sample_id) = prepared_map_state("copy-flash-map-frame.wav");
     state


### PR DESCRIPTION
## Goal

Make Starmap layout loading start while sample playback remains active, instead of waiting for transport to stop.

## Scope

- Admit pending Starmap layout loads in the playback-frame path.
- Keep the existing playback-frame pauses for waveform cache warming, active-folder warming, and preview-audition warming.
- Add regression coverage proving the layout task is queued and playback remains active.

## Non-goals

- Change Starmap layout computation or database queries.
- Change playback, preview warming, or worker-priority policy.
- Change Starmap rendering or interaction behavior.

## Definition of Done

- Opening Starmap during active playback queues the existing off-UI layout load.
- Active playback is not interrupted.
- Opportunistic preview warming remains paused during playback.
- Focused regression coverage passes.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo test --lib playback_frame_starts_pending_starmap_layout_load -- --nocapture`
- `cargo test --lib native_app::shell::message_dispatch::tests:: -- --nocapture` (10 passed)
- `cargo test --lib native_app::tests::sample_browser::starmap_mode_frame_does_not_warm_preview_audition_heads_while_playback_active -- --exact --nocapture`
- `cargo check -p wavecrate --lib`

Known unrelated repository baseline failures:

- `bash scripts/agent.sh request` reaches and passes the non-blocking architecture checks, then fails the existing Wavecrate facade baseline.
- `cargo check --workspace --all-targets` fails existing warnings in `vendor/radiant/examples/popup_window`.
- `cargo test --lib starmap -- --nocapture` passes 155 tests, including this regression, with the existing `starmap_projection_marks_cold_long_wavs_as_preview_candidates` assertion failing in isolation as well.

## Known limitations

None.

User approval is required before merge.

Linear: [OPT-1188](https://linear.app/boostnlvp/issue/OPT-1188/the-starmap-wont-load-until-i-stop-playback-lets-fix-that)
