### PR TITLE
OPT-958: Fix source-processing validation targets

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -276,24 +276,24 @@ The end-to-end tests are ignored by the default suite so normal CI does not
 inherit a real-time soak:
 
 - deterministic liveness oracle:
-  `cargo test -p wavecrate --bin wavecrate liveness_oracle_rejects_actionable_deficits_without_observable_runtime_work`
+  `cargo test -p wavecrate --lib liveness_oracle_rejects_actionable_deficits_without_observable_runtime_work`
 - real temporary source through add, targeted and overflow reconciliation,
   same-size content change, rename, delete, playback pause, committed internal
   mutation, closed-app restart audit, root disappearance/reappearance, and
   source remove/re-add:
-  `cargo test -p wavecrate --bin wavecrate source_processing_liveness_harness_converges_restart_churn_and_root_recovery -- --ignored --nocapture`
+  `cargo test -p wavecrate --lib source_processing_liveness_harness_converges_restart_churn_and_root_recovery -- --ignored --nocapture`
 - 10,000-file / 30,001-target calibrated source-processing profile:
-  `cargo test -p wavecrate --bin wavecrate profile_source_processing_churn_under_playback_and_browser_priority -- --ignored --nocapture`
+  `cargo test -p wavecrate --lib profile_source_processing_churn_under_playback_and_browser_priority -- --ignored --nocapture`
 - fully analyzed 10,000-file periodic-sweep and one-file readiness-delta profile:
-  `cargo test -p wavecrate --bin wavecrate profile_revision_gated_readiness_sweeps_10k -- --ignored --nocapture`
+  `cargo test -p wavecrate --lib profile_revision_gated_readiness_sweeps_10k -- --ignored --nocapture`
 - full mutation and watcher family coverage:
-  `cargo test -p wavecrate --bin wavecrate committed_file_mutations`
+  `cargo test -p wavecrate --lib committed_file_mutations`
   and
-  `cargo test -p wavecrate --bin wavecrate source_watcher`
+  `cargo test -p wavecrate --lib source_watcher`
 - supervisor and durable-readiness failure injection (busy/resource contention,
   retry deadlines, expired leases, cancellation, worker failures, unsupported
   inputs, and stale completions):
-  `cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests`
+  `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests`
   and
   `cargo test -p wavecrate-library sample_sources::readiness::tests`
 - UI frame and input budgets while exercising browser interactions:


### PR DESCRIPTION
## Goal

Close the final OPT-958 validation-contract gap after its source-processing implementation and hardening children landed: make every documented source-processing validation command execute the library-owned native runtime tests instead of silently selecting zero tests from the executable crate.

## Scope and non-goals

- Replace the stale `--bin wavecrate` target in the seven source-processing liveness, churn, performance, mutation, watcher, and supervisor commands with `--lib`.
- Preserve the existing test filters, ignored-profile policy, and validation guidance.
- Non-goal: change source-processing runtime behavior or rerun the intentionally expensive 10,000-file profiles that were already proven by OPT-1184.

## Definition of Done

- Each documented source-processing selector discovers the intended library-owned test coverage.
- The deterministic liveness oracle and full restart/churn/root-recovery harness pass from the corrected target.
- The canonical docs index and patch whitespace checks pass.

## Validation

- `cargo test -p wavecrate --lib liveness_oracle_rejects_actionable_deficits_without_observable_runtime_work` — passed (1 test).
- `cargo test -p wavecrate --lib source_processing_liveness_harness_converges_restart_churn_and_root_recovery -- --ignored --nocapture` — passed (1 test, 45.53s).
- `cargo test -p wavecrate --lib -- --list` plus exact selector assertions — passed; all seven selectors were present, matching 142 test entries in aggregate.
- `bash scripts/check.sh docs-index` — passed.
- `git diff --check` — passed.

The merged OPT-958 child work already contains the automatic convergence runtime, durable readiness state, bounded scheduling, active-context priority, restart/churn handling, protected-source constraints, progress reporting, real-app smoke, and calibrated 10,000-file performance evidence. This PR only repairs the canonical commands used to re-run that evidence.

## Known limitations

- `cargo test -p wavecrate --all-targets -- --list` currently encounters an unrelated pre-existing format-string compile error in `tests/release_workflow_helpers.rs`; the scoped library target and corrected OPT-958 commands compile and pass.

User approval is required before merge.

Linear: OPT-958
