### PR TITLE
OPT-1258 Scope and reset mutable global test controls

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -44,7 +44,9 @@ pub(crate) use open::SourceDatabaseOpenMode;
 #[cfg(test)]
 pub(crate) use open::open_source_database;
 #[cfg(debug_assertions)]
-pub use open::{test_reset_source_db_open_total_count, test_source_db_open_total_count};
+pub use open::test_source_db_open_total_count;
+#[cfg(debug_assertions)]
+pub use open::{TestSourceDbOpenCountGuard, test_scope_source_db_open_total_count};
 pub use open_profiles::SourceDatabaseConnectionRole;
 /// Metadata retained for a pruned row so later scans can recover rename state.
 pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingRenamePruneReport};

--- a/crates/wavecrate-library/src/sample_sources/db/open.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open.rs
@@ -227,10 +227,34 @@ impl SourceDatabaseOpenMode {
     }
 }
 
-/// Reset the debug-only source DB open counter used by regression tests.
+/// Owned scope for one source DB open counter used by regression tests.
 #[cfg(debug_assertions)]
-pub fn test_reset_source_db_open_total_count(root: &Path) {
+pub struct TestSourceDbOpenCountGuard {
+    root: std::path::PathBuf,
+}
+
+#[cfg(debug_assertions)]
+impl Drop for TestSourceDbOpenCountGuard {
+    fn drop(&mut self) {
+        telemetry::reset_open_total_count(&self.root);
+    }
+}
+
+#[cfg(debug_assertions)]
+impl TestSourceDbOpenCountGuard {
+    /// Clear observations accumulated so far while retaining scope ownership.
+    pub fn reset(&self) {
+        telemetry::reset_open_total_count(&self.root);
+    }
+}
+
+/// Clear one source DB open counter for a scope and clear it again on drop.
+#[cfg(debug_assertions)]
+pub fn test_scope_source_db_open_total_count(root: &Path) -> TestSourceDbOpenCountGuard {
     telemetry::reset_open_total_count(root);
+    TestSourceDbOpenCountGuard {
+        root: root.to_path_buf(),
+    }
 }
 
 /// Return the debug-only source DB open count used by regression tests.

--- a/crates/wavecrate-library/src/sample_sources/db/open.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/open.rs
@@ -236,7 +236,7 @@ pub struct TestSourceDbOpenCountGuard {
 #[cfg(debug_assertions)]
 impl Drop for TestSourceDbOpenCountGuard {
     fn drop(&mut self) {
-        telemetry::reset_open_total_count(&self.root);
+        telemetry::release_open_total_count_scope(&self.root);
     }
 }
 
@@ -251,7 +251,7 @@ impl TestSourceDbOpenCountGuard {
 /// Clear one source DB open counter for a scope and clear it again on drop.
 #[cfg(debug_assertions)]
 pub fn test_scope_source_db_open_total_count(root: &Path) -> TestSourceDbOpenCountGuard {
-    telemetry::reset_open_total_count(root);
+    telemetry::acquire_open_total_count_scope(root);
     TestSourceDbOpenCountGuard {
         root: root.to_path_buf(),
     }

--- a/crates/wavecrate-library/src/sample_sources/db/telemetry.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/telemetry.rs
@@ -11,10 +11,17 @@ use crate::diagnostics::{DbDebugEvent, emit_db_debug_event};
 use super::SourceDbError;
 
 #[cfg(debug_assertions)]
-type OpenTotalCounts = std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, usize>>;
+#[derive(Default)]
+struct OpenTotalTestState {
+    counts: std::collections::HashMap<std::path::PathBuf, usize>,
+    active_scopes: std::collections::HashSet<std::path::PathBuf>,
+}
 
 #[cfg(debug_assertions)]
-static SOURCE_DB_OPEN_TOTAL_COUNTS: std::sync::OnceLock<OpenTotalCounts> =
+type OpenTotalTestControls = (std::sync::Mutex<OpenTotalTestState>, std::sync::Condvar);
+
+#[cfg(debug_assertions)]
+static SOURCE_DB_OPEN_TOTAL_TEST_CONTROLS: std::sync::OnceLock<OpenTotalTestControls> =
     std::sync::OnceLock::new();
 
 const SLOW_SOURCE_DB_OPEN_STEP: Duration = Duration::from_millis(15);
@@ -171,27 +178,69 @@ pub(super) fn record_open_total(
 }
 
 #[cfg(debug_assertions)]
-fn test_open_total_counts() -> &'static OpenTotalCounts {
-    SOURCE_DB_OPEN_TOTAL_COUNTS
-        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+fn test_open_total_controls() -> &'static OpenTotalTestControls {
+    SOURCE_DB_OPEN_TOTAL_TEST_CONTROLS.get_or_init(|| {
+        (
+            std::sync::Mutex::new(OpenTotalTestState::default()),
+            std::sync::Condvar::new(),
+        )
+    })
 }
 
 #[cfg(debug_assertions)]
 fn record_test_open_total(source_root: &Path) {
-    let mut counts = test_open_total_counts().lock().unwrap();
-    *counts.entry(source_root.to_path_buf()).or_insert(0) += 1;
+    let mut state = test_open_total_controls()
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *state.counts.entry(source_root.to_path_buf()).or_insert(0) += 1;
+}
+
+#[cfg(debug_assertions)]
+pub(super) fn acquire_open_total_count_scope(source_root: &Path) {
+    let (state, released) = test_open_total_controls();
+    let mut state = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    while state.active_scopes.contains(source_root) {
+        state = released
+            .wait(state)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    }
+    state.active_scopes.insert(source_root.to_path_buf());
+    state.counts.remove(source_root);
+}
+
+#[cfg(debug_assertions)]
+pub(super) fn release_open_total_count_scope(source_root: &Path) {
+    let (state, released) = test_open_total_controls();
+    let mut state = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    state.counts.remove(source_root);
+    let owned = state.active_scopes.remove(source_root);
+    drop(state);
+    debug_assert!(owned, "source DB open-count scope must own its root");
+    released.notify_all();
 }
 
 #[cfg(debug_assertions)]
 pub(super) fn reset_open_total_count(source_root: &Path) {
-    test_open_total_counts().lock().unwrap().remove(source_root);
+    test_open_total_controls()
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .counts
+        .remove(source_root);
 }
 
 #[cfg(debug_assertions)]
 pub(super) fn open_total_count(source_root: &Path) -> usize {
-    test_open_total_counts()
+    test_open_total_controls()
+        .0
         .lock()
-        .unwrap()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .counts
         .get(source_root)
         .copied()
         .unwrap_or(0)
@@ -204,7 +253,7 @@ mod tests {
         open_phase_success_threshold, open_total_count, open_total_success_threshold,
         record_test_open_total, slow_success_outcome,
     };
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
     #[test]
@@ -273,5 +322,37 @@ mod tests {
 
         assert!(unwind.is_err());
         assert_eq!(open_total_count(root), 0);
+    }
+
+    #[test]
+    fn concurrent_same_root_open_total_count_scopes_are_isolated() {
+        let root = PathBuf::from("source-db-open-count-concurrent-scope");
+        let first_scope = super::super::open::test_scope_source_db_open_total_count(root.as_path());
+        record_test_open_total(root.as_path());
+        record_test_open_total(root.as_path());
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let worker_root = root.clone();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _scope = super::super::open::test_scope_source_db_open_total_count(&worker_root);
+            assert_eq!(open_total_count(&worker_root), 0);
+            record_test_open_total(&worker_root);
+            assert_eq!(open_total_count(&worker_root), 1);
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert_eq!(open_total_count(root.as_path()), 2);
+        assert!(matches!(
+            acquired_rx.recv_timeout(Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        drop(first_scope);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.join().unwrap();
+        assert_eq!(open_total_count(root.as_path()), 0);
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/telemetry.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/telemetry.rs
@@ -201,8 +201,10 @@ pub(super) fn open_total_count(source_root: &Path) -> usize {
 mod tests {
     use super::{
         SLOW_SOURCE_DB_OPEN_STEP, SLOW_SOURCE_DB_OPEN_TOTAL, SLOW_SOURCE_DB_OPEN_TOTAL_JOB_WORKER,
-        open_phase_success_threshold, open_total_success_threshold, slow_success_outcome,
+        open_phase_success_threshold, open_total_count, open_total_success_threshold,
+        record_test_open_total, slow_success_outcome,
     };
+    use std::path::Path;
     use std::time::Duration;
 
     #[test]
@@ -257,5 +259,19 @@ mod tests {
             open_total_success_threshold("job_worker", false),
             SLOW_SOURCE_DB_OPEN_TOTAL_JOB_WORKER
         );
+    }
+
+    #[test]
+    fn open_total_count_scope_cleans_up_after_unwind() {
+        let root = Path::new("source-db-open-count-scope");
+        let unwind = std::panic::catch_unwind(|| {
+            let _scope = super::super::open::test_scope_source_db_open_total_count(root);
+            record_test_open_total(root);
+            assert_eq!(open_total_count(root), 1);
+            panic!("exercise source DB open-count cleanup");
+        });
+
+        assert!(unwind.is_err());
+        assert_eq!(open_total_count(root), 0);
     }
 }

--- a/src/app/controller/jobs/source_db_maintenance/tests.rs
+++ b/src/app/controller/jobs/source_db_maintenance/tests.rs
@@ -52,9 +52,9 @@ fn capture_debug_logs(run: impl FnOnce()) -> String {
         .with_max_level(tracing::Level::DEBUG)
         .with_writer(buffer.clone())
         .finish();
-    crate::logging::set_debug_logging_enabled_for_tests(true);
-    tracing::subscriber::with_default(subscriber, run);
-    crate::logging::set_debug_logging_enabled_for_tests(false);
+    crate::logging::with_debug_logging_enabled_for_tests(true, || {
+        tracing::subscriber::with_default(subscriber, run);
+    });
     buffer.captured()
 }
 

--- a/src/app/controller/library/browser_controller/actions/metadata/tests/background/dispatch.rs
+++ b/src/app/controller/library/browser_controller/actions/metadata/tests/background/dispatch.rs
@@ -36,7 +36,8 @@ fn large_background_auto_rename_reuses_source_db_for_batch_execution() {
     const SAMPLE_COUNT: usize = 24;
     let (mut controller, source, paths) = large_auto_rename_fixture(SAMPLE_COUNT);
 
-    crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+    let _open_count_scope =
+        crate::sample_sources::db::test_scope_source_db_open_total_count(&source.root);
     BrowserController::new(&mut controller)
         .auto_rename_browser_sample_paths_background_for_tests(&paths)
         .expect("background auto rename should start");

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation.rs
@@ -69,8 +69,3 @@ impl RenameLoopedMetadata {
 
 pub(crate) use auto_rename::run_sample_auto_rename_job;
 pub(super) use rename::perform_sample_rename;
-
-#[cfg(test)]
-pub(super) use provenance::{
-    RenameLoopedProvenanceLog, take_rename_looped_provenance_logs_for_tests,
-};

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation/provenance.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation/provenance.rs
@@ -1,53 +1,6 @@
-use super::*;
-
-#[cfg(test)]
-use std::sync::{LazyLock, Mutex};
-
-#[cfg(test)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(in crate::app::controller::library::browser_controller::helpers) struct RenameLoopedProvenanceLog
-{
-    pub(in crate::app::controller::library::browser_controller::helpers) old_relative: PathBuf,
-    pub(in crate::app::controller::library::browser_controller::helpers) new_relative: PathBuf,
-    pub(in crate::app::controller::library::browser_controller::helpers) request_looped: bool,
-    pub(in crate::app::controller::library::browser_controller::helpers) db_looped: Option<bool>,
-    pub(in crate::app::controller::library::browser_controller::helpers) final_looped: bool,
-}
-
-#[cfg(test)]
-static RENAME_LOOPED_PROVENANCE_LOGS: LazyLock<Mutex<Vec<RenameLoopedProvenanceLog>>> =
-    LazyLock::new(|| Mutex::new(Vec::new()));
-
-#[cfg(test)]
-pub(in crate::app::controller::library::browser_controller::helpers) fn take_rename_looped_provenance_logs_for_tests()
--> Vec<RenameLoopedProvenanceLog> {
-    std::mem::take(&mut *RENAME_LOOPED_PROVENANCE_LOGS.lock().unwrap())
-}
-
-#[cfg(test)]
 pub(super) fn record_rename_looped_provenance(
-    old_relative: &Path,
-    new_relative: &Path,
-    request_looped: bool,
-    db_looped: Option<bool>,
-    final_looped: bool,
-) {
-    RENAME_LOOPED_PROVENANCE_LOGS
-        .lock()
-        .unwrap()
-        .push(RenameLoopedProvenanceLog {
-            old_relative: old_relative.to_path_buf(),
-            new_relative: new_relative.to_path_buf(),
-            request_looped,
-            db_looped,
-            final_looped,
-        });
-}
-
-#[cfg(not(test))]
-pub(super) fn record_rename_looped_provenance(
-    _old_relative: &Path,
-    _new_relative: &Path,
+    _old_relative: &std::path::Path,
+    _new_relative: &std::path::Path,
     _request_looped: bool,
     _db_looped: Option<bool>,
     _final_looped: bool,

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation_tests/auto_rename_rollback.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation_tests/auto_rename_rollback.rs
@@ -33,31 +33,17 @@ fn sample_auto_rename_logs_looped_metadata_provenance() {
         assert!(result.errors.is_empty(), "{:?}", result.errors);
     });
 
-    if !captured.is_empty() {
-        assert!(
-            captured.contains("auto rename: persisted loop metadata provenance"),
-            "rename persistence should log loop provenance: {captured}"
-        );
-        assert!(
-            captured.contains("old_path=old.wav")
-                && captured.contains("new_path=renamed.wav")
-                && captured.contains("request_looped=true")
-                && captured.contains("db_looped=Some(false)")
-                && captured.contains("final_looped=true"),
-            "log should identify request, DB, and final loop values: {captured}"
-        );
-    }
-    let provenance_logs = take_rename_looped_provenance_logs_for_tests();
-    let expected = RenameLoopedProvenanceLog {
-        old_relative: old_relative.to_path_buf(),
-        new_relative: new_relative.to_path_buf(),
-        request_looped: true,
-        db_looped: Some(false),
-        final_looped: true,
-    };
     assert!(
-        provenance_logs.contains(&expected),
-        "test capture should mirror the emitted loop provenance event"
+        captured.contains("auto rename: persisted loop metadata provenance"),
+        "rename persistence should log loop provenance: {captured}"
+    );
+    assert!(
+        captured.contains("old_path=old.wav")
+            && captured.contains("new_path=renamed.wav")
+            && captured.contains("request_looped=true")
+            && captured.contains("db_looped=Some(false)")
+            && captured.contains("final_looped=true"),
+        "log should identify request, DB, and final loop values: {captured}"
     );
 }
 

--- a/src/app/controller/library/browser_controller/helpers/sample_mutation_tests/mod.rs
+++ b/src/app/controller/library/browser_controller/helpers/sample_mutation_tests/mod.rs
@@ -1,7 +1,4 @@
-use super::sample_mutation::{
-    RenameLoopedMetadata, RenameLoopedProvenanceLog, perform_sample_rename,
-    take_rename_looped_provenance_logs_for_tests,
-};
+use super::sample_mutation::{RenameLoopedMetadata, perform_sample_rename};
 use super::sample_mutation::{
     SAMPLE_RENAME_DB_RETRIES_PRODUCTION, SAMPLE_RENAME_DB_RETRY_DELAY_PRODUCTION,
 };

--- a/src/app/controller/library/source_folders/delete_recovery/journal/atomic_save.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/journal/atomic_save.rs
@@ -1,15 +1,22 @@
 use std::path::Path;
 
 #[cfg(test)]
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
 #[cfg(test)]
-fn fail_save_target() -> &'static Mutex<Option<PathBuf>> {
-    static TARGET: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
-    TARGET.get_or_init(|| Mutex::new(None))
+#[derive(Default)]
+struct FailSaveTargets {
+    next_token: u64,
+    armed: HashMap<PathBuf, u64>,
+}
+
+#[cfg(test)]
+fn fail_save_targets() -> &'static Mutex<FailSaveTargets> {
+    static TARGETS: OnceLock<Mutex<FailSaveTargets>> = OnceLock::new();
+    TARGETS.get_or_init(|| Mutex::new(FailSaveTargets::default()))
 }
 
 pub(super) fn replace_journal_file(tmp_path: &Path, path: &Path) -> Result<(), String> {
@@ -52,20 +59,79 @@ pub(crate) fn fail_save_before_replace(_path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 pub(crate) fn fail_save_before_replace(path: &Path) -> Result<(), String> {
-    let mut guard = fail_save_target()
+    let mut guard = fail_save_targets()
         .lock()
         .map_err(|_| "Delete journal test hook lock poisoned".to_string())?;
-    if guard.as_ref().is_some_and(|target| target == path) {
-        *guard = None;
+    if guard.armed.remove(path).is_some() {
         return Err("Injected delete journal save failure before replace".into());
     }
     Ok(())
 }
 
 #[cfg(test)]
-pub(crate) fn fail_next_save_before_replace_for_tests(path: PathBuf) {
-    let mut guard = fail_save_target()
+pub(crate) struct FailSaveBeforeReplaceGuard {
+    path: PathBuf,
+    token: u64,
+}
+
+#[cfg(test)]
+impl Drop for FailSaveBeforeReplaceGuard {
+    fn drop(&mut self) {
+        let mut targets = fail_save_targets()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if targets.armed.get(&self.path) == Some(&self.token) {
+            targets.armed.remove(&self.path);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn fail_next_save_before_replace_for_tests(path: PathBuf) -> FailSaveBeforeReplaceGuard {
+    let mut guard = fail_save_targets()
         .lock()
         .expect("delete journal test hook lock");
-    *guard = Some(path);
+    assert!(
+        !guard.armed.contains_key(&path),
+        "delete journal failure already armed for {}",
+        path.display()
+    );
+    guard.next_token = guard.next_token.wrapping_add(1);
+    let token = guard.next_token;
+    guard.armed.insert(path.clone(), token);
+    FailSaveBeforeReplaceGuard { path, token }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_scope_cleans_up_on_unwind_and_isolates_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = dir.path().join("first.json");
+        let second = dir.path().join("second.json");
+
+        let unwind = std::panic::catch_unwind({
+            let first = first.clone();
+            move || {
+                let _failure = fail_next_save_before_replace_for_tests(first);
+                panic!("exercise failure-scope cleanup");
+            }
+        });
+        assert!(unwind.is_err());
+        assert!(fail_save_before_replace(&first).is_ok());
+
+        let _first_failure = fail_next_save_before_replace_for_tests(first.clone());
+        let _second_failure = fail_next_save_before_replace_for_tests(second.clone());
+        assert!(fail_save_before_replace(&first).is_err());
+        assert!(fail_save_before_replace(&second).is_err());
+
+        let consumed = fail_next_save_before_replace_for_tests(first.clone());
+        assert!(fail_save_before_replace(&first).is_err());
+        let successor = fail_next_save_before_replace_for_tests(first.clone());
+        drop(consumed);
+        assert!(fail_save_before_replace(&first).is_err());
+        drop(successor);
+    }
 }

--- a/src/app/controller/library/source_folders/delete_recovery/journal/tests.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/journal/tests.rs
@@ -17,7 +17,8 @@ fn failed_journal_replace_preserves_last_committed_delete_state() -> Result<(), 
     let staging_root = source_root.join(DELETE_STAGING_DIR);
     let staged = stage_folder_for_delete(&original, &staging_root, Path::new("gone"), &[])?;
 
-    fail_next_save_before_replace_for_tests(super::store::journal_path(&staging_root));
+    let _failure =
+        fail_next_save_before_replace_for_tests(super::store::journal_path(&staging_root));
     let err = mark_delete_retained(&staging_root, &staged.id).unwrap_err();
 
     assert!(err.contains("Injected delete journal save failure"));

--- a/src/app/controller/library/source_folders/delete_recovery/tests.rs
+++ b/src/app/controller/library/source_folders/delete_recovery/tests.rs
@@ -17,7 +17,7 @@ fn failed_journal_replace_preserves_last_committed_delete_state() -> Result<(), 
     let staging_root = source_root.join(DELETE_STAGING_DIR);
     let staged = stage_folder_for_delete(&original, &staging_root, Path::new("gone"), &[])?;
 
-    fail_next_save_before_replace_for_tests(&staging_root);
+    let _failure = fail_next_save_before_replace_for_tests(staging_root.clone());
     let err = mark_delete_retained(&staging_root, &staged.id).unwrap_err();
 
     assert!(err.contains("Injected delete journal save failure"));

--- a/src/app/controller/library/source_write_priority.rs
+++ b/src/app/controller/library/source_write_priority.rs
@@ -137,17 +137,60 @@ struct SourceWritePriorityState {
 struct SourceWritePriorityTestScope {
     source_id: SourceId,
     previous: SourceWritePriorityState,
-    _owner: std::sync::MutexGuard<'static, ()>,
+    _owner: SourceWritePriorityTestOwner,
+}
+
+#[cfg(test)]
+struct SourceWritePriorityTestOwner {
+    source_id: SourceId,
+}
+
+#[cfg(test)]
+type SourceWritePriorityTestOwners = (Mutex<HashSet<SourceId>>, std::sync::Condvar);
+
+#[cfg(test)]
+fn source_write_priority_test_owners() -> &'static SourceWritePriorityTestOwners {
+    static OWNERS: OnceLock<SourceWritePriorityTestOwners> = OnceLock::new();
+    OWNERS.get_or_init(|| (Mutex::new(HashSet::new()), std::sync::Condvar::new()))
+}
+
+#[cfg(test)]
+impl SourceWritePriorityTestOwner {
+    fn new(source_id: &SourceId) -> Self {
+        let (owners, released) = source_write_priority_test_owners();
+        let mut owners = owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while owners.contains(source_id) {
+            owners = released
+                .wait(owners)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        owners.insert(source_id.clone());
+        Self {
+            source_id: source_id.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for SourceWritePriorityTestOwner {
+    fn drop(&mut self) {
+        let (owners, released) = source_write_priority_test_owners();
+        let mut owners = owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let owned = owners.remove(&self.source_id);
+        drop(owners);
+        debug_assert!(owned, "source write-priority scope must own its source");
+        released.notify_all();
+    }
 }
 
 #[cfg(test)]
 impl SourceWritePriorityTestScope {
     fn new(source_id: &SourceId) -> Self {
-        static OWNER: OnceLock<Mutex<()>> = OnceLock::new();
-        let owner = OWNER
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let owner = SourceWritePriorityTestOwner::new(source_id);
         let previous = take_source_state(source_id);
         Self {
             source_id: source_id.clone(),
@@ -229,6 +272,7 @@ impl CompletedBrowserRenameTestGuard {
 mod tests {
     use super::*;
     use std::sync::mpsc;
+    use std::time::Duration;
 
     #[test]
     fn file_op_guard_is_visible_to_worker_clients_and_cleans_up_after_panic() {
@@ -264,5 +308,51 @@ mod tests {
 
         assert!(unwind.is_err());
         assert_eq!(completed_browser_rename_target(&source_id, old), None);
+    }
+
+    #[test]
+    fn same_source_test_scopes_are_exclusive() {
+        let source_id = SourceId::from_string("same-source-scope-ownership");
+        let first_scope = FileOpWritePriorityGuard::new(&source_id);
+        let worker_source_id = source_id.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _scope = FileOpWritePriorityGuard::new(&worker_source_id);
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(file_op_write_priority_active(&source_id));
+        assert!(matches!(
+            acquired_rx.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        drop(first_scope);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.join().unwrap();
+        assert!(!file_op_write_priority_active(&source_id));
+    }
+
+    #[test]
+    fn distinct_source_test_scopes_acquire_concurrently() {
+        let first_source_id = SourceId::from_string("distinct-source-scope-a");
+        let second_source_id = SourceId::from_string("distinct-source-scope-b");
+        let first_scope = FileOpWritePriorityGuard::new(&first_source_id);
+        let worker_source_id = second_source_id.clone();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let _scope = FileOpWritePriorityGuard::new(&worker_source_id);
+            acquired_tx.send(()).unwrap();
+        });
+
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(file_op_write_priority_active(&first_source_id));
+        worker.join().unwrap();
+        drop(first_scope);
+        assert!(!file_op_write_priority_active(&first_source_id));
+        assert!(!file_op_write_priority_active(&second_source_id));
     }
 }

--- a/src/app/controller/library/source_write_priority.rs
+++ b/src/app/controller/library/source_write_priority.rs
@@ -104,14 +104,17 @@ pub(crate) fn completed_browser_rename_target(
 #[cfg(test)]
 pub(crate) struct FileOpWritePriorityGuard {
     source_id: SourceId,
+    _state_scope: SourceWritePriorityTestScope,
 }
 
 #[cfg(test)]
 impl FileOpWritePriorityGuard {
     pub(crate) fn new(source_id: &SourceId) -> Self {
+        let state_scope = SourceWritePriorityTestScope::new(source_id);
         begin_file_op_write_priority(source_id);
         Self {
             source_id: source_id.clone(),
+            _state_scope: state_scope,
         }
     }
 }
@@ -120,5 +123,146 @@ impl FileOpWritePriorityGuard {
 impl Drop for FileOpWritePriorityGuard {
     fn drop(&mut self) {
         finish_file_op_write_priority(&self.source_id);
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct SourceWritePriorityState {
+    active_count: Option<usize>,
+    remaps: Vec<(PathBuf, PathBuf)>,
+}
+
+#[cfg(test)]
+struct SourceWritePriorityTestScope {
+    source_id: SourceId,
+    previous: SourceWritePriorityState,
+    _owner: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl SourceWritePriorityTestScope {
+    fn new(source_id: &SourceId) -> Self {
+        static OWNER: OnceLock<Mutex<()>> = OnceLock::new();
+        let owner = OWNER
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = take_source_state(source_id);
+        Self {
+            source_id: source_id.clone(),
+            previous,
+            _owner: owner,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for SourceWritePriorityTestScope {
+    fn drop(&mut self) {
+        let _discarded = take_source_state(&self.source_id);
+        restore_source_state(&self.source_id, std::mem::take(&mut self.previous));
+    }
+}
+
+#[cfg(test)]
+fn take_source_state(source_id: &SourceId) -> SourceWritePriorityState {
+    let active_count = active_file_ops()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(source_id);
+    let mut remaps = completed_rename_remaps()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let keys = remaps
+        .entries
+        .keys()
+        .filter(|(candidate, _)| candidate == source_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    let entries = keys
+        .iter()
+        .filter_map(|key| {
+            remaps
+                .entries
+                .remove(key)
+                .map(|target| (key.1.clone(), target))
+        })
+        .collect();
+    remaps.order.retain(|(candidate, _)| candidate != source_id);
+    SourceWritePriorityState {
+        active_count,
+        remaps: entries,
+    }
+}
+
+#[cfg(test)]
+fn restore_source_state(source_id: &SourceId, state: SourceWritePriorityState) {
+    if let Some(active_count) = state.active_count {
+        active_file_ops()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(source_id.clone(), active_count);
+    }
+    for (old_relative, new_relative) in state.remaps {
+        record_completed_browser_rename(source_id, &old_relative, &new_relative);
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct CompletedBrowserRenameTestGuard {
+    _state_scope: SourceWritePriorityTestScope,
+}
+
+#[cfg(test)]
+impl CompletedBrowserRenameTestGuard {
+    pub(crate) fn new(source_id: &SourceId, old_relative: &Path, new_relative: &Path) -> Self {
+        let state_scope = SourceWritePriorityTestScope::new(source_id);
+        record_completed_browser_rename(source_id, old_relative, new_relative);
+        Self {
+            _state_scope: state_scope,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn file_op_guard_is_visible_to_worker_clients_and_cleans_up_after_panic() {
+        let source_id = SourceId::from_string("file-op-guard-panic");
+        let worker_source_id = source_id.clone();
+        let (active_tx, active_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let _guard = FileOpWritePriorityGuard::new(&worker_source_id);
+            active_tx.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            panic!("exercise file-op guard cleanup");
+        });
+
+        active_rx.recv().unwrap();
+        assert!(file_op_write_priority_active(&source_id));
+        assert!(worker.join().is_err());
+        assert!(!file_op_write_priority_active(&source_id));
+    }
+
+    #[test]
+    fn completed_rename_scope_cleans_up_after_panic() {
+        let source_id = SourceId::from_string("completed-rename-restore");
+        let old = Path::new("old.wav");
+        let unwind = std::panic::catch_unwind(|| {
+            let _guard =
+                CompletedBrowserRenameTestGuard::new(&source_id, old, Path::new("scoped.wav"));
+            assert_eq!(
+                completed_browser_rename_target(&source_id, old),
+                Some(PathBuf::from("scoped.wav"))
+            );
+            panic!("exercise completed-rename scope cleanup");
+        });
+
+        assert!(unwind.is_err());
+        assert_eq!(completed_browser_rename_target(&source_id, old), None);
     }
 }

--- a/src/app/controller/library/wavs/browser_search/dispatch_policy.rs
+++ b/src/app/controller/library/wavs/browser_search/dispatch_policy.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::app::state::ProgressTaskKind;
 use std::collections::BTreeMap;
+#[cfg(not(test))]
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(test)]
@@ -177,15 +178,22 @@ impl AppController {
 
 /// Resolve the wav-entry threshold for switching browser search to async jobs.
 fn browser_search_offload_threshold() -> usize {
-    /// Cached parsed offload threshold for browser search jobs.
-    static OFFLOAD_THRESHOLD: OnceLock<usize> = OnceLock::new();
-    *OFFLOAD_THRESHOLD.get_or_init(|| {
-        std::env::var(SEARCH_OFFLOAD_THRESHOLD_ENV)
-            .ok()
-            .and_then(|value| value.trim().parse::<usize>().ok())
-            .filter(|threshold| *threshold > 0)
-            .unwrap_or(DEFAULT_SEARCH_OFFLOAD_THRESHOLD)
-    })
+    #[cfg(test)]
+    {
+        DEFAULT_SEARCH_OFFLOAD_THRESHOLD
+    }
+    #[cfg(not(test))]
+    {
+        /// Cached parsed offload threshold for browser search jobs.
+        static OFFLOAD_THRESHOLD: OnceLock<usize> = OnceLock::new();
+        *OFFLOAD_THRESHOLD.get_or_init(|| {
+            std::env::var(SEARCH_OFFLOAD_THRESHOLD_ENV)
+                .ok()
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .filter(|threshold| *threshold > 0)
+                .unwrap_or(DEFAULT_SEARCH_OFFLOAD_THRESHOLD)
+        })
+    }
 }
 
 /// Resolve whether browser interaction paths should use the async worker pipeline.

--- a/src/app/controller/library/wavs/browser_search_worker/pipeline/stages_tests/metadata_refresh_tests.rs
+++ b/src/app/controller/library/wavs/browser_search_worker/pipeline/stages_tests/metadata_refresh_tests.rs
@@ -188,7 +188,7 @@ fn metadata_delta_refresh_reuses_same_source_db_connection_after_db_write() {
         .expect("expected queued search job generation")
         .generation;
     let mut cache = SearchWorkerCache::default();
-    crate::sample_sources::db::test_reset_source_db_open_total_count(&root);
+    let _open_count_scope = crate::sample_sources::db::test_scope_source_db_open_total_count(&root);
 
     assert!(ensure_search_cache_ready_for_job(
         &mut cache, &base_job, &source_id

--- a/src/app/controller/library/wavs/metadata_async/tests/analysis_resolution.rs
+++ b/src/app/controller/library/wavs/metadata_async/tests/analysis_resolution.rs
@@ -68,7 +68,7 @@ fn analysis_metadata_rename_resolution_reuses_one_source_db_open() {
         .remap_analysis_sample_identity(&other_old_relative, &other_new_relative)
         .expect("remap other analysis identity");
     batch.commit().expect("commit rename batch");
-    source_write_priority::record_completed_browser_rename(
+    let _rename_scope = source_write_priority::CompletedBrowserRenameTestGuard::new(
         &source.id,
         &old_relative,
         &new_relative,
@@ -79,7 +79,8 @@ fn analysis_metadata_rename_resolution_reuses_one_source_db_open() {
         &other_new_relative,
     );
 
-    crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+    let _open_count_scope =
+        crate::sample_sources::db::test_scope_source_db_open_total_count(&source.root);
     let result = run_metadata_mutation_job(MetadataMutationJob {
         request_id: 19,
         source_id: source.id.clone(),

--- a/src/app/controller/library/wavs/metadata_async/tests/loaded_duration.rs
+++ b/src/app/controller/library/wavs/metadata_async/tests/loaded_duration.rs
@@ -44,7 +44,7 @@ fn loaded_duration_metadata_job_follows_completed_browser_rename() {
         .remap_analysis_sample_identity(&old_relative, &new_relative)
         .expect("remap analysis identity");
     batch.commit().expect("commit rename batch");
-    source_write_priority::record_completed_browser_rename(
+    let _rename_scope = source_write_priority::CompletedBrowserRenameTestGuard::new(
         &source.id,
         &old_relative,
         &new_relative,

--- a/src/app/controller/library/wavs/metadata_async/tests/operation_logging.rs
+++ b/src/app/controller/library/wavs/metadata_async/tests/operation_logging.rs
@@ -77,7 +77,7 @@ fn source_metadata_job_logs_operation_path_remap_and_result() {
         .upsert_file(&new_relative, new_size, new_modified_ns)
         .expect("insert new row");
     batch.commit().expect("commit rename batch");
-    source_write_priority::record_completed_browser_rename(
+    let _rename_scope = source_write_priority::CompletedBrowserRenameTestGuard::new(
         &source.id,
         &old_relative,
         &new_relative,

--- a/src/app/controller/library/wavs/metadata_async/tests/priority.rs
+++ b/src/app/controller/library/wavs/metadata_async/tests/priority.rs
@@ -45,12 +45,14 @@ fn metadata_mutation_waits_behind_same_source_file_op_priority() {
         SourceDatabase::open_for_test_fixture_source_write(&source.root).expect("open source db");
     db.upsert_file(&relative_path, 1, 1)
         .expect("insert source row");
-    source_write_priority::begin_file_op_write_priority(&source.id);
-    let release_source_id = source.id.clone();
-    std::thread::spawn(move || {
+    let worker_source_id = source.id.clone();
+    let (active_tx, active_rx) = std::sync::mpsc::channel();
+    let priority_worker = std::thread::spawn(move || {
+        let _guard = source_write_priority::FileOpWritePriorityGuard::new(&worker_source_id);
+        active_tx.send(()).expect("signal active file-op priority");
         std::thread::sleep(Duration::from_millis(260));
-        source_write_priority::finish_file_op_write_priority(&release_source_id);
     });
+    active_rx.recv().expect("wait for active file-op priority");
 
     let result = run_metadata_mutation_job(MetadataMutationJob {
         request_id: 7,
@@ -70,4 +72,5 @@ fn metadata_mutation_waits_behind_same_source_file_op_priority() {
         db.user_tag_for_path(&relative_path).expect("read user tag"),
         Some(String::from("Vintage"))
     );
+    priority_worker.join().expect("priority worker");
 }

--- a/src/app/controller/library/wavs/metadata_async/tests/source_remap.rs
+++ b/src/app/controller/library/wavs/metadata_async/tests/source_remap.rs
@@ -29,7 +29,7 @@ fn source_metadata_job_follows_completed_browser_rename() {
         .upsert_file(&new_relative, new_size, new_modified_ns)
         .expect("insert new row");
     batch.commit().expect("commit rename batch");
-    source_write_priority::record_completed_browser_rename(
+    let _rename_scope = source_write_priority::CompletedBrowserRenameTestGuard::new(
         &source.id,
         &old_relative,
         &new_relative,

--- a/src/app/controller/startup_audio_test_support.rs
+++ b/src/app/controller/startup_audio_test_support.rs
@@ -5,11 +5,31 @@ thread_local! {
 
 /// Stub startup audio probing so tests can assert the deferral boundary without touching drivers.
 pub(crate) fn with_stubbed_startup_audio_refresh_for_tests<T>(run: impl FnOnce() -> T) -> T {
-    STUB_STARTUP_AUDIO_REFRESH_FOR_TESTS.with(|enabled| enabled.set(true));
-    STARTUP_AUDIO_REFRESH_COUNT_FOR_TESTS.with(|count| count.set(0));
-    let result = run();
-    STUB_STARTUP_AUDIO_REFRESH_FOR_TESTS.with(|enabled| enabled.set(false));
-    result
+    struct Reset<'a> {
+        enabled: &'a std::cell::Cell<bool>,
+        previous_enabled: bool,
+        count: &'a std::cell::Cell<usize>,
+        previous_count: usize,
+    }
+
+    impl Drop for Reset<'_> {
+        fn drop(&mut self) {
+            self.count.set(self.previous_count);
+            self.enabled.set(self.previous_enabled);
+        }
+    }
+
+    STUB_STARTUP_AUDIO_REFRESH_FOR_TESTS.with(|enabled| {
+        STARTUP_AUDIO_REFRESH_COUNT_FOR_TESTS.with(|count| {
+            let _reset = Reset {
+                enabled,
+                previous_enabled: enabled.replace(true),
+                count,
+                previous_count: count.replace(0),
+            };
+            run()
+        })
+    })
 }
 
 /// Return how many deferred startup audio refreshes were requested in the current test scope.
@@ -26,4 +46,30 @@ pub(crate) fn record_startup_audio_refresh_for_tests() -> bool {
         count.set(count.get().saturating_add(1));
     });
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_audio_stub_restores_nested_state_after_unwind() {
+        with_stubbed_startup_audio_refresh_for_tests(|| {
+            assert!(record_startup_audio_refresh_for_tests());
+            assert_eq!(startup_audio_refresh_count_for_tests(), 1);
+
+            let unwind = std::panic::catch_unwind(|| {
+                with_stubbed_startup_audio_refresh_for_tests(|| {
+                    assert_eq!(startup_audio_refresh_count_for_tests(), 0);
+                    assert!(record_startup_audio_refresh_for_tests());
+                    panic!("exercise startup audio test scope cleanup");
+                });
+            });
+            assert!(unwind.is_err());
+            assert_eq!(startup_audio_refresh_count_for_tests(), 1);
+        });
+
+        assert!(!record_startup_audio_refresh_for_tests());
+        assert_eq!(startup_audio_refresh_count_for_tests(), 0);
+    }
 }

--- a/src/app/controller/tests/source_async/source_add.rs
+++ b/src/app/controller/tests/source_async/source_add.rs
@@ -15,7 +15,8 @@ fn readding_known_source_prepares_database_off_controller_thread() {
     controller.remove_source(0);
     assert!(controller.library.sources.is_empty());
 
-    crate::sample_sources::db::test_reset_source_db_open_total_count(&source_path);
+    let _open_count_scope =
+        crate::sample_sources::db::test_scope_source_db_open_total_count(&source_path);
     with_source_add_async_enabled_for_tests(true, || {
         controller
             .add_source_from_path(source_path.clone())

--- a/src/app/controller/tests/source_lifecycle.rs
+++ b/src/app/controller/tests/source_lifecycle.rs
@@ -425,7 +425,8 @@ fn remap_rejects_existing_file_mutation() {
     )]);
     let destination = tempfile::tempdir().expect("destination");
     controller.begin_pending_file_mutation(&source.id, [std::path::PathBuf::from("pending.wav")]);
-    crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+    let _open_count_scope =
+        crate::sample_sources::db::test_scope_source_db_open_total_count(&source.root);
 
     let error = controller
         .remap_source_to(0, destination.path().to_path_buf())

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_move_task.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_move_task.rs
@@ -1,4 +1,6 @@
-use super::super::worker::{run_folder_move_task, set_before_folder_move_batch_hook};
+use super::super::worker::{
+    FolderMoveTestHooks, run_folder_move_task, run_folder_move_task_with_hooks,
+};
 use super::support::{
     Must, folder_move_request, folder_move_test_guard, setup_folder_move_fixture,
 };
@@ -15,7 +17,6 @@ use std::time::Duration;
 /// Moving a folder relocates contained files and rewrites their source DB paths.
 fn folder_move_updates_db_entries() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     let request = folder_move_request(&source, &source_root, "old", "dest");
     let result = run_folder_move_task(request, Arc::new(AtomicBool::new(false)), None);
@@ -63,7 +64,6 @@ fn folder_move_updates_db_entries() {
 /// Folder-tree folder moves register undo and redo on the legacy controller stack.
 fn folder_tree_move_supports_undo_and_redo() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     let mut controller = AppController::new(WaveformRenderer::new(16, 16), None);
     controller.library.sources.push(source.clone());
@@ -113,7 +113,6 @@ fn folder_tree_move_supports_undo_and_redo() {
 /// Cancelling before folder processing starts leaves filesystem and DB state unchanged.
 fn folder_move_cancelled_before_processing_keeps_source_unchanged() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     let request = folder_move_request(&source, &source_root, "old", "dest");
     let result = run_folder_move_task(request, Arc::new(AtomicBool::new(true)), None);
@@ -139,7 +138,6 @@ fn folder_move_cancelled_before_processing_keeps_source_unchanged() {
 /// Moving a folder into one of its descendants is rejected without touching the source tree.
 fn folder_move_rejects_descendant_target() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     std::fs::create_dir_all(source_root.join("old/child")).must();
     let request = folder_move_request(&source, &source_root, "old", "old/child");
@@ -159,7 +157,6 @@ fn folder_move_rejects_descendant_target() {
 /// An existing destination folder rejects the move before any filesystem rename occurs.
 fn folder_move_rejects_existing_destination_folder() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     std::fs::create_dir_all(source_root.join("dest/old")).must();
     let request = folder_move_request(&source, &source_root, "old", "dest");
@@ -191,32 +188,38 @@ fn folder_move_rejects_existing_destination_folder() {
 /// A database lock after the filesystem rename rolls the folder back to its original path.
 fn folder_move_db_write_failure_rolls_back_source_and_db_state() {
     let _guard = folder_move_test_guard();
-    set_before_folder_move_batch_hook(None);
     let (_temp, source, source_root) = setup_folder_move_fixture();
     let (lock_release_tx, lock_release_rx) = std::sync::mpsc::channel();
     let (lock_done_tx, lock_done_rx) = std::sync::mpsc::channel();
     let mut lock_release_rx = Some(lock_release_rx);
     let mut lock_done_tx = Some(lock_done_tx);
     let source_root_for_hook = source_root.clone();
-    set_before_folder_move_batch_hook(Some(Box::new(move || {
-        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
-        let db_file = source_root_for_hook.join(DB_FILE_NAME);
-        let lock_release_rx = lock_release_rx.take().must();
-        let lock_done_tx = lock_done_tx.take().must();
-        std::thread::spawn(move || {
-            let conn = rusqlite::Connection::open(db_file).must();
-            conn.execute_batch("BEGIN IMMEDIATE").must();
-            let _ = locked_tx.send(());
-            let _ = lock_release_rx.recv();
-            let _ = conn.execute_batch("COMMIT");
-            drop(conn);
-            let _ = lock_done_tx.send(());
-        });
-        locked_rx.recv().must();
-    })));
+    let mut hooks = FolderMoveTestHooks {
+        before_folder_move_batch: Some(Box::new(move || {
+            let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+            let db_file = source_root_for_hook.join(DB_FILE_NAME);
+            let lock_release_rx = lock_release_rx.take().must();
+            let lock_done_tx = lock_done_tx.take().must();
+            std::thread::spawn(move || {
+                let conn = rusqlite::Connection::open(db_file).must();
+                conn.execute_batch("BEGIN IMMEDIATE").must();
+                let _ = locked_tx.send(());
+                let _ = lock_release_rx.recv();
+                let _ = conn.execute_batch("COMMIT");
+                drop(conn);
+                let _ = lock_done_tx.send(());
+            });
+            locked_rx.recv().must();
+        })),
+        ..Default::default()
+    };
     let request = folder_move_request(&source, &source_root, "old", "dest");
-    let result = run_folder_move_task(request, Arc::new(AtomicBool::new(false)), None);
-    set_before_folder_move_batch_hook(None);
+    let result = run_folder_move_task_with_hooks(
+        request,
+        Arc::new(AtomicBool::new(false)),
+        None,
+        &mut hooks,
+    );
     let _ = lock_release_tx.send(());
     lock_done_rx.recv_timeout(Duration::from_secs(1)).must();
 

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_sample_move_task.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/tests/folder_sample_move_task.rs
@@ -1,6 +1,5 @@
 use super::super::worker::{
-    run_folder_sample_move_task, set_before_folder_sample_batch_hook,
-    set_before_folder_sample_finalize_hook,
+    FolderMoveTestHooks, run_folder_sample_move_task, run_folder_sample_move_task_with_hooks,
 };
 use super::support::{Must, folder_move_test_guard, read_file_metadata};
 use crate::app::controller::jobs::FolderSampleMoveRequest;
@@ -16,8 +15,6 @@ use tempfile::tempdir;
 /// Moving a single file updates filesystem state, DB metadata, and clears journal entries.
 fn folder_sample_move_updates_db_entry() {
     let _guard = folder_move_test_guard();
-    set_before_folder_sample_batch_hook(None);
-    set_before_folder_sample_finalize_hook(None);
     let temp = tempdir().must();
     let source_root = temp.path().join("source");
     let target_dir = source_root.join("folder");
@@ -82,8 +79,6 @@ fn folder_sample_move_updates_db_entry() {
 /// Cancellation before the batch starts leaves source file and DB entries unchanged.
 fn folder_sample_move_cancelled_before_processing_keeps_source_unchanged() {
     let _guard = folder_move_test_guard();
-    set_before_folder_sample_batch_hook(None);
-    set_before_folder_sample_finalize_hook(None);
     let temp = tempdir().must();
     let source_root = temp.path().join("source");
     let target_dir = source_root.join("folder");
@@ -131,8 +126,6 @@ fn folder_sample_move_cancelled_before_processing_keeps_source_unchanged() {
 /// A DB-write failure rolls the file back to source and keeps staged journal data for recovery.
 fn folder_sample_move_db_write_failure_rolls_back_source_and_keeps_journal_for_recovery() {
     let _guard = folder_move_test_guard();
-    set_before_folder_sample_batch_hook(None);
-    set_before_folder_sample_finalize_hook(None);
     let temp = tempdir().must();
     let source_root = temp.path().join("source");
     let target_dir = source_root.join("folder");
@@ -154,24 +147,27 @@ fn folder_sample_move_db_write_failure_rolls_back_source_and_keeps_journal_for_r
     let mut lock_release_rx = Some(lock_release_rx);
     let mut lock_done_tx = Some(lock_done_tx);
     let source_root_for_hook = source_root.clone();
-    set_before_folder_sample_batch_hook(Some(Box::new(move || {
-        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
-        let db_file = source_root_for_hook.join(DB_FILE_NAME);
-        let lock_release_rx = lock_release_rx.take().must();
-        let lock_done_tx = lock_done_tx.take().must();
-        std::thread::spawn(move || {
-            let conn = rusqlite::Connection::open(db_file).must();
-            conn.execute_batch("BEGIN IMMEDIATE").must();
-            let _ = locked_tx.send(());
-            let _ = lock_release_rx.recv();
-            let _ = conn.execute_batch("COMMIT");
-            drop(conn);
-            let _ = lock_done_tx.send(());
-        });
-        locked_rx.recv().must();
-    })));
+    let mut hooks = FolderMoveTestHooks {
+        before_folder_sample_batch: Some(Box::new(move || {
+            let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+            let db_file = source_root_for_hook.join(DB_FILE_NAME);
+            let lock_release_rx = lock_release_rx.take().must();
+            let lock_done_tx = lock_done_tx.take().must();
+            std::thread::spawn(move || {
+                let conn = rusqlite::Connection::open(db_file).must();
+                conn.execute_batch("BEGIN IMMEDIATE").must();
+                let _ = locked_tx.send(());
+                let _ = lock_release_rx.recv();
+                let _ = conn.execute_batch("COMMIT");
+                drop(conn);
+                let _ = lock_done_tx.send(());
+            });
+            locked_rx.recv().must();
+        })),
+        ..Default::default()
+    };
 
-    let result = run_folder_sample_move_task(
+    let result = run_folder_sample_move_task_with_hooks(
         source.id.clone(),
         source_root.clone(),
         vec![FolderSampleMoveRequest {
@@ -181,8 +177,8 @@ fn folder_sample_move_db_write_failure_rolls_back_source_and_keeps_journal_for_r
         Vec::new(),
         Arc::new(AtomicBool::new(false)),
         None,
+        &mut hooks,
     );
-    set_before_folder_sample_batch_hook(None);
     let _ = lock_release_tx.send(());
     lock_done_rx.recv_timeout(Duration::from_secs(1)).must();
 
@@ -225,8 +221,6 @@ fn folder_sample_move_db_write_failure_rolls_back_source_and_keeps_journal_for_r
 /// A final rename failure after DB commit rolls the DB and staged file back immediately.
 fn folder_sample_move_finalize_failure_rolls_back_db_file_and_journal() {
     let _guard = folder_move_test_guard();
-    set_before_folder_sample_batch_hook(None);
-    set_before_folder_sample_finalize_hook(None);
     let temp = tempdir().must();
     let source_root = temp.path().join("source");
     let target_dir = source_root.join("folder");
@@ -247,11 +241,14 @@ fn folder_sample_move_finalize_failure_rolls_back_db_file_and_journal() {
     batch.commit().must();
 
     let target_blocker = source_root.join("folder/one.wav");
-    set_before_folder_sample_finalize_hook(Some(Box::new(move || {
-        std::fs::create_dir(&target_blocker).must();
-    })));
+    let mut hooks = FolderMoveTestHooks {
+        before_folder_sample_finalize: Some(Box::new(move || {
+            std::fs::create_dir(&target_blocker).must();
+        })),
+        ..Default::default()
+    };
 
-    let result = run_folder_sample_move_task(
+    let result = run_folder_sample_move_task_with_hooks(
         source.id.clone(),
         source_root.clone(),
         vec![FolderSampleMoveRequest {
@@ -261,8 +258,8 @@ fn folder_sample_move_finalize_failure_rolls_back_db_file_and_journal() {
         Vec::new(),
         Arc::new(AtomicBool::new(false)),
         None,
+        &mut hooks,
     );
-    set_before_folder_sample_finalize_hook(None);
 
     assert!(result.moved.is_empty());
     assert!(

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker.rs
@@ -10,8 +10,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::Sender,
 };
-#[cfg(test)]
-use std::sync::{Mutex, OnceLock};
 
 /// Folder-level move worker implementation split from the sample-move worker.
 mod folder_move_task;
@@ -24,93 +22,57 @@ pub(super) fn run_folder_move_task(
     cancel: Arc<AtomicBool>,
     sender: Option<&Sender<FileOpMessage>>,
 ) -> FolderMoveResult {
-    folder_move_task::run_folder_move_task(request, cancel, sender)
+    folder_move_task::run_folder_move_task(request, cancel, sender, &mut NoopFolderMoveHooks)
 }
 
 #[cfg(test)]
-/// Optional one-shot hook used by tests to force deterministic timing around DB writes.
-type BeforeFolderMoveBatchHook = Box<dyn FnMut() + Send>;
+pub(super) fn run_folder_move_task_with_hooks(
+    request: FolderMoveRequest,
+    cancel: Arc<AtomicBool>,
+    sender: Option<&Sender<FileOpMessage>>,
+    hooks: &mut FolderMoveTestHooks,
+) -> FolderMoveResult {
+    folder_move_task::run_folder_move_task(request, cancel, sender, hooks)
+}
+
+pub(super) trait FolderMoveHooks {
+    fn before_folder_move_batch(&mut self) {}
+
+    fn before_folder_sample_batch(&mut self) {}
+
+    fn before_folder_sample_finalize(&mut self) {}
+}
+
+struct NoopFolderMoveHooks;
+
+impl FolderMoveHooks for NoopFolderMoveHooks {}
 
 #[cfg(test)]
-/// Optional one-shot hook used by tests to force deterministic timing around DB writes.
-type BeforeFolderSampleBatchHook = Box<dyn FnMut() + Send>;
+#[derive(Default)]
+pub(super) struct FolderMoveTestHooks {
+    pub(super) before_folder_move_batch: Option<Box<dyn FnMut() + Send>>,
+    pub(super) before_folder_sample_batch: Option<Box<dyn FnMut() + Send>>,
+    pub(super) before_folder_sample_finalize: Option<Box<dyn FnMut() + Send>>,
+}
 
 #[cfg(test)]
-/// Optional one-shot hook used by tests to force deterministic finalization failures.
-type BeforeFolderSampleFinalizeHook = Box<dyn FnMut() + Send>;
-
-#[cfg(test)]
-/// Global storage for the optional pre-batch hook used by folder-level move tests.
-static BEFORE_FOLDER_MOVE_BATCH_HOOK: OnceLock<Mutex<Option<BeforeFolderMoveBatchHook>>> =
-    OnceLock::new();
-
-#[cfg(test)]
-/// Global storage for the optional pre-batch hook used by folder-sample move tests.
-static BEFORE_FOLDER_SAMPLE_BATCH_HOOK: OnceLock<Mutex<Option<BeforeFolderSampleBatchHook>>> =
-    OnceLock::new();
-
-#[cfg(test)]
-/// Global storage for the optional pre-finalize hook used by folder-sample move tests.
-static BEFORE_FOLDER_SAMPLE_FINALIZE_HOOK: OnceLock<Mutex<Option<BeforeFolderSampleFinalizeHook>>> =
-    OnceLock::new();
-
-#[cfg(test)]
-/// Invoke and clear the one-shot pre-batch hook when tests configure one.
-fn run_before_folder_move_batch_hook() {
-    if let Some(hook_slot) = BEFORE_FOLDER_MOVE_BATCH_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(mut hook) = guard.take()
-    {
-        hook();
+impl FolderMoveHooks for FolderMoveTestHooks {
+    fn before_folder_move_batch(&mut self) {
+        if let Some(mut hook) = self.before_folder_move_batch.take() {
+            hook();
+        }
     }
-}
 
-#[cfg(test)]
-/// Invoke and clear the one-shot pre-batch hook when tests configure one.
-fn run_before_folder_sample_batch_hook() {
-    if let Some(hook_slot) = BEFORE_FOLDER_SAMPLE_BATCH_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(mut hook) = guard.take()
-    {
-        hook();
+    fn before_folder_sample_batch(&mut self) {
+        if let Some(mut hook) = self.before_folder_sample_batch.take() {
+            hook();
+        }
     }
-}
 
-#[cfg(test)]
-/// Invoke and clear the one-shot pre-finalize hook when tests configure one.
-fn run_before_folder_sample_finalize_hook() {
-    if let Some(hook_slot) = BEFORE_FOLDER_SAMPLE_FINALIZE_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(mut hook) = guard.take()
-    {
-        hook();
-    }
-}
-
-/// Configure an optional test hook invoked immediately before folder-level DB writes.
-#[cfg(test)]
-pub(super) fn set_before_folder_move_batch_hook(hook: Option<BeforeFolderMoveBatchHook>) {
-    let hook_slot = BEFORE_FOLDER_MOVE_BATCH_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
-    }
-}
-
-/// Configure an optional test hook invoked immediately before folder-sample DB writes.
-#[cfg(test)]
-pub(super) fn set_before_folder_sample_batch_hook(hook: Option<BeforeFolderSampleBatchHook>) {
-    let hook_slot = BEFORE_FOLDER_SAMPLE_BATCH_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
-    }
-}
-
-/// Configure an optional test hook invoked immediately before folder-sample finalization.
-#[cfg(test)]
-pub(super) fn set_before_folder_sample_finalize_hook(hook: Option<BeforeFolderSampleFinalizeHook>) {
-    let hook_slot = BEFORE_FOLDER_SAMPLE_FINALIZE_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
+    fn before_folder_sample_finalize(&mut self) {
+        if let Some(mut hook) = self.before_folder_sample_finalize.take() {
+            hook();
+        }
     }
 }
 
@@ -119,9 +81,29 @@ pub(super) fn run_folder_sample_move_task(
     source_id: SourceId,
     source_root: PathBuf,
     requests: Vec<FolderSampleMoveRequest>,
+    errors: Vec<String>,
+    cancel: Arc<AtomicBool>,
+    sender: Option<&Sender<FileOpMessage>>,
+) -> FolderSampleMoveResult {
+    run_folder_sample_move_task_with_hooks(
+        source_id,
+        source_root,
+        requests,
+        errors,
+        cancel,
+        sender,
+        &mut NoopFolderMoveHooks,
+    )
+}
+
+pub(super) fn run_folder_sample_move_task_with_hooks(
+    source_id: SourceId,
+    source_root: PathBuf,
+    requests: Vec<FolderSampleMoveRequest>,
     mut errors: Vec<String>,
     cancel: Arc<AtomicBool>,
     sender: Option<&Sender<FileOpMessage>>,
+    hooks: &mut impl FolderMoveHooks,
 ) -> FolderSampleMoveResult {
     let mut moved = Vec::new();
     let mut completed = 0usize;
@@ -162,15 +144,13 @@ pub(super) fn run_folder_sample_move_task(
                 continue;
             }
         };
-        #[cfg(test)]
-        run_before_folder_sample_batch_hook();
+        hooks.before_folder_sample_batch();
         if !transaction.commit_db_stage(&mut errors) {
             completed += 1;
             report_progress(sender, completed, detail);
             continue;
         }
-        #[cfg(test)]
-        run_before_folder_sample_finalize_hook();
+        hooks.before_folder_sample_finalize();
         if !transaction.finalize_filesystem_stage(&mut errors) {
             completed += 1;
             report_progress(sender, completed, detail);

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker/folder_move_task.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/folder_moves/worker/folder_move_task.rs
@@ -47,6 +47,7 @@ pub(super) fn run_folder_move_task(
     request: FolderMoveRequest,
     cancel: Arc<AtomicBool>,
     sender: Option<&Sender<FileOpMessage>>,
+    hooks: &mut impl super::FolderMoveHooks,
 ) -> FolderMoveResult {
     if cancel.load(Ordering::Relaxed) {
         return cancelled_result(&request);
@@ -59,8 +60,7 @@ pub(super) fn run_folder_move_task(
     if let Err(result) = transaction.commit_filesystem_stage() {
         return result;
     }
-    #[cfg(test)]
-    super::run_before_folder_move_batch_hook();
+    hooks.before_folder_move_batch();
     if let Err(result) = transaction.commit_db_stage() {
         return result;
     }

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/mod.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/mod.rs
@@ -10,17 +10,3 @@ mod apply_result;
 mod plan;
 mod registration;
 mod worker;
-
-#[cfg(test)]
-use std::sync::{Mutex, MutexGuard, OnceLock};
-
-#[cfg(test)]
-static SOURCE_MOVE_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-#[cfg(test)]
-pub(super) fn source_move_test_guard() -> MutexGuard<'static, ()> {
-    SOURCE_MOVE_TEST_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("source-move test lock poisoned")
-}

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/plan.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/plan.rs
@@ -160,7 +160,6 @@ impl DragDropController<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::source_move_test_guard;
     use super::*;
     use crate::app::controller::AppController;
     use crate::app::controller::test_support::{sample_entry, write_test_wav};
@@ -171,7 +170,6 @@ mod tests {
 
     #[test]
     fn dropping_to_same_source_is_a_no_op() {
-        let _guard = source_move_test_guard();
         let temp = tempdir().unwrap();
         let source_root = temp.path().join("source_a");
         std::fs::create_dir_all(&source_root).unwrap();
@@ -197,7 +195,6 @@ mod tests {
 
     #[test]
     fn moving_multiple_samples_to_source_transfers_files() {
-        let _guard = source_move_test_guard();
         let temp = tempdir().unwrap();
         let source_root = temp.path().join("source_a");
         let target_root = temp.path().join("source_b");

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker.rs
@@ -11,8 +11,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::Sender,
 };
-#[cfg(test)]
-use std::sync::{Mutex, OnceLock};
 
 #[cfg(test)]
 mod tests;
@@ -20,32 +18,77 @@ mod transaction;
 
 use transaction::prepare_source_move_transaction;
 
-#[cfg(test)]
-type BeforeSourceMoveTargetDbStageHook = Box<dyn FnMut() -> Result<(), String> + Send>;
-#[cfg(test)]
-type BeforeSourceMoveFinalizeHook = Box<dyn FnMut() + Send>;
-#[cfg(test)]
-type AfterSourceMoveProgressHook = Box<dyn FnMut(usize) + Send>;
+trait SourceMoveHooks {
+    fn before_target_db_stage(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn before_finalize(&mut self) {}
+
+    fn after_progress(&mut self, _completed: usize) {}
+}
+
+struct NoopSourceMoveHooks;
+
+impl SourceMoveHooks for NoopSourceMoveHooks {}
 
 #[cfg(test)]
-static BEFORE_SOURCE_MOVE_TARGET_DB_STAGE_HOOK: OnceLock<
-    Mutex<Option<BeforeSourceMoveTargetDbStageHook>>,
-> = OnceLock::new();
+#[derive(Default)]
+struct SourceMoveTestHooks {
+    before_target_db_stage: Option<Box<dyn FnMut() -> Result<(), String> + Send>>,
+    before_finalize: Option<Box<dyn FnMut() + Send>>,
+    after_progress: Option<Box<dyn FnMut(usize) + Send>>,
+}
+
 #[cfg(test)]
-static BEFORE_SOURCE_MOVE_FINALIZE_HOOK: OnceLock<Mutex<Option<BeforeSourceMoveFinalizeHook>>> =
-    OnceLock::new();
-#[cfg(test)]
-static AFTER_SOURCE_MOVE_PROGRESS_HOOK: OnceLock<Mutex<Option<AfterSourceMoveProgressHook>>> =
-    OnceLock::new();
+impl SourceMoveHooks for SourceMoveTestHooks {
+    fn before_target_db_stage(&mut self) -> Result<(), String> {
+        self.before_target_db_stage
+            .take()
+            .map_or(Ok(()), |mut hook| hook())
+    }
+
+    fn before_finalize(&mut self) {
+        if let Some(mut hook) = self.before_finalize.take() {
+            hook();
+        }
+    }
+
+    fn after_progress(&mut self, completed: usize) {
+        if let Some(hook) = self.after_progress.as_mut() {
+            hook(completed);
+        }
+    }
+}
 
 /// Execute a batch of cross-source sample moves in the background worker.
 pub(super) fn run_source_move_task(
     target_source_id: SourceId,
     target_root: PathBuf,
     requests: Vec<SourceMoveRequest>,
+    errors: Vec<String>,
+    cancel: Arc<AtomicBool>,
+    sender: Option<&Sender<FileOpMessage>>,
+) -> SourceMoveResult {
+    run_source_move_task_with_hooks(
+        target_source_id,
+        target_root,
+        requests,
+        errors,
+        cancel,
+        sender,
+        &mut NoopSourceMoveHooks,
+    )
+}
+
+fn run_source_move_task_with_hooks(
+    target_source_id: SourceId,
+    target_root: PathBuf,
+    requests: Vec<SourceMoveRequest>,
     mut errors: Vec<String>,
     cancel: Arc<AtomicBool>,
     sender: Option<&Sender<FileOpMessage>>,
+    hooks: &mut impl SourceMoveHooks,
 ) -> SourceMoveResult {
     let mut progress = SourceMoveProgress::new(sender);
     let mut moved = Vec::new();
@@ -87,10 +130,12 @@ pub(super) fn run_source_move_task(
             &mut source_dbs,
             request,
             &mut errors,
+            hooks,
         ) {
             moved.push(success);
         }
         progress.complete(detail);
+        hooks.after_progress(progress.completed);
     }
     SourceMoveResult {
         target_source_id,
@@ -117,8 +162,6 @@ impl<'a> SourceMoveProgress<'a> {
     fn complete(&mut self, detail: Option<String>) {
         self.completed = self.completed.saturating_add(1);
         report_progress(self.sender, self.completed, detail);
-        #[cfg(test)]
-        run_after_source_move_progress_hook(self.completed);
     }
 }
 
@@ -129,6 +172,7 @@ fn run_source_move_request(
     source_dbs: &mut HashMap<PathBuf, SourceDatabase>,
     request: SourceMoveRequest,
     errors: &mut Vec<String>,
+    hooks: &mut impl SourceMoveHooks,
 ) -> Option<SourceMoveSuccess> {
     let mut transaction =
         match prepare_source_move_transaction(target_root, target_db, source_dbs, request) {
@@ -138,13 +182,13 @@ fn run_source_move_request(
                 return None;
             }
         };
-    if !transaction.commit_target_db_stage(errors) {
+    if !transaction.commit_target_db_stage(errors, hooks) {
         return None;
     }
     if !transaction.commit_source_db_stage(errors) {
         return None;
     }
-    if !transaction.finalize_filesystem_stage(errors) {
+    if !transaction.finalize_filesystem_stage(errors, hooks) {
         return None;
     }
     Some(transaction.into_success(errors))
@@ -162,64 +206,5 @@ pub(super) fn report_progress(
             detail,
             item: None,
         });
-    }
-}
-
-#[cfg(test)]
-pub(super) fn set_before_source_move_target_db_stage_hook(
-    hook: Option<BeforeSourceMoveTargetDbStageHook>,
-) {
-    let hook_slot = BEFORE_SOURCE_MOVE_TARGET_DB_STAGE_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
-    }
-}
-
-#[cfg(test)]
-pub(super) fn set_before_source_move_finalize_hook(hook: Option<BeforeSourceMoveFinalizeHook>) {
-    let hook_slot = BEFORE_SOURCE_MOVE_FINALIZE_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
-    }
-}
-
-/// Test-only hook runner invoked immediately before the target-db stage begins.
-#[cfg(test)]
-pub(super) fn run_before_source_move_target_db_stage_hook() -> Result<(), String> {
-    if let Some(hook_slot) = BEFORE_SOURCE_MOVE_TARGET_DB_STAGE_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(mut hook) = guard.take()
-    {
-        return hook();
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-pub(super) fn run_before_source_move_finalize_hook() {
-    if let Some(hook_slot) = BEFORE_SOURCE_MOVE_FINALIZE_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(mut hook) = guard.take()
-    {
-        hook();
-    }
-}
-
-/// Configure a test-only hook invoked after each completed source-move request.
-#[cfg(test)]
-pub(super) fn set_after_source_move_progress_hook(hook: Option<AfterSourceMoveProgressHook>) {
-    let hook_slot = AFTER_SOURCE_MOVE_PROGRESS_HOOK.get_or_init(|| Mutex::new(None));
-    if let Ok(mut guard) = hook_slot.lock() {
-        *guard = hook;
-    }
-}
-
-#[cfg(test)]
-fn run_after_source_move_progress_hook(completed: usize) {
-    if let Some(hook_slot) = AFTER_SOURCE_MOVE_PROGRESS_HOOK.get()
-        && let Ok(mut guard) = hook_slot.lock()
-        && let Some(hook) = guard.as_mut()
-    {
-        hook(completed);
     }
 }

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/tests.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/tests.rs
@@ -1,4 +1,3 @@
-use super::super::source_move_test_guard;
 use super::*;
 use crate::app::controller::jobs::SourceMoveRequest;
 use crate::app::controller::test_support::write_test_wav;
@@ -9,10 +8,6 @@ use tempfile::tempdir;
 
 #[test]
 fn source_move_task_uses_unique_target_name_on_collision() {
-    let _guard = source_move_test_guard();
-    set_before_source_move_target_db_stage_hook(None);
-    set_before_source_move_finalize_hook(None);
-    set_after_source_move_progress_hook(None);
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source_a");
     let target_root = temp.path().join("source_b");
@@ -79,10 +74,6 @@ fn source_move_task_uses_unique_target_name_on_collision() {
 
 #[test]
 fn source_move_task_rolls_back_when_target_db_stage_fails() {
-    let _guard = source_move_test_guard();
-    set_before_source_move_target_db_stage_hook(None);
-    set_before_source_move_finalize_hook(None);
-    set_after_source_move_progress_hook(None);
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source_a");
     let target_root = temp.path().join("source_b");
@@ -92,11 +83,12 @@ fn source_move_task_rolls_back_when_target_db_stage_fails() {
     write_test_wav(&source_root.join("one.wav"), &[0.0, 0.1, -0.1]);
     let source_db = SourceDatabase::open_for_test_fixture_source_write(&source_root).unwrap();
     source_db.upsert_file(Path::new("one.wav"), 3, 1).unwrap();
-    set_before_source_move_target_db_stage_hook(Some(Box::new(|| {
-        Err("Simulated target DB failure".into())
-    })));
+    let mut hooks = SourceMoveTestHooks {
+        before_target_db_stage: Some(Box::new(|| Err("Simulated target DB failure".into()))),
+        ..Default::default()
+    };
 
-    let result = run_source_move_task(
+    let result = run_source_move_task_with_hooks(
         SourceId::from_string("target"),
         target_root.clone(),
         vec![SourceMoveRequest {
@@ -107,6 +99,7 @@ fn source_move_task_rolls_back_when_target_db_stage_fails() {
         Vec::new(),
         Arc::new(AtomicBool::new(false)),
         None,
+        &mut hooks,
     );
 
     assert!(source_root.join("one.wav").is_file());
@@ -121,10 +114,6 @@ fn source_move_task_rolls_back_when_target_db_stage_fails() {
 
 #[test]
 fn source_move_task_finalize_failure_rolls_back_dbs_file_and_journal() {
-    let _guard = source_move_test_guard();
-    set_before_source_move_target_db_stage_hook(None);
-    set_before_source_move_finalize_hook(None);
-    set_after_source_move_progress_hook(None);
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source_a");
     let target_root = temp.path().join("source_b");
@@ -144,11 +133,14 @@ fn source_move_task_finalize_failure_rolls_back_dbs_file_and_journal() {
         .unwrap();
 
     let target_blocker = target_root.join("one.wav");
-    set_before_source_move_finalize_hook(Some(Box::new(move || {
-        std::fs::create_dir(&target_blocker).unwrap();
-    })));
+    let mut hooks = SourceMoveTestHooks {
+        before_finalize: Some(Box::new(move || {
+            std::fs::create_dir(&target_blocker).unwrap();
+        })),
+        ..Default::default()
+    };
 
-    let result = run_source_move_task(
+    let result = run_source_move_task_with_hooks(
         SourceId::from_string("target"),
         target_root.clone(),
         vec![SourceMoveRequest {
@@ -159,8 +151,8 @@ fn source_move_task_finalize_failure_rolls_back_dbs_file_and_journal() {
         Vec::new(),
         Arc::new(AtomicBool::new(false)),
         None,
+        &mut hooks,
     );
-    set_before_source_move_finalize_hook(None);
 
     assert!(result.moved.is_empty());
     assert!(
@@ -206,10 +198,6 @@ fn source_move_task_finalize_failure_rolls_back_dbs_file_and_journal() {
 
 #[test]
 fn source_move_task_reports_progress_once_for_missing_file_request() {
-    let _guard = source_move_test_guard();
-    set_before_source_move_target_db_stage_hook(None);
-    set_before_source_move_finalize_hook(None);
-    set_after_source_move_progress_hook(None);
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source_a");
     let target_root = temp.path().join("source_b");
@@ -244,10 +232,6 @@ fn source_move_task_reports_progress_once_for_missing_file_request() {
 
 #[test]
 fn source_move_task_cancels_after_first_completed_request() {
-    let _guard = source_move_test_guard();
-    set_before_source_move_target_db_stage_hook(None);
-    set_before_source_move_finalize_hook(None);
-    set_after_source_move_progress_hook(None);
     let temp = tempdir().unwrap();
     let source_root = temp.path().join("source_a");
     let target_root = temp.path().join("source_b");
@@ -262,35 +246,44 @@ fn source_move_task_cancels_after_first_completed_request() {
     source_db.upsert_file(Path::new("two.wav"), 3, 1).unwrap();
     let cancel = Arc::new(AtomicBool::new(false));
     let cancel_for_hook = cancel.clone();
-    set_after_source_move_progress_hook(Some(Box::new(move |completed| {
-        if completed == 1 {
-            cancel_for_hook.store(true, Ordering::Relaxed);
-        }
-    })));
+    let hooks = SourceMoveTestHooks {
+        after_progress: Some(Box::new(move |completed| {
+            if completed == 1 {
+                cancel_for_hook.store(true, Ordering::Relaxed);
+            }
+        })),
+        ..Default::default()
+    };
 
-    let result = run_source_move_task(
-        SourceId::from_string("target"),
-        target_root.clone(),
-        vec![
-            SourceMoveRequest {
-                source_id: source.id.clone(),
-                source_root: source_root.clone(),
-                relative_path: PathBuf::from("one.wav"),
-            },
-            SourceMoveRequest {
-                source_id: source.id,
-                source_root: source_root.clone(),
-                relative_path: PathBuf::from("two.wav"),
-            },
-        ],
-        Vec::new(),
-        cancel,
-        None,
-    );
+    let target_root_for_worker = target_root.clone();
+    let source_root_for_worker = source_root.clone();
+    let worker = std::thread::spawn(move || {
+        let mut hooks = hooks;
+        run_source_move_task_with_hooks(
+            SourceId::from_string("target"),
+            target_root_for_worker,
+            vec![
+                SourceMoveRequest {
+                    source_id: source.id.clone(),
+                    source_root: source_root_for_worker.clone(),
+                    relative_path: PathBuf::from("one.wav"),
+                },
+                SourceMoveRequest {
+                    source_id: source.id,
+                    source_root: source_root_for_worker,
+                    relative_path: PathBuf::from("two.wav"),
+                },
+            ],
+            Vec::new(),
+            cancel,
+            None,
+            &mut hooks,
+        )
+    });
+    let result = worker.join().expect("source move worker");
 
     assert!(result.cancelled);
     assert_eq!(result.moved.len(), 1);
     assert!(target_root.join(&result.moved[0].target_relative).is_file());
     assert!(source_root.join("two.wav").is_file());
-    set_after_source_move_progress_hook(None);
 }

--- a/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/transaction.rs
+++ b/src/app/controller/ui/drag_drop_controller/drag_effects/source_moves/worker/transaction.rs
@@ -57,9 +57,12 @@ pub(super) fn prepare_source_move_transaction<'a>(
 
 impl SourceMoveTransaction<'_> {
     /// Commit the destination database stage or roll back the staged file on failure.
-    pub(super) fn commit_target_db_stage(&self, errors: &mut Vec<String>) -> bool {
-        #[cfg(test)]
-        if let Err(err) = super::run_before_source_move_target_db_stage_hook() {
+    pub(super) fn commit_target_db_stage(
+        &self,
+        errors: &mut Vec<String>,
+        hooks: &mut impl super::SourceMoveHooks,
+    ) -> bool {
+        if let Err(err) = hooks.before_target_db_stage() {
             report_staged_move_failure(errors, self.target_db, &self.prepared, err);
             return false;
         }
@@ -219,9 +222,12 @@ impl SourceMoveTransaction<'_> {
     }
 
     /// Rename the staged file into its final target location.
-    pub(super) fn finalize_filesystem_stage(&self, errors: &mut Vec<String>) -> bool {
-        #[cfg(test)]
-        super::run_before_source_move_finalize_hook();
+    pub(super) fn finalize_filesystem_stage(
+        &self,
+        errors: &mut Vec<String>,
+        hooks: &mut impl super::SourceMoveHooks,
+    ) -> bool {
+        hooks.before_finalize();
         if let Err(err) = std::fs::rename(
             &self.prepared.staged_absolute,
             &self.prepared.target_absolute,

--- a/src/app/controller/ui/starmap_view/connections.rs
+++ b/src/app/controller/ui/starmap_view/connections.rs
@@ -78,7 +78,8 @@ mod tests {
             sources: vec![source.clone()],
         })
         .expect("save source library");
-        crate::sample_sources::db::test_reset_source_db_open_total_count(&source.root);
+        let _open_count_scope =
+            crate::sample_sources::db::test_scope_source_db_open_total_count(&source.root);
 
         {
             let _guard = FileOpWritePriorityGuard::new(&source.id);

--- a/src/app_core/controller/action_dispatch.rs
+++ b/src/app_core/controller/action_dispatch.rs
@@ -178,6 +178,9 @@ fn record_ui_action(
 
 fn should_record_ui_action(action: &'static str, outcome: &'static str) -> bool {
     if action == "set_browser_view_start" && outcome == "success" {
+        #[cfg(test)]
+        return false;
+        #[cfg(not(test))]
         return crate::env_flags::env_var_truthy(crate::hotpath_telemetry::HOTPATH_TELEMETRY_ENV);
     }
     true

--- a/src/app_core/controller/tests/dispatch/logging.rs
+++ b/src/app_core/controller/tests/dispatch/logging.rs
@@ -45,9 +45,9 @@ where
         .with_max_level(tracing::Level::DEBUG)
         .with_writer(buffer.clone())
         .finish();
-    crate::logging::set_debug_logging_enabled_for_tests(true);
-    tracing::subscriber::with_default(subscriber, run);
-    crate::logging::set_debug_logging_enabled_for_tests(false);
+    crate::logging::with_debug_logging_enabled_for_tests(true, || {
+        tracing::subscriber::with_default(subscriber, run);
+    });
     buffer.captured()
 }
 

--- a/src/app_core/ui_bridge/metrics/registry.rs
+++ b/src/app_core/ui_bridge/metrics/registry.rs
@@ -1,11 +1,10 @@
 //! Process-lifetime bridge metrics registry and feature-flag state.
 
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
+use std::sync::OnceLock;
 #[cfg(feature = "native-bridge-metrics")]
 use std::{
-    sync::{
-        OnceLock,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
 
@@ -14,9 +13,9 @@ pub(crate) const BRIDGE_PROFILE_INTERVAL: u64 = 240;
 #[cfg(not(feature = "native-bridge-metrics"))]
 pub(crate) const BRIDGE_PROFILE_INTERVAL: u64 = 1;
 
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 const BRIDGE_PROFILE_ENV: &str = "WAVECRATE_NATIVE_BRIDGE_PROFILE";
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 /// Enable runtime validation that cached projection-key snapshots stay in sync.
 const PROJECTION_KEY_ASSERT_ENV: &str = "WAVECRATE_NATIVE_BRIDGE_ASSERT_PROJECTION_SNAPSHOT";
 
@@ -154,29 +153,29 @@ impl BridgeMetrics {
 #[cfg(feature = "native-bridge-metrics")]
 /// Process-lifetime grouped counter registry used by bridge profiling hooks.
 pub(crate) static BRIDGE_METRICS: BridgeMetrics = BridgeMetrics::new();
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 static BRIDGE_PROFILE_ENABLED: OnceLock<bool> = OnceLock::new();
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 /// Cached projection-snapshot assertion mode resolved from environment.
 static PROJECTION_KEY_ASSERT_ENABLED: OnceLock<bool> = OnceLock::new();
 
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 pub(crate) fn bridge_profiling_enabled() -> bool {
     *BRIDGE_PROFILE_ENABLED.get_or_init(|| crate::env_flags::env_var_truthy(BRIDGE_PROFILE_ENV))
 }
-#[cfg(not(feature = "native-bridge-metrics"))]
+#[cfg(any(not(feature = "native-bridge-metrics"), test))]
 #[inline]
 pub(crate) fn bridge_profiling_enabled() -> bool {
     false
 }
 
-#[cfg(feature = "native-bridge-metrics")]
+#[cfg(all(feature = "native-bridge-metrics", not(test)))]
 /// Resolve whether projection-key snapshot assertions should run.
 pub(crate) fn projection_key_assertions_enabled() -> bool {
     *PROJECTION_KEY_ASSERT_ENABLED
         .get_or_init(|| crate::env_flags::env_var_truthy(PROJECTION_KEY_ASSERT_ENV))
 }
-#[cfg(not(feature = "native-bridge-metrics"))]
+#[cfg(any(not(feature = "native-bridge-metrics"), test))]
 #[inline]
 /// Disable projection-key assertions when bridge metrics are compiled out.
 pub(crate) fn projection_key_assertions_enabled() -> bool {

--- a/src/app_core/ui_bridge/pending_waveform/config.rs
+++ b/src/app_core/ui_bridge/pending_waveform/config.rs
@@ -1,12 +1,19 @@
 /// Toggle immediate application of waveform overlay preview actions.
+#[cfg(not(test))]
 const IMMEDIATE_WAVEFORM_PREVIEW_ENV: &str = "WAVECRATE_NATIVE_BRIDGE_IMMEDIATE_WAVEFORM_PREVIEW";
 /// Default mode for immediate waveform overlay preview actions.
 const IMMEDIATE_WAVEFORM_PREVIEW_DEFAULT: bool = true;
 /// Cached immediate-waveform-preview mode resolved from environment.
+#[cfg(not(test))]
 static IMMEDIATE_WAVEFORM_PREVIEW_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 /// Resolve whether waveform preview actions should apply immediately.
 pub(in crate::app_core::ui_bridge) fn immediate_waveform_preview_enabled() -> bool {
+    #[cfg(test)]
+    {
+        IMMEDIATE_WAVEFORM_PREVIEW_DEFAULT
+    }
+    #[cfg(not(test))]
     *IMMEDIATE_WAVEFORM_PREVIEW_ENABLED.get_or_init(|| {
         std::env::var(IMMEDIATE_WAVEFORM_PREVIEW_ENV)
             .ok()

--- a/src/hotpath_telemetry.rs
+++ b/src/hotpath_telemetry.rs
@@ -12,9 +12,17 @@ use std::time::Duration;
 /// Environment variable used to toggle hot-path telemetry snapshots.
 pub(crate) const HOTPATH_TELEMETRY_ENV: &str = "WAVECRATE_HOTPATH_TELEMETRY";
 
-/// Resolve hot-path telemetry mode once and cache it in `state`.
+/// Resolve hot-path telemetry mode once and cache it in production.
+#[cfg(not(test))]
 pub(crate) fn enabled(state: &OnceLock<bool>) -> bool {
     *state.get_or_init(|| crate::env_flags::env_var_truthy(HOTPATH_TELEMETRY_ENV))
+}
+
+/// Keep telemetry disabled in unit tests so counters and environment changes
+/// cannot couple otherwise unrelated cases.
+#[cfg(test)]
+pub(crate) fn enabled(_state: &OnceLock<bool>) -> bool {
+    false
 }
 
 /// Add a duration in nanoseconds with saturating conversion to `u64`.

--- a/src/issue_gateway/token_store/fallback_policy.rs
+++ b/src/issue_gateway/token_store/fallback_policy.rs
@@ -1,7 +1,13 @@
 use super::FALLBACK_ALLOW_ENV;
+#[cfg(not(test))]
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(not(test))]
 static FALLBACK_WARNING_EMITTED: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+thread_local! {
+    static FALLBACK_WARNING_EMITTED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 pub(super) fn keyring_disabled() -> bool {
     env_var_truthy("WAVECRATE_DISABLE_KEYRING")
@@ -24,6 +30,11 @@ pub(super) fn env_var_truthy(key: &str) -> bool {
 }
 
 pub(super) fn warn_fallback_active() {
+    #[cfg(test)]
+    {
+        FALLBACK_WARNING_EMITTED.with(|emitted| emitted.set(true));
+    }
+    #[cfg(not(test))]
     if FALLBACK_WARNING_EMITTED
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_ok()
@@ -35,11 +46,26 @@ pub(super) fn warn_fallback_active() {
 }
 
 #[cfg(test)]
-pub(super) fn reset_fallback_warning_for_tests() {
-    FALLBACK_WARNING_EMITTED.store(false, Ordering::SeqCst);
+pub(super) fn with_fallback_warning_scope_for_tests<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset<'a> {
+        emitted: &'a std::cell::Cell<bool>,
+        previous: bool,
+    }
+
+    impl Drop for Reset<'_> {
+        fn drop(&mut self) {
+            self.emitted.set(self.previous);
+        }
+    }
+
+    FALLBACK_WARNING_EMITTED.with(|emitted| {
+        let previous = emitted.replace(false);
+        let _reset = Reset { emitted, previous };
+        run()
+    })
 }
 
 #[cfg(test)]
 pub(super) fn fallback_warning_emitted_for_tests() -> bool {
-    FALLBACK_WARNING_EMITTED.load(Ordering::SeqCst)
+    FALLBACK_WARNING_EMITTED.with(std::cell::Cell::get)
 }

--- a/src/issue_gateway/token_store/tests/mod.rs
+++ b/src/issue_gateway/token_store/tests/mod.rs
@@ -20,8 +20,38 @@ fn enable_mock_keyring() {
     });
 }
 
-fn env_lock() -> TestRuntimeGuard {
-    TestRuntimeGuard::acquire()
+struct TokenStoreTestRuntime {
+    runtime: TestRuntimeGuard,
+    previous_fallback_key: Option<[u8; 32]>,
+}
+
+impl std::ops::Deref for TokenStoreTestRuntime {
+    type Target = TestRuntimeGuard;
+
+    fn deref(&self) -> &Self::Target {
+        &self.runtime
+    }
+}
+
+impl std::ops::DerefMut for TokenStoreTestRuntime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.runtime
+    }
+}
+
+impl Drop for TokenStoreTestRuntime {
+    fn drop(&mut self) {
+        *fallback_key::lock_fallback_key_cache() = self.previous_fallback_key.take();
+    }
+}
+
+fn env_lock() -> TokenStoreTestRuntime {
+    let runtime = TestRuntimeGuard::acquire();
+    let previous_fallback_key = fallback_key::lock_fallback_key_cache().take();
+    TokenStoreTestRuntime {
+        runtime,
+        previous_fallback_key,
+    }
 }
 
 fn allow_fallback(runtime: &mut TestRuntimeGuard) {

--- a/src/issue_gateway/token_store/tests/warning_state.rs
+++ b/src/issue_gateway/token_store/tests/warning_state.rs
@@ -7,11 +7,32 @@ fn fallback_warns_when_active() {
     runtime.set_var("WAVECRATE_DISABLE_KEYRING", "1");
     allow_fallback(&mut runtime);
     set_env_key(&mut runtime);
-    fallback_policy::reset_fallback_warning_for_tests();
     let base = tempdir().unwrap();
     let _guard = app_dirs::ConfigBaseGuard::set(base.path().to_path_buf());
     let store = IssueTokenStore::new().unwrap();
 
-    store.set("tok_abcdefghijklmnopqrstuvwxyz").unwrap();
-    assert!(fallback_policy::fallback_warning_emitted_for_tests());
+    fallback_policy::with_fallback_warning_scope_for_tests(|| {
+        store.set("tok_abcdefghijklmnopqrstuvwxyz").unwrap();
+        assert!(fallback_policy::fallback_warning_emitted_for_tests());
+    });
+}
+
+#[test]
+fn fallback_warning_scope_restores_nested_state_after_unwind() {
+    fallback_policy::with_fallback_warning_scope_for_tests(|| {
+        fallback_policy::warn_fallback_active();
+        assert!(fallback_policy::fallback_warning_emitted_for_tests());
+
+        let unwind = std::panic::catch_unwind(|| {
+            fallback_policy::with_fallback_warning_scope_for_tests(|| {
+                assert!(!fallback_policy::fallback_warning_emitted_for_tests());
+                fallback_policy::warn_fallback_active();
+                panic!("exercise fallback warning scope cleanup");
+            });
+        });
+        assert!(unwind.is_err());
+        assert!(fallback_policy::fallback_warning_emitted_for_tests());
+    });
+
+    assert!(!fallback_policy::fallback_warning_emitted_for_tests());
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -34,6 +34,12 @@ use tracing_subscriber::{Registry, fmt, prelude::*};
 static LOG_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
 static DEBUG_LOGGING_ENABLED: AtomicBool = AtomicBool::new(false);
 
+#[cfg(test)]
+thread_local! {
+    static TEST_DEBUG_LOGGING_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
 /// Errors that may occur while initializing logging.
 #[derive(Debug, thiserror::Error)]
 pub enum LoggingError {
@@ -145,6 +151,10 @@ where
 /// Rich action/database diagnostics should use this gate instead of treating a
 /// broad `RUST_LOG` override as product intent.
 pub fn debug_logging_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(enabled) = TEST_DEBUG_LOGGING_OVERRIDE.with(std::cell::Cell::get) {
+        return enabled;
+    }
     DEBUG_LOGGING_ENABLED.load(Ordering::Relaxed)
 }
 
@@ -154,8 +164,23 @@ pub fn newest_log_file(dir: &Path) -> Result<Option<PathBuf>, LoggingError> {
 }
 
 #[cfg(test)]
-pub(crate) fn set_debug_logging_enabled_for_tests(enabled: bool) {
-    DEBUG_LOGGING_ENABLED.store(enabled, Ordering::Relaxed);
+pub(crate) fn with_debug_logging_enabled_for_tests<T>(enabled: bool, run: impl FnOnce() -> T) -> T {
+    struct Reset<'a> {
+        cell: &'a std::cell::Cell<Option<bool>>,
+        previous: Option<bool>,
+    }
+
+    impl Drop for Reset<'_> {
+        fn drop(&mut self) {
+            self.cell.set(self.previous);
+        }
+    }
+
+    TEST_DEBUG_LOGGING_OVERRIDE.with(|cell| {
+        let previous = cell.replace(Some(enabled));
+        let _reset = Reset { cell, previous };
+        run()
+    })
 }
 
 /// Install a panic hook that writes panic context and backtrace to logs.
@@ -190,6 +215,45 @@ pub fn install_panic_hook() {
         tracing::error!("panic backtrace:\n{:?}", Backtrace::force_capture());
         previous_hook(panic_info);
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_logging_test_override_restores_nested_and_unwound_scopes() {
+        let baseline = debug_logging_enabled();
+        with_debug_logging_enabled_for_tests(!baseline, || {
+            assert_eq!(debug_logging_enabled(), !baseline);
+            with_debug_logging_enabled_for_tests(baseline, || {
+                assert_eq!(debug_logging_enabled(), baseline);
+            });
+            assert_eq!(debug_logging_enabled(), !baseline);
+
+            let unwind = std::panic::catch_unwind(|| {
+                with_debug_logging_enabled_for_tests(baseline, || {
+                    assert_eq!(debug_logging_enabled(), baseline);
+                    panic!("exercise test override restoration");
+                });
+            });
+            assert!(unwind.is_err());
+            assert_eq!(debug_logging_enabled(), !baseline);
+        });
+        assert_eq!(debug_logging_enabled(), baseline);
+    }
+
+    #[test]
+    fn debug_logging_test_override_is_thread_scoped() {
+        let baseline = debug_logging_enabled();
+        with_debug_logging_enabled_for_tests(!baseline, || {
+            assert_eq!(debug_logging_enabled(), !baseline);
+            assert_eq!(
+                std::thread::spawn(debug_logging_enabled).join().unwrap(),
+                baseline
+            );
+        });
+    }
 }
 
 fn build_timer() -> fmt::time::OffsetTime<time::format_description::BorrowedFormatItem<'static>> {

--- a/src/native_app/audio/playback/diagnostics.rs
+++ b/src/native_app/audio/playback/diagnostics.rs
@@ -1,12 +1,13 @@
-use std::{
-    sync::OnceLock,
-    time::{Duration, Instant},
-};
+#[cfg(not(test))]
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use radiant::runtime as runtime_ui;
 
+#[cfg(not(test))]
 const PLAYHEAD_FRAME_DIAGNOSTICS_ENV: &str = "WAVECRATE_PLAYHEAD_FRAME_DIAGNOSTICS";
 
+#[cfg(not(test))]
 static PLAYHEAD_FRAME_DIAGNOSTICS_ENABLED: OnceLock<bool> = OnceLock::new();
 
 #[derive(Default)]
@@ -161,6 +162,11 @@ pub(super) fn log_slow_playback_phase(
 }
 
 fn playhead_frame_diagnostics_enabled() -> bool {
+    #[cfg(test)]
+    {
+        false
+    }
+    #[cfg(not(test))]
     *PLAYHEAD_FRAME_DIAGNOSTICS_ENABLED
         .get_or_init(|| env_var_truthy(PLAYHEAD_FRAME_DIAGNOSTICS_ENV))
 }
@@ -169,12 +175,14 @@ fn duration_ms(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000.0
 }
 
+#[cfg(not(test))]
 fn env_var_truthy(name: &str) -> bool {
     std::env::var(name)
         .ok()
         .is_some_and(|value| is_truthy(&value))
 }
 
+#[cfg(not(test))]
 fn is_truthy(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),

--- a/src/native_app/audio/playback_history/worker.rs
+++ b/src/native_app/audio/playback_history/worker.rs
@@ -176,7 +176,7 @@ mod tests {
         fs::write(&first, [1_u8, 2, 3, 4]).expect("write first sample");
         fs::write(&second, [5_u8, 6, 7, 8]).expect("write second sample");
 
-        source_db_test::test_reset_source_db_open_total_count(&source_root);
+        let open_count_scope = source_db_test::test_scope_source_db_open_total_count(&source_root);
         let first_request = LastPlayedPersistRequest {
             file_id: first.display().to_string(),
             source_root: source_root.clone(),
@@ -193,7 +193,7 @@ mod tests {
         };
 
         persist_last_played_inner(&first_request).expect("persist first");
-        source_db_test::test_reset_source_db_open_total_count(&source_root);
+        open_count_scope.reset();
         persist_last_played_inner(&second_request).expect("persist second");
 
         assert_eq!(

--- a/src/native_app/sample_identity_diagnostics.rs
+++ b/src/native_app/sample_identity_diagnostics.rs
@@ -1,8 +1,9 @@
+#[cfg(not(test))]
+use std::sync::OnceLock;
 use std::{
     fs::File,
     io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
-    sync::OnceLock,
     time::UNIX_EPOCH,
 };
 
@@ -10,8 +11,10 @@ use crate::native_app::app::{NativeAppState, WaveformState};
 
 const SAMPLE_IDENTITY_HASH_CHUNK: usize = 4096;
 const SAMPLE_IDENTITY_HASH_F32_CHUNK: usize = 64;
+#[cfg(not(test))]
 const SAMPLE_IDENTITY_DIAGNOSTICS_ENV: &str = "WAVECRATE_SAMPLE_IDENTITY_DIAGNOSTICS";
 
+#[cfg(not(test))]
 static SAMPLE_IDENTITY_DIAGNOSTICS_ENABLED: OnceLock<bool> = OnceLock::new();
 
 impl NativeAppState {
@@ -234,10 +237,16 @@ fn sample_identity_info_enabled() -> bool {
 }
 
 fn sample_identity_diagnostics_enabled() -> bool {
+    #[cfg(test)]
+    {
+        false
+    }
+    #[cfg(not(test))]
     *SAMPLE_IDENTITY_DIAGNOSTICS_ENABLED
         .get_or_init(|| env_var_truthy(SAMPLE_IDENTITY_DIAGNOSTICS_ENV))
 }
 
+#[cfg(not(test))]
 fn env_var_truthy(name: &str) -> bool {
     std::env::var(name)
         .ok()

--- a/src/native_app/sample_library/folder_scan_actions/maintenance.rs
+++ b/src/native_app/sample_library/folder_scan_actions/maintenance.rs
@@ -200,7 +200,8 @@ mod tests {
         std::fs::write(&first, b"first").unwrap();
         std::fs::write(&second, b"second").unwrap();
         let source = SampleSource::new(root.path().to_path_buf());
-        wavecrate::sample_sources::db::test_reset_source_db_open_total_count(root.path());
+        let _open_count_scope =
+            wavecrate::sample_sources::db::test_scope_source_db_open_total_count(root.path());
 
         let errors = persist_harvest_discoveries(&[source], &[first, second]);
 

--- a/src/native_app/starmap_audition_telemetry.rs
+++ b/src/native_app/starmap_audition_telemetry.rs
@@ -1,16 +1,17 @@
+#[cfg(not(test))]
+use std::sync::OnceLock;
 use std::{
-    sync::{
-        OnceLock,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::atomic::{AtomicU64, Ordering},
     time::{Duration, Instant},
 };
 
+#[cfg(not(test))]
 const HOTPATH_TELEMETRY_ENV: &str = "WAVECRATE_HOTPATH_TELEMETRY";
 
 const STARMAP_AUDITION_TELEMETRY_LOG_EVERY: u64 = 32;
 const STARMAP_AUDITION_SLOW_EVENT_THRESHOLD: Duration = Duration::from_millis(8);
 
+#[cfg(not(test))]
 static STARMAP_AUDITION_TELEMETRY_ENABLED: OnceLock<bool> = OnceLock::new();
 static STARMAP_AUDITION_EVENTS_TOTAL: AtomicU64 = AtomicU64::new(0);
 static STARMAP_AUDITION_DRAG_BEGIN: AtomicU64 = AtomicU64::new(0);
@@ -147,6 +148,11 @@ impl StarmapAuditionDuration {
 }
 
 pub(in crate::native_app) fn enabled() -> bool {
+    #[cfg(test)]
+    {
+        false
+    }
+    #[cfg(not(test))]
     *STARMAP_AUDITION_TELEMETRY_ENABLED.get_or_init(|| env_var_truthy(HOTPATH_TELEMETRY_ENV))
 }
 
@@ -512,6 +518,7 @@ fn should_emit(sample_tick: u64, every: u64) -> bool {
     sample_tick != 0 && sample_tick.is_multiple_of(every)
 }
 
+#[cfg(not(test))]
 fn env_var_truthy(key: &str) -> bool {
     std::env::var(key)
         .ok()

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -36,6 +36,10 @@ pub mod scanner {
 
 /// Per-source database helpers.
 pub mod db {
+    #[cfg(debug_assertions)]
+    pub use wavecrate_library::sample_sources::db::test_scope_source_db_open_total_count;
+    #[cfg(debug_assertions)]
+    pub use wavecrate_library::sample_sources::db::test_source_db_open_total_count;
     pub use wavecrate_library::sample_sources::db::{
         BrowserMetadataSnapshot, ContentAuditCheckpoint, ContentAuditEntryState,
         ContentAuditReport, ContentAuditSkipReason, DB_FILE_NAME, LEGACY_DB_FILE_NAME,
@@ -46,10 +50,6 @@ pub mod db {
         SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError, SourceFileWrite,
         SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry,
         file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
-    };
-    #[cfg(debug_assertions)]
-    pub use wavecrate_library::sample_sources::db::{
-        test_reset_source_db_open_total_count, test_source_db_open_total_count,
     };
 }
 

--- a/src/updater/apply/tests.rs
+++ b/src/updater/apply/tests.rs
@@ -63,9 +63,6 @@ fn relaunch_app_errors_when_executable_missing() {
 
 #[test]
 fn apply_files_and_dirs_keeps_running_executable_on_stage_failure() {
-    let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-        .lock()
-        .expect("updater test lock");
     let tmp = tempdir().unwrap();
     let install_dir = tmp.path().join("install");
     let root_dir = tmp.path().join("root");
@@ -98,9 +95,6 @@ fn apply_files_and_dirs_keeps_running_executable_on_stage_failure() {
 
 #[test]
 fn apply_files_and_dirs_removes_stale_files_from_prior_manifest() {
-    let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-        .lock()
-        .expect("updater test lock");
     let tmp = tempdir().unwrap();
     let install_dir = tmp.path().join("install");
     let root_dir = tmp.path().join("root");
@@ -149,9 +143,6 @@ fn apply_files_and_dirs_removes_stale_files_from_prior_manifest() {
 
 #[test]
 fn apply_files_and_dirs_removes_stale_resources_dir() {
-    let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-        .lock()
-        .expect("updater test lock");
     let tmp = tempdir().unwrap();
     let install_dir = tmp.path().join("install");
     let root_dir = tmp.path().join("root");
@@ -202,9 +193,6 @@ fn apply_files_and_dirs_removes_stale_resources_dir() {
 #[cfg(unix)]
 #[test]
 fn apply_files_and_dirs_reports_stale_removal_failures() {
-    let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-        .lock()
-        .expect("updater test lock");
     let tmp = tempdir().unwrap();
     let install_dir = tmp.path().join("install");
     let root_dir = tmp.path().join("root");

--- a/src/updater/fs_ops.rs
+++ b/src/updater/fs_ops.rs
@@ -251,9 +251,6 @@ mod tests {
 
     #[test]
     fn update_transaction_rolls_back_on_commit_failure() {
-        let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let tmp = tempdir().unwrap();
         let install_dir = tmp.path().join("install");
         let src_dir = tmp.path().join("src");
@@ -287,9 +284,6 @@ mod tests {
 
     #[test]
     fn update_transaction_rejects_destinations_outside_install_root() {
-        let _lock = crate::updater::path_guard::updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let tmp = tempdir().unwrap();
         let install_dir = tmp.path().join("install");
         let src_dir = tmp.path().join("src");

--- a/src/updater/path_guard.rs
+++ b/src/updater/path_guard.rs
@@ -10,9 +10,6 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-#[cfg(test)]
-use std::sync::{Mutex, OnceLock};
-
 use super::UpdateError;
 
 /// Canonical, validated updater install root used to resolve update payload paths.
@@ -37,6 +34,14 @@ impl ValidatedInstallRoot {
 
     /// Return a validated child path rooted under this installation directory.
     pub(crate) fn child_path(&self, name: &str) -> Result<PathBuf, UpdateError> {
+        self.child_path_with_metadata(name, |path| fs::symlink_metadata(path))
+    }
+
+    fn child_path_with_metadata(
+        &self,
+        name: &str,
+        symlink_metadata: impl Fn(&Path) -> std::io::Result<fs::Metadata>,
+    ) -> Result<PathBuf, UpdateError> {
         let relative = sanitize_relative_path(name)?;
         let candidate = self.dir.join(relative);
         if !candidate.starts_with(&self.dir) {
@@ -45,12 +50,15 @@ impl ValidatedInstallRoot {
                 candidate.display()
             )));
         }
-        ensure_no_symlink_path(&candidate)?;
+        ensure_no_symlink_path(&candidate, symlink_metadata)?;
         Ok(candidate)
     }
 }
 
-fn ensure_no_symlink_path(path: &Path) -> Result<(), UpdateError> {
+fn ensure_no_symlink_path(
+    path: &Path,
+    symlink_metadata: impl Fn(&Path) -> std::io::Result<fs::Metadata>,
+) -> Result<(), UpdateError> {
     let mut current = PathBuf::new();
     for component in path.components() {
         match component {
@@ -101,22 +109,6 @@ fn allow_symlink_validation_errors() -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(test)]
-fn symlink_metadata(path: &Path) -> std::io::Result<fs::Metadata> {
-    if let Some(hook) = SYMLINK_METADATA_HOOK.get()
-        && let Ok(guard) = hook.lock()
-        && let Some(hook) = *guard
-    {
-        return hook(path);
-    }
-    fs::symlink_metadata(path)
-}
-
-#[cfg(not(test))]
-fn symlink_metadata(path: &Path) -> std::io::Result<fs::Metadata> {
-    fs::symlink_metadata(path)
-}
-
 fn sanitize_relative_path(name: &str) -> Result<PathBuf, UpdateError> {
     let mut sanitized = PathBuf::new();
     let mut saw_component = false;
@@ -139,43 +131,6 @@ fn sanitize_relative_path(name: &str) -> Result<PathBuf, UpdateError> {
 }
 
 #[cfg(test)]
-type SymlinkMetadataHook = fn(&Path) -> std::io::Result<fs::Metadata>;
-
-#[cfg(test)]
-static SYMLINK_METADATA_HOOK: OnceLock<Mutex<Option<SymlinkMetadataHook>>> = OnceLock::new();
-
-#[cfg(test)]
-pub(super) fn updater_path_guard_test_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-#[cfg(test)]
-struct SymlinkMetadataHookGuard {
-    prev: Option<SymlinkMetadataHook>,
-}
-
-#[cfg(test)]
-impl SymlinkMetadataHookGuard {
-    fn new(hook: Option<SymlinkMetadataHook>) -> Self {
-        let cell = SYMLINK_METADATA_HOOK.get_or_init(|| Mutex::new(None));
-        let mut guard = cell.lock().expect("symlink metadata hook lock");
-        let prev = std::mem::replace(&mut *guard, hook);
-        Self { prev }
-    }
-}
-
-#[cfg(test)]
-impl Drop for SymlinkMetadataHookGuard {
-    fn drop(&mut self) {
-        if let Some(cell) = SYMLINK_METADATA_HOOK.get() {
-            let mut guard = cell.lock().expect("symlink metadata hook lock");
-            *guard = self.prev;
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::io;
@@ -184,9 +139,6 @@ mod tests {
 
     #[test]
     fn ensure_child_path_rejects_parent_dir() {
-        let _lock = updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let dir = tempdir().expect("tempdir");
         let root = ValidatedInstallRoot::new(dir.path()).expect("install root");
         let err = root
@@ -197,9 +149,6 @@ mod tests {
 
     #[test]
     fn ensure_child_path_rejects_absolute_path() {
-        let _lock = updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let dir = tempdir().expect("tempdir");
         #[cfg(windows)]
         let name = "C:\\evil.txt";
@@ -214,9 +163,6 @@ mod tests {
     fn ensure_child_path_allows_relative_path() {
         let mut runtime = TestRuntimeGuard::acquire();
         runtime.set_var("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "1");
-        let _lock = updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let dir = tempdir().expect("tempdir");
         let root = ValidatedInstallRoot::new(dir.path()).expect("install root");
         let path = root.child_path("./ok/file.txt").expect("relative path");
@@ -230,9 +176,6 @@ mod tests {
     fn ensure_child_path_rejects_symlinked_component() {
         use std::os::unix::fs::symlink;
 
-        let _lock = updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         let dir = tempdir().expect("tempdir");
         let install = dir.path().join("install");
         let external = dir.path().join("external");
@@ -252,9 +195,6 @@ mod tests {
     fn ensure_child_path_fails_on_symlink_metadata_error() {
         let mut runtime = TestRuntimeGuard::acquire();
         runtime.set_var("WAVECRATE_UPDATER_ALLOW_SYMLINK_ERRORS", "0");
-        let _lock = updater_path_guard_test_lock()
-            .lock()
-            .expect("updater test lock");
         fn fail_metadata(_: &Path) -> io::Result<fs::Metadata> {
             Err(io::Error::new(
                 ErrorKind::PermissionDenied,
@@ -262,11 +202,10 @@ mod tests {
             ))
         }
 
-        let _guard = SymlinkMetadataHookGuard::new(Some(fail_metadata));
         let dir = tempdir().expect("tempdir");
         let root = ValidatedInstallRoot::new(dir.path()).expect("install root");
         let err = root
-            .child_path("ok/file.txt")
+            .child_path_with_metadata("ok/file.txt", fail_metadata)
             .expect_err("metadata failures must fail closed");
         assert!(
             err.to_string()

--- a/src/waveform/decode/symphonia_reader.rs
+++ b/src/waveform/decode/symphonia_reader.rs
@@ -4,11 +4,6 @@ use crate::audio::decoder::SymphoniaDecoder;
 use crate::waveform::peak_analysis::PeakAnalysisAccumulator;
 use crate::waveform::{DecodedWaveform, WaveformDecodeError, WaveformPeaks, WaveformRenderer};
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-#[cfg(test)]
-static SYMPHONIA_DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 impl WaveformRenderer {
     pub(super) fn load_decoded_via_symphonia(
@@ -17,9 +12,6 @@ impl WaveformRenderer {
         cache_token: u64,
         max_frames: usize,
     ) -> Result<DecodedWaveform, WaveformDecodeError> {
-        #[cfg(test)]
-        SYMPHONIA_DECODE_COUNT.fetch_add(1, Ordering::Relaxed);
-
         let owned: Arc<[u8]> = Arc::from(bytes.to_vec());
         let decoder =
             SymphoniaDecoder::from_bytes(owned).map_err(|error| WaveformDecodeError::Invalid {

--- a/src/waveform/decode/wav_reader.rs
+++ b/src/waveform/decode/wav_reader.rs
@@ -2,11 +2,6 @@ use super::peaks;
 use crate::waveform::{DecodedWaveform, WaveformDecodeError, WaveformRenderer};
 use hound::SampleFormat;
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-#[cfg(test)]
-static WAV_DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 impl WaveformRenderer {
     pub(super) fn load_decoded_wav(
@@ -19,9 +14,6 @@ impl WaveformRenderer {
             Ok(reader) => reader,
             Err(_) => return Ok(None),
         };
-        #[cfg(test)]
-        WAV_DECODE_COUNT.fetch_add(1, Ordering::Relaxed);
-
         let spec = reader.spec();
         let spec_channels = spec.channels.max(1);
         let channels = spec_channels as usize;


### PR DESCRIPTION
## Goal

Make mutable Wavecrate test controls lifecycle-owned so hooks, caches, counters, and configuration overrides cannot outlive the test that installed them or affect unrelated parallel tests.

## Scope

- Replace source/folder move worker hook globals with explicit injected hook contexts; production workers use zero-state no-op hooks.
- Add owned, unwind-safe scopes for source write-priority/remap state, delete-journal failure injection, source-DB open counters, token fallback state, startup-audio stubs, and debug logging.
- Inject updater metadata behavior directly into the path guard test seam instead of retaining a process-global hook.
- Keep environment-derived telemetry and configuration `OnceLock`s inert under libtest while preserving production cache lifetimes.
- Remove unused decode counters and the ambient global provenance mirror; assert against the emitted tracing event instead.

## Non-goals

- No production runtime reset API or production cache-lifetime change.
- No serialization of the complete test suite.
- No changes to environment/current-directory isolation owned by OPT-1259.
- No fixes for unrelated native-app fixture, waveform-cache, watcher, UI contract, or vendored Radiant failures already present at current `main`.

## Definition of Done

- Mutable test controls changed here have explicit owners and deterministic cleanup.
- Panic/unwind paths restore prior state.
- Test hooks are supplied to the worker that consumes them and are visible across worker-thread boundaries.
- Scoped counters and one-shot failures clean only their owned path/source state.
- Production worker and telemetry paths gain no test-only allocation or locking.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p wavecrate --tests --bins`
- `cargo test -p wavecrate-library -- --test-threads=16` — 256 passed; process-boundary helper 1 passed/1 ignored
- Focused Wavecrate owner suites for source/folder workers, source priority/remaps, delete-journal failure injection, updater path guard, startup audio, logging, fallback warning/cache, and source-DB counters — all passed
- `bash scripts/ci.sh smoke` (as part of the agent gate)

Observed current-head limitations:

- Repeated `cargo test -p wavecrate --lib -- --test-threads=16` runs completed with 53 and 54 failures respectively versus a 54-failure pre-change baseline. Changed-scope owner and worker tests pass; the remaining failures are existing native-app fixture/waveform-cache/watcher/UI-contract families, including cases reproducible individually or in isolated modules.
- `bash scripts/ci.sh agent` passes branch guard, smoke, non-blocking architecture, and readiness boundaries, then stops in the pinned Radiant library suite at `gpu_signal_shader_keeps_waveform_bands_visually_distinct` (1 failed, 1,686 passed). This branch does not modify Radiant.

## Known limitations

The current `main` full parallel Wavecrate lane and vendored Radiant suite are not green independently of these scoped-control changes. This PR records the exact baseline instead of masking or retrying those failures.

User approval is required before merge.
