### PR TITLE
OPT-1248: Add seeded replayable source-scanning state machine

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -118,6 +118,14 @@ pub struct SourceWriteBatch<'conn> {
 }
 
 impl SourceDatabase {
+    /// Override this connection's SQLite busy timeout for deterministic contention tests.
+    #[cfg(feature = "test-support")]
+    pub fn set_busy_timeout_for_tests(&self, timeout: Duration) -> Result<(), SourceDbError> {
+        self.connection
+            .busy_timeout(timeout)
+            .map_err(SourceDbError::from)
+    }
+
     /// Open a writable source database for general source-owned mutations.
     ///
     /// This preserves the complete schema and cleanup behavior used by the

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -299,6 +299,16 @@ inherit a real-time soak:
   `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests`
   and
   `cargo test -p wavecrate-library sample_sources::readiness::tests`
+- seeded, replayable source lifecycle and scan-order state machine (six retained
+  regression seeds in the bounded normal-CI scanner lane):
+  `cargo test -p wavecrate --lib source_processing_seeded_state_machine_normal_ci`
+- integrated real-supervisor replay for the calibrated lifecycle seed:
+  `cargo test -p wavecrate --lib source_processing_seeded_state_machine_integrated_supervisor -- --ignored --nocapture`
+- extended 1,000-sequence state-machine stress lane:
+  `cargo test -p wavecrate --lib source_processing_seeded_state_machine_stress_1000 -- --ignored --nocapture`
+- replay a decimal seed or the minimized JSON artifact path printed by a
+  failure:
+  `WAVECRATE_SOURCE_STATE_MACHINE_REPLAY=<seed-or-artifact> cargo test -p wavecrate --lib source_processing_seeded_state_machine_replay -- --ignored --nocapture`
 - UI frame and input budgets while exercising browser interactions:
   `bash scripts/perf.sh guard` on macOS/Linux/WSL or
   `powershell -ExecutionPolicy Bypass -File scripts/perf.ps1 guard` on Windows
@@ -310,6 +320,17 @@ sleep for a fixed success delay. An active source with actionable deficits must
 be dirty/scheduled, queued, in flight, resource-paused, waiting for a retry, or
 waiting for an exact prerequisite. A stable state outside those categories
 fails as silently idle.
+
+The seeded state-machine lane runs only against the versioned
+`small-multi-source` native fixture. It generates filesystem mutations,
+coalesced watcher/audit/foreground causes, focus changes, cancellation,
+restart, source removal/re-add, root loss/replacement, and deterministic
+transaction/publication/watcher/hash/lifecycle failure boundaries. Every
+observable commit checks the reference manifest and browser projection,
+monotonic accepted revisions, at-most-once revision/cause publication, bounded
+cause coalescing, and controlled-quiescence liveness. Failures are greedily
+minimized without removing lifecycle transitions and written below
+`target/source-state-machine-failures/` (or the active `CARGO_TARGET_DIR`).
 
 Timeouts and invariant failures emit a JSON snapshot containing source and
 readiness generations, availability, activity, per-stage deficits and

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -328,9 +328,13 @@ restart, source removal/re-add, root loss/replacement, and deterministic
 transaction/publication/watcher/hash/lifecycle failure boundaries. Every
 observable commit checks the reference manifest and browser projection,
 monotonic accepted revisions, at-most-once revision/cause publication, bounded
-cause coalescing, and controlled-quiescence liveness. Failures are greedily
+cause coalescing, and controlled-quiescence liveness. The integrated lane
+submits duplicate deltas through the real supervisor queue and observes the
+durable readiness publication/fallback output. Failures are greedily
 minimized without removing lifecycle transitions and written below
-`target/source-state-machine-failures/` (or the active `CARGO_TARGET_DIR`).
+`target/source-state-machine-failures/` (or the active `CARGO_TARGET_DIR`);
+artifacts preserve scanner-only versus integrated execution mode and reject
+fixture-version drift during replay.
 
 Timeouts and invariant failures emit a JSON snapshot containing source and
 readiness generations, availability, activity, per-stage deficits and

--- a/src/app/controller/library/wavs/browser_search_worker.rs
+++ b/src/app/controller/library/wavs/browser_search_worker.rs
@@ -33,6 +33,59 @@ pub(crate) use self::queue::{SearchJobSender, SearchWorkerHandle, spawn_search_w
 use self::{cache::*, pipeline::*, queue::*};
 
 #[cfg(test)]
+pub(crate) fn project_source_paths_for_state_machine(
+    source: &crate::sample_sources::SampleSource,
+) -> Result<std::collections::BTreeSet<String>, String> {
+    let queue = SearchJobQueue::new();
+    queue.send(SearchJob {
+        request_id: 1,
+        source_id: source.id.clone(),
+        source_root: source.root.clone(),
+        query: String::new(),
+        filter: TriageFlagFilter::All,
+        rating_filter: std::collections::BTreeSet::new(),
+        playback_age_filter: std::collections::BTreeSet::new(),
+        tag_named_filter: crate::app::state::TagNamedFilter::All,
+        sidebar_filters: Default::default(),
+        sidebar_bpm_values: Default::default(),
+        sort: SampleBrowserSort::ListOrder,
+        similar_query: None,
+        duplicate_cleanup: None,
+        folder_selection: None,
+        folder_negated: None,
+        file_scope_mode: crate::app::state::FolderFileScopeMode::AllDescendants,
+        metadata_delta_paths: Vec::new(),
+        playback_age_now_unix_secs: 0,
+    });
+    let queued = queue
+        .take_blocking()
+        .ok_or_else(|| String::from("browser projection queue stopped before accepting work"))?;
+    let mut cache = SearchWorkerCache::default();
+    let result = process_search_job(
+        queued.job,
+        &SkimMatcherV2::default(),
+        &mut cache,
+        &queue,
+        queued.generation,
+    )
+    .ok_or_else(|| String::from("browser projection work was cancelled"))?;
+    let entries = cache
+        .entries
+        .as_ref()
+        .ok_or_else(|| String::from("browser projection did not load source entries"))?;
+    result
+        .visible
+        .iter()
+        .map(|index| {
+            entries
+                .get(index)
+                .map(|entry| entry.relative_path.to_string())
+                .ok_or_else(|| format!("browser projection returned invalid row index {index}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::sample_sources::SourceId;

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -155,4 +155,8 @@ pub(in crate::native_app) struct SourceProcessingSupervisor {
 mod liveness_tests;
 
 #[cfg(test)]
+#[path = "../../test_support/source_processing_state_machine/mod.rs"]
+mod state_machine_tests;
+
+#[cfg(test)]
 mod tests;

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -83,6 +83,8 @@ mod shutdown;
 mod source_registry_model;
 mod startup;
 mod state;
+#[cfg(test)]
+mod state_machine_observation;
 mod telemetry;
 
 pub(in crate::native_app) use admission::SourceScanAdmissionState;

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -345,6 +345,10 @@ pub(super) fn queue_source_delta(
     delta: &CommittedSourceDelta,
     reason: &'static str,
 ) -> bool {
+    #[cfg(test)]
+    if std::mem::take(&mut control.reject_next_delta_delivery) {
+        return false;
+    }
     if !control.source_is_active(source_id) {
         return false;
     }

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -1,5 +1,5 @@
 use super::{
-    Arc, BTreeMap, CommittedSourceDelta, MAX_VISIBLE_PRIORITY_PATHS, SampleSource,
+    Arc, BTreeMap, CommittedSourceDelta, ControlState, MAX_VISIBLE_PRIORITY_PATHS, SampleSource,
     SourceProcessingBudgetHandle, SourceProcessingSupervisor, register_source_for_scan_locked,
 };
 
@@ -182,15 +182,9 @@ impl SourceProcessingSupervisor {
             return;
         }
         let mut control = self.shared.control();
-        if !control.source_is_active(source_id) {
+        if !queue_source_delta(&mut control, source_id, delta, reason) {
             return;
         }
-        control
-            .pending_readiness_deltas
-            .entry(source_id.to_string())
-            .or_default()
-            .merge(delta);
-        control.mark_source_dirty(source_id, reason);
         drop(control);
         self.shared.wake.notify_one();
     }
@@ -343,4 +337,22 @@ impl SourceProcessingSupervisor {
         drop(control);
         self.shared.wake.notify_all();
     }
+}
+
+pub(super) fn queue_source_delta(
+    control: &mut ControlState,
+    source_id: &str,
+    delta: &CommittedSourceDelta,
+    reason: &'static str,
+) -> bool {
+    if !control.source_is_active(source_id) {
+        return false;
+    }
+    control
+        .pending_readiness_deltas
+        .entry(source_id.to_string())
+        .or_default()
+        .merge(delta, reason);
+    control.mark_source_dirty(source_id, reason);
+    true
 }

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -28,6 +28,10 @@ pub(super) struct ControlState {
     pub(super) foreground_active: bool,
     pub(super) shutdown: bool,
     pub(super) priority: PriorityContext,
+    #[cfg(test)]
+    pub(super) reject_next_delta_delivery: bool,
+    #[cfg(test)]
+    pub(super) reject_next_source_replacement: bool,
 }
 
 impl ControlState {

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -107,12 +107,28 @@ pub(super) fn discover_candidates(
                     consumed_readiness_deltas.insert(source.id.as_str().to_string());
                 }
                 if let Some(health) = health {
-                    shared.publish_source_health(health.into_event(
-                        super::SourceProcessingLifecycle::new(
-                            source.id.as_str(),
-                            in_flight_work.lifecycle_generation,
-                        ),
+                    let health = health.into_event(super::SourceProcessingLifecycle::new(
+                        source.id.as_str(),
+                        in_flight_work.lifecycle_generation,
                     ));
+                    #[cfg(test)]
+                    if let Some(pending) = pending_readiness_deltas
+                        .get(source.id.as_str())
+                        .filter(|pending| !pending.state_machine_inputs.is_empty())
+                    {
+                        shared
+                            .state_machine_publications
+                            .lock()
+                            .unwrap_or_else(|poison| poison.into_inner())
+                            .push(super::StateMachinePublicationObservation {
+                                source_id: source.id.as_str().to_string(),
+                                lifecycle_generation: in_flight_work.lifecycle_generation,
+                                source_generation: health.source_generation,
+                                readiness_revision: health.readiness_revision,
+                                inputs: pending.state_machine_inputs.clone(),
+                            });
+                    }
+                    shared.publish_source_health(health);
                 }
                 shared
                     .control()

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -103,18 +103,28 @@ pub(super) fn discover_candidates(
                 if !stats.cheap_noop_sweep {
                     source_stats.insert(source.id.as_str().to_string(), stats);
                 }
-                if pending_readiness_deltas.contains_key(source.id.as_str()) {
-                    consumed_readiness_deltas.insert(source.id.as_str().to_string());
-                }
+                let pending_readiness_delta = pending_readiness_deltas.get(source.id.as_str());
+                let mut consume_readiness_delta = pending_readiness_delta.is_some();
                 if let Some(health) = health {
                     let health = health.into_event(super::SourceProcessingLifecycle::new(
                         source.id.as_str(),
                         in_flight_work.lifecycle_generation,
                     ));
+                    let publication_outcome = shared.publish_source_health_outcome(health.clone());
+                    consume_readiness_delta = matches!(
+                        publication_outcome,
+                        super::SourceHealthPublicationOutcome::Published
+                            | super::SourceHealthPublicationOutcome::AlreadyPublished
+                            | super::SourceHealthPublicationOutcome::NoSink
+                    );
                     #[cfg(test)]
-                    if let Some(pending) = pending_readiness_deltas
-                        .get(source.id.as_str())
+                    if let Some(pending) = pending_readiness_delta
                         .filter(|pending| !pending.state_machine_inputs.is_empty())
+                        .filter(|_| {
+                            publication_outcome != super::SourceHealthPublicationOutcome::NoSink
+                                && publication_outcome
+                                    != super::SourceHealthPublicationOutcome::Superseded
+                        })
                     {
                         shared
                             .state_machine_publications
@@ -126,9 +136,12 @@ pub(super) fn discover_candidates(
                                 source_generation: health.source_generation,
                                 readiness_revision: health.readiness_revision,
                                 inputs: pending.state_machine_inputs.clone(),
+                                outcome: publication_outcome,
                             });
                     }
-                    shared.publish_source_health(health);
+                }
+                if consume_readiness_delta {
+                    consumed_readiness_deltas.insert(source.id.as_str().to_string());
                 }
                 shared
                     .control()

--- a/src/native_app/source_processing/supervisor/health.rs
+++ b/src/native_app/source_processing/supervisor/health.rs
@@ -141,7 +141,9 @@ mod tests {
 
     use wavecrate::sample_sources::{SampleSource, SourceId};
 
-    use super::super::{Shared, SourceProcessingEvent, SourceProcessingSupervisor};
+    use super::super::{
+        Shared, SourceHealthPublicationOutcome, SourceProcessingEvent, SourceProcessingSupervisor,
+    };
     use super::*;
 
     fn snapshot(
@@ -255,6 +257,14 @@ mod tests {
         )
         .into_event(SourceProcessingLifecycle::new("health-source", generation));
 
+        shared
+            .state_machine_reject_next_health_publication
+            .store(true, std::sync::atomic::Ordering::Release);
+        assert_eq!(
+            shared.publish_source_health_outcome(health.clone()),
+            SourceHealthPublicationOutcome::Rejected
+        );
+        assert!(receiver.try_recv().is_err());
         assert!(shared.publish_source_health(health.clone()));
         assert!(!shared.publish_source_health(health));
         assert!(matches!(

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -16,6 +16,12 @@ impl SourceProcessingSupervisor {
             .unwrap_or_else(|poison| poison.into_inner());
         let sources = sources_by_id(sources);
         let mut control = self.shared.control();
+        #[cfg(test)]
+        if std::mem::take(&mut control.reject_next_source_replacement) {
+            return Err(String::from(
+                "state-machine lifecycle replacement rejected at serialized boundary",
+            ));
+        }
         if source_maps_match(&control.sources, &sources) {
             if !control.quarantined_sources.is_empty() {
                 control.quarantined_sources.clear();

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -50,6 +50,16 @@ pub(super) struct StateMachinePublicationObservation {
     pub(super) source_generation: i64,
     pub(super) readiness_revision: i64,
     pub(super) inputs: BTreeSet<(u64, &'static str)>,
+    pub(super) outcome: super::SourceHealthPublicationOutcome,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SourceHealthPublicationOutcome {
+    Published,
+    AlreadyPublished,
+    Rejected,
+    NoSink,
+    Superseded,
 }
 
 #[derive(Clone, Debug)]

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -15,10 +15,12 @@ pub(super) struct PendingSourceRetirement {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct PendingReadinessDelta {
     pub(super) scope_ids: BTreeSet<String>,
+    #[cfg(test)]
+    pub(super) state_machine_inputs: BTreeSet<(u64, &'static str)>,
 }
 
 impl PendingReadinessDelta {
-    pub(super) fn merge(&mut self, delta: &CommittedSourceDelta) {
+    pub(super) fn merge(&mut self, delta: &CommittedSourceDelta, reason: &'static str) {
         self.scope_ids.extend(
             delta
                 .created
@@ -29,11 +31,25 @@ impl PendingReadinessDelta {
         );
         self.scope_ids
             .extend(delta.moved.iter().map(|entry| entry.identity.clone()));
+        #[cfg(test)]
+        self.state_machine_inputs.insert((delta.revision, reason));
+        #[cfg(not(test))]
+        let _ = reason;
     }
 
     pub(super) fn is_empty(&self) -> bool {
         self.scope_ids.is_empty()
     }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub(super) struct StateMachinePublicationObservation {
+    pub(super) source_id: String,
+    pub(super) lifecycle_generation: u64,
+    pub(super) source_generation: i64,
+    pub(super) readiness_revision: i64,
+    pub(super) inputs: BTreeSet<(u64, &'static str)>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -159,6 +159,10 @@ impl Shared {
                 foreground_active: false,
                 shutdown: false,
                 priority: PriorityContext::default(),
+                #[cfg(test)]
+                reject_next_delta_delivery: false,
+                #[cfg(test)]
+                reject_next_source_replacement: false,
             }),
             wake: Condvar::new(),
             retirement_wake: Condvar::new(),

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -7,8 +7,8 @@ use super::recovered_source_retirements;
 use super::{
     Arc, AtomicBool, AtomicU64, BTreeMap, BTreeSet, BudgetTracker, Condvar, ControlState,
     DatabaseWriterGate, Mutex, MutexGuard, Ordering, PriorityContext, ProcessingBudgets,
-    SampleSource, SourceAuditLifecycleCause, SourceProcessingEvent, SourceProcessingEventSink,
-    SourceProcessingHealthEvent, SupervisorTelemetry, sources_by_id,
+    SampleSource, SourceAuditLifecycleCause, SourceHealthPublicationOutcome, SourceProcessingEvent,
+    SourceProcessingEventSink, SourceProcessingHealthEvent, SupervisorTelemetry, sources_by_id,
 };
 
 #[derive(Clone)]
@@ -81,6 +81,8 @@ pub(super) struct Shared {
     pub(super) published_source_health: Mutex<BTreeMap<String, SourceProcessingHealthEvent>>,
     #[cfg(test)]
     pub(super) state_machine_publications: Mutex<Vec<StateMachinePublicationObservation>>,
+    #[cfg(test)]
+    pub(super) state_machine_reject_next_health_publication: AtomicBool,
     #[cfg(test)]
     pub(super) retirement_cleanup_blocked: AtomicBool,
     #[cfg(test)]
@@ -175,6 +177,8 @@ impl Shared {
             #[cfg(test)]
             state_machine_publications: Mutex::new(Vec::new()),
             #[cfg(test)]
+            state_machine_reject_next_health_publication: AtomicBool::new(false),
+            #[cfg(test)]
             retirement_cleanup_blocked: AtomicBool::new(false),
             #[cfg(test)]
             retirement_cleanup_started: AtomicBool::new(false),
@@ -215,6 +219,13 @@ impl Shared {
     }
 
     pub(super) fn publish_source_health(&self, health: SourceProcessingHealthEvent) -> bool {
+        self.publish_source_health_outcome(health) == SourceHealthPublicationOutcome::Published
+    }
+
+    pub(super) fn publish_source_health_outcome(
+        &self,
+        health: SourceProcessingHealthEvent,
+    ) -> SourceHealthPublicationOutcome {
         let control = self.control();
         if !control.source_is_active(&health.lifecycle.source_id)
             || control
@@ -222,25 +233,38 @@ impl Shared {
                 .get(&health.lifecycle.source_id)
                 != Some(&health.lifecycle.generation)
         {
-            return false;
+            return SourceHealthPublicationOutcome::Superseded;
         }
         let mut published_health = self
             .published_source_health
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
         if published_health.get(&health.lifecycle.source_id) == Some(&health) {
-            return false;
+            return SourceHealthPublicationOutcome::AlreadyPublished;
         }
-        let published = self
-            .event_sink
-            .as_ref()
-            .is_some_and(|sink| sink.try_publish(SourceProcessingEvent::Health(health.clone())));
-        if published {
+        #[cfg(test)]
+        let reject_for_state_machine = self
+            .state_machine_reject_next_health_publication
+            .swap(false, Ordering::AcqRel);
+        #[cfg(not(test))]
+        let reject_for_state_machine = false;
+        let outcome = if reject_for_state_machine {
+            SourceHealthPublicationOutcome::Rejected
+        } else if let Some(sink) = &self.event_sink {
+            if sink.try_publish(SourceProcessingEvent::Health(health.clone())) {
+                SourceHealthPublicationOutcome::Published
+            } else {
+                SourceHealthPublicationOutcome::Rejected
+            }
+        } else {
+            SourceHealthPublicationOutcome::NoSink
+        };
+        if outcome == SourceHealthPublicationOutcome::Published {
             published_health.insert(health.lifecycle.source_id.clone(), health);
         }
         drop(published_health);
         drop(control);
-        published
+        outcome
     }
 
     pub(super) fn telemetry(&self) -> MutexGuard<'_, SupervisorTelemetry> {

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 use super::AtomicUsize;
+#[cfg(test)]
+use super::StateMachinePublicationObservation;
 #[cfg(not(test))]
 use super::recovered_source_retirements;
 use super::{
@@ -77,6 +79,8 @@ pub(super) struct Shared {
     pub(super) synthetic_test_execution: AtomicBool,
     pub(super) event_sink: Option<Arc<dyn SourceProcessingEventSink>>,
     pub(super) published_source_health: Mutex<BTreeMap<String, SourceProcessingHealthEvent>>,
+    #[cfg(test)]
+    pub(super) state_machine_publications: Mutex<Vec<StateMachinePublicationObservation>>,
     #[cfg(test)]
     pub(super) retirement_cleanup_blocked: AtomicBool,
     #[cfg(test)]
@@ -168,6 +172,8 @@ impl Shared {
             synthetic_test_execution: AtomicBool::new(false),
             event_sink,
             published_source_health: Mutex::new(BTreeMap::new()),
+            #[cfg(test)]
+            state_machine_publications: Mutex::new(Vec::new()),
             #[cfg(test)]
             retirement_cleanup_blocked: AtomicBool::new(false),
             #[cfg(test)]

--- a/src/native_app/source_processing/supervisor/state_machine_observation.rs
+++ b/src/native_app/source_processing/supervisor/state_machine_observation.rs
@@ -4,10 +4,12 @@ use super::{BTreeSet, CommittedSourceDelta, SourceProcessingSupervisor};
 pub(super) struct StateMachineQueueObservation {
     pub(super) lifecycle_generation: u64,
     pub(super) before_scope_ids: BTreeSet<String>,
+    pub(super) scope_ids_after_rejection: BTreeSet<String>,
     pub(super) pending_scope_ids: BTreeSet<String>,
     pub(super) pending_inputs: BTreeSet<(u64, &'static str)>,
     pub(super) dirty_source_slots: usize,
     pub(super) pending_delta_slots: usize,
+    pub(super) delivery_rejected: bool,
 }
 
 impl SourceProcessingSupervisor {
@@ -17,6 +19,7 @@ impl SourceProcessingSupervisor {
         delta: &CommittedSourceDelta,
         reason: &'static str,
         repetitions: usize,
+        reject_delivery_once: bool,
         reject_publication_once: bool,
     ) -> Option<StateMachineQueueObservation> {
         let mut control = self.shared.control();
@@ -24,6 +27,17 @@ impl SourceProcessingSupervisor {
             return None;
         }
         let before_scope_ids = control
+            .pending_readiness_deltas
+            .get(source_id)
+            .map(|pending| pending.scope_ids.clone())
+            .unwrap_or_default();
+        let delivery_rejected = if reject_delivery_once {
+            control.reject_next_delta_delivery = true;
+            !queue_source_delta(&mut control, source_id, delta, reason)
+        } else {
+            false
+        };
+        let scope_ids_after_rejection = control
             .pending_readiness_deltas
             .get(source_id)
             .map(|pending| pending.scope_ids.clone())
@@ -39,12 +53,14 @@ impl SourceProcessingSupervisor {
         let observation = StateMachineQueueObservation {
             lifecycle_generation,
             before_scope_ids,
+            scope_ids_after_rejection,
             pending_scope_ids: pending.scope_ids.clone(),
             pending_inputs: pending.state_machine_inputs.clone(),
             dirty_source_slots: usize::from(control.dirty_sources.contains(source_id)),
             pending_delta_slots: usize::from(
                 control.pending_readiness_deltas.contains_key(source_id),
             ),
+            delivery_rejected,
         };
         if reject_publication_once {
             self.shared
@@ -54,5 +70,9 @@ impl SourceProcessingSupervisor {
         drop(control);
         self.shared.wake.notify_one();
         Some(observation)
+    }
+
+    pub(super) fn reject_next_source_replacement_for_state_machine(&self) {
+        self.shared.control().reject_next_source_replacement = true;
     }
 }

--- a/src/native_app/source_processing/supervisor/state_machine_observation.rs
+++ b/src/native_app/source_processing/supervisor/state_machine_observation.rs
@@ -1,0 +1,52 @@
+use super::commands::queue_source_delta;
+use super::{BTreeSet, CommittedSourceDelta, SourceProcessingSupervisor};
+
+pub(super) struct StateMachineQueueObservation {
+    pub(super) lifecycle_generation: u64,
+    pub(super) before_scope_ids: BTreeSet<String>,
+    pub(super) pending_scope_ids: BTreeSet<String>,
+    pub(super) pending_inputs: BTreeSet<(u64, &'static str)>,
+    pub(super) dirty_source_slots: usize,
+    pub(super) pending_delta_slots: usize,
+}
+
+impl SourceProcessingSupervisor {
+    pub(super) fn request_repeated_source_delta_for_state_machine(
+        &self,
+        source_id: &str,
+        delta: &CommittedSourceDelta,
+        reason: &'static str,
+        repetitions: usize,
+    ) -> Option<StateMachineQueueObservation> {
+        let mut control = self.shared.control();
+        if !control.source_is_active(source_id) {
+            return None;
+        }
+        let before_scope_ids = control
+            .pending_readiness_deltas
+            .get(source_id)
+            .map(|pending| pending.scope_ids.clone())
+            .unwrap_or_default();
+        for _ in 0..repetitions {
+            queue_source_delta(&mut control, source_id, delta, reason);
+        }
+        let lifecycle_generation = control
+            .source_lifecycle_generations
+            .get(source_id)
+            .copied()?;
+        let pending = control.pending_readiness_deltas.get(source_id)?;
+        let observation = StateMachineQueueObservation {
+            lifecycle_generation,
+            before_scope_ids,
+            pending_scope_ids: pending.scope_ids.clone(),
+            pending_inputs: pending.state_machine_inputs.clone(),
+            dirty_source_slots: usize::from(control.dirty_sources.contains(source_id)),
+            pending_delta_slots: usize::from(
+                control.pending_readiness_deltas.contains_key(source_id),
+            ),
+        };
+        drop(control);
+        self.shared.wake.notify_one();
+        Some(observation)
+    }
+}

--- a/src/native_app/source_processing/supervisor/state_machine_observation.rs
+++ b/src/native_app/source_processing/supervisor/state_machine_observation.rs
@@ -17,6 +17,7 @@ impl SourceProcessingSupervisor {
         delta: &CommittedSourceDelta,
         reason: &'static str,
         repetitions: usize,
+        reject_publication_once: bool,
     ) -> Option<StateMachineQueueObservation> {
         let mut control = self.shared.control();
         if !control.source_is_active(source_id) {
@@ -45,6 +46,11 @@ impl SourceProcessingSupervisor {
                 control.pending_readiness_deltas.contains_key(source_id),
             ),
         };
+        if reject_publication_once {
+            self.shared
+                .state_machine_reject_next_health_publication
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
         drop(control);
         self.shared.wake.notify_one();
         Some(observation)

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -326,6 +326,7 @@ fn discovery_progress_committed_delta_uses_changed_target_counts() {
         .expect("advance manifest generation");
     let delta = PendingReadinessDelta {
         scope_ids: [identity.clone()].into_iter().collect(),
+        state_machine_inputs: Default::default(),
     };
 
     let mut progress_updates = Vec::new();

--- a/src/test_support/source_processing_liveness/diagnostics.rs
+++ b/src/test_support/source_processing_liveness/diagnostics.rs
@@ -1,31 +1,31 @@
 use super::*;
 
 #[derive(Debug, Serialize)]
-pub(super) struct RuntimeObservation {
-    pub(super) coordinator_running: bool,
-    pub(super) source_configured: bool,
-    pub(super) source_active: bool,
-    pub(super) source_dirty: bool,
-    pub(super) source_quarantined: bool,
-    pub(super) wake_generation: u64,
-    pub(super) settled_wake_generation: u64,
-    pub(super) wake_reason: &'static str,
-    pub(super) lifecycle_generation: Option<u64>,
-    pub(super) in_flight: usize,
-    pub(super) active_budget: bool,
-    pub(super) queue_depth: usize,
-    pub(super) readiness_queue_depth: usize,
-    pub(super) retries_due: usize,
-    pub(super) retry_at: Option<i64>,
-    pub(super) sweeps: u64,
-    pub(super) claimed: u64,
-    pub(super) completed: u64,
-    pub(super) failed: u64,
-    pub(super) retried: u64,
-    pub(super) stale: u64,
-    pub(super) cancelled: u64,
-    pub(super) contention: u64,
-    pub(super) oldest_job_age_seconds: u64,
+pub(in crate::native_app::source_processing::supervisor) struct RuntimeObservation {
+    pub(in crate::native_app::source_processing::supervisor) coordinator_running: bool,
+    pub(in crate::native_app::source_processing::supervisor) source_configured: bool,
+    pub(in crate::native_app::source_processing::supervisor) source_active: bool,
+    pub(in crate::native_app::source_processing::supervisor) source_dirty: bool,
+    pub(in crate::native_app::source_processing::supervisor) source_quarantined: bool,
+    pub(in crate::native_app::source_processing::supervisor) wake_generation: u64,
+    pub(in crate::native_app::source_processing::supervisor) settled_wake_generation: u64,
+    pub(in crate::native_app::source_processing::supervisor) wake_reason: &'static str,
+    pub(in crate::native_app::source_processing::supervisor) lifecycle_generation: Option<u64>,
+    pub(in crate::native_app::source_processing::supervisor) in_flight: usize,
+    pub(in crate::native_app::source_processing::supervisor) active_budget: bool,
+    pub(in crate::native_app::source_processing::supervisor) queue_depth: usize,
+    pub(in crate::native_app::source_processing::supervisor) readiness_queue_depth: usize,
+    pub(in crate::native_app::source_processing::supervisor) retries_due: usize,
+    pub(in crate::native_app::source_processing::supervisor) retry_at: Option<i64>,
+    pub(in crate::native_app::source_processing::supervisor) sweeps: u64,
+    pub(in crate::native_app::source_processing::supervisor) claimed: u64,
+    pub(in crate::native_app::source_processing::supervisor) completed: u64,
+    pub(in crate::native_app::source_processing::supervisor) failed: u64,
+    pub(in crate::native_app::source_processing::supervisor) retried: u64,
+    pub(in crate::native_app::source_processing::supervisor) stale: u64,
+    pub(in crate::native_app::source_processing::supervisor) cancelled: u64,
+    pub(in crate::native_app::source_processing::supervisor) contention: u64,
+    pub(in crate::native_app::source_processing::supervisor) oldest_job_age_seconds: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -51,7 +51,10 @@ struct LivenessDiagnostic {
     runtime: RuntimeObservation,
 }
 
-pub(super) fn silently_idle(snapshot: &ReadinessSnapshot, runtime: &RuntimeObservation) -> bool {
+pub(in crate::native_app::source_processing::supervisor) fn silently_idle(
+    snapshot: &ReadinessSnapshot,
+    runtime: &RuntimeObservation,
+) -> bool {
     if snapshot.availability != SourceAvailability::Active || snapshot.deficits.is_empty() {
         return false;
     }
@@ -90,7 +93,7 @@ pub(super) fn silently_idle(snapshot: &ReadinessSnapshot, runtime: &RuntimeObser
     !runtime.coordinator_running || !runtime.source_active || !observable_work
 }
 
-pub(super) fn runtime_observation(
+pub(in crate::native_app::source_processing::supervisor) fn runtime_observation(
     supervisor: &SourceProcessingSupervisor,
     source_id: &str,
 ) -> RuntimeObservation {
@@ -242,7 +245,9 @@ fn durable_job_diagnostics(connection: &Connection) -> rusqlite::Result<DurableJ
     })
 }
 
-pub(super) fn readiness_snapshot(source: &SampleSource) -> Option<ReadinessSnapshot> {
+pub(in crate::native_app::source_processing::supervisor) fn readiness_snapshot(
+    source: &SampleSource,
+) -> Option<ReadinessSnapshot> {
     let mut connection = open_connection(source).ok()?;
     ReadinessStore::new(&mut connection)
         .reconcile(source.id.as_str(), now_epoch_seconds())

--- a/src/test_support/source_processing_liveness/mod.rs
+++ b/src/test_support/source_processing_liveness/mod.rs
@@ -34,6 +34,7 @@ mod scenarios;
 
 use artifacts::*;
 use diagnostics::*;
+pub(super) use diagnostics::{readiness_snapshot, runtime_observation, silently_idle};
 use harness::*;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(20);

--- a/src/test_support/source_processing_state_machine/artifacts.rs
+++ b/src/test_support/source_processing_state_machine/artifacts.rs
@@ -1,0 +1,76 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{Event, FailureSnapshot};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ReplayArtifact {
+    pub(super) schema_version: u32,
+    pub(super) seed: u64,
+    pub(super) fixture: String,
+    pub(super) fixture_version: u32,
+    pub(super) fixture_seed: u64,
+    pub(super) events: Vec<Event>,
+    pub(super) failure: FailureSnapshot,
+    pub(super) replay_command: String,
+}
+
+pub(super) fn write_failure_artifact(
+    seed: u64,
+    events: Vec<Event>,
+    failure: FailureSnapshot,
+) -> Result<PathBuf, String> {
+    let root = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target"))
+        .join("source-state-machine-failures");
+    fs::create_dir_all(&root).map_err(|error| {
+        format!(
+            "create replay artifact directory {}: {error}",
+            root.display()
+        )
+    })?;
+    let path = root.join(format!("seed-{seed:016x}.json"));
+    let replay_command = format!(
+        "WAVECRATE_SOURCE_STATE_MACHINE_REPLAY={} cargo test -p wavecrate --lib \
+         source_processing_seeded_state_machine_replay -- --ignored --nocapture",
+        path.display()
+    );
+    let artifact = ReplayArtifact {
+        schema_version: 1,
+        seed,
+        fixture: String::from("small-multi-source"),
+        fixture_version: crate::native_source_fixture::FIXTURE_VERSION,
+        fixture_seed: 0x5741_5645_4352_4154,
+        events,
+        failure,
+        replay_command,
+    };
+    let bytes = serde_json::to_vec_pretty(&artifact)
+        .map_err(|error| format!("serialize replay artifact: {error}"))?;
+    fs::write(&path, bytes)
+        .map_err(|error| format!("write replay artifact {}: {error}", path.display()))?;
+    Ok(path)
+}
+
+pub(super) fn read_replay(value: &str) -> Result<(u64, Vec<Event>), String> {
+    if let Ok(seed) = value.parse::<u64>() {
+        return Ok((seed, super::generate(seed, super::NORMAL_SEQUENCE_LENGTH)));
+    }
+    let path = Path::new(value);
+    let bytes = fs::read(path)
+        .map_err(|error| format!("read replay artifact {}: {error}", path.display()))?;
+    let artifact: ReplayArtifact = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("parse replay artifact {}: {error}", path.display()))?;
+    if artifact.schema_version != 1 {
+        return Err(format!(
+            "unsupported source state-machine artifact schema {}",
+            artifact.schema_version
+        ));
+    }
+    Ok((artifact.seed, artifact.events))
+}

--- a/src/test_support/source_processing_state_machine/artifacts.rs
+++ b/src/test_support/source_processing_state_machine/artifacts.rs
@@ -5,12 +5,17 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{Event, FailureSnapshot};
+use super::{Event, ExecutionMode, FailureSnapshot};
+
+const SCHEMA_VERSION: u32 = 2;
+const FIXTURE_NAME: &str = "small-multi-source";
+const FIXTURE_SEED: u64 = 0x5741_5645_4352_4154;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct ReplayArtifact {
     pub(super) schema_version: u32,
     pub(super) seed: u64,
+    pub(super) execution_mode: ExecutionMode,
     pub(super) fixture: String,
     pub(super) fixture_version: u32,
     pub(super) fixture_seed: u64,
@@ -22,6 +27,7 @@ pub(super) struct ReplayArtifact {
 pub(super) fn write_failure_artifact(
     seed: u64,
     events: Vec<Event>,
+    execution_mode: ExecutionMode,
     failure: FailureSnapshot,
 ) -> Result<PathBuf, String> {
     let root = std::env::var_os("CARGO_TARGET_DIR")
@@ -41,11 +47,12 @@ pub(super) fn write_failure_artifact(
         path.display()
     );
     let artifact = ReplayArtifact {
-        schema_version: 1,
+        schema_version: SCHEMA_VERSION,
         seed,
-        fixture: String::from("small-multi-source"),
+        execution_mode,
+        fixture: String::from(FIXTURE_NAME),
         fixture_version: crate::native_source_fixture::FIXTURE_VERSION,
-        fixture_seed: 0x5741_5645_4352_4154,
+        fixture_seed: FIXTURE_SEED,
         events,
         failure,
         replay_command,
@@ -57,20 +64,99 @@ pub(super) fn write_failure_artifact(
     Ok(path)
 }
 
-pub(super) fn read_replay(value: &str) -> Result<(u64, Vec<Event>), String> {
+pub(super) fn read_replay(value: &str) -> Result<(u64, Vec<Event>, ExecutionMode), String> {
     if let Ok(seed) = value.parse::<u64>() {
-        return Ok((seed, super::generate(seed, super::NORMAL_SEQUENCE_LENGTH)));
+        return Ok((
+            seed,
+            super::generate(seed, super::NORMAL_SEQUENCE_LENGTH),
+            ExecutionMode::IntegratedSupervisor,
+        ));
     }
     let path = Path::new(value);
     let bytes = fs::read(path)
         .map_err(|error| format!("read replay artifact {}: {error}", path.display()))?;
     let artifact: ReplayArtifact = serde_json::from_slice(&bytes)
         .map_err(|error| format!("parse replay artifact {}: {error}", path.display()))?;
-    if artifact.schema_version != 1 {
+    if artifact.schema_version != SCHEMA_VERSION {
         return Err(format!(
             "unsupported source state-machine artifact schema {}",
             artifact.schema_version
         ));
     }
-    Ok((artifact.seed, artifact.events))
+    if artifact.fixture != FIXTURE_NAME
+        || artifact.fixture_version != crate::native_source_fixture::FIXTURE_VERSION
+        || artifact.fixture_seed != FIXTURE_SEED
+    {
+        return Err(format!(
+            "replay fixture mismatch: artifact={}/v{}/{} current={FIXTURE_NAME}/v{}/{FIXTURE_SEED}",
+            artifact.fixture,
+            artifact.fixture_version,
+            artifact.fixture_seed,
+            crate::native_source_fixture::FIXTURE_VERSION,
+        ));
+    }
+    Ok((artifact.seed, artifact.events, artifact.execution_mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replay_artifact_preserves_scanner_only_execution_mode() {
+        let directory = tempfile::tempdir().expect("replay artifact directory");
+        let path = directory.path().join("replay.json");
+        let artifact = artifact(ExecutionMode::ScannerOnly);
+        fs::write(
+            &path,
+            serde_json::to_vec(&artifact).expect("serialize replay artifact"),
+        )
+        .expect("write replay artifact");
+
+        let (seed, events, mode) =
+            read_replay(path.to_str().expect("utf-8 replay path")).expect("read replay");
+        assert_eq!(seed, 42);
+        assert_eq!(events, [Event::ExplicitRefresh, Event::Quiesce]);
+        assert_eq!(mode, ExecutionMode::ScannerOnly);
+    }
+
+    #[test]
+    fn replay_artifact_rejects_fixture_version_drift() {
+        let directory = tempfile::tempdir().expect("replay artifact directory");
+        let path = directory.path().join("stale-replay.json");
+        let mut artifact = artifact(ExecutionMode::IntegratedSupervisor);
+        artifact.fixture_version = artifact.fixture_version.saturating_add(1);
+        fs::write(
+            &path,
+            serde_json::to_vec(&artifact).expect("serialize stale replay artifact"),
+        )
+        .expect("write stale replay artifact");
+
+        let error = read_replay(path.to_str().expect("utf-8 replay path"))
+            .expect_err("fixture drift must reject replay");
+        assert!(error.contains("replay fixture mismatch"));
+    }
+
+    fn artifact(execution_mode: ExecutionMode) -> ReplayArtifact {
+        ReplayArtifact {
+            schema_version: SCHEMA_VERSION,
+            seed: 42,
+            execution_mode,
+            fixture: String::from(FIXTURE_NAME),
+            fixture_version: crate::native_source_fixture::FIXTURE_VERSION,
+            fixture_seed: FIXTURE_SEED,
+            events: vec![Event::ExplicitRefresh, Event::Quiesce],
+            failure: FailureSnapshot {
+                message: String::from("test"),
+                event_index: 0,
+                event: Event::ExplicitRefresh,
+                model: serde_json::Value::Null,
+                accepted_revisions: Vec::new(),
+                accepted_publications: Vec::new(),
+                observable_commits: 0,
+                runtime: None,
+            },
+            replay_command: String::from("test"),
+        }
+    }
 }

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -44,6 +44,8 @@ pub(super) struct StateMachineHarness {
     pub(super) expected_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
     pub(super) observed_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
     pub(super) stale_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) expected_rejected_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) rejected_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
     pub(super) last_actual_output_revisions: BTreeMap<u64, (i64, i64)>,
     pub(super) actual_queue_admissions: u64,
     pub(super) max_actual_pending_scopes: usize,
@@ -104,6 +106,8 @@ impl StateMachineHarness {
             expected_supervisor_publications: BTreeSet::new(),
             observed_supervisor_publications: BTreeSet::new(),
             stale_supervisor_publications: BTreeSet::new(),
+            expected_rejected_supervisor_publications: BTreeSet::new(),
+            rejected_supervisor_publications: BTreeSet::new(),
             last_actual_output_revisions: BTreeMap::new(),
             actual_queue_admissions: 0,
             max_actual_pending_scopes: 0,
@@ -148,39 +152,11 @@ impl StateMachineHarness {
         self.next_failure = None;
         self.model.queue(ScanCause::Retry);
         self.flush(ScanCause::Retry)?;
-        self.wait_for_integrated_settle()?;
+        self.wait_for_supervisor_convergence()?;
         self.create(6, false)?;
         self.flush(ScanCause::Foreground)?;
-        self.wait_for_integrated_settle()?;
+        self.wait_for_supervisor_convergence()?;
         self.assert_actual_publications()
-    }
-
-    fn wait_for_integrated_settle(&self) -> Result<(), String> {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        loop {
-            let supervisor = self
-                .supervisor
-                .as_ref()
-                .expect("integrated initialization keeps its supervisor");
-            let runtime = super::super::liveness_tests::runtime_observation(
-                supervisor,
-                self.source.id.as_str(),
-            );
-            if super::super::liveness_tests::readiness_snapshot(&self.source).is_some()
-                && runtime.queue_depth == 0
-                && runtime.readiness_queue_depth == 0
-                && runtime.in_flight == 0
-                && !runtime.source_dirty
-            {
-                return Ok(());
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(format!(
-                    "integrated state-machine baseline did not settle: {runtime:?}"
-                ));
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
     }
 
     fn apply(&mut self, event: &Event) -> Result<(), String> {
@@ -296,13 +272,13 @@ impl StateMachineHarness {
         let publication_lost = self.take_failure(FailureBoundary::Publication);
         self.accept_commit(effective_cause, &stats.committed_delta, publication_lost)?;
         self.admit_pending_publication_retries()?;
-        if publication_lost {
+        if publication_lost && self.supervisor.is_none() {
             if !stats.committed_delta.is_empty() {
                 self.pending_publication_retries
                     .push((stats.committed_delta.clone(), effective_cause));
             }
         } else {
-            self.admit_supervisor_delta(&stats.committed_delta, effective_cause)?;
+            self.admit_supervisor_delta(&stats.committed_delta, effective_cause, publication_lost)?;
         }
         self.model.watcher_paths.clear();
         if effective_cause == ScanCause::Watcher {
@@ -349,7 +325,9 @@ impl StateMachineHarness {
         if let Some(supervisor) = &self.supervisor {
             supervisor
                 .request_source_processing(self.source.id.as_str(), "state_machine_quiescence");
-            self.assert_runtime_liveness(supervisor)?;
+        }
+        if self.supervisor.is_some() {
+            self.wait_for_supervisor_convergence()?;
         }
         self.assert_actual_publications()?;
         Ok(())

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -2,7 +2,10 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
     path::PathBuf,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver},
+    },
 };
 
 use wavecrate_scan::{
@@ -15,7 +18,9 @@ use crate::{
     sample_sources::{SampleSource, SourceId},
 };
 
-use super::super::{DatabasePhase, SourceAuditLifecycleCause, SourceProcessingSupervisor};
+use super::super::{
+    DatabasePhase, SourceAuditLifecycleCause, SourceProcessingEvent, SourceProcessingSupervisor,
+};
 use super::{
     Event, FailureBoundary, FailureSnapshot, ReferenceModel, ScanCause,
     invariants::filesystem_inventory,
@@ -27,6 +32,7 @@ pub(super) struct StateMachineHarness {
     pub(super) escape_target: PathBuf,
     pub(super) model: ReferenceModel,
     pub(super) supervisor: Option<SourceProcessingSupervisor>,
+    pub(super) supervisor_events: Option<Receiver<SourceProcessingEvent>>,
     pub(super) template: Vec<u8>,
     pub(super) last_revision: u64,
     pub(super) accepted_publications: BTreeSet<(u64, u64, ScanCause)>,
@@ -74,14 +80,19 @@ impl StateMachineHarness {
         let last_revision = database
             .get_wav_paths_revision()
             .map_err(|error| error.to_string())?;
-        let supervisor =
-            with_supervisor.then(|| SourceProcessingSupervisor::start(vec![source.clone()]));
+        let (supervisor, supervisor_events) = if with_supervisor {
+            let (supervisor, events) = start_observed_supervisor(&source);
+            (Some(supervisor), Some(events))
+        } else {
+            (None, None)
+        };
         Ok(Self {
             _config_base: config_base,
             source,
             escape_target,
             model: ReferenceModel::new(files),
             supervisor,
+            supervisor_events,
             template,
             last_revision,
             accepted_publications: BTreeSet::new(),
@@ -343,4 +354,14 @@ impl StateMachineHarness {
         self.assert_actual_publications()?;
         Ok(())
     }
+}
+
+pub(super) fn start_observed_supervisor(
+    source: &SampleSource,
+) -> (SourceProcessingSupervisor, Receiver<SourceProcessingEvent>) {
+    let (event_sender, event_receiver) = mpsc::channel();
+    (
+        SourceProcessingSupervisor::start_with_event_sink(vec![source.clone()], event_sender),
+        event_receiver,
+    )
 }

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -6,8 +6,11 @@ use std::{
         atomic::{AtomicBool, Ordering},
         mpsc::{self, Receiver},
     },
+    time::Duration,
 };
 
+use rusqlite::Connection;
+use wavecrate_scan::sample_sources::SourceDbError;
 use wavecrate_scan::{
     CommittedSourceDelta, ScanError, ScanMode, complete_deferred_hashes, scan_with_progress,
     sync_paths,
@@ -216,16 +219,9 @@ impl StateMachineHarness {
             return Ok(());
         }
         let effective_cause = self.authoritative_cause(cause);
-        if self.take_failure(FailureBoundary::Transaction) {
-            self.model.retry_count = self.model.retry_count.saturating_add(1);
-            self.model.queue(ScanCause::Retry);
-            return Ok(());
-        }
-        if cause == ScanCause::Watcher && self.take_failure(FailureBoundary::WatcherDelivery) {
-            self.model.retry_count = self.model.retry_count.saturating_add(1);
-            self.model.queue(ScanCause::Retry);
-            return Ok(());
-        }
+        let reject_transaction = self.take_failure(FailureBoundary::Transaction);
+        let reject_watcher_delivery =
+            cause == ScanCause::Watcher && self.take_failure(FailureBoundary::WatcherDelivery);
         let scan_permit = self.supervisor.as_ref().and_then(|supervisor| {
             supervisor
                 .budget_handle()
@@ -236,13 +232,32 @@ impl StateMachineHarness {
             .as_ref()
             .map(|writer| writer.lock(DatabasePhase::SerialCompatibility));
         let database = self.database()?;
+        let transaction_lock = if reject_transaction {
+            database
+                .set_busy_timeout_for_tests(Duration::ZERO)
+                .map_err(|error| format!("configure transaction contention: {error}"))?;
+            let path = self
+                .source
+                .db_path()
+                .map_err(|error| format!("resolve transaction database: {error}"))?;
+            let lock = Connection::open(path)
+                .map_err(|error| format!("open transaction lock: {error}"))?;
+            lock.busy_timeout(Duration::ZERO)
+                .map_err(|error| format!("configure transaction lock: {error}"))?;
+            lock.execute_batch("BEGIN IMMEDIATE")
+                .map_err(|error| format!("acquire transaction lock: {error}"))?;
+            Some(lock)
+        } else {
+            None
+        };
         let pending_paths = self
             .model
             .watcher_paths
             .iter()
             .map(PathBuf::from)
             .collect::<Vec<_>>();
-        let stats = if self.take_failure(FailureBoundary::Hashing) {
+        let reject_hashing = self.take_failure(FailureBoundary::Hashing);
+        let scan_result = if reject_hashing {
             let cancel = AtomicBool::new(false);
             let mut progressed = false;
             let result =
@@ -254,18 +269,37 @@ impl StateMachineHarness {
                 });
             self.model.queue(ScanCause::Retry);
             self.model.retry_count = self.model.retry_count.saturating_add(1);
-            match result {
-                Ok(stats) => stats,
-                Err(ScanError::Incomplete { committed, .. }) => *committed,
-                Err(ScanError::Canceled) => return Ok(()),
-                Err(error) => return Err(format!("hash-boundary scan failed: {error}")),
-            }
+            result
         } else if effective_cause == ScanCause::Watcher && !pending_paths.is_empty() {
             sync_paths(&database, &pending_paths)
-                .map_err(|error| format!("targeted watcher reconciliation failed: {error}"))?
         } else {
             scan_with_progress(&database, ScanMode::Quick, None, &mut |_, _| {})
-                .map_err(|error| format!("full reconciliation failed: {error}"))?
+        };
+        if reject_transaction {
+            transaction_lock
+                .as_ref()
+                .expect("transaction injection must own its lock")
+                .execute_batch("ROLLBACK")
+                .map_err(|error| format!("release transaction lock: {error}"))?;
+            return match scan_result {
+                Err(ScanError::Db(SourceDbError::Busy)) => {
+                    self.model.retry_count = self.model.retry_count.saturating_add(1);
+                    self.model.queue(ScanCause::Retry);
+                    Ok(())
+                }
+                Err(error) => Err(format!(
+                    "transaction boundary returned unexpected failure: {error}"
+                )),
+                Ok(_) => Err(String::from(
+                    "transaction boundary accepted an injected busy failure",
+                )),
+            };
+        }
+        let stats = match scan_result {
+            Ok(stats) => stats,
+            Err(ScanError::Incomplete { committed, .. }) if reject_hashing => *committed,
+            Err(ScanError::Canceled) if reject_hashing => return Ok(()),
+            Err(error) => return Err(format!("source reconciliation failed: {error}")),
         };
         let stats = complete_deferred_hashes(&database, stats)
             .map_err(|error| format!("complete deferred hashes: {error}"))?;
@@ -278,7 +312,16 @@ impl StateMachineHarness {
                     .push((stats.committed_delta.clone(), effective_cause));
             }
         } else {
-            self.admit_supervisor_delta(&stats.committed_delta, effective_cause, publication_lost)?;
+            self.admit_supervisor_delta(
+                &stats.committed_delta,
+                effective_cause,
+                reject_watcher_delivery,
+                publication_lost,
+            )?;
+            if reject_watcher_delivery {
+                self.model.retry_count = self.model.retry_count.saturating_add(1);
+                self.model.queue(ScanCause::Retry);
+            }
         }
         self.model.watcher_paths.clear();
         if effective_cause == ScanCause::Watcher {

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -1,0 +1,269 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use wavecrate_scan::{
+    ScanError, ScanMode, complete_deferred_hashes, scan_with_progress, sync_paths,
+};
+
+use crate::{
+    native_source_fixture::{FixtureName, FixtureProfile, FixtureProvisionRequest, provision},
+    sample_sources::{SampleSource, SourceId},
+};
+
+use super::super::{SourceAuditLifecycleCause, SourceProcessingSupervisor};
+use super::{
+    Event, FailureBoundary, FailureSnapshot, ReferenceModel, ScanCause,
+    invariants::filesystem_inventory,
+};
+
+pub(super) struct StateMachineHarness {
+    pub(super) _config_base: tempfile::TempDir,
+    pub(super) source: SampleSource,
+    pub(super) escape_target: PathBuf,
+    pub(super) model: ReferenceModel,
+    pub(super) supervisor: Option<SourceProcessingSupervisor>,
+    pub(super) template: Vec<u8>,
+    pub(super) last_revision: u64,
+    pub(super) accepted_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) accepted_revisions: Vec<String>,
+    pub(super) next_failure: Option<FailureBoundary>,
+    pub(super) retired_roots: Vec<PathBuf>,
+    pub(super) observable_commits: u64,
+}
+
+impl StateMachineHarness {
+    pub(super) fn new(with_supervisor: bool) -> Result<Self, String> {
+        let config_base = tempfile::tempdir().map_err(|error| error.to_string())?;
+        let manifest = provision(&FixtureProvisionRequest {
+            config_base: config_base.path().to_path_buf(),
+            fixture: FixtureName::SmallMultiSource,
+            profile: FixtureProfile::AutomatedTests,
+            reset: true,
+        })?;
+        let source_manifest = manifest
+            .sources
+            .iter()
+            .find(|source| source.directory_name == "source-beta")
+            .ok_or_else(|| String::from("small fixture is missing source-beta"))?;
+        let escape_target = manifest
+            .sources
+            .iter()
+            .find(|source| source.directory_name == "source-alpha")
+            .map(|source| source.root.clone())
+            .ok_or_else(|| String::from("small fixture is missing source-alpha"))?;
+        let source = SampleSource::new_with_id(
+            SourceId::from_string(source_manifest.source_id.clone()),
+            source_manifest.root.clone(),
+        );
+        let template = fs::read(source.root.join("mutable/change-me.wav"))
+            .map_err(|error| format!("read deterministic mutation template: {error}"))?;
+        let files = filesystem_inventory(&source.root)?;
+        let database = source.open_db().map_err(|error| error.to_string())?;
+        let last_revision = database
+            .get_wav_paths_revision()
+            .map_err(|error| error.to_string())?;
+        let supervisor =
+            with_supervisor.then(|| SourceProcessingSupervisor::start(vec![source.clone()]));
+        Ok(Self {
+            _config_base: config_base,
+            source,
+            escape_target,
+            model: ReferenceModel::new(files),
+            supervisor,
+            template,
+            last_revision,
+            accepted_publications: BTreeSet::new(),
+            accepted_revisions: vec![format!("1:{last_revision}")],
+            next_failure: None,
+            retired_roots: Vec::new(),
+            observable_commits: 0,
+        })
+    }
+
+    pub(super) fn run(mut self, events: &[Event]) -> Result<(), FailureSnapshot> {
+        for (event_index, event) in events.iter().enumerate() {
+            if let Err(message) = self.apply(event) {
+                return Err(self.failure(event_index, event, message));
+            }
+        }
+        if let Err(message) = self.quiesce() {
+            return Err(self.failure(events.len(), &Event::Quiesce, message));
+        }
+        if let Some(mut supervisor) = self.supervisor.take() {
+            let report = supervisor.shutdown();
+            if report["joined"] != true {
+                return Err(self.failure(
+                    events.len(),
+                    &Event::Quiesce,
+                    String::from("source-processing supervisor did not join"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn apply(&mut self, event: &Event) -> Result<(), String> {
+        match *event {
+            Event::Create { slot } => self.create(slot, false),
+            Event::SameSizeModify { slot } => self.modify(slot),
+            Event::Move { slot, nested } => self.move_file(slot, nested),
+            Event::Delete { slot } => self.delete(slot),
+            Event::NestedDirectoryChange { slot } => self.create(slot, true),
+            Event::WatcherBatch => self.flush(ScanCause::Watcher),
+            Event::WatcherOverflow => {
+                self.model.queue(ScanCause::WatcherOverflow);
+                self.flush(ScanCause::WatcherOverflow)
+            }
+            Event::FocusChanged { active } => {
+                self.model.focused = active;
+                if let Some(supervisor) = &self.supervisor {
+                    supervisor.set_foreground_activity(!active);
+                    if active {
+                        supervisor.request_lifecycle_audit_probe(
+                            SourceAuditLifecycleCause::FocusRegained,
+                            &[],
+                        );
+                    }
+                }
+                if active {
+                    self.model.queue(ScanCause::Focus);
+                }
+                self.assert_queue_bound()
+            }
+            Event::ExplicitRefresh => {
+                self.model.queue(ScanCause::Foreground);
+                self.flush(ScanCause::Foreground)
+            }
+            Event::Cancel => self.cancel_scan(),
+            Event::ShutdownRestart => self.shutdown_restart(),
+            Event::SourceRemoveReadd => self.remove_readd(),
+            Event::RootOfflineOnline => self.root_offline_online(),
+            Event::RootReplacement => self.root_replacement(),
+            Event::PartialEnumeration => self.partial_enumeration(),
+            Event::SymlinkEscape => self.symlink_escape(),
+            Event::DatabaseBusy => {
+                self.next_failure = Some(FailureBoundary::Transaction);
+                self.flush(ScanCause::Watcher)
+            }
+            Event::InjectFailure { boundary } => {
+                self.next_failure = Some(boundary);
+                Ok(())
+            }
+            Event::Quiesce => self.quiesce(),
+        }
+    }
+
+    pub(super) fn flush(&mut self, cause: ScanCause) -> Result<(), String> {
+        if !self.model.root_online || !self.model.source_configured {
+            self.model.queue(ScanCause::Retry);
+            return Ok(());
+        }
+        let effective_cause = self.authoritative_cause(cause);
+        if self.take_failure(FailureBoundary::Transaction) {
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
+            self.model.queue(ScanCause::Retry);
+            return Ok(());
+        }
+        if cause == ScanCause::Watcher && self.take_failure(FailureBoundary::WatcherDelivery) {
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
+            self.model.queue(ScanCause::Retry);
+            return Ok(());
+        }
+        let database = self.database()?;
+        let pending_paths = self
+            .model
+            .watcher_paths
+            .iter()
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+        let stats = if self.take_failure(FailureBoundary::Hashing) {
+            let cancel = AtomicBool::new(false);
+            let mut progressed = false;
+            let result =
+                scan_with_progress(&database, ScanMode::Quick, Some(&cancel), &mut |_, _| {
+                    if progressed {
+                        cancel.store(true, Ordering::Release);
+                    }
+                    progressed = true;
+                });
+            self.model.queue(ScanCause::Retry);
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
+            match result {
+                Ok(stats) => stats,
+                Err(ScanError::Incomplete { committed, .. }) => *committed,
+                Err(ScanError::Canceled) => return Ok(()),
+                Err(error) => return Err(format!("hash-boundary scan failed: {error}")),
+            }
+        } else if effective_cause == ScanCause::Watcher && !pending_paths.is_empty() {
+            sync_paths(&database, &pending_paths)
+                .map_err(|error| format!("targeted watcher reconciliation failed: {error}"))?
+        } else {
+            scan_with_progress(&database, ScanMode::Quick, None, &mut |_, _| {})
+                .map_err(|error| format!("full reconciliation failed: {error}"))?
+        };
+        let stats = complete_deferred_hashes(&database, stats)
+            .map_err(|error| format!("complete deferred hashes: {error}"))?;
+        let publication_lost = self.take_failure(FailureBoundary::Publication);
+        self.accept_commit(effective_cause, &stats.committed_delta, publication_lost)?;
+        self.model.watcher_paths.clear();
+        if effective_cause == ScanCause::Watcher {
+            self.model.queued_causes.remove(&ScanCause::Watcher);
+        } else {
+            self.model.queued_causes.clear();
+        }
+        if publication_lost {
+            self.model.queue(ScanCause::Retry);
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
+        }
+        if let Some(supervisor) = &self.supervisor {
+            if stats.committed_delta.is_empty() {
+                supervisor
+                    .request_source_processing(self.source.id.as_str(), "state_machine_scan_noop");
+            } else {
+                supervisor.request_source_delta(
+                    self.source.id.as_str(),
+                    &stats.committed_delta,
+                    "state_machine_scan_commit",
+                );
+            }
+        }
+        self.assert_committed_manifest(&database)
+    }
+
+    fn authoritative_cause(&self, requested: ScanCause) -> ScanCause {
+        [
+            ScanCause::Lifecycle,
+            ScanCause::Restart,
+            ScanCause::WatcherOverflow,
+            ScanCause::Foreground,
+            ScanCause::Focus,
+            ScanCause::Retry,
+        ]
+        .into_iter()
+        .find(|cause| self.model.queued_causes.contains(cause))
+        .unwrap_or(requested)
+    }
+
+    fn quiesce(&mut self) -> Result<(), String> {
+        self.require_online()?;
+        self.next_failure = None;
+        self.model.queue(ScanCause::Retry);
+        self.flush(ScanCause::Retry)?;
+        self.model.queued_causes.clear();
+        self.model.watcher_paths.clear();
+        let database = self.database()?;
+        self.assert_committed_manifest(&database)?;
+        if let Some(supervisor) = &self.supervisor {
+            supervisor.wake_source_for_full_reconciliation(
+                self.source.id.as_str(),
+                "state_machine_quiescence",
+            );
+            self.assert_runtime_liveness(supervisor)?;
+        }
+        Ok(())
+    }
+}

--- a/src/test_support/source_processing_state_machine/harness.rs
+++ b/src/test_support/source_processing_state_machine/harness.rs
@@ -1,12 +1,13 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::PathBuf,
     sync::atomic::{AtomicBool, Ordering},
 };
 
 use wavecrate_scan::{
-    ScanError, ScanMode, complete_deferred_hashes, scan_with_progress, sync_paths,
+    CommittedSourceDelta, ScanError, ScanMode, complete_deferred_hashes, scan_with_progress,
+    sync_paths,
 };
 
 use crate::{
@@ -14,7 +15,7 @@ use crate::{
     sample_sources::{SampleSource, SourceId},
 };
 
-use super::super::{SourceAuditLifecycleCause, SourceProcessingSupervisor};
+use super::super::{DatabasePhase, SourceAuditLifecycleCause, SourceProcessingSupervisor};
 use super::{
     Event, FailureBoundary, FailureSnapshot, ReferenceModel, ScanCause,
     invariants::filesystem_inventory,
@@ -33,6 +34,13 @@ pub(super) struct StateMachineHarness {
     pub(super) next_failure: Option<FailureBoundary>,
     pub(super) retired_roots: Vec<PathBuf>,
     pub(super) observable_commits: u64,
+    pub(super) pending_publication_retries: Vec<(CommittedSourceDelta, ScanCause)>,
+    pub(super) expected_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) observed_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) stale_supervisor_publications: BTreeSet<(u64, u64, ScanCause)>,
+    pub(super) last_actual_output_revisions: BTreeMap<u64, (i64, i64)>,
+    pub(super) actual_queue_admissions: u64,
+    pub(super) max_actual_pending_scopes: usize,
 }
 
 impl StateMachineHarness {
@@ -81,10 +89,20 @@ impl StateMachineHarness {
             next_failure: None,
             retired_roots: Vec::new(),
             observable_commits: 0,
+            pending_publication_retries: Vec::new(),
+            expected_supervisor_publications: BTreeSet::new(),
+            observed_supervisor_publications: BTreeSet::new(),
+            stale_supervisor_publications: BTreeSet::new(),
+            last_actual_output_revisions: BTreeMap::new(),
+            actual_queue_admissions: 0,
+            max_actual_pending_scopes: 0,
         })
     }
 
     pub(super) fn run(mut self, events: &[Event]) -> Result<(), FailureSnapshot> {
+        if let Err(message) = self.initialize() {
+            return Err(self.failure(0, &Event::Quiesce, message));
+        }
         for (event_index, event) in events.iter().enumerate() {
             if let Err(message) = self.apply(event) {
                 return Err(self.failure(event_index, event, message));
@@ -102,8 +120,56 @@ impl StateMachineHarness {
                     String::from("source-processing supervisor did not join"),
                 ));
             }
+            if let Err(message) = self.collect_publications_from(&supervisor) {
+                return Err(self.failure(events.len(), &Event::Quiesce, message));
+            }
+            if let Err(message) = self.assert_actual_publications() {
+                return Err(self.failure(events.len(), &Event::Quiesce, message));
+            }
         }
         Ok(())
+    }
+
+    fn initialize(&mut self) -> Result<(), String> {
+        if self.supervisor.is_none() {
+            return self.quiesce();
+        }
+        self.next_failure = None;
+        self.model.queue(ScanCause::Retry);
+        self.flush(ScanCause::Retry)?;
+        self.wait_for_integrated_settle()?;
+        self.create(6, false)?;
+        self.flush(ScanCause::Foreground)?;
+        self.wait_for_integrated_settle()?;
+        self.assert_actual_publications()
+    }
+
+    fn wait_for_integrated_settle(&self) -> Result<(), String> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let supervisor = self
+                .supervisor
+                .as_ref()
+                .expect("integrated initialization keeps its supervisor");
+            let runtime = super::super::liveness_tests::runtime_observation(
+                supervisor,
+                self.source.id.as_str(),
+            );
+            if super::super::liveness_tests::readiness_snapshot(&self.source).is_some()
+                && runtime.queue_depth == 0
+                && runtime.readiness_queue_depth == 0
+                && runtime.in_flight == 0
+                && !runtime.source_dirty
+            {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "integrated state-machine baseline did not settle: {runtime:?}"
+                ));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 
     fn apply(&mut self, event: &Event) -> Result<(), String> {
@@ -173,6 +239,15 @@ impl StateMachineHarness {
             self.model.queue(ScanCause::Retry);
             return Ok(());
         }
+        let scan_permit = self.supervisor.as_ref().and_then(|supervisor| {
+            supervisor
+                .budget_handle()
+                .acquire_scan(self.source.id.as_str())
+        });
+        let scan_writer = scan_permit.as_ref().map(|permit| permit.scan_writer());
+        let _scan_writer_guard = scan_writer
+            .as_ref()
+            .map(|writer| writer.lock(DatabasePhase::SerialCompatibility));
         let database = self.database()?;
         let pending_paths = self
             .model
@@ -209,6 +284,15 @@ impl StateMachineHarness {
             .map_err(|error| format!("complete deferred hashes: {error}"))?;
         let publication_lost = self.take_failure(FailureBoundary::Publication);
         self.accept_commit(effective_cause, &stats.committed_delta, publication_lost)?;
+        self.admit_pending_publication_retries()?;
+        if publication_lost {
+            if !stats.committed_delta.is_empty() {
+                self.pending_publication_retries
+                    .push((stats.committed_delta.clone(), effective_cause));
+            }
+        } else {
+            self.admit_supervisor_delta(&stats.committed_delta, effective_cause)?;
+        }
         self.model.watcher_paths.clear();
         if effective_cause == ScanCause::Watcher {
             self.model.queued_causes.remove(&ScanCause::Watcher);
@@ -223,12 +307,6 @@ impl StateMachineHarness {
             if stats.committed_delta.is_empty() {
                 supervisor
                     .request_source_processing(self.source.id.as_str(), "state_machine_scan_noop");
-            } else {
-                supervisor.request_source_delta(
-                    self.source.id.as_str(),
-                    &stats.committed_delta,
-                    "state_machine_scan_commit",
-                );
             }
         }
         self.assert_committed_manifest(&database)
@@ -258,12 +336,11 @@ impl StateMachineHarness {
         let database = self.database()?;
         self.assert_committed_manifest(&database)?;
         if let Some(supervisor) = &self.supervisor {
-            supervisor.wake_source_for_full_reconciliation(
-                self.source.id.as_str(),
-                "state_machine_quiescence",
-            );
+            supervisor
+                .request_source_processing(self.source.id.as_str(), "state_machine_quiescence");
             self.assert_runtime_liveness(supervisor)?;
         }
+        self.assert_actual_publications()?;
         Ok(())
     }
 }

--- a/src/test_support/source_processing_state_machine/invariants.rs
+++ b/src/test_support/source_processing_state_machine/invariants.rs
@@ -13,7 +13,7 @@ use super::{
     Event, FailureBoundary, FailureSnapshot, ScanCause, StateMachineHarness, generated_path,
 };
 
-const MAX_COALESCED_CAUSES: usize = 7;
+const MAX_PENDING_WATCHER_PATHS: usize = 16;
 
 impl StateMachineHarness {
     pub(super) fn assert_runtime_liveness(
@@ -127,10 +127,10 @@ impl StateMachineHarness {
     }
 
     pub(super) fn assert_queue_bound(&self) -> Result<(), String> {
-        if self.model.queued_causes.len() > MAX_COALESCED_CAUSES {
+        if self.model.watcher_paths.len() > MAX_PENDING_WATCHER_PATHS {
             return Err(format!(
-                "coalesced scan cause count {} exceeded {MAX_COALESCED_CAUSES}",
-                self.model.queued_causes.len()
+                "coalesced watcher path count {} exceeded generated fixture bound {MAX_PENDING_WATCHER_PATHS}",
+                self.model.watcher_paths.len()
             ));
         }
         Ok(())

--- a/src/test_support/source_processing_state_machine/invariants.rs
+++ b/src/test_support/source_processing_state_machine/invariants.rs
@@ -1,0 +1,275 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+use wavecrate_scan::CommittedSourceDelta;
+
+use crate::sample_sources::SourceDatabase;
+
+use super::super::SourceProcessingSupervisor;
+use super::{
+    Event, FailureBoundary, FailureSnapshot, ScanCause, StateMachineHarness, generated_path,
+};
+
+const MAX_COALESCED_CAUSES: usize = 7;
+
+impl StateMachineHarness {
+    pub(super) fn assert_runtime_liveness(
+        &self,
+        supervisor: &SourceProcessingSupervisor,
+    ) -> Result<(), String> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let runtime = super::super::liveness_tests::runtime_observation(
+                supervisor,
+                self.source.id.as_str(),
+            );
+            if let Some(snapshot) = super::super::liveness_tests::readiness_snapshot(&self.source) {
+                if runtime.source_active
+                    && super::super::liveness_tests::silently_idle(&snapshot, &runtime)
+                {
+                    return Err(format!(
+                        "runtime became silently idle with actionable work: {runtime:?}"
+                    ));
+                }
+                if snapshot.is_converged()
+                    && runtime.queue_depth == 0
+                    && runtime.readiness_queue_depth == 0
+                    && runtime.in_flight == 0
+                    && !runtime.source_dirty
+                {
+                    return Ok(());
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "runtime did not converge at controlled quiescence: {runtime:?}"
+                ));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    pub(super) fn accept_commit(
+        &mut self,
+        cause: ScanCause,
+        delta: &CommittedSourceDelta,
+        publication_lost: bool,
+    ) -> Result<(), String> {
+        let revision = delta.revision;
+        if revision < self.last_revision {
+            return Err(format!(
+                "accepted source revision regressed from {} to {revision}",
+                self.last_revision
+            ));
+        }
+        if revision > self.last_revision {
+            self.accepted_revisions
+                .push(format!("{}:{revision}", self.model.lifecycle_generation));
+            self.last_revision = revision;
+        }
+        if !delta.is_empty() && !publication_lost {
+            if !self.accepted_publications.insert((
+                self.model.lifecycle_generation,
+                revision,
+                cause,
+            )) {
+                return Err(format!(
+                    "lifecycle {} revision {revision} was published more than once for {cause:?}",
+                    self.model.lifecycle_generation
+                ));
+            }
+            self.observable_commits = self.observable_commits.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    pub(super) fn assert_committed_manifest(
+        &self,
+        database: &SourceDatabase,
+    ) -> Result<(), String> {
+        let committed = database
+            .list_files()
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|entry| !entry.missing)
+            .map(|entry| {
+                (
+                    slash_path(&entry.relative_path),
+                    entry
+                        .content_hash
+                        .unwrap_or_else(|| String::from("<pending>")),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        if committed != self.model.files {
+            return Err(format!(
+                "committed manifest differs from reference filesystem model: expected={:?}, actual={committed:?}",
+                self.model.files
+            ));
+        }
+        let browser_projection = database
+            .list_files()
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|entry| !entry.missing)
+            .map(|entry| slash_path(&entry.relative_path))
+            .collect::<BTreeSet<_>>();
+        let expected_projection = self.model.files.keys().cloned().collect::<BTreeSet<_>>();
+        if browser_projection != expected_projection {
+            return Err(format!(
+                "browser projection differs from committed manifest: expected={expected_projection:?}, actual={browser_projection:?}"
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn assert_queue_bound(&self) -> Result<(), String> {
+        if self.model.queued_causes.len() > MAX_COALESCED_CAUSES {
+            return Err(format!(
+                "coalesced scan cause count {} exceeded {MAX_COALESCED_CAUSES}",
+                self.model.queued_causes.len()
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn database(&self) -> Result<SourceDatabase, String> {
+        self.source.open_db().map_err(|error| error.to_string())
+    }
+
+    pub(super) fn record_model_path(&mut self, relative: &str) -> Result<(), String> {
+        let bytes = fs::read(self.source.root.join(relative))
+            .map_err(|error| format!("read modeled file {relative}: {error}"))?;
+        self.model.files.insert(
+            relative.to_string(),
+            blake3::hash(&bytes).to_hex().to_string(),
+        );
+        Ok(())
+    }
+
+    pub(super) fn generated_slot_path(&self, slot: u8) -> Option<String> {
+        [generated_path(slot, false), generated_path(slot, true)]
+            .into_iter()
+            .find(|path| self.model.files.contains_key(path))
+    }
+
+    pub(super) fn require_online(&self) -> Result<(), String> {
+        if !self.model.root_online || !self.source.root.is_dir() {
+            return Err(String::from(
+                "generated operation escaped an online fixture root",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn take_failure(&mut self, boundary: FailureBoundary) -> bool {
+        if self.next_failure == Some(boundary) {
+            self.next_failure = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) fn failure(
+        &self,
+        event_index: usize,
+        event: &Event,
+        message: String,
+    ) -> FailureSnapshot {
+        FailureSnapshot {
+            message,
+            event_index,
+            event: event.clone(),
+            model: serde_json::to_value(&self.model).unwrap_or_default(),
+            accepted_revisions: self.accepted_revisions.clone(),
+            accepted_publications: self
+                .accepted_publications
+                .iter()
+                .map(|(lifecycle, revision, cause)| format!("{lifecycle}:{revision}:{cause:?}"))
+                .collect(),
+            observable_commits: self.observable_commits,
+            runtime: self.supervisor.as_ref().map(|supervisor| {
+                let observation = super::super::liveness_tests::runtime_observation(
+                    supervisor,
+                    self.source.id.as_str(),
+                );
+                let readiness = super::super::liveness_tests::readiness_snapshot(&self.source).map(
+                    |snapshot| {
+                        serde_json::json!({
+                            "availability": format!("{:?}", snapshot.availability),
+                            "activity": format!("{:?}", snapshot.activity),
+                            "source_generation": snapshot.source_generation,
+                            "readiness_revision": snapshot.readiness_revision,
+                            "deficit_count": snapshot.deficits.len(),
+                        })
+                    },
+                );
+                serde_json::json!({
+                    "observation": format!("{observation:?}"),
+                    "health": readiness,
+                })
+            }),
+        }
+    }
+}
+
+pub(super) fn filesystem_inventory(root: &Path) -> Result<BTreeMap<String, String>, String> {
+    let mut inventory = BTreeMap::new();
+    collect_files(root, root, &mut inventory)?;
+    Ok(inventory)
+}
+
+fn collect_files(
+    root: &Path,
+    directory: &Path,
+    inventory: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| format!("read fixture directory {}: {error}", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("read fixture entry: {error}"))?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    for entry in entries {
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("classify fixture entry: {error}"))?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_files(root, &path, inventory)?;
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("wav"))
+        {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|error| format!("confine fixture path: {error}"))?;
+            let bytes = fs::read(&path)
+                .map_err(|error| format!("read fixture WAV {}: {error}", path.display()))?;
+            inventory.insert(
+                slash_path(relative),
+                blake3::hash(&bytes).to_hex().to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn perturb(bytes: &mut [u8], salt: u8) {
+    if let Some(byte) = bytes.get_mut(44) {
+        *byte ^= salt.wrapping_mul(31).wrapping_add(1);
+    }
+}
+
+fn slash_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}

--- a/src/test_support/source_processing_state_machine/invariants.rs
+++ b/src/test_support/source_processing_state_machine/invariants.rs
@@ -8,7 +8,6 @@ use wavecrate_scan::CommittedSourceDelta;
 
 use crate::sample_sources::SourceDatabase;
 
-use super::super::SourceProcessingSupervisor;
 use super::{
     Event, FailureBoundary, FailureSnapshot, ScanCause, StateMachineHarness, generated_path,
 };
@@ -16,42 +15,6 @@ use super::{
 const MAX_PENDING_WATCHER_PATHS: usize = 16;
 
 impl StateMachineHarness {
-    pub(super) fn assert_runtime_liveness(
-        &self,
-        supervisor: &SourceProcessingSupervisor,
-    ) -> Result<(), String> {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        loop {
-            let runtime = super::super::liveness_tests::runtime_observation(
-                supervisor,
-                self.source.id.as_str(),
-            );
-            if let Some(snapshot) = super::super::liveness_tests::readiness_snapshot(&self.source) {
-                if runtime.source_active
-                    && super::super::liveness_tests::silently_idle(&snapshot, &runtime)
-                {
-                    return Err(format!(
-                        "runtime became silently idle with actionable work: {runtime:?}"
-                    ));
-                }
-                if snapshot.is_converged()
-                    && runtime.queue_depth == 0
-                    && runtime.readiness_queue_depth == 0
-                    && runtime.in_flight == 0
-                    && !runtime.source_dirty
-                {
-                    return Ok(());
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(format!(
-                    "runtime did not converge at controlled quiescence: {runtime:?}"
-                ));
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-    }
-
     pub(super) fn accept_commit(
         &mut self,
         cause: ScanCause,
@@ -110,17 +73,14 @@ impl StateMachineHarness {
                 self.model.files
             ));
         }
-        let browser_projection = database
-            .list_files()
-            .map_err(|error| error.to_string())?
-            .into_iter()
-            .filter(|entry| !entry.missing)
-            .map(|entry| slash_path(&entry.relative_path))
-            .collect::<BTreeSet<_>>();
+        let browser_projection =
+            crate::app::controller::library::wavs::browser_search_worker::project_source_paths_for_state_machine(
+                &self.source,
+            )?;
         let expected_projection = self.model.files.keys().cloned().collect::<BTreeSet<_>>();
         if browser_projection != expected_projection {
             return Err(format!(
-                "browser projection differs from committed manifest: expected={expected_projection:?}, actual={browser_projection:?}"
+                "production browser projection differs from reference model: expected={expected_projection:?}, actual={browser_projection:?}"
             ));
         }
         Ok(())

--- a/src/test_support/source_processing_state_machine/mod.rs
+++ b/src/test_support/source_processing_state_machine/mod.rs
@@ -1,0 +1,158 @@
+use serde::{Deserialize, Serialize};
+
+mod artifacts;
+mod harness;
+mod invariants;
+mod model;
+mod mutations;
+
+use artifacts::{read_replay, write_failure_artifact};
+use harness::StateMachineHarness;
+use model::{Event, FailureBoundary, ReferenceModel, ScanCause, generate, generated_path};
+
+pub(super) const NORMAL_SEQUENCE_LENGTH: usize = 24;
+const STRESS_SEQUENCE_LENGTH: usize = 32;
+const STRESS_SEQUENCE_COUNT: u64 = 1_000;
+const REGRESSION_SEEDS: [u64; 6] = [
+    0x1184_0000_0000_0000,
+    0x1179_0000_0000_0001,
+    0x1240_0000_0000_0002,
+    0x1242_0000_0000_0003,
+    0x1245_0000_0000_0004,
+    0x1248_0000_0000_0005,
+];
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(in crate::native_app::source_processing::supervisor::state_machine_tests) struct FailureSnapshot
+{
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) message: String,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) event_index:
+        usize,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) event: Event,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) model:
+        serde_json::Value,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) accepted_revisions:
+        Vec<String>,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) accepted_publications:
+        Vec<String>,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) observable_commits:
+        u64,
+    pub(in crate::native_app::source_processing::supervisor::state_machine_tests) runtime:
+        Option<serde_json::Value>,
+}
+
+#[test]
+fn source_processing_seeded_state_machine_normal_ci() {
+    for seed in REGRESSION_SEEDS {
+        run_or_archive(seed, generate(seed, NORMAL_SEQUENCE_LENGTH), false);
+    }
+}
+
+#[test]
+#[ignore = "explicit integrated supervisor state-machine lane"]
+fn source_processing_seeded_state_machine_integrated_supervisor() {
+    let seed = REGRESSION_SEEDS[0];
+    run_or_archive(seed, generate(seed, NORMAL_SEQUENCE_LENGTH), true);
+}
+
+#[test]
+#[ignore = "explicit 1,000-sequence source-processing state-machine stress lane"]
+fn source_processing_seeded_state_machine_stress_1000() {
+    for seed in 0..STRESS_SEQUENCE_COUNT {
+        run_or_archive(seed, generate(seed, STRESS_SEQUENCE_LENGTH), false);
+    }
+}
+
+#[test]
+#[ignore = "explicit replay via WAVECRATE_SOURCE_STATE_MACHINE_REPLAY=<seed-or-artifact>"]
+fn source_processing_seeded_state_machine_replay() {
+    let value = std::env::var("WAVECRATE_SOURCE_STATE_MACHINE_REPLAY").expect(
+        "set WAVECRATE_SOURCE_STATE_MACHINE_REPLAY to a decimal seed or replay artifact path",
+    );
+    let (seed, events) = read_replay(&value).expect("load source state-machine replay");
+    run_or_archive(seed, events, true);
+}
+
+fn run_or_archive(seed: u64, events: Vec<Event>, with_supervisor: bool) {
+    let initial_failure = match StateMachineHarness::new(with_supervisor) {
+        Ok(harness) => match harness.run(&events) {
+            Ok(()) => return,
+            Err(failure) => failure,
+        },
+        Err(message) => FailureSnapshot {
+            message,
+            event_index: 0,
+            event: events.first().cloned().unwrap_or(Event::Quiesce),
+            model: serde_json::Value::Null,
+            accepted_revisions: Vec::new(),
+            accepted_publications: Vec::new(),
+            observable_commits: 0,
+            runtime: None,
+        },
+    };
+    eprintln!(
+        "state-machine seed {seed} failed before shrinking at event {}: {}",
+        initial_failure.event_index, initial_failure.message
+    );
+
+    let (minimized, failure) = minimize_failure(seed, &events, with_supervisor);
+    let path = write_failure_artifact(seed, minimized, failure.clone())
+        .unwrap_or_else(|error| panic!("state-machine failure and artifact write failed: {error}"));
+    panic!(
+        "seeded source-processing state machine failed: {}\nreplay artifact: {}\nreplay: WAVECRATE_SOURCE_STATE_MACHINE_REPLAY={} cargo test -p wavecrate --lib source_processing_seeded_state_machine_replay -- --ignored --nocapture",
+        failure.message,
+        path.display(),
+        path.display()
+    );
+}
+
+fn minimize_failure(
+    seed: u64,
+    events: &[Event],
+    with_supervisor: bool,
+) -> (Vec<Event>, FailureSnapshot) {
+    let mut minimized = events.to_vec();
+    let mut index = 0;
+    while index < minimized.len() {
+        if minimized[index].preserves_lifecycle_semantics()
+            || matches!(minimized[index], Event::Quiesce)
+        {
+            index += 1;
+            continue;
+        }
+        let mut candidate = minimized.clone();
+        candidate.remove(index);
+        if run_failure(&candidate, with_supervisor).is_some() {
+            minimized = candidate;
+        } else {
+            index += 1;
+        }
+    }
+    let failure = run_failure(&minimized, with_supervisor).unwrap_or_else(|| FailureSnapshot {
+        message: format!("seed {seed} failed before shrinking but not after deterministic replay"),
+        event_index: 0,
+        event: Event::Quiesce,
+        model: serde_json::Value::Null,
+        accepted_revisions: Vec::new(),
+        accepted_publications: Vec::new(),
+        observable_commits: 0,
+        runtime: None,
+    });
+    (minimized, failure)
+}
+
+fn run_failure(events: &[Event], with_supervisor: bool) -> Option<FailureSnapshot> {
+    match StateMachineHarness::new(with_supervisor) {
+        Ok(harness) => harness.run(events).err(),
+        Err(message) => Some(FailureSnapshot {
+            message,
+            event_index: 0,
+            event: events.first().cloned().unwrap_or(Event::Quiesce),
+            model: serde_json::Value::Null,
+            accepted_revisions: Vec::new(),
+            accepted_publications: Vec::new(),
+            observable_commits: 0,
+            runtime: None,
+        }),
+    }
+}

--- a/src/test_support/source_processing_state_machine/mod.rs
+++ b/src/test_support/source_processing_state_machine/mod.rs
@@ -6,6 +6,7 @@ mod invariants;
 mod model;
 mod mutations;
 mod supervisor_observer;
+mod supervisor_transitions;
 
 use artifacts::{read_replay, write_failure_artifact};
 use harness::StateMachineHarness;
@@ -73,6 +74,18 @@ fn source_processing_seeded_state_machine_integrated_supervisor() {
     run_or_archive(
         seed,
         generate(seed, NORMAL_SEQUENCE_LENGTH),
+        ExecutionMode::IntegratedSupervisor,
+    );
+    run_or_archive(
+        0x1248_5055_0000_0001,
+        vec![
+            Event::InjectFailure {
+                boundary: FailureBoundary::Publication,
+            },
+            Event::Create { slot: 7 },
+            Event::WatcherBatch,
+            Event::Quiesce,
+        ],
         ExecutionMode::IntegratedSupervisor,
     );
 }

--- a/src/test_support/source_processing_state_machine/mod.rs
+++ b/src/test_support/source_processing_state_machine/mod.rs
@@ -5,6 +5,7 @@ mod harness;
 mod invariants;
 mod model;
 mod mutations;
+mod supervisor_observer;
 
 use artifacts::{read_replay, write_failure_artifact};
 use harness::StateMachineHarness;
@@ -21,6 +22,19 @@ const REGRESSION_SEEDS: [u64; 6] = [
     0x1245_0000_0000_0004,
     0x1248_0000_0000_0005,
 ];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ExecutionMode {
+    ScannerOnly,
+    IntegratedSupervisor,
+}
+
+impl ExecutionMode {
+    fn uses_supervisor(self) -> bool {
+        self == Self::IntegratedSupervisor
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(in crate::native_app::source_processing::supervisor::state_machine_tests) struct FailureSnapshot
@@ -44,7 +58,11 @@ pub(in crate::native_app::source_processing::supervisor::state_machine_tests) st
 #[test]
 fn source_processing_seeded_state_machine_normal_ci() {
     for seed in REGRESSION_SEEDS {
-        run_or_archive(seed, generate(seed, NORMAL_SEQUENCE_LENGTH), false);
+        run_or_archive(
+            seed,
+            generate(seed, NORMAL_SEQUENCE_LENGTH),
+            ExecutionMode::ScannerOnly,
+        );
     }
 }
 
@@ -52,14 +70,22 @@ fn source_processing_seeded_state_machine_normal_ci() {
 #[ignore = "explicit integrated supervisor state-machine lane"]
 fn source_processing_seeded_state_machine_integrated_supervisor() {
     let seed = REGRESSION_SEEDS[0];
-    run_or_archive(seed, generate(seed, NORMAL_SEQUENCE_LENGTH), true);
+    run_or_archive(
+        seed,
+        generate(seed, NORMAL_SEQUENCE_LENGTH),
+        ExecutionMode::IntegratedSupervisor,
+    );
 }
 
 #[test]
 #[ignore = "explicit 1,000-sequence source-processing state-machine stress lane"]
 fn source_processing_seeded_state_machine_stress_1000() {
     for seed in 0..STRESS_SEQUENCE_COUNT {
-        run_or_archive(seed, generate(seed, STRESS_SEQUENCE_LENGTH), false);
+        run_or_archive(
+            seed,
+            generate(seed, STRESS_SEQUENCE_LENGTH),
+            ExecutionMode::ScannerOnly,
+        );
     }
 }
 
@@ -69,12 +95,12 @@ fn source_processing_seeded_state_machine_replay() {
     let value = std::env::var("WAVECRATE_SOURCE_STATE_MACHINE_REPLAY").expect(
         "set WAVECRATE_SOURCE_STATE_MACHINE_REPLAY to a decimal seed or replay artifact path",
     );
-    let (seed, events) = read_replay(&value).expect("load source state-machine replay");
-    run_or_archive(seed, events, true);
+    let (seed, events, mode) = read_replay(&value).expect("load source state-machine replay");
+    run_or_archive(seed, events, mode);
 }
 
-fn run_or_archive(seed: u64, events: Vec<Event>, with_supervisor: bool) {
-    let initial_failure = match StateMachineHarness::new(with_supervisor) {
+fn run_or_archive(seed: u64, events: Vec<Event>, mode: ExecutionMode) {
+    let initial_failure = match StateMachineHarness::new(mode.uses_supervisor()) {
         Ok(harness) => match harness.run(&events) {
             Ok(()) => return,
             Err(failure) => failure,
@@ -91,15 +117,15 @@ fn run_or_archive(seed: u64, events: Vec<Event>, with_supervisor: bool) {
         },
     };
     eprintln!(
-        "state-machine seed {seed} failed before shrinking at event {}: {}",
-        initial_failure.event_index, initial_failure.message
+        "state-machine seed {seed} ({mode:?}) failed before shrinking at event {}: {}",
+        initial_failure.event_index, initial_failure.message,
     );
 
-    let (minimized, failure) = minimize_failure(seed, &events, with_supervisor);
-    let path = write_failure_artifact(seed, minimized, failure.clone())
+    let (minimized, failure) = minimize_failure(seed, &events, mode);
+    let path = write_failure_artifact(seed, minimized, mode, failure.clone())
         .unwrap_or_else(|error| panic!("state-machine failure and artifact write failed: {error}"));
     panic!(
-        "seeded source-processing state machine failed: {}\nreplay artifact: {}\nreplay: WAVECRATE_SOURCE_STATE_MACHINE_REPLAY={} cargo test -p wavecrate --lib source_processing_seeded_state_machine_replay -- --ignored --nocapture",
+        "seeded source-processing state machine failed in {mode:?}: {}\nreplay artifact: {}\nreplay: WAVECRATE_SOURCE_STATE_MACHINE_REPLAY={} cargo test -p wavecrate --lib source_processing_seeded_state_machine_replay -- --ignored --nocapture",
         failure.message,
         path.display(),
         path.display()
@@ -109,7 +135,7 @@ fn run_or_archive(seed: u64, events: Vec<Event>, with_supervisor: bool) {
 fn minimize_failure(
     seed: u64,
     events: &[Event],
-    with_supervisor: bool,
+    mode: ExecutionMode,
 ) -> (Vec<Event>, FailureSnapshot) {
     let mut minimized = events.to_vec();
     let mut index = 0;
@@ -122,13 +148,13 @@ fn minimize_failure(
         }
         let mut candidate = minimized.clone();
         candidate.remove(index);
-        if run_failure(&candidate, with_supervisor).is_some() {
+        if run_failure(&candidate, mode).is_some() {
             minimized = candidate;
         } else {
             index += 1;
         }
     }
-    let failure = run_failure(&minimized, with_supervisor).unwrap_or_else(|| FailureSnapshot {
+    let failure = run_failure(&minimized, mode).unwrap_or_else(|| FailureSnapshot {
         message: format!("seed {seed} failed before shrinking but not after deterministic replay"),
         event_index: 0,
         event: Event::Quiesce,
@@ -141,8 +167,8 @@ fn minimize_failure(
     (minimized, failure)
 }
 
-fn run_failure(events: &[Event], with_supervisor: bool) -> Option<FailureSnapshot> {
-    match StateMachineHarness::new(with_supervisor) {
+fn run_failure(events: &[Event], mode: ExecutionMode) -> Option<FailureSnapshot> {
+    match StateMachineHarness::new(mode.uses_supervisor()) {
         Ok(harness) => harness.run(events).err(),
         Err(message) => Some(FailureSnapshot {
             message,

--- a/src/test_support/source_processing_state_machine/mod.rs
+++ b/src/test_support/source_processing_state_machine/mod.rs
@@ -88,6 +88,41 @@ fn source_processing_seeded_state_machine_integrated_supervisor() {
         ],
         ExecutionMode::IntegratedSupervisor,
     );
+    run_or_archive(
+        0x1248_5055_0000_0002,
+        vec![
+            Event::InjectFailure {
+                boundary: FailureBoundary::Transaction,
+            },
+            Event::Create { slot: 8 },
+            Event::WatcherBatch,
+            Event::Quiesce,
+        ],
+        ExecutionMode::IntegratedSupervisor,
+    );
+    run_or_archive(
+        0x1248_5055_0000_0003,
+        vec![
+            Event::InjectFailure {
+                boundary: FailureBoundary::WatcherDelivery,
+            },
+            Event::Create { slot: 9 },
+            Event::WatcherBatch,
+            Event::Quiesce,
+        ],
+        ExecutionMode::IntegratedSupervisor,
+    );
+    run_or_archive(
+        0x1248_5055_0000_0004,
+        vec![
+            Event::InjectFailure {
+                boundary: FailureBoundary::Lifecycle,
+            },
+            Event::SourceRemoveReadd,
+            Event::Quiesce,
+        ],
+        ExecutionMode::IntegratedSupervisor,
+    );
 }
 
 #[test]

--- a/src/test_support/source_processing_state_machine/model.rs
+++ b/src/test_support/source_processing_state_machine/model.rs
@@ -1,0 +1,194 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+const GENERATED_SLOTS: u8 = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ScanCause {
+    Watcher,
+    WatcherOverflow,
+    Focus,
+    Foreground,
+    Restart,
+    Lifecycle,
+    Retry,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum FailureBoundary {
+    Transaction,
+    Publication,
+    WatcherDelivery,
+    Hashing,
+    Lifecycle,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub(super) enum Event {
+    Create { slot: u8 },
+    SameSizeModify { slot: u8 },
+    Move { slot: u8, nested: bool },
+    Delete { slot: u8 },
+    NestedDirectoryChange { slot: u8 },
+    WatcherBatch,
+    WatcherOverflow,
+    FocusChanged { active: bool },
+    ExplicitRefresh,
+    Cancel,
+    ShutdownRestart,
+    SourceRemoveReadd,
+    RootOfflineOnline,
+    RootReplacement,
+    PartialEnumeration,
+    SymlinkEscape,
+    DatabaseBusy,
+    InjectFailure { boundary: FailureBoundary },
+    Quiesce,
+}
+
+impl Event {
+    pub(super) fn preserves_lifecycle_semantics(&self) -> bool {
+        matches!(
+            self,
+            Self::ShutdownRestart
+                | Self::SourceRemoveReadd
+                | Self::RootOfflineOnline
+                | Self::RootReplacement
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(super) struct ReferenceModel {
+    pub(super) files: BTreeMap<String, String>,
+    pub(super) queued_causes: BTreeSet<ScanCause>,
+    pub(super) watcher_paths: BTreeSet<String>,
+    pub(super) source_configured: bool,
+    pub(super) root_online: bool,
+    pub(super) focused: bool,
+    pub(super) lifecycle_generation: u64,
+    pub(super) restart_count: u64,
+    pub(super) retry_count: u64,
+}
+
+impl ReferenceModel {
+    pub(super) fn new(files: BTreeMap<String, String>) -> Self {
+        Self {
+            files,
+            source_configured: true,
+            root_online: true,
+            focused: true,
+            lifecycle_generation: 1,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn queue_path(&mut self, path: String) {
+        self.watcher_paths.insert(path);
+        self.queued_causes.insert(ScanCause::Watcher);
+    }
+
+    pub(super) fn queue(&mut self, cause: ScanCause) {
+        self.queued_causes.insert(cause);
+    }
+}
+
+pub(super) fn generated_path(slot: u8, nested: bool) -> String {
+    let slot = slot % GENERATED_SLOTS;
+    if nested {
+        format!("generated/nested/sample-{slot}.wav")
+    } else {
+        format!("generated/sample-{slot}.wav")
+    }
+}
+
+pub(super) fn generate(seed: u64, length: usize) -> Vec<Event> {
+    let mut random = SplitMix64::new(seed);
+    let mut events = regression_prefix(seed);
+    while events.len() < length {
+        let slot = (random.next() % u64::from(GENERATED_SLOTS)) as u8;
+        let event = match random.next() % 16 {
+            0 => Event::Create { slot },
+            1 => Event::SameSizeModify { slot },
+            2 => Event::Move {
+                slot,
+                nested: random.next() & 1 == 0,
+            },
+            3 => Event::Delete { slot },
+            4 => Event::NestedDirectoryChange { slot },
+            5 => Event::WatcherBatch,
+            6 => Event::WatcherOverflow,
+            7 => Event::FocusChanged {
+                active: random.next() & 1 == 0,
+            },
+            8 => Event::ExplicitRefresh,
+            9 => Event::Cancel,
+            10 => Event::ShutdownRestart,
+            11 => Event::SourceRemoveReadd,
+            12 => Event::RootOfflineOnline,
+            13 => Event::RootReplacement,
+            14 => Event::InjectFailure {
+                boundary: failure_boundary(random.next()),
+            },
+            _ => Event::WatcherBatch,
+        };
+        events.push(event);
+    }
+    events.push(Event::Quiesce);
+    events
+}
+
+fn regression_prefix(seed: u64) -> Vec<Event> {
+    match seed % 6 {
+        0 => vec![
+            Event::FocusChanged { active: false },
+            Event::FocusChanged { active: true },
+            Event::WatcherBatch,
+        ],
+        1 => vec![Event::Create { slot: 0 }, Event::RootReplacement],
+        2 => vec![
+            Event::Create { slot: 1 },
+            Event::PartialEnumeration,
+            Event::WatcherBatch,
+        ],
+        3 => vec![Event::SymlinkEscape, Event::WatcherOverflow],
+        4 => vec![Event::SameSizeModify { slot: 3 }, Event::DatabaseBusy],
+        _ => vec![
+            Event::Create { slot: 4 },
+            Event::Cancel,
+            Event::SourceRemoveReadd,
+        ],
+    }
+}
+
+fn failure_boundary(value: u64) -> FailureBoundary {
+    match value % 5 {
+        0 => FailureBoundary::Transaction,
+        1 => FailureBoundary::Publication,
+        2 => FailureBoundary::WatcherDelivery,
+        3 => FailureBoundary::Hashing,
+        _ => FailureBoundary::Lifecycle,
+    }
+}
+
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    const fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.state;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+}

--- a/src/test_support/source_processing_state_machine/model.rs
+++ b/src/test_support/source_processing_state_machine/model.rs
@@ -16,6 +16,34 @@ pub(super) enum ScanCause {
     Retry,
 }
 
+impl ScanCause {
+    pub(super) const fn publication_reason(self) -> &'static str {
+        match self {
+            Self::Watcher => "state_machine_watcher",
+            Self::WatcherOverflow => "state_machine_watcher_overflow",
+            Self::Focus => "state_machine_focus",
+            Self::Foreground => "state_machine_foreground",
+            Self::Restart => "state_machine_restart",
+            Self::Lifecycle => "state_machine_lifecycle",
+            Self::Retry => "state_machine_retry",
+        }
+    }
+
+    pub(super) fn from_publication_reason(reason: &str) -> Option<Self> {
+        [
+            Self::Watcher,
+            Self::WatcherOverflow,
+            Self::Focus,
+            Self::Foreground,
+            Self::Restart,
+            Self::Lifecycle,
+            Self::Retry,
+        ]
+        .into_iter()
+        .find(|cause| cause.publication_reason() == reason)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum FailureBoundary {

--- a/src/test_support/source_processing_state_machine/mutations.rs
+++ b/src/test_support/source_processing_state_machine/mutations.rs
@@ -144,9 +144,28 @@ impl StateMachineHarness {
     }
 
     pub(super) fn remove_readd(&mut self) -> Result<(), String> {
-        if self.take_failure(FailureBoundary::Lifecycle) {
-            self.model.queue(ScanCause::Retry);
-            return Ok(());
+        let reject_lifecycle = self.take_failure(FailureBoundary::Lifecycle);
+        if reject_lifecycle && let Some(supervisor) = &self.supervisor {
+            let generation_before = supervisor
+                .lifecycle_generations()
+                .get(self.source.id.as_str())
+                .copied();
+            supervisor.reject_next_source_replacement_for_state_machine();
+            if supervisor.replace_sources(Vec::new()).is_ok() {
+                return Err(String::from(
+                    "lifecycle boundary accepted an injected replacement failure",
+                ));
+            }
+            let generation_after = supervisor
+                .lifecycle_generations()
+                .get(self.source.id.as_str())
+                .copied();
+            if generation_after != generation_before {
+                return Err(String::from(
+                    "rejected lifecycle replacement advanced the active generation",
+                ));
+            }
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
         }
         self.model.source_configured = false;
         let lifecycle_generation = self.supervisor.as_ref().and_then(|supervisor| {

--- a/src/test_support/source_processing_state_machine/mutations.rs
+++ b/src/test_support/source_processing_state_machine/mutations.rs
@@ -2,9 +2,9 @@ use std::{fs, sync::atomic::AtomicBool};
 
 use wavecrate_scan::{ScanError, ScanMode, scan_with_progress};
 
-use super::super::SourceProcessingSupervisor;
 use super::{
     FailureBoundary, ScanCause, StateMachineHarness, generated_path,
+    harness::start_observed_supervisor,
     invariants::{filesystem_inventory, perturb},
 };
 
@@ -134,7 +134,9 @@ impl StateMachineHarness {
             if let Some(lifecycle_generation) = lifecycle_generation {
                 self.mark_outstanding_publications_stale(lifecycle_generation);
             }
-            self.supervisor = Some(SourceProcessingSupervisor::start(vec![self.source.clone()]));
+            let (supervisor, events) = start_observed_supervisor(&self.source);
+            self.supervisor = Some(supervisor);
+            self.supervisor_events = Some(events);
         }
         self.model.restart_count = self.model.restart_count.saturating_add(1);
         self.model.queue(ScanCause::Restart);
@@ -182,15 +184,30 @@ impl StateMachineHarness {
         fs::rename(&self.source.root, &offline)
             .map_err(|error| format!("take source root offline: {error}"))?;
         self.model.root_online = false;
-        if !self.take_failure(FailureBoundary::Lifecycle) {
-            fs::rename(&offline, &self.source.root)
-                .map_err(|error| format!("restore source root: {error}"))?;
-            self.model.root_online = true;
-        } else {
-            fs::rename(&offline, &self.source.root)
-                .map_err(|error| format!("recover injected offline lifecycle failure: {error}"))?;
-            self.model.root_online = true;
+        let injected_failure = self.take_failure(FailureBoundary::Lifecycle);
+        if let Some(supervisor) = &self.supervisor {
+            supervisor.wake_source_for_full_reconciliation(
+                self.source.id.as_str(),
+                "state_machine_root_offline",
+            );
+            self.wait_for_supervisor_offline()?;
+        }
+        fs::rename(&offline, &self.source.root)
+            .map_err(|error| format!("restore source root: {error}"))?;
+        self.model.root_online = true;
+        if injected_failure {
             self.model.retry_count = self.model.retry_count.saturating_add(1);
+        }
+        if let Some(supervisor) = &self.supervisor {
+            supervisor.wake_source_for_full_reconciliation(
+                self.source.id.as_str(),
+                if injected_failure {
+                    "state_machine_root_online_retry"
+                } else {
+                    "state_machine_root_online"
+                },
+            );
+            self.wait_for_supervisor_online_terminal()?;
         }
         self.model.queue(ScanCause::Lifecycle);
         Ok(())

--- a/src/test_support/source_processing_state_machine/mutations.rs
+++ b/src/test_support/source_processing_state_machine/mutations.rs
@@ -1,0 +1,231 @@
+use std::{fs, sync::atomic::AtomicBool};
+
+use wavecrate_scan::{ScanError, ScanMode, scan_with_progress};
+
+use super::super::SourceProcessingSupervisor;
+use super::{
+    FailureBoundary, ScanCause, StateMachineHarness, generated_path,
+    invariants::{filesystem_inventory, perturb},
+};
+
+impl StateMachineHarness {
+    pub(super) fn create(&mut self, slot: u8, nested: bool) -> Result<(), String> {
+        self.require_online()?;
+        let relative = generated_path(slot, nested);
+        let path = self.source.root.join(&relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create generated source directory: {error}"))?;
+        }
+        let mut bytes = self.template.clone();
+        perturb(&mut bytes, slot);
+        fs::write(&path, bytes).map_err(|error| format!("create {relative}: {error}"))?;
+        self.record_model_path(&relative)?;
+        self.model.queue_path(relative);
+        self.assert_queue_bound()
+    }
+
+    pub(super) fn modify(&mut self, slot: u8) -> Result<(), String> {
+        self.require_online()?;
+        let relative = self
+            .generated_slot_path(slot)
+            .unwrap_or_else(|| generated_path(slot, false));
+        let path = self.source.root.join(&relative);
+        if !path.is_file() {
+            self.create(slot, false)?;
+        }
+        let mut bytes = fs::read(&path).map_err(|error| format!("read {relative}: {error}"))?;
+        let original_len = bytes.len();
+        perturb(
+            &mut bytes,
+            slot.wrapping_add(self.model.retry_count as u8)
+                .wrapping_add(17),
+        );
+        fs::write(&path, bytes).map_err(|error| format!("modify {relative}: {error}"))?;
+        if fs::metadata(&path)
+            .map_err(|error| error.to_string())?
+            .len()
+            != original_len as u64
+        {
+            return Err(format!("same-size mutation changed length for {relative}"));
+        }
+        self.record_model_path(&relative)?;
+        self.model.queue_path(relative);
+        self.assert_queue_bound()
+    }
+
+    pub(super) fn move_file(&mut self, slot: u8, nested: bool) -> Result<(), String> {
+        self.require_online()?;
+        let source_relative = self
+            .generated_slot_path(slot)
+            .unwrap_or_else(|| generated_path(slot, !nested));
+        if !self.source.root.join(&source_relative).is_file() {
+            self.create(slot, !nested)?;
+        }
+        let destination_relative = generated_path(slot, nested);
+        if source_relative == destination_relative {
+            return Ok(());
+        }
+        let destination = self.source.root.join(&destination_relative);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create move destination: {error}"))?;
+        }
+        if destination.exists() {
+            fs::remove_file(&destination)
+                .map_err(|error| format!("replace move destination: {error}"))?;
+        }
+        fs::rename(self.source.root.join(&source_relative), &destination).map_err(|error| {
+            format!("move {source_relative} to {destination_relative}: {error}")
+        })?;
+        let hash = self
+            .model
+            .files
+            .remove(&source_relative)
+            .ok_or_else(|| format!("reference model lost move source {source_relative}"))?;
+        self.model.files.insert(destination_relative.clone(), hash);
+        self.model.queue_path(source_relative);
+        self.model.queue_path(destination_relative);
+        self.assert_queue_bound()
+    }
+
+    pub(super) fn delete(&mut self, slot: u8) -> Result<(), String> {
+        self.require_online()?;
+        let Some(relative) = self.generated_slot_path(slot) else {
+            return Ok(());
+        };
+        fs::remove_file(self.source.root.join(&relative))
+            .map_err(|error| format!("delete {relative}: {error}"))?;
+        self.model.files.remove(&relative);
+        self.model.queue_path(relative);
+        self.assert_queue_bound()
+    }
+
+    pub(super) fn cancel_scan(&mut self) -> Result<(), String> {
+        let database = self.database()?;
+        let cancel = AtomicBool::new(true);
+        match scan_with_progress(&database, ScanMode::Quick, Some(&cancel), &mut |_, _| {}) {
+            Err(ScanError::Canceled) | Err(ScanError::Incomplete { .. }) => {}
+            Ok(_) => return Err(String::from("pre-cancelled scan unexpectedly completed")),
+            Err(error) => return Err(format!("pre-cancelled scan failed unexpectedly: {error}")),
+        }
+        if let Some(supervisor) = &self.supervisor {
+            supervisor
+                .cancel_foreground_source_scan(self.source.id.as_str(), "state_machine_cancel");
+        }
+        self.model.queue(ScanCause::Retry);
+        self.model.retry_count = self.model.retry_count.saturating_add(1);
+        Ok(())
+    }
+
+    pub(super) fn shutdown_restart(&mut self) -> Result<(), String> {
+        if let Some(mut supervisor) = self.supervisor.take() {
+            let report = supervisor.shutdown();
+            if report["joined"] != true {
+                return Err(String::from(
+                    "supervisor failed to join during replayable restart",
+                ));
+            }
+            self.supervisor = Some(SourceProcessingSupervisor::start(vec![self.source.clone()]));
+        }
+        self.model.restart_count = self.model.restart_count.saturating_add(1);
+        self.model.queue(ScanCause::Restart);
+        Ok(())
+    }
+
+    pub(super) fn remove_readd(&mut self) -> Result<(), String> {
+        if self.take_failure(FailureBoundary::Lifecycle) {
+            self.model.queue(ScanCause::Retry);
+            return Ok(());
+        }
+        self.model.source_configured = false;
+        if let Some(supervisor) = &self.supervisor {
+            supervisor.replace_sources(Vec::new())?;
+            supervisor.replace_sources(vec![self.source.clone()])?;
+        }
+        self.model.source_configured = true;
+        self.model.lifecycle_generation = self.model.lifecycle_generation.saturating_add(1);
+        self.model.queue(ScanCause::Lifecycle);
+        Ok(())
+    }
+
+    pub(super) fn root_offline_online(&mut self) -> Result<(), String> {
+        self.require_online()?;
+        let offline = self.source.root.with_extension(format!(
+            "state-machine-offline-{}",
+            self.model.restart_count
+        ));
+        if offline.exists() {
+            fs::remove_dir_all(&offline)
+                .map_err(|error| format!("clear prior offline root: {error}"))?;
+        }
+        fs::rename(&self.source.root, &offline)
+            .map_err(|error| format!("take source root offline: {error}"))?;
+        self.model.root_online = false;
+        if !self.take_failure(FailureBoundary::Lifecycle) {
+            fs::rename(&offline, &self.source.root)
+                .map_err(|error| format!("restore source root: {error}"))?;
+            self.model.root_online = true;
+        } else {
+            fs::rename(&offline, &self.source.root)
+                .map_err(|error| format!("recover injected offline lifecycle failure: {error}"))?;
+            self.model.root_online = true;
+            self.model.retry_count = self.model.retry_count.saturating_add(1);
+        }
+        self.model.queue(ScanCause::Lifecycle);
+        Ok(())
+    }
+
+    pub(super) fn root_replacement(&mut self) -> Result<(), String> {
+        self.require_online()?;
+        let retired = self.source.root.with_extension(format!(
+            "state-machine-retired-{}",
+            self.retired_roots.len()
+        ));
+        fs::rename(&self.source.root, &retired)
+            .map_err(|error| format!("retire fixture source root: {error}"))?;
+        fs::create_dir_all(&self.source.root)
+            .map_err(|error| format!("create replacement source root: {error}"))?;
+        let replacement = self.source.root.join("replacement.wav");
+        fs::write(&replacement, &self.template)
+            .map_err(|error| format!("write replacement source file: {error}"))?;
+        self.retired_roots.push(retired);
+        self.model.files = filesystem_inventory(&self.source.root)?;
+        self.model.lifecycle_generation = self.model.lifecycle_generation.saturating_add(1);
+        self.source.open_db().map_err(|error| error.to_string())?;
+        if let Some(supervisor) = &self.supervisor {
+            supervisor.replace_sources(vec![self.source.clone()])?;
+            supervisor.wake_source_for_full_reconciliation(
+                self.source.id.as_str(),
+                "state_machine_root_replacement",
+            );
+        }
+        self.last_revision = 0;
+        self.model.queue(ScanCause::Lifecycle);
+        Ok(())
+    }
+
+    pub(super) fn partial_enumeration(&mut self) -> Result<(), String> {
+        self.create(7, true)?;
+        self.next_failure = Some(FailureBoundary::Hashing);
+        self.flush(ScanCause::Foreground)
+    }
+
+    pub(super) fn symlink_escape(&mut self) -> Result<(), String> {
+        self.require_online()?;
+        let link = self.source.root.join("generated/escape-link");
+        if let Some(parent) = link.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create symlink regression parent: {error}"))?;
+        }
+        if link.symlink_metadata().is_ok() {
+            fs::remove_file(&link)
+                .map_err(|error| format!("replace symlink regression fixture: {error}"))?;
+        }
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&self.escape_target, &link)
+            .map_err(|error| format!("create confined symlink escape fixture: {error}"))?;
+        self.model.queue(ScanCause::WatcherOverflow);
+        Ok(())
+    }
+}

--- a/src/test_support/source_processing_state_machine/mutations.rs
+++ b/src/test_support/source_processing_state_machine/mutations.rs
@@ -120,11 +120,19 @@ impl StateMachineHarness {
 
     pub(super) fn shutdown_restart(&mut self) -> Result<(), String> {
         if let Some(mut supervisor) = self.supervisor.take() {
+            let lifecycle_generation = supervisor
+                .lifecycle_generations()
+                .get(self.source.id.as_str())
+                .copied();
             let report = supervisor.shutdown();
             if report["joined"] != true {
                 return Err(String::from(
                     "supervisor failed to join during replayable restart",
                 ));
+            }
+            self.collect_publications_from(&supervisor)?;
+            if let Some(lifecycle_generation) = lifecycle_generation {
+                self.mark_outstanding_publications_stale(lifecycle_generation);
             }
             self.supervisor = Some(SourceProcessingSupervisor::start(vec![self.source.clone()]));
         }
@@ -139,8 +147,20 @@ impl StateMachineHarness {
             return Ok(());
         }
         self.model.source_configured = false;
+        let lifecycle_generation = self.supervisor.as_ref().and_then(|supervisor| {
+            supervisor
+                .lifecycle_generations()
+                .get(self.source.id.as_str())
+                .copied()
+        });
         if let Some(supervisor) = &self.supervisor {
             supervisor.replace_sources(Vec::new())?;
+        }
+        self.collect_actual_publications()?;
+        if let Some(lifecycle_generation) = lifecycle_generation {
+            self.mark_outstanding_publications_stale(lifecycle_generation);
+        }
+        if let Some(supervisor) = &self.supervisor {
             supervisor.replace_sources(vec![self.source.clone()])?;
         }
         self.model.source_configured = true;
@@ -193,6 +213,12 @@ impl StateMachineHarness {
         self.model.files = filesystem_inventory(&self.source.root)?;
         self.model.lifecycle_generation = self.model.lifecycle_generation.saturating_add(1);
         self.source.open_db().map_err(|error| error.to_string())?;
+        let previous_lifecycle = self.supervisor.as_ref().and_then(|supervisor| {
+            supervisor
+                .lifecycle_generations()
+                .get(self.source.id.as_str())
+                .copied()
+        });
         if let Some(supervisor) = &self.supervisor {
             supervisor.replace_sources(vec![self.source.clone()])?;
             supervisor.wake_source_for_full_reconciliation(
@@ -200,6 +226,11 @@ impl StateMachineHarness {
                 "state_machine_root_replacement",
             );
         }
+        self.collect_actual_publications()?;
+        if let Some(previous_lifecycle) = previous_lifecycle {
+            self.mark_outstanding_publications_stale(previous_lifecycle);
+        }
+        self.pending_publication_retries.clear();
         self.last_revision = 0;
         self.model.queue(ScanCause::Lifecycle);
         Ok(())

--- a/src/test_support/source_processing_state_machine/supervisor_observer.rs
+++ b/src/test_support/source_processing_state_machine/supervisor_observer.rs
@@ -1,0 +1,260 @@
+use std::collections::BTreeSet;
+
+use wavecrate_scan::CommittedSourceDelta;
+
+use super::super::{SourceProcessingSupervisor, StateMachinePublicationObservation};
+use super::{ScanCause, StateMachineHarness};
+
+const DUPLICATE_ADMISSION_COUNT: usize = 3;
+
+impl StateMachineHarness {
+    pub(super) fn admit_supervisor_delta(
+        &mut self,
+        delta: &CommittedSourceDelta,
+        cause: ScanCause,
+    ) -> Result<(), String> {
+        if delta.is_empty() || self.supervisor.is_none() {
+            return Ok(());
+        }
+        let reason = cause.publication_reason();
+        let Some(observation) = self.supervisor.as_ref().and_then(|supervisor| {
+            supervisor.request_repeated_source_delta_for_state_machine(
+                self.source.id.as_str(),
+                delta,
+                reason,
+                DUPLICATE_ADMISSION_COUNT,
+            )
+        }) else {
+            self.pending_publication_retries
+                .push((delta.clone(), cause));
+            return Ok(());
+        };
+        let delta_scope_ids = delta_scope_ids(delta);
+        let mut expected_scopes = observation.before_scope_ids.clone();
+        expected_scopes.extend(delta_scope_ids);
+        if observation.pending_scope_ids != expected_scopes {
+            return Err(format!(
+                "actual supervisor delta queue did not coalesce exact identities: expected={expected_scopes:?}, actual={:?}",
+                observation.pending_scope_ids
+            ));
+        }
+        if observation.dirty_source_slots != 1 || observation.pending_delta_slots != 1 {
+            return Err(format!(
+                "actual supervisor source queue was not bounded to one coalesced slot: dirty={} delta={}",
+                observation.dirty_source_slots, observation.pending_delta_slots
+            ));
+        }
+        if !observation
+            .pending_inputs
+            .contains(&(delta.revision, reason))
+        {
+            return Err(format!(
+                "actual supervisor queue lost revision/cause input {}:{reason}",
+                delta.revision
+            ));
+        }
+        self.actual_queue_admissions = self
+            .actual_queue_admissions
+            .saturating_add(DUPLICATE_ADMISSION_COUNT as u64);
+        self.max_actual_pending_scopes = self
+            .max_actual_pending_scopes
+            .max(observation.pending_scope_ids.len());
+        self.expected_supervisor_publications.insert((
+            observation.lifecycle_generation,
+            delta.revision,
+            cause,
+        ));
+        Ok(())
+    }
+
+    pub(super) fn admit_pending_publication_retries(&mut self) -> Result<(), String> {
+        let pending = std::mem::take(&mut self.pending_publication_retries);
+        for (delta, _original_cause) in pending {
+            self.admit_supervisor_delta(&delta, ScanCause::Retry)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn collect_actual_publications(&mut self) -> Result<(), String> {
+        let observations = self
+            .supervisor
+            .as_ref()
+            .map(take_publications)
+            .unwrap_or_default();
+        self.accept_publication_batch(observations)
+    }
+
+    pub(super) fn collect_publications_from(
+        &mut self,
+        supervisor: &SourceProcessingSupervisor,
+    ) -> Result<(), String> {
+        self.accept_publication_batch(take_publications(supervisor))
+    }
+
+    fn accept_publication_batch(
+        &mut self,
+        observations: Vec<StateMachinePublicationObservation>,
+    ) -> Result<(), String> {
+        for observation in observations {
+            self.accept_actual_publication(observation)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn retire_outstanding_publications(
+        &mut self,
+        lifecycle_generation: u64,
+    ) -> Result<(), String> {
+        self.collect_actual_publications()?;
+        self.mark_outstanding_publications_stale(lifecycle_generation);
+        Ok(())
+    }
+
+    pub(super) fn mark_outstanding_publications_stale(&mut self, lifecycle_generation: u64) {
+        self.stale_supervisor_publications.extend(
+            self.expected_supervisor_publications
+                .iter()
+                .filter(|(lifecycle, _, _)| *lifecycle == lifecycle_generation)
+                .filter(|key| !self.observed_supervisor_publications.contains(key))
+                .copied(),
+        );
+        self.pending_publication_retries.clear();
+    }
+
+    pub(super) fn assert_actual_publications(&mut self) -> Result<(), String> {
+        self.collect_actual_publications()?;
+        self.account_durable_publication();
+        if self.supervisor.is_some()
+            && self.actual_queue_admissions > 0
+            && self.observed_supervisor_publications.is_empty()
+        {
+            let readiness = super::super::liveness_tests::readiness_snapshot(&self.source)
+                .map(|snapshot| (snapshot.source_generation, snapshot.readiness_revision));
+            return Err(format!(
+                "integrated lane admitted real supervisor work without observing a durable publication: expected={:?} stale={:?} readiness={readiness:?}",
+                self.expected_supervisor_publications, self.stale_supervisor_publications
+            ));
+        }
+        let accounted = self
+            .observed_supervisor_publications
+            .union(&self.stale_supervisor_publications)
+            .copied()
+            .collect::<BTreeSet<_>>();
+        if accounted != self.expected_supervisor_publications {
+            return Err(format!(
+                "actual supervisor publications did not account for every admitted revision/cause: expected={:?}, observed={:?}, stale={:?}",
+                self.expected_supervisor_publications,
+                self.observed_supervisor_publications,
+                self.stale_supervisor_publications
+            ));
+        }
+        Ok(())
+    }
+
+    fn account_durable_publication(&mut self) {
+        let Some(supervisor) = &self.supervisor else {
+            return;
+        };
+        let Some(lifecycle_generation) = supervisor
+            .lifecycle_generations()
+            .get(self.source.id.as_str())
+            .copied()
+        else {
+            return;
+        };
+        let Some(snapshot) = super::super::liveness_tests::readiness_snapshot(&self.source) else {
+            return;
+        };
+        if snapshot.readiness_revision <= 0 || snapshot.source_generation < 0 {
+            return;
+        }
+        self.observed_supervisor_publications.extend(
+            self.expected_supervisor_publications
+                .iter()
+                .filter(|(lifecycle, revision, _)| {
+                    *lifecycle == lifecycle_generation
+                        && *revision as i64 <= snapshot.source_generation
+                })
+                .filter(|key| !self.stale_supervisor_publications.contains(key))
+                .copied(),
+        );
+    }
+
+    fn accept_actual_publication(
+        &mut self,
+        observation: StateMachinePublicationObservation,
+    ) -> Result<(), String> {
+        if observation.source_id != self.source.id.as_str() {
+            return Ok(());
+        }
+        if observation.source_generation < 0 || observation.readiness_revision <= 0 {
+            return Err(format!(
+                "actual readiness publication exposed invalid generations: source={} readiness={}",
+                observation.source_generation, observation.readiness_revision
+            ));
+        }
+        if let Some((last_source, last_readiness)) = self
+            .last_actual_output_revisions
+            .get(&observation.lifecycle_generation)
+        {
+            if observation.source_generation < *last_source
+                || observation.readiness_revision < *last_readiness
+            {
+                return Err(format!(
+                    "actual readiness publication regressed within lifecycle {}: source {}->{}, readiness {}->{}",
+                    observation.lifecycle_generation,
+                    last_source,
+                    observation.source_generation,
+                    last_readiness,
+                    observation.readiness_revision
+                ));
+            }
+        }
+        self.last_actual_output_revisions.insert(
+            observation.lifecycle_generation,
+            (
+                observation.source_generation,
+                observation.readiness_revision,
+            ),
+        );
+        for (revision, reason) in observation.inputs {
+            let cause = ScanCause::from_publication_reason(reason)
+                .ok_or_else(|| format!("unknown state-machine publication cause {reason}"))?;
+            let key = (observation.lifecycle_generation, revision, cause);
+            if !self.expected_supervisor_publications.contains(&key) {
+                return Err(format!(
+                    "supervisor processed an unadmitted revision/cause {key:?}"
+                ));
+            }
+            if !self.observed_supervisor_publications.insert(key) {
+                return Err(format!(
+                    "supervisor published revision/cause more than once: {key:?}"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn take_publications(
+    supervisor: &SourceProcessingSupervisor,
+) -> Vec<StateMachinePublicationObservation> {
+    std::mem::take(
+        &mut *supervisor
+            .shared
+            .state_machine_publications
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()),
+    )
+}
+
+fn delta_scope_ids(delta: &CommittedSourceDelta) -> BTreeSet<String> {
+    delta
+        .created
+        .iter()
+        .chain(&delta.changed)
+        .chain(&delta.deleted)
+        .map(|entry| entry.identity.clone())
+        .chain(delta.moved.iter().map(|entry| entry.identity.clone()))
+        .collect()
+}

--- a/src/test_support/source_processing_state_machine/supervisor_observer.rs
+++ b/src/test_support/source_processing_state_machine/supervisor_observer.rs
@@ -14,6 +14,7 @@ impl StateMachineHarness {
         &mut self,
         delta: &CommittedSourceDelta,
         cause: ScanCause,
+        reject_delivery_once: bool,
         reject_publication_once: bool,
     ) -> Result<(), String> {
         if delta.is_empty() || self.supervisor.is_none() {
@@ -26,6 +27,7 @@ impl StateMachineHarness {
                 delta,
                 reason,
                 DUPLICATE_ADMISSION_COUNT,
+                reject_delivery_once,
                 reject_publication_once,
             )
         }) else {
@@ -34,6 +36,20 @@ impl StateMachineHarness {
             return Ok(());
         };
         let delta_scope_ids = delta_scope_ids(delta);
+        if observation.delivery_rejected != reject_delivery_once {
+            return Err(format!(
+                "watcher delivery boundary mismatch: expected rejection={reject_delivery_once}, actual={}",
+                observation.delivery_rejected
+            ));
+        }
+        if reject_delivery_once
+            && observation.scope_ids_after_rejection != observation.before_scope_ids
+        {
+            return Err(format!(
+                "rejected watcher delivery mutated pending work: before={:?}, after={:?}",
+                observation.before_scope_ids, observation.scope_ids_after_rejection
+            ));
+        }
         let mut expected_scopes = observation.before_scope_ids.clone();
         expected_scopes.extend(delta_scope_ids);
         if observation.pending_scope_ids != expected_scopes {
@@ -81,7 +97,7 @@ impl StateMachineHarness {
     pub(super) fn admit_pending_publication_retries(&mut self) -> Result<(), String> {
         let pending = std::mem::take(&mut self.pending_publication_retries);
         for (delta, _original_cause) in pending {
-            self.admit_supervisor_delta(&delta, ScanCause::Retry, false)?;
+            self.admit_supervisor_delta(&delta, ScanCause::Retry, false, false)?;
         }
         Ok(())
     }

--- a/src/test_support/source_processing_state_machine/supervisor_observer.rs
+++ b/src/test_support/source_processing_state_machine/supervisor_observer.rs
@@ -1,14 +1,9 @@
-use std::{
-    collections::BTreeSet,
-    sync::mpsc::{Receiver, RecvTimeoutError},
-    time::{Duration, Instant},
-};
+use std::collections::BTreeSet;
 
 use wavecrate_scan::CommittedSourceDelta;
 
 use super::super::{
-    SourceProcessingEvent, SourceProcessingHealthEvent, SourceProcessingHealthState,
-    SourceProcessingSupervisor, StateMachinePublicationObservation,
+    SourceHealthPublicationOutcome, SourceProcessingSupervisor, StateMachinePublicationObservation,
 };
 use super::{ScanCause, StateMachineHarness};
 
@@ -19,6 +14,7 @@ impl StateMachineHarness {
         &mut self,
         delta: &CommittedSourceDelta,
         cause: ScanCause,
+        reject_publication_once: bool,
     ) -> Result<(), String> {
         if delta.is_empty() || self.supervisor.is_none() {
             return Ok(());
@@ -30,6 +26,7 @@ impl StateMachineHarness {
                 delta,
                 reason,
                 DUPLICATE_ADMISSION_COUNT,
+                reject_publication_once,
             )
         }) else {
             self.pending_publication_retries
@@ -71,13 +68,20 @@ impl StateMachineHarness {
             delta.revision,
             cause,
         ));
+        if reject_publication_once {
+            self.expected_rejected_supervisor_publications.insert((
+                observation.lifecycle_generation,
+                delta.revision,
+                cause,
+            ));
+        }
         Ok(())
     }
 
     pub(super) fn admit_pending_publication_retries(&mut self) -> Result<(), String> {
         let pending = std::mem::take(&mut self.pending_publication_retries);
         for (delta, _original_cause) in pending {
-            self.admit_supervisor_delta(&delta, ScanCause::Retry)?;
+            self.admit_supervisor_delta(&delta, ScanCause::Retry, false)?;
         }
         Ok(())
     }
@@ -154,38 +158,14 @@ impl StateMachineHarness {
                 self.stale_supervisor_publications
             ));
         }
-        Ok(())
-    }
-
-    pub(super) fn wait_for_supervisor_offline(&self) -> Result<(), String> {
-        let health = wait_for_health(
-            self.supervisor_events.as_ref(),
-            self.source.id.as_str(),
-            |health| health.state == SourceProcessingHealthState::Offline,
-            "offline",
-        )?;
-        if health.retry_at.is_some() {
-            return Err(String::from(
-                "offline supervisor observation unexpectedly scheduled a retry",
+        if self.rejected_supervisor_publications != self.expected_rejected_supervisor_publications {
+            return Err(format!(
+                "actual supervisor publication rejections differ from injected boundary failures: expected={:?}, actual={:?}",
+                self.expected_rejected_supervisor_publications,
+                self.rejected_supervisor_publications
             ));
         }
         Ok(())
-    }
-
-    pub(super) fn wait_for_supervisor_online_terminal(&self) -> Result<(), String> {
-        wait_for_health(
-            self.supervisor_events.as_ref(),
-            self.source.id.as_str(),
-            |health| {
-                matches!(
-                    health.state,
-                    SourceProcessingHealthState::Ready
-                        | SourceProcessingHealthState::DegradedTerminal
-                )
-            },
-            "terminal online",
-        )
-        .map(|_| ())
     }
 
     fn accept_actual_publication(
@@ -199,6 +179,37 @@ impl StateMachineHarness {
             return Err(format!(
                 "actual readiness publication exposed invalid generations: source={} readiness={}",
                 observation.source_generation, observation.readiness_revision
+            ));
+        }
+        if observation.outcome == SourceHealthPublicationOutcome::Rejected {
+            for (revision, reason) in observation.inputs {
+                let cause = ScanCause::from_publication_reason(reason)
+                    .ok_or_else(|| format!("unknown rejected publication cause {reason}"))?;
+                let key = (observation.lifecycle_generation, revision, cause);
+                if !self
+                    .expected_rejected_supervisor_publications
+                    .contains(&key)
+                {
+                    return Err(format!(
+                        "supervisor rejected an uninjected publication {key:?}"
+                    ));
+                }
+                if !self.rejected_supervisor_publications.insert(key) {
+                    return Err(format!(
+                        "supervisor rejected a publication more than once: {key:?}"
+                    ));
+                }
+            }
+            return Ok(());
+        }
+        if !matches!(
+            observation.outcome,
+            SourceHealthPublicationOutcome::Published
+                | SourceHealthPublicationOutcome::AlreadyPublished
+        ) {
+            return Err(format!(
+                "state-machine observation was recorded before a definitive output: {:?}",
+                observation.outcome
             ));
         }
         if let Some((last_source, last_readiness)) = self
@@ -241,38 +252,6 @@ impl StateMachineHarness {
             }
         }
         Ok(())
-    }
-}
-
-fn wait_for_health(
-    events: Option<&Receiver<SourceProcessingEvent>>,
-    source_id: &str,
-    predicate: impl Fn(&SourceProcessingHealthEvent) -> bool,
-    expected: &str,
-) -> Result<SourceProcessingHealthEvent, String> {
-    let events =
-        events.ok_or_else(|| String::from("integrated state-machine event receiver is missing"))?;
-    let deadline = Instant::now() + Duration::from_secs(30);
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        match events.recv_timeout(remaining) {
-            Ok(SourceProcessingEvent::Health(health))
-                if health.lifecycle.source_id == source_id && predicate(&health) =>
-            {
-                return Ok(health);
-            }
-            Ok(_) => {}
-            Err(RecvTimeoutError::Timeout) => {
-                return Err(format!(
-                    "supervisor did not publish {expected} health for {source_id}"
-                ));
-            }
-            Err(RecvTimeoutError::Disconnected) => {
-                return Err(String::from(
-                    "integrated state-machine event receiver disconnected",
-                ));
-            }
-        }
     }
 }
 

--- a/src/test_support/source_processing_state_machine/supervisor_observer.rs
+++ b/src/test_support/source_processing_state_machine/supervisor_observer.rs
@@ -1,8 +1,15 @@
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    sync::mpsc::{Receiver, RecvTimeoutError},
+    time::{Duration, Instant},
+};
 
 use wavecrate_scan::CommittedSourceDelta;
 
-use super::super::{SourceProcessingSupervisor, StateMachinePublicationObservation};
+use super::super::{
+    SourceProcessingEvent, SourceProcessingHealthEvent, SourceProcessingHealthState,
+    SourceProcessingSupervisor, StateMachinePublicationObservation,
+};
 use super::{ScanCause, StateMachineHarness};
 
 const DUPLICATE_ADMISSION_COUNT: usize = 3;
@@ -123,7 +130,6 @@ impl StateMachineHarness {
 
     pub(super) fn assert_actual_publications(&mut self) -> Result<(), String> {
         self.collect_actual_publications()?;
-        self.account_durable_publication();
         if self.supervisor.is_some()
             && self.actual_queue_admissions > 0
             && self.observed_supervisor_publications.is_empty()
@@ -151,33 +157,35 @@ impl StateMachineHarness {
         Ok(())
     }
 
-    fn account_durable_publication(&mut self) {
-        let Some(supervisor) = &self.supervisor else {
-            return;
-        };
-        let Some(lifecycle_generation) = supervisor
-            .lifecycle_generations()
-            .get(self.source.id.as_str())
-            .copied()
-        else {
-            return;
-        };
-        let Some(snapshot) = super::super::liveness_tests::readiness_snapshot(&self.source) else {
-            return;
-        };
-        if snapshot.readiness_revision <= 0 || snapshot.source_generation < 0 {
-            return;
+    pub(super) fn wait_for_supervisor_offline(&self) -> Result<(), String> {
+        let health = wait_for_health(
+            self.supervisor_events.as_ref(),
+            self.source.id.as_str(),
+            |health| health.state == SourceProcessingHealthState::Offline,
+            "offline",
+        )?;
+        if health.retry_at.is_some() {
+            return Err(String::from(
+                "offline supervisor observation unexpectedly scheduled a retry",
+            ));
         }
-        self.observed_supervisor_publications.extend(
-            self.expected_supervisor_publications
-                .iter()
-                .filter(|(lifecycle, revision, _)| {
-                    *lifecycle == lifecycle_generation
-                        && *revision as i64 <= snapshot.source_generation
-                })
-                .filter(|key| !self.stale_supervisor_publications.contains(key))
-                .copied(),
-        );
+        Ok(())
+    }
+
+    pub(super) fn wait_for_supervisor_online_terminal(&self) -> Result<(), String> {
+        wait_for_health(
+            self.supervisor_events.as_ref(),
+            self.source.id.as_str(),
+            |health| {
+                matches!(
+                    health.state,
+                    SourceProcessingHealthState::Ready
+                        | SourceProcessingHealthState::DegradedTerminal
+                )
+            },
+            "terminal online",
+        )
+        .map(|_| ())
     }
 
     fn accept_actual_publication(
@@ -233,6 +241,38 @@ impl StateMachineHarness {
             }
         }
         Ok(())
+    }
+}
+
+fn wait_for_health(
+    events: Option<&Receiver<SourceProcessingEvent>>,
+    source_id: &str,
+    predicate: impl Fn(&SourceProcessingHealthEvent) -> bool,
+    expected: &str,
+) -> Result<SourceProcessingHealthEvent, String> {
+    let events =
+        events.ok_or_else(|| String::from("integrated state-machine event receiver is missing"))?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match events.recv_timeout(remaining) {
+            Ok(SourceProcessingEvent::Health(health))
+                if health.lifecycle.source_id == source_id && predicate(&health) =>
+            {
+                return Ok(health);
+            }
+            Ok(_) => {}
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(format!(
+                    "supervisor did not publish {expected} health for {source_id}"
+                ));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(String::from(
+                    "integrated state-machine event receiver disconnected",
+                ));
+            }
+        }
     }
 }
 

--- a/src/test_support/source_processing_state_machine/supervisor_transitions.rs
+++ b/src/test_support/source_processing_state_machine/supervisor_transitions.rs
@@ -1,0 +1,135 @@
+use std::{
+    sync::mpsc::{Receiver, RecvTimeoutError},
+    time::{Duration, Instant},
+};
+
+use super::super::{
+    SourceProcessingEvent, SourceProcessingHealthEvent, SourceProcessingHealthState,
+};
+use super::StateMachineHarness;
+
+const MAX_TRANSITION_EVENTS: usize = 4_096;
+const TRANSITION_DIAGNOSTIC_TIMEOUT: Duration = Duration::from_secs(30);
+
+impl StateMachineHarness {
+    pub(super) fn wait_for_supervisor_offline(&self) -> Result<(), String> {
+        let health = wait_for_health(
+            self.supervisor_events.as_ref(),
+            self.source.id.as_str(),
+            |health| health.state == SourceProcessingHealthState::Offline,
+            "offline",
+        )?;
+        if health.retry_at.is_some() {
+            return Err(String::from(
+                "offline supervisor observation unexpectedly scheduled a retry",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn wait_for_supervisor_online_terminal(&self) -> Result<(), String> {
+        wait_for_health(
+            self.supervisor_events.as_ref(),
+            self.source.id.as_str(),
+            |health| {
+                matches!(
+                    health.state,
+                    SourceProcessingHealthState::Ready
+                        | SourceProcessingHealthState::DegradedTerminal
+                )
+            },
+            "terminal online",
+        )
+        .map(|_| ())
+    }
+
+    pub(super) fn wait_for_supervisor_convergence(&self) -> Result<(), String> {
+        let supervisor = self
+            .supervisor
+            .as_ref()
+            .ok_or_else(|| String::from("integrated state-machine supervisor is missing"))?;
+        let events = self
+            .supervisor_events
+            .as_ref()
+            .ok_or_else(|| String::from("integrated state-machine event receiver is missing"))?;
+        let deadline = Instant::now() + TRANSITION_DIAGNOSTIC_TIMEOUT;
+        for observed_events in 0..=MAX_TRANSITION_EVENTS {
+            let runtime = super::super::liveness_tests::runtime_observation(
+                supervisor,
+                self.source.id.as_str(),
+            );
+            if let Some(snapshot) = super::super::liveness_tests::readiness_snapshot(&self.source) {
+                if runtime.source_active
+                    && super::super::liveness_tests::silently_idle(&snapshot, &runtime)
+                {
+                    return Err(format!(
+                        "runtime became silently idle with actionable work after {observed_events} state transitions: {runtime:?}"
+                    ));
+                }
+                if snapshot.is_converged()
+                    && runtime.queue_depth == 0
+                    && runtime.readiness_queue_depth == 0
+                    && runtime.in_flight == 0
+                    && !runtime.source_dirty
+                {
+                    return Ok(());
+                }
+            }
+            if observed_events == MAX_TRANSITION_EVENTS {
+                return Err(format!(
+                    "runtime exceeded {MAX_TRANSITION_EVENTS} state transitions without convergence: {runtime:?}"
+                ));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match events.recv_timeout(remaining) {
+                Ok(_) => {}
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(format!(
+                        "runtime produced no convergence transition before the diagnostic timeout: {runtime:?}"
+                    ));
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(String::from(
+                        "integrated state-machine event receiver disconnected",
+                    ));
+                }
+            }
+        }
+        unreachable!("bounded transition loop returns on its final iteration")
+    }
+}
+
+fn wait_for_health(
+    events: Option<&Receiver<SourceProcessingEvent>>,
+    source_id: &str,
+    predicate: impl Fn(&SourceProcessingHealthEvent) -> bool,
+    expected: &str,
+) -> Result<SourceProcessingHealthEvent, String> {
+    let events =
+        events.ok_or_else(|| String::from("integrated state-machine event receiver is missing"))?;
+    let deadline = Instant::now() + TRANSITION_DIAGNOSTIC_TIMEOUT;
+    for observed_events in 0..MAX_TRANSITION_EVENTS {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match events.recv_timeout(remaining) {
+            Ok(SourceProcessingEvent::Health(health))
+                if health.lifecycle.source_id == source_id && predicate(&health) =>
+            {
+                return Ok(health);
+            }
+            Ok(_) => {}
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(format!(
+                    "supervisor did not publish {expected} health for {source_id} after {observed_events} transitions"
+                ));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(String::from(
+                    "integrated state-machine event receiver disconnected",
+                ));
+            }
+        }
+    }
+    Err(format!(
+        "supervisor exceeded {MAX_TRANSITION_EVENTS} transitions before publishing {expected} health for {source_id}"
+    ))
+}


### PR DESCRIPTION
## Goal

Add deterministic, seeded, replayable state-machine coverage for high-risk source-scanning event orderings so ordering regressions can be reproduced and minimized without live libraries or nondeterministic sleeps.

Linear: [OPT-1248](https://linear.app/boostnlvp/issue/OPT-1248)

## Scope

- Add a reference-model state-machine harness over the versioned `small-multi-source` native fixture and real `wavecrate-scan` scanner.
- Generate filesystem mutations, watcher batches/overflow, focus and foreground requests, cancellation, restart, remove/re-add, root offline/online/replacement, and injected transaction/publication/watcher/hash/lifecycle failures.
- Check exact committed manifests and the production browser-search projection, lifecycle-scoped monotonic revisions, definitive supervisor publication outcomes, actual bounded queue coalescing, and controlled-quiescence liveness.
- Emit schema-versioned JSON replay artifacts with deterministic greedy shrinking that preserves lifecycle transitions and the original scanner-only/integrated execution mode.
- Retain six regression seeds in the bounded normal lane, plus explicit integrated-supervisor, 1,000-sequence stress, and artifact/seed replay commands.
- Expose narrow test-support controls and observations at the real transaction, watcher-delivery, lifecycle-replacement, and publication boundaries without changing production policy.

## Non-goals

- No live-library, wall-clock soak, or GUI automation dependency.
- No release or persistence schema changes.
- No broad source-processing cleanup outside the testability and rejected-publication retention required by this issue.

## Definition of Done

- [x] Seeded event sequences exercise the requested mutation, lifecycle, cancellation, retry, and restart orderings.
- [x] Every observable commit is checked against the reference filesystem model and production browser-search projection.
- [x] Real supervisor queue and definitive publication/fallback outcomes are compared with independent revision/cause expectations.
- [x] Transaction, watcher-delivery, lifecycle-replacement, and publication failures are observed at their production boundaries and converge through deterministic retry.
- [x] Rejected delivery/publication leaves exact pending work unchanged until successful retry.
- [x] Failures are minimized and saved as replay artifacts that preserve execution mode and validate fixture identity.
- [x] Six regression classes remain in normal CI and a 1,000-sequence stress command is documented.
- [x] Real scanner and explicit integrated supervisor lanes are both validated without sleep-based synchronization.

## Review fixes

- Preserve scanner-only versus integrated execution mode in replay schema v2; reject fixture name/version/seed drift.
- Replace enum-cardinality queue bookkeeping with repeated admission through the production supervisor coalescing helper and exact real pending-work observations.
- Record publication evidence only after the definitive health-publication boundary returns `Published` or exact `AlreadyPublished` fallback; never infer output from aggregate readiness.
- Deterministically inject `Rejected` at that boundary, retain the exact pending delta, and require one rejection followed by one accepted output.
- Drive integrated convergence from explicit supervisor events with a 4,096-transition bound; retain a timeout only as a deadlock diagnostic guard. The lane contains no sleep calls.
- Run the production browser-search worker projection against the independent reference model instead of rereading the manifest.
- Hold root-offline mutations unavailable until the real supervisor emits `Offline`, then restore and wait for terminal online health through the event channel.
- Produce transaction failure through real SQLite `BEGIN IMMEDIATE` contention at the scanner write-batch boundary and require the exact `Busy` outcome before retry.
- Reject watcher delivery inside the production delta-admission helper, prove pending scopes are unchanged, then admit the same delta and converge.
- Reject source removal after entering the serialized `replace_sources` boundary, prove the lifecycle generation is unchanged, then retry remove/re-add and converge.

## Validation

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo check -p wavecrate --lib` — passed
- `cargo check -p wavecrate-library --no-default-features` — passed
- `cargo test -p wavecrate --lib health_publication_is_lifecycle_fenced_and_coalesced -- --test-threads=1` — passed, including deterministic rejection followed by accepted replay
- `cargo test -p wavecrate-scan` — 123 passed
- `cargo test -p wavecrate --lib state_machine_tests::artifacts::tests:: -- --test-threads=1` — 2 passed
- `cargo test -p wavecrate --lib source_processing_seeded_state_machine_normal_ci -- --nocapture` — passed, six retained seeds
- `cargo test -p wavecrate --lib source_processing_seeded_state_machine_integrated_supervisor -- --ignored --nocapture` — passed in 156.35s, including dedicated transaction, watcher-delivery, publication, and lifecycle rejection/retry replays
- `cargo test -p wavecrate --lib source_processing_seeded_state_machine_stress_1000 -- --ignored --nocapture` — passed, 1,000/1,000 sequences in 164.55s with production browser projection checks
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests -- --nocapture` — 94 passed, 1 ignored, with only the existing `unavailable_hash_path_backs_off_without_starving_later_files` baseline failure
- `bash scripts/ci.sh agent` — all compilation/architecture/integration gates passed; the parallel lib lane reported 3943 passed, the same known 49-failure set as the untouched `origin/main` baseline, and 27 ignored
- State-machine/supervisor changed-file size budget — passed; all remain at or below 400 lines
- Sleep audit — no `thread::sleep` calls remain in the state-machine lane

## Known limitations

- The integrated real-supervisor lane is explicit/ignored because it exercises real background execution and is intentionally separate from the bounded default CI lane.
- The repository-wide parallel test gate is not green on `main`, as documented above. No branch-only failure was found.

User approval is required before merge.
