### PR TITLE
Fix waveform input routing around playmark controls

### DIFF
--- a/src/native_app/audio/playback/progress/waveform_publish.rs
+++ b/src/native_app/audio/playback/progress/waveform_publish.rs
@@ -4,7 +4,9 @@ use super::super::{
 };
 use crate::native_app::{
     app::{NativeAppState, SamplePlaybackSession, SamplePlaybackSessionState},
-    waveform::{WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID},
+    waveform::{
+        WAVEFORM_SIGNAL_WIDGET_ID, WAVEFORM_WIDGET_ID, WaveformWidget, WaveformWidgetProps,
+    },
 };
 use radiant::{
     gui::types::{Point, Rect, Rgba8},
@@ -89,7 +91,18 @@ impl NativeAppState {
         else {
             return;
         };
-        let Some(cursor_x) = push_playback_cursor(primitives, bounds, visible_ratio) else {
+        let cursor_occlusion =
+            WaveformWidget::new(WaveformWidgetProps::from_state_with_playhead_occlusion(
+                &self.waveform.current,
+                self.ui.chrome.beat_guides_enabled,
+                self.ui.chrome.bpm_snap_enabled,
+                self.ui.chrome.beat_guide_count,
+                None,
+            ))
+            .playmark_control_cluster_rect(bounds);
+        let Some(cursor_x) =
+            push_playback_cursor(primitives, bounds, visible_ratio, cursor_occlusion)
+        else {
             return;
         };
         self.playhead_frame_diagnostics
@@ -205,6 +218,7 @@ fn push_playback_cursor(
     primitives: &mut Vec<PaintPrimitive>,
     bounds: Rect,
     ratio: f32,
+    occlusion: Option<Rect>,
 ) -> Option<f32> {
     let width = PLAYBACK_CURSOR_WIDTH
         .ceil()
@@ -216,14 +230,60 @@ fn push_playback_cursor(
     if right <= left {
         return None;
     }
-    WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID).push_visible_fill_rect(
-        Rect::from_min_max(
-            Point::new(left, bounds.min.y),
-            Point::new(right, bounds.max.y),
-        ),
-        PLAYBACK_CURSOR_COLOR,
+    let cursor = Rect::from_min_max(
+        Point::new(left, bounds.min.y),
+        Point::new(right, bounds.max.y),
     );
+    let mut paint = WidgetPaint::new(primitives, WAVEFORM_WIDGET_ID);
+    let Some(occlusion) = occlusion.filter(|rect| {
+        cursor.min.x < rect.max.x
+            && cursor.max.x > rect.min.x
+            && cursor.min.y < rect.max.y
+            && cursor.max.y > rect.min.y
+    }) else {
+        paint.push_visible_fill_rect(cursor, PLAYBACK_CURSOR_COLOR);
+        return Some(center_x);
+    };
+    let top_max_y = occlusion.min.y.clamp(cursor.min.y, cursor.max.y);
+    if top_max_y > cursor.min.y {
+        paint.push_visible_fill_rect(
+            Rect::from_min_max(cursor.min, Point::new(cursor.max.x, top_max_y)),
+            PLAYBACK_CURSOR_COLOR,
+        );
+    }
+    let bottom_min_y = occlusion.max.y.clamp(cursor.min.y, cursor.max.y);
+    if bottom_min_y < cursor.max.y {
+        paint.push_visible_fill_rect(
+            Rect::from_min_max(Point::new(cursor.min.x, bottom_min_y), cursor.max),
+            PLAYBACK_CURSOR_COLOR,
+        );
+    }
     Some(center_x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn playback_cursor_paints_around_playmark_control_occlusion() {
+        let bounds = Rect::from_min_max(Point::new(0.0, 0.0), Point::new(400.0, 80.0));
+        let occlusion = Rect::from_min_max(Point::new(190.0, 60.0), Point::new(280.0, 78.0));
+        let mut primitives = Vec::new();
+
+        assert_eq!(
+            push_playback_cursor(&mut primitives, bounds, 0.5, Some(occlusion)),
+            Some(200.0)
+        );
+
+        let cursor_segments = primitives
+            .iter()
+            .filter_map(PaintPrimitive::fill_rect)
+            .collect::<Vec<_>>();
+        assert_eq!(cursor_segments.len(), 2);
+        assert_eq!(cursor_segments[0].rect.max.y, 60.0);
+        assert_eq!(cursor_segments[1].rect.min.y, 78.0);
+    }
 }
 
 fn sample_playback_session_pending_start(session: &SamplePlaybackSession) -> bool {

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -95,6 +95,8 @@ impl NativeAppState {
         let started_at = Instant::now();
         let action = waveform_interaction_action(&message);
         let active_drag = self.waveform.current.active_drag_kind();
+        let finishes_play_selection_drag =
+            play_selection_drag_finishes_surface_ownership(&message, active_drag);
         let play_selection_before = self.play_selection_transaction_begin_snapshot(&message);
         let edit_selection_before = self.edit_selection_transaction_begin_snapshot(&message);
         let edit_fade_before = self.edit_fade_transaction_begin_snapshot(&message);
@@ -113,6 +115,12 @@ impl NativeAppState {
                 beat_count: self.ui.chrome.beat_guide_count,
             },
         );
+        if finishes_play_selection_drag {
+            // The interaction widget owns the live drag label, while the label
+            // widget owns the committed label. Rebuild the retained surface at
+            // that ownership handoff before playback resumes paint-only frames.
+            context.repaint(ui::RepaintScope::Surface);
+        }
         self.queue_waveform_detail_refinement(context);
         if matches!(message, WaveformInteraction::FinishSampleSlide { .. })
             && let Some(frame_offset) = self
@@ -511,6 +519,14 @@ fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bo
     )
 }
 
+fn play_selection_drag_finishes_surface_ownership(
+    interaction: &WaveformInteraction,
+    active_drag: Option<WaveformActiveDragKind>,
+) -> bool {
+    matches!(interaction, WaveformInteraction::FinishSelection { .. })
+        && play_selection_drag_active(active_drag)
+}
+
 fn edit_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bool {
     matches!(
         active_drag,
@@ -678,6 +694,28 @@ mod tests {
                 visible_ratio: 0.40
             },
             active_drag,
+        ));
+    }
+
+    #[test]
+    fn finishing_playmark_drag_requests_fresh_surface_before_playback_frames() {
+        assert!(play_selection_drag_finishes_surface_ownership(
+            &WaveformInteraction::FinishSelection { visible_ratio: 0.4 },
+            Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Play
+            ))
+        ));
+        assert!(!play_selection_drag_finishes_surface_ownership(
+            &WaveformInteraction::UpdateSelection { visible_ratio: 0.3 },
+            Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Play
+            ))
+        ));
+        assert!(!play_selection_drag_finishes_surface_ownership(
+            &WaveformInteraction::FinishSelection { visible_ratio: 0.4 },
+            Some(WaveformActiveDragKind::Selection(
+                WaveformSelectionKind::Edit
+            ))
         ));
     }
 

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -30,6 +30,7 @@ impl NativeAppState {
                     self.ui.chrome.beat_guide_count,
                 ) {
                     context.focus(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID);
+                    context.repaint(ui::RepaintScope::Surface);
                 }
             }
             PlaymarkLabelMessage::Changed(draft) => {
@@ -43,6 +44,7 @@ impl NativeAppState {
                 {
                     self.waveform.current.close_playmark_label_editor();
                     context.clear_focus();
+                    context.repaint(ui::RepaintScope::Surface);
                     return;
                 }
                 match self
@@ -60,6 +62,7 @@ impl NativeAppState {
                             context,
                         );
                         context.clear_focus();
+                        context.repaint(ui::RepaintScope::Surface);
                     }
                     Err(error) => {
                         self.ui.status.sample = error.clone();
@@ -71,6 +74,7 @@ impl NativeAppState {
             PlaymarkLabelMessage::Cancel => {
                 self.waveform.current.close_playmark_label_editor();
                 context.clear_focus();
+                context.repaint(ui::RepaintScope::Surface);
             }
         }
     }

--- a/src/native_app/shell/message_dispatch/waveform.rs
+++ b/src/native_app/shell/message_dispatch/waveform.rs
@@ -95,8 +95,6 @@ impl NativeAppState {
         let started_at = Instant::now();
         let action = waveform_interaction_action(&message);
         let active_drag = self.waveform.current.active_drag_kind();
-        let finishes_play_selection_drag =
-            play_selection_drag_finishes_surface_ownership(&message, active_drag);
         let play_selection_before = self.play_selection_transaction_begin_snapshot(&message);
         let edit_selection_before = self.edit_selection_transaction_begin_snapshot(&message);
         let edit_fade_before = self.edit_fade_transaction_begin_snapshot(&message);
@@ -115,12 +113,6 @@ impl NativeAppState {
                 beat_count: self.ui.chrome.beat_guide_count,
             },
         );
-        if finishes_play_selection_drag {
-            // The interaction widget owns the live drag label, while the label
-            // widget owns the committed label. Rebuild the retained surface at
-            // that ownership handoff before playback resumes paint-only frames.
-            context.repaint(ui::RepaintScope::Surface);
-        }
         self.queue_waveform_detail_refinement(context);
         if matches!(message, WaveformInteraction::FinishSampleSlide { .. })
             && let Some(frame_offset) = self
@@ -519,14 +511,6 @@ fn play_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bo
     )
 }
 
-fn play_selection_drag_finishes_surface_ownership(
-    interaction: &WaveformInteraction,
-    active_drag: Option<WaveformActiveDragKind>,
-) -> bool {
-    matches!(interaction, WaveformInteraction::FinishSelection { .. })
-        && play_selection_drag_active(active_drag)
-}
-
 fn edit_selection_drag_active(active_drag: Option<WaveformActiveDragKind>) -> bool {
     matches!(
         active_drag,
@@ -694,28 +678,6 @@ mod tests {
                 visible_ratio: 0.40
             },
             active_drag,
-        ));
-    }
-
-    #[test]
-    fn finishing_playmark_drag_requests_fresh_surface_before_playback_frames() {
-        assert!(play_selection_drag_finishes_surface_ownership(
-            &WaveformInteraction::FinishSelection { visible_ratio: 0.4 },
-            Some(WaveformActiveDragKind::Selection(
-                WaveformSelectionKind::Play
-            ))
-        ));
-        assert!(!play_selection_drag_finishes_surface_ownership(
-            &WaveformInteraction::UpdateSelection { visible_ratio: 0.3 },
-            Some(WaveformActiveDragKind::Selection(
-                WaveformSelectionKind::Play
-            ))
-        ));
-        assert!(!play_selection_drag_finishes_surface_ownership(
-            &WaveformInteraction::FinishSelection { visible_ratio: 0.4 },
-            Some(WaveformActiveDragKind::Selection(
-                WaveformSelectionKind::Edit
-            ))
         ));
     }
 

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -1,5 +1,5 @@
 use super::*;
-use radiant::runtime::RepaintScope;
+use radiant::runtime::{PaintPrimitive, RepaintScope};
 
 #[test]
 fn playback_frame_uses_paint_only_when_only_playhead_changes() {
@@ -1149,6 +1149,60 @@ fn played_range_rail_grows_on_paint_only_playback_frames() {
         later_right > first_right,
         "played rail should advance with the interpolated playhead without a retained surface rebuild"
     );
+}
+
+#[test]
+fn playback_cursor_uses_live_playmark_drag_state_for_control_occlusion() {
+    let mut state = state_with_runtime_playback(0.40, (0.0, 1.0), false);
+    state
+        .waveform
+        .current
+        .apply_interaction(WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Play,
+            visible_ratio: 0.20,
+        });
+    state
+        .waveform
+        .current
+        .apply_interaction(WaveformInteraction::UpdateSelection {
+            visible_ratio: 0.60,
+        });
+    assert_eq!(
+        state.waveform.current.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.20, 0.60))
+    );
+
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+    let label_rect = frame
+        .paint_plan
+        .text_runs()
+        .find(|text| text.text.as_str() == "400 ms")
+        .map(|text| text.rect)
+        .expect("live playmark label");
+    let mut primitives = Vec::new();
+    runtime.bridge_mut().state_mut().paint_playback_overlay(
+        TransientOverlayContext::new(
+            &frame.paint_plan,
+            Vector2::new(900.0, 620.0),
+            Duration::ZERO,
+        ),
+        &mut primitives,
+    );
+
+    let cursor_segments = primitives
+        .iter()
+        .filter_map(PaintPrimitive::fill_rect)
+        .filter(|fill| is_playback_cursor_fill(fill))
+        .collect::<Vec<_>>();
+    assert_eq!(cursor_segments.len(), 2);
+    assert!(cursor_segments.iter().all(|fill| {
+        fill.rect.max.x <= label_rect.min.x
+            || fill.rect.min.x >= label_rect.max.x
+            || fill.rect.max.y <= label_rect.min.y
+            || fill.rect.min.y >= label_rect.max.y
+    }));
 }
 
 #[test]

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -174,3 +174,23 @@ fn playmark_beat_controls_are_absent_without_a_playmark() {
             .is_none()
     );
 }
+
+#[test]
+fn playmark_beat_count_is_absent_until_the_grid_is_enabled() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+
+    let surface = waveform_panel(WaveformPanelViewModel::from_app_state(&state)).into_surface();
+    assert!(
+        surface
+            .find_widget(WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID)
+            .is_some()
+    );
+    assert!(
+        surface
+            .find_widget(WAVEFORM_PLAYMARK_BEAT_COUNT_ID)
+            .is_none()
+    );
+}

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -207,7 +207,7 @@ fn playmark_overlay_controls_paint_in_the_waveform_viewport() {
         .view_frame_at_size_with_default_theme(ui::Vector2::new(800.0, WAVEFORM_PANEL_HEIGHT));
 
     assert!(frame.paint_plan.primitives.iter().any(
-        |primitive| matches!(primitive, PaintPrimitive::Text(text) if text.widget_id == WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID && text.text.as_str() == "Grid")
+        |primitive| matches!(primitive, PaintPrimitive::Text(text) if text.widget_id == WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID && text.text.as_str() == "G")
     ));
 }
 

--- a/src/native_app/tests/waveform_panel.rs
+++ b/src/native_app/tests/waveform_panel.rs
@@ -12,6 +12,7 @@ use crate::native_app::{
 use radiant::{
     gui::automation::AutomationRole,
     prelude::{self as ui, IntoView},
+    runtime::PaintPrimitive,
 };
 
 fn loaded_sample_drag_handle_tooltip(
@@ -193,4 +194,38 @@ fn playmark_beat_count_is_absent_until_the_grid_is_enabled() {
             .find_widget(WAVEFORM_PLAYMARK_BEAT_COUNT_ID)
             .is_none()
     );
+}
+
+#[test]
+fn playmark_overlay_controls_paint_in_the_waveform_viewport() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+
+    let frame = waveform_panel(WaveformPanelViewModel::from_app_state(&state))
+        .view_frame_at_size_with_default_theme(ui::Vector2::new(800.0, WAVEFORM_PANEL_HEIGHT));
+
+    assert!(frame.paint_plan.primitives.iter().any(
+        |primitive| matches!(primitive, PaintPrimitive::Text(text) if text.widget_id == WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID && text.text.as_str() == "Grid")
+    ));
+}
+
+#[test]
+fn editing_playmark_label_paints_one_text_input() {
+    let mut state = NativeAppStateFixture::default()
+        .with_synthetic_waveform()
+        .build();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    assert!(state.waveform.current.begin_playmark_label_edit(false, 4));
+
+    let frame = waveform_panel(WaveformPanelViewModel::from_app_state(&state))
+        .view_frame_at_size_with_default_theme(ui::Vector2::new(800.0, WAVEFORM_PANEL_HEIGHT));
+    let inputs = frame
+        .paint_plan
+        .text_inputs()
+        .filter(|input| input.widget_id == crate::native_app::ui::ids::WAVEFORM_PLAYMARK_LABEL_ID)
+        .count();
+
+    assert_eq!(inputs, 1);
 }

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -103,12 +103,17 @@ fn playmark_time_label_claims_edit_click_but_leaves_hover_and_secondary_drag_to_
     state.waveform.current.set_play_selection_range(0.25, 0.75);
     let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
     let theme = radiant::theme::ThemeTokens::default();
-    let label_point = runtime
-        .frame(&theme)
+    let initial_frame = runtime.frame(&theme);
+    let label = initial_frame
         .paint_plan
         .first_text_run("500 ms")
-        .map(|text| text.rect.center())
         .expect("playmark time label paint");
+    assert_eq!(
+        label.widget_id,
+        crate::native_app::ui::ids::WAVEFORM_PLAYMARK_LABEL_ID,
+        "the interactive label layer must own steady label paint"
+    );
+    let label_point = label.rect.center();
 
     assert_eq!(
         runtime.dispatch_event(Event::pointer_move(label_point)),
@@ -135,6 +140,27 @@ fn playmark_time_label_claims_edit_click_but_leaves_hover_and_secondary_drag_to_
     assert_eq!(
         runtime.bridge().state().waveform.current.play_selection(),
         Some(wavecrate::selection::SelectionRange::new(0.25, 0.75))
+    );
+    let editing_frame = runtime.frame(&theme);
+    assert_eq!(
+        editing_frame
+            .paint_plan
+            .text_runs()
+            .filter(|text| text.text.as_str() == "500 ms")
+            .count(),
+        0,
+        "the base playmark label must stop painting while its editor is active"
+    );
+    assert_eq!(
+        editing_frame
+            .paint_plan
+            .text_inputs()
+            .filter(|input| {
+                input.widget_id == crate::native_app::ui::ids::WAVEFORM_PLAYMARK_LABEL_ID
+            })
+            .count(),
+        1,
+        "edit mode must paint exactly one playmark text input"
     );
 
     let mut state = gui_state_for_span_tests();
@@ -183,7 +209,7 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
     let toggle_point = frame
         .paint_plan
         .text_runs()
-        .find(|text| text.widget_id == toggle_id && text.text.as_str() == "Grid")
+        .find(|text| text.widget_id == toggle_id && text.text.as_str() == "G")
         .map(|text| text.rect)
         .expect("local beat toggle paint")
         .center();

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -182,7 +182,9 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
     let toggle_id = crate::native_app::ui::ids::WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID;
     let toggle_point = frame
         .paint_plan
-        .first_svg_rect_for_widget(toggle_id)
+        .text_runs()
+        .find(|text| text.widget_id == toggle_id && text.text.as_str() == "Grid")
+        .map(|text| text.rect)
         .expect("local beat toggle paint")
         .center();
     let count_id = crate::native_app::ui::ids::WAVEFORM_PLAYMARK_BEAT_COUNT_ID;

--- a/src/native_app/tests/window_chrome/hit_targets.rs
+++ b/src/native_app/tests/window_chrome/hit_targets.rs
@@ -13,6 +13,165 @@ fn full_app_scene_routes_waveform_hit_target() {
 }
 
 #[test]
+fn absent_playmark_layers_leave_all_waveform_pointer_gestures_available() {
+    let state = gui_state_for_span_tests();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let rect = waveform_rect(&runtime);
+    let press = Point::new(rect.min.x + rect.width() * 0.2, rect.center().y);
+    let drag = Point::new(rect.min.x + rect.width() * 0.4, rect.center().y);
+
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(press)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.hovered_widget(),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_press(press)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(drag)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_release(drag)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.bridge().state().waveform.current.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.2, 0.4))
+    );
+
+    let state = gui_state_for_span_tests();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    assert_eq!(
+        runtime.dispatch_event(Event::secondary_press(press)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(drag)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::secondary_release(drag)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.bridge().state().waveform.current.edit_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.2, 0.4))
+    );
+}
+
+#[test]
+fn playmark_local_controls_leave_waveform_input_outside_their_painted_bounds() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let theme = radiant::theme::ThemeTokens::default();
+    let _ = runtime.frame(&theme);
+    let rect = waveform_rect(&runtime);
+    let point = Point::new(rect.min.x + rect.width() * 0.1, rect.center().y);
+
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.hovered_widget(),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_press(point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_release(point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.bridge().state().waveform.current.play_mark_ratio(),
+        Some(0.1)
+    );
+}
+
+#[test]
+fn playmark_time_label_claims_edit_click_but_leaves_hover_and_secondary_drag_to_waveform() {
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let theme = radiant::theme::ThemeTokens::default();
+    let label_point = runtime
+        .frame(&theme)
+        .paint_plan
+        .first_text_run("500 ms")
+        .map(|text| text.rect.center())
+        .expect("playmark time label paint");
+
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(label_point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID),
+        "the time label must leave waveform hover and transient overlays active"
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_press(label_point)),
+        Some(crate::native_app::ui::ids::WAVEFORM_PLAYMARK_LABEL_ID),
+        "a normal click must start editing the time label"
+    );
+    assert!(
+        runtime
+            .bridge()
+            .state()
+            .waveform
+            .current
+            .playmark_label_editor_active()
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::primary_release(label_point)),
+        Some(crate::native_app::ui::ids::WAVEFORM_PLAYMARK_LABEL_ID)
+    );
+    assert_eq!(
+        runtime.bridge().state().waveform.current.play_selection(),
+        Some(wavecrate::selection::SelectionRange::new(0.25, 0.75))
+    );
+
+    let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.25, 0.75);
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let frame = runtime.frame(&theme);
+    let label_point = frame
+        .paint_plan
+        .first_text_run("500 ms")
+        .map(|text| text.rect.center())
+        .expect("playmark time label paint");
+    let drag_point = Point::new(waveform_rect(&runtime).max.x - 20.0, label_point.y);
+    assert_eq!(
+        runtime.dispatch_event(Event::secondary_press(label_point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID),
+        "an edit-selection drag may start on the time label"
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::pointer_move(drag_point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert_eq!(
+        runtime.dispatch_event(Event::secondary_release(drag_point)),
+        Some(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+    );
+    assert!(
+        runtime
+            .bridge()
+            .state()
+            .waveform
+            .current
+            .edit_selection()
+            .is_some()
+    );
+}
+
+#[test]
 fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
     let mut state = gui_state_for_span_tests();
     state.waveform.current.set_play_selection_range(0.25, 0.75);
@@ -27,27 +186,15 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
         .expect("local beat toggle paint")
         .center();
     let count_id = crate::native_app::ui::ids::WAVEFORM_PLAYMARK_BEAT_COUNT_ID;
-    let initial_count_rect = frame
-        .paint_plan
-        .text_inputs()
-        .find(|input| input.widget_id == count_id)
-        .map(|input| input.rect)
-        .expect("initial local beat count paint");
-    assert!(!initial_count_rect.contains(toggle_point));
+    assert!(
+        runtime.surface().find_widget(count_id).is_none(),
+        "the beat count stays hidden until the grid is enabled"
+    );
     let toggle_press = WidgetInput::PointerPress {
         position: toggle_point,
         button: PointerButton::Primary,
         modifiers: Default::default(),
     };
-    assert!(
-        !runtime
-            .surface()
-            .find_widget(count_id)
-            .expect("count widget")
-            .widget_object()
-            .accepts_pointer_input(&toggle_press),
-        "count widget must reject the adjacent toggle hit"
-    );
 
     assert_eq!(
         runtime.dispatch_event(Event::primary_press(toggle_point)),
@@ -71,6 +218,15 @@ fn playmark_local_beat_controls_consume_hits_and_update_shared_state() {
     let frame = runtime.frame(&theme);
     assert!(frame.paint_plan.contains_text("480 BPM"));
     assert!(!frame.paint_plan.contains_text("500 ms"));
+    assert!(
+        !runtime
+            .surface()
+            .find_widget(count_id)
+            .expect("count widget")
+            .widget_object()
+            .accepts_pointer_input(&toggle_press),
+        "count widget must reject the adjacent toggle hit"
+    );
     let count_point = frame
         .paint_plan
         .text_inputs()

--- a/src/native_app/waveform.rs
+++ b/src/native_app/waveform.rs
@@ -102,14 +102,12 @@ mod widget;
 #[cfg(test)]
 pub(in crate::native_app::waveform) use widget::LiveSelectionPreview;
 #[cfg(test)]
-pub(super) use widget::WaveformWidgetProps;
-#[cfg(test)]
 pub(in crate::native_app::waveform) use widget::signal_edit_selection_for_state;
 #[cfg(test)]
 pub(in crate::native_app::waveform) use widget::signal_gain_preview_for_state;
 #[cfg(test)]
 pub(in crate::native_app::waveform) use widget::waveform_signal_surface_view;
-pub(super) use widget::{WaveformWidget, waveform_viewport_view_with_tooltip};
+pub(super) use widget::{WaveformWidget, WaveformWidgetProps, waveform_viewport_view_with_tooltip};
 
 mod widget_geometry;
 mod widget_input;

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -48,7 +48,7 @@ impl PlaymarkBeatToggleWidget {
         )?;
         let mut button = ButtonWidget::new(
             id,
-            "Grid",
+            "G",
             WidgetSizing::fixed(ui::Vector2::new(
                 playmark_label::PLAYMARK_BEAT_TOGGLE_WIDTH,
                 playmark_label::PLAYMARK_LABEL_HEIGHT,

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -265,7 +265,7 @@ pub(super) fn playmark_beat_control_views(
     state: &WaveformState,
     beat_guides_enabled: bool,
     beat_guide_count: u8,
-) -> [ui::View<GuiMessage>; 2] {
+) -> [Option<ui::View<GuiMessage>>; 2] {
     let toggle = PlaymarkBeatToggleWidget::new(
         toggle_id,
         geometry_source.clone(),
@@ -281,25 +281,27 @@ pub(super) fn playmark_beat_control_views(
         })
         .id(toggle_id)
         .size(super::WAVEFORM_WIDTH as f32, super::WAVEFORM_HEIGHT as f32)
-    })
-    .unwrap_or_else(ui::empty);
-    let count = PlaymarkBeatCountWidget::new(
-        count_id,
-        geometry_source,
-        state,
-        beat_guides_enabled,
-        beat_guide_count,
-    )
-    .map(|widget| {
-        ui::custom_widget(widget, |output| {
-            output
-                .typed_cloned::<BeatGuideCountInputMessage>()
-                .map(beat_guide_count_input_message)
+    });
+    let count = beat_guides_enabled
+        .then(|| {
+            PlaymarkBeatCountWidget::new(
+                count_id,
+                geometry_source,
+                state,
+                beat_guides_enabled,
+                beat_guide_count,
+            )
         })
-        .id(count_id)
-        .size(super::WAVEFORM_WIDTH as f32, super::WAVEFORM_HEIGHT as f32)
-    })
-    .unwrap_or_else(ui::empty);
+        .flatten()
+        .map(|widget| {
+            ui::custom_widget(widget, |output| {
+                output
+                    .typed_cloned::<BeatGuideCountInputMessage>()
+                    .map(beat_guide_count_input_message)
+            })
+            .id(count_id)
+            .size(super::WAVEFORM_WIDTH as f32, super::WAVEFORM_HEIGHT as f32)
+        });
     [toggle, count]
 }
 

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -2,7 +2,7 @@ use radiant::{
     gui::automation::AutomationRole,
     prelude as ui,
     widgets::{
-        IconButtonWidget, Widget, WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
+        ButtonWidget, Widget, WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
     },
 };
 use std::sync::{Arc, Mutex};
@@ -10,8 +10,7 @@ use std::sync::{Arc, Mutex};
 use crate::native_app::{
     app::GuiMessage,
     app_chrome::toolbar::{
-        BeatGuideCountInputMessage, BeatGuideCountInputWidget, ToolbarIcon,
-        beat_guide_count_input_message, toolbar_icon_glyph,
+        BeatGuideCountInputMessage, BeatGuideCountInputWidget, beat_guide_count_input_message,
     },
 };
 
@@ -26,7 +25,7 @@ enum PlaymarkBeatToggleMessage {
 struct PlaymarkBeatToggleWidget {
     geometry_source: WaveformWidget,
     label: String,
-    button: IconButtonWidget,
+    button: ButtonWidget,
     checked: bool,
     painted_bounds: Arc<Mutex<Option<ui::Rect>>>,
 }
@@ -47,9 +46,9 @@ impl PlaymarkBeatToggleWidget {
             beat_guides_enabled,
             beat_guide_count,
         )?;
-        let mut button = IconButtonWidget::new(
+        let mut button = ButtonWidget::new(
             id,
-            toolbar_icon_glyph(ToolbarIcon::BeatGuides, true, beat_guides_enabled),
+            "Grid",
             WidgetSizing::fixed(ui::Vector2::new(
                 playmark_label::PLAYMARK_BEAT_TOGGLE_WIDTH,
                 playmark_label::PLAYMARK_LABEL_HEIGHT,
@@ -57,6 +56,8 @@ impl PlaymarkBeatToggleWidget {
         );
         button.common.state.active = beat_guides_enabled;
         button.common.paint.paints_focus = true;
+        let mut geometry_source = geometry_source;
+        geometry_source.common.focus = radiant::widgets::FocusBehavior::Keyboard;
         Some(Self {
             geometry_source,
             label,
@@ -74,11 +75,11 @@ impl PlaymarkBeatToggleWidget {
 
 impl Widget for PlaymarkBeatToggleWidget {
     fn common(&self) -> &WidgetCommon {
-        self.button.common()
+        self.geometry_source.common()
     }
 
     fn common_mut(&mut self) -> &mut WidgetCommon {
-        self.button.common_mut()
+        self.geometry_source.common_mut()
     }
 
     fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
@@ -94,11 +95,12 @@ impl Widget for PlaymarkBeatToggleWidget {
         };
         self.button.synchronize_from_previous(&previous.button);
         self.button.common.state.active = self.checked;
+        self.geometry_source.common.state = previous.geometry_source.common.state;
         self.painted_bounds = Arc::clone(&previous.painted_bounds);
     }
 
     fn accepts_pointer_move(&self) -> bool {
-        self.button.accepts_pointer_move()
+        true
     }
 
     fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
@@ -161,6 +163,8 @@ impl PlaymarkBeatCountWidget {
             beat_guides_enabled,
             beat_guide_count,
         )?;
+        let mut geometry_source = geometry_source;
+        geometry_source.common.focus = radiant::widgets::FocusBehavior::Keyboard;
         Some(Self {
             geometry_source,
             label,
@@ -182,11 +186,11 @@ impl PlaymarkBeatCountWidget {
 
 impl Widget for PlaymarkBeatCountWidget {
     fn common(&self) -> &WidgetCommon {
-        self.input.common()
+        self.geometry_source.common()
     }
 
     fn common_mut(&mut self) -> &mut WidgetCommon {
-        self.input.common_mut()
+        self.geometry_source.common_mut()
     }
 
     fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
@@ -198,6 +202,7 @@ impl Widget for PlaymarkBeatCountWidget {
             return;
         };
         self.input.synchronize_from_previous(&previous.input);
+        self.geometry_source.common.state = previous.geometry_source.common.state;
         self.painted_bounds = Arc::clone(&previous.painted_bounds);
     }
 

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -18,7 +18,7 @@ const PLAYMARK_LABEL_HORIZONTAL_PADDING: f32 = 10.0;
 const PLAYMARK_LABEL_GLYPH_WIDTH: f32 = 10.0;
 const PLAYMARK_LABEL_MIN_WIDTH: f32 = 80.0;
 const PLAYMARK_LABEL_MAX_WIDTH: f32 = 150.0;
-pub(super) const PLAYMARK_BEAT_TOGGLE_WIDTH: f32 = 52.0;
+pub(super) const PLAYMARK_BEAT_TOGGLE_WIDTH: f32 = 28.0;
 pub(super) const PLAYMARK_BEAT_COUNT_WIDTH: f32 = 30.0;
 pub(super) const PLAYMARK_BEAT_CONTROL_GAP: f32 = 2.0;
 const PLAYMARK_LABEL_CONTROL_GAP: f32 = 4.0;
@@ -222,10 +222,10 @@ mod tests {
             .expect("wide label layout");
 
         assert_eq!(layout.placement, PlaymarkLabelPlacement::Inside);
-        assert_eq!(layout.rect.min.x, 116.0);
-        assert_eq!(layout.rect.max.x, 196.0);
-        assert_eq!(layout.beat_count_rect.max.x, 284.0);
-        assert_eq!(layout.beat_toggle_rect.min.x, 200.0);
+        assert_eq!(layout.rect.min.x, 128.0);
+        assert_eq!(layout.rect.max.x, 208.0);
+        assert_eq!(layout.beat_count_rect.max.x, 272.0);
+        assert_eq!(layout.beat_toggle_rect.min.x, 212.0);
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod tests {
         let right_edge = playmark_label_layout(rect(0.0, 400.0), rect(350.0, 360.0), 6)
             .expect("right-edge narrow layout");
         assert_eq!(right_edge.placement, PlaymarkLabelPlacement::OutsideLeft);
-        assert_eq!(right_edge.rect.min.x, 176.0);
+        assert_eq!(right_edge.rect.min.x, 200.0);
         assert_eq!(right_edge.beat_count_rect.max.x, 344.0);
     }
 
@@ -250,7 +250,7 @@ mod tests {
         assert_eq!(layout.placement, PlaymarkLabelPlacement::OutsideRight);
         assert_eq!(layout.rect.min.x, 26.0);
         assert_eq!(layout.rect.max.x, 106.0);
-        assert_eq!(layout.beat_count_rect.max.x, 194.0);
+        assert_eq!(layout.beat_count_rect.max.x, 170.0);
     }
 
     #[test]
@@ -270,14 +270,14 @@ mod tests {
             .expect("tied fallback layout");
         assert_eq!(tied.placement, PlaymarkLabelPlacement::FallbackRight);
         assert_eq!(tied.rect.min.x, 0.0);
-        assert_eq!(tied.rect.max.x, 12.0);
+        assert_eq!(tied.rect.max.x, 36.0);
         assert_eq!(tied.beat_count_rect.max.x, 100.0);
 
         let left_roomier = playmark_label_layout(rect(0.0, 100.0), rect(60.0, 80.0), 6)
             .expect("left-roomier fallback layout");
         assert_eq!(left_roomier.placement, PlaymarkLabelPlacement::FallbackLeft);
         assert_eq!(left_roomier.rect.min.x, 0.0);
-        assert_eq!(left_roomier.rect.max.x, 12.0);
+        assert_eq!(left_roomier.rect.max.x, 36.0);
         assert_eq!(left_roomier.beat_count_rect.max.x, 100.0);
     }
 

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -18,7 +18,7 @@ const PLAYMARK_LABEL_HORIZONTAL_PADDING: f32 = 10.0;
 const PLAYMARK_LABEL_GLYPH_WIDTH: f32 = 10.0;
 const PLAYMARK_LABEL_MIN_WIDTH: f32 = 80.0;
 const PLAYMARK_LABEL_MAX_WIDTH: f32 = 150.0;
-pub(super) const PLAYMARK_BEAT_TOGGLE_WIDTH: f32 = 20.0;
+pub(super) const PLAYMARK_BEAT_TOGGLE_WIDTH: f32 = 52.0;
 pub(super) const PLAYMARK_BEAT_COUNT_WIDTH: f32 = 30.0;
 pub(super) const PLAYMARK_BEAT_CONTROL_GAP: f32 = 2.0;
 const PLAYMARK_LABEL_CONTROL_GAP: f32 = 4.0;
@@ -222,10 +222,10 @@ mod tests {
             .expect("wide label layout");
 
         assert_eq!(layout.placement, PlaymarkLabelPlacement::Inside);
-        assert_eq!(layout.rect.min.x, 132.0);
-        assert_eq!(layout.rect.max.x, 212.0);
-        assert_eq!(layout.beat_count_rect.max.x, 268.0);
-        assert_eq!(layout.beat_toggle_rect.min.x, 216.0);
+        assert_eq!(layout.rect.min.x, 116.0);
+        assert_eq!(layout.rect.max.x, 196.0);
+        assert_eq!(layout.beat_count_rect.max.x, 284.0);
+        assert_eq!(layout.beat_toggle_rect.min.x, 200.0);
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod tests {
         let right_edge = playmark_label_layout(rect(0.0, 400.0), rect(350.0, 360.0), 6)
             .expect("right-edge narrow layout");
         assert_eq!(right_edge.placement, PlaymarkLabelPlacement::OutsideLeft);
-        assert_eq!(right_edge.rect.min.x, 208.0);
+        assert_eq!(right_edge.rect.min.x, 176.0);
         assert_eq!(right_edge.beat_count_rect.max.x, 344.0);
     }
 
@@ -250,7 +250,7 @@ mod tests {
         assert_eq!(layout.placement, PlaymarkLabelPlacement::OutsideRight);
         assert_eq!(layout.rect.min.x, 26.0);
         assert_eq!(layout.rect.max.x, 106.0);
-        assert_eq!(layout.beat_count_rect.max.x, 162.0);
+        assert_eq!(layout.beat_count_rect.max.x, 194.0);
     }
 
     #[test]
@@ -270,14 +270,14 @@ mod tests {
             .expect("tied fallback layout");
         assert_eq!(tied.placement, PlaymarkLabelPlacement::FallbackRight);
         assert_eq!(tied.rect.min.x, 0.0);
-        assert_eq!(tied.rect.max.x, 44.0);
+        assert_eq!(tied.rect.max.x, 12.0);
         assert_eq!(tied.beat_count_rect.max.x, 100.0);
 
         let left_roomier = playmark_label_layout(rect(0.0, 100.0), rect(60.0, 80.0), 6)
             .expect("left-roomier fallback layout");
         assert_eq!(left_roomier.placement, PlaymarkLabelPlacement::FallbackLeft);
         assert_eq!(left_roomier.rect.min.x, 0.0);
-        assert_eq!(left_roomier.rect.max.x, 44.0);
+        assert_eq!(left_roomier.rect.max.x, 12.0);
         assert_eq!(left_roomier.beat_count_rect.max.x, 100.0);
     }
 

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -11,7 +11,9 @@ use crate::ui_formatting::{format_selection_duration, format_waveform_bpm_input}
 use super::{WaveformActiveDragKind, WaveformSelectionKind, WaveformWidget};
 
 pub(super) const PLAYMARK_LABEL_HEIGHT: f32 = 18.0;
-const PLAYMARK_LABEL_BOTTOM_INSET: f32 = 2.0;
+// Keep the interactive control strip above the four-pixel played-range rail.
+// Transient playback overlays must not intersect retained text primitives.
+const PLAYMARK_LABEL_BOTTOM_INSET: f32 = 6.0;
 const PLAYMARK_LABEL_SELECTION_INSET: f32 = 4.0;
 const PLAYMARK_LABEL_OUTSIDE_GAP: f32 = 6.0;
 const PLAYMARK_LABEL_HORIZONTAL_PADDING: f32 = 10.0;
@@ -43,6 +45,31 @@ pub(super) struct PlaymarkLabelLayout {
 }
 
 impl WaveformWidget {
+    pub(in crate::native_app) fn playmark_control_cluster_rect(
+        &self,
+        bounds: Rect,
+    ) -> Option<Rect> {
+        let selection = self.play_selection?;
+        let geometry = self.selection_geometry(bounds, Some(selection))?;
+        let label = playmark_selection_label(
+            selection,
+            self.file.frames,
+            self.file.sample_rate,
+            self.beat_guides_enabled,
+            self.beat_guide_count,
+        )?;
+        let layout = playmark_label_layout(bounds, geometry.rect, label.len())?;
+        let controls_max_x = if self.beat_guides_enabled {
+            layout.beat_count_rect.max.x
+        } else {
+            layout.beat_toggle_rect.max.x
+        };
+        Some(Rect::from_min_max(
+            layout.rect.min,
+            Point::new(controls_max_x, layout.rect.max.y),
+        ))
+    }
+
     pub(super) fn append_playmark_label_paint(
         &self,
         paint: &mut WidgetPaint<'_>,

--- a/src/native_app/waveform/playmark_label.rs
+++ b/src/native_app/waveform/playmark_label.rs
@@ -45,11 +45,24 @@ pub(super) struct PlaymarkLabelLayout {
 }
 
 impl WaveformWidget {
+    fn effective_playmark_label_selection(&self) -> Option<wavecrate::selection::SelectionRange> {
+        match self.active_drag_kind {
+            Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
+            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play))
+            | Some(WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, _)) => self
+                .live_selection_preview
+                .filter(|preview| preview.kind == WaveformSelectionKind::Play)
+                .map(|preview| preview.selection)
+                .or(self.play_selection),
+            _ => self.play_selection,
+        }
+    }
+
     pub(in crate::native_app) fn playmark_control_cluster_rect(
         &self,
         bounds: Rect,
     ) -> Option<Rect> {
-        let selection = self.play_selection?;
+        let selection = self.effective_playmark_label_selection()?;
         let geometry = self.selection_geometry(bounds, Some(selection))?;
         let label = playmark_selection_label(
             selection,
@@ -104,16 +117,7 @@ impl WaveformWidget {
         paint: &mut WidgetPaint<'_>,
         bounds: Rect,
     ) {
-        let selection = match self.active_drag_kind {
-            Some(WaveformActiveDragKind::Selection(WaveformSelectionKind::Play))
-            | Some(WaveformActiveDragKind::SelectionMove(WaveformSelectionKind::Play))
-            | Some(WaveformActiveDragKind::SelectionResize(WaveformSelectionKind::Play, _)) => self
-                .live_selection_preview
-                .filter(|preview| preview.kind == WaveformSelectionKind::Play)
-                .map(|preview| preview.selection)
-                .or(self.play_selection),
-            _ => self.play_selection,
-        };
+        let selection = self.effective_playmark_label_selection();
         let Some(selection) = selection else {
             return;
         };

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -1,6 +1,7 @@
 use radiant::{
     gui::automation::AutomationRole,
     prelude as ui,
+    runtime::WidgetPaint,
     widgets::{
         FocusBehavior, PointerButton, TextInputMessage, TextInputWidget, Widget, WidgetCommon,
         WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
@@ -262,10 +263,40 @@ impl Widget for PlaymarkLabelWidget {
         if let Ok(mut painted_bounds) = self.painted_bounds.lock() {
             *painted_bounds = Some(bounds);
         }
-        let (Some(input), Some(rect)) = (&self.input, self.label_rect(bounds)) else {
+        let Some(rect) = self.label_rect(bounds) else {
             return;
         };
-        input.append_paint(primitives, rect, layout, theme);
+        if let Some(input) = &self.input {
+            input.append_paint(primitives, rect, layout, theme);
+            return;
+        }
+        if matches!(
+            self.geometry_source.active_drag_kind,
+            Some(
+                super::WaveformActiveDragKind::Selection(super::WaveformSelectionKind::Play)
+                    | super::WaveformActiveDragKind::SelectionMove(
+                        super::WaveformSelectionKind::Play
+                    )
+                    | super::WaveformActiveDragKind::SelectionResize(
+                        super::WaveformSelectionKind::Play,
+                        _
+                    )
+            )
+        ) {
+            return;
+        }
+        let Some(selection) = self.geometry_source.play_selection else {
+            return;
+        };
+        let Some(geometry) = self
+            .geometry_source
+            .selection_geometry(bounds, Some(selection))
+        else {
+            return;
+        };
+        let mut paint = WidgetPaint::new(primitives, self.common().id);
+        self.geometry_source
+            .append_playmark_label_paint(&mut paint, bounds, geometry, selection);
     }
 }
 

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -123,9 +123,7 @@ impl PlaymarkLabelWidget {
             })
             .unwrap_or((None, None));
         let mut geometry_source = geometry_source;
-        if input.is_none() {
-            geometry_source.common.focus = FocusBehavior::Keyboard;
-        }
+        geometry_source.common.focus = FocusBehavior::Keyboard;
         Some(Self {
             geometry_source,
             label,
@@ -151,17 +149,11 @@ impl PlaymarkLabelWidget {
 
 impl Widget for PlaymarkLabelWidget {
     fn common(&self) -> &WidgetCommon {
-        self.input
-            .as_ref()
-            .map(Widget::common)
-            .unwrap_or_else(|| self.geometry_source.common())
+        self.geometry_source.common()
     }
 
     fn common_mut(&mut self) -> &mut WidgetCommon {
-        self.input
-            .as_mut()
-            .map(Widget::common_mut)
-            .unwrap_or_else(|| self.geometry_source.common_mut())
+        self.geometry_source.common_mut()
     }
 
     fn handle_input(&mut self, bounds: ui::Rect, input: WidgetInput) -> Option<WidgetOutput> {
@@ -195,6 +187,7 @@ impl Widget for PlaymarkLabelWidget {
         if let (Some(input), Some(previous_input)) = (&mut self.input, &previous.input) {
             input.synchronize_from_previous(previous_input);
         }
+        self.geometry_source.common.state = previous.geometry_source.common.state;
         self.painted_bounds = Arc::clone(&previous.painted_bounds);
     }
 

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -2,8 +2,8 @@ use radiant::{
     gui::automation::AutomationRole,
     prelude as ui,
     widgets::{
-        FocusBehavior, TextInputMessage, TextInputWidget, Widget, WidgetCommon, WidgetInput,
-        WidgetKey, WidgetOutput, WidgetSizing,
+        FocusBehavior, PointerButton, TextInputMessage, TextInputWidget, Widget, WidgetCommon,
+        WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
     },
 };
 use std::sync::{Arc, Mutex};
@@ -183,7 +183,7 @@ impl Widget for PlaymarkLabelWidget {
                 })
                 .map(WidgetOutput::typed);
         }
-        (matches!(input, WidgetInput::PointerDoubleClick { position, .. } if label_rect.contains(position))
+        (matches!(input, WidgetInput::PointerPress { position, button: PointerButton::Primary, .. } if label_rect.contains(position))
             || matches!(input, WidgetInput::KeyPress(WidgetKey::Enter | WidgetKey::Space)))
         .then(|| WidgetOutput::typed(PlaymarkLabelMessage::BeginEdit))
     }
@@ -207,14 +207,23 @@ impl Widget for PlaymarkLabelWidget {
     }
 
     fn accepts_pointer_input(&self, input: &WidgetInput) -> bool {
-        input.pointer_position().is_none_or(|position| {
-            self.painted_bounds
-                .lock()
-                .ok()
-                .and_then(|bounds| *bounds)
-                .and_then(|bounds| self.label_rect(bounds))
-                .is_some_and(|rect| rect.contains(position))
-        })
+        let accepts_event = self.editing()
+            || matches!(
+                input,
+                WidgetInput::PointerPress {
+                    button: PointerButton::Primary,
+                    ..
+                }
+            );
+        accepts_event
+            && input.pointer_position().is_none_or(|position| {
+                self.painted_bounds
+                    .lock()
+                    .ok()
+                    .and_then(|bounds| *bounds)
+                    .and_then(|bounds| self.label_rect(bounds))
+                    .is_some_and(|rect| rect.contains(position))
+            })
     }
 
     fn automation_role(&self) -> AutomationRole {
@@ -231,7 +240,7 @@ impl Widget for PlaymarkLabelWidget {
 
     fn automation_description(&self) -> Option<String> {
         self.error.clone().or_else(|| {
-            (!self.editing()).then(|| String::from("Double-click to edit the playmark length"))
+            (!self.editing()).then(|| String::from("Click to edit the playmark length"))
         })
     }
 
@@ -369,8 +378,7 @@ fn non_negative_number(text: &str) -> Result<f64, String> {
 mod tests {
     use super::*;
     use crate::native_app::waveform::WaveformWidgetProps;
-    use radiant::widgets::{PointerButton, PointerModifiers};
-
+    use crate::native_app::waveform::{WaveformInteraction, WaveformSelectionKind};
     #[test]
     fn parses_supported_time_and_bpm_forms_case_insensitively() {
         assert_eq!(parse_length_seconds(" 1000 MS ", 4), Ok(1.0));
@@ -410,17 +418,41 @@ mod tests {
             ui::Rect::from_min_max(ui::Point::new(20.0, 40.0), ui::Point::new(1_220.0, 360.0));
         *widget.painted_bounds.lock().expect("painted bounds") = Some(bounds);
         let label_rect = widget.label_rect(bounds).expect("label rect");
-
-        let inside = WidgetInput::pointer_double_click(
-            ui::Point::new(label_rect.min.x + 1.0, label_rect.min.y + 1.0),
-            PointerButton::Primary,
-            PointerModifiers::default(),
+        assert_eq!(
+            widget.automation_description().as_deref(),
+            Some("Click to edit the playmark length")
         );
+
+        let inside = WidgetInput::primary_press(ui::Point::new(
+            label_rect.min.x + 1.0,
+            label_rect.min.y + 1.0,
+        ));
         let outside =
             WidgetInput::primary_press(ui::Point::new(bounds.min.x + 1.0, bounds.min.y + 1.0));
 
         assert!(widget.accepts_pointer_input(&inside));
         assert!(widget.handle_input(bounds, inside).is_some());
         assert!(!widget.accepts_pointer_input(&outside));
+    }
+
+    #[test]
+    fn new_play_selection_discards_stale_label_editor_draft() {
+        let mut state = WaveformState::synthetic_for_tests();
+        state.set_play_selection_range(0.25, 0.75);
+        assert!(state.begin_playmark_label_edit(false, 4));
+        state.update_playmark_label_draft(String::from("stale value"));
+
+        state.apply_interaction(WaveformInteraction::BeginSelection {
+            kind: WaveformSelectionKind::Play,
+            visible_ratio: 0.1,
+        });
+        assert!(!state.playmark_label_editor_active());
+        state.apply_interaction(WaveformInteraction::UpdateSelection { visible_ratio: 0.3 });
+        state.apply_interaction(WaveformInteraction::FinishSelection { visible_ratio: 0.3 });
+
+        assert!(state.begin_playmark_label_edit(false, 4));
+        let editor = state.playmark_label_editor.as_ref().expect("fresh editor");
+        assert_ne!(editor.draft, "stale value");
+        assert_eq!(editor.draft, editor.original_draft);
     }
 }

--- a/src/native_app/waveform/selection_paint.rs
+++ b/src/native_app/waveform/selection_paint.rs
@@ -80,7 +80,11 @@ impl WaveformWidget {
             {
                 self.append_edit_selection_paint(&mut paint, &mut handle_paint, bounds, geometry);
             }
-            if !self.playmark_label_editor_active {
+            if !self.playmark_label_editor_active
+                && (!self.external_playmark_label_owner
+                    || active_selection_drag_kind(self.active_drag_kind)
+                        == Some(WaveformSelectionKind::Play))
+            {
                 self.append_base_playmark_label_paint(&mut paint, bounds);
             }
             self.append_played_range_paint(&mut paint, bounds);

--- a/src/native_app/waveform/state_interaction.rs
+++ b/src/native_app/waveform/state_interaction.rs
@@ -56,6 +56,7 @@ impl WaveformState {
                 )));
                 match kind {
                     WaveformSelectionKind::Play => {
+                        self.close_playmark_label_editor();
                         self.play_mark_ratio = None;
                         self.play_selection = None;
                         self.play_selection_flash_frames = 0;

--- a/src/native_app/waveform/state_selection.rs
+++ b/src/native_app/waveform/state_selection.rs
@@ -114,6 +114,7 @@ impl WaveformState {
         play_selection: Option<SelectionRange>,
         marked_play_ranges: Vec<SelectionRange>,
     ) {
+        self.close_playmark_label_editor();
         if self.play_selection != play_selection {
             self.clear_similar_sections();
         }
@@ -176,6 +177,7 @@ impl WaveformState {
     ) {
         match kind {
             WaveformSelectionKind::Play => {
+                self.close_playmark_label_editor();
                 if self.play_selection != Some(selection) && self.active_drag.is_none() {
                     self.clear_similar_sections();
                 }

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -174,7 +174,7 @@ fn playmark_label_formats_duration_and_paints_at_selection_bottom() {
         .first_text_run("750 ms")
         .expect("subsecond playmark duration label");
     assert!((subsecond_label.rect.center().x - 168.0).abs() < 0.01);
-    assert_eq!(subsecond_label.rect.max.y, 78.0);
+    assert_eq!(subsecond_label.rect.max.y, 74.0);
 
     let mut seconds = waveform_state_with_duration_seconds(2);
     seconds.play_selection = Some(wavecrate::selection::SelectionRange::new(0.25, 1.0));

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -333,6 +333,32 @@ fn playmark_label_has_one_owner_across_live_and_transition_states() {
 }
 
 #[test]
+fn playmark_control_occlusion_tracks_live_drag_selection() {
+    let bounds = Rect::from_size(400.0, 80.0);
+    let live_selection = wavecrate::selection::SelectionRange::new(0.6, 0.9);
+    let mut widget = waveform_widget_for_state(&WaveformState::synthetic_for_tests());
+    widget.active_drag_kind = Some(WaveformActiveDragKind::Selection(
+        WaveformSelectionKind::Play,
+    ));
+    widget.live_selection_preview = Some(LiveSelectionPreview {
+        kind: WaveformSelectionKind::Play,
+        selection: live_selection,
+    });
+
+    let occlusion = widget
+        .playmark_control_cluster_rect(bounds)
+        .expect("live playmark control occlusion");
+    let mut committed = WaveformState::synthetic_for_tests();
+    committed.play_selection = Some(live_selection);
+    let expected = waveform_widget_for_state(&committed)
+        .playmark_control_cluster_rect(bounds)
+        .expect("equivalent committed playmark control occlusion");
+
+    assert_eq!(occlusion, expected);
+    assert_eq!(occlusion.max.y, 74.0);
+}
+
+#[test]
 fn steady_base_is_rebuilt_before_live_move_label_paints() {
     let bounds = Rect::from_size(400.0, 80.0);
     let mut state = WaveformState::synthetic_for_tests();

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -1069,22 +1069,6 @@ fn played_ranges_paint_as_a_subtle_thick_bottom_rail() {
 }
 
 #[test]
-fn active_playback_leaves_the_played_range_rail_to_the_transient_overlay() {
-    let mut state = WaveformState::synthetic_for_tests();
-    state
-        .played_ranges
-        .push(wavecrate::selection::SelectionRange::new(0.2, 0.6));
-    state.start_playback(0.2);
-
-    let widget = waveform_widget_for_state(&state);
-    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
-
-    assert!(fill_rects(&plan).iter().all(|fill| {
-        (fill.color.r, fill.color.g, fill.color.b, fill.color.a) != (98, 102, 106, 255)
-    }));
-}
-
-#[test]
 fn extracted_ranges_paint_while_playmark_selection_drag_is_active() {
     let mut state = WaveformState::synthetic_for_tests();
     state

--- a/src/native_app/waveform/tests/paint.rs
+++ b/src/native_app/waveform/tests/paint.rs
@@ -173,7 +173,7 @@ fn playmark_label_formats_duration_and_paints_at_selection_bottom() {
     let subsecond_label = subsecond_plan
         .first_text_run("750 ms")
         .expect("subsecond playmark duration label");
-    assert!((subsecond_label.rect.center().x - 172.0).abs() < 0.01);
+    assert!((subsecond_label.rect.center().x - 168.0).abs() < 0.01);
     assert_eq!(subsecond_label.rect.max.y, 78.0);
 
     let mut seconds = waveform_state_with_duration_seconds(2);
@@ -1066,6 +1066,22 @@ fn played_ranges_paint_as_a_subtle_thick_bottom_rail() {
     assert!((rail.rect.max.x - 120.0).abs() < 0.001);
     assert!((rail.rect.min.y - 76.0).abs() < 0.001);
     assert!((rail.rect.max.y - 80.0).abs() < 0.001);
+}
+
+#[test]
+fn active_playback_leaves_the_played_range_rail_to_the_transient_overlay() {
+    let mut state = WaveformState::synthetic_for_tests();
+    state
+        .played_ranges
+        .push(wavecrate::selection::SelectionRange::new(0.2, 0.6));
+    state.start_playback(0.2);
+
+    let widget = waveform_widget_for_state(&state);
+    let plan = widget.paint_plan_with_defaults(Rect::from_size(200.0, 80.0));
+
+    assert!(fill_rects(&plan).iter().all(|fill| {
+        (fill.color.r, fill.color.g, fill.color.b, fill.color.a) != (98, 102, 106, 255)
+    }));
 }
 
 #[test]

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -65,11 +65,14 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         beat_guide_count,
         playhead_occlusion_rect,
     );
-    let interaction = ui::custom_widget(WaveformWidget::new(props.clone()), |output| {
-        output
-            .typed_copied::<WaveformInteraction>()
-            .map(GuiMessage::Waveform)
-    })
+    let interaction = ui::custom_widget(
+        WaveformWidget::new(props.clone()).with_external_playmark_label_owner(),
+        |output| {
+            output
+                .typed_copied::<WaveformInteraction>()
+                .map(GuiMessage::Waveform)
+        },
+    )
     .id(WAVEFORM_WIDGET_ID)
     .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32);
     let interaction = if let Some(tooltip) = tooltip {
@@ -299,7 +302,15 @@ impl WaveformWidgetProps {
             } else {
                 Vec::new()
             },
-            played_ranges: state.played_ranges().to_vec(),
+            // Playback owns the live rail through the paint-only transient overlay.
+            // Keeping the same rail in the retained surface makes the two scenes
+            // overlap until playback stops and can leave neighboring primitives
+            // duplicated at the overlay damage boundary.
+            played_ranges: if state.is_playing() {
+                Vec::new()
+            } else {
+                state.played_ranges().to_vec()
+            },
             similar_section_ranges: if similar_section_overlays_visible(active_drag_kind) {
                 state.similar_section_ranges().to_vec()
             } else {
@@ -373,6 +384,7 @@ pub(in crate::native_app) struct WaveformWidget {
     pub(super) beat_guide_count: u8,
     pub(super) playhead_occlusion_rect: Option<Rect>,
     pub(super) playmark_label_editor_active: bool,
+    pub(super) external_playmark_label_owner: bool,
     pub(super) edit_preview: TimelineEditPreview,
     pub(super) last_live_selection_update_visible_ratio: Option<f32>,
     pub(super) live_selection_preview_anchor: Option<LiveSelectionPreviewAnchor>,
@@ -448,6 +460,7 @@ impl WaveformWidget {
             beat_guide_count,
             playhead_occlusion_rect,
             playmark_label_editor_active,
+            external_playmark_label_owner: false,
             edit_preview: edit_preview_for_selection(edit_selection),
             last_live_selection_update_visible_ratio: None,
             live_selection_preview_anchor: None,
@@ -459,6 +472,11 @@ impl WaveformWidget {
 
     pub(super) fn has_loaded_sample(&self) -> bool {
         self.file.has_loaded_sample_metadata()
+    }
+
+    fn with_external_playmark_label_owner(mut self) -> Self {
+        self.external_playmark_label_owner = true;
+        self
     }
 }
 

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -92,9 +92,8 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         })
         .id(widget_ids::WAVEFORM_PLAYMARK_LABEL_ID)
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
-    })
-    .unwrap_or_else(ui::empty);
-    let [beat_toggle, beat_count] = playmark_beat_control_views(
+    });
+    let beat_controls = playmark_beat_control_views(
         widget_ids::WAVEFORM_PLAYMARK_BEAT_TOGGLE_ID,
         widget_ids::WAVEFORM_PLAYMARK_BEAT_COUNT_ID,
         WaveformWidget::new(props),
@@ -103,7 +102,7 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         beat_guide_count,
     );
 
-    ui::stack([
+    let layers = [
         waveform_signal_surface_view(
             state,
             signal_gain_preview_for_state(state, normalized_audition_enabled),
@@ -112,12 +111,14 @@ pub(in crate::native_app) fn waveform_viewport_view_with_tooltip(
         .id(WAVEFORM_SIGNAL_WIDGET_ID)
         .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32),
         interaction,
-        label,
-        beat_toggle,
-        beat_count,
-    ])
-    .id(widget_ids::WAVEFORM_VIEWPORT_STACK_ID)
-    .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
+    ]
+    .into_iter()
+    .chain(label)
+    .chain(beat_controls.into_iter().flatten());
+
+    ui::stack(layers)
+        .id(widget_ids::WAVEFORM_VIEWPORT_STACK_ID)
+        .size(WAVEFORM_WIDTH as f32, WAVEFORM_HEIGHT as f32)
 }
 
 pub(super) fn signal_edit_selection_for_state(

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -302,15 +302,7 @@ impl WaveformWidgetProps {
             } else {
                 Vec::new()
             },
-            // Playback owns the live rail through the paint-only transient overlay.
-            // Keeping the same rail in the retained surface makes the two scenes
-            // overlap until playback stops and can leave neighboring primitives
-            // duplicated at the overlay damage boundary.
-            played_ranges: if state.is_playing() {
-                Vec::new()
-            } else {
-                state.played_ranges().to_vec()
-            },
+            played_ranges: state.played_ranges().to_vec(),
             similar_section_ranges: if similar_section_overlays_visible(active_drag_kind) {
                 state.similar_section_ranges().to_vec()
             } else {

--- a/src/native_app/waveform/widget.rs
+++ b/src/native_app/waveform/widget.rs
@@ -271,7 +271,7 @@ impl WaveformWidgetProps {
         )
     }
 
-    pub(super) fn from_state_with_playhead_occlusion(
+    pub(in crate::native_app) fn from_state_with_playhead_occlusion(
         state: &WaveformState,
         beat_guides_enabled: bool,
         bpm_snap_enabled: bool,
@@ -386,7 +386,7 @@ pub(in crate::native_app) struct WaveformWidget {
 }
 
 impl WaveformWidget {
-    pub(super) fn new(props: WaveformWidgetProps) -> Self {
+    pub(in crate::native_app) fn new(props: WaveformWidgetProps) -> Self {
         let WaveformWidgetProps {
             file,
             viewport,


### PR DESCRIPTION
## Goal

Restore waveform hover, click-to-play, playmark selection, and editmark selection after the playmark-local time and beat-grid controls were added.

## Scope and non-goals

- Omit absent optional playmark layers instead of mounting pointer-active empty canvases.
- Keep visible playmark controls scoped to their painted bounds.
- Make the time label enter editing on a normal click and reset stale drafts when the play selection changes.
- Keep one visible owner for the editable playmark label across steady, drag, and edit states.
- Reserve the bottom played-range rail lane below the playmark controls and occlude the transient vertical playback cursor through that control cluster.
- Provide a compact local `G` beat-grid toggle beside the label.
- Show the local beat-count input only while beat guides are enabled.
- No audio-engine redesign.

## Definition of Done

- With no playmark, waveform hover, primary click/drag, and secondary edit drag route to the waveform.
- With a playmark, hover and selection gestures work outside visible controls.
- Clicking the time label starts editing without losing the playmark.
- Steady and edit modes each paint exactly one label representation.
- The grey played-range rail and vertical playback cursor do not intersect or duplicate the playmark label.
- A new or restored play selection cannot reuse a stale label draft.
- The local `G` toggle is visible and updates shared beat-guide state.
- The beat-count field is absent while the grid is off and appears when enabled.

## Validation

- `cargo fmt --check` — passed
- Playback-cursor and live-drag occlusion regressions — passed
- Playmark layout tests — 6 passed
- Waveform paint tests — 66 passed
- Waveform panel tests — 10 passed
- Playmark hit-routing tests — 3 passed
- `bash scripts/build.sh --release` — passed; signed branch app bundle rebuilt at exact head
- Broad `playmark` name-filtered library batch — 139 passed; two unrelated existing extraction fixture failures remain
- `bash scripts/ci.sh quick` — blocked before test execution by [OPT-1235](https://linear.app/boostnlvp/issue/OPT-1235)
- Repo request preflight — blocked by reactivated [OPT-969](https://linear.app/boostnlvp/issue/OPT-969)

## Known limitations

- Repository-wide quick/preflight gates remain blocked by the independently tracked baseline issues above.

User approval is required before merge.