### PR TITLE
Refresh sources when Wavecrate regains focus

### DIFF
--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -282,9 +282,19 @@ impl GuiSourceWatcherHandle {
             });
     }
 
+    /// Request an authoritative reconciliation for every configured source.
+    ///
+    /// This only enqueues coordinator work; filesystem and database access remain on the
+    /// existing background refresh pipeline.
+    pub(in crate::native_app) fn request_full_reconciliation(&self) {
+        let _ = self
+            .command_tx
+            .send(GuiSourceWatchCommand::ReconcileAllSources);
+    }
+
     #[cfg(test)]
     pub(in crate::native_app) fn force_overflow_for_tests(&self) {
-        let _ = self.command_tx.send(GuiSourceWatchCommand::ForceOverflow);
+        self.request_full_reconciliation();
     }
 
     #[cfg(test)]
@@ -337,13 +347,12 @@ impl Drop for GuiSourceWatcherHandle {
 #[derive(Debug)]
 enum GuiSourceWatchCommand {
     ReplaceSources(Vec<SampleSource>),
+    ReconcileAllSources,
     AcknowledgeCommittedPaths {
         source_id: String,
         echoes: Vec<CommittedWatcherEcho>,
         operation_id: u64,
     },
-    #[cfg(test)]
-    ForceOverflow,
     #[cfg(test)]
     ForceRestart,
     #[cfg(test)]
@@ -406,8 +415,7 @@ fn run_source_watcher(
                     Instant::now(),
                 );
             }
-            #[cfg(test)]
-            Ok(GuiSourceWatchCommand::ForceOverflow) => {
+            Ok(GuiSourceWatchCommand::ReconcileAllSources) => {
                 state.mark_all_overflowed(Instant::now());
             }
             #[cfg(test)]

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -535,6 +535,60 @@ fn watcher_restart_marks_every_source_for_authoritative_refresh() {
 }
 
 #[test]
+fn foreground_reconciliation_request_refreshes_every_configured_source() {
+    let first_root = tempfile::tempdir().expect("first watched source root");
+    let second_root = tempfile::tempdir().expect("second watched source root");
+    let first = SampleSource::new_with_id(
+        SourceId::from_string("source_id::foreground-first"),
+        first_root.path().to_path_buf(),
+    );
+    let second = SampleSource::new_with_id(
+        SourceId::from_string("source_id::foreground-second"),
+        second_root.path().to_path_buf(),
+    );
+    let expected_source_ids = [
+        first.id.as_str().to_string(),
+        second.id.as_str().to_string(),
+    ];
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let watcher = GuiSourceWatcherHandle::spawn(vec![first, second], sender);
+    watcher.wait_until_ready_for_tests();
+    while !matches!(
+        receiver
+            .recv_timeout(super::WATCHER_START_TIMEOUT)
+            .expect("watcher-ready message"),
+        GuiMessage::SourceWatcherReady
+    ) {}
+
+    watcher.request_full_reconciliation();
+
+    let deadline = Instant::now()
+        + super::SOURCE_CHANGE_DEBOUNCE
+        + super::WATCHER_POLL_INTERVAL.saturating_mul(4);
+    let mut refreshed_source_ids = Vec::new();
+    while refreshed_source_ids.len() < expected_source_ids.len() {
+        let message = receiver
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .expect("foreground reconciliation event");
+        if let GuiMessage::SourceFilesystemChanged {
+            source_id,
+            paths,
+            overflowed,
+            source_root_available,
+        } = message
+        {
+            assert!(paths.is_empty());
+            assert!(overflowed);
+            assert!(source_root_available);
+            refreshed_source_ids.push(source_id);
+        }
+    }
+    refreshed_source_ids.sort();
+
+    assert_eq!(refreshed_source_ids, expected_source_ids);
+}
+
+#[test]
 fn watcher_restart_backoff_is_bounded() {
     assert_eq!(
         doubled_backoff(super::WATCHER_RESTART_MIN),

--- a/src/native_app/shell/launch/radiant_runtime.rs
+++ b/src/native_app/shell/launch/radiant_runtime.rs
@@ -25,6 +25,9 @@ pub(in crate::native_app) fn native_app_runtime_bridge(
         .view(view)
         .subscriptions(NativeAppState::worker_subscription)
         .auxiliary_windows(settings::auxiliary_windows)
+        .on_native_focus_regained(|state, _context| {
+            state.reconcile_sources_after_focus_regained();
+        })
         .on_native_file_open(|state, open, context| {
             state.open_audio_documents(open.paths, context);
         });

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -159,6 +159,12 @@ impl NativeAppState {
         }
     }
 
+    pub(in crate::native_app) fn reconcile_sources_after_focus_regained(&self) {
+        if let Some(watcher) = self.library.source_watcher.as_ref() {
+            watcher.request_full_reconciliation();
+        }
+    }
+
     pub(in crate::native_app) fn persist_user_configuration(
         &mut self,
         action: &'static str,


### PR DESCRIPTION
## Goal

Reflect external file deletes and moves as soon as Wavecrate returns to the foreground, without requiring the user to click the affected source.

Closes OPT-1192.

## Scope

- Register Wavecrate for Radiant's native focus-regained lifecycle hook.
- Enqueue one authoritative reconciliation request for every configured source after an observed focus loss→regain transition.
- Reuse the source-watcher coordinator's debounce, overflow/full-refresh delivery, source-generation fencing, and background source-processing pipeline.
- Add a two-source regression proving both selected and non-selected sources receive full-refresh events.
- Pin merged Radiant PR [#1426](https://github.com/PORTALSURFER/radiant/pull/1426) at canonical commit `3d7350e23cf9321700a77b29db8a1e9909fccb9b`.

Non-goals: replacing the native watcher, polling while Wavecrate is unfocused, changing source selection, or performing filesystem/database work on the UI thread.

## Definition of Done

- A native focus loss→regain transition requests reconciliation for all configured sources.
- Initial application focus does not synthesize a redundant foreground reconciliation.
- Late external deletes/moves converge through the existing background refresh path without a source click.
- The focus callback only sends a coordinator command and performs no direct filesystem/database work.
- Existing watcher and source-processing liveness behavior remains intact.

## Validation

- Radiant `cargo test native_focus_` — passed (2 tests)
- Radiant `cargo test --lib` — passed (1665 tests)
- Canonical repin verification: reviewed `dc0480be` and merged `3d7350e2` have identical tree `25fa1adf3289d80bc374d9443181d6a7db623828` and an empty diff
- `cargo test -p wavecrate --lib foreground_reconciliation_request_refreshes_every_configured_source` — passed
- `cargo test -p wavecrate --lib source_watcher` — passed (43 tests)
- `cargo test -p wavecrate --lib native_app::tests::window_chrome::app_bridge` — passed (4 tests)
- `cargo test -p wavecrate --lib source_processing_liveness_harness_converges_restart_churn_and_root_recovery -- --ignored` — passed
- `bash scripts/build.sh --release` — passed; signed `Wavecrate OPT-1192.app` produced
- Native launch/focus smoke — signed app launched and revealed after a user-driven Spotlight activation; source mutation smoke was not completed because Computer Use lost the native window during isolated-source setup
- `bash scripts/ci.sh agent` — blocked by the pre-existing invalid format string at `tests/release_workflow_helpers.rs:936`; Radiant checks pass before that failure

## Known limitations

None.

User approval is required before merge.

