### PR TITLE
Ignore local editorial terminal artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ assets/ml/panns_cnn14_16k/*.pth
 /model.json
 /profile.json.gz
 /flamegraph.svg
+assets/wavecrate-editorial-terminal-clean-master.png


### PR DESCRIPTION
## What changed

Ignore `assets/wavecrate-editorial-terminal-clean-master.png` so the local editorial screenshot does not remain as an untracked repository change.

## Why

The image is a local review artifact rather than a Wavecrate product asset.

## Validation

- `git check-ignore -v assets/wavecrate-editorial-terminal-clean-master.png` — matched the new rule.
- `git diff --check` — passed.

## Impact

No runtime or packaged-product behavior changes.