### PR TITLE
OPT-1231: Fix narrow playmark label placement

### DIFF
--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -36,12 +36,6 @@ pub(super) struct PlaymarkLabelLayout {
     pub(super) placement: PlaymarkLabelPlacement,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum PlaymarkLabelPaintOwner {
-    Base,
-    Runtime,
-}
-
 impl WaveformWidget {
     pub(super) fn append_playmark_label_paint(
         &self,
@@ -72,48 +66,27 @@ impl WaveformWidget {
         );
     }
 
-    pub(super) fn base_owns_playmark_label(&self) -> bool {
-        self.playmark_label_paint_owner() == PlaymarkLabelPaintOwner::Base
-    }
-
-    pub(super) fn runtime_owns_playmark_label(&self) -> bool {
-        self.playmark_label_paint_owner() == PlaymarkLabelPaintOwner::Runtime
-    }
-
-    pub(super) fn append_runtime_playmark_label_fallback_paint(
+    pub(super) fn append_base_playmark_label_paint(
         &self,
-        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        paint: &mut WidgetPaint<'_>,
         bounds: Rect,
     ) {
-        if !self.runtime_owns_playmark_label()
-            || self
+        let selection = match self.active_drag_kind {
+            Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
+            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play)) => self
                 .live_selection_preview
-                .is_some_and(|preview| preview.kind == WaveformSelectionKind::Play)
-        {
-            return;
-        }
-        let Some(selection) = self.play_selection else {
+                .filter(|preview| preview.kind == WaveformSelectionKind::Play)
+                .map(|preview| preview.selection)
+                .or(self.play_selection),
+            _ => self.play_selection,
+        };
+        let Some(selection) = selection else {
             return;
         };
         let Some(geometry) = self.selection_geometry(bounds, Some(selection)) else {
             return;
         };
-        self.append_playmark_label_paint(
-            &mut WidgetPaint::new(primitives, self.common.id),
-            bounds,
-            geometry,
-            selection,
-        );
-    }
-
-    fn playmark_label_paint_owner(&self) -> PlaymarkLabelPaintOwner {
-        match self.active_drag_kind {
-            Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
-            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play)) => {
-                PlaymarkLabelPaintOwner::Runtime
-            }
-            _ => PlaymarkLabelPaintOwner::Base,
-        }
+        self.append_playmark_label_paint(paint, bounds, geometry, selection);
     }
 }
 

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -73,7 +73,8 @@ impl WaveformWidget {
     ) {
         let selection = match self.active_drag_kind {
             Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
-            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play)) => self
+            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play))
+            | Some(WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, _)) => self
                 .live_selection_preview
                 .filter(|preview| preview.kind == WaveformSelectionKind::Play)
                 .map(|preview| preview.selection)

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -8,16 +8,39 @@ use radiant::{
 
 use crate::ui_formatting::{format_selection_duration, format_waveform_bpm_input};
 
-use super::WaveformWidget;
+use super::{WaveformActiveDragKind, WaveformSelectionKind, WaveformWidget};
 
 const PLAYMARK_LABEL_HEIGHT: f32 = 18.0;
 const PLAYMARK_LABEL_BOTTOM_INSET: f32 = 2.0;
+const PLAYMARK_LABEL_SELECTION_INSET: f32 = 4.0;
+const PLAYMARK_LABEL_OUTSIDE_GAP: f32 = 6.0;
 const PLAYMARK_LABEL_HORIZONTAL_PADDING: f32 = 10.0;
 const PLAYMARK_LABEL_GLYPH_WIDTH: f32 = 10.0;
 const PLAYMARK_LABEL_MIN_WIDTH: f32 = 80.0;
 const PLAYMARK_LABEL_MAX_WIDTH: f32 = 150.0;
 const PLAYMARK_LABEL_BACKGROUND: Rgba8 = Rgba8::new(25, 18, 16, 214);
 const PLAYMARK_LABEL_TEXT: Rgba8 = Rgba8::new(255, 226, 210, 255);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PlaymarkLabelPlacement {
+    Inside,
+    OutsideRight,
+    OutsideLeft,
+    FallbackRight,
+    FallbackLeft,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct PlaymarkLabelLayout {
+    pub(super) rect: Rect,
+    pub(super) placement: PlaymarkLabelPlacement,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlaymarkLabelPaintOwner {
+    Base,
+    Runtime,
+}
 
 impl WaveformWidget {
     pub(super) fn append_playmark_label_paint(
@@ -36,17 +59,61 @@ impl WaveformWidget {
         ) else {
             return;
         };
-        let Some(label_rect) = playmark_label_rect(bounds, geometry.rect, label.len()) else {
+        let Some(layout) = playmark_label_layout(bounds, geometry.rect, label.len()) else {
             return;
         };
 
-        paint.push_visible_fill_rect(label_rect, PLAYMARK_LABEL_BACKGROUND);
+        paint.push_visible_fill_rect(layout.rect, PLAYMARK_LABEL_BACKGROUND);
         paint.push_text(
             label,
-            label_rect,
+            layout.rect,
             PLAYMARK_LABEL_TEXT,
             PaintTextAlign::Center,
         );
+    }
+
+    pub(super) fn base_owns_playmark_label(&self) -> bool {
+        self.playmark_label_paint_owner() == PlaymarkLabelPaintOwner::Base
+    }
+
+    pub(super) fn runtime_owns_playmark_label(&self) -> bool {
+        self.playmark_label_paint_owner() == PlaymarkLabelPaintOwner::Runtime
+    }
+
+    pub(super) fn append_runtime_playmark_label_fallback_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: Rect,
+    ) {
+        if !self.runtime_owns_playmark_label()
+            || self
+                .live_selection_preview
+                .is_some_and(|preview| preview.kind == WaveformSelectionKind::Play)
+        {
+            return;
+        }
+        let Some(selection) = self.play_selection else {
+            return;
+        };
+        let Some(geometry) = self.selection_geometry(bounds, Some(selection)) else {
+            return;
+        };
+        self.append_playmark_label_paint(
+            &mut WidgetPaint::new(primitives, self.common.id),
+            bounds,
+            geometry,
+            selection,
+        );
+    }
+
+    fn playmark_label_paint_owner(&self) -> PlaymarkLabelPaintOwner {
+        match self.active_drag_kind {
+            Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
+            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play)) => {
+                PlaymarkLabelPaintOwner::Runtime
+            }
+            _ => PlaymarkLabelPaintOwner::Base,
+        }
     }
 }
 
@@ -70,7 +137,11 @@ fn playmark_selection_label(
     Some(format_selection_duration(duration_seconds))
 }
 
-fn playmark_label_rect(bounds: Rect, selection_rect: Rect, label_len: usize) -> Option<Rect> {
+pub(super) fn playmark_label_layout(
+    bounds: Rect,
+    selection_rect: Rect,
+    label_len: usize,
+) -> Option<PlaymarkLabelLayout> {
     if bounds.width() <= 0.0 || bounds.height() <= 0.0 {
         return None;
     }
@@ -80,15 +151,137 @@ fn playmark_label_rect(bounds: Rect, selection_rect: Rect, label_len: usize) -> 
     let width = desired_width
         .clamp(PLAYMARK_LABEL_MIN_WIDTH, PLAYMARK_LABEL_MAX_WIDTH)
         .min(bounds.width());
-    let center_x = selection_rect
-        .center()
-        .x
-        .clamp(bounds.min.x + width * 0.5, bounds.max.x - width * 0.5);
+    let selection_left = selection_rect.min.x.clamp(bounds.min.x, bounds.max.x);
+    let selection_right = selection_rect.max.x.clamp(selection_left, bounds.max.x);
+    let selection_width = selection_right - selection_left;
+    let (left, placement) = if selection_width >= width + PLAYMARK_LABEL_SELECTION_INSET * 2.0 {
+        (
+            (selection_left + (selection_width - width) * 0.5)
+                .clamp(bounds.min.x, bounds.max.x - width),
+            PlaymarkLabelPlacement::Inside,
+        )
+    } else {
+        outside_label_left(bounds, selection_left, selection_right, width)
+    };
     let bottom = (bounds.max.y - PLAYMARK_LABEL_BOTTOM_INSET).max(bounds.min.y);
     let top = (bottom - PLAYMARK_LABEL_HEIGHT).max(bounds.min.y);
 
-    Some(Rect::from_min_max(
-        Point::new(center_x - width * 0.5, top),
-        Point::new(center_x + width * 0.5, bottom),
-    ))
+    Some(PlaymarkLabelLayout {
+        rect: Rect::from_min_max(Point::new(left, top), Point::new(left + width, bottom)),
+        placement,
+    })
+}
+
+fn outside_label_left(
+    bounds: Rect,
+    selection_left: f32,
+    selection_right: f32,
+    width: f32,
+) -> (f32, PlaymarkLabelPlacement) {
+    let right = selection_right + PLAYMARK_LABEL_OUTSIDE_GAP;
+    if right + width <= bounds.max.x {
+        return (right, PlaymarkLabelPlacement::OutsideRight);
+    }
+
+    let left = selection_left - PLAYMARK_LABEL_OUTSIDE_GAP - width;
+    if left >= bounds.min.x {
+        return (left, PlaymarkLabelPlacement::OutsideLeft);
+    }
+
+    let right_room = bounds.max.x - selection_right;
+    let left_room = selection_left - bounds.min.x;
+    if right_room >= left_room {
+        (
+            right.clamp(bounds.min.x, bounds.max.x - width),
+            PlaymarkLabelPlacement::FallbackRight,
+        )
+    } else {
+        (
+            left.clamp(bounds.min.x, bounds.max.x - width),
+            PlaymarkLabelPlacement::FallbackLeft,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(left: f32, right: f32) -> Rect {
+        Rect::from_min_max(Point::new(left, 0.0), Point::new(right, 80.0))
+    }
+
+    #[test]
+    fn wide_playmark_contains_centered_label_with_inset() {
+        let layout = playmark_label_layout(rect(0.0, 400.0), rect(100.0, 300.0), 6)
+            .expect("wide label layout");
+
+        assert_eq!(layout.placement, PlaymarkLabelPlacement::Inside);
+        assert_eq!(layout.rect.min.x, 160.0);
+        assert_eq!(layout.rect.max.x, 240.0);
+    }
+
+    #[test]
+    fn narrow_playmark_prefers_right_then_falls_back_left_at_right_edge() {
+        let centered = playmark_label_layout(rect(0.0, 400.0), rect(195.0, 205.0), 6)
+            .expect("centered narrow layout");
+        assert_eq!(centered.placement, PlaymarkLabelPlacement::OutsideRight);
+        assert_eq!(centered.rect.min.x, 211.0);
+
+        let right_edge = playmark_label_layout(rect(0.0, 400.0), rect(350.0, 360.0), 6)
+            .expect("right-edge narrow layout");
+        assert_eq!(right_edge.placement, PlaymarkLabelPlacement::OutsideLeft);
+        assert_eq!(right_edge.rect.max.x, 344.0);
+    }
+
+    #[test]
+    fn narrow_playmark_near_left_edge_keeps_complete_label_to_right() {
+        let layout = playmark_label_layout(rect(0.0, 400.0), rect(10.0, 20.0), 6)
+            .expect("left-edge narrow layout");
+
+        assert_eq!(layout.placement, PlaymarkLabelPlacement::OutsideRight);
+        assert_eq!(layout.rect.min.x, 26.0);
+        assert_eq!(layout.rect.max.x, 106.0);
+    }
+
+    #[test]
+    fn both_sides_fit_uses_stable_right_side_tie_breaker() {
+        let first =
+            playmark_label_layout(rect(0.0, 400.0), rect(195.0, 205.0), 6).expect("first layout");
+        let second =
+            playmark_label_layout(rect(0.0, 400.0), rect(195.0, 205.0), 6).expect("second layout");
+
+        assert_eq!(first, second);
+        assert_eq!(first.placement, PlaymarkLabelPlacement::OutsideRight);
+    }
+
+    #[test]
+    fn narrow_viewport_fallback_stays_in_bounds_and_chooses_roomier_side() {
+        let tied = playmark_label_layout(rect(0.0, 100.0), rect(35.0, 65.0), 6)
+            .expect("tied fallback layout");
+        assert_eq!(tied.placement, PlaymarkLabelPlacement::FallbackRight);
+        assert_eq!(tied.rect.min.x, 20.0);
+        assert_eq!(tied.rect.max.x, 100.0);
+
+        let left_roomier = playmark_label_layout(rect(0.0, 100.0), rect(60.0, 80.0), 6)
+            .expect("left-roomier fallback layout");
+        assert_eq!(left_roomier.placement, PlaymarkLabelPlacement::FallbackLeft);
+        assert_eq!(left_roomier.rect.min.x, 0.0);
+        assert_eq!(left_roomier.rect.max.x, 80.0);
+    }
+
+    #[test]
+    fn duration_and_bpm_widths_share_outside_placement_policy() {
+        let duration = playmark_label_layout(rect(0.0, 400.0), rect(150.0, 160.0), 6)
+            .expect("duration layout");
+        let bpm =
+            playmark_label_layout(rect(0.0, 400.0), rect(150.0, 160.0), 7).expect("bpm layout");
+
+        assert_eq!(duration.placement, PlaymarkLabelPlacement::OutsideRight);
+        assert_eq!(bpm.placement, PlaymarkLabelPlacement::OutsideRight);
+        assert_eq!(duration.rect.width(), 80.0);
+        assert_eq!(bpm.rect.width(), 90.0);
+        assert!(duration.rect.min.x > 160.0);
+        assert!(bpm.rect.min.x > 160.0);
+    }
 }

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -80,6 +80,7 @@ impl WaveformWidget {
             {
                 self.append_edit_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
             }
+            self.append_base_playmark_label_paint(&mut paint, bounds);
             self.append_played_range_paint(&mut paint, bounds);
         }
         self.append_marker_paint(&mut paint, bounds);
@@ -205,11 +206,6 @@ impl WaveformWidget {
             WaveformSelectionKind::Play,
             self.play_selection,
         );
-        if self.base_owns_playmark_label()
-            && let Some(selection) = self.play_selection
-        {
-            self.append_playmark_label_paint(paint, bounds, geometry, selection);
-        }
         self.append_selection_boundary_cursors(paint, bounds, self.play_selection, style, 1.25);
         self.append_selection_affordance_paint(
             handle_paint,
@@ -330,14 +326,6 @@ impl WaveformWidget {
                     style,
                 );
                 self.append_live_selection_preview_beat_guide_paint(&mut paint, bounds, preview);
-                if self.runtime_owns_playmark_label() {
-                    self.append_playmark_label_paint(
-                        &mut paint,
-                        bounds,
-                        geometry,
-                        preview.selection,
-                    );
-                }
                 self.append_selection_affordance_paint(
                     &mut paint,
                     geometry,

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -205,7 +205,9 @@ impl WaveformWidget {
             WaveformSelectionKind::Play,
             self.play_selection,
         );
-        if let Some(selection) = self.play_selection {
+        if self.base_owns_playmark_label()
+            && let Some(selection) = self.play_selection
+        {
             self.append_playmark_label_paint(paint, bounds, geometry, selection);
         }
         self.append_selection_boundary_cursors(paint, bounds, self.play_selection, style, 1.25);
@@ -328,7 +330,14 @@ impl WaveformWidget {
                     style,
                 );
                 self.append_live_selection_preview_beat_guide_paint(&mut paint, bounds, preview);
-                self.append_playmark_label_paint(&mut paint, bounds, geometry, preview.selection);
+                if self.runtime_owns_playmark_label() {
+                    self.append_playmark_label_paint(
+                        &mut paint,
+                        bounds,
+                        geometry,
+                        preview.selection,
+                    );
+                }
                 self.append_selection_affordance_paint(
                     &mut paint,
                     geometry,

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -11,6 +11,48 @@ fn runtime_overlay_plan(widget: &WaveformWidget, bounds: Rect) -> SurfacePaintPl
     plan
 }
 
+fn composed_widget_plan(widget: &WaveformWidget, bounds: Rect) -> SurfacePaintPlan {
+    cached_base_with_runtime_overlay(widget, widget, bounds)
+}
+
+fn cached_base_with_runtime_overlay(
+    base_widget: &WaveformWidget,
+    runtime_widget: &WaveformWidget,
+    bounds: Rect,
+) -> SurfacePaintPlan {
+    let mut plan = base_widget.paint_plan_with_defaults(bounds);
+    runtime_widget.append_runtime_overlay_paint(
+        &mut plan.primitives,
+        bounds,
+        &radiant::layout::LayoutOutput::default(),
+        &ThemeTokens::default(),
+    );
+    plan
+}
+
+fn playmark_label_background_count(plan: &SurfacePaintPlan) -> usize {
+    plan.fill_rects()
+        .filter(|fill| {
+            (fill.color.r, fill.color.g, fill.color.b, fill.color.a) == (25, 18, 16, 214)
+        })
+        .count()
+}
+
+fn assert_single_playmark_label(plan: &SurfacePaintPlan, text: &str) {
+    assert_eq!(
+        plan.text_runs()
+            .filter(|run| run.text.as_str() == text)
+            .count(),
+        1,
+        "expected exactly one {text:?} text primitive"
+    );
+    assert_eq!(
+        playmark_label_background_count(plan),
+        1,
+        "expected exactly one playmark label background"
+    );
+}
+
 fn assert_no_white_hover_border(plan: &SurfacePaintPlan) {
     assert!(
         !plan.stroke_rects().any(|stroke| {
@@ -173,6 +215,142 @@ fn live_playmark_preview_paints_current_duration_label() {
     let plan = runtime_overlay_plan(&widget, Rect::from_size(400.0, 80.0));
 
     assert!(plan.contains_text("500 ms"));
+}
+
+#[test]
+fn narrow_playmark_labels_move_outside_selection_at_left_center_and_right() {
+    let bounds = Rect::from_size(400.0, 80.0);
+
+    let mut center = WaveformState::synthetic_for_tests();
+    center.play_selection = Some(wavecrate::selection::SelectionRange::new(0.49, 0.51));
+    let center_plan = composed_widget_plan(&waveform_widget_for_state(&center), bounds);
+    let center_label = center_plan.text_runs().next().expect("center label paints");
+    assert!(center_label.rect.min.x >= 204.0 + 6.0 - f32::EPSILON);
+    assert!(center_label.rect.max.x <= bounds.max.x);
+    assert_eq!(playmark_label_background_count(&center_plan), 1);
+
+    let mut left = WaveformState::synthetic_for_tests();
+    left.play_selection = Some(wavecrate::selection::SelectionRange::new(0.0, 0.02));
+    let left_plan = composed_widget_plan(&waveform_widget_for_state(&left), bounds);
+    let left_label = left_plan.text_runs().next().expect("left label paints");
+    assert!(left_label.rect.min.x >= 8.0 + 6.0 - f32::EPSILON);
+    assert!(left_label.rect.max.x <= bounds.max.x);
+
+    let mut right = WaveformState::synthetic_for_tests();
+    right.play_selection = Some(wavecrate::selection::SelectionRange::new(0.95, 1.0));
+    let right_plan = composed_widget_plan(&waveform_widget_for_state(&right), bounds);
+    let right_label = right_plan.text_runs().next().expect("right label paints");
+    assert!(right_label.rect.max.x <= 380.0 - 6.0 + f32::EPSILON);
+    assert!(right_label.rect.min.x >= bounds.min.x);
+
+    let mut zoomed = WaveformState::synthetic_for_tests();
+    let total_frames = zoomed.file.frames as i64;
+    zoomed.viewport = WaveformViewport {
+        start: total_frames / 4,
+        end: total_frames * 3 / 4,
+    };
+    zoomed.play_selection = Some(wavecrate::selection::SelectionRange::new(0.495, 0.505));
+    let zoomed_plan = composed_widget_plan(&waveform_widget_for_state(&zoomed), bounds);
+    let zoomed_label = zoomed_plan.text_runs().next().expect("zoomed label paints");
+    assert!(zoomed_label.rect.min.x >= 204.0 + 6.0 - f32::EPSILON);
+    assert!(zoomed_label.rect.max.x <= bounds.max.x);
+}
+
+#[test]
+fn playmark_label_has_one_owner_across_live_and_transition_states() {
+    let bounds = Rect::from_size(400.0, 80.0);
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.7));
+
+    let steady = waveform_widget_for_state(&state);
+    assert_single_playmark_label(&composed_widget_plan(&steady, bounds), "500 ms");
+
+    let mut creation = waveform_widget_for_state(&WaveformState::synthetic_for_tests());
+    creation.active_drag_kind = Some(WaveformActiveDragKind::Selection(
+        WaveformSelectionKind::Play,
+    ));
+    creation.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.2, 0.7),
+    });
+    assert_single_playmark_label(&composed_widget_plan(&creation, bounds), "500 ms");
+
+    let mut move_start = waveform_widget_for_state(&state);
+    move_start.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+    assert_single_playmark_label(&composed_widget_plan(&move_start, bounds), "500 ms");
+
+    let mut zero_delta_move = waveform_widget_for_state(&state);
+    zero_delta_move.active_drag_kind = move_start.active_drag_kind;
+    zero_delta_move.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: state.play_selection.expect("committed playmark"),
+    });
+    assert_single_playmark_label(&composed_widget_plan(&zero_delta_move, bounds), "500 ms");
+
+    let mut moved = waveform_widget_for_state(&state);
+    moved.active_drag_kind = zero_delta_move.active_drag_kind;
+    moved.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.4, 0.7),
+    });
+    let moved_plan = cached_base_with_runtime_overlay(&move_start, &moved, bounds);
+    assert_single_playmark_label(&moved_plan, "300 ms");
+    assert!(!moved_plan.contains_text("500 ms"));
+
+    let mut resized_state = WaveformState::synthetic_for_tests();
+    resized_state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.5));
+    let mut resized = waveform_widget_for_state(&resized_state);
+    resized.active_drag_kind = Some(WaveformActiveDragKind::SelectionResize(
+        WaveformSelectionKind::Play,
+        WaveformSelectionEdge::End,
+    ));
+    resized.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.2, 0.6),
+    });
+    let resized_plan = composed_widget_plan(&resized, bounds);
+    assert_single_playmark_label(&resized_plan, "300 ms");
+    assert!(!resized_plan.contains_text("400 ms"));
+
+    let mut stale_preview_after_release = waveform_widget_for_state(&state);
+    stale_preview_after_release.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.4, 0.7),
+    });
+    let released_plan = composed_widget_plan(&stale_preview_after_release, bounds);
+    assert_single_playmark_label(&released_plan, "500 ms");
+    assert!(!released_plan.contains_text("300 ms"));
+}
+
+#[test]
+fn rebuilt_move_widget_preserves_one_live_playmark_label_owner() {
+    let bounds = Rect::from_size(400.0, 80.0);
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.7));
+    let active_drag = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+
+    let mut previous = waveform_widget_for_state(&state);
+    previous.active_drag_kind = active_drag;
+    previous.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.4, 0.7),
+    });
+
+    let mut rebuilt = waveform_widget_for_state(&state);
+    rebuilt.active_drag_kind = active_drag;
+    rebuilt.synchronize_from_previous(&previous);
+
+    assert_eq!(
+        rebuilt.live_selection_preview,
+        previous.live_selection_preview
+    );
+    let plan = composed_widget_plan(&rebuilt, bounds);
+    assert_single_playmark_label(&plan, "300 ms");
+    assert!(!plan.contains_text("500 ms"));
 }
 
 fn waveform_state_with_duration_seconds(seconds: usize) -> WaveformState {

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -212,7 +212,7 @@ fn live_playmark_preview_paints_current_duration_label() {
         selection: wavecrate::selection::SelectionRange::new(0.2, 0.7),
     });
 
-    let plan = runtime_overlay_plan(&widget, Rect::from_size(400.0, 80.0));
+    let plan = composed_widget_plan(&widget, Rect::from_size(400.0, 80.0));
 
     assert!(plan.contains_text("500 ms"));
 }
@@ -295,7 +295,11 @@ fn playmark_label_has_one_owner_across_live_and_transition_states() {
         kind: WaveformSelectionKind::Play,
         selection: wavecrate::selection::SelectionRange::new(0.4, 0.7),
     });
-    let moved_plan = cached_base_with_runtime_overlay(&move_start, &moved, bounds);
+    assert!(
+        !moved.prefers_pointer_move_paint_only(),
+        "live playmark text must rebuild the base scene instead of composing over its stale label"
+    );
+    let moved_plan = composed_widget_plan(&moved, bounds);
     assert_single_playmark_label(&moved_plan, "300 ms");
     assert!(!moved_plan.contains_text("500 ms"));
 
@@ -322,6 +326,33 @@ fn playmark_label_has_one_owner_across_live_and_transition_states() {
     let released_plan = composed_widget_plan(&stale_preview_after_release, bounds);
     assert_single_playmark_label(&released_plan, "500 ms");
     assert!(!released_plan.contains_text("300 ms"));
+}
+
+#[test]
+fn steady_base_is_rebuilt_before_live_move_label_paints() {
+    let bounds = Rect::from_size(400.0, 80.0);
+    let mut state = WaveformState::synthetic_for_tests();
+    state.play_selection = Some(wavecrate::selection::SelectionRange::new(0.2, 0.7));
+    let steady = waveform_widget_for_state(&state);
+    let steady_base = steady.paint_plan_with_defaults(bounds);
+    assert_single_playmark_label(&steady_base, "500 ms");
+
+    let mut moved = waveform_widget_for_state(&state);
+    moved.active_drag_kind = Some(WaveformActiveDragKind::SelectionMove(
+        WaveformSelectionKind::Play,
+    ));
+    moved.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: wavecrate::selection::SelectionRange::new(0.4, 0.7),
+    });
+
+    assert!(
+        !moved.prefers_pointer_move_paint_only(),
+        "Base-to-live label ownership must invalidate the cached steady scene"
+    );
+    let rebuilt = composed_widget_plan(&moved, bounds);
+    assert_single_playmark_label(&rebuilt, "300 ms");
+    assert!(!rebuilt.contains_text("500 ms"));
 }
 
 #[test]

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -315,8 +315,12 @@ fn playmark_label_has_one_owner_across_live_and_transition_states() {
         selection: wavecrate::selection::SelectionRange::new(0.2, 0.6),
     });
     let resized_plan = composed_widget_plan(&resized, bounds);
-    assert_single_playmark_label(&resized_plan, "300 ms");
-    assert!(!resized_plan.contains_text("400 ms"));
+    assert!(
+        !resized.prefers_pointer_move_paint_only(),
+        "live playmark resize text must rebuild the base scene"
+    );
+    assert_single_playmark_label(&resized_plan, "400 ms");
+    assert!(!resized_plan.contains_text("300 ms"));
 
     let mut stale_preview_after_release = waveform_widget_for_state(&state);
     stale_preview_after_release.live_selection_preview = Some(LiveSelectionPreview {

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -501,6 +501,7 @@ impl Widget for WaveformWidget {
         _theme: &ThemeTokens,
     ) {
         self.append_live_selection_preview_paint(primitives, bounds);
+        self.append_runtime_playmark_label_fallback_paint(primitives, bounds);
         self.append_playmark_drag_ghost_paint(primitives, bounds);
         self.append_sample_slide_preview_paint(primitives, bounds);
         self.append_hover_edit_fade_handle_paint(primitives, bounds);

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -483,6 +483,9 @@ impl Widget for WaveformWidget {
                 WaveformSelectionKind::Play
             )) | Some(WaveformActiveDragKind::SelectionMove(
                 WaveformSelectionKind::Play
+            )) | Some(WaveformActiveDragKind::SelectionResize(
+                WaveformSelectionKind::Play,
+                _
             ))
         )
     }

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -477,7 +477,14 @@ impl Widget for WaveformWidget {
     }
 
     fn prefers_pointer_move_paint_only(&self) -> bool {
-        true
+        !matches!(
+            self.active_drag_kind,
+            Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Play
+            )) | Some(WaveformActiveDragKind::SelectionMove(
+                WaveformSelectionKind::Play
+            ))
+        )
     }
 
     fn append_paint(
@@ -501,7 +508,6 @@ impl Widget for WaveformWidget {
         _theme: &ThemeTokens,
     ) {
         self.append_live_selection_preview_paint(primitives, bounds);
-        self.append_runtime_playmark_label_fallback_paint(primitives, bounds);
         self.append_playmark_drag_ghost_paint(primitives, bounds);
         self.append_sample_slide_preview_paint(primitives, bounds);
         self.append_hover_edit_fade_handle_paint(primitives, bounds);


### PR DESCRIPTION
## Goal

Keep every playmark duration/BPM label readable and singly owned: center the complete label inside wide playmarks, and place it wholly outside narrow playmarks whenever viewport space permits.

## Scope and non-goals

- Add one reusable playmark-label layout calculation covering inside, right, left, and constrained fallback placement.
- Use a deterministic right-side preference, a visible outside gap, and bounds-clamped fallback on the roomier side.
- Keep all label text in the rebuilt base scene; active playmark creation, move, and resize states opt out of paint-only pointer rendering so cached label text is replaced before the live label paints.
- Apply identical geometry to duration and beat-guide-derived BPM labels.
- Preserve duration/BPM formatting, playmark geometry, beat math, handles, playback, and editmark behavior.
- Do not implement label editing or adjacent beat-grid controls from OPT-1229/OPT-1230.

## Definition of Done

- Wide playmark labels are centered and wholly contained with an inset.
- Narrow labels appear outside on the right when possible and fall back left near the right edge.
- Constrained layouts stay within waveform bounds and choose a deterministic roomier-side fallback.
- Duration and BPM labels use the same reusable rectangle.
- Committed, creation, move, resize, zero-delta, release-transition, and rebuilt-widget states emit exactly one matching text and one background primitive.
- The steady-base to live creation/move/resize transition rebuilds before emitting the current label, preventing stale and live text from composing.
- Existing selection, beat-guide, handle, and playhead paint remains unchanged.

## Validation

- `cargo fmt --check` — passed.
- `cargo test -p wavecrate --lib native_app::waveform::playmark_label::tests -- --test-threads=1` — 6 passed.
- `cargo test -p wavecrate --lib native_app::waveform::tests::paint -- --test-threads=1` — 65 passed.
- Focused OPT-918 continuity regressions for rebuild, zoomed resize parity, live move, and live-until-release behavior — passed.
- `cargo test -p wavecrate --lib native_app::waveform::tests::widget_input -- --test-threads=1` — 53 passed; one established unrelated playback-cache fixture miss.
- `bash scripts/build.sh --release --variant OPT-1231` — passed and signed `Wavecrate OPT-1231.app`.
- Signed-app smoke — passed for wide and extremely narrow playmarks at left, center, and right, with duration/BPM labels, creation, handle interaction, and repeated resize transitions; labels remained single and readable.
- `bash scripts/ci.sh smoke` — reaches the established unrelated invalid format string at `tests/release_workflow_helpers.rs:936`.

## Known limitations

- The repository-wide smoke gate remains blocked by the unrelated baseline format-string error above.
- The full widget-input module retains its unrelated playback-cache fixture miss; all other 53 tests pass.

User approval is required before merge.

Linear: OPT-1231