### PR TITLE
Fix Windows settings replacement failure safety

### DIFF
--- a/src/sample_sources/config_io/save.rs
+++ b/src/sample_sources/config_io/save.rs
@@ -139,6 +139,14 @@ pub(super) fn save_settings_to_path(
 }
 
 fn atomic_write(path: &Path, data: &[u8]) -> Result<(), ConfigError> {
+    atomic_write_with(path, data, publish_temp_file)
+}
+
+fn atomic_write_with(
+    path: &Path,
+    data: &[u8],
+    publish: impl Fn(&Path, &Path, &Path) -> Result<(), ConfigError>,
+) -> Result<(), ConfigError> {
     use rand::TryRngCore;
     let dir = path.parent().ok_or_else(|| ConfigError::Write {
         path: path.to_path_buf(),
@@ -197,14 +205,10 @@ fn atomic_write(path: &Path, data: &[u8]) -> Result<(), ConfigError> {
             });
         }
         drop(file);
-        if let Err(err) = replace_file(&tmp_path, path) {
+        if let Err(err) = publish(&tmp_path, path, dir) {
             let _ = std::fs::remove_file(&tmp_path);
-            return Err(ConfigError::Write {
-                path: path.to_path_buf(),
-                source: err,
-            });
+            return Err(err);
         }
-        sync_parent_dir(dir)?;
         return Ok(());
     }
 
@@ -224,25 +228,43 @@ fn atomic_write(path: &Path, data: &[u8]) -> Result<(), ConfigError> {
     })
 }
 
+fn publish_temp_file(temp_path: &Path, path: &Path, dir: &Path) -> Result<(), ConfigError> {
+    replace_file(temp_path, path).map_err(|source| ConfigError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    sync_parent_dir(dir)
+}
+
+#[cfg(not(target_os = "windows"))]
 fn replace_file(temp_path: &Path, path: &Path) -> Result<(), std::io::Error> {
-    match std::fs::rename(temp_path, path) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            #[cfg(target_os = "windows")]
-            if err.kind() == std::io::ErrorKind::AlreadyExists
-                || err.kind() == std::io::ErrorKind::PermissionDenied
-            {
-                if let Err(inner) = std::fs::remove_file(path)
-                    && inner.kind() != std::io::ErrorKind::NotFound
-                {
-                    return Err(inner);
-                }
-                std::fs::rename(temp_path, path)?;
-                return Ok(());
-            }
-            Err(err)
-        }
-    }
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(target_os = "windows")]
+fn replace_file(temp_path: &Path, path: &Path) -> Result<(), std::io::Error> {
+    use windows::{
+        Win32::Storage::FileSystem::{
+            MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        },
+        core::PCWSTR,
+    };
+
+    let temp_path = wide_path(temp_path);
+    let path = wide_path(path);
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+    unsafe { MoveFileExW(PCWSTR(temp_path.as_ptr()), PCWSTR(path.as_ptr()), flags) }
+        .map_err(std::io::Error::other)
+}
+
+#[cfg(target_os = "windows")]
+fn wide_path(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
 }
 
 fn sync_parent_dir(dir: &Path) -> Result<(), ConfigError> {
@@ -265,9 +287,53 @@ fn sync_parent_dir(dir: &Path) -> Result<(), ConfigError> {
 }
 
 #[cfg(test)]
-mod revision_tests {
-    use super::{ConfigError, SaveRevisionGate, require_current_save};
+mod tests {
+    use super::{ConfigError, SaveRevisionGate, atomic_write_with, require_current_save};
     use std::{cell::Cell, path::PathBuf};
+
+    #[test]
+    fn replacement_failure_preserves_existing_settings_and_cleans_temporary_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("config.toml");
+        std::fs::write(&path, b"old = true\n").unwrap();
+
+        let result = atomic_write_with(&path, b"new = true\n", |temp_path, path, _dir| {
+            assert_eq!(std::fs::read(temp_path).unwrap(), b"new = true\n");
+            Err(ConfigError::Write {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected replacement failure",
+                ),
+            })
+        });
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"old = true\n");
+        let remaining: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(remaining, [path.file_name().unwrap()]);
+    }
+
+    #[test]
+    fn durability_failure_after_replacement_leaves_new_settings_recoverable() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("config.toml");
+        std::fs::write(&path, b"old = true\n").unwrap();
+
+        let result = atomic_write_with(&path, b"new = true\n", |temp_path, path, dir| {
+            std::fs::rename(temp_path, path).unwrap();
+            Err(ConfigError::Write {
+                path: dir.to_path_buf(),
+                source: std::io::Error::other("injected directory sync failure"),
+            })
+        });
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), b"new = true\n");
+    }
 
     #[test]
     fn stale_snapshot_is_skipped_after_newer_revision_is_reserved() {

--- a/src/sample_sources/config_io/tests/save/mod.rs
+++ b/src/sample_sources/config_io/tests/save/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "windows"))]
 use super::super::super::config_types::AppSettings;
 use super::super::super::config_types::{
     AnalysisSettings, AppSettingsCore, AudioWriteChannelBehavior, AudioWriteDither,
@@ -7,7 +7,7 @@ use super::super::super::config_types::{
     UpdateChannel, UpdateSettings,
 };
 use super::super::load::load_settings_from;
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "windows"))]
 use super::super::save::save_settings_to_path;
 use super::super::save::save_to_path;
 use super::TestConfigEnv;
@@ -262,4 +262,41 @@ fn settings_atomic_write_preserves_existing_on_failure() {
 
     let contents = std::fs::read_to_string(&path).unwrap();
     assert_eq!(contents, "sentinel = true\n");
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn settings_atomic_write_preserves_locked_destination_and_retries_cleanly() {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let env = TestConfigEnv::new();
+    let path = env.path("cfg.toml");
+    env.write(&path, "sentinel = true\n");
+    let locked = std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(&path)
+        .unwrap();
+
+    let mut settings = AppSettings::default();
+    settings.core.volume = 0.33;
+    let first_attempt = save_settings_to_path(&settings, &path);
+    assert!(first_attempt.is_err());
+    drop(locked);
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "sentinel = true\n");
+
+    save_settings_to_path(&settings, &path).unwrap();
+    let loaded = load_settings_from(&path).unwrap();
+    assert!((loaded.core.volume - 0.33).abs() < f32::EPSILON);
+
+    let temp_prefix = format!("{}.tmp-", path.file_name().unwrap().to_string_lossy());
+    assert!(
+        std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&temp_prefix))
+    );
 }


### PR DESCRIPTION
## Goal

Preserve an existing valid Wavecrate settings file when Windows cannot atomically replace it.

Linear: OPT-1223

## Scope and non-goals

- Replace the Windows delete-then-rename fallback with one native `MoveFileExW` call using replace-existing and write-through flags.
- Keep the completed temporary-file write and cleanup behavior.
- Add deterministic coverage for replacement failure, post-replacement durability failure, cleanup, and retry.
- Add a Windows-only locked-destination regression using real Windows sharing semantics.
- No settings schema, migration, or public configuration API changes.

## Definition of Done

- A failed Windows replacement leaves the previous complete settings file in place.
- A successful replacement retains atomic visibility and write-through intent.
- Failed temporary files are cleaned up, and retry succeeds without recovery artifacts.
- A failure after replacement leaves the complete new settings file recoverable.
- Existing Unix atomic-save coverage remains green.

## Validation

- `cargo test --lib sample_sources::config::config_io -- --nocapture` — passed (29 tests).
- `cargo fmt --check` — passed.
- `git diff --check` — passed.
- `bash scripts/ci.sh agent` — blocked by an unchanged baseline format-string error in `tests/release_workflow_helpers.rs:936`.
- `cargo check --tests --target x86_64-pc-windows-msvc -j 2` — reached Windows-target dependencies, then stopped in unchanged dependency `ring` because this macOS host lacks the Windows C headers/MSVC toolchain (`assert.h` not found).
- Independent review of head `8d3a7a323cf801bbf079632b043d18b09ef11523` — clean.

## Known limitations

- This repository has no PR CI workflow, so the Windows-only locked-destination test still requires execution on a Windows host.
- The repository-wide agent gate and strict clippy run have unrelated baseline blockers noted in the validation record.

User approval is required before merge.