### PR TITLE
OPT-1220 Make destructive waveform edits failure-atomic

### DIFF
--- a/src/native_app/waveform_edits.rs
+++ b/src/native_app/waveform_edits.rs
@@ -1,3 +1,4 @@
+mod atomic_write;
 mod completion;
 mod entrypoints;
 mod prompt;

--- a/src/native_app/waveform_edits/atomic_write.rs
+++ b/src/native_app/waveform_edits/atomic_write.rs
@@ -244,6 +244,7 @@ fn restore_recovery_copy(
         .tempfile_in(parent)?;
     let mut recovery = fs::File::open(recovery_copy)?;
     io::copy(&mut recovery, staged.as_file_mut())?;
+    fs::set_permissions(staged.path(), fs::metadata(recovery_copy)?.permissions())?;
     staged.as_file().sync_all()?;
     let staged_path = staged.into_temp_path();
     edit_io.replace(&staged_path, target, ReplacePhase::Restore)?;

--- a/src/native_app/waveform_edits/atomic_write.rs
+++ b/src/native_app/waveform_edits/atomic_write.rs
@@ -1,0 +1,297 @@
+use std::{fs, io, path::Path};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplacePhase {
+    Commit,
+    Restore,
+}
+
+#[derive(Debug)]
+pub(super) struct AtomicWriteFailure {
+    message: String,
+    recovery_copy_required: bool,
+}
+
+impl AtomicWriteFailure {
+    fn ordinary(message: String) -> Self {
+        Self {
+            message,
+            recovery_copy_required: false,
+        }
+    }
+
+    fn recovery_required(message: String) -> Self {
+        Self {
+            message,
+            recovery_copy_required: true,
+        }
+    }
+
+    pub(super) fn recovery_copy_required(&self) -> bool {
+        self.recovery_copy_required
+    }
+}
+
+impl std::fmt::Display for AtomicWriteFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+trait AtomicEditIo {
+    fn before_sample_write(&self, _sample_index: usize) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn before_finalize(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn replace(&self, staged: &Path, target: &Path, _phase: ReplacePhase) -> io::Result<()> {
+        replace_file(staged, target)
+    }
+
+    fn sync_parent(&self, parent: &Path) -> io::Result<()> {
+        sync_parent_dir(parent)
+    }
+}
+
+struct RealAtomicEditIo;
+
+impl AtomicEditIo for RealAtomicEditIo {
+    #[cfg(debug_assertions)]
+    fn before_sample_write(&self, sample_index: usize) -> Result<(), String> {
+        if sample_index > 0 && injected_failure() == Some("write") {
+            return Err(String::from("Injected late waveform sample-write failure"));
+        }
+        Ok(())
+    }
+
+    #[cfg(debug_assertions)]
+    fn before_finalize(&self) -> Result<(), String> {
+        if injected_failure() == Some("finalize") {
+            return Err(String::from("Injected waveform finalize failure"));
+        }
+        Ok(())
+    }
+
+    #[cfg(debug_assertions)]
+    fn replace(&self, staged: &Path, target: &Path, phase: ReplacePhase) -> io::Result<()> {
+        let requested = injected_failure();
+        if (phase == ReplacePhase::Commit && matches!(requested, Some("replace" | "restore")))
+            || (phase == ReplacePhase::Restore && requested == Some("restore"))
+        {
+            return Err(io::Error::other(format!(
+                "Injected waveform {} failure",
+                match phase {
+                    ReplacePhase::Commit => "replace",
+                    ReplacePhase::Restore => "restore",
+                }
+            )));
+        }
+        replace_file(staged, target)
+    }
+}
+
+#[cfg(debug_assertions)]
+fn injected_failure() -> Option<&'static str> {
+    match std::env::var("WAVECRATE_INJECT_WAVEFORM_EDIT_FAILURE").as_deref() {
+        Ok("write") => Some("write"),
+        Ok("finalize") => Some("finalize"),
+        Ok("replace") => Some("replace"),
+        Ok("restore") => Some("restore"),
+        _ => None,
+    }
+}
+
+pub(super) fn write_wav_atomically(
+    target: &Path,
+    recovery_copy: &Path,
+    after_snapshot: &Path,
+    channels: usize,
+    sample_rate: u32,
+    samples: &[f32],
+) -> Result<(), AtomicWriteFailure> {
+    write_wav_atomically_with(
+        target,
+        recovery_copy,
+        after_snapshot,
+        channels,
+        sample_rate,
+        samples,
+        &RealAtomicEditIo,
+    )
+}
+
+fn write_wav_atomically_with(
+    target: &Path,
+    recovery_copy: &Path,
+    after_snapshot: &Path,
+    channels: usize,
+    sample_rate: u32,
+    samples: &[f32],
+    edit_io: &impl AtomicEditIo,
+) -> Result<(), AtomicWriteFailure> {
+    let parent = target.parent().ok_or_else(|| {
+        AtomicWriteFailure::ordinary(format!(
+            "Failed to stage edited WAV {}: target has no parent directory",
+            target.display()
+        ))
+    })?;
+    let target_permissions = fs::metadata(target)
+        .map_err(|err| {
+            AtomicWriteFailure::ordinary(format!("Failed to inspect original WAV: {err}"))
+        })?
+        .permissions();
+    let staged = tempfile::Builder::new()
+        .prefix(".wavecrate-edit-")
+        .suffix(".wav")
+        .tempfile_in(parent)
+        .map_err(|err| {
+            AtomicWriteFailure::ordinary(format!("Failed to stage edited WAV: {err}"))
+        })?;
+    let staged_file = staged.as_file().try_clone().map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to prepare edited WAV: {err}"))
+    })?;
+    let spec = hound::WavSpec {
+        channels: channels as u16,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer = hound::WavWriter::new(staged_file, spec).map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to write edited WAV header: {err}"))
+    })?;
+    for (sample_index, sample) in samples.iter().enumerate() {
+        edit_io.before_sample_write(sample_index).map_err(|err| {
+            AtomicWriteFailure::ordinary(format!("Failed to write edited WAV sample: {err}"))
+        })?;
+        writer.write_sample(*sample).map_err(|err| {
+            AtomicWriteFailure::ordinary(format!("Failed to write edited WAV sample: {err}"))
+        })?;
+    }
+    edit_io.before_finalize().map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to finalize edited WAV: {err}"))
+    })?;
+    writer.finalize().map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to finalize edited WAV: {err}"))
+    })?;
+    fs::set_permissions(staged.path(), target_permissions).map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to preserve WAV permissions: {err}"))
+    })?;
+    staged
+        .as_file()
+        .sync_all()
+        .map_err(|err| AtomicWriteFailure::ordinary(format!("Failed to sync edited WAV: {err}")))?;
+    fs::copy(staged.path(), after_snapshot).map_err(|err| {
+        AtomicWriteFailure::ordinary(format!("Failed to snapshot edited audio file: {err}"))
+    })?;
+    fs::File::open(after_snapshot)
+        .and_then(|snapshot| snapshot.sync_all())
+        .map_err(|err| {
+            AtomicWriteFailure::ordinary(format!("Failed to sync edited audio snapshot: {err}"))
+        })?;
+    let staged_path = staged.into_temp_path();
+
+    if let Err(replace_error) = edit_io.replace(&staged_path, target, ReplacePhase::Commit) {
+        return restore_after_failed_commit(
+            target,
+            recovery_copy,
+            parent,
+            edit_io,
+            format!("Failed to replace original WAV: {replace_error}"),
+        );
+    }
+    if let Err(sync_error) = edit_io.sync_parent(parent) {
+        return restore_after_failed_commit(
+            target,
+            recovery_copy,
+            parent,
+            edit_io,
+            format!("Failed to durably commit edited WAV: {sync_error}"),
+        );
+    }
+    Ok(())
+}
+
+fn restore_after_failed_commit(
+    target: &Path,
+    recovery_copy: &Path,
+    parent: &Path,
+    edit_io: &impl AtomicEditIo,
+    commit_error: String,
+) -> Result<(), AtomicWriteFailure> {
+    match restore_recovery_copy(target, recovery_copy, parent, edit_io) {
+        Ok(()) => Err(AtomicWriteFailure::ordinary(format!(
+            "{commit_error}; the original audio was restored"
+        ))),
+        Err(restore_error) => Err(AtomicWriteFailure::recovery_required(format!(
+            "{commit_error}; failed to restore the original audio: {restore_error}; recovery copy retained at {}",
+            recovery_copy.display()
+        ))),
+    }
+}
+
+fn restore_recovery_copy(
+    target: &Path,
+    recovery_copy: &Path,
+    parent: &Path,
+    edit_io: &impl AtomicEditIo,
+) -> io::Result<()> {
+    let mut staged = tempfile::Builder::new()
+        .prefix(".wavecrate-restore-")
+        .suffix(".wav")
+        .tempfile_in(parent)?;
+    let mut recovery = fs::File::open(recovery_copy)?;
+    io::copy(&mut recovery, staged.as_file_mut())?;
+    staged.as_file().sync_all()?;
+    let staged_path = staged.into_temp_path();
+    edit_io.replace(&staged_path, target, ReplacePhase::Restore)?;
+    edit_io.sync_parent(parent)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn replace_file(staged: &Path, target: &Path) -> io::Result<()> {
+    fs::rename(staged, target)
+}
+
+#[cfg(target_os = "windows")]
+fn replace_file(staged: &Path, target: &Path) -> io::Result<()> {
+    use windows::{
+        Win32::Storage::FileSystem::{
+            MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        },
+        core::PCWSTR,
+    };
+
+    let staged = wide_path(staged);
+    let target = wide_path(target);
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+    unsafe { MoveFileExW(PCWSTR(staged.as_ptr()), PCWSTR(target.as_ptr()), flags) }
+        .map_err(io::Error::other)
+}
+
+#[cfg(target_os = "windows")]
+fn wide_path(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    path.as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+fn sync_parent_dir(parent: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(parent)?.sync_all()?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = parent;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/native_app/waveform_edits/atomic_write/tests.rs
+++ b/src/native_app/waveform_edits/atomic_write/tests.rs
@@ -1,0 +1,178 @@
+use std::{fs, io, path::Path};
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InjectedFailure {
+    None,
+    Write,
+    Finalize,
+    Replace,
+    ReplaceAndRestore,
+}
+
+struct TestAtomicEditIo {
+    failure: InjectedFailure,
+}
+
+impl TestAtomicEditIo {
+    fn new(failure: InjectedFailure) -> Self {
+        Self { failure }
+    }
+}
+
+impl AtomicEditIo for TestAtomicEditIo {
+    fn before_sample_write(&self, sample_index: usize) -> Result<(), String> {
+        if self.failure == InjectedFailure::Write && sample_index == 1 {
+            return Err(String::from("injected late write failure"));
+        }
+        Ok(())
+    }
+
+    fn before_finalize(&self) -> Result<(), String> {
+        if self.failure == InjectedFailure::Finalize {
+            return Err(String::from("injected finalize failure"));
+        }
+        Ok(())
+    }
+
+    fn replace(&self, staged: &Path, target: &Path, phase: ReplacePhase) -> io::Result<()> {
+        match (self.failure, phase) {
+            (InjectedFailure::Replace, ReplacePhase::Commit) => {
+                Err(io::Error::other("injected replace failure"))
+            }
+            (InjectedFailure::ReplaceAndRestore, ReplacePhase::Commit) => {
+                fs::write(target, b"damaged replacement")?;
+                Err(io::Error::other("injected late replace failure"))
+            }
+            (InjectedFailure::ReplaceAndRestore, ReplacePhase::Restore) => {
+                Err(io::Error::other("injected restore failure"))
+            }
+            _ => replace_file(staged, target),
+        }
+    }
+}
+
+fn fixture() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let directory = tempfile::tempdir().expect("waveform atomic-write fixture");
+    let target = directory.path().join("sample.wav");
+    let recovery = directory.path().join("before.wav");
+    fs::write(&target, b"original audio bytes").expect("write original fixture");
+    fs::copy(&target, &recovery).expect("write recovery fixture");
+    (directory, target, recovery)
+}
+
+fn run_with_failure(
+    failure: InjectedFailure,
+) -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::path::PathBuf,
+    AtomicWriteFailure,
+) {
+    let (directory, target, recovery) = fixture();
+    let after_snapshot = directory.path().join("after.wav");
+    let error = write_wav_atomically_with(
+        &target,
+        &recovery,
+        &after_snapshot,
+        1,
+        48_000,
+        &[0.0, 0.25, -0.25, 0.5],
+        &TestAtomicEditIo::new(failure),
+    )
+    .expect_err("injected failure should fail the edit");
+    (directory, target, recovery, error)
+}
+
+#[test]
+fn write_failure_leaves_original_bytes_unchanged() {
+    let (_directory, target, recovery, error) = run_with_failure(InjectedFailure::Write);
+
+    assert_eq!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert!(!error.recovery_copy_required());
+    assert!(error.to_string().contains("late write failure"));
+}
+
+#[test]
+fn finalize_failure_leaves_original_bytes_unchanged() {
+    let (_directory, target, recovery, error) = run_with_failure(InjectedFailure::Finalize);
+
+    assert_eq!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert!(!error.recovery_copy_required());
+    assert!(error.to_string().contains("finalize failure"));
+}
+
+#[test]
+fn redo_snapshot_failure_leaves_original_bytes_unchanged() {
+    let (directory, target, recovery) = fixture();
+    let after_snapshot = directory.path().join("missing").join("after.wav");
+
+    let error = write_wav_atomically_with(
+        &target,
+        &recovery,
+        &after_snapshot,
+        1,
+        48_000,
+        &[0.0, 0.25, -0.25, 0.5],
+        &TestAtomicEditIo::new(InjectedFailure::None),
+    )
+    .expect_err("snapshot failure should fail the edit");
+
+    assert_eq!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert!(!error.recovery_copy_required());
+    assert!(error.to_string().contains("snapshot edited audio file"));
+}
+
+#[test]
+fn replace_failure_restores_original_bytes() {
+    let (_directory, target, recovery, error) = run_with_failure(InjectedFailure::Replace);
+
+    assert_eq!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert!(!error.recovery_copy_required());
+    assert!(error.to_string().contains("original audio was restored"));
+}
+
+#[test]
+fn rollback_failure_reports_the_exact_recovery_path() {
+    let (_directory, target, recovery, error) =
+        run_with_failure(InjectedFailure::ReplaceAndRestore);
+
+    assert_eq!(fs::read(&target).unwrap(), b"damaged replacement");
+    assert_eq!(fs::read(&recovery).unwrap(), b"original audio bytes");
+    assert!(error.recovery_copy_required());
+    assert!(error.to_string().contains(&recovery.display().to_string()));
+    assert!(error.to_string().contains("injected restore failure"));
+}
+
+#[test]
+fn successful_commit_publishes_a_complete_synced_wav() {
+    let (directory, target, recovery) = fixture();
+    let after_snapshot = directory.path().join("after.wav");
+    let original_permissions = fs::metadata(&target).unwrap().permissions();
+
+    write_wav_atomically_with(
+        &target,
+        &recovery,
+        &after_snapshot,
+        1,
+        48_000,
+        &[0.0, 0.25, -0.25, 0.5],
+        &TestAtomicEditIo::new(InjectedFailure::None),
+    )
+    .expect("atomic waveform commit");
+
+    assert_ne!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert_eq!(
+        fs::read(&target).unwrap(),
+        fs::read(&after_snapshot).unwrap()
+    );
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions(),
+        original_permissions
+    );
+    let mut reader = hound::WavReader::open(&target).expect("committed WAV");
+    assert_eq!(reader.spec().channels, 1);
+    assert_eq!(reader.spec().sample_rate, 48_000);
+    assert_eq!(reader.samples::<f32>().count(), 4);
+}

--- a/src/native_app/waveform_edits/atomic_write/tests.rs
+++ b/src/native_app/waveform_edits/atomic_write/tests.rs
@@ -129,6 +129,10 @@ fn replace_failure_restores_original_bytes() {
     let (_directory, target, recovery, error) = run_with_failure(InjectedFailure::Replace);
 
     assert_eq!(fs::read(&target).unwrap(), fs::read(&recovery).unwrap());
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions(),
+        fs::metadata(&recovery).unwrap().permissions()
+    );
     assert!(!error.recovery_copy_required());
     assert!(error.to_string().contains("original audio was restored"));
 }

--- a/src/native_app/waveform_edits/worker.rs
+++ b/src/native_app/waveform_edits/worker.rs
@@ -10,12 +10,13 @@ use wavecrate::selection::SelectionRange;
 use crate::native_app::app::{PendingWaveformDestructiveEdit, WaveformDestructiveEditKind};
 use crate::native_app::waveform::{WaveformExtractionRequest, execute_waveform_extraction};
 use crate::native_app::waveform_edit_effects::apply_edit_selection_effects;
+use crate::native_app::waveform_edits::atomic_write::{AtomicWriteFailure, write_wav_atomically};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct OverwriteBackup {
     pub(super) before: PathBuf,
     pub(super) after: PathBuf,
-    dir: PathBuf,
+    dir: Option<PathBuf>,
 }
 
 impl OverwriteBackup {
@@ -29,26 +30,34 @@ impl OverwriteBackup {
         let before = dir.join("before.wav");
         let after = dir.join("after.wav");
         fs::copy(target, &before).map_err(|err| format!("Failed to snapshot audio file: {err}"))?;
-        Ok(Self { before, after, dir })
-    }
-
-    fn capture_after(&self, target: &Path) -> Result<(), String> {
-        fs::copy(target, &self.after)
-            .map_err(|err| format!("Failed to snapshot edited audio file: {err}"))?;
-        Ok(())
+        Ok(Self {
+            before,
+            after,
+            dir: Some(dir),
+        })
     }
 
     fn capture_extracted(&self, target: &Path) -> Result<PathBuf, String> {
-        let extracted = self.dir.join("extracted.wav");
+        let extracted = self
+            .dir
+            .as_ref()
+            .expect("active waveform backup directory")
+            .join("extracted.wav");
         fs::copy(target, &extracted)
             .map_err(|err| format!("Failed to snapshot extracted audio file: {err}"))?;
         Ok(extracted)
+    }
+
+    fn retain_recovery_copy(&mut self) {
+        self.dir = None;
     }
 }
 
 impl Drop for OverwriteBackup {
     fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.dir);
+        if let Some(dir) = self.dir.as_ref() {
+            let _ = fs::remove_dir_all(dir);
+        }
     }
 }
 
@@ -224,7 +233,7 @@ fn execute_destructive_edit_write(
 ) -> Result<AppliedWaveformEdit, String> {
     validate_destructive_edit_target(&request.absolute_path)?;
     let before_content_identity = cache_content_identity(&request.absolute_path);
-    let backup = OverwriteBackup::capture_before(&request.absolute_path)?;
+    let mut backup = OverwriteBackup::capture_before(&request.absolute_path)?;
     let extracted = extracted_path
         .map(|path| {
             let relative_path = source_relative_path(&request.source.root, &path)?;
@@ -244,8 +253,16 @@ fn execute_destructive_edit_write(
             request.prompt.edit.gerund_label()
         ));
     }
-    write_edited_wav(&request.absolute_path, &wav)?;
-    backup.capture_after(&request.absolute_path)?;
+    if let Err(failure) = write_wav_atomically(
+        &request.absolute_path,
+        &backup.before,
+        &backup.after,
+        wav.channels,
+        wav.sample_rate,
+        &wav.samples,
+    ) {
+        return Err(report_atomic_write_failure(&mut backup, failure));
+    }
     Ok(AppliedWaveformEdit {
         source_id: request.source.id.as_str().to_string(),
         relative_path: request.relative_path.clone(),
@@ -430,23 +447,14 @@ fn load_editable_wav(path: &Path) -> Result<EditableWav, String> {
     })
 }
 
-fn write_edited_wav(path: &Path, wav: &EditableWav) -> Result<(), String> {
-    let spec = hound::WavSpec {
-        channels: wav.channels as u16,
-        sample_rate: wav.sample_rate,
-        bits_per_sample: 32,
-        sample_format: hound::SampleFormat::Float,
-    };
-    let mut writer = hound::WavWriter::create(path, spec)
-        .map_err(|err| format!("Failed to write wav: {err}"))?;
-    for sample in &wav.samples {
-        writer
-            .write_sample(*sample)
-            .map_err(|err| format!("Failed to write sample: {err}"))?;
+fn report_atomic_write_failure(
+    backup: &mut OverwriteBackup,
+    failure: AtomicWriteFailure,
+) -> String {
+    if failure.recovery_copy_required() {
+        backup.retain_recovery_copy();
     }
-    writer
-        .finalize()
-        .map_err(|err| format!("Failed to finalize wav: {err}"))
+    failure.to_string()
 }
 
 fn selection_existing_frame_bounds(


### PR DESCRIPTION
## Goal

Make every destructive waveform edit failure-atomic so write, finalize, replace, or rollback errors cannot silently destroy the user's original audio.

Linear: [OPT-1220](https://linear.app/boostnlvp/issue/OPT-1220/wavecrate-make-destructive-waveform-edits-failure-atomic)

## Scope

- Render edits to a unique sibling temporary WAV.
- Finalize and sync the rendered WAV before publishing it.
- Prepare and sync the redo snapshot before changing the source.
- Atomically replace the source on macOS/Linux and use `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` on Windows.
- Restore from a separately staged copy after a failed replace or directory sync.
- Retain and report the exact recovery-copy path if restore also fails.
- Preserve original file permissions and existing edit/undo/readiness behavior.
- Add deterministic write, finalize, snapshot, replace, restore, and success fixtures plus a debug-only injection seam for live-app smoke testing.

## Non-goals

- No DSP, selection math, sample-format, protected-source policy, undo UX, or transaction-history redesign.
- No changes to committed-mutation/readiness invalidation semantics.

## Definition of Done

- [x] Write or finalize failures leave the original byte-for-byte unchanged.
- [x] Replace failure restores the original or retains and reports a recovery copy.
- [x] Failed edits do not leave a truncated/corrupt original.
- [x] Focused tests cover write, finalize, replace, rollback, success, and undo/redo compatibility.
- [x] The real app reports an injected failure without losing the selected source file.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo test -p wavecrate --lib native_app::waveform_edits` — 6 passed
- `cargo test -p wavecrate --lib crop_request_rewrites_file_and_undo_restores_original_audio`
- `cargo test -p wavecrate --lib extract_and_trim_request_extracts_selection_trims_source_and_undo_redo_roundtrips`
- `cargo test -p wavecrate --bin wavecrate committed_file_mutations` — command passed; no matching binary tests
- `cargo check -p wavecrate --lib --bins`
- `git diff --check`
- Debug app bundle smoke with `WAVECRATE_INJECT_WAVEFORM_EDIT_FAILURE=replace`: Wavecrate reported that the crop failed and the original was restored; SHA-256 remained `814085a9b292f95851edfead6e51e470d4f9a13c0cdec22c64ec46ba7619153f`.

Blocked by unrelated existing infrastructure:

- `cargo check -p wavecrate --all-targets` reaches `tests/release_workflow_helpers.rs:936` and fails on the pre-existing unescaped `{` embedded-Python fixture.
- macOS-to-Windows cross-check cannot pass this host because the installed Rust target lacks the Windows C/MSVC sysroot required by `ring` and `libsqlite3-sys`. The Windows replacement code follows the repository's existing `MoveFileExW` implementation pattern.

## Known limitations

- The debug failure injection seam is available only in debug builds through `WAVECRATE_INJECT_WAVEFORM_EDIT_FAILURE`; release builds contain no injection behavior.
- Full all-target and Windows cross-target validation remain blocked as described above.

User approval is required before merge.