### PR TITLE
Preserve uncertain scan subtrees

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
@@ -17,6 +17,7 @@ pub(crate) struct ScanContext {
     pub(crate) last_committed_revision: Option<u64>,
     manifest_audit: Option<ManifestAuditCheckpoint>,
     source_tree_incomplete: bool,
+    uncertain_prefixes: BTreeSet<PathBuf>,
 }
 
 struct ManifestAuditCheckpoint {
@@ -60,6 +61,7 @@ impl ScanContext {
             last_committed_revision: None,
             manifest_audit: None,
             source_tree_incomplete: false,
+            uncertain_prefixes: BTreeSet::new(),
         }
     }
 
@@ -69,6 +71,44 @@ impl ScanContext {
 
     pub(in crate::sample_sources::scanner) fn source_tree_incomplete(&self) -> bool {
         self.source_tree_incomplete
+    }
+
+    /// Record a relative prefix whose descendants could not be observed.
+    /// Missing-row reconciliation must leave every existing row below this
+    /// boundary untouched until a later authoritative traversal succeeds.
+    pub(in crate::sample_sources::scanner) fn mark_uncertain_prefixes(
+        &mut self,
+        prefixes: impl IntoIterator<Item = PathBuf>,
+    ) {
+        let mut recorded = false;
+        for prefix in prefixes {
+            if self.uncertain_prefixes.insert(prefix) {
+                recorded = true;
+            }
+        }
+        if recorded {
+            self.mark_source_tree_incomplete();
+        }
+    }
+
+    pub(in crate::sample_sources::scanner) fn preserves_missing_row(
+        &self,
+        path: &std::path::Path,
+    ) -> bool {
+        self.uncertain_prefixes
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+    }
+
+    pub(in crate::sample_sources::scanner) fn has_uncertain_prefixes(&self) -> bool {
+        !self.uncertain_prefixes.is_empty()
+    }
+
+    pub(in crate::sample_sources::scanner) fn uncertainty_error(&self) -> String {
+        format!(
+            "source traversal could not enumerate {} subtree(s); retry required",
+            self.uncertain_prefixes.len()
+        )
     }
 
     pub(in crate::sample_sources::scanner) fn resume_manifest_audit(
@@ -221,6 +261,12 @@ impl ScanContext {
             revision,
             self.committed_manifest.values().cloned().collect(),
         )
+    }
+
+    pub(in crate::sample_sources::scanner) fn latest_committed_snapshot(
+        &self,
+    ) -> (u64, Vec<SourceManifestEntry>) {
+        self.committed_snapshot(self.committed_manifest_revision)
     }
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -217,6 +217,13 @@ pub(crate) fn reconcile_scan_renames(
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+    // A partial traversal cannot safely consume pending rename state: a
+    // retained source beneath an uncertain prefix may otherwise be claimed as
+    // a move by an observed destination elsewhere. This also keeps hard
+    // rescans from clearing pending metadata until the next complete pass.
+    if context.has_uncertain_prefixes() {
+        return Ok(committed_snapshot);
+    }
     let current_candidates = context
         .stats
         .rename_candidate_paths
@@ -328,6 +335,13 @@ pub(crate) fn finish_scan_result(
                 manifest_before,
                 committed_snapshot,
             );
+            if context.has_uncertain_prefixes() {
+                let error = context.uncertainty_error();
+                return Err(ScanError::Incomplete {
+                    committed: Box::new(context.stats),
+                    error,
+                });
+            }
             Ok(context.stats)
         }
         Err(error) => {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -20,6 +20,14 @@ pub struct SourceTreeSnapshot {
     pub other_files: Vec<SourceTreeFile>,
     /// Bounded diagnostics for entries that could not be classified or enumerated.
     pub diagnostics: Vec<String>,
+    /// Relative directory or entry prefixes whose descendants were not
+    /// authoritatively observed during this traversal.
+    ///
+    /// This is internal scan state carried to missing-row reconciliation. It
+    /// is deliberately unbounded: dropping a prefix here could turn an I/O
+    /// failure into a false deletion.
+    #[doc(hidden)]
+    pub uncertain_prefixes: Vec<PathBuf>,
 }
 
 impl SourceTreeSnapshot {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::sample_sources::scanner::scan_fs::{
+    force_directory_entry_failure, force_directory_read_failure, force_file_type_failure,
+};
 
 #[test]
 fn scan_add_update_and_prune_missing() {
@@ -38,6 +41,108 @@ fn scan_add_update_and_prune_missing() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert!(!rows[0].missing);
+}
+
+#[test]
+fn full_scan_preserves_an_unreadable_subtree_and_recovers_its_real_deletion() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("protected/kick.wav"), Rating::KEEP_1)
+        .unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    let result = scan_once(&db);
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("an unreadable subtree must be retryable rather than authoritative");
+    };
+    assert!(error.contains("retry required"));
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        committed
+            .source_tree_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| !snapshot.is_complete())
+    );
+    assert_eq!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .expect("unobserved descendant must remain indexed")
+            .tag,
+        Rating::KEEP_1
+    );
+
+    drop(failure);
+    let recovered = scan_once(&db).expect("readable retry");
+    assert_eq!(recovered.missing, 1);
+    assert!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn full_scan_preserves_an_unenumerated_subtree_after_a_directory_entry_failure() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    // Keep one entry so the injected iterator failure is exercised after the
+    // indexed audio file disappears during the simulated outage.
+    std::fs::write(protected.join("notes.txt"), b"notes").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("protected/kick.wav"), Rating::KEEP_1)
+        .unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_entry_failure(&protected);
+    let result = scan_once(&db);
+    let ScanError::Incomplete { committed, .. } = result.unwrap_err() else {
+        panic!("directory iterator failure must be retryable");
+    };
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert_eq!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+
+    drop(failure);
+    assert_eq!(scan_once(&db).unwrap().missing, 1);
+}
+
+#[test]
+fn full_scan_preserves_descendants_after_an_entry_type_failure() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("snare.wav"), b"snare").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+
+    std::fs::remove_file(protected.join("snare.wav")).unwrap();
+    let failure = force_file_type_failure(&protected);
+    let result = scan_once(&db);
+    let ScanError::Incomplete { committed, .. } = result.unwrap_err() else {
+        panic!("entry type failure must be retryable");
+    };
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        db.entry_for_path(Path::new("protected/snare.wav"))
+            .unwrap()
+            .is_some()
+    );
+
+    drop(failure);
+    assert_eq!(scan_once(&db).unwrap().missing, 1);
 }
 
 #[test]
@@ -666,6 +771,40 @@ fn bounded_manifest_audit_repairs_same_size_closed_app_edit() {
         Some("1234")
     );
     assert_eq!(stats.committed_delta.revision, db.get_revision().unwrap());
+}
+
+#[test]
+fn manifest_audit_keeps_an_unreadable_subtree_due_for_retry() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    let result = audit_source_and_record(&db, None, 8, 1_234);
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("partial manifest audit must remain retryable");
+    };
+    assert!(error.contains("retry required"));
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .is_none()
+    );
+
+    drop(failure);
+    let recovered = audit_source_and_record(&db, None, 8, 1_234).unwrap();
+    assert_eq!(recovered.missing, 1);
+    assert_eq!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .as_deref(),
+        Some("1234")
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sample_sources::scanner::scan_fs::force_directory_entry_failure;
 
 #[test]
 fn hard_rescan_prunes_missing_rows() {
@@ -36,6 +37,44 @@ fn hard_rescan_prunes_missing_files_with_tags() {
     assert_eq!(stats.missing, 0);
     let rows = db.list_files().unwrap();
     assert!(rows.is_empty());
+    assert!(db.list_pending_renames().unwrap().is_empty());
+}
+
+#[test]
+fn hard_rescan_keeps_pending_rename_metadata_for_an_unreadable_subtree() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    let file_path = protected.join("kick.wav");
+    std::fs::write(&file_path, b"kick").unwrap();
+    std::fs::write(protected.join("notes.txt"), b"notes").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    let tracked = db
+        .entry_for_path(Path::new("protected/kick.wav"))
+        .unwrap()
+        .unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch.stage_pending_rename(&tracked).unwrap();
+    batch.commit().unwrap();
+
+    std::fs::remove_file(file_path).unwrap();
+    let failure = force_directory_entry_failure(&protected);
+    let result = hard_rescan(&db);
+    let ScanError::Incomplete { committed, .. } = result.unwrap_err() else {
+        panic!("hard rescan must leave an unreadable subtree retryable");
+    };
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        db.list_pending_renames()
+            .unwrap()
+            .iter()
+            .any(|entry| entry.relative_path == Path::new("protected/kick.wav"))
+    );
+
+    drop(failure);
+    let recovered = hard_rescan(&db).unwrap();
+    assert_eq!(recovered.missing, 1);
     assert!(db.list_pending_renames().unwrap().is_empty());
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sample_sources::scanner::scan_fs::force_directory_read_failure;
 use crate::sample_sources::scanner::{sync_paths, sync_paths_with_progress};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -126,6 +127,70 @@ fn targeted_sync_prunes_removed_folder_prefix() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("keep.wav"));
+}
+
+#[test]
+fn targeted_sync_preserves_an_unreadable_directory_until_recovery() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("protected/kick.wav"), Rating::KEEP_1)
+        .unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    let result = sync_paths(&db, &[PathBuf::from("protected")]);
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("targeted unreadable directory must be retryable");
+    };
+    assert!(error.contains("retry required"));
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert_eq!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+
+    drop(failure);
+    let recovered = sync_paths(&db, &[PathBuf::from("protected")]).unwrap();
+    assert_eq!(recovered.missing, 1);
+    assert!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn targeted_sync_normalizes_dot_prefixed_uncertainty_boundaries() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    let target = PathBuf::from("./protected");
+    let result = sync_paths(&db, &[target.clone()]);
+    let ScanError::Incomplete { committed, .. } = result.unwrap_err() else {
+        panic!("dot-prefixed uncertain target must be retryable");
+    };
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        db.entry_for_path(Path::new("protected/kick.wav"))
+            .unwrap()
+            .is_some()
+    );
+
+    drop(failure);
+    assert_eq!(sync_paths(&db, &[target]).unwrap().missing, 1);
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -18,6 +18,7 @@ pub(super) fn db_sync_phase(
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
     let mut existing = std::mem::take(&mut context.existing)
         .into_values()
+        .filter(|entry| !context.preserves_missing_row(&entry.relative_path))
         .collect::<Vec<_>>()
         .into_iter();
     loop {
@@ -46,6 +47,13 @@ pub(super) fn db_sync_phase(
 
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
+    }
+    // An unreadable subtree is not a completed source scan. Keep its prior
+    // manifest rows and completion metadata intact so the existing retry/audit
+    // owner will revisit it instead of treating the partial traversal as
+    // authoritative.
+    if context.has_uncertain_prefixes() {
+        return Ok(context.latest_committed_snapshot());
     }
     let _writer = writer.lock(ScanWritePhase::Manifest);
     if cancel_requested(cancel) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -6,6 +6,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(test)]
+use std::{cell::RefCell, collections::BTreeSet};
+
 use tracing::warn;
 use wavecrate_library::filesystem_identity::{
     filesystem_change_marker, stable_filesystem_identity,
@@ -17,6 +20,115 @@ use super::scan::ScanError;
 use super::scan::{SourceTreeFile, SourceTreeSnapshot};
 
 const MAX_LAYOUT_DIAGNOSTICS: usize = 16;
+
+#[cfg(test)]
+thread_local! {
+    static FORCED_DIRECTORY_READ_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
+    static FORCED_DIRECTORY_ENTRY_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
+    static FORCED_FILE_TYPE_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
+}
+
+/// Deterministically emulate an unreadable directory for scanner regression
+/// tests without depending on platform-specific permission behavior.
+#[cfg(test)]
+pub(crate) fn force_directory_read_failure(path: &Path) -> ForcedTraversalFailure {
+    ForcedTraversalFailure::new(path, ForcedFailureKind::DirectoryRead)
+}
+
+/// Deterministically emulate a directory iterator failure for scanner
+/// regression tests without depending on filesystem races.
+#[cfg(test)]
+pub(crate) fn force_directory_entry_failure(path: &Path) -> ForcedTraversalFailure {
+    ForcedTraversalFailure::new(path, ForcedFailureKind::DirectoryEntry)
+}
+
+/// Deterministically emulate an entry-type failure for scanner regression
+/// tests without depending on filesystem races.
+#[cfg(test)]
+pub(crate) fn force_file_type_failure(path: &Path) -> ForcedTraversalFailure {
+    ForcedTraversalFailure::new(path, ForcedFailureKind::FileType)
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum ForcedFailureKind {
+    DirectoryRead,
+    DirectoryEntry,
+    FileType,
+}
+
+#[cfg(test)]
+pub(crate) struct ForcedTraversalFailure {
+    path: PathBuf,
+    kind: ForcedFailureKind,
+}
+
+#[cfg(test)]
+impl ForcedTraversalFailure {
+    fn new(path: &Path, kind: ForcedFailureKind) -> Self {
+        let path = path.to_path_buf();
+        forced_failures(kind).with(|failures| {
+            failures.borrow_mut().insert(path.clone());
+        });
+        Self { path, kind }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ForcedTraversalFailure {
+    fn drop(&mut self) {
+        forced_failures(self.kind).with(|failures| {
+            failures.borrow_mut().remove(&self.path);
+        });
+    }
+}
+
+#[cfg(test)]
+fn forced_failures(
+    kind: ForcedFailureKind,
+) -> &'static std::thread::LocalKey<RefCell<BTreeSet<PathBuf>>> {
+    match kind {
+        ForcedFailureKind::DirectoryRead => &FORCED_DIRECTORY_READ_FAILURES,
+        ForcedFailureKind::DirectoryEntry => &FORCED_DIRECTORY_ENTRY_FAILURES,
+        ForcedFailureKind::FileType => &FORCED_FILE_TYPE_FAILURES,
+    }
+}
+
+#[cfg(test)]
+pub(super) fn forced_directory_read_error(path: &Path) -> Option<std::io::Error> {
+    FORCED_DIRECTORY_READ_FAILURES.with(|failures| {
+        failures.borrow().contains(path).then(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced directory read failure",
+            )
+        })
+    })
+}
+
+#[cfg(test)]
+pub(super) fn forced_directory_entry_error(path: &Path) -> Option<std::io::Error> {
+    FORCED_DIRECTORY_ENTRY_FAILURES.with(|failures| {
+        failures.borrow().contains(path).then(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced directory entry failure",
+            )
+        })
+    })
+}
+
+#[cfg(test)]
+pub(super) fn forced_file_type_error(path: &Path) -> Option<std::io::Error> {
+    FORCED_FILE_TYPE_FAILURES.with(|failures| {
+        failures.borrow().contains(path).then(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced file type failure",
+            )
+        })
+    })
+}
 
 #[derive(Clone, Debug)]
 pub(super) struct FileFacts {
@@ -67,7 +179,7 @@ pub(super) fn visit_dir_with_cancel_check(
         if should_cancel() {
             return Err(ScanError::Canceled);
         }
-        let entries = match fs::read_dir(&dir) {
+        let entries = match read_dir(&dir) {
             Ok(entries) => entries,
             Err(source) if dir != root => {
                 warn!(
@@ -79,6 +191,7 @@ pub(super) fn visit_dir_with_cancel_check(
                     &mut snapshot,
                     format!("read directory {}: {source}", display_relative(root, &dir)),
                 );
+                record_uncertain_prefix(&mut snapshot, root, &dir);
                 continue;
             }
             Err(source) => {
@@ -89,7 +202,7 @@ pub(super) fn visit_dir_with_cancel_check(
             }
         };
         for entry_result in entries {
-            let entry = match entry_result {
+            let entry = match read_dir_entry(entry_result, &dir) {
                 Ok(entry) => entry,
                 Err(err) => {
                     warn!(
@@ -104,12 +217,13 @@ pub(super) fn visit_dir_with_cancel_check(
                             display_relative(root, &dir)
                         ),
                     );
+                    record_uncertain_prefix(&mut snapshot, root, &dir);
                     continue;
                 }
             };
 
             let path = entry.path();
-            let file_type = match entry.file_type() {
+            let file_type = match read_file_type(&entry, &path) {
                 Ok(file_type) => file_type,
                 Err(err) => {
                     warn!(
@@ -121,6 +235,7 @@ pub(super) fn visit_dir_with_cancel_check(
                         &mut snapshot,
                         format!("read file type {}: {err}", display_relative(root, &path)),
                     );
+                    record_uncertain_prefix(&mut snapshot, root, &path);
                     continue;
                 }
             };
@@ -173,7 +288,45 @@ pub(super) fn visit_dir_with_cancel_check(
     snapshot
         .other_files
         .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    snapshot.uncertain_prefixes.sort();
     Ok(snapshot)
+}
+
+fn record_uncertain_prefix(snapshot: &mut SourceTreeSnapshot, root: &Path, path: &Path) {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return;
+    };
+    let relative = relative.to_path_buf();
+    if !snapshot.uncertain_prefixes.contains(&relative) {
+        snapshot.uncertain_prefixes.push(relative);
+    }
+}
+
+fn read_dir(path: &Path) -> Result<fs::ReadDir, std::io::Error> {
+    #[cfg(test)]
+    if let Some(error) = forced_directory_read_error(path) {
+        return Err(error);
+    }
+    fs::read_dir(path)
+}
+
+fn read_file_type(entry: &fs::DirEntry, _path: &Path) -> Result<fs::FileType, std::io::Error> {
+    #[cfg(test)]
+    if let Some(error) = forced_file_type_error(_path) {
+        return Err(error);
+    }
+    entry.file_type()
+}
+
+fn read_dir_entry(
+    entry: Result<fs::DirEntry, std::io::Error>,
+    _directory: &Path,
+) -> Result<fs::DirEntry, std::io::Error> {
+    #[cfg(test)]
+    if let Some(error) = forced_directory_entry_error(_directory) {
+        return Err(error);
+    }
+    entry
 }
 
 fn record_layout_diagnostic(snapshot: &mut SourceTreeSnapshot, diagnostic: String) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -51,16 +51,22 @@ pub fn sync_paths_with_progress_and_writer(
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
     let targets = collect_targets(db, &root, paths, cancel)?;
+    let TargetedScanTargets {
+        current_files,
+        existing,
+        uncertain_prefixes,
+    } = targets;
     let mut context = ScanContext::from_existing(
-        targets.existing,
+        existing,
         ScanMode::Targeted,
         manifest_revision,
         manifest_before.clone(),
     );
+    context.mark_uncertain_prefixes(uncertain_prefixes);
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
     let mut committed = false;
     let result = (|| {
-        for targeted_file in targets.current_files {
+        for targeted_file in current_files {
             if let Some(cancel) = cancel
                 && cancel.load(Ordering::Relaxed)
             {
@@ -107,6 +113,7 @@ pub fn sync_paths_with_progress_and_writer(
 struct TargetedScanTargets {
     current_files: Vec<TargetedFile>,
     existing: HashMap<PathBuf, WavEntry>,
+    uncertain_prefixes: BTreeSet<PathBuf>,
 }
 
 struct TargetedFile {
@@ -128,6 +135,7 @@ fn collect_targets(
         })?;
     let mut current_files = BTreeMap::new();
     let mut existing = HashMap::new();
+    let mut uncertain_prefixes = BTreeSet::new();
     for relative_path in normalized_targets(paths) {
         if let Some(cancel) = cancel
             && cancel.load(Ordering::Relaxed)
@@ -141,25 +149,35 @@ fn collect_targets(
             &relative_path,
             cancel,
             &mut current_files,
+            &mut uncertain_prefixes,
         )?;
     }
     Ok(TargetedScanTargets {
         current_files: current_files.into_values().collect(),
         existing,
+        uncertain_prefixes,
     })
 }
 
 fn normalized_targets(paths: &[PathBuf]) -> BTreeSet<PathBuf> {
     paths
         .iter()
-        .filter(|path| !path.as_os_str().is_empty())
-        .filter(|path| {
-            path.is_relative()
+        .filter_map(|path| {
+            (path.is_relative()
                 && path
                     .components()
-                    .all(|component| matches!(component, Component::CurDir | Component::Normal(_)))
+                    .all(|component| matches!(component, Component::CurDir | Component::Normal(_))))
+            .then(|| {
+                path.components()
+                    .filter_map(|component| match component {
+                        Component::Normal(part) => Some(part),
+                        Component::CurDir => None,
+                        _ => None,
+                    })
+                    .collect::<PathBuf>()
+            })
         })
-        .cloned()
+        .filter(|path| !path.as_os_str().is_empty())
         .collect()
 }
 
@@ -180,8 +198,11 @@ fn collect_current_files(
     relative_path: &Path,
     cancel: Option<&AtomicBool>,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
-    let Some((parent, name)) = open_target_parent(source_root, root, relative_path)? else {
+    let Some((parent, name)) =
+        open_target_parent(source_root, root, relative_path, uncertain_prefixes)?
+    else {
         return Ok(());
     };
     let absolute_path = root.join(relative_path);
@@ -190,10 +211,13 @@ fn collect_current_files(
         Ok(metadata) => metadata,
         Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            return Err(ScanError::Io {
-                path: absolute_path,
-                source,
-            });
+            tracing::warn!(
+                path = %absolute_path.display(),
+                error = %source,
+                "Failed to read targeted sync entry metadata"
+            );
+            uncertain_prefixes.insert(relative_path.to_path_buf());
+            return Ok(());
         }
     };
     let file_type = metadata.file_type();
@@ -205,13 +229,23 @@ fn collect_current_files(
             Ok(dir) => dir,
             Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(source) => {
-                return Err(ScanError::Io {
-                    path: root.join(relative_path),
-                    source,
-                });
+                tracing::warn!(
+                    path = %root.join(relative_path).display(),
+                    error = %source,
+                    "Failed to open targeted sync directory without following links"
+                );
+                uncertain_prefixes.insert(relative_path.to_path_buf());
+                return Ok(());
             }
         };
-        collect_current_files_in_dir(dir, root, relative_path, cancel, current_files)?;
+        collect_current_files_in_dir(
+            dir,
+            root,
+            relative_path,
+            cancel,
+            current_files,
+            uncertain_prefixes,
+        )?;
     } else if file_type.is_file() {
         collect_current_file(
             &parent,
@@ -219,6 +253,7 @@ fn collect_current_files(
             root,
             relative_path,
             current_files,
+            uncertain_prefixes,
         )?;
     }
     Ok(())
@@ -228,6 +263,7 @@ fn open_target_parent(
     source_root: &Dir,
     root: &Path,
     relative_path: &Path,
+    uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<Option<(Dir, std::ffi::OsString)>, ScanError> {
     let Some(name) = relative_path.file_name() else {
         return Ok(None);
@@ -257,7 +293,13 @@ fn open_target_parent(
                 {
                     return Ok(None);
                 }
-                return Err(ScanError::Io { path, source });
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %source,
+                    "Failed to open targeted sync parent directory without following links"
+                );
+                uncertain_prefixes.insert(relative_path.to_path_buf());
+                return Ok(None);
             }
         };
     }
@@ -270,6 +312,7 @@ fn collect_current_files_in_dir(
     start_relative: &Path,
     cancel: Option<&AtomicBool>,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let mut stack = vec![(start_dir, start_relative.to_path_buf())];
     while let Some((dir, relative_dir)) = stack.pop() {
@@ -278,25 +321,20 @@ fn collect_current_files_in_dir(
         {
             return Err(ScanError::Canceled);
         }
-        let entries = match dir.entries() {
+        let entries = match read_targeted_dir_entries(&dir, &root.join(&relative_dir)) {
             Ok(entries) => entries,
-            Err(source) if relative_dir != start_relative => {
+            Err(source) => {
                 tracing::warn!(
                     dir = %root.join(&relative_dir).display(),
                     error = %source,
                     "Failed to read targeted sync directory"
                 );
+                uncertain_prefixes.insert(relative_dir);
                 continue;
-            }
-            Err(source) => {
-                return Err(ScanError::Io {
-                    path: root.join(&relative_dir),
-                    source,
-                });
             }
         };
         for entry in entries {
-            let entry = match entry {
+            let entry = match read_targeted_dir_entry(entry, &root.join(&relative_dir)) {
                 Ok(entry) => entry,
                 Err(err) => {
                     tracing::warn!(
@@ -304,13 +342,14 @@ fn collect_current_files_in_dir(
                         error = %err,
                         "Failed to read targeted sync directory entry"
                     );
+                    uncertain_prefixes.insert(relative_dir.clone());
                     continue;
                 }
             };
             let name = entry.file_name();
             let name_path = Path::new(&name);
             let path = root.join(&relative_dir).join(name_path);
-            let file_type = match entry.file_type() {
+            let file_type = match read_targeted_file_type(&entry, &path) {
                 Ok(file_type) => file_type,
                 Err(err) => {
                     tracing::warn!(
@@ -318,6 +357,7 @@ fn collect_current_files_in_dir(
                         error = %err,
                         "Failed to read targeted sync file type"
                     );
+                    uncertain_prefixes.insert(relative_dir.join(name_path));
                     continue;
                 }
             };
@@ -334,13 +374,26 @@ fn collect_current_files_in_dir(
                             error = %source,
                             "Failed to open targeted sync directory without following links"
                         );
+                        if !dir
+                            .symlink_metadata(name_path)
+                            .is_ok_and(|metadata| metadata.is_symlink())
+                        {
+                            uncertain_prefixes.insert(relative_dir.join(name_path));
+                        }
                         continue;
                     }
                 };
                 stack.push((child_dir, relative_dir.join(name_path)));
             } else if file_type.is_file() {
                 let relative_path = relative_dir.join(name_path);
-                collect_current_file(&dir, name_path, root, &relative_path, current_files)?;
+                collect_current_file(
+                    &dir,
+                    name_path,
+                    root,
+                    &relative_path,
+                    current_files,
+                    uncertain_prefixes,
+                )?;
             }
         }
     }
@@ -353,6 +406,7 @@ fn collect_current_file(
     root: &Path,
     relative_path: &Path,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let absolute_path = root.join(relative_path);
     if !is_supported_audio(&absolute_path) || has_hidden_ancestor(relative_path) {
@@ -371,6 +425,12 @@ fn collect_current_file(
                 error = %source,
                 "Skipping targeted sync file that could not be opened without following links"
             );
+            if !parent
+                .symlink_metadata(name)
+                .is_ok_and(|metadata| metadata.is_symlink())
+            {
+                uncertain_prefixes.insert(relative_path.to_path_buf());
+            }
             return Ok(());
         }
     };
@@ -383,6 +443,39 @@ fn collect_current_file(
             file,
         });
     Ok(())
+}
+
+fn read_targeted_dir_entries(
+    dir: &Dir,
+    _absolute_path: &Path,
+) -> Result<cap_std::fs::ReadDir, io::Error> {
+    #[cfg(test)]
+    if let Some(error) = super::scan_fs::forced_directory_read_error(_absolute_path) {
+        return Err(error);
+    }
+    dir.entries()
+}
+
+fn read_targeted_file_type(
+    entry: &cap_std::fs::DirEntry,
+    _absolute_path: &Path,
+) -> Result<cap_std::fs::FileType, io::Error> {
+    #[cfg(test)]
+    if let Some(error) = super::scan_fs::forced_file_type_error(_absolute_path) {
+        return Err(error);
+    }
+    entry.file_type()
+}
+
+fn read_targeted_dir_entry(
+    entry: Result<cap_std::fs::DirEntry, io::Error>,
+    _absolute_directory: &Path,
+) -> Result<cap_std::fs::DirEntry, io::Error> {
+    #[cfg(test)]
+    if let Some(error) = super::scan_fs::forced_directory_entry_error(_absolute_directory) {
+        return Err(error);
+    }
+    entry
 }
 
 fn has_hidden_ancestor(relative_path: &Path) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -119,6 +119,7 @@ pub(super) fn walk_phase(
         }
     }
     context.flush_manifest_audit_checkpoint(db)?;
+    context.mark_uncertain_prefixes(source_tree_snapshot.uncertain_prefixes.clone());
     context.stats.source_tree_snapshot =
         Some(finalize_source_tree_snapshot(context, source_tree_snapshot));
     Ok(())


### PR DESCRIPTION
## Goal
Prevent uncertain nested filesystem traversal from being reconciled as deletion or a move.

## Scope
- Carry unreadable and unenumerated relative prefixes from full and targeted traversal into missing-row reconciliation.
- Canonicalize targeted paths before prefix matching so `./subtree` shares the same safety boundary.
- Preserve matching manifest rows and pending rename metadata, return a retryable incomplete result, and leave completion metadata unchanged.
- Skip rename reconciliation during a partial traversal; a later authoritative pass converges normally.

Non-goals: changing confirmed-missing root handling or source availability semantics.

## Definition of Done
- Full scans, targeted sync, manifest audits, and hard rescans preserve descendants below uncertain prefixes.
- Iterator and entry-type faults cannot publish deleted or moved identities for unobserved descendants.
- Recovery reconciles real deletion after readability returns.

## Validation
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` (109 passed)
- Focused native manifest-audit and filesystem-refresh test lanes
- `bash scripts/ci.sh agent`
- Independent review is being rerun at the current head

## Known limitations
None.

User approval is required before merge.

Fixes OPT-1241.