### PR TITLE
Show session-local played waveform ranges

### DIFF
--- a/crates/reson/src/lib.rs
+++ b/crates/reson/src/lib.rs
@@ -53,7 +53,9 @@ pub(crate) use routing::normalized_progress;
 pub(crate) use source::OutputAdapter;
 pub use source::{SamplesBuffer, Source};
 
-pub(crate) const DEFAULT_ANTI_CLIP_FADE: Duration = Duration::from_millis(2);
+// Keep the anti-click envelope short enough to preserve sharp audition
+// transients while still smoothing abrupt source starts and stops.
+pub(crate) const DEFAULT_ANTI_CLIP_FADE: Duration = Duration::from_millis(3);
 
 #[cfg(test)]
 mod tests;

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -500,7 +500,14 @@ Regions may be used for auditioning, looping, extraction, editing, markers, or v
 While a sample remains loaded, the waveform should accumulate the portions that
 were actually auditioned and show them as a subtle thick rail along the bottom
 edge. This played-range history is session-local to that loaded waveform, resets
-when another sample is loaded, and is not persisted as sample metadata.
+when another sample is loaded, and is not persisted as sample metadata. The rail
+should advance on paint-only playback frames, use a subdued neutral grey, and
+begin at the sample's actual playback start. Supported WAV navigation should
+stream the original file from frame zero as one continuous runtime source, so
+the waveform can attach to that source without replay, estimated seek offsets,
+or an audition-to-full-source splice. Rapid navigation should replace sources
+through a minimal three-millisecond crossfade rather than clearing the outgoing
+source at an arbitrary sample, preserving sharp transients without hard cuts.
 
 ### Play Selection
 

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -497,6 +497,11 @@ A region is a marked time range inside an audio file.
 
 Regions may be used for auditioning, looping, extraction, editing, markers, or visual history. Regions should be visually clear in the waveform view and should support precise boundary adjustment.
 
+While a sample remains loaded, the waveform should accumulate the portions that
+were actually auditioned and show them as a subtle thick rail along the bottom
+edge. This played-range history is session-local to that loaded waveform, resets
+when another sample is loaded, and is not persisted as sample metadata.
+
 ### Play Selection
 
 A play selection is a waveform range used for auditioning and looping.

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -37,19 +37,20 @@ pub(in crate::native_app) use state::DEFAULT_VOLUME;
 pub(in crate::native_app) use state::ReleaseUpdateStatus;
 pub(in crate::native_app) use state::{
     AudioAppState, AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,
-    ChromeUiState, ClipboardHandoffTarget, CutFileClipboard, ExtractedFilePlaybackType,
-    FolderScanWorkerEvent, LibraryAppState, MAX_BEAT_GUIDE_COUNT, MIN_BEAT_GUIDE_COUNT,
-    MetadataAppState, NativeAppState, PendingFolderDelete, PendingPlaySelectionRetargetCycle,
-    PendingPlaybackStart, PendingProtectedExtractionAction, PendingProtectedExtractionTargetSource,
-    PendingWaveformDestructiveEdit, PlaybackSpanRetargetRejection, SampleBrowserDisplayMode,
-    SamplePlaybackHistory, SamplePlaybackIntent, SamplePlaybackNormalization,
-    SamplePlaybackRequest, SamplePlaybackSession, SamplePlaybackSessionState,
-    SamplePlaybackSourceProbe, SamplePlaybackVisibility, SettingsAppState,
-    SourceFilesystemChangePlan, SourceRefreshRequest, SourceScanFinish, SourceSelectionRequest,
-    StarmapAuditionDragState, StarmapViewport, StarmapViewportChange, StartupState, StatusState,
-    UiAppState, WaveformAppState, WaveformDestructiveEditKind, WaveformDestructiveEditPrompt,
-    WaveformDestructiveEditTarget, WaveformDestructiveEditUiContext, WaveformEditSelectionSnapshot,
-    WaveformPlaySelectionSnapshot, WaveformVisualSnapshot, run_folder_scan_worker,
+    ChromeUiState, ClipboardHandoffTarget, CompletedTransientSamplePlayback, CutFileClipboard,
+    ExtractedFilePlaybackType, FolderScanWorkerEvent, LibraryAppState, MAX_BEAT_GUIDE_COUNT,
+    MIN_BEAT_GUIDE_COUNT, MetadataAppState, NativeAppState, PendingFolderDelete,
+    PendingPlaySelectionRetargetCycle, PendingPlaybackStart, PendingProtectedExtractionAction,
+    PendingProtectedExtractionTargetSource, PendingWaveformDestructiveEdit,
+    PlaybackSpanRetargetRejection, SampleBrowserDisplayMode, SamplePlaybackHistory,
+    SamplePlaybackIntent, SamplePlaybackNormalization, SamplePlaybackRequest,
+    SamplePlaybackSession, SamplePlaybackSessionState, SamplePlaybackSourceProbe,
+    SamplePlaybackVisibility, SettingsAppState, SourceFilesystemChangePlan, SourceRefreshRequest,
+    SourceScanFinish, SourceSelectionRequest, StarmapAuditionDragState, StarmapViewport,
+    StarmapViewportChange, StartupState, StatusState, UiAppState, WaveformAppState,
+    WaveformDestructiveEditKind, WaveformDestructiveEditPrompt, WaveformDestructiveEditTarget,
+    WaveformDestructiveEditUiContext, WaveformEditSelectionSnapshot, WaveformPlaySelectionSnapshot,
+    WaveformVisualSnapshot, run_folder_scan_worker,
 };
 
 pub(super) use crate::native_app::app_chrome::scene::view;

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -51,6 +51,8 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
     pub(in crate::native_app) playback_visual_progress: Option<PlaybackVisualProgress>,
     pub(in crate::native_app) pending_playback_progress_polls: HashSet<u64>,
+    pub(in crate::native_app) completed_transient_playback:
+        Option<CompletedTransientSamplePlayback>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -229,6 +231,13 @@ pub(in crate::native_app) struct SamplePlaybackSession {
     span_retarget: PlaybackSpanRetargetState,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(in crate::native_app) struct CompletedTransientSamplePlayback {
+    pub(in crate::native_app) path: String,
+    pub(in crate::native_app) source_kind: &'static str,
+    pub(in crate::native_app) progress: f32,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::native_app) struct PendingPlaybackStart {
     pub(in crate::native_app) intent: PlaybackIntent,
@@ -281,6 +290,7 @@ impl AudioAppState {
             playback_progress: PlaybackRuntimeProgress::default(),
             playback_visual_progress: None,
             pending_playback_progress_polls: HashSet::new(),
+            completed_transient_playback: None,
         }
     }
 
@@ -296,6 +306,7 @@ impl AudioAppState {
         source_kind: &'static str,
     ) -> u64 {
         self.clear_playback_progress();
+        self.completed_transient_playback = None;
         let generation = self.next_sample_playback_generation;
         self.next_sample_playback_generation = self
             .next_sample_playback_generation
@@ -322,6 +333,7 @@ impl AudioAppState {
         source_kind: &'static str,
     ) -> u64 {
         self.clear_playback_progress();
+        self.completed_transient_playback = None;
         let generation = self.next_sample_playback_generation;
         self.next_sample_playback_generation = self
             .next_sample_playback_generation
@@ -343,6 +355,25 @@ impl AudioAppState {
 
     pub(in crate::native_app) fn clear_sample_playback_session(&mut self) {
         self.sample_playback_session = None;
+        self.completed_transient_playback = None;
+    }
+
+    pub(in crate::native_app) fn take_completed_streamable_sample_playback(
+        &mut self,
+        path: &str,
+    ) -> Option<f32> {
+        let matches = self
+            .completed_transient_playback
+            .as_ref()
+            .is_some_and(|completed| {
+                completed.path == path && completed.source_kind != "preview_samples"
+            });
+        matches.then(|| {
+            self.completed_transient_playback
+                .take()
+                .expect("matching completed transient playback")
+                .progress
+        })
     }
 
     pub(in crate::native_app) fn active_sample_playback_path(&self) -> Option<&str> {

--- a/src/native_app/app/state/audio.rs
+++ b/src/native_app/app/state/audio.rs
@@ -1,4 +1,8 @@
-use std::{sync::mpsc::Receiver, time::Instant};
+use std::{
+    collections::HashSet,
+    sync::mpsc::Receiver,
+    time::{Duration, Instant},
+};
 
 use wavecrate::audio::{
     AudioDeviceSummary, AudioHostSummary, AudioOutputConfig, AudioPlayer, PlaybackRequestId,
@@ -46,6 +50,7 @@ pub(in crate::native_app) struct AudioAppState {
     pub(in crate::native_app) playback_events: Option<Receiver<PlaybackRuntimeEvent>>,
     pub(in crate::native_app) playback_progress: PlaybackRuntimeProgress,
     pub(in crate::native_app) playback_visual_progress: Option<PlaybackVisualProgress>,
+    pub(in crate::native_app) pending_playback_progress_polls: HashSet<u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -219,6 +224,7 @@ pub(in crate::native_app) struct SamplePlaybackSession {
     pub(in crate::native_app) runtime_request_id: Option<u64>,
     pub(in crate::native_app) source_kind: &'static str,
     pub(in crate::native_app) submitted_at: Instant,
+    pub(in crate::native_app) audible_started_at: Option<Instant>,
     pub(in crate::native_app) state: SamplePlaybackSessionState,
     span_retarget: PlaybackSpanRetargetState,
 }
@@ -274,6 +280,7 @@ impl AudioAppState {
             playback_events: None,
             playback_progress: PlaybackRuntimeProgress::default(),
             playback_visual_progress: None,
+            pending_playback_progress_polls: HashSet::new(),
         }
     }
 
@@ -288,6 +295,7 @@ impl AudioAppState {
         runtime_request_id: PlaybackRequestId,
         source_kind: &'static str,
     ) -> u64 {
+        self.clear_playback_progress();
         let generation = self.next_sample_playback_generation;
         self.next_sample_playback_generation = self
             .next_sample_playback_generation
@@ -300,6 +308,7 @@ impl AudioAppState {
             runtime_request_id: Some(runtime_request_id.get()),
             source_kind,
             submitted_at: Instant::now(),
+            audible_started_at: None,
             state: SamplePlaybackSessionState::RuntimePending,
             span_retarget: PlaybackSpanRetargetState::new(confirmed_span),
         });
@@ -312,6 +321,7 @@ impl AudioAppState {
         request: SamplePlaybackRequest,
         source_kind: &'static str,
     ) -> u64 {
+        self.clear_playback_progress();
         let generation = self.next_sample_playback_generation;
         self.next_sample_playback_generation = self
             .next_sample_playback_generation
@@ -324,6 +334,7 @@ impl AudioAppState {
             runtime_request_id: None,
             source_kind,
             submitted_at: Instant::now(),
+            audible_started_at: None,
             state: SamplePlaybackSessionState::ResolvingSource,
             span_retarget: PlaybackSpanRetargetState::new(confirmed_span),
         });
@@ -358,6 +369,41 @@ impl AudioAppState {
             .is_some_and(|session| {
                 session.request.path == path && session.source_kind != "preview_samples"
             })
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_progress(
+        &self,
+        path: &str,
+    ) -> Option<&PlaybackRuntimeProgress> {
+        self.sample_playback_session
+            .as_ref()
+            .filter(|session| {
+                session.request.path == path
+                    && matches!(
+                        session.state,
+                        SamplePlaybackSessionState::AudibleTransient
+                            | SamplePlaybackSessionState::WaveformVisible
+                    )
+            })
+            .map(|_| &self.playback_progress)
+    }
+
+    pub(in crate::native_app) fn active_sample_playback_audible_elapsed(
+        &self,
+        path: &str,
+    ) -> Option<Duration> {
+        self.sample_playback_session
+            .as_ref()
+            .filter(|session| {
+                session.request.path == path
+                    && matches!(
+                        session.state,
+                        SamplePlaybackSessionState::AudibleTransient
+                            | SamplePlaybackSessionState::WaveformVisible
+                    )
+            })
+            .and_then(|session| session.audible_started_at)
+            .map(|started_at| started_at.elapsed())
     }
 
     pub(in crate::native_app) fn active_sample_playback_updates_waveform(

--- a/src/native_app/app/state/audio/span_retarget.rs
+++ b/src/native_app/app/state/audio/span_retarget.rs
@@ -113,14 +113,17 @@ impl AudioAppState {
             || session.source_kind == "preview_samples"
             || !matches!(
                 session.state,
-                SamplePlaybackSessionState::AudibleTransient
+                SamplePlaybackSessionState::RuntimePending
+                    | SamplePlaybackSessionState::AudibleTransient
                     | SamplePlaybackSessionState::WaveformVisible
             )
         {
             return false;
         }
         session.request.visibility = SamplePlaybackVisibility::Waveform;
-        session.state = SamplePlaybackSessionState::WaveformVisible;
+        if !matches!(session.state, SamplePlaybackSessionState::RuntimePending) {
+            session.state = SamplePlaybackSessionState::WaveformVisible;
+        }
         true
     }
 

--- a/src/native_app/app/state/audio/span_retarget.rs
+++ b/src/native_app/app/state/audio/span_retarget.rs
@@ -54,14 +54,7 @@ impl SamplePlaybackSession {
         self.span_retarget.confirmed_span
     }
 
-    pub(in crate::native_app) fn confirm_span_retarget(
-        &mut self,
-        request_id: PlaybackRequestId,
-    ) -> bool {
-        self.confirm_span_retarget_id(request_id.get())
-    }
-
-    pub(super) fn confirm_span_retarget_id(&mut self, request_id: u64) -> bool {
+    pub(in crate::native_app) fn confirm_span_retarget_id(&mut self, request_id: u64) -> bool {
         let Some(index) = self
             .span_retarget
             .pending
@@ -116,7 +109,14 @@ impl AudioAppState {
         let Some(session) = self.sample_playback_session.as_mut() else {
             return false;
         };
-        if session.request.path != path || session.source_kind == "preview_samples" {
+        if session.request.path != path
+            || session.source_kind == "preview_samples"
+            || !matches!(
+                session.state,
+                SamplePlaybackSessionState::AudibleTransient
+                    | SamplePlaybackSessionState::WaveformVisible
+            )
+        {
             return false;
         }
         session.request.visibility = SamplePlaybackVisibility::Waveform;
@@ -171,6 +171,7 @@ mod tests {
             runtime_request_id: None,
             source_kind: "decoded_samples",
             submitted_at: Instant::now(),
+            audible_started_at: None,
             state: SamplePlaybackSessionState::RuntimePending,
             span_retarget: PlaybackSpanRetargetState::new(span),
         }

--- a/src/native_app/app/state/audio/visual_progress.rs
+++ b/src/native_app/app/state/audio/visual_progress.rs
@@ -42,6 +42,7 @@ impl AudioAppState {
     pub(in crate::native_app) fn clear_playback_progress(&mut self) {
         self.playback_progress = PlaybackRuntimeProgress::default();
         self.playback_visual_progress = None;
+        self.pending_playback_progress_polls.clear();
     }
 
     pub(in crate::native_app) fn reset_playback_visual_progress(

--- a/src/native_app/app/state/mod.rs
+++ b/src/native_app/app/state/mod.rs
@@ -13,10 +13,10 @@ mod waveform;
 pub(in crate::native_app) const DEFAULT_VOLUME: f32 = 1.0;
 
 pub(in crate::native_app) use audio::{
-    AudioAppState, PendingPlaybackStart, PlaybackSpanRetargetRejection, SamplePlaybackHistory,
-    SamplePlaybackIntent, SamplePlaybackNormalization, SamplePlaybackRequest,
-    SamplePlaybackSession, SamplePlaybackSessionState, SamplePlaybackSourceProbe,
-    SamplePlaybackVisibility,
+    AudioAppState, CompletedTransientSamplePlayback, PendingPlaybackStart,
+    PlaybackSpanRetargetRejection, SamplePlaybackHistory, SamplePlaybackIntent,
+    SamplePlaybackNormalization, SamplePlaybackRequest, SamplePlaybackSession,
+    SamplePlaybackSessionState, SamplePlaybackSourceProbe, SamplePlaybackVisibility,
 };
 pub(in crate::native_app) use background::{
     AudioOpenCompletion, AudioOpenTaskCompletion, BackgroundTaskState,

--- a/src/native_app/audio/playback/diagnostics.rs
+++ b/src/native_app/audio/playback/diagnostics.rs
@@ -37,6 +37,7 @@ pub(in crate::native_app) struct PlayheadFrameMessageDiagnostics {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum PlayheadProgressSource {
     InterpolatedVisualProgress,
+    PreviewAuditionProgress,
     WaveformPlayheadFallback,
 }
 
@@ -44,6 +45,7 @@ impl PlayheadProgressSource {
     pub(in crate::native_app) fn label(self) -> &'static str {
         match self {
             Self::InterpolatedVisualProgress => "interpolated_visual_progress",
+            Self::PreviewAuditionProgress => "preview_audition_progress",
             Self::WaveformPlayheadFallback => "waveform_playhead_fallback",
         }
     }

--- a/src/native_app/audio/playback/execution.rs
+++ b/src/native_app/audio/playback/execution.rs
@@ -239,7 +239,17 @@ impl NativeAppState {
             PlaybackMode::Looped { offset_ratio } => offset_ratio,
             PlaybackMode::OneShot => command.resolved.start_ratio,
         };
-        if command.intent.show_start_marker {
+        let preserves_existing_marker = self.waveform.current.is_playing()
+            && self
+                .waveform
+                .current
+                .playhead_ratio()
+                .is_some_and(|ratio| (ratio - playback_start).abs() <= 0.000_1);
+        if preserves_existing_marker {
+            self.waveform
+                .current
+                .restart_playback_preserving_marker(playback_start);
+        } else if command.intent.show_start_marker {
             self.waveform.current.start_playback(playback_start);
         } else {
             self.waveform

--- a/src/native_app/audio/playback/progress/events.rs
+++ b/src/native_app/audio/playback/progress/events.rs
@@ -135,7 +135,7 @@ impl NativeAppState {
         );
     }
 
-    fn finish_runtime_playback_started_parts(
+    pub(in crate::native_app) fn finish_runtime_playback_started_parts(
         &mut self,
         request_id: u64,
         output: ResolvedOutput,

--- a/src/native_app/audio/playback/progress/events.rs
+++ b/src/native_app/audio/playback/progress/events.rs
@@ -69,18 +69,48 @@ impl NativeAppState {
             }
             PlaybackRuntimeEvent::Stopped { .. } => {}
             PlaybackRuntimeEvent::Progress { id, progress } => {
-                let confirmed_retarget = self
-                    .audio
-                    .sample_playback_session
-                    .as_mut()
-                    .is_some_and(|session| session.confirm_span_retarget(id));
-                if confirmed_retarget {
-                    self.apply_authoritative_runtime_playback_progress(progress);
-                } else {
-                    self.apply_runtime_playback_progress(progress);
-                }
+                self.apply_runtime_playback_progress_for_request(id.get(), progress);
             }
         }
+    }
+
+    fn apply_runtime_playback_progress_for_request(
+        &mut self,
+        request_id: u64,
+        progress: PlaybackRuntimeProgress,
+    ) {
+        if self
+            .audio
+            .pending_playback_progress_polls
+            .remove(&request_id)
+        {
+            self.apply_runtime_playback_progress(progress);
+            return;
+        }
+        let confirmed_retarget =
+            self.audio
+                .sample_playback_session
+                .as_mut()
+                .is_some_and(|session| {
+                    if !session.confirm_span_retarget_id(request_id) {
+                        return false;
+                    }
+                    session.runtime_request_id = Some(request_id);
+                    true
+                });
+        if confirmed_retarget {
+            self.apply_authoritative_runtime_playback_progress(progress);
+            return;
+        }
+        if self
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .is_some_and(|session| session.runtime_request_id != Some(request_id))
+        {
+            return;
+        }
+        self.apply_runtime_playback_progress(progress);
     }
 
     pub(super) fn apply_runtime_playback_progress(&mut self, progress: PlaybackRuntimeProgress) {
@@ -140,6 +170,7 @@ impl NativeAppState {
         } else {
             SamplePlaybackSessionState::AudibleTransient
         };
+        session.audible_started_at = Some(std::time::Instant::now());
         let path = session.request.path.clone();
         let span = session.request.span;
         let show_start_marker = session.request.show_start_marker;
@@ -165,7 +196,17 @@ impl NativeAppState {
             && !preserves_live_retarget
             && self.waveform.current.path() == Path::new(&path)
         {
-            if show_start_marker {
+            let preserves_existing_marker = self.waveform.current.is_playing()
+                && self
+                    .waveform
+                    .current
+                    .playhead_ratio()
+                    .is_some_and(|ratio| (ratio - playback_start).abs() <= 0.000_1);
+            if preserves_existing_marker {
+                self.waveform
+                    .current
+                    .restart_playback_preserving_marker(playback_start);
+            } else if show_start_marker {
                 self.waveform.current.start_playback(playback_start);
             } else {
                 self.waveform

--- a/src/native_app/audio/playback/progress/events_tests.rs
+++ b/src/native_app/audio/playback/progress/events_tests.rs
@@ -108,3 +108,158 @@ fn confirmed_retarget_reanchors_visual_progress_to_the_audible_span() {
     assert_eq!(clock.span, Some((0.20, 0.80)));
     assert_eq!(clock.anchor_ratio, 0.55);
 }
+
+#[test]
+fn stale_progress_event_cannot_replace_the_active_requests_progress() {
+    let path = PathBuf::from("request-fenced-progress.wav");
+    let file =
+        test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
+    let mut state = NativeAppStateFixture::default().build();
+    state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+    let request = SamplePlaybackRequest::waveform(
+        path.display().to_string(),
+        (0.0, 1.0),
+        SamplePlaybackIntent::WaveformSpan,
+        "waveform",
+        SamplePlaybackHistory::Record,
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "decoded_samples");
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("sample playback session");
+    session.runtime_request_id = Some(22);
+    session.state = SamplePlaybackSessionState::WaveformVisible;
+    state.audio.set_playback_progress(PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(Duration::from_millis(40)),
+        looping: false,
+        progress: Some(0.1),
+        error: None,
+    });
+
+    state.apply_runtime_playback_progress_for_request(
+        21,
+        PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_secs(1)),
+            looping: false,
+            progress: Some(0.9),
+            error: None,
+        },
+    );
+
+    assert_eq!(state.audio.playback_progress.progress, Some(0.1));
+}
+
+#[test]
+fn confirmed_retarget_becomes_active_request_and_its_terminal_progress_stops_playback() {
+    let path = PathBuf::from("retarget-terminal-progress.wav");
+    let file =
+        test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
+    let mut state = NativeAppStateFixture::default().build();
+    state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+    state.waveform.current.start_playback(0.2);
+    state.audio.current_playback_span = Some((0.2, 0.6));
+    let request = SamplePlaybackRequest::waveform(
+        path.display().to_string(),
+        (0.2, 0.6),
+        SamplePlaybackIntent::WaveformSpan,
+        "waveform",
+        SamplePlaybackHistory::Record,
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "decoded_samples");
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("sample playback session");
+    session.runtime_request_id = Some(10);
+    session.state = SamplePlaybackSessionState::WaveformVisible;
+    state.audio.record_span_retarget_for_tests(11, (0.2, 0.6));
+
+    state.apply_runtime_playback_progress_for_request(
+        11,
+        PlaybackRuntimeProgress {
+            active: true,
+            elapsed: Some(Duration::from_millis(20)),
+            looping: false,
+            progress: Some(0.3),
+            error: None,
+        },
+    );
+    assert_eq!(
+        state
+            .audio
+            .sample_playback_session
+            .as_ref()
+            .and_then(|session| session.runtime_request_id),
+        Some(11)
+    );
+
+    state.apply_runtime_playback_progress_for_request(
+        11,
+        PlaybackRuntimeProgress {
+            active: false,
+            elapsed: Some(Duration::from_millis(200)),
+            looping: false,
+            progress: Some(0.6),
+            error: None,
+        },
+    );
+    state.refresh_runtime_playback_progress();
+
+    assert!(
+        !state.waveform.current.is_playing(),
+        "terminal progress for the confirmed retarget should leave play mode"
+    );
+}
+
+#[test]
+fn terminal_progress_poll_for_active_session_stops_playback() {
+    let path = PathBuf::from("terminal-progress-poll.wav");
+    let file =
+        test_decoded_waveform_file_from_mono_samples(path.clone(), vec![0.0, 0.5, -0.5, 0.0]);
+    let mut state = NativeAppStateFixture::default().build();
+    state.waveform.current = WaveformState::from_cached_file(Arc::new(file));
+    state.waveform.current.start_playback(0.2);
+    state.audio.current_playback_span = Some((0.2, 0.6));
+    let request = SamplePlaybackRequest::waveform(
+        path.display().to_string(),
+        (0.2, 0.6),
+        SamplePlaybackIntent::WaveformSpan,
+        "waveform",
+        SamplePlaybackHistory::Record,
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "decoded_samples");
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("sample playback session");
+    session.runtime_request_id = Some(40);
+    session.state = SamplePlaybackSessionState::WaveformVisible;
+    state.audio.pending_playback_progress_polls.insert(41);
+
+    state.apply_runtime_playback_progress_for_request(
+        41,
+        PlaybackRuntimeProgress {
+            active: false,
+            elapsed: Some(Duration::from_millis(200)),
+            looping: false,
+            progress: Some(0.6),
+            error: None,
+        },
+    );
+    state.refresh_runtime_playback_progress();
+
+    assert!(!state.waveform.current.is_playing());
+    assert!(state.audio.pending_playback_progress_polls.is_empty());
+}

--- a/src/native_app/audio/playback/progress/state.rs
+++ b/src/native_app/audio/playback/progress/state.rs
@@ -5,6 +5,7 @@ use crate::native_app::app::{NativeAppState, SamplePlaybackSessionState, emit_gu
 
 const AUDIO_OUTPUT_STREAM_ERROR_PREFIX: &str = "Audio output stream error:";
 const AUDIO_OUTPUT_UNAVAILABLE_ERROR: &str = "Audio output stream is unavailable";
+const MAX_PENDING_PROGRESS_POLLS: usize = 256;
 
 impl NativeAppState {
     pub(in crate::native_app) fn sync_edit_fade_audio_state(&mut self) {
@@ -16,8 +17,20 @@ impl NativeAppState {
     }
 
     pub(in crate::native_app) fn refresh_playback_progress(&mut self) {
-        if let Some(runtime) = self.audio.playback_runtime.as_ref() {
-            let _ = runtime.try_poll_progress();
+        if let Some(poll_id) = self
+            .audio
+            .playback_runtime
+            .as_ref()
+            .and_then(|runtime| runtime.try_poll_progress().ok())
+        {
+            let poll_id = poll_id.get();
+            self.audio.pending_playback_progress_polls.insert(poll_id);
+            if self.audio.pending_playback_progress_polls.len() > MAX_PENDING_PROGRESS_POLLS {
+                let oldest_retained = poll_id.saturating_sub(MAX_PENDING_PROGRESS_POLLS as u64 - 1);
+                self.audio
+                    .pending_playback_progress_polls
+                    .retain(|pending| *pending >= oldest_retained);
+            }
         }
         if self.audio.playback_runtime.is_some() {
             self.refresh_runtime_playback_progress();

--- a/src/native_app/audio/playback/progress/state.rs
+++ b/src/native_app/audio/playback/progress/state.rs
@@ -51,9 +51,12 @@ impl NativeAppState {
 
         if active || within_start_grace || (should_be_looping && player_looping) {
             if let Some(progress) = progress {
-                self.waveform.current.set_playhead_ratio(progress);
+                self.record_waveform_playback_progress(progress, player_looping);
             }
         } else if self.waveform.current.is_playing() {
+            if let Some(progress) = progress {
+                self.record_waveform_playback_progress(progress, player_looping);
+            }
             self.finish_playback_progress();
         }
     }
@@ -101,11 +104,22 @@ impl NativeAppState {
 
         if active || within_start_grace || (should_be_looping && player_looping) {
             if let Some(progress) = progress {
-                self.waveform.current.set_playhead_ratio(progress);
+                self.record_waveform_playback_progress(progress, player_looping);
             }
         } else if self.waveform.current.is_playing() {
+            if let Some(progress) = progress {
+                self.record_waveform_playback_progress(progress, player_looping);
+            }
             self.finish_playback_progress();
         }
+    }
+
+    fn record_waveform_playback_progress(&mut self, progress: f32, looping: bool) {
+        self.waveform.current.set_playhead_ratio_from_playback(
+            progress,
+            self.audio.current_playback_span,
+            looping,
+        );
     }
 
     fn finish_inactive_transient_sample_playback(

--- a/src/native_app/audio/playback/progress/state.rs
+++ b/src/native_app/audio/playback/progress/state.rs
@@ -1,7 +1,9 @@
 use std::time::Instant;
 
 use super::super::PLAYBACK_START_ACTIVE_SOURCE_GRACE;
-use crate::native_app::app::{NativeAppState, SamplePlaybackSessionState, emit_gui_action};
+use crate::native_app::app::{
+    CompletedTransientSamplePlayback, NativeAppState, SamplePlaybackSessionState, emit_gui_action,
+};
 
 const AUDIO_OUTPUT_STREAM_ERROR_PREFIX: &str = "Audio output stream error:";
 const AUDIO_OUTPUT_UNAVAILABLE_ERROR: &str = "Audio output stream is unavailable";
@@ -74,7 +76,7 @@ impl NativeAppState {
         }
     }
 
-    pub(super) fn refresh_runtime_playback_progress(&mut self) {
+    pub(in crate::native_app) fn refresh_runtime_playback_progress(&mut self) {
         if let Some(error) = self.audio.playback_progress.error.take() {
             self.stop_playback_after_progress_error(error);
             return;
@@ -152,7 +154,18 @@ impl NativeAppState {
         if !matches!(session.state, SamplePlaybackSessionState::AudibleTransient) {
             return false;
         }
+        let completed = CompletedTransientSamplePlayback {
+            path: session.request.path.clone(),
+            source_kind: session.source_kind,
+            progress: self
+                .audio
+                .playback_progress
+                .progress
+                .unwrap_or(1.0)
+                .clamp(0.0, 1.0),
+        };
         self.audio.clear_sample_playback_session();
+        self.audio.completed_transient_playback = Some(completed);
         self.audio.current_playback_span = None;
         self.audio.clear_playback_progress();
         true

--- a/src/native_app/audio/playback/progress/tests.rs
+++ b/src/native_app/audio/playback/progress/tests.rs
@@ -47,6 +47,45 @@ fn preview_slice_runtime_progress_does_not_move_full_waveform_playhead() {
     );
     assert_eq!(state.audio.current_playback_span, None);
     assert_eq!(state.audio.playback_progress.progress, Some(0.5));
+    assert!(state.waveform.current.played_ranges().is_empty());
+}
+
+#[test]
+fn runtime_progress_records_the_audible_waveform_span_through_completion() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.start_playback(0.2);
+    state.audio.current_playback_span = Some((0.2, 0.8));
+    state.audio.playback_progress = PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(Duration::from_millis(250)),
+        looping: false,
+        progress: Some(0.55),
+        error: None,
+    };
+
+    state.refresh_runtime_playback_progress();
+
+    assert_eq!(
+        state.waveform.current.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.2, 0.55)]
+    );
+
+    state.audio.playback_progress = PlaybackRuntimeProgress {
+        active: false,
+        elapsed: Some(Duration::from_millis(500)),
+        looping: false,
+        progress: Some(0.8),
+        error: None,
+    };
+    state.refresh_runtime_playback_progress();
+
+    assert_eq!(
+        state.waveform.current.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.2, 0.8)]
+    );
+    assert!(!state.waveform.current.is_playing());
 }
 
 #[test]

--- a/src/native_app/audio/playback/progress/waveform_publish.rs
+++ b/src/native_app/audio/playback/progress/waveform_publish.rs
@@ -1,4 +1,7 @@
-use super::super::diagnostics::PlayheadOverlayFrameDiagnostics;
+use super::super::{
+    diagnostics::{PlayheadOverlayFrameDiagnostics, PlayheadProgressSource},
+    loop_control::PlayheadProgressProjection,
+};
 use crate::native_app::{
     app::{NativeAppState, SamplePlaybackSession, SamplePlaybackSessionState},
     waveform::{WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID},
@@ -37,20 +40,52 @@ impl NativeAppState {
         if self.chrome_overlay_suppresses_waveform_transient_overlay() {
             return;
         }
-        let Some(projection) = self.playhead_progress_projection_for_frame(context.animation_time)
-        else {
-            return;
+        let (projection, preview_audition) = if let Some(projection) =
+            self.playhead_progress_projection_for_frame(context.animation_time)
+        {
+            (projection, false)
+        } else {
+            let path = self.waveform.current.path().display().to_string();
+            let Some(ratio) = self.preview_slice_full_sample_handoff_ratio(path.as_str()) else {
+                return;
+            };
+            (
+                PlayheadProgressProjection {
+                    ratio,
+                    source: PlayheadProgressSource::PreviewAuditionProgress,
+                },
+                true,
+            )
         };
-        let Some(visible_ratio) = self
-            .waveform
-            .current
-            .visible_ratio_for_absolute(projection.ratio)
-        else {
-            return;
+        if preview_audition {
+            self.waveform
+                .current
+                .record_preview_audition_progress(projection.ratio);
+        } else {
+            let visual_progress = self.audio.playback_visual_progress;
+            let span = visual_progress
+                .and_then(|progress| progress.span)
+                .or(self.audio.current_playback_span);
+            let looping = visual_progress
+                .map(|progress| progress.looping)
+                .unwrap_or(self.audio.playback_progress.looping);
+            self.waveform
+                .current
+                .set_playhead_ratio_from_playback(projection.ratio, span, looping);
         };
         let Some(bounds) = context
             .plan
             .first_widget_rect_by_priority([WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID])
+        else {
+            return;
+        };
+        self.waveform
+            .current
+            .append_played_range_overlay(primitives, bounds);
+        let Some(visible_ratio) = self
+            .waveform
+            .current
+            .visible_ratio_for_absolute(projection.ratio)
         else {
             return;
         };

--- a/src/native_app/audio/sample_load_actions/cache_start.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start.rs
@@ -39,6 +39,7 @@ struct CachedPlaybackOutcomes {
 #[derive(Clone, Copy)]
 struct FullSamplePlaybackOptions {
     start_ratio: f32,
+    auditioned_start_ratio: Option<f32>,
     replace_policy: PlaybackRuntimeReplacePolicy,
     origin: &'static str,
     history: SamplePlaybackHistory,
@@ -103,7 +104,7 @@ impl FastAuditionOptions {
             queue_preview_decode: true,
             prefer_preview_decode: false,
             allow_file_backed_source: true,
-            replace_policy: PlaybackRuntimeReplacePolicy::ClearPrevious,
+            replace_policy: PlaybackRuntimeReplacePolicy::FadeOutPrevious,
         }
     }
 
@@ -115,7 +116,7 @@ impl FastAuditionOptions {
             queue_preview_decode: true,
             prefer_preview_decode: false,
             allow_file_backed_source: true,
-            replace_policy: PlaybackRuntimeReplacePolicy::ClearPrevious,
+            replace_policy: PlaybackRuntimeReplacePolicy::FadeOutPrevious,
         }
     }
 
@@ -126,8 +127,8 @@ impl FastAuditionOptions {
             allow_sidecar_lookup: false,
             queue_preview_decode: false,
             prefer_preview_decode: false,
-            allow_file_backed_source: false,
-            replace_policy: PlaybackRuntimeReplacePolicy::ClearPrevious,
+            allow_file_backed_source: true,
+            replace_policy: PlaybackRuntimeReplacePolicy::FadeOutPrevious,
         }
     }
 }
@@ -202,9 +203,9 @@ fn fast_audition_probe_order(options: FastAuditionOptions) -> [FastAuditionProbe
         ]
     } else {
         [
-            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::FileBackedWav,
             FastAuditionProbe::PersistedCache,
+            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::PreviewDecode,
         ]
     }

--- a/src/native_app/audio/sample_load_actions/cache_start/cache_publication.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start/cache_publication.rs
@@ -91,8 +91,9 @@ impl NativeAppState {
             self.runtime_playback_origin_for_path(result.path.as_str()),
             !self.ui.chrome.starmap_audition_drag.is_some(),
         );
-        let started = self.start_preview_clip_instant_audition(clip, context, started_at, options);
-        if started
+        let outcome =
+            self.start_fast_path_audition(result.path.as_str(), context, started_at, options);
+        if outcome == InstantAuditionOutcome::Started
             && self.ui.chrome.starmap_audition_drag.is_some()
             && !self
                 .ui

--- a/src/native_app/audio/sample_load_actions/cache_start/playback_ready.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start/playback_ready.rs
@@ -107,8 +107,9 @@ impl NativeAppState {
         started_at: Instant,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let replacing_preview = self.audio.active_sample_playback_is_preview(path);
         let preview_handoff_start_ratio = self.preview_slice_full_sample_handoff_ratio(path);
-        let replace_policy = if preview_handoff_start_ratio.is_some() {
+        let replace_policy = if replacing_preview && preview_handoff_start_ratio.is_none() {
             PlaybackRuntimeReplacePolicy::ClearPrevious
         } else {
             PlaybackRuntimeReplacePolicy::FadeOutPrevious
@@ -117,6 +118,7 @@ impl NativeAppState {
             path,
             file_name,
             preview_handoff_start_ratio.unwrap_or(0.0),
+            preview_handoff_start_ratio.map(|_| 0.0),
             replace_policy,
             started_at,
             context,
@@ -128,6 +130,7 @@ impl NativeAppState {
         path: &str,
         file_name: &str,
         start_ratio: f32,
+        auditioned_start_ratio: Option<f32>,
         replace_policy: PlaybackRuntimeReplacePolicy,
         started_at: Instant,
         context: &mut ui::UiUpdateContext<GuiMessage>,
@@ -160,6 +163,7 @@ impl NativeAppState {
             &file_name,
             SAMPLE_AUTOPLAY_OUTCOMES,
             start_ratio,
+            auditioned_start_ratio,
             replace_policy,
             started_at,
             context,
@@ -172,12 +176,17 @@ impl NativeAppState {
         file_name: &str,
         outcomes: CachedPlaybackOutcomes,
         start_ratio: f32,
+        auditioned_start_ratio: Option<f32>,
         replace_policy: PlaybackRuntimeReplacePolicy,
         started_at: Instant,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let playback_started_at = Instant::now();
-        match self.start_current_full_sample_runtime_playback(start_ratio, replace_policy) {
+        match self.start_current_full_sample_runtime_playback(
+            start_ratio,
+            auditioned_start_ratio,
+            replace_policy,
+        ) {
             Ok(()) => {
                 self.record_selected_sample_last_played(context);
                 log_sample_load_timing(
@@ -225,12 +234,14 @@ impl NativeAppState {
     fn start_current_full_sample_runtime_playback(
         &mut self,
         start_ratio: f32,
+        auditioned_start_ratio: Option<f32>,
         replace_policy: PlaybackRuntimeReplacePolicy,
     ) -> Result<(), String> {
         let current_path = self.waveform.current.path().display().to_string();
         let origin = self.runtime_playback_origin_for_path(current_path.as_str());
         self.submit_current_full_sample_runtime_playback(FullSamplePlaybackOptions {
             start_ratio,
+            auditioned_start_ratio,
             replace_policy,
             origin,
             history: SamplePlaybackHistory::Record,
@@ -256,6 +267,7 @@ impl NativeAppState {
             } else {
                 PendingPlaybackStart::skip_history(intent)
             });
+            self.start_waveform_playback_for_full_sample(options, start_ratio);
             if self.background.audio_open.active().is_some() {
                 return Ok(());
             }
@@ -335,13 +347,7 @@ impl NativeAppState {
         let request_id = runtime
             .try_play(request)
             .map_err(|err| format!("submit playback request: {err:?}"))?;
-        if options.show_start_marker {
-            self.waveform.current.start_playback(start_ratio);
-        } else {
-            self.waveform
-                .current
-                .start_playback_without_marker(start_ratio);
-        }
+        self.start_waveform_playback_for_full_sample(options, start_ratio);
         self.audio.current_playback_span = Some((0.0, 1.0));
         let source_kind = self.current_waveform_runtime_source_kind();
         let session_request = SamplePlaybackRequest::waveform(
@@ -360,6 +366,26 @@ impl NativeAppState {
         Ok(())
     }
 
+    fn start_waveform_playback_for_full_sample(
+        &mut self,
+        options: FullSamplePlaybackOptions,
+        start_ratio: f32,
+    ) {
+        if let Some(audition_start_ratio) = options.auditioned_start_ratio {
+            self.waveform.current.start_playback_after_audition_handoff(
+                start_ratio,
+                audition_start_ratio,
+                options.show_start_marker,
+            );
+        } else if options.show_start_marker {
+            self.waveform.current.start_playback(start_ratio);
+        } else {
+            self.waveform
+                .current
+                .start_playback_without_marker(start_ratio);
+        }
+    }
+
     pub(in crate::native_app::audio) fn preview_slice_full_sample_handoff_ratio(
         &self,
         path: &str,
@@ -370,11 +396,24 @@ impl NativeAppState {
         {
             return None;
         }
+        let progress = self.audio.active_sample_playback_progress(path)?;
+        let audible_elapsed = self
+            .audio
+            .active_sample_playback_audible_elapsed(path)
+            .map(|elapsed| elapsed.min(PREVIEW_AUDITION_DURATION));
         preview_slice_full_sample_handoff_ratio(
             self.waveform.current.duration_seconds(),
-            self.audio.playback_progress.elapsed,
-            self.audio.playback_progress.progress,
+            latest_duration(progress.elapsed, audible_elapsed),
+            progress.progress,
         )
+    }
+}
+
+fn latest_duration(left: Option<Duration>, right: Option<Duration>) -> Option<Duration> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(duration), None) | (None, Some(duration)) => Some(duration),
+        (None, None) => None,
     }
 }
 

--- a/src/native_app/audio/sample_load_actions/cache_start_tests.rs
+++ b/src/native_app/audio/sample_load_actions/cache_start_tests.rs
@@ -136,9 +136,9 @@ fn starmap_drag_fast_audition_prefers_original_wav_before_persistent_or_preview_
     assert_eq!(
         fast_audition_probe_order(FastAuditionOptions::starmap_drag()),
         [
-            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::FileBackedWav,
             FastAuditionProbe::PersistedCache,
+            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::PreviewDecode,
         ]
     );
@@ -149,9 +149,25 @@ fn instant_navigation_fast_audition_prefers_original_wav_before_persistent_or_pr
     assert_eq!(
         fast_audition_probe_order(FastAuditionOptions::instant_navigation()),
         [
-            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::FileBackedWav,
             FastAuditionProbe::PersistedCache,
+            FastAuditionProbe::PreviewCache,
+            FastAuditionProbe::PreviewDecode,
+        ]
+    );
+}
+
+#[test]
+fn preview_decode_completion_retries_the_original_wav_before_using_the_preview_clip() {
+    let options = FastAuditionOptions::preview_decode_completion("test", false);
+
+    assert!(options.allow_file_backed_source);
+    assert_eq!(
+        fast_audition_probe_order(options),
+        [
+            FastAuditionProbe::FileBackedWav,
+            FastAuditionProbe::PersistedCache,
+            FastAuditionProbe::PreviewCache,
             FastAuditionProbe::PreviewDecode,
         ]
     );
@@ -178,16 +194,16 @@ fn hot_fast_audition_options_submit_unprobed_file_backed_sources() {
 }
 
 #[test]
-fn hot_fast_audition_options_clear_previous_runtime_source() {
+fn hot_fast_audition_options_crossfade_previous_runtime_source() {
     assert_eq!(
         FastAuditionOptions::instant_navigation().replace_policy,
-        PlaybackRuntimeReplacePolicy::ClearPrevious,
-        "list and keyboard navigation should not keep old preview sources fading in the mixer"
+        PlaybackRuntimeReplacePolicy::FadeOutPrevious,
+        "list and keyboard navigation should de-click the previous source instead of severing it"
     );
     assert_eq!(
         FastAuditionOptions::starmap_drag().replace_policy,
-        PlaybackRuntimeReplacePolicy::ClearPrevious,
-        "starmap drag playback should replace the prior preview source immediately"
+        PlaybackRuntimeReplacePolicy::FadeOutPrevious,
+        "starmap drag playback should de-click each rapid source replacement"
     );
 }
 

--- a/src/native_app/audio/sample_load_actions/completion/loaded.rs
+++ b/src/native_app/audio/sample_load_actions/completion/loaded.rs
@@ -140,21 +140,24 @@ impl NativeAppState {
         if !self.audio.active_sample_playback_is_streamable(path) {
             return false;
         }
-        let Some(progress) = self
+        let pending_runtime = self.audio.active_sample_playback_pending_runtime();
+        let progress = self
             .audio
             .active_sample_playback_progress(path)
             .filter(|progress| progress.active)
-            .and_then(|progress| progress.progress)
-        else {
+            .and_then(|progress| progress.progress);
+        if progress.is_none() && !pending_runtime {
             return false;
-        };
+        }
         if !self.audio.promote_sample_playback_session_to_waveform(path) {
             return false;
         }
-        self.waveform
-            .current
-            .start_playback_after_audition_handoff(progress, 0.0, true);
-        self.audio.current_playback_span = Some((0.0, 1.0));
+        if let Some(progress) = progress {
+            self.waveform
+                .current
+                .start_playback_after_audition_handoff(progress, 0.0, true);
+            self.audio.current_playback_span = Some((0.0, 1.0));
+        }
         self.record_current_playback_history(0.0, 1.0);
         self.record_sample_last_played(path.to_owned(), context);
         self.ui.status.sample = format!("Playing {file_name}");
@@ -162,7 +165,11 @@ impl NativeAppState {
             "browser.sample_load.finish",
             Some("browser"),
             Some(file_name),
-            "waveform_ready_playback_continued",
+            if pending_runtime {
+                "waveform_ready_playback_pending_start"
+            } else {
+                "waveform_ready_playback_continued"
+            },
             started_at,
             None,
         );

--- a/src/native_app/audio/sample_load_actions/completion/loaded.rs
+++ b/src/native_app/audio/sample_load_actions/completion/loaded.rs
@@ -148,6 +148,9 @@ impl NativeAppState {
         else {
             return false;
         };
+        if !self.audio.promote_sample_playback_session_to_waveform(path) {
+            return false;
+        }
         self.waveform
             .current
             .start_playback_after_audition_handoff(progress, 0.0, true);

--- a/src/native_app/audio/sample_load_actions/completion/loaded.rs
+++ b/src/native_app/audio/sample_load_actions/completion/loaded.rs
@@ -73,6 +73,9 @@ impl NativeAppState {
         if self.start_pending_sample_playback(&path, &file_name, started_at, context) {
             return;
         }
+        if self.finish_completed_streamable_sample_playback_load(&path, &file_name, started_at) {
+            return;
+        }
         if !autoplay {
             self.ui.status.sample = format!("Loaded {file_name}");
             emit_gui_action(
@@ -98,6 +101,33 @@ impl NativeAppState {
             started_at,
             context,
         );
+    }
+
+    fn finish_completed_streamable_sample_playback_load(
+        &mut self,
+        path: &str,
+        file_name: &str,
+        started_at: Instant,
+    ) -> bool {
+        let Some(progress) = self.audio.take_completed_streamable_sample_playback(path) else {
+            return false;
+        };
+        self.waveform
+            .current
+            .record_already_auditioned_span(0.0, progress);
+        self.waveform.current.stop_playback();
+        self.audio.current_playback_span = None;
+        self.record_current_playback_history(0.0, 1.0);
+        self.ui.status.sample = format!("Loaded {file_name}");
+        emit_gui_action(
+            "browser.sample_load.finish",
+            Some("browser"),
+            Some(file_name),
+            "waveform_ready_after_completed_streamed_playback",
+            started_at,
+            None,
+        );
+        true
     }
 
     fn continue_streamable_sample_playback(

--- a/src/native_app/audio/sample_load_actions/completion/loaded.rs
+++ b/src/native_app/audio/sample_load_actions/completion/loaded.rs
@@ -65,6 +65,7 @@ impl NativeAppState {
             );
             return;
         }
+        let replacing_preview = self.audio.active_sample_playback_is_preview(&path);
         let preview_handoff_start_ratio = self.preview_slice_full_sample_handoff_ratio(&path);
         if self.continue_streamable_sample_playback(&path, &file_name, started_at, context) {
             return;
@@ -88,7 +89,8 @@ impl NativeAppState {
             &path,
             &file_name,
             preview_handoff_start_ratio.unwrap_or(0.0),
-            if preview_handoff_start_ratio.is_some() {
+            preview_handoff_start_ratio.map(|_| 0.0),
+            if replacing_preview && preview_handoff_start_ratio.is_none() {
                 PlaybackRuntimeReplacePolicy::ClearPrevious
             } else {
                 PlaybackRuntimeReplacePolicy::FadeOutPrevious
@@ -108,8 +110,17 @@ impl NativeAppState {
         if !self.audio.active_sample_playback_is_streamable(path) {
             return false;
         }
-        let progress = self.audio.playback_progress.progress.unwrap_or(0.0);
-        self.waveform.current.start_playback(progress);
+        let Some(progress) = self
+            .audio
+            .active_sample_playback_progress(path)
+            .filter(|progress| progress.active)
+            .and_then(|progress| progress.progress)
+        else {
+            return false;
+        };
+        self.waveform
+            .current
+            .start_playback_after_audition_handoff(progress, 0.0, true);
         self.audio.current_playback_span = Some((0.0, 1.0));
         self.record_current_playback_history(0.0, 1.0);
         self.record_sample_last_played(path.to_owned(), context);

--- a/src/native_app/audio/sample_load_actions/entrypoints.rs
+++ b/src/native_app/audio/sample_load_actions/entrypoints.rs
@@ -513,10 +513,15 @@ impl NativeAppState {
             if self.waveform.current.has_loaded_sample()
                 && self.waveform.current.path() == Path::new(path.as_str())
             {
-                let progress = self.audio.playback_progress.progress.unwrap_or(0.0);
+                let progress = self
+                    .audio
+                    .active_sample_playback_progress(path.as_str())
+                    .filter(|progress| progress.active)
+                    .and_then(|progress| progress.progress)
+                    .unwrap_or(0.0);
                 self.waveform
                     .current
-                    .start_playback_without_marker(progress);
+                    .start_playback_after_audition_handoff(progress, 0.0, false);
             }
             emit_gui_action(
                 "browser.select_sample.settled_promotion",

--- a/src/native_app/shell/message_dispatch/navigation.rs
+++ b/src/native_app/shell/message_dispatch/navigation.rs
@@ -274,7 +274,12 @@ impl NativeAppState {
         active_target: Option<&str>,
     ) {
         let active_playback_path = self.audio.active_sample_playback_path().map(str::to_owned);
-        let playback_progress = self.audio.playback_progress.progress.unwrap_or(0.0);
+        let playback_progress = active_playback_path
+            .as_deref()
+            .and_then(|path| self.audio.active_sample_playback_progress(path))
+            .filter(|progress| progress.active)
+            .and_then(|progress| progress.progress)
+            .unwrap_or(0.0);
         let mut playback_span = (0.0, 1.0);
         let last_played_session = self
             .ui
@@ -287,9 +292,11 @@ impl NativeAppState {
             session.request.origin = "starmap_release";
         }
         if loaded_path.is_some_and(|path| active_playback_path.as_deref() == Some(path)) {
-            self.waveform
-                .current
-                .start_playback_without_marker(playback_progress);
+            self.waveform.current.start_playback_after_audition_handoff(
+                playback_progress,
+                playback_span.0,
+                false,
+            );
             self.audio.current_playback_span = Some(playback_span);
         } else if loaded_path.is_some_and(|path| active_playback_path.as_deref() != Some(path))
             && active_playback_path.is_some()

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -990,6 +990,101 @@ fn playback_cursor_overlay_progresses_smoothly_across_timed_frames() {
 }
 
 #[test]
+fn played_range_rail_grows_on_paint_only_playback_frames() {
+    let base_time = Duration::from_secs(30);
+    let mut state = state_with_runtime_playback(0.10, (0.0, 1.0), false);
+    state
+        .audio
+        .playback_visual_progress
+        .as_mut()
+        .expect("visual progress")
+        .anchor_animation_time = Some(base_time);
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+
+    let first_right = played_range_rail_right_x_for_frame(
+        &mut runtime,
+        &frame.paint_plan,
+        base_time + Duration::from_millis(16),
+    )
+    .expect("played rail on first paint-only frame");
+    let later_right = played_range_rail_right_x_for_frame(
+        &mut runtime,
+        &frame.paint_plan,
+        base_time + Duration::from_millis(64),
+    )
+    .expect("played rail on later paint-only frame");
+
+    assert!(
+        later_right > first_right,
+        "played rail should advance with the interpolated playhead without a retained surface rebuild"
+    );
+}
+
+#[test]
+fn preview_audition_cursor_and_rail_grow_before_full_source_handoff() {
+    let mut state = gui_state_for_span_tests();
+    let path = state.waveform.current.path().display().to_string();
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        path,
+        "preview_samples",
+    );
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("preview session");
+    session.state = crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+    session.audible_started_at = Some(std::time::Instant::now() - Duration::from_millis(20));
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(Duration::ZERO),
+        looping: false,
+        progress: Some(0.0),
+        error: None,
+    };
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+
+    let first_right =
+        played_range_rail_right_x_for_frame(&mut runtime, &frame.paint_plan, Duration::ZERO)
+            .expect("preview rail on first frame");
+    runtime
+        .bridge_mut()
+        .state_mut()
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("preview session")
+        .audible_started_at = Some(std::time::Instant::now() - Duration::from_millis(80));
+    let later_right = played_range_rail_right_x_for_frame(
+        &mut runtime,
+        &frame.paint_plan,
+        Duration::from_millis(16),
+    )
+    .expect("preview rail on later frame");
+
+    assert!(
+        later_right > first_right,
+        "preview audition should paint the same growing rail before the full source is ready"
+    );
+    assert_eq!(
+        runtime
+            .bridge()
+            .state()
+            .waveform
+            .current
+            .played_ranges()
+            .first()
+            .map(wavecrate::selection::SelectionRange::start),
+        Some(0.0)
+    );
+}
+
+#[test]
 fn fallback_player_cursor_overlay_uses_seeded_visual_clock() {
     let base_time = Duration::from_secs(30);
     let mut state = gui_state_for_span_tests();
@@ -1242,6 +1337,27 @@ fn playback_cursor_x_for_frame(
         .filter_map(|primitive| primitive.fill_rect())
         .find(|fill| is_playback_cursor_fill(fill))
         .map(|fill| fill.rect.center().x)
+}
+
+fn played_range_rail_right_x_for_frame(
+    runtime: &mut NativeRuntimeForTests,
+    paint_plan: &radiant::runtime::SurfacePaintPlan,
+    animation_time: Duration,
+) -> Option<f32> {
+    let mut primitives = Vec::new();
+    runtime.bridge_mut().state_mut().paint_playback_overlay(
+        TransientOverlayContext::new(paint_plan, Vector2::new(900.0, 620.0), animation_time),
+        &mut primitives,
+    );
+    primitives
+        .iter()
+        .filter_map(|primitive| primitive.fill_rect())
+        .filter(|fill| {
+            fill.widget_id == crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID
+                && (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (98, 102, 106, 255)
+        })
+        .map(|fill| fill.rect.max.x)
+        .max_by(f32::total_cmp)
 }
 
 fn waveform_cursor_x_from_ratio(

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -373,6 +373,91 @@ fn continued_streamed_navigation_stops_the_attached_waveform_at_terminal_progres
 }
 
 #[test]
+fn pending_streamed_navigation_is_retained_when_waveform_load_finishes_first() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join("pending-stream.wav");
+    write_sparse_test_wav_i16(&sample_path, 1, 48_000);
+    let sample_path_string = sample_path.display().to_string();
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path_string.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "audio_file",
+    );
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("streamed navigation session");
+    session.runtime_request_id = Some(77);
+    session.state = crate::native_app::app::SamplePlaybackSessionState::RuntimePending;
+
+    let mut context = ui::UiUpdateContext::default();
+    state.load_navigation_sample_validated(
+        sample_path_string.clone(),
+        &mut context,
+        std::time::Instant::now(),
+    );
+    let ticket = active_sample_load_ticket(&state).expect("waveform load queued");
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SampleLoadFinished(
+            sample_load_completion(
+                ticket,
+                sample_path_string,
+                crate::native_app::test_support::state::WaveformState::load_path(sample_path),
+                true,
+            ),
+        ),
+        &mut context,
+    );
+
+    let retained = state
+        .audio
+        .sample_playback_session
+        .as_ref()
+        .expect("original pending stream should be retained");
+    assert_eq!(retained.runtime_request_id, Some(77));
+    assert_eq!(
+        retained.request.visibility,
+        crate::native_app::app::SamplePlaybackVisibility::Waveform
+    );
+    assert_eq!(
+        retained.state,
+        crate::native_app::app::SamplePlaybackSessionState::RuntimePending
+    );
+    assert!(state.audio.pending_playback_start.is_none());
+    assert!(!state.waveform.current.is_playing());
+
+    state.finish_runtime_playback_started_parts(
+        77,
+        wavecrate::audio::ResolvedOutput::default(),
+        0.0,
+    );
+
+    let started = state
+        .audio
+        .sample_playback_session
+        .as_ref()
+        .expect("retained stream should become visible");
+    assert_eq!(started.runtime_request_id, Some(77));
+    assert_eq!(
+        started.state,
+        crate::native_app::app::SamplePlaybackSessionState::WaveformVisible
+    );
+    assert!(state.waveform.current.is_playing());
+    assert_eq!(state.audio.current_playback_span, Some((0.0, 1.0)));
+}
+
+#[test]
 fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
     let source_root = tempfile::tempdir().expect("source root");
     let sample_path = source_root.path().join("settled-full.wav");

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -210,6 +210,82 @@ fn display_after_preview_waits_for_settled_full_playback_promotion() {
 }
 
 #[test]
+fn completed_streamed_navigation_does_not_restart_when_waveform_load_finishes() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join("completed-stream.wav");
+    write_test_wav_i16(&sample_path, &[0, 1024, -2048, 4096, -1024, 512]);
+    let sample_path_string = sample_path.display().to_string();
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path_string.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "audio_file",
+    );
+    state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("streamed navigation session")
+        .state = crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+
+    let mut context = ui::UiUpdateContext::default();
+    state.load_navigation_sample_validated(
+        sample_path_string.clone(),
+        &mut context,
+        std::time::Instant::now(),
+    );
+    let ticket = active_sample_load_ticket(&state).expect("waveform load queued");
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: false,
+        elapsed: Some(std::time::Duration::from_secs(1)),
+        looping: false,
+        progress: Some(1.0),
+        error: None,
+    };
+    state.refresh_runtime_playback_progress();
+
+    assert!(
+        state.audio.sample_playback_session.is_none(),
+        "terminal transient playback should leave no active session"
+    );
+
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SampleLoadFinished(
+            sample_load_completion(
+                ticket,
+                sample_path_string,
+                crate::native_app::test_support::state::WaveformState::load_path(
+                    sample_path.clone(),
+                ),
+                true,
+            ),
+        ),
+        &mut context,
+    );
+
+    assert!(
+        state.audio.pending_playback_start.is_none(),
+        "completed streamed playback must not queue a second start from frame zero"
+    );
+    assert!(state.audio.sample_playback_session.is_none());
+    assert_eq!(state.audio.current_playback_span, None);
+    assert!(!state.waveform.current.is_playing());
+    assert_eq!(
+        state.waveform.current.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.0, 1.0)]
+    );
+}
+
+#[test]
 fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
     let source_root = tempfile::tempdir().expect("source root");
     let sample_path = source_root.path().join("settled-full.wav");

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -233,7 +233,21 @@ fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
         sample_path_string.clone(),
         "preview_samples",
     );
-    state.audio.playback_progress.elapsed = Some(std::time::Duration::from_millis(110));
+    let preview_session = state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("preview session");
+    preview_session.state = crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+    preview_session.audible_started_at =
+        Some(std::time::Instant::now() - std::time::Duration::from_millis(110));
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(std::time::Duration::ZERO),
+        looping: false,
+        progress: Some(0.0),
+        error: None,
+    };
     let ticket = state.background.settled_sample_promotion_task.begin();
     let mut context = ui::UiUpdateContext::default();
 
@@ -267,6 +281,22 @@ fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
         "settled preview handoff should continue past the heard preview instead of replaying from the top"
     );
     assert_eq!(pending.intent.end_ratio, 1.0);
+    assert_eq!(
+        state.waveform.current.play_mark_ratio(),
+        Some(0.0),
+        "the start marker should describe where the audition began, not the continuation ratio"
+    );
+    let heard = state
+        .waveform
+        .current
+        .played_ranges()
+        .first()
+        .expect("preview handoff should preserve the already auditioned prefix");
+    assert!((heard.start() - 0.0).abs() < 0.001);
+    assert!(
+        (heard.end() - pending.intent.start_ratio).abs() < 0.01,
+        "played history should begin at the sample start and meet the continuing playhead"
+    );
 }
 
 #[test]

--- a/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
+++ b/src/native_app/tests/waveform_playback/sample_loading/playback_ready.rs
@@ -286,6 +286,93 @@ fn completed_streamed_navigation_does_not_restart_when_waveform_load_finishes() 
 }
 
 #[test]
+fn continued_streamed_navigation_stops_the_attached_waveform_at_terminal_progress() {
+    let source_root = tempfile::tempdir().expect("source root");
+    let sample_path = source_root.path().join("continued-stream.wav");
+    write_sparse_test_wav_i16(&sample_path, 1, 48_000);
+    let sample_path_string = sample_path.display().to_string();
+
+    let mut state = gui_state_for_span_tests();
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    state
+        .library
+        .folder_browser
+        .select_file(sample_path_string.clone());
+    crate::native_app::test_support::state::seed_sample_playback_session(
+        &mut state,
+        sample_path_string.clone(),
+        "audio_file",
+    );
+    state
+        .audio
+        .sample_playback_session
+        .as_mut()
+        .expect("streamed navigation session")
+        .state = crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: true,
+        elapsed: Some(std::time::Duration::from_millis(400)),
+        looping: false,
+        progress: Some(0.4),
+        error: None,
+    };
+
+    let mut context = ui::UiUpdateContext::default();
+    state.load_navigation_sample_validated(
+        sample_path_string.clone(),
+        &mut context,
+        std::time::Instant::now(),
+    );
+    let ticket = active_sample_load_ticket(&state).expect("waveform load queued");
+    state.apply_message(
+        crate::native_app::test_support::state::GuiMessage::SampleLoadFinished(
+            sample_load_completion(
+                ticket,
+                sample_path_string,
+                crate::native_app::test_support::state::WaveformState::load_path(sample_path),
+                true,
+            ),
+        ),
+        &mut context,
+    );
+
+    let session = state
+        .audio
+        .sample_playback_session
+        .as_ref()
+        .expect("continued stream keeps its runtime session");
+    assert_eq!(
+        session.request.visibility,
+        crate::native_app::app::SamplePlaybackVisibility::Waveform
+    );
+    assert_eq!(
+        session.state,
+        crate::native_app::app::SamplePlaybackSessionState::WaveformVisible
+    );
+    assert!(state.waveform.current.is_playing());
+
+    state.audio.playback_progress = wavecrate::audio::PlaybackRuntimeProgress {
+        active: false,
+        elapsed: Some(std::time::Duration::from_secs(1)),
+        looping: false,
+        progress: Some(1.0),
+        error: None,
+    };
+    state.refresh_runtime_playback_progress();
+
+    assert!(!state.waveform.current.is_playing());
+    assert!(state.audio.sample_playback_session.is_none());
+    assert_eq!(state.audio.current_playback_span, None);
+    assert_eq!(
+        state.waveform.current.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.0, 1.0)]
+    );
+}
+
+#[test]
 fn settled_preview_promotion_starts_full_playback_for_current_loaded_sample() {
     let source_root = tempfile::tempdir().expect("source root");
     let sample_path = source_root.path().join("settled-full.wav");

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -108,6 +108,7 @@ mod widget_input;
 mod edit_fade_curve_paint;
 mod edit_fade_geometry;
 mod edit_fade_paint;
+mod played_range_paint;
 mod playmark_label;
 mod selection_paint;
 

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -41,6 +41,7 @@ mod state_loading;
 mod state_marked_ranges;
 mod state_playback;
 mod state_preserved_marks;
+mod state_range_history;
 pub(in crate::native_app) use state_preserved_marks::WaveformPreservedMarks;
 mod state_selection;
 mod state_transient;

--- a/src/native_app/waveform/played_range_paint.rs
+++ b/src/native_app/waveform/played_range_paint.rs
@@ -1,0 +1,48 @@
+use radiant::{
+    gui::{
+        feedback::horizontal_value_range_rect,
+        types::{Rect, Rgba8},
+    },
+    runtime::{PaintPrimitive, WidgetPaint},
+};
+
+use super::{WAVEFORM_WIDGET_ID, WaveformState};
+
+pub(super) const PLAYED_RANGE_RAIL: Rgba8 = Rgba8::new(98, 102, 106, 255);
+pub(super) const PLAYED_RANGE_RAIL_HEIGHT: f32 = 4.0;
+
+pub(super) fn append_played_range_rail(
+    paint: &mut WidgetPaint<'_>,
+    bounds: Rect,
+    start_fraction: f32,
+    end_fraction: f32,
+) {
+    let Some(range_rect) = horizontal_value_range_rect(bounds, start_fraction, end_fraction, 1.0)
+    else {
+        return;
+    };
+    paint.push_visible_fill_rect(
+        range_rect.bottom_edge_strip(PLAYED_RANGE_RAIL_HEIGHT),
+        PLAYED_RANGE_RAIL,
+    );
+}
+
+impl WaveformState {
+    pub(in crate::native_app) fn append_played_range_overlay(
+        &self,
+        primitives: &mut Vec<PaintPrimitive>,
+        bounds: Rect,
+    ) {
+        let mut paint = WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID);
+        for range in &self.played_ranges {
+            let Some((start, end)) = self.viewport.visible_range_from_absolute(
+                self.file.frames,
+                range.start(),
+                range.end(),
+            ) else {
+                continue;
+            };
+            append_played_range_rail(&mut paint, bounds, start, end);
+        }
+    }
+}

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -1,5 +1,5 @@
 use radiant::{
-    gui::feedback::horizontal_value_cursor_rect,
+    gui::feedback::{horizontal_value_cursor_rect, horizontal_value_range_rect},
     gui::types::{Point, Rect, Rgba8},
     gui::visualization::{
         CanvasSelectionAffordancePaintParts, CanvasSelectionAffordanceStyle,
@@ -32,6 +32,7 @@ const EXTRACTED_RANGE_RAIL: Rgba8 = Rgba8 {
     b: 219,
     a: 225,
 };
+const PLAYED_RANGE_RAIL: Rgba8 = Rgba8::new(103, 196, 207, 158);
 const SIMILAR_SECTION_FILL: Rgba8 = Rgba8::new(114, 235, 184, 54);
 const SIMILAR_SECTION_RAIL: Rgba8 = Rgba8::new(155, 255, 218, 210);
 const SIMILAR_SECTION_HOVER_FILL: Rgba8 = Rgba8::new(156, 255, 218, 92);
@@ -49,6 +50,7 @@ const HANDLE_HOVER_ALPHA: u8 = 255;
 const EDIT_RESIZE_HANDLE_ALPHA: u8 = 190;
 const EDIT_GAIN_HANDLE_ALPHA: u8 = 225;
 const EXTRACTED_RANGE_RAIL_HEIGHT: f32 = 2.0;
+const PLAYED_RANGE_RAIL_HEIGHT: f32 = 4.0;
 const BEAT_GUIDE_WIDTH: f32 = 1.0;
 const BEAT_GUIDE_HEIGHT_FRACTION: f32 = 0.72;
 const IMPLICIT_SAMPLE_START_RATIO: f32 = 0.000_1;
@@ -79,6 +81,7 @@ impl WaveformWidget {
             {
                 self.append_edit_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
             }
+            self.append_played_range_paint(&mut paint, bounds);
         }
         self.append_marker_paint(&mut paint, bounds);
         paint.primitives_mut().extend(handle_primitives);
@@ -143,6 +146,26 @@ impl WaveformWidget {
             EXTRACTED_RANGE_RAIL_HEIGHT,
             EXTRACTED_RANGE_RAIL,
         );
+    }
+
+    fn append_played_range_paint(&self, paint: &mut WidgetPaint<'_>, bounds: Rect) {
+        for range in &self.played_ranges {
+            let Some(range) = self.visible_normalized_range_for_selection(Some(*range)) else {
+                continue;
+            };
+            let Some(range_rect) = horizontal_value_range_rect(
+                bounds,
+                range.start_fraction(),
+                range.end_fraction(),
+                1.0,
+            ) else {
+                continue;
+            };
+            paint.push_visible_fill_rect(
+                range_rect.bottom_edge_strip(PLAYED_RANGE_RAIL_HEIGHT),
+                PLAYED_RANGE_RAIL,
+            );
+        }
     }
 
     fn append_similar_section_paint(&self, paint: &mut WidgetPaint<'_>, bounds: Rect) {

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -1,5 +1,5 @@
 use radiant::{
-    gui::feedback::{horizontal_value_cursor_rect, horizontal_value_range_rect},
+    gui::feedback::horizontal_value_cursor_rect,
     gui::types::{Point, Rect, Rgba8},
     gui::visualization::{
         CanvasSelectionAffordancePaintParts, CanvasSelectionAffordanceStyle,
@@ -11,6 +11,7 @@ use radiant::{
 use super::{
     DENIED_SELECTION_FLASH_FRAMES, DENIED_SELECTION_FLASH_PULSE_FRAMES, WaveformActiveDragKind,
     WaveformSelectionKind, WaveformWidget,
+    played_range_paint::append_played_range_rail,
     widget_geometry::{
         EDIT_GAIN_HANDLE_HEIGHT, EDIT_GAIN_HANDLE_WIDTH, SELECTION_RESIZE_HANDLE_STRIP_HEIGHT,
         edit_gain_handle_rect_for_geometry, edit_selection_resize_edge_bounds,
@@ -32,7 +33,6 @@ const EXTRACTED_RANGE_RAIL: Rgba8 = Rgba8 {
     b: 219,
     a: 225,
 };
-const PLAYED_RANGE_RAIL: Rgba8 = Rgba8::new(103, 196, 207, 158);
 const SIMILAR_SECTION_FILL: Rgba8 = Rgba8::new(114, 235, 184, 54);
 const SIMILAR_SECTION_RAIL: Rgba8 = Rgba8::new(155, 255, 218, 210);
 const SIMILAR_SECTION_HOVER_FILL: Rgba8 = Rgba8::new(156, 255, 218, 92);
@@ -50,7 +50,6 @@ const HANDLE_HOVER_ALPHA: u8 = 255;
 const EDIT_RESIZE_HANDLE_ALPHA: u8 = 190;
 const EDIT_GAIN_HANDLE_ALPHA: u8 = 225;
 const EXTRACTED_RANGE_RAIL_HEIGHT: f32 = 2.0;
-const PLAYED_RANGE_RAIL_HEIGHT: f32 = 4.0;
 const BEAT_GUIDE_WIDTH: f32 = 1.0;
 const BEAT_GUIDE_HEIGHT_FRACTION: f32 = 0.72;
 const IMPLICIT_SAMPLE_START_RATIO: f32 = 0.000_1;
@@ -153,18 +152,7 @@ impl WaveformWidget {
             let Some(range) = self.visible_normalized_range_for_selection(Some(*range)) else {
                 continue;
             };
-            let Some(range_rect) = horizontal_value_range_rect(
-                bounds,
-                range.start_fraction(),
-                range.end_fraction(),
-                1.0,
-            ) else {
-                continue;
-            };
-            paint.push_visible_fill_rect(
-                range_rect.bottom_edge_strip(PLAYED_RANGE_RAIL_HEIGHT),
-                PLAYED_RANGE_RAIL,
-            );
+            append_played_range_rail(paint, bounds, range.start_fraction(), range.end_fraction());
         }
     }
 

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -50,6 +50,8 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) zero_crossing_snap_enabled: bool,
     pub(in crate::native_app::waveform) marked_play_ranges: Vec<SelectionRange>,
     pub(in crate::native_app::waveform) extracted_ranges: Vec<SelectionRange>,
+    pub(in crate::native_app::waveform) played_ranges: Vec<SelectionRange>,
+    pub(in crate::native_app::waveform) played_progress_anchor: Option<f32>,
     pub(in crate::native_app::waveform) similar_sections: SimilarSectionsState,
     pub(in crate::native_app::waveform) play_selection_flash_frames: u8,
     pub(in crate::native_app::waveform) edit_selection_flash_frames: u8,

--- a/src/native_app/waveform/state_extraction.rs
+++ b/src/native_app/waveform/state_extraction.rs
@@ -252,30 +252,7 @@ impl WaveformState {
     }
 
     fn mark_extracted_range(&mut self, selection: SelectionRange) {
-        if selection.width() <= 0.0 {
-            return;
-        }
-        self.extracted_ranges
-            .push(SelectionRange::new(selection.start(), selection.end()));
-        self.extracted_ranges
-            .sort_by(|a, b| a.start_f64().total_cmp(&b.start_f64()));
-
-        let mut merged = Vec::with_capacity(self.extracted_ranges.len());
-        for range in self.extracted_ranges.drain(..) {
-            let Some(previous) = merged.last_mut() else {
-                merged.push(range);
-                continue;
-            };
-            if range.start_f64() <= previous.end_f64() + 1.0e-6 {
-                *previous = SelectionRange::new_precise(
-                    previous.start_f64(),
-                    previous.end_f64().max(range.end_f64()),
-                );
-            } else {
-                merged.push(range);
-            }
-        }
-        self.extracted_ranges = merged;
+        super::state_range_history::insert_merged_range(&mut self.extracted_ranges, selection);
     }
 
     fn extractable_play_selection(&self) -> Result<SelectionRange, String> {

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -141,6 +141,8 @@ impl WaveformState {
             zero_crossing_snap_enabled: false,
             marked_play_ranges: Vec::new(),
             extracted_ranges: Vec::new(),
+            played_ranges: Vec::new(),
+            played_progress_anchor: None,
             similar_sections: Default::default(),
             play_selection_flash_frames: 0,
             edit_selection_flash_frames: 0,

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -156,6 +156,25 @@ impl WaveformState {
         self.zoom_anchor_ratio = ratio;
     }
 
+    pub(in crate::native_app) fn start_playback_after_audition_handoff(
+        &mut self,
+        current_ratio: f32,
+        audition_start_ratio: f32,
+        show_marker: bool,
+    ) {
+        let current_ratio = current_ratio.clamp(0.0, 1.0);
+        let audition_start_ratio = audition_start_ratio.clamp(0.0, current_ratio);
+        self.start_playback_with_marker(current_ratio, false);
+        self.play_mark_ratio = show_marker.then_some(audition_start_ratio);
+        self.record_already_auditioned_span(audition_start_ratio, current_ratio);
+    }
+
+    pub(in crate::native_app) fn restart_playback_preserving_marker(&mut self, ratio: f32) {
+        let marker = self.play_mark_ratio;
+        self.start_playback_with_marker(ratio, false);
+        self.play_mark_ratio = marker;
+    }
+
     pub(in crate::native_app) fn set_playhead_ratio(&mut self, ratio: f32) {
         let ratio = ratio.clamp(0.0, 1.0);
         self.playhead_ratio = Some(ratio);
@@ -205,6 +224,18 @@ impl WaveformState {
             &mut self.played_ranges,
             SelectionRange::new(start, end),
         );
+    }
+
+    pub(in crate::native_app) fn record_already_auditioned_span(&mut self, start: f32, end: f32) {
+        self.mark_played_range(start, end);
+    }
+
+    pub(in crate::native_app) fn record_preview_audition_progress(&mut self, ratio: f32) {
+        let ratio = ratio.clamp(0.0, 1.0);
+        if self.play_mark_ratio.is_none() {
+            self.play_mark_ratio = Some(0.0);
+        }
+        self.mark_played_range(0.0, ratio);
     }
 
     pub(in crate::native_app) fn played_ranges(&self) -> &[SelectionRange] {

--- a/src/native_app/waveform/state_playback.rs
+++ b/src/native_app/waveform/state_playback.rs
@@ -2,6 +2,9 @@ use super::{
     WaveformState,
     state::{NormalizedAuditionGainCacheKey, NormalizedAuditionGainSourceKey},
 };
+use wavecrate::selection::SelectionRange;
+
+const PLAYED_PROGRESS_EPSILON: f32 = 1.0e-6;
 
 impl WaveformState {
     pub(in crate::native_app) fn normalized_audition_gain_for_span(
@@ -149,6 +152,7 @@ impl WaveformState {
         self.playback_visual_generation = self.playback_visual_generation.wrapping_add(1);
         self.play_mark_ratio = show_marker.then_some(ratio);
         self.playhead_ratio = Some(ratio);
+        self.played_progress_anchor = Some(ratio);
         self.zoom_anchor_ratio = ratio;
     }
 
@@ -158,11 +162,76 @@ impl WaveformState {
         self.zoom_anchor_ratio = ratio;
     }
 
+    pub(in crate::native_app) fn set_playhead_ratio_from_playback(
+        &mut self,
+        ratio: f32,
+        span: Option<(f32, f32)>,
+        looping: bool,
+    ) {
+        let ratio = ratio.clamp(0.0, 1.0);
+        self.playhead_ratio = Some(ratio);
+        self.zoom_anchor_ratio = ratio;
+        if !self.playing {
+            self.played_progress_anchor = None;
+            return;
+        }
+
+        let Some((span_start, span_end)) = normalized_played_span(span) else {
+            self.played_progress_anchor = Some(ratio);
+            return;
+        };
+        let current = ratio.clamp(span_start, span_end);
+        let Some(previous) = self.played_progress_anchor.replace(current) else {
+            return;
+        };
+        if previous < span_start - PLAYED_PROGRESS_EPSILON
+            || previous > span_end + PLAYED_PROGRESS_EPSILON
+        {
+            return;
+        }
+        let previous = previous.clamp(span_start, span_end);
+        if current + PLAYED_PROGRESS_EPSILON < previous {
+            if looping {
+                self.mark_played_range(previous, span_end);
+                self.mark_played_range(span_start, current);
+            }
+            return;
+        }
+        self.mark_played_range(previous, current);
+    }
+
+    fn mark_played_range(&mut self, start: f32, end: f32) {
+        super::state_range_history::insert_merged_range(
+            &mut self.played_ranges,
+            SelectionRange::new(start, end),
+        );
+    }
+
+    pub(in crate::native_app) fn played_ranges(&self) -> &[SelectionRange] {
+        &self.played_ranges
+    }
+
     pub(in crate::native_app) fn stop_playback(&mut self) {
         if self.playing || self.playhead_ratio.is_some() {
             self.playback_visual_generation = self.playback_visual_generation.wrapping_add(1);
         }
         self.playing = false;
         self.playhead_ratio = None;
+        self.played_progress_anchor = None;
     }
+}
+
+fn normalized_played_span(span: Option<(f32, f32)>) -> Option<(f32, f32)> {
+    let (start, end) = span.unwrap_or((0.0, 1.0));
+    if !start.is_finite() || !end.is_finite() {
+        return None;
+    }
+    let start = start.clamp(0.0, 1.0);
+    let end = end.clamp(0.0, 1.0);
+    let (start, end) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    (end - start > PLAYED_PROGRESS_EPSILON).then_some((start, end))
 }

--- a/src/native_app/waveform/state_preserved_marks.rs
+++ b/src/native_app/waveform/state_preserved_marks.rs
@@ -9,6 +9,7 @@ pub(in crate::native_app) struct WaveformPreservedMarks {
     edit_selection: Option<SelectionRange>,
     marked_play_ranges: Vec<SelectionRange>,
     extracted_ranges: Vec<SelectionRange>,
+    played_ranges: Vec<SelectionRange>,
     similar_sections: SimilarSectionsState,
     play_selection_flash_frames: u8,
     edit_selection_flash_frames: u8,
@@ -42,6 +43,8 @@ impl WaveformState {
         self.edit_selection = marks.edit_selection;
         self.marked_play_ranges = marks.marked_play_ranges;
         self.extracted_ranges = marks.extracted_ranges;
+        self.played_ranges = marks.played_ranges;
+        self.played_progress_anchor = None;
         self.similar_sections = marks.similar_sections;
         self.play_selection_flash_frames = marks.play_selection_flash_frames;
         self.edit_selection_flash_frames = marks.edit_selection_flash_frames;
@@ -87,6 +90,11 @@ impl WaveformState {
                 .collect(),
             extracted_ranges: self
                 .extracted_ranges
+                .iter()
+                .filter_map(|range| transform.map_range(*range))
+                .collect(),
+            played_ranges: self
+                .played_ranges
                 .iter()
                 .filter_map(|range| transform.map_range(*range))
                 .collect(),

--- a/src/native_app/waveform/state_range_history.rs
+++ b/src/native_app/waveform/state_range_history.rs
@@ -1,0 +1,31 @@
+use wavecrate::selection::SelectionRange;
+
+const RANGE_MERGE_EPSILON: f64 = 1.0e-6;
+
+pub(super) fn insert_merged_range(ranges: &mut Vec<SelectionRange>, selection: SelectionRange) {
+    if selection.width_f64() <= 0.0 {
+        return;
+    }
+    ranges.push(SelectionRange::new_precise(
+        selection.start_f64(),
+        selection.end_f64(),
+    ));
+    ranges.sort_by(|a, b| a.start_f64().total_cmp(&b.start_f64()));
+
+    let mut merged = Vec::with_capacity(ranges.len());
+    for range in ranges.drain(..) {
+        let Some(previous) = merged.last_mut() else {
+            merged.push(range);
+            continue;
+        };
+        if range.start_f64() <= previous.end_f64() + RANGE_MERGE_EPSILON {
+            *previous = SelectionRange::new_precise(
+                previous.start_f64(),
+                previous.end_f64().max(range.end_f64()),
+            );
+        } else {
+            merged.push(range);
+        }
+    }
+    *ranges = merged;
+}

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -833,6 +833,28 @@ fn extracted_ranges_paint_as_gray_waveform_overlays() {
 }
 
 #[test]
+fn played_ranges_paint_as_a_subtle_thick_bottom_rail() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state
+        .played_ranges
+        .push(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    let widget = waveform_widget_for_state(&state);
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+
+    let fills = fill_rects(&plan);
+    let rail = fills
+        .iter()
+        .find(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (103, 196, 207, 158)
+        })
+        .expect("played range rail");
+    assert!((rail.rect.min.x - 40.0).abs() < 0.001);
+    assert!((rail.rect.max.x - 120.0).abs() < 0.001);
+    assert!((rail.rect.min.y - 76.0).abs() < 0.001);
+    assert!((rail.rect.max.y - 80.0).abs() < 0.001);
+}
+
+#[test]
 fn extracted_ranges_paint_while_playmark_selection_drag_is_active() {
     let mut state = WaveformState::synthetic_for_tests();
     state

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -845,7 +845,7 @@ fn played_ranges_paint_as_a_subtle_thick_bottom_rail() {
     let rail = fills
         .iter()
         .find(|fill| {
-            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (103, 196, 207, 158)
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (98, 102, 106, 255)
         })
         .expect("played range rail");
     assert!((rail.rect.min.x - 40.0).abs() < 0.001);

--- a/src/native_app/waveform/tests/state.rs
+++ b/src/native_app/waveform/tests/state.rs
@@ -73,6 +73,20 @@ fn played_ranges_do_not_fill_a_non_looping_backward_seek_gap() {
 }
 
 #[test]
+fn already_auditioned_handoff_span_backfills_history_before_live_progress() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.start_playback_after_audition_handoff(0.4, 0.0, true);
+    state.set_playhead_ratio_from_playback(0.5, Some((0.0, 1.0)), false);
+
+    assert_eq!(state.play_mark_ratio(), Some(0.0));
+    assert_eq!(state.playhead_ratio(), Some(0.5));
+    assert_eq!(
+        state.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.0, 0.5)]
+    );
+}
+
+#[test]
 fn played_ranges_survive_same_sample_refresh_but_reset_for_a_new_load() {
     let mut state = WaveformState::synthetic_for_tests();
     state.start_playback(0.1);

--- a/src/native_app/waveform/tests/state.rs
+++ b/src/native_app/waveform/tests/state.rs
@@ -24,6 +24,73 @@ fn playback_state_starts_at_head_and_clears_on_stop() {
 }
 
 #[test]
+fn played_ranges_accumulate_and_merge_forward_playback_progress() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.start_playback(0.2);
+
+    state.set_playhead_ratio_from_playback(0.35, Some((0.2, 0.8)), false);
+    state.set_playhead_ratio_from_playback(0.5, Some((0.2, 0.8)), false);
+
+    assert_eq!(
+        state.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.2, 0.5)]
+    );
+}
+
+#[test]
+fn played_ranges_split_loop_wraps_at_the_audible_span_boundaries() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.start_playback(0.7);
+
+    state.set_playhead_ratio_from_playback(0.79, Some((0.2, 0.8)), true);
+    state.set_playhead_ratio_from_playback(0.25, Some((0.2, 0.8)), true);
+
+    assert_eq!(
+        state.played_ranges(),
+        &[
+            wavecrate::selection::SelectionRange::new(0.2, 0.25),
+            wavecrate::selection::SelectionRange::new(0.7, 0.8),
+        ]
+    );
+}
+
+#[test]
+fn played_ranges_do_not_fill_a_non_looping_backward_seek_gap() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.start_playback(0.7);
+    state.set_playhead_ratio_from_playback(0.8, Some((0.0, 1.0)), false);
+
+    state.set_playhead_ratio_from_playback(0.2, Some((0.0, 1.0)), false);
+    state.set_playhead_ratio_from_playback(0.3, Some((0.0, 1.0)), false);
+
+    assert_eq!(
+        state.played_ranges(),
+        &[
+            wavecrate::selection::SelectionRange::new(0.2, 0.3),
+            wavecrate::selection::SelectionRange::new(0.7, 0.8),
+        ]
+    );
+}
+
+#[test]
+fn played_ranges_survive_same_sample_refresh_but_reset_for_a_new_load() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state.start_playback(0.1);
+    state.set_playhead_ratio_from_playback(0.4, Some((0.0, 1.0)), false);
+    let marks = state.preserved_marks_unchanged();
+
+    let mut refreshed = WaveformState::synthetic_for_tests();
+    refreshed.restore_preserved_marks(marks);
+    assert_eq!(
+        refreshed.played_ranges(),
+        &[wavecrate::selection::SelectionRange::new(0.1, 0.4)]
+    );
+
+    let new_load = WaveformState::synthetic_for_tests();
+    assert!(new_load.played_ranges().is_empty());
+}
+
+#[test]
 fn visible_ratio_maps_to_absolute_audio_position_inside_viewport() {
     let mut state = WaveformState::synthetic_for_tests();
     state.viewport = super::WaveformViewport {

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -203,6 +203,7 @@ pub(in crate::native_app) struct WaveformWidgetProps {
     hovered_edit_gain_handle: bool,
     hovered_similar_section: Option<wavecrate::selection::SelectionRange>,
     extracted_ranges: Vec<wavecrate::selection::SelectionRange>,
+    played_ranges: Vec<wavecrate::selection::SelectionRange>,
     similar_section_ranges: Vec<wavecrate::selection::SelectionRange>,
     play_selection_flash_frames: u8,
     edit_selection_flash_frames: u8,
@@ -257,6 +258,7 @@ impl WaveformWidgetProps {
             } else {
                 Vec::new()
             },
+            played_ranges: state.played_ranges().to_vec(),
             similar_section_ranges: if similar_section_overlays_visible(active_drag_kind) {
                 state.similar_section_ranges().to_vec()
             } else {
@@ -314,6 +316,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) hovered_edit_gain_handle: bool,
     pub(super) hovered_similar_section: Option<wavecrate::selection::SelectionRange>,
     pub(super) extracted_ranges: Vec<wavecrate::selection::SelectionRange>,
+    pub(super) played_ranges: Vec<wavecrate::selection::SelectionRange>,
     pub(super) similar_section_ranges: Vec<wavecrate::selection::SelectionRange>,
     pub(super) play_selection_flash_frames: u8,
     pub(super) edit_selection_flash_frames: u8,
@@ -350,6 +353,7 @@ impl WaveformWidget {
             hovered_edit_gain_handle,
             hovered_similar_section,
             extracted_ranges,
+            played_ranges,
             similar_section_ranges,
             play_selection_flash_frames,
             edit_selection_flash_frames,
@@ -383,6 +387,7 @@ impl WaveformWidget {
             hovered_edit_gain_handle,
             hovered_similar_section,
             extracted_ranges,
+            played_ranges,
             similar_section_ranges,
             play_selection_flash_frames,
             edit_selection_flash_frames,


### PR DESCRIPTION
## Goal

Show which parts of the loaded sample have been auditioned during the current load session, with playback and the visual rail advancing together from the actual audible position.

## Scope and non-goals

- Add a subtle neutral-grey 4 px rail along the waveform bottom for merged played ranges.
- Update the rail on paint-only playback frames, including navigation playback.
- Keep history local to the loaded waveform and reset it when another sample is loaded.
- Stream supported WAV navigation from the original file at frame zero so waveform promotion does not splice a short preview into a second full playback source.
- Use a minimal 3 ms crossfade for rapid source replacement and stop play-selection mode at terminal one-shot progress.
- Do not persist played ranges as sample metadata or change extraction markers.

## Definition of Done

- Played portions accumulate as a subtle bottom rail while audio is actually playing.
- The rail grows smoothly in realtime and starts at the true navigation playback start.
- Navigation neither replays the audition prefix nor creates a preview-to-full transition click.
- Rapid navigation avoids hard source cuts without materially softening kick transients.
- A completed one-shot play selection leaves playback stopped, so a later selection does not auto-play.
- Played history survives repaint and selection changes for the current load only, and resets for a different loaded sample.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p reson --lib --no-run`
- `cargo test -p wavecrate --lib --no-run`
- `bash scripts/ci.sh smoke`
- `bash scripts/build.sh --release`
- Signed runtime artifact: `target/app-bundles/opt1194/Wavecrate OPT-1194.app`
- Live runtime: user confirmed continuous progress/played-rail behavior and click-free rapid navigation with the 3 ms crossfade.

The local debug test executables compile but stall before harness entry under this machine setup, so focused test execution is represented by compile coverage plus the established smoke gate and signed-app runtime verification.

## Known limitations

None.

User approval is required before merge.