### PR TITLE
OPT-1193: Highlight Primary after protected extraction

### DIFF
--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/rows.rs
@@ -21,6 +21,8 @@ const SOURCE_ROLE_ICON_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 255);
 const SOURCE_PROTECTED_ERROR_ICON_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 69, 54, 255);
 const SOURCE_PROTECTED_ERROR_FILL: ui::Rgba8 = ui::Rgba8::new(255, 69, 54, 145);
 const SOURCE_PROTECTED_ERROR_HOVER_FILL: ui::Rgba8 = ui::Rgba8::new(255, 82, 62, 175);
+const SOURCE_ACCEPTANCE_FILL: ui::Rgba8 = ui::Rgba8::new(76, 217, 100, 92);
+const SOURCE_ACCEPTANCE_HOVER_FILL: ui::Rgba8 = ui::Rgba8::new(86, 227, 110, 122);
 const SOURCE_ROW_OUTLINE_INSET: f32 = 0.5;
 const SOURCE_ROW_OUTLINE_WIDTH: f32 = 1.0;
 const SOURCE_ROW_OUTLINE_COLOR: ui::Rgba8 = ui::Rgba8::new(255, 255, 255, 30);
@@ -56,7 +58,12 @@ pub(super) fn source_row(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
             RETAINED_SOURCE_ROW_INPUT_SCOPE,
             retained_source_row_key(source.id.as_str()),
         )
-        .selected(source.selected || source.processing || source.protected_source_error_flash)
+        .selected(
+            source.selected
+                || source.processing
+                || source.protected_source_error_flash
+                || source.primary_source_acceptance_flash,
+        )
         .leading_marker_if(source.processing, source_processing_marker())
         .outline(source_row_outline());
     let row = if source.reorder_enabled {
@@ -71,6 +78,8 @@ pub(super) fn source_row(source: &SourceRowViewModel) -> ui::View<GuiMessage> {
         row.dense_chrome_palette(source_protected_error_palette())
     } else if source.processing {
         row.dense_chrome_palette(source_processing_palette())
+    } else if source.primary_source_acceptance_flash {
+        row.dense_chrome_palette(source_acceptance_palette())
     } else {
         row
     };
@@ -241,6 +250,13 @@ fn source_protected_error_palette() -> ui::DenseRowPalette {
         )
 }
 
+fn source_acceptance_palette() -> ui::DenseRowPalette {
+    ui::DenseRowPalette::new()
+        .selected(SOURCE_ACCEPTANCE_FILL)
+        .selected_hovered(SOURCE_ACCEPTANCE_HOVER_FILL)
+        .interaction_fills(SOURCE_ACCEPTANCE_HOVER_FILL, SOURCE_ACCEPTANCE_HOVER_FILL)
+}
+
 pub(super) fn source_missing_color() -> ui::Rgba8 {
     SOURCE_MISSING_COLOR
 }
@@ -280,6 +296,11 @@ pub(super) fn source_processing_marker_color_for_tests() -> ui::Rgba8 {
 #[cfg(test)]
 pub(super) fn source_processing_fill_for_tests() -> ui::Rgba8 {
     SOURCE_PROCESSING_MARKER_COLOR.with_alpha(SOURCE_PROCESSING_FILL_ALPHA)
+}
+
+#[cfg(test)]
+pub(super) fn source_acceptance_fill_for_tests() -> ui::Rgba8 {
+    SOURCE_ACCEPTANCE_FILL
 }
 
 #[cfg(test)]

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -21,6 +21,7 @@ use crate::native_app::sample_library::folder_browser::{FolderBrowserState, mode
 use radiant::prelude as ui;
 use radiant::prelude::IntoView;
 use radiant::widgets::ButtonMessage;
+use std::time::{Duration, Instant};
 use wavecrate::sample_sources::SourceRole;
 
 fn test_source(id: &str) -> SourceEntry {
@@ -401,7 +402,8 @@ fn primary_source_acceptance_flash_projects_paints_and_expires_after_one_second(
         primary.id.clone(),
     );
 
-    state.flash_primary_source_acceptance();
+    let started_at = Instant::now();
+    state.set_primary_source_acceptance_flash_time_for_tests(started_at);
     let model = SourceSelectorViewModel::from_folder_browser(&state, false);
     let primary_row = model
         .rows
@@ -425,20 +427,26 @@ fn primary_source_acceptance_flash_projects_paints_and_expires_after_one_second(
             .any(|fill| fill.color == source_acceptance_fill_for_tests()),
         "accepted extraction should tint the Primary source row green"
     );
-    assert_eq!(state.primary_source_acceptance_flash_frames(), 60);
+    assert!(state.primary_source_acceptance_flash_active_at_for_tests(
+        started_at + Duration::from_millis(999)
+    ));
+    assert!(
+        !state.primary_source_acceptance_flash_active_at_for_tests(
+            started_at + Duration::from_secs(1)
+        )
+    );
 
-    for _ in 0..20 {
-        state.advance_primary_source_acceptance_flash_frame();
-    }
-    state.flash_primary_source_acceptance();
-    assert_eq!(
-        state.primary_source_acceptance_flash_frames(),
-        60,
+    let restarted_at = Instant::now();
+    state.set_primary_source_acceptance_flash_time_for_tests(restarted_at);
+    assert!(
+        state.primary_source_acceptance_flash_active_at_for_tests(
+            restarted_at + Duration::from_millis(999)
+        ),
         "a later extraction should restart the one-second interval"
     );
-    for _ in 0..60 {
-        state.advance_primary_source_acceptance_flash_frame();
-    }
+    state.advance_primary_source_acceptance_flash_time_for_tests(
+        restarted_at + Duration::from_secs(1),
+    );
     assert!(!state.primary_source_acceptance_flash_active());
 }
 

--- a/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
+++ b/src/native_app/app_chrome/library_browser/library_sidebar/source_section/tests.rs
@@ -1,11 +1,11 @@
 use super::identity::{AUTOMATION_SOURCE_ADD_BUTTON_ID, retained_source_row_input_id};
 use super::rows::{
     SOURCE_ADD_BUTTON_HEIGHT, SOURCE_ADD_BUTTON_WIDTH, SOURCE_ROW_HEIGHT,
-    SOURCE_ROW_LABEL_PADDING_X, source_add_button, source_add_button_tooltip_for_tests,
-    source_missing_color_for_tests, source_processing_fill_for_tests,
-    source_processing_marker_color_for_tests, source_protected_error_icon_color_for_tests,
-    source_role_icon_color_for_source_for_tests, source_role_icon_color_for_tests, source_row,
-    source_row_outline_for_tests,
+    SOURCE_ROW_LABEL_PADDING_X, source_acceptance_fill_for_tests, source_add_button,
+    source_add_button_tooltip_for_tests, source_missing_color_for_tests,
+    source_processing_fill_for_tests, source_processing_marker_color_for_tests,
+    source_protected_error_icon_color_for_tests, source_role_icon_color_for_source_for_tests,
+    source_role_icon_color_for_tests, source_row, source_row_outline_for_tests,
 };
 use super::source_selector;
 use crate::native_app::app::GuiMessage;
@@ -156,6 +156,7 @@ fn source_row_routes_drop_to_source_root() {
         processing: false,
         missing: false,
         protected_source_error_flash: false,
+        primary_source_acceptance_flash: false,
         drag_active: true,
         drop_candidate: true,
         drop_target: false,
@@ -388,6 +389,57 @@ fn primary_source_row_uses_role_icon_instead_of_text_badge() {
         "primary sources should not render the old text badge"
     );
     assert_no_left_source_marker!(frame);
+}
+
+#[test]
+fn primary_source_acceptance_flash_projects_paints_and_expires_after_one_second() {
+    let mut primary = test_source("source-primary-acceptance");
+    primary.role = SourceRole::Primary;
+    let normal = test_source("source-normal-acceptance");
+    let mut state = FolderBrowserState::from_sources_deferred(
+        vec![primary.clone(), normal],
+        primary.id.clone(),
+    );
+
+    state.flash_primary_source_acceptance();
+    let model = SourceSelectorViewModel::from_folder_browser(&state, false);
+    let primary_row = model
+        .rows
+        .iter()
+        .find(|row| row.id == primary.id)
+        .expect("primary source row");
+    let normal_row = model
+        .rows
+        .iter()
+        .find(|row| row.role == SourceRole::Normal)
+        .expect("normal source row");
+    let frame = source_row(primary_row)
+        .view_frame_at_size_with_default_theme(ui::Vector2::new(200.0, SOURCE_ROW_HEIGHT));
+
+    assert!(primary_row.primary_source_acceptance_flash);
+    assert!(!normal_row.primary_source_acceptance_flash);
+    assert!(
+        frame
+            .paint_plan
+            .fill_rects()
+            .any(|fill| fill.color == source_acceptance_fill_for_tests()),
+        "accepted extraction should tint the Primary source row green"
+    );
+    assert_eq!(state.primary_source_acceptance_flash_frames(), 60);
+
+    for _ in 0..20 {
+        state.advance_primary_source_acceptance_flash_frame();
+    }
+    state.flash_primary_source_acceptance();
+    assert_eq!(
+        state.primary_source_acceptance_flash_frames(),
+        60,
+        "a later extraction should restart the one-second interval"
+    );
+    for _ in 0..60 {
+        state.advance_primary_source_acceptance_flash_frame();
+    }
+    assert!(!state.primary_source_acceptance_flash_active());
 }
 
 #[test]

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -48,6 +48,7 @@ pub(in crate::native_app) struct SourceRowViewModel {
     pub(in crate::native_app) processing: bool,
     pub(in crate::native_app) missing: bool,
     pub(in crate::native_app) protected_source_error_flash: bool,
+    pub(in crate::native_app) primary_source_acceptance_flash: bool,
     pub(in crate::native_app) drag_active: bool,
     pub(in crate::native_app) drop_candidate: bool,
     pub(in crate::native_app) drop_target: bool,
@@ -276,6 +277,8 @@ impl SourceRowViewModel {
             missing: source.is_missing(),
             protected_source_error_flash: folder_browser
                 .source_protected_error_flash_active(&source.id),
+            primary_source_acceptance_flash: source.role == SourceRole::Primary
+                && folder_browser.primary_source_acceptance_flash_active(),
             drag_active: folder_browser.drag_active(),
             drop_candidate: folder_browser.can_drop_drag_on_source(&source.id),
             drop_target: folder_browser.hovered_drop_target_source_id().as_deref()

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -16,7 +16,7 @@ use wavecrate::sample_sources::{HarvestState, config::SimilarityAspectSettings};
 
 const COPY_FLASH_FRAMES: u8 = 12;
 const PROTECTED_SOURCE_ERROR_FLASH_FRAMES: u8 = 24;
-const PRIMARY_SOURCE_ACCEPTANCE_FLASH_FRAMES: u8 = 60;
+const PRIMARY_SOURCE_ACCEPTANCE_FLASH_DURATION: Duration = Duration::from_secs(1);
 const SLOW_SAMPLE_PROJECTION_CACHE_FILL: Duration = Duration::from_millis(4);
 
 #[derive(Clone, Copy)]
@@ -96,7 +96,7 @@ pub(super) struct SampleListState {
     protected_source_error_flash_file_ids: HashSet<String>,
     protected_source_error_flash_source_ids: HashSet<String>,
     protected_source_error_flash_frames: u8,
-    primary_source_acceptance_flash_frames: u8,
+    primary_source_acceptance_flash_deadline: Option<Instant>,
 }
 
 impl SampleListState {
@@ -129,7 +129,7 @@ impl SampleListState {
             protected_source_error_flash_file_ids: HashSet::new(),
             protected_source_error_flash_source_ids: HashSet::new(),
             protected_source_error_flash_frames: 0,
-            primary_source_acceptance_flash_frames: 0,
+            primary_source_acceptance_flash_deadline: None,
         }
     }
 
@@ -526,24 +526,56 @@ impl FolderBrowserState {
     }
 
     pub(in crate::native_app) fn flash_primary_source_acceptance(&mut self) {
-        self.sample_list.primary_source_acceptance_flash_frames =
-            PRIMARY_SOURCE_ACCEPTANCE_FLASH_FRAMES;
+        self.flash_primary_source_acceptance_at(Instant::now());
     }
 
     pub(in crate::native_app) fn primary_source_acceptance_flash_active(&self) -> bool {
-        self.sample_list.primary_source_acceptance_flash_frames > 0
-    }
-
-    #[cfg(test)]
-    pub(in crate::native_app) fn primary_source_acceptance_flash_frames(&self) -> u8 {
-        self.sample_list.primary_source_acceptance_flash_frames
+        self.primary_source_acceptance_flash_active_at(Instant::now())
     }
 
     pub(in crate::native_app) fn advance_primary_source_acceptance_flash_frame(&mut self) {
-        self.sample_list.primary_source_acceptance_flash_frames = self
-            .sample_list
-            .primary_source_acceptance_flash_frames
-            .saturating_sub(1);
+        self.advance_primary_source_acceptance_flash_at(Instant::now());
+    }
+
+    fn flash_primary_source_acceptance_at(&mut self, now: Instant) {
+        self.sample_list.primary_source_acceptance_flash_deadline =
+            Some(now + PRIMARY_SOURCE_ACCEPTANCE_FLASH_DURATION);
+    }
+
+    fn primary_source_acceptance_flash_active_at(&self, now: Instant) -> bool {
+        self.sample_list
+            .primary_source_acceptance_flash_deadline
+            .is_some_and(|deadline| now < deadline)
+    }
+
+    fn advance_primary_source_acceptance_flash_at(&mut self, now: Instant) {
+        if !self.primary_source_acceptance_flash_active_at(now) {
+            self.sample_list.primary_source_acceptance_flash_deadline = None;
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn set_primary_source_acceptance_flash_time_for_tests(
+        &mut self,
+        now: Instant,
+    ) {
+        self.flash_primary_source_acceptance_at(now);
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn advance_primary_source_acceptance_flash_time_for_tests(
+        &mut self,
+        now: Instant,
+    ) {
+        self.advance_primary_source_acceptance_flash_at(now);
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn primary_source_acceptance_flash_active_at_for_tests(
+        &self,
+        now: Instant,
+    ) -> bool {
+        self.primary_source_acceptance_flash_active_at(now)
     }
 
     pub(in crate::native_app) fn advance_copy_flash_frame(&mut self) {

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -16,6 +16,7 @@ use wavecrate::sample_sources::{HarvestState, config::SimilarityAspectSettings};
 
 const COPY_FLASH_FRAMES: u8 = 12;
 const PROTECTED_SOURCE_ERROR_FLASH_FRAMES: u8 = 24;
+const PRIMARY_SOURCE_ACCEPTANCE_FLASH_FRAMES: u8 = 60;
 const SLOW_SAMPLE_PROJECTION_CACHE_FILL: Duration = Duration::from_millis(4);
 
 #[derive(Clone, Copy)]
@@ -95,6 +96,7 @@ pub(super) struct SampleListState {
     protected_source_error_flash_file_ids: HashSet<String>,
     protected_source_error_flash_source_ids: HashSet<String>,
     protected_source_error_flash_frames: u8,
+    primary_source_acceptance_flash_frames: u8,
 }
 
 impl SampleListState {
@@ -127,6 +129,7 @@ impl SampleListState {
             protected_source_error_flash_file_ids: HashSet::new(),
             protected_source_error_flash_source_ids: HashSet::new(),
             protected_source_error_flash_frames: 0,
+            primary_source_acceptance_flash_frames: 0,
         }
     }
 
@@ -520,6 +523,27 @@ impl FolderBrowserState {
 
     pub(in crate::native_app) fn copy_flash_frames(&self) -> u8 {
         self.sample_list.copy_flash_frames
+    }
+
+    pub(in crate::native_app) fn flash_primary_source_acceptance(&mut self) {
+        self.sample_list.primary_source_acceptance_flash_frames =
+            PRIMARY_SOURCE_ACCEPTANCE_FLASH_FRAMES;
+    }
+
+    pub(in crate::native_app) fn primary_source_acceptance_flash_active(&self) -> bool {
+        self.sample_list.primary_source_acceptance_flash_frames > 0
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn primary_source_acceptance_flash_frames(&self) -> u8 {
+        self.sample_list.primary_source_acceptance_flash_frames
+    }
+
+    pub(in crate::native_app) fn advance_primary_source_acceptance_flash_frame(&mut self) {
+        self.sample_list.primary_source_acceptance_flash_frames = self
+            .sample_list
+            .primary_source_acceptance_flash_frames
+            .saturating_sub(1);
     }
 
     pub(in crate::native_app) fn advance_copy_flash_frame(&mut self) {

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -19,8 +19,9 @@ use std::{
     time::Instant,
 };
 use wavecrate::sample_sources::{
-    HarvestDerivationOperation, WholeFileHarvestExtractionPlan, WholeFileHarvestExtractionRequest,
-    WholeFileHarvestExtractionResult, execute_whole_file_harvest_extraction,
+    HarvestDerivationOperation, SourceRole, WholeFileHarvestExtractionPlan,
+    WholeFileHarvestExtractionRequest, WholeFileHarvestExtractionResult,
+    execute_whole_file_harvest_extraction,
 };
 
 #[derive(Clone, Copy)]
@@ -510,6 +511,10 @@ impl NativeAppState {
                     .library
                     .folder_browser
                     .path_is_in_protected_source(&completion.source_path);
+                self.flash_primary_source_acceptance_for_protected_extraction(
+                    &completion.source_path,
+                    &path,
+                );
                 let focus_derivative = focus_derivative && cross_source_derivative;
                 self.log_sample_identity_checkpoint(
                     "waveform.extract.finished_after_refresh",
@@ -659,6 +664,13 @@ impl NativeAppState {
 
         let copied_count = result.copied.len();
         let failed_count = result.failed.len();
+        if result.copied.iter().any(|copy| {
+            self.protected_extraction_was_accepted_by_primary(&copy.source_path, &copy.output_path)
+        }) {
+            self.library
+                .folder_browser
+                .flash_primary_source_acceptance();
+        }
         self.queue_partially_committed_file_mutation(
             FileMutationOperation::Extract,
             result
@@ -755,5 +767,32 @@ impl NativeAppState {
             .sample_source_for_file_path(child_path)
             .map(|(source, _)| source.id);
         source_id.is_some() && child_id.is_some() && source_id != child_id
+    }
+
+    fn flash_primary_source_acceptance_for_protected_extraction(
+        &mut self,
+        source_path: &std::path::Path,
+        child_path: &std::path::Path,
+    ) {
+        if self.protected_extraction_was_accepted_by_primary(source_path, child_path) {
+            self.library
+                .folder_browser
+                .flash_primary_source_acceptance();
+        }
+    }
+
+    fn protected_extraction_was_accepted_by_primary(
+        &self,
+        source_path: &std::path::Path,
+        child_path: &std::path::Path,
+    ) -> bool {
+        self.library
+            .folder_browser
+            .path_is_in_protected_source(source_path)
+            && self
+                .library
+                .folder_browser
+                .sample_source_for_file_path(child_path)
+                .is_some_and(|(source, _)| source.role == SourceRole::Primary)
     }
 }

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -209,6 +209,9 @@ impl NativeAppState {
                 .advance_protected_source_error_flash_frame();
             self.library
                 .folder_browser
+                .advance_primary_source_acceptance_flash_frame();
+            self.library
+                .folder_browser
                 .advance_drag_hover_folder_auto_expand();
             self.drain_playback_runtime_events();
             self.refresh_playback_progress();
@@ -240,6 +243,9 @@ impl NativeAppState {
         self.library
             .folder_browser
             .advance_protected_source_error_flash_frame();
+        self.library
+            .folder_browser
+            .advance_primary_source_acceptance_flash_frame();
         self.library
             .folder_browser
             .advance_drag_hover_folder_auto_expand();

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -966,6 +966,14 @@ fn playmark_extraction_completion_evicts_reused_output_cache() {
             .contains_key(&extracted),
         "finishing an extraction must discard stale in-memory audio for the output path"
     );
+    assert!(
+        !scenario
+            .state
+            .library
+            .folder_browser
+            .primary_source_acceptance_flash_active(),
+        "ordinary extraction must not show protected-source acceptance feedback"
+    );
 }
 
 #[test]
@@ -1202,6 +1210,14 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
         "protected-source extraction should not load the derivative automatically"
     );
     assert_eq!(scenario.state.waveform.current.path(), source_path);
+    assert!(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .primary_source_acceptance_flash_active(),
+        "successful protected extraction should light the Primary source row"
+    );
     assert_extracted_metadata_tags(&scenario.state, &extracted, &["one-shot"]);
     let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
         protected_source.id.clone(),
@@ -1227,6 +1243,49 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
         PathBuf::from("_Harvests")
             .join(harvest_source_folder)
             .join("playmark-extract-protected-primary_extraction.wav")
+    );
+
+    while scenario
+        .state
+        .library
+        .folder_browser
+        .primary_source_acceptance_flash_frames()
+        > 1
+    {
+        scenario
+            .state
+            .library
+            .folder_browser
+            .advance_primary_source_acceptance_flash_frame();
+    }
+    let selection = scenario
+        .state
+        .waveform
+        .current
+        .play_selection()
+        .expect("play selection remains available");
+    let mut failed_context = ui::UiUpdateContext::default();
+    scenario.state.finish_play_selection_extraction(
+        crate::native_app::waveform::WaveformExtractionCompletion {
+            source_path: source_path.clone(),
+            selection,
+            result: Err(String::from("simulated write failure")),
+        },
+        None,
+        crate::native_app::app::ExtractedFilePlaybackType::OneShot,
+        wavecrate::sample_sources::HarvestDerivationOperation::Extract,
+        false,
+        std::time::Instant::now(),
+        &mut failed_context,
+    );
+    assert_eq!(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .primary_source_acceptance_flash_frames(),
+        1,
+        "failed extraction completion must not restart the success feedback"
     );
 }
 
@@ -1911,6 +1970,13 @@ fn e_without_playmark_copies_protected_whole_file_to_primary_harvest_and_keeps_f
     assert!(
         active_sample_load_ticket(&state).is_none(),
         "whole-file fallback should not load the derivative automatically"
+    );
+    assert!(
+        state
+            .library
+            .folder_browser
+            .primary_source_acceptance_flash_active(),
+        "successful protected whole-file extraction should light the Primary source row"
     );
     let parent_key = wavecrate::sample_sources::HarvestFileKey::new(
         protected_source.id.clone(),

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -1245,19 +1245,12 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
             .join("playmark-extract-protected-primary_extraction.wav")
     );
 
-    while scenario
+    let failed_flash_started = std::time::Instant::now();
+    scenario
         .state
         .library
         .folder_browser
-        .primary_source_acceptance_flash_frames()
-        > 1
-    {
-        scenario
-            .state
-            .library
-            .folder_browser
-            .advance_primary_source_acceptance_flash_frame();
-    }
+        .set_primary_source_acceptance_flash_time_for_tests(failed_flash_started);
     let selection = scenario
         .state
         .waveform
@@ -1278,13 +1271,19 @@ fn protected_playmark_extraction_routes_to_primary_harvest_destination() {
         std::time::Instant::now(),
         &mut failed_context,
     );
-    assert_eq!(
-        scenario
+    scenario
+        .state
+        .library
+        .folder_browser
+        .advance_primary_source_acceptance_flash_time_for_tests(
+            failed_flash_started + std::time::Duration::from_secs(1),
+        );
+    assert!(
+        !scenario
             .state
             .library
             .folder_browser
-            .primary_source_acceptance_flash_frames(),
-        1,
+            .primary_source_acceptance_flash_active(),
         "failed extraction completion must not restart the success feedback"
     );
 }


### PR DESCRIPTION
## Goal

Give immediate visual confirmation that Wavecrate accepted an extraction from a protected source into the configured Primary source.

## Scope and non-goals

- Add a one-second green acceptance highlight to the Primary source row after successful protected-source range or whole-file extraction.
- Restart the interval when another accepted extraction completes.
- Keep protected-error and processing palettes higher priority.
- Do not navigate to Primary or change extraction routing, naming, ratings, harvest metadata, source selection, focus, or playback.
- Do not highlight prompts, cancellations, failures, ordinary extraction, or output owned by another source.

## Definition of Done

- Successful protected-to-Primary extraction highlights only the Primary source row for one second.
- Repeated successes restart the interval.
- Failed and non-protected completions do not trigger or restart it.
- Range and whole-file protected extraction paths are covered.
- The signed macOS app demonstrates activation and expiry without changing source selection.

## Validation

- `cargo test --lib primary_source_acceptance_flash --no-default-features` — passed.
- `cargo test --lib protected_playmark_extraction_routes_to_primary_harvest_destination --no-default-features` — passed.
- `cargo test --lib e_without_playmark_copies_protected_whole_file_to_primary_harvest_and_keeps_focus --no-default-features` — passed.
- `cargo test --lib playmark_extraction_completion_evicts_reused_output_cache --no-default-features` — passed.
- `bash scripts/build.sh --release` — passed; produced and signed `Wavecrate OPT-1193.app`.
- Signed-app smoke with an isolated protected source and Primary source — passed; Primary turned green on accepted extraction, returned to neutral after one second, and protected-source selection remained unchanged.
- `bash scripts/ci.sh agent` — blocked by the pre-existing invalid format string in `tests/release_workflow_helpers.rs:936`.
- `bash scripts/ci.sh quick` — blocked before tests because `.config/nextest.toml` references missing benchmark binary IDs.

## Known limitations

- The two repository-wide validation lanes above remain unavailable because of existing checkout/tooling failures unrelated to this diff.

User approval is required before merge.

Closes OPT-1193
