### PR TITLE
OPT-1236: contain targeted symlink sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cap-primitives"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +839,18 @@ dependencies = [
  "rustix-linux-procfs",
  "windows-sys 0.61.2",
  "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6234,6 +6258,8 @@ name = "wavecrate-scan"
 version = "0.19.1"
 dependencies = [
  "blake3",
+ "cap-fs-ext",
+ "cap-std",
  "libc",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6265,6 +6265,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "wavecrate-library",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/wavecrate-scan/Cargo.toml
+++ b/crates/wavecrate-scan/Cargo.toml
@@ -20,3 +20,6 @@ tempfile = "3.23.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.176"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }

--- a/crates/wavecrate-scan/Cargo.toml
+++ b/crates/wavecrate-scan/Cargo.toml
@@ -9,6 +9,8 @@ missing_docs = "deny"
 
 [dependencies]
 blake3 = "1.6.1"
+cap-fs-ext = "4.0.2"
+cap-std = "4.0.2"
 wavecrate-library = { path = "../wavecrate-library" }
 thiserror = "2.0.17"
 tracing = "0.1.41"

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -229,3 +229,63 @@ fn targeted_sync_cancels_after_a_committed_batch_and_resumes_safely() {
     assert_eq!(resumed.total_files, 70);
     assert_eq!(db.count_files().unwrap(), 70);
 }
+
+#[cfg(unix)]
+#[test]
+fn targeted_sync_skips_directory_symlink_targets() {
+    use std::os::unix::fs as unix_fs;
+
+    let source = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    std::fs::create_dir_all(source.path().join("nested")).unwrap();
+    std::fs::write(source.path().join("nested/keep.wav"), b"keep").unwrap();
+    std::fs::write(outside.path().join("outside.wav"), b"outside").unwrap();
+    unix_fs::symlink(outside.path(), source.path().join("outside-link")).unwrap();
+    unix_fs::symlink(source.path(), source.path().join("ancestor-loop")).unwrap();
+
+    let db = SourceDatabase::open_for_scan(source.path()).unwrap();
+    scan_once(&db).unwrap();
+    let stats = sync_paths(
+        &db,
+        &[
+            PathBuf::from("outside-link"),
+            PathBuf::from("outside-link/outside.wav"),
+            PathBuf::from("ancestor-loop"),
+            PathBuf::from("ancestor-loop/nested/keep.wav"),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(stats.total_files, 0);
+    let rows = db.list_files().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].relative_path, Path::new("nested/keep.wav"));
+}
+
+#[cfg(unix)]
+#[test]
+fn targeted_sync_retires_a_file_replaced_by_a_symlink() {
+    use std::os::unix::fs as unix_fs;
+
+    let source = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let tracked = source.path().join("tracked.wav");
+    std::fs::write(&tracked, b"tracked").unwrap();
+    std::fs::write(outside.path().join("outside.wav"), b"outside").unwrap();
+
+    let db = SourceDatabase::open_for_scan(source.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::remove_file(&tracked).unwrap();
+    unix_fs::symlink(outside.path().join("outside.wav"), &tracked).unwrap();
+
+    let stats = sync_paths(&db, &[PathBuf::from("tracked.wav")]).unwrap();
+
+    assert_eq!(stats.total_files, 0);
+    assert_eq!(stats.missing, 1);
+    assert!(
+        db.entry_for_path(Path::new("tracked.wav"))
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(stats.committed_delta.deleted.len(), 1);
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -17,6 +17,11 @@ pub(super) struct PreparedFile {
     pub(super) requires_apply: bool,
     pub(super) identity_replaced: bool,
     pub(super) content_hash: Option<String>,
+    /// A targeted-sync descriptor opened through the source-root capability.
+    /// It is consumed during preparation so hashing cannot re-resolve a path
+    /// that was replaced by a link after classification.
+    pub(super) targeted_file: Option<std::fs::File>,
+    pub(super) targeted_handle_verified: bool,
 }
 
 pub(super) fn apply_diff(
@@ -32,6 +37,7 @@ pub(super) fn apply_diff(
         requires_apply: _,
         identity_replaced,
         content_hash,
+        ..
     } = prepared;
     let path = facts.relative.clone();
     let should_hash = hash_required;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -1,6 +1,6 @@
 use super::scan::{ScanContext, ScanError, ScanMode};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
-use super::scan_fs::read_facts;
+use super::scan_fs::{FileFacts, read_facts};
 use std::path::Path;
 
 pub(super) fn prepare_diff(
@@ -9,6 +9,10 @@ pub(super) fn prepare_diff(
     context: &ScanContext,
 ) -> Result<PreparedFile, ScanError> {
     let facts = read_facts(root, path)?;
+    Ok(prepare_diff_from_facts(facts, context))
+}
+
+pub(super) fn prepare_diff_from_facts(facts: FileFacts, context: &ScanContext) -> PreparedFile {
     let existing = context.existing.get(&facts.relative);
     let persisted_identity = context
         .committed_file_identity(&facts.relative)
@@ -43,12 +47,14 @@ pub(super) fn prepare_diff(
             || (entry.content_hash.is_none() && needs_hash)
             || identity_requires_update
     });
-    Ok(PreparedFile {
+    PreparedFile {
         facts,
         hash_required,
         needs_hash,
         requires_apply,
         identity_replaced,
         content_hash: None,
-    })
+        targeted_file: None,
+        targeted_handle_verified: false,
+    }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -211,6 +211,60 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
     })
 }
 
+/// Read facts from an already-open regular file.
+///
+/// Targeted watcher reconciliation uses this after opening through a
+/// capability-scoped, no-follow path. Keeping the descriptor through hashing
+/// ensures the object that was classified is the one whose contents are read.
+pub(super) fn read_facts_from_open_file(
+    root: &Path,
+    path: &Path,
+    file: &fs::File,
+) -> Result<FileFacts, ScanError> {
+    let relative = strip_relative(root, path)?;
+    let meta = file.metadata().map_err(|source| ScanError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let modified_ns = to_nanos(
+        &meta.modified().map_err(|source| ScanError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?,
+        path,
+    )?;
+    Ok(FileFacts {
+        relative,
+        size: meta.len(),
+        modified_ns,
+        // On Windows these helpers reopen the supplied path to query handle
+        // metadata. A targeted path may have changed after its no-follow open,
+        // so keep the capability guarantee by omitting the optional markers.
+        // The targeted mode already hashes existing rows and records the
+        // descriptor-derived size and modification time.
+        file_identity: {
+            #[cfg(windows)]
+            {
+                None
+            }
+            #[cfg(not(windows))]
+            {
+                stable_filesystem_identity(path, &meta)
+            }
+        },
+        change_marker: {
+            #[cfg(windows)]
+            {
+                None
+            }
+            #[cfg(not(windows))]
+            {
+                filesystem_change_marker(path, &meta)
+            }
+        },
+    })
+}
+
 pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
     fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
         && is_supported_audio(path)
@@ -240,7 +294,7 @@ pub(super) fn compute_content_hash(
     compute_content_hash_with_reader(path, &mut file, cancel)
 }
 
-fn compute_content_hash_with_reader(
+pub(super) fn compute_content_hash_with_reader(
     path: &Path,
     reader: &mut impl Read,
     cancel: Option<&AtomicBool>,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -1,16 +1,19 @@
 use std::{
-    collections::{BTreeSet, HashMap},
-    fs,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    io,
     path::{Component, Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
+use cap_std::fs::{Dir, OpenOptions};
 
 use crate::sample_sources::{SourceDatabase, WavEntry, is_supported_audio};
 
 use super::{
     scan::{ScanContext, ScanError, ScanMode, ScanStats},
     scan_db_sync::db_sync_phase,
-    scan_diff_phase::prepare_diff,
+    scan_diff_phase::prepare_diff_from_facts,
     scan_fs::ensure_root_dir,
     scan_walk::apply_prepared_chunk,
     scan_writer::{ScanWriter, UncoordinatedScanWriter},
@@ -57,28 +60,16 @@ pub fn sync_paths_with_progress_and_writer(
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     let result = (|| {
-        for relative_path in targets.current_files {
+        for targeted_file in targets.current_files {
             if let Some(cancel) = cancel
                 && cancel.load(Ordering::Relaxed)
             {
                 return Err(ScanError::Canceled);
             }
-            let absolute = root.join(&relative_path);
-            let prepared_file = match prepare_diff(&root, &absolute, &context) {
-                Ok(prepared) => prepared,
-                Err(error) if committed => {
-                    if absolute.exists() {
-                        context.existing.remove(&relative_path);
-                    }
-                    tracing::warn!(
-                        path = %absolute.display(),
-                        error = %error,
-                        "Skipping targeted file after an earlier chunk committed"
-                    );
-                    continue;
-                }
-                Err(error) => return Err(error),
-            };
+            let absolute = root.join(&targeted_file.relative);
+            let mut prepared_file = prepare_diff_from_facts(targeted_file.facts, &context);
+            prepared_file.targeted_file = Some(targeted_file.file);
+            prepared_file.targeted_handle_verified = true;
             prepared.push(prepared_file);
             context.stats.total_files += 1;
             on_progress(context.stats.total_files, &absolute);
@@ -114,8 +105,14 @@ pub fn sync_paths_with_progress_and_writer(
 }
 
 struct TargetedScanTargets {
-    current_files: BTreeSet<PathBuf>,
+    current_files: Vec<TargetedFile>,
     existing: HashMap<PathBuf, WavEntry>,
+}
+
+struct TargetedFile {
+    relative: PathBuf,
+    facts: super::scan_fs::FileFacts,
+    file: std::fs::File,
 }
 
 fn collect_targets(
@@ -124,7 +121,12 @@ fn collect_targets(
     paths: &[PathBuf],
     cancel: Option<&AtomicBool>,
 ) -> Result<TargetedScanTargets, ScanError> {
-    let mut current_files = BTreeSet::new();
+    let source_root =
+        Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+    let mut current_files = BTreeMap::new();
     let mut existing = HashMap::new();
     for relative_path in normalized_targets(paths) {
         if let Some(cancel) = cancel
@@ -132,12 +134,17 @@ fn collect_targets(
         {
             return Err(ScanError::Canceled);
         }
-        let absolute = root.join(&relative_path);
         collect_existing_rows(db, &relative_path, &mut existing)?;
-        collect_current_files(&absolute, root, cancel, &mut current_files)?;
+        collect_current_files(
+            &source_root,
+            root,
+            &relative_path,
+            cancel,
+            &mut current_files,
+        )?;
     }
     Ok(TargetedScanTargets {
-        current_files,
+        current_files: current_files.into_values().collect(),
         existing,
     })
 }
@@ -168,20 +175,23 @@ fn collect_existing_rows(
 }
 
 fn collect_current_files(
-    absolute_path: &Path,
+    source_root: &Dir,
     root: &Path,
+    relative_path: &Path,
     cancel: Option<&AtomicBool>,
-    current_files: &mut BTreeSet<PathBuf>,
+    current_files: &mut BTreeMap<PathBuf, TargetedFile>,
 ) -> Result<(), ScanError> {
-    if has_symlinked_target_ancestor(root, absolute_path)? {
+    let Some((parent, name)) = open_target_parent(source_root, root, relative_path)? else {
         return Ok(());
-    }
-    let metadata = match fs::symlink_metadata(absolute_path) {
+    };
+    let absolute_path = root.join(relative_path);
+    let name_path = Path::new(&name);
+    let metadata = match parent.symlink_metadata(name_path) {
         Ok(metadata) => metadata,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
             return Err(ScanError::Io {
-                path: absolute_path.to_path_buf(),
+                path: absolute_path,
                 source,
             });
         }
@@ -191,63 +201,98 @@ fn collect_current_files(
         return Ok(());
     }
     if file_type.is_dir() {
-        collect_current_files_in_dir(absolute_path, root, cancel, current_files)?;
-    } else if file_type.is_file() && is_supported_audio(absolute_path) {
-        current_files.insert(strip_relative(root, absolute_path)?);
+        let dir = match parent.open_dir_nofollow(name_path) {
+            Ok(dir) => dir,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(source) => {
+                return Err(ScanError::Io {
+                    path: root.join(relative_path),
+                    source,
+                });
+            }
+        };
+        collect_current_files_in_dir(dir, root, relative_path, cancel, current_files)?;
+    } else if file_type.is_file() {
+        collect_current_file(
+            &parent,
+            Path::new(&name),
+            root,
+            relative_path,
+            current_files,
+        )?;
     }
     Ok(())
 }
 
-fn has_symlinked_target_ancestor(root: &Path, absolute_path: &Path) -> Result<bool, ScanError> {
-    let relative_path = absolute_path
-        .strip_prefix(root)
-        .map_err(|_| ScanError::InvalidRoot(absolute_path.to_path_buf()))?;
-    let mut candidate = root.to_path_buf();
-    for component in relative_path.components() {
+fn open_target_parent(
+    source_root: &Dir,
+    root: &Path,
+    relative_path: &Path,
+) -> Result<Option<(Dir, std::ffi::OsString)>, ScanError> {
+    let Some(name) = relative_path.file_name() else {
+        return Ok(None);
+    };
+    let mut dir = source_root.try_clone().map_err(|source| ScanError::Io {
+        path: root.to_path_buf(),
+        source,
+    })?;
+    let mut traversed = PathBuf::new();
+    for component in relative_path
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+    {
         let Component::Normal(part) = component else {
             continue;
         };
-        candidate.push(part);
-        match fs::symlink_metadata(&candidate) {
-            Ok(metadata) if metadata.file_type().is_symlink() => return Ok(true),
-            Ok(_) => {}
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        traversed.push(part);
+        dir = match dir.open_dir_nofollow(part) {
+            Ok(dir) => dir,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(source) => {
-                return Err(ScanError::Io {
-                    path: candidate,
-                    source,
-                });
+                let path = root.join(&traversed);
+                if dir
+                    .symlink_metadata(part)
+                    .is_ok_and(|metadata| metadata.is_symlink())
+                {
+                    return Ok(None);
+                }
+                return Err(ScanError::Io { path, source });
             }
-        }
+        };
     }
-    Ok(false)
+    Ok(Some((dir, name.to_os_string())))
 }
 
 fn collect_current_files_in_dir(
-    start_dir: &Path,
+    start_dir: Dir,
     root: &Path,
+    start_relative: &Path,
     cancel: Option<&AtomicBool>,
-    current_files: &mut BTreeSet<PathBuf>,
+    current_files: &mut BTreeMap<PathBuf, TargetedFile>,
 ) -> Result<(), ScanError> {
-    let mut stack = vec![start_dir.to_path_buf()];
-    while let Some(dir) = stack.pop() {
+    let mut stack = vec![(start_dir, start_relative.to_path_buf())];
+    while let Some((dir, relative_dir)) = stack.pop() {
         if let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
         {
             return Err(ScanError::Canceled);
         }
-        let entries = match fs::read_dir(&dir) {
+        let entries = match dir.entries() {
             Ok(entries) => entries,
-            Err(source) if dir != start_dir => {
+            Err(source) if relative_dir != start_relative => {
                 tracing::warn!(
-                    dir = %dir.display(),
+                    dir = %root.join(&relative_dir).display(),
                     error = %source,
                     "Failed to read targeted sync directory"
                 );
                 continue;
             }
             Err(source) => {
-                return Err(ScanError::Io { path: dir, source });
+                return Err(ScanError::Io {
+                    path: root.join(&relative_dir),
+                    source,
+                });
             }
         };
         for entry in entries {
@@ -255,14 +300,16 @@ fn collect_current_files_in_dir(
                 Ok(entry) => entry,
                 Err(err) => {
                     tracing::warn!(
-                        dir = %dir.display(),
+                        dir = %root.join(&relative_dir).display(),
                         error = %err,
                         "Failed to read targeted sync directory entry"
                     );
                     continue;
                 }
             };
-            let path = entry.path();
+            let name = entry.file_name();
+            let name_path = Path::new(&name);
+            let path = root.join(&relative_dir).join(name_path);
             let file_type = match entry.file_type() {
                 Ok(file_type) => file_type,
                 Err(err) => {
@@ -278,17 +325,73 @@ fn collect_current_files_in_dir(
                 continue;
             }
             if file_type.is_dir() {
-                stack.push(path);
-            } else if file_type.is_file() && is_supported_audio(&path) {
-                current_files.insert(strip_relative(root, &path)?);
+                let child_dir = match dir.open_dir_nofollow(name_path) {
+                    Ok(child_dir) => child_dir,
+                    Err(source) if source.kind() == io::ErrorKind::NotFound => continue,
+                    Err(source) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %source,
+                            "Failed to open targeted sync directory without following links"
+                        );
+                        continue;
+                    }
+                };
+                stack.push((child_dir, relative_dir.join(name_path)));
+            } else if file_type.is_file() {
+                let relative_path = relative_dir.join(name_path);
+                collect_current_file(&dir, name_path, root, &relative_path, current_files)?;
             }
         }
     }
     Ok(())
 }
 
-fn strip_relative(root: &Path, path: &Path) -> Result<PathBuf, ScanError> {
-    path.strip_prefix(root)
-        .map(PathBuf::from)
-        .map_err(|_| ScanError::InvalidRoot(path.to_path_buf()))
+fn collect_current_file(
+    parent: &Dir,
+    name: &Path,
+    root: &Path,
+    relative_path: &Path,
+    current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+) -> Result<(), ScanError> {
+    let absolute_path = root.join(relative_path);
+    if !is_supported_audio(&absolute_path) || has_hidden_ancestor(relative_path) {
+        return Ok(());
+    }
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = match parent.open_with(name, &options) {
+        Ok(file) => file.into_std(),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            // The no-follow open is the source-boundary decision. A file that
+            // became a link after directory enumeration is rejected here.
+            tracing::warn!(
+                path = %absolute_path.display(),
+                error = %source,
+                "Skipping targeted sync file that could not be opened without following links"
+            );
+            return Ok(());
+        }
+    };
+    let facts = super::scan_fs::read_facts_from_open_file(root, &absolute_path, &file)?;
+    current_files
+        .entry(relative_path.to_path_buf())
+        .or_insert(TargetedFile {
+            relative: relative_path.to_path_buf(),
+            facts,
+            file,
+        });
+    Ok(())
+}
+
+fn has_hidden_ancestor(relative_path: &Path) -> bool {
+    relative_path.parent().is_some_and(|parent| {
+        parent.components().any(|component| {
+            let Component::Normal(name) = component else {
+                return false;
+            };
+            name.to_str().is_some_and(|name| name.starts_with('.'))
+        })
+    })
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -146,7 +146,12 @@ fn normalized_targets(paths: &[PathBuf]) -> BTreeSet<PathBuf> {
     paths
         .iter()
         .filter(|path| !path.as_os_str().is_empty())
-        .filter(|path| path.is_relative())
+        .filter(|path| {
+            path.is_relative()
+                && path
+                    .components()
+                    .all(|component| matches!(component, Component::CurDir | Component::Normal(_)))
+        })
         .cloned()
         .collect()
 }
@@ -168,12 +173,54 @@ fn collect_current_files(
     cancel: Option<&AtomicBool>,
     current_files: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
-    if absolute_path.is_dir() {
+    if has_symlinked_target_ancestor(root, absolute_path)? {
+        return Ok(());
+    }
+    let metadata = match fs::symlink_metadata(absolute_path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(ScanError::Io {
+                path: absolute_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Ok(());
+    }
+    if file_type.is_dir() {
         collect_current_files_in_dir(absolute_path, root, cancel, current_files)?;
-    } else if absolute_path.is_file() && is_supported_audio(absolute_path) {
+    } else if file_type.is_file() && is_supported_audio(absolute_path) {
         current_files.insert(strip_relative(root, absolute_path)?);
     }
     Ok(())
+}
+
+fn has_symlinked_target_ancestor(root: &Path, absolute_path: &Path) -> Result<bool, ScanError> {
+    let relative_path = absolute_path
+        .strip_prefix(root)
+        .map_err(|_| ScanError::InvalidRoot(absolute_path.to_path_buf()))?;
+    let mut candidate = root.to_path_buf();
+    for component in relative_path.components() {
+        let Component::Normal(part) = component else {
+            continue;
+        };
+        candidate.push(part);
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return Ok(true),
+            Ok(_) => {}
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(source) => {
+                return Err(ScanError::Io {
+                    path: candidate,
+                    source,
+                });
+            }
+        }
+    }
+    Ok(false)
 }
 
 fn collect_current_files_in_dir(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -314,10 +314,16 @@ fn apply_batch(
                 .targeted_file
                 .as_ref()
                 .expect("verified targeted files retain their descriptor through apply");
-            if !targeted_path_matches_handle(root, &relative_path, file_handle)? {
-                context.mark_source_tree_incomplete();
-                context.existing.remove(&relative_path);
-                continue;
+            match targeted_path_binding(root, &relative_path, file_handle)? {
+                TargetedPathBinding::Matches => {}
+                // A link or absence is a definite deletion: leave its old row
+                // in `existing` for the missing phase to retire.
+                TargetedPathBinding::Retire => continue,
+                TargetedPathBinding::Changed => {
+                    context.mark_source_tree_incomplete();
+                    context.existing.remove(&relative_path);
+                    continue;
+                }
             }
         } else {
             let absolute = root.join(&relative_path);
@@ -472,11 +478,17 @@ fn prepare_targeted_for_apply(
 
 /// Confirm that the path used as the manifest key is still bound to the same
 /// no-follow file descriptor that targeted discovery classified and hashed.
-fn targeted_path_matches_handle(
+enum TargetedPathBinding {
+    Matches,
+    Retire,
+    Changed,
+}
+
+fn targeted_path_binding(
     root: &Path,
     relative_path: &Path,
     expected: &std::fs::File,
-) -> Result<bool, ScanError> {
+) -> Result<TargetedPathBinding, ScanError> {
     let source_root =
         Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
             path: root.to_path_buf(),
@@ -484,28 +496,41 @@ fn targeted_path_matches_handle(
         })?;
     let Some((parent, name)) = open_target_parent_nofollow(&source_root, root, relative_path)?
     else {
-        return Ok(false);
+        return Ok(TargetedPathBinding::Retire);
     };
     let mut options = OpenOptions::new();
     options.read(true).follow(FollowSymlinks::No);
     let current = match parent.open_with(&name, &options) {
         Ok(file) => file.into_std(),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(TargetedPathBinding::Retire);
+        }
         Err(source) => {
+            if parent
+                .symlink_metadata(&name)
+                .is_ok_and(|metadata| metadata.is_symlink())
+            {
+                return Ok(TargetedPathBinding::Retire);
+            }
             tracing::warn!(
                 path = %root.join(relative_path).display(),
                 error = %source,
                 "Skipping targeted sync path that no longer opens without following links"
             );
-            return Ok(false);
+            return Ok(TargetedPathBinding::Changed);
         }
     };
     if !current.metadata().is_ok_and(|metadata| metadata.is_file()) {
-        return Ok(false);
+        return Ok(TargetedPathBinding::Retire);
     }
-    same_open_file(expected, &current).map_err(|source| ScanError::Io {
+    let matches = same_open_file(expected, &current).map_err(|source| ScanError::Io {
         path: root.join(relative_path),
         source,
+    })?;
+    Ok(if matches {
+        TargetedPathBinding::Matches
+    } else {
+        TargetedPathBinding::Changed
     })
 }
 
@@ -753,10 +778,10 @@ mod tests {
         std::fs::remove_file(&source).unwrap();
         symlink(&outside_file, &source).unwrap();
 
-        assert!(
-            !super::targeted_path_matches_handle(dir.path(), Path::new("one.wav"), &expected,)
-                .unwrap()
-        );
+        assert!(matches!(
+            super::targeted_path_binding(dir.path(), Path::new("one.wav"), &expected).unwrap(),
+            super::TargetedPathBinding::Retire
+        ));
     }
 
     #[cfg(unix)]
@@ -776,13 +801,59 @@ mod tests {
         std::fs::rename(&nested, dir.path().join("moved")).unwrap();
         symlink(outside.path(), &nested).unwrap();
 
-        assert!(
-            !super::targeted_path_matches_handle(
-                dir.path(),
-                Path::new("nested/one.wav"),
-                &expected,
-            )
-            .unwrap()
+        assert!(matches!(
+            super::targeted_path_binding(dir.path(), Path::new("nested/one.wav"), &expected,)
+                .unwrap(),
+            super::TargetedPathBinding::Retire
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targeted_apply_retires_a_file_replaced_by_a_link_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("one.wav");
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"source").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        let entry = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::from([(Path::new("one.wav").to_path_buf(), entry)]),
+            ScanMode::Targeted,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
         );
+        let file = std::fs::File::open(&source).unwrap();
+        let prepared = PreparedFile {
+            facts: super::super::scan_fs::read_facts_from_open_file(dir.path(), &source, &file)
+                .unwrap(),
+            hash_required: false,
+            needs_hash: false,
+            requires_apply: true,
+            identity_replaced: false,
+            content_hash: None,
+            targeted_file: Some(file),
+            targeted_handle_verified: true,
+        };
+
+        std::fs::remove_file(&source).unwrap();
+        symlink(&outside_file, &source).unwrap();
+        apply_batch(
+            &db,
+            dir.path(),
+            None,
+            &mut context,
+            vec![prepared],
+            false,
+            &super::super::scan_writer::UncoordinatedScanWriter,
+        )
+        .unwrap();
+
+        assert!(context.existing.contains_key(Path::new("one.wav")));
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -2,6 +2,7 @@
 
 use std::{
     cell::Cell,
+    io::{Seek, SeekFrom},
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -12,8 +13,8 @@ use super::scan::{ScanContext, ScanError};
 use super::scan_diff::{PreparedFile, apply_diff};
 use super::scan_diff_phase::prepare_diff;
 use super::scan_fs::{
-    compute_content_hash, is_supported_scannable_audio_file, read_facts,
-    visit_dir_with_cancel_check,
+    compute_content_hash, compute_content_hash_with_reader, is_supported_scannable_audio_file,
+    read_facts, read_facts_from_open_file, visit_dir_with_cancel_check,
 };
 use super::scan_writer::{ScanWritePhase, ScanWriter};
 
@@ -305,13 +306,15 @@ fn apply_batch(
     let mut audited_paths = Vec::with_capacity(ready.len());
     for file in ready {
         let relative_path = file.facts.relative.clone();
-        let absolute = root.join(&relative_path);
-        match read_facts(root, &absolute) {
-            Ok(current) if prepared_still_current(&file, &current) => {}
-            _ => {
-                context.mark_source_tree_incomplete();
-                skip_changed_or_unavailable(context, root, &relative_path);
-                continue;
+        if !file.targeted_handle_verified {
+            let absolute = root.join(&relative_path);
+            match read_facts(root, &absolute) {
+                Ok(current) if prepared_still_current(&file, &current) => {}
+                _ => {
+                    context.mark_source_tree_incomplete();
+                    skip_changed_or_unavailable(context, root, &relative_path);
+                    continue;
+                }
             }
         }
         apply_diff(db, &mut batch, file, context)?;
@@ -361,6 +364,9 @@ fn prepare_for_apply_with_post_hash_hook(
     mut prepared: PreparedFile,
     mut post_hash: impl FnMut(&Path),
 ) -> Result<PrepareForApply, ScanError> {
+    if prepared.targeted_handle_verified {
+        return prepare_targeted_for_apply(db, root, cancel, prepared, &mut post_hash);
+    }
     let absolute = root.join(&prepared.facts.relative);
     if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
         return Ok(PrepareForApply::Gone);
@@ -399,6 +405,49 @@ fn prepare_for_apply_with_post_hash_hook(
         if !prepared.facts.same_content_snapshot(&after_hash) {
             return Ok(PrepareForApply::Skip);
         }
+    }
+    Ok(PrepareForApply::Ready(prepared))
+}
+
+fn prepare_targeted_for_apply(
+    db: &SourceDatabase,
+    root: &Path,
+    cancel: Option<&AtomicBool>,
+    mut prepared: PreparedFile,
+    post_hash: &mut impl FnMut(&Path),
+) -> Result<PrepareForApply, ScanError> {
+    let absolute = root.join(&prepared.facts.relative);
+    let mut file = prepared
+        .targeted_file
+        .take()
+        .expect("verified targeted files retain their open descriptor until preparation");
+    let before_hash = read_facts_from_open_file(root, &absolute, &file)?;
+    if !facts_match(&prepared, &before_hash) {
+        return Ok(PrepareForApply::Skip);
+    }
+    let current_needs_hash = db
+        .entry_for_path(&prepared.facts.relative)?
+        .is_none_or(|entry| {
+            entry.file_size != prepared.facts.size
+                || entry.modified_ns != prepared.facts.modified_ns
+                || entry.content_hash.is_none()
+        });
+    if prepared.hash_required && (prepared.needs_hash || current_needs_hash) {
+        prepared.facts = before_hash;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|source| ScanError::Io {
+                path: absolute.clone(),
+                source,
+            })?;
+        prepared.content_hash = Some(compute_content_hash_with_reader(
+            &absolute, &mut file, cancel,
+        )?);
+        post_hash(&absolute);
+        let after_hash = read_facts_from_open_file(root, &absolute, &file)?;
+        if !prepared.facts.same_content_snapshot(&after_hash) {
+            return Ok(PrepareForApply::Skip);
+        }
+        prepared.facts = after_hash;
     }
     Ok(PrepareForApply::Ready(prepared))
 }
@@ -449,6 +498,8 @@ mod tests {
             requires_apply: true,
             identity_replaced: false,
             content_hash: None,
+            targeted_file: None,
+            targeted_handle_verified: false,
         };
 
         assert!(prepared.requires_apply);
@@ -539,6 +590,8 @@ mod tests {
             requires_apply: true,
             identity_replaced: false,
             content_hash: None,
+            targeted_file: None,
+            targeted_handle_verified: false,
         };
 
         let outcome =

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -3,9 +3,12 @@
 use std::{
     cell::Cell,
     io::{Seek, SeekFrom},
-    path::Path,
+    path::{Component, Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
+use cap_std::fs::{Dir, OpenOptions};
 
 use crate::sample_sources::SourceDatabase;
 
@@ -306,7 +309,17 @@ fn apply_batch(
     let mut audited_paths = Vec::with_capacity(ready.len());
     for file in ready {
         let relative_path = file.facts.relative.clone();
-        if !file.targeted_handle_verified {
+        if file.targeted_handle_verified {
+            let file_handle = file
+                .targeted_file
+                .as_ref()
+                .expect("verified targeted files retain their descriptor through apply");
+            if !targeted_path_matches_handle(root, &relative_path, file_handle)? {
+                context.mark_source_tree_incomplete();
+                context.existing.remove(&relative_path);
+                continue;
+            }
+        } else {
             let absolute = root.join(&relative_path);
             match read_facts(root, &absolute) {
                 Ok(current) if prepared_still_current(&file, &current) => {}
@@ -417,14 +430,21 @@ fn prepare_targeted_for_apply(
     post_hash: &mut impl FnMut(&Path),
 ) -> Result<PrepareForApply, ScanError> {
     let absolute = root.join(&prepared.facts.relative);
-    let mut file = prepared
-        .targeted_file
-        .take()
-        .expect("verified targeted files retain their open descriptor until preparation");
-    let before_hash = read_facts_from_open_file(root, &absolute, &file)?;
+    let before_hash = read_facts_from_open_file(
+        root,
+        &absolute,
+        prepared
+            .targeted_file
+            .as_ref()
+            .expect("verified targeted files retain their open descriptor until preparation"),
+    )?;
     if !facts_match(&prepared, &before_hash) {
         return Ok(PrepareForApply::Skip);
     }
+    let file = prepared
+        .targeted_file
+        .as_mut()
+        .expect("verified targeted files retain their open descriptor until preparation");
     let current_needs_hash = db
         .entry_for_path(&prepared.facts.relative)?
         .is_none_or(|entry| {
@@ -439,9 +459,7 @@ fn prepare_targeted_for_apply(
                 path: absolute.clone(),
                 source,
             })?;
-        prepared.content_hash = Some(compute_content_hash_with_reader(
-            &absolute, &mut file, cancel,
-        )?);
+        prepared.content_hash = Some(compute_content_hash_with_reader(&absolute, file, cancel)?);
         post_hash(&absolute);
         let after_hash = read_facts_from_open_file(root, &absolute, &file)?;
         if !prepared.facts.same_content_snapshot(&after_hash) {
@@ -450,6 +468,122 @@ fn prepare_targeted_for_apply(
         prepared.facts = after_hash;
     }
     Ok(PrepareForApply::Ready(prepared))
+}
+
+/// Confirm that the path used as the manifest key is still bound to the same
+/// no-follow file descriptor that targeted discovery classified and hashed.
+fn targeted_path_matches_handle(
+    root: &Path,
+    relative_path: &Path,
+    expected: &std::fs::File,
+) -> Result<bool, ScanError> {
+    let source_root =
+        Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+    let Some((parent, name)) = open_target_parent_nofollow(&source_root, root, relative_path)?
+    else {
+        return Ok(false);
+    };
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let current = match parent.open_with(&name, &options) {
+        Ok(file) => file.into_std(),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(source) => {
+            tracing::warn!(
+                path = %root.join(relative_path).display(),
+                error = %source,
+                "Skipping targeted sync path that no longer opens without following links"
+            );
+            return Ok(false);
+        }
+    };
+    if !current.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return Ok(false);
+    }
+    same_open_file(expected, &current).map_err(|source| ScanError::Io {
+        path: root.join(relative_path),
+        source,
+    })
+}
+
+fn open_target_parent_nofollow(
+    source_root: &Dir,
+    root: &Path,
+    relative_path: &Path,
+) -> Result<Option<(Dir, PathBuf)>, ScanError> {
+    let Some(name) = relative_path.file_name() else {
+        return Ok(None);
+    };
+    let mut dir = source_root.try_clone().map_err(|source| ScanError::Io {
+        path: root.to_path_buf(),
+        source,
+    })?;
+    let mut traversed = PathBuf::new();
+    for component in relative_path
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+    {
+        let Component::Normal(part) = component else {
+            continue;
+        };
+        traversed.push(part);
+        dir = match dir.open_dir_nofollow(part) {
+            Ok(dir) => dir,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                if dir
+                    .symlink_metadata(part)
+                    .is_ok_and(|metadata| metadata.is_symlink())
+                {
+                    return Ok(None);
+                }
+                return Err(ScanError::Io {
+                    path: root.join(&traversed),
+                    source,
+                });
+            }
+        };
+    }
+    Ok(Some((dir, PathBuf::from(name))))
+}
+
+#[cfg(unix)]
+fn same_open_file(left: &std::fs::File, right: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let left = left.metadata()?;
+    let right = right.metadata()?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(windows)]
+fn same_open_file(left: &std::fs::File, right: &std::fs::File) -> std::io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
+    };
+
+    let information = |file: &std::fs::File| {
+        let mut information = BY_HANDLE_FILE_INFORMATION::default();
+        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
+            .map_err(std::io::Error::other)?;
+        Ok::<_, std::io::Error>((
+            information.dwVolumeSerialNumber,
+            information.nFileIndexHigh,
+            information.nFileIndexLow,
+        ))
+    };
+    Ok(information(left)? == information(right)?)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_open_file(_left: &std::fs::File, _right: &std::fs::File) -> std::io::Result<bool> {
+    Ok(false)
 }
 
 fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
@@ -601,5 +735,54 @@ mod tests {
             .unwrap();
 
         assert!(matches!(outcome, PrepareForApply::Skip));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targeted_apply_rejects_a_file_replaced_by_a_symlink_after_hashing() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("one.wav");
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"source").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let expected = std::fs::File::open(&source).unwrap();
+
+        std::fs::remove_file(&source).unwrap();
+        symlink(&outside_file, &source).unwrap();
+
+        assert!(
+            !super::targeted_path_matches_handle(dir.path(), Path::new("one.wav"), &expected,)
+                .unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targeted_apply_rejects_a_descendant_of_a_replaced_directory() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        let source = nested.join("one.wav");
+        std::fs::write(&source, b"source").unwrap();
+        let expected = std::fs::File::open(&source).unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("one.wav"), b"outside").unwrap();
+
+        std::fs::rename(&nested, dir.path().join("moved")).unwrap();
+        symlink(outside.path(), &nested).unwrap();
+
+        assert!(
+            !super::targeted_path_matches_handle(
+                dir.path(),
+                Path::new("nested/one.wav"),
+                &expected,
+            )
+            .unwrap()
+        );
     }
 }

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -383,6 +383,47 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn filesystem_sync_retires_a_symlinked_file_from_the_browser_projection() {
+        use std::os::unix::fs as unix_fs;
+
+        let root = tempfile::tempdir().expect("source root");
+        let outside = tempfile::tempdir().expect("outside source root");
+        let tracked = root.path().join("tracked.wav");
+        std::fs::write(&tracked, b"tracked").expect("tracked wav");
+        std::fs::write(outside.path().join("outside.wav"), b"outside").expect("outside wav");
+        let db =
+            SourceDatabase::open_for_test_fixture_source_write(root.path()).expect("source db");
+        scanner::hard_rescan(&db).expect("initial scan");
+        std::fs::remove_file(&tracked).expect("replace tracked wav");
+        unix_fs::symlink(outside.path().join("outside.wav"), &tracked).expect("file link");
+
+        let result = sync_source_database_paths(
+            String::from("source-a"),
+            root.path().to_path_buf(),
+            root.path().to_path_buf(),
+            vec![PathBuf::from("tracked.wav")],
+            1,
+            &AtomicBool::new(false),
+        );
+
+        let success = result.result.expect("sync result");
+        assert!(
+            db.entry_for_path(Path::new("tracked.wav"))
+                .expect("read tracked entry")
+                .is_none()
+        );
+        let projection = success
+            .browser_projection_delta
+            .expect("browser projection delta");
+        assert_eq!(
+            projection.removed_file_ids,
+            vec![tracked.display().to_string()]
+        );
+        assert!(projection.upserted_files.is_empty());
+    }
+
     #[test]
     fn filesystem_sync_reports_lifecycle_cancellation_for_requeue() {
         let root = tempfile::tempdir().expect("source root");


### PR DESCRIPTION
## Goal
Close OPT-1236's targeted watcher-sync symlink escape: a watcher-reported link, or a descendant below one, must not enumerate or index content outside the configured source.

## Scope
- Traverse targeted paths from a capability-scoped source-root handle, opening each component and file without following links.
- Carry the verified file descriptor through fact collection, hashing, and the apply boundary.
- Re-open and identity-check the manifest path immediately before commit; reject link, missing, non-file, and changed bindings safely.
- Reject parent-relative targets, preserve ordinary reconciliation, and retire rows when a tracked file becomes a link.
- Verify the native browser projection removes the retired file rather than exposing its link target.

## Non-goals
- No opt-in symlink traversal, watcher-debounce redesign, or source-root replacement changes.

## Definition of Done
- File links, directory links, ancestor loops, outside-root links, and link descendants are not indexed by targeted sync.
- A replaced regular WAV is removed from the source manifest and browser projection, including when replacement occurs during targeted apply.
- Existing nested-file reconciliation remains intact.

## Validation
- `cargo fmt --check`
- `cargo test -p wavecrate-scan --lib targeted_sync -- --test-threads=1` (11 passed)
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` (102 passed)
- `cargo test -p wavecrate --lib filesystem_sync_ -- --test-threads=1` (6 passed)
- `bash scripts/ci.sh smoke` (passed)
- Fresh specialist filesystem-boundary review: clean at `142333217`.

## Known limitations
`bash scripts/ci.sh agent` reaches its broad Wavecrate library lane but remains red in unrelated pre-existing UI/status and destructive-edit tests. Focused scanner/native tests and the smoke gate are green.

User approval is required before merge.