### PR TITLE
OPT-1229: edit playmark length from its label

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -42,7 +42,7 @@ use crate::native_app::sample_library::folder_scan_actions::FolderScanMaintenanc
 use crate::native_app::sample_library::native_file_open_actions::NativeAudioDocumentOpenValidation;
 use crate::native_app::sample_library::similarity_scores::SimilarityScoresResult;
 use crate::native_app::sample_library::trash_actions::movement::TrashMoveOutcome;
-use crate::native_app::waveform::WaveformInteraction;
+use crate::native_app::waveform::{PlaymarkLabelMessage, WaveformInteraction};
 use crate::native_app::waveform::{SimilarSectionsResult, WaveformExtractionCompletion};
 use crate::native_app::waveform_edits::WaveformDestructiveEditResult;
 
@@ -386,6 +386,7 @@ pub(in crate::native_app) enum GuiMessage {
     CancelBrowserDragOnSampleList,
     DropWaveformSelectionOnSampleList,
     Waveform(WaveformInteraction),
+    PlaymarkLabel(PlaymarkLabelMessage),
     WaveformDetailRefined(crate::native_app::waveform::WaveformDetailResult),
     WaveformFileDrop(NativeFileDrop),
     Frame,

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -264,6 +264,9 @@ impl NativeAppState {
                 self.apply_navigation_dispatch(message, context);
             }
             GuiMessage::Waveform(message) => self.apply_waveform_message(message, context),
+            GuiMessage::PlaymarkLabel(message) => {
+                self.apply_playmark_label_message(message, context)
+            }
             GuiMessage::WaveformDetailRefined(result) => {
                 self.finish_waveform_detail_refinement(result, context);
             }
@@ -365,6 +368,7 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::NormalizationProgress(_) => "NormalizationProgress",
         GuiMessage::NormalizationFinished(_) => "NormalizationFinished",
         GuiMessage::Waveform(_) => "Waveform",
+        GuiMessage::PlaymarkLabel(_) => "PlaymarkLabel",
         GuiMessage::PlaySelectedSample => "PlaySelectedSample",
         GuiMessage::PlayFromCurrentPlayStart => "PlayFromCurrentPlayStart",
         GuiMessage::PlayRandomSampleRange => "PlayRandomSampleRange",

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -7,6 +7,8 @@ use crate::native_app::app::{
     WaveformContextMenu, WaveformEditSelectionSnapshot, WaveformInteraction,
     WaveformPlaySelectionSnapshot, WaveformSelectionKind, emit_gui_action,
 };
+use crate::native_app::ui::ids as widget_ids;
+use crate::native_app::waveform::PlaymarkLabelMessage;
 
 pub(in crate::native_app) const PLAY_SELECTION_TRANSACTION_LABEL: &str =
     "Change play mark selection";
@@ -16,6 +18,63 @@ const EDIT_RESIZE_TRANSACTION_LABEL: &str = "Editmark resize";
 const EDIT_MOVE_TRANSACTION_LABEL: &str = "Editmark move";
 
 impl NativeAppState {
+    pub(super) fn apply_playmark_label_message(
+        &mut self,
+        message: PlaymarkLabelMessage,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
+    ) {
+        match message {
+            PlaymarkLabelMessage::BeginEdit => {
+                if self.waveform.current.begin_playmark_label_edit(
+                    self.ui.chrome.beat_guides_enabled,
+                    self.ui.chrome.beat_guide_count,
+                ) {
+                    context.focus(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID);
+                }
+            }
+            PlaymarkLabelMessage::Changed(draft) => {
+                self.waveform.current.update_playmark_label_draft(draft);
+            }
+            PlaymarkLabelMessage::Commit(draft) => {
+                if self
+                    .waveform
+                    .current
+                    .playmark_label_commit_is_unchanged(&draft)
+                {
+                    self.waveform.current.close_playmark_label_editor();
+                    context.clear_focus();
+                    return;
+                }
+                match self
+                    .waveform
+                    .current
+                    .playmark_frame_range_from_text(&draft, self.ui.chrome.beat_guide_count)
+                {
+                    Ok((start_frame, end_frame)) => {
+                        self.waveform.current.close_playmark_label_editor();
+                        self.apply_waveform_message(
+                            WaveformInteraction::SetPlaySelectionFrameRange {
+                                start_frame,
+                                end_frame,
+                            },
+                            context,
+                        );
+                        context.clear_focus();
+                    }
+                    Err(error) => {
+                        self.ui.status.sample = error.clone();
+                        self.waveform.current.set_playmark_label_error(error);
+                        context.focus(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID);
+                    }
+                }
+            }
+            PlaymarkLabelMessage::Cancel => {
+                self.waveform.current.close_playmark_label_editor();
+                context.clear_focus();
+            }
+        }
+    }
+
     pub(super) fn apply_waveform_message(
         &mut self,
         message: WaveformInteraction,
@@ -62,8 +121,11 @@ impl NativeAppState {
         self.mark_harvest_touched_after_waveform_mark_change(harvest_mark_before);
         if let Some(before) = play_selection_before {
             self.waveform.pending_play_selection_transaction =
-                play_selection_drag_active(self.waveform.current.active_drag_kind())
-                    .then_some(before);
+                (matches!(
+                    message,
+                    WaveformInteraction::SetPlaySelectionFrameRange { .. }
+                ) || play_selection_drag_active(self.waveform.current.active_drag_kind()))
+                .then_some(before);
         }
         if let Some(before) = edit_selection_before {
             self.waveform.pending_edit_selection_transaction =
@@ -140,6 +202,7 @@ impl NativeAppState {
                 kind: WaveformSelectionKind::Play,
                 ..
             } | WaveformInteraction::SlidePlaySelection { .. }
+                | WaveformInteraction::SetPlaySelectionFrameRange { .. }
         );
         begins_play_selection_change
             .then(|| WaveformPlaySelectionSnapshot::from_waveform(&self.waveform.current))
@@ -330,10 +393,17 @@ fn waveform_interaction_updates_play_selection(
         WaveformInteraction::UpdateSelection { .. }
             | WaveformInteraction::FinishSelection { .. }
             | WaveformInteraction::SlidePlaySelection { .. }
+            | WaveformInteraction::SetPlaySelectionFrameRange { .. }
     ) {
         return false;
     }
     if matches!(interaction, WaveformInteraction::SlidePlaySelection { .. }) {
+        return true;
+    }
+    if matches!(
+        interaction,
+        WaveformInteraction::SetPlaySelectionFrameRange { .. }
+    ) {
         return true;
     }
     match active_drag {
@@ -353,6 +423,7 @@ fn waveform_interaction_finishes_play_selection_update(interaction: &WaveformInt
         interaction,
         WaveformInteraction::FinishSelection { .. }
             | WaveformInteraction::SlidePlaySelection { .. }
+            | WaveformInteraction::SetPlaySelectionFrameRange { .. }
     )
 }
 
@@ -403,6 +474,7 @@ fn waveform_interaction_can_finish_mark_change(interaction: &WaveformInteraction
         WaveformInteraction::FinishSelection { .. }
             | WaveformInteraction::SelectSimilarSection { .. }
             | WaveformInteraction::SlidePlaySelection { .. }
+            | WaveformInteraction::SetPlaySelectionFrameRange { .. }
             | WaveformInteraction::ClearEditFadeSilence { .. }
             | WaveformInteraction::FinishEditFadeOuterGain { .. }
             | WaveformInteraction::FinishEditGain { .. }
@@ -413,9 +485,12 @@ fn play_selection_transaction_finishes(
     interaction: &WaveformInteraction,
     active_drag: Option<WaveformActiveDragKind>,
 ) -> bool {
-    matches!(interaction, WaveformInteraction::SlidePlaySelection { .. })
-        || (matches!(interaction, WaveformInteraction::FinishSelection { .. })
-            && play_selection_drag_active(active_drag))
+    matches!(
+        interaction,
+        WaveformInteraction::SlidePlaySelection { .. }
+            | WaveformInteraction::SetPlaySelectionFrameRange { .. }
+    ) || (matches!(interaction, WaveformInteraction::FinishSelection { .. })
+        && play_selection_drag_active(active_drag))
 }
 
 fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bool {
@@ -490,6 +565,9 @@ fn waveform_interaction_action(interaction: &WaveformInteraction) -> Option<&'st
         WaveformInteraction::Wheel { .. } => Some("waveform.zoom_wheel"),
         WaveformInteraction::ZoomToPlaySelection => Some("waveform.zoom_to_play_selection"),
         WaveformInteraction::SlidePlaySelection { .. } => Some("waveform.playmark.slide"),
+        WaveformInteraction::SetPlaySelectionFrameRange { .. } => {
+            Some("waveform.playmark.length_commit")
+        }
         WaveformInteraction::ZoomFull => Some("waveform.zoom_full"),
         WaveformInteraction::ScrollTo { .. } => Some("waveform.scroll"),
         WaveformInteraction::BeginSelection { .. } => Some("waveform.selection.begin"),
@@ -623,6 +701,24 @@ mod tests {
                 active_drag,
             ));
         }
+    }
+
+    #[test]
+    fn committed_label_length_is_one_finished_playmark_mutation() {
+        let interaction = WaveformInteraction::SetPlaySelectionFrameRange {
+            start_frame: 120,
+            end_frame: 480,
+        };
+
+        assert!(waveform_interaction_can_finish_mark_change(&interaction));
+        assert!(waveform_interaction_updates_play_selection(
+            &interaction,
+            None
+        ));
+        assert!(waveform_interaction_finishes_play_selection_update(
+            &interaction
+        ));
+        assert!(play_selection_transaction_finishes(&interaction, None));
     }
 
     #[test]

--- a/src/native_app/shell/shortcuts.rs
+++ b/src/native_app/shell/shortcuts.rs
@@ -29,6 +29,12 @@ pub(in crate::native_app) fn default_gui_shortcuts(
             )),
         )
         .layer_when(
+            state.waveform.current.playmark_label_editor_active(),
+            ui::ShortcutLayer::modal_escape(GuiMessage::PlaymarkLabel(
+                crate::native_app::waveform::PlaymarkLabelMessage::Cancel,
+            )),
+        )
+        .layer_when(
             state.library.folder_browser.file_column_drag_active(),
             ui::ShortcutLayer::modal_escape(GuiMessage::FolderBrowser(
                 FolderBrowserMessage::CancelFileColumnDrag,

--- a/src/native_app/tests/shortcuts_context/transactions.rs
+++ b/src/native_app/tests/shortcuts_context/transactions.rs
@@ -1,4 +1,9 @@
-use crate::native_app::test_support::state::{GuiMessage, NativeAppState, default_gui_shortcuts};
+use crate::native_app::{
+    test_support::state::{
+        GuiMessage, NativeAppState, NativeAppStateFixture, default_gui_shortcuts,
+    },
+    waveform::PlaymarkLabelMessage,
+};
 use radiant::prelude as ui;
 
 fn transaction_list_shortcut() -> ui::KeyPress {
@@ -29,6 +34,26 @@ fn transaction_list_modal_escape_closes_transaction_list() {
 
     assert_eq!(resolution.action, Some(GuiMessage::CloseTransactionList));
     assert!(resolution.handled);
+}
+
+#[test]
+fn playmark_label_editor_owns_escape_and_blocks_transport_shortcuts() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.2, 0.4);
+    assert!(state.waveform.current.begin_playmark_label_edit(false, 4));
+
+    let escape = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Escape));
+    let space = default_gui_shortcuts(&state).resolve(ui::KeyPress::new(ui::KeyCode::Space));
+
+    assert_eq!(
+        escape.action,
+        Some(GuiMessage::PlaymarkLabel(PlaymarkLabelMessage::Cancel))
+    );
+    assert!(escape.handled);
+    assert_eq!(space.action, None);
+    assert!(space.handled);
 }
 
 #[test]

--- a/src/native_app/tests/transactions.rs
+++ b/src/native_app/tests/transactions.rs
@@ -2,8 +2,8 @@ use super::gui_state_for_span_tests;
 use crate::native_app::{
     test_support::state::{GuiMessage, WaveformInteraction},
     waveform::{
-        WaveformEditFadeHandle, WaveformEditFadeOuterGainHandle, WaveformSelectionEdge,
-        WaveformSelectionKind,
+        PlaymarkLabelMessage, WaveformEditFadeHandle, WaveformEditFadeOuterGainHandle,
+        WaveformSelectionEdge, WaveformSelectionKind,
     },
 };
 use radiant::prelude::{self as ui, IntoView};
@@ -45,6 +45,45 @@ fn transaction_group_undoes_and_redoes_as_one_entry() {
     state.redo_transaction(&mut radiant::prelude::UiUpdateContext::default());
     assert_eq!(state.ui.status.sample, "Redid Grouped edit");
     assert_eq!(state.audio.volume, 0.8);
+}
+
+#[test]
+fn playmark_label_length_commit_registers_one_undoable_frame_exact_transaction() {
+    let mut state = gui_state_for_span_tests();
+    let mut context = ui::UiUpdateContext::default();
+    let total_frames = state.waveform.current.frames();
+    let before = SelectionRange::from_frame_bounds(total_frames, 12_000, 18_000);
+    state
+        .waveform
+        .current
+        .set_play_selection_range(before.start(), before.end());
+
+    state.apply_message(
+        GuiMessage::PlaymarkLabel(PlaymarkLabelMessage::BeginEdit),
+        &mut context,
+    );
+    state.apply_message(
+        GuiMessage::PlaymarkLabel(PlaymarkLabelMessage::Commit(String::from("500ms"))),
+        &mut context,
+    );
+
+    let after = state
+        .waveform
+        .current
+        .play_selection()
+        .expect("playmark selection after label commit");
+    assert_eq!(
+        after.frame_bounds(total_frames).end_frame - after.frame_bounds(total_frames).start_frame,
+        24_000
+    );
+    let items = state.transactions.history.list_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].label, "Change play mark selection");
+
+    state.apply_message(GuiMessage::UndoTransaction, &mut context);
+    assert_eq!(state.waveform.current.play_selection(), Some(before));
+    state.apply_message(GuiMessage::RedoTransaction, &mut context);
+    assert_eq!(state.waveform.current.play_selection(), Some(after));
 }
 
 #[test]

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -42,6 +42,7 @@ pub(in crate::native_app) const WAVEFORM_VIEWPORT_STACK_ID: u64 = WAVEFORM.id(10
 pub(in crate::native_app) const WAVEFORM_SIGNAL_WIDGET_ID: u64 = WAVEFORM.id(11);
 pub(in crate::native_app) const WAVEFORM_WIDGET_ID: u64 = WAVEFORM.id(12);
 pub(in crate::native_app) const WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID: u64 = WAVEFORM.id(13);
+pub(in crate::native_app) const WAVEFORM_PLAYMARK_LABEL_ID: u64 = WAVEFORM.id(14);
 
 pub(in crate::native_app) const FOLDER_TREE_LIST_ID: u64 = FOLDER_TREE.id(0);
 pub(in crate::native_app) const FOLDER_TREE_INCLUDE_SUBFOLDERS_TOGGLE_ID: u64 = FOLDER_TREE.id(1);

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -21,7 +21,7 @@ const SYNTHETIC_SECONDS: usize = 1;
 
 mod types;
 pub(super) use types::{
-    WaveformActiveDragKind, WaveformContextMenu, WaveformEditFadeHandle,
+    PlaymarkLabelMessage, WaveformActiveDragKind, WaveformContextMenu, WaveformEditFadeHandle,
     WaveformEditFadeOuterGainHandle, WaveformInteraction, WaveformSelectionEdge,
     WaveformSelectionKind,
 };
@@ -118,6 +118,8 @@ mod edit_fade_geometry;
 mod edit_fade_paint;
 mod played_range_paint;
 mod playmark_label;
+mod playmark_label_editor;
+pub(super) use playmark_label_editor::PlaymarkLabelEditorState;
 mod selection_paint;
 
 mod viewport;

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -91,7 +91,7 @@ impl WaveformWidget {
     }
 }
 
-fn playmark_selection_label(
+pub(super) fn playmark_selection_label(
     selection: wavecrate::selection::SelectionRange,
     frames: usize,
     sample_rate: u32,

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -1,0 +1,426 @@
+use radiant::{
+    gui::automation::AutomationRole,
+    prelude as ui,
+    widgets::{
+        FocusBehavior, TextInputMessage, TextInputWidget, Widget, WidgetCommon, WidgetInput,
+        WidgetKey, WidgetOutput, WidgetSizing,
+    },
+};
+use std::sync::{Arc, Mutex};
+
+use super::{PlaymarkLabelMessage, WaveformState, WaveformWidget, playmark_label};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct PlaymarkLabelEditorState {
+    pub(super) draft: String,
+    pub(super) original_draft: String,
+    pub(super) error: Option<String>,
+}
+
+impl WaveformState {
+    pub(in crate::native_app) fn playmark_label_editor_active(&self) -> bool {
+        self.playmark_label_editor.is_some()
+    }
+
+    pub(in crate::native_app) fn begin_playmark_label_edit(
+        &mut self,
+        beat_guides_enabled: bool,
+        beat_guide_count: u8,
+    ) -> bool {
+        let Some(selection) = self.play_selection else {
+            return false;
+        };
+        let Some(draft) = playmark_label::playmark_selection_label(
+            selection,
+            self.frames(),
+            self.sample_rate(),
+            beat_guides_enabled,
+            beat_guide_count,
+        ) else {
+            return false;
+        };
+        self.playmark_label_editor = Some(PlaymarkLabelEditorState {
+            original_draft: draft.clone(),
+            draft,
+            error: None,
+        });
+        true
+    }
+
+    pub(in crate::native_app) fn update_playmark_label_draft(&mut self, draft: String) {
+        if let Some(editor) = self.playmark_label_editor.as_mut() {
+            editor.draft = draft;
+            editor.error = None;
+        }
+    }
+
+    pub(in crate::native_app) fn set_playmark_label_error(&mut self, error: String) {
+        if let Some(editor) = self.playmark_label_editor.as_mut() {
+            editor.error = Some(error);
+        }
+    }
+
+    pub(in crate::native_app) fn close_playmark_label_editor(&mut self) {
+        self.playmark_label_editor = None;
+    }
+
+    pub(in crate::native_app) fn playmark_label_commit_is_unchanged(&self, draft: &str) -> bool {
+        self.playmark_label_editor
+            .as_ref()
+            .is_some_and(|editor| editor.original_draft == draft)
+    }
+
+    pub(in crate::native_app) fn playmark_frame_range_from_text(
+        &self,
+        text: &str,
+        beat_count: u8,
+    ) -> Result<(usize, usize), String> {
+        let current = self
+            .play_selection
+            .ok_or_else(|| String::from("Set a playmark selection first"))?;
+        parsed_playmark_frame_range(text, self.sample_rate(), self.frames(), beat_count, current)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PlaymarkLabelWidget {
+    geometry_source: WaveformWidget,
+    label: String,
+    input: Option<TextInputWidget>,
+    error: Option<String>,
+    painted_bounds: Arc<Mutex<Option<ui::Rect>>>,
+}
+
+impl PlaymarkLabelWidget {
+    pub(super) fn new(
+        id: u64,
+        geometry_source: WaveformWidget,
+        state: &WaveformState,
+        beat_guides_enabled: bool,
+        beat_guide_count: u8,
+    ) -> Option<Self> {
+        let selection = state.play_selection()?;
+        let label = playmark_label::playmark_selection_label(
+            selection,
+            state.frames(),
+            state.sample_rate(),
+            beat_guides_enabled,
+            beat_guide_count,
+        )?;
+        let (input, error) = state
+            .playmark_label_editor
+            .as_ref()
+            .map(|editor| {
+                let mut input = TextInputWidget::new(
+                    id,
+                    editor.draft.clone(),
+                    WidgetSizing::fixed(ui::Vector2::new(150.0, 18.0)),
+                );
+                input.props.character_limit = Some(64);
+                input.state.selection_anchor = 0;
+                input.state.caret = input.state.char_len();
+                (Some(input), editor.error.clone())
+            })
+            .unwrap_or((None, None));
+        let mut geometry_source = geometry_source;
+        if input.is_none() {
+            geometry_source.common.focus = FocusBehavior::Keyboard;
+        }
+        Some(Self {
+            geometry_source,
+            label,
+            input,
+            error,
+            painted_bounds: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    fn label_rect(&self, bounds: ui::Rect) -> Option<ui::Rect> {
+        let selection = self.geometry_source.play_selection?;
+        let geometry = self
+            .geometry_source
+            .selection_geometry(bounds, Some(selection))?;
+        playmark_label::playmark_label_layout(bounds, geometry.rect, self.label.len())
+            .map(|layout| layout.rect)
+    }
+
+    fn editing(&self) -> bool {
+        self.input.is_some()
+    }
+}
+
+impl Widget for PlaymarkLabelWidget {
+    fn common(&self) -> &WidgetCommon {
+        self.input
+            .as_ref()
+            .map(Widget::common)
+            .unwrap_or_else(|| self.geometry_source.common())
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        self.input
+            .as_mut()
+            .map(Widget::common_mut)
+            .unwrap_or_else(|| self.geometry_source.common_mut())
+    }
+
+    fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        let label_rect = self.label_rect(bounds)?;
+        if let Some(text_input) = self.input.as_mut() {
+            if matches!(input, WidgetInput::FocusChanged(false)) {
+                let value = text_input.state.value.clone();
+                let _ = text_input.handle_input(label_rect, input);
+                return Some(WidgetOutput::typed(PlaymarkLabelMessage::Commit(value)));
+            }
+            return text_input
+                .handle_input(label_rect, input)
+                .map(|message| match message {
+                    TextInputMessage::Changed { value } => PlaymarkLabelMessage::Changed(value),
+                    TextInputMessage::Submitted { value }
+                    | TextInputMessage::CompletionRequested { value } => {
+                        PlaymarkLabelMessage::Commit(value)
+                    }
+                })
+                .map(WidgetOutput::typed);
+        }
+        (matches!(input, WidgetInput::PointerDoubleClick { position, .. } if label_rect.contains(position))
+            || matches!(input, WidgetInput::KeyPress(WidgetKey::Enter | WidgetKey::Space)))
+        .then(|| WidgetOutput::typed(PlaymarkLabelMessage::BeginEdit))
+    }
+
+    fn synchronize_from_previous(&mut self, previous: &dyn Widget) {
+        let Some(previous) = previous.as_any().downcast_ref::<Self>() else {
+            return;
+        };
+        if let (Some(input), Some(previous_input)) = (&mut self.input, &previous.input) {
+            input.synchronize_from_previous(previous_input);
+        }
+        self.painted_bounds = Arc::clone(&previous.painted_bounds);
+    }
+
+    fn accepts_text_input(&self) -> bool {
+        self.input.as_ref().is_some_and(Widget::accepts_text_input)
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        false
+    }
+
+    fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
+        input.pointer_position().is_none_or(|position| {
+            self.painted_bounds
+                .lock()
+                .ok()
+                .and_then(|bounds| *bounds)
+                .and_then(|bounds| self.label_rect(bounds))
+                .is_some_and(|rect| rect.contains(position))
+        })
+    }
+
+    fn automation_role(&self) -> AutomationRole {
+        if self.editing() {
+            AutomationRole::TextInput
+        } else {
+            AutomationRole::Button
+        }
+    }
+
+    fn automation_label(&self) -> Option<String> {
+        Some(String::from("Playmark length"))
+    }
+
+    fn automation_description(&self) -> Option<String> {
+        self.error.clone().or_else(|| {
+            (!self.editing()).then(|| String::from("Double-click to edit the playmark length"))
+        })
+    }
+
+    fn automation_value_text(&self) -> Option<String> {
+        self.input
+            .as_ref()
+            .map(|input| input.state.value.clone())
+            .or_else(|| Some(self.label.clone()))
+    }
+
+    fn selected_text_slice(&self) -> Option<&str> {
+        self.input.as_ref().and_then(Widget::selected_text_slice)
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        self.input.as_ref().and_then(Widget::selected_text)
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: ui::Rect,
+        layout: &ui::LayoutOutput,
+        theme: &ui::ThemeTokens,
+    ) {
+        if let Ok(mut painted_bounds) = self.painted_bounds.lock() {
+            *painted_bounds = Some(bounds);
+        }
+        let (Some(input), Some(rect)) = (&self.input, self.label_rect(bounds)) else {
+            return;
+        };
+        input.append_paint(primitives, rect, layout, theme);
+    }
+}
+
+pub(super) fn parsed_playmark_frame_range(
+    text: &str,
+    sample_rate: u32,
+    total_frames: usize,
+    beat_count: u8,
+    current: wavecrate::selection::SelectionRange,
+) -> Result<(usize, usize), String> {
+    if total_frames == 0 {
+        return Err(String::from("The loaded sample has no audio frames"));
+    }
+    let seconds = parse_length_seconds(text, beat_count)?;
+    let requested_frames = (seconds * f64::from(sample_rate.max(1))).round();
+    if !requested_frames.is_finite() || requested_frames < 1.0 {
+        return Err(String::from(
+            "Playmark length must be at least one sample frame",
+        ));
+    }
+    if requested_frames > total_frames as f64 {
+        return Err(String::from("Playmark length exceeds the loaded sample"));
+    }
+    let requested_frames = requested_frames as usize;
+    let current = current.frame_bounds(total_frames);
+    let midpoint_twice = current.start_frame.saturating_add(current.end_frame);
+    let centered_start = midpoint_twice.saturating_sub(requested_frames) / 2;
+    let start = centered_start.min(total_frames - requested_frames);
+    Ok((start, start + requested_frames))
+}
+
+fn parse_length_seconds(text: &str, beat_count: u8) -> Result<f64, String> {
+    let compact = text
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    if let Some(number) = compact.strip_suffix("bpm") {
+        let bpm = positive_number(number)?;
+        if beat_count == 0 {
+            return Err(String::from(
+                "Set a positive beat count before entering BPM",
+            ));
+        }
+        return Ok(f64::from(beat_count) * 60.0 / bpm);
+    }
+
+    let mut remaining = compact.as_str();
+    let mut seconds = 0.0;
+    let mut components = 0;
+    while !remaining.is_empty() {
+        let number_end = remaining
+            .char_indices()
+            .take_while(|(_, character)| character.is_ascii_digit() || *character == '.')
+            .map(|(index, character)| index + character.len_utf8())
+            .last()
+            .unwrap_or(0);
+        if number_end == 0 {
+            return Err(String::from(
+                "Use a value such as 1000ms, 1.5s, 1min, or 142bpm",
+            ));
+        }
+        let number = non_negative_number(&remaining[..number_end])?;
+        remaining = &remaining[number_end..];
+        let (factor, unit_len) = if remaining.starts_with("min") {
+            (60.0, 3)
+        } else if remaining.starts_with("ms") {
+            (0.001, 2)
+        } else if remaining.starts_with('m') {
+            (60.0, 1)
+        } else if remaining.starts_with('s') {
+            (1.0, 1)
+        } else {
+            return Err(String::from(
+                "Use a value such as 1000ms, 1.5s, 1min, or 142bpm",
+            ));
+        };
+        seconds += number * factor;
+        components += 1;
+        remaining = &remaining[unit_len..];
+    }
+    if components == 0 || !seconds.is_finite() || seconds <= 0.0 {
+        return Err(String::from("Playmark length must be positive and finite"));
+    }
+    Ok(seconds)
+}
+
+fn positive_number(text: &str) -> Result<f64, String> {
+    text.parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .ok_or_else(|| String::from("Playmark length must be positive and finite"))
+}
+
+fn non_negative_number(text: &str) -> Result<f64, String> {
+    text.parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .ok_or_else(|| String::from("Playmark length must be positive and finite"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native_app::waveform::WaveformWidgetProps;
+    use radiant::widgets::{PointerButton, PointerModifiers};
+
+    #[test]
+    fn parses_supported_time_and_bpm_forms_case_insensitively() {
+        assert_eq!(parse_length_seconds(" 1000 MS ", 4), Ok(1.0));
+        assert_eq!(parse_length_seconds("1.5s", 4), Ok(1.5));
+        assert_eq!(parse_length_seconds("1 MIN", 4), Ok(60.0));
+        assert_eq!(parse_length_seconds("2m 05.00s", 4), Ok(125.0));
+        assert_eq!(parse_length_seconds("2m 00s", 4), Ok(120.0));
+        assert_eq!(parse_length_seconds("120 bpm", 4), Ok(2.0));
+    }
+
+    #[test]
+    fn preserves_frame_length_and_moves_centered_range_inside_edges() {
+        let current = wavecrate::selection::SelectionRange::from_frame_bounds(1_000, 850, 950);
+        assert_eq!(
+            parsed_playmark_frame_range("0.4s", 1_000, 1_000, 4, current),
+            Ok((600, 1_000))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_too_short_and_too_long_lengths() {
+        let current = wavecrate::selection::SelectionRange::from_frame_bounds(100, 20, 40);
+        assert!(parse_length_seconds("NaNs", 4).is_err());
+        assert!(parsed_playmark_frame_range("0.0001s", 1_000, 100, 4, current).is_err());
+        assert!(parsed_playmark_frame_range("1s", 1_000, 100, 4, current).is_err());
+    }
+
+    #[test]
+    fn label_widget_only_claims_pointer_input_inside_its_painted_label() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.set_play_selection_range(0.25, 0.75);
+        let geometry_source =
+            WaveformWidget::new(WaveformWidgetProps::from_state(&state, false, false, 4));
+        let mut widget = PlaymarkLabelWidget::new(14, geometry_source, &state, false, 4)
+            .expect("playmark label widget");
+        let bounds =
+            ui::Rect::from_min_max(ui::Point::new(20.0, 40.0), ui::Point::new(1_220.0, 360.0));
+        *widget.painted_bounds.lock().expect("painted bounds") = Some(bounds);
+        let label_rect = widget.label_rect(bounds).expect("label rect");
+
+        let inside = WidgetInput::pointer_double_click(
+            ui::Point::new(label_rect.min.x + 1.0, label_rect.min.y + 1.0),
+            PointerButton::Primary,
+            PointerModifiers::default(),
+        );
+        let outside =
+            WidgetInput::primary_press(ui::Point::new(bounds.min.x + 1.0, bounds.min.y + 1.0));
+
+        assert!(widget.accepts_pointer_input(&inside));
+        assert!(widget.handle_input(bounds, inside).is_some());
+        assert!(!widget.accepts_pointer_input(&outside));
+    }
+}

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -80,7 +80,9 @@ impl WaveformWidget {
             {
                 self.append_edit_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
             }
-            self.append_base_playmark_label_paint(&mut paint, bounds);
+            if !self.playmark_label_editor_active {
+                self.append_base_playmark_label_paint(&mut paint, bounds);
+            }
             self.append_played_range_paint(&mut paint, bounds);
         }
         self.append_marker_paint(&mut paint, bounds);

--- a/src/native_app/waveform/state.rs
+++ b/src/native_app/waveform/state.rs
@@ -66,6 +66,8 @@ pub(in crate::native_app) struct WaveformState {
     pub(in crate::native_app::waveform) detail_summary: Option<WaveformDetailSummary>,
     pub(in crate::native_app::waveform) pending_detail_key: Option<WaveformDetailKey>,
     pub(in crate::native_app::waveform) failed_detail_key: Option<WaveformDetailKey>,
+    pub(in crate::native_app::waveform) playmark_label_editor:
+        Option<super::PlaymarkLabelEditorState>,
 }
 
 impl WaveformState {

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -183,6 +183,10 @@ impl WaveformState {
                 self.apply_play_selection_export_drag(drag);
             }
             WaveformInteraction::DragLoadedSample(_) => {}
+            WaveformInteraction::SetPlaySelectionFrameRange {
+                start_frame,
+                end_frame,
+            } => self.set_play_selection_frame_range(start_frame, end_frame),
             WaveformInteraction::Frame => {
                 self.play_selection_flash_frames =
                     self.play_selection_flash_frames.saturating_sub(1);

--- a/src/native_app/waveform/state_loading.rs
+++ b/src/native_app/waveform/state_loading.rs
@@ -157,6 +157,7 @@ impl WaveformState {
             detail_summary: None,
             pending_detail_key: None,
             failed_detail_key: None,
+            playmark_label_editor: None,
         }
     }
 

--- a/src/native_app/waveform/state_selection.rs
+++ b/src/native_app/waveform/state_selection.rs
@@ -78,6 +78,12 @@ impl WaveformState {
         self.record_current_play_selection_mark();
     }
 
+    pub(super) fn set_play_selection_frame_range(&mut self, start_frame: usize, end_frame: usize) {
+        let selection = SelectionRange::from_frame_bounds(self.file.frames, start_frame, end_frame);
+        self.set_selection_for_kind(WaveformSelectionKind::Play, selection.start(), selection);
+        self.record_current_play_selection_mark();
+    }
+
     pub(in crate::native_app) fn slide_play_selection_by_width(&mut self, direction: i8) -> bool {
         let direction = direction.signum();
         let Some(selection) = self

--- a/src/native_app/waveform/types.rs
+++ b/src/native_app/waveform/types.rs
@@ -1,6 +1,14 @@
 use radiant::gui::types::{Point, Vector2};
 use radiant::widgets::DragHandleMessage;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum PlaymarkLabelMessage {
+    BeginEdit,
+    Changed(String),
+    Commit(String),
+    Cancel,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::native_app) enum WaveformInteraction {
     Wheel {
@@ -11,6 +19,10 @@ pub(in crate::native_app) enum WaveformInteraction {
     ZoomToPlaySelection,
     SlidePlaySelection {
         direction: i8,
+    },
+    SetPlaySelectionFrameRange {
+        start_frame: usize,
+        end_frame: usize,
     },
     ZoomFull,
     ScrollTo {

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -23,6 +23,7 @@ use super::{
     WaveformState, WaveformViewport,
     audio_file::{gain_preview_for_range_with_gain, gain_preview_for_selection},
     edit_preview_for_selection,
+    playmark_label_editor::PlaymarkLabelWidget,
     widget_geometry::WaveformSelectionHandleHover,
 };
 
@@ -56,20 +57,18 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     normalized_audition_enabled: bool,
     playhead_occlusion_rect: Option<Rect>,
 ) -> ui::View<GuiMessage> {
-    let interaction = ui::custom_widget(
-        WaveformWidget::new(WaveformWidgetProps::from_state_with_playhead_occlusion(
-            state,
-            beat_guides_enabled,
-            bpm_snap_enabled,
-            beat_guide_count,
-            playhead_occlusion_rect,
-        )),
-        |output| {
-            output
-                .typed_copied::<WaveformInteraction>()
-                .map(GuiMessage::Waveform)
-        },
-    )
+    let props = WaveformWidgetProps::from_state_with_playhead_occlusion(
+        state,
+        beat_guides_enabled,
+        bpm_snap_enabled,
+        beat_guide_count,
+        playhead_occlusion_rect,
+    );
+    let interaction = ui::custom_widget(WaveformWidget::new(props.clone()), |output| {
+        output
+            .typed_copied::<WaveformInteraction>()
+            .map(GuiMessage::Waveform)
+    })
     .id(WAVEFORM_WIDGET_ID)
     .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32);
     let interaction = if let Some(tooltip) = tooltip {
@@ -77,6 +76,23 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     } else {
         interaction
     };
+    let label = PlaymarkLabelWidget::new(
+        widget_ids::WAVEFORM_PLAYMARK_LABEL_ID,
+        WaveformWidget::new(props),
+        state,
+        beat_guides_enabled,
+        beat_guide_count,
+    )
+    .map(|widget| {
+        ui::custom_widget(widget, |output| {
+            output
+                .typed_cloned::<super::PlaymarkLabelMessage>()
+                .map(GuiMessage::PlaymarkLabel)
+        })
+        .id(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID)
+        .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
+    })
+    .unwrap_or_else(ui::empty);
 
     ui::stack([
         waveform_signal_surface_view(
@@ -87,6 +103,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         .id(WAVEFORM_SIGNAL_WIDGET_ID)
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32),
         interaction,
+        label,
     ])
     .id(widget_ids::WAVEFORM_VIEWPORT_STACK_ID)
     .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
@@ -218,6 +235,7 @@ pub(in crate::native_app) struct WaveformWidgetProps {
     bpm_snap_enabled: bool,
     beat_guide_count: u8,
     playhead_occlusion_rect: Option<Rect>,
+    playmark_label_editor_active: bool,
     pub(in crate::native_app::waveform) active_drag_kind: Option<WaveformActiveDragKind>,
 }
 
@@ -286,6 +304,7 @@ impl WaveformWidgetProps {
             bpm_snap_enabled,
             beat_guide_count,
             playhead_occlusion_rect,
+            playmark_label_editor_active: state.playmark_label_editor.is_some(),
             active_drag_kind,
         }
     }
@@ -341,6 +360,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) bpm_snap_enabled: bool,
     pub(super) beat_guide_count: u8,
     pub(super) playhead_occlusion_rect: Option<Rect>,
+    pub(super) playmark_label_editor_active: bool,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
     pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
@@ -379,6 +399,7 @@ impl WaveformWidget {
             bpm_snap_enabled,
             beat_guide_count,
             playhead_occlusion_rect,
+            playmark_label_editor_active,
             active_drag_kind,
         } = props;
         let common = WidgetCommon::fixed(0, WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
@@ -414,6 +435,7 @@ impl WaveformWidget {
             bpm_snap_enabled,
             beat_guide_count,
             playhead_occlusion_rect,
+            playmark_label_editor_active,
             edit_preview: edit_preview_for_selection(edit_selection),
             last_live_selection_update_visible_ratio: None,
             live_selection_preview_anchor: None,


### PR DESCRIPTION
## Goal

Let users edit a playmark's exact length by double-clicking its visible duration/BPM label.

## Scope and non-goals

- Adds a focused inline label editor with select-all behavior, Enter/focus-loss commit, and Escape cancel.
- Accepts whitespace-tolerant, case-insensitive time values (`1000ms`, `1.5s`, `1min`) and BPM values (`142bpm`) using the configured beat count.
- Converts accepted values to deterministic frame ranges while preserving the playmark midpoint and shifting the result within sample bounds.
- Routes successful commits through the existing finished playmark mutation path so playback, history, beat guides, selection state, and harvest touch behavior remain coherent.
- Adds automation semantics and modal shortcut suppression while editing.
- Does not edit audio content, BPM metadata, editmarks, or resize the mark live while typing.

## Definition of Done

- Double-clicking only the painted playmark label opens the inline editor with the current label selected.
- Valid time/BPM values commit a frame-exact playmark length and create one undoable transaction.
- Invalid, non-finite, zero, sub-frame, or overlong values show an error and leave the editor open.
- Enter and valid focus loss commit; Escape cancels; global transport/destructive shortcuts remain suppressed during text entry.
- Protected-source behavior remains transient and uses the same existing mutation path.

## Validation

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `CARGO_TARGET_DIR=/tmp/wavecrate-opt1229-target cargo test -p wavecrate playmark_label --lib` — passed, 16 tests.
- `bash scripts/build.sh --release` — passed; signed app bundle produced.
- Live signed-app exercise — double-click opened the editor with the current label selected; typed value and accessibility role/value were verified.
- `bash scripts/ci.sh smoke` — blocked by the pre-existing invalid format string at `tests/release_workflow_helpers.rs:936` (unescaped `{`), before this change's tests run.

## Known limitations

The live commit attempt in the active profile encountered an existing UI stall in `mark_harvest_touched_for_path` while source processing held/opened the source database. The new editor's commit behavior is covered through the application-state transaction test, but a second isolated live commit could not be completed after macOS locked the test session.

User approval is required before merge.

Linear: OPT-1229
