### PR TITLE
Wavecrate: route protected playmark extraction only to Primary

### DIFF
--- a/src/native_app/sample_library/harvest_tracking/destination.rs
+++ b/src/native_app/sample_library/harvest_tracking/destination.rs
@@ -18,11 +18,34 @@ impl NativeAppState {
         if !origin_source.is_protected() {
             return Ok(None);
         }
-        self.harvest_destination_for_source(&origin_source)
-            .map(Some)
-            .map_err(|_| {
+        let primary_source = self
+            .library
+            .folder_browser
+            .primary_sample_source()
+            .ok_or_else(|| {
                 String::from("Set a Primary source before extracting from a protected source")
-            })
+            })?;
+        Ok(Some(
+            primary_source
+                .root
+                .join(HARVEST_ROOT_FOLDER)
+                .join(harvest_source_folder_name(&origin_source)),
+        ))
+    }
+
+    pub(in crate::native_app) fn protected_playmark_extraction_needs_primary_source(
+        &self,
+        source_path: &Path,
+    ) -> bool {
+        self.library
+            .folder_browser
+            .sample_source_for_file_path(source_path)
+            .is_some_and(|(source, _)| source.is_protected())
+            && self
+                .library
+                .folder_browser
+                .primary_sample_source()
+                .is_none()
     }
 
     pub(in crate::native_app) fn harvest_destination_for_origin(

--- a/src/native_app/sample_library/selected_file_actions.rs
+++ b/src/native_app/sample_library/selected_file_actions.rs
@@ -216,7 +216,7 @@ impl NativeAppState {
                 let request = request.with_gain(
                     self.normalized_audition_gain_for_span(selection.start(), selection.end()),
                 );
-                if self.protected_extraction_needs_target_source(request.source_path()) {
+                if self.protected_playmark_extraction_needs_primary_source(request.source_path()) {
                     self.request_protected_extraction_target_source(
                         target.pending_protected_extraction_action(),
                     );
@@ -465,7 +465,11 @@ impl NativeAppState {
         &self,
         request: WaveformExtractionRequest,
     ) -> Result<WaveformExtractionRequest, String> {
-        let target_folder = self.harvest_destination_for_origin(request.source_path())?;
+        let target_folder =
+            match self.harvest_destination_for_protected_origin(request.source_path())? {
+                Some(target_folder) => target_folder,
+                None => self.harvest_destination_for_origin(request.source_path())?,
+            };
         wavecrate::sample_sources::harvest_file_ops::ensure_dir(
             &target_folder,
             "Could not create harvest destination",

--- a/src/native_app/tests/waveform_playback.rs
+++ b/src/native_app/tests/waveform_playback.rs
@@ -1344,6 +1344,64 @@ fn protected_playmark_extraction_redirects_explicit_protected_target_to_primary(
 }
 
 #[test]
+fn protected_playmark_extraction_redirects_explicit_normal_target_to_primary() {
+    let config_root = tempfile::tempdir().expect("config root");
+    let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
+    let mut scenario = WaveformPlaybackScenario::with_temp_wav(
+        "playmark-extract-protected-explicit-normal.wav",
+        &[0, 1024, -1024, 512],
+    );
+    let source_path = PathBuf::from(
+        scenario
+            .state
+            .library
+            .folder_browser
+            .selected_file_id()
+            .expect("selected source sample"),
+    );
+    let source_root = source_path.parent().expect("sample parent").to_path_buf();
+    let primary_root = tempfile::tempdir().expect("primary source root");
+    let normal_target_root = tempfile::tempdir().expect("normal target root");
+    let protected_source = wavecrate::sample_sources::SampleSource::new(source_root).protected();
+    let primary_source =
+        wavecrate::sample_sources::SampleSource::new(primary_root.path().to_path_buf()).primary();
+    let normal_target =
+        wavecrate::sample_sources::SampleSource::new(normal_target_root.path().to_path_buf());
+    scenario.state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            protected_source.clone(),
+            primary_source,
+            normal_target.clone(),
+        ]);
+    scenario
+        .state
+        .library
+        .folder_browser
+        .select_file(source_path.display().to_string());
+    load_selected_sample_into_waveform(&mut scenario);
+    scenario.select_play_range(0.25, 0.60);
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(Some(normal_target.root.join("incoming")))
+        .expect("explicit normal extraction request");
+
+    let routed = scenario
+        .state
+        .route_harvest_extraction_request(request)
+        .expect("protected origin should override explicit normal target");
+    let expected_folder = primary_root.path().join("_Harvests").join(
+        protected_source
+            .root
+            .file_name()
+            .expect("source root folder name"),
+    );
+
+    assert_eq!(routed.target_folder(), Ok(expected_folder.as_path()));
+}
+
+#[test]
 fn protected_playmark_extraction_without_writable_destination_reports_error() {
     let config_root = tempfile::tempdir().expect("config root");
     let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
@@ -1392,7 +1450,7 @@ fn protected_playmark_extraction_without_writable_destination_reports_error() {
 }
 
 #[test]
-fn protected_playmark_extraction_without_writable_destination_opens_target_source_prompt() {
+fn protected_playmark_extraction_without_primary_prompts_even_with_single_normal_source() {
     let config_root = tempfile::tempdir().expect("config root");
     let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
     let mut scenario = WaveformPlaybackScenario::with_temp_wav(
@@ -1400,6 +1458,7 @@ fn protected_playmark_extraction_without_writable_destination_opens_target_sourc
         &[0, 1024, -1024, 512],
     );
     let target_root = tempfile::tempdir().expect("target source root");
+    let normal_root = tempfile::tempdir().expect("normal source root");
     let source_path = PathBuf::from(
         scenario
             .state
@@ -1411,9 +1470,12 @@ fn protected_playmark_extraction_without_writable_destination_opens_target_sourc
     let source_root = source_path.parent().expect("sample parent").to_path_buf();
     let protected_source =
         wavecrate::sample_sources::SampleSource::new(source_root.clone()).protected();
+    let normal_source =
+        wavecrate::sample_sources::SampleSource::new(normal_root.path().to_path_buf());
     scenario.state.library.folder_browser =
         crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
             protected_source.clone(),
+            normal_source,
         ]);
     scenario
         .state
@@ -1488,7 +1550,7 @@ fn protected_playmark_extraction_without_writable_destination_opens_target_sourc
 }
 
 #[test]
-fn protected_playmark_extraction_with_single_normal_source_routes_to_normal_harvest_destination() {
+fn protected_playmark_extraction_with_single_normal_source_still_requires_primary() {
     let config_root = tempfile::tempdir().expect("config root");
     let (_lock, _guard) = set_waveform_test_config_base(config_root.path().to_path_buf());
     let mut scenario = WaveformPlaybackScenario::with_temp_wav(
@@ -1528,18 +1590,30 @@ fn protected_playmark_extraction_with_single_normal_source_routes_to_normal_harv
         .play_selection_extraction_request(None)
         .expect("protected extraction request");
 
-    let routed = scenario
+    let default_error = scenario
         .state
         .route_harvest_extraction_request(request)
-        .expect("single normal source should be an unambiguous writable destination");
-    let expected_folder = normal_source.root.join("_Harvests").join(
-        protected_source
-            .root
-            .file_name()
-            .expect("source root folder name"),
+        .expect_err("protected playmark extraction requires Primary");
+    assert_eq!(
+        default_error,
+        "Set a Primary source before extracting from a protected source"
     );
 
-    assert_eq!(routed.target_folder(), Ok(expected_folder.as_path()));
+    let request = scenario
+        .state
+        .waveform
+        .current
+        .play_selection_extraction_request(None)
+        .expect("protected harvest extraction request");
+    let harvest_error = scenario
+        .state
+        .route_harvest_destination_extraction_request(request)
+        .expect_err("protected harvest extraction requires Primary");
+
+    assert_eq!(
+        harvest_error,
+        "Set a Primary source before extracting from a protected source"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Goal
Allow playmark extraction from protected sources while guaranteeing that every derivative lands under the configured Primary source.

## Scope
- Require an actual Primary source for protected-origin playmark extraction instead of falling back to a lone Normal source.
- Keep `Extract Selection` and `Extract to Harvest Destination` available for protected playmarks.
- Route default, harvest-destination, and explicit copy/drag targets into Primary `_Harvests/<protected-source>` when Primary exists.
- Use the existing target-source prompt for direct extraction when Primary is missing; the added source becomes Primary and the pending extraction resumes.
- Fail closed for copy/drag extraction when Primary is unavailable.
- Preserve protected originals, loaded waveform and browser focus, metadata/derivation recording, committed-mutation publication, and Primary acceptance feedback.
- Preserve normal-origin extraction and selected whole-file writable-source fallback behavior.

## Non-goals
- No protected-source writes.
- No change to destructive-edit policy or selected whole-file extraction routing.
- No change to extraction naming, rendering, metadata, collision handling, or harvest layout.

## Definition of Done
- Protected playmark extraction succeeds with Primary and writes only beneath Primary.
- A lone Normal source is never silently used for a protected playmark derivative.
- Direct extraction without Primary prompts for a target, promotes it to Primary, and resumes successfully.
- Explicit target folders cannot bypass Primary routing for protected playmarks.
- Protected original, current source/file selection, and loaded waveform remain intact.
- Existing success feedback and mutation/harvest bookkeeping remain intact.
- Normal playmark and selected whole-file extraction behavior does not regress.

## Validation
- `cargo test -p wavecrate protected_playmark_extraction --lib -- --test-threads=1` — 7 passed.
- `cargo test -p wavecrate normal_playmark_extraction --lib -- --test-threads=1` — 3 passed.
- `cargo test -p wavecrate e_without_playmark --lib -- --test-threads=1` — 5 passed, including protected and multi-selected whole-file extraction.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `bash scripts/build.sh --release --variant OPT-1233` — passed; signed app bundle produced.
- `bash scripts/ci.sh smoke` — blocked by the pre-existing invalid format string at `tests/release_workflow_helpers.rs:936`; this PR does not modify that file.
- Live isolated-profile smoke — blocked because the Mac is locked. The launched test process was stopped and temporary QA/profile folders were moved to Trash.

## Known limitations
- Live visual verification remains pending until the Mac is unlocked.

User approval is required before merge.