### PR TITLE
OPT-1225 Disable stable release publication

### DIFF
--- a/.github/workflows/release-stable.yml.disabled
+++ b/.github/workflows/release-stable.yml.disabled
@@ -1,5 +1,9 @@
 name: Wavecrate stable release
 
+# Temporarily stored outside GitHub's active workflow extensions while Wavecrate
+# remains in release-candidate stabilization. Restore the .yml suffix only when
+# stable publication is explicitly re-enabled.
+
 on:
   workflow_dispatch:
     inputs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@ likely to miss important reasoning.
   stable release. Stable must promote the exact commit already published and
   reviewed as the latest `vX.Y.Z-rc.N`; it must never silently include newer,
   un-RCed commits from `main`.
+- Stable publication is temporarily disabled while Wavecrate remains in RC
+  stabilization. Keep publishing RCs and preserve the stable implementation;
+  re-enabling it requires a dedicated reviewed change that restores the active
+  workflow and command entrypoint.
 - A stable release requires an explicit user instruction such as "release
   X.Y.Z stable" or "promote RC N to stable." PR approval, `approved`, sign-off,
   or acceptance of an RC authorizes the applicable PR merge and cleanup only;

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -93,7 +93,8 @@ Maximum macOS directory metadata size allowed for a validation target's
 
 ### Release upload secrets
 
-Wavecrate has four public release workflows:
+Wavecrate has three active public release workflows and one preserved inactive
+stable workflow:
 
 - `.github/workflows/release-train-prepare.yml`
   - manual release-train branch/version preparation for `release/X.Y`
@@ -101,8 +102,9 @@ Wavecrate has four public release workflows:
   - automatic and manual nightly builds from `main`
 - `.github/workflows/release-rc.yml`
   - manual release-candidate builds from `release/X.Y`
-- `.github/workflows/release-stable.yml`
-  - manual stable releases from `release/X.Y`
+- `.github/workflows/release-stable.yml.disabled`
+  - preserved stable implementation; the non-YAML suffix keeps it unavailable
+    to GitHub Actions while Wavecrate remains in RC stabilization
 
 ### Release lifecycle policy
 
@@ -122,11 +124,12 @@ workflow deliberately requires the latest `vX.Y.Z-rc.N` tag and
 `release/X.Y` to point at the same commit, so stable cannot silently include
 changes that were never published as an RC.
 
-Stable publication requires an explicit operator decision such as "release
-X.Y.Z stable" or "promote RC N to stable." PR approval, `approved`, sign-off,
-or acceptance of an RC only authorizes the relevant PR merge and cleanup. None
-of those phrases alone authorizes `release-stable.yml` or
-`scripts/release.sh stable --dispatch`.
+Stable publication is temporarily disabled. The workflow implementation and
+promotion checks remain in the repository, but GitHub does not register the
+`.yml.disabled` file and `scripts/release.sh stable` fails closed before any
+release resolution or dispatch. Re-enabling stable publication requires a
+dedicated reviewed change; an RC approval or ordinary merge approval is not
+sufficient.
 
 Nightly runs publish rolling `nightly` builds for Windows x86_64 plus macOS
 x86_64/aarch64 assets from the current `main` commit. The schedule is
@@ -152,21 +155,19 @@ scripts/release.sh prepare --bump minor --source-ref main --dry-run
 scripts/release.sh prepare --bump minor --source-ref main --push
 scripts/release.sh prepare --bump patch --source-ref release/0.19 --dry-run
 scripts/release.sh rc --version 0.20.0 --rc-number 1 --branch release/0.20 --dispatch
-scripts/release.sh stable --version 0.20.0 --branch release/0.20 --dispatch
 ```
 
 `prepare --bump major` bumps `X.Y.Z` to `(X+1).0.0`; `prepare --bump minor`
 bumps to `X.(Y+1).0`; `prepare --bump patch` bumps to `X.Y.(Z+1)` on the same
-`release/X.Y` train. Without `--dispatch`, `rc` and `stable` validate inputs
-and print the exact `gh workflow run ...` command instead of publishing. With
-`--dispatch`, the script requires an authenticated GitHub CLI (`gh`) and invokes
-the existing workflows with their native input names. When `origin` is a GitHub
+`release/X.Y` train. Without `--dispatch`, `rc` validates inputs and prints the
+exact `gh workflow run ...` command instead of publishing. Stable commands fail
+closed while publication is disabled. With `--dispatch`, the RC path requires
+an authenticated GitHub CLI (`gh`) and invokes the active workflow with its
+native input names. When `origin` is a GitHub
 remote, it must match `WAVECRATE_GITHUB_REPO` so local ref resolution and
 workflow dispatch target the same repository. `prepare --dispatch` dispatches
 the workflow file from `--workflow-ref` (default `main`) while passing the
-resolved source commit SHA as the workflow `source_ref` input. Stable dispatch
-also preflights the safety invariant locally: the latest `vX.Y.Z-rc.N` tag must
-point at the same commit as the release branch.
+resolved source commit SHA as the workflow `source_ref` input.
 
 Local equivalent:
 

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2754,6 +2754,11 @@ Stable publication is a separate explicit product decision. PR approval,
 of them authorize a stable release unless the user explicitly asks to release
 or promote the version as stable.
 
+Stable publication is temporarily disabled while Wavecrate remains in RC
+stabilization. The promotion implementation stays preserved, but both the
+active GitHub workflow and local dispatch entrypoint must fail closed until a
+dedicated reviewed change explicitly re-enables them.
+
 ### Data-Format Notes
 
 Keep these formats stable unless there is a coordinated migration:

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -116,11 +116,13 @@ branch freeze or an automatic precursor to an immediate stable release.
      --dispatch
    ```
 
-5. Trigger stable only after an explicit stable-release decision. The stable
-   workflow promotes the exact latest RC commit; if later changes intended for
-   `X.Y.Z` have not been published as an RC, publish another RC first. PR
-   approval, `approved`, sign-off, or RC acceptance does not authorize stable
-   publication.
+5. Continue publishing RCs while stable publication is temporarily disabled.
+   Ensure every change intended for the train is published as an RC.
+   The preserved stable workflow promotes the exact latest RC commit, but it is
+   stored outside GitHub's active workflow extensions and the local stable
+   command fails closed. Re-enabling stable publication requires a dedicated
+   reviewed change; PR approval, `approved`, sign-off, or RC acceptance does
+   not authorize that change or a stable publication.
 
 Keep the remote `release/X.Y` branch as the release coordination ref. It is not
 a disposable feature branch and must remain available for subsequent RCs and
@@ -139,19 +141,20 @@ the eventual explicit stable promotion.
 | Perf guard | none | `scripts/perf.* guard` | Local/manual or release-risk validation |
 | Nightly release build/sync | `Wavecrate nightly release` on the evening schedule or manual dispatch | release workflow dispatch | Resolves the exact `main` SHA, runs `scripts/internal/release/run_release_validation.sh` on Ubuntu before package builds or publication, builds Windows/macOS nightly assets from that SHA, embeds `X.Y.Z-nightly.DATE+SHA` metadata, verifies the checksum signing key against the pinned public key before public publication, uploads and verifies the immutable PortalSurfer release plus full changelog first, then refreshes the rolling GitHub `nightly` release assets and promotes the immutable and rolling GitHub tags as the final public identity step |
 | RC release | `Wavecrate RC release` manual dispatch | release workflow dispatch | Builds Windows/macOS RC assets from `release/X.Y`, validates the requested package version and branch, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z-rc.N` as a GitHub pre-release |
-| Stable release | `Wavecrate stable release` manual dispatch | release workflow dispatch | Builds Windows/macOS stable assets from `release/X.Y`, validates that the latest `vX.Y.Z-rc.N` tag points at the same commit, runs `scripts/internal/release/run_release_validation.sh`, verifies the checksum signing key against the pinned public key before public publication, and publishes `vX.Y.Z` as the normal GitHub release |
+| Stable release | Disabled | `scripts/release.sh stable` fails closed | The implementation is preserved in `.github/workflows/release-stable.yml.disabled`; restore it through a dedicated reviewed change only when Wavecrate is ready for stable publication |
 
 Use `scripts/release.sh` from a clean repo root for macOS/Linux release
 orchestration. It derives major, minor, and patch target versions from the
 package version at the resolved source ref, delegates release-train prep to
-`scripts/internal/release/prepare_release_train.py`, and dispatches the RC and
-stable GitHub workflows only when `--dispatch` is passed. Prepare dispatch uses
+`scripts/internal/release/prepare_release_train.py`, and dispatches the RC
+GitHub workflow only when `--dispatch` is passed. Prepare dispatch uses
 `--workflow-ref` (default `main`) for the workflow file ref and sends the
 resolved source commit SHA through the `source_ref` workflow input. The script
 requires `gh` only for explicit workflow dispatch. When `origin` is a GitHub
 remote, it must match `WAVECRATE_GITHUB_REPO` before release refs are fetched or
-resolved. Dry RC/stable runs print the exact workflow command and follow-up
-run-list command without publishing.
+resolved. Dry RC runs print the exact workflow command and follow-up run-list
+command without publishing. Stable commands fail before resolving release refs
+or invoking GitHub.
 
 The nextest policy is:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,11 +23,13 @@ dispatcher maps. These are the public entrypoints people should run directly:
   `calibrate-startup` command is optional Linux developer tooling for refreshing
   startup threshold lock files; it is not shipped Linux product support.
 - `release.sh`: Bash release orchestration for release-train prep and explicit
-  RC/stable GitHub workflow dispatch. It derives major, minor, and patch targets
+  RC GitHub workflow dispatch. It derives major, minor, and patch targets
   from the resolved source release package version and delegates
   packaging/publication to the existing release workflows. RC publication
-  starts stabilization while normal PRs continue on `main`; stable publication
-  remains a separate explicit action and is never implied by PR or RC approval.
+  starts stabilization while normal PRs continue on `main`. Stable publication
+  is temporarily disabled and its command fails closed while the implementation
+  remains preserved until an explicit, reviewed change re-enables stable
+  publication.
 - `gui.ps1`: Windows GUI validation lanes.
 
 PowerShell compatibility wrappers also remain available for the older

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,11 +9,12 @@ usage() {
 Usage:
   scripts/release.sh prepare --bump <major|minor|patch> [--source-ref <ref>] [--workflow-ref <branch-or-tag>] [--dry-run|--push] [--dispatch]
   scripts/release.sh rc --version <X.Y.Z> --rc-number <N> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
-  scripts/release.sh stable --version <X.Y.Z> --branch <release/X.Y> [--release-notes <text>] [--dispatch]
+  scripts/release.sh stable [options]  # temporarily disabled
 
 Prepare derives the target version from Cargo.toml at the resolved source ref.
 Without --dispatch, prepare runs scripts/internal/release/prepare_release_train.py locally.
-Without --dispatch, rc/stable validate inputs and print the exact gh workflow command.
+Without --dispatch, rc validates inputs and prints the exact gh workflow command.
+Stable publication is temporarily disabled while release candidates continue.
 Public publishing workflow dispatch requires --dispatch.
 EOF
 }
@@ -408,6 +409,10 @@ stable() {
       *) die "unknown stable argument: $1" ;;
     esac
   done
+  die "stable releases are temporarily disabled; continue publishing release candidates"
+
+  # Preserve the promotion implementation below so it can be re-enabled once
+  # Wavecrate is ready for stable publication.
   [[ -n "$version" && -n "$branch" ]] || die "stable requires --version and --branch"
   validate_version "$version"
   validate_branch_for_version "$branch" "$version"

--- a/tests/release_contract.rs
+++ b/tests/release_contract.rs
@@ -1,6 +1,7 @@
 //! Release contract checks for active targets and release asset labels.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use toml::Value;
 
@@ -38,7 +39,7 @@ const NIGHTLY_WORKFLOW: &str = include_str!("../.github/workflows/release-build.
 const RELEASE_TRAIN_PREP_WORKFLOW: &str =
     include_str!("../.github/workflows/release-train-prepare.yml");
 const RC_WORKFLOW: &str = include_str!("../.github/workflows/release-rc.yml");
-const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml");
+const STABLE_WORKFLOW: &str = include_str!("../.github/workflows/release-stable.yml.disabled");
 const RELEASE_TRAIN_PREP_SCRIPT: &str =
     include_str!("../scripts/internal/release/prepare_release_train.py");
 const ASSEMBLE_RELEASE_FILES_SCRIPT: &str =
@@ -133,6 +134,25 @@ fn workspace_release_identity_is_pre_one_and_consistent() {
             && STABLE_WORKFLOW.contains("example 0.")
             && STABLE_WORKFLOW.contains("example release/0."),
         "manual release workflows must demonstrate the pre-1.0 version and branch shape"
+    );
+}
+
+#[test]
+fn stable_workflow_is_inert_while_its_implementation_is_preserved() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for active_name in ["release-stable.yml", "release-stable.yaml"] {
+        assert!(
+            !repo_root
+                .join(".github/workflows")
+                .join(active_name)
+                .exists(),
+            "stable publication must not be exposed as active workflow {active_name}"
+        );
+    }
+    assert!(
+        STABLE_WORKFLOW.contains("name: Wavecrate stable release")
+            && STABLE_WORKFLOW.contains("Publish GitHub stable release"),
+        "the stable workflow implementation must remain available for later re-enablement"
     );
 }
 

--- a/tests/release_orchestration.rs
+++ b/tests/release_orchestration.rs
@@ -414,89 +414,10 @@ fn rc_rejects_release_branch_with_mismatched_manifest_version() {
 }
 
 #[test]
-fn stable_requires_latest_rc_tag_to_match_release_branch_commit() {
+fn stable_command_fails_closed_before_resolving_or_dispatching() {
     let repo = FixtureRepo::new();
     repo.write_workspace("19.2.0");
     repo.commit_all("seed workspace");
-    let release_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
-    repo.create_release_branch("release/19.2");
-    repo.write("src/lib.rs", "// changed after release branch\n");
-    repo.commit_all("advance main");
-    repo.git(&["tag", "v19.2.0-rc.1"]);
-    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
-    assert_ne!(repo.git_stdout(&["rev-parse", "HEAD"]), release_sha);
-
-    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
-
-    assert_failure(&output);
-    assert!(stderr(&output).contains("stable target is"));
-}
-
-#[test]
-fn stable_prunes_stale_local_rc_tags_before_selecting_promoted_rc() {
-    let repo = FixtureRepo::new();
-    repo.write_workspace("19.2.0");
-    repo.commit_all("seed workspace");
-    repo.create_release_branch("release/19.2");
-    repo.git(&["tag", "v19.2.0-rc.1"]);
-    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
-    repo.write("src/lib.rs", "// stale local rc tag only\n");
-    repo.commit_all("advance main after remote rc");
-    repo.git(&["tag", "v19.2.0-rc.2"]);
-    assert_eq!(
-        repo.git_stdout(&["tag", "-l", "v19.2.0-rc.*", "--sort=-v:refname"])
-            .lines()
-            .next(),
-        Some("v19.2.0-rc.2"),
-        "stale local rc tag should sort ahead before the wrapper fetches"
-    );
-
-    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
-
-    assert_success(&output);
-    let stdout = stdout(&output);
-    assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
-    assert!(
-        !repo
-            .git_stdout(&["tag", "-l", "v19.2.0-rc.2"])
-            .contains("v19.2.0-rc.2")
-    );
-}
-
-#[test]
-fn stable_rejects_existing_tag_that_points_at_different_commit() {
-    let repo = FixtureRepo::new();
-    repo.write_workspace("19.2.0");
-    repo.commit_all("seed workspace");
-    let release_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
-    repo.create_release_branch("release/19.2");
-    repo.git(&["tag", "v19.2.0-rc.1"]);
-    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
-    repo.write("src/lib.rs", "// later commit with reused stable tag\n");
-    repo.commit_all("advance main after release branch");
-    let tag_sha = repo.git_stdout(&["rev-parse", "HEAD"]);
-    repo.git(&["tag", "v19.2.0"]);
-    repo.git(&["push", "origin", "v19.2.0"]);
-    assert_ne!(release_sha, tag_sha);
-
-    let output = repo.run_release(&["stable", "--version", "19.2.0", "--branch", "release/19.2"]);
-
-    assert_failure(&output);
-    assert!(stderr(&output).contains(&format!(
-        "stable tag v19.2.0 already points at {tag_sha}, not {release_sha}"
-    )));
-    assert!(!stdout(&output).contains("Promoted RC tag: v19.2.0-rc.1"));
-    assert!(!stdout(&output).contains("Dry command: gh workflow run"));
-}
-
-#[test]
-fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
-    let repo = FixtureRepo::new();
-    repo.write_workspace("19.2.0");
-    repo.commit_all("seed workspace");
-    repo.create_release_branch("release/19.2");
-    repo.git(&["tag", "v19.2.0-rc.1"]);
-    repo.git(&["push", "origin", "v19.2.0-rc.1"]);
 
     let output = repo.run_release(&[
         "stable",
@@ -504,17 +425,15 @@ fn stable_dry_run_accepts_matching_latest_rc_tag_and_prints_dispatch_command() {
         "19.2.0",
         "--branch",
         "release/19.2",
-        "--release-notes",
-        "Stable notes with spaces",
+        "--dispatch",
     ]);
 
-    assert_success(&output);
-    let stdout = stdout(&output);
-    assert!(stdout.contains("Promoted RC tag: v19.2.0-rc.1"));
-    assert!(stdout.contains("Dry command: gh workflow run release-stable.yml"));
-    assert!(stdout.contains("--repo PORTALSURFER/wavecrate"));
-    assert!(stdout.contains("-f release_notes=Stable\\ notes\\ with\\ spaces"));
-    assert!(stdout.contains("release-stable.yml"));
+    assert_failure(&output);
+    assert!(stderr(&output).contains(
+        "stable releases are temporarily disabled; continue publishing release candidates"
+    ));
+    assert!(!stdout(&output).contains("git fetch"));
+    assert!(!stdout(&output).contains("gh workflow run"));
 }
 
 struct FixtureRepo {
@@ -573,7 +492,6 @@ edition = "2024"
         self.write("src/lib.rs", "");
         self.write(".github/workflows/release-train-prepare.yml", "");
         self.write(".github/workflows/release-rc.yml", "");
-        self.write(".github/workflows/release-stable.yml", "");
         self.write(
             "scripts/internal/release/prepare_release_train.py",
             "#!/usr/bin/env bash\nversion=\"$(awk '/^\\[package\\]$/ { in_package = 1; next } in_package && /^\\[/ { exit } in_package && /^[[:space:]]*version[[:space:]]*=/ { gsub(/\\\"/, \"\", $3); print $3; exit }' Cargo.toml)\"\nradiant_status=\"\"\nif [[ -f .gitmodules ]]; then\n  if [[ ! -f vendor/radiant/radiant.marker ]]; then\n    echo 'missing vendor/radiant submodule contents' >&2\n    exit 42\n  fi\n  radiant_status=' [radiant-submodule=present]'\nfi\nprintf 'prepare-helper'\nfor arg in \"$@\"; do printf ' [%s]' \"$arg\"; done\nprintf ' [cwd-version=%s]%s\\n' \"$version\" \"$radiant_status\"\n",


### PR DESCRIPTION
## Goal

Disable stable Wavecrate publication while the product remains in release-candidate stabilization, without deleting the release implementation needed for a later re-enable.

## Scope

- move the stable workflow definition outside GitHub's active workflow extensions
- make `scripts/release.sh stable` fail closed before release-ref resolution or GitHub dispatch
- preserve the stable workflow, packaging helpers, promotion validation, and release contract coverage
- update operator and engineering documentation to describe the temporary hold
- add regression coverage for both disabled entrypoints

Non-goals:
- changing nightly or RC publication
- deleting stable packaging/promotion support
- publishing or promoting any release

## Definition of Done

- GitHub cannot register `release-stable.yml` or `release-stable.yaml`
- the local stable command cannot resolve refs or dispatch a workflow
- stable implementation remains in the repository for a dedicated reviewed re-enable
- nightly and RC release paths remain unchanged
- release-specific tests pass

## Validation

- `bash -n scripts/release.sh` — passed
- `cargo fmt --all -- --check` — passed
- `cargo test --locked --test release_contract` — passed (31 tests)
- `cargo test --locked --test release_orchestration` — passed (17 tests)
- `git diff --check` — passed
- `bash scripts/ci.sh agent` — blocked by a pre-existing compile error in `tests/release_workflow_helpers.rs:936`: unescaped Python dictionary braces inside a Rust format string; this PR does not modify that file

## Known limitations

The broad agent gate cannot complete until the unrelated existing `tests/release_workflow_helpers.rs:936` format-string error is fixed.

User approval is required before merge.

Linear: OPT-1225