### PR TITLE
Adopt 0.19.1 pre-1.0 release identity

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Stable target version, for example 19.1.0
+        description: Stable target version, for example 0.19.1
         required: true
         type: string
       rc_number:
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       branch:
-        description: Release branch, for example release/19.1
+        description: Release branch, for example release/0.19
         required: true
         type: string
       release_notes:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Stable version, for example 19.1.0
+        description: Stable version, for example 0.19.1
         required: true
         type: string
       branch:
-        description: Release branch, for example release/19.1
+        description: Release branch, for example release/0.19
         required: true
         type: string
       release_notes:

--- a/.github/workflows/release-train-prepare.yml
+++ b/.github/workflows/release-train-prepare.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Stable target version, for example 19.1.0
+        description: Stable target version, for example 0.19.1
         required: true
         type: string
       source_ref:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "arboard",
  "base64",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-analysis"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "directories",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-analysis-admin"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "rusqlite",
  "wavecrate",
@@ -6194,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-bench-cli"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "hound",
  "rand 0.9.5",
@@ -6209,7 +6209,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-library"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "cap-primitives",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-scan"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "blake3",
  "libc",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "wavecrate-updater-helper"
-version = "19.1.1"
+version = "0.19.1"
 dependencies = [
  "wavecrate",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "3"
 
 [package]
 name = "wavecrate"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 default-run = "wavecrate"
 autobins = false

--- a/apps/updater-helper/Cargo.toml
+++ b/apps/updater-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-updater-helper"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [[bin]]

--- a/crates/wavecrate-analysis/Cargo.toml
+++ b/crates/wavecrate-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-analysis"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [features]

--- a/crates/wavecrate-library/Cargo.toml
+++ b/crates/wavecrate-library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-library"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [lints.rust]

--- a/crates/wavecrate-scan/Cargo.toml
+++ b/crates/wavecrate-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-scan"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [lints.rust]

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -28,13 +28,13 @@ expected to be an Ed25519 private key in PEM form that OpenSSL can use for
 
 - `WAVECRATE_RELEASE_VERSION`
 Full semver release identity embedded into a packaged binary. Examples:
-`19.1.0-nightly.20260701+abc1234`, `19.1.0-rc.1`, `19.1.0`.
+`0.19.1-nightly.20260701+abc1234`, `0.19.1-rc.1`, `0.19.1`.
 
 - `WAVECRATE_RELEASE_CHANNEL`
 Embedded release channel: `nightly`, `rc`, or `stable`.
 
 - `WAVECRATE_RELEASE_TARGET_VERSION`
-Stable target version for the release train, such as `19.1.0`.
+Stable target version for the release train, such as `0.19.1`.
 
 - `WAVECRATE_RELEASE_BUILD_DATE`
 UTC build date embedded into the binary in `YYYY-MM-DD` form.
@@ -109,9 +109,9 @@ behind explicit operator intent:
 ```bash
 scripts/release.sh prepare --bump minor --source-ref main --dry-run
 scripts/release.sh prepare --bump minor --source-ref main --push
-scripts/release.sh prepare --bump patch --source-ref release/19.1 --dry-run
-scripts/release.sh rc --version 19.2.0 --rc-number 1 --branch release/19.2 --dispatch
-scripts/release.sh stable --version 19.2.0 --branch release/19.2 --dispatch
+scripts/release.sh prepare --bump patch --source-ref release/0.19 --dry-run
+scripts/release.sh rc --version 0.20.0 --rc-number 1 --branch release/0.20 --dispatch
+scripts/release.sh stable --version 0.20.0 --branch release/0.20 --dispatch
 ```
 
 `prepare --bump major` bumps `X.Y.Z` to `(X+1).0.0`; `prepare --bump minor`
@@ -131,7 +131,7 @@ Local equivalent:
 
 ```bash
 scripts/internal/release/prepare_release_train.py \
-  --version 19.1.0 \
+  --version 0.19.1 \
   --source-ref main \
   --push
 ```
@@ -221,7 +221,7 @@ the workflow verifies that the public per-release log and full changelog bodies
 match the generated files.
 Only after PortalSurfer publication has been verified does the workflow refresh
 the rolling GitHub `nightly` release assets, publish the immutable nightly
-version tag named like `19.1.0-nightly.20260701+abc1234`, move the rolling
+version tag named like `0.19.1-nightly.20260701+abc1234`, move the rolling
 `nightly` tag, and update the rolling release metadata. Scheduled and manual
 nightly runs do not cancel an in-flight run because tag movement is the final
 public identity transition. If a run fails before the PortalSurfer commit step,
@@ -270,11 +270,11 @@ release metadata from the workflow run:
 scripts/internal/release/verify_published_release.py \
   --surface github \
   --channel stable \
-  --version 19.1.0 \
-  --target-version 19.1.0 \
+  --version 0.19.1 \
+  --target-version 0.19.1 \
   --commit <target-sha> \
   --build-date <yyyy-mm-dd> \
-  --tag v19.1.0 \
+  --tag v0.19.1 \
   --repo PORTALSURFER/wavecrate \
   --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
 ```
@@ -285,12 +285,12 @@ To rerun the PortalSurfer verifier for the same release:
 scripts/internal/release/verify_published_release.py \
   --surface portalsurfer \
   --channel stable \
-  --version 19.1.0 \
-  --target-version 19.1.0 \
+  --version 0.19.1 \
+  --target-version 0.19.1 \
   --commit <target-sha> \
   --build-date <yyyy-mm-dd> \
   --portal-catalog-url https://portalsurfer.org/wavecrate/api/v1/releases \
-  --portal-build-id wavecrate-19.1.0 \
+  --portal-build-id wavecrate-0.19.1 \
   --build-number <build-number> \
   --checksum-public-key 8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=
 ```

--- a/docs/MACOS_RELEASE_SIGNING.md
+++ b/docs/MACOS_RELEASE_SIGNING.md
@@ -51,8 +51,8 @@ scripts/internal/release/build_release_zip.sh \
   --platform macos \
   --arch aarch64 \
   --channel nightly \
-  --version "19.1.0-nightly.$(date -u +%Y%m%d)+$(git rev-parse --short=8 HEAD)" \
-  --target-version 19.1.0 \
+  --version "0.19.1-nightly.$(date -u +%Y%m%d)+$(git rev-parse --short=8 HEAD)" \
+  --target-version 0.19.1 \
   --build-number 1 \
   --git-sha "$(git rev-parse HEAD)" \
   --build-date "$(date -u +%Y-%m-%d)"

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -184,7 +184,7 @@ Opportunistic metadata updates such as listen-history writes should never delay 
 
 Wavecrate uses pre-1.0 semantic versions until the product is explicitly declared ready for a 1.0 release. The current line is `0.19.1`, with release coordination on `release/0.19` and artifact identities such as `v0.19.1-rc.N` and `v0.19.1`. New builds must not continue the legacy `19.x` numbering.
 
-Previously published `19.x` artifacts remain immutable historical releases. During the one-time renumbering, update checks must allow an installed legacy `19.x` build to discover the first `0.19.1` or newer pre-1.0 release even though ordinary SemVer ordering would treat the new major-zero version as lower. Once an installation is on `0.x`, normal SemVer ordering applies. PortalSurfer must display catalog artifact versions truthfully; it may identify the current development line separately, but it must never relabel an existing signed `19.x` artifact as `0.19.1`.
+Previously published `19.x` artifacts remain immutable historical releases. During the one-time renumbering, update checks must allow an installed legacy `19.1.x` build to discover `0.19.1` or a later pre-1.0 release even though ordinary SemVer ordering would treat the new major-zero version as lower. Conversely, a pre-1.0 installation must ignore historical `19.1.x` catalog entries. This exception is scoped to the colliding `19.1.x` line so that a future ordinary upgrade to a real `19.x` release retains normal SemVer ordering. PortalSurfer must display catalog artifact versions truthfully; it may identify the current development line separately, but it must never relabel an existing signed `19.x` artifact as `0.19.1`.
 
 ## Non-Goals
 

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -180,6 +180,12 @@ Perceived stalls are product bugs. If a source scan, decode, rename, edit render
 
 Opportunistic metadata updates such as listen-history writes should never delay sample selection, validation, cache loading, or playback. They should use low-priority background work, short database busy timeouts, and skip/retry behavior when source databases are locked by higher-value work.
 
+## Release Identity
+
+Wavecrate uses pre-1.0 semantic versions until the product is explicitly declared ready for a 1.0 release. The current line is `0.19.1`, with release coordination on `release/0.19` and artifact identities such as `v0.19.1-rc.N` and `v0.19.1`. New builds must not continue the legacy `19.x` numbering.
+
+Previously published `19.x` artifacts remain immutable historical releases. During the one-time renumbering, update checks must allow an installed legacy `19.x` build to discover the first `0.19.1` or newer pre-1.0 release even though ordinary SemVer ordering would treat the new major-zero version as lower. Once an installation is on `0.x`, normal SemVer ordering applies. PortalSurfer must display catalog artifact versions truthfully; it may identify the current development line separately, but it must never relabel an existing signed `19.x` artifact as `0.19.1`.
+
 ## Non-Goals
 
 Wavecrate should not become:

--- a/scripts/internal/release/generate_release_log.sh
+++ b/scripts/internal/release/generate_release_log.sh
@@ -157,7 +157,7 @@ git fetch --tags --force >/dev/null 2>&1 || true
 find_previous_stable_tag() {
   local exclude_tag="$1"
   local target="$2"
-  local tag commit
+  local tag commit distance best_tag="" best_distance=""
   while IFS= read -r tag; do
     if [[ "$tag" == "$exclude_tag" || ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       continue
@@ -169,10 +169,16 @@ find_previous_stable_tag() {
       continue
     fi
     if git merge-base --is-ancestor "$commit" "$target"; then
-      printf '%s\n' "$tag"
-      return 0
+      distance="$(git rev-list --count "${commit}..${target}")"
+      if [[ -z "$best_distance" ]] || (( distance < best_distance )); then
+        best_tag="$tag"
+        best_distance="$distance"
+      fi
     fi
-  done < <(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname)
+  done < <(git tag -l 'v[0-9]*.[0-9]*.[0-9]*')
+  if [[ -n "$best_tag" ]]; then
+    printf '%s\n' "$best_tag"
+  fi
 }
 
 find_previous_rc_tag() {

--- a/scripts/internal/release/prepare_release_train.py
+++ b/scripts/internal/release/prepare_release_train.py
@@ -34,7 +34,7 @@ def main() -> int:
     parser.add_argument(
         "--version",
         required=True,
-        help="Target release version, for example 19.1.0.",
+        help="Target release version, for example 0.19.1.",
     )
     parser.add_argument(
         "--source-ref",

--- a/scripts/internal/release/validate_promoted_rc_release.py
+++ b/scripts/internal/release/validate_promoted_rc_release.py
@@ -63,8 +63,8 @@ def main() -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--version", required=True, help="Stable version, e.g. 19.1.0")
-    parser.add_argument("--rc-tag", required=True, help="Promoted RC tag, e.g. v19.1.0-rc.2")
+    parser.add_argument("--version", required=True, help="Stable version, e.g. 0.19.1")
+    parser.add_argument("--rc-tag", required=True, help="Promoted RC tag, e.g. v0.19.1-rc.2")
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""), help="GitHub repo owner/name")
     parser.add_argument(
         "--contract",

--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -98,7 +98,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--channel", required=True, choices=["nightly", "rc", "stable"])
     parser.add_argument("--version", required=True, help="Release version embedded in update-manifest.json")
-    parser.add_argument("--target-version", required=True, help="Stable target version, e.g. 19.1.0")
+    parser.add_argument("--target-version", required=True, help="Stable target version, e.g. 0.19.1")
     parser.add_argument("--commit", required=True, help="Expected release commit SHA")
     parser.add_argument("--build-date", required=True, help="Expected release build date, YYYY-MM-DD")
     parser.add_argument("--tag", help="GitHub release tag to inspect")

--- a/src/updater/asset_names.rs
+++ b/src/updater/asset_names.rs
@@ -102,18 +102,18 @@ mod tests {
         assert_eq!(
             expected_zip_asset_name(
                 &identity(UpdateChannel::Stable, "windows", "x86_64"),
-                Some("19.1.0")
+                Some("0.19.1")
             )
             .unwrap(),
-            "wavecrate-19.1.0-windows-x86_64.zip"
+            "wavecrate-0.19.1-windows-x86_64.zip"
         );
         assert_eq!(
             expected_zip_asset_name(
                 &identity(UpdateChannel::Rc, "macos", "aarch64"),
-                Some("19.1.0-rc.2")
+                Some("0.19.1-rc.2")
             )
             .unwrap(),
-            "wavecrate-19.1.0-rc.2-macos-aarch64.zip"
+            "wavecrate-0.19.1-rc.2-macos-aarch64.zip"
         );
     }
 

--- a/src/updater/check.rs
+++ b/src/updater/check.rs
@@ -6,6 +6,10 @@ use tracing::warn;
 use super::github;
 use super::{RuntimeIdentity, UpdateChannel, UpdateError};
 
+const PRE_ONE_RENUMBERING_MAJOR: u64 = 19;
+const FIRST_PRE_ONE_MINOR: u64 = 19;
+const FIRST_PRE_ONE_PATCH: u64 = 1;
+
 /// Input for checking whether an update is available.
 #[derive(Debug, Clone)]
 pub struct UpdateCheckRequest {
@@ -74,7 +78,7 @@ fn stable_outcome(
     let latest = Version::parse(version_text).map_err(|err| {
         UpdateError::Invalid(format!("Invalid stable version '{version_text}': {err}"))
     })?;
-    if &latest > current {
+    if release_version_is_newer(current, &latest) {
         Ok(UpdateCheckOutcome::UpdateAvailable {
             tag,
             html_url: release.html_url,
@@ -98,7 +102,7 @@ fn rc_outcome(
     let latest = Version::parse(version_text).map_err(|err| {
         UpdateError::Invalid(format!("Invalid RC version '{version_text}': {err}"))
     })?;
-    if &latest > current {
+    if release_version_is_newer(current, &latest) {
         Ok(UpdateCheckOutcome::UpdateAvailable {
             tag,
             html_url: release.html_url,
@@ -107,6 +111,20 @@ fn rc_outcome(
     } else {
         Ok(UpdateCheckOutcome::UpToDate)
     }
+}
+
+fn release_version_is_newer(current: &Version, candidate: &Version) -> bool {
+    if current.major == 0 && candidate.major == PRE_ONE_RENUMBERING_MAJOR {
+        return false;
+    }
+
+    candidate > current || is_legacy_to_pre_one_transition(current, candidate)
+}
+
+fn is_legacy_to_pre_one_transition(current: &Version, candidate: &Version) -> bool {
+    current.major == PRE_ONE_RENUMBERING_MAJOR
+        && candidate.major == 0
+        && (candidate.minor, candidate.patch) >= (FIRST_PRE_ONE_MINOR, FIRST_PRE_ONE_PATCH)
 }
 
 fn nightly_outcome(
@@ -208,6 +226,48 @@ mod tests {
         assert!(matches!(
             outcome,
             UpdateCheckOutcome::UpdateAvailable { .. }
+        ));
+    }
+
+    #[test]
+    fn legacy_release_line_updates_to_pre_one_version() {
+        let current = Version::parse("19.1.1").unwrap();
+        let candidate = Version::parse("0.19.1").unwrap();
+
+        assert!(release_version_is_newer(&current, &candidate));
+    }
+
+    #[test]
+    fn pre_one_versions_keep_normal_semver_ordering() {
+        let current = Version::parse("0.19.1").unwrap();
+
+        assert!(release_version_is_newer(
+            &current,
+            &Version::parse("0.19.2").unwrap()
+        ));
+        assert!(!release_version_is_newer(
+            &current,
+            &Version::parse("0.19.0").unwrap()
+        ));
+    }
+
+    #[test]
+    fn pre_one_versions_reject_legacy_catalog_entries() {
+        let current = Version::parse("0.19.1").unwrap();
+
+        assert!(!release_version_is_newer(
+            &current,
+            &Version::parse("19.1.1").unwrap()
+        ));
+    }
+
+    #[test]
+    fn legacy_transition_rejects_versions_before_first_pre_one_release() {
+        let current = Version::parse("19.1.0").unwrap();
+
+        assert!(!release_version_is_newer(
+            &current,
+            &Version::parse("0.19.0").unwrap()
         ));
     }
 }

--- a/src/updater/check.rs
+++ b/src/updater/check.rs
@@ -6,7 +6,8 @@ use tracing::warn;
 use super::github;
 use super::{RuntimeIdentity, UpdateChannel, UpdateError};
 
-const PRE_ONE_RENUMBERING_MAJOR: u64 = 19;
+const LEGACY_RENUMBERING_MAJOR: u64 = 19;
+const LEGACY_RENUMBERING_MINOR: u64 = 1;
 const FIRST_PRE_ONE_MINOR: u64 = 19;
 const FIRST_PRE_ONE_PATCH: u64 = 1;
 
@@ -114,7 +115,7 @@ fn rc_outcome(
 }
 
 fn release_version_is_newer(current: &Version, candidate: &Version) -> bool {
-    if current.major == 0 && candidate.major == PRE_ONE_RENUMBERING_MAJOR {
+    if is_pre_one_install_with_historical_legacy_candidate(current, candidate) {
         return false;
     }
 
@@ -122,9 +123,20 @@ fn release_version_is_newer(current: &Version, candidate: &Version) -> bool {
 }
 
 fn is_legacy_to_pre_one_transition(current: &Version, candidate: &Version) -> bool {
-    current.major == PRE_ONE_RENUMBERING_MAJOR
+    current.major == LEGACY_RENUMBERING_MAJOR
+        && current.minor == LEGACY_RENUMBERING_MINOR
         && candidate.major == 0
         && (candidate.minor, candidate.patch) >= (FIRST_PRE_ONE_MINOR, FIRST_PRE_ONE_PATCH)
+}
+
+fn is_pre_one_install_with_historical_legacy_candidate(
+    current: &Version,
+    candidate: &Version,
+) -> bool {
+    current.major == 0
+        && (current.minor, current.patch) >= (FIRST_PRE_ONE_MINOR, FIRST_PRE_ONE_PATCH)
+        && candidate.major == LEGACY_RENUMBERING_MAJOR
+        && candidate.minor == LEGACY_RENUMBERING_MINOR
 }
 
 fn nightly_outcome(
@@ -259,6 +271,14 @@ mod tests {
             &current,
             &Version::parse("19.1.1").unwrap()
         ));
+    }
+
+    #[test]
+    fn future_major_nineteen_release_keeps_normal_semver_ordering() {
+        let current = Version::parse("18.9.0").unwrap();
+        let candidate = Version::parse("19.1.0").unwrap();
+
+        assert!(release_version_is_newer(&current, &candidate));
     }
 
     #[test]

--- a/src/updater/public_catalog.rs
+++ b/src/updater/public_catalog.rs
@@ -477,23 +477,23 @@ mod tests {
         let catalog = catalog(&[
             release_with_version(
                 250,
-                "wavecrate-19.1.0-nightly.20260701+abcdef0",
-                "19.1.0-nightly.20260701+abcdef0",
-                "wavecrate-19.1.0-nightly.20260701+abcdef0-windows-x86_64.zip",
+                "wavecrate-0.19.1-nightly.20260701+abcdef0",
+                "0.19.1-nightly.20260701+abcdef0",
+                "wavecrate-0.19.1-nightly.20260701+abcdef0-windows-x86_64.zip",
                 "2026-07-01T20:00:00.000Z",
             ),
             release_with_version(
                 251,
-                "wavecrate-19.1.0-rc.1",
-                "19.1.0-rc.1",
-                "wavecrate-19.1.0-rc.1-windows-x86_64.zip",
+                "wavecrate-0.19.1-rc.1",
+                "0.19.1-rc.1",
+                "wavecrate-0.19.1-rc.1-windows-x86_64.zip",
                 "2026-07-02T20:00:00.000Z",
             ),
             release_with_version(
                 252,
-                "wavecrate-19.1.0",
-                "19.1.0",
-                "wavecrate-19.1.0-windows-x86_64.zip",
+                "wavecrate-0.19.1",
+                "0.19.1",
+                "wavecrate-0.19.1-windows-x86_64.zip",
                 "2026-07-03T20:00:00.000Z",
             ),
         ]);
@@ -529,20 +529,20 @@ mod tests {
         .expect("release contract")
         .expect("nightly");
 
-        assert_eq!(stable.version, "19.1.0");
-        assert_eq!(stable.build_id, "wavecrate-19.1.0");
-        assert_eq!(rc.version, "19.1.0");
-        assert_eq!(rc.build_id, "wavecrate-19.1.0");
-        assert_eq!(nightly.version, "19.1.0-nightly.20260701+abcdef0");
+        assert_eq!(stable.version, "0.19.1");
+        assert_eq!(stable.build_id, "wavecrate-0.19.1");
+        assert_eq!(rc.version, "0.19.1");
+        assert_eq!(rc.build_id, "wavecrate-0.19.1");
+        assert_eq!(nightly.version, "0.19.1-nightly.20260701+abcdef0");
     }
 
     #[test]
     fn public_catalog_exposes_rc_when_no_newer_stable_supersedes_it() {
         let catalog = catalog(&[release_with_version(
             251,
-            "wavecrate-19.1.0-rc.1",
-            "19.1.0-rc.1",
-            "wavecrate-19.1.0-rc.1-macos-aarch64.zip",
+            "wavecrate-0.19.1-rc.1",
+            "0.19.1-rc.1",
+            "wavecrate-0.19.1-rc.1-macos-aarch64.zip",
             "2026-07-02T20:00:00.000Z",
         )]);
 
@@ -557,8 +557,8 @@ mod tests {
         .expect("release contract")
         .expect("rc");
 
-        assert_eq!(rc.build_id, "wavecrate-19.1.0-rc.1");
-        assert_eq!(rc.version, "19.1.0-rc.1");
+        assert_eq!(rc.build_id, "wavecrate-0.19.1-rc.1");
+        assert_eq!(rc.version, "0.19.1-rc.1");
     }
 
     fn catalog(releases: &[PublicReleaseCatalogRelease]) -> PublicReleaseCatalog {

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -124,13 +124,15 @@ fn workspace_release_identity_is_pre_one_and_consistent() {
     }
 
     assert!(
-        TARGET_DOCS.contains(&format!("current line is `{current_version}`")),
-        "docs/TARGET.md must name the current pre-1.0 release line"
+        TARGET_DOCS.contains("Wavecrate uses pre-1.0 semantic versions"),
+        "docs/TARGET.md must preserve the pre-1.0 release policy"
     );
     assert!(
-        RC_WORKFLOW.contains(&format!("example {current_version}"))
-            && STABLE_WORKFLOW.contains(&format!("example {current_version}")),
-        "manual release workflows must show the current pre-1.0 version"
+        RC_WORKFLOW.contains("example 0.")
+            && RC_WORKFLOW.contains("example release/0.")
+            && STABLE_WORKFLOW.contains("example 0.")
+            && STABLE_WORKFLOW.contains("example release/0."),
+        "manual release workflows must demonstrate the pre-1.0 version and branch shape"
     );
 }
 

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -7,6 +7,32 @@ use toml::Value;
 const RELEASE_CONTRACT: &str = include_str!("../release_contract.toml");
 const WORKSPACE_MANIFEST: &str = include_str!("../Cargo.toml");
 const WORKSPACE_LOCKFILE: &str = include_str!("../Cargo.lock");
+const RELEASE_PACKAGE_MANIFESTS: &[(&str, &str)] = &[
+    (
+        "wavecrate-analysis",
+        include_str!("../crates/wavecrate-analysis/Cargo.toml"),
+    ),
+    (
+        "wavecrate-library",
+        include_str!("../crates/wavecrate-library/Cargo.toml"),
+    ),
+    (
+        "wavecrate-scan",
+        include_str!("../crates/wavecrate-scan/Cargo.toml"),
+    ),
+    (
+        "wavecrate-updater-helper",
+        include_str!("../apps/updater-helper/Cargo.toml"),
+    ),
+    (
+        "wavecrate-analysis-admin",
+        include_str!("../tools/analysis-admin/Cargo.toml"),
+    ),
+    (
+        "wavecrate-bench-cli",
+        include_str!("../tools/bench-cli/Cargo.toml"),
+    ),
+];
 const CODEOWNERS: &str = include_str!("../.github/CODEOWNERS");
 const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.yml");
 const RELEASE_TRAIN_PREP_WORKFLOW: &str =
@@ -49,6 +75,64 @@ const GETTING_STARTED_DOCS: &str = include_str!("../docs/book/src/getting-starte
 const MANUAL_USAGE_DOCS: &str = include_str!("../manual/usage.md");
 const UPDATER_ASSET_NAMES: &str = include_str!("../src/updater/asset_names.rs");
 const CHECKSUMS_PUBLIC_KEY: &str = "8Z7dQJBRMbxCFkFMeBYa1FMSWOUm6nePFgoK5c43jT4=";
+
+#[test]
+fn workspace_release_identity_is_pre_one_and_consistent() {
+    let workspace = WORKSPACE_MANIFEST
+        .parse::<Value>()
+        .expect("workspace manifest parses");
+    let current_version = workspace["package"]["version"]
+        .as_str()
+        .expect("workspace package version");
+    let parsed = semver::Version::parse(current_version).expect("workspace version is semver");
+
+    assert_eq!(
+        parsed.major, 0,
+        "Wavecrate must remain pre-1.0 until an explicit 1.0 decision"
+    );
+
+    let release_package_names = RELEASE_PACKAGE_MANIFESTS
+        .iter()
+        .map(|(name, manifest)| {
+            let manifest = manifest
+                .parse::<Value>()
+                .unwrap_or_else(|err| panic!("{name} manifest parses: {err}"));
+            assert_eq!(
+                manifest["package"]["version"].as_str(),
+                Some(current_version),
+                "{name} must share the Wavecrate release version"
+            );
+            *name
+        })
+        .chain(std::iter::once("wavecrate"))
+        .collect::<BTreeSet<_>>();
+
+    let lockfile = WORKSPACE_LOCKFILE
+        .parse::<Value>()
+        .expect("workspace lockfile parses");
+    for package in lockfile["package"].as_array().expect("lockfile packages") {
+        let Some(name) = package["name"].as_str() else {
+            continue;
+        };
+        if release_package_names.contains(name) {
+            assert_eq!(
+                package["version"].as_str(),
+                Some(current_version),
+                "Cargo.lock entry for {name} must share the Wavecrate release version"
+            );
+        }
+    }
+
+    assert!(
+        TARGET_DOCS.contains(&format!("current line is `{current_version}`")),
+        "docs/TARGET.md must name the current pre-1.0 release line"
+    );
+    assert!(
+        RC_WORKFLOW.contains(&format!("example {current_version}"))
+            && STABLE_WORKFLOW.contains(&format!("example {current_version}")),
+        "manual release workflows must show the current pre-1.0 version"
+    );
+}
 
 #[test]
 fn platform_labels_are_active_release_labels_only() {
@@ -617,29 +701,29 @@ fn release_contract_templates_emit_supported_rc_and_stable_asset_names() {
 
     let rc_names: BTreeSet<String> = active_target_matrix(&targets)
         .iter()
-        .map(|target| apply_asset_template(rc_template, app_name(&contract), target, "19.1.0", "2"))
+        .map(|target| apply_asset_template(rc_template, app_name(&contract), target, "0.19.1", "2"))
         .collect();
     let stable_names: BTreeSet<String> = active_target_matrix(&targets)
         .iter()
         .map(|target| {
-            apply_asset_template(stable_template, app_name(&contract), target, "19.1.0", "2")
+            apply_asset_template(stable_template, app_name(&contract), target, "0.19.1", "2")
         })
         .collect();
 
     assert_eq!(
         rc_names,
         BTreeSet::from([
-            "wavecrate-19.1.0-rc.2-macos-aarch64.zip".to_string(),
-            "wavecrate-19.1.0-rc.2-macos-x86_64.zip".to_string(),
-            "wavecrate-19.1.0-rc.2-windows-x86_64.zip".to_string(),
+            "wavecrate-0.19.1-rc.2-macos-aarch64.zip".to_string(),
+            "wavecrate-0.19.1-rc.2-macos-x86_64.zip".to_string(),
+            "wavecrate-0.19.1-rc.2-windows-x86_64.zip".to_string(),
         ])
     );
     assert_eq!(
         stable_names,
         BTreeSet::from([
-            "wavecrate-19.1.0-macos-aarch64.zip".to_string(),
-            "wavecrate-19.1.0-macos-x86_64.zip".to_string(),
-            "wavecrate-19.1.0-windows-x86_64.zip".to_string(),
+            "wavecrate-0.19.1-macos-aarch64.zip".to_string(),
+            "wavecrate-0.19.1-macos-x86_64.zip".to_string(),
+            "wavecrate-0.19.1-windows-x86_64.zip".to_string(),
         ])
     );
 }

--- a/tests/release_log_generator.rs
+++ b/tests/release_log_generator.rs
@@ -15,8 +15,8 @@ fn rc_first_release_log_uses_previous_stable_boundary_and_manual_notes() {
     let release_dir = repo.release_dir();
     write_release_files(
         &release_dir,
-        "wavecrate-19.1.0-rc.1-windows-x86_64.zip",
-        "checksums-19.1.0-rc.1.txt",
+        "wavecrate-0.19.1-rc.1-windows-x86_64.zip",
+        "checksums-0.19.1-rc.1.txt",
     );
 
     let out = release_dir.join("release-log.md");
@@ -26,25 +26,25 @@ fn rc_first_release_log_uses_previous_stable_boundary_and_manual_notes() {
             "--channel",
             "rc",
             "--version",
-            "19.1.0-rc.1",
+            "0.19.1-rc.1",
             "--target-version",
-            "19.1.0",
+            "0.19.1",
             "--target-sha",
             &target_sha,
             "--target-branch",
-            "release/19.1",
+            "release/0.19",
             "--build-date",
             "2026-07-02",
             "--artifact-dir",
             release_dir.to_str().expect("release dir utf-8"),
             "--checksum-name",
-            "checksums-19.1.0-rc.1.txt",
+            "checksums-0.19.1-rc.1.txt",
             "--checksum-sig-name",
-            "checksums-19.1.0-rc.1.txt.sig",
+            "checksums-0.19.1-rc.1.txt.sig",
             "--rc-number",
             "1",
             "--release-tag",
-            "v19.1.0-rc.1",
+            "v0.19.1-rc.1",
             "--out",
             out.to_str().expect("output path utf-8"),
         ],
@@ -52,14 +52,14 @@ fn rc_first_release_log_uses_previous_stable_boundary_and_manual_notes() {
     );
 
     let log = fs::read_to_string(out).expect("read generated log");
-    assert!(log.contains("# Wavecrate 19.1.0-rc.1"));
+    assert!(log.contains("# Wavecrate 0.19.1-rc.1"));
     assert!(log.contains("- Channel: Release Candidate"));
-    assert!(log.contains("- Target branch: release/19.1"));
+    assert!(log.contains("- Target branch: release/0.19"));
     assert!(log.contains("- RC number: 1"));
     assert!(log.contains("- Previous release boundary: v19.0.0"));
-    assert!(log.contains("- windows / x86_64: `wavecrate-19.1.0-rc.1-windows-x86_64.zip`"));
-    assert!(log.contains("- Checksums: `checksums-19.1.0-rc.1.txt`"));
-    assert!(log.contains("- Signature: `checksums-19.1.0-rc.1.txt.sig`"));
+    assert!(log.contains("- windows / x86_64: `wavecrate-0.19.1-rc.1-windows-x86_64.zip`"));
+    assert!(log.contains("- Checksums: `checksums-0.19.1-rc.1.txt`"));
+    assert!(log.contains("- Signature: `checksums-0.19.1-rc.1.txt.sig`"));
     assert!(log.contains("## Manual Notes"));
     assert!(log.contains("Manual review note."));
     assert!(log.contains("## Generated Changes"));
@@ -72,13 +72,13 @@ fn later_rc_release_log_uses_previous_rc_boundary() {
     repo.commit("initial stable");
     repo.tag("v19.0.0");
     repo.commit("prepare rc one");
-    repo.tag("v19.1.0-rc.1");
+    repo.tag("v0.19.1-rc.1");
     let target_sha = repo.commit("fix rc two blocker");
     let release_dir = repo.release_dir();
     write_release_files(
         &release_dir,
-        "wavecrate-19.1.0-rc.2-macos-aarch64.zip",
-        "checksums-19.1.0-rc.2.txt",
+        "wavecrate-0.19.1-rc.2-macos-aarch64.zip",
+        "checksums-0.19.1-rc.2.txt",
     );
 
     let out = release_dir.join("release-log.md");
@@ -88,25 +88,25 @@ fn later_rc_release_log_uses_previous_rc_boundary() {
             "--channel",
             "rc",
             "--version",
-            "19.1.0-rc.2",
+            "0.19.1-rc.2",
             "--target-version",
-            "19.1.0",
+            "0.19.1",
             "--target-sha",
             &target_sha,
             "--target-branch",
-            "release/19.1",
+            "release/0.19",
             "--build-date",
             "2026-07-02",
             "--artifact-dir",
             release_dir.to_str().expect("release dir utf-8"),
             "--checksum-name",
-            "checksums-19.1.0-rc.2.txt",
+            "checksums-0.19.1-rc.2.txt",
             "--checksum-sig-name",
-            "checksums-19.1.0-rc.2.txt.sig",
+            "checksums-0.19.1-rc.2.txt.sig",
             "--rc-number",
             "2",
             "--release-tag",
-            "v19.1.0-rc.2",
+            "v0.19.1-rc.2",
             "--out",
             out.to_str().expect("output path utf-8"),
         ],
@@ -114,7 +114,7 @@ fn later_rc_release_log_uses_previous_rc_boundary() {
     );
 
     let log = fs::read_to_string(out).expect("read generated log");
-    assert!(log.contains("- Previous release boundary: v19.1.0-rc.1"));
+    assert!(log.contains("- Previous release boundary: v0.19.1-rc.1"));
     assert!(log.contains("- fix rc two blocker"));
     assert!(!log.contains("- prepare rc one"));
 }
@@ -126,12 +126,12 @@ fn stable_release_log_records_promoted_rc_and_previous_stable_boundary() {
     repo.tag("v19.0.0");
     repo.commit("prepare final train");
     let target_sha = repo.commit("final release polish");
-    repo.tag("v19.1.0-rc.2");
+    repo.tag("v0.19.1-rc.2");
     let release_dir = repo.release_dir();
     write_release_files(
         &release_dir,
-        "wavecrate-19.1.0-macos-x86_64.zip",
-        "checksums-19.1.0.txt",
+        "wavecrate-0.19.1-macos-x86_64.zip",
+        "checksums-0.19.1.txt",
     );
 
     let out = release_dir.join("release-log.md");
@@ -141,23 +141,23 @@ fn stable_release_log_records_promoted_rc_and_previous_stable_boundary() {
             "--channel",
             "stable",
             "--version",
-            "19.1.0",
+            "0.19.1",
             "--target-sha",
             &target_sha,
             "--target-branch",
-            "release/19.1",
+            "release/0.19",
             "--build-date",
             "2026-07-02",
             "--artifact-dir",
             release_dir.to_str().expect("release dir utf-8"),
             "--checksum-name",
-            "checksums-19.1.0.txt",
+            "checksums-0.19.1.txt",
             "--checksum-sig-name",
-            "checksums-19.1.0.txt.sig",
+            "checksums-0.19.1.txt.sig",
             "--promoted-rc-tag",
-            "v19.1.0-rc.2",
+            "v0.19.1-rc.2",
             "--release-tag",
-            "v19.1.0",
+            "v0.19.1",
             "--out",
             out.to_str().expect("output path utf-8"),
         ],
@@ -165,11 +165,11 @@ fn stable_release_log_records_promoted_rc_and_previous_stable_boundary() {
     );
 
     let log = fs::read_to_string(out).expect("read generated log");
-    assert!(log.contains("# Wavecrate 19.1.0"));
+    assert!(log.contains("# Wavecrate 0.19.1"));
     assert!(log.contains("- Channel: Stable"));
-    assert!(log.contains("- Promoted from: v19.1.0-rc.2"));
+    assert!(log.contains("- Promoted from: v0.19.1-rc.2"));
     assert!(log.contains("- Previous release boundary: v19.0.0"));
-    assert!(log.contains("- macos / x86_64: `wavecrate-19.1.0-macos-x86_64.zip`"));
+    assert!(log.contains("- macos / x86_64: `wavecrate-0.19.1-macos-x86_64.zip`"));
     assert!(log.contains("- prepare final train"));
     assert!(log.contains("- final release polish"));
 }

--- a/tests/release_log_generator.rs
+++ b/tests/release_log_generator.rs
@@ -67,6 +67,59 @@ fn rc_first_release_log_uses_previous_stable_boundary_and_manual_notes() {
 }
 
 #[test]
+fn rc_release_log_prefers_nearest_pre_one_stable_over_legacy_version_sort() {
+    let repo = FixtureRepo::new();
+    repo.commit("legacy stable");
+    repo.tag("v19.1.0");
+    repo.commit("publish pre-one stable");
+    repo.tag("v0.19.1");
+    let target_sha = repo.commit("add current train change");
+    let release_dir = repo.release_dir();
+    write_release_files(
+        &release_dir,
+        "wavecrate-0.20.0-rc.1-windows-x86_64.zip",
+        "checksums-0.20.0-rc.1.txt",
+    );
+
+    let out = release_dir.join("release-log.md");
+    run_generator(
+        &repo,
+        &[
+            "--channel",
+            "rc",
+            "--version",
+            "0.20.0-rc.1",
+            "--target-version",
+            "0.20.0",
+            "--target-sha",
+            &target_sha,
+            "--target-branch",
+            "release/0.20",
+            "--build-date",
+            "2026-07-21",
+            "--artifact-dir",
+            release_dir.to_str().expect("release dir utf-8"),
+            "--checksum-name",
+            "checksums-0.20.0-rc.1.txt",
+            "--checksum-sig-name",
+            "checksums-0.20.0-rc.1.txt.sig",
+            "--rc-number",
+            "1",
+            "--release-tag",
+            "v0.20.0-rc.1",
+            "--out",
+            out.to_str().expect("output path utf-8"),
+        ],
+        None,
+    );
+
+    let log = fs::read_to_string(out).expect("read generated log");
+    assert!(log.contains("- Previous release boundary: v0.19.1"));
+    assert!(log.contains("- add current train change"));
+    assert!(!log.contains("- publish pre-one stable"));
+}
+
+#[test]
 fn later_rc_release_log_uses_previous_rc_boundary() {
     let repo = FixtureRepo::new();
     repo.commit("initial stable");

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 #[test]
 fn prepare_minor_bump_derives_target_version_branch_and_runs_prep_helper() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
 
@@ -25,9 +25,9 @@ fn prepare_minor_bump_derives_target_version_branch_and_runs_prep_helper() {
 
     assert_success(&output);
     let stdout = stdout(&output);
-    assert!(stdout.contains("Resolved version: 19.2.0"));
-    assert!(stdout.contains("Release branch: release/19.2"));
-    assert!(stdout.contains("prepare-helper [--version] [19.2.0]"));
+    assert!(stdout.contains("Resolved version: 0.20.0"));
+    assert!(stdout.contains("Release branch: release/0.20"));
+    assert!(stdout.contains("prepare-helper [--version] [0.20.0]"));
     assert!(stdout.contains("[--dry-run]"));
     assert!(stdout.contains("release-train-prepare.yml"));
 }
@@ -35,7 +35,7 @@ fn prepare_minor_bump_derives_target_version_branch_and_runs_prep_helper() {
 #[test]
 fn prepare_major_bump_derives_next_major_train() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.4.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
 
@@ -43,17 +43,17 @@ fn prepare_major_bump_derives_next_major_train() {
 
     assert_success(&output);
     let stdout = stdout(&output);
-    assert!(stdout.contains("Resolved version: 20.0.0"));
-    assert!(stdout.contains("Release branch: release/20.0"));
+    assert!(stdout.contains("Resolved version: 1.0.0"));
+    assert!(stdout.contains("Release branch: release/1.0"));
 }
 
 #[test]
 fn prepare_patch_bump_derives_next_patch_on_existing_release_train() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.3");
+    repo.write_workspace("0.19.3");
     repo.commit_all("seed release train workspace");
-    repo.create_release_branch("release/19.1");
-    let release_sha = repo.git_stdout(&["rev-parse", "origin/release/19.1"]);
+    repo.create_release_branch("release/0.19");
+    let release_sha = repo.git_stdout(&["rev-parse", "origin/release/0.19"]);
     repo.write_workspace("20.5.0");
     repo.commit_all("advance local checkout after release branch");
     repo.push_branch("main");
@@ -63,23 +63,23 @@ fn prepare_patch_bump_derives_next_patch_on_existing_release_train() {
         "--bump",
         "patch",
         "--source-ref",
-        "release/19.1",
+        "release/0.19",
         "--dry-run",
     ]);
 
     assert_success(&output);
     let stdout = stdout(&output);
-    assert!(stdout.contains("Resolved version: 19.1.4"));
-    assert!(stdout.contains("Release branch: release/19.1"));
+    assert!(stdout.contains("Resolved version: 0.19.4"));
+    assert!(stdout.contains("Release branch: release/0.19"));
     assert!(stdout.contains(&format!("Target SHA: {release_sha}")));
-    assert!(stdout.contains("prepare-helper [--version] [19.1.4]"));
-    assert!(stdout.contains("[cwd-version=19.1.3]"));
+    assert!(stdout.contains("prepare-helper [--version] [0.19.4]"));
+    assert!(stdout.contains("[cwd-version=0.19.3]"));
 }
 
 #[test]
 fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.add_radiant_submodule();
     repo.commit_all("seed workspace");
     repo.push_branch("main");
@@ -90,7 +90,7 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
     repo.push_branch("main");
     repo.git(&["switch", "stale-local"]);
     assert!(
-        repo.read("Cargo.toml").contains("version = \"19.1.0\""),
+        repo.read("Cargo.toml").contains("version = \"0.19.1\""),
         "fixture checkout should stay on the stale package version"
     );
 
@@ -119,7 +119,7 @@ fn prepare_derives_bump_from_resolved_source_ref_not_local_checkout() {
 #[test]
 fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
     let configured_repo = "PORTALSURFER/wavecrate-fork";
@@ -154,7 +154,7 @@ fn prepare_dispatch_uses_workflow_ref_for_gh_ref_and_source_sha_input() {
 #[test]
 fn prepare_dispatch_rejects_local_only_source_ref() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
     repo.write_workspace("19.2.0");
@@ -185,7 +185,7 @@ fn prepare_dispatch_rejects_local_only_source_ref() {
 #[test]
 fn prepare_rejects_invalid_bump_argument() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
 
@@ -198,7 +198,7 @@ fn prepare_rejects_invalid_bump_argument() {
 #[test]
 fn release_wrapper_rejects_dirty_worktree_before_release_actions() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
     repo.write("dirty.txt", "not committed\n");
@@ -212,7 +212,7 @@ fn release_wrapper_rejects_dirty_worktree_before_release_actions() {
 #[test]
 fn release_wrapper_rejects_github_origin_that_differs_from_target_repo() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.push_branch("main");
     repo.git(&[
@@ -395,7 +395,7 @@ fn rc_dry_run_preserves_release_notes_input() {
 #[test]
 fn rc_rejects_release_branch_with_mismatched_manifest_version() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.commit_all("seed workspace");
     repo.create_release_branch("release/19.2");
 
@@ -410,7 +410,7 @@ fn rc_rejects_release_branch_with_mismatched_manifest_version() {
     ]);
 
     assert_failure(&output);
-    assert!(stderr(&output).contains("Cargo.toml version 19.1.0"));
+    assert!(stderr(&output).contains("Cargo.toml version 0.19.1"));
 }
 
 #[test]

--- a/tests/release_train_prepare.rs
+++ b/tests/release_train_prepare.rs
@@ -9,12 +9,12 @@ use tempfile::TempDir;
 #[test]
 fn prepare_release_train_updates_wavecrate_packages_and_lockfile() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0");
+    repo.write_workspace("0.19.1");
     repo.git(&["add", "."]);
     repo.git(&["commit", "-m", "seed workspace"]);
     let output = repo.run_prepare(&[
         "--version",
-        "19.2.0",
+        "0.20.0",
         "--source-ref",
         "HEAD",
         "--skip-release-tests",
@@ -28,15 +28,15 @@ fn prepare_release_train_updates_wavecrate_packages_and_lockfile() {
     );
     assert_eq!(
         repo.git_stdout(&["branch", "--show-current"]),
-        "release/19.2"
+        "release/0.20"
     );
     assert!(
         repo.read("Cargo.toml")
-            .contains("name = \"wavecrate\"\nversion = \"19.2.0\"")
+            .contains("name = \"wavecrate\"\nversion = \"0.20.0\"")
     );
     assert!(
         repo.read("crates/wavecrate-tool/Cargo.toml")
-            .contains("name = \"wavecrate-tool\"\nversion = \"19.2.0\"")
+            .contains("name = \"wavecrate-tool\"\nversion = \"0.20.0\"")
     );
     assert!(
         repo.read("crates/reson/Cargo.toml")
@@ -48,27 +48,27 @@ fn prepare_release_train_updates_wavecrate_packages_and_lockfile() {
     );
     assert!(
         repo.read("Cargo.lock")
-            .contains("name = \"wavecrate\"\nversion = \"19.2.0\"")
+            .contains("name = \"wavecrate\"\nversion = \"0.20.0\"")
     );
     assert!(
         repo.read("Cargo.lock")
-            .contains("name = \"wavecrate-tool\"\nversion = \"19.2.0\"")
+            .contains("name = \"wavecrate-tool\"\nversion = \"0.20.0\"")
     );
     assert!(
         repo.git_stdout(&["log", "-1", "--pretty=%s"])
-            .contains("Prepare Wavecrate 19.2.0 release train")
+            .contains("Prepare Wavecrate 0.20.0 release train")
     );
 }
 
 #[test]
 fn prepare_release_train_rejects_stale_prerelease_package_versions() {
     let repo = FixtureRepo::new();
-    repo.write_workspace("19.1.0-alpha.1");
+    repo.write_workspace("0.19.1-alpha.1");
     repo.git(&["add", "."]);
     repo.git(&["commit", "-m", "seed prerelease workspace"]);
     let output = repo.run_prepare(&[
         "--version",
-        "19.1.0",
+        "0.19.1",
         "--source-ref",
         "HEAD",
         "--dry-run",

--- a/tests/release_train_prepare.rs
+++ b/tests/release_train_prepare.rs
@@ -12,13 +12,7 @@ fn prepare_release_train_updates_wavecrate_packages_and_lockfile() {
     repo.write_workspace("0.19.1");
     repo.git(&["add", "."]);
     repo.git(&["commit", "-m", "seed workspace"]);
-    let output = repo.run_prepare(&[
-        "--version",
-        "0.20.0",
-        "--source-ref",
-        "HEAD",
-        "--skip-release-tests",
-    ]);
+    let output = repo.run_prepare(&["--version", "0.20.0", "--source-ref", "HEAD"]);
 
     assert!(
         output.status.success(),
@@ -155,6 +149,14 @@ edition = "2024"
 "#,
         );
         self.write("src/lib.rs", "");
+        self.write(
+            "tests/release_contract.rs",
+            "#[test]\nfn release_contract() {}\n",
+        );
+        self.write(
+            "tests/manual_release_matching.rs",
+            "#[test]\nfn manual_release_matching() {}\n",
+        );
         self.write("crates/wavecrate-tool/src/lib.rs", "");
         self.write("crates/reson/src/lib.rs", "");
         self.write("tools/gui-test-cli/src/lib.rs", "");

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -81,13 +81,13 @@ fn release_summary_helper_writes_public_metadata_without_secret_values() {
     let summary_file = temp.path().join("summary.md");
     fs::create_dir_all(&artifact_dir).expect("create release dir");
     fs::write(
-        artifact_dir.join("wavecrate-19.1.0-windows-x86_64.zip"),
+        artifact_dir.join("wavecrate-0.19.1-windows-x86_64.zip"),
         "not a real zip but enough for summary hashing\n",
     )
     .expect("write artifact");
     fs::write(
-        artifact_dir.join("checksums-19.1.0.txt"),
-        "abc  wavecrate-19.1.0-windows-x86_64.zip\n",
+        artifact_dir.join("checksums-0.19.1.txt"),
+        "abc  wavecrate-0.19.1-windows-x86_64.zip\n",
     )
     .expect("write checksum");
 
@@ -103,25 +103,25 @@ fn release_summary_helper_writes_public_metadata_without_secret_values() {
             .arg("--channel")
             .arg("stable")
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--target-version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--commit")
             .arg("abcdef123456")
             .arg("--build-id")
-            .arg("wavecrate-19.1.0")
+            .arg("wavecrate-0.19.1")
             .arg("--build-number")
             .arg("6258")
             .arg("--github-release-url")
-            .arg("https://github.com/PORTALSURFER/wavecrate/releases/tag/v19.1.0")
+            .arg("https://github.com/PORTALSURFER/wavecrate/releases/tag/v0.19.1")
             .arg("--portal-catalog-url")
             .arg("https://portalsurfer.org/wavecrate/api/v1/releases")
             .arg("--portal-build-id")
-            .arg("wavecrate-19.1.0")
+            .arg("wavecrate-0.19.1")
             .arg("--artifact-dir")
             .arg(&artifact_dir)
             .arg("--checksum-file")
-            .arg(artifact_dir.join("checksums-19.1.0.txt"))
+            .arg(artifact_dir.join("checksums-0.19.1.txt"))
             .arg("--note")
             .arg("fixture note")
             .env("GITHUB_STEP_SUMMARY", &summary_file)
@@ -138,8 +138,8 @@ fn release_summary_helper_writes_public_metadata_without_secret_values() {
 
     let summary = fs::read_to_string(summary_file).expect("read summary");
     assert!(summary.contains("## Stable release publication"));
-    assert!(summary.contains("wavecrate-19.1.0-windows-x86_64.zip"));
-    assert!(summary.contains("checksums-19.1.0.txt"));
+    assert!(summary.contains("wavecrate-0.19.1-windows-x86_64.zip"));
+    assert!(summary.contains("checksums-0.19.1.txt"));
     assert!(summary.contains("PortalSurfer catalog"));
     assert!(summary.contains("SHA-256"));
     assert!(!summary.contains("super-secret"));
@@ -150,7 +150,7 @@ fn github_release_body_helper_leaves_short_logs_unchanged() {
     let temp = tempfile::tempdir().expect("create GitHub body fixture");
     let input = temp.path().join("release-log.md");
     let output = temp.path().join("github-release-body.md");
-    let body = "# Wavecrate 19.1.0-rc.1\n\n- Short release log\n";
+    let body = "# Wavecrate 0.19.1-rc.1\n\n- Short release log\n";
     fs::write(&input, body).expect("write release log");
 
     run_success(
@@ -178,7 +178,7 @@ fn github_release_body_helper_caps_oversized_logs_with_full_log_notice() {
     let input = temp.path().join("release-log.md");
     let output = temp.path().join("github-release-body.md");
     let body = format!(
-        "# Wavecrate 19.1.0-rc.1\n\n## Generated Changes\n\n- {}\n",
+        "# Wavecrate 0.19.1-rc.1\n\n## Generated Changes\n\n- {}\n",
         "very long generated change ".repeat(200)
     );
     fs::write(&input, body).expect("write release log");
@@ -198,7 +198,7 @@ fn github_release_body_helper_caps_oversized_logs_with_full_log_notice() {
 
     let github_body = fs::read_to_string(output).expect("read GitHub release body");
     assert!(github_body.len() <= 1000);
-    assert!(github_body.starts_with("# Wavecrate 19.1.0-rc.1"));
+    assert!(github_body.starts_with("# Wavecrate 0.19.1-rc.1"));
     assert!(github_body.contains("## Full Release Log"));
     assert!(github_body.contains("`release-log.md`"));
     assert!(github_body.contains("PortalSurfer release changelog"));
@@ -217,7 +217,7 @@ fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog(
                 {
                     "build_id": "wavecrate-nightly-b6306-deadbee",
                     "build_number": 6306,
-                    "version": "19.1.0-nightly.6306+deadbee",
+                    "version": "0.19.1-nightly.6306+deadbee",
                     "released_at": "2026-07-03T19:00:00Z",
                     "changelog": {
                         "title": "Wavecrate nightly-b6306-deadbee",
@@ -232,7 +232,7 @@ fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog(
     .expect("write catalog");
     fs::write(
         &release_log,
-        "# Wavecrate 19.1.0-nightly.6307+8f1a7aa2\n\n- Current staged nightly\n",
+        "# Wavecrate 0.19.1-nightly.6307+8f1a7aa2\n\n- Current staged nightly\n",
     )
     .expect("write current log");
 
@@ -248,7 +248,7 @@ fn portal_changelog_assembler_accepts_current_staged_release_not_yet_in_catalog(
             .arg("--current-build-number")
             .arg("6307")
             .arg("--current-version")
-            .arg("19.1.0-nightly.6307+8f1a7aa2")
+            .arg("0.19.1-nightly.6307+8f1a7aa2")
             .arg("--current-released-at")
             .arg("2026-07-03T20:00:00Z")
             .arg("--current-log")
@@ -278,14 +278,14 @@ fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_st
         serde_json::to_string_pretty(&json!({
             "releases": [
                 {
-                    "build_id": "wavecrate-19.1.0",
+                    "build_id": "wavecrate-0.19.1",
                     "build_number": 6315,
-                    "version": "19.1.0",
+                    "version": "0.19.1",
                     "released_at": "2026-07-04T10:00:00Z",
                     "changelog": {
-                        "title": "Wavecrate 19.1.0",
+                        "title": "Wavecrate 0.19.1",
                         "format": "markdown",
-                        "body": "# Wavecrate 19.1.0\n\n- Current stable\n"
+                        "body": "# Wavecrate 0.19.1\n\n- Current stable\n"
                     }
                 }
             ]
@@ -299,7 +299,7 @@ fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_st
             "changelog": {
                 "title": "Wavecrate changelog",
                 "format": "markdown",
-                "body": "# Wavecrate Changelog\n\n- Latest release: wavecrate-19.1.0\n\n# Wavecrate 19.1.0\n\n- Old stable body\n\n## [nightly-b6307-8f1a7aa2]\n\n- Legacy nightly\n"
+                "body": "# Wavecrate Changelog\n\n- Latest release: wavecrate-0.19.1\n\n# Wavecrate 0.19.1\n\n- Old stable body\n\n## [nightly-b6307-8f1a7aa2]\n\n- Legacy nightly\n"
             }
         }))
         .expect("serialize existing changelog"),
@@ -307,7 +307,7 @@ fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_st
     .expect("write existing changelog");
     fs::write(
         &release_log,
-        "# Wavecrate 19.1.0\n\n- Repaired stable body\n",
+        "# Wavecrate 0.19.1\n\n- Repaired stable body\n",
     )
     .expect("write current log");
 
@@ -319,11 +319,11 @@ fn portal_changelog_assembler_preserves_legacy_nightly_sections_after_current_st
             .arg("--catalog-file")
             .arg(&catalog)
             .arg("--current-build-id")
-            .arg("wavecrate-19.1.0")
+            .arg("wavecrate-0.19.1")
             .arg("--current-build-number")
             .arg("6315")
             .arg("--current-version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--current-released-at")
             .arg("2026-07-04T10:00:00Z")
             .arg("--current-log")
@@ -417,9 +417,9 @@ fn build_release_artifact_helper_names_zip_and_checksum_entry() {
         .arg("--channel")
         .arg("nightly")
         .arg("--version")
-        .arg("19.1.0-nightly.20260702+abcdef0")
+        .arg("0.19.1-nightly.20260702+abcdef0")
         .arg("--target-version")
-        .arg("19.1.0")
+        .arg("0.19.1")
         .arg("--build-number")
         .arg("123")
         .arg("--git-sha")
@@ -487,7 +487,7 @@ fn build_release_artifact_helper_names_zip_and_checksum_entry() {
 fn promoted_rc_validator_accepts_complete_release_fixture() {
     let temp = tempfile::tempdir().expect("create promoted RC fixture");
     let (release_json, asset_dir) =
-        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 0.19.1-rc.2\n", true);
 
     run_success(
         Command::new("python3")
@@ -495,9 +495,9 @@ fn promoted_rc_validator_accepts_complete_release_fixture() {
                 "scripts/internal/release/validate_promoted_rc_release.py",
             ))
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--rc-tag")
-            .arg("v19.1.0-rc.2")
+            .arg("v0.19.1-rc.2")
             .arg("--release-json")
             .arg(&release_json)
             .arg("--asset-dir")
@@ -509,7 +509,7 @@ fn promoted_rc_validator_accepts_complete_release_fixture() {
 fn promoted_rc_validator_verifies_checksum_signature_when_public_key_is_supplied() {
     let temp = tempfile::tempdir().expect("create promoted RC fixture");
     let (release_json, asset_dir) =
-        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 0.19.1-rc.2\n", true);
     let key = temp.path().join("ed25519.pem");
     let keygen = Command::new("openssl")
         .arg("genpkey")
@@ -542,9 +542,9 @@ fn promoted_rc_validator_verifies_checksum_signature_when_public_key_is_supplied
                 "scripts/internal/release/sign_release_checksums.sh",
             ))
             .arg("--checksum-file")
-            .arg(asset_dir.join("checksums-19.1.0-rc.2.txt"))
+            .arg(asset_dir.join("checksums-0.19.1-rc.2.txt"))
             .arg("--signature-file")
-            .arg(asset_dir.join("checksums-19.1.0-rc.2.txt.sig"))
+            .arg(asset_dir.join("checksums-0.19.1-rc.2.txt.sig"))
             .env("CHECKSUMS_SIGNING_KEY", key_pem),
     );
     run_success(
@@ -553,9 +553,9 @@ fn promoted_rc_validator_verifies_checksum_signature_when_public_key_is_supplied
                 "scripts/internal/release/validate_promoted_rc_release.py",
             ))
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--rc-tag")
-            .arg("v19.1.0-rc.2")
+            .arg("v0.19.1-rc.2")
             .arg("--release-json")
             .arg(&release_json)
             .arg("--asset-dir")
@@ -568,12 +568,12 @@ fn promoted_rc_validator_verifies_checksum_signature_when_public_key_is_supplied
 #[test]
 fn promoted_rc_validator_rejects_missing_release_assets() {
     let temp = tempfile::tempdir().expect("create promoted RC fixture");
-    let missing = "wavecrate-19.1.0-rc.2-macos-aarch64.zip";
+    let missing = "wavecrate-0.19.1-rc.2-macos-aarch64.zip";
     let (release_json, asset_dir) = write_promoted_rc_fixture(
         &temp,
         Some(missing),
         false,
-        "# Wavecrate 19.1.0-rc.2\n",
+        "# Wavecrate 0.19.1-rc.2\n",
         true,
     );
 
@@ -583,9 +583,9 @@ fn promoted_rc_validator_rejects_missing_release_assets() {
                 "scripts/internal/release/validate_promoted_rc_release.py",
             ))
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--rc-tag")
-            .arg("v19.1.0-rc.2")
+            .arg("v0.19.1-rc.2")
             .arg("--release-json")
             .arg(&release_json)
             .arg("--asset-dir")
@@ -601,9 +601,9 @@ fn promoted_rc_validator_rejects_missing_release_assets() {
 #[test]
 fn promoted_rc_validator_rejects_undownloadable_release_assets() {
     let temp = tempfile::tempdir().expect("create promoted RC fixture");
-    let missing = "wavecrate-19.1.0-rc.2-macos-aarch64.zip";
+    let missing = "wavecrate-0.19.1-rc.2-macos-aarch64.zip";
     let (release_json, asset_dir) =
-        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 19.1.0-rc.2\n", true);
+        write_promoted_rc_fixture(&temp, None, false, "# Wavecrate 0.19.1-rc.2\n", true);
     fs::remove_file(asset_dir.join(missing)).expect("remove fixture asset");
 
     let output = run_failure(
@@ -612,9 +612,9 @@ fn promoted_rc_validator_rejects_undownloadable_release_assets() {
                 "scripts/internal/release/validate_promoted_rc_release.py",
             ))
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--rc-tag")
-            .arg("v19.1.0-rc.2")
+            .arg("v0.19.1-rc.2")
             .arg("--release-json")
             .arg(&release_json)
             .arg("--asset-dir")
@@ -631,7 +631,7 @@ fn promoted_rc_validator_rejects_undownloadable_release_assets() {
 fn promoted_rc_validator_rejects_checksum_mismatches() {
     let temp = tempfile::tempdir().expect("create promoted RC fixture");
     let (release_json, asset_dir) =
-        write_promoted_rc_fixture(&temp, None, true, "# Wavecrate 19.1.0-rc.2\n", true);
+        write_promoted_rc_fixture(&temp, None, true, "# Wavecrate 0.19.1-rc.2\n", true);
 
     let output = run_failure(
         Command::new("python3")
@@ -639,9 +639,9 @@ fn promoted_rc_validator_rejects_checksum_mismatches() {
                 "scripts/internal/release/validate_promoted_rc_release.py",
             ))
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--rc-tag")
-            .arg("v19.1.0-rc.2")
+            .arg("v0.19.1-rc.2")
             .arg("--release-json")
             .arg(&release_json)
             .arg("--asset-dir")
@@ -677,15 +677,15 @@ fn published_release_verifier_accepts_portalsurfer_catalog_fixture() {
             .arg("--channel")
             .arg("stable")
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--target-version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--commit")
             .arg("abcdef1")
             .arg("--build-date")
             .arg("2026-07-02")
             .arg("--portal-build-id")
-            .arg("wavecrate-19.1.0")
+            .arg("wavecrate-0.19.1")
             .arg("--build-number")
             .arg("6200")
             .arg("--release-json")
@@ -767,15 +767,15 @@ fn published_release_verifier_rejects_manifest_mismatches() {
             .arg("--channel")
             .arg("stable")
             .arg("--version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--target-version")
-            .arg("19.1.0")
+            .arg("0.19.1")
             .arg("--commit")
             .arg("abcdef1")
             .arg("--build-date")
             .arg("2026-07-02")
             .arg("--portal-build-id")
-            .arg("wavecrate-19.1.0")
+            .arg("wavecrate-0.19.1")
             .arg("--build-number")
             .arg("6200")
             .arg("--release-json")
@@ -816,7 +816,7 @@ fn published_release_verifier_rejects_flattened_archives() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(
-            "wavecrate-19.1.0-windows-x86_64.zip manifest must be at wavecrate/update-manifest.json"
+            "wavecrate-0.19.1-windows-x86_64.zip manifest must be at wavecrate/update-manifest.json"
         ) && stderr.contains("must contain expected archive root wavecrate/"),
         "flattened archive failure should name the asset and missing root\nstderr:\n{stderr}"
     );
@@ -846,7 +846,7 @@ fn published_release_verifier_rejects_missing_platform_executable() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(
-            "wavecrate-19.1.0-windows-x86_64.zip is missing required archive file wavecrate/wavecrate.exe"
+            "wavecrate-0.19.1-windows-x86_64.zip is missing required archive file wavecrate/wavecrate.exe"
         ),
         "missing executable failure should name the asset and missing executable path\nstderr:\n{stderr}"
     );
@@ -870,7 +870,7 @@ fn portalsurfer_upload_catalog_verifier_accepts_equivalent_timestamp_precision()
             .arg("--build-number")
             .arg("6242")
             .arg("--release-version")
-            .arg("19.1.0-nightly.20260702+5e5f4198")
+            .arg("0.19.1-nightly.20260702+5e5f4198")
             .arg("--released-at")
             .arg("2026-07-02T10:10:24Z")
             .arg("--expected-file")
@@ -896,7 +896,7 @@ fn portalsurfer_upload_catalog_verifier_rejects_different_timestamps() {
             .arg("--build-number")
             .arg("6242")
             .arg("--release-version")
-            .arg("19.1.0-nightly.20260702+5e5f4198")
+            .arg("0.19.1-nightly.20260702+5e5f4198")
             .arg("--released-at")
             .arg("2026-07-02T10:10:24Z")
             .arg("--expected-file")
@@ -960,7 +960,7 @@ fn write_portalsurfer_upload_catalog(path: &Path, released_at: &str) {
         "releases": [{
             "build_id": "wavecrate-nightly-b6242-5e5f4198",
             "build_number": 6242,
-            "version": "19.1.0-nightly.20260702+5e5f4198",
+            "version": "0.19.1-nightly.20260702+5e5f4198",
             "released_at": released_at,
             "changelog": {
                 "title": "Wavecrate nightly",
@@ -1022,12 +1022,12 @@ fn write_promoted_rc_fixture(
     let asset_dir = temp.path().join("assets");
     fs::create_dir_all(&asset_dir).expect("create asset dir");
     let zip_assets = [
-        "wavecrate-19.1.0-rc.2-macos-aarch64.zip",
-        "wavecrate-19.1.0-rc.2-macos-x86_64.zip",
-        "wavecrate-19.1.0-rc.2-windows-x86_64.zip",
+        "wavecrate-0.19.1-rc.2-macos-aarch64.zip",
+        "wavecrate-0.19.1-rc.2-macos-x86_64.zip",
+        "wavecrate-0.19.1-rc.2-windows-x86_64.zip",
     ];
-    let checksum_asset = "checksums-19.1.0-rc.2.txt";
-    let signature_asset = "checksums-19.1.0-rc.2.txt.sig";
+    let checksum_asset = "checksums-0.19.1-rc.2.txt";
+    let signature_asset = "checksums-0.19.1-rc.2.txt.sig";
 
     let mut checksum_lines = Vec::new();
     for zip in zip_assets {
@@ -1051,7 +1051,7 @@ fn write_promoted_rc_fixture(
         .map(|name| json!({ "name": name }))
         .collect::<Vec<_>>();
     let release = json!({
-        "tagName": "v19.1.0-rc.2",
+        "tagName": "v0.19.1-rc.2",
         "isPrerelease": is_prerelease,
         "body": body,
         "assets": asset_names,
@@ -1091,26 +1091,26 @@ fn write_published_release_fixture_with_zip_mutation(
     fs::create_dir_all(&asset_dir).expect("create asset dir");
     let zip_assets = [
         (
-            "wavecrate-19.1.0-macos-aarch64.zip",
+            "wavecrate-0.19.1-macos-aarch64.zip",
             "aarch64-apple-darwin",
             "macos",
             "aarch64",
         ),
         (
-            "wavecrate-19.1.0-macos-x86_64.zip",
+            "wavecrate-0.19.1-macos-x86_64.zip",
             "x86_64-apple-darwin",
             "macos",
             "x86_64",
         ),
         (
-            "wavecrate-19.1.0-windows-x86_64.zip",
+            "wavecrate-0.19.1-windows-x86_64.zip",
             "x86_64-pc-windows-msvc",
             "windows",
             "x86_64",
         ),
     ];
-    let checksum_asset = "checksums-19.1.0.txt";
-    let signature_asset = "checksums-19.1.0.txt.sig";
+    let checksum_asset = "checksums-0.19.1.txt";
+    let signature_asset = "checksums-0.19.1.txt.sig";
 
     let mut checksum_lines = Vec::new();
     let mut files = Vec::new();
@@ -1133,7 +1133,7 @@ fn write_published_release_fixture_with_zip_mutation(
         checksum_lines.push(format!("{hash}  {zip_name}\n"));
         files.push(json!({
             "name": zip_name,
-            "url": format!("/wavecrate/api/v1/releases/wavecrate-19.1.0/files/{zip_name}/download"),
+            "url": format!("/wavecrate/api/v1/releases/wavecrate-0.19.1/files/{zip_name}/download"),
             "sha256": hash,
             "size_bytes": fs::metadata(asset_dir.join(zip_name)).expect("zip metadata").len()
         }));
@@ -1155,7 +1155,7 @@ fn write_published_release_fixture_with_zip_mutation(
     for file_name in [checksum_asset, signature_asset] {
         files.push(json!({
             "name": file_name,
-            "url": format!("/wavecrate/api/v1/releases/wavecrate-19.1.0/files/{file_name}/download"),
+            "url": format!("/wavecrate/api/v1/releases/wavecrate-0.19.1/files/{file_name}/download"),
             "sha256": sha256_file(&asset_dir.join(file_name)),
             "size_bytes": fs::metadata(asset_dir.join(file_name)).expect("asset metadata").len()
         }));
@@ -1164,15 +1164,15 @@ fn write_published_release_fixture_with_zip_mutation(
     let catalog = json!({
         "app": "wavecrate",
         "releases": [{
-            "build_id": "wavecrate-19.1.0",
+            "build_id": "wavecrate-0.19.1",
             "build_number": 6200,
-            "version": "19.1.0",
+            "version": "0.19.1",
             "released_at": "2026-07-02T09:00:00Z",
             "changelog": {
-                "title": "Wavecrate 19.1.0",
+                "title": "Wavecrate 0.19.1",
                 "format": "markdown",
-                "body": "# Wavecrate 19.1.0\n\n## Release Metadata\n",
-                "url": "/wavecrate/api/v1/releases/wavecrate-19.1.0/changelog"
+                "body": "# Wavecrate 0.19.1\n\n## Release Metadata\n",
+                "url": "/wavecrate/api/v1/releases/wavecrate-0.19.1/changelog"
             },
             "files": files
         }]
@@ -1201,15 +1201,15 @@ fn published_release_verifier_command(
         .arg("--channel")
         .arg("stable")
         .arg("--version")
-        .arg("19.1.0")
+        .arg("0.19.1")
         .arg("--target-version")
-        .arg("19.1.0")
+        .arg("0.19.1")
         .arg("--commit")
         .arg("abcdef1")
         .arg("--build-date")
         .arg("2026-07-02")
         .arg("--portal-build-id")
-        .arg("wavecrate-19.1.0")
+        .arg("wavecrate-0.19.1")
         .arg("--build-number")
         .arg("6200")
         .arg("--release-json")
@@ -1238,8 +1238,8 @@ fn write_release_zip(
         "target": target,
         "platform": platform,
         "arch": arch,
-        "version": "19.1.0",
-        "target_version": "19.1.0",
+        "version": "0.19.1",
+        "target_version": "0.19.1",
         "commit": "abcdef1",
         "build_date": "2026-07-02",
         "files": payload_files.iter().chain(["update-manifest.json"].iter()).collect::<Vec<_>>()

--- a/tools/analysis-admin/Cargo.toml
+++ b/tools/analysis-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-analysis-admin"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [dependencies]

--- a/tools/bench-cli/Cargo.toml
+++ b/tools/bench-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavecrate-bench-cli"
-version = "19.1.1"
+version = "0.19.1"
 edition = "2024"
 
 [lints.rust]


### PR DESCRIPTION
## Goal

Represent Wavecrate as an unreleased pre-1.0 product by making `0.19.1` the authoritative application, CI, and release-pipeline version.

Related landing-page change: https://github.com/PORTALSURFER/portalsurfer.org/pull/32

## Scope and non-goals

- Set every Wavecrate-owned release package and lockfile entry to `0.19.1`.
- Update RC/stable/release-train examples, documentation, fixtures, and CI contract coverage to use `0.19.1` and `release/0.19`.
- Preserve update continuity from installed legacy `19.1.x` builds while preventing pre-one installations from treating the colliding historical `19.1.x` catalog entries as newer.
- Keep the compatibility exception scoped to that one renumbering collision so a future ordinary upgrade to a real `19.x` release follows normal SemVer.
- Select changelog boundaries by nearest reachable release lineage so immutable legacy tags cannot outrank newer pre-one releases.
- Document the pre-1.0 identity and the immutability of already-published legacy artifacts.
- Non-goals: dispatching an RC/stable workflow, rewriting signed `19.x` artifacts, or deploying the website.

## Definition of Done

- Workspace release packages and Cargo.lock consistently report `0.19.1`.
- Release workflows and tests use the pre-1.0 identity and `release/0.19` coordination branch.
- CI enforces major-zero release identity and release-package consistency without breaking ordinary release-train version bumps.
- Legacy `19.1.x` installs can discover `0.19.1+`, pre-one installs ignore colliding historical `19.1.x` entries, and later real `19.x` upgrades retain ordinary SemVer behavior.
- Mixed legacy/pre-one tag history anchors release logs to the nearest reachable stable boundary.

## Validation

- `bash scripts/internal/release/run_release_validation.sh` — passed (workspace test-target build; 30 release-contract, 23 workflow-helper, and 91 scanner tests).
- `CARGO_INCREMENTAL=0 cargo test --locked -j 1 -p wavecrate --lib updater::check` — 8 passed.
- Focused release suite — 30 release-contract, 4 release-log, and 2 release-train-prep tests passed.
- `cargo fmt --all --check`, `bash -n scripts/internal/release/generate_release_log.sh`, and `git diff --check` — passed.
- `cargo metadata --locked --format-version 1 --no-deps` — all Wavecrate-owned release packages resolve to `0.19.1`.

## Known limitations

- No release was dispatched; publishing `0.19.1` remains a separate explicitly authorized operation.
- A full clippy attempt reaches a pre-existing `clippy::type_complexity` denial in unchanged `crates/wavecrate-library/src/sample_sources/db/write/transaction.rs`.

User approval is required before merge.