### PR TITLE
OPT-1228: Reduce routine source-processing INFO log spam

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2155,6 +2155,13 @@ Logs should be structured enough to support debugging. Important operations shou
 
 Logging should help answer practical debugging questions: what happened, in what order, on which thread or worker, for which file or source, how long it took, and why it failed. Logging itself must not cause UI stalls, excessive disk writes, or unreadable noise.
 
+Default `INFO` logging should favor bounded aggregate health and convergence summaries over
+routine per-transition, per-phase, or per-source success-path events. Detailed structured
+source-processing lifecycle events remain available at `DEBUG`, while warnings, failures,
+actionable parked states, and aggregate sweep outcomes stay visible at their appropriate
+operational levels. Use explicit severity and deterministic aggregation rather than time-based
+rate limiting so incident reconstruction remains reliable.
+
 ## UI Target
 
 The Wavecrate UI should be compact, stable, and optimized for scanning, auditioning, extracting, editing, naming, tagging, rating, organizing, and using sample files.

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -237,7 +237,7 @@ impl SourceProcessingSupervisor {
         if control.playback_active != active {
             control.playback_active = active;
             control.notify("playback_activity_changed");
-            tracing::info!(
+            tracing::debug!(
                 target: "wavecrate::source_processing",
                 event = "source_processing.playback_activity_changed",
                 active,
@@ -255,7 +255,7 @@ impl SourceProcessingSupervisor {
         }
         control.foreground_active = active;
         control.notify("foreground_activity_changed");
-        tracing::info!(
+        tracing::debug!(
             target: "wavecrate::source_processing",
             event = "source_processing.foreground_activity_changed",
             active,

--- a/src/native_app/source_processing/supervisor/progress.rs
+++ b/src/native_app/source_processing/supervisor/progress.rs
@@ -49,7 +49,7 @@ impl DiscoveryProgressPublisher<'_> {
                 published_at.elapsed() >= DISCOVERY_PROGRESS_LOG_INTERVAL
             });
         if log_due {
-            tracing::info!(
+            tracing::debug!(
                 target: "wavecrate::source_processing",
                 event = "source_processing.discovery_progress",
                 source_id = self.source_id,

--- a/src/native_app/source_processing/supervisor/retirement.rs
+++ b/src/native_app/source_processing/supervisor/retirement.rs
@@ -59,6 +59,12 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
             .map(|(retirement_id, retirement)| (*retirement_id, retirement.clone()))
             .collect::<Vec<_>>()
     };
+    let scheduled = candidates.len();
+    let mut started = 0_usize;
+    let mut retired = 0_usize;
+    let mut offline = 0_usize;
+    let mut cancelled = 0_usize;
+    let mut retrying = 0_usize;
 
     for (retirement_id, retirement) in candidates {
         // Fence only the admission snapshot and final publication. The potentially blocking
@@ -103,7 +109,8 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
                 continue;
             }
         }
-        tracing::info!(
+        started = started.saturating_add(1);
+        tracing::debug!(
             target: "wavecrate::source_processing",
             event = "source_processing.retirement.started",
             source_id = retirement.source.id.as_str(),
@@ -160,7 +167,8 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
         match result {
             Ok(Some(SourceRetirementOutcome::Retired { retired_cache_refs })) => {
                 control.pending_retirements.remove(&retirement_id);
-                tracing::info!(
+                retired = retired.saturating_add(1);
+                tracing::debug!(
                     target: "wavecrate::source_processing",
                     event = "source_processing.retirement.completed",
                     source_id = retirement.source.id.as_str(),
@@ -173,7 +181,8 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
                     pending.terminal_offline = true;
                     pending.retry_at = i64::MAX;
                 }
-                tracing::info!(
+                offline = offline.saturating_add(1);
+                tracing::debug!(
                     target: "wavecrate::source_processing",
                     event = "source_processing.retirement.offline",
                     source_id = retirement.source.id.as_str(),
@@ -183,7 +192,8 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
             }
             Ok(None) => {
                 control.pending_retirements.remove(&retirement_id);
-                tracing::info!(
+                cancelled = cancelled.saturating_add(1);
+                tracing::debug!(
                     target: "wavecrate::source_processing",
                     event = "source_processing.retirement.cancelled",
                     source_id = retirement.source.id.as_str(),
@@ -198,6 +208,7 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
                         .saturating_mul(1_i64 << pending.attempts.min(6));
                     pending.retry_at = now.saturating_add(delay);
                 }
+                retrying = retrying.saturating_add(1);
                 tracing::warn!(
                     target: "wavecrate::source_processing",
                     event = "source_processing.retirement.retry",
@@ -215,6 +226,19 @@ pub(super) fn process_ready_source_retirements(shared: &Shared) {
                 );
             }
         }
+    }
+    if started > 0 {
+        tracing::info!(
+            target: "wavecrate::source_processing",
+            event = "source_processing.retirement.sweep",
+            scheduled,
+            started,
+            retired,
+            offline,
+            cancelled,
+            retrying,
+            "Removed-source retirement pass complete"
+        );
     }
 }
 

--- a/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
+++ b/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
@@ -181,6 +181,39 @@ fn discovery_progress_publisher_exposes_advancing_counter() {
 }
 
 #[test]
+fn discovery_phase_progress_is_debug_only() {
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("progress-log-policy"),
+        PathBuf::from("/library/progress-log-policy"),
+    );
+    let shared = Shared::new(vec![source], None);
+    let lifecycle_generation = shared.control().source_lifecycle_generations["progress-log-policy"];
+    let mut publisher = DiscoveryProgressPublisher {
+        shared: &shared,
+        source_id: "progress-log-policy",
+        lifecycle_generation,
+        started_at: Instant::now(),
+        last_phase: None,
+        last_event_publish_at: None,
+        last_log_publish_at: None,
+        event_published: false,
+    };
+
+    let info = capture_logs(tracing::Level::INFO, || {
+        publisher.advance("Reading manifest and readiness targets", 1);
+    });
+    assert!(!info.contains("source_processing.discovery_progress"));
+
+    publisher.last_phase = None;
+    publisher.last_log_publish_at = None;
+    let debug = capture_logs(tracing::Level::DEBUG, || {
+        publisher.advance("Comparing durable readiness", 2);
+    });
+    assert!(debug.contains("source_processing.discovery_progress"));
+    assert!(debug.contains("work_units=2"));
+}
+
+#[test]
 fn large_source_discovery_cancels_mid_manifest_and_resumes_cleanly() {
     const FILE_COUNT: usize = 512;
     let directory = tempfile::tempdir().expect("large cancellation source");

--- a/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
+++ b/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
@@ -40,6 +40,69 @@ fn playback_and_foreground_activity_do_not_publish_pause_feedback() {
 }
 
 #[test]
+fn routine_activity_transitions_are_debug_only() {
+    let supervisor = SourceProcessingSupervisor::dormant();
+
+    let info = capture_logs(tracing::Level::INFO, || {
+        supervisor.set_playback_active(true);
+        supervisor.set_foreground_activity(true);
+    });
+    assert!(!info.contains("source_processing.playback_activity_changed"));
+    assert!(!info.contains("source_processing.foreground_activity_changed"));
+
+    let debug = capture_logs(tracing::Level::DEBUG, || {
+        supervisor.set_playback_active(false);
+        supervisor.set_foreground_activity(false);
+    });
+    assert!(debug.contains("source_processing.playback_activity_changed"));
+    assert!(debug.contains("source_processing.foreground_activity_changed"));
+}
+
+#[test]
+fn retirement_logging_is_bounded_at_info_and_detailed_at_debug() {
+    fn offline_retirement_supervisor(prefix: &str) -> SourceProcessingSupervisor {
+        let first = SampleSource::new_with_id(
+            SourceId::from_string(format!("{prefix}-first")),
+            PathBuf::from(format!("/missing/{prefix}/first")),
+        );
+        let second = SampleSource::new_with_id(
+            SourceId::from_string(format!("{prefix}-second")),
+            PathBuf::from(format!("/missing/{prefix}/second")),
+        );
+        let supervisor = SourceProcessingSupervisor::dormant();
+        supervisor
+            .replace_sources(vec![first, second])
+            .expect("configure missing sources");
+        supervisor
+            .replace_sources(Vec::new())
+            .expect("remove missing sources");
+        supervisor
+    }
+
+    let mut info_supervisor = offline_retirement_supervisor("info-retirement");
+    let info = capture_logs(tracing::Level::INFO, || {
+        process_ready_source_retirements(&info_supervisor.shared);
+    });
+    assert!(info.contains("source_processing.retirement.sweep"));
+    assert!(info.contains("scheduled=2"));
+    assert!(info.contains("started=2"));
+    assert!(info.contains("offline=2"));
+    assert!(!info.contains("source_processing.retirement.started"));
+    assert!(!info.contains("source_processing.retirement.offline"));
+    assert_eq!(info.matches("source_processing.retirement.sweep").count(), 1);
+    assert_eq!(info_supervisor.shutdown()["joined"], true);
+
+    let mut debug_supervisor = offline_retirement_supervisor("debug-retirement");
+    let debug = capture_logs(tracing::Level::DEBUG, || {
+        process_ready_source_retirements(&debug_supervisor.shared);
+    });
+    assert!(debug.contains("source_processing.retirement.started"));
+    assert!(debug.contains("source_processing.retirement.offline"));
+    assert!(debug.contains("source_processing.retirement.sweep"));
+    assert_eq!(debug_supervisor.shutdown()["joined"], true);
+}
+
+#[test]
 fn brief_discovery_reconciliation_does_not_flash_processing_feedback() {
     let source = SampleSource::new_with_id(
         SourceId::from_string("stable-discovery"),

--- a/src/native_app/source_processing/supervisor/tests/mod.rs
+++ b/src/native_app/source_processing/supervisor/tests/mod.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
+use std::{io, sync::Mutex};
 
 use rusqlite::OptionalExtension;
+use tracing_subscriber::fmt::MakeWriter;
 use wavecrate::sample_sources::{
     SourceId,
     readiness::{
@@ -11,6 +13,48 @@ use wavecrate::sample_sources::{
 };
 
 use super::*;
+
+#[derive(Clone, Default)]
+struct LogBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl LogBuffer {
+    fn captured(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogBuffer {
+    type Writer = LogBufferWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogBufferWriter(Arc::clone(&self.0))
+    }
+}
+
+struct LogBufferWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for LogBufferWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn capture_logs(level: tracing::Level, run: impl FnOnce()) -> String {
+    let buffer = LogBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(level)
+        .with_writer(buffer.clone())
+        .finish();
+    tracing::subscriber::with_default(subscriber, run);
+    buffer.captured()
+}
 
 fn reconcile_readiness(
     connection: &rusqlite::Connection,


### PR DESCRIPTION
## Goal

Reduce routine source-processing noise in Wavecrate's default INFO log while preserving actionable health signal and detailed diagnostics.

Linear: [OPT-1228](https://linear.app/boostnlvp/issue/OPT-1228/wavecrate-reduce-routine-source-processing-info-log-spam)

## Scope

- Move foreground/playback activity transitions and discovery-phase progress to DEBUG.
- Move detailed per-source retirement lifecycle events to DEBUG.
- Add one bounded INFO `source_processing.retirement.sweep` summary per retirement pass.
- Preserve retirement retry warnings and the existing aggregate `source_processing.sweep`.
- Document the durable INFO/DEBUG telemetry policy.
- Add INFO/DEBUG log-capture regression tests.

Non-goals: no source discovery, retirement, scheduling, persistence, readiness, or synchronization behavior changes; no logging redesign outside the source-processing supervisor.

## Definition of Done

- [x] Rapid sample navigation does not emit repeated detailed activity transitions at INFO.
- [x] Many historical removed/offline sources produce one aggregate retirement INFO event.
- [x] Detailed structured events remain available at DEBUG.
- [x] Warnings and aggregate source-processing health remain unchanged.
- [x] Regression tests cover INFO suppression, aggregate counts, and DEBUG visibility.
- [x] Signed-app runtime smoke confirms readable INFO logging and correct processing.

## Validation

- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests`
  - 84 passed, 1 ignored.
- Three new exact telemetry tests
  - 3 passed.
- `cargo test -p wavecrate --bin wavecrate native_app::source_processing::supervisor::tests`
  - command succeeds but selects 0 tests on the current binary target; the owning library suite above provides the real coverage.
- `cargo fmt --check`
  - passed.
- `git diff --check`
  - passed.
- `bash scripts/check.sh docs-index`
  - passed.
- `bash scripts/build.sh --release`
  - passed; signed app bundle built at `target/app-bundles/opt1228/Wavecrate OPT-1228.app`.
- Real app, standard INFO:
  - 37 startup retirements became one `source_processing.retirement.sweep` event (`retired=11`, `offline=26`).
  - rapid navigation produced no detailed foreground/playback/discovery/retirement lifecycle lines; the existing aggregate sweep remained visible.
- Real app, targeted DEBUG:
  - detailed events remained recoverable (37 starts, 11 completions, 26 offline outcomes, 24 foreground transitions, 15 playback transitions, and 18 discovery progress events).
- `bash scripts/ci.sh smoke`
  - blocked by a pre-existing compile error in unchanged `tests/release_workflow_helpers.rs:936`: an unescaped `{` in a format string.
- `bash scripts/agent.sh request`
  - baseline on `main` is blocked by pre-existing non-blocking guardrail violations in unchanged `src/native_app/waveform_edits/atomic_write.rs`.

## Known limitations

The repository-wide smoke/preflight blockers above remain outside this PR's scope. None specific to the source-processing logging change.

User approval is required before merge.