### PR TITLE
Gate lifecycle audits on durable watcher recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,6 +6135,7 @@ dependencies = [
  "ed25519-dalek",
  "embed-resource",
  "filetime",
+ "fsevent-sys",
  "fuzzy-matcher",
  "hound",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ crossbeam-queue = "0.3.12"
 reson = { path = "crates/reson" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+fsevent-sys = "4.1.0"
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSApplication",

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -62,6 +62,11 @@ pub const LEGACY_DB_FILE_NAME: &str = ".wavecrate_samples.db";
 pub const META_LAST_SCAN_COMPLETED_AT: &str = "last_scan_completed_at";
 /// Metadata key storing the last completed periodic source-manifest audit timestamp.
 pub const META_LAST_MANIFEST_AUDIT_AT: &str = "last_manifest_audit_at_v1";
+/// Metadata key storing the durable macOS filesystem-event coverage checkpoint.
+///
+/// The value is owned by the native source watcher. It is deliberately separate from manifest
+/// revisions: a watcher cursor proves what needs replaying, not that the manifest itself changed.
+pub const META_SOURCE_WATCHER_CHECKPOINT: &str = "source_watcher_checkpoint_v1";
 /// Metadata key for the last similarity-prep scan timestamp.
 /// Metadata key storing the last data revision cleaned by deferred maintenance.
 pub const META_DEFERRED_MAINTENANCE_REVISION: &str = "deferred_maintenance_revision_v1";

--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -80,11 +80,23 @@ pub(in crate::native_app) enum GuiMessage {
         paths: Vec<PathBuf>,
         overflowed: bool,
         source_root_available: bool,
+        /// A durable FSEvents cursor that may advance only after this targeted sync commits.
+        journal_checkpoint_event_id: Option<u64>,
     },
-    /// The initial watcher stream is live. Re-arming startup manifest audits at
-    /// this boundary covers filesystem changes made while native roots were
-    /// being registered.
-    SourceWatcherReady,
+    /// The initial watcher stream is live and journal recovery has completed. This boundary
+    /// admits the durable lifecycle gate without assuming that every source needs a traversal.
+    SourceWatcherReady {
+        /// Sources whose earlier unavailable-watcher fallback is still completing. Their
+        /// lifecycle probes remain held until the watcher captures a fresh audit barrier.
+        deferred_audit_sources: Vec<String>,
+    },
+    /// Durable closed-application watcher coverage was unavailable for one source. The
+    /// supervisor owns the bounded manifest-audit fallback so browser projection remains last-good
+    /// until the committed reconciliation delta is ready.
+    SourceWatcherJournalGap {
+        source_id: String,
+        reason: &'static str,
+    },
     SourceFilesystemSyncFinished(SourceFilesystemSyncResult),
     CommittedFileMutationRequested(FileMutationWork),
     CommittedFileMutationFinished(FileMutationOutcome),
@@ -92,6 +104,11 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         lifecycle_generation: u64,
         committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta,
+    },
+    SourceManifestAuditFinished {
+        source_id: String,
+        lifecycle_generation: u64,
+        complete: bool,
     },
     NormalizationProgress(NormalizationProgress),
     NormalizationFinished(NormalizationResult),
@@ -401,6 +418,7 @@ pub(in crate::native_app) struct SourceFilesystemSyncResult {
     pub(in crate::native_app) source_id: String,
     pub(in crate::native_app) lifecycle_generation: u64,
     pub(in crate::native_app) changed_count: usize,
+    pub(in crate::native_app) journal_checkpoint_event_id: Option<u64>,
     pub(in crate::native_app) cancelled: bool,
     pub(in crate::native_app) result: Result<SourceFilesystemSyncSuccess, String>,
 }

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -52,6 +52,14 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
             lifecycle_generation: lifecycle.generation,
             committed_delta,
         },
+        SourceProcessingEvent::ManifestAuditFinished {
+            lifecycle,
+            complete,
+        } => GuiMessage::SourceManifestAuditFinished {
+            source_id: lifecycle.source_id,
+            lifecycle_generation: lifecycle.generation,
+            complete,
+        },
         SourceProcessingEvent::Completed => {
             GuiMessage::SourceProcessingProgress(SourceProcessingProgress {
                 source_id: String::new(),

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -33,6 +33,7 @@ impl NativeAppState {
         paths: Vec<PathBuf>,
         overflowed: bool,
         source_root_available: bool,
+        journal_checkpoint_event_id: Option<u64>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let started_at = Instant::now();
@@ -72,7 +73,13 @@ impl NativeAppState {
                 source_id,
                 changed_count,
             } => {
-                self.queue_source_filesystem_sync(source_id.clone(), paths, changed_count, context);
+                self.queue_source_filesystem_sync(
+                    source_id.clone(),
+                    paths,
+                    changed_count,
+                    journal_checkpoint_event_id,
+                    context,
+                );
                 emit_gui_action(
                     "folder_browser.source.filesystem_change",
                     Some("sources"),
@@ -110,6 +117,7 @@ impl NativeAppState {
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         let source_id = result.source_id;
+        let journal_checkpoint_event_id = result.journal_checkpoint_event_id;
         self.library
             .mark_targeted_source_sync_finished(&source_id, result.lifecycle_generation);
         if self.background.source_lifecycle_generations.get(&source_id)
@@ -176,6 +184,15 @@ impl NativeAppState {
                             &source_id,
                             "filesystem_sync_incomplete_after_commit",
                         );
+                }
+                if !result.cancelled
+                    && incomplete_error.is_none()
+                    && let (Some(watcher), Some(event_id)) = (
+                        self.library.source_watcher.as_ref(),
+                        journal_checkpoint_event_id,
+                    )
+                {
+                    watcher.advance_journal_checkpoint(source_id.clone(), event_id);
                 }
                 if result.cancelled || incomplete_error.is_some() {
                     self.queue_filesystem_source_refresh(
@@ -340,6 +357,7 @@ impl NativeAppState {
                 pending.source_id,
                 pending.paths,
                 changed_count,
+                None,
                 context,
             );
             break;
@@ -443,6 +461,7 @@ impl NativeAppState {
         source_id: String,
         paths: Vec<PathBuf>,
         changed_count: usize,
+        journal_checkpoint_event_id: Option<u64>,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if paths.is_empty() {
@@ -496,6 +515,7 @@ impl NativeAppState {
                         source_id,
                         lifecycle_generation: expected_lifecycle_generation,
                         changed_count,
+                        journal_checkpoint_event_id,
                         cancelled: true,
                         result: Err(String::from("Source filesystem sync canceled")),
                     };
@@ -504,7 +524,7 @@ impl NativeAppState {
                 let cancel = permit.cancel_token();
                 let scan_writer = permit.scan_writer();
                 let recovery_source_id = source_id.clone();
-                let result = recover_source_filesystem_sync(
+                let mut result = recover_source_filesystem_sync(
                     recovery_source_id,
                     lifecycle_generation,
                     changed_count,
@@ -520,6 +540,7 @@ impl NativeAppState {
                         )
                     },
                 );
+                result.journal_checkpoint_event_id = journal_checkpoint_event_id;
                 drop(permit);
                 result
             },

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh_worker.rs
@@ -35,6 +35,7 @@ pub(in crate::native_app) fn recover_source_filesystem_sync(
             source_id,
             lifecycle_generation,
             changed_count,
+            journal_checkpoint_event_id: None,
             cancelled: false,
             result: Err(String::from(
                 "Source filesystem sync worker stopped unexpectedly",
@@ -103,6 +104,7 @@ pub(in crate::native_app) fn sync_source_database_paths_with_writer(
         source_id,
         lifecycle_generation: 0,
         changed_count,
+        journal_checkpoint_event_id: None,
         cancelled: cancel.load(Ordering::Acquire),
         result,
     }

--- a/src/native_app/sample_library/source_watcher.rs
+++ b/src/native_app/sample_library/source_watcher.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 mod classification;
 mod debounce;
 mod handle;
+mod journal;
 mod path_mapping;
 mod roots;
 mod state;

--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -15,6 +15,7 @@ use std::{
 use wavecrate::sample_sources::SampleSource;
 
 use super::classification::retain_source_refresh_candidates;
+use super::journal::{self, JournalRecovery};
 use super::roots::{
     RootIdentityRecovery, RootWatchUpdate, WatchedRootIdentities, root_watch_status,
     update_watched_roots,
@@ -63,7 +64,7 @@ const MAX_UNRESOLVED_TEARDOWNS: usize = 3;
 /// lifecycle work remains; completed handles are joined when the next handoff is registered.
 static SHUTDOWN_LIFECYCLE_WORKERS: OnceLock<Mutex<Vec<thread::JoinHandle<()>>>> = OnceLock::new();
 
-fn retain_shutdown_lifecycle_worker(worker: thread::JoinHandle<()>) {
+pub(super) fn retain_shutdown_lifecycle_worker(worker: thread::JoinHandle<()>) {
     let workers = SHUTDOWN_LIFECYCLE_WORKERS.get_or_init(|| Mutex::new(Vec::new()));
     let mut workers = workers.lock().expect("shutdown lifecycle worker registry");
     let mut index = 0;
@@ -282,6 +283,32 @@ impl GuiSourceWatcherHandle {
             });
     }
 
+    pub(in crate::native_app) fn advance_journal_checkpoint(
+        &self,
+        source_id: String,
+        event_id: u64,
+    ) {
+        let _ = self
+            .command_tx
+            .send(GuiSourceWatchCommand::AdvanceJournalCheckpoint {
+                source_id,
+                event_id,
+            });
+    }
+
+    pub(in crate::native_app) fn finish_journal_barrier_audit(
+        &self,
+        source_id: String,
+        complete: bool,
+    ) {
+        let _ = self
+            .command_tx
+            .send(GuiSourceWatchCommand::FinishJournalBarrierAudit {
+                source_id,
+                complete,
+            });
+    }
+
     #[cfg(test)]
     pub(in crate::native_app) fn request_full_reconciliation(&self) {
         let _ = self
@@ -351,6 +378,14 @@ enum GuiSourceWatchCommand {
         echoes: Vec<CommittedWatcherEcho>,
         operation_id: u64,
     },
+    AdvanceJournalCheckpoint {
+        source_id: String,
+        event_id: u64,
+    },
+    FinishJournalBarrierAudit {
+        source_id: String,
+        complete: bool,
+    },
     #[cfg(test)]
     ForceRestart,
     #[cfg(test)]
@@ -382,7 +417,10 @@ fn run_source_watcher(
     let mut restart_delay = WATCHER_RESTART_MIN;
     let mut next_root_refresh = Instant::now();
     let mut root_identity_recovery = RootIdentityRecovery::default();
+    let mut audit_barriers = HashMap::new();
+    let mut deferred_audit_barrier_sources = HashSet::new();
     let mut watcher_has_been_ready = false;
+    let mut watcher_unavailable_reported = false;
     #[cfg(any(test, feature = "legacy-controller"))]
     let mut readiness_waiters = Vec::<Sender<()>>::new();
 
@@ -412,6 +450,34 @@ fn run_source_watcher(
                     operation_id,
                     Instant::now(),
                 );
+            }
+            Ok(GuiSourceWatchCommand::AdvanceJournalCheckpoint {
+                source_id,
+                event_id,
+            }) => journal::advance_after_reconciliation(&state.sources, &source_id, event_id),
+            Ok(GuiSourceWatchCommand::FinishJournalBarrierAudit {
+                source_id,
+                complete,
+            }) => {
+                if complete {
+                    if let Some(barrier) = audit_barriers.remove(&source_id) {
+                        journal::commit_audit_barrier(&state.sources, &source_id, barrier);
+                    }
+                }
+                if deferred_audit_barrier_sources.remove(&source_id) {
+                    // The unavailable-watcher audit predates watcher recovery. Capture only now,
+                    // after that audit has completed, then schedule a fresh audit tied to this
+                    // barrier instead of letting the older completion advance a new cursor.
+                    if let Some(barrier) =
+                        journal::capture_audit_barrier(&state.sources, &source_id)
+                    {
+                        audit_barriers.insert(source_id.clone(), barrier);
+                        let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
+                            source_id,
+                            reason: "watcher_recovered_after_unavailable",
+                        });
+                    }
+                }
             }
             #[cfg(test)]
             Ok(GuiSourceWatchCommand::ReconcileAllSources) => {
@@ -480,6 +546,13 @@ fn run_source_watcher(
                     Arc::clone(&ingress_overflowed),
                     backend,
                 ) {
+                    if !watcher_has_been_ready {
+                        publish_watcher_unavailable_fallback(
+                            &message_tx,
+                            &state.sources,
+                            &mut watcher_unavailable_reported,
+                        );
+                    }
                     next_restart = now + restart_delay;
                     restart_delay = doubled_backoff(restart_delay);
                 }
@@ -489,6 +562,13 @@ fn run_source_watcher(
                     max_unresolved_initializers = MAX_UNRESOLVED_INITIALIZERS,
                     "All GUI source watcher initializer slots are unresolved; backing off recovery"
                 );
+                if !watcher_has_been_ready {
+                    publish_watcher_unavailable_fallback(
+                        &message_tx,
+                        &state.sources,
+                        &mut watcher_unavailable_reported,
+                    );
+                }
                 next_restart = now + restart_delay;
                 restart_delay = doubled_backoff(restart_delay);
             }
@@ -533,15 +613,30 @@ fn run_source_watcher(
                     } else {
                         restarted.ingress_enabled.store(true, Ordering::Release);
                         let first_ready = !watcher_has_been_ready;
+                        let recovered_after_unavailability = watcher_unavailable_reported;
                         watcher_has_been_ready = true;
                         watcher = Some(restarted);
                         if first_ready {
                             // Registration callbacks were fenced while every root was installed.
-                            // Re-arm the authoritative startup audit after ingress is live so it
-                            // closes that short construction window without queuing foreground
-                            // scans for every source.
-                            let _ = message_tx.send(GuiMessage::SourceWatcherReady);
+                            // Now that ingress is live, replay the durable macOS journal before
+                            // admitting the lifecycle probe. A history gap is scoped to the one
+                            // affected source and deliberately falls back to its bounded audit.
+                            publish_closed_app_journal_recovery(
+                                &message_tx,
+                                &state.sources,
+                                backend == SourceWatcherBackend::Native,
+                                &mut audit_barriers,
+                                &mut deferred_audit_barrier_sources,
+                                recovered_after_unavailability,
+                            );
+                            let _ = message_tx.send(GuiMessage::SourceWatcherReady {
+                                deferred_audit_sources: deferred_audit_barrier_sources
+                                    .iter()
+                                    .cloned()
+                                    .collect(),
+                            });
                         }
+                        watcher_unavailable_reported = false;
                         restart_delay = WATCHER_RESTART_MIN;
                         next_root_refresh = now
                             + if unavailable {
@@ -574,6 +669,13 @@ fn run_source_watcher(
                             restart_delay = doubled_backoff(restart_delay);
                         }
                     } else {
+                        if !watcher_has_been_ready {
+                            publish_watcher_unavailable_fallback(
+                                &message_tx,
+                                &state.sources,
+                                &mut watcher_unavailable_reported,
+                            );
+                        }
                         next_restart = now + restart_delay;
                         restart_delay = doubled_backoff(restart_delay);
                     }
@@ -620,6 +722,13 @@ fn run_source_watcher(
                             restart_delay = doubled_backoff(restart_delay);
                         }
                     } else {
+                        if !watcher_has_been_ready {
+                            publish_watcher_unavailable_fallback(
+                                &message_tx,
+                                &state.sources,
+                                &mut watcher_unavailable_reported,
+                            );
+                        }
                         next_restart = now + restart_delay;
                         restart_delay = doubled_backoff(restart_delay);
                     }
@@ -647,6 +756,13 @@ fn run_source_watcher(
                             restart_delay = doubled_backoff(restart_delay);
                         }
                     } else {
+                        if !watcher_has_been_ready {
+                            publish_watcher_unavailable_fallback(
+                                &message_tx,
+                                &state.sources,
+                                &mut watcher_unavailable_reported,
+                            );
+                        }
                         next_restart = now + restart_delay;
                         restart_delay = doubled_backoff(restart_delay);
                     }
@@ -734,6 +850,7 @@ fn run_source_watcher(
                 paths: event.paths,
                 overflowed: event.overflowed,
                 source_root_available: event.source_root_available,
+                journal_checkpoint_event_id: None,
             });
         }
     }
@@ -756,6 +873,92 @@ fn run_source_watcher(
         lifecycle_tx
             .send(lifecycle)
             .expect("source watcher lifecycle service must outlive its coordinator");
+    }
+}
+
+fn publish_closed_app_journal_recovery(
+    message_tx: &Sender<GuiMessage>,
+    sources: &[SampleSource],
+    native_watcher: bool,
+    audit_barriers: &mut HashMap<String, journal::AuditBarrier>,
+    deferred_audit_barrier_sources: &mut HashSet<String>,
+    defer_audit_barriers: bool,
+) {
+    for (source, recovery) in sources
+        .iter()
+        .zip(journal::recover_sources(sources, native_watcher))
+    {
+        match recovery {
+            JournalRecovery::Changes { paths, event_id } if paths.is_empty() => {
+                journal::advance_after_reconciliation(sources, source.id.as_str(), event_id);
+                tracing::debug!(
+                    source_id = source.id.as_str(),
+                    "Durable source watcher journal found no closed-application changes"
+                );
+            }
+            JournalRecovery::Changes { paths, event_id } => {
+                tracing::info!(
+                    source_id = source.id.as_str(),
+                    path_count = paths.len(),
+                    "Replaying closed-application source watcher changes"
+                );
+                let _ = message_tx.send(GuiMessage::SourceFilesystemChanged {
+                    source_id: source.id.as_str().to_string(),
+                    paths,
+                    overflowed: false,
+                    source_root_available: true,
+                    journal_checkpoint_event_id: Some(event_id),
+                });
+            }
+            JournalRecovery::FullAudit { reason } => {
+                tracing::info!(
+                    source_id = source.id.as_str(),
+                    reason,
+                    "Durable source watcher coverage requires a bounded manifest audit"
+                );
+                if defer_audit_barriers {
+                    // An unavailable-watcher fallback may already be auditing this source.
+                    // Wait for that completion command before capturing the barrier and emitting
+                    // the replacement audit request; otherwise the replacement could start
+                    // before its fence exists.
+                    deferred_audit_barrier_sources.insert(source.id.as_str().to_string());
+                } else {
+                    if let Some(barrier) =
+                        journal::capture_audit_barrier(sources, source.id.as_str())
+                    {
+                        audit_barriers.insert(source.id.as_str().to_string(), barrier);
+                    }
+                    let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
+                        source_id: source.id.as_str().to_string(),
+                        reason,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// A watcher that cannot initialize must not hold startup reconciliation hostage. This fallback
+/// deliberately has no audit barrier: without a live ingress stream, advancing a durable cursor
+/// would risk hiding mutations made during the audit. The old cursor remains replayable when a
+/// watcher eventually recovers, while the supervisor gets a bounded, retryable source audit now.
+fn publish_watcher_unavailable_fallback(
+    message_tx: &Sender<GuiMessage>,
+    sources: &[SampleSource],
+    already_reported: &mut bool,
+) {
+    if std::mem::replace(already_reported, true) {
+        return;
+    }
+    tracing::warn!(
+        source_count = sources.len(),
+        "Source watcher unavailable at startup; admitting bounded source audit fallback"
+    );
+    for source in sources {
+        let _ = message_tx.send(GuiMessage::SourceWatcherJournalGap {
+            source_id: source.id.as_str().to_string(),
+            reason: "watcher_unavailable",
+        });
     }
 }
 
@@ -1016,6 +1219,7 @@ mod lifecycle_tests {
             mpsc::{Receiver, SyncSender},
         },
     };
+    use wavecrate::sample_sources::{SampleSource, SourceId};
 
     static LIFECYCLE_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
@@ -1024,6 +1228,29 @@ mod lifecycle_tests {
             .get_or_init(|| Mutex::new(()))
             .lock()
             .expect("lifecycle test lock")
+    }
+
+    #[test]
+    fn startup_watcher_unavailability_admits_one_scoped_fallback_per_source() {
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("watcher-unavailable"),
+            PathBuf::from("/tmp/watcher-unavailable"),
+        );
+        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        let mut reported = false;
+
+        publish_watcher_unavailable_fallback(&message_tx, &[source], &mut reported);
+        publish_watcher_unavailable_fallback(&message_tx, &[], &mut reported);
+
+        assert!(matches!(
+            message_rx.recv().expect("watcher fallback message"),
+            GuiMessage::SourceWatcherJournalGap { source_id, reason }
+                if source_id == "watcher-unavailable" && reason == "watcher_unavailable"
+        ));
+        assert!(matches!(
+            message_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
     }
 
     fn blocking_initializer(

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -1,0 +1,512 @@
+//! Durable closed-application coverage for source roots.
+//!
+//! The live `notify` watcher deliberately starts before this module replays a persisted FSEvents
+//! cursor. That ordering closes the handoff window: replay covers the time Wavecrate was not
+//! running, while the live watcher owns changes made during replay. A missing cursor, changed
+//! filesystem identity, or any FSEvents history-loss flag fails closed to the existing bounded
+//! manifest audit.
+
+use std::path::{Path, PathBuf};
+
+use notify::EventKind;
+use serde::{Deserialize, Serialize};
+use wavecrate::sample_sources::{SampleSource, db::SourceDatabase};
+use wavecrate_library::{
+    filesystem_identity::stable_filesystem_identity,
+    sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SourceWatcherCheckpoint {
+    root_identity: String,
+    event_id: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct AuditBarrier(SourceWatcherCheckpoint);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum JournalRecovery {
+    Changes { paths: Vec<PathBuf>, event_id: u64 },
+    FullAudit { reason: &'static str },
+}
+
+/// Recover the changes made while the process was not observing a source root.
+///
+/// This returns paths relative to `source.root`; callers feed them through the normal debounced
+/// source-sync path. The fallback is intentionally per source so a mounted volume or a single
+/// unavailable database cannot make healthy sources traverse too.
+pub(super) fn recover_sources(
+    sources: &[SampleSource],
+    native_watcher: bool,
+) -> Vec<JournalRecovery> {
+    sources
+        .iter()
+        .map(|source| recover_source(source, native_watcher))
+        .collect()
+}
+
+fn recover_source(source: &SampleSource, native_watcher: bool) -> JournalRecovery {
+    if !native_watcher {
+        return JournalRecovery::FullAudit {
+            reason: "watcher_backend_has_no_durable_journal",
+        };
+    }
+    let Some(root_identity) = std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
+    else {
+        return JournalRecovery::FullAudit {
+            reason: "source_root_identity_unavailable",
+        };
+    };
+    let checkpoint = match load_checkpoint(source) {
+        Ok(Some(checkpoint)) if checkpoint.root_identity == root_identity => checkpoint,
+        Ok(Some(_)) => {
+            return JournalRecovery::FullAudit {
+                reason: "source_root_identity_changed",
+            };
+        }
+        Ok(None) => {
+            // Do not persist a cursor yet. The caller must first capture a barrier before the
+            // fallback audit and commit that exact barrier after it completes; writing "now"
+            // here could skip a mutation the audit had already passed.
+            let _ = root_identity;
+            return JournalRecovery::FullAudit {
+                reason: "watcher_checkpoint_missing",
+            };
+        }
+        Err(error) => {
+            tracing::warn!(
+                source_id = source.id.as_str(),
+                "Could not read durable source watcher checkpoint: {error}"
+            );
+            return JournalRecovery::FullAudit {
+                reason: "watcher_checkpoint_unavailable",
+            };
+        }
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        match replay_fsevents(&source.root, checkpoint.event_id) {
+            Ok((paths, event_id)) => JournalRecovery::Changes {
+                paths: paths
+                    .into_iter()
+                    .filter(|path| {
+                        super::classification::path_is_source_refresh_candidate(
+                            path,
+                            EventKind::Any,
+                        )
+                    })
+                    .filter_map(|path| path.strip_prefix(&source.root).ok().map(PathBuf::from))
+                    .filter(|path| !path.as_os_str().is_empty())
+                    .collect(),
+                event_id,
+            },
+            Err(reason) => JournalRecovery::FullAudit { reason },
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = checkpoint;
+        JournalRecovery::FullAudit {
+            reason: "durable_journal_unsupported",
+        }
+    }
+}
+
+/// Advance a replay cursor only after the target filesystem reconciliation has committed.
+pub(super) fn advance_after_reconciliation(
+    sources: &[SampleSource],
+    source_id: &str,
+    event_id: u64,
+) {
+    let Some(source) = sources
+        .iter()
+        .find(|source| source.id.as_str() == source_id)
+    else {
+        return;
+    };
+    let Some(root_identity) = std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
+    else {
+        return;
+    };
+    let Ok(Some(mut checkpoint)) = load_checkpoint(source) else {
+        return;
+    };
+    if checkpoint.root_identity != root_identity || checkpoint.event_id > event_id {
+        return;
+    }
+    checkpoint.event_id = event_id;
+    if let Err(error) = store_checkpoint(source, &checkpoint) {
+        tracing::warn!(
+            source_id,
+            "Could not advance durable source watcher checkpoint: {error}"
+        );
+    }
+}
+
+/// Capture a journal barrier before a fallback audit starts. It remains in watcher memory until a
+/// successful completion, so a crash or incomplete audit keeps the older cursor and replays safe
+/// overlap on the next launch.
+pub(super) fn capture_audit_barrier(
+    sources: &[SampleSource],
+    source_id: &str,
+) -> Option<AuditBarrier> {
+    #[cfg(target_os = "macos")]
+    let event_id = unsafe { fsevent_sys::FSEventsGetCurrentEventId() };
+    #[cfg(not(target_os = "macos"))]
+    let event_id = 0;
+    let source = sources
+        .iter()
+        .find(|source| source.id.as_str() == source_id)?;
+    let root_identity = std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))?;
+    Some(AuditBarrier(SourceWatcherCheckpoint {
+        root_identity,
+        event_id,
+    }))
+}
+
+/// Commit a pre-audit barrier only after a complete audit. Never sample the current global ID at
+/// completion: a live event after the barrier may not yet have committed and must stay replayable.
+pub(super) fn commit_audit_barrier(
+    sources: &[SampleSource],
+    source_id: &str,
+    barrier: AuditBarrier,
+) {
+    let Some(source) = sources
+        .iter()
+        .find(|source| source.id.as_str() == source_id)
+    else {
+        return;
+    };
+    let Some(root_identity) = std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
+    else {
+        return;
+    };
+    if root_identity != barrier.0.root_identity {
+        return;
+    }
+    if let Err(error) = store_checkpoint(source, &barrier.0) {
+        tracing::warn!(
+            source_id,
+            "Could not establish post-audit source watcher checkpoint: {error}"
+        );
+    }
+}
+
+fn source_database(source: &SampleSource) -> Result<SourceDatabase, String> {
+    let database_root = source.database_root().map_err(|error| error.to_string())?;
+    SourceDatabase::open_for_background_job_with_database_root(&source.root, database_root)
+        .map_err(|error| error.to_string())
+}
+
+fn load_checkpoint(source: &SampleSource) -> Result<Option<SourceWatcherCheckpoint>, String> {
+    let database = source_database(source)?;
+    database
+        .get_metadata(META_SOURCE_WATCHER_CHECKPOINT)
+        .map_err(|error| error.to_string())?
+        .map(|value| serde_json::from_str(&value).map_err(|error| error.to_string()))
+        .transpose()
+}
+
+fn store_checkpoint(
+    source: &SampleSource,
+    checkpoint: &SourceWatcherCheckpoint,
+) -> Result<(), String> {
+    let database = source_database(source)?;
+    let value = serde_json::to_string(checkpoint).map_err(|error| error.to_string())?;
+    database
+        .set_metadata(META_SOURCE_WATCHER_CHECKPOINT, &value)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn replay_fsevents(root: &Path, event_id: u64) -> Result<(Vec<PathBuf>, u64), &'static str> {
+    macos::replay(root, event_id).map(|replay| (replay.paths, replay.event_id))
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use fsevent_sys::{self as fs, core_foundation as cf};
+    use std::{
+        ffi::{CStr, c_void},
+        ptr,
+        sync::{Mutex, mpsc},
+        time::Duration,
+    };
+
+    const HISTORY_TIMEOUT: Duration = Duration::from_secs(10);
+    const HISTORY_LOSS_FLAGS: fs::FSEventStreamEventFlags =
+        fs::kFSEventStreamEventFlagMustScanSubDirs
+            | fs::kFSEventStreamEventFlagUserDropped
+            | fs::kFSEventStreamEventFlagKernelDropped
+            | fs::kFSEventStreamEventFlagEventIdsWrapped
+            | fs::kFSEventStreamEventFlagRootChanged
+            | fs::kFSEventStreamEventFlagMount
+            | fs::kFSEventStreamEventFlagUnmount;
+
+    #[derive(Default)]
+    struct HistoryState {
+        paths: Vec<PathBuf>,
+        history_done: bool,
+        history_lost: bool,
+        latest_event_id: u64,
+    }
+
+    pub(super) struct HistoryReplay {
+        pub(super) paths: Vec<PathBuf>,
+        pub(super) event_id: u64,
+    }
+
+    struct HistoryContext {
+        root: PathBuf,
+        state: Mutex<HistoryState>,
+        ready_tx: mpsc::Sender<()>,
+    }
+
+    /// CoreFoundation run-loop references can be stopped from another thread. The handle remains
+    /// owned by the history worker; the caller uses it only to request a bounded shutdown before
+    /// joining that worker.
+    struct RunLoopHandle(cf::CFRunLoopRef);
+
+    // Safety: CoreFoundation documents run-loop stop as cross-thread safe. The caller never
+    // dereferences or releases this handle; stream teardown and context destruction stay on the
+    // history worker that created them.
+    unsafe impl Send for RunLoopHandle {}
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFRetain(cf: cf::CFRef) -> cf::CFRef;
+    }
+
+    pub(super) fn replay(root: &Path, event_id: u64) -> Result<HistoryReplay, &'static str> {
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        let (run_loop_tx, run_loop_rx) = mpsc::sync_channel(1);
+        let root = root.to_path_buf();
+        let worker = std::thread::Builder::new()
+            .name("wavecrate-fsevents-history".to_string())
+            .spawn(move || {
+                let _ = result_tx.send(replay_on_run_loop(&root, event_id, run_loop_tx));
+            })
+            .map_err(|_| "watcher_history_thread_unavailable")?;
+        let run_loop = match run_loop_rx.recv_timeout(HISTORY_TIMEOUT) {
+            Ok(run_loop) => run_loop,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = worker.join();
+                return Err("watcher_history_start_failed");
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // The worker has not entered a callback-capable run loop. Dropping the receiver
+                // makes its eventual run-loop handoff fail closed and it tears down on its owner
+                // thread. Retain the join handle for bounded asynchronous reaping rather than
+                // wedging the watcher coordinator on a stalled CoreServices constructor.
+                super::super::handle::retain_shutdown_lifecycle_worker(worker);
+                return Err("watcher_history_start_timeout");
+            }
+        };
+        let result = match result_rx.recv_timeout(HISTORY_TIMEOUT) {
+            Ok(result) => result,
+            Err(_) => {
+                unsafe { cf::CFRunLoopStop(run_loop.0) };
+                let _ = worker.join();
+                unsafe { cf::CFRelease(run_loop.0) };
+                return Err("watcher_history_timeout");
+            }
+        };
+        let _ = worker.join();
+        unsafe { cf::CFRelease(run_loop.0) };
+        result
+    }
+
+    fn replay_on_run_loop(
+        root: &Path,
+        event_id: u64,
+        run_loop_tx: mpsc::SyncSender<RunLoopHandle>,
+    ) -> Result<HistoryReplay, &'static str> {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let context = Box::new(HistoryContext {
+            root: root.to_path_buf(),
+            state: Mutex::new(HistoryState::default()),
+            ready_tx,
+        });
+        let context = Box::into_raw(context);
+        let stream = match unsafe { create_stream(root, event_id, context) } {
+            Ok(stream) => stream,
+            Err(error) => {
+                unsafe { drop(Box::from_raw(context)) };
+                return Err(error);
+            }
+        };
+        let run_loop = unsafe { cf::CFRunLoopGetCurrent() };
+        unsafe {
+            fs::FSEventStreamScheduleWithRunLoop(stream, run_loop, cf::kCFRunLoopDefaultMode);
+            if fs::FSEventStreamStart(stream) == 0 {
+                fs::FSEventStreamInvalidate(stream);
+                fs::FSEventStreamRelease(stream);
+                drop(Box::from_raw(context));
+                return Err("watcher_history_start_failed");
+            }
+        }
+        let retained_run_loop = unsafe { CFRetain(run_loop) as cf::CFRunLoopRef };
+        if run_loop_tx.send(RunLoopHandle(retained_run_loop)).is_err() {
+            unsafe {
+                cf::CFRelease(retained_run_loop);
+                fs::FSEventStreamStop(stream);
+                fs::FSEventStreamInvalidate(stream);
+                fs::FSEventStreamRelease(stream);
+                drop(Box::from_raw(context));
+            }
+            return Err("watcher_history_start_timeout");
+        }
+        // `HistoryDone` is delivered on this run loop and stops it in the callback. The outer
+        // receiver timeout in `replay` bounds a wedged CoreServices stream without ever blocking
+        // the watcher coordinator or the UI thread.
+        unsafe { cf::CFRunLoopRun() };
+        let completed = ready_rx.try_recv().is_ok();
+        unsafe {
+            fs::FSEventStreamStop(stream);
+            fs::FSEventStreamInvalidate(stream);
+            fs::FSEventStreamRelease(stream);
+        }
+        let context = unsafe { Box::from_raw(context) };
+        if !completed || !context.state.lock().expect("history state").history_done {
+            return Err("watcher_history_timeout");
+        }
+        let mut state = context.state.into_inner().expect("history state");
+        if state.history_lost {
+            return Err("watcher_history_gap");
+        }
+        state.paths.sort();
+        state.paths.dedup();
+        Ok(HistoryReplay {
+            paths: state.paths,
+            event_id: state.latest_event_id.max(event_id),
+        })
+    }
+
+    unsafe fn create_stream(
+        root: &Path,
+        event_id: u64,
+        context: *mut HistoryContext,
+    ) -> Result<fs::FSEventStreamRef, &'static str> {
+        let root = root.to_str().ok_or("watcher_root_not_utf8")?;
+        let mut error = ptr::null_mut();
+        let path = unsafe { cf::str_path_to_cfstring_ref(root, &mut error) };
+        if path.is_null() {
+            return Err("watcher_history_path_unavailable");
+        }
+        let paths = unsafe {
+            cf::CFArrayCreateMutable(cf::kCFAllocatorDefault, 1, &cf::kCFTypeArrayCallBacks)
+        };
+        if paths.is_null() {
+            unsafe { cf::CFRelease(path) };
+            return Err("watcher_history_path_unavailable");
+        }
+        unsafe {
+            cf::CFArrayAppendValue(paths, path);
+            cf::CFRelease(path);
+        }
+        let stream_context = fs::FSEventStreamContext {
+            version: 0,
+            info: context.cast::<c_void>(),
+            retain: None,
+            release: None,
+            copy_description: None,
+        };
+        let stream = unsafe {
+            fs::FSEventStreamCreate(
+                cf::kCFAllocatorDefault,
+                history_callback,
+                &stream_context,
+                paths,
+                event_id,
+                0.0,
+                fs::kFSEventStreamCreateFlagFileEvents | fs::kFSEventStreamCreateFlagNoDefer,
+            )
+        };
+        unsafe { cf::CFRelease(paths) };
+        if stream.is_null() {
+            return Err("watcher_history_create_failed");
+        }
+        Ok(stream)
+    }
+
+    extern "C" fn history_callback(
+        _stream: fs::FSEventStreamRef,
+        info: *mut c_void,
+        count: usize,
+        event_paths: *mut c_void,
+        event_flags: *const fs::FSEventStreamEventFlags,
+        event_ids: *const fs::FSEventStreamEventId,
+    ) {
+        // The FSEvents callback owns only this short mutex and never reaches the GUI or SQLite;
+        // a stalled history stream is therefore bounded by the outer timeout.
+        let context = unsafe { &*(info.cast::<HistoryContext>()) };
+        let paths = event_paths.cast::<*const std::ffi::c_char>();
+        let mut state = context.state.lock().expect("history state");
+        for index in 0..count {
+            let flags = unsafe { *event_flags.add(index) };
+            state.latest_event_id = state.latest_event_id.max(unsafe { *event_ids.add(index) });
+            if flags & HISTORY_LOSS_FLAGS != 0 {
+                state.history_lost = true;
+            }
+            if flags & fs::kFSEventStreamEventFlagHistoryDone != 0 {
+                state.history_done = true;
+                let _ = context.ready_tx.send(());
+                unsafe { cf::CFRunLoopStop(cf::CFRunLoopGetCurrent()) };
+                continue;
+            }
+            let path = unsafe { CStr::from_ptr(*paths.add(index)) };
+            let path = PathBuf::from(path.to_string_lossy().into_owned());
+            if path.starts_with(&context.root) {
+                state.paths.push(path);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wavecrate::sample_sources::SourceId;
+
+    #[test]
+    fn committed_reconciliation_advances_but_never_regresses_the_cursor() {
+        let directory = tempfile::tempdir().expect("source directory");
+        let source = SampleSource::new_with_id(
+            SourceId::from_string("journal-cursor-advance"),
+            directory.path().to_path_buf(),
+        );
+        let metadata = std::fs::metadata(&source.root).expect("source metadata");
+        let root_identity = stable_filesystem_identity(&source.root, &metadata)
+            .expect("stable source root identity");
+        store_checkpoint(
+            &source,
+            &SourceWatcherCheckpoint {
+                root_identity,
+                event_id: 7,
+            },
+        )
+        .expect("store checkpoint");
+
+        advance_after_reconciliation(std::slice::from_ref(&source), source.id.as_str(), 11);
+        advance_after_reconciliation(std::slice::from_ref(&source), source.id.as_str(), 9);
+
+        assert_eq!(
+            load_checkpoint(&source)
+                .expect("load checkpoint")
+                .expect("checkpoint")
+                .event_id,
+            11
+        );
+    }
+}

--- a/src/native_app/sample_library/source_watcher/tests.rs
+++ b/src/native_app/sample_library/source_watcher/tests.rs
@@ -591,7 +591,7 @@ fn foreground_reconciliation_request_refreshes_every_configured_source() {
         receiver
             .recv_timeout(super::WATCHER_START_TIMEOUT)
             .expect("watcher-ready message"),
-        GuiMessage::SourceWatcherReady
+        GuiMessage::SourceWatcherReady { .. }
     ) {}
 
     watcher.request_full_reconciliation();
@@ -609,6 +609,7 @@ fn foreground_reconciliation_request_refreshes_every_configured_source() {
             paths,
             overflowed,
             source_root_available,
+            ..
         } = message
         {
             assert!(paths.is_empty());
@@ -654,7 +655,7 @@ fn idempotent_startup_source_sync_does_not_refresh_every_source() {
     assert_eq!(
         messages
             .iter()
-            .filter(|message| matches!(message, GuiMessage::SourceWatcherReady))
+            .filter(|message| matches!(message, GuiMessage::SourceWatcherReady { .. }))
             .count(),
         1,
         "the startup audit boundary must be published exactly once"
@@ -667,6 +668,7 @@ fn idempotent_startup_source_sync_does_not_refresh_every_source() {
                 paths,
                 overflowed,
                 source_root_available,
+                ..
             } = message
             else {
                 return None;
@@ -696,7 +698,7 @@ fn filesystem_event_after_initial_watcher_ready_is_not_suppressed() {
         receiver
             .recv_timeout(super::WATCHER_START_TIMEOUT)
             .expect("watcher-ready message"),
-        GuiMessage::SourceWatcherReady
+        GuiMessage::SourceWatcherReady { .. }
     ) {}
 
     let created = root.path().join("recording.wav");
@@ -716,6 +718,7 @@ fn filesystem_event_after_initial_watcher_ready_is_not_suppressed() {
             paths,
             overflowed,
             source_root_available,
+            ..
         } = message
         {
             break (source_id, paths, overflowed, source_root_available);
@@ -746,7 +749,7 @@ fn watcher_restarts_and_overflows_when_a_live_root_is_replaced_at_the_same_path(
         receiver
             .recv_timeout(super::WATCHER_START_TIMEOUT)
             .expect("watcher-ready message"),
-        GuiMessage::SourceWatcherReady
+        GuiMessage::SourceWatcherReady { .. }
     ) {}
 
     fs::rename(&root, &retired).expect("retire watched source root");
@@ -764,6 +767,7 @@ fn watcher_restarts_and_overflows_when_a_live_root_is_replaced_at_the_same_path(
             paths,
             overflowed,
             source_root_available,
+            ..
         } = message
             && source_id == expected_source_id
             && overflowed

--- a/src/native_app/shell/lifecycle.rs
+++ b/src/native_app/shell/lifecycle.rs
@@ -181,13 +181,14 @@ impl NativeAppState {
 
     pub(in crate::native_app) fn reconcile_sources_after_focus_regained(&self) {
         // Refocus is a correctness hint for changes made while Wavecrate was inactive, not proof
-        // that the watcher lost events. Re-arm the authoritative manifest audit so unchanged
-        // sources stop at their durable checkpoints and real deltas publish a revision-backed
-        // browser refresh. Treating every focus transition as watcher overflow queues one full
-        // scan per source and can make repeated app activation look like a self-feeding scan loop.
+        // that the watcher lost events. The supervisor evaluates durable watcher coverage, root
+        // identity, revision, and deadline gates; unchanged refocus stays a cheap no-op.
         self.background
             .source_processing
-            .request_manifest_audits("application_focus_regained");
+            .request_lifecycle_audit_probe(
+                crate::native_app::source_processing::SourceAuditLifecycleCause::FocusRegained,
+                &[],
+            );
     }
 
     pub(in crate::native_app) fn persist_user_configuration(

--- a/src/native_app/shell/message_dispatch.rs
+++ b/src/native_app/shell/message_dispatch.rs
@@ -91,9 +91,11 @@ impl NativeAppState {
             | GuiMessage::FolderTreeRefreshFinished(_)
             | GuiMessage::SelectedFolderVerifyFinished(_)
             | GuiMessage::SourceFilesystemChanged { .. }
-            | GuiMessage::SourceWatcherReady
+            | GuiMessage::SourceWatcherReady { .. }
+            | GuiMessage::SourceWatcherJournalGap { .. }
             | GuiMessage::SourceFilesystemSyncFinished(_)
             | GuiMessage::SourceManifestAuditCommitted { .. }
+            | GuiMessage::SourceManifestAuditFinished { .. }
             | GuiMessage::NormalizationProgress(_)
             | GuiMessage::NormalizationFinished(_)
             | GuiMessage::SelectSampleWithModifiers { .. }
@@ -364,9 +366,11 @@ fn gui_message_profile_label(message: &GuiMessage) -> &'static str {
         GuiMessage::FolderTreeRefreshFinished(_) => "FolderTreeRefreshFinished",
         GuiMessage::SelectedFolderVerifyFinished(_) => "SelectedFolderVerifyFinished",
         GuiMessage::SourceFilesystemChanged { .. } => "SourceFilesystemChanged",
-        GuiMessage::SourceWatcherReady => "SourceWatcherReady",
+        GuiMessage::SourceWatcherReady { .. } => "SourceWatcherReady",
+        GuiMessage::SourceWatcherJournalGap { .. } => "SourceWatcherJournalGap",
         GuiMessage::SourceFilesystemSyncFinished(_) => "SourceFilesystemSyncFinished",
         GuiMessage::SourceManifestAuditCommitted { .. } => "SourceManifestAuditCommitted",
+        GuiMessage::SourceManifestAuditFinished { .. } => "SourceManifestAuditFinished",
         GuiMessage::SourceProcessingProgress(_) => "SourceProcessingProgress",
         GuiMessage::NormalizationProgress(_) => "NormalizationProgress",
         GuiMessage::NormalizationFinished(_) => "NormalizationFinished",

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -121,19 +121,31 @@ impl NativeAppState {
                 paths,
                 overflowed,
                 source_root_available,
+                journal_checkpoint_event_id,
             } => {
                 self.refresh_source_after_filesystem_change(
                     source_id,
                     paths,
                     overflowed,
                     source_root_available,
+                    journal_checkpoint_event_id,
                     context,
                 );
             }
-            GuiMessage::SourceWatcherReady => {
+            GuiMessage::SourceWatcherReady {
+                deferred_audit_sources,
+            } => {
                 self.background
                     .source_processing
-                    .request_manifest_audits("source_watcher_ready");
+                    .request_lifecycle_audit_probe(
+                    crate::native_app::source_processing::SourceAuditLifecycleCause::WatcherReady,
+                    &deferred_audit_sources,
+                );
+            }
+            GuiMessage::SourceWatcherJournalGap { source_id, reason } => {
+                self.background
+                    .source_processing
+                    .request_source_manifest_audit(&source_id, reason);
             }
             GuiMessage::SourceFilesystemSyncFinished(result) => {
                 self.finish_source_filesystem_sync(result, context);
@@ -149,6 +161,20 @@ impl NativeAppState {
                     committed_delta,
                     context,
                 );
+            }
+            GuiMessage::SourceManifestAuditFinished {
+                source_id,
+                lifecycle_generation,
+                complete,
+            } => {
+                let source_is_current = self.library.folder_browser.source_exists(&source_id)
+                    && self.background.source_lifecycle_generations.get(&source_id)
+                        == Some(&lifecycle_generation);
+                if source_is_current {
+                    if let Some(watcher) = self.library.source_watcher.as_ref() {
+                        watcher.finish_journal_barrier_audit(source_id, complete);
+                    }
+                }
             }
             GuiMessage::NormalizationProgress(progress) => {
                 self.apply_normalization_progress(progress);

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -378,6 +378,7 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
             source_id: source_id.clone(),
             lifecycle_generation: old_generation,
             changed_count: 1,
+            journal_checkpoint_event_id: None,
             cancelled: true,
             result: Err(String::from("old epoch cancelled")),
         }),

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -104,6 +104,10 @@ pub(in crate::native_app) enum SourceProcessingEvent {
         lifecycle: SourceProcessingLifecycle,
         committed_delta: CommittedSourceDelta,
     },
+    ManifestAuditFinished {
+        lifecycle: SourceProcessingLifecycle,
+        complete: bool,
+    },
     Completed,
 }
 
@@ -113,7 +117,8 @@ impl SourceProcessingEvent {
             Self::Progress(progress) => Some(&progress.lifecycle),
             Self::Health(health) => Some(&health.lifecycle),
             Self::SimilarityReadinessAdvanced { lifecycle }
-            | Self::ManifestAuditCommitted { lifecycle, .. } => Some(lifecycle),
+            | Self::ManifestAuditCommitted { lifecycle, .. }
+            | Self::ManifestAuditFinished { lifecycle, .. } => Some(lifecycle),
             Self::Completed => None,
         }
     }

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -10,7 +10,9 @@ pub(in crate::native_app) use events::{
     SourceProcessingEventSink, SourceProcessingHealthEvent, SourceProcessingHealthState,
     SourceProcessingLifecycle, SourceProcessingProgressEvent,
 };
-pub(in crate::native_app) use supervisor::{SourceProcessingSupervisor, SourceScanAdmissionState};
+pub(in crate::native_app) use supervisor::{
+    SourceAuditLifecycleCause, SourceProcessingSupervisor, SourceScanAdmissionState,
+};
 pub(in crate::native_app) use worker::run_internal_source_analysis_from_args;
 #[cfg(not(test))]
 pub(in crate::native_app) use worker::wait_for_cancellable_child;

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -87,6 +87,7 @@ mod telemetry;
 pub(in crate::native_app) use admission::SourceScanAdmissionState;
 use admission::{SourceProcessingBudgetHandle, install_worker_app_root};
 use cache_ownership::*;
+pub(in crate::native_app) use commands::SourceAuditLifecycleCause;
 use control::*;
 use coordination::*;
 use coordinator::*;

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -3,6 +3,25 @@ use super::{
     SourceProcessingBudgetHandle, SourceProcessingSupervisor, register_source_for_scan_locked,
 };
 
+/// Lifecycle hints that may require source-audit admission, but are not proof that a complete
+/// traversal is required. The durable readiness and watcher coverage gates decide that per source.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::native_app) enum SourceAuditLifecycleCause {
+    Startup,
+    WatcherReady,
+    FocusRegained,
+}
+
+impl SourceAuditLifecycleCause {
+    pub(super) fn reason(self) -> &'static str {
+        match self {
+            Self::Startup => "startup",
+            Self::WatcherReady => "source_watcher_ready",
+            Self::FocusRegained => "application_focus_regained",
+        }
+    }
+}
+
 impl SourceProcessingSupervisor {
     /// Admit a newly configured source before its first external scan starts.
     ///
@@ -32,27 +51,51 @@ impl SourceProcessingSupervisor {
         self.shared.control().source_lifecycle_generations.clone()
     }
 
-    /// Re-arm the authoritative source audits after the watcher stream is live.
+    /// Admit a cheap lifecycle health probe for every active source.
     ///
-    /// The initial audit and this watcher-ready request coalesce while an audit
-    /// is in flight. If it already completed, this request runs one final audit
-    /// that closes the gap between its snapshot and native event delivery.
-    pub(in crate::native_app) fn request_manifest_audits(&self, reason: &'static str) {
+    /// Lifecycle transitions are intentionally only hints. The discovery gate decides whether a
+    /// source needs a bounded manifest audit from durable revision, audit deadline, root identity,
+    /// or watcher-history evidence; unchanged startup, watcher-ready, and focus transitions stay
+    /// cheap no-ops.
+    pub(in crate::native_app) fn request_lifecycle_audit_probe(
+        &self,
+        cause: SourceAuditLifecycleCause,
+        deferred_source_ids: &[String],
+    ) {
         let mut control = self.shared.control();
-        let active_source_ids = control
-            .sources
-            .keys()
-            .filter(|source_id| control.source_is_active(source_id))
-            .cloned()
-            .collect::<Vec<_>>();
-        if active_source_ids.is_empty() {
+        if cause == SourceAuditLifecycleCause::WatcherReady {
+            // The source watcher emits this only after it has either replayed the durable journal
+            // or synchronously captured a per-source fallback-audit barrier.
+            control.lifecycle_audits_deferred_until_watcher_ready = false;
+            control.deferred_lifecycle_audit_sources = deferred_source_ids
+                .iter()
+                .filter(|source_id| control.source_is_active(source_id))
+                .cloned()
+                .collect();
+        }
+        control.mark_all_sources_for_safety_probe();
+        control.notify(cause.reason());
+        drop(control);
+        self.shared.wake.notify_one();
+    }
+
+    /// Force the bounded manifest-audit fallback for one source whose durable watcher coverage
+    /// has a proven gap. This is intentionally source-scoped; lifecycle hints must never turn an
+    /// unrelated healthy source into a full traversal.
+    pub(in crate::native_app) fn request_source_manifest_audit(
+        &self,
+        source_id: &str,
+        reason: &'static str,
+    ) {
+        let mut control = self.shared.control();
+        if !control.source_is_active(source_id) {
             return;
         }
         control
             .force_manifest_audit_sources
-            .extend(active_source_ids.iter().cloned());
-        control.dirty_sources.extend(active_source_ids);
-        control.notify(reason);
+            .insert(source_id.to_string());
+        control.deferred_lifecycle_audit_sources.remove(source_id);
+        control.mark_source_dirty(source_id, reason);
         drop(control);
         self.shared.wake.notify_one();
     }

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -10,6 +10,11 @@ pub(super) struct ControlState {
     pub(super) next_lifecycle_generation: u64,
     pub(super) dirty_sources: BTreeSet<String>,
     pub(super) safety_probe_sources: BTreeSet<String>,
+    /// Initial lifecycle probes must wait until the source watcher has replayed its durable
+    /// journal. A journal-gap request clears the safety-probe bit for its source and can still
+    /// proceed because its watcher-side audit barrier was captured first.
+    pub(super) lifecycle_audits_deferred_until_watcher_ready: bool,
+    pub(super) deferred_lifecycle_audit_sources: BTreeSet<String>,
     pub(super) pending_readiness_deltas: BTreeMap<String, PendingReadinessDelta>,
     pub(super) awaiting_foreground_refresh_sources: BTreeSet<String>,
     pub(super) force_manifest_audit_sources: BTreeSet<String>,

--- a/src/native_app/source_processing/supervisor/coordinator.rs
+++ b/src/native_app/source_processing/supervisor/coordinator.rs
@@ -106,11 +106,36 @@ pub(super) fn run_coordinator(shared: Arc<Shared>) {
             }
             let awaiting_foreground_refresh_sources =
                 control.awaiting_foreground_refresh_sources.clone();
-            let dirty_sources = std::mem::take(&mut control.dirty_sources)
-                .into_iter()
-                .filter(|source_id| !awaiting_foreground_refresh_sources.contains(source_id))
+            let lifecycle_audits_deferred = control.lifecycle_audits_deferred_until_watcher_ready;
+            let deferred_lifecycle_audit_sources = control.deferred_lifecycle_audit_sources.clone();
+            let pending_safety_probe_sources = std::mem::take(&mut control.safety_probe_sources);
+            let pending_dirty_sources = std::mem::take(&mut control.dirty_sources);
+            let deferred_sources = pending_dirty_sources
+                .iter()
+                .filter(|source_id| {
+                    (lifecycle_audits_deferred && pending_safety_probe_sources.contains(*source_id))
+                        || deferred_lifecycle_audit_sources.contains(*source_id)
+                })
+                .cloned()
                 .collect::<BTreeSet<_>>();
-            let safety_probe_sources = std::mem::take(&mut control.safety_probe_sources)
+            let dirty_sources = pending_dirty_sources
+                .into_iter()
+                .filter(|source_id| {
+                    !awaiting_foreground_refresh_sources.contains(source_id)
+                        && !deferred_sources.contains(source_id)
+                })
+                .collect::<BTreeSet<_>>();
+            if !deferred_sources.is_empty() {
+                control
+                    .dirty_sources
+                    .extend(deferred_sources.iter().cloned());
+                control.safety_probe_sources.extend(
+                    deferred_sources
+                        .intersection(&pending_safety_probe_sources)
+                        .cloned(),
+                );
+            }
+            let safety_probe_sources = pending_safety_probe_sources
                 .into_iter()
                 .filter(|source_id| dirty_sources.contains(source_id))
                 .collect::<BTreeSet<_>>();

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -243,7 +243,7 @@ pub(super) fn discover_source_candidates_with_progress(
             Ok(mut probe_connection) => {
                 if readiness_safety_probe_is_current(
                     &mut probe_connection,
-                    source.id.as_str(),
+                    source,
                     now,
                     force_manifest_audit,
                 )? {
@@ -286,7 +286,7 @@ pub(super) fn discover_source_candidates_with_progress(
         force_manifest_audit,
         force_reanalysis,
         pending_readiness_delta,
-        false,
+        safety_probe_only,
         cancel,
         progress,
     )

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -10,16 +10,22 @@ use super::{
     source_processing_schema_available,
 };
 use rusqlite::OptionalExtension;
+#[cfg(target_os = "macos")]
+use wavecrate_library::{
+    filesystem_identity::stable_filesystem_identity,
+    sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
+};
 
 pub(super) fn readiness_safety_probe_is_current(
     connection: &mut rusqlite::Connection,
-    source_id: &str,
+    source: &SampleSource,
     now: i64,
     force_manifest_audit: bool,
 ) -> Result<bool, String> {
     if force_manifest_audit || !source_processing_schema_available(connection)? {
         return Ok(false);
     }
+    let source_id = source.id.as_str();
     let last_manifest_audit_at = connection
         .query_row(
             "SELECT value FROM metadata WHERE key = ?1",
@@ -44,14 +50,64 @@ pub(super) fn readiness_safety_probe_is_current(
         )
         .map_err(|error| error.to_string())?;
     let contract_version = readiness_contract_version();
-    Ok(ReadinessStore::new(connection)
+    let readiness_is_current = ReadinessStore::new(connection)
         .source_state(source_id)
         .map_err(|error| error.to_string())?
         .is_some_and(|state| {
             state.source_generation == source_generation
                 && state.availability == SourceAvailability::Active
                 && state.contract_version == contract_version
-        }))
+        });
+    Ok(readiness_is_current && durable_watcher_coverage_is_current(connection, source)?)
+}
+
+/// On macOS a current readiness revision is only safe to skip when its root still matches the
+/// durable FSEvents replay cursor. The watcher advances work from that cursor after it is live;
+/// a missing or replaced cursor deliberately leaves admission eligible for the bounded audit.
+#[cfg(target_os = "macos")]
+fn durable_watcher_coverage_is_current(
+    connection: &rusqlite::Connection,
+    source: &SampleSource,
+) -> Result<bool, String> {
+    let Some(root_identity) = std::fs::metadata(&source.root)
+        .ok()
+        .and_then(|metadata| stable_filesystem_identity(&source.root, &metadata))
+    else {
+        return Ok(false);
+    };
+    let checkpoint = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [META_SOURCE_WATCHER_CHECKPOINT],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some(checkpoint) = checkpoint else {
+        return Ok(false);
+    };
+    let value: serde_json::Value = match serde_json::from_str(&checkpoint) {
+        Ok(value) => value,
+        Err(_) => return Ok(false),
+    };
+    Ok(value
+        .get("root_identity")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|identity| identity == root_identity)
+        && value
+            .get("event_id")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|event_id| event_id > 0))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn durable_watcher_coverage_is_current(
+    _connection: &rusqlite::Connection,
+    _source: &SampleSource,
+) -> Result<bool, String> {
+    // Other platforms keep their established bounded audit behavior until a comparable durable
+    // journal is available. They must not treat a process-local notify stream as a durable cursor.
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -133,6 +189,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
             )),
         )));
     }
+    let durable_watcher_coverage_current = durable_watcher_coverage_is_current(connection, source)?;
     let last_manifest_audit_at = connection
         .query_row(
             "SELECT value FROM metadata WHERE key = ?1",
@@ -144,7 +201,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
         .and_then(|value| value.parse::<i64>().ok())
         .unwrap_or_default();
     if safety_probe_only
-        && readiness_safety_probe_is_current(connection, source_id, now, force_manifest_audit)?
+        && readiness_safety_probe_is_current(connection, source, now, force_manifest_audit)?
     {
         stats.cheap_noop_sweep = true;
         tracing::debug!(
@@ -181,6 +238,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
         .map_err(|error| error.to_string())?;
     if force_manifest_audit
         || manifest_identity_repair_due
+        || (safety_probe_only && !durable_watcher_coverage_current)
         || now.saturating_sub(last_manifest_audit_at) >= MANIFEST_AUDIT_INTERVAL_SECONDS
     {
         candidates.push(RuntimeCandidate {

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -83,7 +83,16 @@ pub(super) fn execute_candidate(
             ) {
                 Ok(outcome) => (outcome, None),
                 Err(ScanError::Incomplete { committed, error }) => (*committed, Some(error)),
-                Err(error) => return Err(error.to_string()),
+                Err(error) => {
+                    publish_event(SourceProcessingEvent::ManifestAuditFinished {
+                        lifecycle: SourceProcessingLifecycle::new(
+                            candidate.source.id.as_str(),
+                            lifecycle_generation,
+                        ),
+                        complete: false,
+                    });
+                    return Err(error.to_string());
+                }
             };
             tracing::debug!(
                 target: "wavecrate::source_processing",
@@ -111,7 +120,7 @@ pub(super) fn execute_candidate(
                 && crate::native_app::source_processing::manifest_delta_requires_browser_refresh(
                     &outcome.committed_delta,
                 );
-            let audit_published = !outcome.committed_delta.is_empty()
+            let audit_published = !incomplete_error.is_some()
                 && publish_event(SourceProcessingEvent::ManifestAuditCommitted {
                     lifecycle: SourceProcessingLifecycle::new(
                         candidate.source.id.as_str(),
@@ -122,6 +131,13 @@ pub(super) fn execute_candidate(
             let foreground_refresh_owns_reconciliation =
                 browser_refresh_required && audit_published;
             let incomplete = incomplete_error.is_some();
+            publish_event(SourceProcessingEvent::ManifestAuditFinished {
+                lifecycle: SourceProcessingLifecycle::new(
+                    candidate.source.id.as_str(),
+                    lifecycle_generation,
+                ),
+                complete: !incomplete,
+            });
             if let Some(error) = incomplete_error {
                 tracing::warn!(
                     target: "wavecrate::source_processing",

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -141,6 +141,9 @@ impl SourceProcessingSupervisor {
         control.safety_probe_sources.retain(|source_id| {
             retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
         });
+        control
+            .deferred_lifecycle_audit_sources
+            .retain(|source_id| retained_source_ids.contains(source_id));
         control.pending_readiness_deltas.retain(|source_id, _| {
             retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
         });

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -5,8 +5,8 @@ use super::recovered_source_retirements;
 use super::{
     Arc, AtomicBool, AtomicU64, BTreeMap, BTreeSet, BudgetTracker, Condvar, ControlState,
     DatabaseWriterGate, Mutex, MutexGuard, Ordering, PriorityContext, ProcessingBudgets,
-    SampleSource, SourceProcessingEvent, SourceProcessingEventSink, SourceProcessingHealthEvent,
-    SupervisorTelemetry, sources_by_id,
+    SampleSource, SourceAuditLifecycleCause, SourceProcessingEvent, SourceProcessingEventSink,
+    SourceProcessingHealthEvent, SupervisorTelemetry, sources_by_id,
 };
 
 #[derive(Clone)]
@@ -124,7 +124,11 @@ impl Shared {
         #[cfg(test)]
         let next_retirement_id = 1_u64;
         let dirty_sources = sources.keys().cloned().collect();
-        let force_manifest_audit_sources = sources.keys().cloned().collect();
+        let safety_probe_sources = sources.keys().cloned().collect();
+        #[cfg(not(test))]
+        let lifecycle_audits_deferred_until_watcher_ready = true;
+        #[cfg(test)]
+        let lifecycle_audits_deferred_until_watcher_ready = false;
         Self {
             source_replacement: Mutex::new(()),
             state: Mutex::new(ControlState {
@@ -133,16 +137,18 @@ impl Shared {
                 source_lifecycle_generations,
                 next_lifecycle_generation,
                 dirty_sources,
-                safety_probe_sources: BTreeSet::new(),
+                safety_probe_sources,
+                lifecycle_audits_deferred_until_watcher_ready,
+                deferred_lifecycle_audit_sources: BTreeSet::new(),
                 pending_readiness_deltas: BTreeMap::new(),
                 awaiting_foreground_refresh_sources: BTreeSet::new(),
-                force_manifest_audit_sources,
+                force_manifest_audit_sources: BTreeSet::new(),
                 force_reanalysis_sources: BTreeSet::new(),
                 quarantined_sources: BTreeSet::new(),
                 pending_retirements,
                 next_retirement_id,
                 wake_generation: 1,
-                wake_reason: "startup",
+                wake_reason: SourceAuditLifecycleCause::Startup.reason(),
                 playback_active: false,
                 foreground_active: false,
                 shutdown: false,

--- a/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
@@ -348,7 +348,7 @@ fn background_scan_registration_cannot_readd_source_removed_behind_fence() {
 }
 
 #[test]
-fn watcher_ready_rearms_authoritative_manifest_audits() {
+fn watcher_ready_requests_only_a_gated_lifecycle_probe() {
     let (_directory, source) = unhashed_source("watcher-ready-audit");
     let mut supervisor = SourceProcessingSupervisor::dormant();
     supervisor
@@ -358,23 +358,35 @@ fn watcher_ready_rearms_authoritative_manifest_audits() {
         let mut control = supervisor.shared.control();
         control.force_manifest_audit_sources.clear();
         control.dirty_sources.clear();
+        control.safety_probe_sources.clear();
     }
 
-    supervisor.request_manifest_audits("source_watcher_ready");
+    supervisor.request_lifecycle_audit_probe(
+        SourceAuditLifecycleCause::WatcherReady,
+        &[source.id.as_str().to_string()],
+    );
 
     let control = supervisor.shared.control();
     assert!(
-        control
+        !control
             .force_manifest_audit_sources
-            .contains(source.id.as_str())
+            .contains(source.id.as_str()),
+        "watcher readiness must not force a full audit when durable coverage is current"
     );
     assert!(control.dirty_sources.contains(source.id.as_str()));
+    assert!(control.safety_probe_sources.contains(source.id.as_str()));
+    assert!(
+        control
+            .deferred_lifecycle_audit_sources
+            .contains(source.id.as_str()),
+        "watcher-ready must retain a source whose unavailable fallback still needs a fresh audit barrier"
+    );
     drop(control);
     assert_eq!(supervisor.shutdown()["joined"], true);
 }
 
 #[test]
-fn focus_regain_rearms_revisioned_audits_instead_of_assuming_watcher_overflow() {
+fn repeated_focus_regain_requests_never_force_manifest_audits() {
     let (_directory, source) = unhashed_source("focus-regained-audit");
     let mut supervisor = SourceProcessingSupervisor::dormant();
     supervisor
@@ -384,24 +396,29 @@ fn focus_regain_rearms_revisioned_audits_instead_of_assuming_watcher_overflow() 
         let mut control = supervisor.shared.control();
         control.force_manifest_audit_sources.clear();
         control.dirty_sources.clear();
+        control.safety_probe_sources.clear();
     }
 
-    supervisor.request_manifest_audits("application_focus_regained");
-
-    let control = supervisor.shared.control();
-    assert!(
-        control
-            .force_manifest_audit_sources
-            .contains(source.id.as_str()),
-        "refocus must enter the revisioned manifest path"
-    );
-    assert!(control.dirty_sources.contains(source.id.as_str()));
-    drop(control);
+    for _ in 0..10 {
+        supervisor.request_lifecycle_audit_probe(SourceAuditLifecycleCause::FocusRegained, &[]);
+        let mut control = supervisor.shared.control();
+        assert!(
+            !control
+                .force_manifest_audit_sources
+                .contains(source.id.as_str()),
+            "refocus must remain gated by durable health rather than force a traversal"
+        );
+        assert!(control.dirty_sources.contains(source.id.as_str()));
+        assert!(control.safety_probe_sources.contains(source.id.as_str()));
+        // Model a current durable no-op probe before the next focus transition.
+        control.dirty_sources.clear();
+        control.safety_probe_sources.clear();
+    }
     assert_eq!(supervisor.shutdown()["joined"], true);
 }
 
 #[test]
-fn watcher_ready_request_survives_older_in_flight_audit_completion() {
+fn watcher_ready_probe_coalesces_after_an_older_probe_was_captured() {
     let (_directory, source) = unhashed_source("watcher-ready-in-flight-audit");
     let mut supervisor = SourceProcessingSupervisor::dormant();
     supervisor
@@ -409,33 +426,26 @@ fn watcher_ready_request_survives_older_in_flight_audit_completion() {
         .expect("configure source");
     {
         let mut control = supervisor.shared.control();
-        // Model the coordinator having already captured the original
-        // startup audit request and started its candidate.
+        // Model the coordinator having already captured the original startup
+        // probe and started its candidate.
         control.dirty_sources.clear();
-        assert!(
-            control
-                .force_manifest_audit_sources
-                .contains(source.id.as_str())
-        );
+        control.safety_probe_sources.clear();
+        control.force_manifest_audit_sources.clear();
     }
 
-    supervisor.request_manifest_audits("source_watcher_ready");
-    clear_satisfied_manifest_audit_request(&supervisor.shared, source.id.as_str());
+    supervisor.request_lifecycle_audit_probe(SourceAuditLifecycleCause::WatcherReady, &[]);
 
     {
         let mut control = supervisor.shared.control();
         assert!(control.dirty_sources.contains(source.id.as_str()));
         assert!(
-            control
-                .force_manifest_audit_sources
-                .contains(source.id.as_str()),
-            "the older audit must not erase the watcher-ready closing audit"
+            control.safety_probe_sources.contains(source.id.as_str()),
+            "the watcher-ready probe must survive an older captured lifecycle probe"
         );
-        // Once the coordinator captures that newer dirty request, its own
-        // successful audit may satisfy and clear the force flag.
+        assert!(!control.force_manifest_audit_sources.contains(source.id.as_str()));
         control.dirty_sources.remove(source.id.as_str());
+        control.safety_probe_sources.remove(source.id.as_str());
     }
-    clear_satisfied_manifest_audit_request(&supervisor.shared, source.id.as_str());
     assert!(
         !supervisor
             .shared
@@ -443,6 +453,32 @@ fn watcher_ready_request_survives_older_in_flight_audit_completion() {
             .force_manifest_audit_sources
             .contains(source.id.as_str())
     );
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn watcher_history_gap_forces_only_the_affected_source_audit() {
+    let (_first_directory, first) = unhashed_source("watcher-history-gap-first");
+    let (_second_directory, second) = unhashed_source("watcher-history-gap-second");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![first.clone(), second.clone()])
+        .expect("configure sources");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+        control.safety_probe_sources.clear();
+        control.force_manifest_audit_sources.clear();
+    }
+
+    supervisor.request_source_manifest_audit(first.id.as_str(), "watcher_history_gap");
+
+    let control = supervisor.shared.control();
+    assert!(control.force_manifest_audit_sources.contains(first.id.as_str()));
+    assert!(control.dirty_sources.contains(first.id.as_str()));
+    assert!(!control.force_manifest_audit_sources.contains(second.id.as_str()));
+    assert!(!control.dirty_sources.contains(second.id.as_str()));
+    drop(control);
     assert_eq!(supervisor.shutdown()["joined"], true);
 }
 

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -120,6 +120,21 @@ fn discovery_progress_converged_safety_probe_is_a_silent_noop() {
     .expect("open source database");
     publish_current_readiness_targets(&mut connection, source.id.as_str(), 100)
         .expect("publish initial readiness");
+    let metadata = std::fs::metadata(&source.root).expect("source root metadata");
+    let root_identity = wavecrate_library::filesystem_identity::stable_filesystem_identity(
+        &source.root,
+        &metadata,
+    )
+    .expect("stable source root identity");
+    connection
+        .execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+            rusqlite::params![
+                wavecrate_library::sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
+                serde_json::json!({ "root_identity": root_identity, "event_id": 1_u64 }).to_string(),
+            ],
+        )
+        .expect("persist durable watcher coverage");
     let durable_before = discovery_durable_counts(&connection);
     let source_before = ReadinessStore::new(&mut connection)
         .source_state(source.id.as_str())
@@ -161,6 +176,51 @@ fn discovery_progress_converged_safety_probe_is_a_silent_noop() {
             .expect("source state exists"),
         source_before
     );
+}
+
+#[test]
+fn macos_safety_probe_requires_durable_watcher_coverage() {
+    let (_directory, source) = unhashed_source(&format!(
+        "missing-watcher-coverage-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let database_root = source.database_root().expect("database root");
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("open source database");
+    publish_current_readiness_targets(&mut connection, source.id.as_str(), 100)
+        .expect("publish initial readiness");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("run safety probe")
+    else {
+        panic!("safety probe unexpectedly cancelled");
+    };
+
+    #[cfg(target_os = "macos")]
+    assert!(
+        candidates
+            .iter()
+            .any(|candidate| matches!(candidate.task, RuntimeTask::ManifestAudit)),
+        "a macOS source without a durable watcher checkpoint must remain audit-eligible"
+    );
+    #[cfg(not(target_os = "macos"))]
+    assert!(candidates.is_empty());
+    assert!(!stats.cheap_noop_sweep);
 }
 
 #[test]

--- a/src/native_app/tests/config_sources/refresh.rs
+++ b/src/native_app/tests/config_sources/refresh.rs
@@ -271,6 +271,7 @@ fn source_filesystem_change_queues_refresh_without_clearing_loaded_tree() {
             paths: Vec::new(),
             overflowed: true,
             source_root_available: true,
+            journal_checkpoint_event_id: None,
         },
         &mut context,
     );
@@ -325,6 +326,7 @@ fn source_filesystem_change_syncs_removed_file_to_source_database() {
             paths: vec![PathBuf::from("stale.wav")],
             overflowed: false,
             source_root_available: true,
+            journal_checkpoint_event_id: None,
         },
         &mut context,
     );

--- a/src/native_app/tests/config_sources/scan_handoff.rs
+++ b/src/native_app/tests/config_sources/scan_handoff.rs
@@ -100,6 +100,7 @@ fn foreground_scan_terminal_release_admits_coalesced_watcher_paths() {
         vec![sample_path],
         false,
         true,
+        None,
         &mut context,
     );
     assert!(
@@ -252,6 +253,7 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
         Vec::new(),
         true,
         true,
+        None,
         &mut context,
     );
 
@@ -261,6 +263,7 @@ fn source_filesystem_change_during_scan_is_refreshed_after_scan_finishes() {
             paths: Vec::new(),
             overflowed: true,
             source_root_available: true,
+            journal_checkpoint_event_id: None,
         },
         &mut context,
     );

--- a/src/test_support/source_processing_liveness/harness.rs
+++ b/src/test_support/source_processing_liveness/harness.rs
@@ -224,6 +224,7 @@ impl LivenessHarness {
                 paths,
                 overflowed,
                 source_root_available: reported_source_root_available,
+                ..
             }) = message
             else {
                 if Instant::now() >= deadline {

--- a/tests/gui_boundary.rs
+++ b/tests/gui_boundary.rs
@@ -1035,6 +1035,10 @@ fn wavecrate_non_blocking_guardrail() -> WavecrateNonBlockingGuardrail {
             "source watcher worker",
         ),
         (
+            "src/native_app/sample_library/source_watcher/journal.rs",
+            "durable source watcher journal worker",
+        ),
+        (
             "src/native_app/sample_library/source_watcher/roots.rs",
             "source watcher worker",
         ),


### PR DESCRIPTION
## Goal
Expose durable macOS source-watcher recovery so startup, watcher-ready, and focus lifecycle events avoid unnecessary full manifest audits while exact closed-app changes still reconcile.

## Scope
- Persist per-source FSEvents checkpoints and replay closed-app changes through existing targeted sync.
- Gate lifecycle audit admission on durable coverage and defer recovery fences per source.
- Fall back to bounded scoped audits for gaps, unavailable watchers, root changes, and incomplete recovery.

## Non-goals
- No browser-blocking traversal or source-availability redesign.

## Definition of Done
- Lifecycle probes are cheap when durable coverage is current.
- Recovery preserves exact mutation reconciliation and retries safely without advancing an unsafe cursor.
- Watcher gaps and failures remain scoped and retryable.

## Validation
- `cargo check -p wavecrate --bin wavecrate`
- Focused watcher-gap, unavailable-watcher, durable-coverage, and GUI-boundary tests
- `git diff --check`
- `bash scripts/ci.sh agent` progressed through smoke and non-blocking guardrails, then was interrupted by local disk exhaustion; regenerated-cache cleanup restored 124 GiB and the final exact-head compile/diff checks passed.

## Known limitations
- No manual removable-volume/permission-loss smoke in this environment.

User approval is required before merge.