### PR TITLE
OPT-1199 Keep hotkeys active with job details open

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2300,6 +2300,7 @@ Commands should be routed by focus context:
 - Other global application shortcuts should not fire while a focused text or value editor expects the same key input.
 - Browser-focused commands apply to selected sample rows or folders.
 - Waveform-focused commands apply to the active waveform, play selection, edit selection, cursor, or active waveform mode.
+- Non-modal utility popovers such as job details may own dismissal shortcuts such as Escape, but must pass unrelated application and navigation shortcuts through.
 - Modal dialogs and confirmation prompts own Enter, Escape, arrow keys, Tab, and text input until dismissed.
 
 The command layer should expose enabled, disabled, hidden, pending, and destructive states so the UI can present actions consistently across menus, buttons, tooltips, status text, and keyboard handling.

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -69,10 +69,7 @@ pub(in crate::native_app) fn default_gui_shortcuts(
             state.ui.chrome.harvest_filter_dropdown_open,
             ui::ShortcutLayer::modal_escape(GuiMessage::CloseHarvestFilterDropdown),
         )
-        .layer_when(
-            state.ui.chrome.job_details_open,
-            ui::ShortcutLayer::modal_escape(GuiMessage::CloseJobDetails),
-        )
+        .layer_when(state.ui.chrome.job_details_open, job_details_shortcuts())
         .layer_when(
             state.ui.chrome.transaction_list_open,
             ui::ShortcutLayer::modal_escape(GuiMessage::CloseTransactionList),
@@ -91,6 +88,13 @@ pub(in crate::native_app) fn default_gui_shortcuts(
         )
         .layer(default_shortcuts(state))
         .fallback(navigation_shortcut)
+}
+
+fn job_details_shortcuts() -> ui::ShortcutLayer<GuiMessage> {
+    ui::ShortcutLayer::new().bind(
+        ui::KeyPress::new(ui::KeyCode::Escape),
+        GuiMessage::CloseJobDetails,
+    )
 }
 
 fn shortcut_help_modal_shortcuts() -> ui::ShortcutLayer<GuiMessage> {

--- a/src/native_app/tests/shortcuts_context.rs
+++ b/src/native_app/tests/shortcuts_context.rs
@@ -2,6 +2,7 @@ mod context_menu;
 mod folder_browser;
 mod handoff;
 mod help;
+mod jobs;
 mod metadata;
 mod settings;
 mod shell;

--- a/src/native_app/tests/shortcuts_context/jobs.rs
+++ b/src/native_app/tests/shortcuts_context/jobs.rs
@@ -1,0 +1,50 @@
+use crate::native_app::test_support::state::{GuiMessage, NativeAppState, default_gui_shortcuts};
+use radiant::prelude as ui;
+
+fn state_with_job_details_open() -> NativeAppState {
+    let mut state = NativeAppState::load_default().expect("default state loads");
+    state.ui.chrome.job_details_open = true;
+    state
+}
+
+#[test]
+fn job_details_escape_shortcut_closes_the_popover() {
+    let state = state_with_job_details_open();
+
+    let resolution = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Escape));
+
+    assert_eq!(resolution.action, Some(GuiMessage::CloseJobDetails));
+    assert!(resolution.handled);
+}
+
+#[test]
+fn job_details_popover_keeps_default_shortcuts_active() {
+    let state = state_with_job_details_open();
+
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::CloseBracket));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::AdjustSelectedRatingWithoutAdvance(1))
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn job_details_popover_keeps_navigation_shortcuts_active() {
+    let state = state_with_job_details_open();
+
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowDown));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::NavigateBrowser {
+            delta: 1,
+            extend: false,
+            preserve_selection: false,
+        })
+    );
+    assert!(resolution.handled);
+}


### PR DESCRIPTION
## Goal
Keep Wavecrate keyboard shortcuts working while the non-modal background-job details popover is open.

## Scope
- replace the job-details modal shortcut layer with a non-modal Escape binding
- preserve Escape-to-close while allowing default application and browser-navigation shortcuts to continue through the catalog
- add focused regression coverage for dismissal, rating, and navigation shortcuts
- document the durable non-modal popover shortcut contract

## Non-goals
- changing true modal behavior such as the transaction list or confirmation dialogs
- changing focused text/value-editor shortcut ownership
- redesigning the job-details popover or background-job model

## Definition of Done
- [x] opening job details no longer consumes unrelated global/default shortcuts
- [x] browser navigation shortcuts continue to resolve while job details is open
- [x] Escape still closes job details
- [x] true modal shortcut layers remain unchanged
- [x] focused regression tests cover the affected routing

## Validation
Passed:
- `CARGO_TARGET_DIR=target/opt1199 cargo test -p wavecrate shortcuts_context --lib` (82 passed)
- `bash scripts/build.sh --release --variant OPT-1199`
- `git diff --check`

Baseline-blocked on current `main` (unchanged file):
- `bash scripts/ci.sh smoke`
- `bash scripts/ci.sh agent`
- both stop in `tests/release_workflow_helpers.rs:936` because an existing generated Python dictionary literal is embedded in a Rust format string without escaping its opening brace

The signed app launched in an isolated sandbox, but Radiant did not reveal the prepared macOS window and logged `radiant.window.activation.confirmation-timeout`; Computer Use could not attach before a visible window existed. The deterministic catalog tests cover the reported shortcut-routing failure.

## Known limitations
- Manual in-app interaction could not be completed because of the existing macOS Radiant activation/window-availability issue.
- The unrelated current-main format-string failure prevents a green repository-wide lane.

User approval is required before merge.

Linear: OPT-1199
