### PR TITLE
OPT-1235: repair nextest quick-profile inventory filter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,8 +28,7 @@ path = "junit-ci-quarantine.xml"
 
 [profile.quick]
 default-filter = '''
-not binary_id(=wavecrate::bench/ann_index)
-and not binary_id(=wavecrate::bench/tagging)
-and not binary_id(=wavecrate::bin/wavecrate)
+not kind(bench)
+and not (package(=wavecrate) and kind(bin))
 and not test(=app::controller::ui::drag_drop_controller::drag_effects::folder_moves::tests::folder_sample_move_db_write_failure_rolls_back_source_and_keeps_journal_for_recovery)
 '''

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -238,6 +238,9 @@ Use for most app/domain behavior under `src/`.
   - `cargo test --doc`
 - quick app-development subset:
   - `cargo nextest run --profile quick --lib --tests`
+  - `scripts/ci.* quick` first lists the selected binaries with the same profile
+    and target set, so stale inventory-dependent filter predicates fail before
+    the test run starts
 - agent-safe library suite:
   - `cargo test -p wavecrate --lib`
   - `scripts/ci.* agent` runs the library suite with two known legacy

--- a/scripts/internal/check/check_script_guardrails.sh
+++ b/scripts/internal/check/check_script_guardrails.sh
@@ -488,6 +488,38 @@ EOF
     HEAD
 }
 
+run_nextest_quick_profile_fixture() {
+  local fixture_dir
+  fixture_dir="$(mktemp -d)"
+  trap 'rm -rf "$fixture_dir"' RETURN
+
+  local config_path="$fixture_dir/nextest.toml"
+  cat >"$config_path" <<'EOF'
+[profile.quick]
+default-filter = 'binary_id(=wavecrate::definitely-missing-binary)'
+EOF
+
+  run_expect_output \
+    "nextest quick-profile fixture rejects a stale binary ID" \
+    96 \
+    "$ROOT_DIR" \
+    "operator didn't match any binary IDs" \
+    -- \
+    cargo \
+    nextest \
+    list \
+    --config-file \
+    "$config_path" \
+    --package \
+    wavecrate \
+    --profile \
+    quick \
+    --lib \
+    --tests \
+    --list-type \
+    binaries-only
+}
+
 while IFS= read -r script_path; do
   run_expect_exit_code \
     "bash -n $script_path" \
@@ -556,6 +588,7 @@ run_file_size_budget_fixture
 run_cleanup_audit_fixture
 run_docs_index_fixture
 run_taste_invariants_fixture
+run_nextest_quick_profile_fixture
 
 run_expect_exit_code \
   "validation watchdog fixtures" \

--- a/scripts/internal/ci/ci_quick.ps1
+++ b/scripts/internal/ci/ci_quick.ps1
@@ -55,11 +55,19 @@ try {
   }
 
   if ($Workspace) {
+    Write-Host "[ci_quick] validate quick profile against workspace binary inventory"
+    Invoke-NativeStep -Label "validate quick profile against workspace binary inventory" -Command {
+      Invoke-WavecrateCargo nextest list --workspace --profile quick --all-targets --list-type binaries-only | Out-Null
+    }
     Write-Host "[ci_quick] cargo nextest run --workspace --profile quick --all-targets"
     Invoke-NativeStep -Label "cargo nextest run --workspace --profile quick --all-targets" -Command {
       Invoke-WavecrateCargo nextest run --workspace --profile quick --all-targets
     }
   } else {
+    Write-Host "[ci_quick] validate quick profile against Wavecrate binary inventory"
+    Invoke-NativeStep -Label "validate quick profile against Wavecrate binary inventory" -Command {
+      Invoke-WavecrateCargo nextest list --package wavecrate --profile quick --lib --tests --list-type binaries-only | Out-Null
+    }
     Write-Host "[ci_quick] cargo nextest run --package wavecrate --profile quick --lib --tests"
     Invoke-NativeStep -Label "cargo nextest run --package wavecrate --profile quick --lib --tests" -Command {
       Invoke-WavecrateCargo nextest run --package wavecrate --profile quick --lib --tests

--- a/scripts/internal/ci/ci_quick.sh
+++ b/scripts/internal/ci/ci_quick.sh
@@ -53,9 +53,13 @@ echo "[ci_quick] branch policy"
 ./scripts/internal/check/check_main_branch.sh
 
 if (( WORKSPACE == 1 )); then
+  echo "[ci_quick] validate quick profile against workspace binary inventory"
+  cargo nextest list --workspace --profile quick --all-targets --list-type binaries-only >/dev/null
   echo "[ci_quick] cargo nextest run --workspace --profile quick --all-targets"
   cargo nextest run --workspace --profile quick --all-targets
 else
+  echo "[ci_quick] validate quick profile against Wavecrate binary inventory"
+  cargo nextest list -p wavecrate --profile quick --lib --tests --list-type binaries-only >/dev/null
   echo "[ci_quick] cargo nextest run -p wavecrate --profile quick --lib --tests"
   cargo nextest run -p wavecrate --profile quick --lib --tests
 fi

--- a/scripts/internal/data/validation_contract.json
+++ b/scripts/internal/data/validation_contract.json
@@ -146,6 +146,26 @@
         "fragment": "--test controller_browser_integration --features legacy-controller"
       },
       {
+        "label": "PowerShell quick CI validates its package filter against discovered binaries",
+        "path": "scripts/internal/ci/ci_quick.ps1",
+        "fragment": "nextest list --package wavecrate --profile quick --lib --tests --list-type binaries-only"
+      },
+      {
+        "label": "Bash quick CI validates its package filter against discovered binaries",
+        "path": "scripts/internal/ci/ci_quick.sh",
+        "fragment": "nextest list -p wavecrate --profile quick --lib --tests --list-type binaries-only"
+      },
+      {
+        "label": "PowerShell workspace quick CI validates its filter against discovered binaries",
+        "path": "scripts/internal/ci/ci_quick.ps1",
+        "fragment": "nextest list --workspace --profile quick --all-targets --list-type binaries-only"
+      },
+      {
+        "label": "Bash workspace quick CI validates its filter against discovered binaries",
+        "path": "scripts/internal/ci/ci_quick.sh",
+        "fragment": "nextest list --workspace --profile quick --all-targets --list-type binaries-only"
+      },
+      {
         "label": "PowerShell perf guard uses shared report evaluator",
         "path": "scripts/internal/perf/run_perf_guard.ps1",
         "fragment": "scripts/internal/perf/evaluate_perf_guard_report.py"

--- a/tests/release_workflow_helpers.rs
+++ b/tests/release_workflow_helpers.rs
@@ -932,9 +932,9 @@ assert url == "https://portalsurfer.org/wavecrate/api/v1/releases/build/files/fi
 request = module.request_for_url(url, verification_token="verification-secret")
 assert request.get_header("X-wavecrate-release-verification") == module.hashlib.sha256(b"verification-secret").hexdigest()
 
-args = type("Args", (), {
+args = type("Args", (), {{
     "portal_catalog_url": "https://portalsurfer.org/wavecrate/api/v1/releases",
-})()
+}})()
 module.ensure_portalsurfer_origin(args, url)
 try:
     module.ensure_portalsurfer_origin(args, "https://example.com/file.zip")


### PR DESCRIPTION
## Goal

Repair the nextest `quick` profile so it remains valid against the current binary inventory and cannot silently accumulate stale exact binary IDs.

## Scope and non-goals

- Replace inventory-fragile quick-profile `binary_id(=...)` exclusions with stable target-kind/package predicates.
- Preserve exclusion of benchmark targets, the Wavecrate application binary, and the named slow rollback test.
- Make Bash and PowerShell quick lanes validate the selected profile against the actual discovered binary inventory before running tests.
- Add a deterministic guardrail fixture proving nextest rejects a configured stale binary ID.
- Fix the pre-existing unescaped Python dictionary braces in `release_workflow_helpers.rs`, which was the next compile blocker after the filter began parsing.
- Keep `ci-required`, `ci-quarantine`, and the default profile unchanged.
- Do not skip or quarantine unrelated tests.

## Definition of Done

- The pinned cargo-nextest accepts the quick profile for both package and workspace/all-target inventories.
- Quick CI performs an inventory-backed configuration check before its test run.
- Benchmark targets and the Wavecrate application binary remain excluded by stable semantic predicates.
- A deterministic fixture fails with nextest's unmatched-binary diagnostic for a stale target ID.
- The direct post-filter compile blocker is repaired without changing release behavior.

## Validation

- Original failure reproduced: stale `wavecrate::bench/ann_index` binary ID rejected before compilation.
- `cargo nextest list -p wavecrate --profile quick --lib --tests --list-type binaries-only -T json-pretty` — passed against the current package inventory.
- `cargo nextest list --workspace --profile quick --all-targets --list-type binaries-only -T oneline` — passed against the current workspace inventory; current IDs include `wavecrate::bench/tagging` and `wavecrate::bin/wavecrate`.
- Deliberately invalid fixture using `binary_id(=wavecrate::definitely-missing-binary)` — passed: nextest exited 96 with `operator didn't match any binary IDs`.
- `bash scripts/internal/check/check_script_guardrails.sh` — passed through all syntax, required-fragment, and configuration checks before the host-wide dyld startup stall affected later `/usr/bin/env` fixture launches.
- `cargo fmt --check` — passed.
- `git diff --check` — passed.
- `jq empty scripts/internal/data/validation_contract.json` — passed.
- `bash -n scripts/internal/ci/ci_quick.sh scripts/internal/check/check_script_guardrails.sh` — passed.
- `bash scripts/ci.sh quick` — profile parse error is fixed and the wrapper reached the new inventory lane. The isolated validation-target build then stalled before `main` in the freshly built Wavecrate build script at macOS `_dyld_start`.
- `bash scripts/internal/ci/ci_quick.sh` — inventory check passed and nextest reached the intended `run` lane. Fresh test binaries then stalled before `main` at macOS `_dyld_start`.
- `bash scripts/ci.sh agent` — not repeated after `/usr/bin/env`, the build script, and individual Rust test binaries independently demonstrated the same host-wide dyld startup stall.

## Known limitations

- This macOS host currently cannot reliably start newly launched executables: sampled processes remain at `_dyld_start` with no application frames. That prevented full quick/agent runtime completion after the configuration and compile blockers were cleared. No test exclusions were added to work around it.
- Existing unrelated broad facade/test-support guardrail debt remains outside this PR.

User approval is required before merge.

Linear: OPT-1235
