### PR TITLE
Share Wavecrate source entry traversal policy

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/error.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/error.rs
@@ -25,6 +25,9 @@ pub enum SourceDbError {
     /// Provided path contained disallowed components or was empty.
     #[error("Path contains invalid relative components: {0}")]
     InvalidRelativePath(PathBuf),
+    /// A relative path could not be represented without losing filesystem identity.
+    #[error("Path is not valid Unicode and cannot be persisted safely: {0}")]
+    NonUnicodeRelativePath(PathBuf),
     /// Database is locked or busy.
     #[error("Database is busy, please retry")]
     Busy,

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -22,7 +22,10 @@ pub(super) fn map_sql_error(err: rusqlite::Error) -> SourceDbError {
 /// Rejects absolute paths, parent traversal, root prefixes, and empty paths.
 pub fn normalize_relative_path(path: &Path) -> Result<String, SourceDbError> {
     let cleaned = sanitize_relative_path(path)?;
-    Ok(cleaned.to_string_lossy().replace('\\', "/"))
+    let value = cleaned
+        .to_str()
+        .ok_or_else(|| SourceDbError::NonUnicodeRelativePath(cleaned.clone()))?;
+    Ok(value.replace('\\', "/"))
 }
 
 /// Parse and validate a stored relative path from the database.
@@ -61,7 +64,9 @@ fn sanitize_relative_path(path: &Path) -> Result<PathBuf, SourceDbError> {
 }
 
 fn has_windows_absolute_prefix(path: &Path) -> bool {
-    let value = path.to_string_lossy();
+    let Some(value) = path.to_str() else {
+        return false;
+    };
     let bytes = value.as_bytes();
     value.starts_with('\\')
         || (bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic())
@@ -124,5 +129,27 @@ mod tests {
     fn normalize_relative_path_skips_curdir_components() {
         let normalized = normalize_relative_path(Path::new("folder/./file.wav")).unwrap();
         assert_eq!(normalized, "folder/file.wav");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_relative_path_rejects_non_unicode_names_without_aliasing_them() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from(std::ffi::OsString::from_vec(b"kick-\xFF.wav".to_vec()));
+        let err = normalize_relative_path(&path).unwrap_err();
+        assert!(matches!(err, SourceDbError::NonUnicodeRelativePath(_)));
+    }
+
+    #[test]
+    fn normalize_relative_path_preserves_case_and_normalization_distinctions() {
+        assert_ne!(
+            normalize_relative_path(Path::new("Kick.wav")).unwrap(),
+            normalize_relative_path(Path::new("kick.wav")).unwrap()
+        );
+        assert_ne!(
+            normalize_relative_path(Path::new("café.wav")).unwrap(),
+            normalize_relative_path(Path::new("café.wav")).unwrap()
+        );
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -10,6 +10,7 @@ pub mod db;
 pub mod library;
 /// Durable source-readiness and convergence coordination contracts.
 pub mod readiness;
+mod source_entry;
 
 pub use audio_support::{
     is_apple_double_sidecar, is_supported_audio, supported_audio_where_clause,
@@ -25,6 +26,10 @@ pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,
     HarvestFileRecord, HarvestMetadataSnapshot, HarvestSourceRange, HarvestState,
     LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation,
+};
+pub use source_entry::{
+    SourceEntryClassification, SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
+    SourceEntryRejection, classify_path_without_following, classify_source_entry,
 };
 
 /// Identifier for a configured sample source.

--- a/crates/wavecrate-library/src/sample_sources/source_entry.rs
+++ b/crates/wavecrate-library/src/sample_sources/source_entry.rs
@@ -1,0 +1,240 @@
+//! Shared no-follow policy for entries discovered below a sample source root.
+
+use std::{
+    fmt, fs, io,
+    path::{Component, Path},
+};
+
+use super::{is_apple_double_sidecar, is_supported_audio};
+
+/// A filesystem entry type observed without following links or reparse points.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceEntryFileType {
+    /// A directory entry.
+    Directory,
+    /// A regular file entry.
+    File,
+    /// A symbolic link or platform reparse point.
+    Link,
+    /// Any other filesystem object.
+    Other,
+}
+
+impl SourceEntryFileType {
+    /// Convert no-follow file-type predicates into the shared entry type.
+    pub fn from_no_followed_type(is_directory: bool, is_file: bool, is_link: bool) -> Self {
+        if is_link {
+            Self::Link
+        } else if is_directory {
+            Self::Directory
+        } else if is_file {
+            Self::File
+        } else {
+            Self::Other
+        }
+    }
+}
+
+/// A visible regular source-entry kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceEntryKind {
+    /// A directory that may be traversed without following links.
+    Directory,
+    /// A regular file.
+    File,
+}
+
+/// Why a source entry is not visible to source traversals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceEntryRejection {
+    /// Links and platform reparse points are never traversed as source entries.
+    Link,
+    /// AppleDouble sidecars are implementation metadata, not source files.
+    AppleDouble,
+    /// The entry is neither a regular file nor a directory.
+    UnsupportedType,
+}
+
+/// Policy result for one entry below a sample source root.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceEntryClassification {
+    /// A directory, including whether its basename is hidden.
+    Directory {
+        /// Whether this directory's own name starts with `.`.
+        hidden: bool,
+    },
+    /// A regular file, including its source-index eligibility.
+    File {
+        /// Whether the file has a supported sample-audio format.
+        supported_audio: bool,
+        /// Whether the file is below a hidden directory.
+        below_hidden_directory: bool,
+    },
+    /// An entry excluded by the shared source boundary policy.
+    Rejected(SourceEntryRejection),
+}
+
+impl SourceEntryClassification {
+    /// Return the visible browser/tree kind, if this entry is not rejected.
+    pub fn visible_kind(self) -> Option<SourceEntryKind> {
+        match self {
+            Self::Directory { .. } => Some(SourceEntryKind::Directory),
+            Self::File { .. } => Some(SourceEntryKind::File),
+            Self::Rejected(_) => None,
+        }
+    }
+
+    /// Return whether a regular file is eligible for the source audio index.
+    pub fn indexes_audio(self) -> bool {
+        matches!(
+            self,
+            Self::File {
+                supported_audio: true,
+                below_hidden_directory: false,
+            }
+        )
+    }
+
+    /// Return whether a regular file has a supported sample-audio format.
+    pub fn has_supported_audio(self) -> bool {
+        matches!(
+            self,
+            Self::File {
+                supported_audio: true,
+                ..
+            }
+        )
+    }
+}
+
+/// Classify a path relative to a sample-source root from no-follow type facts.
+///
+/// This policy deliberately preserves the browser's visibility of unsupported
+/// files and hidden directories while preventing audio indexing below hidden
+/// directories. Callers retain their own traversal mechanics and diagnostics.
+pub fn classify_source_entry(
+    relative_path: &Path,
+    file_type: SourceEntryFileType,
+) -> SourceEntryClassification {
+    match file_type {
+        SourceEntryFileType::Link => {
+            SourceEntryClassification::Rejected(SourceEntryRejection::Link)
+        }
+        SourceEntryFileType::Other => {
+            SourceEntryClassification::Rejected(SourceEntryRejection::UnsupportedType)
+        }
+        SourceEntryFileType::Directory => SourceEntryClassification::Directory {
+            hidden: path_name_is_hidden(relative_path),
+        },
+        SourceEntryFileType::File if is_apple_double_sidecar(relative_path) => {
+            SourceEntryClassification::Rejected(SourceEntryRejection::AppleDouble)
+        }
+        SourceEntryFileType::File => SourceEntryClassification::File {
+            supported_audio: is_supported_audio(relative_path),
+            below_hidden_directory: has_hidden_ancestor(relative_path),
+        },
+    }
+}
+
+/// Inspect and classify one path without following links or reparse points.
+pub fn classify_path_without_following(
+    path: &Path,
+) -> Result<SourceEntryClassification, SourceEntryProbeError> {
+    let metadata = fs::symlink_metadata(path).map_err(SourceEntryProbeError::from)?;
+    let file_type = metadata.file_type();
+    Ok(classify_source_entry(
+        path,
+        SourceEntryFileType::from_no_followed_type(
+            file_type.is_dir(),
+            file_type.is_file(),
+            file_type.is_symlink(),
+        ),
+    ))
+}
+
+/// Bounded failure category for a no-follow source-entry inspection.
+#[derive(Debug)]
+pub enum SourceEntryProbeError {
+    /// The entry disappeared before it could be inspected.
+    Missing,
+    /// The entry could not be inspected, for example because it is unavailable.
+    Unavailable(io::Error),
+}
+
+impl From<io::Error> for SourceEntryProbeError {
+    fn from(error: io::Error) -> Self {
+        if error.kind() == io::ErrorKind::NotFound {
+            Self::Missing
+        } else {
+            Self::Unavailable(error)
+        }
+    }
+}
+
+impl fmt::Display for SourceEntryProbeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing => formatter.write_str("entry does not exist"),
+            Self::Unavailable(error) => write!(formatter, "entry is unavailable: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for SourceEntryProbeError {}
+
+fn path_name_is_hidden(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn has_hidden_ancestor(relative_path: &Path) -> bool {
+    relative_path.parent().is_some_and(|parent| {
+        parent.components().any(|component| {
+            let Component::Normal(name) = component else {
+                return false;
+            };
+            name.to_str().is_some_and(|name| name.starts_with('.'))
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_agrees_on_visible_and_indexed_entries() {
+        assert_eq!(
+            classify_source_entry(Path::new("drums"), SourceEntryFileType::Directory),
+            SourceEntryClassification::Directory { hidden: false }
+        );
+        assert_eq!(
+            classify_source_entry(Path::new("._kick.wav"), SourceEntryFileType::File),
+            SourceEntryClassification::Rejected(SourceEntryRejection::AppleDouble)
+        );
+        assert!(
+            classify_source_entry(Path::new("kick.wav"), SourceEntryFileType::File).indexes_audio()
+        );
+        assert!(
+            !classify_source_entry(Path::new(".cache/kick.wav"), SourceEntryFileType::File)
+                .indexes_audio()
+        );
+        assert_eq!(
+            classify_source_entry(Path::new("linked.wav"), SourceEntryFileType::Link),
+            SourceEntryClassification::Rejected(SourceEntryRejection::Link)
+        );
+        assert_eq!(
+            classify_source_entry(Path::new("socket"), SourceEntryFileType::Other),
+            SourceEntryClassification::Rejected(SourceEntryRejection::UnsupportedType)
+        );
+    }
+
+    #[test]
+    fn unsupported_files_remain_visible_but_are_not_indexed() {
+        let entry = classify_source_entry(Path::new("notes.txt"), SourceEntryFileType::File);
+        assert_eq!(entry.visible_kind(), Some(SourceEntryKind::File));
+        assert!(!entry.has_supported_audio());
+        assert!(!entry.indexes_audio());
+    }
+}

--- a/crates/wavecrate-scan/src/sample_sources/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/mod.rs
@@ -21,7 +21,6 @@ pub use scanner::{
     RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeFile, SourceTreeSnapshot,
     UpdatedSample,
 };
-pub(crate) use wavecrate_library::sample_sources::is_supported_audio;
 pub use wavecrate_library::sample_sources::normalize_relative_path;
 pub use wavecrate_library::sample_sources::{
     DB_FILE_NAME, LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, Rating, SampleSource,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -13,8 +13,11 @@ use tracing::warn;
 use wavecrate_library::filesystem_identity::{
     filesystem_change_marker, stable_filesystem_identity,
 };
+use wavecrate_library::sample_sources::{
+    SourceEntryClassification, SourceEntryFileType, classify_source_entry,
+};
 
-use crate::sample_sources::{SourceDatabase, is_supported_audio};
+use crate::sample_sources::SourceDatabase;
 
 use super::scan::ScanError;
 use super::scan::{SourceTreeFile, SourceTreeSnapshot};
@@ -174,8 +177,8 @@ pub(super) fn visit_dir_with_cancel_check(
         directories: vec![PathBuf::new()],
         ..SourceTreeSnapshot::default()
     };
-    let mut stack = vec![(root.to_path_buf(), true)];
-    while let Some((dir, scan_audio)) = stack.pop() {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
         if should_cancel() {
             return Err(ScanError::Canceled);
         }
@@ -239,48 +242,35 @@ pub(super) fn visit_dir_with_cancel_check(
                     continue;
                 }
             };
-            if file_type.is_symlink() {
-                continue;
-            }
-            if file_type.is_dir() {
-                let relative = path
-                    .strip_prefix(root)
-                    .map(Path::to_path_buf)
-                    .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
-                snapshot.directories.push(relative);
-                let hidden = path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name.starts_with('.'));
-                stack.push((path, scan_audio && !hidden));
-                continue;
-            }
-            if file_type.is_file() {
-                if wavecrate_library::sample_sources::is_apple_double_sidecar(&path) {
-                    continue;
+            let relative = path
+                .strip_prefix(root)
+                .map(Path::to_path_buf)
+                .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
+            match classify_source_entry(&relative, source_entry_file_type(&file_type)) {
+                SourceEntryClassification::Directory { .. } => {
+                    snapshot.directories.push(relative);
+                    stack.push(path);
                 }
-                if is_supported_audio(&path) {
-                    if scan_audio {
+                classification @ SourceEntryClassification::File { .. } => {
+                    if classification.indexes_audio() {
                         visitor(&path)?;
-                    }
-                } else {
-                    match entry.metadata() {
-                        Ok(metadata) => snapshot.other_files.push(SourceTreeFile {
-                            relative_path: path
-                                .strip_prefix(root)
-                                .map(Path::to_path_buf)
-                                .map_err(|_| ScanError::InvalidRoot(path.clone()))?,
-                            file_size: metadata.len(),
-                        }),
-                        Err(err) => record_layout_diagnostic(
-                            &mut snapshot,
-                            format!(
-                                "read file metadata {}: {err}",
-                                display_relative(root, &path)
+                    } else if !classification.has_supported_audio() {
+                        match entry.metadata() {
+                            Ok(metadata) => snapshot.other_files.push(SourceTreeFile {
+                                relative_path: relative,
+                                file_size: metadata.len(),
+                            }),
+                            Err(err) => record_layout_diagnostic(
+                                &mut snapshot,
+                                format!(
+                                    "read file metadata {}: {err}",
+                                    display_relative(root, &path)
+                                ),
                             ),
-                        ),
+                        }
                     }
                 }
+                SourceEntryClassification::Rejected(_) => {}
             }
         }
     }
@@ -418,21 +408,20 @@ pub(super) fn read_facts_from_open_file(
     })
 }
 
-pub(super) fn is_supported_regular_audio_file(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
-        && is_supported_audio(path)
+pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
+    let absolute_path = root.join(relative_path);
+    fs::symlink_metadata(&absolute_path).is_ok_and(|metadata| {
+        let file_type = metadata.file_type();
+        classify_source_entry(relative_path, source_entry_file_type(&file_type)).indexes_audio()
+    })
 }
 
-pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
-    let hidden_ancestor = relative_path.parent().is_some_and(|parent| {
-        parent.components().any(|component| {
-            let std::path::Component::Normal(name) = component else {
-                return false;
-            };
-            name.to_str().is_some_and(|name| name.starts_with('.'))
-        })
-    });
-    !hidden_ancestor && is_supported_regular_audio_file(&root.join(relative_path))
+fn source_entry_file_type(file_type: &fs::FileType) -> SourceEntryFileType {
+    SourceEntryFileType::from_no_followed_type(
+        file_type.is_dir(),
+        file_type.is_file(),
+        file_type.is_symlink(),
+    )
 }
 
 /// Hash the entire file contents for change detection, honoring cancellation when requested.

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -2,8 +2,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{PendingRenameEntry, SourceWriteBatch, WavEntry};
-use crate::sample_sources::{SourceDatabase, is_supported_audio};
+use wavecrate_library::sample_sources::{SourceEntryFileType, classify_source_entry};
 
 use super::scan::{ChangedSample, RenamedSample, ScanError, ScanStats, UpdatedSample};
 use super::scan_fs::{compute_content_hash, ensure_root_dir, read_facts};
@@ -129,8 +130,18 @@ pub(super) fn verify_content_batch(
 }
 
 fn is_supported_regular_audio_file(path: &std::path::Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_file())
-        && is_supported_audio(path)
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        let file_type = metadata.file_type();
+        classify_source_entry(
+            path,
+            SourceEntryFileType::from_no_followed_type(
+                file_type.is_dir(),
+                file_type.is_file(),
+                file_type.is_symlink(),
+            ),
+        )
+        .has_supported_audio()
+    })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -7,8 +7,11 @@ use std::{
 
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
 use cap_std::fs::{Dir, OpenOptions};
+use wavecrate_library::sample_sources::{
+    SourceEntryClassification, SourceEntryFileType, classify_source_entry,
+};
 
-use crate::sample_sources::{SourceDatabase, WavEntry, is_supported_audio};
+use crate::sample_sources::{SourceDatabase, WavEntry};
 
 use super::{
     scan::{ScanContext, ScanError, ScanMode, ScanStats},
@@ -221,40 +224,43 @@ fn collect_current_files(
         }
     };
     let file_type = metadata.file_type();
-    if file_type.is_symlink() {
-        return Ok(());
-    }
-    if file_type.is_dir() {
-        let dir = match parent.open_dir_nofollow(name_path) {
-            Ok(dir) => dir,
-            Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
-            Err(source) => {
-                tracing::warn!(
-                    path = %root.join(relative_path).display(),
-                    error = %source,
-                    "Failed to open targeted sync directory without following links"
-                );
-                uncertain_prefixes.insert(relative_path.to_path_buf());
-                return Ok(());
-            }
-        };
-        collect_current_files_in_dir(
-            dir,
-            root,
-            relative_path,
-            cancel,
-            current_files,
-            uncertain_prefixes,
-        )?;
-    } else if file_type.is_file() {
-        collect_current_file(
-            &parent,
-            Path::new(&name),
-            root,
-            relative_path,
-            current_files,
-            uncertain_prefixes,
-        )?;
+    match classify_source_entry(relative_path, targeted_source_entry_file_type(&file_type)) {
+        SourceEntryClassification::Directory { .. } => {
+            let dir = match parent.open_dir_nofollow(name_path) {
+                Ok(dir) => dir,
+                Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(source) => {
+                    tracing::warn!(
+                        path = %root.join(relative_path).display(),
+                        error = %source,
+                        "Failed to open targeted sync directory without following links"
+                    );
+                    uncertain_prefixes.insert(relative_path.to_path_buf());
+                    return Ok(());
+                }
+            };
+            collect_current_files_in_dir(
+                dir,
+                root,
+                relative_path,
+                cancel,
+                current_files,
+                uncertain_prefixes,
+            )?;
+        }
+        classification @ SourceEntryClassification::File { .. }
+            if classification.indexes_audio() =>
+        {
+            collect_current_file(
+                &parent,
+                Path::new(&name),
+                root,
+                relative_path,
+                current_files,
+                uncertain_prefixes,
+            )?;
+        }
+        SourceEntryClassification::File { .. } | SourceEntryClassification::Rejected(_) => {}
     }
     Ok(())
 }
@@ -361,39 +367,44 @@ fn collect_current_files_in_dir(
                     continue;
                 }
             };
-            if file_type.is_symlink() {
-                continue;
-            }
-            if file_type.is_dir() {
-                let child_dir = match dir.open_dir_nofollow(name_path) {
-                    Ok(child_dir) => child_dir,
-                    Err(source) if source.kind() == io::ErrorKind::NotFound => continue,
-                    Err(source) => {
-                        tracing::warn!(
-                            path = %path.display(),
-                            error = %source,
-                            "Failed to open targeted sync directory without following links"
-                        );
-                        if !dir
-                            .symlink_metadata(name_path)
-                            .is_ok_and(|metadata| metadata.is_symlink())
-                        {
-                            uncertain_prefixes.insert(relative_dir.join(name_path));
+            let relative_path = relative_dir.join(name_path);
+            match classify_source_entry(&relative_path, targeted_source_entry_file_type(&file_type))
+            {
+                SourceEntryClassification::Directory { .. } => {
+                    let child_dir = match dir.open_dir_nofollow(name_path) {
+                        Ok(child_dir) => child_dir,
+                        Err(source) if source.kind() == io::ErrorKind::NotFound => continue,
+                        Err(source) => {
+                            tracing::warn!(
+                                path = %path.display(),
+                                error = %source,
+                                "Failed to open targeted sync directory without following links"
+                            );
+                            if !dir
+                                .symlink_metadata(name_path)
+                                .is_ok_and(|metadata| metadata.is_symlink())
+                            {
+                                uncertain_prefixes.insert(relative_dir.join(name_path));
+                            }
+                            continue;
                         }
-                        continue;
-                    }
-                };
-                stack.push((child_dir, relative_dir.join(name_path)));
-            } else if file_type.is_file() {
-                let relative_path = relative_dir.join(name_path);
-                collect_current_file(
-                    &dir,
-                    name_path,
-                    root,
-                    &relative_path,
-                    current_files,
-                    uncertain_prefixes,
-                )?;
+                    };
+                    stack.push((child_dir, relative_path));
+                }
+                classification @ SourceEntryClassification::File { .. }
+                    if classification.indexes_audio() =>
+                {
+                    collect_current_file(
+                        &dir,
+                        name_path,
+                        root,
+                        &relative_path,
+                        current_files,
+                        uncertain_prefixes,
+                    )?;
+                }
+                SourceEntryClassification::File { .. } | SourceEntryClassification::Rejected(_) => {
+                }
             }
         }
     }
@@ -409,7 +420,7 @@ fn collect_current_file(
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let absolute_path = root.join(relative_path);
-    if !is_supported_audio(&absolute_path) || has_hidden_ancestor(relative_path) {
+    if !classify_source_entry(relative_path, SourceEntryFileType::File).indexes_audio() {
         return Ok(());
     }
     let mut options = OpenOptions::new();
@@ -478,13 +489,10 @@ fn read_targeted_dir_entry(
     entry
 }
 
-fn has_hidden_ancestor(relative_path: &Path) -> bool {
-    relative_path.parent().is_some_and(|parent| {
-        parent.components().any(|component| {
-            let Component::Normal(name) = component else {
-                return false;
-            };
-            name.to_str().is_some_and(|name| name.starts_with('.'))
-        })
-    })
+fn targeted_source_entry_file_type(file_type: &cap_std::fs::FileType) -> SourceEntryFileType {
+    SourceEntryFileType::from_no_followed_type(
+        file_type.is_dir(),
+        file_type.is_file(),
+        file_type.is_symlink(),
+    )
 }

--- a/src/native_app/sample_library/folder_browser/scanning/entry.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/entry.rs
@@ -2,14 +2,14 @@ use std::{
     fs::{self, FileType},
     path::{Path, PathBuf},
 };
+use wavecrate_library::sample_sources::{
+    SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
+    classify_path_without_following as classify_source_entry_path, classify_source_entry,
+};
 
 use super::super::path_helpers::file_label;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(in crate::native_app::sample_library::folder_browser) enum BrowserEntryKind {
-    Directory,
-    File,
-}
+pub(in crate::native_app::sample_library::folder_browser) type BrowserEntryKind = SourceEntryKind;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct BrowserEntry {
@@ -20,16 +20,15 @@ pub(super) struct BrowserEntry {
 pub(in crate::native_app::sample_library::folder_browser) fn classify_path_without_following(
     path: &Path,
 ) -> Option<BrowserEntryKind> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => classify_file_type(metadata.file_type()),
+    match classify_source_entry_path(path) {
+        Ok(classification) => classification.visible_kind(),
+        Err(SourceEntryProbeError::Missing) => None,
         Err(error) => {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!(
-                    path = %path.display(),
-                    %error,
-                    "Failed to read browser entry type without following links"
-                );
-            }
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "Failed to read browser entry type without following links"
+            );
             None
         }
     }
@@ -64,14 +63,15 @@ pub(super) fn read_sorted_entries(path: &Path) -> Option<Vec<BrowserEntry>> {
         })
         .filter_map(|entry| {
             let entry_path = entry.path();
-            if wavecrate_library::sample_sources::is_apple_double_sidecar(&entry_path) {
-                return None;
-            }
             match entry.file_type() {
-                Ok(file_type) => classify_file_type(file_type).map(|kind| BrowserEntry {
-                    path: entry_path,
-                    kind,
-                }),
+                Ok(file_type) => {
+                    classify_source_entry(&entry_path, source_entry_file_type(&file_type))
+                        .visible_kind()
+                        .map(|kind| BrowserEntry {
+                            path: entry_path,
+                            kind,
+                        })
+                }
                 Err(error) => {
                     tracing::warn!(
                         path = %entry_path.display(),
@@ -91,12 +91,10 @@ pub(super) fn read_sorted_entries(path: &Path) -> Option<Vec<BrowserEntry>> {
     Some(entries)
 }
 
-fn classify_file_type(file_type: FileType) -> Option<BrowserEntryKind> {
-    if file_type.is_symlink() {
-        return None;
-    }
-    if file_type.is_dir() {
-        return Some(BrowserEntryKind::Directory);
-    }
-    file_type.is_file().then_some(BrowserEntryKind::File)
+fn source_entry_file_type(file_type: &FileType) -> SourceEntryFileType {
+    SourceEntryFileType::from_no_followed_type(
+        file_type.is_dir(),
+        file_type.is_file(),
+        file_type.is_symlink(),
+    )
 }

--- a/src/native_app/sample_library/source_watcher/classification.rs
+++ b/src/native_app/sample_library/source_watcher/classification.rs
@@ -1,5 +1,9 @@
 use notify::{Event, EventKind};
 use std::path::Path;
+use wavecrate_library::sample_sources::{
+    SourceEntryFileType, SourceEntryKind, SourceEntryProbeError, classify_path_without_following,
+    classify_source_entry,
+};
 
 pub(super) fn event_triggers_source_refresh(event: &Event) -> bool {
     matches!(
@@ -25,10 +29,32 @@ pub(super) fn path_is_source_refresh_candidate(path: &Path, kind: EventKind) -> 
     {
         return false;
     }
-    matches!(kind, EventKind::Remove(_) | EventKind::Any)
-        || path_has_supported_audio_extension(path)
+    matches!(kind, EventKind::Remove(_) | EventKind::Any) || watcher_entry_is_candidate(path)
+}
+
+fn watcher_entry_is_candidate(path: &Path) -> bool {
+    match classify_path_without_following(path) {
+        Ok(classification) => {
+            classification.has_supported_audio()
+                || classification.visible_kind() == Some(SourceEntryKind::Directory)
+                // A live link is not visible to source traversal, but it can
+                // replace a previously indexed WAV. Keep the bounded watcher
+                // candidate so targeted sync can retire that stale row while
+                // refusing to follow the link.
+                || path_only_source_candidate(path)
+        }
+        // Watcher events commonly arrive after the entry vanished. Retain a
+        // bounded path-only candidate so targeted reconciliation can remove a
+        // previously indexed WAV or a directory subtree without following it.
+        Err(SourceEntryProbeError::Missing | SourceEntryProbeError::Unavailable(_)) => {
+            path_only_source_candidate(path)
+        }
+    }
+}
+
+fn path_only_source_candidate(path: &Path) -> bool {
+    classify_source_entry(path, SourceEntryFileType::File).has_supported_audio()
         || path.extension().is_none()
-        || path.is_dir()
 }
 
 fn is_wavecrate_transient_analysis_path(path: &Path) -> bool {
@@ -43,17 +69,6 @@ fn is_tempfile_name(name: &str, prefix: &str) -> bool {
         return false;
     };
     suffix.len() == 6 && suffix.bytes().all(|byte| byte.is_ascii_alphanumeric())
-}
-
-fn path_has_supported_audio_extension(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| {
-            matches!(
-                extension.to_ascii_lowercase().as_str(),
-                "wav" | "wave" | "aif" | "aiff"
-            )
-        })
 }
 
 fn is_wavecrate_metadata_file(path: &Path) -> bool {

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -9,7 +9,8 @@ use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
-use wavecrate::sample_sources::{SampleSource, SourceId};
+use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId};
+use wavecrate_scan::sample_sources::scanner::{scan_once, sync_paths};
 
 use crate::native_app::app::GuiMessage;
 
@@ -94,6 +95,39 @@ fn apple_double_sidecars_do_not_trigger_source_refresh() {
         &root.join("drums").join("._snare.wav"),
         EventKind::Create(notify::event::CreateKind::File),
     ));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_replacement_stays_a_watcher_candidate_until_targeted_sync_retires_it() {
+    use std::os::unix::fs as unix_fs;
+
+    let root = tempfile::tempdir().expect("create source watcher fixture");
+    let outside = tempfile::tempdir().expect("create outside fixture");
+    let tracked = root.path().join("kick.wav");
+    let target = outside.path().join("outside.wav");
+    fs::write(&tracked, b"indexed").expect("write indexed source file");
+    fs::write(&target, b"outside").expect("write outside file");
+    let database = SourceDatabase::open_for_source_write(root.path()).expect("open source db");
+    scan_once(&database).expect("index tracked file");
+
+    fs::remove_file(&tracked).expect("remove indexed source file");
+    unix_fs::symlink(&target, &tracked).expect("replace source file with link");
+    assert!(path_is_source_refresh_candidate(
+        &tracked,
+        EventKind::Modify(notify::event::ModifyKind::Data(
+            notify::event::DataChange::Any,
+        )),
+    ));
+    let stats = sync_paths(&database, &[PathBuf::from("kick.wav")])
+        .expect("reconcile link replacement without following it");
+    assert_eq!(stats.missing, 1);
+    assert!(
+        database
+            .entry_for_path(Path::new("kick.wav"))
+            .expect("read indexed entry")
+            .is_none()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Goal
Unify no-follow source-entry classification so full scans, targeted sync, browser traversal, and watcher refreshes cannot drift on source-boundary behavior.

## Scope and non-goals
- Adds a library-owned typed entry policy for regular files, directories, links/reparse points, AppleDouble sidecars, supported audio, hidden-directory indexing, and bounded probe outcomes.
- Routes full scans, targeted sync, deep-hash checks, folder-browser traversal/refresh, and watcher candidates through that policy.
- Rejects non-Unicode relative paths before persistence instead of lossy conversion; retains case and Unicode-normalization distinctions.
- Does not enable symlink traversal, alter supported formats, merge UI ownership into scanning, or change committed-revision/uncertainty behavior.

## Definition of Done
- Source consumers share one no-follow classification contract.
- A live symlink replacement remains a bounded watcher candidate so targeted sync safely retires stale indexed rows without following it.
- AppleDouble, hidden-directory, unsupported-file, and persisted-identity behavior have regression coverage.

## Validation
- `cargo test -p wavecrate-library --lib sample_sources:: -- --test-threads=1`
- `cargo test -p wavecrate-scan --lib -- --test-threads=1`
- `cargo test --lib native_app::sample_library::source_watcher::tests -- --test-threads=1`
- `cargo test --lib native_app::sample_library::folder_browser::tests::source_scanning_symlinks -- --test-threads=1`
- `bash scripts/ci.sh agent`
- Independent current-diff review: clean.

## Known limitations
None. Windows reparse behavior uses the shared no-follow file-type contract; platform-specific runtime fixture coverage remains gated by the host.

User approval is required before merge.