### PR TITLE
Authenticate PortalSurfer release verification

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -472,6 +472,7 @@ jobs:
       - name: Verify published PortalSurfer nightly release artifacts
         shell: bash
         env:
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
           PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
         run: |
           upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -299,6 +299,7 @@ jobs:
       - name: Verify published PortalSurfer RC release artifacts
         shell: bash
         env:
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
           PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
         run: |
           upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -310,6 +310,7 @@ jobs:
       - name: Verify published PortalSurfer stable release artifacts
         shell: bash
         env:
+          PORTALSURFER_RELEASE_UPLOAD_TOKEN: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_TOKEN }}
           PORTALSURFER_RELEASE_UPLOAD_URL: ${{ secrets.PORTALSURFER_RELEASE_UPLOAD_URL }}
         run: |
           upload_base="${PORTALSURFER_RELEASE_UPLOAD_URL:-https://portalsurfer.org/wavecrate/api/v1/release-uploads}"

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -174,7 +174,9 @@ under `scripts/internal/release/`:
 - `verify_published_release.py` downloads public GitHub or PortalSurfer release
   assets after publication, verifies checksum signatures and zip hashes, and
   inspects each `update-manifest.json` for the expected channel, version,
-  commit, build date, target, platform, and architecture.
+  commit, build date, target, platform, and architecture. PortalSurfer downloads
+  authenticate with the release upload token so integrity verification is not
+  counted as a user download.
 - `publish_portalsurfer_release.sh` stages release files privately in
   PortalSurfer, assembles the full Wavecrate changelog, commits the staged
   files, generated release log, catalog entry, and full changelog in one
@@ -282,6 +284,7 @@ scripts/internal/release/verify_published_release.py \
 To rerun the PortalSurfer verifier for the same release:
 
 ```bash
+export PORTALSURFER_RELEASE_UPLOAD_TOKEN=<release-upload-token>
 scripts/internal/release/verify_published_release.py \
   --surface portalsurfer \
   --channel stable \
@@ -296,9 +299,12 @@ scripts/internal/release/verify_published_release.py \
 ```
 
 - `PORTALSURFER_RELEASE_UPLOAD_TOKEN`
-Bearer token sent by the workflow to the PortalSurfer upload endpoint. Store
-the matching `WAVECRATE_RELEASE_UPLOAD_TOKEN_SHA256` on the PortalSurfer server
-when possible, so the server does not keep the raw token.
+Bearer token sent by the workflow to the PortalSurfer upload endpoint. The
+post-publish verifier sends only a SHA-256 proof derived from this token, so its
+downloads still stream and validate the public artifact bytes without exposing
+upload credentials or incrementing the public user-download total. Store the
+matching `WAVECRATE_RELEASE_UPLOAD_TOKEN_SHA256` on the PortalSurfer server when
+possible, so the server does not keep the raw token.
 
 - `PORTALSURFER_RELEASE_UPLOAD_URL`
 Optional upload endpoint. Defaults to

--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -833,10 +833,15 @@ def fetch_json(url: str | None) -> dict[str, Any]:
 
 def download_url(url: str, path: Path, verification_token: str = "") -> None:
     try:
-        with urllib.request.urlopen(
-            request_for_url(url, verification_token=verification_token),
-            timeout=120,
-        ) as response:
+        request = request_for_url(url, verification_token=verification_token)
+        if verification_token:
+            opener = urllib.request.build_opener(
+                SameOriginRedirectHandler(normalized_url_origin(url))
+            )
+            response_context = opener.open(request, timeout=120)
+        else:
+            response_context = urllib.request.urlopen(request, timeout=120)
+        with response_context as response:
             with path.open("wb") as output:
                 shutil.copyfileobj(response, output)
     except urllib.error.URLError as error:
@@ -850,6 +855,29 @@ def request_for_url(url: str, verification_token: str = "") -> urllib.request.Re
             verification_token.encode("utf-8")
         ).hexdigest()
     return urllib.request.Request(url, headers=headers)
+
+
+class SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def __init__(self, allowed_origin: tuple[str, str, int | None]) -> None:
+        super().__init__()
+        self.allowed_origin = allowed_origin
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        resolved_url = urllib.parse.urljoin(req.full_url, newurl)
+        if normalized_url_origin(resolved_url) != self.allowed_origin:
+            raise urllib.error.URLError(
+                "refusing to send PortalSurfer release verification proof to a different origin: "
+                f"{resolved_url}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, resolved_url)
 
 
 def fetch_portalsurfer_download_token(args: argparse.Namespace) -> str:

--- a/scripts/internal/release/verify_published_release.py
+++ b/scripts/internal/release/verify_published_release.py
@@ -109,6 +109,11 @@ def parse_args() -> argparse.Namespace:
         "--portal-download-token",
         help="Pre-issued PortalSurfer download token for fixture or diagnostic runs",
     )
+    parser.add_argument(
+        "--portal-verification-token",
+        default=os.environ.get("PORTALSURFER_RELEASE_UPLOAD_TOKEN", "").strip(),
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--build-number", type=int, help="Expected PortalSurfer build number")
     parser.add_argument(
         "--source",
@@ -167,6 +172,11 @@ def validate_args(args: argparse.Namespace) -> list[str]:
             errors.append("PortalSurfer verification requires --build-number")
         if not args.release_json and not args.portal_catalog_url:
             errors.append("PortalSurfer live verification requires --portal-catalog-url")
+        if not args.asset_dir and not args.portal_verification_token:
+            errors.append(
+                "PortalSurfer live verification requires PORTALSURFER_RELEASE_UPLOAD_TOKEN "
+                "so verification downloads are not counted as user downloads"
+            )
     return errors
 
 
@@ -521,9 +531,12 @@ class local_asset_dir:
             url = str(entry.get("url") or entry.get("download_url") or entry.get("href") or "")
             if not url:
                 raise SystemExit(f"PortalSurfer catalog entry for {asset} does not include a download URL")
+            resolved_url = resolve_portalsurfer_url(self.args, url)
+            ensure_portalsurfer_origin(self.args, resolved_url)
             download_url(
-                portalsurfer_download_url(resolve_portalsurfer_url(self.args, url), download_token),
+                portalsurfer_download_url(resolved_url, download_token),
                 asset_dir / asset,
+                verification_token=self.args.portal_verification_token,
             )
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
@@ -818,17 +831,25 @@ def fetch_json(url: str | None) -> dict[str, Any]:
         raise SystemExit(f"Failed to fetch JSON from {url}: {error}") from error
 
 
-def download_url(url: str, path: Path) -> None:
+def download_url(url: str, path: Path, verification_token: str = "") -> None:
     try:
-        with urllib.request.urlopen(request_for_url(url), timeout=120) as response:
+        with urllib.request.urlopen(
+            request_for_url(url, verification_token=verification_token),
+            timeout=120,
+        ) as response:
             with path.open("wb") as output:
                 shutil.copyfileobj(response, output)
     except urllib.error.URLError as error:
         raise SystemExit(f"Failed to download {url}: {error}") from error
 
 
-def request_for_url(url: str) -> urllib.request.Request:
-    return urllib.request.Request(url, headers={"User-Agent": "wavecrate-release-verifier"})
+def request_for_url(url: str, verification_token: str = "") -> urllib.request.Request:
+    headers = {"User-Agent": "wavecrate-release-verifier"}
+    if verification_token:
+        headers["X-Wavecrate-Release-Verification"] = hashlib.sha256(
+            verification_token.encode("utf-8")
+        ).hexdigest()
+    return urllib.request.Request(url, headers=headers)
 
 
 def fetch_portalsurfer_download_token(args: argparse.Namespace) -> str:
@@ -862,6 +883,23 @@ def resolve_portalsurfer_url(args: argparse.Namespace, url: str) -> str:
         return url
     base = args.portal_catalog_url or "https://portalsurfer.org/wavecrate/api/v1/releases"
     return urllib.parse.urljoin(base, url)
+
+
+def ensure_portalsurfer_origin(args: argparse.Namespace, url: str) -> None:
+    catalog_url = args.portal_catalog_url or "https://portalsurfer.org/wavecrate/api/v1/releases"
+    if normalized_url_origin(url) != normalized_url_origin(catalog_url):
+        raise SystemExit(
+            "Refusing to send PortalSurfer release verification credentials to a different origin: "
+            f"{url}"
+        )
+
+
+def normalized_url_origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlparse(url)
+    port = parsed.port
+    if port is None:
+        port = {"http": 80, "https": 443}.get(parsed.scheme.lower())
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), port
 
 
 def print_errors(errors: list[str]) -> None:

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -920,6 +920,13 @@ fn release_workflows_verify_published_artifacts_after_publication() {
             workflow.contains("--surface portalsurfer"),
             "{name} must verify PortalSurfer downloads after PortalSurfer publication"
         );
+        assert!(
+            workflow
+                .matches("PORTALSURFER_RELEASE_UPLOAD_TOKEN:")
+                .count()
+                >= 2,
+            "{name} must authenticate both PortalSurfer publication and post-publish verification"
+        );
     }
     assert!(
         NIGHTLY_WORKFLOW.contains("Verify published GitHub nightly release"),

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -925,6 +925,19 @@ url = module.portalsurfer_download_url(
     "token with spaces",
 )
 assert url == "https://portalsurfer.org/wavecrate/api/v1/releases/build/files/file.zip/download?existing=1&download_token=token+with+spaces", url
+request = module.request_for_url(url, verification_token="verification-secret")
+assert request.get_header("X-wavecrate-release-verification") == module.hashlib.sha256(b"verification-secret").hexdigest()
+
+args = type("Args", (), {
+    "portal_catalog_url": "https://portalsurfer.org/wavecrate/api/v1/releases",
+})()
+module.ensure_portalsurfer_origin(args, url)
+try:
+    module.ensure_portalsurfer_origin(args, "https://example.com/file.zip")
+except SystemExit as error:
+    assert "different origin" in str(error)
+else:
+    raise AssertionError("cross-origin verifier credentials must be rejected")
 "#,
         script = script.display().to_string(),
     );

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -915,7 +915,11 @@ fn published_release_verifier_adds_portalsurfer_download_tokens_to_file_urls() {
     let python = format!(
         r#"
 import importlib.util
+import http.server
 import sys
+import tempfile
+import threading
+from pathlib import Path
 spec = importlib.util.spec_from_file_location("verify_published_release", {script:?})
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
@@ -938,6 +942,57 @@ except SystemExit as error:
     assert "different origin" in str(error)
 else:
     raise AssertionError("cross-origin verifier credentials must be rejected")
+
+class TargetHandler(http.server.BaseHTTPRequestHandler):
+    verification_proof = None
+
+    def do_GET(self):
+        type(self).verification_proof = self.headers.get("X-Wavecrate-Release-Verification")
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"unexpected target response")
+
+    def log_message(self, *args):
+        pass
+
+class RedirectHandler(http.server.BaseHTTPRequestHandler):
+    target_url = ""
+
+    def do_GET(self):
+        self.send_response(302)
+        self.send_header("Location", type(self).target_url)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+target_server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), TargetHandler)
+RedirectHandler.target_url = f"http://127.0.0.1:{{target_server.server_port}}/artifact.zip"
+redirect_server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+threads = [
+    threading.Thread(target=target_server.serve_forever, daemon=True),
+    threading.Thread(target=redirect_server.serve_forever, daemon=True),
+]
+for thread in threads:
+    thread.start()
+try:
+    with tempfile.TemporaryDirectory() as directory:
+        try:
+            module.download_url(
+                f"http://127.0.0.1:{{redirect_server.server_port}}/artifact.zip",
+                Path(directory) / "artifact.zip",
+                verification_token="verification-secret",
+            )
+        except SystemExit as error:
+            assert "different origin" in str(error)
+        else:
+            raise AssertionError("cross-origin redirects must fail verification downloads")
+finally:
+    redirect_server.shutdown()
+    target_server.shutdown()
+    redirect_server.server_close()
+    target_server.server_close()
+assert TargetHandler.verification_proof is None
 "#,
         script = script.display().to_string(),
     );


### PR DESCRIPTION
## Goal

Prevent nightly, RC, and stable post-publication verification from inflating PortalSurfer's public Wavecrate download total.

## Scope

- Provide the existing release credential to PortalSurfer verification steps.
- Send only a SHA-256 verification proof on artifact GETs, never the reusable upload credential.
- Restrict credential-bearing artifact requests to the catalog origin.
- Keep downloading and validating every public artifact byte.
- Document the operator contract and cover workflow/proof behavior.

Non-goals: changing artifact contents, release channels, GitHub release verification, or public download-gate behavior.

## Definition of Done

- Nightly, RC, and stable PortalSurfer verification steps authenticate their downloads.
- The reusable upload credential is not sent on public artifact requests.
- Cross-origin artifact URLs are rejected before the verification proof is attached.
- Existing checksum, signature, hash, manifest, and archive validation remains intact.

## Validation

- `bash scripts/agent.sh request` — repository and release guardrails passed; the unchanged Radiant compile reached the known macOS compiler stall and was stopped
- `python3 -m py_compile scripts/internal/release/verify_published_release.py` — passed
- verifier proof and origin regression harness — passed
- workflow YAML parse for nightly, RC, and stable — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Known limitations

The focused Rust integration-test binary could not be rebuilt locally because the unchanged Radiant dependency hit the known macOS compiler stall; GitHub CI remains the full compiled release-contract lane.

Depends on PORTALSURFER/portalsurfer.org#34 being merged and deployed first.

User approval is required before merge.
