### PR TITLE
OPT-1259 Isolate process-wide test runtime state

### DIFF
--- a/crates/wavecrate-library/src/app_dirs/overrides.rs
+++ b/crates/wavecrate-library/src/app_dirs/overrides.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use super::{
     AppDirError,
-    state::{APP_ROOT_OVERRIDE, SCOPED_APP_ROOT_OVERRIDE, TEST_CONFIG_OVERRIDE},
+    state::{IGNORE_GLOBAL_APP_ROOT_OVERRIDE, SCOPED_APP_ROOT_OVERRIDE, TEST_CONFIG_OVERRIDE},
 };
 
 /// Guard that pins application-root resolution on the current thread.
@@ -45,7 +45,7 @@ impl Drop for AppRootGuard {
 pub struct ConfigBaseGuard {
     previous: Option<PathBuf>,
     previous_scoped_root: Option<PathBuf>,
-    previous_root: Option<PathBuf>,
+    previous_ignore_global_root: bool,
 }
 
 impl ConfigBaseGuard {
@@ -63,15 +63,12 @@ impl ConfigBaseGuard {
             *slot = None;
             prev
         });
-        let mut root_guard = APP_ROOT_OVERRIDE
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let previous_root = root_guard.clone();
-        *root_guard = None;
+        let previous_ignore_global_root =
+            IGNORE_GLOBAL_APP_ROOT_OVERRIDE.with(|ignore| ignore.replace(true));
         Self {
             previous,
-            previous_root,
             previous_scoped_root,
+            previous_ignore_global_root,
         }
     }
 }
@@ -86,9 +83,6 @@ impl Drop for ConfigBaseGuard {
         SCOPED_APP_ROOT_OVERRIDE.with(|override_path| {
             *override_path.borrow_mut() = previous_scoped_root;
         });
-        let mut root_guard = APP_ROOT_OVERRIDE
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *root_guard = self.previous_root.take();
+        IGNORE_GLOBAL_APP_ROOT_OVERRIDE.with(|ignore| ignore.set(self.previous_ignore_global_root));
     }
 }

--- a/crates/wavecrate-library/src/app_dirs/resolution.rs
+++ b/crates/wavecrate-library/src/app_dirs/resolution.rs
@@ -4,8 +4,8 @@ use directories::BaseDirs;
 
 use super::profile::{ProfileSelection, ResolvedPersistence, persistence_mode_from_selection};
 use super::state::{
-    APP_ROOT_OVERRIDE, CONFIG_BASE_OVERRIDE, SCOPED_APP_ROOT_OVERRIDE, SCOPED_PROFILE_OVERRIDE,
-    TEST_CONFIG_BASE, TEST_CONFIG_OVERRIDE,
+    APP_ROOT_OVERRIDE, CONFIG_BASE_OVERRIDE, IGNORE_GLOBAL_APP_ROOT_OVERRIDE,
+    SCOPED_APP_ROOT_OVERRIDE, SCOPED_PROFILE_OVERRIDE, TEST_CONFIG_BASE, TEST_CONFIG_OVERRIDE,
 };
 use super::{
     APP_DIR_NAME, AUTOMATED_PROFILE_NAME, AppDirError, CONFIG_PROFILE_ENV, PROFILE_DIR_NAME,
@@ -113,6 +113,9 @@ fn scoped_or_global_app_root_override() -> Result<Option<PathBuf>, AppDirError> 
     {
         create_dir(&path)?;
         return Ok(Some(path));
+    }
+    if IGNORE_GLOBAL_APP_ROOT_OVERRIDE.with(std::cell::Cell::get) {
+        return Ok(None);
     }
     if let Some(path) = APP_ROOT_OVERRIDE
         .lock()

--- a/crates/wavecrate-library/src/app_dirs/state.rs
+++ b/crates/wavecrate-library/src/app_dirs/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     path::PathBuf,
     sync::{LazyLock, Mutex},
 };
@@ -22,6 +22,9 @@ thread_local! {
 }
 thread_local! {
     pub(super) static SCOPED_APP_ROOT_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+thread_local! {
+    pub(super) static IGNORE_GLOBAL_APP_ROOT_OVERRIDE: Cell<bool> = const { Cell::new(false) };
 }
 thread_local! {
     pub(super) static SCOPED_PROFILE_OVERRIDE: RefCell<Option<ProfileSelection>> = const { RefCell::new(None) };

--- a/crates/wavecrate-library/src/app_dirs/tests.rs
+++ b/crates/wavecrate-library/src/app_dirs/tests.rs
@@ -1,14 +1,20 @@
-use super::state::CONFIG_BASE_OVERRIDE;
+use super::state::{APP_ROOT_OVERRIDE, CONFIG_BASE_OVERRIDE};
 use super::*;
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use crate::test_runtime::TestRuntimeGuard;
 use tempfile::tempdir;
 
-static APP_DIRS_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+fn app_dirs_test_lock() -> TestRuntimeGuard {
+    TestRuntimeGuard::acquire()
+}
 
-fn app_dirs_test_lock() -> MutexGuard<'static, ()> {
-    APP_DIRS_TEST_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+struct GlobalAppRootRestore(Option<std::path::PathBuf>);
+
+impl Drop for GlobalAppRootRestore {
+    fn drop(&mut self) {
+        *APP_ROOT_OVERRIDE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = self.0.take();
+    }
 }
 
 #[test]
@@ -154,4 +160,28 @@ fn rejects_invalid_profile_names() {
     let error = app_root_dir().expect_err("invalid profile should fail");
 
     assert!(matches!(error, AppDirError::InvalidProfileName { .. }));
+}
+
+#[test]
+fn scoped_config_base_does_not_clear_global_root_for_other_threads() {
+    let _lock = app_dirs_test_lock();
+    let global_parent = tempdir().unwrap();
+    let global_root = global_parent.path().join("global-root");
+    let previous = APP_ROOT_OVERRIDE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    let _restore = GlobalAppRootRestore(previous);
+    set_app_root_override(global_root.clone()).unwrap();
+
+    let scoped_base = tempdir().unwrap();
+    let scoped_guard = ConfigBaseGuard::set(scoped_base.path().to_path_buf());
+    let scoped_root = app_root_dir().unwrap();
+    let other_thread_root = std::thread::spawn(app_root_dir).join().unwrap().unwrap();
+
+    assert!(scoped_root.starts_with(scoped_base.path()));
+    assert_eq!(other_thread_root, global_root);
+
+    drop(scoped_guard);
+    assert_eq!(app_root_dir().unwrap(), global_root);
 }

--- a/crates/wavecrate-library/src/lib.rs
+++ b/crates/wavecrate-library/src/lib.rs
@@ -15,3 +15,6 @@ pub mod sample_sources;
 /// Optional SQLite extension loader shared by storage code.
 pub mod sqlite_ext;
 mod sqlite_wal;
+/// Process-global test runtime isolation helpers.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_runtime;

--- a/crates/wavecrate-library/src/sqlite_ext/policy.rs
+++ b/crates/wavecrate-library/src/sqlite_ext/policy.rs
@@ -366,22 +366,16 @@ fn validate_extension_file(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_runtime::TestRuntimeGuard;
     use std::fs;
-    use std::sync::Mutex;
     use tempfile::tempdir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-    #[cfg(feature = "sqlite-ext-unsafe")]
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn missing_env_var_is_structured_noop() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::remove_var(SQLITE_EXT_ENV);
-            std::env::remove_var(SQLITE_EXT_ENABLE_ENV);
-            std::env::remove_var(SQLITE_EXT_UNSAFE_ENV);
-        }
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.remove_var(SQLITE_EXT_ENV);
+        runtime.remove_var(SQLITE_EXT_ENABLE_ENV);
+        runtime.remove_var(SQLITE_EXT_UNSAFE_ENV);
 
         assert_eq!(
             extension_policy_from_env(),
@@ -391,12 +385,10 @@ mod tests {
 
     #[test]
     fn configured_extension_requires_explicit_enable_flag() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::set_var(SQLITE_EXT_ENV, "test_ext");
-            std::env::remove_var(SQLITE_EXT_ENABLE_ENV);
-            std::env::remove_var(SQLITE_EXT_UNSAFE_ENV);
-        }
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.set_var(SQLITE_EXT_ENV, "test_ext");
+        runtime.remove_var(SQLITE_EXT_ENABLE_ENV);
+        runtime.remove_var(SQLITE_EXT_UNSAFE_ENV);
 
         assert_eq!(
             extension_policy_from_env(),
@@ -404,10 +396,6 @@ mod tests {
                 path: String::from("test_ext"),
             })
         );
-
-        unsafe {
-            std::env::remove_var(SQLITE_EXT_ENV);
-        }
     }
 
     #[test]
@@ -438,15 +426,13 @@ mod tests {
     #[cfg(feature = "sqlite-ext-unsafe")]
     #[test]
     fn unsafe_mode_uses_cwd_for_relative_paths() {
-        let _guard = CWD_LOCK.lock().unwrap();
+        let mut runtime = TestRuntimeGuard::acquire();
         let temp = tempdir().unwrap();
         let ext_path = temp.path().join("test_ext.so");
         fs::write(&ext_path, b"not a sqlite extension").unwrap();
 
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp.path()).unwrap();
+        runtime.set_current_dir(temp.path()).unwrap();
         let resolved = resolve_extension_path("test_ext.so", None, true).unwrap();
-        std::env::set_current_dir(original_dir).unwrap();
 
         assert_eq!(resolved, ext_path.canonicalize().unwrap());
     }
@@ -454,12 +440,10 @@ mod tests {
     #[cfg(not(feature = "sqlite-ext-unsafe"))]
     #[test]
     fn unsafe_env_is_structured_unavailable_without_feature() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        unsafe {
-            std::env::set_var(SQLITE_EXT_ENV, "test_ext");
-            std::env::set_var(SQLITE_EXT_ENABLE_ENV, "1");
-            std::env::set_var(SQLITE_EXT_UNSAFE_ENV, "1");
-        }
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.set_var(SQLITE_EXT_ENV, "test_ext");
+        runtime.set_var(SQLITE_EXT_ENABLE_ENV, "1");
+        runtime.set_var(SQLITE_EXT_UNSAFE_ENV, "1");
 
         assert_eq!(
             extension_policy_from_env(),
@@ -467,11 +451,5 @@ mod tests {
                 path: String::from("test_ext"),
             })
         );
-
-        unsafe {
-            std::env::remove_var(SQLITE_EXT_ENV);
-            std::env::remove_var(SQLITE_EXT_ENABLE_ENV);
-            std::env::remove_var(SQLITE_EXT_UNSAFE_ENV);
-        }
     }
 }

--- a/crates/wavecrate-library/src/test_runtime.rs
+++ b/crates/wavecrate-library/src/test_runtime.rs
@@ -1,0 +1,282 @@
+//! Scoped isolation for tests that mutate process-global runtime state.
+
+use std::{
+    ffi::{OsStr, OsString},
+    marker::PhantomData,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::{Condvar, Mutex, MutexGuard, OnceLock},
+    thread::{self, ThreadId},
+};
+
+static PROCESS_STATE_LOCK: OnceLock<ReentrantProcessLock> = OnceLock::new();
+
+#[derive(Default)]
+struct LockState {
+    owner: Option<ThreadId>,
+    depth: usize,
+}
+
+#[derive(Default)]
+struct ReentrantProcessLock {
+    state: Mutex<LockState>,
+    available: Condvar,
+}
+
+impl ReentrantProcessLock {
+    fn acquire(&self) {
+        let current = thread::current().id();
+        let mut state = lock_unpoisoned(&self.state);
+        loop {
+            match state.owner.as_ref() {
+                None => {
+                    state.owner = Some(current);
+                    state.depth = 1;
+                    return;
+                }
+                Some(owner) if *owner == current => {
+                    state.depth += 1;
+                    return;
+                }
+                Some(_) => {
+                    state = self
+                        .available
+                        .wait(state)
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                }
+            }
+        }
+    }
+
+    fn release(&self) {
+        let current = thread::current().id();
+        let mut state = lock_unpoisoned(&self.state);
+        assert_eq!(
+            state.owner.as_ref(),
+            Some(&current),
+            "process test runtime guard dropped by a non-owner thread"
+        );
+        state.depth -= 1;
+        if state.depth == 0 {
+            state.owner = None;
+            self.available.notify_one();
+        }
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+enum Restoration {
+    Environment {
+        key: OsString,
+        previous: Option<OsString>,
+    },
+    CurrentDirectory(PathBuf),
+}
+
+/// Serializes and restores process-global environment and working-directory changes.
+///
+/// The lock is shared by every Wavecrate test owner in the current test binary,
+/// is re-entrant on one thread, and recovers from mutex poisoning. Each guard
+/// restores its own mutations in reverse order before allowing another thread
+/// to enter the scope.
+pub struct TestRuntimeGuard {
+    restorations: Vec<Restoration>,
+    _not_send_or_sync: PhantomData<Rc<()>>,
+}
+
+impl TestRuntimeGuard {
+    /// Acquire exclusive ownership of process-global test runtime state.
+    pub fn acquire() -> Self {
+        process_state_lock().acquire();
+        Self {
+            restorations: Vec::new(),
+            _not_send_or_sync: PhantomData,
+        }
+    }
+
+    /// Set an environment variable for this scope and remember its exact prior value.
+    pub fn set_var(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) {
+        let key = key.as_ref().to_os_string();
+        let previous = std::env::var_os(&key);
+        // SAFETY: every Wavecrate test environment mutation is serialized by
+        // the shared process-state lock held for this guard's lifetime.
+        unsafe {
+            std::env::set_var(&key, value);
+        }
+        self.restorations
+            .push(Restoration::Environment { key, previous });
+    }
+
+    /// Remove an environment variable for this scope and remember its exact prior value.
+    pub fn remove_var(&mut self, key: impl AsRef<OsStr>) {
+        let key = key.as_ref().to_os_string();
+        let previous = std::env::var_os(&key);
+        // SAFETY: every Wavecrate test environment mutation is serialized by
+        // the shared process-state lock held for this guard's lifetime.
+        unsafe {
+            std::env::remove_var(&key);
+        }
+        self.restorations
+            .push(Restoration::Environment { key, previous });
+    }
+
+    /// Change the process working directory for this scope.
+    ///
+    /// The exact prior directory is restored when the guard is dropped.
+    pub fn set_current_dir(&mut self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        let previous = std::env::current_dir()?;
+        std::env::set_current_dir(path)?;
+        self.restorations
+            .push(Restoration::CurrentDirectory(previous));
+        Ok(())
+    }
+}
+
+impl Drop for TestRuntimeGuard {
+    fn drop(&mut self) {
+        let mut current_dir_restore_error = None;
+        for restoration in self.restorations.drain(..).rev() {
+            match restoration {
+                Restoration::Environment { key, previous } => {
+                    // SAFETY: the shared process-state lock remains held until
+                    // every scoped mutation has been restored.
+                    unsafe {
+                        match previous {
+                            Some(value) => std::env::set_var(key, value),
+                            None => std::env::remove_var(key),
+                        }
+                    }
+                }
+                Restoration::CurrentDirectory(previous) => {
+                    if let Err(error) = std::env::set_current_dir(&previous) {
+                        current_dir_restore_error = Some((previous, error));
+                    }
+                }
+            }
+        }
+        process_state_lock().release();
+
+        if let Some((path, error)) = current_dir_restore_error {
+            if thread::panicking() {
+                eprintln!(
+                    "failed to restore process working directory to {} while unwinding: {error}",
+                    path.display()
+                );
+            } else {
+                panic!(
+                    "failed to restore process working directory to {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+fn process_state_lock() -> &'static ReentrantProcessLock {
+    PROCESS_STATE_LOCK.get_or_init(ReentrantProcessLock::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
+        time::Duration,
+    };
+    use tempfile::tempdir;
+
+    const TEST_ENV: &str = "WAVECRATE_TEST_RUNTIME_GUARD_REGRESSION";
+
+    #[test]
+    fn nested_scopes_restore_unset_and_empty_values_exactly() {
+        let mut outer = TestRuntimeGuard::acquire();
+        outer.remove_var(TEST_ENV);
+        assert_eq!(std::env::var_os(TEST_ENV), None);
+
+        {
+            let mut nested = TestRuntimeGuard::acquire();
+            nested.set_var(TEST_ENV, "");
+            assert_eq!(std::env::var_os(TEST_ENV), Some(OsString::new()));
+        }
+
+        assert_eq!(std::env::var_os(TEST_ENV), None);
+    }
+
+    #[test]
+    fn panic_unwind_restores_environment_and_current_directory() {
+        let original_dir = std::env::current_dir().expect("current directory");
+        let temp = tempdir().expect("temporary working directory");
+        let mut outer = TestRuntimeGuard::acquire();
+        outer.set_var(TEST_ENV, "before-panic");
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut nested = TestRuntimeGuard::acquire();
+            nested.set_var(TEST_ENV, "during-panic");
+            nested
+                .set_current_dir(temp.path())
+                .expect("set temporary working directory");
+            panic!("exercise scoped cleanup");
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::env::var_os(TEST_ENV),
+            Some(OsString::from("before-panic"))
+        );
+        assert_eq!(
+            std::env::current_dir().expect("restored current directory"),
+            original_dir
+        );
+    }
+
+    #[test]
+    fn concurrent_contender_waits_for_owner_cleanup() {
+        let mut owner = TestRuntimeGuard::acquire();
+        owner.set_var(TEST_ENV, "owner");
+        let attempting = Arc::new(AtomicBool::new(false));
+        let contender_attempting = Arc::clone(&attempting);
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+
+        let contender = thread::spawn(move || {
+            contender_attempting.store(true, Ordering::Release);
+            let _guard = TestRuntimeGuard::acquire();
+            acquired_tx.send(()).expect("report guard acquisition");
+        });
+
+        while !attempting.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+        assert!(
+            acquired_rx.recv_timeout(Duration::from_millis(25)).is_err(),
+            "contender acquired process state before owner cleanup"
+        );
+
+        drop(owner);
+        acquired_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("contender acquires after owner cleanup");
+        contender.join().expect("join contender");
+    }
+
+    #[test]
+    fn internal_lock_recovers_after_poisoning() {
+        let lock = ReentrantProcessLock::default();
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _state = lock.state.lock().expect("lock state before poisoning");
+            panic!("poison test lock");
+        }));
+
+        lock.acquire();
+        lock.release();
+    }
+}

--- a/crates/wavecrate-library/src/test_runtime.rs
+++ b/crates/wavecrate-library/src/test_runtime.rs
@@ -5,16 +5,17 @@ use std::{
     marker::PhantomData,
     path::{Path, PathBuf},
     rc::Rc,
-    sync::{Condvar, Mutex, MutexGuard, OnceLock},
+    sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock},
     thread::{self, ThreadId},
 };
 
-static PROCESS_STATE_LOCK: OnceLock<ReentrantProcessLock> = OnceLock::new();
+static PROCESS_STATE_LOCK: OnceLock<Arc<ReentrantProcessLock>> = OnceLock::new();
 
 #[derive(Default)]
 struct LockState {
     owner: Option<ThreadId>,
     depth: usize,
+    failure: Option<String>,
 }
 
 #[derive(Default)]
@@ -28,6 +29,11 @@ impl ReentrantProcessLock {
         let current = thread::current().id();
         let mut state = lock_unpoisoned(&self.state);
         loop {
+            if let Some(failure) = state.failure.clone() {
+                drop(state);
+                panic!("process test runtime is unavailable: {failure}");
+            }
+
             match state.owner.as_ref() {
                 None => {
                     state.owner = Some(current);
@@ -51,6 +57,9 @@ impl ReentrantProcessLock {
     fn release(&self) {
         let current = thread::current().id();
         let mut state = lock_unpoisoned(&self.state);
+        if state.failure.is_some() {
+            return;
+        }
         assert_eq!(
             state.owner.as_ref(),
             Some(&current),
@@ -60,6 +69,33 @@ impl ReentrantProcessLock {
         if state.depth == 0 {
             state.owner = None;
             self.available.notify_one();
+        }
+    }
+
+    fn complete_scope(&self, current_dir_restore_error: Option<(PathBuf, std::io::Error)>) {
+        let Some((path, error)) = current_dir_restore_error else {
+            self.release();
+            return;
+        };
+
+        let failure = format!(
+            "failed to restore process working directory to {}: {error}",
+            path.display()
+        );
+        {
+            let mut state = lock_unpoisoned(&self.state);
+            if state.failure.is_none() {
+                state.failure = Some(failure.clone());
+            }
+            state.owner = None;
+            state.depth = 0;
+            self.available.notify_all();
+        }
+
+        if thread::panicking() {
+            eprintln!("{failure} while unwinding; future process test runtime access is disabled");
+        } else {
+            panic!("{failure}; future process test runtime access is disabled");
         }
     }
 }
@@ -85,6 +121,7 @@ enum Restoration {
 /// restores its own mutations in reverse order before allowing another thread
 /// to enter the scope.
 pub struct TestRuntimeGuard {
+    lock: Arc<ReentrantProcessLock>,
     restorations: Vec<Restoration>,
     _not_send_or_sync: PhantomData<Rc<()>>,
 }
@@ -92,8 +129,13 @@ pub struct TestRuntimeGuard {
 impl TestRuntimeGuard {
     /// Acquire exclusive ownership of process-global test runtime state.
     pub fn acquire() -> Self {
-        process_state_lock().acquire();
+        Self::acquire_with(Arc::clone(process_state_lock()))
+    }
+
+    fn acquire_with(lock: Arc<ReentrantProcessLock>) -> Self {
+        lock.acquire();
         Self {
+            lock,
             restorations: Vec::new(),
             _not_send_or_sync: PhantomData,
         }
@@ -159,26 +201,12 @@ impl Drop for TestRuntimeGuard {
                 }
             }
         }
-        process_state_lock().release();
-
-        if let Some((path, error)) = current_dir_restore_error {
-            if thread::panicking() {
-                eprintln!(
-                    "failed to restore process working directory to {} while unwinding: {error}",
-                    path.display()
-                );
-            } else {
-                panic!(
-                    "failed to restore process working directory to {}: {error}",
-                    path.display()
-                );
-            }
-        }
+        self.lock.complete_scope(current_dir_restore_error);
     }
 }
 
-fn process_state_lock() -> &'static ReentrantProcessLock {
-    PROCESS_STATE_LOCK.get_or_init(ReentrantProcessLock::default)
+fn process_state_lock() -> &'static Arc<ReentrantProcessLock> {
+    PROCESS_STATE_LOCK.get_or_init(|| Arc::new(ReentrantProcessLock::default()))
 }
 
 #[cfg(test)]
@@ -187,7 +215,6 @@ mod tests {
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
         sync::{
-            Arc,
             atomic::{AtomicBool, Ordering},
             mpsc,
         },
@@ -278,5 +305,43 @@ mod tests {
 
         lock.acquire();
         lock.release();
+    }
+
+    #[test]
+    fn failed_current_directory_restore_disables_future_access_after_caught_panic() {
+        let original_dir = std::env::current_dir().expect("current directory");
+        let saved_dir = tempdir().expect("saved temporary working directory");
+        let mutated_dir = tempdir().expect("mutated temporary working directory");
+        let mut outer = TestRuntimeGuard::acquire();
+        outer
+            .set_current_dir(saved_dir.path())
+            .expect("enter saved working directory");
+
+        let isolated_lock = Arc::new(ReentrantProcessLock::default());
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut nested = TestRuntimeGuard::acquire_with(Arc::clone(&isolated_lock));
+            nested
+                .set_current_dir(mutated_dir.path())
+                .expect("enter mutated working directory");
+            saved_dir
+                .close()
+                .expect("remove the saved working directory");
+            panic!("exercise failed restoration while unwinding");
+        }));
+
+        assert!(result.is_err());
+        let reacquire = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = TestRuntimeGuard::acquire_with(Arc::clone(&isolated_lock));
+        }));
+        assert!(
+            reacquire.is_err(),
+            "a failed CWD restoration must disable future guarded access"
+        );
+
+        drop(outer);
+        assert_eq!(
+            std::env::current_dir().expect("outer guard restores current directory"),
+            original_dir
+        );
     }
 }

--- a/src/app_core/controller/tests/dispatch/logging.rs
+++ b/src/app_core/controller/tests/dispatch/logging.rs
@@ -2,6 +2,7 @@ use super::*;
 use std::io;
 use std::sync::{Arc, Mutex};
 use tracing_subscriber::fmt::MakeWriter;
+use wavecrate_library::test_runtime::TestRuntimeGuard;
 
 #[derive(Clone, Default)]
 struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
@@ -33,34 +34,6 @@ impl io::Write for SharedBufferWriter {
     }
 }
 
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<std::ffi::OsString>,
-}
-
-impl EnvVarGuard {
-    fn remove(key: &'static str) -> Self {
-        let previous = std::env::var_os(key);
-        // Tests in this module need the default incident-log policy, so keep
-        // the opt-in hot-path override absent for the captured scope.
-        unsafe {
-            std::env::remove_var(key);
-        }
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        unsafe {
-            match self.previous.as_ref() {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
-
 fn capture_debug_logs<F>(run: F) -> String
 where
     F: FnOnce(),
@@ -80,7 +53,8 @@ where
 
 #[test]
 fn default_action_debug_log_suppresses_browser_view_start_scroll_bursts() {
-    let _hotpath_guard = EnvVarGuard::remove(crate::hotpath_telemetry::HOTPATH_TELEMETRY_ENV);
+    let mut runtime = TestRuntimeGuard::acquire();
+    runtime.remove_var(crate::hotpath_telemetry::HOTPATH_TELEMETRY_ENV);
     let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
 
     let captured = capture_debug_logs(|| {

--- a/src/issue_gateway/token_store/fallback_key.rs
+++ b/src/issue_gateway/token_store/fallback_key.rs
@@ -126,12 +126,14 @@ pub(super) fn fallback_key_cache() -> &'static Mutex<Option<[u8; 32]>> {
 
 /// Lock the process-wide fallback key cache and recover from poisoning.
 pub(super) fn lock_fallback_key_cache() -> std::sync::MutexGuard<'static, Option<[u8; 32]>> {
-    match fallback_key_cache().lock() {
+    let cache = fallback_key_cache();
+    match cache.lock() {
         Ok(guard) => guard,
         Err(poisoned) => {
             tracing::warn!("Fallback key cache mutex poisoned; clearing cached key.");
             let mut inner = poisoned.into_inner();
             *inner = None;
+            cache.clear_poison();
             inner
         }
     }

--- a/src/issue_gateway/token_store/tests/cleanup_failures.rs
+++ b/src/issue_gateway/token_store/tests/cleanup_failures.rs
@@ -3,12 +3,10 @@ use super::*;
 #[test]
 fn fallback_get_reports_cleanup_failure_after_decrypt_failure() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -27,23 +25,16 @@ fn fallback_get_reports_cleanup_failure_after_decrypt_failure() {
         "token payload should be removed even when another cleanup artifact fails"
     );
     assert!(store.legacy_fallback_key_path().is_dir());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
 }
 
 #[test]
 fn env_fallback_key_reports_legacy_key_cleanup_failure() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -57,24 +48,16 @@ fn env_fallback_key_reports_legacy_key_cleanup_failure() {
         store.cached_fallback_key().is_none(),
         "failed cleanup should not cache the env key as fully resolved"
     );
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_delete_reports_legacy_key_cleanup_failure() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -87,24 +70,16 @@ fn fallback_delete_reports_legacy_key_cleanup_failure() {
     assert_cleanup_failure_for(&err, "legacy fallback key");
     assert!(!store.fallback_token_path().exists());
     assert!(store.cached_fallback_key().is_none());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn delete_removes_fallback_payload_and_clears_key_cache() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -117,10 +92,4 @@ fn delete_removes_fallback_payload_and_clears_key_cache() {
 
     assert!(!store.fallback_token_path().exists());
     assert!(store.cached_fallback_key().is_none());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }

--- a/src/issue_gateway/token_store/tests/env_flags.rs
+++ b/src/issue_gateway/token_store/tests/env_flags.rs
@@ -3,40 +3,24 @@ use super::*;
 /// Security toggles must only accept strict `1`/`true` tokens.
 #[test]
 fn strict_env_var_truthy_only_accepts_one_and_true() {
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     /// Test-only env var for strict token parsing behavior.
     const STRICT_ENV: &str = "WAVECRATE_TOKEN_STORE_STRICT_PARSE_TEST";
-    unsafe {
-        std::env::remove_var(STRICT_ENV);
-    }
+    runtime.remove_var(STRICT_ENV);
     assert!(!fallback_policy::env_var_truthy(STRICT_ENV));
 
-    unsafe {
-        std::env::set_var(STRICT_ENV, "1");
-    }
+    runtime.set_var(STRICT_ENV, "1");
     assert!(fallback_policy::env_var_truthy(STRICT_ENV));
 
-    unsafe {
-        std::env::set_var(STRICT_ENV, "TrUe");
-    }
+    runtime.set_var(STRICT_ENV, "TrUe");
     assert!(fallback_policy::env_var_truthy(STRICT_ENV));
 
-    unsafe {
-        std::env::set_var(STRICT_ENV, "on");
-    }
+    runtime.set_var(STRICT_ENV, "on");
     assert!(!fallback_policy::env_var_truthy(STRICT_ENV));
 
-    unsafe {
-        std::env::set_var(STRICT_ENV, "yes");
-    }
+    runtime.set_var(STRICT_ENV, "yes");
     assert!(!fallback_policy::env_var_truthy(STRICT_ENV));
 
-    unsafe {
-        std::env::set_var(STRICT_ENV, "true ");
-    }
+    runtime.set_var(STRICT_ENV, "true ");
     assert!(!fallback_policy::env_var_truthy(STRICT_ENV));
-
-    unsafe {
-        std::env::remove_var(STRICT_ENV);
-    }
 }

--- a/src/issue_gateway/token_store/tests/env_key_fallback.rs
+++ b/src/issue_gateway/token_store/tests/env_key_fallback.rs
@@ -3,12 +3,10 @@ use super::*;
 #[test]
 fn fallback_requires_env_key_without_keyring() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -20,23 +18,16 @@ fn fallback_requires_env_key_without_keyring() {
         }
         other => panic!("expected unavailable error, got {other:?}"),
     }
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
 }
 
 #[test]
 fn malformed_env_fallback_key_is_rejected() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-        std::env::set_var(FALLBACK_KEY_ENV_VAR, "not-hex");
-    }
-    allow_fallback();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    runtime.set_var(FALLBACK_KEY_ENV_VAR, "not-hex");
+    allow_fallback(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -48,24 +39,16 @@ fn malformed_env_fallback_key_is_rejected() {
         }
         other => panic!("expected decode error, got {other:?}"),
     }
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_works_with_env_key() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
 
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
@@ -77,10 +60,4 @@ fn fallback_works_with_env_key() {
     assert!(!store.legacy_fallback_key_path().exists());
 
     store.delete().unwrap();
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }

--- a/src/issue_gateway/token_store/tests/keyring_disabled.rs
+++ b/src/issue_gateway/token_store/tests/keyring_disabled.rs
@@ -3,13 +3,11 @@ use super::*;
 #[test]
 fn fallback_key_cache_recovers_after_poison() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -26,24 +24,21 @@ fn fallback_key_cache_recovers_after_poison() {
         store.get().unwrap().as_deref(),
         Some("tok_abcdefghijklmnopqrstuvwxyz")
     );
+    assert!(
+        !fallback_key::fallback_key_cache().is_poisoned(),
+        "cache recovery must clear poison for later test owners"
+    );
     store.delete().unwrap();
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_roundtrip_when_keyring_disabled() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -55,46 +50,32 @@ fn fallback_roundtrip_when_keyring_disabled() {
     );
     store.delete().unwrap();
     assert_eq!(store.get().unwrap(), None);
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn set_empty_token_clears_storage() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
     store.set("tok_abcdefghijklmnopqrstuvwxyz").unwrap();
     store.set("").unwrap();
     assert_eq!(store.get().unwrap(), None);
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_is_only_used_when_explicitly_allowed() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    disallow_fallback();
-    clear_env_key();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
+    disallow_fallback(&mut runtime);
+    clear_env_key(&mut runtime);
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
     let base = tempdir().unwrap();
     let _guard = crate::app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -107,9 +88,4 @@ fn fallback_is_only_used_when_explicitly_allowed() {
         other => panic!("expected unavailable error, got {other:?}"),
     }
     assert!(!store.fallback_token_path().exists());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    clear_env_key();
 }

--- a/src/issue_gateway/token_store/tests/legacy_migration.rs
+++ b/src/issue_gateway/token_store/tests/legacy_migration.rs
@@ -3,9 +3,9 @@ use super::*;
 #[test]
 fn fallback_get_migrates_legacy_key_file() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    allow_fallback();
+    allow_fallback(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -21,17 +21,15 @@ fn fallback_get_migrates_legacy_key_file() {
 
     assert_eq!(store.fallback_get().unwrap().as_deref(), Some("tok_legacy"));
     assert!(!store.legacy_fallback_key_path().exists());
-
-    disallow_fallback();
 }
 
 #[test]
 fn corrupt_legacy_fallback_key_file_is_removed() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    allow_fallback();
-    clear_env_key();
+    allow_fallback(&mut runtime);
+    clear_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -39,6 +37,4 @@ fn corrupt_legacy_fallback_key_file_is_removed() {
 
     assert_eq!(store.get_key_from_file().unwrap(), None);
     assert!(!store.legacy_fallback_key_path().exists());
-
-    disallow_fallback();
 }

--- a/src/issue_gateway/token_store/tests/mod.rs
+++ b/src/issue_gateway/token_store/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
-use std::sync::{Mutex, Once, OnceLock};
+use std::sync::Once;
 use tempfile::tempdir;
+use wavecrate_library::test_runtime::TestRuntimeGuard;
 
 mod cleanup_failures;
 /// Strict env-toggle parsing tests.
@@ -12,7 +13,6 @@ mod payload_validation;
 mod warning_state;
 
 static MOCK_KEYRING_INIT: Once = Once::new();
-static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn enable_mock_keyring() {
     MOCK_KEYRING_INIT.call_once(|| {
@@ -20,37 +20,26 @@ fn enable_mock_keyring() {
     });
 }
 
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    ENV_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+fn env_lock() -> TestRuntimeGuard {
+    TestRuntimeGuard::acquire()
 }
 
-fn allow_fallback() {
-    unsafe {
-        std::env::set_var(FALLBACK_ALLOW_ENV, "1");
-    }
+fn allow_fallback(runtime: &mut TestRuntimeGuard) {
+    runtime.set_var(FALLBACK_ALLOW_ENV, "1");
 }
 
-fn disallow_fallback() {
-    unsafe {
-        std::env::remove_var(FALLBACK_ALLOW_ENV);
-    }
+fn disallow_fallback(runtime: &mut TestRuntimeGuard) {
+    runtime.remove_var(FALLBACK_ALLOW_ENV);
 }
 
-fn set_env_key() -> String {
+fn set_env_key(runtime: &mut TestRuntimeGuard) -> String {
     let env_key = "A".repeat(64);
-    unsafe {
-        std::env::set_var(FALLBACK_KEY_ENV_VAR, &env_key);
-    }
+    runtime.set_var(FALLBACK_KEY_ENV_VAR, &env_key);
     env_key
 }
 
-fn clear_env_key() {
-    unsafe {
-        std::env::remove_var(FALLBACK_KEY_ENV_VAR);
-    }
+fn clear_env_key(runtime: &mut TestRuntimeGuard) {
+    runtime.remove_var(FALLBACK_KEY_ENV_VAR);
 }
 
 fn reset_cache() {

--- a/src/issue_gateway/token_store/tests/payload_validation.rs
+++ b/src/issue_gateway/token_store/tests/payload_validation.rs
@@ -3,13 +3,11 @@ use super::*;
 #[test]
 fn fallback_get_rejects_corrupted_payload() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -20,26 +18,18 @@ fn fallback_get_rejects_corrupted_payload() {
         IssueTokenStoreError::Decode(_) => {}
         other => panic!("expected decode error, got {other:?}"),
     }
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[cfg(unix)]
 #[test]
 fn fallback_token_file_is_private_on_unix() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
     use std::os::unix::fs::PermissionsExt;
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -52,24 +42,16 @@ fn fallback_token_file_is_private_on_unix() {
         & 0o777;
 
     assert_eq!(token_mode, 0o600);
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_get_rejects_oversized_payload() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -83,24 +65,16 @@ fn fallback_get_rejects_oversized_payload() {
         }
         other => panic!("expected decode error, got {other:?}"),
     }
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }
 
 #[test]
 fn fallback_get_clears_unreadable_payload() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
+    let mut runtime = env_lock();
     reset_cache();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
@@ -110,10 +84,4 @@ fn fallback_get_clears_unreadable_payload() {
     std::fs::write(store.fallback_token_path(), payload).unwrap();
     assert_eq!(store.fallback_get().unwrap(), None);
     assert!(!store.fallback_token_path().exists());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }

--- a/src/issue_gateway/token_store/tests/warning_state.rs
+++ b/src/issue_gateway/token_store/tests/warning_state.rs
@@ -3,12 +3,10 @@ use super::*;
 #[test]
 fn fallback_warns_when_active() {
     enable_mock_keyring();
-    let _env_guard = env_lock();
-    unsafe {
-        std::env::set_var("WAVECRATE_DISABLE_KEYRING", "1");
-    }
-    allow_fallback();
-    set_env_key();
+    let mut runtime = env_lock();
+    runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
+    allow_fallback(&mut runtime);
+    set_env_key(&mut runtime);
     fallback_policy::reset_fallback_warning_for_tests();
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
@@ -16,10 +14,4 @@ fn fallback_warns_when_active() {
 
     store.set("tok_abcdefghijklmnopqrstuvwxyz").unwrap();
     assert!(fallback_policy::fallback_warning_emitted_for_tests());
-
-    unsafe {
-        std::env::remove_var("WAVECRATE_DISABLE_KEYRING");
-    }
-    disallow_fallback();
-    clear_env_key();
 }

--- a/src/updater/path_guard.rs
+++ b/src/updater/path_guard.rs
@@ -180,38 +180,7 @@ mod tests {
     use super::*;
     use std::io;
     use tempfile::tempdir;
-
-    struct EnvVarGuard {
-        key: String,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self {
-                key: key.to_string(),
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.previous.take() {
-                unsafe {
-                    std::env::set_var(&self.key, value);
-                }
-            } else {
-                unsafe {
-                    std::env::remove_var(&self.key);
-                }
-            }
-        }
-    }
+    use wavecrate_library::test_runtime::TestRuntimeGuard;
 
     #[test]
     fn ensure_child_path_rejects_parent_dir() {
@@ -243,10 +212,11 @@ mod tests {
 
     #[test]
     fn ensure_child_path_allows_relative_path() {
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.set_var("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "1");
         let _lock = updater_path_guard_test_lock()
             .lock()
             .expect("updater test lock");
-        let _guard = EnvVarGuard::set("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "1");
         let dir = tempdir().expect("tempdir");
         let root = ValidatedInstallRoot::new(dir.path()).expect("install root");
         let path = root.child_path("./ok/file.txt").expect("relative path");
@@ -280,6 +250,8 @@ mod tests {
 
     #[test]
     fn ensure_child_path_fails_on_symlink_metadata_error() {
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.set_var("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "0");
         let _lock = updater_path_guard_test_lock()
             .lock()
             .expect("updater test lock");
@@ -290,7 +262,6 @@ mod tests {
             ))
         }
 
-        let _env = EnvVarGuard::set("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "0");
         let _guard = SymlinkMetadataHookGuard::new(Some(fail_metadata));
         let dir = tempdir().expect("tempdir");
         let root = ValidatedInstallRoot::new(dir.path()).expect("install root");

--- a/tests/support/wavecrate_env.rs
+++ b/tests/support/wavecrate_env.rs
@@ -1,45 +1,14 @@
-use std::{
-    path::PathBuf,
-    sync::{Mutex, OnceLock},
-};
-
-static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+use std::path::PathBuf;
+use wavecrate_library::test_runtime::TestRuntimeGuard;
 
 pub struct WavecrateEnvGuard {
-    previous: Option<String>,
-    _lock: std::sync::MutexGuard<'static, ()>,
+    _runtime: TestRuntimeGuard,
 }
 
 impl WavecrateEnvGuard {
     pub fn set_config_home(path: PathBuf) -> Self {
-        let lock = ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|err| err.into_inner());
-        let previous = std::env::var("WAVECRATE_CONFIG_HOME").ok();
-        // SAFETY: tests run under a global lock to prevent concurrent env mutations.
-        unsafe {
-            std::env::set_var("WAVECRATE_CONFIG_HOME", path);
-        }
-        Self {
-            previous,
-            _lock: lock,
-        }
-    }
-}
-
-impl Drop for WavecrateEnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests run under a global lock to prevent concurrent env mutations.
-            unsafe {
-                std::env::set_var("WAVECRATE_CONFIG_HOME", value);
-            }
-        } else {
-            // SAFETY: tests run under a global lock to prevent concurrent env mutations.
-            unsafe {
-                std::env::remove_var("WAVECRATE_CONFIG_HOME");
-            }
-        }
+        let mut runtime = TestRuntimeGuard::acquire();
+        runtime.set_var("WAVECRATE_CONFIG_HOME", path);
+        Self { _runtime: runtime }
     }
 }

--- a/tests/unit/source_db_mod_tests/mod.rs
+++ b/tests/unit/source_db_mod_tests/mod.rs
@@ -1,66 +1,18 @@
 use super::*;
+use crate::test_runtime::TestRuntimeGuard;
 use rusqlite::{OptionalExtension, params};
-use std::ffi::OsString;
-use std::sync::{Mutex, OnceLock};
 use tempfile::tempdir;
 
 mod metadata;
 mod opening;
 mod snapshot;
 
-fn source_db_env_lock() -> &'static Mutex<()> {
-    static SOURCE_DB_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    SOURCE_DB_ENV_LOCK.get_or_init(|| Mutex::new(()))
-}
-
 fn with_home_env_override<T>(home: &Path, test: impl FnOnce() -> T) -> T {
-    let _lock = match source_db_env_lock().lock() {
-        Ok(lock) => lock,
-        Err(_) => panic!("HOME env override lock was poisoned"),
-    };
-    let prev_home = std::env::var_os("HOME");
-    let prev_homedrive = std::env::var_os("HOMEDRIVE");
-    let prev_hompath = std::env::var_os("HOMEPATH");
-    let prev_user_profile = std::env::var_os("USERPROFILE");
-
-    unsafe {
-        std::env::set_var("HOME", home);
-    }
-
-    struct HomeEnvGuard {
-        prev_home: Option<OsString>,
-        prev_homedrive: Option<OsString>,
-        prev_hompath: Option<OsString>,
-        prev_user_profile: Option<OsString>,
-    }
-
-    impl Drop for HomeEnvGuard {
-        fn drop(&mut self) {
-            match self.prev_home.take() {
-                Some(home) => unsafe { std::env::set_var("HOME", home) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
-            match self.prev_homedrive.take() {
-                Some(value) => unsafe { std::env::set_var("HOMEDRIVE", value) },
-                None => unsafe { std::env::remove_var("HOMEDRIVE") },
-            }
-            match self.prev_hompath.take() {
-                Some(value) => unsafe { std::env::set_var("HOMEPATH", value) },
-                None => unsafe { std::env::remove_var("HOMEPATH") },
-            }
-            match self.prev_user_profile.take() {
-                Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
-                None => unsafe { std::env::remove_var("USERPROFILE") },
-            }
-        }
-    }
-
-    let _home_guard = HomeEnvGuard {
-        prev_home,
-        prev_homedrive,
-        prev_hompath,
-        prev_user_profile,
-    };
+    let mut runtime = TestRuntimeGuard::acquire();
+    runtime.set_var("HOME", home);
+    runtime.remove_var("HOMEDRIVE");
+    runtime.remove_var("HOMEPATH");
+    runtime.set_var("USERPROFILE", home);
 
     test()
 }


### PR DESCRIPTION
## Goal

Make Wavecrate tests that touch process-wide environment, HOME/profile roots, configuration-root state, or the process working directory share one panic-safe isolation contract.

Linear: [OPT-1259](https://linear.app/boostnlvp/issue/OPT-1259/wavecrate-tests-isolate-process-wide-environment-and-working-directory)

## Scope and non-goals

- Add a reusable, re-entrant, poison-safe `TestRuntimeGuard` under the existing `test-support` feature.
- Restore exact `OsString` environment values and the prior working directory in reverse mutation order, including unwind paths.
- Fail closed and reject later scoped access if the prior working directory becomes unrestorable.
- Migrate config-home, HOME/profile, SQLite-extension, token-store, updater, and logging test owners from module-local locks/manual cleanup.
- Keep `ConfigBaseGuard` thread-local instead of temporarily clearing the process-global app-root override.
- Clear the fallback-key cache mutex poison flag after recovery so later scoped owners can reuse it.
- Do not serialize the entire library suite or change production environment/path resolution.

## Definition of Done

- Direct Wavecrate test-side environment/CWD mutation is centralized in `TestRuntimeGuard`.
- Cross-module contenders in one test binary cannot overlap.
- Nested, unset/empty, panic cleanup, failed-CWD fail-closed behavior, concurrent contention, poison recovery, and cross-thread config-root visibility have regression coverage.
- Test roots used by migrated owners remain explicit temporary roots.
- Production builds do not expose the test-runtime module unless `test-support` is enabled.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p wavecrate-library`
- `cargo check -p wavecrate`
- `cargo test -q -p wavecrate-library app_dirs::tests -- --test-threads=16` (9 passed)
- `cargo test -q -p wavecrate-library test_runtime -- --test-threads=16` (5 passed)
- `cargo test -q -p wavecrate-library sqlite_ext::policy::tests --features sqlite-ext-unsafe -- --test-threads=16` (5 passed)
- `cargo test -q -p wavecrate-library source_db_mod_tests::opening::user_library -- --test-threads=16` (4 passed)
- `cargo test -q -p wavecrate issue_gateway::token_store::tests --lib -- --test-threads=16` (19 passed; repeated five consecutive times)
- `cargo test -q -p wavecrate updater::path_guard::tests --lib -- --test-threads=16` (5 passed)
- `cargo test -q -p wavecrate app_core::controller::tests::dispatch::logging --lib -- --test-threads=16` (1 passed)
- `cargo test -p wavecrate --test controller_browser_integration --features legacy-controller click_clears_selection_and_focuses_row -- --exact --test-threads=1` (1 passed)
- `bash scripts/ci.sh agent`: Wavecrate smoke and architecture gates passed before the limitation below.

## Known limitations

- Two requested full `cargo test -p wavecrate --lib -- --test-threads=16` runs completed with 54 and 56 failures respectively. The sets were dominated by existing load-sensitive native-app/source-watcher/cache tests and included a deterministic source-shape assertion (`root_facade_exports_only_stable_entrypoints`); none of the migrated process-state owner families failed.
- `bash scripts/ci.sh agent` is currently blocked in the vendored Radiant suite by `gpu_signal_shader_keeps_waveform_bands_visually_distinct`, which expects a stale shader color literal. The preceding Wavecrate smoke and architecture gates passed.

User approval is required before merge.