### PR TITLE
OPT-1221 Prevent late destination collisions in native transfers

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1555,6 +1555,8 @@ Batch operations should be cancellable where practical. If a user cancels a batc
 
 Rollback should be best-effort but serious. For audio edits, file moves, generated renames, tag/rating/metadata changes, temporary color collection changes, and trash moves, Wavecrate should capture enough before-state to undo completed items when cancellation happens. If rollback is unsafe or impossible for an item, Wavecrate must inform the user that not everything could be rolled back. The UI and logs should say exactly which items remain changed and why.
 
+Native file moves, copies, and external-file imports must claim their final destination without replacing an existing filesystem entry. A destination that appears after planning is a recoverable collision: moves keep the source, copy and import flows continue the predictable collision-numbering policy, and rollback or failure cleanup mutates only a destination whose filesystem identity still belongs to the transaction. Cross-device move fallback must publish a complete same-folder staged copy with the same no-replace guarantee before removing the source.
+
 Silence trimming should be available both as a waveform-editor action and as an item-based batch action.
 
 In the waveform editor, silence trimming should let the user visually inspect and apply removal of silence at the start and/or end of the current audio file or selected range.

--- a/src/native_app/sample_library.rs
+++ b/src/native_app/sample_library.rs
@@ -6,6 +6,7 @@ pub(in crate::native_app) const DRAG_PREVIEW_HEIGHT: f32 = 20.0;
 pub(in crate::native_app) mod committed_file_mutations;
 pub(in crate::native_app) mod context_menu_target;
 pub(in crate::native_app) mod drag_drop_actions;
+mod exclusive_file_transfer;
 pub(in crate::native_app) mod file_actions;
 pub(in crate::native_app) mod folder_browser;
 pub(in crate::native_app) mod folder_browser_actions;

--- a/src/native_app/sample_library/exclusive_file_transfer.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer.rs
@@ -5,6 +5,8 @@ use std::{
     sync::Arc,
 };
 
+use platform::{rename_no_replace, same_file_handles};
+
 #[derive(Clone, Debug)]
 pub(super) struct CommittedFile {
     path: PathBuf,
@@ -17,10 +19,51 @@ impl CommittedFile {
     }
 
     pub(super) fn remove_if_owned(&self) -> io::Result<bool> {
+        self.remove_if_owned_with(|| {})
+    }
+
+    fn remove_if_owned_with(&self, before_quarantine: impl FnOnce()) -> io::Result<bool> {
         if !self.still_owned()? {
             return Ok(false);
         }
-        fs::remove_file(&self.path)?;
+        before_quarantine();
+        let parent = self.path.parent().unwrap_or_else(|| Path::new(""));
+        let quarantine = tempfile::Builder::new()
+            .prefix(".wavecrate-cleanup-")
+            .tempdir_in(parent)?;
+        let quarantined = quarantine.path().join("owned-file");
+        rename_no_replace(&self.path, &quarantined)?;
+        // From this point onward, keep the private directory on every error path. Its
+        // destructor must never recursively remove an object that was moved from the
+        // user-visible destination before its identity was verified.
+        let quarantine = quarantine.keep();
+        let moved = fs::metadata(&quarantined)
+            .and_then(|metadata| {
+                metadata
+                    .is_file()
+                    .then(|| File::open(&quarantined))
+                    .transpose()
+            })
+            .map_err(|error| preserved_cleanup_error(error, &quarantined))?;
+        let owned = match moved.as_ref() {
+            Some(moved) => same_file_handles(&self.owned_file, moved)
+                .map_err(|error| preserved_cleanup_error(error, &quarantined))?,
+            None => false,
+        };
+        if !owned {
+            return restore_quarantined_destination(&quarantined, &self.path, &quarantine);
+        }
+        drop(moved);
+        if let Err(remove_error) = fs::remove_file(&quarantined) {
+            return Err(io::Error::new(
+                remove_error.kind(),
+                format!(
+                    "owned destination cleanup failed and was preserved at {}: {remove_error}",
+                    quarantined.display()
+                ),
+            ));
+        }
+        fs::remove_dir(quarantine)?;
         Ok(true)
     }
 
@@ -43,6 +86,36 @@ impl CommittedFile {
             Err(error) => return Err(error),
         };
         same_file_handles(&self.owned_file, &actual)
+    }
+}
+
+fn preserved_cleanup_error(error: io::Error, quarantined: &Path) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!(
+            "destination cleanup could not verify the quarantined object at {}; it was preserved: {error}",
+            quarantined.display()
+        ),
+    )
+}
+
+fn restore_quarantined_destination(
+    quarantined: &Path,
+    destination: &Path,
+    quarantine: &Path,
+) -> io::Result<bool> {
+    match rename_no_replace(quarantined, destination) {
+        Ok(()) => {
+            fs::remove_dir(quarantine)?;
+            Ok(false)
+        }
+        Err(restore_error) => Err(io::Error::new(
+            restore_error.kind(),
+            format!(
+                "destination changed during cleanup and was preserved at {} after restore failed: {restore_error}",
+                quarantined.display()
+            ),
+        )),
     }
 }
 
@@ -199,42 +272,6 @@ fn committed_file(path: &Path, owned_file: File) -> CommittedFile {
     }
 }
 
-#[cfg(unix)]
-fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
-    use std::os::unix::fs::MetadataExt;
-
-    let expected = expected.metadata()?;
-    let actual = actual.metadata()?;
-    Ok(expected.dev() == actual.dev() && expected.ino() == actual.ino())
-}
-
-#[cfg(windows)]
-fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
-    use std::os::windows::io::AsRawHandle;
-    use windows::Win32::{
-        Foundation::HANDLE,
-        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
-    };
-
-    fn identity(file: &File) -> io::Result<(u32, u64, u64)> {
-        let mut information = BY_HANDLE_FILE_INFORMATION::default();
-        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
-            .map_err(io::Error::other)?;
-        let index =
-            (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
-        let created = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
-            | u64::from(information.ftCreationTime.dwLowDateTime);
-        Ok((information.dwVolumeSerialNumber, index, created))
-    }
-
-    Ok(identity(expected)? == identity(actual)?)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn same_file_handles(_expected: &File, _actual: &File) -> io::Result<bool> {
-    Ok(false)
-}
-
 fn rename_requires_copy_fallback(error: &io::Error) -> bool {
     error.kind() == ErrorKind::CrossesDevices
         || error.kind() == ErrorKind::Unsupported
@@ -245,105 +282,6 @@ fn rename_requires_copy_fallback(error: &io::Error) -> bool {
             )
 }
 
-#[cfg(target_os = "windows")]
-fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows::{
-        Win32::{
-            Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_NOT_SAME_DEVICE},
-            Storage::FileSystem::{MOVE_FILE_FLAGS, MoveFileExW},
-        },
-        core::{HRESULT, PCWSTR},
-    };
-
-    let source = source
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let destination = destination
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    unsafe {
-        MoveFileExW(
-            PCWSTR(source.as_ptr()),
-            PCWSTR(destination.as_ptr()),
-            MOVE_FILE_FLAGS(0),
-        )
-    }
-    .map_err(|error| {
-        let code = error.code();
-        if code == HRESULT::from_win32(ERROR_ALREADY_EXISTS.0)
-            || code == HRESULT::from_win32(ERROR_FILE_EXISTS.0)
-        {
-            io::Error::from(ErrorKind::AlreadyExists)
-        } else if code == HRESULT::from_win32(ERROR_NOT_SAME_DEVICE.0) {
-            io::Error::from(ErrorKind::CrossesDevices)
-        } else {
-            io::Error::other(error)
-        }
-    })
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
-fn path_to_c_string(path: &Path) -> io::Result<std::ffi::CString> {
-    use std::os::unix::ffi::OsStrExt;
-
-    std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-        io::Error::new(
-            ErrorKind::InvalidInput,
-            "file transfer path contains an interior NUL byte",
-        )
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
-    let source = path_to_c_string(source)?;
-    let destination = path_to_c_string(destination)?;
-    let result =
-        unsafe { libc::renamex_np(source.as_ptr(), destination.as_ptr(), libc::RENAME_EXCL) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
-    let source = path_to_c_string(source)?;
-    let destination = path_to_c_string(destination)?;
-    let result = unsafe {
-        libc::renameat2(
-            libc::AT_FDCWD,
-            source.as_ptr(),
-            libc::AT_FDCWD,
-            destination.as_ptr(),
-            libc::RENAME_NOREPLACE,
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-#[cfg(not(any(
-    target_os = "windows",
-    target_os = "macos",
-    target_os = "linux",
-    target_os = "android"
-)))]
-fn rename_no_replace(_source: &Path, _destination: &Path) -> io::Result<()> {
-    Err(io::Error::new(
-        ErrorKind::Unsupported,
-        "atomic no-replace rename is unavailable on this platform",
-    ))
-}
-
+mod platform;
 #[cfg(test)]
 mod tests;

--- a/src/native_app/sample_library/exclusive_file_transfer.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer.rs
@@ -132,6 +132,16 @@ pub(super) fn copy_file_to_unique_destination(
 }
 
 pub(super) fn move_file_no_replace(source: &Path, destination: &Path) -> io::Result<CommittedFile> {
+    let source_entry = fs::symlink_metadata(source)?;
+    if !source_entry.file_type().is_file() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "native file moves require a regular source file: {}",
+                source.display()
+            ),
+        ));
+    }
     let source_file = File::open(source)?;
     match rename_no_replace(source, destination) {
         Ok(()) => Ok(committed_file(destination, source_file)),

--- a/src/native_app/sample_library/exclusive_file_transfer.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer.rs
@@ -1,0 +1,349 @@
+use std::{
+    fs::{self, File},
+    io::{self, ErrorKind, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[derive(Clone, Debug)]
+pub(super) struct CommittedFile {
+    path: PathBuf,
+    owned_file: Arc<File>,
+}
+
+impl CommittedFile {
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn remove_if_owned(&self) -> io::Result<bool> {
+        if !self.still_owned()? {
+            return Ok(false);
+        }
+        fs::remove_file(&self.path)?;
+        Ok(true)
+    }
+
+    pub(super) fn move_back_if_owned(&self, source: &Path) -> io::Result<bool> {
+        let mut input = self.owned_file.try_clone()?;
+        input.seek(SeekFrom::Start(0))?;
+        copy_open_file_no_replace(
+            &mut input,
+            self.owned_file.metadata()?.permissions(),
+            source,
+        )?;
+        let _ = self.remove_if_owned();
+        Ok(true)
+    }
+
+    fn still_owned(&self) -> io::Result<bool> {
+        let actual = match File::open(&self.path) {
+            Ok(actual) => actual,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        same_file_handles(&self.owned_file, &actual)
+    }
+}
+
+pub(super) fn copy_file_no_replace(source: &Path, destination: &Path) -> io::Result<CommittedFile> {
+    let staged = stage_file_copy(source, destination)?;
+    publish_staged_file(staged, destination)
+}
+
+pub(super) fn copy_file_to_unique_destination(
+    source: &Path,
+    first_candidate: &Path,
+) -> io::Result<CommittedFile> {
+    copy_file_to_unique_destination_with(source, first_candidate, |_, _| {})
+}
+
+pub(super) fn move_file_no_replace(source: &Path, destination: &Path) -> io::Result<CommittedFile> {
+    let source_file = File::open(source)?;
+    match rename_no_replace(source, destination) {
+        Ok(()) => Ok(committed_file(destination, source_file)),
+        Err(error) => move_file_after_rename_error(source, destination, error),
+    }
+}
+
+fn move_file_after_rename_error(
+    source: &Path,
+    destination: &Path,
+    rename_error: io::Error,
+) -> io::Result<CommittedFile> {
+    if rename_requires_copy_fallback(&rename_error) {
+        let committed = copy_file_no_replace(source, destination)?;
+        if let Err(remove_error) = fs::remove_file(source) {
+            return Err(io::Error::new(
+                remove_error.kind(),
+                format!(
+                    "copied to {} without replacing another file, but failed to remove the source: {remove_error}; the completed copy was preserved",
+                    destination.display()
+                ),
+            ));
+        }
+        Ok(committed)
+    } else {
+        Err(rename_error)
+    }
+}
+
+pub(super) fn move_file_to_unique_destination(
+    source: &Path,
+    first_candidate: &Path,
+) -> io::Result<CommittedFile> {
+    for index in 0..10_000 {
+        let candidate = unique_copy_candidate(first_candidate, index);
+        match move_file_no_replace(source, &candidate) {
+            Ok(committed) => return Ok(committed),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        ErrorKind::AlreadyExists,
+        "could not find an available destination name",
+    ))
+}
+
+pub(super) fn unique_copy_candidate(first_candidate: &Path, index: usize) -> PathBuf {
+    if index == 0 {
+        return first_candidate.to_path_buf();
+    }
+    let parent = first_candidate.parent().unwrap_or_else(|| Path::new(""));
+    let stem = first_candidate
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().to_string())
+        .unwrap_or_else(|| String::from("sample"));
+    let extension = first_candidate
+        .extension()
+        .map(|extension| extension.to_string_lossy().to_string());
+    let file_name = match extension {
+        Some(extension) => format!("{stem}_copy{index:03}.{extension}"),
+        None => format!("{stem}_copy{index:03}"),
+    };
+    parent.join(file_name)
+}
+
+fn stage_file_copy(source: &Path, destination: &Path) -> io::Result<tempfile::NamedTempFile> {
+    let parent = destination.parent().unwrap_or_else(|| Path::new(""));
+    let mut input = File::open(source)?;
+    let permissions = input.metadata()?.permissions();
+    stage_open_file_copy(&mut input, permissions, parent)
+}
+
+fn stage_open_file_copy(
+    input: &mut File,
+    permissions: fs::Permissions,
+    parent: &Path,
+) -> io::Result<tempfile::NamedTempFile> {
+    let mut staged = tempfile::Builder::new()
+        .prefix(".wavecrate-transfer-")
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    io::copy(input, staged.as_file_mut())?;
+    staged.as_file().set_permissions(permissions)?;
+    staged.as_file().sync_all()?;
+    Ok(staged)
+}
+
+fn copy_open_file_no_replace(
+    input: &mut File,
+    permissions: fs::Permissions,
+    destination: &Path,
+) -> io::Result<CommittedFile> {
+    let parent = destination.parent().unwrap_or_else(|| Path::new(""));
+    publish_staged_file(
+        stage_open_file_copy(input, permissions, parent)?,
+        destination,
+    )
+}
+
+fn publish_staged_file(
+    staged: tempfile::NamedTempFile,
+    destination: &Path,
+) -> io::Result<CommittedFile> {
+    let file = staged
+        .persist_noclobber(destination)
+        .map_err(|error| error.error)?;
+    Ok(committed_file(destination, file))
+}
+
+pub(super) fn copy_file_to_unique_destination_with(
+    source: &Path,
+    first_candidate: &Path,
+    mut before_publish: impl FnMut(usize, &Path),
+) -> io::Result<CommittedFile> {
+    let mut staged = stage_file_copy(source, first_candidate)?;
+    for index in 0..10_000 {
+        let candidate = unique_copy_candidate(first_candidate, index);
+        before_publish(index, &candidate);
+        match staged.persist_noclobber(&candidate) {
+            Ok(file) => return Ok(committed_file(&candidate, file)),
+            Err(error) if error.error.kind() == ErrorKind::AlreadyExists => {
+                staged = error.file;
+            }
+            Err(error) => return Err(error.error),
+        }
+    }
+    Err(io::Error::new(
+        ErrorKind::AlreadyExists,
+        "could not find an available destination name",
+    ))
+}
+
+fn committed_file(path: &Path, owned_file: File) -> CommittedFile {
+    CommittedFile {
+        path: path.to_path_buf(),
+        owned_file: Arc::new(owned_file),
+    }
+}
+
+#[cfg(unix)]
+fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let expected = expected.metadata()?;
+    let actual = actual.metadata()?;
+    Ok(expected.dev() == actual.dev() && expected.ino() == actual.ino())
+}
+
+#[cfg(windows)]
+fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
+    };
+
+    fn identity(file: &File) -> io::Result<(u32, u64, u64)> {
+        let mut information = BY_HANDLE_FILE_INFORMATION::default();
+        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
+            .map_err(io::Error::other)?;
+        let index =
+            (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
+        let created = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
+            | u64::from(information.ftCreationTime.dwLowDateTime);
+        Ok((information.dwVolumeSerialNumber, index, created))
+    }
+
+    Ok(identity(expected)? == identity(actual)?)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_file_handles(_expected: &File, _actual: &File) -> io::Result<bool> {
+    Ok(false)
+}
+
+fn rename_requires_copy_fallback(error: &io::Error) -> bool {
+    error.kind() == ErrorKind::CrossesDevices
+        || error.kind() == ErrorKind::Unsupported
+        || cfg!(any(target_os = "linux", target_os = "android"))
+            && matches!(
+                error.raw_os_error(),
+                Some(libc::ENOSYS | libc::EINVAL | libc::EOPNOTSUPP)
+            )
+}
+
+#[cfg(target_os = "windows")]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::{
+        Win32::{
+            Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_NOT_SAME_DEVICE},
+            Storage::FileSystem::{MOVE_FILE_FLAGS, MoveFileExW},
+        },
+        core::{HRESULT, PCWSTR},
+    };
+
+    let source = source
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source.as_ptr()),
+            PCWSTR(destination.as_ptr()),
+            MOVE_FILE_FLAGS(0),
+        )
+    }
+    .map_err(|error| {
+        let code = error.code();
+        if code == HRESULT::from_win32(ERROR_ALREADY_EXISTS.0)
+            || code == HRESULT::from_win32(ERROR_FILE_EXISTS.0)
+        {
+            io::Error::from(ErrorKind::AlreadyExists)
+        } else if code == HRESULT::from_win32(ERROR_NOT_SAME_DEVICE.0) {
+            io::Error::from(ErrorKind::CrossesDevices)
+        } else {
+            io::Error::other(error)
+        }
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+fn path_to_c_string(path: &Path) -> io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            "file transfer path contains an interior NUL byte",
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result =
+        unsafe { libc::renamex_np(source.as_ptr(), destination.as_ptr(), libc::RENAME_EXCL) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "android"
+)))]
+fn rename_no_replace(_source: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/native_app/sample_library/exclusive_file_transfer.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer.rs
@@ -37,7 +37,7 @@ impl CommittedFile {
         // destructor must never recursively remove an object that was moved from the
         // user-visible destination before its identity was verified.
         let quarantine = quarantine.keep();
-        let moved = fs::metadata(&quarantined)
+        let moved = fs::symlink_metadata(&quarantined)
             .and_then(|metadata| {
                 metadata
                     .is_file()

--- a/src/native_app/sample_library/exclusive_file_transfer/platform.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/platform.rs
@@ -1,0 +1,137 @@
+use std::{fs::File, io, path::Path};
+
+#[cfg(unix)]
+pub(super) fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let expected = expected.metadata()?;
+    let actual = actual.metadata()?;
+    Ok(expected.dev() == actual.dev() && expected.ino() == actual.ino())
+}
+
+#[cfg(windows)]
+pub(super) fn same_file_handles(expected: &File, actual: &File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
+    };
+
+    fn identity(file: &File) -> io::Result<(u32, u64, u64)> {
+        let mut information = BY_HANDLE_FILE_INFORMATION::default();
+        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
+            .map_err(io::Error::other)?;
+        let index =
+            (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
+        let created = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
+            | u64::from(information.ftCreationTime.dwLowDateTime);
+        Ok((information.dwVolumeSerialNumber, index, created))
+    }
+
+    Ok(identity(expected)? == identity(actual)?)
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(super) fn same_file_handles(_expected: &File, _actual: &File) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(target_os = "windows")]
+pub(super) fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::{
+        Win32::{
+            Foundation::{ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_NOT_SAME_DEVICE},
+            Storage::FileSystem::{MOVE_FILE_FLAGS, MoveFileExW},
+        },
+        core::{HRESULT, PCWSTR},
+    };
+
+    let source = source
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source.as_ptr()),
+            PCWSTR(destination.as_ptr()),
+            MOVE_FILE_FLAGS(0),
+        )
+    }
+    .map_err(|error| {
+        let code = error.code();
+        if code == HRESULT::from_win32(ERROR_ALREADY_EXISTS.0)
+            || code == HRESULT::from_win32(ERROR_FILE_EXISTS.0)
+        {
+            io::Error::from(io::ErrorKind::AlreadyExists)
+        } else if code == HRESULT::from_win32(ERROR_NOT_SAME_DEVICE.0) {
+            io::Error::from(io::ErrorKind::CrossesDevices)
+        } else {
+            io::Error::other(error)
+        }
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+fn path_to_c_string(path: &Path) -> io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "file transfer path contains an interior NUL byte",
+        )
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result =
+        unsafe { libc::renamex_np(source.as_ptr(), destination.as_ptr(), libc::RENAME_EXCL) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(super) fn rename_no_replace(source: &Path, destination: &Path) -> io::Result<()> {
+    let source = path_to_c_string(source)?;
+    let destination = path_to_c_string(destination)?;
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "android"
+)))]
+pub(super) fn rename_no_replace(_source: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable on this platform",
+    ))
+}

--- a/src/native_app/sample_library/exclusive_file_transfer/tests.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/tests.rs
@@ -130,6 +130,36 @@ fn ownership_cleanup_preserves_a_replacement_directory_after_the_initial_check()
     }));
 }
 
+#[cfg(unix)]
+#[test]
+fn ownership_cleanup_preserves_a_replacement_symlink_to_the_owned_file() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    let owned_alias = temp.path().join("owned-alias.wav");
+    fs::write(&source, b"source").unwrap();
+    let committed = copy_file_no_replace(&source, &destination).unwrap();
+    fs::hard_link(&destination, &owned_alias).unwrap();
+
+    let removed = committed
+        .remove_if_owned_with(|| {
+            fs::remove_file(&destination).unwrap();
+            symlink(&owned_alias, &destination).unwrap();
+        })
+        .unwrap();
+
+    assert!(!removed);
+    assert!(
+        fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(fs::read(&destination).unwrap(), b"source");
+}
+
 #[test]
 fn cross_device_fallback_preserves_a_late_destination() {
     let temp = tempdir().unwrap();

--- a/src/native_app/sample_library/exclusive_file_transfer/tests.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/tests.rs
@@ -160,6 +160,31 @@ fn ownership_cleanup_preserves_a_replacement_symlink_to_the_owned_file() {
     assert_eq!(fs::read(&destination).unwrap(), b"source");
 }
 
+#[cfg(unix)]
+#[test]
+fn native_move_rejects_a_symlink_source_without_moving_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempdir().unwrap();
+    let target = temp.path().join("target.wav");
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&target, b"target").unwrap();
+    symlink(&target, &source).unwrap();
+
+    let error = move_file_no_replace(&source, &destination).unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    assert!(
+        fs::symlink_metadata(&source)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(fs::read(&target).unwrap(), b"target");
+    assert!(!destination.exists());
+}
+
 #[test]
 fn cross_device_fallback_preserves_a_late_destination() {
     let temp = tempdir().unwrap();

--- a/src/native_app/sample_library/exclusive_file_transfer/tests.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/tests.rs
@@ -75,6 +75,62 @@ fn ownership_cleanup_preserves_a_replaced_destination() {
 }
 
 #[test]
+fn ownership_cleanup_preserves_replacement_after_the_initial_check() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    let committed = copy_file_no_replace(&source, &destination).unwrap();
+
+    let removed = committed
+        .remove_if_owned_with(|| {
+            fs::remove_file(&destination).unwrap();
+            fs::write(&destination, b"late replacement").unwrap();
+        })
+        .unwrap();
+
+    assert!(!removed);
+    assert_eq!(fs::read(&destination).unwrap(), b"late replacement");
+    assert!(fs::read_dir(temp.path()).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".wavecrate-cleanup-")
+    }));
+}
+
+#[test]
+fn ownership_cleanup_preserves_a_replacement_directory_after_the_initial_check() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    let committed = copy_file_no_replace(&source, &destination).unwrap();
+
+    let removed = committed
+        .remove_if_owned_with(|| {
+            fs::remove_file(&destination).unwrap();
+            fs::create_dir(&destination).unwrap();
+            fs::write(destination.join("unrelated.wav"), b"unrelated").unwrap();
+        })
+        .unwrap();
+
+    assert!(!removed);
+    assert_eq!(
+        fs::read(destination.join("unrelated.wav")).unwrap(),
+        b"unrelated"
+    );
+    assert!(fs::read_dir(temp.path()).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".wavecrate-cleanup-")
+    }));
+}
+
+#[test]
 fn cross_device_fallback_preserves_a_late_destination() {
     let temp = tempdir().unwrap();
     let source = temp.path().join("source.wav");

--- a/src/native_app/sample_library/exclusive_file_transfer/tests.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+use tempfile::tempdir;
+
+#[test]
+fn copy_commit_preserves_an_existing_destination() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    fs::write(&destination, b"existing").unwrap();
+
+    let error = copy_file_no_replace(&source, &destination).unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(&source).unwrap(), b"source");
+    assert_eq!(fs::read(&destination).unwrap(), b"existing");
+}
+
+#[test]
+fn unique_copy_retries_a_collision_injected_before_commit() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+
+    let committed =
+        copy_file_to_unique_destination_with(&source, &destination, |index, candidate| {
+            if index == 0 {
+                fs::write(candidate, b"late owner").unwrap();
+            }
+        })
+        .unwrap();
+
+    assert_eq!(
+        committed.path(),
+        temp.path().join("destination_copy001.wav")
+    );
+    assert_eq!(fs::read(&destination).unwrap(), b"late owner");
+    assert_eq!(fs::read(committed.path()).unwrap(), b"source");
+}
+
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "android"
+))]
+#[test]
+fn same_filesystem_move_preserves_an_existing_destination() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    fs::write(&destination, b"late owner").unwrap();
+
+    let error = move_file_no_replace(&source, &destination).unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(&source).unwrap(), b"source");
+    assert_eq!(fs::read(&destination).unwrap(), b"late owner");
+}
+
+#[test]
+fn ownership_cleanup_preserves_a_replaced_destination() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    let committed = copy_file_no_replace(&source, &destination).unwrap();
+    fs::remove_file(&destination).unwrap();
+    fs::write(&destination, b"replacement").unwrap();
+
+    assert!(!committed.remove_if_owned().unwrap());
+    assert_eq!(fs::read(&destination).unwrap(), b"replacement");
+}
+
+#[test]
+fn cross_device_fallback_preserves_a_late_destination() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+    fs::write(&destination, b"late owner").unwrap();
+
+    let error = move_file_after_rename_error(
+        &source,
+        &destination,
+        io::Error::from(ErrorKind::CrossesDevices),
+    )
+    .unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::AlreadyExists);
+    assert_eq!(fs::read(&source).unwrap(), b"source");
+    assert_eq!(fs::read(&destination).unwrap(), b"late owner");
+}
+
+#[test]
+fn cross_device_fallback_commits_before_removing_the_source() {
+    let temp = tempdir().unwrap();
+    let source = temp.path().join("source.wav");
+    let destination = temp.path().join("destination.wav");
+    fs::write(&source, b"source").unwrap();
+
+    let committed = move_file_after_rename_error(
+        &source,
+        &destination,
+        io::Error::from(ErrorKind::CrossesDevices),
+    )
+    .unwrap();
+
+    assert_eq!(committed.path(), destination);
+    assert!(!source.exists());
+    assert_eq!(fs::read(destination).unwrap(), b"source");
+}

--- a/src/native_app/sample_library/folder_browser/file_move_transaction.rs
+++ b/src/native_app/sample_library/folder_browser/file_move_transaction.rs
@@ -1,10 +1,13 @@
 use std::{
     collections::HashSet,
-    fs,
     path::{Path, PathBuf},
 };
 
 use super::{FileMoveConflict, FileMoveItem};
+use crate::native_app::sample_library::exclusive_file_transfer::{
+    CommittedFile, copy_file_to_unique_destination, move_file_no_replace,
+    move_file_to_unique_destination as move_to_unique_destination, unique_copy_candidate,
+};
 
 #[derive(Debug, Default)]
 pub(super) struct FileMovePlan {
@@ -40,7 +43,13 @@ impl FileTransfer {
 #[derive(Debug)]
 pub(super) struct OverwriteBackup {
     destination_path: PathBuf,
-    backup_path: PathBuf,
+    backup: CommittedFile,
+}
+
+#[derive(Clone, Debug)]
+struct CompletedTransfer {
+    transfer: FileTransfer,
+    committed: CommittedFile,
 }
 
 pub(super) fn file_move_plan_to_folder(
@@ -136,20 +145,46 @@ pub(super) fn transfer_files_with_rollback_and_progress(
     let mut completed = Vec::new();
     for transfer in transfers {
         let result = if transfer.copy_only {
-            copy_file(&transfer.source_path, &transfer.destination_path)
+            let first_candidate = transfer
+                .source_path
+                .file_name()
+                .and_then(|file_name| {
+                    transfer
+                        .destination_path
+                        .parent()
+                        .map(|parent| parent.join(file_name))
+                })
+                .unwrap_or_else(|| transfer.destination_path.clone());
+            copy_file_to_unique_destination(&transfer.source_path, &first_candidate)
+                .map_err(|err| format!("File copy failed: {err}"))
         } else {
-            move_file(&transfer.source_path, &transfer.destination_path)
+            move_file_with_prefix(
+                &transfer.source_path,
+                &transfer.destination_path,
+                "File move failed",
+            )
         };
-        if let Err(error) = result {
-            rollback_completed_file_transfers(&completed);
-            return Err(error);
-        }
-        completed.push(transfer.clone());
-        progress(completed.len(), &transfer.destination_path);
+        let committed = match result {
+            Ok(committed) => committed,
+            Err(error) => {
+                rollback_completed_file_transfers(&completed);
+                return Err(error);
+            }
+        };
+        progress(completed.len() + 1, committed.path());
+        completed.push(CompletedTransfer {
+            transfer: transfer.clone(),
+            committed,
+        });
     }
     Ok(completed
         .into_iter()
-        .map(|transfer| (transfer.source_path, transfer.destination_path))
+        .map(|completed| {
+            (
+                completed.transfer.source_path,
+                completed.committed.path().to_path_buf(),
+            )
+        })
         .collect())
 }
 
@@ -161,73 +196,35 @@ pub(super) fn move_file_to_unique_destination(
     let Some(file_name) = source_path.file_name() else {
         return Err(format!("{error_prefix}: file has no name"));
     };
-    let destination = unique_destination(&target_folder.join(file_name));
-    move_file_with_prefix(source_path, &destination, error_prefix)?;
-    Ok((source_path.to_path_buf(), destination))
+    let first_candidate = target_folder.join(file_name);
+    let committed = move_to_unique_destination(source_path, &first_candidate)
+        .map_err(|err| format!("{error_prefix}: {err}"))?;
+    Ok((source_path.to_path_buf(), committed.path().to_path_buf()))
 }
 
-fn rollback_completed_file_transfers(completed: &[FileTransfer]) {
-    for transfer in completed.iter().rev() {
-        if transfer.copy_only {
-            let _ = fs::remove_file(&transfer.destination_path);
+fn rollback_completed_file_transfers(completed: &[CompletedTransfer]) {
+    for completed in completed.iter().rev() {
+        if completed.transfer.copy_only {
+            let _ = completed.committed.remove_if_owned();
         } else {
-            let _ = move_file(&transfer.destination_path, &transfer.source_path);
+            let _ = completed
+                .committed
+                .move_back_if_owned(&completed.transfer.source_path);
         }
     }
-}
-
-pub(super) fn move_file(source: &Path, destination: &Path) -> Result<(), String> {
-    move_file_with_prefix(source, destination, "File move failed")
-}
-
-fn copy_file(source: &Path, destination: &Path) -> Result<(), String> {
-    fs::copy(source, destination)
-        .map(|_| ())
-        .map_err(|err| format!("File copy failed: {err}"))
 }
 
 fn move_file_with_prefix(
     source: &Path,
     destination: &Path,
     error_prefix: &'static str,
-) -> Result<(), String> {
-    match fs::rename(source, destination) {
-        Ok(()) => Ok(()),
-        Err(rename_error) => {
-            if let Err(copy_error) = fs::copy(source, destination) {
-                return Err(format!(
-                    "{error_prefix}: {rename_error}; copy failed: {copy_error}"
-                ));
-            }
-            if let Err(remove_error) = fs::remove_file(source) {
-                let _ = fs::remove_file(destination);
-                return Err(format!(
-                    "{error_prefix}: copied but failed to remove original: {remove_error}"
-                ));
-            }
-            Ok(())
-        }
-    }
+) -> Result<CommittedFile, String> {
+    move_file_no_replace(source, destination).map_err(|err| format!("{error_prefix}: {err}"))
 }
 
 pub(super) fn unique_destination(first_candidate: &Path) -> PathBuf {
-    if !first_candidate.exists() {
-        return first_candidate.to_path_buf();
-    }
-    let parent = first_candidate.parent().unwrap_or_else(|| Path::new(""));
-    let stem = first_candidate
-        .file_stem()
-        .map(|stem| stem.to_string_lossy().to_string())
-        .unwrap_or_else(|| String::from("sample"));
-    let extension = first_candidate
-        .extension()
-        .map(|extension| extension.to_string_lossy().to_string());
-    for count in 1.. {
-        let file_name = match &extension {
-            Some(extension) => format!("{stem}_copy{count:03}.{extension}"),
-            None => format!("{stem}_copy{count:03}"),
-        };
-        let candidate = parent.join(file_name);
+    for index in 0.. {
+        let candidate = unique_copy_candidate(first_candidate, index);
         if !candidate.exists() {
             return candidate;
         }
@@ -242,20 +239,8 @@ fn unique_planned_destination(
     if !first_candidate.exists() && planned_destinations.insert(first_candidate.clone()) {
         return first_candidate;
     }
-    let parent = first_candidate.parent().unwrap_or_else(|| Path::new(""));
-    let stem = first_candidate
-        .file_stem()
-        .map(|stem| stem.to_string_lossy().to_string())
-        .unwrap_or_else(|| String::from("sample"));
-    let extension = first_candidate
-        .extension()
-        .map(|extension| extension.to_string_lossy().to_string());
     for count in 1.. {
-        let file_name = match &extension {
-            Some(extension) => format!("{stem}_copy{count:03}.{extension}"),
-            None => format!("{stem}_copy{count:03}"),
-        };
-        let candidate = parent.join(file_name);
+        let candidate = unique_copy_candidate(&first_candidate, count);
         if !candidate.exists() && planned_destinations.insert(candidate.clone()) {
             return candidate;
         }
@@ -266,160 +251,49 @@ fn unique_planned_destination(
 pub(super) fn move_existing_destination_to_backup(
     destination_path: &Path,
 ) -> Result<OverwriteBackup, String> {
-    let backup_path = unique_overwrite_backup_path(destination_path);
-    move_file_with_prefix(destination_path, &backup_path, "File overwrite failed")?;
-    Ok(OverwriteBackup {
-        destination_path: destination_path.to_path_buf(),
-        backup_path,
-    })
+    for count in 1..10_000 {
+        let backup_path = overwrite_backup_path(destination_path, count);
+        match move_file_no_replace(destination_path, &backup_path) {
+            Ok(backup) => {
+                return Ok(OverwriteBackup {
+                    destination_path: destination_path.to_path_buf(),
+                    backup,
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(format!("File overwrite failed: {error}")),
+        }
+    }
+    Err(String::from(
+        "File overwrite failed: could not reserve a backup path",
+    ))
 }
 
 pub(super) fn move_file_over_backup(
     source_path: &Path,
     destination_path: &Path,
 ) -> Result<(), String> {
-    move_file_with_prefix(source_path, destination_path, "File overwrite failed")
+    move_file_with_prefix(source_path, destination_path, "File overwrite failed").map(|_| ())
 }
 
 pub(super) fn restore_overwrite_backup(backup: &OverwriteBackup) {
-    let _ = move_file(&backup.backup_path, &backup.destination_path);
+    let _ = backup.backup.move_back_if_owned(&backup.destination_path);
 }
 
 pub(super) fn remove_overwrite_backup(backup: &OverwriteBackup) {
-    let _ = fs::remove_file(&backup.backup_path);
+    let _ = backup.backup.remove_if_owned();
 }
 
-fn unique_overwrite_backup_path(destination_path: &Path) -> PathBuf {
+fn overwrite_backup_path(destination_path: &Path, count: usize) -> PathBuf {
     let parent = destination_path.parent().unwrap_or_else(|| Path::new(""));
     let file_name = destination_path
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| String::from("file"));
-    for count in 1.. {
-        let candidate = parent.join(format!(
-            ".wavecrate-overwrite-backup-{count:03}-{file_name}"
-        ));
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    unreachable!("unbounded backup suffix search should find a destination")
+    parent.join(format!(
+        ".wavecrate-overwrite-backup-{count:03}-{file_name}"
+    ))
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn temp_dir(name: &str) -> PathBuf {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock before epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("{name}-{suffix}"));
-        fs::create_dir_all(&dir).expect("create temp dir");
-        dir
-    }
-
-    #[test]
-    fn file_move_plan_deduplicates_ready_paths_and_reports_conflicts() {
-        let root = temp_dir("wavecrate-file-move-plan");
-        let source = root.join("source");
-        let target = root.join("target");
-        fs::create_dir_all(&source).expect("create source");
-        fs::create_dir_all(&target).expect("create target");
-        let ready = source.join("ready.wav");
-        let conflict = source.join("conflict.wav");
-        let existing = target.join("conflict.wav");
-        fs::write(&ready, b"ready").expect("write ready");
-        fs::write(&conflict, b"source").expect("write conflict source");
-        fs::write(&existing, b"existing").expect("write conflict destination");
-
-        let plan = file_move_plan_to_folder(
-            &root,
-            &root,
-            &[
-                ready.display().to_string(),
-                ready.display().to_string(),
-                conflict.display().to_string(),
-            ],
-            &target,
-            true,
-        )
-        .expect("plan file moves");
-
-        assert_eq!(
-            plan.ready,
-            vec![FileTransfer::move_file(
-                ready.clone(),
-                target.join("ready.wav")
-            )]
-        );
-        assert_eq!(
-            plan.conflicts,
-            vec![FileMoveConflict {
-                source_root: root.clone(),
-                source_database_root: root.clone(),
-                source_path: conflict,
-                destination_path: existing,
-                destination_protected: true,
-            }]
-        );
-        let _ = fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn rename_files_with_rollback_restores_completed_moves_after_later_failure() {
-        let root = temp_dir("wavecrate-file-move-rollback");
-        let source = root.join("source");
-        let target = root.join("target");
-        fs::create_dir_all(&source).expect("create source");
-        fs::create_dir_all(&target).expect("create target");
-        let first_source = source.join("first.wav");
-        let second_source = source.join("second.wav");
-        let first_destination = target.join("first.wav");
-        let missing_destination = root.join("missing-parent").join("second.wav");
-        fs::write(&first_source, b"first").expect("write first");
-        fs::write(&second_source, b"second").expect("write second");
-
-        let result = rename_files_with_rollback(&[
-            (first_source.clone(), first_destination.clone()),
-            (second_source.clone(), missing_destination),
-        ]);
-
-        assert!(result.is_err());
-        assert_eq!(
-            fs::read(&first_source).expect("read first source"),
-            b"first"
-        );
-        assert!(!first_destination.exists());
-        assert_eq!(
-            fs::read(&second_source).expect("read second source"),
-            b"second"
-        );
-        let _ = fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn move_file_to_unique_destination_renames_conflicting_extracted_file() {
-        let root = temp_dir("wavecrate-file-move-unique-extracted");
-        let source = root.join("source");
-        let target = root.join("target");
-        fs::create_dir_all(&source).expect("create source");
-        fs::create_dir_all(&target).expect("create target");
-        let extracted = source.join("loop.wav");
-        let existing = target.join("loop.wav");
-        fs::write(&extracted, b"extracted").expect("write extracted");
-        fs::write(&existing, b"existing").expect("write existing");
-
-        let moved = move_file_to_unique_destination(&extracted, &target, "Extraction move failed")
-            .expect("move extracted file");
-
-        let renamed = target.join("loop_copy001.wav");
-        assert_eq!(moved, (extracted.clone(), renamed.clone()));
-        assert!(!extracted.exists());
-        assert_eq!(fs::read(existing).expect("read existing"), b"existing");
-        assert_eq!(fs::read(renamed).expect("read renamed"), b"extracted");
-        let _ = fs::remove_dir_all(root);
-    }
-}
+mod tests;

--- a/src/native_app/sample_library/folder_browser/file_move_transaction/tests.rs
+++ b/src/native_app/sample_library/folder_browser/file_move_transaction/tests.rs
@@ -1,0 +1,221 @@
+use super::*;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn file_move_plan_deduplicates_ready_paths_and_reports_conflicts() {
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&target).unwrap();
+    let ready = source.join("ready.wav");
+    let conflict = source.join("conflict.wav");
+    let existing = target.join("conflict.wav");
+    fs::write(&ready, b"ready").unwrap();
+    fs::write(&conflict, b"source").unwrap();
+    fs::write(&existing, b"existing").unwrap();
+
+    let plan = file_move_plan_to_folder(
+        root.path(),
+        root.path(),
+        &[
+            ready.display().to_string(),
+            ready.display().to_string(),
+            conflict.display().to_string(),
+        ],
+        &target,
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(
+        plan.ready,
+        vec![FileTransfer::move_file(
+            ready.clone(),
+            target.join("ready.wav")
+        )]
+    );
+    assert_eq!(
+        plan.conflicts,
+        vec![FileMoveConflict {
+            source_root: root.path().to_path_buf(),
+            source_database_root: root.path().to_path_buf(),
+            source_path: conflict,
+            destination_path: existing,
+            destination_protected: true,
+        }]
+    );
+}
+
+#[test]
+fn planned_move_rejects_a_destination_created_before_commit() {
+    let root = tempdir().unwrap();
+    let source_folder = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir(&source_folder).unwrap();
+    fs::create_dir(&target).unwrap();
+    let source = source_folder.join("kick.wav");
+    let destination = target.join("kick.wav");
+    fs::write(&source, b"source").unwrap();
+    let plan = file_move_plan_to_folder(
+        root.path(),
+        root.path(),
+        &[source.display().to_string()],
+        &target,
+        false,
+    )
+    .unwrap();
+    fs::write(&destination, b"late owner").unwrap();
+
+    let error = transfer_files_with_rollback_and_progress(&plan.ready, |_, _| {}).unwrap_err();
+
+    assert!(error.contains("File move failed"));
+    assert_eq!(fs::read(source).unwrap(), b"source");
+    assert_eq!(fs::read(destination).unwrap(), b"late owner");
+}
+
+#[test]
+fn planned_copy_retries_a_destination_created_before_commit() {
+    let root = tempdir().unwrap();
+    let source_folder = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir(&source_folder).unwrap();
+    fs::create_dir(&target).unwrap();
+    let source = source_folder.join("kick.wav");
+    let destination = target.join("kick.wav");
+    fs::write(&source, b"source").unwrap();
+    let plan = file_move_items_plan_to_folder(
+        &[FileMoveItem {
+            source_root: root.path().to_path_buf(),
+            source_database_root: root.path().to_path_buf(),
+            file_id: source.display().to_string(),
+            copy_only: true,
+        }],
+        &target,
+        false,
+    )
+    .unwrap();
+    fs::write(&destination, b"late owner").unwrap();
+
+    let completed = transfer_files_with_rollback_and_progress(&plan.ready, |_, _| {}).unwrap();
+
+    let copied = target.join("kick_copy001.wav");
+    assert_eq!(completed, vec![(source.clone(), copied.clone())]);
+    assert_eq!(fs::read(source).unwrap(), b"source");
+    assert_eq!(fs::read(destination).unwrap(), b"late owner");
+    assert_eq!(fs::read(copied).unwrap(), b"source");
+}
+
+#[test]
+fn planned_numbered_copy_continues_the_original_suffix_sequence() {
+    let root = tempdir().unwrap();
+    let source_folder = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir(&source_folder).unwrap();
+    fs::create_dir(&target).unwrap();
+    let source = source_folder.join("kick.wav");
+    let direct_destination = target.join("kick.wav");
+    let planned_destination = target.join("kick_copy001.wav");
+    fs::write(&source, b"source").unwrap();
+    fs::write(&direct_destination, b"existing").unwrap();
+    let plan = file_move_items_plan_to_folder(
+        &[FileMoveItem {
+            source_root: root.path().to_path_buf(),
+            source_database_root: root.path().to_path_buf(),
+            file_id: source.display().to_string(),
+            copy_only: true,
+        }],
+        &target,
+        false,
+    )
+    .unwrap();
+    assert_eq!(plan.ready[0].destination_path, planned_destination);
+    fs::write(&planned_destination, b"late owner").unwrap();
+
+    let completed = transfer_files_with_rollback_and_progress(&plan.ready, |_, _| {}).unwrap();
+
+    let copied = target.join("kick_copy002.wav");
+    assert_eq!(completed, vec![(source, copied.clone())]);
+    assert_eq!(fs::read(direct_destination).unwrap(), b"existing");
+    assert_eq!(fs::read(planned_destination).unwrap(), b"late owner");
+    assert_eq!(fs::read(copied).unwrap(), b"source");
+}
+
+#[test]
+fn rename_files_with_rollback_restores_completed_moves_after_later_failure() {
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&target).unwrap();
+    let first_source = source.join("first.wav");
+    let second_source = source.join("second.wav");
+    let first_destination = target.join("first.wav");
+    let missing_destination = root.path().join("missing-parent").join("second.wav");
+    fs::write(&first_source, b"first").unwrap();
+    fs::write(&second_source, b"second").unwrap();
+
+    let result = rename_files_with_rollback(&[
+        (first_source.clone(), first_destination.clone()),
+        (second_source.clone(), missing_destination),
+    ]);
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(&first_source).unwrap(), b"first");
+    assert!(!first_destination.exists());
+    assert_eq!(fs::read(&second_source).unwrap(), b"second");
+}
+
+#[test]
+fn rollback_restores_source_without_touching_a_replaced_destination() {
+    let root = tempdir().unwrap();
+    let source_folder = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir(&source_folder).unwrap();
+    fs::create_dir(&target).unwrap();
+    let first_source = source_folder.join("first.wav");
+    let second_source = source_folder.join("second.wav");
+    let first_destination = target.join("first.wav");
+    let missing_destination = root.path().join("missing-parent").join("second.wav");
+    fs::write(&first_source, b"first").unwrap();
+    fs::write(&second_source, b"second").unwrap();
+    let transfers = [
+        FileTransfer::move_file(first_source.clone(), first_destination.clone()),
+        FileTransfer::move_file(second_source.clone(), missing_destination),
+    ];
+
+    let result = transfer_files_with_rollback_and_progress(&transfers, |completed, path| {
+        if completed == 1 {
+            fs::remove_file(path).unwrap();
+            fs::write(path, b"replacement").unwrap();
+        }
+    });
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(first_source).unwrap(), b"first");
+    assert_eq!(fs::read(first_destination).unwrap(), b"replacement");
+    assert_eq!(fs::read(second_source).unwrap(), b"second");
+}
+
+#[test]
+fn move_file_to_unique_destination_renames_conflicting_extracted_file() {
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let target = root.path().join("target");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&target).unwrap();
+    let extracted = source.join("loop.wav");
+    let existing = target.join("loop.wav");
+    fs::write(&extracted, b"extracted").unwrap();
+    fs::write(&existing, b"existing").unwrap();
+
+    let moved = move_file_to_unique_destination(&extracted, &target, "Extraction move failed")
+        .expect("move extracted file");
+
+    let renamed = target.join("loop_copy001.wav");
+    assert_eq!(moved, (extracted.clone(), renamed.clone()));
+    assert!(!extracted.exists());
+    assert_eq!(fs::read(existing).unwrap(), b"existing");
+    assert_eq!(fs::read(renamed).unwrap(), b"extracted");
+}

--- a/src/native_app/sample_library/native_file_drop_actions.rs
+++ b/src/native_app/sample_library/native_file_drop_actions.rs
@@ -11,6 +11,7 @@ use crate::native_app::app::{GuiMessage, NativeAppState, NativeFileDropHover, em
 use crate::native_app::sample_library::committed_file_mutations::{
     FileMutationChange, FileMutationOperation, FileMutationProjection,
 };
+use crate::native_app::sample_library::exclusive_file_transfer::copy_file_to_unique_destination_with;
 
 impl NativeAppState {
     pub(in crate::native_app) fn apply_native_file_drop(
@@ -238,34 +239,17 @@ fn file_name_or_path(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-fn unique_copy_destination(first_candidate: &Path) -> PathBuf {
-    if !first_candidate.exists() {
-        return first_candidate.to_path_buf();
-    }
-    let parent = first_candidate.parent().unwrap_or_else(|| Path::new(""));
-    let stem = first_candidate
-        .file_stem()
-        .map(|stem| stem.to_string_lossy().to_string())
-        .unwrap_or_else(|| String::from("sample"));
-    let extension = first_candidate
-        .extension()
-        .map(|extension| extension.to_string_lossy().to_string());
-    for count in 1.. {
-        let file_name = match &extension {
-            Some(extension) => format!("{stem}_copy{count:03}.{extension}"),
-            None => format!("{stem}_copy{count:03}"),
-        };
-        let candidate = parent.join(file_name);
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    unreachable!("unbounded copy suffix search should find a destination")
-}
-
 fn execute_external_waveform_file_drop(
     source: &Path,
     target_folder: &Path,
+) -> Result<PathBuf, String> {
+    execute_external_waveform_file_drop_with(source, target_folder, |_, _| {})
+}
+
+fn execute_external_waveform_file_drop_with(
+    source: &Path,
+    target_folder: &Path,
+    before_publish: impl FnMut(usize, &Path),
 ) -> Result<PathBuf, String> {
     if !source.is_file() {
         return Err(format!("not a file: {}", source.display()));
@@ -283,15 +267,15 @@ fn execute_external_waveform_file_drop(
     if paths_refer_to_same_file(source, &direct_target) {
         return Err(String::from("drop target unchanged"));
     }
-    let target = unique_copy_destination(&direct_target);
-    fs::copy(source, &target).map_err(|err| {
-        format!(
-            "failed to copy {} to {}: {err}",
-            source.display(),
-            target.display()
-        )
-    })?;
-    Ok(target)
+    let committed = copy_file_to_unique_destination_with(source, &direct_target, before_publish)
+        .map_err(|err| {
+            format!(
+                "failed to copy {} into {}: {err}",
+                source.display(),
+                target_folder.display()
+            )
+        })?;
+    Ok(committed.path().to_path_buf())
 }
 
 fn paths_refer_to_same_file(left: &Path, right: &Path) -> bool {
@@ -310,5 +294,33 @@ mod tests {
         assert!(supported_waveform_drop_file(Path::new("kick.wav")));
         assert!(!supported_waveform_drop_file(Path::new("._kick.wav")));
         assert!(!supported_waveform_drop_file(Path::new("drums/._kick.wav")));
+    }
+
+    #[test]
+    fn external_drop_retries_a_destination_created_before_commit() {
+        let root = tempfile::tempdir().unwrap();
+        let source_folder = root.path().join("external");
+        let target_folder = root.path().join("target");
+        fs::create_dir(&source_folder).unwrap();
+        fs::create_dir(&target_folder).unwrap();
+        let source = source_folder.join("kick.wav");
+        let direct_target = target_folder.join("kick.wav");
+        fs::write(&source, b"source").unwrap();
+
+        let copied = execute_external_waveform_file_drop_with(
+            &source,
+            &target_folder,
+            |index, candidate| {
+                if index == 0 {
+                    fs::write(candidate, b"late owner").unwrap();
+                }
+            },
+        )
+        .unwrap();
+
+        assert_eq!(copied, target_folder.join("kick_copy001.wav"));
+        assert_eq!(fs::read(direct_target).unwrap(), b"late owner");
+        assert_eq!(fs::read(copied).unwrap(), b"source");
+        assert_eq!(fs::read(source).unwrap(), b"source");
     }
 }

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -792,6 +792,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "waveform clipboard clip staging worker",
         ),
         (
+            "src/native_app/sample_library/exclusive_file_transfer.rs",
+            "exclusive file-transfer worker boundary",
+        ),
+        (
             "src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs",
             "source database filesystem-sync worker",
         ),


### PR DESCRIPTION
## Goal
Prevent files created after transfer planning from being overwritten by native move, copy, conflict-resolution, and external-drop execution.

## Scope
- add a shared exclusive file-transfer primitive with staged no-clobber copy publication and platform no-replace rename
- apply it to folder-browser transfers, unique-name moves, overwrite backups, rollback cleanup, and external waveform drops
- preserve predictable `_copyNNN` allocation while retrying late copy/import collisions
- document the durable no-replace transfer contract and add deterministic race coverage

## Non-goals
- folder-browser redesign
- source-database transaction changes
- unrelated filesystem-operation cleanup

## Definition of Done
- [x] same-filesystem moves cannot replace a late destination
- [x] copy and external-drop commits publish only into an absent destination and retry predictable unique names
- [x] cross-device fallback commits a complete staged copy before source removal and rejects late collisions
- [x] rollback and cleanup act only on transaction-owned destination identities
- [x] deterministic tests inject late destinations for move, copy, fallback, and external-drop paths
- [x] existing conflict and cancellation routing remains intact

## Validation
Passed:
- `cargo test -p wavecrate --lib exclusive_file_transfer -- --nocapture` (10 passed)
- `cargo test -p wavecrate --lib file_move_transaction -- --nocapture` (7 passed)
- `cargo test -p wavecrate --lib native_file_drop_actions -- --nocapture` (2 passed)
- `cargo test -p wavecrate --lib committed_file_mutations -- --nocapture` (14 passed)
- `bash scripts/build.sh --release`
- signed sandbox app launch and isolated source-add smoke

Baseline-blocked on current `main` (unchanged files):
- `bash scripts/ci.sh agent` / `cargo check -p wavecrate --all-targets`: `tests/release_workflow_helpers.rs:936` has an invalid unescaped format-string brace
- agent request preflight: `tests/gui_boundary.rs` reports existing filesystem calls in `src/native_app/waveform_edits/atomic_write.rs`
- strict clippy: existing type-complexity/too-many-arguments findings in wavecrate-library and Radiant
- file-size guard: existing over-budget Radiant `native_file_open.rs` and `runner.rs`

Manual move/copy/rename/drop completion was limited by Radiant macOS activation/window availability after the successful app launch and source add; deterministic filesystem tests above cover the collision states.

## Known limitations
- Windows and Linux platform implementations are source-validated here; this local run exercised macOS.
- The unrelated current-main gate failures listed above prevent a fully green repository-wide lane.

User approval is required before merge.

Linear: OPT-1221


