### PR TITLE
Fence deferred hash publication against stale manifests

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/manifest.rs
@@ -6,12 +6,6 @@ use super::scan::{
     CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity, ScanError, ScanStats,
 };
 
-pub(super) fn capture_manifest(
-    database: &SourceDatabase,
-) -> Result<Vec<SourceManifestEntry>, ScanError> {
-    database.list_manifest_entries().map_err(ScanError::from)
-}
-
 pub(super) fn capture_manifest_with_revision(
     database: &SourceDatabase,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -664,7 +664,7 @@ fn deep_hash_scan_with_post_hash_hook(
     writer: &impl ScanWriter,
     mut post_hash: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
-    let manifest_before = super::manifest::capture_manifest(db)?;
+    let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
@@ -765,6 +765,12 @@ fn deep_hash_scan_with_post_hash_hook(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    if !batch.matches_revision(manifest_revision)? {
+        return Err(ScanError::StaleRevision {
+            expected: manifest_revision,
+            actual: db.get_revision()?,
+        });
+    }
     for backfill in &hash_backfills {
         batch.upsert_file_with_hash(
             &backfill.relative_path,
@@ -1586,6 +1592,151 @@ mod tests {
                 .content_hash
                 .is_none(),
             "an unstable read must remain pending for a later hash pass"
+        );
+    }
+
+    #[test]
+    fn deep_hash_scan_does_not_recreate_a_row_deleted_after_hash_planning() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let relative = Path::new("deleted.wav");
+        std::fs::write(dir.path().join(relative), [1_u8; 32]).expect("write wav");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(relative, 32, 1).expect("insert pending row");
+
+        let result = deep_hash_scan_with_post_hash_hook(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(relative),
+            &UncoordinatedScanWriter,
+            |_| {
+                let mut batch = db.write_batch().expect("delete batch");
+                batch.remove_file(relative).expect("delete planned row");
+                batch.commit().expect("commit deletion");
+            },
+        );
+
+        assert!(matches!(result, Err(ScanError::StaleRevision { .. })));
+        assert!(
+            db.entry_for_path(relative)
+                .expect("read deleted row")
+                .is_none(),
+            "stale hash publication must not recreate a deleted manifest row"
+        );
+    }
+
+    #[test]
+    fn deep_hash_scan_does_not_overwrite_a_replacement_row() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let relative = Path::new("replaced.wav");
+        std::fs::write(dir.path().join(relative), [2_u8; 32]).expect("write wav");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(relative, 32, 1).expect("insert pending row");
+
+        let result = deep_hash_scan_with_post_hash_hook(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(relative),
+            &UncoordinatedScanWriter,
+            |_| {
+                let mut batch = db.write_batch().expect("replacement batch");
+                batch.remove_file(relative).expect("remove planned row");
+                batch
+                    .upsert_file_with_hash(relative, 64, 99, "replacement-hash")
+                    .expect("insert replacement row");
+                batch
+                    .set_file_identity(relative, Some("replacement-identity"))
+                    .expect("set replacement identity");
+                batch.commit().expect("commit replacement");
+            },
+        );
+
+        assert!(matches!(result, Err(ScanError::StaleRevision { .. })));
+        let replacement = db
+            .entry_for_path(relative)
+            .expect("read replacement row")
+            .expect("replacement row");
+        assert_eq!(replacement.file_size, 64);
+        assert_eq!(replacement.modified_ns, 99);
+        assert_eq!(
+            replacement.content_hash.as_deref(),
+            Some("replacement-hash")
+        );
+        let replacement_manifest = db
+            .list_manifest_entries()
+            .expect("read replacement manifest")
+            .into_iter()
+            .find(|entry| entry.relative_path == relative)
+            .expect("replacement manifest row");
+        assert_eq!(
+            replacement_manifest.file_identity.as_deref(),
+            Some("replacement-identity")
+        );
+    }
+
+    #[test]
+    fn deep_hash_scan_retries_after_an_unrelated_manifest_revision() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let target = Path::new("target.wav");
+        let unrelated = Path::new("unrelated.wav");
+        std::fs::write(dir.path().join(target), [3_u8; 32]).expect("write target");
+        std::fs::write(dir.path().join(unrelated), [4_u8; 16]).expect("write unrelated");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(target, 32, 1)
+            .expect("insert pending target");
+
+        let result = deep_hash_scan_with_post_hash_hook(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(target),
+            &UncoordinatedScanWriter,
+            |_| {
+                db.upsert_file(unrelated, 16, 2)
+                    .expect("commit unrelated manifest row");
+            },
+        );
+
+        assert!(matches!(result, Err(ScanError::StaleRevision { .. })));
+        assert!(
+            db.entry_for_path(target)
+                .expect("read target row")
+                .expect("target row")
+                .content_hash
+                .is_none(),
+            "a revision mismatch must leave the planned hash pending for retry"
+        );
+        assert!(
+            db.entry_for_path(unrelated)
+                .expect("read unrelated row")
+                .is_some(),
+            "the concurrent committed manifest change must remain authoritative"
+        );
+
+        let retried = deep_hash_scan(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(target),
+        )
+        .expect("retry deferred hash from the current manifest revision");
+        assert_eq!(retried.hashes_computed, 1);
+        assert!(
+            db.entry_for_path(target)
+                .expect("read retried target row")
+                .expect("retried target row")
+                .content_hash
+                .is_some(),
+            "the typed stale outcome must remain safely retryable"
         );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -610,6 +610,7 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         return Ok(Vec::new());
     }
 
+    let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let entries_by_path = db
         .list_files()?
         .into_iter()
@@ -621,8 +622,7 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
     if !db.has_pending_renames()? {
         return Ok(Vec::new());
     }
-    let candidate_identities = db
-        .list_manifest_entries()?
+    let candidate_identities = manifest_before
         .into_iter()
         .filter(|entry| rename_candidates.contains(&entry.relative_path))
         .filter_map(|entry| {
@@ -640,6 +640,12 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    if !batch.matches_revision(manifest_revision)? {
+        return Err(ScanError::StaleRevision {
+            expected: manifest_revision,
+            actual: db.get_revision()?,
+        });
+    }
     let (renamed_samples, retained_candidates) = reconcile_indexed_rename_candidates(
         &mut batch,
         &root,
@@ -957,6 +963,11 @@ mod tests {
 
     struct ObservedWriterGuard(Arc<AtomicBool>);
 
+    struct InterleavedManifestWriter {
+        root: PathBuf,
+        committed: AtomicBool,
+    }
+
     impl Drop for ObservedWriterGuard {
         fn drop(&mut self) {
             self.0.store(false, Ordering::Release);
@@ -970,6 +981,20 @@ mod tests {
             assert!(!self.active.swap(true, Ordering::AcqRel));
             self.locks.fetch_add(1, Ordering::AcqRel);
             ObservedWriterGuard(Arc::clone(&self.active))
+        }
+    }
+
+    impl ScanWriter for InterleavedManifestWriter {
+        type Guard = ();
+
+        fn lock(&self, _phase: ScanWritePhase) -> Self::Guard {
+            if !self.committed.swap(true, Ordering::AcqRel) {
+                let database = SourceDatabase::open_for_source_write(&self.root)
+                    .expect("open concurrent source writer");
+                database
+                    .upsert_file(Path::new("unrelated.wav"), 1, 1)
+                    .expect("commit unrelated manifest revision");
+            }
         }
     }
 
@@ -1592,6 +1617,75 @@ mod tests {
                 .content_hash
                 .is_none(),
             "an unstable read must remain pending for a later hash pass"
+        );
+    }
+
+    #[test]
+    fn hashed_rename_reconciliation_rejects_a_stale_manifest_revision() {
+        let dir = tempfile::tempdir().expect("temp source");
+        let old_relative = Path::new("old.wav");
+        let new_relative = Path::new("new.wav");
+        let old_absolute = dir.path().join(old_relative);
+        let new_absolute = dir.path().join(new_relative);
+        std::fs::write(&old_absolute, [5_u8; 32]).expect("write original wav");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        let mut batch = db.write_batch().expect("seed source batch");
+        batch
+            .upsert_file_with_hash(old_relative, 32, 1, "shared-hash")
+            .expect("insert original row");
+        batch
+            .set_tag(
+                old_relative,
+                wavecrate_library::sample_sources::Rating::KEEP_1,
+            )
+            .expect("curate original row");
+        batch.commit().expect("commit original row");
+
+        let original = db
+            .entry_for_path(old_relative)
+            .expect("read original row")
+            .expect("original row");
+        let mut batch = db.write_batch().expect("stage rename batch");
+        batch
+            .stage_pending_rename(&original)
+            .expect("stage pending rename");
+        batch
+            .remove_file(old_relative)
+            .expect("remove original row");
+        batch.commit().expect("commit pending rename");
+        std::fs::rename(&old_absolute, &new_absolute).expect("rename wav");
+        let mut batch = db.write_batch().expect("seed destination batch");
+        batch
+            .upsert_file_with_hash(new_relative, 32, 1, "shared-hash")
+            .expect("insert destination row");
+        batch.commit().expect("commit destination row");
+
+        let writer = InterleavedManifestWriter {
+            root: dir.path().to_path_buf(),
+            committed: AtomicBool::new(false),
+        };
+        let result = reconcile_hashed_rename_candidates_with_writer(
+            &db,
+            &HashSet::from([new_relative.to_path_buf()]),
+            None,
+            &writer,
+        );
+
+        assert!(matches!(result, Err(ScanError::StaleRevision { .. })));
+        assert!(
+            db.list_pending_renames()
+                .expect("read pending renames")
+                .iter()
+                .any(|entry| entry.relative_path == old_relative),
+            "stale reconciliation must leave the pending rename available for retry"
+        );
+        assert_eq!(
+            db.entry_for_path(new_relative)
+                .expect("read destination row")
+                .expect("destination row")
+                .tag,
+            wavecrate_library::sample_sources::Rating::NEUTRAL,
+            "stale reconciliation must not transfer source metadata"
         );
     }
 


### PR DESCRIPTION
## Goal

Complete the active OPT-1179 deferred-hash regression by preventing work planned from an older source manifest from overwriting newer committed state.

Linear: https://linear.app/boostnlvp/issue/OPT-1179/wavecrate-make-source-discovery-revisioned-ordered-and-self-healing

## Scope and non-goals

- Capture the manifest revision atomically with the manifest snapshot used to plan deferred hashing.
- Validate that revision inside the short deferred-hash write phase before any hash upsert or rename reconciliation.
- Return the existing typed `ScanError::StaleRevision` outcome so the source-processing owner can retry from current state.
- Add regressions for concurrent deletion, same-path replacement, and unrelated manifest revision changes.
- Keep filesystem reads and hashing outside the database writer.
- Do not redesign pending-rename matching or hold the writer during hashing.

## Definition of Done

- A deferred hash cannot recreate a row deleted after planning.
- A deferred hash cannot overwrite a replacement identity or newer content generation.
- A stale publication is reported as a typed, safely retryable outcome and is not reported as committed.
- Existing scanner rename, cancellation, content-audit, and writer-coordination coverage remains green.

## Validation

- `cargo test -p wavecrate-scan --lib` — 132 passed.
- `cargo test -p wavecrate --lib committed_file_mutations -- --nocapture` — 14 passed.
- `cargo test -p wavecrate --lib foreground_scan_admission_does_not_retain_database_writer -- --nocapture` — passed.
- `cargo test -p wavecrate --lib foreground_scan_traversal_does_not_block_independent_publication -- --nocapture` — passed.
- `bash scripts/ci.sh agent` — Wavecrate smoke and architecture gates passed; the later unchanged Radiant dependency suite failed at `gpu_signal_shader_keeps_waveform_bands_visually_distinct` because the shader no longer contains its hard-coded expected color. `vendor/radiant` is byte-for-byte unchanged from `origin/main`.

## Known limitations

- The full agent gate is blocked by the pre-existing Radiant shader assertion described above.
- No signed-app smoke was run because this follow-up is a deterministic source-database publication fence with no UI behavior.

User approval is required before merge.