### PR TITLE
OPT-1222 Make waveform extraction output atomic and collision-safe

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -954,6 +954,8 @@ Extraction is not the same as destructive editing.
 
 When a user selects a region of an audio file and extracts it, Wavecrate should create a new sample file containing that region. The original file should remain unchanged unless the user separately performs a destructive edit on it.
 
+Extraction output should be failure-atomic and collision-safe. Wavecrate should write and finalize an exclusively owned staging file in the destination folder, then publish it without replacing any path that appeared concurrently. Failed or cancelled work should remove only its own staging artifact and must never expose a partial WAV as a completed extraction.
+
 If audition-time processing is active, such as target-BPM warping, extraction should create what the user hears. If a user auditions a warped loop and extracts it, the created sample file should bake the auditioned warp result into the new file.
 
 Extraction should support:

--- a/src/native_app/waveform/audio_file.rs
+++ b/src/native_app/waveform/audio_file.rs
@@ -4,6 +4,8 @@ mod diagnostics;
 mod downmix;
 mod extraction;
 #[cfg(test)]
+mod extraction_output_tests;
+#[cfg(test)]
 mod extraction_tests;
 mod file_io;
 mod loader;

--- a/src/native_app/waveform/audio_file/extraction.rs
+++ b/src/native_app/waveform/audio_file/extraction.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufReader, Cursor, Read, Seek, SeekFrom},
+    io::{BufReader, BufWriter, Cursor, ErrorKind, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
 
@@ -77,27 +77,24 @@ pub(in crate::native_app) fn extract_interleaved_f32_range_to_folder(
         channels,
         samples.len(),
     )?;
-    let output_path = next_extraction_path(source_path, target_folder)?;
-    let mut writer = hound::WavWriter::create(&output_path, spec)
-        .map_err(|err| format!("failed to create extraction: {err}"))?;
-    write_f32_samples_with_edge_fade(
-        &mut writer,
-        &samples[sample_bounds.start..sample_bounds.end],
-        channels,
-        sample_rate,
-        frame_range
-            .end_frame
-            .saturating_sub(frame_range.start_frame),
-        gain,
-    )?;
-    writer
-        .finalize()
-        .map_err(|err| format!("failed to finalize extraction: {err}"))?;
-    Ok(output_path)
+    write_extraction_atomically(source_path, target_folder, |output| {
+        let mut writer = wav_writer(output, spec)?;
+        write_f32_samples_with_edge_fade(
+            &mut writer,
+            &samples[sample_bounds.start..sample_bounds.end],
+            channels,
+            sample_rate,
+            frame_range
+                .end_frame
+                .saturating_sub(frame_range.start_frame),
+            gain,
+        )?;
+        finalize_wav_writer(writer)
+    })
 }
 
-fn write_f32_samples_with_edge_fade(
-    writer: &mut hound::WavWriter<std::io::BufWriter<std::fs::File>>,
+fn write_f32_samples_with_edge_fade<W: Write + Seek>(
+    writer: &mut hound::WavWriter<W>,
     samples: &[f32],
     channels: usize,
     sample_rate: u32,
@@ -139,30 +136,27 @@ pub(in crate::native_app) fn extract_interleaved_f32_file_range_to_folder(
         .saturating_sub(frame_range.start_frame)
         .checked_mul(cache.channels)
         .ok_or_else(|| String::from("Playback cache selection is too large"))?;
-    let output_path = next_extraction_path(source_path, target_folder)?;
     let mut reader = open_f32_reader_at(cache.cache_path, start_sample as u64)?;
-    let mut writer = hound::WavWriter::create(&output_path, spec)
-        .map_err(|err| format!("failed to create extraction: {err}"))?;
-    let mut bytes = [0_u8; F32_SAMPLE_BYTES as usize];
-    let frame_count = frame_range
-        .end_frame
-        .saturating_sub(frame_range.start_frame);
-    let fade_frames =
-        short_edge_fade_frame_count(cache.sample_rate, frame_count, DEFAULT_SHORT_EDGE_FADE);
-    for sample_index in 0..samples_to_write {
-        reader
-            .read_exact(&mut bytes)
-            .map_err(|err| format!("failed to read playback cache: {err}"))?;
-        let frame = sample_index / cache.channels.max(1);
-        let gain = gain * short_edge_fade_gain(frame, frame_count, fade_frames);
-        writer
-            .write_sample((f32::from_le_bytes(bytes) * gain).clamp(-1.0, 1.0))
-            .map_err(|err| format!("failed to write extraction: {err}"))?;
-    }
-    writer
-        .finalize()
-        .map_err(|err| format!("failed to finalize extraction: {err}"))?;
-    Ok(output_path)
+    write_extraction_atomically(source_path, target_folder, |output| {
+        let mut writer = wav_writer(output, spec)?;
+        let mut bytes = [0_u8; F32_SAMPLE_BYTES as usize];
+        let frame_count = frame_range
+            .end_frame
+            .saturating_sub(frame_range.start_frame);
+        let fade_frames =
+            short_edge_fade_frame_count(cache.sample_rate, frame_count, DEFAULT_SHORT_EDGE_FADE);
+        for sample_index in 0..samples_to_write {
+            reader
+                .read_exact(&mut bytes)
+                .map_err(|err| format!("failed to read playback cache: {err}"))?;
+            let frame = sample_index / cache.channels.max(1);
+            let gain = gain * short_edge_fade_gain(frame, frame_count, fade_frames);
+            writer
+                .write_sample((f32::from_le_bytes(bytes) * gain).clamp(-1.0, 1.0))
+                .map_err(|err| format!("failed to write extraction: {err}"))?;
+        }
+        finalize_wav_writer(writer)
+    })
 }
 
 pub(super) fn extract_wav_reader_range_to_folder<R: Read + Seek>(
@@ -173,41 +167,41 @@ pub(super) fn extract_wav_reader_range_to_folder<R: Read + Seek>(
     selection: wavecrate::selection::SelectionRange,
     gain: f32,
 ) -> Result<PathBuf, String> {
-    let output_path = next_extraction_path(source_path, target_folder)?;
-    // Prefer the raw WAV path so extraction preserves the source bit depth/sample format
-    // while applying the same edge fade and gain policy.
-    if raw_wav::copy_selection_to_file(
-        &mut reader,
-        loaded_frames,
-        selection,
-        &output_path,
-        gain,
-        DEFAULT_SHORT_EDGE_FADE,
-    )? {
-        return Ok(output_path);
-    }
-    reader
-        .seek(SeekFrom::Start(0))
-        .map_err(|err| format!("failed to rewind WAV after fast extraction check: {err}"))?;
-    let reader =
-        hound::WavReader::new(reader).map_err(|err| format!("failed to open WAV: {err}"))?;
-    let spec = reader.spec();
-    let channels = usize::from(spec.channels).max(1);
-    let total_frames = (reader.duration() as usize).min(loaded_frames);
-    if total_frames == 0 {
-        return Err(String::from("WAV contains no complete frames"));
-    }
-    let frame_range = selection.frame_bounds(total_frames);
-    write_wav_frame_range(
-        reader,
-        spec,
-        channels,
-        frame_range.start_frame,
-        frame_range.end_frame,
-        &output_path,
-        gain,
-    )?;
-    Ok(output_path)
+    write_extraction_atomically(source_path, target_folder, |output| {
+        // Prefer the raw WAV path so extraction preserves the source bit depth/sample format
+        // while applying the same edge fade and gain policy.
+        if raw_wav::copy_selection_to_file(
+            &mut reader,
+            loaded_frames,
+            selection,
+            output,
+            gain,
+            DEFAULT_SHORT_EDGE_FADE,
+        )? {
+            return Ok(());
+        }
+        reader
+            .seek(SeekFrom::Start(0))
+            .map_err(|err| format!("failed to rewind WAV after fast extraction check: {err}"))?;
+        let reader =
+            hound::WavReader::new(reader).map_err(|err| format!("failed to open WAV: {err}"))?;
+        let spec = reader.spec();
+        let channels = usize::from(spec.channels).max(1);
+        let total_frames = (reader.duration() as usize).min(loaded_frames);
+        if total_frames == 0 {
+            return Err(String::from("WAV contains no complete frames"));
+        }
+        let frame_range = selection.frame_bounds(total_frames);
+        write_wav_frame_range(
+            reader,
+            spec,
+            channels,
+            frame_range.start_frame,
+            frame_range.end_frame,
+            output,
+            gain,
+        )
+    })
 }
 
 fn playback_wav_spec(sample_rate: u32, channels: usize) -> Result<hound::WavSpec, String> {
@@ -287,26 +281,84 @@ fn open_f32_reader_at(path: &Path, sample: u64) -> Result<BufReader<File>, Strin
     Ok(BufReader::new(file))
 }
 
-fn next_extraction_path(source_path: &Path, target_folder: &Path) -> Result<PathBuf, String> {
+fn extraction_path(
+    source_path: &Path,
+    target_folder: &Path,
+    index: usize,
+) -> Result<PathBuf, String> {
     let stem = source_path
         .file_stem()
         .and_then(|stem| stem.to_str())
         .filter(|stem| !stem.is_empty())
         .ok_or_else(|| String::from("Source sample has no file name"))?;
+    let suffix = if index == 0 {
+        String::from("_extraction")
+    } else {
+        format!("_extraction_{index}")
+    };
+    Ok(target_folder.join(format!("{stem}{suffix}.wav")))
+}
+
+pub(super) fn write_extraction_atomically(
+    source_path: &Path,
+    target_folder: &Path,
+    write: impl FnOnce(&mut File) -> Result<(), String>,
+) -> Result<PathBuf, String> {
+    // Same-directory staging keeps publication on one filesystem. Dropping this owned file
+    // removes every pre-publication failure without touching any user-visible destination.
+    let mut staged = tempfile::Builder::new()
+        .prefix(".wavecrate-extraction-")
+        .suffix(".wav.tmp")
+        .tempfile_in(target_folder)
+        .map_err(|err| format!("failed to create extraction staging file: {err}"))?;
+    write(staged.as_file_mut())?;
+    staged
+        .as_file()
+        .sync_all()
+        .map_err(|err| format!("failed to sync finalized extraction: {err}"))?;
+    publish_staged_extraction(staged, source_path, target_folder)
+}
+
+pub(super) fn publish_staged_extraction(
+    mut staged: tempfile::NamedTempFile,
+    source_path: &Path,
+    target_folder: &Path,
+) -> Result<PathBuf, String> {
     for index in 0..10_000 {
-        let suffix = if index == 0 {
-            String::from("_extraction")
-        } else {
-            format!("_extraction_{index}")
-        };
-        let candidate = target_folder.join(format!("{stem}{suffix}.wav"));
-        if !candidate.exists() {
-            return Ok(candidate);
+        let candidate = extraction_path(source_path, target_folder, index)?;
+        match staged.persist_noclobber(&candidate) {
+            Ok(_) => return Ok(candidate),
+            Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
+                staged = error.file;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to publish extraction {}: {}",
+                    candidate.display(),
+                    error.error
+                ));
+            }
         }
     }
     Err(String::from(
         "Could not find an available extraction file name",
     ))
+}
+
+pub(super) fn wav_writer(
+    output: &mut File,
+    spec: hound::WavSpec,
+) -> Result<hound::WavWriter<BufWriter<&mut File>>, String> {
+    hound::WavWriter::new(BufWriter::new(output), spec)
+        .map_err(|err| format!("failed to create extraction: {err}"))
+}
+
+pub(super) fn finalize_wav_writer<W: Write + Seek>(
+    writer: hound::WavWriter<W>,
+) -> Result<(), String> {
+    writer
+        .finalize()
+        .map_err(|err| format!("failed to finalize extraction: {err}"))
 }
 
 pub(super) fn write_wav_frame_range<R: Read + Seek>(
@@ -315,21 +367,20 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
     channels: usize,
     start_frame: usize,
     end_frame: usize,
-    output_path: &Path,
+    output: &mut File,
     gain: f32,
 ) -> Result<(), String> {
     let sample_count = end_frame
         .saturating_sub(start_frame)
         .saturating_mul(channels);
-    let mut writer = hound::WavWriter::create(output_path, spec)
-        .map_err(|err| format!("failed to create extraction: {err}"))?;
+    let mut writer = wav_writer(output, spec)?;
     let start_frame =
         u32::try_from(start_frame).map_err(|_| String::from("WAV selection starts too late"))?;
     reader
         .seek(start_frame)
         .map_err(|err| format!("failed to seek WAV selection: {err}"))?;
     match spec.sample_format {
-        hound::SampleFormat::Float => write_samples::<_, f32>(
+        hound::SampleFormat::Float => write_samples::<_, _, f32>(
             &mut reader,
             &mut writer,
             sample_count,
@@ -338,7 +389,7 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             spec.bits_per_sample,
             gain,
         )?,
-        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => write_samples::<_, i16>(
+        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => write_samples::<_, _, i16>(
             &mut reader,
             &mut writer,
             sample_count,
@@ -347,7 +398,7 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             spec.bits_per_sample,
             gain,
         )?,
-        hound::SampleFormat::Int => write_samples::<_, i32>(
+        hound::SampleFormat::Int => write_samples::<_, _, i32>(
             &mut reader,
             &mut writer,
             sample_count,
@@ -357,15 +408,12 @@ pub(super) fn write_wav_frame_range<R: Read + Seek>(
             gain,
         )?,
     }
-    writer
-        .finalize()
-        .map_err(|err| format!("failed to finalize extraction: {err}"))?;
-    Ok(())
+    finalize_wav_writer(writer)
 }
 
-fn write_samples<R, S>(
+fn write_samples<R, W, S>(
     reader: &mut hound::WavReader<R>,
-    writer: &mut hound::WavWriter<std::io::BufWriter<std::fs::File>>,
+    writer: &mut hound::WavWriter<W>,
     sample_count: usize,
     channels: usize,
     sample_rate: u32,
@@ -374,6 +422,7 @@ fn write_samples<R, S>(
 ) -> Result<(), String>
 where
     R: std::io::Read,
+    W: Write + Seek,
     S: hound::Sample + FadedSample,
 {
     let frame_count = sample_count / channels.max(1);

--- a/src/native_app/waveform/audio_file/extraction.rs
+++ b/src/native_app/waveform/audio_file/extraction.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufReader, BufWriter, Cursor, ErrorKind, Read, Seek, SeekFrom, Write},
+    io::{BufReader, Cursor, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
 };
 
@@ -8,7 +8,16 @@ use wavecrate::audio::{
     DEFAULT_SHORT_EDGE_FADE, short_edge_fade_frame_count, short_edge_fade_gain,
 };
 
+mod output;
 mod raw_wav;
+
+#[cfg(test)]
+pub(super) use output::{
+    finalize_wav_writer, publish_staged_extraction, wav_writer, write_extraction_atomically,
+    write_wav_frame_range,
+};
+#[cfg(not(test))]
+use output::{finalize_wav_writer, wav_writer, write_extraction_atomically, write_wav_frame_range};
 
 const F32_SAMPLE_BYTES: u64 = std::mem::size_of::<f32>() as u64;
 
@@ -279,199 +288,4 @@ fn open_f32_reader_at(path: &Path, sample: u64) -> Result<BufReader<File>, Strin
     file.seek(SeekFrom::Start(sample.saturating_mul(F32_SAMPLE_BYTES)))
         .map_err(|err| format!("failed to seek playback cache {}: {err}", path.display()))?;
     Ok(BufReader::new(file))
-}
-
-fn extraction_path(
-    source_path: &Path,
-    target_folder: &Path,
-    index: usize,
-) -> Result<PathBuf, String> {
-    let stem = source_path
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .filter(|stem| !stem.is_empty())
-        .ok_or_else(|| String::from("Source sample has no file name"))?;
-    let suffix = if index == 0 {
-        String::from("_extraction")
-    } else {
-        format!("_extraction_{index}")
-    };
-    Ok(target_folder.join(format!("{stem}{suffix}.wav")))
-}
-
-pub(super) fn write_extraction_atomically(
-    source_path: &Path,
-    target_folder: &Path,
-    write: impl FnOnce(&mut File) -> Result<(), String>,
-) -> Result<PathBuf, String> {
-    // Same-directory staging keeps publication on one filesystem. Dropping this owned file
-    // removes every pre-publication failure without touching any user-visible destination.
-    let mut staged = tempfile::Builder::new()
-        .prefix(".wavecrate-extraction-")
-        .suffix(".wav.tmp")
-        .tempfile_in(target_folder)
-        .map_err(|err| format!("failed to create extraction staging file: {err}"))?;
-    write(staged.as_file_mut())?;
-    staged
-        .as_file()
-        .sync_all()
-        .map_err(|err| format!("failed to sync finalized extraction: {err}"))?;
-    publish_staged_extraction(staged, source_path, target_folder)
-}
-
-pub(super) fn publish_staged_extraction(
-    mut staged: tempfile::NamedTempFile,
-    source_path: &Path,
-    target_folder: &Path,
-) -> Result<PathBuf, String> {
-    for index in 0..10_000 {
-        let candidate = extraction_path(source_path, target_folder, index)?;
-        match staged.persist_noclobber(&candidate) {
-            Ok(_) => return Ok(candidate),
-            Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
-                staged = error.file;
-            }
-            Err(error) => {
-                return Err(format!(
-                    "failed to publish extraction {}: {}",
-                    candidate.display(),
-                    error.error
-                ));
-            }
-        }
-    }
-    Err(String::from(
-        "Could not find an available extraction file name",
-    ))
-}
-
-pub(super) fn wav_writer(
-    output: &mut File,
-    spec: hound::WavSpec,
-) -> Result<hound::WavWriter<BufWriter<&mut File>>, String> {
-    hound::WavWriter::new(BufWriter::new(output), spec)
-        .map_err(|err| format!("failed to create extraction: {err}"))
-}
-
-pub(super) fn finalize_wav_writer<W: Write + Seek>(
-    writer: hound::WavWriter<W>,
-) -> Result<(), String> {
-    writer
-        .finalize()
-        .map_err(|err| format!("failed to finalize extraction: {err}"))
-}
-
-pub(super) fn write_wav_frame_range<R: Read + Seek>(
-    mut reader: hound::WavReader<R>,
-    spec: hound::WavSpec,
-    channels: usize,
-    start_frame: usize,
-    end_frame: usize,
-    output: &mut File,
-    gain: f32,
-) -> Result<(), String> {
-    let sample_count = end_frame
-        .saturating_sub(start_frame)
-        .saturating_mul(channels);
-    let mut writer = wav_writer(output, spec)?;
-    let start_frame =
-        u32::try_from(start_frame).map_err(|_| String::from("WAV selection starts too late"))?;
-    reader
-        .seek(start_frame)
-        .map_err(|err| format!("failed to seek WAV selection: {err}"))?;
-    match spec.sample_format {
-        hound::SampleFormat::Float => write_samples::<_, _, f32>(
-            &mut reader,
-            &mut writer,
-            sample_count,
-            channels,
-            spec.sample_rate,
-            spec.bits_per_sample,
-            gain,
-        )?,
-        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => write_samples::<_, _, i16>(
-            &mut reader,
-            &mut writer,
-            sample_count,
-            channels,
-            spec.sample_rate,
-            spec.bits_per_sample,
-            gain,
-        )?,
-        hound::SampleFormat::Int => write_samples::<_, _, i32>(
-            &mut reader,
-            &mut writer,
-            sample_count,
-            channels,
-            spec.sample_rate,
-            spec.bits_per_sample,
-            gain,
-        )?,
-    }
-    finalize_wav_writer(writer)
-}
-
-fn write_samples<R, W, S>(
-    reader: &mut hound::WavReader<R>,
-    writer: &mut hound::WavWriter<W>,
-    sample_count: usize,
-    channels: usize,
-    sample_rate: u32,
-    bits_per_sample: u16,
-    gain: f32,
-) -> Result<(), String>
-where
-    R: std::io::Read,
-    W: Write + Seek,
-    S: hound::Sample + FadedSample,
-{
-    let frame_count = sample_count / channels.max(1);
-    let fade_frames =
-        short_edge_fade_frame_count(sample_rate, frame_count, DEFAULT_SHORT_EDGE_FADE);
-    for (sample_index, sample) in reader.samples::<S>().take(sample_count).enumerate() {
-        let frame = sample_index / channels.max(1);
-        let gain = gain * short_edge_fade_gain(frame, frame_count, fade_frames);
-        writer
-            .write_sample(
-                sample
-                    .map_err(|err| format!("failed to read sample: {err}"))?
-                    .with_gain(gain, bits_per_sample),
-            )
-            .map_err(|err| format!("failed to write extraction: {err}"))?;
-    }
-    Ok(())
-}
-
-trait FadedSample {
-    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self;
-}
-
-impl FadedSample for f32 {
-    fn with_gain(self, gain: f32, _bits_per_sample: u16) -> Self {
-        (self * gain).clamp(-1.0, 1.0)
-    }
-}
-
-impl FadedSample for i16 {
-    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
-        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(16));
-        (f64::from(self) * f64::from(gain))
-            .round()
-            .clamp(min as f64, max as f64) as i16
-    }
-}
-
-impl FadedSample for i32 {
-    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
-        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(32));
-        (f64::from(self) * f64::from(gain))
-            .round()
-            .clamp(min as f64, max as f64) as i32
-    }
-}
-
-fn signed_integer_sample_bounds(bits_per_sample: u16) -> (i64, i64) {
-    let bits = u32::from(bits_per_sample.clamp(1, 32));
-    let max = (1_i64 << (bits - 1)) - 1;
-    (-1_i64 << (bits - 1), max)
 }

--- a/src/native_app/waveform/audio_file/extraction/output.rs
+++ b/src/native_app/waveform/audio_file/extraction/output.rs
@@ -1,0 +1,203 @@
+use std::{
+    fs::File,
+    io::{BufWriter, ErrorKind, Read, Seek, Write},
+    path::{Path, PathBuf},
+};
+use wavecrate::audio::{
+    DEFAULT_SHORT_EDGE_FADE, short_edge_fade_frame_count, short_edge_fade_gain,
+};
+
+pub(in super::super) fn write_extraction_atomically(
+    source_path: &Path,
+    target_folder: &Path,
+    write: impl FnOnce(&mut File) -> Result<(), String>,
+) -> Result<PathBuf, String> {
+    // Same-directory staging keeps publication on one filesystem. Dropping this owned file
+    // removes every pre-publication failure without touching any user-visible destination.
+    let mut staged = tempfile::Builder::new()
+        .prefix(".wavecrate-extraction-")
+        .suffix(".wav.tmp")
+        .tempfile_in(target_folder)
+        .map_err(|err| format!("failed to create extraction staging file: {err}"))?;
+    write(staged.as_file_mut())?;
+    staged
+        .as_file()
+        .sync_all()
+        .map_err(|err| format!("failed to sync finalized extraction: {err}"))?;
+    publish_staged_extraction(staged, source_path, target_folder)
+}
+
+pub(in super::super) fn publish_staged_extraction(
+    mut staged: tempfile::NamedTempFile,
+    source_path: &Path,
+    target_folder: &Path,
+) -> Result<PathBuf, String> {
+    for index in 0..10_000 {
+        let candidate = extraction_path(source_path, target_folder, index)?;
+        match staged.persist_noclobber(&candidate) {
+            Ok(_) => return Ok(candidate),
+            Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
+                staged = error.file;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to publish extraction {}: {}",
+                    candidate.display(),
+                    error.error
+                ));
+            }
+        }
+    }
+    Err(String::from(
+        "Could not find an available extraction file name",
+    ))
+}
+
+fn extraction_path(
+    source_path: &Path,
+    target_folder: &Path,
+    index: usize,
+) -> Result<PathBuf, String> {
+    let stem = source_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .ok_or_else(|| String::from("Source sample has no file name"))?;
+    let suffix = if index == 0 {
+        String::from("_extraction")
+    } else {
+        format!("_extraction_{index}")
+    };
+    Ok(target_folder.join(format!("{stem}{suffix}.wav")))
+}
+
+pub(in super::super) fn wav_writer(
+    output: &mut File,
+    spec: hound::WavSpec,
+) -> Result<hound::WavWriter<BufWriter<&mut File>>, String> {
+    hound::WavWriter::new(BufWriter::new(output), spec)
+        .map_err(|err| format!("failed to create extraction: {err}"))
+}
+
+pub(in super::super) fn finalize_wav_writer<W: Write + Seek>(
+    writer: hound::WavWriter<W>,
+) -> Result<(), String> {
+    writer
+        .finalize()
+        .map_err(|err| format!("failed to finalize extraction: {err}"))
+}
+
+pub(in super::super) fn write_wav_frame_range<R: Read + Seek>(
+    mut reader: hound::WavReader<R>,
+    spec: hound::WavSpec,
+    channels: usize,
+    start_frame: usize,
+    end_frame: usize,
+    output: &mut File,
+    gain: f32,
+) -> Result<(), String> {
+    let sample_count = end_frame
+        .saturating_sub(start_frame)
+        .saturating_mul(channels);
+    let mut writer = wav_writer(output, spec)?;
+    let start_frame =
+        u32::try_from(start_frame).map_err(|_| String::from("WAV selection starts too late"))?;
+    reader
+        .seek(start_frame)
+        .map_err(|err| format!("failed to seek WAV selection: {err}"))?;
+    match spec.sample_format {
+        hound::SampleFormat::Float => write_samples::<_, _, f32>(
+            &mut reader,
+            &mut writer,
+            sample_count,
+            channels,
+            spec.sample_rate,
+            spec.bits_per_sample,
+            gain,
+        )?,
+        hound::SampleFormat::Int if spec.bits_per_sample <= 16 => write_samples::<_, _, i16>(
+            &mut reader,
+            &mut writer,
+            sample_count,
+            channels,
+            spec.sample_rate,
+            spec.bits_per_sample,
+            gain,
+        )?,
+        hound::SampleFormat::Int => write_samples::<_, _, i32>(
+            &mut reader,
+            &mut writer,
+            sample_count,
+            channels,
+            spec.sample_rate,
+            spec.bits_per_sample,
+            gain,
+        )?,
+    }
+    finalize_wav_writer(writer)
+}
+
+fn write_samples<R, W, S>(
+    reader: &mut hound::WavReader<R>,
+    writer: &mut hound::WavWriter<W>,
+    sample_count: usize,
+    channels: usize,
+    sample_rate: u32,
+    bits_per_sample: u16,
+    gain: f32,
+) -> Result<(), String>
+where
+    R: Read,
+    W: Write + Seek,
+    S: hound::Sample + FadedSample,
+{
+    let frame_count = sample_count / channels.max(1);
+    let fade_frames =
+        short_edge_fade_frame_count(sample_rate, frame_count, DEFAULT_SHORT_EDGE_FADE);
+    for (sample_index, sample) in reader.samples::<S>().take(sample_count).enumerate() {
+        let frame = sample_index / channels.max(1);
+        let gain = gain * short_edge_fade_gain(frame, frame_count, fade_frames);
+        writer
+            .write_sample(
+                sample
+                    .map_err(|err| format!("failed to read sample: {err}"))?
+                    .with_gain(gain, bits_per_sample),
+            )
+            .map_err(|err| format!("failed to write extraction: {err}"))?;
+    }
+    Ok(())
+}
+
+trait FadedSample {
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self;
+}
+
+impl FadedSample for f32 {
+    fn with_gain(self, gain: f32, _bits_per_sample: u16) -> Self {
+        (self * gain).clamp(-1.0, 1.0)
+    }
+}
+
+impl FadedSample for i16 {
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
+        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(16));
+        (f64::from(self) * f64::from(gain))
+            .round()
+            .clamp(min as f64, max as f64) as i16
+    }
+}
+
+impl FadedSample for i32 {
+    fn with_gain(self, gain: f32, bits_per_sample: u16) -> Self {
+        let (min, max) = signed_integer_sample_bounds(bits_per_sample.min(32));
+        (f64::from(self) * f64::from(gain))
+            .round()
+            .clamp(min as f64, max as f64) as i32
+    }
+}
+
+fn signed_integer_sample_bounds(bits_per_sample: u16) -> (i64, i64) {
+    let bits = u32::from(bits_per_sample.clamp(1, 32));
+    let max = (1_i64 << (bits - 1)) - 1;
+    (-1_i64 << (bits - 1), max)
+}

--- a/src/native_app/waveform/audio_file/extraction/raw_wav.rs
+++ b/src/native_app/waveform/audio_file/extraction/raw_wav.rs
@@ -1,8 +1,6 @@
-use std::{
-    fs::File,
-    io::{BufWriter, ErrorKind, Read, Seek, SeekFrom, Write},
-    time::Duration,
-};
+use std::fs::File;
+use std::io::{BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::time::Duration;
 
 use wavecrate::audio::short_edge_fade_frame_count;
 use wavecrate::selection::SelectionRange;

--- a/src/native_app/waveform/audio_file/extraction/raw_wav.rs
+++ b/src/native_app/waveform/audio_file/extraction/raw_wav.rs
@@ -1,7 +1,6 @@
 use std::{
     fs::File,
     io::{BufWriter, ErrorKind, Read, Seek, SeekFrom, Write},
-    path::Path,
     time::Duration,
 };
 
@@ -27,7 +26,7 @@ pub(super) fn copy_selection_to_file<R: Read + Seek>(
     reader: &mut R,
     loaded_frames: usize,
     selection: SelectionRange,
-    output_path: &Path,
+    output: &mut File,
     gain: f32,
     fade_duration: Duration,
 ) -> Result<bool, String> {
@@ -43,7 +42,7 @@ pub(super) fn copy_selection_to_file<R: Read + Seek>(
     }
     let frame_range = selection.frame_bounds(total_frames);
     let byte_span = layout.byte_span(frame_range.start_frame, frame_range.end_frame)?;
-    write_raw_slice(reader, &layout, byte_span, output_path, gain, fade_duration)?;
+    write_raw_slice(reader, &layout, byte_span, output, gain, fade_duration)?;
     Ok(true)
 }
 
@@ -282,7 +281,7 @@ fn write_raw_slice<R: Read + Seek>(
     reader: &mut R,
     layout: &RawWavLayout,
     span: RawByteSpan,
-    output_path: &Path,
+    output: &mut File,
     gain: f32,
     fade_duration: Duration,
 ) -> Result<(), String> {
@@ -294,13 +293,7 @@ fn write_raw_slice<R: Read + Seek>(
         .seek(SeekFrom::Start(span.source_offset))
         .map_err(|err| format!("failed to seek WAV selection: {err}"))?;
 
-    let file = File::create(output_path).map_err(|err| {
-        format!(
-            "failed to create extraction {}: {err}",
-            output_path.display()
-        )
-    })?;
-    let mut writer = BufWriter::new(file);
+    let mut writer = BufWriter::new(output);
     write_header(&mut writer, layout, data_len, riff_size)
         .map_err(|err| format!("failed to write extraction header: {err}"))?;
 

--- a/src/native_app/waveform/audio_file/extraction_output_tests.rs
+++ b/src/native_app/waveform/audio_file/extraction_output_tests.rs
@@ -1,0 +1,158 @@
+use super::extraction::{
+    extract_wav_reader_range_to_folder, finalize_wav_writer, publish_staged_extraction, wav_writer,
+    write_extraction_atomically,
+};
+use std::{
+    io::{Cursor, Read, Seek, SeekFrom, Write},
+    path::Path,
+};
+use wavecrate::selection::SelectionRange;
+
+struct FailingDataCursor {
+    inner: Cursor<Vec<u8>>,
+    fail_at: u64,
+}
+
+impl Read for FailingDataCursor {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let position = self.inner.position();
+        if position >= self.fail_at {
+            return Err(std::io::Error::other("injected extraction read failure"));
+        }
+        let remaining = usize::try_from(self.fail_at - position).unwrap_or(usize::MAX);
+        let read_len = buffer.len().min(remaining);
+        self.inner.read(&mut buffer[..read_len])
+    }
+}
+
+impl Seek for FailingDataCursor {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(position)
+    }
+}
+
+#[test]
+fn late_collision_preserves_existing_file_and_publishes_next_name() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let mut staged = tempfile::NamedTempFile::new_in(root.path()).expect("create staging file");
+    staged.write_all(b"complete extraction").unwrap();
+    staged.as_file().sync_all().unwrap();
+    let first_candidate = root.path().join("source_extraction.wav");
+    // This file represents a late arrival while the complete extraction was still staged.
+    std::fs::write(&first_candidate, b"late arrival").expect("inject late collision");
+
+    let output = publish_staged_extraction(staged, &source, root.path())
+        .expect("publish after late collision");
+
+    assert_eq!(std::fs::read(first_candidate).unwrap(), b"late arrival");
+    assert_eq!(output, root.path().join("source_extraction_1.wav"));
+    assert_eq!(std::fs::read(output).unwrap(), b"complete extraction");
+}
+
+#[test]
+fn partial_write_and_cancel_failures_remove_owned_staging_file() {
+    for error in ["injected write failure", "extraction cancelled"] {
+        let root = tempfile::tempdir().expect("temp root");
+        let source = root.path().join("source.wav");
+        let result = write_extraction_atomically(&source, root.path(), |output| {
+            output.write_all(b"partial WAV header").unwrap();
+            Err(String::from(error))
+        });
+
+        assert_eq!(result.unwrap_err(), error);
+        assert_no_extraction_artifacts(root.path());
+    }
+}
+
+#[test]
+fn finalize_failure_removes_owned_staging_file() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let spec = hound::WavSpec {
+        channels: 2,
+        sample_rate: 44_100,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let error = write_extraction_atomically(&source, root.path(), |output| {
+        let mut writer = wav_writer(output, spec)?;
+        writer.write_sample(1_i16).unwrap();
+        finalize_wav_writer(writer)
+    })
+    .unwrap_err();
+
+    assert!(error.contains("failed to finalize extraction"));
+    assert_no_extraction_artifacts(root.path());
+}
+
+#[test]
+fn raw_read_failure_never_exposes_partial_wav() {
+    assert_read_failure_removes_partial_wav(SelectionRange::new_precise(0.0, 1.0));
+}
+
+#[test]
+fn decoded_read_failure_never_exposes_partial_wav() {
+    assert_read_failure_removes_partial_wav(SelectionRange::new_precise(0.0, 1.0).with_gain(0.5));
+}
+
+fn assert_read_failure_removes_partial_wav(selection: SelectionRange) {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    write_i16_wav(&source, 256);
+    let bytes = std::fs::read(&source).expect("read source wav");
+    let reader = FailingDataCursor {
+        inner: Cursor::new(bytes),
+        fail_at: 52,
+    };
+
+    let error =
+        extract_wav_reader_range_to_folder(&source, root.path(), reader, 256, selection, 1.0)
+            .unwrap_err();
+
+    assert!(error.contains("injected extraction read failure"));
+    assert_no_extraction_artifacts_except_source(root.path(), &source);
+}
+
+#[test]
+fn staging_open_failure_creates_no_final_output() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let missing = root.path().join("missing");
+
+    let error = write_extraction_atomically(&source, &missing, |_| Ok(())).unwrap_err();
+
+    assert!(error.contains("failed to create extraction staging file"));
+    assert!(!root.path().join("source_extraction.wav").exists());
+}
+
+fn assert_no_extraction_artifacts(root: &Path) {
+    assert_no_extraction_artifacts_except_source(root, Path::new(""));
+}
+
+fn assert_no_extraction_artifacts_except_source(root: &Path, source: &Path) {
+    let artifacts = std::fs::read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path != source)
+        .collect::<Vec<_>>();
+    assert!(
+        artifacts.is_empty(),
+        "unexpected extraction artifacts: {artifacts:?}"
+    );
+}
+
+fn write_i16_wav(path: &Path, frames: i16) {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 44_100,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+    for sample in 0..frames {
+        writer.write_sample(sample).expect("write sample");
+    }
+    writer.finalize().expect("finalize wav");
+}

--- a/src/native_app/waveform/audio_file/extraction_tests.rs
+++ b/src/native_app/waveform/audio_file/extraction_tests.rs
@@ -1,12 +1,8 @@
-use super::extraction::{
-    extract_wav_reader_range_to_folder, finalize_wav_writer, publish_staged_extraction, wav_writer,
-    write_extraction_atomically, write_wav_frame_range,
-};
+use super::extraction::{extract_wav_reader_range_to_folder, write_wav_frame_range};
 use std::{
     cell::Cell,
     fs::File,
-    io::{Cursor, Read, Seek, SeekFrom, Write},
-    path::Path,
+    io::{Cursor, Read, Seek, SeekFrom},
     rc::Rc,
 };
 use wavecrate::selection::SelectionRange;
@@ -15,29 +11,6 @@ struct CountingCursor {
     inner: Cursor<Vec<u8>>,
     read_bytes: Rc<Cell<usize>>,
     read_calls: Rc<Cell<usize>>,
-}
-
-struct FailingDataCursor {
-    inner: Cursor<Vec<u8>>,
-    fail_at: u64,
-}
-
-impl Read for FailingDataCursor {
-    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
-        let position = self.inner.position();
-        if position >= self.fail_at {
-            return Err(std::io::Error::other("injected extraction read failure"));
-        }
-        let remaining = usize::try_from(self.fail_at - position).unwrap_or(usize::MAX);
-        let read_len = buffer.len().min(remaining);
-        self.inner.read(&mut buffer[..read_len])
-    }
-}
-
-impl Seek for FailingDataCursor {
-    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
-        self.inner.seek(position)
-    }
 }
 
 impl CountingCursor {
@@ -241,135 +214,6 @@ fn wav_range_extraction_handles_metadata_chunk_before_data() {
     assert_eq!(extracted[0], 0);
     assert_eq!(extracted[16], 80);
     assert_eq!(extracted[31], 0);
-}
-
-#[test]
-fn late_collision_preserves_existing_file_and_publishes_next_name() {
-    let root = tempfile::tempdir().expect("temp root");
-    let source = root.path().join("source.wav");
-    let mut staged = tempfile::NamedTempFile::new_in(root.path()).expect("create staging file");
-    staged.write_all(b"complete extraction").unwrap();
-    staged.as_file().sync_all().unwrap();
-    let first_candidate = root.path().join("source_extraction.wav");
-    // This file represents a late arrival while the complete extraction was still staged.
-    std::fs::write(&first_candidate, b"late arrival").expect("inject late collision");
-
-    let output = publish_staged_extraction(staged, &source, root.path())
-        .expect("publish after late collision");
-
-    assert_eq!(std::fs::read(first_candidate).unwrap(), b"late arrival");
-    assert_eq!(output, root.path().join("source_extraction_1.wav"));
-    assert_eq!(std::fs::read(output).unwrap(), b"complete extraction");
-}
-
-#[test]
-fn partial_write_and_cancel_failures_remove_owned_staging_file() {
-    for error in ["injected write failure", "extraction cancelled"] {
-        let root = tempfile::tempdir().expect("temp root");
-        let source = root.path().join("source.wav");
-        let result = write_extraction_atomically(&source, root.path(), |output| {
-            output.write_all(b"partial WAV header").unwrap();
-            Err(String::from(error))
-        });
-
-        assert_eq!(result.unwrap_err(), error);
-        assert_no_extraction_artifacts(root.path());
-    }
-}
-
-#[test]
-fn finalize_failure_removes_owned_staging_file() {
-    let root = tempfile::tempdir().expect("temp root");
-    let source = root.path().join("source.wav");
-    let spec = hound::WavSpec {
-        channels: 2,
-        sample_rate: 44_100,
-        bits_per_sample: 16,
-        sample_format: hound::SampleFormat::Int,
-    };
-
-    let error = write_extraction_atomically(&source, root.path(), |output| {
-        let mut writer = wav_writer(output, spec)?;
-        writer.write_sample(1_i16).unwrap();
-        finalize_wav_writer(writer)
-    })
-    .unwrap_err();
-
-    assert!(error.contains("failed to finalize extraction"));
-    assert_no_extraction_artifacts(root.path());
-}
-
-#[test]
-fn raw_read_failure_never_exposes_partial_wav() {
-    let root = tempfile::tempdir().expect("temp root");
-    let source = root.path().join("source.wav");
-    write_i16_wav(&source, 256);
-    let bytes = std::fs::read(&source).expect("read source wav");
-    let reader = FailingDataCursor {
-        inner: Cursor::new(bytes),
-        fail_at: 52,
-    };
-
-    let error = extract_wav_reader_range_to_folder(
-        &source,
-        root.path(),
-        reader,
-        256,
-        SelectionRange::new_precise(0.0, 1.0),
-        1.0,
-    )
-    .unwrap_err();
-
-    assert!(error.contains("injected extraction read failure"));
-    assert_no_extraction_artifacts_except_source(root.path(), &source);
-}
-
-#[test]
-fn decoded_read_failure_never_exposes_partial_wav() {
-    let root = tempfile::tempdir().expect("temp root");
-    let source = root.path().join("source.wav");
-    write_i16_wav(&source, 256);
-    let bytes = std::fs::read(&source).expect("read source wav");
-    let reader = FailingDataCursor {
-        inner: Cursor::new(bytes),
-        fail_at: 52,
-    };
-    let selection = SelectionRange::new_precise(0.0, 1.0).with_gain(0.5);
-
-    let error =
-        extract_wav_reader_range_to_folder(&source, root.path(), reader, 256, selection, 1.0)
-            .unwrap_err();
-
-    assert!(error.contains("injected extraction read failure"));
-    assert_no_extraction_artifacts_except_source(root.path(), &source);
-}
-
-#[test]
-fn staging_open_failure_creates_no_final_output() {
-    let root = tempfile::tempdir().expect("temp root");
-    let source = root.path().join("source.wav");
-    let missing = root.path().join("missing");
-
-    let error = write_extraction_atomically(&source, &missing, |_| Ok(())).unwrap_err();
-
-    assert!(error.contains("failed to create extraction staging file"));
-    assert!(!root.path().join("source_extraction.wav").exists());
-}
-
-fn assert_no_extraction_artifacts(root: &Path) {
-    assert_no_extraction_artifacts_except_source(root, Path::new(""));
-}
-
-fn assert_no_extraction_artifacts_except_source(root: &Path, source: &Path) {
-    let artifacts = std::fs::read_dir(root)
-        .unwrap()
-        .map(|entry| entry.unwrap().path())
-        .filter(|path| path != source)
-        .collect::<Vec<_>>();
-    assert!(
-        artifacts.is_empty(),
-        "unexpected extraction artifacts: {artifacts:?}"
-    );
 }
 
 fn write_i16_wav(path: &std::path::Path, frames: i16) {

--- a/src/native_app/waveform/audio_file/extraction_tests.rs
+++ b/src/native_app/waveform/audio_file/extraction_tests.rs
@@ -1,7 +1,12 @@
-use super::extraction::{extract_wav_reader_range_to_folder, write_wav_frame_range};
+use super::extraction::{
+    extract_wav_reader_range_to_folder, finalize_wav_writer, publish_staged_extraction, wav_writer,
+    write_extraction_atomically, write_wav_frame_range,
+};
 use std::{
     cell::Cell,
-    io::{Cursor, Read, Seek, SeekFrom},
+    fs::File,
+    io::{Cursor, Read, Seek, SeekFrom, Write},
+    path::Path,
     rc::Rc,
 };
 use wavecrate::selection::SelectionRange;
@@ -10,6 +15,29 @@ struct CountingCursor {
     inner: Cursor<Vec<u8>>,
     read_bytes: Rc<Cell<usize>>,
     read_calls: Rc<Cell<usize>>,
+}
+
+struct FailingDataCursor {
+    inner: Cursor<Vec<u8>>,
+    fail_at: u64,
+}
+
+impl Read for FailingDataCursor {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let position = self.inner.position();
+        if position >= self.fail_at {
+            return Err(std::io::Error::other("injected extraction read failure"));
+        }
+        let remaining = usize::try_from(self.fail_at - position).unwrap_or(usize::MAX);
+        let read_len = buffer.len().min(remaining);
+        self.inner.read(&mut buffer[..read_len])
+    }
+}
+
+impl Seek for FailingDataCursor {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(position)
+    }
 }
 
 impl CountingCursor {
@@ -58,7 +86,8 @@ fn late_wav_range_extraction_seeks_instead_of_reading_prefix() {
     let spec = reader.spec();
     read_bytes.set(0);
 
-    write_wav_frame_range(reader, spec, 1, 19_000, 19_100, &output, 1.0)
+    let mut output_file = File::create(&output).expect("create output");
+    write_wav_frame_range(reader, spec, 1, 19_000, 19_100, &mut output_file, 1.0)
         .expect("extract late range");
 
     assert!(
@@ -174,7 +203,8 @@ fn decoded_wav_range_writer_clamps_i24_samples_to_destination_depth() {
     let reader = hound::WavReader::open(&source).expect("open 24-bit wav");
     let spec = reader.spec();
 
-    write_wav_frame_range(reader, spec, 1, 0, 256, &output, 2.0)
+    let mut output_file = File::create(&output).expect("create decoded output");
+    write_wav_frame_range(reader, spec, 1, 0, 256, &mut output_file, 2.0)
         .expect("write decoded 24-bit range with gain");
 
     let mut reader = hound::WavReader::open(&output).expect("open decoded 24-bit output");
@@ -211,6 +241,135 @@ fn wav_range_extraction_handles_metadata_chunk_before_data() {
     assert_eq!(extracted[0], 0);
     assert_eq!(extracted[16], 80);
     assert_eq!(extracted[31], 0);
+}
+
+#[test]
+fn late_collision_preserves_existing_file_and_publishes_next_name() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let mut staged = tempfile::NamedTempFile::new_in(root.path()).expect("create staging file");
+    staged.write_all(b"complete extraction").unwrap();
+    staged.as_file().sync_all().unwrap();
+    let first_candidate = root.path().join("source_extraction.wav");
+    // This file represents a late arrival while the complete extraction was still staged.
+    std::fs::write(&first_candidate, b"late arrival").expect("inject late collision");
+
+    let output = publish_staged_extraction(staged, &source, root.path())
+        .expect("publish after late collision");
+
+    assert_eq!(std::fs::read(first_candidate).unwrap(), b"late arrival");
+    assert_eq!(output, root.path().join("source_extraction_1.wav"));
+    assert_eq!(std::fs::read(output).unwrap(), b"complete extraction");
+}
+
+#[test]
+fn partial_write_and_cancel_failures_remove_owned_staging_file() {
+    for error in ["injected write failure", "extraction cancelled"] {
+        let root = tempfile::tempdir().expect("temp root");
+        let source = root.path().join("source.wav");
+        let result = write_extraction_atomically(&source, root.path(), |output| {
+            output.write_all(b"partial WAV header").unwrap();
+            Err(String::from(error))
+        });
+
+        assert_eq!(result.unwrap_err(), error);
+        assert_no_extraction_artifacts(root.path());
+    }
+}
+
+#[test]
+fn finalize_failure_removes_owned_staging_file() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let spec = hound::WavSpec {
+        channels: 2,
+        sample_rate: 44_100,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let error = write_extraction_atomically(&source, root.path(), |output| {
+        let mut writer = wav_writer(output, spec)?;
+        writer.write_sample(1_i16).unwrap();
+        finalize_wav_writer(writer)
+    })
+    .unwrap_err();
+
+    assert!(error.contains("failed to finalize extraction"));
+    assert_no_extraction_artifacts(root.path());
+}
+
+#[test]
+fn raw_read_failure_never_exposes_partial_wav() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    write_i16_wav(&source, 256);
+    let bytes = std::fs::read(&source).expect("read source wav");
+    let reader = FailingDataCursor {
+        inner: Cursor::new(bytes),
+        fail_at: 52,
+    };
+
+    let error = extract_wav_reader_range_to_folder(
+        &source,
+        root.path(),
+        reader,
+        256,
+        SelectionRange::new_precise(0.0, 1.0),
+        1.0,
+    )
+    .unwrap_err();
+
+    assert!(error.contains("injected extraction read failure"));
+    assert_no_extraction_artifacts_except_source(root.path(), &source);
+}
+
+#[test]
+fn decoded_read_failure_never_exposes_partial_wav() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    write_i16_wav(&source, 256);
+    let bytes = std::fs::read(&source).expect("read source wav");
+    let reader = FailingDataCursor {
+        inner: Cursor::new(bytes),
+        fail_at: 52,
+    };
+    let selection = SelectionRange::new_precise(0.0, 1.0).with_gain(0.5);
+
+    let error =
+        extract_wav_reader_range_to_folder(&source, root.path(), reader, 256, selection, 1.0)
+            .unwrap_err();
+
+    assert!(error.contains("injected extraction read failure"));
+    assert_no_extraction_artifacts_except_source(root.path(), &source);
+}
+
+#[test]
+fn staging_open_failure_creates_no_final_output() {
+    let root = tempfile::tempdir().expect("temp root");
+    let source = root.path().join("source.wav");
+    let missing = root.path().join("missing");
+
+    let error = write_extraction_atomically(&source, &missing, |_| Ok(())).unwrap_err();
+
+    assert!(error.contains("failed to create extraction staging file"));
+    assert!(!root.path().join("source_extraction.wav").exists());
+}
+
+fn assert_no_extraction_artifacts(root: &Path) {
+    assert_no_extraction_artifacts_except_source(root, Path::new(""));
+}
+
+fn assert_no_extraction_artifacts_except_source(root: &Path, source: &Path) {
+    let artifacts = std::fs::read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path != source)
+        .collect::<Vec<_>>();
+    assert!(
+        artifacts.is_empty(),
+        "unexpected extraction artifacts: {artifacts:?}"
+    );
 }
 
 fn write_i16_wav(path: &std::path::Path, frames: i16) {


### PR DESCRIPTION
## Goal

Make waveform extraction failure-atomic and collision-safe so incomplete output is never visible as a completed WAV and late collisions never overwrite an existing file.

## Scope and non-goals

- Stage decoded and raw-WAV extraction output in an owned temporary file beside the destination.
- Finalize and sync the WAV before publishing it.
- Publish without clobbering and retry the next suffix after a late collision.
- Remove only the staging file owned by the active extraction on error or cancellation.
- Add deterministic regression coverage for staging-open, read, partial-write/cancel, finalize, collision, and success behavior.
- Non-goal: change extraction format selection, sample conversion, or UI behavior.

## Definition of Done

- Successful decoded and raw extraction publishes a readable WAV only after finalization.
- A file arriving at the selected destination is preserved and extraction publishes at the next available suffix.
- Open, read, write/cancel, and finalize failures leave neither a visible partial final file nor an owned staging file.
- Existing successful extraction behavior remains covered.

## Validation

- PASS: `cargo fmt --check`
- PASS: `cargo test -p wavecrate --lib extraction -- --test-threads=1` (42 passed)
- PASS: `cargo test -p wavecrate --lib extraction_output_tests -- --test-threads=1` (6 passed)
- PASS: `cargo test -p wavecrate --lib committed_file_mutations -- --test-threads=1` (14 passed)
- PASS: changed-file size budget (6 files checked)
- PASS: `bash scripts/build.sh --release` produced and signed the exact-head app bundle
- PASS: sandbox runtime successful extraction produced a readable WAV
- PASS: sandbox forced staging-open failure reported the error and left no final or staging artifact
- BLOCKED (pre-existing): `bash scripts/ci.sh agent` and `cargo check -p wavecrate --all-targets` stop at `tests/release_workflow_helpers.rs:936`, where the existing fixture contains an invalid format string
- BLOCKED (pre-existing): strict repository Clippy reports existing warnings outside this change

## Known limitations

None.

User approval is required before merge.