### PR TITLE
Wavecrate browser metadata: use one bulk snapshot

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -45,8 +45,8 @@ pub use open_profiles::SourceDatabaseConnectionRole;
 pub use pending_renames::PendingRenameEntry;
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
-    Rating, SampleCollection, SampleSoundType, SourceManifestEntry, SourceTag, SourceTagUsage,
-    WavEntry,
+    BrowserFileMetadata, BrowserMetadataSnapshot, Rating, SampleCollection, SampleSoundType,
+    SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
 };
 pub use util::normalize_relative_path;
 pub use write::{

--- a/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
@@ -1,13 +1,194 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use rusqlite::OptionalExtension;
 
 use super::super::util::map_sql_error;
 use super::super::{
-    META_WAV_PATHS_REVISION, Rating, SampleCollection, SampleSoundType, SourceDatabase,
-    SourceDbError,
+    BrowserFileMetadata, BrowserMetadataSnapshot, META_WAV_PATHS_REVISION, Rating,
+    SampleCollection, SampleSoundType, SourceDatabase, SourceDbError,
 };
-use super::decode::{table_has_columns, wav_file_has_column};
+use super::decode::{
+    decode_path_row, decode_relative_path, table_has_columns, wav_file_has_column,
+};
+
+struct BrowserMetadataCapabilities {
+    wav_columns: std::collections::HashSet<String>,
+    collection_memberships: bool,
+    metadata_revision: bool,
+}
+
+fn optional_browser_column<'a>(
+    columns: &std::collections::HashSet<String>,
+    column: &'a str,
+    fallback: &'a str,
+) -> &'a str {
+    if columns.contains(column) {
+        column
+    } else {
+        fallback
+    }
+}
+
+fn browser_metadata_snapshot_with_observer(
+    db: &SourceDatabase,
+    mut statement_started: impl FnMut(),
+) -> Result<BrowserMetadataSnapshot, SourceDbError> {
+    let transaction = db
+        .connection
+        .unchecked_transaction()
+        .map_err(map_sql_error)?;
+
+    statement_started();
+    let wav_columns = super::super::schema::table_columns(&transaction, "wav_files")?;
+    statement_started();
+    let collection_columns =
+        super::super::schema::table_columns(&transaction, "wav_file_collections")?;
+    statement_started();
+    let metadata_columns = super::super::schema::table_columns(&transaction, "metadata")?;
+    let capabilities = BrowserMetadataCapabilities {
+        wav_columns,
+        collection_memberships: collection_columns.contains("path")
+            && collection_columns.contains("collection"),
+        metadata_revision: metadata_columns.contains("key") && metadata_columns.contains("value"),
+    };
+
+    let revision = if capabilities.metadata_revision {
+        statement_started();
+        transaction
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default()
+    } else {
+        0
+    };
+
+    let supported_filter = if capabilities.wav_columns.contains("extension") {
+        crate::sample_sources::supported_audio_where_clause()
+    } else {
+        String::from("lower(path) GLOB '*.wav' AND path NOT GLOB '._*' AND path NOT GLOB '*/._*'")
+    };
+    let legacy_collection = optional_browser_column(
+        &capabilities.wav_columns,
+        "collection",
+        "NULL AS collection",
+    );
+    let sql = format!(
+        "SELECT path, {}, {}, {}, {}, {legacy_collection}
+         FROM wav_files
+         WHERE {supported_filter}
+         ORDER BY path ASC",
+        optional_browser_column(&capabilities.wav_columns, "tag", "0 AS tag"),
+        optional_browser_column(&capabilities.wav_columns, "locked", "0 AS locked"),
+        optional_browser_column(
+            &capabilities.wav_columns,
+            "last_played_at",
+            "NULL AS last_played_at"
+        ),
+        optional_browser_column(
+            &capabilities.wav_columns,
+            "last_curated_at",
+            "NULL AS last_curated_at"
+        ),
+    );
+    statement_started();
+    let mut files = {
+        let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+        statement
+            .query_map([], |row| {
+                let Some(relative_path) = decode_path_row(
+                    row,
+                    "Skipping browser metadata row with invalid relative path",
+                )?
+                else {
+                    return Ok(None);
+                };
+                let legacy_collection = if capabilities.collection_memberships {
+                    Vec::new()
+                } else {
+                    row.get::<_, Option<i64>>(5)?
+                        .and_then(SampleCollection::from_i64)
+                        .into_iter()
+                        .collect()
+                };
+                Ok(Some(BrowserFileMetadata {
+                    relative_path,
+                    rating: Rating::from_i64(row.get(1)?),
+                    locked: row.get::<_, i64>(2)? != 0,
+                    collections: legacy_collection,
+                    last_played_at: row.get(3)?,
+                    last_curated_at: row.get(4)?,
+                }))
+            })
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+
+    if capabilities.collection_memberships {
+        statement_started();
+        let memberships = {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT path, collection
+                     FROM wav_file_collections
+                     ORDER BY path ASC, collection ASC",
+                )
+                .map_err(map_sql_error)?;
+            statement
+                .query_map([], |row| {
+                    let path = row.get::<_, String>(0)?;
+                    Ok((
+                        decode_relative_path(
+                            path,
+                            "Skipping browser collection row with invalid relative path",
+                        )?,
+                        row.get::<_, i64>(1)?,
+                    ))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+        };
+        let by_path = files
+            .iter_mut()
+            .map(|file| (file.relative_path.clone(), file))
+            .collect::<HashMap<_, _>>();
+        let mut by_path = by_path;
+        for (path, collection) in memberships {
+            let Some(path) = path else {
+                continue;
+            };
+            if let (Some(file), Some(collection)) = (
+                by_path.get_mut(&path),
+                SampleCollection::from_i64(collection),
+            ) {
+                file.collections.push(collection);
+            }
+        }
+    }
+
+    transaction.rollback().map_err(map_sql_error)?;
+    Ok(BrowserMetadataSnapshot { revision, files })
+}
+
+#[cfg(test)]
+pub(super) fn browser_metadata_snapshot_statement_count(
+    db: &SourceDatabase,
+) -> Result<(BrowserMetadataSnapshot, usize), SourceDbError> {
+    let mut count = 0;
+    let snapshot = browser_metadata_snapshot_with_observer(db, || count += 1)?;
+    Ok((snapshot, count))
+}
 
 fn normalize_supported_audio_path(path: &Path) -> Result<Option<String>, SourceDbError> {
     if !crate::sample_sources::is_supported_audio(path) {
@@ -31,6 +212,13 @@ fn query_flag_for_path(
 }
 
 impl SourceDatabase {
+    /// Fetch all browser metadata from one committed read snapshot.
+    ///
+    /// Schema capabilities and data are read with a fixed statement budget that is independent
+    /// of the number of tracked files.
+    pub fn browser_metadata_snapshot(&self) -> Result<BrowserMetadataSnapshot, SourceDbError> {
+        browser_metadata_snapshot_with_observer(self, || {})
+    }
     /// Return the numeric metadata value for `key` (0 if missing).
     fn get_numeric_metadata(&self, key: &str) -> Result<u64, SourceDbError> {
         let value = self.get_metadata(key)?;

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -6,6 +6,96 @@ use tempfile::tempdir;
 use super::super::{DB_FILE_NAME, Rating, SampleCollection, SampleSoundType, SourceDatabase};
 
 #[test]
+fn browser_metadata_snapshot_reads_multi_collection_rows_coherently() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    db.upsert_file(Path::new("one.wav"), 10, 5).unwrap();
+    db.set_tag(Path::new("one.wav"), Rating::new(2)).unwrap();
+    db.set_locked(Path::new("one.wav"), true).unwrap();
+    db.set_last_played_at(Path::new("one.wav"), 123).unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .add_collection(Path::new("one.wav"), SampleCollection::new(3).unwrap())
+        .unwrap();
+    batch
+        .add_collection(Path::new("one.wav"), SampleCollection::new(1).unwrap())
+        .unwrap();
+    batch.commit().unwrap();
+    db.set_last_curated_at(Path::new("one.wav"), 456).unwrap();
+
+    let snapshot = db.browser_metadata_snapshot().unwrap();
+
+    assert_eq!(snapshot.files.len(), 1);
+    let file = &snapshot.files[0];
+    assert_eq!(file.relative_path, PathBuf::from("one.wav"));
+    assert_eq!(file.rating, Rating::new(2));
+    assert!(file.locked);
+    assert_eq!(file.last_played_at, Some(123));
+    assert_eq!(file.last_curated_at, Some(456));
+    assert_eq!(
+        file.collections,
+        vec![
+            SampleCollection::new(1).unwrap(),
+            SampleCollection::new(3).unwrap()
+        ]
+    );
+}
+
+#[test]
+fn browser_metadata_snapshot_has_constant_statement_count_for_large_sources() {
+    let dir = tempdir().unwrap();
+    let mut db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    let (_, empty_statement_count) =
+        super::metadata_queries::browser_metadata_snapshot_statement_count(&db).unwrap();
+    let transaction = db.connection.transaction().unwrap();
+    {
+        let mut insert = transaction
+            .prepare(
+                "INSERT INTO wav_files (path, file_size, modified_ns, extension)
+                 VALUES (?1, 10, 5, 'wav')",
+            )
+            .unwrap();
+        for index in 0..2_000 {
+            insert.execute([format!("sample-{index:04}.wav")]).unwrap();
+        }
+    }
+    transaction.commit().unwrap();
+
+    let started_at = std::time::Instant::now();
+    let (snapshot, statement_count) =
+        super::metadata_queries::browser_metadata_snapshot_statement_count(&db).unwrap();
+
+    assert_eq!(snapshot.files.len(), 2_000);
+    assert_eq!(statement_count, empty_statement_count);
+    assert!(
+        statement_count <= 6,
+        "browser metadata used {statement_count} statements"
+    );
+    assert!(
+        started_at.elapsed() < std::time::Duration::from_secs(5),
+        "large browser metadata snapshot exceeded its five-second test budget"
+    );
+}
+
+#[test]
+fn browser_metadata_snapshot_returns_typed_decode_failures() {
+    let dir = tempdir().unwrap();
+    let connection = Connection::open(dir.path().join(DB_FILE_NAME)).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE wav_files (path TEXT PRIMARY KEY, tag TEXT);
+             INSERT INTO wav_files (path, tag) VALUES ('broken.wav', 'not-a-rating');",
+        )
+        .unwrap();
+    drop(connection);
+    let db = SourceDatabase::open_for_ui_read(dir.path()).unwrap();
+
+    let error = db.browser_metadata_snapshot().unwrap_err();
+
+    assert!(!error.to_string().is_empty());
+}
+
+#[test]
 fn list_files_page_orders_supported_audio_and_applies_offsets() {
     let dir = tempdir().unwrap();
     let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
@@ -474,6 +564,15 @@ fn legacy_read_only_minimal_wav_files_schema_reads_with_defaults() {
     assert_eq!(row.user_tag, None);
     assert!(!row.tag_named);
     assert!(row.normal_tags.is_empty());
+    let browser_snapshot = db.browser_metadata_snapshot().unwrap();
+    assert_eq!(browser_snapshot.revision, 0);
+    assert_eq!(browser_snapshot.files.len(), 1);
+    assert_eq!(
+        browser_snapshot.files[0].relative_path,
+        PathBuf::from("nested/One.WAV")
+    );
+    assert_eq!(browser_snapshot.files[0].rating, Rating::NEUTRAL);
+    assert!(browser_snapshot.files[0].collections.is_empty());
     assert_eq!(db.count_files().unwrap(), 1);
     assert_eq!(db.count_present_files().unwrap(), 1);
     assert_eq!(db.list_files_page(10, 0).unwrap().len(), 1);

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -265,6 +265,32 @@ pub struct WavEntry {
     pub tag_named: bool,
 }
 
+/// Browser-facing metadata for one tracked audio file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFileMetadata {
+    /// File path relative to the source root.
+    pub relative_path: PathBuf,
+    /// Current rating/tag for the file.
+    pub rating: Rating,
+    /// Whether the keep rating is locked.
+    pub locked: bool,
+    /// Fixed collection slots assigned to the file, in stable slot order.
+    pub collections: Vec<SampleCollection>,
+    /// Epoch seconds of the most recent playback, if any.
+    pub last_played_at: Option<i64>,
+    /// Epoch seconds of the most recent explicit curation decision, if any.
+    pub last_curated_at: Option<i64>,
+}
+
+/// Coherent browser metadata projection read from one committed SQLite snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMetadataSnapshot {
+    /// Source metadata revision observed by the snapshot, or zero for legacy databases.
+    pub revision: u64,
+    /// Metadata rows in deterministic path order.
+    pub files: Vec<BrowserFileMetadata>,
+}
+
 /// Authoritative identity facts for one live source-manifest row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceManifestEntry {

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -6,6 +6,15 @@ use super::super::util::{map_sql_error, normalize_relative_path};
 use super::super::{SourceDatabase, SourceDbError, SourceManifestEntry, SourceWriteBatch};
 
 impl SourceWriteBatch<'_> {
+    /// Return whether this write transaction began at `expected_revision`.
+    ///
+    /// The batch owns SQLite's immediate writer reservation, so a successful match remains valid
+    /// until this batch commits or rolls back. Callers can use this to discard work derived from
+    /// an older read snapshot without overwriting newer metadata.
+    pub fn matches_revision(&self, expected_revision: u64) -> Result<bool, SourceDbError> {
+        Ok(manifest_revision(&self.tx)? == expected_revision)
+    }
+
     /// Commit all batched operations atomically.
     pub fn commit(self) -> Result<(), SourceDbError> {
         self.prepare_commit()?;

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -16,9 +16,10 @@ pub use audio_support::{
 };
 pub use db::normalize_relative_path;
 pub use db::{
-    DB_FILE_NAME, Rating, SampleCollection, SourceCollectionWrite, SourceContentHashWrite,
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite,
-    SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
+    BrowserFileMetadata, BrowserMetadataSnapshot, DB_FILE_NAME, Rating, SampleCollection,
+    SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
+    SourceDbError, SourceFileWrite, SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite,
+    SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -303,6 +303,8 @@ If the operating system, permissions, file locks, or external tools prevent Wave
 
 Source database schema changes must be migratable through the explicit source-write or maintenance open path. Additive tables and columns should be repaired even when a database already carries the current schema stamp, because development and prerelease builds may leave current-stamped files with incomplete structure. Every runtime caller must select a role-specific open for UI reads, background reads/jobs, source writes, user metadata writes, playback history, or maintenance; general `open` aliases are not part of the supported API. Read-only source database opens must not mutate the database and must tolerate older schema shapes through safe default projections or feature-specific query avoidance.
 
+Browser metadata hydration should read ratings, locks, collection memberships, and playback/curation timestamps from one coherent typed snapshot with a statement count that is independent of source size. Capability discovery happens once per snapshot so legacy read-only compatibility cannot regress into per-file schema inspection. A failed hydration preserves the last good browser metadata projection and reports the failure; opportunistic mutations such as rating decay run later through bounded background maintenance and explicitly refresh affected metadata.
+
 The source database should store information that belongs to that source and its files, such as:
 
 - stable Wavecrate Sample IDs for files in that source

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -42,6 +42,13 @@ fn run_folder_scan_worker_with_emit_and_cancel(
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
     cancel: &AtomicBool,
 ) -> PreparedFolderScanResult {
+    let rating_decay_maintenance =
+        crate::native_app::sample_library::folder_browser::scan::RatingDecayMaintenanceRequest {
+            source_id: request.source_id.clone(),
+            root: request.root.clone(),
+            database_root: request.database_root.clone(),
+            rating_decay_weeks: request.rating_decay_weeks,
+        };
     let mut discovery_transport =
         FolderScanDiscoveryTransport::new(emit.clone(), request.task_id, request.source_id.clone());
     let scan = scan::scan_source_with_progress_cancellable(
@@ -64,6 +71,7 @@ fn run_folder_scan_worker_with_emit_and_cancel(
         audio_file_paths,
         scan_cache_update,
         lifecycle_generation: None,
+        rating_decay_maintenance: Some(rating_decay_maintenance),
     }
 }
 

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -56,6 +56,7 @@ pub(in crate::native_app) enum SourceScanFinish {
         file_count: usize,
         folder_count: usize,
         source_db_error: Option<String>,
+        metadata_hydration_error: Option<String>,
         source_root_available: bool,
     },
     Stale {
@@ -348,6 +349,7 @@ impl SourceScanWorkflow {
         let file_count = result.file_count;
         let folder_count = result.folder_count;
         let source_db_error = result.source_db_error.clone();
+        let metadata_hydration_error = result.metadata_hydration.error().map(str::to_owned);
         let source_root_available = result.source_root_available;
         if result.cancelled {
             if browser.cancel_scan(&source_id, result.task_id) {
@@ -365,6 +367,7 @@ impl SourceScanWorkflow {
                 file_count,
                 folder_count,
                 source_db_error,
+                metadata_hydration_error,
                 source_root_available,
             }
         } else {

--- a/src/native_app/sample_library/folder_browser/scan.rs
+++ b/src/native_app/sample_library/folder_browser/scan.rs
@@ -3,7 +3,7 @@ pub(in crate::native_app) use super::scan_types::FolderScanItem;
 pub(in crate::native_app) use super::scan_types::{
     FolderScanDiscovery, FolderScanDiscoveryBatch, FolderScanProgress, FolderScanRequest,
     FolderScanResult, FolderTreeRefreshRequest, FolderTreeRefreshResult, FolderVerifyResult,
-    PreparedFolderScanResult,
+    PreparedFolderScanResult, RatingDecayMaintenanceRequest,
 };
 #[cfg(test)]
 pub(in crate::native_app) use super::scanning::INDEX_PROGRESS_REPORT_INTERVAL;

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -64,8 +64,25 @@ pub(in crate::native_app) struct FolderScanResult {
     pub(in crate::native_app) file_count: usize,
     pub(in crate::native_app) folder_count: usize,
     pub(in crate::native_app) source_db_error: Option<String>,
+    pub(in crate::native_app) metadata_hydration: MetadataHydrationStatus,
     pub(in crate::native_app) source_root_available: bool,
     pub(in crate::native_app) cancelled: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum MetadataHydrationStatus {
+    Complete { revision: u64 },
+    Failed { error: String },
+    NotAttempted,
+}
+
+impl MetadataHydrationStatus {
+    pub(in crate::native_app) fn error(&self) -> Option<&str> {
+        match self {
+            Self::Failed { error } => Some(error),
+            Self::Complete { .. } | Self::NotAttempted => None,
+        }
+    }
 }
 
 impl FolderScanResult {
@@ -85,6 +102,7 @@ pub(in crate::native_app) struct PreparedFolderScanResult {
     pub(in crate::native_app) audio_file_paths: Vec<PathBuf>,
     pub(in crate::native_app) scan_cache_update: FolderScanCacheUpdate,
     pub(in crate::native_app) lifecycle_generation: Option<u64>,
+    pub(in crate::native_app) rating_decay_maintenance: Option<RatingDecayMaintenanceRequest>,
 }
 
 impl From<FolderScanResult> for PreparedFolderScanResult {
@@ -96,8 +114,17 @@ impl From<FolderScanResult> for PreparedFolderScanResult {
             audio_file_paths,
             scan_cache_update,
             lifecycle_generation: None,
+            rating_decay_maintenance: None,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct RatingDecayMaintenanceRequest {
+    pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) root: PathBuf,
+    pub(in crate::native_app) database_root: PathBuf,
+    pub(in crate::native_app) rating_decay_weeks: u16,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
+    fmt,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use super::super::FileEntry;
@@ -10,10 +10,8 @@ use super::{
     file_entry_metadata::file_entry_with_metadata,
 };
 use wavecrate::sample_sources::{
-    Rating, SampleCollection, SourceDatabase, config::clamp_rating_decay_weeks,
+    BrowserMetadataSnapshot, Rating, SampleCollection, SourceDatabase,
 };
-
-const SECONDS_PER_WEEK: i64 = 7 * 24 * 60 * 60;
 
 pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap = HashMap<
     PathBuf,
@@ -26,151 +24,46 @@ pub(in crate::native_app::sample_library::folder_browser) type SourceMetadataMap
     ),
 >;
 
-pub(super) fn source_rating_map(root: &Path, database_root: &Path) -> SourceMetadataMap {
-    let Ok(db) = SourceDatabase::open_for_ui_read_with_database_root(root, database_root) else {
-        return HashMap::new();
-    };
-    let Ok(entries) = db.list_files() else {
-        return HashMap::new();
-    };
-    entries
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SourceMetadataHydrationError {
+    Open(String),
+    Snapshot(String),
+}
+
+impl fmt::Display for SourceMetadataHydrationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Open(error) => write!(formatter, "open source metadata: {error}"),
+            Self::Snapshot(error) => write!(formatter, "read browser metadata snapshot: {error}"),
+        }
+    }
+}
+
+pub(super) fn source_rating_map(
+    root: &Path,
+    database_root: &Path,
+) -> Result<(SourceMetadataMap, u64), SourceMetadataHydrationError> {
+    let db = SourceDatabase::open_for_ui_read_with_database_root(root, database_root)
+        .map_err(|error| SourceMetadataHydrationError::Open(error.to_string()))?;
+    let BrowserMetadataSnapshot { revision, files } = db
+        .browser_metadata_snapshot()
+        .map_err(|error| SourceMetadataHydrationError::Snapshot(error.to_string()))?;
+    let metadata = files
         .into_iter()
         .map(|entry| {
-            let collections = db
-                .collections_for_path(&entry.relative_path)
-                .unwrap_or_default();
             (
                 entry.relative_path,
                 (
-                    entry.tag,
+                    entry.rating,
                     entry.locked,
-                    collections,
+                    entry.collections,
                     entry.last_played_at,
                     entry.last_curated_at,
                 ),
             )
         })
-        .collect()
-}
-
-pub(super) fn source_rating_map_with_rating_decay(
-    root: &Path,
-    database_root: &Path,
-    rating_decay_weeks: u16,
-) -> SourceMetadataMap {
-    source_rating_map_with_rating_decay_at(
-        root,
-        database_root,
-        rating_decay_weeks,
-        current_epoch_seconds(),
-    )
-}
-
-fn source_rating_map_with_rating_decay_at(
-    root: &Path,
-    database_root: &Path,
-    rating_decay_weeks: u16,
-    now_epoch_seconds: i64,
-) -> SourceMetadataMap {
-    let Ok(db) =
-        SourceDatabase::open_for_user_metadata_write_with_database_root(root, database_root)
-    else {
-        return source_rating_map(root, database_root);
-    };
-    let Ok(mut entries) = db.list_files() else {
-        return HashMap::new();
-    };
-    let mut updates = Vec::new();
-    for (index, entry) in entries.iter().enumerate() {
-        if let Some(decayed) = decayed_keep_rating(
-            entry.tag,
-            entry.locked,
-            entry.last_curated_at,
-            rating_decay_weeks,
-            now_epoch_seconds,
-        ) {
-            updates.push((index, decayed.rating, decayed.last_curated_at));
-        }
-    }
-    if !updates.is_empty() {
-        let result = (|| {
-            let mut batch = db.write_batch()?;
-            for (index, rating, last_curated_at) in &updates {
-                let relative_path = entries[*index].relative_path.as_path();
-                batch.set_tag(relative_path, *rating)?;
-                batch.set_last_curated_at(relative_path, *last_curated_at)?;
-            }
-            batch.commit()
-        })();
-        if result.is_ok() {
-            for (index, rating, last_curated_at) in updates {
-                entries[index].tag = rating;
-                entries[index].last_curated_at = Some(last_curated_at);
-            }
-        }
-    }
-    entries
-        .into_iter()
-        .map(|entry| {
-            let collections = db
-                .collections_for_path(&entry.relative_path)
-                .unwrap_or_default();
-            (
-                entry.relative_path,
-                (
-                    entry.tag,
-                    entry.locked,
-                    collections,
-                    entry.last_played_at,
-                    entry.last_curated_at,
-                ),
-            )
-        })
-        .collect()
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct DecayedRating {
-    rating: Rating,
-    last_curated_at: i64,
-}
-
-fn decayed_keep_rating(
-    rating: Rating,
-    locked: bool,
-    last_curated_at: Option<i64>,
-    rating_decay_weeks: u16,
-    now_epoch_seconds: i64,
-) -> Option<DecayedRating> {
-    if locked || !rating.is_keep() {
-        return None;
-    }
-    let last_curated_at = last_curated_at?;
-    let elapsed_seconds = now_epoch_seconds.checked_sub(last_curated_at)?;
-    if elapsed_seconds <= 0 {
-        return None;
-    }
-    let period_seconds = i64::from(clamp_rating_decay_weeks(rating_decay_weeks)) * SECONDS_PER_WEEK;
-    let elapsed_periods = elapsed_seconds / period_seconds;
-    if elapsed_periods <= 0 {
-        return None;
-    }
-    let applied_periods = elapsed_periods.min(i64::from(rating.val()));
-    let next_rating = Rating::new(rating.val() - applied_periods as i8);
-    if next_rating == rating {
-        return None;
-    }
-    Some(DecayedRating {
-        rating: next_rating,
-        last_curated_at: last_curated_at.saturating_add(applied_periods * period_seconds),
-    })
-}
-
-fn current_epoch_seconds() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
-        .unwrap_or_default()
+        .collect();
+    Ok((metadata, revision))
 }
 
 pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_source_path(
@@ -190,84 +83,17 @@ pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_sour
     )
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn decays_keep_rating_by_elapsed_intervals() {
-        let decayed = decayed_keep_rating(
-            Rating::KEEP_3,
-            false,
-            Some(1_000),
-            4,
-            1_000 + 9 * SECONDS_PER_WEEK,
-        )
-        .expect("rating should decay");
-
-        assert_eq!(decayed.rating, Rating::KEEP_1);
-        assert_eq!(decayed.last_curated_at, 1_000 + 8 * SECONDS_PER_WEEK);
-    }
-
-    #[test]
-    fn keeps_locked_keep_rating_unchanged() {
-        assert_eq!(
-            decayed_keep_rating(
-                Rating::KEEP_3,
-                true,
-                Some(1_000),
-                4,
-                1_000 + 12 * SECONDS_PER_WEEK
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn leaves_neutral_and_trash_ratings_unchanged() {
-        assert_eq!(
-            decayed_keep_rating(
-                Rating::NEUTRAL,
-                false,
-                Some(1_000),
-                4,
-                1_000 + 12 * SECONDS_PER_WEEK
-            ),
-            None
-        );
-        assert_eq!(
-            decayed_keep_rating(
-                Rating::TRASH_3,
-                false,
-                Some(1_000),
-                4,
-                1_000 + 12 * SECONDS_PER_WEEK
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn waits_until_full_interval_elapsed() {
-        assert_eq!(
-            decayed_keep_rating(
-                Rating::KEEP_1,
-                false,
-                Some(1_000),
-                4,
-                1_000 + 3 * SECONDS_PER_WEEK
-            ),
-            None
-        );
-    }
-}
-
 pub(in crate::native_app::sample_library::folder_browser) fn refreshed_file_entries_for_paths(
     paths: &[PathBuf],
     source_root: &Path,
     source_database_root: &Path,
 ) -> Vec<FileEntry> {
-    let ratings = source_rating_map(source_root, source_database_root);
+    let ratings = source_rating_map(source_root, source_database_root)
+        .map(|(ratings, _)| ratings)
+        .unwrap_or_else(|error| {
+            tracing::warn!(source = %source_root.display(), "{error}");
+            SourceMetadataMap::new()
+        });
     paths
         .iter()
         .filter(|path| classify_path_without_following(path) == Some(BrowserEntryKind::File))

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -10,11 +10,11 @@ use super::{
         path_helpers::{folder_label, path_id},
         scan_types::{
             FolderScanDiscovery, FolderScanItem, FolderScanProgress, FolderScanRequest,
-            FolderScanResult,
+            FolderScanResult, MetadataHydrationStatus,
         },
     },
     entry::{BrowserEntryKind, classify_path_without_following, read_sorted_entries},
-    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map_with_rating_decay},
+    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map},
     traversal::placeholder_folder,
 };
 use wavecrate::sample_sources::{SourceDatabase, scanner};
@@ -44,15 +44,24 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
     } else {
         None
     };
-    let ratings = if source_root_available && !cancel.load(Ordering::Acquire) {
-        source_rating_map_with_rating_decay(
-            &request.root,
-            &request.database_root,
-            request.rating_decay_weeks,
-        )
+    let (ratings, metadata_hydration) = if source_root_available && !cancel.load(Ordering::Acquire)
+    {
+        match source_rating_map(&request.root, &request.database_root) {
+            Ok((ratings, revision)) => (ratings, MetadataHydrationStatus::Complete { revision }),
+            Err(error) => (
+                SourceMetadataMap::new(),
+                MetadataHydrationStatus::Failed {
+                    error: error.to_string(),
+                },
+            ),
+        }
     } else {
-        SourceMetadataMap::new()
+        (
+            SourceMetadataMap::new(),
+            MetadataHydrationStatus::NotAttempted,
+        )
     };
+    let publish_discoveries = !matches!(metadata_hydration, MetadataHydrationStatus::Failed { .. });
     let mut scan = ScanProgressContext {
         request: &request,
         ratings,
@@ -64,6 +73,7 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
         progress: &mut progress,
         discovered: &mut discovered,
         cancel,
+        publish_discoveries,
     };
     scan.report_initial();
     let folder = load_folder_with_progress(&request.root, &mut scan)
@@ -82,6 +92,7 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
         file_count,
         folder_count,
         source_db_error,
+        metadata_hydration,
         source_root_available,
         cancelled: cancel.load(Ordering::Acquire),
     }
@@ -147,6 +158,7 @@ where
     progress: &'a mut P,
     discovered: &'a mut D,
     cancel: &'a AtomicBool,
+    publish_discoveries: bool,
 }
 
 impl<P, D> ScanProgressContext<'_, P, D>
@@ -170,33 +182,39 @@ where
         self.counter.completed += 1;
         self.counter.folders += 1;
         self.maybe_report_progress(path);
-        (self.discovered)(FolderScanDiscovery {
-            task_id: self.request.task_id,
-            source_id: self.request.source_id.clone(),
-            parent_id: parent_id.to_string(),
-            item: FolderScanItem::Folder(placeholder_folder(path)),
-        });
+        if self.publish_discoveries {
+            (self.discovered)(FolderScanDiscovery {
+                task_id: self.request.task_id,
+                source_id: self.request.source_id.clone(),
+                parent_id: parent_id.to_string(),
+                item: FolderScanItem::Folder(placeholder_folder(path)),
+            });
+        }
     }
 
     fn record_folder_snapshot_start(&mut self, folder_id: &str) {
-        (self.discovered)(FolderScanDiscovery {
-            task_id: self.request.task_id,
-            source_id: self.request.source_id.clone(),
-            parent_id: folder_id.to_string(),
-            item: FolderScanItem::ResetFolder,
-        });
+        if self.publish_discoveries {
+            (self.discovered)(FolderScanDiscovery {
+                task_id: self.request.task_id,
+                source_id: self.request.source_id.clone(),
+                parent_id: folder_id.to_string(),
+                item: FolderScanItem::ResetFolder,
+            });
+        }
     }
 
     fn record_file(&mut self, path: &Path, parent_id: &str, file: FileEntry) {
         self.counter.completed += 1;
         self.counter.files += 1;
         self.maybe_report_progress(path);
-        (self.discovered)(FolderScanDiscovery {
-            task_id: self.request.task_id,
-            source_id: self.request.source_id.clone(),
-            parent_id: parent_id.to_string(),
-            item: FolderScanItem::File(file),
-        });
+        if self.publish_discoveries {
+            (self.discovered)(FolderScanDiscovery {
+                task_id: self.request.task_id,
+                source_id: self.request.source_id.clone(),
+                parent_id: parent_id.to_string(),
+                item: FolderScanItem::File(file),
+            });
+        }
     }
 
     fn maybe_report_progress(&mut self, path: &Path) {

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -21,7 +21,12 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_source_snapsho
     root: PathBuf,
     database_root: PathBuf,
 ) -> LoadedSourceSnapshot {
-    let ratings = source_rating_map(&root, &database_root);
+    let ratings = source_rating_map(&root, &database_root)
+        .map(|(ratings, _)| ratings)
+        .unwrap_or_else(|error| {
+            tracing::warn!(source = %root.display(), "{error}");
+            SourceMetadataMap::new()
+        });
     let folder = load_folder(&root, &root, &ratings).unwrap_or_else(|| placeholder_folder(&root));
     let missing_collection_snapshot =
         MissingCollectionSnapshot::from_source_metadata(&root, &folder, &ratings);
@@ -63,7 +68,12 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_folder_at_path
     source_root: &Path,
     source_database_root: &Path,
 ) -> Option<FolderEntry> {
-    let ratings = source_rating_map(source_root, source_database_root);
+    let ratings = source_rating_map(source_root, source_database_root)
+        .map(|(ratings, _)| ratings)
+        .unwrap_or_else(|error| {
+            tracing::warn!(source = %source_root.display(), "{error}");
+            SourceMetadataMap::new()
+        });
     load_folder(path, source_root, &ratings)
 }
 

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -1,9 +1,12 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 #[cfg(test)]
 use super::super::scan_types::FolderScanDiscovery;
 use super::super::{
-    FolderBrowserState, FolderEntry, SourceEntry,
+    FileEntry, FolderBrowserState, FolderEntry, SourceEntry,
     path_helpers::{folder_label, path_id},
     scan_types::{
         FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult, FolderTreeRefreshResult,
@@ -279,7 +282,10 @@ impl FolderBrowserState {
         source.parked_tree_loaded && source.root_folder.is_some()
     }
 
-    pub(in crate::native_app) fn apply_scan_finished(&mut self, result: FolderScanResult) -> bool {
+    pub(in crate::native_app) fn apply_scan_finished(
+        &mut self,
+        mut result: FolderScanResult,
+    ) -> bool {
         let Some(source_index) = self
             .source
             .sources
@@ -294,6 +300,19 @@ impl FolderBrowserState {
         let source_id = self.source.sources[source_index].id.clone();
         let should_select = self.source.selected_source == source_id;
         let refreshing_selected_loaded_source = should_select && self.selected_source_loaded();
+        if result.metadata_hydration.error().is_some() {
+            let previous_folder = if should_select {
+                self.tree.folders.first()
+            } else {
+                self.source.sources[source_index].root_folder.as_ref()
+            };
+            if let Some(previous_folder) = previous_folder {
+                preserve_folder_metadata(&mut result.folder, previous_folder);
+            }
+            result.missing_collection_snapshot = self.source.sources[source_index]
+                .missing_collection_snapshot
+                .clone();
+        }
         self.source.sources[source_index].loading_task = None;
         if !result.source_root_available {
             self.source.sources[source_index].mark_missing();
@@ -433,6 +452,36 @@ impl FolderBrowserState {
             self.bump_file_content_revision();
         }
         changed
+    }
+}
+
+fn preserve_folder_metadata(folder: &mut FolderEntry, previous: &FolderEntry) {
+    let previous_files = previous
+        .all_files()
+        .into_iter()
+        .map(|file| (file.id.clone(), file.clone()))
+        .collect::<HashMap<_, _>>();
+    preserve_folder_metadata_from_map(folder, &previous_files);
+}
+
+fn preserve_folder_metadata_from_map(
+    folder: &mut FolderEntry,
+    previous_files: &HashMap<String, FileEntry>,
+) {
+    for file in &mut folder.files {
+        let Some(previous) = previous_files.get(&file.id) else {
+            continue;
+        };
+        file.rating = previous.rating;
+        file.rating_locked = previous.rating_locked;
+        file.last_curated_at = previous.last_curated_at;
+        file.collection = previous.collection;
+        file.collections = previous.collections.clone();
+        file.modified = previous.modified.clone();
+        file.modified_rank = previous.modified_rank;
+    }
+    for child in &mut folder.children {
+        preserve_folder_metadata_from_map(child, previous_files);
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/source_scan_cache.rs
+++ b/src/native_app/sample_library/folder_browser/source_scan_cache.rs
@@ -144,12 +144,14 @@ pub(in crate::native_app) fn prepare_folder_scan_cache_update(
 ) -> FolderScanCacheUpdate {
     FolderScanCacheUpdate {
         source_id: result.source_id.clone(),
-        source: result.source_root_available.then(|| CachedSourceScan {
-            source_id: result.source_id.clone(),
-            root: PathBuf::from(&result.folder.id),
-            root_folder: result.folder.clone(),
-            missing_collection_snapshot: result.missing_collection_snapshot.clone(),
-        }),
+        source: (result.source_root_available && result.metadata_hydration.error().is_none()).then(
+            || CachedSourceScan {
+                source_id: result.source_id.clone(),
+                root: PathBuf::from(&result.folder.id),
+                root_folder: result.folder.clone(),
+                missing_collection_snapshot: result.missing_collection_snapshot.clone(),
+            },
+        ),
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::native_app::sample_library::folder_browser::scan_types::FolderScanItem;
+use crate::native_app::sample_library::folder_browser::scan_types::{
+    FolderScanItem, MetadataHydrationStatus,
+};
 
 #[test]
 fn switching_away_from_pending_source_does_not_cache_its_placeholder() {
@@ -89,7 +91,7 @@ fn source_scan_installs_finished_tree_after_placeholder_selection() {
 }
 
 #[test]
-fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
+fn source_scan_hydration_does_not_mutate_ratings() {
     let root = temp_source_root("wavecrate-gui-rating-decay");
     fs::write(root.join("unlocked.wav"), [0_u8; 8]).expect("write wav");
     fs::write(root.join("locked.wav"), [0_u8; 8]).expect("write wav");
@@ -140,7 +142,7 @@ fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
         .find(|file| file.name == "locked.wav")
         .expect("locked file");
 
-    assert_eq!(unlocked_file.rating, Rating::KEEP_1);
+    assert_eq!(unlocked_file.rating, Rating::KEEP_3);
     assert_eq!(locked_file.rating, Rating::KEEP_3);
     let rows = db.list_files().expect("decayed source db files");
     assert_eq!(
@@ -148,7 +150,7 @@ fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
             .find(|entry| entry.relative_path == unlocked_relative)
             .expect("unlocked row")
             .tag,
-        Rating::KEEP_1
+        Rating::KEEP_3
     );
     assert_eq!(
         rows.iter()
@@ -157,6 +159,41 @@ fn source_scan_applies_rating_decay_to_unlocked_keep_ratings() {
             .tag,
         Rating::KEEP_3
     );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn metadata_hydration_failure_preserves_last_good_browser_metadata() {
+    let root = temp_source_root("wavecrate-gui-metadata-hydration-failure");
+    fs::write(root.join("sample.wav"), [0_u8; 8]).expect("write wav");
+    let mut browser = FolderBrowserState::load_default();
+    let initial_request = browser
+        .begin_add_source_path(root.clone(), 42)
+        .expect("new source should request scan");
+    assert!(browser.apply_scan_finished(scan_source_with_progress(
+        initial_request,
+        |_| {},
+        |_| {}
+    )));
+    let db = SourceDatabase::open_for_test_fixture_source_write(&root).expect("source db");
+    db.set_tag(std::path::Path::new("sample.wav"), Rating::KEEP_3)
+        .expect("seed rating");
+    let refresh = browser
+        .begin_selected_source_scan(43)
+        .expect("metadata refresh");
+    assert!(browser.apply_scan_finished(scan_source_with_progress(refresh, |_| {}, |_| {})));
+
+    let failed_refresh = browser
+        .begin_selected_source_scan(44)
+        .expect("failed metadata refresh");
+    let mut failed = scan_source_with_progress(failed_refresh, |_| {}, |_| {});
+    failed.metadata_hydration = MetadataHydrationStatus::Failed {
+        error: String::from("database unavailable"),
+    };
+    failed.folder.files[0].rating = Rating::NEUTRAL;
+    assert!(browser.apply_scan_finished(failed));
+
+    assert_eq!(browser.selected_audio_files()[0].rating, Rating::KEEP_3);
     let _ = fs::remove_dir_all(root);
 }
 

--- a/src/native_app/sample_library/folder_scan_actions.rs
+++ b/src/native_app/sample_library/folder_scan_actions.rs
@@ -3,6 +3,7 @@ mod filesystem_refresh;
 mod filesystem_refresh_worker;
 mod maintenance;
 mod progress;
+mod rating_decay_worker;
 mod source_commands;
 mod task_ids;
 mod worker;

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -10,7 +10,7 @@ use wavecrate::sample_sources::{
 };
 
 use crate::native_app::sample_library::folder_browser::scan::{
-    FolderScanCacheUpdate, apply_folder_scan_cache_update,
+    FolderScanCacheUpdate, RatingDecayMaintenanceRequest, apply_folder_scan_cache_update,
 };
 
 #[derive(Clone)]
@@ -21,6 +21,7 @@ pub(super) struct FolderScanMaintenanceRequest {
     pub(super) audio_file_paths: Vec<PathBuf>,
     pub(super) scan_cache_update: FolderScanCacheUpdate,
     pub(super) scan_cache_revision: u64,
+    pub(super) rating_decay: Option<RatingDecayMaintenanceRequest>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -28,6 +29,9 @@ pub(in crate::native_app) struct FolderScanMaintenanceResult {
     pub(in crate::native_app) config_error: Option<String>,
     pub(in crate::native_app) scan_cache_error: Option<String>,
     pub(in crate::native_app) harvest_errors: Vec<String>,
+    pub(in crate::native_app) rating_decay_source_id: Option<String>,
+    pub(in crate::native_app) rating_decay_updated_count: usize,
+    pub(in crate::native_app) rating_decay_error: Option<String>,
 }
 
 impl FolderScanMaintenanceResult {
@@ -54,10 +58,23 @@ pub(super) fn persist_folder_scan_maintenance(
             .err();
     let config_error = persist_config_revision(&request.config, &request.config_revision);
     let harvest_errors = persist_harvest_discoveries(&request.sources, &request.audio_file_paths);
+    let (rating_decay_source_id, rating_decay_updated_count, rating_decay_error) = request
+        .rating_decay
+        .map(|request| {
+            let source_id = request.source_id.clone();
+            match super::rating_decay_worker::apply_rating_decay_maintenance(&request) {
+                Ok(updated_count) => (Some(source_id), updated_count, None),
+                Err(error) => (Some(source_id), 0, Some(error)),
+            }
+        })
+        .unwrap_or_default();
     FolderScanMaintenanceResult {
         config_error,
         scan_cache_error,
         harvest_errors,
+        rating_decay_source_id,
+        rating_decay_updated_count,
+        rating_decay_error,
     }
 }
 
@@ -163,6 +180,9 @@ mod tests {
             config_error: Some(String::from("config denied")),
             scan_cache_error: Some(String::from("cache full")),
             harvest_errors: Vec::new(),
+            rating_decay_source_id: None,
+            rating_decay_updated_count: 0,
+            rating_decay_error: None,
         };
 
         assert_eq!(

--- a/src/native_app/sample_library/folder_scan_actions/rating_decay_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/rating_decay_worker.rs
@@ -1,4 +1,7 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use wavecrate::sample_sources::{Rating, SourceDatabase, config::clamp_rating_decay_weeks};
 
@@ -24,6 +27,7 @@ fn apply_rating_decay_maintenance_at(
     let snapshot = db
         .browser_metadata_snapshot()
         .map_err(|error| format!("read rating-decay metadata snapshot: {error}"))?;
+    let snapshot_revision = snapshot.revision;
     let updates = snapshot
         .files
         .into_iter()
@@ -38,13 +42,27 @@ fn apply_rating_decay_maintenance_at(
             .map(|decayed| (file.relative_path, decayed))
         })
         .collect::<Vec<_>>();
+    apply_rating_decay_updates(&db, snapshot_revision, &updates)
+}
+
+fn apply_rating_decay_updates(
+    db: &SourceDatabase,
+    snapshot_revision: u64,
+    updates: &[(PathBuf, DecayedRating)],
+) -> Result<usize, String> {
     if updates.is_empty() {
         return Ok(0);
     }
     let mut batch = db
         .write_batch()
         .map_err(|error| format!("begin rating-decay metadata batch: {error}"))?;
-    for (path, decayed) in &updates {
+    if !batch
+        .matches_revision(snapshot_revision)
+        .map_err(|error| format!("fence rating-decay metadata snapshot: {error}"))?
+    {
+        return Ok(0);
+    }
+    for (path, decayed) in updates {
         batch
             .set_tag(path, decayed.rating)
             .map_err(|error| format!("stage rating decay for {}: {error}", path.display()))?;
@@ -156,5 +174,51 @@ mod tests {
         let file = db.browser_metadata_snapshot().unwrap().files.pop().unwrap();
         assert_eq!(file.rating, Rating::KEEP_1);
         assert_eq!(file.last_curated_at, Some(1_000 + 8 * SECONDS_PER_WEEK));
+    }
+
+    #[test]
+    fn rating_decay_maintenance_skips_snapshot_after_newer_user_curation() {
+        let root = tempfile::tempdir().unwrap();
+        let relative = Path::new("sample.wav");
+        let db = SourceDatabase::open_for_test_fixture_source_write(root.path()).unwrap();
+        db.upsert_file(relative, 10, 5).unwrap();
+        db.set_tag(relative, Rating::KEEP_3).unwrap();
+        db.set_last_curated_at(relative, 1_000).unwrap();
+        let concurrent_db =
+            SourceDatabase::open_for_test_fixture_source_write(root.path()).unwrap();
+        let request = RatingDecayMaintenanceRequest {
+            source_id: String::from("source"),
+            root: root.path().to_path_buf(),
+            database_root: root.path().to_path_buf(),
+            rating_decay_weeks: 4,
+        };
+
+        let snapshot = db.browser_metadata_snapshot().unwrap();
+        let snapshot_revision = snapshot.revision;
+        let candidate = snapshot.files.into_iter().next().unwrap();
+        let updates = vec![(
+            candidate.relative_path,
+            decayed_keep_rating(
+                candidate.rating,
+                candidate.locked,
+                candidate.last_curated_at,
+                request.rating_decay_weeks,
+                1_000 + 9 * SECONDS_PER_WEEK,
+            )
+            .unwrap(),
+        )];
+        let mut user_batch = concurrent_db.write_batch().unwrap();
+        user_batch.set_tag(relative, Rating::TRASH_1).unwrap();
+        user_batch.set_locked(relative, true).unwrap();
+        user_batch.set_last_curated_at(relative, 9_999).unwrap();
+        user_batch.commit().unwrap();
+
+        let updated = apply_rating_decay_updates(&db, snapshot_revision, &updates).unwrap();
+
+        assert_eq!(updated, 0);
+        let file = db.browser_metadata_snapshot().unwrap().files.pop().unwrap();
+        assert_eq!(file.rating, Rating::TRASH_1);
+        assert!(file.locked);
+        assert_eq!(file.last_curated_at, Some(9_999));
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/rating_decay_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/rating_decay_worker.rs
@@ -1,0 +1,160 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use wavecrate::sample_sources::{Rating, SourceDatabase, config::clamp_rating_decay_weeks};
+
+use crate::native_app::sample_library::folder_browser::scan::RatingDecayMaintenanceRequest;
+
+const SECONDS_PER_WEEK: i64 = 7 * 24 * 60 * 60;
+
+pub(super) fn apply_rating_decay_maintenance(
+    request: &RatingDecayMaintenanceRequest,
+) -> Result<usize, String> {
+    apply_rating_decay_maintenance_at(request, current_epoch_seconds())
+}
+
+fn apply_rating_decay_maintenance_at(
+    request: &RatingDecayMaintenanceRequest,
+    now_epoch_seconds: i64,
+) -> Result<usize, String> {
+    let db = SourceDatabase::open_for_user_metadata_write_with_database_root(
+        &request.root,
+        &request.database_root,
+    )
+    .map_err(|error| format!("open rating-decay metadata writer: {error}"))?;
+    let snapshot = db
+        .browser_metadata_snapshot()
+        .map_err(|error| format!("read rating-decay metadata snapshot: {error}"))?;
+    let updates = snapshot
+        .files
+        .into_iter()
+        .filter_map(|file| {
+            decayed_keep_rating(
+                file.rating,
+                file.locked,
+                file.last_curated_at,
+                request.rating_decay_weeks,
+                now_epoch_seconds,
+            )
+            .map(|decayed| (file.relative_path, decayed))
+        })
+        .collect::<Vec<_>>();
+    if updates.is_empty() {
+        return Ok(0);
+    }
+    let mut batch = db
+        .write_batch()
+        .map_err(|error| format!("begin rating-decay metadata batch: {error}"))?;
+    for (path, decayed) in &updates {
+        batch
+            .set_tag(path, decayed.rating)
+            .map_err(|error| format!("stage rating decay for {}: {error}", path.display()))?;
+        batch
+            .set_last_curated_at(path, decayed.last_curated_at)
+            .map_err(|error| {
+                format!(
+                    "stage rating-decay curation timestamp for {}: {error}",
+                    path.display()
+                )
+            })?;
+    }
+    batch
+        .commit()
+        .map_err(|error| format!("commit rating-decay metadata batch: {error}"))?;
+    Ok(updates.len())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DecayedRating {
+    rating: Rating,
+    last_curated_at: i64,
+}
+
+fn decayed_keep_rating(
+    rating: Rating,
+    locked: bool,
+    last_curated_at: Option<i64>,
+    rating_decay_weeks: u16,
+    now_epoch_seconds: i64,
+) -> Option<DecayedRating> {
+    if locked || !rating.is_keep() {
+        return None;
+    }
+    let last_curated_at = last_curated_at?;
+    let elapsed_seconds = now_epoch_seconds.checked_sub(last_curated_at)?;
+    if elapsed_seconds <= 0 {
+        return None;
+    }
+    let period_seconds = i64::from(clamp_rating_decay_weeks(rating_decay_weeks)) * SECONDS_PER_WEEK;
+    let elapsed_periods = elapsed_seconds / period_seconds;
+    if elapsed_periods <= 0 {
+        return None;
+    }
+    let applied_periods = elapsed_periods.min(i64::from(rating.val()));
+    let next_rating = Rating::new(rating.val() - applied_periods as i8);
+    (next_rating != rating).then_some(DecayedRating {
+        rating: next_rating,
+        last_curated_at: last_curated_at.saturating_add(applied_periods * period_seconds),
+    })
+}
+
+fn current_epoch_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn rating_decay_maintenance_preserves_decay_semantics() {
+        let decayed = decayed_keep_rating(
+            Rating::KEEP_3,
+            false,
+            Some(1_000),
+            4,
+            1_000 + 9 * SECONDS_PER_WEEK,
+        )
+        .expect("rating should decay");
+        assert_eq!(decayed.rating, Rating::KEEP_1);
+        assert_eq!(decayed.last_curated_at, 1_000 + 8 * SECONDS_PER_WEEK);
+        assert_eq!(
+            decayed_keep_rating(
+                Rating::KEEP_3,
+                true,
+                Some(1_000),
+                4,
+                1_000 + 12 * SECONDS_PER_WEEK,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn rating_decay_maintenance_persists_one_bounded_batch() {
+        let root = tempfile::tempdir().unwrap();
+        let relative = Path::new("sample.wav");
+        let db = SourceDatabase::open_for_test_fixture_source_write(root.path()).unwrap();
+        db.upsert_file(relative, 10, 5).unwrap();
+        db.set_tag(relative, Rating::KEEP_3).unwrap();
+        db.set_last_curated_at(relative, 1_000).unwrap();
+        let request = RatingDecayMaintenanceRequest {
+            source_id: String::from("source"),
+            root: root.path().to_path_buf(),
+            database_root: root.path().to_path_buf(),
+            rating_decay_weeks: 4,
+        };
+
+        let updated =
+            apply_rating_decay_maintenance_at(&request, 1_000 + 9 * SECONDS_PER_WEEK).unwrap();
+
+        assert_eq!(updated, 1);
+        let file = db.browser_metadata_snapshot().unwrap().files.pop().unwrap();
+        assert_eq!(file.rating, Rating::KEEP_1);
+        assert_eq!(file.last_curated_at, Some(1_000 + 8 * SECONDS_PER_WEEK));
+    }
+}

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -158,6 +158,7 @@ impl NativeAppState {
             }
         }
         let scan_cache_update = prepared.scan_cache_update;
+        let rating_decay_maintenance = prepared.rating_decay_maintenance;
         match self.library.finish_folder_scan(prepared.scan) {
             SourceScanFinish::Applied {
                 source_id,
@@ -165,6 +166,7 @@ impl NativeAppState {
                 file_count,
                 folder_count,
                 source_db_error,
+                metadata_hydration_error,
                 source_root_available,
             } => {
                 self.queue_folder_scan_maintenance(
@@ -172,6 +174,7 @@ impl NativeAppState {
                         .then_some(prepared.audio_file_paths)
                         .unwrap_or_default(),
                     scan_cache_update,
+                    rating_decay_maintenance.filter(|_| source_root_available),
                     context,
                 );
                 self.apply_finished_folder_scan(
@@ -181,6 +184,7 @@ impl NativeAppState {
                         file_count,
                         folder_count,
                         source_db_error,
+                        metadata_hydration_error,
                         source_root_available,
                     },
                     started_at,
@@ -218,6 +222,9 @@ impl NativeAppState {
         &self,
         audio_file_paths: Vec<std::path::PathBuf>,
         scan_cache_update: crate::native_app::sample_library::folder_browser::scan::FolderScanCacheUpdate,
+        rating_decay: Option<
+            crate::native_app::sample_library::folder_browser::scan::RatingDecayMaintenanceRequest,
+        >,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let sources = self.library.folder_browser.configured_sample_sources();
@@ -231,6 +238,7 @@ impl NativeAppState {
             audio_file_paths,
             scan_cache_update,
             scan_cache_revision: reserve_source_scan_cache_revision(),
+            rating_decay,
         };
         #[cfg(test)]
         {
@@ -257,6 +265,7 @@ impl NativeAppState {
     pub(in crate::native_app) fn finish_folder_scan_maintenance(
         &mut self,
         result: FolderScanMaintenanceResult,
+        context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if let Some(error) = result.persistence_error() {
             self.ui.status.sample = format!("Settings not saved: {error}");
@@ -277,6 +286,13 @@ impl NativeAppState {
         }
         for error in result.harvest_errors {
             tracing::warn!("{error}");
+        }
+        if let Some(error) = result.rating_decay_error {
+            tracing::warn!("rating decay maintenance failed: {error}");
+        } else if result.rating_decay_updated_count > 0
+            && let Some(source_id) = result.rating_decay_source_id
+        {
+            self.refresh_source(source_id, context);
         }
     }
 
@@ -320,6 +336,26 @@ impl NativeAppState {
                 started_at,
                 Some(&error),
             );
+        } else if let Some(error) = scan.metadata_hydration_error {
+            self.background
+                .source_processing
+                .wake_source(&scan.source_id, "folder_scan_metadata_hydration_failed");
+            self.ui.status.sample = format!(
+                "Loaded source {}: {} files in {} folders; metadata refresh failed and the previous metadata was preserved: {error}",
+                scan.label, scan.file_count, scan.folder_count
+            );
+            tracing::warn!(
+                source_id = scan.source_id,
+                "browser metadata hydration failed: {error}"
+            );
+            emit_gui_action(
+                "folder_browser.scan.metadata_hydration",
+                Some("folder_browser"),
+                Some(&scan.label),
+                "error",
+                started_at,
+                Some(&error),
+            );
         } else {
             self.ui.status.sample = format!(
                 "Loaded source {}: {} files in {} folders",
@@ -357,6 +393,7 @@ struct AppliedFolderScan {
     file_count: usize,
     folder_count: usize,
     source_db_error: Option<String>,
+    metadata_hydration_error: Option<String>,
     source_root_available: bool,
 }
 

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -93,7 +93,7 @@ impl NativeAppState {
             }
             GuiMessage::FolderScanFinished(result) => self.finish_folder_scan(result, context),
             GuiMessage::FolderScanMaintenanceFinished(result) => {
-                self.finish_folder_scan_maintenance(result)
+                self.finish_folder_scan_maintenance(result, context)
             }
             GuiMessage::FolderTreeRefreshFinished(completion) => {
                 self.finish_folder_tree_refresh(completion, context);

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -34,14 +34,14 @@ pub mod scanner {
 /// Per-source database helpers.
 pub mod db {
     pub use wavecrate_library::sample_sources::db::{
-        DB_FILE_NAME, LEGACY_DB_FILE_NAME, META_DEFERRED_MAINTENANCE_REVISION,
-        META_DEFERRED_MAINTENANCE_SCHEMA, META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT,
-        META_WAV_PATHS_REVISION, PendingRenameEntry, Rating, SOURCE_DB_READ_ONLY_ENV,
-        SampleCollection, SampleSoundType, SourceCollectionWrite, SourceContentHashWrite,
-        SourceDatabase, SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError,
-        SourceFileWrite, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch,
-        SourceWriteCommand, WavEntry, file_ops_journal, normalize_relative_path, read, schema,
-        tags, util, write,
+        BrowserMetadataSnapshot, DB_FILE_NAME, LEGACY_DB_FILE_NAME,
+        META_DEFERRED_MAINTENANCE_REVISION, META_DEFERRED_MAINTENANCE_SCHEMA,
+        META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT, META_WAV_PATHS_REVISION,
+        PendingRenameEntry, Rating, SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType,
+        SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
+        SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError, SourceFileWrite,
+        SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry,
+        file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
     };
     #[cfg(debug_assertions)]
     pub use wavecrate_library::sample_sources::db::{
@@ -86,12 +86,13 @@ pub(crate) use wavecrate_library::sample_sources::is_supported_audio;
 pub use wavecrate_library::sample_sources::normalize_relative_path;
 pub use wavecrate_library::sample_sources::readiness;
 pub use wavecrate_library::sample_sources::{
-    DB_FILE_NAME, HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity,
-    HarvestFileKey, HarvestFileRecord, HarvestMetadataSnapshot, HarvestSourceRange, HarvestState,
-    LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation, Rating, SampleSource,
-    SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
-    SourceDbError, SourceFileWrite, SourceId, SourceMetadataStorage, SourceRole, SourceTagWrite,
-    SourceWriteCommand, WavEntry, database_path_for, default_primary_import_folder, normalize_path,
+    BrowserMetadataSnapshot, DB_FILE_NAME, HarvestDerivationOperation, HarvestDerivationRecord,
+    HarvestFileIdentity, HarvestFileKey, HarvestFileRecord, HarvestMetadataSnapshot,
+    HarvestSourceRange, HarvestState, LIBRARY_DB_FILE_NAME, LibraryError, LibraryState,
+    NewHarvestDerivation, Rating, SampleSource, SourceCollectionWrite, SourceContentHashWrite,
+    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceId,
+    SourceMetadataStorage, SourceRole, SourceTagWrite, SourceWriteCommand, WavEntry,
+    database_path_for, default_primary_import_folder, normalize_path,
 };
 pub use wavecrate_scan::sample_sources::ScanTracker;
 pub use wavecrate_scan::sample_sources::{

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -935,6 +935,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "source database filesystem-sync worker",
         ),
         (
+            "src/native_app/sample_library/folder_scan_actions/rating_decay_worker.rs",
+            "rating-decay metadata maintenance worker",
+        ),
+        (
             "src/native_app/sample_library/folder_browser/file_move_execution.rs",
             "file operation worker",
         ),


### PR DESCRIPTION
## Goal

Replace per-file browser metadata queries with one coherent typed bulk snapshot so large-source refresh cost is bounded and metadata failures do not blank the current browser projection.

Closes OPT-1237.

## Scope

- Add a library-layer browser metadata snapshot read inside one SQLite transaction, including ratings, locks, collections, playback and curation timestamps, and a source revision marker.
- Resolve legacy schema capabilities once and use at most six schema/data statements independent of file count.
- Preserve the last good browser metadata and cache projection when hydration fails, while surfacing actionable status and diagnostics.
- Move rating decay into the existing asynchronous post-scan maintenance lane, commit one bounded batch, and explicitly refresh changed metadata.
- Add coherent multi-collection, legacy, typed-failure, large-source statement-budget, last-good projection, and maintenance regression coverage.

## Non-goals

- No rating-decay semantic or collection-order changes.
- No source-schema migration.
- No browser row-model or filesystem scanning redesign.

## Definition of Done

- Browser hydration performs a bounded number of SQL statements independent of source size.
- Schema capabilities are resolved once per snapshot and legacy read-only databases retain safe defaults.
- Source scans no longer open a writer to hydrate browser metadata.
- Rating decay runs separately and triggers an explicit refresh only when it changes rows.
- Hydration failures retain the last good metadata projection and report the failure.
- Large-source and compatibility regressions are covered.

## Validation

- `cargo test -p wavecrate-library --lib sample_sources::db::read::tests -- --test-threads=1` — passed (15 tests).
- `cargo test -p wavecrate-library --lib browser_metadata_snapshot -- --test-threads=1` — passed (3 tests; 2,000 rows, constant statement count, completed in 0.03s).
- `cargo test -p wavecrate --lib source_scanning -- --test-threads=1` — passed (19 tests).
- `cargo test -p wavecrate --lib rating_decay_maintenance -- --test-threads=1` — passed (3 tests, including stale-snapshot fencing).
- Exact native GUI blocking-boundary guardrail — passed.
- `bash scripts/build.sh --release` — passed; built branch-specific signed `Wavecrate OPT-1237.app`.
- Real-app sandbox smoke — passed; loaded a 2,000-file source, switched to a one-file source, and switched back while the browser stayed responsive and retained all 2,000 rows.
- `bash scripts/ci.sh agent` — smoke, non-blocking architecture, Radiant, runtime, and controller-browser phases passed; the broad Wavecrate library phase reached execution but remains blocked by 53 unrelated existing test failures.

## Known limitations

- The broad agent lane is not globally green because of the existing unrelated Wavecrate library-suite failures noted above; this diff does not quarantine or weaken those tests.

User approval is required before merge.