### PR TITLE
OPT-1217 Show global database and cache usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +809,24 @@ dependencies = [
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
 ]
 
 [[package]]
@@ -1846,6 +1870,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2458,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3008,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -4668,6 +4737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,6 +6212,7 @@ name = "wavecrate-library"
 version = "19.1.1"
 dependencies = [
  "blake3",
+ "cap-primitives",
  "directories",
  "libc",
  "rusqlite",
@@ -7152,6 +7232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
  "windows-sys 0.59.0",
 ]
 

--- a/crates/wavecrate-library/Cargo.toml
+++ b/crates/wavecrate-library/Cargo.toml
@@ -14,6 +14,7 @@ test-support = []
 
 [dependencies]
 blake3 = "1.6.1"
+cap-primitives = "4.0.2"
 directories = "6.0.0"
 rusqlite = { version = "0.37.0", features = ["backup", "bundled", "load_extension"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/wavecrate-library/src/app_dirs.rs
+++ b/crates/wavecrate-library/src/app_dirs.rs
@@ -12,6 +12,7 @@ mod paths;
 mod profile;
 mod resolution;
 mod state;
+mod storage_usage;
 
 pub use error::AppDirError;
 pub use overrides::{AppRootGuard, ConfigBaseGuard};
@@ -24,6 +25,7 @@ pub use resolution::{
     app_root_dir, config_base_dir_path, ensure_test_config_base, persistence_mode,
     resolve_persistence, set_app_root_override,
 };
+pub use storage_usage::{GlobalStorageUsage, global_storage_usage};
 
 /// Name of the application directory that lives under the OS config root.
 pub const APP_DIR_NAME: &str = ".wavecrate";

--- a/crates/wavecrate-library/src/app_dirs/storage_usage.rs
+++ b/crates/wavecrate-library/src/app_dirs/storage_usage.rs
@@ -50,6 +50,15 @@ fn global_storage_usage_at(root: &Path) -> Result<GlobalStorageUsage, String> {
 }
 
 fn directory_regular_file_size(root: &Path) -> Result<u64, String> {
+    let root_metadata = match fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(read_error("metadata", root, error)),
+    };
+    if !root_metadata.file_type().is_dir() {
+        return Ok(0);
+    }
+
     let mut total = 0_u64;
     let mut pending = vec![root.to_path_buf()];
     while let Some(directory) = pending.pop() {
@@ -152,5 +161,21 @@ mod tests {
         let usage = global_storage_usage_at(root.path()).expect("measure linked cache");
 
         assert_eq!(usage.cache_bytes, 5);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_traversal_does_not_follow_symbolic_cache_root() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("create storage root");
+        let external = tempfile::tempdir().expect("create external cache root");
+        fs::write(external.path().join("external.cache"), [0_u8; 61])
+            .expect("write external payload");
+        symlink(external.path(), root.path().join(CACHE_DIR_NAME)).expect("link cache root");
+
+        let usage = global_storage_usage_at(root.path()).expect("measure linked cache root");
+
+        assert_eq!(usage.cache_bytes, 0);
     }
 }

--- a/crates/wavecrate-library/src/app_dirs/storage_usage.rs
+++ b/crates/wavecrate-library/src/app_dirs/storage_usage.rs
@@ -2,6 +2,8 @@
 
 use std::{fs, io, path::Path};
 
+use cap_primitives::{ambient_authority, fs as capability_fs};
+
 use crate::sample_sources::LIBRARY_DB_FILE_NAME;
 
 use super::app_root_dir;
@@ -27,8 +29,8 @@ impl GlobalStorageUsage {
 
 /// Measure the current global library database and rebuildable cache footprint.
 ///
-/// The traversal does not follow symbolic links, so a link below the cache root
-/// cannot make the reported size escape the app-owned storage boundary.
+/// The traversal does not follow symbolic links, so a linked cache root or
+/// descendant cannot make the reported size escape the app-owned boundary.
 pub fn global_storage_usage() -> Result<GlobalStorageUsage, String> {
     let root = app_root_dir().map_err(|error| error.to_string())?;
     global_storage_usage_at(&root)
@@ -50,6 +52,13 @@ fn global_storage_usage_at(root: &Path) -> Result<GlobalStorageUsage, String> {
 }
 
 fn directory_regular_file_size(root: &Path) -> Result<u64, String> {
+    directory_regular_file_size_with_observer(root, |_| {})
+}
+
+fn directory_regular_file_size_with_observer(
+    root: &Path,
+    mut before_descend: impl FnMut(&Path),
+) -> Result<u64, String> {
     let root_metadata = match fs::symlink_metadata(root) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
@@ -59,34 +68,79 @@ fn directory_regular_file_size(root: &Path) -> Result<u64, String> {
         return Ok(0);
     }
 
+    let parent = root
+        .parent()
+        .ok_or_else(|| format!("Global cache root has no parent: {}", root.display()))?;
+    let root_name = root
+        .file_name()
+        .ok_or_else(|| format!("Global cache root has no file name: {}", root.display()))?;
+    let parent_directory = capability_fs::open_ambient_dir(parent, ambient_authority())
+        .map_err(|error| read_error("cache parent directory", parent, error))?;
+    let root_directory =
+        match capability_fs::open_dir_nofollow(&parent_directory, Path::new(root_name)) {
+            Ok(directory) => directory,
+            Err(error) if entry_changed_before_open(&error) => return Ok(0),
+            Err(error) => return Err(read_error("cache directory", root, error)),
+        };
+
     let mut total = 0_u64;
-    let mut pending = vec![root.to_path_buf()];
-    while let Some(directory) = pending.pop() {
-        let entries = match fs::read_dir(&directory) {
+    let mut pending = vec![(root_directory, root.to_path_buf())];
+    while let Some((directory, display_path)) = pending.pop() {
+        let entries = match capability_fs::read_base_dir(&directory) {
             Ok(entries) => entries,
             Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(read_error("directory", &directory, error)),
+            Err(error) => return Err(read_error("directory", &display_path, error)),
         };
         for entry in entries {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-                Err(error) => return Err(read_error("directory entry", &directory, error)),
+                Err(error) => return Err(read_error("directory entry", &display_path, error)),
             };
-            let path = entry.path();
+            let path = display_path.join(entry.file_name());
             let file_type = match entry.file_type() {
                 Ok(file_type) => file_type,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
                 Err(error) => return Err(read_error("file type", &path, error)),
             };
             if file_type.is_dir() {
-                pending.push(path);
+                before_descend(&path);
+                match capability_fs::open_dir_nofollow(&directory, Path::new(&entry.file_name())) {
+                    Ok(child) => pending.push((child, path)),
+                    Err(error) if entry_changed_before_open(&error) => continue,
+                    Err(error) => return Err(read_error("directory", &path, error)),
+                }
             } else if file_type.is_file() {
-                total = checked_add(total, regular_file_size(&path)?, &path)?;
+                let metadata = match entry.metadata() {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(read_error("metadata", &path, error)),
+                };
+                if metadata.file_type().is_file() {
+                    total = checked_add(total, metadata.len(), &path)?;
+                }
             }
         }
     }
     Ok(total)
+}
+
+fn entry_changed_before_open(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+    ) {
+        return true;
+    }
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(libc::ELOOP) {
+        return true;
+    }
+    #[cfg(target_os = "windows")]
+    if error.raw_os_error() == Some(windows::Win32::Foundation::ERROR_STOPPED_ON_SYMLINK.0 as i32) {
+        return true;
+    }
+    false
 }
 
 fn regular_file_size(path: &Path) -> Result<u64, String> {
@@ -177,5 +231,34 @@ mod tests {
         let usage = global_storage_usage_at(root.path()).expect("measure linked cache root");
 
         assert_eq!(usage.cache_bytes, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_traversal_does_not_follow_directory_replaced_by_symbolic_link() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("create storage root");
+        let external = tempfile::tempdir().expect("create external cache root");
+        fs::write(external.path().join("external.cache"), [0_u8; 61])
+            .expect("write external payload");
+        let cache = root.path().join(CACHE_DIR_NAME);
+        let replaceable = cache.join("replaceable");
+        fs::create_dir_all(&replaceable).expect("create replaceable cache directory");
+        fs::write(replaceable.join("owned.cache"), [0_u8; 5]).expect("write owned payload");
+        let detached = root.path().join("detached-cache");
+        let mut replaced = false;
+
+        let cache_bytes = directory_regular_file_size_with_observer(&cache, |path| {
+            if path == replaceable && !replaced {
+                fs::rename(&replaceable, &detached).expect("detach enumerated directory");
+                symlink(external.path(), &replaceable).expect("replace directory with symlink");
+                replaced = true;
+            }
+        })
+        .expect("measure cache during directory replacement");
+
+        assert!(replaced, "replacement hook should observe the directory");
+        assert_eq!(cache_bytes, 0);
     }
 }

--- a/crates/wavecrate-library/src/app_dirs/storage_usage.rs
+++ b/crates/wavecrate-library/src/app_dirs/storage_usage.rs
@@ -1,0 +1,156 @@
+//! On-disk usage reporting for the global database and rebuildable cache.
+
+use std::{fs, io, path::Path};
+
+use crate::sample_sources::LIBRARY_DB_FILE_NAME;
+
+use super::app_root_dir;
+
+const CACHE_DIR_NAME: &str = "cache";
+const SQLITE_SIDECAR_SUFFIXES: [&str; 3] = ["", "-wal", "-shm"];
+
+/// Logical on-disk bytes owned by the global library database and cache.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct GlobalStorageUsage {
+    /// Bytes in `library.db` and its SQLite WAL/shared-memory sidecars.
+    pub database_bytes: u64,
+    /// Bytes in regular files below the rebuildable global cache root.
+    pub cache_bytes: u64,
+}
+
+impl GlobalStorageUsage {
+    /// Total bytes represented by the database and cache measurements.
+    pub fn total_bytes(self) -> u64 {
+        self.database_bytes.saturating_add(self.cache_bytes)
+    }
+}
+
+/// Measure the current global library database and rebuildable cache footprint.
+///
+/// The traversal does not follow symbolic links, so a link below the cache root
+/// cannot make the reported size escape the app-owned storage boundary.
+pub fn global_storage_usage() -> Result<GlobalStorageUsage, String> {
+    let root = app_root_dir().map_err(|error| error.to_string())?;
+    global_storage_usage_at(&root)
+}
+
+fn global_storage_usage_at(root: &Path) -> Result<GlobalStorageUsage, String> {
+    let database_bytes = SQLITE_SIDECAR_SUFFIXES
+        .into_iter()
+        .try_fold(0_u64, |total, suffix| {
+            let path = root.join(format!("{LIBRARY_DB_FILE_NAME}{suffix}"));
+            checked_add(total, regular_file_size(&path)?, &path)
+        })?;
+    let cache_root = root.join(CACHE_DIR_NAME);
+    let cache_bytes = directory_regular_file_size(&cache_root)?;
+    Ok(GlobalStorageUsage {
+        database_bytes,
+        cache_bytes,
+    })
+}
+
+fn directory_regular_file_size(root: &Path) -> Result<u64, String> {
+    let mut total = 0_u64;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let entries = match fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(read_error("directory", &directory, error)),
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(read_error("directory entry", &directory, error)),
+            };
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(read_error("file type", &path, error)),
+            };
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file() {
+                total = checked_add(total, regular_file_size(&path)?, &path)?;
+            }
+        }
+    }
+    Ok(total)
+}
+
+fn regular_file_size(path: &Path) -> Result<u64, String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(metadata.len()),
+        Ok(_) => Ok(0),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(0),
+        Err(error) => Err(read_error("metadata", path, error)),
+    }
+}
+
+fn checked_add(total: u64, bytes: u64, path: &Path) -> Result<u64, String> {
+    total.checked_add(bytes).ok_or_else(|| {
+        format!(
+            "Global storage size overflow while measuring {}",
+            path.display()
+        )
+    })
+}
+
+fn read_error(kind: &str, path: &Path, error: io::Error) -> String {
+    format!("Failed to read {kind} at {}: {error}", path.display())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn measures_database_sidecars_and_nested_cache_only() {
+        let root = tempfile::tempdir().expect("create storage root");
+        fs::write(root.path().join(LIBRARY_DB_FILE_NAME), [0_u8; 7]).expect("write database");
+        fs::write(root.path().join("library.db-wal"), [0_u8; 5]).expect("write database WAL");
+        fs::write(root.path().join("library.db-shm"), [0_u8; 3])
+            .expect("write database shared memory");
+        fs::write(root.path().join("config.toml"), [0_u8; 19]).expect("write unrelated config");
+        let cache = root.path().join(CACHE_DIR_NAME).join("waveforms");
+        fs::create_dir_all(&cache).expect("create cache tree");
+        fs::write(cache.join("one.cache"), [0_u8; 11]).expect("write first cache payload");
+        fs::write(cache.join("two.cache"), [0_u8; 13]).expect("write second cache payload");
+
+        let usage = global_storage_usage_at(root.path()).expect("measure global storage");
+
+        assert_eq!(usage.database_bytes, 15);
+        assert_eq!(usage.cache_bytes, 24);
+        assert_eq!(usage.total_bytes(), 39);
+    }
+
+    #[test]
+    fn missing_database_and_cache_report_zero_bytes() {
+        let root = tempfile::tempdir().expect("create empty storage root");
+
+        assert_eq!(
+            global_storage_usage_at(root.path()).expect("measure empty global storage"),
+            GlobalStorageUsage::default()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_traversal_does_not_follow_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("create storage root");
+        let external = tempfile::tempdir().expect("create external root");
+        fs::write(external.path().join("large.cache"), [0_u8; 61]).expect("write external payload");
+        let cache = root.path().join(CACHE_DIR_NAME);
+        fs::create_dir_all(&cache).expect("create cache root");
+        fs::write(cache.join("owned.cache"), [0_u8; 5]).expect("write owned payload");
+        symlink(external.path(), cache.join("external")).expect("link external directory");
+
+        let usage = global_storage_usage_at(root.path()).expect("measure linked cache");
+
+        assert_eq!(usage.cache_bytes, 5);
+    }
+}

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -314,6 +314,8 @@ Caches, logs, handoff staging, and recovery files should not be scattered across
 
 Cache payloads should live under the global `.wavecrate` folder in the current target. Source-local `.wavecrate.db` files may store cache references, status, fingerprints, and invalidation state for files in that source, but waveform, analysis, similarity, map, handoff, and other cache payloads should not be written next to the source database.
 
+Settings should report the current on-disk footprint of the global `library.db` (including active SQLite sidecars) and rebuildable cache, with the filesystem traversal performed outside the GUI thread. This read-only usage insight excludes source-local databases, logs, configuration, and handoff staging so the displayed scope stays consistent with the cache-maintenance surface.
+
 Browser row cache indicators describe compact waveform or browser projections only. They must not imply that decoded playback is persisted or reuse source-readiness markers; supported WAV auditionability comes from the current source file and file-backed playback runtime.
 
 ### Durable Source Readiness and Convergence

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -494,4 +494,7 @@ pub(in crate::native_app) enum SettingsMessage {
     PickTrashFolder,
     ClearTrashFolder,
     ClearRebuildableCaches,
+    GlobalStorageUsageFinished(
+        ui::TaskCompletion<Result<wavecrate::app_dirs::GlobalStorageUsage, String>>,
+    ),
 }

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -28,7 +28,7 @@ pub(in crate::native_app) use progress::{
     NormalizationQueueItem, NormalizationResult, SourceProcessingProgress,
 };
 pub(in crate::native_app) use settings::{
-    AppSettingsTab, AudioSettingsDropdown, SampleNameViewMode,
+    AppSettingsTab, AudioSettingsDropdown, GlobalStorageUsageState, SampleNameViewMode,
 };
 pub(in crate::native_app) use source_processing_events::GuiSourceProcessingEventSink;
 #[cfg(test)]

--- a/src/native_app/app/settings.rs
+++ b/src/native_app/app/settings.rs
@@ -12,6 +12,15 @@ pub(in crate::native_app) enum AppSettingsTab {
     AudioEngine,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(in crate::native_app) enum GlobalStorageUsageState {
+    #[default]
+    NotLoaded,
+    Loading,
+    Ready(wavecrate::app_dirs::GlobalStorageUsage),
+    Unavailable,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum SampleNameViewMode {
     DiskFilename,

--- a/src/native_app/app/state/background.rs
+++ b/src/native_app/app/state/background.rs
@@ -36,6 +36,7 @@ pub(in crate::native_app) struct BackgroundTaskState {
     pub(in crate::native_app) folder_tree_refresh_task: ui::LatestTask,
     pub(in crate::native_app) folder_verify_task: ui::LatestTask,
     pub(in crate::native_app) release_update_check_task: ui::LatestTask,
+    pub(in crate::native_app) global_storage_usage_task: ui::LatestTask,
     pub(in crate::native_app) waveform_destructive_edit_task: ui::LatestTask,
     pub(in crate::native_app) waveform_destructive_edit_context:
         Option<WaveformDestructiveEditUiContext>,
@@ -110,6 +111,7 @@ impl BackgroundTaskState {
             folder_tree_refresh_task: ui::LatestTask::new(),
             folder_verify_task: ui::LatestTask::new(),
             release_update_check_task: ui::LatestTask::new(),
+            global_storage_usage_task: ui::LatestTask::new(),
             waveform_destructive_edit_task: ui::LatestTask::new(),
             waveform_destructive_edit_context: None,
             normalization_progress: None,

--- a/src/native_app/app/state/ui_state.rs
+++ b/src/native_app/app/state/ui_state.rs
@@ -11,7 +11,8 @@ use wavecrate::sample_sources::config::AppSettingsCore;
 use wavecrate::selection::SelectionRange;
 
 use crate::native_app::app::{
-    AppSettingsTab, AudioSettingsDropdown, NativeFileDropHover, SamplePlaybackSession,
+    AppSettingsTab, AudioSettingsDropdown, GlobalStorageUsageState, NativeFileDropHover,
+    SamplePlaybackSession,
 };
 use crate::native_app::sample_library::context_menu_target::{
     BrowserContextMenu, BrowserContextPointerAnchor,
@@ -222,6 +223,7 @@ pub(in crate::native_app) struct SettingsUiState {
     pub(in crate::native_app) audio_settings_open: bool,
     pub(in crate::native_app) app_settings_tab: AppSettingsTab,
     pub(in crate::native_app) audio_settings_dropdown: ui::ExclusiveOpen<AudioSettingsDropdown>,
+    pub(in crate::native_app) global_storage_usage: GlobalStorageUsageState,
 }
 
 impl Default for SettingsUiState {
@@ -230,6 +232,7 @@ impl Default for SettingsUiState {
             audio_settings_open: false,
             app_settings_tab: Default::default(),
             audio_settings_dropdown: ui::ExclusiveOpen::new(),
+            global_storage_usage: GlobalStorageUsageState::default(),
         }
     }
 }

--- a/src/native_app/app_chrome/settings/window/panels.rs
+++ b/src/native_app/app_chrome/settings/window/panels.rs
@@ -3,8 +3,9 @@ use radiant::prelude as ui;
 mod projection;
 
 use self::projection::{
-    CacheMaintenanceProjection, RatingDecayProjection, SettingsActionProjection,
-    SettingsPanelRowProjection, TrashFolderProjection, settings_panel_projection,
+    CacheMaintenanceProjection, GlobalStorageProjection, RatingDecayProjection,
+    SettingsActionProjection, SettingsPanelRowProjection, TrashFolderProjection,
+    settings_panel_projection,
 };
 use super::AUDIO_SETTINGS_LABELED_ROW_HEIGHT;
 use super::AUDIO_SETTINGS_ROW_SPACING;
@@ -34,10 +35,20 @@ fn settings_panel_row(
         }
         SettingsPanelRowProjection::TrashFolder(projection) => trash_folder_section(projection),
         SettingsPanelRowProjection::RatingDecay(projection) => rating_decay_section(projection),
+        SettingsPanelRowProjection::GlobalStorage(projection) => global_storage_section(projection),
         SettingsPanelRowProjection::CacheMaintenance(projection) => {
             cache_maintenance_section(projection)
         }
     }
+}
+
+fn global_storage_section(projection: GlobalStorageProjection) -> ui::View<GuiMessage> {
+    let mut values = vec![ui::text_line(projection.total_label, 20.0)];
+    if let Some(detail_label) = projection.detail_label {
+        values.push(ui::text_line(detail_label, 16.0));
+    }
+    let control = ui::column(values).spacing(2.0).fill_width().height(42.0);
+    ui::labeled_control(projection.label, control, 54.0)
 }
 
 fn audio_engine_detail_row(detail_label: String) -> ui::View<GuiMessage> {

--- a/src/native_app/app_chrome/settings/window/panels/projection.rs
+++ b/src/native_app/app_chrome/settings/window/panels/projection.rs
@@ -1,3 +1,4 @@
+use crate::native_app::app::GlobalStorageUsageState;
 use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, SettingsMessage};
 use crate::native_app::app_chrome::view_models::settings::AudioSettingsSnapshot;
 use wavecrate::sample_sources::config::{
@@ -39,6 +40,7 @@ pub(super) enum SettingsPanelRowProjection {
     },
     TrashFolder(TrashFolderProjection),
     RatingDecay(RatingDecayProjection),
+    GlobalStorage(GlobalStorageProjection),
     CacheMaintenance(CacheMaintenanceProjection),
 }
 
@@ -54,6 +56,13 @@ pub(super) struct TrashFolderProjection {
 pub(super) struct CacheMaintenanceProjection {
     pub(super) label: &'static str,
     pub(super) clear_action: SettingsActionProjection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct GlobalStorageProjection {
+    pub(super) label: &'static str,
+    pub(super) total_label: String,
+    pub(super) detail_label: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -144,6 +153,9 @@ fn general_settings_panel_rows(
                 message: SettingsMessage::ClearTrashFolder,
             },
         }),
+        SettingsPanelRowProjection::GlobalStorage(global_storage_projection(
+            &snapshot.global_storage_usage,
+        )),
         SettingsPanelRowProjection::CacheMaintenance(CacheMaintenanceProjection {
             label: "Maintenance",
             clear_action: SettingsActionProjection {
@@ -152,6 +164,47 @@ fn general_settings_panel_rows(
             },
         }),
     ]
+}
+
+fn global_storage_projection(state: &GlobalStorageUsageState) -> GlobalStorageProjection {
+    match state {
+        GlobalStorageUsageState::NotLoaded | GlobalStorageUsageState::Loading => {
+            GlobalStorageProjection {
+                label: "Database + Cache",
+                total_label: "Calculating...".to_string(),
+                detail_label: None,
+            }
+        }
+        GlobalStorageUsageState::Ready(usage) => GlobalStorageProjection {
+            label: "Database + Cache",
+            total_label: format!("{} total", format_storage_bytes(usage.total_bytes())),
+            detail_label: Some(format!(
+                "{} database + {} cache",
+                format_storage_bytes(usage.database_bytes),
+                format_storage_bytes(usage.cache_bytes)
+            )),
+        },
+        GlobalStorageUsageState::Unavailable => GlobalStorageProjection {
+            label: "Database + Cache",
+            total_label: "Size unavailable".to_string(),
+            detail_label: None,
+        },
+    }
+}
+
+fn format_storage_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 fn rating_decay_slider_value(weeks: u16) -> f32 {
@@ -233,7 +286,7 @@ mod tests {
             panic!("expected general panel");
         };
 
-        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.len(), 5);
         assert_eq!(
             rows[0],
             SettingsPanelRowProjection::Title { label: "General" }
@@ -265,7 +318,14 @@ mod tests {
             SettingsMessage::ClearTrashFolder
         );
 
-        let SettingsPanelRowProjection::CacheMaintenance(maintenance) = &rows[3] else {
+        let SettingsPanelRowProjection::GlobalStorage(storage) = &rows[3] else {
+            panic!("expected global storage row");
+        };
+        assert_eq!(storage.label, "Database + Cache");
+        assert_eq!(storage.total_label, "Calculating...");
+        assert_eq!(storage.detail_label, None);
+
+        let SettingsPanelRowProjection::CacheMaintenance(maintenance) = &rows[4] else {
             panic!("expected cache maintenance row");
         };
         assert_eq!(maintenance.label, "Maintenance");
@@ -313,5 +373,39 @@ mod tests {
             RatingDecayProjection::weeks_from_slider_value(rating_decay.slider_value),
             12
         );
+    }
+
+    #[test]
+    fn global_storage_projection_formats_total_and_breakdown() {
+        let snapshot = snapshot(|snapshot| {
+            snapshot.tab = AppSettingsTab::General;
+            snapshot.global_storage_usage =
+                GlobalStorageUsageState::Ready(wavecrate::app_dirs::GlobalStorageUsage {
+                    database_bytes: 9 * 1024 * 1024 + 512 * 1024,
+                    cache_bytes: 470 * 1024 * 1024,
+                });
+        });
+
+        let SettingsPanelProjection::General { rows } = settings_panel_projection(&snapshot) else {
+            panic!("expected general panel");
+        };
+        let SettingsPanelRowProjection::GlobalStorage(storage) = &rows[3] else {
+            panic!("expected global storage row");
+        };
+
+        assert_eq!(storage.total_label, "479.5 MiB total");
+        assert_eq!(
+            storage.detail_label.as_deref(),
+            Some("9.5 MiB database + 470.0 MiB cache")
+        );
+    }
+
+    #[test]
+    fn storage_size_formatter_preserves_small_values_and_scales_large_values() {
+        assert_eq!(format_storage_bytes(0), "0 B");
+        assert_eq!(format_storage_bytes(512), "512 B");
+        assert_eq!(format_storage_bytes(1536), "1.5 KiB");
+        assert_eq!(format_storage_bytes(2 * 1024 * 1024), "2.0 MiB");
+        assert_eq!(format_storage_bytes(3 * 1024 * 1024 * 1024), "3.0 GiB");
     }
 }

--- a/src/native_app/app_chrome/view_models/settings.rs
+++ b/src/native_app/app_chrome/view_models/settings.rs
@@ -3,13 +3,16 @@ use wavecrate::audio::{AudioDeviceSummary, AudioHostSummary, AudioOutputConfig};
 #[cfg(test)]
 use wavecrate::sample_sources::config::DEFAULT_RATING_DECAY_WEEKS;
 
-use crate::native_app::app::{AppSettingsTab, AudioSettingsDropdown, NativeAppState};
+use crate::native_app::app::{
+    AppSettingsTab, AudioSettingsDropdown, GlobalStorageUsageState, NativeAppState,
+};
 
 #[derive(Clone, Debug)]
 pub(in crate::native_app) struct AudioSettingsSnapshot {
     pub(in crate::native_app) tab: AppSettingsTab,
     pub(in crate::native_app) trash_folder: Option<PathBuf>,
     pub(in crate::native_app) rating_decay_weeks: u16,
+    pub(in crate::native_app) global_storage_usage: GlobalStorageUsageState,
     pub(in crate::native_app) detail_label: String,
     pub(in crate::native_app) error: Option<String>,
     pub(in crate::native_app) audio_output_config: AudioOutputConfig,
@@ -25,6 +28,7 @@ impl AudioSettingsSnapshot {
             tab: state.ui.settings.ui.app_settings_tab,
             trash_folder: state.ui.settings.persisted.trash_folder.clone(),
             rating_decay_weeks: state.ui.settings.persisted.controls.rating_decay_weeks,
+            global_storage_usage: state.ui.settings.ui.global_storage_usage.clone(),
             detail_label: state.audio_engine_detail_label(),
             error: state.audio.settings_error.clone(),
             audio_output_config: state.audio.output_config.clone(),
@@ -55,6 +59,7 @@ impl AudioSettingsSnapshot {
             tab: AppSettingsTab::AudioEngine,
             trash_folder: None,
             rating_decay_weeks: DEFAULT_RATING_DECAY_WEEKS,
+            global_storage_usage: GlobalStorageUsageState::NotLoaded,
             detail_label: "no audio".to_string(),
             error: None,
             audio_output_config: AudioOutputConfig::default(),

--- a/src/native_app/audio/audio_engine.rs
+++ b/src/native_app/audio/audio_engine.rs
@@ -3,5 +3,6 @@ mod lifecycle;
 mod options;
 mod output_config;
 mod settings;
+mod storage_usage;
 mod timing;
 mod volume;

--- a/src/native_app/audio/audio_engine/cache.rs
+++ b/src/native_app/audio/audio_engine/cache.rs
@@ -1,9 +1,14 @@
 use std::time::Instant;
 
-use crate::native_app::app::{NativeAppState, emit_gui_action};
+use radiant::prelude as ui;
+
+use crate::native_app::app::{GuiMessage, NativeAppState, emit_gui_action};
 
 impl NativeAppState {
-    pub(in crate::native_app) fn clear_rebuildable_caches(&mut self) {
+    pub(in crate::native_app) fn clear_rebuildable_caches(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         let started_at = Instant::now();
         match wavecrate::app_dirs::clear_rebuildable_cache_payloads() {
             Ok(path) => {
@@ -32,5 +37,6 @@ impl NativeAppState {
                 );
             }
         }
+        self.queue_global_storage_usage_refresh(context);
     }
 }

--- a/src/native_app/audio/audio_engine/settings.rs
+++ b/src/native_app/audio/audio_engine/settings.rs
@@ -1,18 +1,23 @@
 use std::time::Instant;
 
+use radiant::prelude as ui;
+
 use crate::native_app::app::{
-    AppSettingsTab, AudioSettingsDropdown, NativeAppState, emit_gui_action,
+    AppSettingsTab, AudioSettingsDropdown, GuiMessage, NativeAppState, emit_gui_action,
 };
 
 impl NativeAppState {
-    pub(in crate::native_app) fn toggle_audio_settings(&mut self) {
+    pub(in crate::native_app) fn toggle_audio_settings(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         let started_at = Instant::now();
         if self.ui.settings.ui.audio_settings_open
             && self.ui.settings.ui.app_settings_tab == AppSettingsTab::AudioEngine
         {
             self.close_audio_settings_window();
         } else {
-            self.open_settings_window(AppSettingsTab::AudioEngine);
+            self.open_settings_window(AppSettingsTab::AudioEngine, context);
         }
         emit_gui_action(
             "audio.settings.toggle",
@@ -28,9 +33,12 @@ impl NativeAppState {
         );
     }
 
-    pub(in crate::native_app) fn open_general_settings(&mut self) {
+    pub(in crate::native_app) fn open_general_settings(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         let started_at = Instant::now();
-        self.open_settings_window(AppSettingsTab::General);
+        self.open_settings_window(AppSettingsTab::General, context);
         emit_gui_action(
             "settings.general.open",
             Some("top_bar"),
@@ -55,8 +63,13 @@ impl NativeAppState {
         );
     }
 
-    fn open_settings_window(&mut self, tab: AppSettingsTab) {
+    fn open_settings_window(
+        &mut self,
+        tab: AppSettingsTab,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
         self.refresh_audio_options();
+        self.queue_global_storage_usage_refresh(context);
         self.ui.settings.ui.audio_settings_open = true;
         self.ui.settings.ui.app_settings_tab = tab;
         self.close_audio_settings_dropdowns();

--- a/src/native_app/audio/audio_engine/storage_usage.rs
+++ b/src/native_app/audio/audio_engine/storage_usage.rs
@@ -1,0 +1,91 @@
+use radiant::prelude as ui;
+
+use crate::native_app::app::{
+    GlobalStorageUsageState, GuiMessage, NativeAppState, SettingsMessage,
+};
+
+impl NativeAppState {
+    pub(in crate::native_app) fn queue_global_storage_usage_refresh(
+        &mut self,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        self.ui.settings.ui.global_storage_usage = GlobalStorageUsageState::Loading;
+        context
+            .business()
+            .blocking_io("gui-global-storage-usage")
+            .latest(&mut self.background.global_storage_usage_task)
+            .run(
+                |_| wavecrate::app_dirs::global_storage_usage(),
+                |completion| {
+                    GuiMessage::Settings(SettingsMessage::GlobalStorageUsageFinished(completion))
+                },
+            );
+    }
+
+    pub(in crate::native_app) fn finish_global_storage_usage_refresh(
+        &mut self,
+        completion: ui::TaskCompletion<Result<wavecrate::app_dirs::GlobalStorageUsage, String>>,
+    ) {
+        let Some(result) = self
+            .background
+            .global_storage_usage_task
+            .finish_completion(completion)
+        else {
+            return;
+        };
+        match result {
+            Ok(usage) => {
+                self.ui.settings.ui.global_storage_usage = GlobalStorageUsageState::Ready(usage);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "wavecrate::debug::storage",
+                    event = "global_storage_usage.failed",
+                    error = error.as_str(),
+                    "Failed to measure global database and cache usage"
+                );
+                self.ui.settings.ui.global_storage_usage = GlobalStorageUsageState::Unavailable;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_completion_ignores_stale_measurements() {
+        let mut state =
+            crate::native_app::test_support::state::NativeAppStateFixture::default().build();
+        let stale_ticket = state.background.global_storage_usage_task.begin();
+        let current_ticket = state.background.global_storage_usage_task.begin();
+
+        state.finish_global_storage_usage_refresh(ui::TaskCompletion {
+            ticket: stale_ticket,
+            output: Ok(wavecrate::app_dirs::GlobalStorageUsage {
+                database_bytes: 1,
+                cache_bytes: 2,
+            }),
+        });
+        assert_eq!(
+            state.ui.settings.ui.global_storage_usage,
+            GlobalStorageUsageState::NotLoaded
+        );
+
+        state.finish_global_storage_usage_refresh(ui::TaskCompletion {
+            ticket: current_ticket,
+            output: Ok(wavecrate::app_dirs::GlobalStorageUsage {
+                database_bytes: 3,
+                cache_bytes: 5,
+            }),
+        });
+        assert_eq!(
+            state.ui.settings.ui.global_storage_usage,
+            GlobalStorageUsageState::Ready(wavecrate::app_dirs::GlobalStorageUsage {
+                database_bytes: 3,
+                cache_bytes: 5,
+            })
+        );
+    }
+}

--- a/src/native_app/shell/message_dispatch/settings.rs
+++ b/src/native_app/shell/message_dispatch/settings.rs
@@ -18,8 +18,8 @@ impl NativeAppState {
                 self.set_normalized_audition_enabled(enabled, context);
             }
             SettingsMessage::ToggleHelpTooltips => self.toggle_help_tooltips(),
-            SettingsMessage::ToggleAudioSettings => self.toggle_audio_settings(),
-            SettingsMessage::OpenGeneralSettings => self.open_general_settings(),
+            SettingsMessage::ToggleAudioSettings => self.toggle_audio_settings(context),
+            SettingsMessage::OpenGeneralSettings => self.open_general_settings(context),
             SettingsMessage::SelectSettingsTab(tab) => self.select_settings_tab(tab),
             SettingsMessage::CloseAudioSettings => self.close_audio_settings_window(),
             SettingsMessage::ToggleAudioBackendDropdown => self.toggle_audio_backend_dropdown(),
@@ -36,7 +36,10 @@ impl NativeAppState {
             SettingsMessage::SetRatingDecayWeeks(weeks) => self.set_rating_decay_weeks(weeks),
             SettingsMessage::PickTrashFolder => self.pick_trash_folder(context),
             SettingsMessage::ClearTrashFolder => self.clear_trash_folder(),
-            SettingsMessage::ClearRebuildableCaches => self.clear_rebuildable_caches(),
+            SettingsMessage::ClearRebuildableCaches => self.clear_rebuildable_caches(context),
+            SettingsMessage::GlobalStorageUsageFinished(completion) => {
+                self.finish_global_storage_usage_refresh(completion);
+            }
         }
     }
 

--- a/src/native_app/tests/audio_settings_controls/routing.rs
+++ b/src/native_app/tests/audio_settings_controls/routing.rs
@@ -167,6 +167,10 @@ fn settings_top_bar_actions_open_expected_tabs() {
         state.ui.settings.ui.app_settings_tab,
         crate::native_app::test_support::state::AppSettingsTab::General
     );
+    assert_eq!(
+        state.ui.settings.ui.global_storage_usage,
+        crate::native_app::app::GlobalStorageUsageState::Loading
+    );
 
     state.apply_message(
         crate::native_app::test_support::state::GuiMessage::Settings(

--- a/src/native_app/tests/cache_cleanup.rs
+++ b/src/native_app/tests/cache_cleanup.rs
@@ -31,6 +31,10 @@ fn clear_rebuildable_caches_action_removes_cache_payloads_only() {
     assert!(!cache_payload.exists());
     assert!(handoff_payload.exists());
     assert_eq!(state.audio.settings_error, None);
+    assert_eq!(
+        state.ui.settings.ui.global_storage_usage,
+        crate::native_app::app::GlobalStorageUsageState::Loading
+    );
     assert!(
         state
             .ui


### PR DESCRIPTION
## Goal

Give users clear, read-only insight into the disk footprint of Wavecrate's global database and rebuildable cache from General Settings.

Linear: [OPT-1217](https://linear.app/boostnlvp/issue/OPT-1217/add-insight-into-the-size-of-the-global-wavecrate-databasecache-to-the)

## Scope and non-goals

- Report `library.db` plus active SQLite `-wal` / `-shm` sidecars.
- Recursively report regular files under the global rebuildable `cache/` root without following symbolic links.
- Refresh asynchronously whenever Settings opens and after cache cleanup; fence stale completions.
- Render a human-readable total and database/cache breakdown in General Settings.
- Excludes source-local `.wavecrate.db` files, logs, config, handoff staging, cleanup policy, and storage limits.

## Definition of Done

- General Settings shows the current global database/cache total and breakdown.
- Filesystem traversal does not block the GUI thread.
- Missing database/cache paths report zero and transient deletion races do not fail the measurement.
- Cache cleanup refreshes the displayed value.
- Formatting, scope, async routing, and stale-result behavior have regression coverage.
- The exact branch build is exercised in a uniquely identified sandbox app.

## Validation

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt-1217.LITP1d CARGO_INCREMENTAL=0 cargo check -j2 -p wavecrate --all-targets` — passed.
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt-1217.LITP1d CARGO_INCREMENTAL=0 cargo test -p wavecrate-library --lib app_dirs::storage_usage` — 5 passed.
- Focused Wavecrate tests for projection/formatting, stale completion, Settings-open routing, and cache-clear refresh — passed.
- `bash scripts/ci.sh agent` — smoke, Radiant/Wavecrate architecture guardrails, Radiant tests, and 3,719 Wavecrate tests passed; the gate remains red on 52 unrelated pre-existing Wavecrate failures. A representative exact failure (`filter_section_projects_curation_scope_dropdown_and_dispatches_changes`) reproduces unchanged on pristine `origin/main` at `5c21e04dc`.
- `scripts/build.sh --release --variant OPT-1217 --no-build` — signed branch-specific app bundle passed code-sign verification.
- Manual sandbox runtime — General Settings rendered `Database + Cache`, `152.0 KiB total`, and the database/cache breakdown without clipping.

## Known limitations

- The repository-wide agent gate is not green because of the confirmed `origin/main` baseline failures described above; no OPT-1217-focused validation failed.

User approval is required before merge.


