### PR TITLE
OPT-1243: Report truthful source reconciliation progress

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/mod.rs
@@ -16,7 +16,7 @@ pub use model::{
 };
 pub use snapshot::{
     ArtifactPublishOutcome, ReadinessActivity, ReadinessClassification, ReadinessDeficit,
-    ReadinessEntry, ReadinessSnapshot, ReadinessStageCounts,
+    ReadinessEntry, ReadinessProgress, ReadinessSnapshot, ReadinessStageCounts,
 };
 #[cfg(test)]
 pub(crate) use store::reconcile_readiness_with_hook;

--- a/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/snapshot.rs
@@ -116,6 +116,31 @@ pub enum ReadinessActivity {
     WaitingForRetry,
 }
 
+/// User-meaningful progress emitted while readiness is inspected and reconciled.
+///
+/// The indeterminate inspection phase deliberately does not expose internal row visits. Once the
+/// target set is loaded, comparison and queueing report exact target counts without another
+/// database pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessProgress {
+    /// Durable targets, artifacts, and existing work are being loaded.
+    Inspecting,
+    /// Loaded readiness targets are being classified.
+    ComparingTargets {
+        /// Targets classified so far.
+        completed: usize,
+        /// Total loaded targets to classify.
+        total: usize,
+    },
+    /// Actionable readiness targets are being checked for durable queue work.
+    QueueingTargets {
+        /// Actionable targets checked so far.
+        completed: usize,
+        /// Total actionable targets to check.
+        total: usize,
+    },
+}
+
 /// Reconciled source readiness plus observable per-stage diagnostics.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadinessSnapshot {

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -220,7 +220,7 @@ impl<'connection> ReadinessStore<'connection> {
         source_id: &str,
         now: i64,
     ) -> Result<ReadinessSnapshot, ReadinessError> {
-        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut || {})
+        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut |_| {})
     }
 
     /// Reconcile a source while reporting checkpoints and honoring cancellation.
@@ -229,7 +229,7 @@ impl<'connection> ReadinessStore<'connection> {
         source_id: &str,
         now: i64,
         cancel: &AtomicBool,
-        progress: &mut dyn FnMut(),
+        progress: &mut dyn FnMut(super::ReadinessProgress),
     ) -> Result<ReadinessSnapshot, ReadinessError> {
         reconcile::reconcile_readiness_inner(
             self.connection,
@@ -251,7 +251,7 @@ impl<'connection> ReadinessStore<'connection> {
         scope_ids: &BTreeSet<String>,
         now: i64,
         cancel: &AtomicBool,
-        progress: &mut dyn FnMut(),
+        progress: &mut dyn FnMut(super::ReadinessProgress),
     ) -> Result<ReadinessSnapshot, ReadinessError> {
         reconcile::reconcile_readiness_scopes_inner(
             self.connection,
@@ -274,7 +274,7 @@ impl<'connection> ReadinessStore<'connection> {
             deficits,
             created_at,
             None,
-            &mut || {},
+            &mut |_| {},
         )
     }
 
@@ -284,7 +284,7 @@ impl<'connection> ReadinessStore<'connection> {
         deficits: &[ReadinessDeficit],
         created_at: i64,
         cancel: &AtomicBool,
-        progress: &mut dyn FnMut(),
+        progress: &mut dyn FnMut(super::ReadinessProgress),
     ) -> Result<usize, ReadinessError> {
         persistence::persist_readiness_deficits_inner(
             self.connection,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/persistence.rs
@@ -612,7 +612,7 @@ pub fn persist_readiness_deficits(
     deficits: &[ReadinessDeficit],
     created_at: i64,
 ) -> Result<usize, ReadinessError> {
-    persist_readiness_deficits_inner(connection, deficits, created_at, None, &mut || {})
+    persist_readiness_deficits_inner(connection, deficits, created_at, None, &mut |_| {})
 }
 
 pub(super) fn persist_readiness_deficits_inner(
@@ -620,15 +620,19 @@ pub(super) fn persist_readiness_deficits_inner(
     deficits: &[ReadinessDeficit],
     created_at: i64,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(super::super::ReadinessProgress),
 ) -> Result<usize, ReadinessError> {
     cancellation_checkpoint(cancel)?;
     let mut unique = BTreeSet::new();
     let tx = connection.transaction()?;
     let mut changed = 0;
-    for deficit in deficits {
+    let total = deficits.len();
+    for (index, deficit) in deficits.iter().enumerate() {
         cancellation_checkpoint(cancel)?;
-        progress();
+        progress(super::super::ReadinessProgress::QueueingTargets {
+            completed: index.saturating_add(1),
+            total,
+        });
         let target = &deficit.target;
         if !unique.insert((
             target.key(),

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/reconcile.rs
@@ -12,7 +12,7 @@ use super::super::{
     },
     snapshot::{
         ReadinessActivity, ReadinessClassification, ReadinessDeficit, ReadinessEntry,
-        ReadinessSnapshot, ReadinessStageCounts,
+        ReadinessProgress, ReadinessSnapshot, ReadinessStageCounts,
     },
 };
 use super::error::ReadinessError;
@@ -24,7 +24,7 @@ pub fn reconcile_readiness(
     source_id: &str,
     now: i64,
 ) -> Result<ReadinessSnapshot, ReadinessError> {
-    reconcile_readiness_inner(connection, source_id, now, None, &mut || {})
+    reconcile_readiness_inner(connection, source_id, now, None, &mut |_| {})
 }
 
 pub(super) fn reconcile_readiness_inner(
@@ -32,7 +32,7 @@ pub(super) fn reconcile_readiness_inner(
     source_id: &str,
     now: i64,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     let tx = connection.unchecked_transaction()?;
     let snapshot = reconcile_readiness_snapshot(&tx, source_id, now, || {}, cancel, progress)?;
@@ -46,7 +46,7 @@ pub(super) fn reconcile_readiness_scopes_inner(
     scope_ids: &std::collections::BTreeSet<String>,
     now: i64,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     let tx = connection.unchecked_transaction()?;
     let snapshot = reconcile_readiness_snapshot_for_scopes(
@@ -71,7 +71,7 @@ pub(crate) fn reconcile_readiness_with_hook(
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     let tx = connection.unchecked_transaction()?;
     let snapshot =
-        reconcile_readiness_snapshot(&tx, source_id, now, after_source_state, None, &mut || {})?;
+        reconcile_readiness_snapshot(&tx, source_id, now, after_source_state, None, &mut |_| {})?;
     tx.commit()?;
     Ok(snapshot)
 }
@@ -82,7 +82,7 @@ fn reconcile_readiness_snapshot(
     now: i64,
     after_source_state: impl FnOnce(),
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     reconcile_readiness_snapshot_for_scopes(
         connection,
@@ -103,7 +103,7 @@ fn reconcile_readiness_snapshot_for_scopes(
     now: i64,
     after_source_state: impl FnOnce(),
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     cancellation_checkpoint(cancel)?;
     if !readiness_schema_available(connection)? {
@@ -199,7 +199,7 @@ fn load_targets(
     source_id: &str,
     scope_ids: Option<&std::collections::BTreeSet<String>>,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<Vec<ReadinessTarget>, ReadinessError> {
     let filter = scoped_filter(scope_ids, "scope_kind", "scope_id");
     let sql = format!(
@@ -217,7 +217,7 @@ fn load_targets(
     let mut targets = Vec::new();
     while let Some(row) = rows.next()? {
         cancellation_checkpoint(cancel)?;
-        progress();
+        progress(ReadinessProgress::Inspecting);
         targets.push(ReadinessTarget {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -238,7 +238,7 @@ fn load_artifacts(
     source_id: &str,
     scope_ids: Option<&std::collections::BTreeSet<String>>,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<BTreeMap<ReadinessKey, StoredArtifact>, ReadinessError> {
     let filter = scoped_filter(scope_ids, "scope_kind", "scope_id");
     let sql = format!(
@@ -255,7 +255,7 @@ fn load_artifacts(
     let mut artifacts = BTreeMap::new();
     while let Some(row) = rows.next()? {
         cancellation_checkpoint(cancel)?;
-        progress();
+        progress(ReadinessProgress::Inspecting);
         let key = ReadinessKey {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -279,7 +279,7 @@ fn load_work(
     source_id: &str,
     scope_ids: Option<&std::collections::BTreeSet<String>>,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<BTreeMap<ReadinessKey, StoredWork>, ReadinessError> {
     let filter = scoped_filter(scope_ids, "readiness_scope_kind", "readiness_scope_id");
     let sql = format!(
@@ -299,7 +299,7 @@ fn load_work(
     let mut work = BTreeMap::new();
     while let Some(row) = rows.next()? {
         cancellation_checkpoint(cancel)?;
-        progress();
+        progress(ReadinessProgress::Inspecting);
         let key = ReadinessKey {
             source_id: source_id.to_string(),
             scope_kind: decode_scope_kind(row.get(0)?)?,
@@ -372,14 +372,18 @@ fn build_snapshot(
     work: BTreeMap<ReadinessKey, StoredWork>,
     now: i64,
     cancel: Option<&AtomicBool>,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
-    let mut entries = Vec::with_capacity(targets.len());
+    let total = targets.len();
+    let mut entries = Vec::with_capacity(total);
     let mut deficits = Vec::new();
     let mut stage_counts = BTreeMap::new();
-    for target in targets {
+    for (index, target) in targets.into_iter().enumerate() {
         cancellation_checkpoint(cancel)?;
-        progress();
+        progress(ReadinessProgress::ComparingTargets {
+            completed: index.saturating_add(1),
+            total,
+        });
         let key = target.key();
         let classification = classify_target(
             &target,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
@@ -24,7 +24,7 @@ impl<'connection> ReadinessView<'connection> {
         source_id: &str,
         now: i64,
     ) -> Result<ReadinessSnapshot, ReadinessError> {
-        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut || {})
+        reconcile::reconcile_readiness_inner(self.connection, source_id, now, None, &mut |_| {})
     }
 
     /// Reconcile with cancellation-safe progress reporting.
@@ -33,7 +33,7 @@ impl<'connection> ReadinessView<'connection> {
         source_id: &str,
         now: i64,
         cancel: &AtomicBool,
-        progress: &mut dyn FnMut(),
+        progress: &mut dyn FnMut(crate::sample_sources::readiness::ReadinessProgress),
     ) -> Result<ReadinessSnapshot, ReadinessError> {
         reconcile::reconcile_readiness_inner(
             self.connection,

--- a/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/tests/persistence.rs
@@ -975,7 +975,7 @@ fn one_identity_delta_preserves_unchanged_targets_and_running_work() {
             &BTreeSet::from([String::from("change"), String::from("delete")]),
             200,
             &std::sync::atomic::AtomicBool::new(false),
-            &mut || {},
+            &mut |_| {},
         )
         .expect("reconcile only affected readiness scopes");
     assert_eq!(delta_snapshot.entries.len(), 4);

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -350,6 +350,14 @@ Configured source lifecycles also carry a runtime epoch distinct from the durabl
 
 The source-processing supervisor publishes progress, readiness advancement, manifest-audit handoff, retry/block state, and completion through one typed backend-neutral event sink. Every source-scoped event carries its configured lifecycle epoch and is rejected before delivery when that epoch is no longer current. The supervisor owns ordering and bounded progress throttling; native-app adapters own `GuiMessage` construction and user-facing stage/detail wording. Telemetry and non-GUI observers consume the semantic event model without depending on native presentation types.
 
+Source-readiness reconciliation progress is phase-specific and must not expose cancellation
+checkpoints or cumulative database row visits as completed product work. Manifest inspection is
+indeterminate until the existing pass has a reliable file denominator; target preparation,
+readiness comparison, and unfinished-work queueing then report monotonic completed/total counts
+using files or readiness targets. Internal checkpoints remain frequent diagnostic and
+cancellation telemetry, while lifecycle fencing prevents retired-source progress from replacing
+the current source presentation.
+
 The native source-processing implementation has one public supervisor facade and one
 coordinator thread. Internally, the facade owns lifecycle and admission calls, while the
 coordinator delegates through focused discovery/reconciliation, work-execution,

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -63,7 +63,7 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
 }
 
 fn map_progress(event: SourceProcessingProgressEvent) -> SourceProcessingProgress {
-    let (stage, detail) = activity_copy(&event.activity);
+    let (stage, detail) = activity_copy(&event.activity, event.completed, event.total);
     SourceProcessingProgress {
         source_id: event.lifecycle.source_id,
         lifecycle_generation: event.lifecycle.generation,
@@ -76,15 +76,15 @@ fn map_progress(event: SourceProcessingProgressEvent) -> SourceProcessingProgres
     }
 }
 
-fn activity_copy(activity: &SourceProcessingActivity) -> (String, String) {
+fn activity_copy(
+    activity: &SourceProcessingActivity,
+    completed: usize,
+    total: usize,
+) -> (String, String) {
     match activity {
-        SourceProcessingActivity::Discovering {
-            phase,
-            completed_steps,
-        } => (
-            String::from("Checking pending work"),
-            format!("{phase} | {completed_steps} reconciliation steps completed"),
-        ),
+        SourceProcessingActivity::Discovering { phase } => {
+            discovery_copy(*phase, completed.min(total), total)
+        }
         SourceProcessingActivity::Readiness {
             stage,
             relative_path,
@@ -135,6 +135,56 @@ fn activity_copy(activity: &SourceProcessingActivity) -> (String, String) {
                 },
             )
         }
+    }
+}
+
+fn discovery_copy(
+    phase: crate::native_app::source_processing::SourceDiscoveryPhase,
+    completed: usize,
+    total: usize,
+) -> (String, String) {
+    use crate::native_app::source_processing::SourceDiscoveryPhase;
+
+    let determinate = |unit: &str| {
+        if total > 0 {
+            format!("{completed} / {total} {unit}")
+        } else {
+            String::new()
+        }
+    };
+    match phase {
+        SourceDiscoveryPhase::Preparing => (
+            String::from("Preparing source readiness"),
+            String::from("Checking durable readiness state"),
+        ),
+        SourceDiscoveryPhase::InspectingManifest => (
+            String::from("Inspecting source manifest"),
+            String::from("Reading eligible files"),
+        ),
+        SourceDiscoveryPhase::PreparingTargets => (
+            String::from("Inspecting source manifest"),
+            determinate("files inspected"),
+        ),
+        SourceDiscoveryPhase::ComparingReadiness => (
+            String::from("Comparing source readiness"),
+            if total > 0 {
+                determinate("readiness targets compared")
+            } else {
+                String::from("Loading durable readiness")
+            },
+        ),
+        SourceDiscoveryPhase::ComparingChangedReadiness => (
+            String::from("Comparing changed readiness"),
+            if total > 0 {
+                determinate("readiness targets compared")
+            } else {
+                String::from("Loading changed readiness")
+            },
+        ),
+        SourceDiscoveryPhase::QueueingWork => (
+            String::from("Queueing unfinished work"),
+            determinate("readiness targets checked"),
+        ),
     }
 }
 
@@ -225,16 +275,12 @@ mod tests {
     }
 
     #[test]
-    fn maps_discovery_audit_and_completion_without_changing_visible_copy() {
+    fn maps_truthful_discovery_audit_and_completion_copy() {
         let discovery = mapped_progress(SourceProcessingActivity::Discovering {
-            phase: String::from("Comparing durable readiness"),
-            completed_steps: 128,
+            phase: crate::native_app::source_processing::SourceDiscoveryPhase::ComparingReadiness,
         });
-        assert_eq!(discovery.stage, "Checking pending work");
-        assert_eq!(
-            discovery.detail,
-            "Comparing durable readiness | 128 reconciliation steps completed"
-        );
+        assert_eq!(discovery.stage, "Comparing source readiness");
+        assert_eq!(discovery.detail, "3 / 5 readiness targets compared");
 
         let audit = mapped_progress(SourceProcessingActivity::ManifestAudit {
             checked: Some(9),
@@ -250,6 +296,19 @@ mod tests {
         };
         assert!(!completed.active);
         assert!(completed.source_id.is_empty());
+    }
+
+    #[test]
+    fn large_discovery_counts_keep_the_phase_unit_and_denominator() {
+        let (stage, detail) = discovery_copy(
+            crate::native_app::source_processing::SourceDiscoveryPhase::ComparingReadiness,
+            17_435,
+            21_697,
+        );
+        assert_eq!(stage, "Comparing source readiness");
+        assert_eq!(detail, "17435 / 21697 readiness targets compared");
+        assert!(!detail.contains("reconciliation steps"));
+        assert!(!detail.contains("101506"));
     }
 
     #[test]

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -162,8 +162,8 @@ fn discovery_copy(
             String::from("Reading eligible files"),
         ),
         SourceDiscoveryPhase::PreparingTargets => (
-            String::from("Inspecting source manifest"),
-            determinate("files inspected"),
+            String::from("Preparing readiness targets"),
+            determinate("files prepared"),
         ),
         SourceDiscoveryPhase::ComparingReadiness => (
             String::from("Comparing source readiness"),
@@ -276,6 +276,12 @@ mod tests {
 
     #[test]
     fn maps_truthful_discovery_audit_and_completion_copy() {
+        let target_preparation = mapped_progress(SourceProcessingActivity::Discovering {
+            phase: crate::native_app::source_processing::SourceDiscoveryPhase::PreparingTargets,
+        });
+        assert_eq!(target_preparation.stage, "Preparing readiness targets");
+        assert_eq!(target_preparation.detail, "3 / 5 files prepared");
+
         let discovery = mapped_progress(SourceProcessingActivity::Discovering {
             phase: crate::native_app::source_processing::SourceDiscoveryPhase::ComparingReadiness,
         });

--- a/src/native_app/app_chrome/view_models/library_sidebar.rs
+++ b/src/native_app/app_chrome/view_models/library_sidebar.rs
@@ -613,8 +613,8 @@ mod tests {
             source_row_active: true,
             completed: 0,
             total: 0,
-            stage: String::from("Checking pending work"),
-            detail: String::from("Queueing unfinished jobs | 256 reconciliation steps completed"),
+            stage: String::from("Queueing unfinished work"),
+            detail: String::from("128 / 256 readiness targets checked"),
         });
         let sustained_discovery = LibrarySidebarViewModel::from_app_state(&state);
         assert!(

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -357,6 +357,7 @@ impl JobDetailsViewModel {
 fn source_processing_progress_unit(stage: &str) -> Option<&'static str> {
     match stage {
         "Inspecting source manifest" => Some("files inspected"),
+        "Preparing readiness targets" => Some("files prepared"),
         "Comparing source readiness" | "Comparing changed readiness" => {
             Some("readiness targets compared")
         }

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -331,15 +331,10 @@ impl JobDetailsViewModel {
             .unwrap_or(progress.source_id.as_str());
         Self {
             rows: if progress.total == 0 {
-                let progress_label = if progress.stage == "Checking pending work" {
-                    "Progress: Counting pending jobs"
-                } else {
-                    "Progress: Active (total not available)"
-                };
                 [
                     String::from("Type: Source processing"),
                     format!("Source: {source}"),
-                    String::from(progress_label),
+                    String::from("Progress: Active (total not available)"),
                     format!("Current: {current}"),
                 ]
             } else {

--- a/src/native_app/app_chrome/view_models/status_bar.rs
+++ b/src/native_app/app_chrome/view_models/status_bar.rs
@@ -329,26 +329,39 @@ impl JobDetailsViewModel {
             .folder_browser
             .source_label(progress.source_id.as_str())
             .unwrap_or(progress.source_id.as_str());
+        let progress_label = if progress.total == 0 {
+            String::from("Active (total not available)")
+        } else {
+            let counts = format!(
+                "{}/{}",
+                progress.completed.min(progress.total),
+                progress.total
+            );
+            match source_processing_progress_unit(progress.stage.as_str()) {
+                Some(unit) => format!("{counts} {unit}"),
+                None => counts,
+            }
+        };
         Self {
-            rows: if progress.total == 0 {
-                [
-                    String::from("Type: Source processing"),
-                    format!("Source: {source}"),
-                    String::from("Progress: Active (total not available)"),
-                    format!("Current: {current}"),
-                ]
-            } else {
-                job_rows(
-                    "Source processing",
-                    source,
-                    progress.completed,
-                    progress.total,
-                    current.as_str(),
-                    "processed",
-                )
-            },
+            rows: [
+                String::from("Type: Source processing"),
+                format!("Source: {source}"),
+                format!("Progress: {progress_label}"),
+                format!("Current: {current}"),
+            ],
             source_scan_recovery: false,
         }
+    }
+}
+
+fn source_processing_progress_unit(stage: &str) -> Option<&'static str> {
+    match stage {
+        "Inspecting source manifest" => Some("files inspected"),
+        "Comparing source readiness" | "Comparing changed readiness" => {
+            Some("readiness targets compared")
+        }
+        "Queueing unfinished work" => Some("readiness targets checked"),
+        _ => None,
     }
 }
 

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -25,8 +25,7 @@ impl SourceProcessingLifecycle {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) enum SourceProcessingActivity {
     Discovering {
-        phase: String,
-        completed_steps: usize,
+        phase: SourceDiscoveryPhase,
     },
     Readiness {
         stage: ReadinessStage,
@@ -42,6 +41,17 @@ pub(in crate::native_app) enum SourceProcessingActivity {
     WaitingForRetry {
         retry_at: i64,
     },
+}
+
+/// Stable user-facing phases within source readiness discovery.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum SourceDiscoveryPhase {
+    Preparing,
+    InspectingManifest,
+    PreparingTargets,
+    ComparingReadiness,
+    ComparingChangedReadiness,
+    QueueingWork,
 }
 
 /// Backend-neutral progress for one source lifecycle.

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -6,8 +6,8 @@ mod supervisor;
 mod worker;
 
 pub(in crate::native_app) use events::{
-    SourceProcessingActivity, SourceProcessingEvent, SourceProcessingEventSink,
-    SourceProcessingLifecycle, SourceProcessingProgressEvent,
+    SourceDiscoveryPhase, SourceProcessingActivity, SourceProcessingEvent,
+    SourceProcessingEventSink, SourceProcessingLifecycle, SourceProcessingProgressEvent,
 };
 pub(in crate::native_app) use supervisor::{SourceProcessingSupervisor, SourceScanAdmissionState};
 pub(in crate::native_app) use worker::run_internal_source_analysis_from_args;

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -23,8 +23,8 @@ use wavecrate::sample_sources::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessClassification,
         ReadinessDeltaPublicationOutcome, ReadinessEligibility, ReadinessFailureClassification,
         ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessMembership,
-        ReadinessRetryPolicy, ReadinessScopeKind, ReadinessSnapshot, ReadinessStage,
-        ReadinessStore, ReadinessTarget, ReadinessTargetDeltaPublication,
+        ReadinessProgress, ReadinessRetryPolicy, ReadinessScopeKind, ReadinessSnapshot,
+        ReadinessStage, ReadinessStore, ReadinessTarget, ReadinessTargetDeltaPublication,
         ReadinessTargetPublication, ReadinessWorkMutationOutcome, SourceAvailability,
     },
     scanner::{
@@ -35,8 +35,8 @@ use wavecrate::sample_sources::{
 
 use super::worker::{SourceProcessingFailure, source_database_failure};
 use super::{
-    SourceProcessingActivity, SourceProcessingEvent, SourceProcessingEventSink,
-    SourceProcessingLifecycle, SourceProcessingProgressEvent,
+    SourceDiscoveryPhase, SourceProcessingActivity, SourceProcessingEvent,
+    SourceProcessingEventSink, SourceProcessingLifecycle, SourceProcessingProgressEvent,
     scheduler::{
         BudgetTracker, FairScheduler, PriorityContext, ProcessingBudgets, ProcessingLane,
         WorkCandidate,

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -1,7 +1,7 @@
 use super::{
-    Arc, AtomicBool, BTreeMap, BTreeSet, Cancellable, DiscoveryProgressPublisher, Instant,
-    PendingReadinessDelta, ProcessingLane, ReadinessStore, RuntimeCandidate,
-    SOURCE_DISCOVERY_RETRY_SECONDS, SampleSource, Shared, SourceDatabase,
+    Arc, AtomicBool, BTreeMap, BTreeSet, Cancellable, DiscoveryProgressPublisher,
+    DiscoveryProgressUpdate, Instant, PendingReadinessDelta, ProcessingLane, ReadinessStore,
+    RuntimeCandidate, SOURCE_DISCOVERY_RETRY_SECONDS, SampleSource, Shared, SourceDatabase,
     SourceDatabaseConnectionRole, SourceDiscoveryStats, cancelled,
     discover_source_candidates_with_connection_and_progress, now_epoch_seconds,
     readiness_safety_probe_is_current, source_processing_schema_available,
@@ -67,10 +67,11 @@ pub(super) fn discover_candidates(
             source_id: source.id.as_str(),
             lifecycle_generation: in_flight_work.lifecycle_generation,
             started_at: Instant::now(),
-            last_phase: None,
+            last_progress: None,
             last_event_publish_at: None,
             last_log_publish_at: None,
             event_published: false,
+            work_units: 0,
         };
         let discovery_result = {
             let _writer = shared
@@ -84,7 +85,7 @@ pub(super) fn discover_candidates(
                 pending_readiness_deltas.get(source.id.as_str()),
                 safety_probe_only,
                 source_cancel,
-                &mut |phase, work_units| progress.advance(phase, work_units),
+                &mut |update| progress.advance(update),
             )
         };
         match discovery_result {
@@ -155,7 +156,7 @@ pub(super) fn discover_source_candidates(
         None,
         false,
         cancel,
-        &mut |_, _| {},
+        &mut |_| {},
     )
 }
 
@@ -167,7 +168,7 @@ pub(super) fn discover_source_candidates_with_progress(
     pending_readiness_delta: Option<&PendingReadinessDelta>,
     safety_probe_only: bool,
     cancel: &AtomicBool,
-    progress: &mut dyn FnMut(&'static str, usize),
+    progress: &mut dyn FnMut(DiscoveryProgressUpdate),
 ) -> Result<Cancellable<(Vec<RuntimeCandidate>, SourceDiscoveryStats)>, String> {
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);

--- a/src/native_app/source_processing/supervisor/discovery_publication.rs
+++ b/src/native_app/source_processing/supervisor/discovery_publication.rs
@@ -33,7 +33,7 @@ pub(super) fn publish_current_readiness_targets_with_cancel(
         now,
         cancel,
         false,
-        &mut || {},
+        &mut |_| {},
     )
 }
 

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -1,8 +1,9 @@
 use super::{
-    AtomicBool, Cancellable, MANIFEST_AUDIT_INTERVAL_SECONDS, META_LAST_MANIFEST_AUDIT_AT,
-    META_WAV_PATHS_REVISION, PendingReadinessDelta, ProcessingLane, ReadinessClassification,
-    ReadinessStore, RuntimeCandidate, RuntimeTask, SampleSource, SourceAvailability,
-    SourceDiscoveryStats, WorkCandidate, active_recording_deferrals, cancelled, earliest_deadline,
+    AtomicBool, Cancellable, DiscoveryProgressUpdate, MANIFEST_AUDIT_INTERVAL_SECONDS,
+    META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION, PendingReadinessDelta, ProcessingLane,
+    ReadinessClassification, ReadinessProgress, ReadinessStore, RuntimeCandidate, RuntimeTask,
+    SampleSource, SourceAvailability, SourceDiscoveryPhase, SourceDiscoveryStats, WorkCandidate,
+    active_recording_deferrals, cancelled, earliest_deadline,
     legacy_unsupported_decode_failure_text, publish_current_readiness_delta_with_cancel,
     publish_current_readiness_targets_with_cancel_and_checkpoint, readiness_contract_version,
     retire_legacy_playback_readiness, similarity_prerequisite_blocker_stats,
@@ -70,7 +71,7 @@ pub(super) fn discover_source_candidates_with_connection(
         None,
         false,
         cancel,
-        &mut |_, _| {},
+        &mut |_| {},
     )
 }
 
@@ -83,10 +84,9 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
     pending_readiness_delta: Option<&PendingReadinessDelta>,
     safety_probe_only: bool,
     cancel: &AtomicBool,
-    progress: &mut dyn FnMut(&'static str, usize),
+    progress: &mut dyn FnMut(DiscoveryProgressUpdate),
 ) -> Result<Cancellable<(Vec<RuntimeCandidate>, SourceDiscoveryStats)>, String> {
     let source_id = source.id.as_str();
-    let mut work_units = 0_usize;
     let mut candidates = Vec::new();
     let mut stats = SourceDiscoveryStats::default();
     if connection
@@ -164,7 +164,9 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
             task: RuntimeTask::ManifestAudit,
         });
     }
-    progress("Retiring legacy playback readiness", work_units);
+    progress(DiscoveryProgressUpdate::indeterminate(
+        SourceDiscoveryPhase::Preparing,
+    ));
     if matches!(
         retire_legacy_playback_readiness(source, connection, cancel)?,
         Cancellable::Cancelled
@@ -186,15 +188,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
     }
     if !delta_applied {
         let target_publication = publish_current_readiness_targets_with_cancel_and_checkpoint(
-            connection,
-            source_id,
-            now,
-            cancel,
-            true,
-            &mut || {
-                work_units = work_units.saturating_add(1);
-                progress("Reading manifest and readiness targets", work_units);
-            },
+            connection, source_id, now, cancel, true, progress,
         )?;
         if matches!(target_publication, Cancellable::Cancelled) {
             return Ok(Cancellable::Cancelled);
@@ -226,9 +220,20 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
                     .scope_ids,
                 now,
                 cancel,
-                &mut || {
-                    work_units = work_units.saturating_add(1);
-                    progress("Comparing changed readiness", work_units);
+                &mut |update| {
+                    progress(match update {
+                        ReadinessProgress::Inspecting => DiscoveryProgressUpdate::indeterminate(
+                            SourceDiscoveryPhase::ComparingChangedReadiness,
+                        ),
+                        ReadinessProgress::ComparingTargets { completed, total } => {
+                            DiscoveryProgressUpdate::determinate(
+                                SourceDiscoveryPhase::ComparingChangedReadiness,
+                                completed,
+                                total,
+                            )
+                        }
+                        ReadinessProgress::QueueingTargets { .. } => unreachable!(),
+                    });
                 },
             )
         } else {
@@ -236,9 +241,20 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
                 source_id,
                 now,
                 cancel,
-                &mut || {
-                    work_units = work_units.saturating_add(1);
-                    progress("Comparing durable readiness", work_units);
+                &mut |update| {
+                    progress(match update {
+                        ReadinessProgress::Inspecting => DiscoveryProgressUpdate::indeterminate(
+                            SourceDiscoveryPhase::ComparingReadiness,
+                        ),
+                        ReadinessProgress::ComparingTargets { completed, total } => {
+                            DiscoveryProgressUpdate::determinate(
+                                SourceDiscoveryPhase::ComparingReadiness,
+                                completed,
+                                total,
+                            )
+                        }
+                        ReadinessProgress::QueueingTargets { .. } => unreachable!(),
+                    });
                 },
             )
         };
@@ -264,9 +280,15 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
             &persistable_deficits,
             now,
             cancel,
-            &mut || {
-                work_units = work_units.saturating_add(1);
-                progress("Queueing unfinished jobs", work_units);
+            &mut |update| {
+                let ReadinessProgress::QueueingTargets { completed, total } = update else {
+                    unreachable!();
+                };
+                progress(DiscoveryProgressUpdate::determinate(
+                    SourceDiscoveryPhase::QueueingWork,
+                    completed,
+                    total,
+                ));
             },
         ) {
             Ok(_) => {}

--- a/src/native_app/source_processing/supervisor/discovery_targets.rs
+++ b/src/native_app/source_processing/supervisor/discovery_targets.rs
@@ -1,7 +1,8 @@
 use super::{
-    AtomicBool, Cancellable, META_WAV_PATHS_REVISION, Ordering, READINESS_MANIFEST_VERSION,
-    READINESS_MEMBERSHIP_VERSION, ReadinessEligibility, ReadinessMembership, ReadinessStage,
-    ReadinessStore, ReadinessTarget, ReadinessTargetPublication, SampleSource, SourceAvailability,
+    AtomicBool, Cancellable, DiscoveryProgressUpdate, META_WAV_PATHS_REVISION, Ordering,
+    READINESS_MANIFEST_VERSION, READINESS_MEMBERSHIP_VERSION, ReadinessEligibility,
+    ReadinessMembership, ReadinessStage, ReadinessStore, ReadinessTarget,
+    ReadinessTargetPublication, SampleSource, SourceAvailability, SourceDiscoveryPhase,
     invalidate_persisted_waveform_cache_ref, native_similarity_artifact_version,
     retained_waveform_cache_ref_is_owned,
 };
@@ -59,9 +60,11 @@ pub(super) fn publish_current_readiness_targets_with_cancel_and_checkpoint(
     now: i64,
     cancel: &AtomicBool,
     allow_revision_noop: bool,
-    checkpoint: &mut impl FnMut(),
+    progress: &mut (impl FnMut(DiscoveryProgressUpdate) + ?Sized),
 ) -> Result<Cancellable<bool>, String> {
-    checkpoint();
+    progress(DiscoveryProgressUpdate::indeterminate(
+        SourceDiscoveryPhase::InspectingManifest,
+    ));
     if cancelled(cancel) {
         return Ok(Cancellable::Cancelled);
     }
@@ -100,7 +103,9 @@ pub(super) fn publish_current_readiness_targets_with_cancel_and_checkpoint(
         let mut query = statement.query([]).map_err(|error| error.to_string())?;
         let mut rows = Vec::new();
         while let Some(row) = query.next().map_err(|error| error.to_string())? {
-            checkpoint();
+            progress(DiscoveryProgressUpdate::indeterminate(
+                SourceDiscoveryPhase::InspectingManifest,
+            ));
             if cancelled(cancel) {
                 return Ok(Cancellable::Cancelled);
             }
@@ -121,7 +126,9 @@ pub(super) fn publish_current_readiness_targets_with_cancel_and_checkpoint(
         .map_err(|error| error.to_string())?;
     let mut manifest = Vec::with_capacity(rows.len());
     for (path, identity, content_hash, file_size, modified_ns) in rows {
-        checkpoint();
+        progress(DiscoveryProgressUpdate::indeterminate(
+            SourceDiscoveryPhase::InspectingManifest,
+        ));
         if cancelled(cancel) {
             return Ok(Cancellable::Cancelled);
         }
@@ -148,8 +155,15 @@ pub(super) fn publish_current_readiness_targets_with_cancel_and_checkpoint(
     let similarity_artifact_version = native_similarity_artifact_version();
     let mut membership = ReadinessMembership::default();
     let mut targets = Vec::with_capacity(manifest.len().saturating_mul(3).saturating_add(1));
-    for (path, identity, content_hash, content_generation, file_size) in &manifest {
-        checkpoint();
+    let manifest_total = manifest.len();
+    for (index, (path, identity, content_hash, content_generation, file_size)) in
+        manifest.iter().enumerate()
+    {
+        progress(DiscoveryProgressUpdate::determinate(
+            SourceDiscoveryPhase::PreparingTargets,
+            index.saturating_add(1),
+            manifest_total,
+        ));
         if cancelled(cancel) {
             return Ok(Cancellable::Cancelled);
         }

--- a/src/native_app/source_processing/supervisor/progress.rs
+++ b/src/native_app/source_processing/supervisor/progress.rs
@@ -58,8 +58,8 @@ impl DiscoveryProgressPublisher<'_> {
             discovery_phase_rank(progress.phase) < discovery_phase_rank(previous.phase)
                 || (previous.phase == progress.phase
                     && previous.total > 0
-                    && progress.total > 0
-                    && progress.completed < previous.completed)
+                    && (progress.total != previous.total
+                        || progress.completed < previous.completed))
         });
         let event_due = self.started_at.elapsed() >= DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL
             && !regressed

--- a/src/native_app/source_processing/supervisor/progress.rs
+++ b/src/native_app/source_processing/supervisor/progress.rs
@@ -2,9 +2,9 @@ use super::{
     BTreeMap, BTreeSet, DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL, DISCOVERY_PROGRESS_LOG_INTERVAL,
     DISCOVERY_PROGRESS_REFRESH_INTERVAL, Instant, PROGRESS_REFRESH_INTERVAL,
     ReadinessClassification, ReadinessEligibility, ReadinessScopeKind, ReadinessSnapshot,
-    ReadinessStage, RuntimeCandidate, RuntimeTask, Shared, SourceDiscoveryStats,
-    SourceProcessingActivity, SourceProcessingEvent, SourceProcessingLifecycle,
-    SourceProcessingProgressEvent, earliest_deadline,
+    ReadinessStage, RuntimeCandidate, RuntimeTask, Shared, SourceDiscoveryPhase,
+    SourceDiscoveryStats, SourceProcessingActivity, SourceProcessingEvent,
+    SourceProcessingLifecycle, SourceProcessingProgressEvent, earliest_deadline,
 };
 
 pub(super) struct DiscoveryProgressPublisher<'a> {
@@ -12,16 +12,57 @@ pub(super) struct DiscoveryProgressPublisher<'a> {
     pub(super) source_id: &'a str,
     pub(super) lifecycle_generation: u64,
     pub(super) started_at: Instant,
-    pub(super) last_phase: Option<&'static str>,
+    pub(super) last_progress: Option<DiscoveryProgressUpdate>,
     pub(super) last_event_publish_at: Option<Instant>,
     pub(super) last_log_publish_at: Option<Instant>,
     pub(super) event_published: bool,
+    pub(super) work_units: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct DiscoveryProgressUpdate {
+    pub(super) phase: SourceDiscoveryPhase,
+    pub(super) completed: usize,
+    pub(super) total: usize,
+}
+
+impl DiscoveryProgressUpdate {
+    pub(super) const fn indeterminate(phase: SourceDiscoveryPhase) -> Self {
+        Self {
+            phase,
+            completed: 0,
+            total: 0,
+        }
+    }
+
+    pub(super) const fn determinate(
+        phase: SourceDiscoveryPhase,
+        completed: usize,
+        total: usize,
+    ) -> Self {
+        Self {
+            phase,
+            completed,
+            total,
+        }
+    }
 }
 
 impl DiscoveryProgressPublisher<'_> {
-    pub(super) fn advance(&mut self, phase: &'static str, work_units: usize) {
-        let phase_changed = self.last_phase != Some(phase);
+    pub(super) fn advance(&mut self, progress: DiscoveryProgressUpdate) {
+        self.work_units = self.work_units.saturating_add(1);
+        let phase_changed = self
+            .last_progress
+            .is_none_or(|previous| previous.phase != progress.phase);
+        let regressed = self.last_progress.is_some_and(|previous| {
+            discovery_phase_rank(progress.phase) < discovery_phase_rank(previous.phase)
+                || (previous.phase == progress.phase
+                    && previous.total > 0
+                    && progress.total > 0
+                    && progress.completed < previous.completed)
+        });
         let event_due = self.started_at.elapsed() >= DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL
+            && !regressed
             && (phase_changed
                 || self.last_event_publish_at.is_none_or(|published_at| {
                     published_at.elapsed() >= DISCOVERY_PROGRESS_REFRESH_INTERVAL
@@ -34,11 +75,10 @@ impl DiscoveryProgressPublisher<'_> {
                         self.lifecycle_generation,
                     ),
                     source_row_active: true,
-                    completed: 0,
-                    total: 0,
+                    completed: progress.completed.min(progress.total),
+                    total: progress.total,
                     activity: SourceProcessingActivity::Discovering {
-                        phase: phase.to_string(),
-                        completed_steps: work_units,
+                        phase: progress.phase,
                     },
                 },
             ));
@@ -54,13 +94,28 @@ impl DiscoveryProgressPublisher<'_> {
                 event = "source_processing.discovery_progress",
                 source_id = self.source_id,
                 lifecycle_generation = self.lifecycle_generation,
-                phase,
-                work_units,
+                phase = ?progress.phase,
+                work_units = self.work_units,
+                completed = progress.completed,
+                total = progress.total,
                 "Source discovery reconciliation advanced"
             );
             self.last_log_publish_at = Some(Instant::now());
         }
-        self.last_phase = Some(phase);
+        if !regressed {
+            self.last_progress = Some(progress);
+        }
+    }
+}
+
+fn discovery_phase_rank(phase: SourceDiscoveryPhase) -> u8 {
+    match phase {
+        SourceDiscoveryPhase::Preparing => 0,
+        SourceDiscoveryPhase::InspectingManifest => 1,
+        SourceDiscoveryPhase::PreparingTargets => 2,
+        SourceDiscoveryPhase::ComparingReadiness
+        | SourceDiscoveryPhase::ComparingChangedReadiness => 3,
+        SourceDiscoveryPhase::QueueingWork => 4,
     }
 }
 

--- a/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
+++ b/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
@@ -62,7 +62,7 @@ fn profile_large_source_discovery_baseline() {
 }
 
 #[test]
-fn discovery_reports_monotonic_work_backed_progress() {
+fn discovery_progress_reports_phase_specific_truthful_counts() {
     const FILE_COUNT: usize = 8;
     let directory = tempfile::tempdir().expect("progress source");
     let source = SampleSource::new_with_id(
@@ -105,7 +105,7 @@ fn discovery_reports_monotonic_work_backed_progress() {
         None,
         false,
         &AtomicBool::new(false),
-        &mut |phase, work_units| updates.push((phase, work_units)),
+        &mut |update| updates.push(update),
     )
     .expect("discover source with progress") else {
         panic!("progress discovery unexpectedly cancelled");
@@ -113,24 +113,35 @@ fn discovery_reports_monotonic_work_backed_progress() {
 
     assert!(updates.len() > FILE_COUNT);
     assert!(
-        updates.windows(2).all(|pair| pair[0].1 <= pair[1].1),
-        "discovery work units must never move backward"
-    );
-    assert!(updates.last().unwrap().1 > updates.first().unwrap().1);
-    assert!(
         updates
             .iter()
-            .any(|(phase, _)| *phase == "Comparing durable readiness")
+            .any(|update| update.phase == SourceDiscoveryPhase::InspectingManifest)
     );
     assert!(
         updates
             .iter()
-            .any(|(phase, _)| *phase == "Queueing unfinished jobs")
+            .any(|update| update.phase == SourceDiscoveryPhase::PreparingTargets
+                && update.completed == FILE_COUNT
+                && update.total == FILE_COUNT)
+    );
+    assert!(
+        updates.iter().any(|update| {
+            update.phase == SourceDiscoveryPhase::ComparingReadiness
+                && update.completed == FILE_COUNT * 3 + 1
+                && update.total == FILE_COUNT * 3 + 1
+        })
+    );
+    assert!(
+        updates.iter().any(|update| {
+            update.phase == SourceDiscoveryPhase::QueueingWork
+                && update.completed == FILE_COUNT * 3 + 1
+                && update.total == FILE_COUNT * 3 + 1
+        })
     );
 }
 
 #[test]
-fn discovery_progress_publisher_exposes_advancing_counter() {
+fn discovery_progress_publisher_exposes_determinate_target_progress() {
     let directory = tempfile::tempdir().expect("progress source");
     let source = SampleSource::new_with_id(
         SourceId::from_string("progress-publisher"),
@@ -144,15 +155,24 @@ fn discovery_progress_publisher_exposes_advancing_counter() {
         source_id: "progress-publisher",
         lifecycle_generation,
         started_at: Instant::now() - DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL,
-        last_phase: None,
+        last_progress: None,
         last_event_publish_at: None,
         last_log_publish_at: None,
         event_published: false,
+        work_units: 0,
     };
 
-    publisher.advance("Comparing durable readiness", 128);
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::ComparingReadiness,
+        128,
+        512,
+    ));
     publisher.last_event_publish_at = Some(Instant::now() - DISCOVERY_PROGRESS_REFRESH_INTERVAL);
-    publisher.advance("Comparing durable readiness", 256);
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::ComparingReadiness,
+        256,
+        512,
+    ));
 
     let updates = receiver
         .try_iter()
@@ -164,19 +184,72 @@ fn discovery_progress_publisher_exposes_advancing_counter() {
     assert_eq!(updates.len(), 2);
     assert_eq!(updates[0].lifecycle.source_id, "progress-publisher");
     assert_eq!(updates[0].lifecycle.generation, lifecycle_generation);
+    assert_eq!((updates[0].completed, updates[0].total), (128, 512));
     assert_eq!(
         updates[0].activity,
         SourceProcessingActivity::Discovering {
-            phase: String::from("Comparing durable readiness"),
-            completed_steps: 128,
+            phase: SourceDiscoveryPhase::ComparingReadiness,
         }
     );
+    assert_eq!((updates[1].completed, updates[1].total), (256, 512));
     assert_eq!(
         updates[1].activity,
         SourceProcessingActivity::Discovering {
-            phase: String::from("Comparing durable readiness"),
-            completed_steps: 256,
+            phase: SourceDiscoveryPhase::ComparingReadiness,
         }
+    );
+}
+
+#[test]
+fn discovery_progress_publisher_rejects_phase_and_count_regressions() {
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("progress-regression"),
+        PathBuf::from("/library/progress-regression"),
+    );
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let shared = Shared::new(vec![source], Some(Arc::new(sender)));
+    let lifecycle_generation = shared.control().source_lifecycle_generations["progress-regression"];
+    let mut publisher = DiscoveryProgressPublisher {
+        shared: &shared,
+        source_id: "progress-regression",
+        lifecycle_generation,
+        started_at: Instant::now() - DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL,
+        last_progress: None,
+        last_event_publish_at: None,
+        last_log_publish_at: None,
+        event_published: false,
+        work_units: 0,
+    };
+
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::QueueingWork,
+        4,
+        8,
+    ));
+    publisher.last_event_publish_at = Some(Instant::now() - DISCOVERY_PROGRESS_REFRESH_INTERVAL);
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::QueueingWork,
+        3,
+        8,
+    ));
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::ComparingReadiness,
+        8,
+        8,
+    ));
+
+    let updates = receiver
+        .try_iter()
+        .filter(|event| matches!(event, SourceProcessingEvent::Progress(_)))
+        .count();
+    assert_eq!(updates, 1, "stale progress must not replace newer progress");
+    assert_eq!(
+        publisher.last_progress,
+        Some(DiscoveryProgressUpdate::determinate(
+            SourceDiscoveryPhase::QueueingWork,
+            4,
+            8,
+        ))
     );
 }
 
@@ -193,28 +266,35 @@ fn discovery_phase_progress_is_debug_only() {
         source_id: "progress-log-policy",
         lifecycle_generation,
         started_at: Instant::now(),
-        last_phase: None,
+        last_progress: None,
         last_event_publish_at: None,
         last_log_publish_at: None,
         event_published: false,
+        work_units: 0,
     };
 
     let info = capture_logs(tracing::Level::INFO, || {
-        publisher.advance("Reading manifest and readiness targets", 1);
+        publisher.advance(DiscoveryProgressUpdate::indeterminate(
+            SourceDiscoveryPhase::InspectingManifest,
+        ));
     });
     assert!(!info.contains("source_processing.discovery_progress"));
 
-    publisher.last_phase = None;
+    publisher.last_progress = None;
     publisher.last_log_publish_at = None;
     let debug = capture_logs(tracing::Level::DEBUG, || {
-        publisher.advance("Comparing durable readiness", 2);
+        publisher.advance(DiscoveryProgressUpdate::determinate(
+            SourceDiscoveryPhase::ComparingReadiness,
+            1,
+            2,
+        ));
     });
     assert!(debug.contains("source_processing.discovery_progress"));
     assert!(debug.contains("work_units=2"));
 }
 
 #[test]
-fn large_source_discovery_cancels_mid_manifest_and_resumes_cleanly() {
+fn discovery_progress_cancellation_mid_manifest_resumes_cleanly() {
     const FILE_COUNT: usize = 512;
     let directory = tempfile::tempdir().expect("large cancellation source");
     let source = SampleSource::new_with_id(
@@ -262,7 +342,7 @@ fn large_source_discovery_cancels_mid_manifest_and_resumes_cleanly() {
         100,
         &cancel,
         false,
-        &mut || {
+        &mut |_| {
             checkpoints += 1;
             if checkpoints == 128 {
                 cancel.store(true, Ordering::Release);

--- a/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
+++ b/src/native_app/source_processing/supervisor/tests/discovery_progress.rs
@@ -233,6 +233,11 @@ fn discovery_progress_publisher_rejects_phase_and_count_regressions() {
         8,
     ));
     publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::QueueingWork,
+        4,
+        6,
+    ));
+    publisher.advance(DiscoveryProgressUpdate::determinate(
         SourceDiscoveryPhase::ComparingReadiness,
         8,
         8,

--- a/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
+++ b/src/native_app/source_processing/supervisor/tests/lifecycle_retirement.rs
@@ -118,14 +118,19 @@ fn brief_discovery_reconciliation_does_not_flash_processing_feedback() {
         source_id: source.id.as_str(),
         lifecycle_generation,
         started_at: Instant::now(),
-        last_phase: None,
+        last_progress: None,
         last_event_publish_at: None,
         last_log_publish_at: None,
         event_published: false,
+        work_units: 0,
     };
 
-    publisher.advance("Reading manifest and readiness targets", 1);
-    publisher.advance("Comparing durable readiness", 2);
+    publisher.advance(DiscoveryProgressUpdate::indeterminate(
+        SourceDiscoveryPhase::InspectingManifest,
+    ));
+    publisher.advance(DiscoveryProgressUpdate::indeterminate(
+        SourceDiscoveryPhase::ComparingReadiness,
+    ));
     assert!(
         receiver.try_recv().is_err(),
         "a brief converged-source check must not flash active processing feedback"
@@ -133,7 +138,11 @@ fn brief_discovery_reconciliation_does_not_flash_processing_feedback() {
     assert!(!publisher.event_published);
 
     publisher.started_at = Instant::now() - DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL;
-    publisher.advance("Queueing unfinished jobs", 3);
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::QueueingWork,
+        3,
+        5,
+    ));
     let SourceProcessingEvent::Progress(progress) = receiver
         .recv_timeout(Duration::from_secs(1))
         .expect("sustained discovery feedback")
@@ -143,10 +152,10 @@ fn brief_discovery_reconciliation_does_not_flash_processing_feedback() {
     assert_eq!(
         progress.activity,
         SourceProcessingActivity::Discovering {
-            phase: String::from("Queueing unfinished jobs"),
-            completed_steps: 3,
+            phase: SourceDiscoveryPhase::QueueingWork,
         }
     );
+    assert_eq!((progress.completed, progress.total), (3, 5));
     assert!(
         progress.source_row_active,
         "grace-surviving discovery must identify its active source row"
@@ -155,7 +164,7 @@ fn brief_discovery_reconciliation_does_not_flash_processing_feedback() {
 }
 
 #[test]
-fn discovery_snapshot_from_previous_readded_epoch_is_not_published() {
+fn discovery_progress_from_previous_readded_epoch_is_not_published() {
     let directory = tempfile::tempdir().expect("discovery source");
     let source = SampleSource::new_with_id(
         SourceId::from_string("readded-discovery-source"),
@@ -182,12 +191,17 @@ fn discovery_snapshot_from_previous_readded_epoch_is_not_published() {
         source_id: source.id.as_str(),
         lifecycle_generation: old_generation,
         started_at: Instant::now() - DISCOVERY_PROGRESS_EVENT_GRACE_INTERVAL,
-        last_phase: None,
+        last_progress: None,
         last_event_publish_at: None,
         last_log_publish_at: None,
         event_published: false,
+        work_units: 0,
     };
-    publisher.advance("Comparing durable readiness", 1);
+    publisher.advance(DiscoveryProgressUpdate::determinate(
+        SourceDiscoveryPhase::ComparingReadiness,
+        1,
+        5,
+    ));
     assert!(!publisher.event_published);
     assert!(receiver.try_recv().is_err());
 }

--- a/src/native_app/source_processing/supervisor/tests/mod.rs
+++ b/src/native_app/source_processing/supervisor/tests/mod.rs
@@ -69,7 +69,7 @@ fn reconcile_readiness_with_cancel_and_progress(
     source_id: &str,
     now: i64,
     cancel: &AtomicBool,
-    progress: &mut dyn FnMut(),
+    progress: &mut dyn FnMut(ReadinessProgress),
 ) -> Result<ReadinessSnapshot, ReadinessError> {
     ReadinessView::new(connection)
         .reconcile_with_cancel_and_progress(source_id, now, cancel, progress)

--- a/src/native_app/source_processing/supervisor/tests/readiness_execution.rs
+++ b/src/native_app/source_processing/supervisor/tests/readiness_execution.rs
@@ -112,7 +112,7 @@ fn legacy_playback_readiness_is_retired_without_requeueing_source_work() {
         source.id.as_str(),
         now_epoch_seconds(),
         &AtomicBool::new(false),
-        &mut || {},
+        &mut |_| {},
     )
     .expect("ignore legacy playback rows during reconciliation");
     assert_eq!(snapshot.entries.len(), 4);

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -109,7 +109,7 @@ fn startup_recovery_enqueues_retained_sources_missing_from_configuration() {
 }
 
 #[test]
-fn converged_periodic_safety_probes_do_not_rematerialize_targets() {
+fn discovery_progress_converged_safety_probe_is_a_silent_noop() {
     let (_directory, source) = unhashed_source("revision-gated-safety-probe");
     let database_root = source.database_root().expect("database root");
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
@@ -137,7 +137,7 @@ fn converged_periodic_safety_probes_do_not_rematerialize_targets() {
             None,
             true,
             &cancel,
-            &mut |_, _| panic!("cheap safety probe must not materialize target work"),
+            &mut |_| panic!("cheap safety probe must not materialize target work"),
         )
         .expect("run revision-gated safety probe") else {
             panic!("safety probe unexpectedly cancelled");
@@ -205,7 +205,7 @@ fn safety_probe_recovers_manifest_commit_without_delta_publication() {
             None,
             true,
             &AtomicBool::new(false),
-            &mut |_, _| {},
+            &mut |_| {},
         )
         .expect("recover readiness publication")
     else {
@@ -223,7 +223,7 @@ fn safety_probe_recovers_manifest_commit_without_delta_publication() {
 }
 
 #[test]
-fn committed_one_file_delta_updates_only_that_identity_targets() {
+fn discovery_progress_committed_delta_uses_changed_target_counts() {
     let (_directory, source) = unhashed_source("one-file-readiness-delta");
     let database_root = source.database_root().expect("database root");
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
@@ -267,6 +267,7 @@ fn committed_one_file_delta_updates_only_that_identity_targets() {
         scope_ids: [identity.clone()].into_iter().collect(),
     };
 
+    let mut progress_updates = Vec::new();
     let Cancellable::Completed((_candidates, stats)) =
         discover_source_candidates_with_connection_and_progress(
             &source,
@@ -277,13 +278,27 @@ fn committed_one_file_delta_updates_only_that_identity_targets() {
             Some(&delta),
             false,
             &AtomicBool::new(false),
-            &mut |_, _| {},
+            &mut |update| progress_updates.push(update),
         )
         .expect("reconcile committed delta")
     else {
         panic!("delta reconciliation unexpectedly cancelled");
     };
     assert!(stats.delta_reconciled);
+    assert!(
+        progress_updates.iter().any(|update| {
+            update.phase == SourceDiscoveryPhase::ComparingChangedReadiness
+                && update.completed == 4
+                && update.total == 4
+        }),
+        "the changed file's three targets plus the source target must provide the denominator"
+    );
+    assert!(
+        !progress_updates
+            .iter()
+            .any(|update| update.phase == SourceDiscoveryPhase::InspectingManifest),
+        "a committed delta must not claim a complete manifest inspection"
+    );
     assert_eq!(
         connection
             .query_row(

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -461,6 +461,55 @@ fn status_bar_routes_source_processing_through_worker_progress_and_job_details()
 }
 
 #[test]
+fn source_processing_job_details_use_truthful_discovery_units() {
+    let mut state = gui_state_for_span_tests();
+    let source_root = tempfile::tempdir().expect("source root");
+    state.library.folder_browser =
+        crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+            wavecrate::sample_sources::SampleSource::new(source_root.path().to_path_buf()),
+        ]);
+    let source_id = state
+        .library
+        .folder_browser
+        .selected_source_id()
+        .to_string();
+
+    for (stage, detail, expected) in [
+        (
+            "Comparing source readiness",
+            "17435 / 21697 readiness targets compared",
+            "Progress: 17435/21697 readiness targets compared",
+        ),
+        (
+            "Queueing unfinished work",
+            "14460 / 21697 readiness targets checked",
+            "Progress: 14460/21697 readiness targets checked",
+        ),
+    ] {
+        state.background.source_processing_progress = Some(
+            crate::native_app::test_support::state::SourceProcessingProgress {
+                source_id: source_id.clone(),
+                lifecycle_generation: 0,
+                active: true,
+                source_row_active: true,
+                completed: if stage.starts_with("Comparing") {
+                    17_435
+                } else {
+                    14_460
+                },
+                total: 21_697,
+                stage: String::from(stage),
+                detail: String::from(detail),
+            },
+        );
+
+        let model = crate::native_app::test_support::status_bar::status_bar_projection(&state);
+
+        assert_eq!(model.job_details.expect("job details")[2], expected);
+    }
+}
+
+#[test]
 fn status_bar_view_model_uses_normalization_work_progress_for_worker_bar() {
     let mut state = NativeAppState::load_default().expect("default state loads");
     state.ui.status.sample = String::from("Ready");

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -474,14 +474,25 @@ fn source_processing_job_details_use_truthful_discovery_units() {
         .selected_source_id()
         .to_string();
 
-    for (stage, detail, expected) in [
+    for (stage, completed, total, detail, expected) in [
+        (
+            "Preparing readiness targets",
+            7_232,
+            7_232,
+            "7232 / 7232 files prepared",
+            "Progress: 7232/7232 files prepared",
+        ),
         (
             "Comparing source readiness",
+            17_435,
+            21_697,
             "17435 / 21697 readiness targets compared",
             "Progress: 17435/21697 readiness targets compared",
         ),
         (
             "Queueing unfinished work",
+            14_460,
+            21_697,
             "14460 / 21697 readiness targets checked",
             "Progress: 14460/21697 readiness targets checked",
         ),
@@ -492,12 +503,8 @@ fn source_processing_job_details_use_truthful_discovery_units() {
                 lifecycle_generation: 0,
                 active: true,
                 source_row_active: true,
-                completed: if stage.starts_with("Comparing") {
-                    17_435
-                } else {
-                    14_460
-                },
-                total: 21_697,
+                completed,
+                total,
                 stage: String::from(stage),
                 detail: String::from(detail),
             },

--- a/src/native_app/tests/status_bar.rs
+++ b/src/native_app/tests/status_bar.rs
@@ -292,8 +292,8 @@ fn source_processing_discovery_uses_compact_activity_feedback() {
             source_row_active: true,
             completed: 0,
             total: 0,
-            stage: String::from("Checking pending work"),
-            detail: String::from("Counting unfinished analysis, similarity, and indexing jobs"),
+            stage: String::from("Inspecting source manifest"),
+            detail: String::from("Reading eligible files"),
         },
     );
 
@@ -314,10 +314,8 @@ fn source_processing_discovery_uses_compact_activity_feedback() {
         [
             String::from("Type: Source processing"),
             String::from("Source: Projects"),
-            String::from("Progress: Counting pending jobs"),
-            String::from(
-                "Current: Checking pending work | Counting unfinished analysis, similarity, and indexing jobs"
-            ),
+            String::from("Progress: Active (total not available)"),
+            String::from("Current: Inspecting source manifest | Reading eligible files"),
         ]
     );
 }


### PR DESCRIPTION
## Goal

Replace the misleading cumulative reconciliation checkpoint count with phase-specific, truthful source-processing progress for OPT-1243.

## Scope and non-goals

- Publish typed manifest inspection, target preparation, readiness comparison, changed-readiness comparison, and unfinished-work queueing phases.
- Report determinate completed/total file or readiness-target counts only when the denominator is known; otherwise report indeterminate activity.
- Keep internal row-visit checkpoints as diagnostic/cancellation work units without exposing them as user progress.
- Fence publication against phase/count regression and stale source lifecycles.
- Preserve readiness classification, persistence, job convergence, and scheduling behavior.

## Definition of Done

- The UI no longer presents internal reconciliation steps as completed work.
- Full, delta, no-op, cancellation/resume, source replacement, stale publication, and large-count projections have regression coverage.
- Normal and compact status projections use phase-specific copy and truthful units.
- Existing source-processing readiness behavior remains green in scoped validation.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -q -p wavecrate --lib native_app::source_processing::supervisor::tests -- --test-threads=1` — 93 passed, 1 ignored
- `cargo test -p wavecrate --lib native_app::tests::status_bar -- --test-threads=1` — 23 passed
- `cargo test -p wavecrate-library sample_sources::readiness -- --test-threads=1` — 47 passed
- `cargo test -p wavecrate --lib source_processing_events -- --nocapture` — 4 passed
- `cargo test -p wavecrate --lib source_processing_progress -- --nocapture` — 3 passed
- `cargo test -p wavecrate --bin wavecrate discovery_progress` and `status_bar` — compiled and passed (the filters select no binary tests; behavioral coverage lives in the library suites above)
- `bash scripts/build.sh --release` — passed; signed app built as `Wavecrate OPT-1243.app` (b6707)
- Signed-app smoke — source scan progressed against the active large source (`6708 / 7232`) and the job-details panel remained source-scoped in the normal layout. Higher-priority waveform-cache work preempted the brief reconciliation phases; their exact normal/compact copy is covered by deterministic projection tests.
- `git diff --check` — passed
- `bash scripts/ci.sh agent` — smoke/architecture/build stages passed; the repository-wide parallel lib lane reproduced 48 global-state-sensitive failures across unrelated UI/source/cache tests. The affected source-processing, readiness, and status suites all pass serially as listed above.

## Known limitations

The live reconciliation phases finish too quickly to remain visible when a higher-priority cache job owns the status lane; deterministic normal/compact projection tests provide the phase-copy evidence.

User approval is required before merge.