### PR TITLE
OPT-1249: Bound pending rename retention and reconciliation cost

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use open::open_source_database;
 pub use open::{test_reset_source_db_open_total_count, test_source_db_open_total_count};
 pub use open_profiles::SourceDatabaseConnectionRole;
 /// Metadata retained for a pruned row so later scans can recover rename state.
-pub use pending_renames::PendingRenameEntry;
+pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingRenamePruneReport};
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
     BrowserFileMetadata, BrowserMetadataSnapshot, Rating, SampleCollection, SampleSoundType,

--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -433,19 +433,6 @@ impl<'conn> SourceWriteBatch<'conn> {
         self.find_unique_pending_rename(TAKE_PENDING_RENAME_BY_HASH_SQL, params![hash])
     }
 
-    /// Return whether at least one retained source candidate has this content hash.
-    pub fn has_pending_rename_with_hash(&self, hash: &str) -> Result<bool, SourceDbError> {
-        self.tx
-            .query_row(
-                "SELECT EXISTS(
-                    SELECT 1 FROM pending_wav_renames WHERE content_hash = ?1 LIMIT 1
-                 )",
-                params![hash],
-                |row| row.get::<_, bool>(0),
-            )
-            .map_err(map_sql_error)
-    }
-
     /// Claim one unique retained rename candidate by stable filesystem identity.
     pub fn take_pending_rename_by_file_identity(
         &mut self,

--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{OptionalExtension, params};
 
@@ -9,18 +10,27 @@ use super::{
 };
 
 const DELETE_PENDING_RENAME_SQL: &str = "DELETE FROM pending_wav_renames WHERE path = ?1";
+const PENDING_RENAME_AUTHORITATIVE_GENERATION_KEY: &str =
+    "pending_rename_authoritative_generation_v1";
+const PENDING_RENAME_RETENTION_GENERATIONS: u64 = 2;
+const MAX_PENDING_RENAME_GENERATION: u64 = i64::MAX as u64;
 const TAKE_PENDING_RENAME_BY_HASH_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity, staged_generation, staged_at
      FROM pending_wav_renames
      WHERE content_hash = ?1
      LIMIT 2";
 const TAKE_PENDING_RENAME_BY_FILE_IDENTITY_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity, staged_generation, staged_at
      FROM pending_wav_renames
      WHERE file_identity = ?1 AND file_size = ?2 AND modified_ns = ?3
      LIMIT 2";
+const FIND_PENDING_RENAME_BY_FILE_IDENTITY_SQL: &str =
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity, staged_generation, staged_at
+     FROM pending_wav_renames
+     WHERE file_identity = ?1
+     LIMIT 2";
 const TAKE_PENDING_RENAME_BY_FACTS_SQL: &str =
-    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
+    "SELECT path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity, staged_generation, staged_at
      FROM pending_wav_renames
      WHERE file_size = ?1 AND modified_ns = ?2
      LIMIT 2";
@@ -39,8 +49,36 @@ pub struct PendingRenameEntry {
     pub content_hash: Option<String>,
     /// Stable filesystem-object identity captured before pruning, when supported.
     pub file_identity: Option<String>,
+    /// Completed authoritative generation this candidate was staged against.
+    pub staged_generation: u64,
+    /// Wall-clock staging time used only for diagnostics, never pruning eligibility.
+    pub staged_at: Option<i64>,
     /// Complete user metadata restored when the rename is reconciled.
     pub metadata: RenameMetadataSnapshot,
+}
+
+/// Bounded aggregate diagnostics for retained rename metadata.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PendingRenameDiagnostics {
+    /// Number of retained source candidates.
+    pub candidate_count: usize,
+    /// Latest successfully completed authoritative source enumeration.
+    pub authoritative_generation: u64,
+    /// Oldest candidate generation, when any candidates remain.
+    pub oldest_staged_generation: Option<u64>,
+    /// Oldest diagnostic staging timestamp, when recorded.
+    pub oldest_staged_at: Option<i64>,
+    /// Non-negative diagnostic age of the oldest timestamp at observation time.
+    pub oldest_candidate_age_seconds: Option<u64>,
+}
+
+/// Result of atomically completing one authoritative retention generation.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PendingRenamePruneReport {
+    /// Candidates removed by this completion.
+    pub candidates_pruned: usize,
+    /// Aggregate population after pruning.
+    pub diagnostics: PendingRenameDiagnostics,
 }
 
 impl SourceDatabase {
@@ -59,30 +97,76 @@ impl SourceDatabase {
                     );
                     return Ok(None);
                 };
-                let file_size: i64 = row.get(1)?;
-                let file_size = u64::try_from(file_size).map_err(|_| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        1,
-                        rusqlite::types::Type::Integer,
-                        Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "pending rename file_size out of range",
-                        )),
-                    )
-                })?;
-                Ok(Some(PendingRenameEntry {
-                    relative_path,
-                    file_size,
-                    modified_ns: row.get(2)?,
-                    content_hash: row.get(3)?,
-                    file_identity: row.get(15)?,
-                    metadata: metadata_from_row(row)?,
-                }))
+                pending_rename_from_row(row, relative_path).map(Some)
             })
             .map_err(map_sql_error)?
             .collect::<Result<Vec<_>, _>>()
             .map_err(map_sql_error)?;
         Ok(rows.into_iter().flatten().collect())
+    }
+
+    /// Return whether any pending source candidate exists without loading candidate rows.
+    pub fn has_pending_renames(&self) -> Result<bool, SourceDbError> {
+        if super::schema::table_columns(&self.connection, "pending_wav_renames")?.is_empty() {
+            return Ok(false);
+        }
+        self.connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM pending_wav_renames LIMIT 1)",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(map_sql_error)
+    }
+
+    /// Read aggregate lifecycle diagnostics without materializing candidate rows.
+    pub fn pending_rename_diagnostics(&self) -> Result<PendingRenameDiagnostics, SourceDbError> {
+        let columns = super::schema::table_columns(&self.connection, "pending_wav_renames")?;
+        if columns.is_empty() {
+            return Ok(PendingRenameDiagnostics::default());
+        }
+        let staged_generation = if columns.contains("staged_generation") {
+            "MIN(staged_generation)"
+        } else {
+            "CASE WHEN COUNT(*) = 0 THEN NULL ELSE 0 END"
+        };
+        let staged_at = if columns.contains("staged_at") {
+            "MIN(staged_at)"
+        } else {
+            "NULL"
+        };
+        let (count, oldest_generation, oldest_staged_at) = self
+            .connection
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*), {staged_generation}, {staged_at}
+                     FROM pending_wav_renames"
+                ),
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Option<i64>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .map_err(map_sql_error)?;
+        let authoritative_generation =
+            if super::schema::table_columns(&self.connection, "metadata")?.is_empty() {
+                0
+            } else {
+                self.get_metadata(PENDING_RENAME_AUTHORITATIVE_GENERATION_KEY)?
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .unwrap_or(0)
+            };
+        Ok(PendingRenameDiagnostics {
+            candidate_count: usize::try_from(count).unwrap_or(usize::MAX),
+            authoritative_generation,
+            oldest_staged_generation: oldest_generation.and_then(|value| value.try_into().ok()),
+            oldest_staged_at,
+            oldest_candidate_age_seconds: pending_rename_age_seconds(oldest_staged_at),
+        })
     }
 }
 
@@ -108,8 +192,10 @@ fn pending_rename_list_query(
     let collections = optional_column("collections", "NULL AS collections");
     let tag_named = optional_column("tag_named", "0 AS tag_named");
     let file_identity = optional_column("file_identity", "NULL AS file_identity");
+    let staged_generation = optional_column("staged_generation", "0 AS staged_generation");
+    let staged_at = optional_column("staged_at", "NULL AS staged_at");
     Ok(Some(format!(
-        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type}, locked, last_played_at, {last_curated_at}, {user_tag}, {normal_tags}, {collection}, {collections}, {tag_named}, {file_identity}
+        "SELECT path, file_size, modified_ns, content_hash, tag, looped, {sound_type}, locked, last_played_at, {last_curated_at}, {user_tag}, {normal_tags}, {collection}, {collections}, {tag_named}, {file_identity}, {staged_generation}, {staged_at}
          FROM pending_wav_renames
          ORDER BY path ASC"
     )))
@@ -122,6 +208,12 @@ impl<'conn> SourceWriteBatch<'conn> {
     /// quick scan can reconcile path changes without losing user metadata.
     pub fn stage_pending_rename(&mut self, entry: &WavEntry) -> Result<(), SourceDbError> {
         let path = normalize_relative_path(&entry.relative_path)?;
+        let staged_generation = self.pending_rename_staging_generation()?;
+        let staged_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .min(i64::MAX as u64) as i64;
         let metadata = self.snapshot_rename_metadata(&entry.relative_path)?;
         let normal_tags = encode_normal_tags(&metadata.normal_tags)?;
         let collections = encode_collections(&metadata.collections)?;
@@ -139,8 +231,8 @@ impl<'conn> SourceWriteBatch<'conn> {
         self.tx
             .prepare_cached(
                 "INSERT INTO pending_wav_renames (
-                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+                     path, file_size, modified_ns, content_hash, tag, looped, sound_type, locked, last_played_at, last_curated_at, user_tag, normal_tags, collection, collections, tag_named, file_identity, staged_generation, staged_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
                  ON CONFLICT(path) DO UPDATE SET
                      file_size = excluded.file_size,
                      modified_ns = excluded.modified_ns,
@@ -156,7 +248,9 @@ impl<'conn> SourceWriteBatch<'conn> {
                      collection = excluded.collection,
                      collections = excluded.collections,
                      tag_named = excluded.tag_named,
-                     file_identity = excluded.file_identity",
+                     file_identity = excluded.file_identity,
+                     staged_generation = excluded.staged_generation,
+                     staged_at = excluded.staged_at",
             )
             .map_err(map_sql_error)?
             .execute(params![
@@ -176,9 +270,110 @@ impl<'conn> SourceWriteBatch<'conn> {
                 collections.as_deref(),
                 metadata.tag_named as i64,
                 file_identity,
+                staged_generation as i64,
+                staged_at,
             ])
             .map_err(map_sql_error)?;
         Ok(())
+    }
+
+    fn pending_rename_staging_generation(&self) -> Result<u64, SourceDbError> {
+        self.read_pending_rename_authoritative_generation()
+            .map(next_pending_rename_generation)
+    }
+
+    fn read_pending_rename_authoritative_generation(&self) -> Result<u64, SourceDbError> {
+        self.tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![PENDING_RENAME_AUTHORITATIVE_GENERATION_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)
+            .map(|value| value.and_then(|value| value.parse().ok()).unwrap_or(0))
+    }
+
+    /// Atomically advance authoritative retention state and prune safely expired candidates.
+    ///
+    /// Quick scans keep candidates through two later complete full-source enumerations. A hard
+    /// scan may additionally drop unmatched candidates immediately because it has enumerated the
+    /// complete source and already attempted current-destination reconciliation. Any unresolved
+    /// destination defers quick-scan pruning so a crash between enumeration and deferred hashing
+    /// cannot discard the only copy of user metadata.
+    pub fn complete_pending_rename_authoritative_scan(
+        &mut self,
+        hard_scan: bool,
+    ) -> Result<PendingRenamePruneReport, SourceDbError> {
+        let generation =
+            next_pending_rename_generation(self.read_pending_rename_authoritative_generation()?);
+        let pruned = if hard_scan {
+            self.tx
+                .execute(
+                    "DELETE FROM pending_wav_renames AS pending
+                     WHERE pending.content_hash IS NULL
+                        OR NOT EXISTS (
+                            SELECT 1
+                            FROM pending_wav_rename_destinations AS destination
+                            WHERE destination.retained_hash = pending.content_hash
+                        )",
+                    [],
+                )
+                .map_err(map_sql_error)?
+        } else {
+            let oldest_retained = generation.saturating_sub(PENDING_RENAME_RETENTION_GENERATIONS);
+            self.tx
+                .execute(
+                    "DELETE FROM pending_wav_renames AS pending
+                     WHERE ?2 > ?3
+                       AND pending.staged_generation <= ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM pending_wav_rename_destinations AS destination
+                           WHERE destination.retained_hash = pending.content_hash
+                       )
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM pending_wav_rename_destinations AS active
+                           WHERE active.retained_hash IS NULL
+                       )",
+                    params![
+                        oldest_retained as i64,
+                        generation as i64,
+                        PENDING_RENAME_RETENTION_GENERATIONS as i64,
+                    ],
+                )
+                .map_err(map_sql_error)?
+        };
+        self.set_metadata(
+            PENDING_RENAME_AUTHORITATIVE_GENERATION_KEY,
+            &generation.to_string(),
+        )?;
+        let (count, oldest_generation, oldest_staged_at) = self
+            .tx
+            .query_row(
+                "SELECT COUNT(*), MIN(staged_generation), MIN(staged_at)
+                 FROM pending_wav_renames",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Option<i64>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                },
+            )
+            .map_err(map_sql_error)?;
+        Ok(PendingRenamePruneReport {
+            candidates_pruned: pruned,
+            diagnostics: PendingRenameDiagnostics {
+                candidate_count: usize::try_from(count).unwrap_or(usize::MAX),
+                authoritative_generation: generation,
+                oldest_staged_generation: oldest_generation.and_then(|value| value.try_into().ok()),
+                oldest_staged_at,
+                oldest_candidate_age_seconds: pending_rename_age_seconds(oldest_staged_at),
+            },
+        })
     }
 
     /// Remove one retained rename candidate by its original relative path.
@@ -216,7 +411,32 @@ impl<'conn> SourceWriteBatch<'conn> {
         &mut self,
         hash: &str,
     ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
-        self.take_unique_pending_rename(TAKE_PENDING_RENAME_BY_HASH_SQL, params![hash])
+        let entry = self.unique_pending_rename_by_hash(hash)?;
+        if let Some(entry) = entry.as_ref() {
+            self.clear_pending_rename(&entry.relative_path)?;
+        }
+        Ok(entry)
+    }
+
+    /// Find one globally unique retained candidate by content hash without consuming it.
+    pub fn unique_pending_rename_by_hash(
+        &mut self,
+        hash: &str,
+    ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
+        self.find_unique_pending_rename(TAKE_PENDING_RENAME_BY_HASH_SQL, params![hash])
+    }
+
+    /// Return whether at least one retained source candidate has this content hash.
+    pub fn has_pending_rename_with_hash(&self, hash: &str) -> Result<bool, SourceDbError> {
+        self.tx
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM pending_wav_renames WHERE content_hash = ?1 LIMIT 1
+                 )",
+                params![hash],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(map_sql_error)
     }
 
     /// Claim one unique retained rename candidate by stable filesystem identity.
@@ -226,9 +446,35 @@ impl<'conn> SourceWriteBatch<'conn> {
         file_size: u64,
         modified_ns: i64,
     ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
-        self.take_unique_pending_rename(
+        let entry =
+            self.unique_pending_rename_by_file_identity(file_identity, file_size, modified_ns)?;
+        if let Some(entry) = entry.as_ref() {
+            self.clear_pending_rename(&entry.relative_path)?;
+        }
+        Ok(entry)
+    }
+
+    /// Find one unique retained candidate by stable filesystem identity without consuming it.
+    pub fn unique_pending_rename_by_file_identity(
+        &mut self,
+        file_identity: &str,
+        file_size: u64,
+        modified_ns: i64,
+    ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
+        self.find_unique_pending_rename(
             TAKE_PENDING_RENAME_BY_FILE_IDENTITY_SQL,
             params![file_identity, file_size as i64, modified_ns],
+        )
+    }
+
+    /// Find one globally unique candidate by stable filesystem identity without consuming it.
+    pub fn unique_pending_rename_by_file_identity_only(
+        &mut self,
+        file_identity: &str,
+    ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
+        self.find_unique_pending_rename(
+            FIND_PENDING_RENAME_BY_FILE_IDENTITY_SQL,
+            params![file_identity],
         )
     }
 
@@ -238,13 +484,17 @@ impl<'conn> SourceWriteBatch<'conn> {
         file_size: u64,
         modified_ns: i64,
     ) -> Result<Option<PendingRenameEntry>, SourceDbError> {
-        self.take_unique_pending_rename(
+        let entry = self.find_unique_pending_rename(
             TAKE_PENDING_RENAME_BY_FACTS_SQL,
             params![file_size as i64, modified_ns],
-        )
+        )?;
+        if let Some(entry) = entry.as_ref() {
+            self.clear_pending_rename(&entry.relative_path)?;
+        }
+        Ok(entry)
     }
 
-    fn take_unique_pending_rename(
+    fn find_unique_pending_rename(
         &mut self,
         sql: &str,
         params: impl rusqlite::Params,
@@ -260,25 +510,7 @@ impl<'conn> SourceWriteBatch<'conn> {
                         Box::new(err),
                     )
                 })?;
-                let file_size: i64 = row.get(1)?;
-                let file_size = u64::try_from(file_size).map_err(|_| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        1,
-                        rusqlite::types::Type::Integer,
-                        Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "pending rename file_size out of range",
-                        )),
-                    )
-                })?;
-                Ok(PendingRenameEntry {
-                    relative_path,
-                    file_size,
-                    modified_ns: row.get(2)?,
-                    content_hash: row.get(3)?,
-                    file_identity: row.get(15)?,
-                    metadata: metadata_from_row(row)?,
-                })
+                pending_rename_from_row(row, relative_path)
             })
             .map_err(map_sql_error)?
             .collect::<Result<Vec<_>, _>>()
@@ -287,10 +519,60 @@ impl<'conn> SourceWriteBatch<'conn> {
         if rows.len() != 1 {
             return Ok(None);
         }
-        let entry = rows.into_iter().next().expect("exactly one pending rename");
-        self.clear_pending_rename(&entry.relative_path)?;
-        Ok(Some(entry))
+        Ok(rows.into_iter().next())
     }
+}
+
+fn pending_rename_from_row(
+    row: &rusqlite::Row<'_>,
+    relative_path: PathBuf,
+) -> rusqlite::Result<PendingRenameEntry> {
+    let file_size: i64 = row.get(1)?;
+    let file_size = u64::try_from(file_size).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            1,
+            rusqlite::types::Type::Integer,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "pending rename file_size out of range",
+            )),
+        )
+    })?;
+    let staged_generation = row.get::<_, i64>(16)?;
+    let staged_generation = u64::try_from(staged_generation).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            16,
+            rusqlite::types::Type::Integer,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "pending rename staged_generation out of range",
+            )),
+        )
+    })?;
+    Ok(PendingRenameEntry {
+        relative_path,
+        file_size,
+        modified_ns: row.get(2)?,
+        content_hash: row.get(3)?,
+        file_identity: row.get(15)?,
+        staged_generation,
+        staged_at: row.get(17)?,
+        metadata: metadata_from_row(row)?,
+    })
+}
+
+fn next_pending_rename_generation(current: u64) -> u64 {
+    current.saturating_add(1).min(MAX_PENDING_RENAME_GENERATION)
+}
+
+fn pending_rename_age_seconds(staged_at: Option<i64>) -> Option<u64> {
+    let staged_at = staged_at?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .min(i64::MAX as u64) as i64;
+    Some(now.saturating_sub(staged_at).max(0) as u64)
 }
 
 fn metadata_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RenameMetadataSnapshot> {
@@ -354,4 +636,137 @@ fn decode_collections(
     collections.sort_by_key(|collection| collection.index());
     collections.dedup();
     collections
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn pending_reconciliation_lookups_use_bounded_indices() {
+        let directory = tempdir().unwrap();
+        let database =
+            SourceDatabase::open_for_test_fixture_source_write(directory.path()).unwrap();
+        for (sql, parameters, expected_index) in [
+            (
+                TAKE_PENDING_RENAME_BY_HASH_SQL,
+                vec![rusqlite::types::Value::Text(String::from("hash"))],
+                "idx_pending_wav_renames_hash",
+            ),
+            (
+                TAKE_PENDING_RENAME_BY_FILE_IDENTITY_SQL,
+                vec![
+                    rusqlite::types::Value::Text(String::from("unix:1:2:3")),
+                    rusqlite::types::Value::Integer(1),
+                    rusqlite::types::Value::Integer(2),
+                ],
+                "idx_pending_wav_renames_identity_facts",
+            ),
+            (
+                TAKE_PENDING_RENAME_BY_FACTS_SQL,
+                vec![
+                    rusqlite::types::Value::Integer(1),
+                    rusqlite::types::Value::Integer(2),
+                ],
+                "idx_pending_wav_renames_facts",
+            ),
+        ] {
+            let mut statement = database
+                .connection
+                .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+                .unwrap();
+            let details = statement
+                .query_map(rusqlite::params_from_iter(parameters), |row| {
+                    row.get::<_, String>(3)
+                })
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n");
+            assert!(
+                details.contains(expected_index),
+                "expected {expected_index} in query plan:\n{details}"
+            );
+            assert!(!details.contains("SCAN pending_wav_renames"));
+        }
+    }
+
+    #[test]
+    fn unresolved_destination_defers_generation_pruning() {
+        let directory = tempdir().unwrap();
+        std::fs::write(directory.path().join("old.wav"), b"same").unwrap();
+        let database =
+            SourceDatabase::open_for_test_fixture_source_write(directory.path()).unwrap();
+        let mut batch = database.write_batch().unwrap();
+        batch
+            .upsert_file_with_hash(Path::new("old.wav"), 4, 1, "same-hash")
+            .unwrap();
+        batch.commit().unwrap();
+        let entry = database
+            .entry_for_path(Path::new("old.wav"))
+            .unwrap()
+            .unwrap();
+        let mut batch = database.write_batch().unwrap();
+        batch.stage_pending_rename(&entry).unwrap();
+        batch.remove_file(Path::new("old.wav")).unwrap();
+        batch
+            .stage_pending_rename_destination(Path::new("new.wav"), 1)
+            .unwrap();
+        batch.commit().unwrap();
+
+        for _ in 0..4 {
+            let mut batch = database.write_batch().unwrap();
+            let report = batch
+                .complete_pending_rename_authoritative_scan(false)
+                .unwrap();
+            assert_eq!(report.candidates_pruned, 0);
+            batch.commit().unwrap();
+        }
+        assert_eq!(
+            database
+                .pending_rename_diagnostics()
+                .unwrap()
+                .candidate_count,
+            1
+        );
+    }
+
+    #[test]
+    fn interrupted_pruning_rolls_back_candidate_and_generation() {
+        let directory = tempdir().unwrap();
+        let database =
+            SourceDatabase::open_for_test_fixture_source_write(directory.path()).unwrap();
+        let mut batch = database.write_batch().unwrap();
+        batch
+            .upsert_file_with_hash(Path::new("old.wav"), 4, 1, "same-hash")
+            .unwrap();
+        batch.commit().unwrap();
+        let entry = database
+            .entry_for_path(Path::new("old.wav"))
+            .unwrap()
+            .unwrap();
+        let mut batch = database.write_batch().unwrap();
+        batch.stage_pending_rename(&entry).unwrap();
+        batch.remove_file(Path::new("old.wav")).unwrap();
+        batch.commit().unwrap();
+
+        for _ in 0..2 {
+            let mut batch = database.write_batch().unwrap();
+            batch
+                .complete_pending_rename_authoritative_scan(false)
+                .unwrap();
+            batch.commit_auxiliary_state().unwrap();
+        }
+        let mut interrupted = database.write_batch().unwrap();
+        let report = interrupted
+            .complete_pending_rename_authoritative_scan(false)
+            .unwrap();
+        assert_eq!(report.candidates_pruned, 1);
+        drop(interrupted);
+
+        let diagnostics = database.pending_rename_diagnostics().unwrap();
+        assert_eq!(diagnostics.authoritative_generation, 2);
+        assert_eq!(diagnostics.candidate_count, 1);
+    }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/pending_renames.rs
@@ -311,12 +311,19 @@ impl<'conn> SourceWriteBatch<'conn> {
             self.tx
                 .execute(
                     "DELETE FROM pending_wav_renames AS pending
-                     WHERE pending.content_hash IS NULL
-                        OR NOT EXISTS (
-                            SELECT 1
-                            FROM pending_wav_rename_destinations AS destination
-                            WHERE destination.retained_hash = pending.content_hash
-                        )",
+                     WHERE (
+                         pending.content_hash IS NULL
+                         OR NOT EXISTS (
+                             SELECT 1
+                             FROM pending_wav_rename_destinations AS destination
+                             WHERE destination.retained_hash = pending.content_hash
+                         )
+                     )
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM pending_wav_rename_destinations AS active
+                           WHERE active.retained_hash IS NULL
+                       )",
                     [],
                 )
                 .map_err(map_sql_error)?
@@ -693,7 +700,7 @@ mod tests {
     }
 
     #[test]
-    fn unresolved_destination_defers_generation_pruning() {
+    fn unresolved_destination_defers_quick_and_hard_pruning() {
         let directory = tempdir().unwrap();
         std::fs::write(directory.path().join("old.wav"), b"same").unwrap();
         let database =
@@ -729,6 +736,21 @@ mod tests {
                 .unwrap()
                 .candidate_count,
             1
+        );
+
+        let mut batch = database.write_batch().unwrap();
+        let report = batch
+            .complete_pending_rename_authoritative_scan(true)
+            .unwrap();
+        assert_eq!(report.candidates_pruned, 0);
+        batch.commit_auxiliary_state().unwrap();
+        assert_eq!(
+            database
+                .pending_rename_diagnostics()
+                .unwrap()
+                .candidate_count,
+            1,
+            "hard completion must retain metadata while a destination hash is unresolved"
         );
     }
 

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -404,6 +404,8 @@ fn legacy_read_only_pending_renames_project_optional_defaults() {
     assert_eq!(entry.modified_ns, 5);
     assert_eq!(entry.content_hash.as_deref(), Some("hash-a"));
     assert_eq!(entry.file_identity, None);
+    assert_eq!(entry.staged_generation, 0);
+    assert_eq!(entry.staged_at, None);
     assert_eq!(entry.metadata.tag, Rating::KEEP_1);
     assert!(entry.metadata.looped);
     assert!(entry.metadata.locked);
@@ -417,6 +419,16 @@ fn legacy_read_only_pending_renames_project_optional_defaults() {
         vec![SampleCollection::new(2).unwrap()]
     );
     assert!(!entry.metadata.tag_named);
+    assert_eq!(
+        db.pending_rename_diagnostics().unwrap(),
+        super::super::PendingRenameDiagnostics {
+            candidate_count: 1,
+            authoritative_generation: 0,
+            oldest_staged_generation: Some(0),
+            oldest_staged_at: None,
+            oldest_candidate_age_seconds: None,
+        }
+    );
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -176,31 +176,6 @@ impl SourceWriteBatch<'_> {
         Ok(())
     }
 
-    /// Resolve transient destinations whose authoritative manifest hash is now available.
-    pub fn resolve_hashed_pending_rename_destinations(&mut self) -> Result<(), SourceDbError> {
-        self.tx
-            .execute(
-                "UPDATE pending_wav_rename_destinations AS destination
-                 SET retained_hash = (
-                     SELECT present.content_hash
-                     FROM wav_files AS present
-                     WHERE present.path = destination.path
-                       AND present.missing = 0
-                 )
-                 WHERE destination.retained_hash IS NULL
-                   AND EXISTS (
-                       SELECT 1
-                       FROM wav_files AS present
-                       WHERE present.path = destination.path
-                         AND present.missing = 0
-                         AND present.content_hash IS NOT NULL
-                   )",
-                [],
-            )
-            .map_err(map_sql_error)?;
-        Ok(())
-    }
-
     /// Remove a retained destination and report whether it belonged to unresolved recovery.
     pub fn clear_retained_pending_rename_destination(
         &mut self,
@@ -217,13 +192,30 @@ impl SourceWriteBatch<'_> {
             .map_err(map_sql_error)
     }
 
-    /// Drop retained candidates whose path, content, or pending source no longer matches.
+    /// Drop destinations that an authoritative manifest proves cannot recover pending metadata.
     pub fn prune_invalid_retained_rename_destinations(&mut self) -> Result<(), SourceDbError> {
         self.tx
             .execute(
                 "DELETE FROM pending_wav_rename_destinations AS destination
-                 WHERE destination.retained_hash IS NOT NULL
-                   AND NOT EXISTS (
+                 WHERE NOT EXISTS (
+                           SELECT 1
+                           FROM wav_files AS present
+                           WHERE present.path = destination.path
+                             AND present.missing = 0
+                       )
+                    OR (
+                        destination.retained_hash IS NULL
+                        AND EXISTS (
+                            SELECT 1
+                            FROM wav_files AS present
+                            WHERE present.path = destination.path
+                              AND present.missing = 0
+                              AND present.content_hash IS NOT NULL
+                        )
+                    )
+                    OR (
+                       destination.retained_hash IS NOT NULL
+                       AND NOT EXISTS (
                        SELECT 1
                        FROM wav_files AS present
                        JOIN pending_wav_renames AS missing
@@ -231,7 +223,8 @@ impl SourceWriteBatch<'_> {
                        WHERE present.path = destination.path
                          AND present.missing = 0
                          AND present.content_hash = destination.retained_hash
-                   )",
+                       )
+                    )",
                 [],
             )
             .map_err(map_sql_error)?;

--- a/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/rename_destinations.rs
@@ -176,6 +176,31 @@ impl SourceWriteBatch<'_> {
         Ok(())
     }
 
+    /// Resolve transient destinations whose authoritative manifest hash is now available.
+    pub fn resolve_hashed_pending_rename_destinations(&mut self) -> Result<(), SourceDbError> {
+        self.tx
+            .execute(
+                "UPDATE pending_wav_rename_destinations AS destination
+                 SET retained_hash = (
+                     SELECT present.content_hash
+                     FROM wav_files AS present
+                     WHERE present.path = destination.path
+                       AND present.missing = 0
+                 )
+                 WHERE destination.retained_hash IS NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM wav_files AS present
+                       WHERE present.path = destination.path
+                         AND present.missing = 0
+                         AND present.content_hash IS NOT NULL
+                   )",
+                [],
+            )
+            .map_err(map_sql_error)?;
+        Ok(())
+    }
+
     /// Remove a retained destination and report whether it belonged to unresolved recovery.
     pub fn clear_retained_pending_rename_destination(
         &mut self,

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -321,7 +321,9 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         collection INTEGER,
         collections TEXT,
         tag_named INTEGER NOT NULL DEFAULT 0,
-        file_identity TEXT
+        file_identity TEXT,
+        staged_generation INTEGER NOT NULL DEFAULT 0,
+        staged_at INTEGER
     );
     CREATE TABLE IF NOT EXISTS pending_wav_rename_destinations (
         path TEXT PRIMARY KEY,
@@ -341,8 +343,12 @@ const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing
          ON pending_wav_renames (content_hash);
      CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_file_identity
          ON pending_wav_renames (file_identity);
+     CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_identity_facts
+         ON pending_wav_renames (file_identity, file_size, modified_ns);
      CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_facts
          ON pending_wav_renames (file_size, modified_ns);
+     CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_generation
+         ON pending_wav_renames (staged_generation);
      CREATE INDEX IF NOT EXISTS idx_analysis_jobs_source_job_status_created
          ON analysis_jobs (source_id, job_type, status, created_at);
      CREATE INDEX IF NOT EXISTS idx_analysis_jobs_job_relative_path_status

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/columns.rs
@@ -123,6 +123,28 @@ pub(super) fn ensure_pending_rename_optional_columns(
         &columns,
         OptionalColumn::new("pending_wav_renames", "file_identity", "TEXT"),
     )?;
+    add_column_if_missing(
+        connection,
+        &columns,
+        OptionalColumn::new(
+            "pending_wav_renames",
+            "staged_generation",
+            "INTEGER NOT NULL DEFAULT 0",
+        ),
+    )?;
+    add_column_if_missing(
+        connection,
+        &columns,
+        OptionalColumn::new("pending_wav_renames", "staged_at", "INTEGER"),
+    )?;
+    connection
+        .execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_generation
+                 ON pending_wav_renames (staged_generation);
+             CREATE INDEX IF NOT EXISTS idx_pending_wav_renames_identity_facts
+                 ON pending_wav_renames (file_identity, file_size, modified_ns);",
+        )
+        .map_err(map_sql_error)?;
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -171,6 +171,30 @@ fn pending_rename_migration_adds_extended_metadata_columns() {
     assert!(columns.contains("user_tag"));
     assert!(columns.contains("normal_tags"));
     assert!(columns.contains("file_identity"));
+    assert!(columns.contains("staged_generation"));
+    assert!(columns.contains("staged_at"));
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*)
+             FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_pending_wav_renames_generation'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        1
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*)
+             FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_pending_wav_renames_identity_facts'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        1
+    );
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -27,6 +27,24 @@ impl SourceWriteBatch<'_> {
         Ok(())
     }
 
+    /// Commit source-local coordination metadata without advancing the manifest revision.
+    ///
+    /// This is restricted to batches that did not touch `wav_files` or the ordered path set.
+    /// Callers use it for transactionally coherent auxiliary lifecycle state whose publication
+    /// must not impersonate a new source-manifest generation.
+    pub fn commit_auxiliary_state(self) -> Result<(), SourceDbError> {
+        if self.paths_revision_dirty || !self.manifest_touched_paths.is_empty() {
+            return Err(SourceDbError::Unexpected);
+        }
+        self.tx.commit().map_err(map_sql_error)?;
+        crate::sqlite_wal::maybe_checkpoint_database_file(
+            &self.db_path,
+            "source_db",
+            self.telemetry_label,
+        );
+        Ok(())
+    }
+
     /// Commit the batch and return the manifest snapshot owned by that exact revision.
     ///
     /// The snapshot is read from the active write transaction after its revision bump and before
@@ -209,6 +227,28 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn auxiliary_commit_rejects_manifest_mutations() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let mut batch = database.write_batch().expect("write batch");
+        batch
+            .upsert_file(Path::new("sample.wav"), 1, 1)
+            .expect("stage manifest mutation");
+
+        assert!(matches!(
+            batch.commit_auxiliary_state(),
+            Err(SourceDbError::Unexpected)
+        ));
+        assert!(
+            database
+                .entry_for_path(Path::new("sample.wav"))
+                .expect("read rolled-back manifest")
+                .is_none()
+        );
+    }
 
     #[test]
     fn commit_snapshot_stays_bound_to_its_own_revision() {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -31,13 +31,13 @@ pub enum ScanMode {
 /// Recursively scan the source root, syncing supported audio files into the database.
 /// Returns counts of added/updated/removed rows.
 pub fn scan_once(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
-    scan(db, ScanMode::Quick, None, None, None)
+    scan(db, ScanMode::Quick, None, None, None, true)
 }
 
 /// Rescan the entire source, pruning rows for files that no longer exist and
 /// clearing pending rename rows that have no matching current destinations.
 pub fn hard_rescan(db: &SourceDatabase) -> Result<ScanStats, ScanError> {
-    scan(db, ScanMode::Hard, None, None, None)
+    scan(db, ScanMode::Hard, None, None, None, true)
 }
 
 /// Reconcile the full source manifest and verify a bounded rotating content batch.
@@ -46,8 +46,8 @@ pub fn audit_source(
     cancel: Option<&AtomicBool>,
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None, None)?;
-    merge_audit_verification(
+    let mut stats = scan(db, ScanMode::Quick, cancel, None, None, false)?;
+    let mut stats = merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch(
             db,
@@ -55,7 +55,9 @@ pub fn audit_source(
             ContentAuditBudget::entry_limited(max_hashes),
             now_epoch_seconds(),
         ),
-    )
+    )?;
+    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, &UncoordinatedScanWriter)?;
+    Ok(stats)
 }
 
 /// Reconcile a source and verify content under explicit time, byte, and entry ceilings.
@@ -64,11 +66,13 @@ pub fn audit_source_with_budget(
     cancel: Option<&AtomicBool>,
     budget: ContentAuditBudget,
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None, None)?;
-    merge_audit_verification(
+    let mut stats = scan(db, ScanMode::Quick, cancel, None, None, false)?;
+    let mut stats = merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch(db, cancel, budget, now_epoch_seconds()),
-    )
+    )?;
+    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, &UncoordinatedScanWriter)?;
+    Ok(stats)
 }
 
 /// Reconcile a source audit and durably record manifest completion before content verification.
@@ -153,11 +157,12 @@ fn audit_source_and_record_after_scan(
         cancel,
         on_progress,
         Some(completed_at),
+        false,
         writer,
     )?;
     record_manifest_audit_completion(db, &mut stats, completed_at, writer)?;
     after_scan();
-    merge_audit_verification(
+    let mut stats = merge_audit_verification(
         &mut stats,
         super::super::scan_hash::verify_content_batch_with_writer(
             db,
@@ -166,7 +171,9 @@ fn audit_source_and_record_after_scan(
             completed_at,
             writer,
         ),
-    )
+    )?;
+    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, writer)?;
+    Ok(stats)
 }
 
 fn record_manifest_audit_completion(
@@ -264,7 +271,7 @@ pub fn scan_with_progress(
     cancel: Option<&AtomicBool>,
     on_progress: &mut impl FnMut(usize, &Path),
 ) -> Result<ScanStats, ScanError> {
-    scan(db, mode, cancel, Some(on_progress), None)
+    scan(db, mode, cancel, Some(on_progress), None, true)
 }
 
 /// Scan with progress while acquiring an owning runtime's writer guard only for bounded database
@@ -276,7 +283,7 @@ pub fn scan_with_progress_and_writer(
     on_progress: &mut impl FnMut(usize, &Path),
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
-    scan_with_writer(db, mode, cancel, Some(on_progress), None, writer)
+    scan_with_writer(db, mode, cancel, Some(on_progress), None, true, writer)
 }
 
 fn scan(
@@ -285,6 +292,7 @@ fn scan(
     cancel: Option<&AtomicBool>,
     on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     manifest_audit_started_at: Option<i64>,
+    finalize_pending_renames: bool,
 ) -> Result<ScanStats, ScanError> {
     scan_with_writer(
         db,
@@ -292,6 +300,7 @@ fn scan(
         cancel,
         on_progress,
         manifest_audit_started_at,
+        finalize_pending_renames,
         &UncoordinatedScanWriter,
     )
 }
@@ -302,6 +311,7 @@ fn scan_with_writer(
     cancel: Option<&AtomicBool>,
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     manifest_audit_started_at: Option<i64>,
+    finalize_pending_renames: bool,
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
@@ -329,6 +339,12 @@ fn scan_with_writer(
                 cancel,
                 writer,
             )
+        })
+        .and_then(|committed_snapshot| {
+            if finalize_pending_renames && !context.has_uncertain_prefixes() {
+                finalize_pending_rename_completion(db, &mut context.stats, mode, writer)?;
+            }
+            Ok(committed_snapshot)
         });
     finish_scan_result(manifest_before, context, result)
 }
@@ -363,6 +379,10 @@ pub(crate) fn reconcile_scan_renames(
     let carried_candidates_need_revalidation = persisted_candidates
         .iter()
         .any(|path| !current_candidates.contains(path));
+    context.stats.pending_renames_considered = context
+        .stats
+        .pending_renames_considered
+        .saturating_add(candidates.len());
     let renamed = if carried_candidates_need_revalidation {
         super::super::scan_hash::deep_hash_scan_with_writer(
             db,
@@ -411,34 +431,41 @@ pub(crate) fn reconcile_scan_renames(
     context.stats.updated += renamed.len();
     context.stats.renames_reconciled += renamed.len();
     context.stats.renamed_samples.extend(renamed);
-    if context.mode == ScanMode::Hard {
-        let candidate_hashes = db
-            .list_manifest_entries()?
-            .into_iter()
-            .filter(|entry| candidates.contains(&entry.relative_path))
-            .filter_map(|entry| entry.content_hash)
-            .collect::<HashSet<_>>();
-        let pending_to_clear = db
-            .list_pending_renames()?
-            .into_iter()
-            .filter(|entry| {
-                entry
-                    .content_hash
-                    .as_ref()
-                    .is_none_or(|hash| !candidate_hashes.contains(hash))
-            })
-            .map(|entry| entry.relative_path)
-            .collect::<Vec<_>>();
-        let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
-        let mut batch = db.write_batch()?;
-        for path in pending_to_clear {
-            batch.clear_pending_rename(&path)?;
-        }
-        batch.prune_invalid_retained_rename_destinations()?;
-        batch.clear_unretained_pending_rename_destinations()?;
-        batch.commit()?;
-    }
     Ok(db.manifest_snapshot_with_revision()?)
+}
+
+fn finalize_pending_rename_completion(
+    db: &SourceDatabase,
+    stats: &mut ScanStats,
+    mode: ScanMode,
+    writer: &impl ScanWriter,
+) -> Result<(), ScanError> {
+    debug_assert_ne!(mode, ScanMode::Targeted);
+    let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
+    let mut batch = db.write_batch()?;
+    if mode == ScanMode::Hard {
+        batch.prune_invalid_retained_rename_destinations()?;
+    }
+    let report = batch.complete_pending_rename_authoritative_scan(mode == ScanMode::Hard)?;
+    if mode == ScanMode::Hard {
+        batch.clear_unretained_pending_rename_destinations()?;
+    }
+    batch.commit_auxiliary_state()?;
+    stats.pending_renames_pruned = stats
+        .pending_renames_pruned
+        .saturating_add(report.candidates_pruned);
+    stats.pending_rename_diagnostics = Some(report.diagnostics.clone());
+    tracing::debug!(
+        authoritative_generation = report.diagnostics.authoritative_generation,
+        candidates = report.diagnostics.candidate_count,
+        oldest_generation = report.diagnostics.oldest_staged_generation,
+        oldest_staged_at = report.diagnostics.oldest_staged_at,
+        oldest_age_seconds = report.diagnostics.oldest_candidate_age_seconds,
+        considered = stats.pending_renames_considered,
+        pruned = report.candidates_pruned,
+        "Completed bounded pending-rename retention"
+    );
+    Ok(())
 }
 
 pub(crate) fn finish_scan_result(
@@ -542,7 +569,7 @@ pub fn complete_deferred_rename_candidates_with_cancel_and_writer(
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
-    if db.list_pending_renames()?.is_empty() {
+    if !db.has_pending_renames()? {
         return Ok(stats);
     }
     let persisted_candidates = db.list_pending_rename_destinations()?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -370,10 +370,13 @@ pub(crate) fn reconcile_scan_renames(
         .iter()
         .cloned()
         .collect::<HashSet<_>>();
-    let persisted_candidates = db
-        .list_retained_rename_destinations()?
-        .into_iter()
-        .collect::<HashSet<_>>();
+    let persisted_candidates = if context.mode == ScanMode::Hard {
+        db.list_pending_rename_destinations()?
+    } else {
+        db.list_retained_rename_destinations()?
+    }
+    .into_iter()
+    .collect::<HashSet<_>>();
     let mut candidates = current_candidates.clone();
     candidates.extend(persisted_candidates.iter().cloned());
     let carried_candidates_need_revalidation = persisted_candidates
@@ -444,10 +447,11 @@ fn finalize_pending_rename_completion(
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
     let mut batch = db.write_batch()?;
     if mode == ScanMode::Hard {
+        batch.resolve_hashed_pending_rename_destinations()?;
         batch.prune_invalid_retained_rename_destinations()?;
     }
     let report = batch.complete_pending_rename_authoritative_scan(mode == ScanMode::Hard)?;
-    if mode == ScanMode::Hard {
+    if mode == ScanMode::Hard && report.diagnostics.candidate_count == 0 {
         batch.clear_unretained_pending_rename_destinations()?;
     }
     batch.commit_auxiliary_state()?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -447,7 +447,6 @@ fn finalize_pending_rename_completion(
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
     let mut batch = db.write_batch()?;
     if mode == ScanMode::Hard {
-        batch.resolve_hashed_pending_rename_destinations()?;
         batch.prune_invalid_retained_rename_destinations()?;
     }
     let report = batch.complete_pending_rename_authoritative_scan(mode == ScanMode::Hard)?;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use wavecrate_library::sample_sources::SourceManifestEntry;
-use wavecrate_library::sample_sources::db::ContentAuditReport;
+use wavecrate_library::sample_sources::db::{ContentAuditReport, PendingRenameDiagnostics};
 
 /// One non-audio regular file observed during the authoritative source traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +61,12 @@ pub struct ScanStats {
     pub content_audit: Option<ContentAuditReport>,
     /// Number of missing rows reconciled to renamed files.
     pub renames_reconciled: usize,
+    /// Current destination candidates examined through indexed pending-source lookups.
+    pub pending_renames_considered: usize,
+    /// Expired pending-source candidates removed by authoritative completion.
+    pub pending_renames_pruned: usize,
+    /// Aggregate pending-source population after authoritative completion.
+    pub pending_rename_diagnostics: Option<PendingRenameDiagnostics>,
     /// Detailed list of files whose source-visible metadata was updated in place.
     pub updated_samples: Vec<UpdatedSample>,
     /// Detailed list of source-visible rename reconciliations.
@@ -85,6 +91,12 @@ impl ScanStats {
         self.content_audit = deferred.content_audit.take().or(self.content_audit.take());
         self.hashes_pending = self.hashes_pending.saturating_sub(deferred.hashes_computed);
         self.renames_reconciled += deferred.renames_reconciled;
+        self.pending_renames_considered += deferred.pending_renames_considered;
+        self.pending_renames_pruned += deferred.pending_renames_pruned;
+        self.pending_rename_diagnostics = deferred
+            .pending_rename_diagnostics
+            .take()
+            .or(self.pending_rename_diagnostics.take());
         self.updated_samples.append(&mut deferred.updated_samples);
         self.renamed_samples.append(&mut deferred.renamed_samples);
         self.changed_samples.append(&mut deferred.changed_samples);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
@@ -9,6 +9,7 @@ mod basics;
 mod filesystem_edges;
 mod hard_rescan;
 mod rename_reconciliation;
+mod rename_retention;
 mod targeted_sync;
 
 #[cfg(unix)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -813,6 +813,10 @@ fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled()
     let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
     std::fs::write(dir.path().join("missed.wav"), b"missed watcher event").unwrap();
     let cancel = std::sync::atomic::AtomicBool::new(false);
+    let generation_before = db
+        .pending_rename_diagnostics()
+        .unwrap()
+        .authoritative_generation;
 
     let result = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
         cancel.store(true, std::sync::atomic::Ordering::Release)
@@ -838,6 +842,13 @@ fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled()
     let coverage = db.content_audit_report(1_234).unwrap();
     assert_eq!(coverage.remaining_entries, 1);
     assert_eq!(coverage.verified_entries, 0);
+    assert_eq!(
+        db.pending_rename_diagnostics()
+            .unwrap()
+            .authoritative_generation,
+        generation_before,
+        "failed audit verification must not authorize retention pruning"
+    );
 }
 
 #[test]
@@ -847,6 +858,10 @@ fn manifest_audit_publishes_unchanged_committed_revision_when_verification_is_ca
     let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
     scan_once(&db).unwrap();
     let cancel = std::sync::atomic::AtomicBool::new(false);
+    let generation_before = db
+        .pending_rename_diagnostics()
+        .unwrap()
+        .authoritative_generation;
 
     let result = audit_source_and_record_with_post_scan_hook(&db, Some(&cancel), 8, 1_234, || {
         cancel.store(true, std::sync::atomic::Ordering::Release)
@@ -862,6 +877,12 @@ fn manifest_audit_publishes_unchanged_committed_revision_when_verification_is_ca
         db.get_revision().unwrap()
     );
     assert!(committed.committed_delta.revision > 0);
+    assert_eq!(
+        db.pending_rename_diagnostics()
+            .unwrap()
+            .authoritative_generation,
+        generation_before
+    );
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/hard_rescan.rs
@@ -57,6 +57,10 @@ fn hard_rescan_keeps_pending_rename_metadata_for_an_unreadable_subtree() {
     let mut batch = db.write_batch().unwrap();
     batch.stage_pending_rename(&tracked).unwrap();
     batch.commit().unwrap();
+    let generation_before = db
+        .pending_rename_diagnostics()
+        .unwrap()
+        .authoritative_generation;
 
     std::fs::remove_file(file_path).unwrap();
     let failure = force_directory_entry_failure(&protected);
@@ -70,6 +74,13 @@ fn hard_rescan_keeps_pending_rename_metadata_for_an_unreadable_subtree() {
             .unwrap()
             .iter()
             .any(|entry| entry.relative_path == Path::new("protected/kick.wav"))
+    );
+    assert_eq!(
+        db.pending_rename_diagnostics()
+            .unwrap()
+            .authoritative_generation,
+        generation_before,
+        "partial enumeration must not advance retention eligibility"
     );
 
     drop(failure);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -254,6 +254,76 @@ fn hard_rescan_retains_destinations_when_pending_source_is_only_prior_state() {
 }
 
 #[test]
+fn hard_rescan_converges_two_pending_sources_with_one_matching_destination() {
+    let dir = tempdir().unwrap();
+    let first_old = dir.path().join("first-old.wav");
+    let second_old = dir.path().join("second-old.wav");
+    let destination = dir.path().join("destination.wav");
+    let payload = b"ambiguous source identity";
+    std::fs::write(&first_old, payload).unwrap();
+    std::fs::write(&second_old, payload).unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("first-old.wav"), Rating::KEEP_1)
+        .unwrap();
+    db.set_tag(Path::new("second-old.wav"), Rating::KEEP_3)
+        .unwrap();
+
+    std::fs::remove_file(&first_old).unwrap();
+    std::fs::remove_file(&second_old).unwrap();
+    sync_paths(
+        &db,
+        &[
+            PathBuf::from("first-old.wav"),
+            PathBuf::from("second-old.wav"),
+        ],
+    )
+    .unwrap();
+    std::fs::write(&destination, payload).unwrap();
+    let added = sync_paths(&db, &[PathBuf::from("destination.wav")]).unwrap();
+    let unresolved = complete_deferred_hashes(&db, added).unwrap();
+    assert_eq!(unresolved.renames_reconciled, 0);
+    assert_eq!(db.list_pending_renames().unwrap().len(), 2);
+
+    let converged = hard_rescan(&db).unwrap();
+
+    assert_eq!(converged.pending_renames_pruned, 2);
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+    assert_eq!(
+        db.entry_for_path(Path::new("destination.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::NEUTRAL
+    );
+}
+
+#[test]
+fn hard_rescan_ignores_stale_unresolved_destination_when_pruning() {
+    let dir = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    std::fs::write(&old, b"deleted sample").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::remove_file(&old).unwrap();
+    sync_paths(&db, &[PathBuf::from("old.wav")]).unwrap();
+    let mut batch = db.write_batch().unwrap();
+    batch
+        .stage_pending_rename_destination(Path::new("stale.wav"), u64::MAX / 2)
+        .unwrap();
+    batch.commit().unwrap();
+
+    let converged = hard_rescan(&db).unwrap();
+
+    assert_eq!(converged.pending_renames_pruned, 1);
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+}
+
+#[test]
 fn rename_apply_refreshes_metadata_changed_during_discovery() {
     let dir = tempdir().unwrap();
     let first_path = dir.path().join("one.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_retention.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_retention.rs
@@ -1,0 +1,126 @@
+use super::*;
+use crate::sample_sources::scanner::sync_paths;
+
+#[test]
+fn authoritative_scans_converge_large_deletion_churn_after_restart() {
+    const FILES: usize = 256;
+
+    let dir = tempdir().unwrap();
+    for index in 0..FILES {
+        std::fs::write(
+            dir.path().join(format!("deleted-{index:04}.wav")),
+            format!("sample-{index}"),
+        )
+        .unwrap();
+    }
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let initial = scan_once(&db).unwrap();
+    assert_eq!(
+        initial
+            .pending_rename_diagnostics
+            .as_ref()
+            .unwrap()
+            .authoritative_generation,
+        1
+    );
+
+    for index in 0..FILES {
+        std::fs::remove_file(dir.path().join(format!("deleted-{index:04}.wav"))).unwrap();
+    }
+    let deleted = scan_once(&db).unwrap();
+    let deleted_diagnostics = deleted.pending_rename_diagnostics.as_ref().unwrap();
+    assert_eq!(deleted_diagnostics.candidate_count, FILES);
+    assert_eq!(deleted_diagnostics.oldest_staged_generation, Some(2));
+    assert!(deleted_diagnostics.oldest_candidate_age_seconds.is_some());
+    assert_eq!(deleted.pending_renames_pruned, 0);
+
+    drop(db);
+    let reopened = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let grace = scan_once(&reopened).unwrap();
+    assert_eq!(
+        grace
+            .pending_rename_diagnostics
+            .as_ref()
+            .unwrap()
+            .candidate_count,
+        FILES
+    );
+    assert_eq!(grace.pending_renames_pruned, 0);
+
+    let converged = scan_once(&reopened).unwrap();
+    let diagnostics = converged.pending_rename_diagnostics.as_ref().unwrap();
+    assert_eq!(converged.pending_renames_pruned, FILES);
+    assert_eq!(diagnostics.candidate_count, 0);
+    assert_eq!(diagnostics.authoritative_generation, 4);
+    assert!(reopened.list_pending_renames().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_batches_do_not_age_pending_metadata() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("deleted.wav");
+    std::fs::write(&file, b"metadata").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("deleted.wav"), Rating::KEEP_1)
+        .unwrap();
+
+    std::fs::remove_file(file).unwrap();
+    let deleted = sync_paths(&db, &[Path::new("deleted.wav").to_path_buf()]).unwrap();
+    assert_eq!(deleted.missing, 1);
+    let generation = db
+        .pending_rename_diagnostics()
+        .unwrap()
+        .authoritative_generation;
+
+    for index in 0..8 {
+        let missing = Path::new(&format!("unrelated-{index}.wav")).to_path_buf();
+        sync_paths(&db, &[missing]).unwrap();
+    }
+
+    let diagnostics = db.pending_rename_diagnostics().unwrap();
+    assert_eq!(diagnostics.authoritative_generation, generation);
+    assert_eq!(diagnostics.candidate_count, 1);
+    let pending = db.list_pending_renames().unwrap();
+    assert_eq!(pending[0].metadata.tag, Rating::KEEP_1);
+}
+
+#[test]
+fn offline_source_does_not_age_and_recovers_rename_after_reconnect() {
+    let parent = tempdir().unwrap();
+    let source = parent.path().join("source");
+    let offline = parent.path().join("offline");
+    std::fs::create_dir(&source).unwrap();
+    std::fs::write(source.join("old.wav"), b"retained metadata").unwrap();
+    let db = SourceDatabase::open_for_scan(&source).unwrap();
+    scan_once(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+
+    std::fs::remove_file(source.join("old.wav")).unwrap();
+    sync_paths(&db, &[Path::new("old.wav").to_path_buf()]).unwrap();
+    let generation_before = db
+        .pending_rename_diagnostics()
+        .unwrap()
+        .authoritative_generation;
+
+    std::fs::rename(&source, &offline).unwrap();
+    std::fs::write(offline.join("new.wav"), b"retained metadata").unwrap();
+    assert!(scan_once(&db).is_err());
+    std::fs::rename(&offline, &source).unwrap();
+
+    assert_eq!(
+        db.pending_rename_diagnostics()
+            .unwrap()
+            .authoritative_generation,
+        generation_before
+    );
+    let recovered = scan_once(&db).unwrap();
+    assert_eq!(recovered.renames_reconciled, 1);
+    assert_eq!(
+        db.entry_for_path(Path::new("new.wav"))
+            .unwrap()
+            .unwrap()
+            .tag,
+        Rating::KEEP_1
+    );
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -618,53 +618,19 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         })
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect::<HashMap<_, _>>();
-    let manifest_entries = db.list_manifest_entries()?;
-    let pending_entries = db
-        .list_pending_renames()?
-        .into_iter()
-        .filter(|entry| !root.join(&entry.relative_path).exists())
-        .collect::<Vec<_>>();
-    if pending_entries.is_empty() {
+    if !db.has_pending_renames()? {
         return Ok(Vec::new());
     }
-
-    let mut present_by_hash = HashMap::new();
-    let mut pending_by_hash = HashMap::new();
-    let mut present_by_file_identity = HashMap::new();
-    let mut pending_by_file_identity = HashMap::new();
-    for entry in manifest_entries {
-        if !entries_by_path.contains_key(&entry.relative_path) {
-            continue;
-        }
-        if let Some(hash) = entry.content_hash.as_deref() {
-            present_by_hash
-                .entry(hash.to_string())
-                .or_insert_with(Vec::new)
-                .push(entry.relative_path.clone());
-        }
-        if rename_candidates.contains(&entry.relative_path)
-            && let Some(file_identity) = entry.file_identity.as_deref()
-        {
-            present_by_file_identity
-                .entry(file_identity.to_string())
-                .or_insert_with(Vec::new)
-                .push(entry.relative_path.clone());
-        }
-    }
-    for entry in pending_entries {
-        if let Some(hash) = entry.content_hash.as_deref() {
-            pending_by_hash
-                .entry(hash.to_string())
-                .or_insert_with(Vec::new)
-                .push(entry.clone());
-        }
-        if let Some(file_identity) = entry.file_identity.as_deref() {
-            pending_by_file_identity
-                .entry(file_identity.to_string())
-                .or_insert_with(Vec::new)
-                .push(entry);
-        }
-    }
+    let candidate_identities = db
+        .list_manifest_entries()?
+        .into_iter()
+        .filter(|entry| rename_candidates.contains(&entry.relative_path))
+        .filter_map(|entry| {
+            entry
+                .file_identity
+                .map(|identity| (entry.relative_path, identity))
+        })
+        .collect::<HashMap<_, _>>();
 
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
@@ -674,28 +640,13 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
-    let retained_candidates = retain_matching_rename_candidates(
+    let (renamed_samples, retained_candidates) = reconcile_indexed_rename_candidates(
         &mut batch,
-        &present_by_hash,
-        &pending_by_hash,
+        &root,
+        &entries_by_path,
+        &candidate_identities,
         &rename_candidates,
     )?;
-    let mut renamed_samples = reconcile_same_file_renames(
-        &mut batch,
-        &entries_by_path,
-        &present_by_file_identity,
-        &pending_by_file_identity,
-        &HashSet::new(),
-    )?;
-    let already_reconciled = reconciled_paths(&renamed_samples);
-    renamed_samples.extend(reconcile_missing_renames(
-        &mut batch,
-        &entries_by_path,
-        &present_by_hash,
-        &pending_by_hash,
-        &rename_candidates,
-        &already_reconciled,
-    )?);
     if renamed_samples.is_empty() && retained_candidates == 0 {
         return Ok(renamed_samples);
     }
@@ -740,44 +691,19 @@ fn deep_hash_scan_with_post_hash_hook(
         super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
         return Ok(stats);
     }
-    let pending_entries = db.list_pending_renames()?;
     let mut stats = ScanStats::default();
-    let mut present_by_hash = HashMap::new();
-    let mut pending_by_hash = HashMap::new();
-    let mut present_by_file_identity = HashMap::new();
-    let mut pending_by_file_identity = HashMap::new();
+    stats.pending_renames_considered = rename_candidates.len();
     let mut hash_backfills = Vec::new();
-
-    for entry in entries_by_path.values() {
-        if entry.missing
-            || rename_candidates.contains(&entry.relative_path)
-            || !is_supported_regular_audio_file(&root.join(&entry.relative_path))
-        {
-            continue;
-        }
-        let Some(hash) = entry.content_hash.as_deref() else {
-            continue;
-        };
-        present_by_hash
-            .entry(hash.to_string())
-            .or_insert_with(Vec::new)
-            .push(entry.relative_path.clone());
-    }
-    for entry in pending_entries {
-        if let Some(file_identity) = entry.file_identity.as_deref() {
-            pending_by_file_identity
-                .entry(file_identity.to_string())
-                .or_insert_with(Vec::new)
-                .push(entry.clone());
-        }
-        let Some(hash) = entry.content_hash.as_deref() else {
-            continue;
-        };
-        pending_by_hash
-            .entry(hash.to_string())
-            .or_insert_with(Vec::new)
-            .push(entry);
-    }
+    let mut candidate_identities = db
+        .list_manifest_entries()?
+        .into_iter()
+        .filter(|entry| rename_candidates.contains(&entry.relative_path))
+        .filter_map(|entry| {
+            entry
+                .file_identity
+                .map(|identity| (entry.relative_path, identity))
+        })
+        .collect::<HashMap<_, _>>();
 
     for entry in entries_by_path.values_mut() {
         if let Some(cancel) = cancel
@@ -823,26 +749,9 @@ fn deep_hash_scan_with_post_hash_hook(
         entry.file_size = after_hash.size;
         entry.modified_ns = after_hash.modified_ns;
         entry.content_hash = Some(hash.clone());
-        present_by_hash
-            .entry(hash)
-            .or_insert_with(Vec::new)
-            .push(entry.relative_path.clone());
         if was_unhashed {
             stats.hashes_computed += 1;
         }
-    }
-
-    for backfill in &hash_backfills {
-        if !rename_candidates.contains(&backfill.relative_path) {
-            continue;
-        }
-        let Some(file_identity) = backfill.file_identity.as_ref() else {
-            continue;
-        };
-        present_by_file_identity
-            .entry(file_identity.clone())
-            .or_insert_with(Vec::new)
-            .push(backfill.relative_path.clone());
     }
 
     if let Some(cancel) = cancel
@@ -864,30 +773,17 @@ fn deep_hash_scan_with_post_hash_hook(
             &backfill.content_hash,
         )?;
         batch.set_file_identity(&backfill.relative_path, backfill.file_identity.as_deref())?;
+        if let Some(identity) = backfill.file_identity.as_ref() {
+            candidate_identities.insert(backfill.relative_path.clone(), identity.clone());
+        }
     }
-    retain_matching_rename_candidates(
+    let (renamed_samples, _) = reconcile_indexed_rename_candidates(
         &mut batch,
-        &present_by_hash,
-        &pending_by_hash,
+        &root,
+        &entries_by_path,
+        &candidate_identities,
         &rename_candidates,
     )?;
-
-    let mut renamed_samples = reconcile_same_file_renames(
-        &mut batch,
-        &entries_by_path,
-        &present_by_file_identity,
-        &pending_by_file_identity,
-        &HashSet::new(),
-    )?;
-    let already_reconciled = reconciled_paths(&renamed_samples);
-    renamed_samples.extend(reconcile_missing_renames(
-        &mut batch,
-        &entries_by_path,
-        &present_by_hash,
-        &pending_by_hash,
-        &rename_candidates,
-        &already_reconciled,
-    )?);
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
 
@@ -896,45 +792,67 @@ fn deep_hash_scan_with_post_hash_hook(
     }
     let committed_snapshot = batch.commit_with_manifest_snapshot()?;
     super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
+    stats.pending_rename_diagnostics = Some(db.pending_rename_diagnostics()?);
     Ok(stats)
 }
 
-fn reconcile_same_file_renames(
+fn reconcile_indexed_rename_candidates(
     batch: &mut SourceWriteBatch<'_>,
+    root: &std::path::Path,
     entries_by_path: &HashMap<PathBuf, WavEntry>,
-    present_by_file_identity: &HashMap<String, Vec<PathBuf>>,
-    pending_by_file_identity: &HashMap<String, Vec<PendingRenameEntry>>,
-    already_reconciled: &HashSet<PathBuf>,
-) -> Result<Vec<RenamedSample>, ScanError> {
+    candidate_identities: &HashMap<PathBuf, String>,
+    rename_candidates: &HashSet<PathBuf>,
+) -> Result<(Vec<RenamedSample>, usize), ScanError> {
+    let mut candidates_by_identity = HashMap::<String, Vec<PathBuf>>::new();
+    let mut candidates_by_hash = HashMap::<String, Vec<PathBuf>>::new();
+    for path in rename_candidates {
+        let Some(entry) = entries_by_path.get(path) else {
+            continue;
+        };
+        if entry.missing {
+            continue;
+        }
+        if let Some(identity) = candidate_identities.get(path) {
+            candidates_by_identity
+                .entry(identity.clone())
+                .or_default()
+                .push(path.clone());
+        }
+        if let Some(hash) = entry.content_hash.as_ref() {
+            candidates_by_hash
+                .entry(hash.clone())
+                .or_default()
+                .push(path.clone());
+        }
+    }
+
     let mut reconciled = Vec::new();
-    for (file_identity, pending_entries) in pending_by_file_identity {
-        let [pending_entry] = pending_entries.as_slice() else {
-            continue;
-        };
-        let Some(present_paths) = present_by_file_identity.get(file_identity) else {
-            continue;
-        };
+    let mut reconciled_paths = HashSet::new();
+    for (file_identity, present_paths) in &candidates_by_identity {
         let [present_path] = present_paths.as_slice() else {
             continue;
         };
-        if pending_entry.relative_path == *present_path
-            || already_reconciled.contains(&pending_entry.relative_path)
-            || already_reconciled.contains(present_path)
-        {
-            continue;
-        }
         let Some(present_entry) = entries_by_path.get(present_path) else {
             continue;
         };
-        if present_entry.file_size != pending_entry.file_size
-            || present_entry.modified_ns != pending_entry.modified_ns
+        let Some(pending_entry) =
+            batch.unique_pending_rename_by_file_identity_only(file_identity)?
+        else {
+            continue;
+        };
+        if pending_entry.relative_path == *present_path
+            || root.join(&pending_entry.relative_path).exists()
+            || pending_entry.file_size != present_entry.file_size
+            || pending_entry.modified_ns != present_entry.modified_ns
         {
             continue;
         }
         let Some(hash) = present_entry.content_hash.as_deref() else {
             continue;
         };
-        apply_deep_rename(batch, present_entry, pending_entry, hash)?;
+        apply_deep_rename(batch, present_entry, &pending_entry, hash)?;
+        reconciled_paths.insert(pending_entry.relative_path.clone());
+        reconciled_paths.insert(present_entry.relative_path.clone());
         reconciled.push(RenamedSample {
             old_relative_path: pending_entry.relative_path.clone(),
             new_relative_path: present_entry.relative_path.clone(),
@@ -943,43 +861,42 @@ fn reconcile_same_file_renames(
             content_hash: Some(hash.to_string()),
         });
     }
-    Ok(reconciled)
-}
 
-fn reconcile_missing_renames(
-    batch: &mut SourceWriteBatch<'_>,
-    entries_by_path: &HashMap<PathBuf, WavEntry>,
-    present_by_hash: &HashMap<String, Vec<PathBuf>>,
-    pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
-    rename_candidates: &HashSet<PathBuf>,
-    already_reconciled: &HashSet<PathBuf>,
-) -> Result<Vec<RenamedSample>, ScanError> {
-    let mut reconciled = Vec::new();
-    for (hash, pending_entries) in pending_by_hash {
-        let [pending_entry] = pending_entries.as_slice() else {
-            continue;
-        };
-        if already_reconciled.contains(&pending_entry.relative_path) {
+    let mut retained = 0;
+    for (hash, present_paths) in &candidates_by_hash {
+        if !batch.has_pending_rename_with_hash(hash)? {
             continue;
         }
-        let Some(present_paths) = present_by_hash.get(hash) else {
-            continue;
-        };
-        let candidates = present_paths
+        for present_path in present_paths {
+            if reconciled_paths.contains(present_path) {
+                continue;
+            }
+            batch.retain_pending_rename_destination(present_path, hash)?;
+            retained += 1;
+        }
+        let available_paths = present_paths
             .iter()
-            .filter(|path| rename_candidates.contains(*path) && !already_reconciled.contains(*path))
+            .filter(|path| !reconciled_paths.contains(*path))
             .collect::<Vec<_>>();
-        let [present_path] = candidates.as_slice() else {
+        let [present_path] = available_paths.as_slice() else {
             continue;
         };
         let present_path = *present_path;
-        if pending_entry.relative_path == *present_path {
-            continue;
-        }
         let Some(present_entry) = entries_by_path.get(present_path) else {
             continue;
         };
-        apply_deep_rename(batch, present_entry, pending_entry, hash)?;
+        let Some(pending_entry) = batch.unique_pending_rename_by_hash(hash)? else {
+            continue;
+        };
+        if pending_entry.relative_path == *present_path
+            || reconciled_paths.contains(&pending_entry.relative_path)
+            || root.join(&pending_entry.relative_path).exists()
+        {
+            continue;
+        }
+        apply_deep_rename(batch, present_entry, &pending_entry, hash)?;
+        reconciled_paths.insert(pending_entry.relative_path.clone());
+        reconciled_paths.insert(present_entry.relative_path.clone());
         reconciled.push(RenamedSample {
             old_relative_path: pending_entry.relative_path.clone(),
             new_relative_path: present_entry.relative_path.clone(),
@@ -988,41 +905,7 @@ fn reconcile_missing_renames(
             content_hash: Some(hash.clone()),
         });
     }
-    Ok(reconciled)
-}
-
-fn retain_matching_rename_candidates(
-    batch: &mut SourceWriteBatch<'_>,
-    present_by_hash: &HashMap<String, Vec<PathBuf>>,
-    pending_by_hash: &HashMap<String, Vec<PendingRenameEntry>>,
-    rename_candidates: &HashSet<PathBuf>,
-) -> Result<usize, ScanError> {
-    let mut retained = 0;
-    for hash in pending_by_hash.keys() {
-        let Some(present_paths) = present_by_hash.get(hash) else {
-            continue;
-        };
-        for path in present_paths
-            .iter()
-            .filter(|path| rename_candidates.contains(*path))
-        {
-            batch.retain_pending_rename_destination(path, hash)?;
-            retained += 1;
-        }
-    }
-    Ok(retained)
-}
-
-fn reconciled_paths(renamed_samples: &[RenamedSample]) -> HashSet<PathBuf> {
-    renamed_samples
-        .iter()
-        .flat_map(|renamed| {
-            [
-                renamed.old_relative_path.clone(),
-                renamed.new_relative_path.clone(),
-            ]
-        })
-        .collect()
+    Ok((reconciled, retained))
 }
 
 fn apply_deep_rename(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -864,9 +864,9 @@ fn reconcile_indexed_rename_candidates(
 
     let mut retained = 0;
     for (hash, present_paths) in &candidates_by_hash {
-        if !batch.has_pending_rename_with_hash(hash)? {
+        let Some(pending_entry) = batch.unique_pending_rename_by_hash(hash)? else {
             continue;
-        }
+        };
         for present_path in present_paths {
             if reconciled_paths.contains(present_path) {
                 continue;
@@ -883,9 +883,6 @@ fn reconcile_indexed_rename_candidates(
         };
         let present_path = *present_path;
         let Some(present_entry) = entries_by_path.get(present_path) else {
-            continue;
-        };
-        let Some(pending_entry) = batch.unique_pending_rename_by_hash(hash)? else {
             continue;
         };
         if pending_entry.relative_path == *present_path

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -314,6 +314,19 @@ The source database should store information that belongs to that source and its
 - per-file metadata, ratings, global tag assignments, labels, generated-name inputs, listen history, and analysis state where those records belong to files in that source
 - reconciliation state for missing, moved, renamed, changed, unsupported, or failed files
 
+Pending rename metadata is retained by completed authoritative source generations, not by a
+wall-clock TTL. A targeted watcher batch may stage or consume candidates but never ages them.
+Quick-scan candidates remain eligible through two later successfully completed full-source
+enumerations; a partial traversal, cancellation, unavailable root, failed audit verification, or
+database failure does not advance that generation. A complete hard scan may remove an unmatched
+candidate immediately after current destinations have been reconciled. Pruning and authoritative
+generation publication are one source-database transaction, and unresolved deferred-hash
+destinations defer pruning. Rename reconciliation queries current destination candidates through
+indexed unique lookups capped at two source rows, so memory and lookup work do not scale with
+historical deletions. Aggregate diagnostics expose the retained count, authoritative and oldest
+candidate generations, oldest diagnostic staging time and age, destinations considered, and
+candidates pruned without per-file logging.
+
 Global application state should live in a user-level `.wavecrate` folder. On Windows, the initial target should be a conventional user config/home location such as `%USERPROFILE%\.wavecrate`, similar in spirit to `.cargo`, `.codex`, and other developer/user configuration folders. Future macOS and Linux support should map this same logical root to the platform's appropriate user config/home location.
 
 The global `.wavecrate` folder should contain app-wide state such as:


### PR DESCRIPTION
## Goal

Bound pending-rename metadata retention and reconciliation work to current actionable rename state without losing metadata across delayed watcher delivery, restarts, temporarily offline sources, or valid rename transfers.

Linear: OPT-1249

## Scope and non-goals

- Persist a source-local authoritative scan generation and diagnostic staging time for pending rename candidates.
- Advance retention only after a complete authoritative scan (and, for audits, successful verification); targeted, partial, canceled, unavailable-root, and failed-audit work does not age candidates.
- Prune expired candidates transactionally with generation publication, with hard-scan and unresolved-destination safeguards.
- Replace full pending-table reconciliation loads with indexed, uniqueness-bounded lookups against current destination candidates.
- Expose aggregate retention/reconciliation diagnostics and document the invariant in `docs/TARGET.md`.
- Add compatible schema repair for existing source databases and legacy read-only projections.
- Non-goals: wall-clock TTL pruning, changes to watcher delivery semantics, or broader source-database cleanup.

## Definition of Done

- Pending candidates converge after the configured authoritative-generation grace period.
- Targeted scans, incomplete traversal, cancellation, offline roots, and failed audits cannot advance pruning eligibility.
- Restart and delayed rename recovery preserve user metadata.
- Reconciliation does not materialize the historical pending source table and uses indexed lookups capped at two rows.
- Pruning and generation publication are atomic.
- Aggregate diagnostics report candidate count, generation/age, considered destinations, and pruned count.
- Migration and regression coverage exercise legacy databases, high churn, restart, rollback, offline, partial, canceled, and unresolved-destination cases.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `cargo check -p wavecrate-library -p wavecrate-scan`
- `cargo test -p wavecrate-library --lib -- --test-threads=1` (247 passed)
- `cargo test -p wavecrate-scan --lib -- --test-threads=1` (128 passed)
- focused migration, read-only compatibility, retention, reconciliation, query-plan, and transaction rollback tests
- `git diff --check`

Repository-wide observations outside this diff:

- `bash scripts/ci.sh agent` reached the native app suite; 3,943 tests passed and 49 unrelated UI/cache tests failed. An isolated native-app failure reproduces with no touched files in that subsystem.
- `cargo clippy -p wavecrate-library -p wavecrate-scan --all-targets -- -D warnings` is blocked by the pre-existing `clippy::type_complexity` warning on `SourceWriteBatch::commit_with_manifest_changes`.
- Repo preflight reports five pre-existing native-app `app_chrome` boundary violations.

## Known limitations

The repository-wide native-app gate and strict clippy gate have the unrelated baseline failures recorded above. The complete affected-crate test suites pass.

User approval is required before merge.
