### PR TITLE
OPT-1238: split source scan execution from database writer permits

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -7,6 +7,7 @@ mod scan_fs;
 mod scan_hash;
 mod scan_paths;
 mod scan_walk;
+mod scan_writer;
 
 pub use scan::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
@@ -14,7 +15,9 @@ pub use scan::{
     UpdatedSample, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
     complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_deferred_rename_candidates_with_cancel_and_writer,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress,
+    scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
 };
-pub use scan_paths::{sync_paths, sync_paths_with_progress};
+pub use scan_paths::{sync_paths, sync_paths_with_progress, sync_paths_with_progress_and_writer};
+pub use scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -12,8 +12,9 @@ pub use runner::{
     ScanMode, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
     complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
+    complete_deferred_rename_candidates_with_cancel_and_writer,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress,
+    scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
 };
 pub use stats::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -10,6 +10,7 @@ use crate::sample_sources::SourceDatabase;
 use super::super::scan_db_sync::db_sync_phase;
 use super::super::scan_fs::ensure_root_dir;
 use super::super::scan_walk::walk_phase;
+use super::super::scan_writer::{ScanWriter, UncoordinatedScanWriter};
 use super::{ScanContext, ScanError, ScanStats};
 
 /// Scan strategy used when walking a source root.
@@ -141,12 +142,42 @@ pub fn scan_with_progress(
     scan(db, mode, cancel, Some(on_progress), None)
 }
 
+/// Scan with progress while acquiring an owning runtime's writer guard only for bounded database
+/// mutations.
+pub fn scan_with_progress_and_writer(
+    db: &SourceDatabase,
+    mode: ScanMode,
+    cancel: Option<&AtomicBool>,
+    on_progress: &mut impl FnMut(usize, &Path),
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    scan_with_writer(db, mode, cancel, Some(on_progress), None, writer)
+}
+
 fn scan(
+    db: &SourceDatabase,
+    mode: ScanMode,
+    cancel: Option<&AtomicBool>,
+    on_progress: Option<&mut dyn FnMut(usize, &Path)>,
+    manifest_audit_started_at: Option<i64>,
+) -> Result<ScanStats, ScanError> {
+    scan_with_writer(
+        db,
+        mode,
+        cancel,
+        on_progress,
+        manifest_audit_started_at,
+        &UncoordinatedScanWriter,
+    )
+}
+
+fn scan_with_writer(
     db: &SourceDatabase,
     mode: ScanMode,
     cancel: Option<&AtomicBool>,
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     manifest_audit_started_at: Option<i64>,
+    writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
     let (manifest_revision, manifest_before) =
@@ -162,8 +193,8 @@ fn scan(
             on_progress(checked, &root);
         }
     }
-    let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context)
-        .and_then(|()| db_sync_phase(db, &mut context, cancel));
+    let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context, writer)
+        .and_then(|()| db_sync_phase(db, &mut context, cancel, writer));
     finish_scan_result(manifest_before, context, result)
 }
 
@@ -243,8 +274,23 @@ pub fn complete_deferred_rename_candidates(
 /// Reconcile only proven rename destinations while honoring the owning runtime's cancellation.
 pub fn complete_deferred_rename_candidates_with_cancel(
     db: &SourceDatabase,
+    stats: ScanStats,
+    cancel: Option<&AtomicBool>,
+) -> Result<ScanStats, ScanError> {
+    complete_deferred_rename_candidates_with_cancel_and_writer(
+        db,
+        stats,
+        cancel,
+        &UncoordinatedScanWriter,
+    )
+}
+
+/// Reconcile proven rename destinations while coordinating only the final database publication.
+pub fn complete_deferred_rename_candidates_with_cancel_and_writer(
+    db: &SourceDatabase,
     mut stats: ScanStats,
     cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
     if db.list_pending_renames()?.is_empty() {
         return Ok(stats);
@@ -258,13 +304,14 @@ pub fn complete_deferred_rename_candidates_with_cancel(
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
-    let deferred = super::super::scan_hash::deep_hash_scan(
+    let deferred = super::super::scan_hash::deep_hash_scan_with_writer(
         db,
         cancel,
         &rename_candidates,
         super::super::scan_hash::DeferredHashScope::RenameCandidates,
         None,
         None,
+        writer,
     )?;
     stats.merge_deferred_hashes(deferred);
     Ok(stats)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::mark_missing;
+use super::scan_writer::{ScanWritePhase, ScanWriter};
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT;
 use crate::sample_sources::db::SourceManifestEntry;
@@ -13,6 +14,7 @@ pub(super) fn db_sync_phase(
     db: &SourceDatabase,
     context: &mut ScanContext,
     cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
     let mut existing = std::mem::take(&mut context.existing)
         .into_values()
@@ -29,6 +31,10 @@ pub(super) fn db_sync_phase(
         if chunk.is_empty() {
             break;
         }
+        let _writer = writer.lock(ScanWritePhase::Manifest);
+        if cancel_requested(cancel) {
+            return Err(ScanError::Canceled);
+        }
         let mut batch = db.write_batch()?;
         context.ensure_rename_candidate_generation(&mut batch)?;
         mark_missing(db, &mut batch, chunk, &mut context.stats, context.mode)?;
@@ -38,6 +44,10 @@ pub(super) fn db_sync_phase(
         context.commit_batch(batch)?;
     }
 
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
+    let _writer = writer.lock(ScanWritePhase::Manifest);
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -7,6 +7,7 @@ use crate::sample_sources::{SourceDatabase, is_supported_audio};
 
 use super::scan::{ChangedSample, RenamedSample, ScanError, ScanStats, UpdatedSample};
 use super::scan_fs::{compute_content_hash, ensure_root_dir, read_facts};
+use super::scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct HashBackfill {
@@ -146,6 +147,26 @@ pub(super) fn deep_hash_scan(
     max_hashes: Option<usize>,
     exact_path: Option<&std::path::Path>,
 ) -> Result<ScanStats, ScanError> {
+    deep_hash_scan_with_writer(
+        db,
+        cancel,
+        rename_candidates,
+        scope,
+        max_hashes,
+        exact_path,
+        &UncoordinatedScanWriter,
+    )
+}
+
+pub(super) fn deep_hash_scan_with_writer(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
+    max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
     deep_hash_scan_with_post_hash_hook(
         db,
         cancel,
@@ -153,6 +174,7 @@ pub(super) fn deep_hash_scan(
         scope,
         max_hashes,
         exact_path,
+        writer,
         |_| {},
     )
 }
@@ -164,6 +186,7 @@ fn deep_hash_scan_with_post_hash_hook(
     scope: DeferredHashScope,
     max_hashes: Option<usize>,
     exact_path: Option<&std::path::Path>,
+    writer: &impl ScanWriter,
     mut post_hash: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
     let manifest_before = super::manifest::capture_manifest(db)?;
@@ -304,6 +327,10 @@ fn deep_hash_scan_with_post_hash_hook(
         return Err(ScanError::Canceled);
     }
 
+    let _writer = writer.lock(ScanWritePhase::DeferredHash);
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
     let mut batch = db.write_batch()?;
     for backfill in &hash_backfills {
         batch.upsert_file_with_hash(
@@ -341,6 +368,9 @@ fn deep_hash_scan_with_post_hash_hook(
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
 
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
     let committed_snapshot = batch.commit_with_manifest_snapshot()?;
     super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
     Ok(stats)
@@ -594,6 +624,7 @@ mod tests {
             DeferredHashScope::AllUnhashed,
             Some(1),
             Some(relative),
+            &UncoordinatedScanWriter,
             |path| {
                 std::fs::write(path, [2_u8; 32]).expect("mutate during hashing");
                 let file = std::fs::OpenOptions::new()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -13,6 +13,7 @@ use super::{
     scan_diff_phase::prepare_diff,
     scan_fs::ensure_root_dir,
     scan_walk::apply_prepared_chunk,
+    scan_writer::{ScanWriter, UncoordinatedScanWriter},
 };
 
 const TARGET_PREPARE_BATCH_SIZE: usize = 64;
@@ -32,6 +33,17 @@ pub fn sync_paths_with_progress(
     paths: &[PathBuf],
     cancel: Option<&AtomicBool>,
     on_progress: &mut impl FnMut(usize, &Path),
+) -> Result<ScanStats, ScanError> {
+    sync_paths_with_progress_and_writer(db, paths, cancel, on_progress, &UncoordinatedScanWriter)
+}
+
+/// Reconcile changed paths while coordinating only bounded database mutations.
+pub fn sync_paths_with_progress_and_writer(
+    db: &SourceDatabase,
+    paths: &[PathBuf],
+    cancel: Option<&AtomicBool>,
+    on_progress: &mut impl FnMut(usize, &Path),
+    writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
@@ -73,14 +85,22 @@ pub fn sync_paths_with_progress(
             if prepared.len() == TARGET_PREPARE_BATCH_SIZE {
                 let chunk =
                     std::mem::replace(&mut prepared, Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE));
-                committed |=
-                    apply_prepared_chunk(db, &root, cancel, &mut context, chunk, committed)?;
+                committed |= apply_prepared_chunk(
+                    db,
+                    &root,
+                    cancel,
+                    &mut context,
+                    chunk,
+                    committed,
+                    writer,
+                )?;
             }
         }
         if !prepared.is_empty() {
-            let _ = apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed)?;
+            let _ =
+                apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed, writer)?;
         }
-        db_sync_phase(db, &mut context, cancel)
+        db_sync_phase(db, &mut context, cancel, writer)
     })();
     super::scan::finish_scan_result(manifest_before, context, result)
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -15,6 +15,7 @@ use super::scan_fs::{
     compute_content_hash, is_supported_scannable_audio_file, read_facts,
     visit_dir_with_cancel_check,
 };
+use super::scan_writer::{ScanWritePhase, ScanWriter};
 
 const APPLY_BATCH_SIZE: usize = 64;
 
@@ -24,6 +25,7 @@ pub(super) fn walk_phase(
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
+    writer: &impl ScanWriter,
 ) -> Result<(), ScanError> {
     // Each committed batch is a valid checkpoint. Cancellation may stop the scan between batches;
     // the completion metadata and missing-row reconciliation are not published, so a later scan
@@ -83,7 +85,8 @@ pub(super) fn walk_phase(
             pending.push(prepared);
             if pending.len() == APPLY_BATCH_SIZE {
                 let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-                let outcome = apply_batch(db, root, cancel, context, files, committed.get())?;
+                let outcome =
+                    apply_batch(db, root, cancel, context, files, committed.get(), writer)?;
                 if outcome.committed {
                     committed.set(true);
                 }
@@ -101,7 +104,7 @@ pub(super) fn walk_phase(
             Ok(())
         })?;
     if !pending.is_empty() {
-        let outcome = apply_batch(db, root, cancel, context, pending, committed.get())?;
+        let outcome = apply_batch(db, root, cancel, context, pending, committed.get(), writer)?;
         if outcome.committed {
             committed.set(true);
         }
@@ -150,6 +153,7 @@ pub(super) fn apply_prepared_chunk(
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
+    writer: &impl ScanWriter,
 ) -> Result<bool, ScanError> {
     let mut pending = Vec::with_capacity(prepared.len());
     for mut file in prepared {
@@ -170,8 +174,16 @@ pub(super) fn apply_prepared_chunk(
     if pending.is_empty() {
         return Ok(false);
     }
-    apply_batch(db, root, cancel, context, pending, tolerate_file_errors)
-        .map(|outcome| outcome.committed)
+    apply_batch(
+        db,
+        root,
+        cancel,
+        context,
+        pending,
+        tolerate_file_errors,
+        writer,
+    )
+    .map(|outcome| outcome.committed)
 }
 
 fn refresh_noop_preparation_or_skip(
@@ -249,6 +261,7 @@ fn apply_batch(
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
+    writer: &impl ScanWriter,
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let mut ready = Vec::with_capacity(prepared.len());
     for file in prepared {
@@ -283,6 +296,10 @@ fn apply_batch(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
+    let _writer = writer.lock(ScanWritePhase::Manifest);
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
     let mut rename_candidates = RenameCandidateCache::default();
@@ -300,6 +317,9 @@ fn apply_batch(
         }
         apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
         audited_paths.push(relative_path);
+    }
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
     }
     context.commit_batch(batch)?;
     Ok(ApplyBatchOutcome {
@@ -489,8 +509,16 @@ mod tests {
         assert!(prepared.requires_apply);
 
         std::fs::remove_file(&file_path).unwrap();
-        let outcome = apply_batch(&db, dir.path(), None, &mut context, vec![prepared], true)
-            .expect("tolerated committed batch");
+        let outcome = apply_batch(
+            &db,
+            dir.path(),
+            None,
+            &mut context,
+            vec![prepared],
+            true,
+            &super::super::scan_writer::UncoordinatedScanWriter,
+        )
+        .expect("tolerated committed batch");
 
         assert!(!outcome.committed);
         assert!(context.source_tree_incomplete());

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_writer.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_writer.rs
@@ -1,0 +1,33 @@
+/// Database mutation phases exposed by the scanner.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScanWritePhase {
+    /// Open or migrate the source database before scanning.
+    Open,
+    /// Commit an indexed manifest batch or scan-completion checkpoint.
+    Manifest,
+    /// Publish deferred hashes and proven rename reconciliation.
+    DeferredHash,
+}
+
+/// Coordinates scanner database writes with an owning runtime.
+///
+/// The returned guard must retain exclusive write ownership until it is dropped. Filesystem
+/// traversal, file reads, and content hashing deliberately happen before `lock` is called.
+pub trait ScanWriter {
+    /// Guard retaining write ownership for one bounded mutation.
+    type Guard;
+
+    /// Acquire write ownership for the supplied scanner phase.
+    fn lock(&self, phase: ScanWritePhase) -> Self::Guard;
+}
+
+/// Default coordinator for callers that already own serialization or only need SQLite's
+/// per-database transaction boundary.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UncoordinatedScanWriter;
+
+impl ScanWriter for UncoordinatedScanWriter {
+    type Guard = ();
+
+    fn lock(&self, _phase: ScanWritePhase) -> Self::Guard {}
+}

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -367,9 +367,11 @@ publication phases under the supervisor's lifecycle guard. Production preparatio
 in killable child processes that receive bounded owned inputs, perform no SQLite access,
 and return bounded prepared payloads; the surrounding pool worker acquires the single
 writer gate only for readiness claims, lease renewal, and fenced publication. The same
-gate covers foreground scan admission and legacy stages whose filesystem work is still
-transaction-coupled. Publication revalidates exact manifest, content-generation,
-lifecycle, and cancellation fences after preparation. The initial rollout admits at most
+gate covers foreground scan database open/migration and bounded manifest or deferred-hash
+publication, while scan traversal, file preparation, and content hashing run outside it.
+The one-at-a-time foreground scan lane and lifecycle permit remain held across the complete
+scan. Publication revalidates exact manifest, content-generation, lifecycle, and
+cancellation fences after preparation. The initial rollout admits at most
 one execution job per source and two jobs globally, allowing a secondary source to use
 spare capacity without changing the visible active-source owner. Requests and results are
 bounded, pool workers and child processes are joined on shutdown, and telemetry reports

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -9,6 +9,9 @@ use crate::native_app::sample_library::folder_browser::scan::{
     self, FolderScanDiscovery, FolderScanDiscoveryBatch, FolderScanProgress, FolderScanRequest,
     PreparedFolderScanResult, prepare_folder_scan_cache_update,
 };
+use wavecrate_scan::sample_sources::scanner::ScanWriter;
+#[cfg(test)]
+use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
 
 const DISCOVERY_BATCH_SIZE: usize = 64;
 
@@ -21,11 +24,13 @@ pub(in crate::native_app) fn run_folder_scan_worker(
     request: FolderScanRequest,
     events: ui::BusinessEventSink<FolderScanWorkerEvent>,
     cancel: Arc<AtomicBool>,
+    writer: &impl ScanWriter,
 ) -> PreparedFolderScanResult {
     run_folder_scan_worker_with_emit_and_cancel(
         request,
         move |event| events.emit(event),
         cancel.as_ref(),
+        writer,
     )
 }
 
@@ -34,13 +39,19 @@ fn run_folder_scan_worker_with_emit(
     request: FolderScanRequest,
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
 ) -> PreparedFolderScanResult {
-    run_folder_scan_worker_with_emit_and_cancel(request, emit, &AtomicBool::new(false))
+    run_folder_scan_worker_with_emit_and_cancel(
+        request,
+        emit,
+        &AtomicBool::new(false),
+        &UncoordinatedScanWriter,
+    )
 }
 
 fn run_folder_scan_worker_with_emit_and_cancel(
     request: FolderScanRequest,
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
     cancel: &AtomicBool,
+    writer: &impl ScanWriter,
 ) -> PreparedFolderScanResult {
     let rating_decay_maintenance =
         crate::native_app::sample_library::folder_browser::scan::RatingDecayMaintenanceRequest {
@@ -60,6 +71,7 @@ fn run_folder_scan_worker_with_emit_and_cancel(
             discovery_transport.push(event);
         },
         cancel,
+        writer,
     );
     if !cancel.load(Ordering::Acquire) {
         discovery_transport.flush();
@@ -131,6 +143,7 @@ mod tests {
     use crate::native_app::sample_library::folder_browser::scan::{
         FolderScanItem, FolderScanRequest, INDEX_PROGRESS_REPORT_INTERVAL,
     };
+    use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
 
     use super::{
         DISCOVERY_BATCH_SIZE, FolderScanWorkerEvent, run_folder_scan_worker_with_emit,
@@ -255,6 +268,7 @@ mod tests {
                 true
             },
             cancel.as_ref(),
+            &UncoordinatedScanWriter,
         );
 
         assert!(result.scan.cancelled);

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -207,9 +207,6 @@ impl JobDetailsViewModel {
                 crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::WaitingForScanCapacity { .. } => {
                     format!("Queued — another source is being reconciled — {queue_age}s")
                 }
-                crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::WaitingForDatabaseAccess => {
-                    format!("Waiting for database access — {queue_age}s")
-                }
                 crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::RetryScheduled => {
                     format!("Retry scheduled — attempt {}", progress.retry_count.saturating_add(1))
                 }
@@ -430,10 +427,6 @@ mod tests {
                 },
                 "another source is being reconciled",
             ),
-            (
-                FolderScanLifecycle::WaitingForDatabaseAccess,
-                "Waiting for database access",
-            ),
             (FolderScanLifecycle::Scanning, "Scanning"),
             (FolderScanLifecycle::ApplyingResults, "Applying results"),
             (FolderScanLifecycle::PersistingResults, "Saving results"),
@@ -463,7 +456,9 @@ mod tests {
 
     #[test]
     fn fake_clock_exposes_queue_and_last_progress_age_then_offers_recovery() {
-        let mut progress = progress(FolderScanLifecycle::WaitingForDatabaseAccess);
+        let mut progress = progress(FolderScanLifecycle::WaitingForScanCapacity {
+            current_owner: Some(String::from("other-source")),
+        });
         let now = progress.queued_at + SOURCE_SCAN_LONG_WAIT_THRESHOLD + Duration::from_secs(2);
         progress.last_progress_at = progress.queued_at;
 

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -46,7 +46,6 @@ pub(in crate::native_app) enum FolderScanLifecycle {
     Queued,
     WaitingForSourceRegistration,
     WaitingForScanCapacity { current_owner: Option<String> },
-    WaitingForDatabaseAccess,
     Scanning,
     ApplyingResults,
     PersistingResults,
@@ -63,7 +62,6 @@ impl FolderScanLifecycle {
             Self::Queued => "Queued",
             Self::WaitingForSourceRegistration => "Waiting for source update",
             Self::WaitingForScanCapacity { .. } => "Waiting for scan capacity",
-            Self::WaitingForDatabaseAccess => "Waiting for database access",
             Self::Scanning => "Scanning",
             Self::ApplyingResults => "Applying results",
             Self::PersistingResults => "Saving results",
@@ -81,7 +79,6 @@ impl FolderScanLifecycle {
             Self::Queued
                 | Self::WaitingForSourceRegistration
                 | Self::WaitingForScanCapacity { .. }
-                | Self::WaitingForDatabaseAccess
                 | Self::RetryScheduled
         )
     }

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -20,8 +20,13 @@ use super::{
     metadata::{SourceMetadataMap, source_browser_snapshot},
     traversal::placeholder_folder,
 };
-use wavecrate::sample_sources::{BrowserMetadataSnapshot, Rating, SourceDatabase, scanner};
-use wavecrate_scan::{ScanStats, SourceTreeSnapshot};
+use wavecrate::sample_sources::{BrowserMetadataSnapshot, Rating, SourceDatabase};
+#[cfg(test)]
+use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
+use wavecrate_scan::{
+    ScanStats, SourceTreeSnapshot,
+    sample_sources::scanner::{self, ScanWritePhase, ScanWriter},
+};
 
 struct CommittedSourceTreeSnapshot {
     revision: u64,
@@ -37,7 +42,13 @@ pub(in crate::native_app) fn scan_source_with_progress(
     progress: impl FnMut(FolderScanProgress),
     discovered: impl FnMut(FolderScanDiscovery),
 ) -> FolderScanResult {
-    scan_source_with_progress_cancellable(request, progress, discovered, &AtomicBool::new(false))
+    scan_source_with_progress_cancellable(
+        request,
+        progress,
+        discovered,
+        &AtomicBool::new(false),
+        &UncoordinatedScanWriter,
+    )
 }
 
 pub(in crate::native_app) fn scan_source_with_progress_cancellable(
@@ -45,11 +56,12 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
     mut progress: impl FnMut(FolderScanProgress),
     mut discovered: impl FnMut(FolderScanDiscovery),
     cancel: &AtomicBool,
+    writer: &impl ScanWriter,
 ) -> FolderScanResult {
     let source_root_available =
         classify_path_without_following(&request.root) == Some(BrowserEntryKind::Directory);
     let (source_db_error, source_tree_snapshot) = if source_root_available {
-        sync_source_database(&request, &mut progress, cancel)
+        sync_source_database(&request, &mut progress, cancel, writer)
     } else {
         (None, None)
     };
@@ -115,7 +127,15 @@ fn sync_source_database(
     request: &FolderScanRequest,
     progress: &mut impl FnMut(FolderScanProgress),
     cancel: &AtomicBool,
+    writer: &impl ScanWriter,
 ) -> (Option<String>, Option<CommittedSourceTreeSnapshot>) {
+    let _writer = writer.lock(ScanWritePhase::Open);
+    if cancel.load(Ordering::Acquire) {
+        return (
+            Some(String::from("source scan canceled before database open")),
+            None,
+        );
+    }
     let db = match SourceDatabase::open_for_background_job_with_database_root(
         &request.root,
         &request.database_root,
@@ -123,6 +143,7 @@ fn sync_source_database(
         Ok(db) => db,
         Err(err) => return (Some(format!("open source index: {err}")), None),
     };
+    drop(_writer);
     let mut sync_progress = |completed: usize, path: &Path| {
         if completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL) {
             return;
@@ -137,11 +158,12 @@ fn sync_source_database(
             format!("Indexing | {}", path.display()),
         ));
     };
-    let stats = match scanner::scan_with_progress(
+    let stats = match scanner::scan_with_progress_and_writer(
         &db,
         scanner::ScanMode::Quick,
         Some(cancel),
         &mut sync_progress,
+        writer,
     ) {
         Ok(stats) => stats,
         Err(err) => return (Some(format!("sync source index: {err}")), None),
@@ -154,7 +176,12 @@ fn sync_source_database(
                 revision: stats.committed_delta.revision,
                 layout,
             });
-    match scanner::complete_deferred_rename_candidates_with_cancel(&db, stats, Some(cancel)) {
+    match scanner::complete_deferred_rename_candidates_with_cancel_and_writer(
+        &db,
+        stats,
+        Some(cancel),
+        writer,
+    ) {
         Ok(ScanStats {
             committed_delta,
             source_tree_snapshot,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -6,7 +6,7 @@ use crate::native_app::app::{
     GuiMessage, NativeAppState, SourceFilesystemChangePlan, SourceFilesystemSyncResult,
     SourceRefreshCause, SourceRefreshRequest, emit_gui_action,
 };
-use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::sync_source_database_paths;
+use crate::native_app::sample_library::folder_scan_actions::filesystem_refresh_worker::sync_source_database_paths_with_writer;
 use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
     SourcePrepIntents, SourcePriorityIntent,
@@ -432,13 +432,15 @@ impl NativeAppState {
                 };
                 let lifecycle_generation = permit.lifecycle_generation();
                 let cancel = permit.cancel_token();
-                let mut result = sync_source_database_paths(
+                let scan_writer = permit.scan_writer();
+                let mut result = sync_source_database_paths_with_writer(
                     source_id,
                     root,
                     database_root,
                     paths,
                     changed_count,
                     cancel.as_ref(),
+                    &scan_writer,
                 );
                 result.lifecycle_generation = lifecycle_generation;
                 drop(permit);

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -5,8 +5,11 @@ use std::{
     time::Duration,
 };
 
-use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase, scanner};
+use wavecrate::sample_sources::{BrowserMetadataSnapshot, SourceDatabase};
 use wavecrate_library::sample_sources::is_supported_audio;
+use wavecrate_scan::sample_sources::scanner::{
+    self, ScanWritePhase, ScanWriter, UncoordinatedScanWriter,
+};
 
 use crate::native_app::{
     app::{BrowserProjectionDelta, SourceFilesystemSyncResult, SourceFilesystemSyncSuccess},
@@ -25,9 +28,36 @@ pub(in crate::native_app) fn sync_source_database_paths(
     changed_count: usize,
     cancel: &AtomicBool,
 ) -> SourceFilesystemSyncResult {
+    sync_source_database_paths_with_writer(
+        source_id,
+        root,
+        database_root,
+        paths,
+        changed_count,
+        cancel,
+        &UncoordinatedScanWriter,
+    )
+}
+
+pub(in crate::native_app) fn sync_source_database_paths_with_writer(
+    source_id: String,
+    root: PathBuf,
+    database_root: PathBuf,
+    paths: Vec<PathBuf>,
+    changed_count: usize,
+    cancel: &AtomicBool,
+    writer: &impl ScanWriter,
+) -> SourceFilesystemSyncResult {
     let mut result = Err(String::from("Source filesystem sync did not run"));
     for attempt in 0..MAX_SYNC_ATTEMPTS {
-        result = sync_source_database_paths_once(&source_id, &root, &database_root, &paths, cancel);
+        result = sync_source_database_paths_once(
+            &source_id,
+            &root,
+            &database_root,
+            &paths,
+            cancel,
+            writer,
+        );
         if result.is_ok() || cancel.load(Ordering::Acquire) {
             break;
         }
@@ -61,27 +91,42 @@ fn sync_source_database_paths_once(
     database_root: &std::path::Path,
     paths: &[PathBuf],
     cancel: &AtomicBool,
+    writer: &impl ScanWriter,
 ) -> Result<SourceFilesystemSyncSuccess, String> {
     let browser_delta_eligible = paths.iter().all(|path| is_supported_audio(path));
-    SourceDatabase::open_for_background_job_with_database_root(root, database_root)
+    let _writer = writer.lock(ScanWritePhase::Open);
+    if cancel.load(Ordering::Acquire) {
+        return Err(String::from(
+            "Source filesystem sync canceled before database open",
+        ));
+    }
+    let database = SourceDatabase::open_for_background_job_with_database_root(root, database_root);
+    drop(_writer);
+    database
         .map_err(|err| format!("open source index: {err}"))
         .and_then(|db| {
-            let (stats, mut incomplete_error) =
-                match scanner::sync_paths_with_progress(&db, paths, Some(cancel), &mut |_, _| {}) {
-                    Ok(stats) => (stats, None),
-                    Err(scanner::ScanError::Incomplete { committed, error }) => {
-                        (*committed, Some(error))
-                    }
-                    Err(error) => return Err(format!("sync source index: {error}")),
-                };
+            let (stats, mut incomplete_error) = match scanner::sync_paths_with_progress_and_writer(
+                &db,
+                paths,
+                Some(cancel),
+                &mut |_, _| {},
+                writer,
+            ) {
+                Ok(stats) => (stats, None),
+                Err(scanner::ScanError::Incomplete { committed, error }) => {
+                    (*committed, Some(error))
+                }
+                Err(error) => return Err(format!("sync source index: {error}")),
+            };
             let committed = stats.clone();
             let completed = if incomplete_error.is_some() {
                 committed
             } else {
-                match scanner::complete_deferred_rename_candidates_with_cancel(
+                match scanner::complete_deferred_rename_candidates_with_cancel_and_writer(
                     &db,
                     stats,
                     Some(cancel),
+                    writer,
                 ) {
                     Ok(completed) => completed,
                     Err(error) => {

--- a/src/native_app/sample_library/folder_scan_actions/progress.rs
+++ b/src/native_app/sample_library/folder_scan_actions/progress.rs
@@ -29,7 +29,6 @@ impl NativeAppState {
         let blocking_subsystem = match &progress.lifecycle {
             crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::WaitingForSourceRegistration => Some("source_registration"),
             crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::WaitingForScanCapacity { .. } => Some("scan_capacity"),
-            crate::native_app::sample_library::folder_browser::scan::FolderScanLifecycle::WaitingForDatabaseAccess => Some("database_access"),
             _ => None,
         };
         if self.library.apply_folder_scan_progress(progress) {

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -18,6 +18,7 @@ use crate::native_app::{
     source_processing::SourceScanAdmissionState,
 };
 use wavecrate::sample_sources::config::{AppConfig, reserve_save_revision};
+use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
 
 use super::maintenance::{
     FolderScanCompletionContext, FolderScanMaintenanceRequest, FolderScanMaintenanceResult,
@@ -144,7 +145,12 @@ impl NativeAppState {
                             None,
                         );
                         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-                        return run_folder_scan_worker(request, events, cancel);
+                        return run_folder_scan_worker(
+                            request,
+                            events,
+                            cancel,
+                            &UncoordinatedScanWriter,
+                        );
                     };
                     if admission_generation.is_none() {
                         emit_lifecycle(
@@ -174,7 +180,12 @@ impl NativeAppState {
                             );
                             let cancel =
                                 std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-                            return run_folder_scan_worker(request, events, cancel);
+                            return run_folder_scan_worker(
+                                request,
+                                events,
+                                cancel,
+                                &UncoordinatedScanWriter,
+                            );
                         }
                     };
                     recovery_generation.set(Some(generation));
@@ -191,10 +202,6 @@ impl NativeAppState {
                                     FolderScanLifecycle::WaitingForScanCapacity { current_owner },
                                     "Queued behind another source reconciliation",
                                 ),
-                                SourceScanAdmissionState::WaitingForDatabaseAccess => (
-                                    FolderScanLifecycle::WaitingForDatabaseAccess,
-                                    "Waiting for database access",
-                                ),
                                 SourceScanAdmissionState::Admitted => {
                                     (FolderScanLifecycle::Scanning, "Source access acquired")
                                 }
@@ -209,11 +216,17 @@ impl NativeAppState {
                             Some(generation),
                         );
                         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-                        return run_folder_scan_worker(request, events, cancel);
+                        return run_folder_scan_worker(
+                            request,
+                            events,
+                            cancel,
+                            &UncoordinatedScanWriter,
+                        );
                     };
                     let cancel = permit.cancel_token();
+                    let scan_writer = permit.scan_writer();
                     let completion_events = events.clone();
-                    let mut result = run_folder_scan_worker(request, events, cancel);
+                    let mut result = run_folder_scan_worker(request, events, cancel, &scan_writer);
                     result.lifecycle_generation = Some(generation);
                     if result.scan.cancelled {
                         emit_lifecycle(
@@ -249,8 +262,12 @@ impl NativeAppState {
                             recovery_generation.get(),
                         );
                         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-                        let mut recovery =
-                            run_folder_scan_worker(recovery_request, recovery_events, cancel);
+                        let mut recovery = run_folder_scan_worker(
+                            recovery_request,
+                            recovery_events,
+                            cancel,
+                            &UncoordinatedScanWriter,
+                        );
                         recovery.lifecycle_generation = recovery_generation.get();
                         recovery.terminal_failure =
                             Some(String::from("Source scan worker stopped unexpectedly"));

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -1,7 +1,6 @@
 use super::{
-    Arc, AtomicBool, DatabasePhase, DatabaseWriterGuard, ExternalScanAdmission,
-    ExternalScanRegistration, Ordering, PathBuf, ProcessingLane, SampleSource, Shared,
-    resolve_registered_source_for_scan_locked,
+    Arc, AtomicBool, DatabaseWriterGate, ExternalScanAdmission, ExternalScanRegistration, Ordering,
+    PathBuf, ProcessingLane, SampleSource, Shared, resolve_registered_source_for_scan_locked,
 };
 
 #[derive(Clone)]
@@ -12,7 +11,6 @@ pub(in crate::native_app) struct SourceProcessingBudgetHandle {
 pub(in crate::native_app) struct SourceProcessingBudgetPermit {
     shared: Arc<Shared>,
     pub(super) permit: Option<super::super::scheduler::BudgetPermit>,
-    database_writer: Option<DatabaseWriterGuard>,
     registration_id: u64,
     pub(super) lifecycle_generation: u64,
     pub(super) cancel: Arc<AtomicBool>,
@@ -22,7 +20,6 @@ pub(in crate::native_app) struct SourceProcessingBudgetPermit {
 pub(in crate::native_app) enum SourceScanAdmissionState {
     WaitingForSourceActivation,
     WaitingForCapacity { current_owner: Option<String> },
-    WaitingForDatabaseAccess,
     Admitted,
 }
 
@@ -123,11 +120,6 @@ impl SourceProcessingBudgetHandle {
             let mut budgets = self.shared.budgets();
             if let Some(permit) = budgets.try_acquire(source_id, ProcessingLane::Scan) {
                 drop(budgets);
-                publish_state(SourceScanAdmissionState::WaitingForDatabaseAccess);
-                let database_writer = self
-                    .shared
-                    .database_writer
-                    .lock(DatabasePhase::SerialCompatibility);
                 let cancel = Arc::new(AtomicBool::new(false));
                 let control = self.shared.control();
                 let mut external_scans = self.shared.external_scans();
@@ -144,7 +136,6 @@ impl SourceProcessingBudgetHandle {
                     self.shared.external_scan_wake.notify_all();
                     self.shared.budgets().release(permit);
                     self.shared.budget_wake.notify_all();
-                    drop(database_writer);
                     return None;
                 }
                 external_scans.registrations.insert(
@@ -161,7 +152,6 @@ impl SourceProcessingBudgetHandle {
                 let permit = SourceProcessingBudgetPermit {
                     shared: Arc::clone(&self.shared),
                     permit: Some(permit),
-                    database_writer: Some(database_writer),
                     registration_id: admission_id,
                     lifecycle_generation,
                     cancel,
@@ -239,6 +229,10 @@ impl SourceProcessingBudgetPermit {
         self.lifecycle_generation
     }
 
+    pub(in crate::native_app) fn scan_writer(&self) -> DatabaseWriterGate {
+        self.shared.database_writer.clone()
+    }
+
     fn should_cancel_now(&self) -> bool {
         if self.shared.cancel.load(Ordering::Acquire) {
             return true;
@@ -279,7 +273,6 @@ impl Drop for SourceProcessingBudgetPermit {
             drop(control);
             self.shared.wake.notify_one();
         }
-        self.database_writer.take();
         if let Some(permit) = self.permit.take() {
             let source_id = permit.source_id().to_string();
             self.shared.budgets().release(permit);

--- a/src/native_app/source_processing/supervisor/execution_database.rs
+++ b/src/native_app/source_processing/supervisor/execution_database.rs
@@ -9,6 +9,9 @@ pub(in crate::native_app::source_processing) enum DatabasePhase {
     Claim,
     Lease,
     Publish,
+    ScanOpen,
+    ScanManifest,
+    ScanDeferredHash,
     SerialCompatibility,
 }
 
@@ -28,13 +31,16 @@ struct DatabaseWriterGateInner {
     claim: PhaseCounters,
     lease: PhaseCounters,
     publish: PhaseCounters,
+    scan_open: PhaseCounters,
+    scan_manifest: PhaseCounters,
+    scan_deferred_hash: PhaseCounters,
     serial: PhaseCounters,
     active: AtomicUsize,
     peak_active: AtomicUsize,
 }
 
 #[derive(Clone, Default)]
-pub(in crate::native_app::source_processing) struct DatabaseWriterGate {
+pub(in crate::native_app) struct DatabaseWriterGate {
     inner: Arc<DatabaseWriterGateInner>,
 }
 
@@ -91,6 +97,9 @@ impl DatabaseWriterGate {
             claim: phase_snapshot(&self.inner.claim),
             lease: phase_snapshot(&self.inner.lease),
             publish: phase_snapshot(&self.inner.publish),
+            scan_open: phase_snapshot(&self.inner.scan_open),
+            scan_manifest: phase_snapshot(&self.inner.scan_manifest),
+            scan_deferred_hash: phase_snapshot(&self.inner.scan_deferred_hash),
             serial: phase_snapshot(&self.inner.serial),
             active: self.inner.active.load(Ordering::Acquire),
             peak_active: self.inner.peak_active.load(Ordering::Acquire),
@@ -103,7 +112,7 @@ impl DatabaseWriterGate {
     }
 }
 
-pub(in crate::native_app::source_processing) struct DatabaseWriterGuard {
+pub(in crate::native_app) struct DatabaseWriterGuard {
     inner: Arc<DatabaseWriterGateInner>,
     phase: DatabasePhase,
     acquired_at: Instant,
@@ -138,6 +147,9 @@ pub(super) struct DatabaseWriterSnapshot {
     pub(super) claim: DatabasePhaseSnapshot,
     pub(super) lease: DatabasePhaseSnapshot,
     pub(super) publish: DatabasePhaseSnapshot,
+    pub(super) scan_open: DatabasePhaseSnapshot,
+    pub(super) scan_manifest: DatabasePhaseSnapshot,
+    pub(super) scan_deferred_hash: DatabasePhaseSnapshot,
     pub(super) serial: DatabasePhaseSnapshot,
     pub(super) active: usize,
     pub(super) peak_active: usize,
@@ -148,7 +160,29 @@ fn counters(inner: &DatabaseWriterGateInner, phase: DatabasePhase) -> &PhaseCoun
         DatabasePhase::Claim => &inner.claim,
         DatabasePhase::Lease => &inner.lease,
         DatabasePhase::Publish => &inner.publish,
+        DatabasePhase::ScanOpen => &inner.scan_open,
+        DatabasePhase::ScanManifest => &inner.scan_manifest,
+        DatabasePhase::ScanDeferredHash => &inner.scan_deferred_hash,
         DatabasePhase::SerialCompatibility => &inner.serial,
+    }
+}
+
+impl wavecrate_scan::sample_sources::scanner::ScanWriter for DatabaseWriterGate {
+    type Guard = DatabaseWriterGuard;
+
+    fn lock(&self, phase: wavecrate_scan::sample_sources::scanner::ScanWritePhase) -> Self::Guard {
+        let phase = match phase {
+            wavecrate_scan::sample_sources::scanner::ScanWritePhase::Open => {
+                DatabasePhase::ScanOpen
+            }
+            wavecrate_scan::sample_sources::scanner::ScanWritePhase::Manifest => {
+                DatabasePhase::ScanManifest
+            }
+            wavecrate_scan::sample_sources::scanner::ScanWritePhase::DeferredHash => {
+                DatabasePhase::ScanDeferredHash
+            }
+        };
+        DatabaseWriterGate::lock(self, phase)
     }
 }
 

--- a/src/native_app/source_processing/supervisor/shutdown.rs
+++ b/src/native_app/source_processing/supervisor/shutdown.rs
@@ -34,6 +34,9 @@ impl SourceProcessingSupervisor {
             "claim": { "count": database.claim.count, "wait_ms": database.claim.wait_ms, "held_ms": database.claim.held_ms },
             "lease": { "count": database.lease.count, "wait_ms": database.lease.wait_ms, "held_ms": database.lease.held_ms },
             "publish": { "count": database.publish.count, "wait_ms": database.publish.wait_ms, "held_ms": database.publish.held_ms },
+            "scan_open": { "count": database.scan_open.count, "wait_ms": database.scan_open.wait_ms, "held_ms": database.scan_open.held_ms },
+            "scan_manifest": { "count": database.scan_manifest.count, "wait_ms": database.scan_manifest.wait_ms, "held_ms": database.scan_manifest.held_ms },
+            "scan_deferred_hash": { "count": database.scan_deferred_hash.count, "wait_ms": database.scan_deferred_hash.wait_ms, "held_ms": database.scan_deferred_hash.held_ms },
             "serial": { "count": database.serial.count, "wait_ms": database.serial.wait_ms, "held_ms": database.serial.held_ms },
         });
         let telemetry = self.shared.telemetry();

--- a/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_and_audits.rs
@@ -86,56 +86,11 @@ fn foreground_scan_admission_waits_without_cancelling_background_work() {
             SourceScanAdmissionState::WaitingForCapacity {
                 current_owner: Some(first.id.to_string()),
             },
-            SourceScanAdmissionState::WaitingForDatabaseAccess,
             SourceScanAdmissionState::Admitted,
         ],
         "admission must publish each semantic wait transition once"
     );
     drop(foreground_permit);
-}
-
-#[test]
-fn foreground_scan_reports_database_wait_before_admission() {
-    let (_directory, source) = unhashed_source("database-waiter");
-    let shared = Arc::new(Shared::new(vec![source.clone()], None));
-    let database_guard = shared
-        .database_writer
-        .lock(DatabasePhase::SerialCompatibility);
-    let generation = shared.control().source_lifecycle_generations[source.id.as_str()];
-    let states = Arc::new(Mutex::new(Vec::new()));
-    let worker_states = Arc::clone(&states);
-    let worker_shared = Arc::clone(&shared);
-    let source_id = source.id.to_string();
-    let waiting = thread::spawn(move || {
-        SourceProcessingBudgetHandle {
-            shared: worker_shared,
-        }
-        .acquire_scan_for_generation_with_state(&source_id, generation, |state| {
-            worker_states.lock().unwrap().push(state);
-        })
-    });
-
-    wait_until(Duration::from_secs(2), || {
-        states
-            .lock()
-            .unwrap()
-            .contains(&SourceScanAdmissionState::WaitingForDatabaseAccess)
-    });
-    assert_eq!(
-        states.lock().unwrap().as_slice(),
-        [SourceScanAdmissionState::WaitingForDatabaseAccess]
-    );
-
-    drop(database_guard);
-    let permit = waiting
-        .join()
-        .expect("join database waiter")
-        .expect("scan admitted after database writer releases");
-    assert_eq!(
-        states.lock().unwrap().last(),
-        Some(&SourceScanAdmissionState::Admitted)
-    );
-    drop(permit);
 }
 
 #[test]

--- a/src/native_app/source_processing/supervisor/tests/mod.rs
+++ b/src/native_app/source_processing/supervisor/tests/mod.rs
@@ -164,6 +164,7 @@ include!("priority_and_epochs.rs");
 include!("retirement_recovery.rs");
 include!("discovery_progress.rs");
 include!("admission_and_audits.rs");
+include!("scan_writer_coordination.rs");
 include!("progress_events.rs");
 include!("progress_lifecycle.rs");
 include!("readiness_execution.rs");

--- a/src/native_app/source_processing/supervisor/tests/scan_writer_coordination.rs
+++ b/src/native_app/source_processing/supervisor/tests/scan_writer_coordination.rs
@@ -1,0 +1,113 @@
+#[test]
+fn foreground_scan_admission_does_not_retain_database_writer() {
+    let (_directory, source) = unhashed_source("database-waiter");
+    let shared = Arc::new(Shared::new(vec![source.clone()], None));
+    let database_guard = shared.database_writer.lock(DatabasePhase::Publish);
+    let generation = shared.control().source_lifecycle_generations[source.id.as_str()];
+    let states = Arc::new(Mutex::new(Vec::new()));
+    let source_id = source.id.to_string();
+    let permit = SourceProcessingBudgetHandle {
+        shared: Arc::clone(&shared),
+    }
+    .acquire_scan_for_generation_with_state(&source_id, generation, |state| {
+        states.lock().unwrap().push(state);
+    })
+    .expect("scan admission must not wait for database access");
+    assert_eq!(
+        states.lock().unwrap().as_slice(),
+        [SourceScanAdmissionState::Admitted]
+    );
+
+    let writer = permit.scan_writer();
+    let waiting = thread::spawn(move || writer.lock(DatabasePhase::ScanManifest));
+    wait_until(Duration::from_secs(2), || {
+        shared.database_writer.waiting_count() == 1
+    });
+    drop(database_guard);
+    drop(waiting.join().expect("scan writer acquires after publication"));
+    drop(permit);
+}
+
+#[test]
+fn foreground_scan_traversal_does_not_block_independent_publication() {
+    let directory = tempfile::tempdir().expect("scan source directory");
+    let publication_directory = tempfile::tempdir().expect("publication source directory");
+    for index in 0..128 {
+        std::fs::write(
+            directory.path().join(format!("sample-{index:03}.wav")),
+            [index as u8; 16],
+        )
+        .expect("write source file");
+    }
+    SourceDatabase::open_for_scan(directory.path()).expect("create source database");
+    let scan_source = SampleSource::new_with_id(
+        SourceId::from_string("slow-scan-source"),
+        directory.path().to_path_buf(),
+    );
+    let publication_source = SampleSource::new_with_id(
+        SourceId::from_string("independent-publication-source"),
+        publication_directory.path().to_path_buf(),
+    );
+    let shared = Arc::new(Shared::new(
+        vec![scan_source.clone(), publication_source.clone()],
+        None,
+    ));
+    let scan_permit = SourceProcessingBudgetHandle {
+        shared: Arc::clone(&shared),
+    }
+    .acquire_scan(scan_source.id.as_str())
+    .expect("admit foreground scan");
+    let publication_budget = shared
+        .budgets()
+        .try_acquire(
+            publication_source.id.as_str(),
+            ProcessingLane::FeatureAnalysis,
+        )
+        .expect("independent feature work retains bounded execution capacity");
+    let writer = scan_permit.scan_writer();
+    let scan_writer = writer.clone();
+    let root = directory.path().to_path_buf();
+    let (traversal_started, wait_for_traversal) = std::sync::mpsc::channel();
+    let (release_traversal, traversal_release) = std::sync::mpsc::channel();
+    let scan = thread::spawn(move || {
+        let database = SourceDatabase::open_for_scan(&root).expect("open source database");
+        let mut traversal_started = Some(traversal_started);
+        wavecrate_scan::sample_sources::scanner::scan_with_progress_and_writer(
+            &database,
+            wavecrate_scan::sample_sources::scanner::ScanMode::Quick,
+            None,
+            &mut |_, _| {
+                if let Some(started) = traversal_started.take() {
+                    started.send(()).expect("publish traversal start");
+                    traversal_release.recv().expect("release slow traversal");
+                }
+            },
+            &scan_writer,
+        )
+        .expect("complete coordinated scan");
+    });
+    wait_for_traversal
+        .recv_timeout(Duration::from_secs(2))
+        .expect("scan reaches filesystem traversal");
+
+    let publication_writer = writer.clone();
+    let (publication_finished, wait_for_publication) = std::sync::mpsc::channel();
+    let publication = thread::spawn(move || {
+        drop(publication_writer.lock(DatabasePhase::Publish));
+        publication_finished
+            .send(())
+            .expect("publish completion signal");
+    });
+    wait_for_publication
+        .recv_timeout(Duration::from_secs(1))
+        .expect("publication must not wait for filesystem traversal");
+
+    release_traversal
+        .send(())
+        .expect("release filesystem traversal");
+    publication.join().expect("publication worker joins");
+    scan.join().expect("scan worker joins");
+    assert!(writer.snapshot().scan_manifest.count > 0);
+    shared.budgets().release(publication_budget);
+    drop(scan_permit);
+}


### PR DESCRIPTION
## Goal

Prevent foreground source scans from retaining the global database writer permit while traversing files, hashing content, or performing other CPU/I/O work.

## Scope and non-goals

- Add writer-aware scan APIs with explicit open, manifest, and deferred-hash write phases.
- Acquire the native database writer gate only around database open/migration and short commit/publication phases.
- Preserve source lifecycle fencing, cancellation checks, foreground lane reservation, and compatibility wrappers for uncoordinated scan callers.
- Route full foreground scans and targeted filesystem refreshes through the coordinated writer.
- Add phase-specific shutdown telemetry and remove the obsolete admission-time database-wait UI state.
- Non-goal: changing CPU lane capacities, readiness algorithms, schema, or source-generation semantics.

## Definition of Done

- Filesystem traversal, hash preparation, and hashing execute without retaining the global database writer permit.
- Database mutation and final publication remain serialized and cancellation/generation fenced.
- A stalled scan for source A does not block independent ready work for source B from acquiring the publication writer.
- Writer telemetry distinguishes scan open, manifest, and deferred-hash phases.
- Focused regressions, scan tests, supervisor tests, performance guard, and signed-app contention smoke complete.

## Validation

Passed:

- cargo check -p wavecrate --tests --bins
- cargo test -p wavecrate-scan --lib (95 passed)
- cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests::foreground_scan_admission_does_not_retain_database_writer -- --exact
- cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests::foreground_scan_traversal_does_not_block_independent_publication -- --exact
- source-processing supervisor suite (91 passed, 1 ignored)
- readiness-store suite (47 passed)
- source_scan filter (69 passed)
- filesystem_refresh filter (25 passed)
- status_bar filter (50 passed)
- bash scripts/perf.sh guard
- bash scripts/check_readiness_executor_boundary.sh
- bash scripts/check_source_db_open_roles.sh
- cargo fmt --all -- --check
- git diff --check

Signed-app smoke:

- Built and verified target/app-bundles/opt1238/Wavecrate OPT-1238.app.
- Exercised an isolated 10,000-WAV source with 30,001 readiness targets; observed concurrent CPU work and database/cache publication with no Database is busy, panic, fatal, or error logs.
- TERM shutdown completed in under one second with no residual process.

Baseline note:

- bash scripts/ci.sh agent reports 3920 passed, 47 failed, 24 ignored, 2 filtered. Representative failures reproduce unchanged on origin/main at c43bda271, including root_facade_exports_only_stable_entrypoints and playback_ready_persisted_cache_marks_row_without_memory_warm_after_restart.

## Known limitations

The signed app launched and processed the contention fixture, but UI activation was unavailable in the automated runtime session, so visual progress stability, interactive browsing/playback, and cancellation were not demonstrated there. Focused state/lifecycle tests cover those contracts.

User approval is required before merge.