### PR TITLE
OPT-1189: Disallow trimming samples in protected sources

### DIFF
--- a/src/native_app/tests/waveform_destructive_edit_tests.rs
+++ b/src/native_app/tests/waveform_destructive_edit_tests.rs
@@ -1007,9 +1007,7 @@ fn normal_harvest_mode_reverse_selection_renders_reverse_copy_to_primary_without
 }
 
 #[test]
-fn protected_trim_selection_renders_trim_copy_to_primary_without_mutating_origin() {
-    let config_base = tempfile::tempdir().expect("config base");
-    let _base_guard = wavecrate::app_dirs::ConfigBaseGuard::set(config_base.path().to_path_buf());
+fn protected_trim_selection_is_denied_with_red_feedback_even_with_primary_source() {
     let (mut state, source_root, selected_file) =
         native_app_state_with_temp_sample("protected-trim.wav");
     let primary_root = tempfile::tempdir().expect("primary source root");
@@ -1045,7 +1043,10 @@ fn protected_trim_selection_renders_trim_copy_to_primary_without_mutating_origin
     let mut context = ui::UiUpdateContext::default();
 
     state.apply_message(GuiMessage::RequestTrimWaveformSelection, &mut context);
-    run_command_for_tests(&mut state, context.into_command());
+    assert!(
+        context.into_command().is_empty(),
+        "denied trim must not queue background file work"
+    );
 
     assert_samples_close(
         &read_test_wav_f32(&path),
@@ -1053,39 +1054,36 @@ fn protected_trim_selection_renders_trim_copy_to_primary_without_mutating_origin
             0.0, 1_000.0, 2_000.0, 3_000.0, 4_000.0, 5_000.0, 6_000.0, 7_000.0,
         ],
     );
-    assert_samples_close(
-        &read_test_wav_f32(&trim_copy),
-        &[0.0, 1_000.0, 6_000.0, 7_000.0],
-    );
+    assert!(!trim_copy.exists(), "denied trim must not create a copy");
     assert_eq!(
         state.library.folder_browser.selected_file_id(),
-        Some(trim_copy.to_string_lossy().as_ref())
+        Some(selected_file.as_str())
     );
-    let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
-        protected_source.id.clone(),
-        PathBuf::from("protected-trim.wav"),
+    assert!(
+        state
+            .ui
+            .browser_interaction
+            .pending_waveform_destructive_edit
+            .is_none()
     );
-    let parent = wavecrate::sample_sources::library::harvest_file(&parent_key)
-        .expect("load harvest parent")
-        .expect("harvest parent");
     assert_eq!(
-        parent.state,
-        wavecrate::sample_sources::HarvestState::Touched
+        state.ui.status.sample,
+        "Protected source cannot be modified"
     );
-    let edges = wavecrate::sample_sources::library::harvest_derivations_for_parent(&parent_key)
-        .expect("load harvest derivations");
-    assert_eq!(edges.len(), 1);
-    assert_eq!(
-        edges[0].operation,
-        wavecrate::sample_sources::HarvestDerivationOperation::TrimCopy
+    assert!(
+        state.waveform.current.play_selection_denied_flash_frames() > 0,
+        "the denied play selection should start its red pulse"
     );
-    assert_eq!(edges[0].child.key.source_id, primary_source.id);
-    assert_eq!(
-        edges[0].child.key.relative_path,
-        PathBuf::from("_Harvests")
-            .join(harvest_source_folder)
-            .join("protected-trim_trim.wav")
+    assert!(
+        state
+            .library
+            .folder_browser
+            .protected_source_error_flash_frames()
+            > 0,
+        "the protected source and file rows should start their red pulse"
     );
+    assert!(state.waveform.current.protected_source_error_flash_frames() > 0);
+    assert_protected_source_error_projected(&state, &selected_file, &protected_source.id);
 }
 
 #[test]

--- a/src/native_app/waveform_edits/entrypoints.rs
+++ b/src/native_app/waveform_edits/entrypoints.rs
@@ -161,6 +161,9 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
+        if self.reject_protected_trim_request(kind, target) {
+            return;
+        }
         if let Some(harvest_operation) = harvest_whole_file_copy_operation(kind) {
             match self.queue_harvest_whole_file_copy_edit_request(
                 kind,
@@ -223,6 +226,36 @@ impl NativeAppState {
         self.ui
             .browser_interaction
             .pending_waveform_destructive_edit = Some(request);
+    }
+
+    fn reject_protected_trim_request(
+        &mut self,
+        kind: WaveformDestructiveEditKind,
+        target: WaveformDestructiveEditTarget,
+    ) -> bool {
+        if kind != WaveformDestructiveEditKind::TrimSelection {
+            return false;
+        }
+        let Ok((path, _)) = self.destructive_edit_target_for_kind(kind, target) else {
+            return false;
+        };
+        if !self
+            .library
+            .folder_browser
+            .path_is_in_protected_source(&path)
+        {
+            return false;
+        }
+        let Some(error) = self
+            .library
+            .folder_browser
+            .file_change_lock_error(&path, kind.action_label())
+        else {
+            return false;
+        };
+        self.flash_denied_destructive_selection_for_error(&error, kind, target);
+        self.ui.status.sample = self.denied_destructive_edit_status(&error, kind, target);
+        true
     }
 
     pub(super) fn destructive_edit_target_for_kind(


### PR DESCRIPTION
## Goal

Prevent direct Trim actions from operating on samples in protected sources, and give immediate red denial feedback.

## Scope and non-goals

- Reject protected-source Trim before harvest-copy routing, even when a Primary source exists.
- Reuse the existing protected-source status and red pulse feedback for the waveform selection, waveform surface, sample row, and source row.
- Keep writable-source trimming, normal harvest-mode copy edits, and protected-source extraction/other copy-edit behavior unchanged.
- No Radiant or persistence changes.

## Definition of Done

- Protected-source Trim queues no destructive prompt or background file work.
- The protected source sample and any potential derivative remain unchanged.
- The UI reports that the protected source cannot be modified.
- The selected range and protected-source surfaces start their red denial pulse.
- Writable-source Trim behavior remains covered by the existing suite.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test --lib protected_trim_selection_is_denied_with_red_feedback_even_with_primary_source` — passed
- `cargo test --lib edit_selection_denied_flash_paints_red_twice` — passed
- `cargo test --lib protected_source_error_flash_paints_waveform_error_overlay` — passed
- `git diff --check` — passed
- `bash scripts/build.sh --release` — passed; built signed `Wavecrate OPT-1189.app`
- Isolated live-app smoke — passed: protected source + loaded WAV + marked range + `D` produced “Protected source cannot be modified”, preserved the selection, opened no prompt, created no derivative, and kept the WAV SHA-256 at `314bac979bff648c0c8b61e04b7b092dc90d1029d887bd6add3c03fa4d2698e0`.
- `bash scripts/ci.sh agent` — not green in this environment: 3,695 passed / 51 failed across unrelated global-state/source-cache/config/status tests; the OPT-1189 regression passed in that same run.

## Known limitations

The repository agent gate currently has the 51 unrelated failures listed above; focused behavior and live runtime validation are green.

User approval is required before merge.

Linear: [OPT-1189](https://linear.app/boostnlvp/issue/OPT-1189/disallow-trimming-for-samples-in-protected-sources-add-red-blinking)