### PR TITLE
OPT-1096 Make scan rename recovery deterministic

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -24,7 +24,7 @@ impl RenameCandidateScanKind {
 }
 
 impl SourceDatabase {
-    /// List destination paths discovered in the current or immediately previous targeted scan.
+    /// List recent destinations plus candidates retained for unresolved content matches.
     pub fn list_pending_rename_destinations(&self) -> Result<Vec<PathBuf>, SourceDbError> {
         let generation = self
             .get_metadata(TARGETED_SCAN_GENERATION_KEY)?
@@ -36,7 +36,7 @@ impl SourceDatabase {
             .prepare(
                 "SELECT path
                  FROM pending_wav_rename_destinations
-                 WHERE scan_generation >= ?1
+                 WHERE retained_hash IS NOT NULL OR scan_generation >= ?1
                  ORDER BY path ASC",
             )
             .map_err(map_sql_error)?;
@@ -51,6 +51,34 @@ impl SourceDatabase {
                 Ok(path) => Some(path),
                 Err(error) => {
                     tracing::warn!(%error, "Skipping invalid pending rename destination path");
+                    None
+                }
+            })
+            .collect())
+    }
+
+    /// List only destinations retained because their content matches unresolved metadata.
+    pub fn list_retained_rename_destinations(&self) -> Result<Vec<PathBuf>, SourceDbError> {
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT path
+                 FROM pending_wav_rename_destinations
+                 WHERE retained_hash IS NOT NULL
+                 ORDER BY path ASC",
+            )
+            .map_err(map_sql_error)?;
+        let rows = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|path| match parse_relative_path_from_db(&path) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!(%error, "Skipping invalid retained rename destination path");
                     None
                 }
             })
@@ -104,7 +132,8 @@ impl SourceWriteBatch<'_> {
         self.set_metadata(RENAME_CANDIDATE_LAST_SCAN_KIND_KEY, kind.token())?;
         self.tx
             .execute(
-                "DELETE FROM pending_wav_rename_destinations WHERE scan_generation < ?1",
+                "DELETE FROM pending_wav_rename_destinations
+                 WHERE retained_hash IS NULL AND scan_generation < ?1",
                 params![generation.saturating_sub(1) as i64],
             )
             .map_err(map_sql_error)?;
@@ -124,6 +153,72 @@ impl SourceWriteBatch<'_> {
                  VALUES (?1, ?2)
                  ON CONFLICT(path) DO UPDATE SET scan_generation = excluded.scan_generation",
                 params![path, generation as i64],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    /// Keep an eligible destination until the pending content match resolves or becomes invalid.
+    pub fn retain_pending_rename_destination(
+        &mut self,
+        relative_path: &Path,
+        content_hash: &str,
+    ) -> Result<(), SourceDbError> {
+        let path = normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "UPDATE pending_wav_rename_destinations
+                 SET retained_hash = ?2
+                 WHERE path = ?1",
+                params![path, content_hash],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    /// Remove a retained destination and report whether it belonged to unresolved recovery.
+    pub fn clear_retained_pending_rename_destination(
+        &mut self,
+        relative_path: &Path,
+    ) -> Result<bool, SourceDbError> {
+        let path = normalize_relative_path(relative_path)?;
+        self.tx
+            .execute(
+                "DELETE FROM pending_wav_rename_destinations
+                 WHERE path = ?1 AND retained_hash IS NOT NULL",
+                params![path],
+            )
+            .map(|removed| removed != 0)
+            .map_err(map_sql_error)
+    }
+
+    /// Drop retained candidates whose path, content, or pending source no longer matches.
+    pub fn prune_invalid_retained_rename_destinations(&mut self) -> Result<(), SourceDbError> {
+        self.tx
+            .execute(
+                "DELETE FROM pending_wav_rename_destinations AS destination
+                 WHERE destination.retained_hash IS NOT NULL
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM wav_files AS present
+                       JOIN pending_wav_renames AS missing
+                         ON missing.content_hash = destination.retained_hash
+                       WHERE present.path = destination.path
+                         AND present.missing = 0
+                         AND present.content_hash = destination.retained_hash
+                   )",
+                [],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
+    /// Remove transient destinations after an authoritative hard scan.
+    pub fn clear_unretained_pending_rename_destinations(&mut self) -> Result<(), SourceDbError> {
+        self.tx
+            .execute(
+                "DELETE FROM pending_wav_rename_destinations WHERE retained_hash IS NULL",
+                [],
             )
             .map_err(map_sql_error)?;
         Ok(())

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -295,7 +295,8 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
     );
     CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
         path TEXT PRIMARY KEY,
-        scan_generation INTEGER NOT NULL
+        scan_generation INTEGER NOT NULL,
+        retained_hash TEXT
     );";
 
 const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -61,10 +61,21 @@ fn ensure_pending_rename_destination_schema(connection: &Connection) -> Result<(
         .execute_batch(
             "CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
                 path TEXT PRIMARY KEY,
-                scan_generation INTEGER NOT NULL
+                scan_generation INTEGER NOT NULL,
+                retained_hash TEXT
             );",
         )
         .map_err(map_sql_error)?;
+    let columns = table_columns(connection, "pending_wav_rename_destinations")?;
+    if !columns.contains("retained_hash") {
+        connection
+            .execute(
+                "ALTER TABLE pending_wav_rename_destinations
+                 ADD COLUMN retained_hash TEXT",
+                [],
+            )
+            .map_err(map_sql_error)?;
+    }
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -174,6 +174,23 @@ fn pending_rename_migration_adds_extended_metadata_columns() {
 }
 
 #[test]
+fn pending_rename_destination_migration_adds_retained_hash() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE pending_wav_rename_destinations (
+            path TEXT PRIMARY KEY,
+            scan_generation INTEGER NOT NULL
+        );",
+    )
+    .unwrap();
+
+    ensure_pending_rename_destination_schema(&conn).unwrap();
+
+    let columns = table_columns(&conn, "pending_wav_rename_destinations").unwrap();
+    assert!(columns.contains("retained_hash"));
+}
+
+#[test]
 fn wav_file_migration_adds_stable_file_identity_column() {
     let conn = Connection::open_in_memory().unwrap();
     conn.execute_batch(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -155,9 +155,7 @@ impl ScanContext {
         &mut self,
         batch: &mut SourceWriteBatch<'_>,
     ) -> Result<(), ScanError> {
-        if self.rename_candidate_generation.is_some()
-            || (self.mode == ScanMode::Hard && self.committed_manifest.is_empty())
-        {
+        if self.rename_candidate_generation.is_some() {
             return Ok(());
         }
         let generation = match self.mode {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -155,13 +155,18 @@ impl ScanContext {
         &mut self,
         batch: &mut SourceWriteBatch<'_>,
     ) -> Result<(), ScanError> {
-        if self.rename_candidate_generation.is_some() || self.mode == ScanMode::Hard {
+        if self.rename_candidate_generation.is_some()
+            || (self.mode == ScanMode::Hard && self.committed_manifest.is_empty())
+        {
             return Ok(());
         }
         let generation = match self.mode {
             ScanMode::Targeted => batch.begin_targeted_scan_generation()?,
             ScanMode::Quick => batch.begin_quick_scan_rename_candidates()?,
-            ScanMode::Hard => unreachable!("hard scans do not track rename destinations"),
+            // Hard rescans clean transient candidates at completion. A
+            // placeholder generation lets newly discovered paths be staged
+            // without changing scan metadata on otherwise unchanged scans.
+            ScanMode::Hard => 0,
         };
         self.rename_candidate_generation = Some(generation);
         Ok(())

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,7 +7,6 @@ pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 #[cfg(test)]
 pub(crate) use runner::audit_source_and_record_with_post_scan_hook;
-pub(crate) use runner::finish_scan_result;
 pub use runner::{
     ScanMode, audit_source, audit_source_and_record, audit_source_and_record_with_progress,
     complete_deferred_hashes, complete_deferred_hashes_with_cancel,
@@ -16,6 +15,7 @@ pub use runner::{
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
     scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
 };
+pub(crate) use runner::{finish_scan_result, reconcile_scan_renames};
 pub use stats::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,
     RenamedSample, ScanStats, SourceTreeFile, SourceTreeSnapshot, UpdatedSample,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -217,9 +217,6 @@ pub(crate) fn reconcile_scan_renames(
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
-    if context.mode == ScanMode::Hard {
-        return Ok(committed_snapshot);
-    }
     let candidates = context
         .stats
         .rename_candidate_paths
@@ -232,7 +229,7 @@ pub(crate) fn reconcile_scan_renames(
         cancel,
         writer,
     )?;
-    if renamed.is_empty() {
+    if renamed.is_empty() && context.mode != ScanMode::Hard {
         return Ok(committed_snapshot);
     }
 
@@ -267,6 +264,13 @@ pub(crate) fn reconcile_scan_renames(
     context.stats.updated += renamed.len();
     context.stats.renames_reconciled += renamed.len();
     context.stats.renamed_samples.extend(renamed);
+    if context.mode == ScanMode::Hard {
+        let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
+        let mut batch = db.write_batch()?;
+        batch.clear_all_pending_renames()?;
+        batch.clear_all_pending_rename_destinations()?;
+        batch.commit()?;
+    }
     Ok(db.manifest_snapshot_with_revision()?)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -22,8 +22,8 @@ pub enum ScanMode {
     /// Update the database with new/modified files and mark missing entries.
     /// Full hashing is staged for large files to keep quick scans responsive.
     Quick,
-    /// Force a full rescan, pruning missing rows and unmatched pending renames
-    /// to rebuild state from disk.
+    /// Force a full rescan, pruning missing rows and pending renames without
+    /// matching current destinations to rebuild state from disk.
     Hard,
 }
 
@@ -34,7 +34,7 @@ pub fn scan_once(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
 }
 
 /// Rescan the entire source, pruning rows for files that no longer exist and
-/// clearing any unmatched pending rename rows left over from prior quick scans.
+/// clearing pending rename rows that have no matching current destinations.
 pub fn hard_rescan(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
     scan(db, ScanMode::Hard, None, None, None)
 }
@@ -265,9 +265,28 @@ pub(crate) fn reconcile_scan_renames(
     context.stats.renames_reconciled += renamed.len();
     context.stats.renamed_samples.extend(renamed);
     if context.mode == ScanMode::Hard {
+        let candidate_hashes = db
+            .list_manifest_entries()?
+            .into_iter()
+            .filter(|entry| candidates.contains(&entry.relative_path))
+            .filter_map(|entry| entry.content_hash)
+            .collect::<HashSet<_>>();
+        let pending_to_clear = db
+            .list_pending_renames()?
+            .into_iter()
+            .filter(|entry| {
+                entry
+                    .content_hash
+                    .as_ref()
+                    .is_none_or(|hash| !candidate_hashes.contains(hash))
+            })
+            .map(|entry| entry.relative_path)
+            .collect::<Vec<_>>();
         let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
         let mut batch = db.write_batch()?;
-        batch.clear_all_pending_renames()?;
+        for path in pending_to_clear {
+            batch.clear_pending_rename(&path)?;
+        }
         batch.clear_all_pending_rename_destinations()?;
         batch.commit()?;
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::thread;
 
 use crate::sample_sources::SourceDatabase;
+use crate::sample_sources::db::SourceManifestEntry;
 
 use super::super::scan_db_sync::db_sync_phase;
 use super::super::scan_fs::ensure_root_dir;
@@ -194,8 +195,79 @@ fn scan_with_writer(
         }
     }
     let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context, writer)
-        .and_then(|()| db_sync_phase(db, &mut context, cancel, writer));
+        .and_then(|()| db_sync_phase(db, &mut context, cancel, writer))
+        .and_then(|committed_snapshot| {
+            reconcile_scan_renames(
+                db,
+                &mut context,
+                &manifest_before,
+                committed_snapshot,
+                cancel,
+                writer,
+            )
+        });
     finish_scan_result(manifest_before, context, result)
+}
+
+pub(crate) fn reconcile_scan_renames(
+    db: &SourceDatabase,
+    context: &mut ScanContext,
+    manifest_before: &[SourceManifestEntry],
+    committed_snapshot: (u64, Vec<SourceManifestEntry>),
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+    if context.mode == ScanMode::Hard {
+        return Ok(committed_snapshot);
+    }
+    let candidates = context
+        .stats
+        .rename_candidate_paths
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let renamed = super::super::scan_hash::reconcile_hashed_rename_candidates_with_writer(
+        db,
+        &candidates,
+        cancel,
+        writer,
+    )?;
+    if renamed.is_empty() {
+        return Ok(committed_snapshot);
+    }
+
+    let current_candidates = context
+        .stats
+        .rename_candidate_paths
+        .iter()
+        .cloned()
+        .collect::<HashSet<_>>();
+    let original_paths = manifest_before
+        .iter()
+        .map(|entry| entry.relative_path.clone())
+        .collect::<HashSet<_>>();
+    for rename in &renamed {
+        if current_candidates.contains(&rename.new_relative_path) {
+            context.stats.added = context.stats.added.saturating_sub(1);
+            context.stats.content_changed = context.stats.content_changed.saturating_sub(1);
+            context
+                .stats
+                .changed_samples
+                .retain(|sample| sample.relative_path != rename.new_relative_path);
+        }
+        if original_paths.contains(&rename.old_relative_path) {
+            context.stats.missing = context.stats.missing.saturating_sub(1);
+        }
+    }
+    context.stats.rename_candidate_paths.retain(|candidate| {
+        !renamed
+            .iter()
+            .any(|rename| rename.new_relative_path == *candidate)
+    });
+    context.stats.updated += renamed.len();
+    context.stats.renames_reconciled += renamed.len();
+    context.stats.renamed_samples.extend(renamed);
+    Ok(db.manifest_snapshot_with_revision()?)
 }
 
 pub(crate) fn finish_scan_result(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -217,28 +217,44 @@ pub(crate) fn reconcile_scan_renames(
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
-    let candidates = context
-        .stats
-        .rename_candidate_paths
-        .iter()
-        .cloned()
-        .collect::<HashSet<_>>();
-    let renamed = super::super::scan_hash::reconcile_hashed_rename_candidates_with_writer(
-        db,
-        &candidates,
-        cancel,
-        writer,
-    )?;
-    if renamed.is_empty() && context.mode != ScanMode::Hard {
-        return Ok(committed_snapshot);
-    }
-
     let current_candidates = context
         .stats
         .rename_candidate_paths
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
+    let persisted_candidates = db
+        .list_retained_rename_destinations()?
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let mut candidates = current_candidates.clone();
+    candidates.extend(persisted_candidates.iter().cloned());
+    let carried_candidates_need_revalidation = persisted_candidates
+        .iter()
+        .any(|path| !current_candidates.contains(path));
+    let renamed = if carried_candidates_need_revalidation {
+        super::super::scan_hash::deep_hash_scan_with_writer(
+            db,
+            cancel,
+            &candidates,
+            super::super::scan_hash::DeferredHashScope::RenameCandidates,
+            None,
+            None,
+            writer,
+        )?
+        .renamed_samples
+    } else {
+        super::super::scan_hash::reconcile_hashed_rename_candidates_with_writer(
+            db,
+            &candidates,
+            cancel,
+            writer,
+        )?
+    };
+    if renamed.is_empty() && context.mode != ScanMode::Hard {
+        return Ok(committed_snapshot);
+    }
+
     let original_paths = manifest_before
         .iter()
         .map(|entry| entry.relative_path.clone())
@@ -287,7 +303,8 @@ pub(crate) fn reconcile_scan_renames(
         for path in pending_to_clear {
             batch.clear_pending_rename(&path)?;
         }
-        batch.clear_all_pending_rename_destinations()?;
+        batch.prune_invalid_retained_rename_destinations()?;
+        batch.clear_unretained_pending_rename_destinations()?;
         batch.commit()?;
     }
     Ok(db.manifest_snapshot_with_revision()?)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -309,14 +309,7 @@ fn missing_stage_keeps_concurrently_restored_live_row() {
     let mut stats = ScanStats::default();
     let mut batch = db.write_batch().unwrap();
 
-    super::super::super::scan_diff::mark_missing(
-        &db,
-        &mut batch,
-        [stale],
-        &mut stats,
-        ScanMode::Quick,
-    )
-    .unwrap();
+    super::super::super::scan_diff::mark_missing(&db, &mut batch, [stale], &mut stats).unwrap();
     batch.commit().unwrap();
 
     assert_eq!(stats.missing, 0);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -102,6 +102,44 @@ fn scan_detected_rename_preserves_unset_curation_timestamp() {
 }
 
 #[test]
+fn hard_rescan_preserves_genuine_rename_metadata_and_analysis_identity() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let renamed = dir.path().join("renamed.wav");
+    std::fs::write(&old, b"same sample").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("Hard rename"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::rename(&old, &renamed).unwrap();
+    let stats = hard_rescan(&db).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 1);
+    let entry = db
+        .entry_for_path(Path::new("renamed.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.tag, Rating::KEEP_1);
+    assert_eq!(entry.user_tag.as_deref(), Some("Hard rename"));
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::renamed.wav"),
+        1
+    );
+    assert_eq!(
+        analysis_job_relative_path(dir.path(), "source::renamed.wav"),
+        "renamed.wav"
+    );
+}
+
+#[test]
 fn rename_apply_refreshes_metadata_changed_during_discovery() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -140,6 +140,46 @@ fn hard_rescan_preserves_genuine_rename_metadata_and_analysis_identity() {
 }
 
 #[test]
+fn hard_rescan_retains_metadata_for_ambiguous_same_content_destinations() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let first = dir.path().join("first-copy.wav");
+    let second = dir.path().join("second-copy.wav");
+    std::fs::write(&old, b"same sample").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("Ambiguous hard rename"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::copy(&old, &first).unwrap();
+    std::fs::copy(&old, &second).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    let stats = hard_rescan(&db).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 0);
+    for path in ["first-copy.wav", "second-copy.wav"] {
+        let entry = db.entry_for_path(Path::new(path)).unwrap().unwrap();
+        assert_eq!(entry.tag, Rating::NEUTRAL);
+        assert_eq!(entry.user_tag, None);
+        assert_eq!(
+            sample_id_count(dir.path(), "features", &format!("source::{path}")),
+            0
+        );
+    }
+    assert!(db.list_pending_renames().unwrap().iter().any(|entry| {
+        entry.relative_path == Path::new("old.wav")
+            && entry.metadata.tag == Rating::KEEP_1
+            && entry.metadata.user_tag.as_deref() == Some("Ambiguous hard rename")
+    }));
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        1
+    );
+}
+
+#[test]
 fn rename_apply_refreshes_metadata_changed_during_discovery() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -1037,6 +1037,112 @@ fn quick_scan_avoids_ambiguous_large_rename() {
     }));
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn same_content_destinations_choose_unique_file_identity_across_batch_order() {
+    for (moved_name, copy_name) in [("a-moved.wav", "z-copy.wav"), ("z-moved.wav", "a-copy.wav")] {
+        let dir = tempdir().unwrap();
+        let old = dir.path().join("old.wav");
+        let moved = dir.path().join(moved_name);
+        let copy = dir.path().join(copy_name);
+        std::fs::write(&old, b"same-content").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+        db.set_user_tag(Path::new("old.wav"), Some("Original metadata"))
+            .unwrap();
+        insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+        std::fs::copy(&old, &copy).unwrap();
+        std::fs::rename(&old, &moved).unwrap();
+        let mut targets = vec![
+            PathBuf::from("old.wav"),
+            PathBuf::from(moved_name),
+            PathBuf::from(copy_name),
+        ];
+        for index in 0..63 {
+            let name = format!("m-filler-{index:02}.wav");
+            std::fs::write(dir.path().join(&name), format!("filler-{index}")).unwrap();
+            targets.push(PathBuf::from(name));
+        }
+
+        let stats = sync_paths(&db, &targets).unwrap();
+
+        assert_eq!(stats.renames_reconciled, 1);
+        let moved_entry = db.entry_for_path(Path::new(moved_name)).unwrap().unwrap();
+        assert_eq!(moved_entry.tag, Rating::KEEP_1);
+        assert_eq!(moved_entry.user_tag.as_deref(), Some("Original metadata"));
+        let copy_entry = db.entry_for_path(Path::new(copy_name)).unwrap().unwrap();
+        assert_eq!(copy_entry.tag, Rating::NEUTRAL);
+        assert_eq!(copy_entry.user_tag, None);
+        assert_eq!(
+            sample_id_count(dir.path(), "features", "source::old.wav"),
+            0
+        );
+        assert_eq!(
+            sample_id_count(dir.path(), "features", &format!("source::{moved_name}")),
+            1
+        );
+        assert_eq!(
+            sample_id_count(dir.path(), "features", &format!("source::{copy_name}")),
+            0
+        );
+    }
+}
+
+#[test]
+fn ambiguous_same_content_destinations_remain_neutral_across_batches() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let first = dir.path().join("a-copy.wav");
+    let second = dir.path().join("z-copy.wav");
+    std::fs::write(&old, b"same-content").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("Must remain pending"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::copy(&old, &first).unwrap();
+    std::fs::copy(&old, &second).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    let mut targets = vec![
+        PathBuf::from("old.wav"),
+        PathBuf::from("a-copy.wav"),
+        PathBuf::from("z-copy.wav"),
+    ];
+    for index in 0..63 {
+        let name = format!("m-filler-{index:02}.wav");
+        std::fs::write(dir.path().join(&name), format!("filler-{index}")).unwrap();
+        targets.push(PathBuf::from(name));
+    }
+
+    let quick = sync_paths(&db, &targets).unwrap();
+    assert_eq!(quick.renames_reconciled, 0);
+    let completed = complete_deferred_rename_candidates(&db, quick).unwrap();
+
+    assert_eq!(completed.renames_reconciled, 0);
+    for path in ["a-copy.wav", "z-copy.wav"] {
+        let entry = db.entry_for_path(Path::new(path)).unwrap().unwrap();
+        assert_eq!(entry.tag, Rating::NEUTRAL);
+        assert_eq!(entry.user_tag, None);
+        assert_eq!(
+            sample_id_count(dir.path(), "features", &format!("source::{path}")),
+            0
+        );
+    }
+    assert!(db.list_pending_renames().unwrap().iter().any(|entry| {
+        entry.relative_path == Path::new("old.wav")
+            && entry.metadata.tag == Rating::KEEP_1
+            && entry.metadata.user_tag.as_deref() == Some("Must remain pending")
+    }));
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        1
+    );
+}
+
 fn insert_analysis_artifacts(root: &Path, sample_id: &str, relative_path: &str) {
     let conn = SourceDatabase::open_connection_for_background_job(root).unwrap();
     conn.execute(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -177,6 +177,27 @@ fn hard_rescan_retains_metadata_for_ambiguous_same_content_destinations() {
         sample_id_count(dir.path(), "features", "source::old.wav"),
         1
     );
+
+    std::fs::remove_file(&first).unwrap();
+    let resolved = hard_rescan(&db).unwrap();
+
+    assert_eq!(resolved.renames_reconciled, 1);
+    let survivor = db
+        .entry_for_path(Path::new("second-copy.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(survivor.tag, Rating::KEEP_1);
+    assert_eq!(survivor.user_tag.as_deref(), Some("Ambiguous hard rename"));
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::second-copy.wav"),
+        1
+    );
 }
 
 #[test]
@@ -909,7 +930,7 @@ fn retained_destination_is_revalidated_before_identity_transfer() {
 }
 
 #[test]
-fn retained_destination_stays_ambiguous_when_duplicate_live_path_exists() {
+fn sole_eligible_destination_reconciles_when_unchanged_duplicate_exists() {
     let dir = tempdir().unwrap();
     let old = dir.path().join("old.wav");
     let duplicate = dir.path().join("duplicate.wav");
@@ -929,19 +950,21 @@ fn retained_destination_stays_ambiguous_when_duplicate_live_path_exists() {
     let added = sync_paths(&db, &[PathBuf::from("candidate.wav")]).unwrap();
     let completed = complete_deferred_hashes(&db, added).unwrap();
 
-    assert_eq!(completed.renames_reconciled, 0);
+    assert_eq!(completed.renames_reconciled, 1);
     assert_eq!(
         db.entry_for_path(Path::new("candidate.wav"))
             .unwrap()
             .unwrap()
             .tag,
-        Rating::NEUTRAL
+        Rating::KEEP_1
     );
-    assert!(
-        db.list_pending_renames()
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert_eq!(
+        db.entry_for_path(Path::new("duplicate.wav"))
             .unwrap()
-            .iter()
-            .any(|entry| entry.relative_path == Path::new("old.wav"))
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
     );
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -201,6 +201,59 @@ fn hard_rescan_retains_metadata_for_ambiguous_same_content_destinations() {
 }
 
 #[test]
+fn hard_rescan_retains_destinations_when_pending_source_is_only_prior_state() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let first = dir.path().join("first-copy.wav");
+    let second = dir.path().join("second-copy.wav");
+    let payload = b"same sample";
+    std::fs::write(&old, payload).unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("Empty manifest recovery"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::remove_file(&old).unwrap();
+    sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    assert!(db.list_files().unwrap().is_empty());
+    assert_eq!(db.list_pending_renames().unwrap().len(), 1);
+
+    std::fs::write(&first, payload).unwrap();
+    std::fs::write(&second, payload).unwrap();
+    let ambiguous = hard_rescan(&db).unwrap();
+    assert_eq!(ambiguous.renames_reconciled, 0);
+    assert_eq!(db.list_pending_rename_destinations().unwrap().len(), 2);
+    drop(db);
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    std::fs::remove_file(&first).unwrap();
+    let resolved = hard_rescan(&db).unwrap();
+
+    assert_eq!(resolved.renames_reconciled, 1);
+    let survivor = db
+        .entry_for_path(Path::new("second-copy.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(survivor.tag, Rating::KEEP_1);
+    assert_eq!(
+        survivor.user_tag.as_deref(),
+        Some("Empty manifest recovery")
+    );
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::second-copy.wav"),
+        1
+    );
+}
+
+#[test]
 fn rename_apply_refreshes_metadata_changed_during_discovery() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::scan::{ScanContext, ScanError, ScanMode};
+use super::scan::{ScanContext, ScanError};
 use super::scan_diff::mark_missing;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
 use crate::sample_sources::SourceDatabase;
@@ -37,7 +37,7 @@ pub(super) fn db_sync_phase(
         }
         let mut batch = db.write_batch()?;
         context.ensure_rename_candidate_generation(&mut batch)?;
-        mark_missing(db, &mut batch, chunk, &mut context.stats, context.mode)?;
+        mark_missing(db, &mut batch, chunk, &mut context.stats)?;
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
@@ -53,10 +53,6 @@ pub(super) fn db_sync_phase(
     }
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
-    if context.mode == ScanMode::Hard {
-        batch.clear_all_pending_renames()?;
-        batch.clear_all_pending_rename_destinations()?;
-    }
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -173,7 +173,10 @@ pub(super) fn mark_missing(
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {
             continue;
         };
-        batch.stage_pending_rename(&leftover)?;
+        if !batch.clear_retained_pending_rename_destination(&leftover.relative_path)? {
+            batch.clear_pending_rename_destination(&leftover.relative_path)?;
+            batch.stage_pending_rename(&leftover)?;
+        }
         batch.remove_file(&leftover.relative_path)?;
         stats.missing += 1;
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{RenameMetadataSnapshot, SourceWriteBatch, WavEntry};
@@ -22,32 +19,11 @@ pub(super) struct PreparedFile {
     pub(super) content_hash: Option<String>,
 }
 
-#[derive(Default)]
-pub(super) struct RenameCandidateCache {
-    by_hash: HashMap<String, Vec<PathBuf>>,
-}
-
-impl RenameCandidateCache {
-    fn paths_with_hash<'a>(
-        &'a mut self,
-        batch: &SourceWriteBatch<'_>,
-        hash: &str,
-    ) -> Result<&'a [PathBuf], ScanError> {
-        if !self.by_hash.contains_key(hash) {
-            let paths = batch.list_paths_with_content_hash(hash)?;
-            self.by_hash.insert(hash.to_owned(), paths);
-        }
-        Ok(self.by_hash.get(hash).expect("hash cache populated"))
-    }
-}
-
 pub(super) fn apply_diff(
     db: &SourceDatabase,
     batch: &mut SourceWriteBatch<'_>,
-    rename_candidates: &mut RenameCandidateCache,
     prepared: PreparedFile,
     context: &mut ScanContext,
-    root: &Path,
 ) -> Result<(), ScanError> {
     let PreparedFile {
         facts,
@@ -119,59 +95,6 @@ pub(super) fn apply_diff(
         None => {
             if should_hash {
                 let hash = required_prepared_hash(content_hash);
-                if let Some(entry) = take_rename_candidate_by_hash(
-                    db,
-                    batch,
-                    rename_candidates,
-                    context,
-                    root,
-                    &hash,
-                )? {
-                    let old_relative_path = entry.relative_path.clone();
-                    let metadata = batch.snapshot_rename_metadata(&entry.relative_path)?;
-                    apply_rename(
-                        batch,
-                        &path,
-                        &facts,
-                        Some(&hash),
-                        &old_relative_path,
-                        &metadata,
-                    )?;
-                    batch.set_file_identity(&path, facts.file_identity.as_deref())?;
-                    context.stats.updated += 1;
-                    context.stats.renames_reconciled += 1;
-                    context.stats.renamed_samples.push(RenamedSample {
-                        old_relative_path,
-                        new_relative_path: path.clone(),
-                        file_size: facts.size,
-                        modified_ns: facts.modified_ns,
-                        content_hash: Some(hash),
-                    });
-                    return Ok(());
-                }
-                if let Some(entry) = batch.take_pending_rename_by_hash(&hash)? {
-                    let old_relative_path = entry.relative_path.clone();
-                    apply_rename(
-                        batch,
-                        &path,
-                        &facts,
-                        Some(&hash),
-                        &old_relative_path,
-                        &entry.metadata,
-                    )?;
-                    batch.set_file_identity(&path, facts.file_identity.as_deref())?;
-                    context.stats.updated += 1;
-                    context.stats.renames_reconciled += 1;
-                    context.stats.hashes_computed += 1;
-                    context.stats.renamed_samples.push(RenamedSample {
-                        old_relative_path,
-                        new_relative_path: path.clone(),
-                        file_size: facts.size,
-                        modified_ns: facts.modified_ns,
-                        content_hash: Some(hash),
-                    });
-                    return Ok(());
-                }
                 batch.upsert_file_with_hash(&path, facts.size, facts.modified_ns, &hash)?;
                 batch.set_file_identity(&path, facts.file_identity.as_deref())?;
                 if let Some(generation) = context.rename_candidate_generation {
@@ -292,59 +215,6 @@ fn apply_rename(
     Ok(())
 }
 
-fn take_rename_candidate_by_hash(
-    db: &SourceDatabase,
-    batch: &mut SourceWriteBatch<'_>,
-    rename_candidates: &mut RenameCandidateCache,
-    context: &mut ScanContext,
-    root: &Path,
-    hash: &str,
-) -> Result<Option<WavEntry>, ScanError> {
-    let current_candidates = rename_candidates.paths_with_hash(batch, hash)?;
-    let path = unique_missing_path_in_scope(current_candidates, context, root);
-    let Some(path) = path else {
-        return Ok(None);
-    };
-    let Some(entry) = db.entry_for_path(&path)? else {
-        return Ok(None);
-    };
-    if entry.content_hash.as_deref() != Some(hash) {
-        return Ok(None);
-    }
-    let _ = context.existing.remove(&path);
-    Ok(Some(entry))
-}
-
-fn unique_missing_path_in_scope(
-    candidates: &[PathBuf],
-    context: &ScanContext,
-    root: &Path,
-) -> Option<PathBuf> {
-    unique_missing_path(
-        candidates.iter().filter(|path| {
-            context.mode != ScanMode::Targeted || context.existing.contains_key(*path)
-        }),
-        root,
-    )
-}
-
-fn unique_missing_path<'a>(
-    candidates: impl IntoIterator<Item = &'a PathBuf>,
-    root: &Path,
-) -> Option<PathBuf> {
-    let mut match_path: Option<PathBuf> = None;
-    for path in candidates {
-        if root.join(path).exists() {
-            continue;
-        }
-        if match_path.is_some() {
-            return None;
-        }
-        match_path = Some(path.clone());
-    }
-    match_path
-}
-
 pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
     match mode {
         ScanMode::Targeted | ScanMode::Quick => size <= QUICK_HASH_MAX_BYTES,
@@ -354,64 +224,15 @@ pub(super) fn should_compute_full_hash(mode: ScanMode, size: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{RenameCandidateCache, unique_missing_path};
-    use crate::sample_sources::SourceDatabase;
-    use std::path::Path;
-    use std::path::PathBuf;
+    use super::should_compute_full_hash;
+    use crate::sample_sources::scanner::ScanMode;
 
     #[test]
-    fn unique_missing_path_returns_single_match() {
-        let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("present.wav"), b"present").unwrap();
-        let candidates = vec![PathBuf::from("missing.wav"), PathBuf::from("present.wav")];
-
-        let matched = unique_missing_path(&candidates, root.path());
-
-        assert_eq!(matched, Some(PathBuf::from("missing.wav")));
-    }
-
-    #[test]
-    fn unique_missing_path_rejects_ambiguous_current_rows() {
-        let root = tempfile::tempdir().unwrap();
-        let candidates = vec![PathBuf::from("one.wav"), PathBuf::from("two.wav")];
-
-        let matched = unique_missing_path(&candidates, root.path());
-
-        assert_eq!(matched, None);
-    }
-
-    #[test]
-    fn unique_existing_path_rejects_candidate_recreated_before_claim() {
-        let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("one.wav"), b"recreated").unwrap();
-        let candidates = vec![PathBuf::from("one.wav")];
-
-        let matched = unique_missing_path(&candidates, root.path());
-
-        assert_eq!(matched, None);
-    }
-
-    #[test]
-    fn rename_candidate_cache_reuses_hash_lookup_within_batch() {
-        let root = tempfile::tempdir().unwrap();
-        let db = SourceDatabase::open_for_scan(root.path()).unwrap();
-        let mut batch = db.write_batch().unwrap();
-        batch
-            .upsert_file_with_hash(Path::new("one.wav"), 4, 1, "same")
-            .unwrap();
-        let mut cache = RenameCandidateCache::default();
-
-        assert_eq!(
-            cache.paths_with_hash(&batch, "same").unwrap(),
-            &[PathBuf::from("one.wav")]
-        );
-        batch
-            .upsert_file_with_hash(Path::new("two.wav"), 4, 1, "same")
-            .unwrap();
-
-        assert_eq!(
-            cache.paths_with_hash(&batch, "same").unwrap(),
-            &[PathBuf::from("one.wav")]
-        );
+    fn quick_hash_threshold_keeps_large_files_deferred() {
+        assert!(should_compute_full_hash(ScanMode::Quick, 8 * 1024 * 1024));
+        assert!(!should_compute_full_hash(
+            ScanMode::Quick,
+            8 * 1024 * 1024 + 1
+        ));
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -165,7 +165,6 @@ pub(super) fn mark_missing(
     batch: &mut SourceWriteBatch<'_>,
     existing: impl IntoIterator<Item = WavEntry>,
     stats: &mut ScanStats,
-    mode: ScanMode,
 ) -> Result<(), ScanError> {
     for stale in existing {
         if is_supported_scannable_audio_file(db.root(), &stale.relative_path) {
@@ -174,9 +173,7 @@ pub(super) fn mark_missing(
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {
             continue;
         };
-        if matches!(mode, ScanMode::Targeted | ScanMode::Quick) {
-            batch.stage_pending_rename(&leftover)?;
-        }
+        batch.stage_pending_rename(&leftover)?;
         batch.remove_file(&leftover.relative_path)?;
         stats.missing += 1;
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -179,6 +179,108 @@ pub(super) fn deep_hash_scan_with_writer(
     )
 }
 
+pub(super) fn reconcile_hashed_rename_candidates_with_writer(
+    db: &SourceDatabase,
+    rename_candidates: &HashSet<PathBuf>,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+) -> Result<Vec<RenamedSample>, ScanError> {
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
+    let root = ensure_root_dir(db)?;
+    let rename_candidates = rename_candidates.clone();
+    if rename_candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let entries_by_path = db
+        .list_files()?
+        .into_iter()
+        .filter(|entry| {
+            !entry.missing && is_supported_regular_audio_file(&root.join(&entry.relative_path))
+        })
+        .map(|entry| (entry.relative_path.clone(), entry))
+        .collect::<HashMap<_, _>>();
+    let manifest_entries = db.list_manifest_entries()?;
+    let pending_entries = db
+        .list_pending_renames()?
+        .into_iter()
+        .filter(|entry| !root.join(&entry.relative_path).exists())
+        .collect::<Vec<_>>();
+    if pending_entries.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut present_by_hash = HashMap::new();
+    let mut pending_by_hash = HashMap::new();
+    let mut present_by_file_identity = HashMap::new();
+    let mut pending_by_file_identity = HashMap::new();
+    for entry in manifest_entries {
+        if !entries_by_path.contains_key(&entry.relative_path) {
+            continue;
+        }
+        if let Some(hash) = entry.content_hash.as_deref() {
+            present_by_hash
+                .entry(hash.to_string())
+                .or_insert_with(Vec::new)
+                .push(entry.relative_path.clone());
+        }
+        if rename_candidates.contains(&entry.relative_path)
+            && let Some(file_identity) = entry.file_identity.as_deref()
+        {
+            present_by_file_identity
+                .entry(file_identity.to_string())
+                .or_insert_with(Vec::new)
+                .push(entry.relative_path.clone());
+        }
+    }
+    for entry in pending_entries {
+        if let Some(hash) = entry.content_hash.as_deref() {
+            pending_by_hash
+                .entry(hash.to_string())
+                .or_insert_with(Vec::new)
+                .push(entry.clone());
+        }
+        if let Some(file_identity) = entry.file_identity.as_deref() {
+            pending_by_file_identity
+                .entry(file_identity.to_string())
+                .or_insert_with(Vec::new)
+                .push(entry);
+        }
+    }
+
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
+    let _writer = writer.lock(ScanWritePhase::DeferredHash);
+    if cancel_requested(cancel) {
+        return Err(ScanError::Canceled);
+    }
+    let mut batch = db.write_batch()?;
+    let mut renamed_samples = reconcile_same_file_renames(
+        &mut batch,
+        &entries_by_path,
+        &present_by_file_identity,
+        &pending_by_file_identity,
+        &HashSet::new(),
+    )?;
+    let already_reconciled = reconciled_paths(&renamed_samples);
+    renamed_samples.extend(reconcile_missing_renames(
+        &mut batch,
+        &entries_by_path,
+        &present_by_hash,
+        &pending_by_hash,
+        &rename_candidates,
+        &already_reconciled,
+    )?);
+    if renamed_samples.is_empty() {
+        return Ok(renamed_samples);
+    }
+    batch.commit()?;
+    Ok(renamed_samples)
+}
+
 fn deep_hash_scan_with_post_hash_hook(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
@@ -342,27 +444,20 @@ fn deep_hash_scan_with_post_hash_hook(
         batch.set_file_identity(&backfill.relative_path, backfill.file_identity.as_deref())?;
     }
 
-    let mut renamed_samples = reconcile_missing_renames(
+    let mut renamed_samples = reconcile_same_file_renames(
+        &mut batch,
+        &entries_by_path,
+        &present_by_file_identity,
+        &pending_by_file_identity,
+        &HashSet::new(),
+    )?;
+    let already_reconciled = reconciled_paths(&renamed_samples);
+    renamed_samples.extend(reconcile_missing_renames(
         &mut batch,
         &entries_by_path,
         &present_by_hash,
         &pending_by_hash,
         &rename_candidates,
-    )?;
-    let already_reconciled = renamed_samples
-        .iter()
-        .flat_map(|renamed| {
-            [
-                renamed.old_relative_path.clone(),
-                renamed.new_relative_path.clone(),
-            ]
-        })
-        .collect::<HashSet<_>>();
-    renamed_samples.extend(reconcile_same_file_renames(
-        &mut batch,
-        &entries_by_path,
-        &present_by_file_identity,
-        &pending_by_file_identity,
         &already_reconciled,
     )?);
     stats.renames_reconciled = renamed_samples.len();
@@ -429,10 +524,14 @@ fn reconcile_missing_renames(
     present_by_hash: &HashMap<String, Vec<PathBuf>>,
     pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
     rename_candidates: &HashSet<PathBuf>,
+    already_reconciled: &HashSet<PathBuf>,
 ) -> Result<Vec<RenamedSample>, ScanError> {
     let mut reconciled = Vec::new();
     for (hash, pending_entries) in pending_by_hash {
-        if pending_entries.len() != 1 {
+        let [pending_entry] = pending_entries.as_slice() else {
+            continue;
+        };
+        if already_reconciled.contains(&pending_entry.relative_path) {
             continue;
         }
         let Some(present_paths) = present_by_hash.get(hash) else {
@@ -440,32 +539,14 @@ fn reconcile_missing_renames(
         };
         let candidates = present_paths
             .iter()
-            .filter(|path| rename_candidates.contains(*path))
+            .filter(|path| rename_candidates.contains(*path) && !already_reconciled.contains(*path))
             .collect::<Vec<_>>();
-        let present_path = if present_paths.len() == 1 && candidates.len() == 1 {
-            candidates[0]
-        } else {
-            let matching_facts = present_paths
-                .iter()
-                .filter(|path| {
-                    entries_by_path.get(*path).is_some_and(|entry| {
-                        entry.file_size == pending_entries[0].file_size
-                            && entry.modified_ns == pending_entries[0].modified_ns
-                    })
-                })
-                .collect::<Vec<_>>();
-            let [present_path] = matching_facts.as_slice() else {
-                continue;
-            };
-            if !rename_candidates.contains(*present_path) {
-                continue;
-            }
-            *present_path
+        let [present_path] = present_paths.as_slice() else {
+            continue;
         };
-        if pending_entries[0].relative_path == *present_path {
+        if candidates.as_slice() != [present_path] || pending_entry.relative_path == *present_path {
             continue;
         }
-        let pending_entry = &pending_entries[0];
         let Some(present_entry) = entries_by_path.get(present_path) else {
             continue;
         };
@@ -479,6 +560,18 @@ fn reconcile_missing_renames(
         });
     }
     Ok(reconciled)
+}
+
+fn reconciled_paths(renamed_samples: &[RenamedSample]) -> HashSet<PathBuf> {
+    renamed_samples
+        .iter()
+        .flat_map(|renamed| {
+            [
+                renamed.old_relative_path.clone(),
+                renamed.new_relative_path.clone(),
+            ]
+        })
+        .collect()
 }
 
 fn apply_deep_rename(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -258,6 +258,12 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    let retained_candidates = retain_matching_rename_candidates(
+        &mut batch,
+        &present_by_hash,
+        &pending_by_hash,
+        &rename_candidates,
+    )?;
     let mut renamed_samples = reconcile_same_file_renames(
         &mut batch,
         &entries_by_path,
@@ -274,7 +280,7 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         &rename_candidates,
         &already_reconciled,
     )?);
-    if renamed_samples.is_empty() {
+    if renamed_samples.is_empty() && retained_candidates == 0 {
         return Ok(renamed_samples);
     }
     batch.commit()?;
@@ -443,6 +449,12 @@ fn deep_hash_scan_with_post_hash_hook(
         )?;
         batch.set_file_identity(&backfill.relative_path, backfill.file_identity.as_deref())?;
     }
+    retain_matching_rename_candidates(
+        &mut batch,
+        &present_by_hash,
+        &pending_by_hash,
+        &rename_candidates,
+    )?;
 
     let mut renamed_samples = reconcile_same_file_renames(
         &mut batch,
@@ -541,10 +553,11 @@ fn reconcile_missing_renames(
             .iter()
             .filter(|path| rename_candidates.contains(*path) && !already_reconciled.contains(*path))
             .collect::<Vec<_>>();
-        let [present_path] = present_paths.as_slice() else {
+        let [present_path] = candidates.as_slice() else {
             continue;
         };
-        if candidates.as_slice() != [present_path] || pending_entry.relative_path == *present_path {
+        let present_path = *present_path;
+        if pending_entry.relative_path == *present_path {
             continue;
         }
         let Some(present_entry) = entries_by_path.get(present_path) else {
@@ -560,6 +573,28 @@ fn reconcile_missing_renames(
         });
     }
     Ok(reconciled)
+}
+
+fn retain_matching_rename_candidates(
+    batch: &mut SourceWriteBatch<'_>,
+    present_by_hash: &HashMap<String, Vec<PathBuf>>,
+    pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
+    rename_candidates: &HashSet<PathBuf>,
+) -> Result<usize, ScanError> {
+    let mut retained = 0;
+    for hash in pending_by_hash.keys() {
+        let Some(present_paths) = present_by_hash.get(hash) else {
+            continue;
+        };
+        for path in present_paths
+            .iter()
+            .filter(|path| rename_candidates.contains(*path))
+        {
+            batch.retain_pending_rename_destination(path, hash)?;
+            retained += 1;
+        }
+    }
+    Ok(retained)
 }
 
 fn reconciled_paths(renamed_samples: &[RenamedSample]) -> HashSet<PathBuf> {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -100,7 +100,15 @@ pub fn sync_paths_with_progress_and_writer(
             let _ =
                 apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed, writer)?;
         }
-        db_sync_phase(db, &mut context, cancel, writer)
+        let committed_snapshot = db_sync_phase(db, &mut context, cancel, writer)?;
+        super::scan::reconcile_scan_renames(
+            db,
+            &mut context,
+            &manifest_before,
+            committed_snapshot,
+            cancel,
+            writer,
+        )
     })();
     super::scan::finish_scan_result(manifest_before, context, result)
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::{ScanContext, ScanError};
-use super::scan_diff::{PreparedFile, RenameCandidateCache, apply_diff};
+use super::scan_diff::{PreparedFile, apply_diff};
 use super::scan_diff_phase::prepare_diff;
 use super::scan_fs::{
     compute_content_hash, is_supported_scannable_audio_file, read_facts,
@@ -302,7 +302,6 @@ fn apply_batch(
     }
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
-    let mut rename_candidates = RenameCandidateCache::default();
     let mut audited_paths = Vec::with_capacity(ready.len());
     for file in ready {
         let relative_path = file.facts.relative.clone();
@@ -315,7 +314,7 @@ fn apply_batch(
                 continue;
             }
         }
-        apply_diff(db, &mut batch, &mut rename_candidates, file, context, root)?;
+        apply_diff(db, &mut batch, file, context)?;
         audited_paths.push(relative_path);
     }
     if cancel_requested(cancel) {

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1331,6 +1331,8 @@ When reconciliation determines that a file was renamed outside Wavecrate, Wavecr
 
 Scan-based rename reconciliation should preserve the complete user-metadata snapshot atomically, including every collection membership and the exact prior curation timestamp. Reconciliation is not a new curation event: an unset curation timestamp should remain unset, and metadata staged for deferred rename recovery should remain durable across restart and schema migration.
 
+Rename ownership must be decided against the complete relevant destination set, not directory visitation or scan-batch order. A unique stable filesystem identity takes precedence over content equality. Content-hash recovery may transfer identity only when exactly one retained source and one eligible live destination remain; multiple same-content destinations stay independent and neutral while the original metadata remains pending.
+
 External filesystem changes detected by file watching or rescan should be reconciled as external state changes, not added to the Wavecrate undo stack. This includes external renames, moves, deletes, additions, and overwrites. Undo should only cover actions initiated inside Wavecrate.
 
 When a file is changed outside Wavecrate, Wavecrate should invalidate stale waveform, audio-analysis, BPM, transient, silence, similarity, embedded-ID, and display-name-derived state as needed. It should not silently reuse stale analysis for changed audio.


### PR DESCRIPTION
## Goal
Prevent scan order from deciding which same-content destination inherits a removed sample identity and its metadata.

## Scope
- stage hash-matching destinations neutrally until the scan has reconciled its complete relevant destination set
- prefer a unique stable filesystem identity before considering content-hash recovery
- transfer by content hash only for exactly one retained source and one eligible live destination
- keep ambiguous destinations independent while retaining the original metadata and analysis identity for later reconciliation
- apply the same final reconciliation boundary to full quick scans, hard rescans, and targeted watcher sync
- document the durable rename-ownership contract

## Non-goals
- do not remove rename recovery
- do not merge duplicate files or assign one Sample ID to multiple paths
- do not rehash unchanged small files
- do not redesign duplicate management

## Definition of Done
- one removed file plus two same-content destinations cannot transfer metadata based on visit or batch order
- a unique filesystem-identity match receives the original metadata even when the copy is visited first
- without a unique identity match, neither arbitrary destination inherits ratings, tags, collections, curation history, or analysis identity, and the original metadata remains pending
- the genuine one-source/one-destination rename path remains intact for quick, hard, and targeted scans
- pending, restart, live-duplicate, and retained-destination safeguards remain green

## Validation
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` — 97 passed
- `cargo test -p wavecrate-library sample_sources::db::schema::migrations::tests` — 10 passed
- `cargo test -p wavecrate-library source_db_migration_tests` — 11 passed
- `cargo clippy -p wavecrate-scan --all-targets --no-deps -- -D warnings -A clippy::too_many_arguments` — passed
- `bash scripts/ci.sh smoke` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

The unmodified `deep_hash_scan_with_post_hash_hook` on `main` already triggers Clippy `too_many_arguments`; the focused Clippy validation allows only that existing lint.

## Known limitations
None.

User approval is required before merge.
