### PR TITLE
OPT-1257: refine waveform frequency colors

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -152,7 +152,7 @@ Wavecrate should provide:
 21. A session-local undo/redo system for destructive edits, file operations, metadata operations, rating operations, and meaningful UI interaction state.
 22. Clean separation between Wavecrate product logic, Radiant GUI-library logic, reusable audio-engine logic, and persistence/indexing logic.
 23. Tests, diagnostics, and validation workflows that protect real user behavior, performance, and recovery guarantees.
-24. A cohesive editorial-terminal visual language: near-black charcoal surfaces, cool neutral dividers, warm off-white typography, and a restrained coral accent that keeps dense controls and waveform states legible without visual noise.
+24. A cohesive editorial-terminal visual language: near-black charcoal surfaces, cool neutral dividers, warm off-white typography, and a restrained coral accent that keeps dense controls and waveform states legible without visual noise. Spectral waveforms keep low energy in a deep blue-purple lane, mids in coral, and highs in bright cool ivory so frequency content remains distinguishable at a glance.
 
 ## Product Principles
 


### PR DESCRIPTION
## Goal
Render waveform sub/bass energy as a strong, dark blue-purple instead of dark red, while making mids and highs more visually distinct.

Linear: [OPT-1257](https://linear.app/boostnlvp/issue/OPT-1257/for-our-waveform-the-subbass-freqs-became-dark-red-lets-make-them-a)
Dependency: [PORTALSURFER/radiant#1432](https://github.com/PORTALSURFER/radiant/pull/1432)

## Scope and non-goals
- Repin Radiant to canonical merged commit `3f1fef9c`, which contains the reviewed waveform palette implementation.
- Record the low/mid/high spectral color contract in `docs/TARGET.md`.
- Preserve waveform extraction, normalization, geometry, gain, animation, and interaction behavior.
- Do not change general Wavecrate theme tokens or non-waveform surfaces.
- The canonical Radiant pin also contains preceding PR #1431, an opt-in virtual-list API with no default behavior change; Wavecrate does not opt in here.

## Definition of Done
- Low-frequency energy reads as dark, blue-forward blue-purple rather than red.
- Mid energy remains saturated coral and is visibly distinct from lows and highs.
- High energy reads as brighter cool ivory.
- The merged shader parses, frequency lanes remain separate, and Wavecrate builds through the production GPU path.

## Validation
- `bash scripts/ci.sh smoke` — passed.
- `cargo test -p wavecrate --lib frequency_bands` — passed (5 tests).
- `cargo test -p radiant gpu_signal_shader_parses_as_wgsl --lib` — passed (1 test).
- `cargo test -p radiant --example waveform_view` — passed (11 tests).
- `bash scripts/build.sh --release` — passed; production GPU rendering inspected with an isolated sandbox profile.
- Radiant dependency PR independent current-diff review — clean, no required fixes.

## Known limitations
- Repository request preflight currently reports native-app boundary violations already present on `main`; this diff does not touch those files.
- The deterministic sandbox kick/snare fixtures are broadband and emphasize the high-frequency core; mixed-band visual inspection verified the dark blue low silhouette and coral/ivory separation.

User approval is required before merge.