### PR TITLE
Wavecrate: add beat-grid controls beside the playmark label

### DIFF
--- a/src/native_app/app_chrome/toolbar.rs
+++ b/src/native_app/app_chrome/toolbar.rs
@@ -7,7 +7,9 @@ use radiant::{prelude as ui, widgets::ButtonMessage};
 
 use crate::native_app::app::GuiMessage;
 use crate::native_app::app_chrome::view_models::toolbar::MainToolbarViewModel;
-use beat_count_input::{BeatGuideCountInputMessage, BeatGuideCountInputWidget};
+pub(in crate::native_app) use beat_count_input::{
+    BeatGuideCountInputMessage, BeatGuideCountInputWidget,
+};
 
 pub(in crate::native_app) use icons::{ToolbarIcon, toolbar_icon_color, toolbar_icon_glyph};
 pub(in crate::native_app) use projection::{
@@ -66,7 +68,9 @@ fn beat_guide_count_field(count: u8, id: u64, key: &'static str) -> ui::View<Gui
     .size(34.0, 24.0)
 }
 
-fn beat_guide_count_input_message(message: BeatGuideCountInputMessage) -> GuiMessage {
+pub(in crate::native_app) fn beat_guide_count_input_message(
+    message: BeatGuideCountInputMessage,
+) -> GuiMessage {
     match message {
         BeatGuideCountInputMessage::Changed(value) => GuiMessage::ChangeBeatGuideCountInput(value),
         BeatGuideCountInputMessage::Committed(value) => {

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -8,19 +8,19 @@ use radiant::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum BeatGuideCountInputMessage {
+pub(in crate::native_app) enum BeatGuideCountInputMessage {
     Changed(String),
     Committed(String),
     Set(u8),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(super) struct BeatGuideCountInputWidget {
+pub(in crate::native_app) struct BeatGuideCountInputWidget {
     input: TextInputWidget,
 }
 
 impl BeatGuideCountInputWidget {
-    pub(super) fn new(id: u64, count: u8, width: f32, height: f32) -> Self {
+    pub(in crate::native_app) fn new(id: u64, count: u8, width: f32, height: f32) -> Self {
         let mut input = TextInputWidget::new(
             id,
             count.to_string(),

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -4,9 +4,15 @@ use crate::native_app::{
         waveform_panel::{WAVEFORM_PANEL_HEIGHT, waveform_panel},
     },
     test_support::state::NativeAppStateFixture,
-    ui::ids::WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID,
+    ui::ids::{
+        WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID, WAVEFORM_PLAYMARK_BEAT_COUNT_ID,
+        WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID,
+    },
 };
-use radiant::prelude::{self as ui, IntoView};
+use radiant::{
+    gui::automation::AutomationRole,
+    prelude::{self as ui, IntoView},
+};
 
 fn loaded_sample_drag_handle_tooltip(
     state: &crate::native_app::app::NativeAppState,
@@ -118,5 +124,53 @@ fn waveform_help_tooltip_attaches_to_interaction_widget() {
         Some(
             "Waveform: click to set playback start, drag to select, Z zooms to selection, X zooms out."
         )
+    );
+}
+
+#[test]
+fn playmark_beat_controls_project_shared_toolbar_state_and_semantics() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    state.ui.chrome.beat_guides_enabled = true;
+    state.ui.chrome.beat_guide_count = 16;
+
+    let surface = waveform_panel(WaveformPanelViewModel::from_app_state(&state)).into_surface();
+    let toggle = surface
+        .find_widget(WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID)
+        .expect("playmark beat toggle")
+        .widget_object()
+        .automation_semantics();
+    let count = surface
+        .find_widget(WAVEFORM_PLAYMARK_BEAT_COUNT_ID)
+        .expect("playmark beat count")
+        .widget_object()
+        .automation_semantics();
+
+    assert_eq!(toggle.role, AutomationRole::Toggle);
+    assert_eq!(toggle.label.as_deref(), Some("Playmark beat grid"));
+    assert_eq!(toggle.checked, Some(true));
+    assert_eq!(count.role, AutomationRole::TextInput);
+    assert_eq!(count.label.as_deref(), Some("Playmark beat count"));
+    assert_eq!(count.value_text.as_deref(), Some("16"));
+}
+
+#[test]
+fn playmark_beat_controls_are_absent_without_a_playmark() {
+    let state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    let surface = waveform_panel(WaveformPanelViewModel::from_app_state(&state)).into_surface();
+
+    assert!(
+        surface
+            .find_widget(WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID)
+            .is_none()
+    );
+    assert!(
+        surface
+            .find_widget(WAVEFORM_PLAYMARK_BEAT_COUNT_ID)
+            .is_none()
     );
 }

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -13,6 +13,98 @@ fn full_app_scene_routes_waveform_hit_target() {
 }
 
 #[test]
+fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    let original_selection = state.waveform.current.play_selection();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let theme = radiant::theme::ThemeTokens::default();
+    let frame = runtime.frame(&theme);
+    let toggle_id = crate::native_app::ui::ids::WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID;
+    let toggle_point = frame
+        .paint_plan
+        .first_svg_rect_for_widget(toggle_id)
+        .expect("local beat toggle paint")
+        .center();
+    let count_id = crate::native_app::ui::ids::WAVEFORM_PLAYMARK_BEAT_COUNT_ID;
+    let initial_count_rect = frame
+        .paint_plan
+        .text_inputs()
+        .find(|input| input.widget_id == count_id)
+        .map(|input| input.rect)
+        .expect("initial local beat count paint");
+    assert!(!initial_count_rect.contains(toggle_point));
+    let toggle_press = WidgetInput::PointerPress {
+        position: toggle_point,
+        button: PointerButton::Primary,
+        modifiers: Default::default(),
+    };
+    assert!(
+        !runtime
+            .surface()
+            .find_widget(count_id)
+            .expect("count widget")
+            .widget_object()
+            .accepts_pointer_input(&toggle_press),
+        "count widget must reject the adjacent toggle hit"
+    );
+
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_press(toggle_point)),
+        Some(toggle_id)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_release(toggle_point)),
+        Some(toggle_id)
+    );
+    assert!(runtime.bridge().state().ui.chrome.beat_guides_enabled);
+    assert!(
+        crate::native_app::test_support::toolbar::main_toolbar_projection(runtime.bridge().state())
+            .beat_guides_enabled
+    );
+    assert_eq!(
+        runtime.bridge().state().waveform.current.play_selection(),
+        original_selection,
+        "local toggle must not leak into waveform gestures"
+    );
+
+    let frame = runtime.frame(&theme);
+    assert!(frame.paint_plan.contains_text("480 BPM"));
+    assert!(!frame.paint_plan.contains_text("500 ms"));
+    let count_point = frame
+        .paint_plan
+        .text_inputs()
+        .find(|input| input.widget_id == count_id)
+        .map(|input| input.rect)
+        .expect("local beat count paint")
+        .center();
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_press(count_point)),
+        Some(count_id)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_release(count_point)),
+        Some(count_id)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::KeyPress(WidgetKey::ArrowUp)),
+        Some(count_id)
+    );
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 5);
+    assert_eq!(
+        crate::native_app::test_support::toolbar::main_toolbar_projection(runtime.bridge().state())
+            .beat_guide_count,
+        5
+    );
+    assert!(runtime.frame(&theme).paint_plan.contains_text("600 BPM"));
+    assert_eq!(
+        runtime.bridge().state().waveform.current.play_selection(),
+        original_selection,
+        "local count editing must not leak into waveform gestures"
+    );
+}
+
+#[test]
 fn stale_waveform_loading_label_does_not_mask_waveform_hit_target() {
     let mut state = gui_state_for_span_tests();
     state.waveform.load.label = Some(String::from("previous.wav"));

--- a/src/native_app/ui/ids.rs
+++ b/src/native_app/ui/ids.rs
@@ -43,6 +43,8 @@ pub(in crate::native_app) const WAVEFORM_SIGNAL_WIDGET_ID: u64 = WAVEFORM.id(11)
 pub(in crate::native_app) const WAVEFORM_WIDGET_ID: u64 = WAVEFORM.id(12);
 pub(in crate::native_app) const WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID: u64 = WAVEFORM.id(13);
 pub(in crate::native_app) const WAVEFORM_PLAYMARK_LABEL_ID: u64 = WAVEFORM.id(14);
+pub(in crate::native_app) const WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID: u64 = WAVEFORM.id(15);
+pub(in crate::native_app) const WAVEFORM_PLAYMARK_BEAT_COUNT_ID: u64 = WAVEFORM.id(16);
 
 pub(in crate::native_app) const FOLDER_TREE_LIST_ID: u64 = FOLDER_TREE.id(0);
 pub(in crate::native_app) const FOLDER_TREE_INCLUDE_SUBFOLDERS_TOGGLE_ID: u64 = FOLDER_TREE.id(1);

--- a/src/native_app/ui/ids/registry.rs
+++ b/src/native_app/ui/ids/registry.rs
@@ -70,6 +70,21 @@ const REGISTERED_WIDGET_IDS: &[RegisteredWidgetId] = &[
     registered_widget_id!(Waveform, WAVEFORM_WIDGET_ID, "waveform.interaction_widget"),
     registered_widget_id!(
         Waveform,
+        WAVEFORM_PLAYMARK_LABEL_ID,
+        "waveform.playmark_label"
+    ),
+    registered_widget_id!(
+        Waveform,
+        WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID,
+        "waveform.playmark_beat_toggle"
+    ),
+    registered_widget_id!(
+        Waveform,
+        WAVEFORM_PLAYMARK_BEAT_COUNT_ID,
+        "waveform.playmark_beat_count"
+    ),
+    registered_widget_id!(
+        Waveform,
         WAVEFORM_LOADED_SAMPLE_DRAG_HANDLE_ID,
         "waveform.loaded_sample_drag_handle"
     ),

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -30,6 +30,7 @@ mod interaction;
 use interaction::{WaveformDrag, edit_preview_for_selection};
 mod bpm_snap;
 use bpm_snap::snap_resize_ratio_to_whole_bpm;
+mod playmark_beat_controls;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(in crate::native_app) struct WaveformBpmSnapSettings {

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -1,0 +1,449 @@
+use radiant::{
+    gui::automation::AutomationRole,
+    prelude as ui,
+    widgets::{
+        IconButtonWidget, Widget, WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
+    },
+};
+use std::sync::{Arc, Mutex};
+
+use crate::native_app::{
+    app::GuiMessage,
+    app_chrome::toolbar::{
+        BeatGuideCountInputMessage, BeatGuideCountInputWidget, ToolbarIcon,
+        beat_guide_count_input_message, toolbar_icon_glyph,
+    },
+};
+
+use super::{WaveformState, WaveformWidget, playmark_label};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlaymarkBeatToggleMessage {
+    Toggle,
+}
+
+#[derive(Clone, Debug)]
+struct PlaymarkBeatToggleWidget {
+    geometry_source: WaveformWidget,
+    label: String,
+    button: IconButtonWidget,
+    checked: bool,
+    painted_bounds: Arc<Mutex<Option<ui::Rect>>>,
+}
+
+impl PlaymarkBeatToggleWidget {
+    fn new(
+        id: u64,
+        geometry_source: WaveformWidget,
+        state: &WaveformState,
+        beat_guides_enabled: bool,
+        beat_guide_count: u8,
+    ) -> Option<Self> {
+        let selection = state.play_selection()?;
+        let label = playmark_label::playmark_selection_label(
+            selection,
+            state.frames(),
+            state.sample_rate(),
+            beat_guides_enabled,
+            beat_guide_count,
+        )?;
+        let mut button = IconButtonWidget::new(
+            id,
+            toolbar_icon_glyph(ToolbarIcon::BeatGuides, true, beat_guides_enabled),
+            WidgetSizing::fixed(ui::Vector2::new(
+                playmark_label::PLAYMARK_BEAT_TOGGLE_WIDTH,
+                playmark_label::PLAYMARK_LABEL_HEIGHT,
+            )),
+        );
+        button.common.state.active = beat_guides_enabled;
+        button.common.paint.paints_focus = true;
+        Some(Self {
+            geometry_source,
+            label,
+            button,
+            checked: beat_guides_enabled,
+            painted_bounds: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    fn control_rect(&self, bounds: ui::Rect) -> Option<ui::Rect> {
+        playmark_control_layout(&self.geometry_source, &self.label, bounds)
+            .map(|layout| layout.beat_toggle_rect)
+    }
+}
+
+impl Widget for PlaymarkBeatToggleWidget {
+    fn common(&self) -> &WidgetCommon {
+        self.button.common()
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        self.button.common_mut()
+    }
+
+    fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        let rect = self.control_rect(bounds)?;
+        self.button
+            .handle_input(rect, input)
+            .map(|_| WidgetOutput::typed(PlaymarkBeatToggleMessage::Toggle))
+    }
+
+    fn synchronize_from_previous(&mut self, previous: &dyn Widget) {
+        let Some(previous) = previous.as_any().downcast_ref::<Self>() else {
+            return;
+        };
+        self.button.synchronize_from_previous(&previous.button);
+        self.button.common.state.active = self.checked;
+        self.painted_bounds = Arc::clone(&previous.painted_bounds);
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        self.button.accepts_pointer_move()
+    }
+
+    fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
+        pointer_is_inside_control(input, &self.painted_bounds, |bounds| {
+            self.control_rect(bounds)
+        })
+    }
+
+    fn automation_role(&self) -> AutomationRole {
+        AutomationRole::Toggle
+    }
+
+    fn automation_label(&self) -> Option<String> {
+        Some(String::from("Playmark beat grid"))
+    }
+
+    fn automation_description(&self) -> Option<String> {
+        Some(String::from("Show beat guide lines inside the playmark"))
+    }
+
+    fn automation_checked(&self) -> Option<bool> {
+        Some(self.checked)
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: ui::Rect,
+        layout: &ui::LayoutOutput,
+        theme: &ui::ThemeTokens,
+    ) {
+        remember_painted_bounds(&self.painted_bounds, bounds);
+        if let Some(rect) = self.control_rect(bounds) {
+            self.button.append_paint(primitives, rect, layout, theme);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PlaymarkBeatCountWidget {
+    geometry_source: WaveformWidget,
+    label: String,
+    input: BeatGuideCountInputWidget,
+    painted_bounds: Arc<Mutex<Option<ui::Rect>>>,
+}
+
+impl PlaymarkBeatCountWidget {
+    fn new(
+        id: u64,
+        geometry_source: WaveformWidget,
+        state: &WaveformState,
+        beat_guides_enabled: bool,
+        beat_guide_count: u8,
+    ) -> Option<Self> {
+        let selection = state.play_selection()?;
+        let label = playmark_label::playmark_selection_label(
+            selection,
+            state.frames(),
+            state.sample_rate(),
+            beat_guides_enabled,
+            beat_guide_count,
+        )?;
+        Some(Self {
+            geometry_source,
+            label,
+            input: BeatGuideCountInputWidget::new(
+                id,
+                beat_guide_count,
+                playmark_label::PLAYMARK_BEAT_COUNT_WIDTH,
+                playmark_label::PLAYMARK_LABEL_HEIGHT,
+            ),
+            painted_bounds: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    fn control_rect(&self, bounds: ui::Rect) -> Option<ui::Rect> {
+        playmark_control_layout(&self.geometry_source, &self.label, bounds)
+            .map(|layout| layout.beat_count_rect)
+    }
+}
+
+impl Widget for PlaymarkBeatCountWidget {
+    fn common(&self) -> &WidgetCommon {
+        self.input.common()
+    }
+
+    fn common_mut(&mut self) -> &mut WidgetCommon {
+        self.input.common_mut()
+    }
+
+    fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
+        self.input.handle_input(self.control_rect(bounds)?, input)
+    }
+
+    fn synchronize_from_previous(&mut self, previous: &dyn Widget) {
+        let Some(previous) = previous.as_any().downcast_ref::<Self>() else {
+            return;
+        };
+        self.input.synchronize_from_previous(&previous.input);
+        self.painted_bounds = Arc::clone(&previous.painted_bounds);
+    }
+
+    fn accepts_text_input(&self) -> bool {
+        self.input.accepts_text_input()
+    }
+
+    fn preempts_host_shortcut_key(&self, key: WidgetKey) -> bool {
+        self.input.preempts_host_shortcut_key(key)
+    }
+
+    fn accepts_pointer_move(&self) -> bool {
+        self.input.accepts_pointer_move()
+    }
+
+    fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
+        pointer_is_inside_control(input, &self.painted_bounds, |bounds| {
+            self.control_rect(bounds)
+        })
+    }
+
+    fn automation_role(&self) -> AutomationRole {
+        self.input.automation_role()
+    }
+
+    fn automation_label(&self) -> Option<String> {
+        Some(String::from("Playmark beat count"))
+    }
+
+    fn automation_value_text(&self) -> Option<String> {
+        self.input.automation_value_text()
+    }
+
+    fn selected_text_slice(&self) -> Option<&str> {
+        self.input.selected_text_slice()
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        self.input.selected_text()
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: ui::Rect,
+        layout: &ui::LayoutOutput,
+        theme: &ui::ThemeTokens,
+    ) {
+        remember_painted_bounds(&self.painted_bounds, bounds);
+        if let Some(rect) = self.control_rect(bounds) {
+            self.input.append_paint(primitives, rect, layout, theme);
+        }
+    }
+}
+
+pub(super) fn playmark_beat_control_views(
+    toggle_id: u64,
+    count_id: u64,
+    geometry_source: WaveformWidget,
+    state: &WaveformState,
+    beat_guides_enabled: bool,
+    beat_guide_count: u8,
+) -> [ui::View<GuiMessage>; 2] {
+    let toggle = PlaymarkBeatToggleWidget::new(
+        toggle_id,
+        geometry_source.clone(),
+        state,
+        beat_guides_enabled,
+        beat_guide_count,
+    )
+    .map(|widget| {
+        ui::custom_widget(widget, |output| {
+            output
+                .typed_copied::<PlaymarkBeatToggleMessage>()
+                .map(|_| GuiMessage::ToggleBeatGuides)
+        })
+        .id(toggle_id)
+        .size(super::WAVEFORM_WIDTH as f32, super::WAVEFORM_HEIGHT as f32)
+    })
+    .unwrap_or_else(ui::empty);
+    let count = PlaymarkBeatCountWidget::new(
+        count_id,
+        geometry_source,
+        state,
+        beat_guides_enabled,
+        beat_guide_count,
+    )
+    .map(|widget| {
+        ui::custom_widget(widget, |output| {
+            output
+                .typed_cloned::<BeatGuideCountInputMessage>()
+                .map(beat_guide_count_input_message)
+        })
+        .id(count_id)
+        .size(super::WAVEFORM_WIDTH as f32, super::WAVEFORM_HEIGHT as f32)
+    })
+    .unwrap_or_else(ui::empty);
+    [toggle, count]
+}
+
+fn playmark_control_layout(
+    geometry_source: &WaveformWidget,
+    label: &str,
+    bounds: ui::Rect,
+) -> Option<playmark_label::PlaymarkLabelLayout> {
+    let selection = geometry_source.play_selection?;
+    let geometry = geometry_source.selection_geometry(bounds, Some(selection))?;
+    playmark_label::playmark_label_layout(bounds, geometry.rect, label.len())
+}
+
+fn pointer_is_inside_control(
+    input: &WidgetInput,
+    painted_bounds: &Arc<Mutex<Option<ui::Rect>>>,
+    rect: impl FnOnce(ui::Rect) -> Option<ui::Rect>,
+) -> bool {
+    input.pointer_position().is_none_or(|position| {
+        painted_bounds
+            .lock()
+            .ok()
+            .and_then(|bounds| *bounds)
+            .and_then(rect)
+            .is_some_and(|bounds| bounds.contains(position))
+    })
+}
+
+fn remember_painted_bounds(painted_bounds: &Arc<Mutex<Option<ui::Rect>>>, bounds: ui::Rect) {
+    if let Ok(mut painted_bounds) = painted_bounds.lock() {
+        *painted_bounds = Some(bounds);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use radiant::widgets::{PointerButton, PointerModifiers};
+
+    fn rect(left: f32, top: f32, width: f32, height: f32) -> ui::Rect {
+        ui::Rect::from_min_size(ui::Point::new(left, top), ui::Vector2::new(width, height))
+    }
+
+    #[test]
+    fn local_control_hit_testing_only_claims_its_own_painted_rect() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.set_play_selection_range(0.4, 0.6);
+        let geometry_source = WaveformWidget::new(super::super::WaveformWidgetProps::from_state(
+            &state, false, false, 4,
+        ));
+        let toggle = PlaymarkBeatToggleWidget::new(15, geometry_source, &state, false, 4)
+            .expect("toggle widget");
+        let bounds = rect(0.0, 0.0, 400.0, 80.0);
+        toggle.append_paint(
+            &mut Vec::new(),
+            bounds,
+            &Default::default(),
+            &Default::default(),
+        );
+        let toggle_rect = toggle.control_rect(bounds).expect("toggle rect");
+
+        assert!(toggle.accepts_pointer_input(&WidgetInput::PointerPress {
+            position: toggle_rect.center(),
+            button: PointerButton::Primary,
+            modifiers: PointerModifiers::default(),
+        }));
+        assert!(!toggle.accepts_pointer_input(&WidgetInput::PointerPress {
+            position: ui::Point::new(bounds.min.x + 2.0, bounds.min.y + 2.0),
+            button: PointerButton::Primary,
+            modifiers: PointerModifiers::default(),
+        }));
+    }
+
+    #[test]
+    fn local_toggle_exposes_checked_semantics_and_activates() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.set_play_selection_range(0.4, 0.6);
+        let geometry_source = WaveformWidget::new(super::super::WaveformWidgetProps::from_state(
+            &state, true, false, 4,
+        ));
+        let mut toggle = PlaymarkBeatToggleWidget::new(15, geometry_source, &state, true, 4)
+            .expect("toggle widget");
+        let bounds = rect(0.0, 0.0, 400.0, 80.0);
+        let control = toggle.control_rect(bounds).expect("toggle rect");
+        let modifiers = PointerModifiers::default();
+
+        assert_eq!(toggle.automation_role(), AutomationRole::Toggle);
+        assert_eq!(
+            toggle.automation_label().as_deref(),
+            Some("Playmark beat grid")
+        );
+        assert_eq!(toggle.automation_checked(), Some(true));
+        assert!(
+            toggle
+                .handle_input(
+                    bounds,
+                    WidgetInput::PointerPress {
+                        position: control.center(),
+                        button: PointerButton::Primary,
+                        modifiers,
+                    },
+                )
+                .is_none()
+        );
+        let output = toggle
+            .handle_input(
+                bounds,
+                WidgetInput::PointerRelease {
+                    position: control.center(),
+                    button: PointerButton::Primary,
+                    modifiers,
+                },
+            )
+            .expect("toggle activation");
+        assert_eq!(
+            output.typed_copied::<PlaymarkBeatToggleMessage>(),
+            Some(PlaymarkBeatToggleMessage::Toggle)
+        );
+    }
+
+    #[test]
+    fn local_count_reuses_focused_bounded_step_contract() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.set_play_selection_range(0.4, 0.6);
+        let geometry_source = WaveformWidget::new(super::super::WaveformWidgetProps::from_state(
+            &state, false, false, 4,
+        ));
+        let mut count = PlaymarkBeatCountWidget::new(16, geometry_source, &state, false, 4)
+            .expect("count widget");
+        let bounds = rect(0.0, 0.0, 400.0, 80.0);
+
+        assert_eq!(count.automation_role(), AutomationRole::TextInput);
+        assert_eq!(
+            count.automation_label().as_deref(),
+            Some("Playmark beat count")
+        );
+        assert_eq!(count.automation_value_text().as_deref(), Some("4"));
+        assert!(
+            count
+                .handle_input(bounds, WidgetInput::FocusChanged(true))
+                .is_none()
+        );
+        assert!(count.preempts_host_shortcut_key(WidgetKey::ArrowUp));
+        let output = count
+            .handle_input(bounds, WidgetInput::KeyPress(WidgetKey::ArrowUp))
+            .expect("focused up step");
+        assert_eq!(
+            output.typed_cloned::<BeatGuideCountInputMessage>(),
+            Some(BeatGuideCountInputMessage::Set(5))
+        );
+    }
+}

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -10,7 +10,7 @@ use crate::ui_formatting::{format_selection_duration, format_waveform_bpm_input}
 
 use super::{WaveformActiveDragKind, WaveformSelectionKind, WaveformWidget};
 
-const PLAYMARK_LABEL_HEIGHT: f32 = 18.0;
+pub(super) const PLAYMARK_LABEL_HEIGHT: f32 = 18.0;
 const PLAYMARK_LABEL_BOTTOM_INSET: f32 = 2.0;
 const PLAYMARK_LABEL_SELECTION_INSET: f32 = 4.0;
 const PLAYMARK_LABEL_OUTSIDE_GAP: f32 = 6.0;
@@ -18,6 +18,10 @@ const PLAYMARK_LABEL_HORIZONTAL_PADDING: f32 = 10.0;
 const PLAYMARK_LABEL_GLYPH_WIDTH: f32 = 10.0;
 const PLAYMARK_LABEL_MIN_WIDTH: f32 = 80.0;
 const PLAYMARK_LABEL_MAX_WIDTH: f32 = 150.0;
+pub(super) const PLAYMARK_BEAT_TOGGLE_WIDTH: f32 = 20.0;
+pub(super) const PLAYMARK_BEAT_COUNT_WIDTH: f32 = 30.0;
+pub(super) const PLAYMARK_BEAT_CONTROL_GAP: f32 = 2.0;
+const PLAYMARK_LABEL_CONTROL_GAP: f32 = 4.0;
 const PLAYMARK_LABEL_BACKGROUND: Rgba8 = Rgba8::new(25, 18, 16, 214);
 const PLAYMARK_LABEL_TEXT: Rgba8 = Rgba8::new(255, 226, 210, 255);
 
@@ -33,6 +37,8 @@ pub(super) enum PlaymarkLabelPlacement {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) struct PlaymarkLabelLayout {
     pub(super) rect: Rect,
+    pub(super) beat_toggle_rect: Rect,
+    pub(super) beat_count_rect: Rect,
     pub(super) placement: PlaymarkLabelPlacement,
 }
 
@@ -120,28 +126,53 @@ pub(super) fn playmark_label_layout(
         return None;
     }
 
-    let desired_width =
+    let desired_label_width =
         label_len as f32 * PLAYMARK_LABEL_GLYPH_WIDTH + PLAYMARK_LABEL_HORIZONTAL_PADDING * 2.0;
-    let width = desired_width
+    let controls_width = PLAYMARK_LABEL_CONTROL_GAP
+        + PLAYMARK_BEAT_TOGGLE_WIDTH
+        + PLAYMARK_BEAT_CONTROL_GAP
+        + PLAYMARK_BEAT_COUNT_WIDTH;
+    if bounds.width() <= controls_width {
+        return None;
+    }
+    let label_width = desired_label_width
         .clamp(PLAYMARK_LABEL_MIN_WIDTH, PLAYMARK_LABEL_MAX_WIDTH)
-        .min(bounds.width());
+        .min(bounds.width() - controls_width);
+    let cluster_width = label_width + controls_width;
     let selection_left = selection_rect.min.x.clamp(bounds.min.x, bounds.max.x);
     let selection_right = selection_rect.max.x.clamp(selection_left, bounds.max.x);
     let selection_width = selection_right - selection_left;
-    let (left, placement) = if selection_width >= width + PLAYMARK_LABEL_SELECTION_INSET * 2.0 {
-        (
-            (selection_left + (selection_width - width) * 0.5)
-                .clamp(bounds.min.x, bounds.max.x - width),
-            PlaymarkLabelPlacement::Inside,
-        )
-    } else {
-        outside_label_left(bounds, selection_left, selection_right, width)
-    };
+    let (left, placement) =
+        if selection_width >= cluster_width + PLAYMARK_LABEL_SELECTION_INSET * 2.0 {
+            (
+                (selection_left + (selection_width - cluster_width) * 0.5)
+                    .clamp(bounds.min.x, bounds.max.x - cluster_width),
+                PlaymarkLabelPlacement::Inside,
+            )
+        } else {
+            outside_label_left(bounds, selection_left, selection_right, cluster_width)
+        };
     let bottom = (bounds.max.y - PLAYMARK_LABEL_BOTTOM_INSET).max(bounds.min.y);
     let top = (bottom - PLAYMARK_LABEL_HEIGHT).max(bounds.min.y);
+    let label_rect = Rect::from_min_max(
+        Point::new(left, top),
+        Point::new(left + label_width, bottom),
+    );
+    let toggle_left = label_rect.max.x + PLAYMARK_LABEL_CONTROL_GAP;
+    let beat_toggle_rect = Rect::from_min_max(
+        Point::new(toggle_left, top),
+        Point::new(toggle_left + PLAYMARK_BEAT_TOGGLE_WIDTH, bottom),
+    );
+    let count_left = beat_toggle_rect.max.x + PLAYMARK_BEAT_CONTROL_GAP;
+    let beat_count_rect = Rect::from_min_max(
+        Point::new(count_left, top),
+        Point::new(count_left + PLAYMARK_BEAT_COUNT_WIDTH, bottom),
+    );
 
     Some(PlaymarkLabelLayout {
-        rect: Rect::from_min_max(Point::new(left, top), Point::new(left + width, bottom)),
+        rect: label_rect,
+        beat_toggle_rect,
+        beat_count_rect,
         placement,
     })
 }
@@ -186,13 +217,15 @@ mod tests {
     }
 
     #[test]
-    fn wide_playmark_contains_centered_label_with_inset() {
+    fn wide_playmark_contains_centered_label_and_controls_with_inset() {
         let layout = playmark_label_layout(rect(0.0, 400.0), rect(100.0, 300.0), 6)
             .expect("wide label layout");
 
         assert_eq!(layout.placement, PlaymarkLabelPlacement::Inside);
-        assert_eq!(layout.rect.min.x, 160.0);
-        assert_eq!(layout.rect.max.x, 240.0);
+        assert_eq!(layout.rect.min.x, 132.0);
+        assert_eq!(layout.rect.max.x, 212.0);
+        assert_eq!(layout.beat_count_rect.max.x, 268.0);
+        assert_eq!(layout.beat_toggle_rect.min.x, 216.0);
     }
 
     #[test]
@@ -205,7 +238,8 @@ mod tests {
         let right_edge = playmark_label_layout(rect(0.0, 400.0), rect(350.0, 360.0), 6)
             .expect("right-edge narrow layout");
         assert_eq!(right_edge.placement, PlaymarkLabelPlacement::OutsideLeft);
-        assert_eq!(right_edge.rect.max.x, 344.0);
+        assert_eq!(right_edge.rect.min.x, 208.0);
+        assert_eq!(right_edge.beat_count_rect.max.x, 344.0);
     }
 
     #[test]
@@ -216,6 +250,7 @@ mod tests {
         assert_eq!(layout.placement, PlaymarkLabelPlacement::OutsideRight);
         assert_eq!(layout.rect.min.x, 26.0);
         assert_eq!(layout.rect.max.x, 106.0);
+        assert_eq!(layout.beat_count_rect.max.x, 162.0);
     }
 
     #[test]
@@ -234,14 +269,16 @@ mod tests {
         let tied = playmark_label_layout(rect(0.0, 100.0), rect(35.0, 65.0), 6)
             .expect("tied fallback layout");
         assert_eq!(tied.placement, PlaymarkLabelPlacement::FallbackRight);
-        assert_eq!(tied.rect.min.x, 20.0);
-        assert_eq!(tied.rect.max.x, 100.0);
+        assert_eq!(tied.rect.min.x, 0.0);
+        assert_eq!(tied.rect.max.x, 44.0);
+        assert_eq!(tied.beat_count_rect.max.x, 100.0);
 
         let left_roomier = playmark_label_layout(rect(0.0, 100.0), rect(60.0, 80.0), 6)
             .expect("left-roomier fallback layout");
         assert_eq!(left_roomier.placement, PlaymarkLabelPlacement::FallbackLeft);
         assert_eq!(left_roomier.rect.min.x, 0.0);
-        assert_eq!(left_roomier.rect.max.x, 80.0);
+        assert_eq!(left_roomier.rect.max.x, 44.0);
+        assert_eq!(left_roomier.beat_count_rect.max.x, 100.0);
     }
 
     #[test]

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -173,7 +173,7 @@ fn playmark_label_formats_duration_and_paints_at_selection_bottom() {
     let subsecond_label = subsecond_plan
         .first_text_run("750 ms")
         .expect("subsecond playmark duration label");
-    assert!((subsecond_label.rect.center().x - 200.0).abs() < 0.01);
+    assert!((subsecond_label.rect.center().x - 172.0).abs() < 0.01);
     assert_eq!(subsecond_label.rect.max.y, 78.0);
 
     let mut seconds = waveform_state_with_duration_seconds(2);

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -23,6 +23,7 @@ use super::{
     WaveformState, WaveformViewport,
     audio_file::{gain_preview_for_range_with_gain, gain_preview_for_selection},
     edit_preview_for_selection,
+    playmark_beat_controls::playmark_beat_control_views,
     playmark_label_editor::PlaymarkLabelWidget,
     widget_geometry::WaveformSelectionHandleHover,
 };
@@ -78,7 +79,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
     };
     let label = PlaymarkLabelWidget::new(
         widget_ids::WAVEFORM_PLAYMARK_LABEL_ID,
-        WaveformWidget::new(props),
+        WaveformWidget::new(props.clone()),
         state,
         beat_guides_enabled,
         beat_guide_count,
@@ -93,6 +94,14 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
     })
     .unwrap_or_else(ui::empty);
+    let [beat_toggle, beat_count] = playmark_beat_control_views(
+        widget_ids::WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID,
+        widget_ids::WAVEFORM_PLAYMARK_BEAT_COUNT_ID,
+        WaveformWidget::new(props),
+        state,
+        beat_guides_enabled,
+        beat_guide_count,
+    );
 
     ui::stack([
         waveform_signal_surface_view(
@@ -104,6 +113,8 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32),
         interaction,
         label,
+        beat_toggle,
+        beat_count,
     ])
     .id(widget_ids::WAVEFORM_VIEWPORT_STACK_ID)
     .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)


### PR DESCRIPTION
## Goal
Add compact beat-grid controls beside the playmark label so users can toggle guides and edit beat count at the selection without moving to the toolbar.

## Scope
- Add a playmark-local beat-grid toggle and beat-count field adjacent to the existing label.
- Reuse the authoritative `beat_guides_enabled` and `beat_guide_count` state and existing `GuiMessage` update paths.
- Reuse the toolbar count field contract, including 2..32 bounds, text editing, focus, and keyboard stepping.
- Keep the label/control cluster deterministic and within waveform bounds.
- Add stable semantic IDs, accessibility roles/labels, focus paint, and local pointer hit policies.
- Add geometry, semantic, state-sync, keyboard, paint, and native hit-routing regression coverage.
- Repin Radiant to the canonical merge of PORTALSURFER/radiant#1427 so stacked custom overlays honor per-widget pointer acceptance.

## Non-goals
- No separate beat-grid state.
- No toolbar redesign.
- No BPM math, audio-engine, or persistence changes.

## Definition of Done
- The local toggle immediately updates guides and switches the playmark label between time and BPM.
- The local count field updates the same value shown by the toolbar and preserves the existing 2..32 editing contract.
- The full label/control cluster stays bounded at narrow widths and near either waveform edge.
- Pointer events on the controls cannot leak into waveform selection gestures.
- Controls remain projected from live playmark state and expose stable automation semantics.

## Validation
- `cargo fmt --all -- --check` — passed.
- `git diff --check` and nested Radiant diff check — passed.
- `cargo test -p radiant runtime::controller::pointer::tests` — 8 passed, including after canonical merged repin.
- `cargo test -p wavecrate beat_guide --lib` — 16 passed.
- `cargo test -p wavecrate playmark_label --lib` — 16 passed.
- `cargo test -p wavecrate playmark_local_beat_controls_consume_hits_and_update_shared_state --lib` — passed, including after canonical merged repin.
- `bash scripts/build.sh --release --variant OPT-1230` — passed; signed app bundle produced.
- `bash scripts/ci.sh smoke` — blocked by the existing malformed format string at `tests/release_workflow_helpers.rs:936`; this PR does not modify that file.
- Live computer-use verification — blocked because the Mac is locked. Native integration coverage exercises the actual painted control rectangles, selection non-interference, shared state, toolbar projection, and label repaint.

## Known limitations
- Live visual verification remains pending until the Mac is unlocked.

User approval is required before merge.