### PR TITLE
Add keyboard navigation for focused sources

### DIFF
--- a/src/native_app/sample_library/folder_browser/collections/focus.rs
+++ b/src/native_app/sample_library/folder_browser/collections/focus.rs
@@ -7,6 +7,7 @@ impl FolderBrowserState {
         &mut self,
         collection: SampleCollection,
     ) {
+        self.clear_source_keyboard_focus();
         if self.selection.selected_collection != Some(collection) {
             self.collection_panel.rename_edit = None;
             self.selection.enter_collection(collection);

--- a/src/native_app/sample_library/folder_browser/file_selection/cross_source_focus.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/cross_source_focus.rs
@@ -78,6 +78,7 @@ impl FolderBrowserState {
         if let Some((tags_by_file, reason)) = tags_by_file {
             self.reveal_selected_file_if_hidden(tags_by_file, reason);
         }
+        self.clear_source_keyboard_focus();
         true
     }
 
@@ -95,6 +96,7 @@ impl FolderBrowserState {
         }
         self.cancel_rename();
         self.selection.set_focus_file_set(file_id.to_owned());
+        self.clear_source_keyboard_focus();
         true
     }
 
@@ -118,6 +120,7 @@ impl FolderBrowserState {
             .any(|id| id == file_id);
         if visible {
             self.cancel_rename();
+            self.clear_source_keyboard_focus();
             return true;
         }
 

--- a/src/native_app/sample_library/folder_browser/file_selection/selection_mutation.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection/selection_mutation.rs
@@ -10,6 +10,7 @@ impl FolderBrowserState {
         let file_ids = self.selected_audio_file_ids();
         if file_ids.contains(&id) {
             self.cancel_rename();
+            self.clear_source_keyboard_focus();
             self.selection.select_single_file(id, &file_ids);
         }
     }
@@ -25,6 +26,7 @@ impl FolderBrowserState {
             return;
         }
         self.cancel_rename();
+        self.clear_source_keyboard_focus();
         self.selection
             .select_file_with_modifiers(id, &file_ids, modifiers);
     }
@@ -40,6 +42,7 @@ impl FolderBrowserState {
             return;
         }
         self.cancel_rename();
+        self.clear_source_keyboard_focus();
         self.selection
             .select_file_with_modifiers(id, &file_ids, modifiers);
     }
@@ -49,13 +52,19 @@ impl FolderBrowserState {
             return;
         }
         self.cancel_rename();
-        self.selection.select_known_single_file(id);
+        if self.selection.select_known_single_file(id) {
+            self.clear_source_keyboard_focus();
+        }
     }
 
     pub(in crate::native_app) fn focus_file_preserving_selection(&mut self, id: String) {
         let file_ids = self.selected_audio_file_ids();
-        self.selection
-            .focus_file_preserving_selection(id, &file_ids);
+        if self
+            .selection
+            .focus_file_preserving_selection(id, &file_ids)
+        {
+            self.clear_source_keyboard_focus();
+        }
     }
 
     pub(in crate::native_app) fn focus_file_preserving_selection_matching_tags(
@@ -64,8 +73,12 @@ impl FolderBrowserState {
         tags_by_file: &HashMap<String, Vec<String>>,
     ) {
         let file_ids = self.selected_audio_file_ids_matching_tags(tags_by_file);
-        self.selection
-            .focus_file_preserving_selection(id, &file_ids);
+        if self
+            .selection
+            .focus_file_preserving_selection(id, &file_ids)
+        {
+            self.clear_source_keyboard_focus();
+        }
     }
 
     #[cfg(test)]
@@ -111,7 +124,11 @@ impl FolderBrowserState {
     }
 
     fn select_audio_file_ids(&mut self, ids: Vec<String>) -> usize {
-        self.selection.select_all_files(ids)
+        let count = self.selection.select_all_files(ids);
+        if count > 0 {
+            self.clear_source_keyboard_focus();
+        }
+        count
     }
 
     fn focus_first_active_collection_file_matching_tags(

--- a/src/native_app/sample_library/folder_browser/messages.rs
+++ b/src/native_app/sample_library/folder_browser/messages.rs
@@ -22,6 +22,7 @@ pub(in crate::native_app) enum FilterFamily {
 pub(in crate::native_app) enum FolderBrowserMessage {
     AddSource,
     SelectSource(String),
+    NavigateSource(i32),
     DragSource(String, DragHandleMessage),
     OpenSourceContextMenu(String, Point),
     ActivateFolder(String, PointerModifiers),

--- a/src/native_app/sample_library/folder_browser/source_management/catalog.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/catalog.rs
@@ -12,6 +12,7 @@ use wavecrate::sample_sources::{SampleSource, SourceRole};
 #[derive(Clone, Debug)]
 pub(in crate::native_app::sample_library::folder_browser) struct BrowserSourceState {
     pub(in crate::native_app::sample_library::folder_browser) selected_source: String,
+    pub(in crate::native_app::sample_library::folder_browser) keyboard_focus_active: bool,
     pub(in crate::native_app::sample_library::folder_browser) selected_tree_loaded: bool,
     pub(in crate::native_app::sample_library::folder_browser) sources: Vec<SourceEntry>,
     pub(in crate::native_app::sample_library::folder_browser) reorder_drag:
@@ -26,6 +27,7 @@ impl BrowserSourceState {
     ) -> Self {
         Self {
             selected_source,
+            keyboard_focus_active: false,
             selected_tree_loaded,
             sources,
             reorder_drag: None,
@@ -40,6 +42,41 @@ impl FolderBrowserState {
 
     pub(in crate::native_app) fn selected_source_id(&self) -> &str {
         self.source.selected_source.as_str()
+    }
+
+    pub(in crate::native_app) fn source_keyboard_focus_active(&self) -> bool {
+        self.source.keyboard_focus_active
+    }
+
+    pub(in crate::native_app) fn focus_selected_source_for_keyboard(&mut self) {
+        self.source.keyboard_focus_active = self
+            .source
+            .sources
+            .iter()
+            .any(|source| source.id == self.source.selected_source);
+    }
+
+    pub(in crate::native_app) fn clear_source_keyboard_focus(&mut self) {
+        self.source.keyboard_focus_active = false;
+    }
+
+    pub(in crate::native_app) fn adjacent_source_id(&self, delta: i32) -> Option<String> {
+        if delta == 0 || !self.source.keyboard_focus_active {
+            return None;
+        }
+        let current_index = self
+            .source
+            .sources
+            .iter()
+            .position(|source| source.id == self.source.selected_source)?;
+        let last_index = self.source.sources.len().checked_sub(1)?;
+        let steps = delta.unsigned_abs() as usize;
+        let target_index = if delta.is_negative() {
+            current_index.saturating_sub(steps)
+        } else {
+            current_index.saturating_add(steps).min(last_index)
+        };
+        (target_index != current_index).then(|| self.source.sources[target_index].id.clone())
     }
 
     pub(in crate::native_app) fn source_label(&self, source_id: &str) -> Option<&str> {

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -334,6 +334,7 @@ impl FolderBrowserState {
         match message {
             FolderBrowserMessage::AddSource
             | FolderBrowserMessage::SelectSource(_)
+            | FolderBrowserMessage::NavigateSource(_)
             | FolderBrowserMessage::DragSource(_, _)
             | FolderBrowserMessage::OpenSourceContextMenu(_, _)
             | FolderBrowserMessage::OpenCollectionContextMenu(_, _)

--- a/src/native_app/sample_library/folder_browser/tests/source_management.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_management.rs
@@ -13,6 +13,58 @@ fn deferred_source(
 }
 
 #[test]
+fn source_keyboard_focus_navigates_configured_order_and_clamps_at_edges() {
+    let sources = vec![
+        deferred_source("source-a", wavecrate::sample_sources::SourceRole::Normal),
+        deferred_source("source-b", wavecrate::sample_sources::SourceRole::Normal),
+        deferred_source("source-c", wavecrate::sample_sources::SourceRole::Normal),
+    ];
+    let mut browser = FolderBrowserState::from_sample_sources_deferred(&sources);
+
+    assert!(!browser.source_keyboard_focus_active());
+    assert_eq!(browser.adjacent_source_id(1), None);
+
+    browser.focus_selected_source_for_keyboard();
+    assert!(browser.source_keyboard_focus_active());
+    assert_eq!(browser.adjacent_source_id(-1), None);
+    assert_eq!(browser.adjacent_source_id(1).as_deref(), Some("source-b"));
+    assert!(browser.select_source_without_scan(String::from("source-b")));
+    assert_eq!(browser.adjacent_source_id(-1).as_deref(), Some("source-a"));
+    assert_eq!(browser.adjacent_source_id(1).as_deref(), Some("source-c"));
+    assert!(browser.select_source_without_scan(String::from("source-c")));
+    assert_eq!(browser.adjacent_source_id(1), None);
+}
+
+#[test]
+fn folder_collection_and_file_activation_clear_source_keyboard_focus() {
+    let root = temp_source_root("wavecrate-gui-source-keyboard-focus");
+    let sample = root.join("sample.wav");
+    fs::write(&sample, []).expect("sample file");
+    let sources = vec![wavecrate::sample_sources::SampleSource::new_with_id(
+        wavecrate::sample_sources::SourceId::from_string("source-a"),
+        root.clone(),
+    )];
+    let mut browser = FolderBrowserState::from_sample_sources(&sources);
+
+    browser.focus_selected_source_for_keyboard();
+    browser.activate_folder(path_id(&root));
+    assert!(!browser.source_keyboard_focus_active());
+
+    browser.focus_selected_source_for_keyboard();
+    browser.activate_collection(
+        wavecrate::sample_sources::SampleCollection::new(0).expect("collection"),
+    );
+    assert!(!browser.source_keyboard_focus_active());
+
+    browser.exit_collection_focus();
+    browser.focus_selected_source_for_keyboard();
+    browser.select_file(path_id(&sample));
+    assert!(!browser.source_keyboard_focus_active());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn source_reorder_drag_commits_stable_source_order_without_changing_selection_or_roles() {
     let sources = vec![
         deferred_source("source-a", wavecrate::sample_sources::SourceRole::Primary),

--- a/src/native_app/sample_library/folder_browser/tree_state.rs
+++ b/src/native_app/sample_library/folder_browser/tree_state.rs
@@ -100,6 +100,7 @@ impl FolderBrowserState {
         id: String,
         modifiers: PointerModifiers,
     ) {
+        self.clear_source_keyboard_focus();
         if modifiers.shift || modifiers.command {
             let previous_folder_id = self.selection.selected_folder.clone();
             let visible_ids = self

--- a/src/native_app/sample_library/folder_browser_actions.rs
+++ b/src/native_app/sample_library/folder_browser_actions.rs
@@ -34,6 +34,9 @@ impl NativeAppState {
             FolderBrowserMessage::SelectSource(id) => {
                 self.select_folder_browser_source(id, context)
             }
+            FolderBrowserMessage::NavigateSource(delta) => {
+                self.navigate_folder_browser_source(delta, context)
+            }
             FolderBrowserMessage::DragSource(source_id, message) => {
                 let started_at = std::time::Instant::now();
                 if self.drag_source_row(source_id.clone(), message, context) {

--- a/src/native_app/sample_library/folder_browser_actions/navigation.rs
+++ b/src/native_app/sample_library/folder_browser_actions/navigation.rs
@@ -366,6 +366,7 @@ impl NativeAppState {
     ) {
         let started_at = Instant::now();
         let direction = if delta < 0 { "previous" } else { "next" };
+        self.library.folder_browser.clear_source_keyboard_focus();
         if self
             .library
             .folder_browser

--- a/src/native_app/sample_library/folder_browser_actions/source.rs
+++ b/src/native_app/sample_library/folder_browser_actions/source.rs
@@ -29,6 +29,11 @@ impl NativeAppState {
         self.ui.browser_interaction.context_menu = None;
         let selection_started_at = Instant::now();
         self.select_source(id, context);
+        if self.library.folder_browser.selected_source_id() == source {
+            self.library
+                .folder_browser
+                .focus_selected_source_for_keyboard();
+        }
         log_select_source_phase("select_source", selection_started_at);
         let prep_started_at = Instant::now();
         self.queue_selected_source_prep(
@@ -45,6 +50,17 @@ impl NativeAppState {
             started_at,
             None,
         );
+    }
+
+    pub(super) fn navigate_folder_browser_source(
+        &mut self,
+        delta: i32,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        let Some(source_id) = self.library.folder_browser.adjacent_source_id(delta) else {
+            return;
+        };
+        self.select_folder_browser_source(source_id, context);
     }
 }
 

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -396,6 +396,7 @@ fn folder_browser_profile_label(message: &FolderBrowserMessage) -> &'static str 
     match message {
         FolderBrowserMessage::AddSource => "FolderBrowser::AddSource",
         FolderBrowserMessage::SelectSource(_) => "FolderBrowser::SelectSource",
+        FolderBrowserMessage::NavigateSource(_) => "FolderBrowser::NavigateSource",
         FolderBrowserMessage::DragSource(_, _) => "FolderBrowser::DragSource",
         FolderBrowserMessage::OpenSourceContextMenu(_, _) => "FolderBrowser::OpenSourceContextMenu",
         FolderBrowserMessage::ActivateFolder(_, _) => "FolderBrowser::ActivateFolder",

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -83,11 +83,27 @@ pub(in crate::native_app) fn default_gui_shortcuts(
             selected_metadata_tag_shortcuts(),
         )
         .layer_when(
+            state.library.folder_browser.source_keyboard_focus_active(),
+            source_focus_shortcuts(),
+        )
+        .layer_when(
             state.library.folder_browser.collection_focus_active(),
             collection_focus_shortcuts(),
         )
         .layer(default_shortcuts(state))
         .fallback(navigation_shortcut)
+}
+
+fn source_focus_shortcuts() -> ui::ShortcutLayer<GuiMessage> {
+    ui::ShortcutLayer::new()
+        .bind(
+            ui::KeyPress::new(ui::KeyCode::ArrowUp),
+            GuiMessage::FolderBrowser(FolderBrowserMessage::NavigateSource(-1)),
+        )
+        .bind(
+            ui::KeyPress::new(ui::KeyCode::ArrowDown),
+            GuiMessage::FolderBrowser(FolderBrowserMessage::NavigateSource(1)),
+        )
 }
 
 fn job_details_shortcuts() -> ui::ShortcutLayer<GuiMessage> {

--- a/src/native_app/tests/shortcuts_context/folder_browser.rs
+++ b/src/native_app/tests/shortcuts_context/folder_browser.rs
@@ -113,6 +113,90 @@ fn command_arrow_navigation_preserves_folder_selection() {
 }
 
 #[test]
+fn plain_arrows_navigate_sources_while_a_source_has_keyboard_focus() {
+    let mut state = state_with_deferred_sources();
+    state
+        .library
+        .folder_browser
+        .focus_selected_source_for_keyboard();
+
+    let up = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowUp));
+    let down = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::ArrowDown));
+
+    assert_eq!(
+        up.action,
+        Some(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::NavigateSource(-1)
+        ))
+    );
+    assert_eq!(
+        down.action,
+        Some(GuiMessage::FolderBrowser(
+            FolderBrowserMessage::NavigateSource(1)
+        ))
+    );
+    assert!(up.handled);
+    assert!(down.handled);
+}
+
+#[test]
+fn modified_arrows_keep_existing_browser_navigation_during_source_focus() {
+    let mut state = state_with_deferred_sources();
+    state
+        .library
+        .folder_browser
+        .focus_selected_source_for_keyboard();
+
+    let resolution =
+        default_gui_shortcuts(&state).resolve(ui::KeyPress::with_shift(ui::KeyCode::ArrowDown));
+
+    assert_eq!(
+        resolution.action,
+        Some(GuiMessage::NavigateBrowser {
+            delta: 1,
+            extend: true,
+            preserve_selection: false,
+        })
+    );
+    assert!(resolution.handled);
+}
+
+#[test]
+fn source_arrow_action_selects_the_adjacent_source_through_app_dispatch() {
+    let mut state = state_with_deferred_sources();
+    state
+        .library
+        .folder_browser
+        .focus_selected_source_for_keyboard();
+    let mut context = ui::UiUpdateContext::default();
+
+    state.apply_message(
+        GuiMessage::FolderBrowser(FolderBrowserMessage::NavigateSource(1)),
+        &mut context,
+    );
+
+    assert_eq!(
+        state.library.folder_browser.selected_source_id(),
+        "source-b"
+    );
+    assert!(state.library.folder_browser.source_keyboard_focus_active());
+}
+
+fn state_with_deferred_sources() -> NativeAppState {
+    let roots = tempfile::tempdir().expect("source roots");
+    let sources = ["source-a", "source-b"].map(|id| {
+        wavecrate::sample_sources::SampleSource::new_with_id(
+            wavecrate::sample_sources::SourceId::from_string(id),
+            roots.path().join(id),
+        )
+    });
+    let folder_browser = FolderBrowserState::from_sample_sources_deferred(&sources);
+    NativeAppStateFixture::default()
+        .with_folder_browser(folder_browser)
+        .build()
+}
+
+#[test]
 /// Command-A keeps selecting all visible samples in the normal list browser.
 fn command_a_selects_all_samples_in_list_mode() {
     let (mut state, _source_root) = state_with_two_samples();


### PR DESCRIPTION
## Goal

Let users move between configured sources with plain Up/Down after explicitly activating a source row, without stealing arrow navigation from folders, collections, samples, or the starmap.

Linear: [OPT-1201](https://linear.app/boostnlvp/issue/OPT-1201/add-keyboard-updown-navigation-for-sources-when-a-source-has-user)

## Scope

- Track transient keyboard focus for the selected source.
- Bind plain Up/Down to the previous or next configured source while that focus is active.
- Route keyboard movement through the existing source selection, scan, preparation, and feedback lifecycle.
- Clamp at the first and last source.
- Return focus ownership to the browser when a folder, collection, or sample is activated.
- Preserve the existing modified-arrow browser selection behavior.

Non-goals:

- Source reordering or drag-and-drop changes.
- Wraparound navigation.
- Source scan, cache, or processing policy changes.

## Definition of Done

- Activating a source then pressing Down selects the next configured source; Up selects the previous.
- First/last source boundaries are stable no-ops.
- Modified arrows retain their existing browser-selection behavior.
- Folder, collection, and sample activation end source keyboard focus.
- Source changes continue through the established asynchronous scan/prep path.

## Validation

- `cargo test -p wavecrate --lib source_keyboard -- --nocapture` — 2 passed.
- `cargo test -p wavecrate --lib native_app::tests::shortcuts_context::folder_browser -- --nocapture` — 13 passed.
- `cargo check -p wavecrate --lib` — passed.
- `bash scripts/build.sh --release` — passed; signed `Wavecrate OPT-1201.app` produced.
- Real-app smoke on the signed bundle — passed:
  - click `samples`, Down selects `temp`;
  - Up returns to `samples`;
  - click a folder, then Down navigates the folder tree while `samples` remains selected.
- `bash scripts/ci.sh agent` — blocked before branch tests by the existing invalid format string in `tests/release_workflow_helpers.rs:936`.
- Full serial library survey — 3,786 passed, 53 failed, 24 ignored; failures are existing shared cache/audio fixture and stale facade-contract failures unrelated to this diff.

## Known limitations

The repository-wide agent gate cannot currently complete because of the pre-existing `tests/release_workflow_helpers.rs:936` compile error. No product limitation is known for this change.

User approval is required before merge.