### PR TITLE
OPT-1239: Build browser projection from one committed source snapshot

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
@@ -80,7 +80,7 @@ fn browser_metadata_snapshot_with_observer(
         "NULL AS collection",
     );
     let sql = format!(
-        "SELECT path, {}, {}, {}, {}, {legacy_collection}
+        "SELECT path, {}, {}, {}, {}, {legacy_collection}, {}, {}, {}
          FROM wav_files
          WHERE {supported_filter}
          ORDER BY path ASC",
@@ -96,6 +96,9 @@ fn browser_metadata_snapshot_with_observer(
             "last_curated_at",
             "NULL AS last_curated_at"
         ),
+        optional_browser_column(&capabilities.wav_columns, "file_size", "0 AS file_size"),
+        optional_browser_column(&capabilities.wav_columns, "modified_ns", "0 AS modified_ns"),
+        optional_browser_column(&capabilities.wav_columns, "missing", "0 AS missing"),
     );
     statement_started();
     let mut files = {
@@ -119,6 +122,9 @@ fn browser_metadata_snapshot_with_observer(
                 };
                 Ok(Some(BrowserFileMetadata {
                     relative_path,
+                    file_size: u64::try_from(row.get::<_, i64>(6)?).unwrap_or_default(),
+                    modified_ns: row.get(7)?,
+                    missing: row.get::<_, i64>(8)? != 0,
                     rating: Rating::from_i64(row.get(1)?),
                     locked: row.get::<_, i64>(2)? != 0,
                     collections: legacy_collection,

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -572,6 +572,9 @@ fn legacy_read_only_minimal_wav_files_schema_reads_with_defaults() {
         PathBuf::from("nested/One.WAV")
     );
     assert_eq!(browser_snapshot.files[0].rating, Rating::NEUTRAL);
+    assert_eq!(browser_snapshot.files[0].file_size, 2048);
+    assert_eq!(browser_snapshot.files[0].modified_ns, 99);
+    assert!(!browser_snapshot.files[0].missing);
     assert!(browser_snapshot.files[0].collections.is_empty());
     assert_eq!(db.count_files().unwrap(), 1);
     assert_eq!(db.count_present_files().unwrap(), 1);

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -270,6 +270,12 @@ pub struct WavEntry {
 pub struct BrowserFileMetadata {
     /// File path relative to the source root.
     pub relative_path: PathBuf,
+    /// File size recorded by the authoritative source manifest.
+    pub file_size: u64,
+    /// Last modified timestamp recorded by the authoritative source manifest.
+    pub modified_ns: i64,
+    /// Whether the authoritative manifest currently considers the file absent.
+    pub missing: bool,
     /// Current rating/tag for the file.
     pub rating: Rating,
     /// Whether the keep rating is locked.

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -9,9 +9,10 @@ pub mod sample_sources;
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
-    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
-    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, sync_paths, sync_paths_with_progress,
+    RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeFile, SourceTreeSnapshot,
+    UpdatedSample, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
+    complete_deferred_hashes, complete_deferred_rename_candidates,
+    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
+    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/mod.rs
@@ -18,7 +18,8 @@ pub mod library {
 pub use scan_state::ScanTracker;
 pub use scanner::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample,
+    RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeFile, SourceTreeSnapshot,
+    UpdatedSample,
 };
 pub(crate) use wavecrate_library::sample_sources::is_supported_audio;
 pub use wavecrate_library::sample_sources::normalize_relative_path;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -10,10 +10,11 @@ mod scan_walk;
 
 pub use scan::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
-    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
-    complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
-    complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,
-    complete_pending_deep_hashes, hard_rescan, scan_in_background, scan_once, scan_with_progress,
+    RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeFile, SourceTreeSnapshot,
+    UpdatedSample, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
+    complete_deferred_hashes, complete_deferred_hashes_with_cancel,
+    complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
+    scan_in_background, scan_once, scan_with_progress,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -16,6 +16,7 @@ pub(crate) struct ScanContext {
     committed_manifest_revision: u64,
     pub(crate) last_committed_revision: Option<u64>,
     manifest_audit: Option<ManifestAuditCheckpoint>,
+    source_tree_incomplete: bool,
 }
 
 struct ManifestAuditCheckpoint {
@@ -58,7 +59,16 @@ impl ScanContext {
             committed_manifest_revision: manifest_revision,
             last_committed_revision: None,
             manifest_audit: None,
+            source_tree_incomplete: false,
         }
+    }
+
+    pub(in crate::sample_sources::scanner) fn mark_source_tree_incomplete(&mut self) {
+        self.source_tree_incomplete = true;
+    }
+
+    pub(in crate::sample_sources::scanner) fn source_tree_incomplete(&self) -> bool {
+        self.source_tree_incomplete
     }
 
     pub(in crate::sample_sources::scanner) fn resume_manifest_audit(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -17,7 +17,7 @@ pub use runner::{
 };
 pub use stats::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanStats, UpdatedSample,
+    RenamedSample, ScanStats, SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -2,6 +2,33 @@ use std::path::PathBuf;
 
 use wavecrate_library::sample_sources::SourceManifestEntry;
 
+/// One non-audio regular file observed during the authoritative source traversal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceTreeFile {
+    /// File path relative to the source root.
+    pub relative_path: PathBuf,
+    /// File size observed without following symbolic links.
+    pub file_size: u64,
+}
+
+/// Browser layout facts captured by the same traversal that reconciles the source manifest.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SourceTreeSnapshot {
+    /// All visible directories, relative to the source root, including the empty root path.
+    pub directories: Vec<PathBuf>,
+    /// Visible regular files that are not authoritative supported-audio manifest rows.
+    pub other_files: Vec<SourceTreeFile>,
+    /// Bounded diagnostics for entries that could not be classified or enumerated.
+    pub diagnostics: Vec<String>,
+}
+
+impl SourceTreeSnapshot {
+    /// A projection is safe to publish only when every encountered entry was classified.
+    pub fn is_complete(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
 /// Summary of a scan run.
 #[derive(Debug, Default, Clone)]
 pub struct ScanStats {
@@ -36,6 +63,9 @@ pub struct ScanStats {
     pub manifest_before: Vec<SourceManifestEntry>,
     #[doc(hidden)]
     pub manifest_after: Vec<SourceManifestEntry>,
+    /// Filesystem layout captured by the authoritative full traversal.
+    #[doc(hidden)]
+    pub source_tree_snapshot: Option<SourceTreeSnapshot>,
 }
 
 impl ScanStats {
@@ -53,6 +83,9 @@ impl ScanStats {
                 &self.manifest_after,
                 deferred.committed_delta.revision,
             );
+        }
+        if deferred.source_tree_snapshot.is_some() {
+            self.source_tree_snapshot = deferred.source_tree_snapshot;
         }
     }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -120,6 +120,36 @@ fn full_scan_captures_browser_layout_in_the_authoritative_traversal() {
     assert_eq!(notes.file_size, 5);
 }
 
+#[test]
+fn browser_layout_keeps_hidden_non_audio_entries_but_excludes_hidden_audio() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::write(hidden.join("kick.wav"), b"kick").unwrap();
+    std::fs::write(hidden.join("notes.txt"), b"notes").unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let stats = scan_once(&db).unwrap();
+    let snapshot = stats.source_tree_snapshot.expect("source tree snapshot");
+
+    assert!(snapshot.directories.contains(&PathBuf::from(".hidden")));
+    assert!(snapshot.other_files.iter().any(|file| {
+        file.relative_path == Path::new(".hidden/notes.txt") && file.file_size == 5
+    }));
+    assert!(
+        snapshot
+            .other_files
+            .iter()
+            .all(|file| file.relative_path != Path::new(".hidden/kick.wav"))
+    );
+    assert!(
+        db.list_files()
+            .unwrap()
+            .iter()
+            .all(|file| file.relative_path != Path::new(".hidden/kick.wav"))
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn browser_layout_snapshot_does_not_include_symlink_entries() {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -93,3 +93,70 @@ fn scan_skips_appledouble_sidecar_files() {
         vec![PathBuf::from("drums/snare.wav"), PathBuf::from("kick.wav")]
     );
 }
+
+#[test]
+fn full_scan_captures_browser_layout_in_the_authoritative_traversal() {
+    let dir = tempdir().unwrap();
+    let nested = dir.path().join("nested");
+    let empty = dir.path().join("empty");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::create_dir_all(&empty).unwrap();
+    std::fs::write(nested.join("kick.wav"), b"kick").unwrap();
+    std::fs::write(nested.join("notes.txt"), b"notes").unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let stats = scan_once(&db).unwrap();
+    let snapshot = stats.source_tree_snapshot.expect("source tree snapshot");
+
+    assert!(snapshot.is_complete());
+    assert!(snapshot.directories.contains(&PathBuf::new()));
+    assert!(snapshot.directories.contains(&PathBuf::from("empty")));
+    assert!(snapshot.directories.contains(&PathBuf::from("nested")));
+    let notes = snapshot
+        .other_files
+        .iter()
+        .find(|file| file.relative_path == Path::new("nested/notes.txt"))
+        .expect("notes layout entry");
+    assert_eq!(notes.file_size, 5);
+}
+
+#[cfg(unix)]
+#[test]
+fn browser_layout_snapshot_does_not_include_symlink_entries() {
+    use std::os::unix::fs as unix_fs;
+
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    std::fs::write(outside.path().join("outside.txt"), b"outside").unwrap();
+    unix_fs::symlink(outside.path(), dir.path().join("outside-link")).unwrap();
+    std::fs::write(dir.path().join("real.txt"), b"real").unwrap();
+    unix_fs::symlink(
+        dir.path().join("real.txt"),
+        dir.path().join("file-link.txt"),
+    )
+    .unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let snapshot = scan_once(&db)
+        .unwrap()
+        .source_tree_snapshot
+        .expect("source tree snapshot");
+
+    assert!(snapshot.directories.contains(&PathBuf::new()));
+    assert!(
+        snapshot
+            .directories
+            .iter()
+            .all(|path| path != Path::new("outside-link"))
+    );
+    assert!(
+        snapshot
+            .other_files
+            .iter()
+            .any(|file| file.relative_path == Path::new("real.txt"))
+    );
+    assert!(snapshot.other_files.iter().all(|file| {
+        file.relative_path != Path::new("file-link.txt")
+            && file.relative_path != Path::new("outside-link/outside.txt")
+    }));
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -14,6 +14,9 @@ use wavecrate_library::filesystem_identity::{
 use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
 use super::scan::ScanError;
+use super::scan::{SourceTreeFile, SourceTreeSnapshot};
+
+const MAX_LAYOUT_DIAGNOSTICS: usize = 16;
 
 #[derive(Clone, Debug)]
 pub(super) struct FileFacts {
@@ -54,9 +57,13 @@ pub(super) fn visit_dir_with_cancel_check(
     root: &Path,
     should_cancel: &mut impl FnMut() -> bool,
     visitor: &mut impl FnMut(&Path) -> Result<(), ScanError>,
-) -> Result<(), ScanError> {
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
+) -> Result<SourceTreeSnapshot, ScanError> {
+    let mut snapshot = SourceTreeSnapshot {
+        directories: vec![PathBuf::new()],
+        ..SourceTreeSnapshot::default()
+    };
+    let mut stack = vec![(root.to_path_buf(), true)];
+    while let Some((dir, scan_audio)) = stack.pop() {
         if should_cancel() {
             return Err(ScanError::Canceled);
         }
@@ -67,6 +74,10 @@ pub(super) fn visit_dir_with_cancel_check(
                     dir = %dir.display(),
                     error = %source,
                     "Failed to read directory during scan"
+                );
+                record_layout_diagnostic(
+                    &mut snapshot,
+                    format!("read directory {}: {source}", display_relative(root, &dir)),
                 );
                 continue;
             }
@@ -86,6 +97,13 @@ pub(super) fn visit_dir_with_cancel_check(
                         error = %err,
                         "Failed to read directory entry during scan"
                     );
+                    record_layout_diagnostic(
+                        &mut snapshot,
+                        format!(
+                            "read directory entry {}: {err}",
+                            display_relative(root, &dir)
+                        ),
+                    );
                     continue;
                 }
             };
@@ -99,6 +117,10 @@ pub(super) fn visit_dir_with_cancel_check(
                         error = %err,
                         "Failed to read file type during scan"
                     );
+                    record_layout_diagnostic(
+                        &mut snapshot,
+                        format!("read file type {}: {err}", display_relative(root, &path)),
+                    );
                     continue;
                 }
             };
@@ -106,20 +128,63 @@ pub(super) fn visit_dir_with_cancel_check(
                 continue;
             }
             if file_type.is_dir() {
-                if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                    && name.starts_with('.')
-                {
-                    continue;
-                }
-                stack.push(path);
+                let relative = path
+                    .strip_prefix(root)
+                    .map(Path::to_path_buf)
+                    .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
+                snapshot.directories.push(relative);
+                let hidden = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with('.'));
+                stack.push((path, scan_audio && !hidden));
                 continue;
             }
-            if file_type.is_file() && is_supported_audio(&path) {
-                visitor(&path)?;
+            if file_type.is_file() {
+                if wavecrate_library::sample_sources::is_apple_double_sidecar(&path) {
+                    continue;
+                }
+                if scan_audio && is_supported_audio(&path) {
+                    visitor(&path)?;
+                } else {
+                    match entry.metadata() {
+                        Ok(metadata) => snapshot.other_files.push(SourceTreeFile {
+                            relative_path: path
+                                .strip_prefix(root)
+                                .map(Path::to_path_buf)
+                                .map_err(|_| ScanError::InvalidRoot(path.clone()))?,
+                            file_size: metadata.len(),
+                        }),
+                        Err(err) => record_layout_diagnostic(
+                            &mut snapshot,
+                            format!(
+                                "read file metadata {}: {err}",
+                                display_relative(root, &path)
+                            ),
+                        ),
+                    }
+                }
             }
         }
     }
-    Ok(())
+    snapshot.directories.sort();
+    snapshot
+        .other_files
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(snapshot)
+}
+
+fn record_layout_diagnostic(snapshot: &mut SourceTreeSnapshot, diagnostic: String) {
+    if snapshot.diagnostics.len() < MAX_LAYOUT_DIAGNOSTICS {
+        snapshot.diagnostics.push(diagnostic);
+    }
+}
+
+fn display_relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
 }
 
 pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanError> {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -144,8 +144,10 @@ pub(super) fn visit_dir_with_cancel_check(
                 if wavecrate_library::sample_sources::is_apple_double_sidecar(&path) {
                     continue;
                 }
-                if scan_audio && is_supported_audio(&path) {
-                    visitor(&path)?;
+                if is_supported_audio(&path) {
+                    if scan_audio {
+                        visitor(&path)?;
+                    }
                 } else {
                     match entry.metadata() {
                         Ok(metadata) => snapshot.other_files.push(SourceTreeFile {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -45,6 +45,7 @@ pub(super) fn walk_phase(
             let mut prepared = match prepare_diff(root, path, context) {
                 Ok(prepared) => prepared,
                 Err(error) if committed.get() => {
+                    context.mark_source_tree_incomplete();
                     if let Ok(relative) = path.strip_prefix(root)
                         && is_supported_scannable_audio_file(root, relative)
                     {
@@ -111,8 +112,21 @@ pub(super) fn walk_phase(
         }
     }
     context.flush_manifest_audit_checkpoint(db)?;
-    context.stats.source_tree_snapshot = Some(source_tree_snapshot);
+    context.stats.source_tree_snapshot =
+        Some(finalize_source_tree_snapshot(context, source_tree_snapshot));
     Ok(())
+}
+
+fn finalize_source_tree_snapshot(
+    context: &ScanContext,
+    mut source_tree_snapshot: super::scan::SourceTreeSnapshot,
+) -> super::scan::SourceTreeSnapshot {
+    if context.source_tree_incomplete() {
+        source_tree_snapshot.diagnostics.push(String::from(
+            "supported audio changed or became unavailable after an earlier scan batch committed",
+        ));
+    }
+    source_tree_snapshot
 }
 
 fn publish_manifest_audit_progress(
@@ -171,6 +185,7 @@ fn refresh_noop_preparation_or_skip(
     match refresh_noop_preparation(db, root, context, prepared) {
         Ok(prepared) => Ok(Some(prepared)),
         Err(error) if tolerate_file_errors => {
+            context.mark_source_tree_incomplete();
             skip_changed_or_unavailable(context, root, &relative_path);
             tracing::warn!(
                 path = %root.join(&relative_path).display(),
@@ -242,6 +257,7 @@ fn apply_batch(
             Ok(outcome) => outcome,
             Err(ScanError::Canceled) => return Err(ScanError::Canceled),
             Err(error) if tolerate_file_errors => {
+                context.mark_source_tree_incomplete();
                 skip_changed_or_unavailable(context, root, &relative_path);
                 tracing::warn!(
                     path = %root.join(&relative_path).display(),
@@ -256,6 +272,7 @@ fn apply_batch(
             PrepareForApply::Ready(file) => ready.push(file),
             PrepareForApply::Gone => {}
             PrepareForApply::Skip => {
+                context.mark_source_tree_incomplete();
                 skip_changed_or_unavailable(context, root, &relative_path);
             }
         }
@@ -276,6 +293,7 @@ fn apply_batch(
         match read_facts(root, &absolute) {
             Ok(current) if prepared_still_current(&file, &current) => {}
             _ => {
+                context.mark_source_tree_incomplete();
                 skip_changed_or_unavailable(context, root, &relative_path);
                 continue;
             }
@@ -385,8 +403,8 @@ fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        PrepareForApply, prepare_for_apply, prepare_for_apply_with_post_hash_hook,
-        refresh_noop_preparation_or_skip,
+        PrepareForApply, finalize_source_tree_snapshot, prepare_for_apply,
+        prepare_for_apply_with_post_hash_hook, refresh_noop_preparation_or_skip,
     };
     use crate::sample_sources::SourceDatabase;
     use crate::sample_sources::scanner::scan::{ScanContext, ScanMode, scan_once};
@@ -450,6 +468,9 @@ mod tests {
                 .unwrap();
 
         assert!(refreshed.is_none());
+        assert!(context.source_tree_incomplete());
+        let snapshot = finalize_source_tree_snapshot(&context, Default::default());
+        assert!(!snapshot.is_complete());
     }
 
     #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -30,69 +30,75 @@ pub(super) fn walk_phase(
     // resumes from the durable partial index without presenting it as a complete generation.
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
-    visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
-        if cancel_requested(cancel) {
-            return Err(ScanError::Canceled);
-        }
-        let relative_path = path
-            .strip_prefix(root)
-            .map(Path::to_path_buf)
-            .map_err(|_| ScanError::InvalidRoot(path.to_path_buf()))?;
-        if context.skip_previously_audited_path(&relative_path) {
-            return Ok(());
-        }
-        let mut prepared = match prepare_diff(root, path, context) {
-            Ok(prepared) => prepared,
-            Err(error) if committed.get() => {
-                if let Ok(relative) = path.strip_prefix(root)
-                    && is_supported_scannable_audio_file(root, relative)
-                {
-                    context.existing.remove(relative);
+    let source_tree_snapshot =
+        visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
+            if cancel_requested(cancel) {
+                return Err(ScanError::Canceled);
+            }
+            let relative_path = path
+                .strip_prefix(root)
+                .map(Path::to_path_buf)
+                .map_err(|_| ScanError::InvalidRoot(path.to_path_buf()))?;
+            if context.skip_previously_audited_path(&relative_path) {
+                return Ok(());
+            }
+            let mut prepared = match prepare_diff(root, path, context) {
+                Ok(prepared) => prepared,
+                Err(error) if committed.get() => {
+                    if let Ok(relative) = path.strip_prefix(root)
+                        && is_supported_scannable_audio_file(root, relative)
+                    {
+                        context.existing.remove(relative);
+                    }
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "Skipping file that changed after an earlier scan batch committed"
+                    );
+                    return Ok(());
                 }
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %error,
-                    "Skipping file that changed after an earlier scan batch committed"
-                );
-                return Ok(());
-            }
-            Err(error) => return Err(error),
-        };
-        if !context.resumable_manifest_audit_active() {
-            context.stats.total_files += 1;
-            if let Some(on_progress) = on_progress.as_mut() {
-                on_progress(context.stats.total_files, path);
-            }
-        }
-        if !prepared.requires_apply {
-            let Some(refreshed) =
-                refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
-            else {
-                return Ok(());
+                Err(error) => return Err(error),
             };
-            prepared = refreshed;
-        }
-        if !prepared.requires_apply {
-            skip_noop(context, &prepared);
-            context.record_manifest_audit_paths(db, [relative_path])?;
-            publish_manifest_audit_progress(context, root, path, on_progress);
-            return Ok(());
-        }
-        pending.push(prepared);
-        if pending.len() == APPLY_BATCH_SIZE {
-            let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-            let outcome = apply_batch(db, root, cancel, context, files, committed.get())?;
-            if outcome.committed {
-                committed.set(true);
+            if !context.resumable_manifest_audit_active() {
+                context.stats.total_files += 1;
+                if let Some(on_progress) = on_progress.as_mut() {
+                    on_progress(context.stats.total_files, path);
+                }
             }
-            let last_path = outcome.audited_paths.last().cloned();
-            context.record_manifest_audit_paths(db, outcome.audited_paths)?;
-            if let Some(last_path) = last_path {
-                publish_manifest_audit_progress(context, root, &root.join(last_path), on_progress);
+            if !prepared.requires_apply {
+                let Some(refreshed) =
+                    refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
+                else {
+                    return Ok(());
+                };
+                prepared = refreshed;
             }
-        }
-        Ok(())
-    })?;
+            if !prepared.requires_apply {
+                skip_noop(context, &prepared);
+                context.record_manifest_audit_paths(db, [relative_path])?;
+                publish_manifest_audit_progress(context, root, path, on_progress);
+                return Ok(());
+            }
+            pending.push(prepared);
+            if pending.len() == APPLY_BATCH_SIZE {
+                let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
+                let outcome = apply_batch(db, root, cancel, context, files, committed.get())?;
+                if outcome.committed {
+                    committed.set(true);
+                }
+                let last_path = outcome.audited_paths.last().cloned();
+                context.record_manifest_audit_paths(db, outcome.audited_paths)?;
+                if let Some(last_path) = last_path {
+                    publish_manifest_audit_progress(
+                        context,
+                        root,
+                        &root.join(last_path),
+                        on_progress,
+                    );
+                }
+            }
+            Ok(())
+        })?;
     if !pending.is_empty() {
         let outcome = apply_batch(db, root, cancel, context, pending, committed.get())?;
         if outcome.committed {
@@ -105,6 +111,7 @@ pub(super) fn walk_phase(
         }
     }
     context.flush_manifest_audit_checkpoint(db)?;
+    context.stats.source_tree_snapshot = Some(source_tree_snapshot);
     Ok(())
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -270,7 +270,7 @@ fn apply_batch(
         };
         match outcome {
             PrepareForApply::Ready(file) => ready.push(file),
-            PrepareForApply::Gone => {}
+            PrepareForApply::Gone => context.mark_source_tree_incomplete(),
             PrepareForApply::Skip => {
                 context.mark_source_tree_incomplete();
                 skip_changed_or_unavailable(context, root, &relative_path);
@@ -403,7 +403,7 @@ fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        PrepareForApply, finalize_source_tree_snapshot, prepare_for_apply,
+        PrepareForApply, apply_batch, finalize_source_tree_snapshot, prepare_for_apply,
         prepare_for_apply_with_post_hash_hook, refresh_noop_preparation_or_skip,
     };
     use crate::sample_sources::SourceDatabase;
@@ -468,6 +468,31 @@ mod tests {
                 .unwrap();
 
         assert!(refreshed.is_none());
+        assert!(context.source_tree_incomplete());
+        let snapshot = finalize_source_tree_snapshot(&context, Default::default());
+        assert!(!snapshot.is_complete());
+    }
+
+    #[test]
+    fn committed_batch_marks_disappeared_file_projection_incomplete() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("one.wav");
+        std::fs::write(&file_path, b"one").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let prepared = prepare_diff(dir.path(), &file_path, &context).unwrap();
+        assert!(prepared.requires_apply);
+
+        std::fs::remove_file(&file_path).unwrap();
+        let outcome = apply_batch(&db, dir.path(), None, &mut context, vec![prepared], true)
+            .expect("tolerated committed batch");
+
+        assert!(!outcome.committed);
         assert!(context.source_tree_incomplete());
         let snapshot = finalize_source_tree_snapshot(&context, Default::default());
         assert!(!snapshot.is_complete());

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -3131,3 +3131,14 @@ Wavecrate is moving toward the target when:
 * Radiant code owns reusable GUI/runtime primitives
 * reusable audio-engine code is not unnecessarily coupled to Wavecrate product behavior
 * the current GUI preserves core workflows without depending on removed UI paths
+
+## Source Refresh Projection Contract
+
+Native source refreshes build the browser from the authoritative scanner traversal and one
+coherent committed database snapshot. A routine refresh must not recursively enumerate the same
+source a second time to construct browser rows. Full projections are prepared off the UI thread,
+published in bounded batches, and replace the visible tree only after the complete snapshot is
+ready. Failed or stale hydration retains the last good projection and never replaces the cache
+with an empty or partial tree. Exact watcher deltas may update the projection incrementally only
+at the next committed revision; stale deltas are ignored and revision gaps recover through a full
+authoritative snapshot. The source scan cache is startup assistance, never source authority.

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -407,6 +407,17 @@ pub(in crate::native_app) struct SourceFilesystemSyncSuccess {
     pub(in crate::native_app) incomplete_error: Option<String>,
     pub(in crate::native_app) committed_delta:
         wavecrate::sample_sources::scanner::CommittedSourceDelta,
+    pub(in crate::native_app) browser_projection_delta: Option<BrowserProjectionDelta>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) struct BrowserProjectionDelta {
+    pub(in crate::native_app) manifest_revision: u64,
+    pub(in crate::native_app) snapshot_revision: u64,
+    pub(in crate::native_app) folders: Vec<PathBuf>,
+    pub(in crate::native_app) removed_file_ids: Vec<String>,
+    pub(in crate::native_app) upserted_files:
+        Vec<crate::native_app::sample_library::folder_browser::model::FileEntry>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/native_app/app/mod.rs
+++ b/src/native_app/app/mod.rs
@@ -19,9 +19,9 @@ pub(in crate::native_app) use loading::{
     SamplePlaybackReady, SampleSelectionLoadState,
 };
 pub(in crate::native_app) use message::{
-    GuiMessage, MetadataMessage, SettingsMessage, SimilaritySettingsPersistResult,
-    SourceFilesystemSyncResult, SourceFilesystemSyncSuccess, TrashMoveTarget,
-    VolumeSettingsPersistResult,
+    BrowserProjectionDelta, GuiMessage, MetadataMessage, SettingsMessage,
+    SimilaritySettingsPersistResult, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess,
+    TrashMoveTarget, VolumeSettingsPersistResult,
 };
 pub(in crate::native_app) use progress::{
     FileMoveProgress, NormalizationFailure, NormalizationHarvestDerivation, NormalizationProgress,

--- a/src/native_app/sample_library/folder_browser/folder_entry.rs
+++ b/src/native_app/sample_library/folder_browser/folder_entry.rs
@@ -5,7 +5,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{FileEntry, file_entry, folder_label, path_id, rewrite_path_id};
+use super::{
+    FileEntry, file_entry, folder_label, path_id, rewrite_path_id,
+    scanning::{upsert_file, upsert_folder},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(in crate::native_app) struct FolderEntry {
@@ -16,6 +19,35 @@ pub(in crate::native_app) struct FolderEntry {
 }
 
 impl FolderEntry {
+    pub(super) fn ensure_folder_path(&mut self, path: &Path) -> Option<&mut FolderEntry> {
+        let self_path = Path::new(&self.id);
+        if self_path == path {
+            return Some(self);
+        }
+        let relative = path.strip_prefix(self_path).ok()?;
+        let component = relative.components().next()?;
+        let child_path = self_path.join(component.as_os_str());
+        let child_id = path_id(&child_path);
+        if self.children.iter().all(|child| child.id != child_id) {
+            upsert_folder(
+                &mut self.children,
+                FolderEntry {
+                    id: child_id.clone(),
+                    name: folder_label(&child_path),
+                    children: Vec::new(),
+                    files: Vec::new(),
+                },
+            );
+        }
+        self.children
+            .iter_mut()
+            .find(|child| child.id == child_id)?
+            .ensure_folder_path(path)
+    }
+
+    pub(super) fn upsert_projected_file(&mut self, file: FileEntry) -> bool {
+        upsert_file(&mut self.files, file)
+    }
     pub(super) fn find(&self, id: &str) -> Option<&FolderEntry> {
         if self.id == id {
             return Some(self);

--- a/src/native_app/sample_library/folder_browser/model.rs
+++ b/src/native_app/sample_library/folder_browser/model.rs
@@ -1,3 +1,4 @@
+pub(in crate::native_app) use super::scanning::file_entry_with_snapshot_metadata;
 pub(in crate::native_app) use super::{
     curation::{BROWSER_CURATION_SCOPES, BrowserCurationScope},
     file_model::FileEntry,

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -83,6 +83,13 @@ impl MetadataHydrationStatus {
             Self::Complete { .. } | Self::NotAttempted => None,
         }
     }
+
+    pub(in crate::native_app) fn revision(&self) -> Option<u64> {
+        match self {
+            Self::Complete { revision } => Some(*revision),
+            Self::Failed { .. } | Self::NotAttempted => None,
+        }
+    }
 }
 
 impl FolderScanResult {

--- a/src/native_app/sample_library/folder_browser/scanning.rs
+++ b/src/native_app/sample_library/folder_browser/scanning.rs
@@ -9,6 +9,7 @@ mod verification;
 pub(super) use discovery_merge::{merge_scan_discovery, upsert_file, upsert_folder};
 pub(super) use entry::{BrowserEntryKind, classify_path_without_following};
 pub(super) use file_entry_metadata::file_entry;
+pub(in crate::native_app) use file_entry_metadata::file_entry_with_snapshot_metadata;
 pub(in crate::native_app::sample_library::folder_browser) use metadata::refreshed_file_entries_for_paths;
 pub(super) use metadata::{SourceMetadataMap, file_entry_for_source_path};
 #[cfg(test)]

--- a/src/native_app/sample_library/folder_browser/scanning/file_entry_metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/file_entry_metadata.rs
@@ -26,6 +26,26 @@ pub(in crate::native_app::sample_library::folder_browser) fn file_entry_with_met
 ) -> FileEntry {
     let metadata = fs::metadata(path).ok();
     let size_bytes = metadata.as_ref().map(fs::Metadata::len).unwrap_or_default();
+    file_entry_with_snapshot_metadata(
+        path,
+        size_bytes,
+        rating,
+        rating_locked,
+        collections,
+        last_played_at,
+        last_curated_at,
+    )
+}
+
+pub(in crate::native_app) fn file_entry_with_snapshot_metadata(
+    path: &PathBuf,
+    size_bytes: u64,
+    rating: Rating,
+    rating_locked: bool,
+    collections: Vec<SampleCollection>,
+    last_played_at: Option<i64>,
+    last_curated_at: Option<i64>,
+) -> FileEntry {
     FileEntry {
         id: path_id(path),
         name: file_label(path),

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -66,6 +66,16 @@ pub(super) fn source_rating_map(
     Ok((metadata, revision))
 }
 
+pub(super) fn source_browser_snapshot(
+    root: &Path,
+    database_root: &Path,
+) -> Result<BrowserMetadataSnapshot, SourceMetadataHydrationError> {
+    let db = SourceDatabase::open_for_ui_read_with_database_root(root, database_root)
+        .map_err(|error| SourceMetadataHydrationError::Open(error.to_string()))?;
+    db.browser_metadata_snapshot()
+        .map_err(|error| SourceMetadataHydrationError::Snapshot(error.to_string()))
+}
+
 pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_source_path(
     path: &PathBuf,
     source_root: &Path,

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -1,6 +1,8 @@
 use std::{
-    path::Path,
+    collections::BTreeMap,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
+    time::Instant,
 };
 
 use super::{
@@ -13,11 +15,18 @@ use super::{
             FolderScanResult, MetadataHydrationStatus,
         },
     },
-    entry::{BrowserEntryKind, classify_path_without_following, read_sorted_entries},
-    metadata::{SourceMetadataMap, rated_file_entry, source_rating_map},
+    entry::{BrowserEntryKind, classify_path_without_following},
+    file_entry_metadata::file_entry_with_snapshot_metadata,
+    metadata::{SourceMetadataMap, source_browser_snapshot},
     traversal::placeholder_folder,
 };
-use wavecrate::sample_sources::{SourceDatabase, scanner};
+use wavecrate::sample_sources::{BrowserMetadataSnapshot, Rating, SourceDatabase, scanner};
+use wavecrate_scan::{ScanStats, SourceTreeSnapshot};
+
+struct CommittedSourceTreeSnapshot {
+    revision: u64,
+    layout: SourceTreeSnapshot,
+}
 
 /// Publish at most one source-index progress update per bounded file batch.
 pub(in crate::native_app) const INDEX_PROGRESS_REPORT_INTERVAL: usize = 128;
@@ -39,29 +48,34 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
 ) -> FolderScanResult {
     let source_root_available =
         classify_path_without_following(&request.root) == Some(BrowserEntryKind::Directory);
-    let source_db_error = if source_root_available {
+    let (source_db_error, source_tree_snapshot) = if source_root_available {
         sync_source_database(&request, &mut progress, cancel)
     } else {
-        None
+        (None, None)
     };
-    let (ratings, metadata_hydration) = if source_root_available && !cancel.load(Ordering::Acquire)
-    {
-        match source_rating_map(&request.root, &request.database_root) {
-            Ok((ratings, revision)) => (ratings, MetadataHydrationStatus::Complete { revision }),
-            Err(error) => (
-                SourceMetadataMap::new(),
-                MetadataHydrationStatus::Failed {
-                    error: error.to_string(),
-                },
-            ),
-        }
+    let projection = if source_root_available && !cancel.load(Ordering::Acquire) {
+        build_committed_projection(&request, source_tree_snapshot)
     } else {
-        (
+        Err(String::from("source projection was not attempted"))
+    };
+    let (folder, ratings, metadata_hydration) = match projection {
+        Ok((folder, ratings, revision)) => (
+            folder,
+            ratings,
+            MetadataHydrationStatus::Complete { revision },
+        ),
+        Err(error) if source_root_available && !cancel.load(Ordering::Acquire) => (
+            placeholder_folder(&request.root),
+            SourceMetadataMap::new(),
+            MetadataHydrationStatus::Failed { error },
+        ),
+        Err(_) => (
+            placeholder_folder(&request.root),
             SourceMetadataMap::new(),
             MetadataHydrationStatus::NotAttempted,
-        )
+        ),
     };
-    let publish_discoveries = !matches!(metadata_hydration, MetadataHydrationStatus::Failed { .. });
+    let publish_discoveries = metadata_hydration.error().is_none();
     let mut scan = ScanProgressContext {
         request: &request,
         ratings,
@@ -76,8 +90,7 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
         publish_discoveries,
     };
     scan.report_initial();
-    let folder = load_folder_with_progress(&request.root, &mut scan)
-        .unwrap_or_else(|| placeholder_folder(&request.root));
+    publish_projection(&folder, &mut scan);
     let missing_collection_snapshot =
         MissingCollectionSnapshot::from_source_metadata(&request.root, &folder, &scan.ratings);
     let file_count = scan.counter.files;
@@ -102,13 +115,13 @@ fn sync_source_database(
     request: &FolderScanRequest,
     progress: &mut impl FnMut(FolderScanProgress),
     cancel: &AtomicBool,
-) -> Option<String> {
+) -> (Option<String>, Option<CommittedSourceTreeSnapshot>) {
     let db = match SourceDatabase::open_for_background_job_with_database_root(
         &request.root,
         &request.database_root,
     ) {
         Ok(db) => db,
-        Err(err) => return Some(format!("open source index: {err}")),
+        Err(err) => return (Some(format!("open source index: {err}")), None),
     };
     let mut sync_progress = |completed: usize, path: &Path| {
         if completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL) {
@@ -131,14 +144,199 @@ fn sync_source_database(
         &mut sync_progress,
     ) {
         Ok(stats) => stats,
-        Err(err) => return Some(format!("sync source index: {err}")),
+        Err(err) => return (Some(format!("sync source index: {err}")), None),
     };
-    if let Err(err) =
-        scanner::complete_deferred_rename_candidates_with_cancel(&db, stats, Some(cancel))
-    {
-        return Some(format!("finish deferred rename hashing: {err}"));
+    let fallback_snapshot =
+        stats
+            .source_tree_snapshot
+            .clone()
+            .map(|layout| CommittedSourceTreeSnapshot {
+                revision: stats.committed_delta.revision,
+                layout,
+            });
+    match scanner::complete_deferred_rename_candidates_with_cancel(&db, stats, Some(cancel)) {
+        Ok(ScanStats {
+            committed_delta,
+            source_tree_snapshot,
+            ..
+        }) => (
+            None,
+            source_tree_snapshot.map(|layout| CommittedSourceTreeSnapshot {
+                revision: committed_delta.revision,
+                layout,
+            }),
+        ),
+        Err(err) => (
+            Some(format!("finish deferred rename hashing: {err}")),
+            fallback_snapshot,
+        ),
     }
-    None
+}
+
+#[derive(Default)]
+struct ProjectionFolder {
+    children: Vec<PathBuf>,
+    files: Vec<FileEntry>,
+}
+
+fn build_committed_projection(
+    request: &FolderScanRequest,
+    source_tree_snapshot: Option<CommittedSourceTreeSnapshot>,
+) -> Result<(FolderEntry, SourceMetadataMap, u64), String> {
+    let started_at = Instant::now();
+    let committed = source_tree_snapshot
+        .ok_or_else(|| String::from("authoritative source traversal did not produce a layout"))?;
+    let layout = committed.layout;
+    if !layout.is_complete() {
+        return Err(format!(
+            "authoritative source traversal was incomplete: {}",
+            layout.diagnostics.join("; ")
+        ));
+    }
+    let BrowserMetadataSnapshot { revision, files } =
+        source_browser_snapshot(&request.root, &request.database_root)
+            .map_err(|error| error.to_string())?;
+    if revision != committed.revision {
+        return Err(format!(
+            "browser snapshot revision {revision} did not match authoritative traversal revision {}",
+            committed.revision
+        ));
+    }
+    let ratings = files
+        .iter()
+        .map(|entry| {
+            (
+                entry.relative_path.clone(),
+                (
+                    entry.rating,
+                    entry.locked,
+                    entry.collections.clone(),
+                    entry.last_played_at,
+                    entry.last_curated_at,
+                ),
+            )
+        })
+        .collect::<SourceMetadataMap>();
+
+    let mut folders = layout
+        .directories
+        .iter()
+        .cloned()
+        .map(|path| (path, ProjectionFolder::default()))
+        .collect::<BTreeMap<_, _>>();
+    folders.entry(PathBuf::new()).or_default();
+    for directory in layout
+        .directories
+        .iter()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        let parent = directory.parent().unwrap_or_else(|| Path::new(""));
+        folders
+            .entry(parent.to_path_buf())
+            .or_default()
+            .children
+            .push(directory.clone());
+    }
+    for entry in files.iter().filter(|entry| !entry.missing) {
+        let absolute = request.root.join(&entry.relative_path);
+        let file = file_entry_with_snapshot_metadata(
+            &absolute,
+            entry.file_size,
+            entry.rating,
+            entry.locked,
+            entry.collections.clone(),
+            entry.last_played_at,
+            entry.last_curated_at,
+        );
+        folders
+            .entry(
+                entry
+                    .relative_path
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .to_path_buf(),
+            )
+            .or_default()
+            .files
+            .push(file);
+    }
+    let other_file_count = layout.other_files.len();
+    for entry in layout.other_files {
+        let absolute = request.root.join(&entry.relative_path);
+        let file = file_entry_with_snapshot_metadata(
+            &absolute,
+            entry.file_size,
+            Rating::NEUTRAL,
+            false,
+            Vec::new(),
+            None,
+            None,
+        );
+        let parent = entry
+            .relative_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .to_path_buf();
+        let destination = folders.entry(parent).or_default();
+        if !destination
+            .files
+            .iter()
+            .any(|existing| existing.id == file.id)
+        {
+            destination.files.push(file);
+        }
+    }
+    for folder in folders.values_mut() {
+        folder.children.sort_by(|left, right| {
+            folder_label(&request.root.join(left))
+                .to_ascii_lowercase()
+                .cmp(&folder_label(&request.root.join(right)).to_ascii_lowercase())
+        });
+        folder.files.sort_by_key(FileEntry::name_sort_key);
+    }
+    let folder_count = folders.len();
+    let file_count = files.iter().filter(|entry| !entry.missing).count() + other_file_count;
+    let folder = materialize_projection_folder(&request.root, Path::new(""), &folders);
+    tracing::info!(
+        source_id = request.source_id,
+        revision,
+        filesystem_traversals = 1,
+        sqlite_snapshots = 1,
+        folder_count,
+        file_count,
+        elapsed_ms = started_at.elapsed().as_millis(),
+        "Built browser projection from committed source snapshot"
+    );
+    Ok((folder, ratings, revision))
+}
+
+fn materialize_projection_folder(
+    root: &Path,
+    relative: &Path,
+    folders: &BTreeMap<PathBuf, ProjectionFolder>,
+) -> FolderEntry {
+    let absolute = if relative.as_os_str().is_empty() {
+        root.to_path_buf()
+    } else {
+        root.join(relative)
+    };
+    let projection = folders.get(relative);
+    FolderEntry {
+        id: path_id(&absolute),
+        name: folder_label(&absolute),
+        children: projection
+            .map(|folder| {
+                folder
+                    .children
+                    .iter()
+                    .map(|child| materialize_projection_folder(root, child, folders))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        files: projection
+            .map(|folder| folder.files.clone())
+            .unwrap_or_default(),
+    }
 }
 
 struct ScanProgressCounter {
@@ -232,49 +430,29 @@ where
     }
 }
 
-fn load_folder_with_progress<P, D>(
-    path: &Path,
-    scan: &mut ScanProgressContext<'_, P, D>,
-) -> Option<FolderEntry>
+fn publish_projection<P, D>(folder: &FolderEntry, scan: &mut ScanProgressContext<'_, P, D>)
 where
     P: FnMut(FolderScanProgress),
     D: FnMut(FolderScanDiscovery),
 {
     if scan.cancel.load(Ordering::Acquire) {
-        return None;
+        return;
     }
-    let entries = read_sorted_entries(path)?;
-    let parent_id = path_id(path);
+    let path = PathBuf::from(&folder.id);
+    let parent_id = folder.id.clone();
     scan.record_folder_snapshot_start(&parent_id);
-    let children = entries
-        .iter()
-        .filter(|entry| entry.kind == BrowserEntryKind::Directory)
-        .filter_map(|entry| {
-            if scan.cancel.load(Ordering::Acquire) {
-                return None;
-            }
-            scan.record_folder(&entry.path, &parent_id);
-            load_folder_with_progress(&entry.path, scan)
-        })
-        .collect::<Vec<_>>();
-    let files = entries
-        .iter()
-        .filter(|entry| entry.kind == BrowserEntryKind::File)
-        .map(|entry| {
-            if scan.cancel.load(Ordering::Acquire) {
-                return None;
-            }
-            let file = rated_file_entry(&entry.path, &scan.request.root, &scan.ratings);
-            scan.record_file(&entry.path, &parent_id, file.clone());
-            Some(file)
-        })
-        .take_while(Option::is_some)
-        .flatten()
-        .collect::<Vec<_>>();
-    Some(FolderEntry {
-        id: path_id(path),
-        name: folder_label(path),
-        children,
-        files,
-    })
+    for child in &folder.children {
+        if scan.cancel.load(Ordering::Acquire) {
+            return;
+        }
+        let child_path = PathBuf::from(&child.id);
+        scan.record_folder(&child_path, &parent_id);
+        publish_projection(child, scan);
+    }
+    for file in &folder.files {
+        if scan.cancel.load(Ordering::Acquire) {
+            return;
+        }
+        scan.record_file(&path.join(&file.name), &parent_id, file.clone());
+    }
 }

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -1,20 +1,89 @@
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::{collections::HashSet, path::PathBuf};
 
 #[cfg(test)]
 use super::super::scan_types::FolderScanDiscovery;
 use super::super::{
-    FileEntry, FolderBrowserState, FolderEntry, SourceEntry,
+    FolderBrowserState, FolderEntry, SourceEntry,
     path_helpers::{folder_label, path_id},
     scan_types::{
         FolderScanDiscoveryBatch, FolderScanRequest, FolderScanResult, FolderTreeRefreshResult,
     },
     scanning::{merge_scan_discovery, placeholder_folder},
 };
+use crate::native_app::app::BrowserProjectionDelta;
 
 impl FolderBrowserState {
+    pub(in crate::native_app) fn apply_committed_projection_delta(
+        &mut self,
+        source_id: &str,
+        delta: BrowserProjectionDelta,
+    ) -> bool {
+        let Some(source_index) = self
+            .source
+            .sources
+            .iter()
+            .position(|source| source.id == source_id)
+        else {
+            return false;
+        };
+        let Some(current_revision) = self.source.sources[source_index].projection_revision else {
+            return false;
+        };
+        if delta.manifest_revision <= current_revision {
+            return true;
+        }
+        if delta.manifest_revision != current_revision.saturating_add(1) {
+            tracing::info!(
+                source_id,
+                current_revision,
+                incoming_revision = delta.manifest_revision,
+                "Browser projection revision gap requires a full snapshot refresh"
+            );
+            return false;
+        }
+        let selected = self.source.selected_source == source_id && self.source.selected_tree_loaded;
+        let changed = {
+            let root = if selected {
+                self.tree.folders.first_mut()
+            } else {
+                self.source.sources[source_index].root_folder.as_mut()
+            };
+            let Some(root) = root else {
+                return false;
+            };
+            let removed = delta
+                .removed_file_ids
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>();
+            let mut changed = root.remove_files_by_ids(&removed);
+            for folder in &delta.folders {
+                if root.ensure_folder_path(folder).is_none() {
+                    return false;
+                }
+            }
+            for file in delta.upserted_files {
+                let Some(parent) = PathBuf::from(&file.id).parent().map(PathBuf::from) else {
+                    return false;
+                };
+                let Some(folder) = root.ensure_folder_path(&parent) else {
+                    return false;
+                };
+                changed |= folder.upsert_projected_file(file);
+            }
+            changed
+        };
+        self.source.sources[source_index].projection_revision = Some(delta.snapshot_revision);
+        if changed {
+            if selected {
+                self.retain_tree_state_after_selected_source_refresh();
+            }
+            self.bump_file_content_revision();
+            self.refresh_missing_collection_state();
+        }
+        true
+    }
+
     pub(in crate::native_app) fn defer_add_source_path(
         &mut self,
         root: PathBuf,
@@ -282,10 +351,7 @@ impl FolderBrowserState {
         source.parked_tree_loaded && source.root_folder.is_some()
     }
 
-    pub(in crate::native_app) fn apply_scan_finished(
-        &mut self,
-        mut result: FolderScanResult,
-    ) -> bool {
+    pub(in crate::native_app) fn apply_scan_finished(&mut self, result: FolderScanResult) -> bool {
         let Some(source_index) = self
             .source
             .sources
@@ -300,19 +366,6 @@ impl FolderBrowserState {
         let source_id = self.source.sources[source_index].id.clone();
         let should_select = self.source.selected_source == source_id;
         let refreshing_selected_loaded_source = should_select && self.selected_source_loaded();
-        if result.metadata_hydration.error().is_some() {
-            let previous_folder = if should_select {
-                self.tree.folders.first()
-            } else {
-                self.source.sources[source_index].root_folder.as_ref()
-            };
-            if let Some(previous_folder) = previous_folder {
-                preserve_folder_metadata(&mut result.folder, previous_folder);
-            }
-            result.missing_collection_snapshot = self.source.sources[source_index]
-                .missing_collection_snapshot
-                .clone();
-        }
         self.source.sources[source_index].loading_task = None;
         if !result.source_root_available {
             self.source.sources[source_index].mark_missing();
@@ -320,13 +373,22 @@ impl FolderBrowserState {
             return true;
         }
         self.source.sources[source_index].mark_available();
+        let Some(projection_revision) = result.metadata_hydration.revision() else {
+            tracing::warn!(
+                source_id = %source_id,
+                error = result.metadata_hydration.error().unwrap_or("projection unavailable"),
+                "Keeping the last good browser projection after snapshot hydration failed"
+            );
+            return true;
+        };
+        self.source.sources[source_index].projection_revision = Some(projection_revision);
         self.source.sources[source_index].missing_collection_snapshot =
             result.missing_collection_snapshot.clone();
         if should_select {
-            self.source.sources[source_index].root_folder = None;
             if refreshing_selected_loaded_source {
                 self.refresh_selected_source_tree(source_id, result.folder, true);
             } else {
+                self.source.sources[source_index].root_folder = None;
                 self.select_loaded_source(source_id, result.folder);
                 self.refresh_missing_collection_state();
             }
@@ -409,8 +471,8 @@ impl FolderBrowserState {
         &mut self,
         batch: FolderScanDiscoveryBatch,
     ) -> bool {
-        let preserve_selected_tree =
-            self.source.selected_source == batch.source_id && self.source.selected_tree_loaded;
+        let selected_source = self.source.selected_source == batch.source_id;
+        let preserve_selected_tree = selected_source && self.source.selected_tree_loaded;
         let Some(source) = self
             .source
             .sources
@@ -422,7 +484,7 @@ impl FolderBrowserState {
         if source.loading_task != Some(batch.task_id) {
             return false;
         }
-        if preserve_selected_tree {
+        if preserve_selected_tree || (!selected_source && source.root_folder.is_some()) {
             return false;
         }
 
@@ -452,36 +514,6 @@ impl FolderBrowserState {
             self.bump_file_content_revision();
         }
         changed
-    }
-}
-
-fn preserve_folder_metadata(folder: &mut FolderEntry, previous: &FolderEntry) {
-    let previous_files = previous
-        .all_files()
-        .into_iter()
-        .map(|file| (file.id.clone(), file.clone()))
-        .collect::<HashMap<_, _>>();
-    preserve_folder_metadata_from_map(folder, &previous_files);
-}
-
-fn preserve_folder_metadata_from_map(
-    folder: &mut FolderEntry,
-    previous_files: &HashMap<String, FileEntry>,
-) {
-    for file in &mut folder.files {
-        let Some(previous) = previous_files.get(&file.id) else {
-            continue;
-        };
-        file.rating = previous.rating;
-        file.rating_locked = previous.rating_locked;
-        file.last_curated_at = previous.last_curated_at;
-        file.collection = previous.collection;
-        file.collections = previous.collections.clone();
-        file.modified = previous.modified.clone();
-        file.modified_rank = previous.modified_rank;
-    }
-    for child in &mut folder.children {
-        preserve_folder_metadata_from_map(child, previous_files);
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/source_scan_cache.rs
+++ b/src/native_app/sample_library/folder_browser/source_scan_cache.rs
@@ -358,6 +358,7 @@ mod tests {
             parked_tree_loaded: false,
             missing_collection_snapshot: MissingCollectionSnapshot::default(),
             loading_task: None,
+            projection_revision: Some(1),
         };
         let path = temp.path().join(SOURCE_SCAN_CACHE_FILE_NAME);
 

--- a/src/native_app/sample_library/folder_browser/state_types.rs
+++ b/src/native_app/sample_library/folder_browser/state_types.rs
@@ -46,6 +46,7 @@ pub(in crate::native_app) struct SourceEntry {
     pub(super) parked_tree_loaded: bool,
     pub(super) missing_collection_snapshot: MissingCollectionSnapshot,
     pub(in crate::native_app) loading_task: Option<u64>,
+    pub(super) projection_revision: Option<u64>,
 }
 
 impl SourceEntry {
@@ -67,6 +68,7 @@ impl SourceEntry {
             parked_tree_loaded: false,
             missing_collection_snapshot: MissingCollectionSnapshot::default(),
             loading_task: None,
+            projection_revision: None,
         }
     }
 
@@ -94,6 +96,7 @@ impl SourceEntry {
             parked_tree_loaded: false,
             missing_collection_snapshot: MissingCollectionSnapshot::default(),
             loading_task: None,
+            projection_revision: None,
         }
     }
 

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::native_app::app::BrowserProjectionDelta;
+use crate::native_app::sample_library::folder_browser::model::file_entry_with_snapshot_metadata;
 use crate::native_app::sample_library::folder_browser::scan_types::{
     FolderScanItem, MetadataHydrationStatus,
 };
@@ -190,10 +192,66 @@ fn metadata_hydration_failure_preserves_last_good_browser_metadata() {
     failed.metadata_hydration = MetadataHydrationStatus::Failed {
         error: String::from("database unavailable"),
     };
-    failed.folder.files[0].rating = Rating::NEUTRAL;
+    failed.folder.files.clear();
     assert!(browser.apply_scan_finished(failed));
 
+    assert_eq!(browser.selected_audio_files().len(), 1);
     assert_eq!(browser.selected_audio_files()[0].rating, Rating::KEEP_3);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn committed_projection_delta_applies_only_at_the_next_revision() {
+    let root = temp_source_root("wavecrate-gui-committed-projection-delta");
+    let old = root.join("old.wav");
+    let new = root.join("nested/new.wav");
+    fs::write(&old, [0_u8; 8]).expect("write original");
+    let mut browser = FolderBrowserState::load_default();
+    let request = browser
+        .begin_add_source_path(root.clone(), 51)
+        .expect("initial scan");
+    let source_id = request.source_id.clone();
+    assert!(browser.apply_scan_finished(scan_source_with_progress(request, |_| {}, |_| {})));
+    let revision = browser
+        .source
+        .sources
+        .iter()
+        .find(|source| source.id == source_id)
+        .and_then(|source| source.projection_revision)
+        .expect("projection revision");
+    let new_file =
+        file_entry_with_snapshot_metadata(&new, 12, Rating::KEEP_1, false, Vec::new(), None, None);
+
+    assert!(browser.apply_committed_projection_delta(
+        &source_id,
+        BrowserProjectionDelta {
+            manifest_revision: revision + 1,
+            snapshot_revision: revision + 1,
+            folders: vec![root.join("nested")],
+            removed_file_ids: vec![path_id(&old)],
+            upserted_files: vec![new_file],
+        },
+    ));
+    assert!(browser.tree.folders[0].find_file(&path_id(&old)).is_none());
+    assert_eq!(
+        browser.tree.folders[0]
+            .find_file(&path_id(&new))
+            .expect("incremental file")
+            .rating,
+        Rating::KEEP_1
+    );
+
+    assert!(!browser.apply_committed_projection_delta(
+        &source_id,
+        BrowserProjectionDelta {
+            manifest_revision: revision + 3,
+            snapshot_revision: revision + 3,
+            folders: Vec::new(),
+            removed_file_ids: vec![path_id(&new)],
+            upserted_files: Vec::new(),
+        },
+    ));
+    assert!(browser.tree.folders[0].find_file(&path_id(&new)).is_some());
     let _ = fs::remove_dir_all(root);
 }
 

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -119,6 +119,14 @@ impl NativeAppState {
                 let renames_reconciled = success.renames_reconciled;
                 let incomplete_error = success.incomplete_error;
                 let delta = success.committed_delta;
+                let browser_delta_applied = success
+                    .browser_projection_delta
+                    .map(|projection| {
+                        self.library
+                            .folder_browser
+                            .apply_committed_projection_delta(&source_id, projection)
+                    })
+                    .unwrap_or(false);
                 tracing::info!(
                     source_id = %source_id,
                     revision = delta.revision,
@@ -151,7 +159,9 @@ impl NativeAppState {
                             "filesystem_sync_incomplete_after_commit",
                         );
                 }
-                self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
+                if !browser_delta_applied {
+                    self.queue_filesystem_source_refresh(source_id, Instant::now(), context);
+                }
             }
             Err(error) => {
                 tracing::warn!(

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -5,9 +5,13 @@ use std::{
     time::Duration,
 };
 
-use wavecrate::sample_sources::{SourceDatabase, scanner};
+use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase, scanner};
+use wavecrate_library::sample_sources::is_supported_audio;
 
-use crate::native_app::app::{SourceFilesystemSyncResult, SourceFilesystemSyncSuccess};
+use crate::native_app::{
+    app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
+    sample_library::folder_browser::model::file_entry_with_snapshot_metadata,
+};
 
 const MAX_SYNC_ATTEMPTS: usize = 3;
 const SYNC_RETRY_DELAYS: [Duration; MAX_SYNC_ATTEMPTS - 1] =
@@ -58,6 +62,7 @@ fn sync_source_database_paths_once(
     paths: &[PathBuf],
     cancel: &AtomicBool,
 ) -> Result<SourceFilesystemSyncSuccess, String> {
+    let browser_delta_eligible = paths.iter().all(|path| is_supported_audio(path));
     SourceDatabase::open_for_background_job_with_database_root(root, database_root)
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
@@ -90,12 +95,107 @@ fn sync_source_database_paths_once(
                     }
                 }
             };
+            let browser_projection_delta = if browser_delta_eligible
+                && incomplete_error.is_none()
+                && completed.committed_delta.revision > 0
+            {
+                match build_browser_projection_delta(root, &db, &completed.committed_delta) {
+                    Ok(projection) => projection,
+                    Err(error) => {
+                        tracing::warn!(
+                            source_id,
+                            error,
+                            "Falling back to a full browser projection after delta hydration failed"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
             Ok(SourceFilesystemSyncSuccess {
                 renames_reconciled: completed.renames_reconciled,
                 incomplete_error,
                 committed_delta: completed.committed_delta,
+                browser_projection_delta,
             })
         })
+}
+
+fn build_browser_projection_delta(
+    root: &std::path::Path,
+    db: &SourceDatabase,
+    delta: &scanner::CommittedSourceDelta,
+) -> Result<Option<BrowserProjectionDelta>, String> {
+    let BrowserMetadataSnapshot { revision, files } = db
+        .browser_metadata_snapshot()
+        .map_err(|error| format!("read committed browser projection delta: {error}"))?;
+    if revision != delta.revision {
+        tracing::info!(
+            committed_revision = delta.revision,
+            snapshot_revision = revision,
+            "Browser delta snapshot was not the exact committed revision"
+        );
+        return Ok(None);
+    }
+    let upsert_paths = delta
+        .created
+        .iter()
+        .map(|entry| entry.relative_path.as_path())
+        .chain(
+            delta
+                .changed
+                .iter()
+                .map(|entry| entry.relative_path.as_path()),
+        )
+        .chain(
+            delta
+                .moved
+                .iter()
+                .map(|entry| entry.new_relative_path.as_path()),
+        )
+        .collect::<std::collections::HashSet<_>>();
+    let mut folders = std::collections::BTreeSet::new();
+    let upserted_files = files
+        .into_iter()
+        .filter(|entry| !entry.missing && upsert_paths.contains(entry.relative_path.as_path()))
+        .map(|entry| {
+            let absolute = root.join(&entry.relative_path);
+            if let Some(parent) = absolute.parent() {
+                folders.insert(parent.to_path_buf());
+            }
+            file_entry_with_snapshot_metadata(
+                &absolute,
+                entry.file_size,
+                entry.rating,
+                entry.locked,
+                entry.collections,
+                entry.last_played_at,
+                entry.last_curated_at,
+            )
+        })
+        .collect();
+    let removed_file_ids = delta
+        .deleted
+        .iter()
+        .map(|entry| {
+            root.join(&entry.relative_path)
+                .to_string_lossy()
+                .to_string()
+        })
+        .chain(delta.moved.iter().map(|entry| {
+            root.join(&entry.old_relative_path)
+                .to_string_lossy()
+                .to_string()
+        }))
+        .collect();
+    Ok(Some(BrowserProjectionDelta {
+        manifest_revision: delta.revision,
+        snapshot_revision: revision,
+        folders: folders.into_iter().collect(),
+        removed_file_ids,
+        upserted_files,
+    }))
 }
 
 fn wait_for_retry(cancel: &AtomicBool, delay: Duration) -> bool {
@@ -145,6 +245,11 @@ mod tests {
         let success = result.result.expect("sync result");
         assert_eq!(success.renames_reconciled, 1);
         assert_eq!(success.committed_delta.moved.len(), 1);
+        let projection = success
+            .browser_projection_delta
+            .expect("exact browser projection delta");
+        assert_eq!(projection.removed_file_ids.len(), 1);
+        assert_eq!(projection.upserted_files.len(), 1);
         assert_eq!(
             db.entry_for_path(Path::new("new.wav"))
                 .unwrap()
@@ -172,6 +277,14 @@ mod tests {
         let success = result.result.expect("sync result");
         assert_eq!(success.renames_reconciled, 0);
         assert_eq!(success.committed_delta.created.len(), 1);
+        assert_eq!(
+            success
+                .browser_projection_delta
+                .expect("exact browser projection delta")
+                .upserted_files
+                .len(),
+            1
+        );
         let db =
             SourceDatabase::open_for_test_fixture_source_write(root.path()).expect("source db");
         assert!(

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -141,7 +141,7 @@ impl NativeAppState {
         prepared: impl Into<PreparedFolderScanResult>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
-        let prepared = prepared.into();
+        let mut prepared = prepared.into();
         let started_at = Instant::now();
         if let Some(generation) = prepared.lifecycle_generation {
             let source_id = prepared.scan.source_id.clone();
@@ -155,6 +155,13 @@ impl NativeAppState {
                 self.background
                     .source_lifecycle_generations
                     .insert(source_id, generation);
+            } else {
+                tracing::debug!(
+                    source_id,
+                    lifecycle_generation = generation,
+                    "Rejecting folder projection from an inactive source generation"
+                );
+                prepared.scan.cancelled = true;
             }
         }
         let scan_cache_update = prepared.scan_cache_update;


### PR DESCRIPTION
## Goal

Build each native source-refresh browser projection from the authoritative scanner traversal and one coherent metadata snapshot, eliminating the second recursive filesystem walk and mixed-revision UI states.

Closes OPT-1239.

## Scope and non-goals

- Capture browser directory/file layout during the existing authoritative scanner traversal.
- Hydrate supported audio rows from one typed read-only metadata transaction and require its revision to match the committed scan revision.
- Preserve the last complete browser tree and metadata projection when scan hydration is incomplete or fails.
- Fence full results by source lifecycle generation and projection revision.
- Apply contiguous exact watcher deltas directly; fall back to a full refresh for revision gaps, non-audio/directory changes, or incoherent metadata.
- Publish discovery updates in bounded batches and record traversal/snapshot/revision/count/elapsed telemetry.
- Preserve symlink, AppleDouble, ordering, cancellation, collection, and legacy database behavior.
- Does not redesign source processing, watcher ownership, or the source schema.

## Definition of Done

- A full refresh uses one authoritative filesystem traversal and one coherent SQLite snapshot.
- Browser rows cannot combine scanner and metadata revisions.
- Failed or incomplete hydration retains the last good complete projection.
- Tolerated post-commit file-preparation races mark the traversal snapshot incomplete and cannot publish.
- Stale lifecycle generations and non-contiguous deltas cannot overwrite current state.
- Contiguous supported-audio watcher deltas avoid an unnecessary full rescan.
- Empty/nested directories, non-audio files, symlinks, collections, cancellation, and bounded delivery remain covered.
- Runtime telemetry reports traversal count, snapshot count, revision, row counts, and elapsed time.

## Validation

Passed at `bad8caf1b`:

- `cargo check -p wavecrate --lib`
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` (95 passed, including incomplete post-commit snapshot regression)
- `cargo test -p wavecrate-library --lib browser_metadata -- --test-threads=1` (3 passed)
- `cargo test -p wavecrate --lib source_scanning -- --test-threads=1` (20 passed at the implementation head)
- `cargo test -p wavecrate --lib filesystem_refresh -- --test-threads=1` (25 passed)
- `cargo test -p wavecrate --lib source_scan_worker -- --test-threads=1` (3 passed)
- focused watcher tests (48 passed)
- focused committed-file-mutation tests (14 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/ci.sh smoke`
- `bash scripts/build.sh --release`
- `codesign --verify --deep --strict --verbose=2 target/app-bundles/opt1239/Wavecrate\ OPT-1239.app`
- Exact signed branch bundle launched from `target/app-bundles/opt1239/Wavecrate OPT-1239.app`; startup log confirmed that executable and live source initialization.

After the review fix, the complete scanner suite, `cargo check -p wavecrate --lib`, formatting/diff checks, and `bash scripts/ci.sh smoke` pass. Re-linking the native lib-test binary was retried twice but slept at 0% CPU with no linker child and was stopped; this is the known macOS Rust relink stall, not a test failure.

`bash scripts/ci.sh agent` reached the broad test lane. Remaining failures are pre-existing/unrelated: the native-app root-facade guardrail is tracked by OPT-969, and the broad parallel lane contains existing load-sensitive failures. The focused starmap size expectation also fails alone on current main because current WAV policy classifies every WAV as file-backed regardless of size. This diff introduced no additional facade exports.

## Known limitations

- Computer-use accessibility capture timed out while the live app was spending high CPU in the existing main-thread harvest projection, so signed-app evidence covers exact bundle launch/startup rather than a completed automated source-switch interaction.
- Existing broad CI failures and the macOS lib-test relink stall described above remain independently owned/environmental.

User approval is required before merge.

