### PR TITLE
OPT-1234: add hover-wheel beat-grid count adjustment

### DIFF
--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -82,6 +82,12 @@ impl BeatGuideCountInputWidget {
             WidgetInput::KeyPress(WidgetKey::ArrowDown) if self.accepts_editing_input() => {
                 Some(BeatGuideCountInputMessage::Set(self.step_value(-1)))
             }
+            WidgetInput::Wheel { delta, .. } if delta.y < 0.0 => {
+                Some(BeatGuideCountInputMessage::Set(self.step_value(1)))
+            }
+            WidgetInput::Wheel { delta, .. } if delta.y > 0.0 => {
+                Some(BeatGuideCountInputMessage::Set(self.step_value(-1)))
+            }
             WidgetInput::FocusChanged(false) => {
                 let message = Some(BeatGuideCountInputMessage::Committed(
                     self.value().to_owned(),
@@ -140,6 +146,10 @@ impl Widget for BeatGuideCountInputWidget {
 
     fn accepts_pointer_move(&self) -> bool {
         self.input.accepts_pointer_move()
+    }
+
+    fn accepts_wheel_input(&self) -> bool {
+        true
     }
 
     fn automation_role(&self) -> AutomationRole {

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -148,6 +148,15 @@ impl Widget for BeatGuideCountInputWidget {
         self.input.accepts_pointer_move()
     }
 
+    fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
+        match input {
+            WidgetInput::Wheel { delta, .. } => {
+                delta.y.abs() >= delta.x.abs() && delta.y.abs() > f32::EPSILON
+            }
+            _ => self.input.accepts_pointer_input(input),
+        }
+    }
+
     fn accepts_wheel_input(&self) -> bool {
         true
     }

--- a/src/native_app/tests/toolbar_playback/basics.rs
+++ b/src/native_app/tests/toolbar_playback/basics.rs
@@ -643,6 +643,41 @@ fn beat_guide_count_field_owns_up_down_only_while_focused() {
 }
 
 #[test]
+fn beat_guide_count_field_steps_on_hovered_vertical_wheel_input() {
+    let state = NativeAppState::load_default().expect("default state loads");
+    let mut runtime = SurfaceRuntime::new(
+        radiant::runtime::DeclarativeOwnedRuntimeBridge::new(
+            state,
+            |state| crate::native_app::test_support::toolbar::main_toolbar(state).into_surface(),
+            |state, message| {
+                let mut context = ui::UiUpdateContext::default();
+                state.apply_message(message, &mut context);
+            },
+        ),
+        Vector2::new(664.0, 34.0),
+    );
+    let input_id = crate::native_app::test_support::toolbar::TOOLBAR_BEAT_GUIDE_COUNT_ID;
+    let input_point = runtime.layout().rects[&input_id].center();
+
+    assert!(runtime.wheel_or_scroll_at(input_point, Vector2::new(0.0, -40.0)));
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 5);
+    assert!(runtime.wheel_or_scroll_at(input_point, Vector2::new(0.0, 40.0)));
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 4);
+    assert!(
+        !runtime.wheel_or_scroll_at(input_point, Vector2::new(40.0, 0.0)),
+        "horizontal-only wheel input should remain available to another target"
+    );
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 4);
+
+    for _ in 0..40 {
+        assert!(runtime.wheel_or_scroll_at(input_point, Vector2::new(0.0, -1.0)));
+    }
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 32);
+    assert!(runtime.wheel_or_scroll_at(input_point, Vector2::new(0.0, 1.0)));
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 31);
+}
+
+#[test]
 fn metronome_toolbar_message_updates_audio_state() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     let mut context = radiant::prelude::UiUpdateContext::default();

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -102,6 +102,22 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
         original_selection,
         "local count editing must not leak into waveform gestures"
     );
+
+    runtime.clear_focus();
+    assert!(runtime.wheel_or_scroll_at(count_point, Vector2::new(0.0, -40.0)));
+    assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 6);
+    assert!(runtime.frame(&theme).paint_plan.contains_text("720 BPM"));
+
+    let waveform_wheel_point = Point::new(
+        waveform_rect(&runtime).min.x + 12.0,
+        waveform_rect(&runtime).center().y,
+    );
+    assert!(runtime.wheel_or_scroll_at(waveform_wheel_point, Vector2::new(0.0, -40.0)));
+    assert_eq!(
+        runtime.bridge().state().ui.chrome.beat_guide_count,
+        6,
+        "the full-size playmark overlay must not steal wheel input outside its painted field"
+    );
 }
 
 #[test]

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -108,6 +108,27 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
     assert_eq!(runtime.bridge().state().ui.chrome.beat_guide_count, 6);
     assert!(runtime.frame(&theme).paint_plan.contains_text("720 BPM"));
 
+    let horizontal_wheel = WidgetInput::Wheel {
+        position: count_point,
+        delta: Vector2::new(40.0, 0.0),
+        modifiers: Default::default(),
+    };
+    assert!(
+        !runtime
+            .surface()
+            .find_widget(count_id)
+            .expect("count widget")
+            .widget_object()
+            .accepts_pointer_input(&horizontal_wheel),
+        "the local count field must leave horizontal wheel input to the waveform"
+    );
+    assert!(runtime.wheel_or_scroll_at(count_point, Vector2::new(40.0, 0.0)));
+    assert_eq!(
+        runtime.bridge().state().ui.chrome.beat_guide_count,
+        6,
+        "horizontal wheel fallback must not change the beat count"
+    );
+
     let waveform_wheel_point = Point::new(
         waveform_rect(&runtime).min.x + 12.0,
         waveform_rect(&runtime).center().y,

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -213,6 +213,10 @@ impl Widget for PlaymarkBeatCountWidget {
         self.input.accepts_pointer_move()
     }
 
+    fn accepts_wheel_input(&self) -> bool {
+        self.input.accepts_wheel_input()
+    }
+
     fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
         pointer_is_inside_control(input, &self.painted_bounds, |bounds| {
             self.control_rect(bounds)

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -218,9 +218,10 @@ impl Widget for PlaymarkBeatCountWidget {
     }
 
     fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
-        pointer_is_inside_control(input, &self.painted_bounds, |bounds| {
-            self.control_rect(bounds)
-        })
+        self.input.accepts_pointer_input(input)
+            && pointer_is_inside_control(input, &self.painted_bounds, |bounds| {
+                self.control_rect(bounds)
+            })
     }
 
     fn automation_role(&self) -> AutomationRole {


### PR DESCRIPTION
## Goal

Let users adjust the beat-grid count with vertical wheel input while hovering either beat-count field.

## Scope and non-goals

- Scroll up increments by one; scroll down decrements by one.
- Support both toolbar and playmark-local count fields without requiring keyboard focus.
- Preserve the existing 2–32 bounds and text/keyboard editing behavior.
- Leave horizontal-only wheel input available to other targets.
- Repin Radiant to PORTALSURFER/radiant#1428 so the playmark overlay owns wheel input only inside its painted field.
- No accelerated or modifier-based stepping and no visual redesign.

## Definition of Done

- Hovered vertical wheel input changes the count in the expected direction on both surfaces.
- Both surfaces remain synchronized.
- Values remain within 2–32.
- Wheel input elsewhere on the waveform still reaches the waveform.

## Validation

- Focused Radiant geometry and modifier-sensitive wheel ownership regressions: passed.
- Radiant library suite: 1666 passed before the focused review fix; affected focused tests rerun after the fix.
- Focused Wavecrate toolbar wheel regression: passed at current head.
- Focused Wavecrate playmark wheel/hit-routing regression: passed at current head.
- scripts/ci.sh agent: reached known baseline compile failure at tests/release_workflow_helpers.rs:936 after earlier smoke checks passed.
- scripts/build.sh --release: passed at current head; signed Wavecrate OPT-1234.app produced.
- Live UI smoke: pending because the Mac is locked and computer-use cannot unlock it.

## Known limitations

Live UI validation remains pending until the Mac is unlocked.

User approval is required before merge.