### PR TITLE
OPT-1219: Prevent starmap audition UI flashes

### DIFF
--- a/src/native_app/audio/playback/progress/telemetry.rs
+++ b/src/native_app/audio/playback/progress/telemetry.rs
@@ -6,7 +6,9 @@ use radiant::runtime::{RepaintScope, SurfaceRevisions};
 
 use super::super::diagnostics::PlayheadFrameMessageDiagnostics;
 use crate::native_app::{
-    app::{NativeAppState, SamplePlaybackSession},
+    app::{
+        NativeAppState, SamplePlaybackIntent, SamplePlaybackSession, SamplePlaybackSessionState,
+    },
     starmap_audition_telemetry::{
         self as starmap_telemetry, StarmapAuditionCounter, StarmapAuditionDuration,
     },
@@ -22,7 +24,7 @@ thread_local! {
 pub(in crate::native_app) struct FrameSurfaceRevisionTracker {
     last: Option<FrameSurfaceRevisionInputs>,
     revisions: SurfaceRevisions,
-    playback_fast_path_active: bool,
+    transient_fast_path_active: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -64,19 +66,20 @@ struct FrameProjectionState {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct FrameSurfaceRevisionGuard {
-    before: Option<PlaybackFrameRevisionInputs>,
+    before: Option<TransientFrameRevisionInputs>,
     forced_surface: bool,
+    starmap_retained_scene_active_before_message: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PlaybackFrameRevisionInputs {
-    structure: PlaybackFrameStructureState,
+struct TransientFrameRevisionInputs {
+    structure: TransientFrameStructureState,
     layout: FrameLayoutState,
-    projection: PlaybackFrameProjectionState,
+    projection: TransientFrameProjectionState,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PlaybackFrameStructureState {
+struct TransientFrameStructureState {
     drag_hover_auto_expand_pending: bool,
     source_cache_progress_active: bool,
     sample_loading: bool,
@@ -86,7 +89,7 @@ struct PlaybackFrameStructureState {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PlaybackFrameProjectionState {
+struct TransientFrameProjectionState {
     playback_visual_generation: u64,
     play_selection_flash_active: bool,
     copy_flash_frames: u8,
@@ -96,15 +99,15 @@ struct PlaybackFrameProjectionState {
 
 impl NativeAppState {
     pub(in crate::native_app) fn frame_surface_revisions(&mut self) -> SurfaceRevisions {
-        let playing = self.playback_visual_activity_active();
-        if playing
+        let transient_active = self.transient_frame_fast_path_active();
+        if transient_active
             || self
                 .frame_surface_revision_tracker
-                .playback_fast_path_active
+                .transient_fast_path_active
         {
-            if playing {
+            if transient_active {
                 self.frame_surface_revision_tracker
-                    .playback_fast_path_active = true;
+                    .transient_fast_path_active = true;
             }
             return self.frame_surface_revision_tracker.revisions;
         }
@@ -136,20 +139,21 @@ impl NativeAppState {
     pub(in crate::native_app) fn begin_frame_surface_revision_tracking(
         &mut self,
     ) -> FrameSurfaceRevisionGuard {
-        let playing = self.playback_visual_activity_active();
+        let transient_active = self.transient_frame_fast_path_active();
         let forced_surface = self
             .frame_surface_revision_tracker
-            .playback_fast_path_active
-            && !playing;
+            .transient_fast_path_active
+            && !transient_active;
         if forced_surface {
             self.frame_surface_revision_tracker
                 .bump(RepaintScope::Surface);
             self.frame_surface_revision_tracker
-                .playback_fast_path_active = false;
+                .transient_fast_path_active = false;
         }
         FrameSurfaceRevisionGuard {
-            before: playing.then(|| PlaybackFrameRevisionInputs::from_state(self)),
+            before: transient_active.then(|| TransientFrameRevisionInputs::from_state(self)),
             forced_surface,
+            starmap_retained_scene_active_before_message: self.starmap_retained_scene_active(),
         }
     }
 
@@ -157,9 +161,14 @@ impl NativeAppState {
         &mut self,
         guard: FrameSurfaceRevisionGuard,
     ) {
-        let playing = self.playback_visual_activity_active();
-        let after = playing.then(|| PlaybackFrameRevisionInputs::from_state(self));
-        let scope = if guard.forced_surface || guard.before.is_some() != after.is_some() {
+        let transient_active = self.transient_frame_fast_path_active();
+        let after = transient_active.then(|| TransientFrameRevisionInputs::from_state(self));
+        let starmap_retained_scene_touched_frame = guard
+            .starmap_retained_scene_active_before_message
+            || self.starmap_retained_scene_active();
+        let scope = if starmap_retained_scene_touched_frame {
+            RepaintScope::PaintOnly
+        } else if guard.forced_surface || guard.before.is_some() != after.is_some() {
             RepaintScope::Surface
         } else {
             match (guard.before, after) {
@@ -172,7 +181,7 @@ impl NativeAppState {
             self.frame_surface_revision_tracker.bump(scope);
         }
         self.frame_surface_revision_tracker
-            .playback_fast_path_active = playing;
+            .transient_fast_path_active = transient_active;
         if guard.before.is_some() || after.is_some() || guard.forced_surface {
             self.playhead_frame_diagnostics
                 .record_frame_message(PlayheadFrameMessageDiagnostics {
@@ -185,6 +194,27 @@ impl NativeAppState {
     #[cfg(test)]
     pub(in crate::native_app) fn broad_frame_revision_observations() -> u64 {
         BROAD_FRAME_REVISION_OBSERVATIONS.get()
+    }
+
+    fn transient_frame_fast_path_active(&self) -> bool {
+        self.playback_visual_activity_active() || self.starmap_retained_scene_active()
+    }
+
+    pub(in crate::native_app) fn starmap_retained_scene_active(&self) -> bool {
+        self.ui.chrome.starmap_audition_drag.is_some()
+            || self
+                .audio
+                .sample_playback_session
+                .as_ref()
+                .is_some_and(|session| {
+                    session.request.intent == SamplePlaybackIntent::StarmapDrag
+                        && !matches!(session.state, SamplePlaybackSessionState::Failed(_))
+                })
+            || self
+                .audio
+                .pending_sample_playback
+                .as_ref()
+                .is_some_and(|request| request.intent == SamplePlaybackIntent::StarmapDrag)
     }
 
     pub(in crate::native_app) fn observe_playhead_native_frame_diagnostics(
@@ -346,10 +376,10 @@ impl FrameSurfaceRevisionInputs {
     }
 }
 
-impl PlaybackFrameRevisionInputs {
+impl TransientFrameRevisionInputs {
     fn from_state(state: &NativeAppState) -> Self {
         Self {
-            structure: PlaybackFrameStructureState {
+            structure: TransientFrameStructureState {
                 drag_hover_auto_expand_pending: state
                     .library
                     .folder_browser
@@ -371,7 +401,7 @@ impl PlaybackFrameRevisionInputs {
                     .as_ref()
                     .map(|output| output.sample_rate),
             },
-            projection: PlaybackFrameProjectionState {
+            projection: TransientFrameProjectionState {
                 playback_visual_generation: state.waveform.current.playback_visual_generation(),
                 play_selection_flash_active: state.waveform.current.play_selection_flash_active(),
                 copy_flash_frames: state

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -30,6 +30,8 @@ impl NativeAppState {
         message: GuiMessage,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
+        let starmap_retained_scene_message = starmap_message_uses_retained_scene(&message);
+        let starmap_scene_active_before = self.starmap_retained_scene_active();
         let frame_preparation_state = matches!(message, GuiMessage::Frame)
             .then(|| SampleBrowserFramePreparationState::capture(self));
         self.apply_message(message, context);
@@ -38,6 +40,11 @@ impl NativeAppState {
             .unwrap_or(true)
         {
             prepare_sample_browser_view(self);
+        }
+        if starmap_retained_scene_message
+            && (starmap_scene_active_before || self.starmap_retained_scene_active())
+        {
+            context.request_paint_only();
         }
     }
 
@@ -287,6 +294,31 @@ impl NativeAppState {
             "Slow UI message dispatch"
         );
     }
+}
+
+fn starmap_message_uses_retained_scene(message: &GuiMessage) -> bool {
+    matches!(
+        message,
+        GuiMessage::BeginStarmapAuditionDrag { .. }
+            | GuiMessage::UpdateStarmapAuditionDrag { .. }
+            | GuiMessage::AdvanceStarmapAudition { .. }
+            | GuiMessage::PromoteStarmapAudition { .. }
+            | GuiMessage::FinishStarmapAuditionDrag
+            | GuiMessage::DeferredSampleLoad { .. }
+            | GuiMessage::SettledSamplePromotion { .. }
+            | GuiMessage::SampleLoadPathValidated { .. }
+            | GuiMessage::SampleLoadProgress(..)
+            | GuiMessage::SamplePlaybackReady(_)
+            | GuiMessage::PreviewAuditionDecoded { .. }
+            | GuiMessage::PreviewAuditionWarmFinished { .. }
+            | GuiMessage::SampleLoadFinished(_)
+            | GuiMessage::AudioPlayerOpenFinished(_)
+            | GuiMessage::LastPlayedPersistReady { .. }
+            | GuiMessage::LastPlayedPersisted(_)
+            | GuiMessage::SourceProcessingProgress(_)
+            | GuiMessage::FolderScanProgress(_)
+            | GuiMessage::NormalizationProgress(_)
+    )
 }
 
 fn gui_message_profile_label(message: &GuiMessage) -> &'static str {

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -79,7 +79,11 @@ impl NativeAppState {
                 } else {
                     self.background.source_processing_progress = Some(progress);
                 }
-                context.repaint(ui::RepaintScope::Projection);
+                context.repaint(if self.starmap_retained_scene_active() {
+                    ui::RepaintScope::PaintOnly
+                } else {
+                    ui::RepaintScope::Projection
+                });
             }
             GuiMessage::FolderScanProgress(progress) => {
                 self.apply_folder_scan_progress(progress);

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -118,6 +118,50 @@ fn source_processing_progress_refreshes_the_retained_details_projection() {
 }
 
 #[test]
+fn source_processing_progress_does_not_reproject_during_starmap_audition() {
+    let mut state = NativeAppStateFixture::default().build();
+    let source_id = state
+        .library
+        .folder_browser
+        .defer_add_source_path(
+            std::path::PathBuf::from("/tmp/starmap-progress-source"),
+            false,
+        )
+        .expect("source registered");
+    state
+        .background
+        .source_lifecycle_generations
+        .insert(source_id.clone(), 0);
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+    let mut context = ui::UiUpdateContext::default();
+
+    state.handle_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id,
+            lifecycle_generation: 0,
+            active: true,
+            source_row_active: true,
+            completed: 4,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("snare.wav"),
+        }),
+        &mut context,
+    );
+
+    assert_eq!(
+        context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::PaintOnly),
+        "background progress must not rebuild the starmap scene during audition"
+    );
+}
+
+#[test]
 fn late_progress_for_removed_source_is_ignored() {
     let mut state = NativeAppStateFixture::default().build();
     let mut context = ui::UiUpdateContext::default();

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -142,7 +142,7 @@ fn source_processing_progress_does_not_reproject_during_starmap_audition() {
 
     state.handle_message(
         GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
-            source_id,
+            source_id: source_id.clone(),
             lifecycle_generation: 0,
             active: true,
             source_row_active: true,
@@ -158,6 +158,58 @@ fn source_processing_progress_does_not_reproject_during_starmap_audition() {
         context.into_command().repaint_scope(),
         Some(ui::RepaintScope::PaintOnly),
         "background progress must not rebuild the starmap scene during audition"
+    );
+
+    state.ui.chrome.starmap_audition_drag = None;
+    let request = crate::native_app::app::SamplePlaybackRequest::transient(
+        String::from("/samples/kick.wav"),
+        crate::native_app::app::SamplePlaybackIntent::StarmapDrag,
+        "starmap_release",
+    );
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "audio_file");
+    state.audio.sample_playback_session.as_mut().unwrap().state =
+        crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+    let mut active_session_context = ui::UiUpdateContext::default();
+    state.handle_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: source_id.clone(),
+            lifecycle_generation: 0,
+            active: true,
+            source_row_active: true,
+            completed: 5,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("hat.wav"),
+        }),
+        &mut active_session_context,
+    );
+    assert_eq!(
+        active_session_context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::PaintOnly),
+        "the retained scene must cover an audible starmap release session"
+    );
+
+    state.audio.clear_sample_playback_session();
+    let mut settled_context = ui::UiUpdateContext::default();
+    state.handle_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id,
+            lifecycle_generation: 0,
+            active: true,
+            source_row_active: true,
+            completed: 6,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("clap.wav"),
+        }),
+        &mut settled_context,
+    );
+    assert_eq!(
+        settled_context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::Projection),
+        "normal progress projection must resume when the starmap session ends"
     );
 }
 

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -106,6 +106,105 @@ fn playback_restart_refreshes_projection_to_clear_stale_playhead_visuals() {
 }
 
 #[test]
+fn starmap_drag_frame_keeps_audio_handoffs_and_progress_ticks_paint_only() {
+    let mut state = gui_state_for_span_tests();
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+    state.waveform.current.start_playback(0.25);
+
+    let before = state.frame_surface_revisions();
+    let guard = state.begin_frame_surface_revision_tracking();
+    state.waveform.current.stop_playback();
+    state.background.progress_tick = 0.5;
+    state.finish_frame_surface_revision_tracking(guard);
+
+    assert_eq!(
+        state.frame_surface_revisions().repaint_scope_since(before),
+        RepaintScope::PaintOnly,
+        "starmap drag handoffs should keep frame-clock work on retained paint"
+    );
+}
+
+#[test]
+fn starmap_drag_begin_and_release_frames_stay_paint_only() {
+    let mut state = gui_state_for_span_tests();
+    let before_begin = state.frame_surface_revisions();
+    let begin_guard = state.begin_frame_surface_revision_tracking();
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+    state.waveform.current.start_playback(0.0);
+    state.finish_frame_surface_revision_tracking(begin_guard);
+    assert_eq!(
+        state
+            .frame_surface_revisions()
+            .repaint_scope_since(before_begin),
+        RepaintScope::PaintOnly,
+        "the pointer-down frame must not rebuild the scene"
+    );
+
+    let before_release = state.frame_surface_revisions();
+    let release_guard = state.begin_frame_surface_revision_tracking();
+    state.ui.chrome.starmap_audition_drag = None;
+    state.finish_frame_surface_revision_tracking(release_guard);
+    assert_eq!(
+        state
+            .frame_surface_revisions()
+            .repaint_scope_since(before_release),
+        RepaintScope::PaintOnly,
+        "the pointer-release frame must not rebuild the scene"
+    );
+}
+
+#[test]
+fn starmap_audition_handoff_stays_paint_only_after_pointer_release() {
+    let mut state = gui_state_for_span_tests();
+    let request = crate::native_app::app::SamplePlaybackRequest::transient(
+        String::from("/samples/kick.wav"),
+        crate::native_app::app::SamplePlaybackIntent::StarmapDrag,
+        "starmap_drag",
+    );
+    state.audio.pending_sample_playback = Some(request.clone());
+
+    let before = state.frame_surface_revisions();
+    let guard = state.begin_frame_surface_revision_tracking();
+    state.background.progress_tick = 0.5;
+    state.finish_frame_surface_revision_tracking(guard);
+
+    assert_eq!(
+        state.frame_surface_revisions().repaint_scope_since(before),
+        RepaintScope::PaintOnly,
+        "a queued starmap audition must retain the scene after pointer release"
+    );
+
+    state.audio.pending_sample_playback = None;
+    state
+        .audio
+        .start_resolving_sample_playback_session(request, "audio_file");
+    state.audio.sample_playback_session.as_mut().unwrap().state =
+        crate::native_app::app::SamplePlaybackSessionState::AudibleTransient;
+    let before_runtime = state.frame_surface_revisions();
+    let runtime_guard = state.begin_frame_surface_revision_tracking();
+    state.background.progress_tick = 0.75;
+    state.finish_frame_surface_revision_tracking(runtime_guard);
+
+    assert_eq!(
+        state
+            .frame_surface_revisions()
+            .repaint_scope_since(before_runtime),
+        RepaintScope::PaintOnly,
+        "an audible starmap session must retain the scene even between runtime progress events"
+    );
+}
+
+#[test]
 fn idle_frame_uses_paint_only_when_frame_state_is_stable() {
     let mut state = gui_state_for_span_tests();
 
@@ -399,6 +498,36 @@ fn scene_playback_frame_uses_paint_only_repaint_scope() {
         broad_observations,
         "repeated playback frames must remain on the revision fast path"
     );
+}
+
+#[test]
+fn scene_starmap_drag_frame_uses_paint_only_repaint_scope_during_background_progress() {
+    let mut state = gui_state_for_span_tests();
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+    state.waveform.cache.active_folder_warm_folder_id = Some(String::from("source"));
+    state.waveform.cache.active_folder_warm_total = 10;
+    let bridge = radiant::app(state)
+        .view(crate::native_app::test_support::state::view)
+        .handle_message(apply_gui_message_for_presentation_test)
+        .into_bridge();
+    let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
+    apply_strict_update_diagnostics(&mut runtime);
+
+    assert!(runtime.host_animation_activity().needs_frame_message());
+    assert!(runtime.host_queue_animation_frame());
+    let outcome = runtime.drain_runtime_messages();
+
+    assert_eq!(outcome.messages_dispatched, 1);
+    assert!(
+        outcome.paint_only_requested,
+        "background progress during a starmap drag must retain the existing scene"
+    );
+    assert!(!outcome.surface_refresh_requested);
 }
 
 #[test]


### PR DESCRIPTION
## Goal
Prevent the whole Wavecrate window from flashing while dragging across starmap nodes, releasing an active drag, or selecting another node immediately afterward.

## Scope and non-goals
- Keep the existing declarative scene retained across the starmap gesture and asynchronous audition handoff.
- Downgrade eligible background progress and sample-loading messages to paint-only while that retained-scene window is active.
- Restore the normal correctness-first surface refresh after the starmap audition session ends.
- Preserve existing starmap selection, waveform restoration, and audition behavior.
- Non-goal: change starmap hit testing, playback scheduling, or waveform restore semantics.

## Definition of Done
- Pointer-down, active drag, audio replacement, pointer-up, queued load, and audible handoff frames do not rebuild the full scene.
- Background source-processing progress cannot force a starmap scene reprojection during audition.
- Background source-processing progress resumes normal projection once the starmap audition session ends.n- Normal non-starmap projection refresh remains unchanged.
- The signed macOS app no longer flashes in the reported drag-release-click sequence and audition remains immediate.

## Validation
- `cargo test -p wavecrate --lib starmap_drag_begin_and_release_frames_stay_paint_only -- --nocapture` — passed
- `cargo test -p wavecrate --lib starmap_audition_handoff_stays_paint_only -- --nocapture` — passed
- `cargo test -p wavecrate --lib scene_starmap_drag_frame_uses_paint_only_repaint_scope_during_background_progress -- --nocapture` — passed
- `cargo test -p wavecrate --lib source_processing_progress_does_not_reproject_during_starmap_audition -- --nocapture` — passed
- `cargo check --release -p wavecrate --bin wavecrate` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `bash scripts/build.sh --release --variant OPT-1219` — passed; signed app at `target/app-bundles/opt1219/Wavecrate OPT-1219.app`
- Real-app macOS validation with the configured 57-node starmap — drag, release, and immediate follow-up selections were clean in the quiet release build; audition latency remained immediate.

## Known limitations
- The repository-wide smoke lane is currently blocked on `main` by the pre-existing invalid format string in `tests/release_workflow_helpers.rs:936`; this PR does not modify that test.
- Release-mode library tests are currently blocked on `main` because debug-only source DB test helpers are unavailable under release assertions.

User approval is required before merge.