### PR TITLE
OPT-1262 Persist typed index-only source entries

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/audio_support.rs
+++ b/crates/wavecrate-library/src/sample_sources/audio_support.rs
@@ -3,6 +3,13 @@ use std::path::Path;
 /// Supported audio extensions for sample sources (lowercase, without dots).
 pub const SUPPORTED_AUDIO_EXTENSIONS: [&str; 1] = ["wav"];
 
+/// Audio-container extensions recognized for unsupported-file diagnostics.
+///
+/// Recognition does not imply decode, playback, or indexing support.
+pub const RECOGNIZED_AUDIO_EXTENSIONS: [&str; 10] = [
+    "aac", "aif", "aiff", "flac", "m4a", "mp3", "ogg", "opus", "wav", "wma",
+];
+
 /// Return true if the path has a supported audio extension.
 pub fn is_supported_audio(path: &Path) -> bool {
     if is_apple_double_sidecar(path) {
@@ -14,6 +21,19 @@ pub fn is_supported_audio(path: &Path) -> bool {
     SUPPORTED_AUDIO_EXTENSIONS
         .iter()
         .any(|supported| ext.eq_ignore_ascii_case(supported))
+}
+
+/// Return true when a path has a recognized audio-container extension.
+pub fn is_recognized_audio(path: &Path) -> bool {
+    if is_apple_double_sidecar(path) {
+        return false;
+    }
+    let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+    RECOGNIZED_AUDIO_EXTENSIONS
+        .iter()
+        .any(|recognized| ext.eq_ignore_ascii_case(recognized))
 }
 
 /// Return true for macOS AppleDouble sidecars such as `._kick.wav`.
@@ -52,6 +72,17 @@ mod tests {
                 "{unsupported} should not be treated as supported audio"
             );
         }
+    }
+
+    #[test]
+    fn recognized_audio_does_not_expand_supported_formats() {
+        for unsupported in ["loop.aif", "loop.aiff", "loop.flac", "loop.mp3"] {
+            let path = Path::new(unsupported);
+            assert!(is_recognized_audio(path));
+            assert!(!is_supported_audio(path));
+        }
+        assert!(!is_recognized_audio(Path::new("notes.txt")));
+        assert!(!is_recognized_audio(Path::new("._loop.flac")));
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -1,0 +1,382 @@
+use std::path::Path;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::schema;
+use super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
+use super::{
+    META_SOURCE_INDEX_REVISION, SourceDatabase, SourceDbError, SourceIndexClassification,
+    SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceWriteBatch,
+};
+
+const REQUIRED_COLUMNS: [&str; 7] = [
+    "path",
+    "classification",
+    "file_size",
+    "modified_ns",
+    "file_identity",
+    "diagnostic",
+    "format_policy_version",
+];
+
+impl SourceDatabase {
+    /// Read the complete index-only file set and its independent revision atomically.
+    ///
+    /// Legacy read-only databases without the table project revision zero and
+    /// an empty set instead of requiring a migration on the reader.
+    pub fn source_index_snapshot(&self) -> Result<SourceIndexSnapshot, SourceDbError> {
+        if !source_index_schema_available(&self.connection)? {
+            return Ok(SourceIndexSnapshot {
+                revision: 0,
+                entries: Vec::new(),
+            });
+        }
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = read_index_revision(&transaction)?;
+        let entries = collect_entries(
+            &transaction,
+            "SELECT path, classification, file_size, modified_ns, file_identity,
+                    diagnostic, format_policy_version
+             FROM source_index_entries
+             ORDER BY path ASC",
+            [],
+        )?;
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(SourceIndexSnapshot { revision, entries })
+    }
+
+    /// Read all durable index-only entries in deterministic path order.
+    pub fn list_source_index_entries(&self) -> Result<Vec<SourceIndexEntry>, SourceDbError> {
+        Ok(self.source_index_snapshot()?.entries)
+    }
+
+    /// Read index-only entries at or below one source-relative path.
+    pub fn list_source_index_entries_under_path(
+        &self,
+        relative_path: &Path,
+    ) -> Result<Vec<SourceIndexEntry>, SourceDbError> {
+        if !source_index_schema_available(&self.connection)? {
+            return Ok(Vec::new());
+        }
+        let normalized = normalize_relative_path(relative_path)?;
+        let prefix = format!("{}/%", escape_like_pattern(&normalized));
+        collect_entries(
+            &self.connection,
+            "SELECT path, classification, file_size, modified_ns, file_identity,
+                    diagnostic, format_policy_version
+             FROM source_index_entries
+             WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'
+             ORDER BY path ASC",
+            params![normalized, prefix],
+        )
+    }
+}
+
+impl SourceWriteBatch<'_> {
+    /// Insert or update one index-only file without creating sample metadata.
+    pub fn upsert_source_index_entry(
+        &mut self,
+        entry: &SourceIndexEntry,
+    ) -> Result<(), SourceDbError> {
+        validate_entry(entry)?;
+        let path = normalize_relative_path(&entry.relative_path)?;
+        let live_manifest_row = self
+            .tx
+            .query_row(
+                "SELECT 1 FROM wav_files WHERE path = ?1 AND missing = 0",
+                [&path],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .is_some();
+        if live_manifest_row {
+            return Err(SourceDbError::Unexpected);
+        }
+        let changed = self
+            .tx
+            .execute(
+                "INSERT INTO source_index_entries (
+                    path, classification, file_size, modified_ns, file_identity,
+                    diagnostic, format_policy_version
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(path) DO UPDATE SET
+                    classification = excluded.classification,
+                    file_size = excluded.file_size,
+                    modified_ns = excluded.modified_ns,
+                    file_identity = excluded.file_identity,
+                    diagnostic = excluded.diagnostic,
+                    format_policy_version = excluded.format_policy_version
+                 WHERE classification IS NOT excluded.classification
+                    OR file_size IS NOT excluded.file_size
+                    OR modified_ns IS NOT excluded.modified_ns
+                    OR file_identity IS NOT excluded.file_identity
+                    OR diagnostic IS NOT excluded.diagnostic
+                    OR format_policy_version IS NOT excluded.format_policy_version",
+                params![
+                    path,
+                    entry.classification.token(),
+                    entry.file_size.map(saturating_i64),
+                    entry.modified_ns,
+                    entry.file_identity,
+                    entry.diagnostic.map(SourceIndexDiagnostic::token),
+                    i64::from(entry.format_policy_version),
+                ],
+            )
+            .map_err(map_sql_error)?;
+        self.index_revision_dirty |= changed > 0;
+        Ok(())
+    }
+
+    /// Remove one index-only row, including during promotion to the supported manifest.
+    pub fn remove_source_index_entry(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
+        let path = normalize_relative_path(relative_path)?;
+        let changed = self
+            .tx
+            .execute("DELETE FROM source_index_entries WHERE path = ?1", [path])
+            .map_err(map_sql_error)?;
+        self.index_revision_dirty |= changed > 0;
+        Ok(())
+    }
+}
+
+fn source_index_schema_available(connection: &Connection) -> Result<bool, SourceDbError> {
+    let columns = schema::table_columns(connection, "source_index_entries")?;
+    Ok(REQUIRED_COLUMNS
+        .iter()
+        .all(|column| columns.contains(*column)))
+}
+
+fn read_index_revision(connection: &Connection) -> Result<u64, SourceDbError> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [META_SOURCE_INDEX_REVISION],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(map_sql_error)?
+        .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
+fn collect_entries(
+    connection: &Connection,
+    sql: &str,
+    query_params: impl rusqlite::Params,
+) -> Result<Vec<SourceIndexEntry>, SourceDbError> {
+    let mut statement = connection.prepare(sql).map_err(map_sql_error)?;
+    let rows = statement
+        .query_map(query_params, |row| {
+            let raw_path: String = row.get(0)?;
+            let relative_path = match parse_relative_path_from_db(&raw_path) {
+                Ok(path) => path,
+                Err(error) => {
+                    tracing::warn!(
+                        path = raw_path,
+                        %error,
+                        "Skipping source index row with invalid relative path"
+                    );
+                    return Ok(None);
+                }
+            };
+            let raw_classification: String = row.get(1)?;
+            let Some(classification) = SourceIndexClassification::from_token(&raw_classification)
+            else {
+                tracing::warn!(
+                    classification = raw_classification,
+                    "Skipping source index row with invalid classification"
+                );
+                return Ok(None);
+            };
+            let diagnostic = row
+                .get::<_, Option<String>>(5)?
+                .as_deref()
+                .and_then(SourceIndexDiagnostic::from_token);
+            Ok(Some(SourceIndexEntry {
+                relative_path,
+                classification,
+                file_size: row
+                    .get::<_, Option<i64>>(2)?
+                    .map(|value| value.max(0) as u64),
+                modified_ns: row.get(3)?,
+                file_identity: row.get(4)?,
+                diagnostic,
+                format_policy_version: row.get::<_, i64>(6)?.clamp(0, i64::from(u32::MAX)) as u32,
+            }))
+        })
+        .map_err(map_sql_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_sql_error)?;
+    Ok(rows.into_iter().flatten().collect())
+}
+
+fn validate_entry(entry: &SourceIndexEntry) -> Result<(), SourceDbError> {
+    let complete_facts = entry.file_size.is_some() && entry.modified_ns.is_some();
+    let valid = match entry.classification {
+        SourceIndexClassification::UnsupportedAudio
+        | SourceIndexClassification::UnsupportedNonAudio => {
+            complete_facts && entry.diagnostic.is_none()
+        }
+        SourceIndexClassification::Inaccessible => entry.diagnostic.is_some(),
+        SourceIndexClassification::PracticallyUnsupportedAudio => {
+            complete_facts && entry.diagnostic == Some(SourceIndexDiagnostic::PracticalSupportLimit)
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(SourceDbError::Unexpected)
+    }
+}
+
+fn saturating_i64(value: u64) -> i64 {
+    value.min(i64::MAX as u64) as i64
+}
+
+fn escape_like_pattern(value: &str) -> String {
+    value
+        .replace('!', "!!")
+        .replace('%', "!%")
+        .replace('_', "!_")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::sample_sources::SOURCE_FORMAT_POLICY_VERSION;
+
+    #[test]
+    fn index_only_writes_advance_only_the_index_revision() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let manifest_revision = database.get_revision().expect("manifest revision");
+        let entry = SourceIndexEntry {
+            relative_path: PathBuf::from("notes.txt"),
+            classification: SourceIndexClassification::UnsupportedNonAudio,
+            file_size: Some(5),
+            modified_ns: Some(10),
+            file_identity: None,
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&entry)
+            .expect("upsert index entry");
+        batch
+            .commit_auxiliary_state()
+            .expect("commit index-only state");
+
+        let snapshot = database.source_index_snapshot().expect("index snapshot");
+        assert_eq!(snapshot.revision, 1);
+        assert_eq!(snapshot.entries, vec![entry]);
+        assert_eq!(
+            database.get_revision().expect("manifest revision"),
+            manifest_revision
+        );
+    }
+
+    #[test]
+    fn live_manifest_and_index_only_rows_cannot_share_a_path() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        database
+            .upsert_file(Path::new("sample.wav"), 5, 10)
+            .expect("supported row");
+        let entry = SourceIndexEntry {
+            relative_path: PathBuf::from("sample.wav"),
+            classification: SourceIndexClassification::Inaccessible,
+            file_size: None,
+            modified_ns: None,
+            file_identity: None,
+            diagnostic: Some(SourceIndexDiagnostic::OpenUnavailable),
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        assert!(matches!(
+            batch.upsert_source_index_entry(&entry),
+            Err(SourceDbError::Unexpected)
+        ));
+    }
+
+    #[test]
+    fn practical_support_and_inaccessible_diagnostics_round_trip() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let entries = [
+            SourceIndexEntry {
+                relative_path: PathBuf::from("too-long.wav"),
+                classification: SourceIndexClassification::PracticallyUnsupportedAudio,
+                file_size: Some(1_000),
+                modified_ns: Some(20),
+                file_identity: Some(String::from("file-1")),
+                diagnostic: Some(SourceIndexDiagnostic::PracticalSupportLimit),
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            },
+            SourceIndexEntry {
+                relative_path: PathBuf::from("unknown.bin"),
+                classification: SourceIndexClassification::Inaccessible,
+                file_size: None,
+                modified_ns: None,
+                file_identity: None,
+                diagnostic: Some(SourceIndexDiagnostic::EntryTypeUnavailable),
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            },
+        ];
+        let mut batch = database.write_batch().expect("index batch");
+        for entry in &entries {
+            batch
+                .upsert_source_index_entry(entry)
+                .expect("upsert index entry");
+        }
+        batch.commit_auxiliary_state().expect("commit index rows");
+
+        assert_eq!(
+            database
+                .list_source_index_entries()
+                .expect("read index rows"),
+            entries
+        );
+    }
+
+    #[test]
+    fn subtree_reads_treat_sql_wildcards_as_literal_path_characters() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let entries =
+            ["literal%/inside.txt", "literalx/outside.txt"].map(|path| SourceIndexEntry {
+                relative_path: PathBuf::from(path),
+                classification: SourceIndexClassification::UnsupportedNonAudio,
+                file_size: Some(5),
+                modified_ns: Some(10),
+                file_identity: None,
+                diagnostic: None,
+                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+            });
+        let mut batch = database.write_batch().expect("index batch");
+        for entry in &entries {
+            batch
+                .upsert_source_index_entry(entry)
+                .expect("upsert index entry");
+        }
+        batch.commit_auxiliary_state().expect("commit index rows");
+
+        assert_eq!(
+            database
+                .list_source_index_entries_under_path(Path::new("literal%"))
+                .expect("read literal subtree"),
+            vec![entries[0].clone()]
+        );
+    }
+}

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -11,6 +11,7 @@ mod content_audit;
 mod error;
 /// Persistent file operation journal for crash recovery.
 pub mod file_ops_journal;
+mod index_entries;
 mod open;
 mod open_profiles;
 /// Private rename-recovery metadata retained after immediate file pruning.
@@ -53,6 +54,7 @@ pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingR
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
     BrowserFileMetadata, BrowserMetadataSnapshot, Rating, SampleCollection, SampleSoundType,
+    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
     SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
 };
 pub use util::normalize_relative_path;
@@ -81,6 +83,8 @@ pub const META_DEFERRED_MAINTENANCE_REVISION: &str = "deferred_maintenance_revis
 pub const META_DEFERRED_MAINTENANCE_SCHEMA: &str = "deferred_maintenance_schema_v1";
 /// Metadata key storing the last revision that changed the ordered wav path set.
 pub const META_WAV_PATHS_REVISION: &str = "wav_paths_revision_v1";
+/// Metadata key storing the revision of the index-only unsupported file set.
+pub const META_SOURCE_INDEX_REVISION: &str = "source_index_revision_v1";
 /// Env var that enables read-only source DB opening by default.
 pub const SOURCE_DB_READ_ONLY_ENV: &str = "WAVECRATE_SOURCE_DB_READ_ONLY";
 
@@ -116,6 +120,7 @@ pub struct SourceWriteBatch<'conn> {
     tx: Transaction<'conn>,
     db_path: PathBuf,
     paths_revision_dirty: bool,
+    index_revision_dirty: bool,
     manifest_touched_paths: BTreeSet<PathBuf>,
     telemetry_label: &'static str,
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -64,6 +64,20 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
         collection INTEGER,
         file_identity TEXT
     );
+    CREATE TABLE IF NOT EXISTS source_index_entries (
+        path TEXT PRIMARY KEY,
+        classification TEXT NOT NULL CHECK(classification IN (
+            'unsupported_audio',
+            'unsupported_non_audio',
+            'inaccessible',
+            'practically_unsupported_audio'
+        )),
+        file_size INTEGER,
+        modified_ns INTEGER,
+        file_identity TEXT,
+        diagnostic TEXT,
+        format_policy_version INTEGER NOT NULL
+    ) WITHOUT ROWID;
     CREATE TABLE IF NOT EXISTS source_tags (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         normalized_text TEXT NOT NULL UNIQUE,
@@ -335,6 +349,8 @@ const INDEX_SQL: &str = "CREATE INDEX IF NOT EXISTS idx_wav_files_missing
          ON wav_files(path) WHERE missing != 0;
      CREATE INDEX IF NOT EXISTS idx_wav_files_extension
          ON wav_files(extension);
+     CREATE INDEX IF NOT EXISTS idx_source_index_entries_classification_path
+         ON source_index_entries(classification, path);
      CREATE INDEX IF NOT EXISTS idx_source_content_audit_forward_path
          ON wav_files(path)
          WHERE missing = 0

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -42,6 +42,7 @@ pub(super) fn apply_current_stamp_repairs(connection: &Connection) -> Result<(),
 
 fn apply_structural_migrations(connection: &Connection) -> Result<(), SourceDbError> {
     ensure_wav_files_optional_columns(connection)?;
+    ensure_source_index_schema(connection)?;
     ensure_pending_rename_optional_columns(connection)?;
     ensure_file_ops_journal_optional_columns(connection)?;
     ensure_analysis_jobs_optional_columns(connection)?;
@@ -53,6 +54,30 @@ fn apply_structural_migrations(connection: &Connection) -> Result<(), SourceDbEr
     ensure_collection_membership_schema(connection)?;
     ensure_pending_rename_destination_schema(connection)?;
     ensure_aspect_descriptor_tables(connection)?;
+    Ok(())
+}
+
+fn ensure_source_index_schema(connection: &Connection) -> Result<(), SourceDbError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS source_index_entries (
+                path TEXT PRIMARY KEY,
+                classification TEXT NOT NULL CHECK(classification IN (
+                    'unsupported_audio',
+                    'unsupported_non_audio',
+                    'inaccessible',
+                    'practically_unsupported_audio'
+                )),
+                file_size INTEGER,
+                modified_ns INTEGER,
+                file_identity TEXT,
+                diagnostic TEXT,
+                format_policy_version INTEGER NOT NULL
+            ) WITHOUT ROWID;
+            CREATE INDEX IF NOT EXISTS idx_source_index_entries_classification_path
+                ON source_index_entries(classification, path);",
+        )
+        .map_err(map_sql_error)?;
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use migrations::table_columns;
 /// A matching stamp means the file has already passed the full schema-assurance
 /// path once. Current-stamped opens still run low-cost additive table/column
 /// repairs, but they skip index rebuilds and deferred cleanup work.
-pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 10;
+pub(super) const SOURCE_DB_SCHEMA_VERSION: i64 = 11;
 
 /// Apply the full source-database schema, including deferred cleanup work.
 pub(super) fn apply_schema(connection: &Connection) -> Result<SchemaApplyOutcome, SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -312,6 +312,102 @@ pub struct SourceManifestEntry {
     pub modified_ns: i64,
 }
 
+/// Durable classification for a file that is intentionally outside the supported sample manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceIndexClassification {
+    /// A recognized audio container that Wavecrate does not currently support.
+    UnsupportedAudio,
+    /// A regular file that is not recognized as audio.
+    UnsupportedNonAudio,
+    /// A source entry whose type or file facts could not be inspected safely.
+    Inaccessible,
+    /// Supported-format audio rejected by an explicit practical constraint.
+    PracticallyUnsupportedAudio,
+}
+
+impl SourceIndexClassification {
+    pub(crate) const fn token(self) -> &'static str {
+        match self {
+            Self::UnsupportedAudio => "unsupported_audio",
+            Self::UnsupportedNonAudio => "unsupported_non_audio",
+            Self::Inaccessible => "inaccessible",
+            Self::PracticallyUnsupportedAudio => "practically_unsupported_audio",
+        }
+    }
+
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "unsupported_audio" => Some(Self::UnsupportedAudio),
+            "unsupported_non_audio" => Some(Self::UnsupportedNonAudio),
+            "inaccessible" => Some(Self::Inaccessible),
+            "practically_unsupported_audio" => Some(Self::PracticallyUnsupportedAudio),
+            _ => None,
+        }
+    }
+}
+
+/// Bounded diagnostic attached to an index-only entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceIndexDiagnostic {
+    /// The filesystem entry type could not be inspected without following links.
+    EntryTypeUnavailable,
+    /// File size, modification time, or stable identity could not be inspected.
+    MetadataUnavailable,
+    /// A regular file could not be opened through the source-root boundary.
+    OpenUnavailable,
+    /// An explicit practical audio constraint rejected the file.
+    PracticalSupportLimit,
+}
+
+impl SourceIndexDiagnostic {
+    pub(crate) const fn token(self) -> &'static str {
+        match self {
+            Self::EntryTypeUnavailable => "entry_type_unavailable",
+            Self::MetadataUnavailable => "metadata_unavailable",
+            Self::OpenUnavailable => "open_unavailable",
+            Self::PracticalSupportLimit => "practical_support_limit",
+        }
+    }
+
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "entry_type_unavailable" => Some(Self::EntryTypeUnavailable),
+            "metadata_unavailable" => Some(Self::MetadataUnavailable),
+            "open_unavailable" => Some(Self::OpenUnavailable),
+            "practical_support_limit" => Some(Self::PracticalSupportLimit),
+            _ => None,
+        }
+    }
+}
+
+/// Restart-safe facts for one source file intentionally excluded from normal sample state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceIndexEntry {
+    /// File path relative to the configured source root.
+    pub relative_path: PathBuf,
+    /// Typed reason this path is outside the supported sample manifest.
+    pub classification: SourceIndexClassification,
+    /// File size when metadata inspection succeeded.
+    pub file_size: Option<u64>,
+    /// Last modified timestamp in epoch nanoseconds when inspection succeeded.
+    pub modified_ns: Option<i64>,
+    /// Stable filesystem-object identity when available.
+    pub file_identity: Option<String>,
+    /// Bounded diagnostic category without host paths or unbounded error text.
+    pub diagnostic: Option<SourceIndexDiagnostic>,
+    /// Format-classification policy that produced this row.
+    pub format_policy_version: u32,
+}
+
+/// Coherent read projection of the durable index-only file set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceIndexSnapshot {
+    /// Monotonic index-only revision, independent from the supported manifest revision.
+    pub revision: u64,
+    /// Index-only entries in deterministic path order.
+    pub entries: Vec<SourceIndexEntry>,
+}
+
 /// One normal library tag stored in a source database.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceTag {

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -175,6 +175,7 @@ impl SourceDatabase {
             tx,
             db_path: self.db_path.clone(),
             paths_revision_dirty: false,
+            index_revision_dirty: false,
             manifest_touched_paths: std::collections::BTreeSet::new(),
             telemetry_label: self.telemetry_label,
         })
@@ -193,6 +194,12 @@ impl SourceDatabase {
         conn: &rusqlite::Connection,
     ) -> Result<(), SourceDbError> {
         Self::bump_metadata_counter(conn, META_WAV_PATHS_REVISION)
+    }
+
+    pub(super) fn bump_source_index_revision(
+        conn: &rusqlite::Connection,
+    ) -> Result<(), SourceDbError> {
+        Self::bump_metadata_counter(conn, super::super::META_SOURCE_INDEX_REVISION)
     }
 
     fn bump_metadata_counter(conn: &rusqlite::Connection, key: &str) -> Result<(), SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -36,6 +36,9 @@ impl SourceWriteBatch<'_> {
         if self.paths_revision_dirty || !self.manifest_touched_paths.is_empty() {
             return Err(SourceDbError::Unexpected);
         }
+        if self.index_revision_dirty {
+            SourceDatabase::bump_source_index_revision(&self.tx)?;
+        }
         self.tx.commit().map_err(map_sql_error)?;
         crate::sqlite_wal::maybe_checkpoint_database_file(
             &self.db_path,
@@ -144,6 +147,9 @@ impl SourceWriteBatch<'_> {
         SourceDatabase::bump_revision(&self.tx)?;
         if self.paths_revision_dirty {
             SourceDatabase::bump_wav_paths_revision(&self.tx)?;
+        }
+        if self.index_revision_dirty {
+            SourceDatabase::bump_source_index_revision(&self.tx)?;
         }
         Ok(())
     }

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -31,7 +31,7 @@ pub use library::{
 pub use source_entry::{
     SOURCE_FORMAT_POLICY_VERSION, SourceEntryClassification, SourceEntryFileType, SourceEntryKind,
     SourceEntryProbeError, SourceEntryRejection, SourceFileClassification,
-    classify_path_without_following, classify_source_entry,
+    classify_path_without_following, classify_source_entry, is_rejected_source_file_path,
 };
 
 /// Identifier for a configured sample source.

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -13,14 +13,15 @@ pub mod readiness;
 mod source_entry;
 
 pub use audio_support::{
-    is_apple_double_sidecar, is_supported_audio, supported_audio_where_clause,
+    is_apple_double_sidecar, is_recognized_audio, is_supported_audio, supported_audio_where_clause,
 };
 pub use db::normalize_relative_path;
 pub use db::{
     BrowserFileMetadata, BrowserMetadataSnapshot, DB_FILE_NAME, Rating, SampleCollection,
     SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
-    SourceDbError, SourceFileWrite, SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite,
-    SourceWriteCommand, WavEntry,
+    SourceDbError, SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic,
+    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
+    SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,
@@ -28,8 +29,9 @@ pub use library::{
     LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation,
 };
 pub use source_entry::{
-    SourceEntryClassification, SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
-    SourceEntryRejection, classify_path_without_following, classify_source_entry,
+    SOURCE_FORMAT_POLICY_VERSION, SourceEntryClassification, SourceEntryFileType, SourceEntryKind,
+    SourceEntryProbeError, SourceEntryRejection, SourceFileClassification,
+    classify_path_without_following, classify_source_entry,
 };
 
 /// Identifier for a configured sample source.

--- a/crates/wavecrate-library/src/sample_sources/source_entry.rs
+++ b/crates/wavecrate-library/src/sample_sources/source_entry.rs
@@ -174,6 +174,14 @@ pub fn classify_source_entry(
     }
 }
 
+/// Return whether a regular-file path is excluded by name from source indexing.
+///
+/// This predicate is usable when entry-type inspection fails, before callers
+/// can construct a complete [`SourceEntryClassification`].
+pub fn is_rejected_source_file_path(relative_path: &Path) -> bool {
+    is_apple_double_sidecar(relative_path) || is_source_database_artifact(relative_path)
+}
+
 fn is_source_database_artifact(relative_path: &Path) -> bool {
     let Some(name) = relative_path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -306,5 +314,18 @@ mod tests {
                 .file_classification(),
             Some(SourceFileClassification::UnsupportedNonAudio)
         );
+    }
+
+    #[test]
+    fn path_only_rejections_cover_internal_database_and_apple_double_names() {
+        for path in [
+            ".wavecrate.db",
+            ".wavecrate.db-wal",
+            ".wavecrate_samples.db-shm",
+            "nested/._loop.flac",
+        ] {
+            assert!(is_rejected_source_file_path(Path::new(path)), "{path}");
+        }
+        assert!(!is_rejected_source_file_path(Path::new("nested/loop.flac")));
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/source_entry.rs
+++ b/crates/wavecrate-library/src/sample_sources/source_entry.rs
@@ -5,7 +5,10 @@ use std::{
     path::{Component, Path},
 };
 
-use super::{is_apple_double_sidecar, is_supported_audio};
+use super::{is_apple_double_sidecar, is_recognized_audio, is_supported_audio};
+
+/// Version of the source format-classification policy persisted with index-only rows.
+pub const SOURCE_FORMAT_POLICY_VERSION: u32 = 1;
 
 /// A filesystem entry type observed without following links or reparse points.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -44,6 +47,22 @@ pub enum SourceEntryKind {
     File,
 }
 
+/// Format support assigned to one regular file by the shared source policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceFileClassification {
+    /// A file whose format is eligible for the supported sample manifest.
+    SupportedAudio,
+    /// A recognized audio container that Wavecrate does not currently support.
+    UnsupportedAudio,
+    /// A regular file that is not recognized as audio.
+    UnsupportedNonAudio,
+    /// Audio whose format is supported but whose practical constraints reject indexing.
+    ///
+    /// The current format policy has no such limit. The explicit state lets
+    /// format inspection record one without conflating it with inaccessible I/O.
+    PracticallyUnsupportedAudio,
+}
+
 /// Why a source entry is not visible to source traversals.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SourceEntryRejection {
@@ -51,6 +70,8 @@ pub enum SourceEntryRejection {
     Link,
     /// AppleDouble sidecars are implementation metadata, not source files.
     AppleDouble,
+    /// Wavecrate's embedded source database and SQLite sidecars are implementation metadata.
+    SourceDatabase,
     /// The entry is neither a regular file nor a directory.
     UnsupportedType,
 }
@@ -65,8 +86,8 @@ pub enum SourceEntryClassification {
     },
     /// A regular file, including its source-index eligibility.
     File {
-        /// Whether the file has a supported sample-audio format.
-        supported_audio: bool,
+        /// Audio-format support assigned by the shared source policy.
+        classification: SourceFileClassification,
         /// Whether the file is below a hidden directory.
         below_hidden_directory: bool,
     },
@@ -89,7 +110,7 @@ impl SourceEntryClassification {
         matches!(
             self,
             Self::File {
-                supported_audio: true,
+                classification: SourceFileClassification::SupportedAudio,
                 below_hidden_directory: false,
             }
         )
@@ -100,10 +121,18 @@ impl SourceEntryClassification {
         matches!(
             self,
             Self::File {
-                supported_audio: true,
+                classification: SourceFileClassification::SupportedAudio,
                 ..
             }
         )
+    }
+
+    /// Return the regular-file classification, if this is a visible file.
+    pub fn file_classification(self) -> Option<SourceFileClassification> {
+        match self {
+            Self::File { classification, .. } => Some(classification),
+            Self::Directory { .. } | Self::Rejected(_) => None,
+        }
     }
 }
 
@@ -129,11 +158,34 @@ pub fn classify_source_entry(
         SourceEntryFileType::File if is_apple_double_sidecar(relative_path) => {
             SourceEntryClassification::Rejected(SourceEntryRejection::AppleDouble)
         }
+        SourceEntryFileType::File if is_source_database_artifact(relative_path) => {
+            SourceEntryClassification::Rejected(SourceEntryRejection::SourceDatabase)
+        }
         SourceEntryFileType::File => SourceEntryClassification::File {
-            supported_audio: is_supported_audio(relative_path),
+            classification: if is_supported_audio(relative_path) {
+                SourceFileClassification::SupportedAudio
+            } else if is_recognized_audio(relative_path) {
+                SourceFileClassification::UnsupportedAudio
+            } else {
+                SourceFileClassification::UnsupportedNonAudio
+            },
             below_hidden_directory: has_hidden_ancestor(relative_path),
         },
     }
+}
+
+fn is_source_database_artifact(relative_path: &Path) -> bool {
+    let Some(name) = relative_path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    [".wavecrate.db", ".wavecrate_samples.db"]
+        .iter()
+        .any(|database_name| {
+            name == *database_name
+                || ["-wal", "-shm", "-journal"]
+                    .iter()
+                    .any(|suffix| name == format!("{database_name}{suffix}"))
+        })
 }
 
 /// Inspect and classify one path without following links or reparse points.
@@ -228,6 +280,10 @@ mod tests {
             classify_source_entry(Path::new("socket"), SourceEntryFileType::Other),
             SourceEntryClassification::Rejected(SourceEntryRejection::UnsupportedType)
         );
+        assert_eq!(
+            classify_source_entry(Path::new(".wavecrate.db-wal"), SourceEntryFileType::File),
+            SourceEntryClassification::Rejected(SourceEntryRejection::SourceDatabase)
+        );
     }
 
     #[test]
@@ -236,5 +292,19 @@ mod tests {
         assert_eq!(entry.visible_kind(), Some(SourceEntryKind::File));
         assert!(!entry.has_supported_audio());
         assert!(!entry.indexes_audio());
+    }
+
+    #[test]
+    fn unsupported_audio_and_non_audio_are_distinct() {
+        assert_eq!(
+            classify_source_entry(Path::new("loop.flac"), SourceEntryFileType::File)
+                .file_classification(),
+            Some(SourceFileClassification::UnsupportedAudio)
+        );
+        assert_eq!(
+            classify_source_entry(Path::new("notes.txt"), SourceEntryFileType::File)
+                .file_classification(),
+            Some(SourceFileClassification::UnsupportedNonAudio)
+        );
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -5,6 +5,7 @@ mod scan_diff;
 mod scan_diff_phase;
 mod scan_fs;
 mod scan_hash;
+mod scan_index;
 mod scan_paths;
 mod scan_walk;
 mod scan_writer;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
-use crate::sample_sources::db::{SourceWriteBatch, WavEntry};
+use crate::sample_sources::db::{SourceIndexEntry, SourceWriteBatch, WavEntry};
 use wavecrate_library::sample_sources::SourceManifestEntry;
 
 use super::{ScanError, ScanMode, ScanStats};
@@ -12,6 +12,8 @@ pub(crate) struct ScanContext {
     pub(crate) stats: ScanStats,
     pub(crate) mode: ScanMode,
     pub(crate) rename_candidate_generation: Option<u64>,
+    existing_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
+    observed_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
     committed_manifest: BTreeMap<PathBuf, SourceManifestEntry>,
     committed_manifest_revision: u64,
     pub(crate) last_committed_revision: Option<u64>,
@@ -34,12 +36,13 @@ impl ScanContext {
         manifest: Vec<SourceManifestEntry>,
     ) -> Result<Self, ScanError> {
         let existing = index_existing(db)?;
-        Ok(Self::from_existing(
-            existing,
-            mode,
-            manifest_revision,
-            manifest,
-        ))
+        let mut context = Self::from_existing(existing, mode, manifest_revision, manifest);
+        context.existing_index_entries = db
+            .list_source_index_entries()?
+            .into_iter()
+            .map(|entry| (entry.relative_path.clone(), entry))
+            .collect();
+        Ok(context)
     }
 
     pub(in crate::sample_sources::scanner) fn from_existing(
@@ -53,6 +56,8 @@ impl ScanContext {
             stats: ScanStats::default(),
             mode,
             rename_candidate_generation: None,
+            existing_index_entries: BTreeMap::new(),
+            observed_index_entries: BTreeMap::new(),
             committed_manifest: manifest
                 .into_iter()
                 .map(|entry| (entry.relative_path.clone(), entry))
@@ -63,6 +68,41 @@ impl ScanContext {
             source_tree_incomplete: false,
             uncertain_prefixes: BTreeSet::new(),
         }
+    }
+
+    pub(in crate::sample_sources::scanner) fn set_targeted_index_entries(
+        &mut self,
+        existing: impl IntoIterator<Item = SourceIndexEntry>,
+        observed: impl IntoIterator<Item = SourceIndexEntry>,
+    ) {
+        self.existing_index_entries = existing
+            .into_iter()
+            .map(|entry| (entry.relative_path.clone(), entry))
+            .collect();
+        self.observe_index_entries(observed);
+    }
+
+    pub(in crate::sample_sources::scanner) fn observe_index_entries(
+        &mut self,
+        entries: impl IntoIterator<Item = SourceIndexEntry>,
+    ) {
+        self.observed_index_entries.extend(
+            entries
+                .into_iter()
+                .map(|entry| (entry.relative_path.clone(), entry)),
+        );
+    }
+
+    pub(in crate::sample_sources::scanner) fn take_index_reconciliation(
+        &mut self,
+    ) -> (
+        BTreeMap<PathBuf, SourceIndexEntry>,
+        BTreeMap<PathBuf, SourceIndexEntry>,
+    ) {
+        (
+            std::mem::take(&mut self.existing_index_entries),
+            std::mem::take(&mut self.observed_index_entries),
+        )
     }
 
     pub(in crate::sample_sources::scanner) fn mark_source_tree_incomplete(&mut self) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use wavecrate_library::sample_sources::SourceManifestEntry;
 use wavecrate_library::sample_sources::db::{ContentAuditReport, PendingRenameDiagnostics};
+use wavecrate_library::sample_sources::{SourceIndexEntry, SourceManifestEntry};
 
 /// One non-audio regular file observed during the authoritative source traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,6 +19,9 @@ pub struct SourceTreeSnapshot {
     pub directories: Vec<PathBuf>,
     /// Visible regular files that are not authoritative supported-audio manifest rows.
     pub other_files: Vec<SourceTreeFile>,
+    /// Typed index-only file facts captured by this traversal.
+    #[doc(hidden)]
+    pub index_entries: Vec<SourceIndexEntry>,
     /// Bounded diagnostics for entries that could not be classified or enumerated.
     pub diagnostics: Vec<String>,
     /// Relative directory or entry prefixes whose descendants were not

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
@@ -8,6 +8,7 @@ mod basics;
 #[cfg(unix)]
 mod filesystem_edges;
 mod hard_rescan;
+mod index_entries;
 mod rename_reconciliation;
 mod rename_retention;
 mod targeted_sync;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -65,6 +65,7 @@ fn scan_skips_symlink_files() {
     let stats = scan_once(&db).unwrap();
     assert_eq!(stats.total_files, 1);
     assert_eq!(stats.added, 1);
+    assert!(db.list_source_index_entries().unwrap().is_empty());
 }
 
 #[test]
@@ -92,6 +93,7 @@ fn scan_skips_appledouble_sidecar_files() {
         paths,
         vec![PathBuf::from("drums/snare.wav"), PathBuf::from("kick.wav")]
     );
+    assert!(db.list_source_index_entries().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -271,19 +271,72 @@ fn failed_type_probes_never_persist_internal_database_or_appledouble_paths() {
 
     let full_sidecar_failure = force_file_type_failure(&sidecar);
     let full_database_failure = force_file_type_failure(&database_path);
-    scan_once(&database).unwrap();
+    assert!(matches!(
+        scan_once(&database),
+        Err(ScanError::Incomplete { .. })
+    ));
     assert!(database.list_source_index_entries().unwrap().is_empty());
     drop((full_sidecar_failure, full_database_failure));
 
     let targeted_sidecar_failure = force_file_type_failure(&sidecar);
     let targeted_database_failure = force_file_type_failure(&database_path);
-    sync_paths(
-        &database,
-        &[sidecar_relative.clone(), database_relative.clone()],
-    )
-    .unwrap();
+    assert!(matches!(
+        sync_paths(
+            &database,
+            &[sidecar_relative.clone(), database_relative.clone()],
+        ),
+        Err(ScanError::Incomplete { .. })
+    ));
     assert!(database.list_source_index_entries().unwrap().is_empty());
     drop((targeted_sidecar_failure, targeted_database_failure));
+}
+
+#[test]
+fn failed_type_probes_preserve_descendants_below_reserved_name_directories() {
+    let directory = tempdir().unwrap();
+    let reserved_directories = [
+        PathBuf::from("nested/.wavecrate.db"),
+        PathBuf::from("._assets"),
+    ];
+    for reserved in &reserved_directories {
+        std::fs::create_dir_all(directory.path().join(reserved)).unwrap();
+        std::fs::write(directory.path().join(reserved).join("sample.wav"), b"wav").unwrap();
+        std::fs::write(directory.path().join(reserved).join("notes.txt"), b"notes").unwrap();
+    }
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    let expected_manifest = database.list_manifest_entries().unwrap();
+    let expected_index = database.list_source_index_entries().unwrap();
+
+    let full_failures = reserved_directories
+        .iter()
+        .map(|path| force_file_type_failure(&directory.path().join(path)))
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        scan_once(&database),
+        Err(ScanError::Incomplete { .. })
+    ));
+    assert_eq!(database.list_manifest_entries().unwrap(), expected_manifest);
+    assert_eq!(
+        database.list_source_index_entries().unwrap(),
+        expected_index
+    );
+    drop(full_failures);
+
+    let targeted_failures = reserved_directories
+        .iter()
+        .map(|path| force_file_type_failure(&directory.path().join(path)))
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        sync_paths(&database, &reserved_directories),
+        Err(ScanError::Incomplete { .. })
+    ));
+    assert_eq!(database.list_manifest_entries().unwrap(), expected_manifest);
+    assert_eq!(
+        database.list_source_index_entries().unwrap(),
+        expected_index
+    );
+    drop(targeted_failures);
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -6,7 +6,9 @@ use wavecrate_library::sample_sources::{
 };
 
 use super::*;
-use crate::sample_sources::scanner::scan_fs::force_file_metadata_failure;
+use crate::sample_sources::scanner::scan_fs::{
+    force_file_metadata_failure, force_file_type_failure,
+};
 use crate::sample_sources::scanner::sync_paths;
 
 #[test]
@@ -255,6 +257,33 @@ fn targeted_sync_persists_and_recovers_a_supported_file_availability_diagnostic(
     sync_paths(&database, &[relative.to_path_buf()]).unwrap();
     assert!(!database.entry_for_path(relative).unwrap().unwrap().missing);
     assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
+fn failed_type_probes_never_persist_internal_database_or_appledouble_paths() {
+    let directory = tempdir().unwrap();
+    let sidecar_relative = PathBuf::from("._sidecar.flac");
+    let database_relative = PathBuf::from(".wavecrate.db");
+    let sidecar = directory.path().join(&sidecar_relative);
+    let database_path = directory.path().join(&database_relative);
+    std::fs::write(&sidecar, b"sidecar").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+
+    let full_sidecar_failure = force_file_type_failure(&sidecar);
+    let full_database_failure = force_file_type_failure(&database_path);
+    scan_once(&database).unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+    drop((full_sidecar_failure, full_database_failure));
+
+    let targeted_sidecar_failure = force_file_type_failure(&sidecar);
+    let targeted_database_failure = force_file_type_failure(&database_path);
+    sync_paths(
+        &database,
+        &[sidecar_relative.clone(), database_relative.clone()],
+    )
+    .unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+    drop((targeted_sidecar_failure, targeted_database_failure));
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -1,0 +1,232 @@
+use std::path::{Path, PathBuf};
+
+use wavecrate_library::sample_sources::{
+    SOURCE_FORMAT_POLICY_VERSION, SourceIndexClassification, SourceIndexDiagnostic,
+    SourceIndexEntry,
+};
+
+use super::*;
+use crate::sample_sources::scanner::scan_fs::force_file_metadata_failure;
+use crate::sample_sources::scanner::sync_paths;
+
+#[test]
+fn full_scan_persists_typed_index_only_entries_across_restart() {
+    let directory = tempdir().unwrap();
+    std::fs::write(directory.path().join("supported.wav"), b"wav").unwrap();
+    std::fs::write(directory.path().join("unsupported.flac"), b"flac").unwrap();
+    std::fs::write(directory.path().join("notes.txt"), b"notes").unwrap();
+    std::fs::write(directory.path().join("._sidecar.flac"), b"sidecar").unwrap();
+
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    assert_eq!(database.list_files().unwrap().len(), 1);
+    assert_eq!(
+        typed_paths(&database),
+        vec![
+            (
+                PathBuf::from("notes.txt"),
+                SourceIndexClassification::UnsupportedNonAudio,
+            ),
+            (
+                PathBuf::from("unsupported.flac"),
+                SourceIndexClassification::UnsupportedAudio,
+            ),
+        ]
+    );
+    assert!(
+        database
+            .set_tag(Path::new("notes.txt"), Rating::KEEP_1)
+            .is_err()
+    );
+    drop(database);
+
+    let reopened = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    assert_eq!(
+        typed_paths(&reopened),
+        vec![
+            (
+                PathBuf::from("notes.txt"),
+                SourceIndexClassification::UnsupportedNonAudio,
+            ),
+            (
+                PathBuf::from("unsupported.flac"),
+                SourceIndexClassification::UnsupportedAudio,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn full_scan_reconciles_index_only_change_move_and_delete() {
+    let directory = tempdir().unwrap();
+    let original = directory.path().join("notes.txt");
+    std::fs::write(&original, b"one").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    let first = database.list_source_index_entries().unwrap().remove(0);
+
+    std::fs::write(&original, b"longer").unwrap();
+    scan_once(&database).unwrap();
+    let changed = database.list_source_index_entries().unwrap().remove(0);
+    assert_eq!(changed.file_size, Some(6));
+    assert_eq!(changed.classification, first.classification);
+
+    let moved = directory.path().join("moved.txt");
+    std::fs::rename(&original, &moved).unwrap();
+    scan_once(&database).unwrap();
+    assert_eq!(
+        typed_paths(&database),
+        vec![(
+            PathBuf::from("moved.txt"),
+            SourceIndexClassification::UnsupportedNonAudio,
+        )]
+    );
+
+    std::fs::remove_file(moved).unwrap();
+    scan_once(&database).unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_sync_uses_the_same_index_only_classification_and_reconciliation() {
+    let directory = tempdir().unwrap();
+    let nested = directory.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+
+    std::fs::write(nested.join("loop.mp3"), b"mp3").unwrap();
+    std::fs::write(nested.join("notes.md"), b"notes").unwrap();
+    sync_paths(&database, &[PathBuf::from("nested")]).unwrap();
+    assert_eq!(
+        typed_paths(&database),
+        vec![
+            (
+                PathBuf::from("nested/loop.mp3"),
+                SourceIndexClassification::UnsupportedAudio,
+            ),
+            (
+                PathBuf::from("nested/notes.md"),
+                SourceIndexClassification::UnsupportedNonAudio,
+            ),
+        ]
+    );
+
+    std::fs::remove_file(nested.join("loop.mp3")).unwrap();
+    std::fs::rename(nested.join("notes.md"), nested.join("moved.md")).unwrap();
+    sync_paths(&database, &[PathBuf::from("nested")]).unwrap();
+    let entries = database.list_source_index_entries().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].relative_path, Path::new("nested/moved.md"));
+
+    std::fs::write(nested.join("moved.md"), b"longer").unwrap();
+    sync_paths(&database, &[PathBuf::from("nested/moved.md")]).unwrap();
+    let entries = database.list_source_index_entries().unwrap();
+    assert_eq!(entries[0].file_size, Some(6));
+
+    std::fs::remove_file(nested.join("moved.md")).unwrap();
+    sync_paths(&database, &[PathBuf::from("nested/moved.md")]).unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
+fn uncertain_subtree_does_not_false_delete_index_only_rows() {
+    use crate::sample_sources::scanner::scan_fs::force_directory_read_failure;
+
+    let directory = tempdir().unwrap();
+    let protected = directory.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("notes.txt"), b"notes").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+
+    std::fs::remove_file(protected.join("notes.txt")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    assert!(matches!(
+        scan_once(&database),
+        Err(ScanError::Incomplete { .. })
+    ));
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].relative_path,
+        Path::new("protected/notes.txt")
+    );
+
+    drop(failure);
+    scan_once(&database).unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
+fn inaccessible_observation_is_typed_without_deleting_a_prior_index_row() {
+    let directory = tempdir().unwrap();
+    let path = directory.path().join("notes.txt");
+    std::fs::write(&path, b"notes").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].classification,
+        SourceIndexClassification::UnsupportedNonAudio
+    );
+
+    let failure = force_file_metadata_failure(&path);
+    let ScanError::Incomplete { .. } = scan_once(&database).unwrap_err() else {
+        panic!("unavailable metadata must leave a retryable scan");
+    };
+    let inaccessible = database.list_source_index_entries().unwrap().remove(0);
+    assert_eq!(
+        inaccessible.classification,
+        SourceIndexClassification::Inaccessible
+    );
+    assert_eq!(
+        inaccessible.diagnostic,
+        Some(SourceIndexDiagnostic::MetadataUnavailable)
+    );
+
+    drop(failure);
+    scan_once(&database).unwrap();
+    let recovered = database.list_source_index_entries().unwrap().remove(0);
+    assert_eq!(
+        recovered.classification,
+        SourceIndexClassification::UnsupportedNonAudio
+    );
+    assert_eq!(recovered.diagnostic, None);
+}
+
+#[test]
+fn supported_scan_promotes_a_legacy_index_only_row_without_metadata_inheritance() {
+    let directory = tempdir().unwrap();
+    let path = Path::new("promoted.wav");
+    std::fs::write(directory.path().join(path), b"sample").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    let mut batch = database.write_batch().unwrap();
+    batch
+        .upsert_source_index_entry(&SourceIndexEntry {
+            relative_path: path.to_path_buf(),
+            classification: SourceIndexClassification::UnsupportedAudio,
+            file_size: Some(6),
+            modified_ns: Some(1),
+            file_identity: None,
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION.saturating_sub(1),
+        })
+        .unwrap();
+    batch.commit_auxiliary_state().unwrap();
+
+    scan_once(&database).unwrap();
+
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+    let promoted = database.entry_for_path(path).unwrap().unwrap();
+    assert_eq!(promoted.tag, Rating::NEUTRAL);
+    assert!(!promoted.looped);
+    assert!(!promoted.locked);
+    assert!(promoted.normal_tags.is_empty());
+}
+
+fn typed_paths(database: &SourceDatabase) -> Vec<(PathBuf, SourceIndexClassification)> {
+    database
+        .list_source_index_entries()
+        .unwrap()
+        .into_iter()
+        .map(|entry| (entry.relative_path, entry.classification))
+        .collect()
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -193,6 +193,71 @@ fn inaccessible_observation_is_typed_without_deleting_a_prior_index_row() {
 }
 
 #[test]
+fn full_scan_moves_an_inaccessible_supported_file_out_of_the_live_manifest_until_recovery() {
+    let directory = tempdir().unwrap();
+    let relative = Path::new("supported.wav");
+    let path = directory.path().join(relative);
+    std::fs::write(&path, b"wav").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    database.set_tag(relative, Rating::KEEP_1).unwrap();
+
+    let failure = force_file_metadata_failure(&path);
+    let ScanError::Incomplete { .. } = scan_once(&database).unwrap_err() else {
+        panic!("inaccessible supported audio must leave a retryable scan");
+    };
+    let unavailable = database.entry_for_path(relative).unwrap().unwrap();
+    assert!(unavailable.missing);
+    assert_eq!(unavailable.tag, Rating::KEEP_1);
+    assert_eq!(
+        database.list_source_index_entries().unwrap(),
+        vec![SourceIndexEntry {
+            relative_path: relative.to_path_buf(),
+            classification: SourceIndexClassification::Inaccessible,
+            file_size: None,
+            modified_ns: None,
+            file_identity: None,
+            diagnostic: Some(SourceIndexDiagnostic::MetadataUnavailable),
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        }]
+    );
+
+    drop(failure);
+    scan_once(&database).unwrap();
+    let recovered = database.entry_for_path(relative).unwrap().unwrap();
+    assert!(!recovered.missing);
+    assert_eq!(recovered.tag, Rating::KEEP_1);
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
+fn targeted_sync_persists_and_recovers_a_supported_file_availability_diagnostic() {
+    let directory = tempdir().unwrap();
+    let relative = Path::new("supported.wav");
+    let path = directory.path().join(relative);
+    std::fs::write(&path, b"wav").unwrap();
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+
+    let failure = force_file_metadata_failure(&path);
+    let ScanError::Incomplete { .. } =
+        sync_paths(&database, &[relative.to_path_buf()]).unwrap_err()
+    else {
+        panic!("targeted unavailability must leave a retryable scan");
+    };
+    assert!(database.entry_for_path(relative).unwrap().unwrap().missing);
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].classification,
+        SourceIndexClassification::Inaccessible
+    );
+
+    drop(failure);
+    sync_paths(&database, &[relative.to_path_buf()]).unwrap();
+    assert!(!database.entry_for_path(relative).unwrap().unwrap().missing);
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+}
+
+#[test]
 fn supported_scan_promotes_a_legacy_index_only_row_without_metadata_inheritance() {
     let directory = tempdir().unwrap();
     let path = Path::new("promoted.wav");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -104,6 +104,7 @@ fn targeted_sync_hides_confirmed_missing_file() {
     assert_eq!(stats.missing, 1);
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
+    assert!(db.list_source_index_entries().unwrap().is_empty());
     assert_eq!(rows[0].relative_path, Path::new("two.wav"));
     assert_eq!(stats.committed_delta.deleted.len(), 1);
 }
@@ -259,6 +260,7 @@ fn targeted_sync_ignores_appledouble_sidecars() {
     let rows = db.list_files().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].relative_path, Path::new("drums/kick.wav"));
+    assert!(db.list_source_index_entries().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::scan::{ScanContext, ScanError};
 use super::scan_diff::mark_missing;
+use super::scan_index::reconcile_index_entries;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::META_LAST_SCAN_COMPLETED_AT;
@@ -45,6 +46,7 @@ pub(super) fn db_sync_phase(
         context.commit_batch(batch)?;
     }
 
+    reconcile_index_entries(db, context, writer)?;
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -42,6 +42,7 @@ pub(super) fn apply_diff(
     let path = facts.relative.clone();
     let should_hash = hash_required;
     let _ = context.existing.remove(&path);
+    batch.remove_source_index_entry(&path)?;
     let existing = db.entry_for_path(&path)?;
     match existing {
         Some(entry)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -14,13 +14,15 @@ use wavecrate_library::filesystem_identity::{
     filesystem_change_marker, stable_filesystem_identity,
 };
 use wavecrate_library::sample_sources::{
-    SourceEntryClassification, SourceEntryFileType, classify_source_entry,
+    SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
+    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry,
 };
 
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::ScanError;
 use super::scan::{SourceTreeFile, SourceTreeSnapshot};
+use super::scan_index::{inaccessible_index_entry, index_entry_from_file_facts};
 
 const MAX_LAYOUT_DIAGNOSTICS: usize = 16;
 
@@ -29,6 +31,7 @@ thread_local! {
     static FORCED_DIRECTORY_READ_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
     static FORCED_DIRECTORY_ENTRY_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
     static FORCED_FILE_TYPE_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
+    static FORCED_FILE_METADATA_FAILURES: RefCell<BTreeSet<PathBuf>> = const { RefCell::new(BTreeSet::new()) };
 }
 
 /// Deterministically emulate an unreadable directory for scanner regression
@@ -52,12 +55,19 @@ pub(crate) fn force_file_type_failure(path: &Path) -> ForcedTraversalFailure {
     ForcedTraversalFailure::new(path, ForcedFailureKind::FileType)
 }
 
+/// Deterministically emulate an unreadable file-metadata observation.
+#[cfg(test)]
+pub(crate) fn force_file_metadata_failure(path: &Path) -> ForcedTraversalFailure {
+    ForcedTraversalFailure::new(path, ForcedFailureKind::FileMetadata)
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy)]
 enum ForcedFailureKind {
     DirectoryRead,
     DirectoryEntry,
     FileType,
+    FileMetadata,
 }
 
 #[cfg(test)]
@@ -94,6 +104,7 @@ fn forced_failures(
         ForcedFailureKind::DirectoryRead => &FORCED_DIRECTORY_READ_FAILURES,
         ForcedFailureKind::DirectoryEntry => &FORCED_DIRECTORY_ENTRY_FAILURES,
         ForcedFailureKind::FileType => &FORCED_FILE_TYPE_FAILURES,
+        ForcedFailureKind::FileMetadata => &FORCED_FILE_METADATA_FAILURES,
     }
 }
 
@@ -128,6 +139,18 @@ pub(super) fn forced_file_type_error(path: &Path) -> Option<std::io::Error> {
             std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 "forced file type failure",
+            )
+        })
+    })
+}
+
+#[cfg(test)]
+fn forced_file_metadata_error(path: &Path) -> Option<std::io::Error> {
+    FORCED_FILE_METADATA_FAILURES.with(|failures| {
+        failures.borrow().contains(path).then(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced file metadata failure",
             )
         })
     })
@@ -239,6 +262,12 @@ pub(super) fn visit_dir_with_cancel_check(
                         format!("read file type {}: {err}", display_relative(root, &path)),
                     );
                     record_uncertain_prefix(&mut snapshot, root, &path);
+                    if let Ok(relative_path) = path.strip_prefix(root) {
+                        snapshot.index_entries.push(inaccessible_index_entry(
+                            relative_path.to_path_buf(),
+                            SourceIndexDiagnostic::EntryTypeUnavailable,
+                        ));
+                    }
                     continue;
                 }
             };
@@ -254,19 +283,33 @@ pub(super) fn visit_dir_with_cancel_check(
                 classification @ SourceEntryClassification::File { .. } => {
                     if classification.indexes_audio() {
                         visitor(&path)?;
-                    } else if !classification.has_supported_audio() {
-                        match entry.metadata() {
-                            Ok(metadata) => snapshot.other_files.push(SourceTreeFile {
-                                relative_path: relative,
-                                file_size: metadata.len(),
-                            }),
-                            Err(err) => record_layout_diagnostic(
-                                &mut snapshot,
-                                format!(
-                                    "read file metadata {}: {err}",
-                                    display_relative(root, &path)
-                                ),
-                            ),
+                    } else if let Some(file_classification) = classification.file_classification()
+                        && file_classification != SourceFileClassification::SupportedAudio
+                    {
+                        match source_index_entry(root, &path, file_classification) {
+                            Ok(index_entry) => {
+                                if let Some(file_size) = index_entry.file_size {
+                                    snapshot.other_files.push(SourceTreeFile {
+                                        relative_path: relative,
+                                        file_size,
+                                    });
+                                }
+                                snapshot.index_entries.push(index_entry);
+                            }
+                            Err(err) => {
+                                record_layout_diagnostic(
+                                    &mut snapshot,
+                                    format!(
+                                        "read file metadata {}: {err}",
+                                        display_relative(root, &path)
+                                    ),
+                                );
+                                record_uncertain_prefix(&mut snapshot, root, &path);
+                                snapshot.index_entries.push(inaccessible_index_entry(
+                                    relative,
+                                    SourceIndexDiagnostic::MetadataUnavailable,
+                                ));
+                            }
                         }
                     }
                 }
@@ -278,8 +321,46 @@ pub(super) fn visit_dir_with_cancel_check(
     snapshot
         .other_files
         .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    snapshot
+        .index_entries
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     snapshot.uncertain_prefixes.sort();
     Ok(snapshot)
+}
+
+fn source_index_entry(
+    root: &Path,
+    path: &Path,
+    classification: SourceFileClassification,
+) -> Result<SourceIndexEntry, std::io::Error> {
+    #[cfg(test)]
+    if let Some(error) = forced_file_metadata_error(path) {
+        return Err(error);
+    }
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(std::io::Error::other(
+            "entry changed type during metadata inspection",
+        ));
+    }
+    let modified = metadata.modified()?;
+    let modified_ns = modified
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .min(i64::MAX as u128) as i64;
+    let relative_path = path
+        .strip_prefix(root)
+        .map(Path::to_path_buf)
+        .map_err(|_| std::io::Error::other("entry is outside the source root"))?;
+    index_entry_from_file_facts(
+        relative_path,
+        classification,
+        metadata.len(),
+        modified_ns,
+        stable_filesystem_identity(path, &metadata),
+    )
+    .ok_or_else(|| std::io::Error::other("supported audio is not an index-only entry"))
 }
 
 fn record_uncertain_prefix(snapshot: &mut SourceTreeSnapshot, root: &Path, path: &Path) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -415,6 +415,13 @@ fn display_relative(root: &Path, path: &Path) -> String {
 
 pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanError> {
     let relative = strip_relative(root, path)?;
+    #[cfg(test)]
+    if let Some(source) = forced_file_metadata_error(path) {
+        return Err(ScanError::Io {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
     let meta = path.metadata().map_err(|source| ScanError::Io {
         path: path.to_path_buf(),
         source,
@@ -446,6 +453,13 @@ pub(super) fn read_facts_from_open_file(
     file: &fs::File,
 ) -> Result<FileFacts, ScanError> {
     let relative = strip_relative(root, path)?;
+    #[cfg(test)]
+    if let Some(source) = forced_file_metadata_error(path) {
+        return Err(ScanError::Io {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
     let meta = file.metadata().map_err(|source| ScanError::Io {
         path: path.to_path_buf(),
         source,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -257,6 +257,7 @@ pub(super) fn visit_dir_with_cancel_check(
                 Ok(file_type) => file_type,
                 Err(err) => {
                     if is_rejected_source_file_path(&relative) {
+                        record_uncertain_prefix(&mut snapshot, root, &path);
                         continue;
                     }
                     warn!(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -15,7 +15,7 @@ use wavecrate_library::filesystem_identity::{
 };
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
-    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry,
+    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry, is_rejected_source_file_path,
 };
 
 use crate::sample_sources::SourceDatabase;
@@ -249,9 +249,16 @@ pub(super) fn visit_dir_with_cancel_check(
             };
 
             let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .map(Path::to_path_buf)
+                .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
             let file_type = match read_file_type(&entry, &path) {
                 Ok(file_type) => file_type,
                 Err(err) => {
+                    if is_rejected_source_file_path(&relative) {
+                        continue;
+                    }
                     warn!(
                         path = %path.display(),
                         error = %err,
@@ -262,19 +269,13 @@ pub(super) fn visit_dir_with_cancel_check(
                         format!("read file type {}: {err}", display_relative(root, &path)),
                     );
                     record_uncertain_prefix(&mut snapshot, root, &path);
-                    if let Ok(relative_path) = path.strip_prefix(root) {
-                        snapshot.index_entries.push(inaccessible_index_entry(
-                            relative_path.to_path_buf(),
-                            SourceIndexDiagnostic::EntryTypeUnavailable,
-                        ));
-                    }
+                    snapshot.index_entries.push(inaccessible_index_entry(
+                        relative,
+                        SourceIndexDiagnostic::EntryTypeUnavailable,
+                    ));
                     continue;
                 }
             };
-            let relative = path
-                .strip_prefix(root)
-                .map(Path::to_path_buf)
-                .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
             match classify_source_entry(&relative, source_entry_file_type(&file_type)) {
                 SourceEntryClassification::Directory { .. } => {
                     snapshot.directories.push(relative);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
@@ -1,0 +1,98 @@
+use std::{collections::BTreeSet, path::PathBuf};
+
+use wavecrate_library::sample_sources::{
+    SOURCE_FORMAT_POLICY_VERSION, SourceFileClassification, SourceIndexClassification,
+    SourceIndexDiagnostic, SourceIndexEntry,
+};
+
+use crate::sample_sources::SourceDatabase;
+
+use super::scan::{ScanContext, ScanError};
+use super::scan_writer::{ScanWritePhase, ScanWriter};
+
+pub(super) fn index_entry_from_file_facts(
+    relative_path: PathBuf,
+    classification: SourceFileClassification,
+    file_size: u64,
+    modified_ns: i64,
+    file_identity: Option<String>,
+) -> Option<SourceIndexEntry> {
+    let (classification, diagnostic) = match classification {
+        SourceFileClassification::UnsupportedAudio => {
+            (SourceIndexClassification::UnsupportedAudio, None)
+        }
+        SourceFileClassification::UnsupportedNonAudio => {
+            (SourceIndexClassification::UnsupportedNonAudio, None)
+        }
+        SourceFileClassification::PracticallyUnsupportedAudio => (
+            SourceIndexClassification::PracticallyUnsupportedAudio,
+            Some(SourceIndexDiagnostic::PracticalSupportLimit),
+        ),
+        SourceFileClassification::SupportedAudio => return None,
+    };
+    Some(SourceIndexEntry {
+        relative_path,
+        classification,
+        file_size: Some(file_size),
+        modified_ns: Some(modified_ns),
+        file_identity,
+        diagnostic,
+        format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+    })
+}
+
+pub(super) fn inaccessible_index_entry(
+    relative_path: PathBuf,
+    diagnostic: SourceIndexDiagnostic,
+) -> SourceIndexEntry {
+    SourceIndexEntry {
+        relative_path,
+        classification: SourceIndexClassification::Inaccessible,
+        file_size: None,
+        modified_ns: None,
+        file_identity: None,
+        diagnostic: Some(diagnostic),
+        format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+    }
+}
+
+pub(super) fn reconcile_index_entries(
+    database: &SourceDatabase,
+    context: &mut ScanContext,
+    writer: &impl ScanWriter,
+) -> Result<(), ScanError> {
+    let (existing, observed) = context.take_index_reconciliation();
+    let live_manifest_paths = database
+        .list_manifest_entries()?
+        .into_iter()
+        .map(|entry| entry.relative_path)
+        .collect::<BTreeSet<_>>();
+
+    let removals = existing
+        .keys()
+        .filter(|path| {
+            live_manifest_paths.contains(*path)
+                || (!observed.contains_key(*path) && !context.preserves_missing_row(path))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let upserts = observed
+        .into_values()
+        .filter(|entry| !live_manifest_paths.contains(&entry.relative_path))
+        .filter(|entry| existing.get(&entry.relative_path) != Some(entry))
+        .collect::<Vec<SourceIndexEntry>>();
+
+    if removals.is_empty() && upserts.is_empty() {
+        return Ok(());
+    }
+    let _writer = writer.lock(ScanWritePhase::Manifest);
+    let mut batch = database.write_batch()?;
+    for path in removals {
+        batch.remove_source_index_entry(&path)?;
+    }
+    for entry in upserts {
+        batch.upsert_source_index_entry(&entry)?;
+    }
+    batch.commit_auxiliary_state()?;
+    Ok(())
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
@@ -67,32 +67,50 @@ pub(super) fn reconcile_index_entries(
         .into_iter()
         .map(|entry| entry.relative_path)
         .collect::<BTreeSet<_>>();
+    let unavailable_manifest_paths = observed
+        .values()
+        .filter(|entry| entry.classification == SourceIndexClassification::Inaccessible)
+        .map(|entry| &entry.relative_path)
+        .filter(|path| live_manifest_paths.contains(*path))
+        .cloned()
+        .collect::<BTreeSet<_>>();
 
     let removals = existing
         .keys()
         .filter(|path| {
-            live_manifest_paths.contains(*path)
+            (live_manifest_paths.contains(*path) && !unavailable_manifest_paths.contains(*path))
                 || (!observed.contains_key(*path) && !context.preserves_missing_row(path))
         })
         .cloned()
         .collect::<Vec<_>>();
     let upserts = observed
         .into_values()
-        .filter(|entry| !live_manifest_paths.contains(&entry.relative_path))
+        .filter(|entry| {
+            !live_manifest_paths.contains(&entry.relative_path)
+                || entry.classification == SourceIndexClassification::Inaccessible
+        })
         .filter(|entry| existing.get(&entry.relative_path) != Some(entry))
         .collect::<Vec<SourceIndexEntry>>();
 
-    if removals.is_empty() && upserts.is_empty() {
+    if removals.is_empty() && upserts.is_empty() && unavailable_manifest_paths.is_empty() {
         return Ok(());
     }
     let _writer = writer.lock(ScanWritePhase::Manifest);
     let mut batch = database.write_batch()?;
+    for path in &unavailable_manifest_paths {
+        batch.set_missing(path, true)?;
+        context.stats.missing = context.stats.missing.saturating_add(1);
+    }
     for path in removals {
         batch.remove_source_index_entry(&path)?;
     }
     for entry in upserts {
         batch.upsert_source_index_entry(&entry)?;
     }
-    batch.commit_auxiliary_state()?;
+    if unavailable_manifest_paths.is_empty() {
+        batch.commit_auxiliary_state()?;
+    } else {
+        context.commit_batch(batch)?;
+    }
     Ok(())
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -9,7 +9,7 @@ use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority
 use cap_std::fs::{Dir, OpenOptions};
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
-    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry,
+    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry, is_rejected_source_file_path,
 };
 
 use crate::sample_sources::{SourceDatabase, WavEntry};
@@ -238,10 +238,13 @@ fn collect_current_files(
     };
     let absolute_path = root.join(relative_path);
     let name_path = Path::new(&name);
-    let metadata = match parent.symlink_metadata(name_path) {
+    let metadata = match read_targeted_metadata(&parent, name_path, &absolute_path) {
         Ok(metadata) => metadata,
         Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
+            if is_rejected_source_file_path(relative_path) {
+                return Ok(());
+            }
             tracing::warn!(
                 path = %absolute_path.display(),
                 error = %source,
@@ -407,13 +410,16 @@ fn collect_current_files_in_dir(
             let file_type = match read_targeted_file_type(&entry, &path) {
                 Ok(file_type) => file_type,
                 Err(err) => {
+                    let relative_path = relative_dir.join(name_path);
+                    if is_rejected_source_file_path(&relative_path) {
+                        continue;
+                    }
                     tracing::warn!(
                         path = %path.display(),
                         error = %err,
                         "Failed to read targeted sync file type"
                     );
-                    uncertain_prefixes.insert(relative_dir.join(name_path));
-                    let relative_path = relative_dir.join(name_path);
+                    uncertain_prefixes.insert(relative_path.clone());
                     current_index_entries.insert(
                         relative_path.clone(),
                         inaccessible_index_entry(
@@ -634,6 +640,18 @@ fn read_targeted_dir_entries(
         return Err(error);
     }
     dir.entries()
+}
+
+fn read_targeted_metadata(
+    parent: &Dir,
+    name: &Path,
+    _absolute_path: &Path,
+) -> Result<cap_std::fs::Metadata, io::Error> {
+    #[cfg(test)]
+    if let Some(error) = super::scan_fs::forced_file_type_error(_absolute_path) {
+        return Err(error);
+    }
+    parent.symlink_metadata(name)
 }
 
 fn read_targeted_file_type(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -8,7 +8,8 @@ use std::{
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
 use cap_std::fs::{Dir, OpenOptions};
 use wavecrate_library::sample_sources::{
-    SourceEntryClassification, SourceEntryFileType, classify_source_entry,
+    SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
+    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry,
 };
 
 use crate::sample_sources::{SourceDatabase, WavEntry};
@@ -18,6 +19,7 @@ use super::{
     scan_db_sync::db_sync_phase,
     scan_diff_phase::prepare_diff_from_facts,
     scan_fs::ensure_root_dir,
+    scan_index::{inaccessible_index_entry, index_entry_from_file_facts},
     scan_walk::apply_prepared_chunk,
     scan_writer::{ScanWriter, UncoordinatedScanWriter},
 };
@@ -57,6 +59,8 @@ pub fn sync_paths_with_progress_and_writer(
     let TargetedScanTargets {
         current_files,
         existing,
+        current_index_entries,
+        existing_index_entries,
         uncertain_prefixes,
     } = targets;
     let mut context = ScanContext::from_existing(
@@ -64,6 +68,10 @@ pub fn sync_paths_with_progress_and_writer(
         ScanMode::Targeted,
         manifest_revision,
         manifest_before.clone(),
+    );
+    context.set_targeted_index_entries(
+        existing_index_entries.into_values(),
+        current_index_entries.into_values(),
     );
     context.mark_uncertain_prefixes(uncertain_prefixes);
     let mut prepared = Vec::with_capacity(TARGET_PREPARE_BATCH_SIZE);
@@ -116,6 +124,8 @@ pub fn sync_paths_with_progress_and_writer(
 struct TargetedScanTargets {
     current_files: Vec<TargetedFile>,
     existing: HashMap<PathBuf, WavEntry>,
+    current_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
+    existing_index_entries: BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: BTreeSet<PathBuf>,
 }
 
@@ -138,6 +148,8 @@ fn collect_targets(
         })?;
     let mut current_files = BTreeMap::new();
     let mut existing = HashMap::new();
+    let mut current_index_entries = BTreeMap::new();
+    let mut existing_index_entries = BTreeMap::new();
     let mut uncertain_prefixes = BTreeSet::new();
     for relative_path in normalized_targets(paths) {
         if let Some(cancel) = cancel
@@ -146,18 +158,22 @@ fn collect_targets(
             return Err(ScanError::Canceled);
         }
         collect_existing_rows(db, &relative_path, &mut existing)?;
+        collect_existing_index_entries(db, &relative_path, &mut existing_index_entries)?;
         collect_current_files(
             &source_root,
             root,
             &relative_path,
             cancel,
             &mut current_files,
+            &mut current_index_entries,
             &mut uncertain_prefixes,
         )?;
     }
     Ok(TargetedScanTargets {
         current_files: current_files.into_values().collect(),
         existing,
+        current_index_entries,
+        existing_index_entries,
         uncertain_prefixes,
     })
 }
@@ -195,12 +211,24 @@ fn collect_existing_rows(
     Ok(())
 }
 
+fn collect_existing_index_entries(
+    db: &SourceDatabase,
+    relative_path: &Path,
+    existing: &mut BTreeMap<PathBuf, SourceIndexEntry>,
+) -> Result<(), ScanError> {
+    for entry in db.list_source_index_entries_under_path(relative_path)? {
+        existing.entry(entry.relative_path.clone()).or_insert(entry);
+    }
+    Ok(())
+}
+
 fn collect_current_files(
     source_root: &Dir,
     root: &Path,
     relative_path: &Path,
     cancel: Option<&AtomicBool>,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let Some((parent, name)) =
@@ -220,6 +248,13 @@ fn collect_current_files(
                 "Failed to read targeted sync entry metadata"
             );
             uncertain_prefixes.insert(relative_path.to_path_buf());
+            current_index_entries.insert(
+                relative_path.to_path_buf(),
+                inaccessible_index_entry(
+                    relative_path.to_path_buf(),
+                    SourceIndexDiagnostic::EntryTypeUnavailable,
+                ),
+            );
             return Ok(());
         }
     };
@@ -245,6 +280,7 @@ fn collect_current_files(
                 relative_path,
                 cancel,
                 current_files,
+                current_index_entries,
                 uncertain_prefixes,
             )?;
         }
@@ -257,10 +293,22 @@ fn collect_current_files(
                 root,
                 relative_path,
                 current_files,
+                current_index_entries,
                 uncertain_prefixes,
             )?;
         }
-        SourceEntryClassification::File { .. } | SourceEntryClassification::Rejected(_) => {}
+        classification @ SourceEntryClassification::File { .. } => {
+            collect_current_index_file(
+                &parent,
+                Path::new(&name),
+                root,
+                relative_path,
+                classification,
+                current_index_entries,
+                uncertain_prefixes,
+            )?;
+        }
+        SourceEntryClassification::Rejected(_) => {}
     }
     Ok(())
 }
@@ -318,6 +366,7 @@ fn collect_current_files_in_dir(
     start_relative: &Path,
     cancel: Option<&AtomicBool>,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let mut stack = vec![(start_dir, start_relative.to_path_buf())];
@@ -364,6 +413,14 @@ fn collect_current_files_in_dir(
                         "Failed to read targeted sync file type"
                     );
                     uncertain_prefixes.insert(relative_dir.join(name_path));
+                    let relative_path = relative_dir.join(name_path);
+                    current_index_entries.insert(
+                        relative_path.clone(),
+                        inaccessible_index_entry(
+                            relative_path,
+                            SourceIndexDiagnostic::EntryTypeUnavailable,
+                        ),
+                    );
                     continue;
                 }
             };
@@ -400,11 +457,22 @@ fn collect_current_files_in_dir(
                         root,
                         &relative_path,
                         current_files,
+                        current_index_entries,
                         uncertain_prefixes,
                     )?;
                 }
-                SourceEntryClassification::File { .. } | SourceEntryClassification::Rejected(_) => {
+                classification @ SourceEntryClassification::File { .. } => {
+                    collect_current_index_file(
+                        &dir,
+                        name_path,
+                        root,
+                        &relative_path,
+                        classification,
+                        current_index_entries,
+                        uncertain_prefixes,
+                    )?;
                 }
+                SourceEntryClassification::Rejected(_) => {}
             }
         }
     }
@@ -417,6 +485,7 @@ fn collect_current_file(
     root: &Path,
     relative_path: &Path,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
+    current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let absolute_path = root.join(relative_path);
@@ -441,11 +510,36 @@ fn collect_current_file(
                 .is_ok_and(|metadata| metadata.is_symlink())
             {
                 uncertain_prefixes.insert(relative_path.to_path_buf());
+                current_index_entries.insert(
+                    relative_path.to_path_buf(),
+                    inaccessible_index_entry(
+                        relative_path.to_path_buf(),
+                        SourceIndexDiagnostic::OpenUnavailable,
+                    ),
+                );
             }
             return Ok(());
         }
     };
-    let facts = super::scan_fs::read_facts_from_open_file(root, &absolute_path, &file)?;
+    let facts = match super::scan_fs::read_facts_from_open_file(root, &absolute_path, &file) {
+        Ok(facts) => facts,
+        Err(error) => {
+            tracing::warn!(
+                path = %absolute_path.display(),
+                %error,
+                "Skipping targeted sync file with unavailable metadata"
+            );
+            uncertain_prefixes.insert(relative_path.to_path_buf());
+            current_index_entries.insert(
+                relative_path.to_path_buf(),
+                inaccessible_index_entry(
+                    relative_path.to_path_buf(),
+                    SourceIndexDiagnostic::MetadataUnavailable,
+                ),
+            );
+            return Ok(());
+        }
+    };
     current_files
         .entry(relative_path.to_path_buf())
         .or_insert(TargetedFile {
@@ -453,6 +547,81 @@ fn collect_current_file(
             facts,
             file,
         });
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_current_index_file(
+    parent: &Dir,
+    name: &Path,
+    root: &Path,
+    relative_path: &Path,
+    classification: SourceEntryClassification,
+    current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
+    uncertain_prefixes: &mut BTreeSet<PathBuf>,
+) -> Result<(), ScanError> {
+    let Some(file_classification) = classification.file_classification() else {
+        return Ok(());
+    };
+    if file_classification == SourceFileClassification::SupportedAudio {
+        return Ok(());
+    }
+    let absolute_path = root.join(relative_path);
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = match parent.open_with(name, &options) {
+        Ok(file) => file.into_std(),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            if !parent
+                .symlink_metadata(name)
+                .is_ok_and(|metadata| metadata.is_symlink())
+            {
+                tracing::warn!(
+                    path = %absolute_path.display(),
+                    error = %source,
+                    "Targeted index-only file could not be opened without following links"
+                );
+                uncertain_prefixes.insert(relative_path.to_path_buf());
+                current_index_entries.insert(
+                    relative_path.to_path_buf(),
+                    inaccessible_index_entry(
+                        relative_path.to_path_buf(),
+                        SourceIndexDiagnostic::OpenUnavailable,
+                    ),
+                );
+            }
+            return Ok(());
+        }
+    };
+    let facts = match super::scan_fs::read_facts_from_open_file(root, &absolute_path, &file) {
+        Ok(facts) => facts,
+        Err(error) => {
+            tracing::warn!(
+                path = %absolute_path.display(),
+                %error,
+                "Targeted index-only file metadata is unavailable"
+            );
+            uncertain_prefixes.insert(relative_path.to_path_buf());
+            current_index_entries.insert(
+                relative_path.to_path_buf(),
+                inaccessible_index_entry(
+                    relative_path.to_path_buf(),
+                    SourceIndexDiagnostic::MetadataUnavailable,
+                ),
+            );
+            return Ok(());
+        }
+    };
+    if let Some(entry) = index_entry_from_file_facts(
+        relative_path.to_path_buf(),
+        file_classification,
+        facts.size,
+        facts.modified_ns,
+        facts.file_identity,
+    ) {
+        current_index_entries.insert(relative_path.to_path_buf(), entry);
+    }
     Ok(())
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -243,6 +243,7 @@ fn collect_current_files(
         Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
             if is_rejected_source_file_path(relative_path) {
+                uncertain_prefixes.insert(relative_path.to_path_buf());
                 return Ok(());
             }
             tracing::warn!(
@@ -412,6 +413,7 @@ fn collect_current_files_in_dir(
                 Err(err) => {
                     let relative_path = relative_dir.join(name_path);
                     if is_rejected_source_file_path(&relative_path) {
+                        uncertain_prefixes.insert(relative_path);
                         continue;
                     }
                     tracing::warn!(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -11,6 +11,7 @@ use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority
 use cap_std::fs::{Dir, OpenOptions};
 
 use crate::sample_sources::SourceDatabase;
+use wavecrate_library::sample_sources::SourceIndexDiagnostic;
 
 use super::scan::{ScanContext, ScanError};
 use super::scan_diff::{PreparedFile, apply_diff};
@@ -19,6 +20,7 @@ use super::scan_fs::{
     compute_content_hash, compute_content_hash_with_reader, is_supported_scannable_audio_file,
     read_facts, read_facts_from_open_file, visit_dir_with_cancel_check,
 };
+use super::scan_index::inaccessible_index_entry;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
 
 const APPLY_BATCH_SIZE: usize = 64;
@@ -50,21 +52,22 @@ pub(super) fn walk_phase(
             }
             let mut prepared = match prepare_diff(root, path, context) {
                 Ok(prepared) => prepared,
-                Err(error) if committed.get() => {
+                Err(error) => {
                     context.mark_source_tree_incomplete();
-                    if let Ok(relative) = path.strip_prefix(root)
-                        && is_supported_scannable_audio_file(root, relative)
-                    {
-                        context.existing.remove(relative);
-                    }
+                    context.existing.remove(&relative_path);
+                    context.mark_uncertain_prefixes([relative_path.clone()]);
+                    context.observe_index_entries([inaccessible_index_entry(
+                        relative_path,
+                        SourceIndexDiagnostic::MetadataUnavailable,
+                    )]);
                     tracing::warn!(
                         path = %path.display(),
                         error = %error,
-                        "Skipping file that changed after an earlier scan batch committed"
+                        committed = committed.get(),
+                        "Persisting an inaccessible supported file for retry"
                     );
                     return Ok(());
                 }
-                Err(error) => return Err(error),
             };
             if !context.resumable_manifest_audit_active() {
                 context.stats.total_files += 1;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -120,6 +120,7 @@ pub(super) fn walk_phase(
     }
     context.flush_manifest_audit_checkpoint(db)?;
     context.mark_uncertain_prefixes(source_tree_snapshot.uncertain_prefixes.clone());
+    context.observe_index_entries(source_tree_snapshot.index_entries.clone());
     context.stats.source_tree_snapshot =
         Some(finalize_source_tree_snapshot(context, source_tree_snapshot));
     Ok(())

--- a/tests/unit/source_db_migration_tests.rs
+++ b/tests/unit/source_db_migration_tests.rs
@@ -6,6 +6,8 @@ mod analysis_jobs;
 mod contract;
 #[path = "source_db_migration_tests/fixtures.rs"]
 mod fixtures;
+#[path = "source_db_migration_tests/index_entries.rs"]
+mod index_entries;
 #[path = "source_db_migration_tests/pending_rename.rs"]
 mod pending_rename;
 #[path = "source_db_migration_tests/samples.rs"]

--- a/tests/unit/source_db_migration_tests/fixtures.rs
+++ b/tests/unit/source_db_migration_tests/fixtures.rs
@@ -34,6 +34,18 @@ pub(super) const SOURCE_DB_SCHEMA_CONTRACT: &[TableContract] = &[
         ],
     },
     TableContract {
+        name: "source_index_entries",
+        columns: &[
+            "path",
+            "classification",
+            "file_size",
+            "modified_ns",
+            "file_identity",
+            "diagnostic",
+            "format_policy_version",
+        ],
+    },
+    TableContract {
         name: "source_tags",
         columns: &["id", "normalized_text", "display_label"],
     },

--- a/tests/unit/source_db_migration_tests/index_entries.rs
+++ b/tests/unit/source_db_migration_tests/index_entries.rs
@@ -1,0 +1,131 @@
+use super::*;
+use fixtures::{column_names, with_legacy_db};
+
+#[test]
+fn v10_migration_adds_index_only_schema_without_changing_sample_metadata() {
+    let dir = with_legacy_db(
+        "CREATE TABLE metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO metadata (key, value) VALUES ('revision', '41');
+        CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            tag INTEGER NOT NULL DEFAULT 0,
+            looped INTEGER NOT NULL DEFAULT 0,
+            locked INTEGER NOT NULL DEFAULT 0,
+            missing INTEGER NOT NULL DEFAULT 0,
+            extension TEXT NOT NULL DEFAULT '',
+            last_played_at INTEGER,
+            last_curated_at INTEGER
+        );
+        INSERT INTO wav_files (
+            path, file_size, modified_ns, tag, looped, locked, missing,
+            extension, last_played_at, last_curated_at
+        ) VALUES ('kept.wav', 10, 5, 3, 1, 1, 0, 'wav', 20, 30);
+        PRAGMA user_version = 10;",
+    );
+
+    let db = SourceDatabase::open_for_test_fixture_source_write(dir.path()).unwrap();
+
+    assert_eq!(
+        column_names(&db.connection, "source_index_entries"),
+        vec![
+            "path",
+            "classification",
+            "file_size",
+            "modified_ns",
+            "file_identity",
+            "diagnostic",
+            "format_policy_version",
+        ]
+    );
+    let preserved = db
+        .connection
+        .query_row(
+            "SELECT tag, looped, locked, last_played_at, last_curated_at
+             FROM wav_files WHERE path = 'kept.wav'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(preserved, (3, 1, 1, 20, 30));
+    assert_eq!(db.get_revision().unwrap(), 41);
+}
+
+#[test]
+fn legacy_read_only_database_projects_an_empty_index_without_migrating() {
+    let dir = with_legacy_db(
+        "CREATE TABLE metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL
+        );
+        PRAGMA user_version = 10;",
+    );
+
+    let db = SourceDatabase::open_for_ui_read(dir.path()).unwrap();
+    let snapshot = db.source_index_snapshot().unwrap();
+
+    assert_eq!(snapshot.revision, 0);
+    assert!(snapshot.entries.is_empty());
+    assert!(column_names(&db.connection, "source_index_entries").is_empty());
+}
+
+#[test]
+fn failed_index_schema_migration_keeps_existing_rows_and_old_stamp() {
+    let dir = with_legacy_db(
+        "CREATE TABLE metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE wav_files (
+            path TEXT PRIMARY KEY,
+            file_size INTEGER NOT NULL,
+            modified_ns INTEGER NOT NULL,
+            tag INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO wav_files (path, file_size, modified_ns, tag)
+        VALUES ('kept.wav', 10, 5, 2);
+        CREATE VIEW source_index_entries AS SELECT path FROM wav_files;
+        PRAGMA user_version = 10;",
+    );
+
+    assert!(SourceDatabase::open_for_test_fixture_source_write(dir.path()).is_err());
+
+    let connection = rusqlite::Connection::open(dir.path().join(DB_FILE_NAME)).unwrap();
+    assert_eq!(
+        connection
+            .query_row(
+                "SELECT file_size, modified_ns, tag FROM wav_files WHERE path = 'kept.wav'",
+                [],
+                |row| Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?
+                ))
+            )
+            .unwrap(),
+        (10, 5, 2)
+    );
+    assert_eq!(
+        connection
+            .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        10
+    );
+}


### PR DESCRIPTION
## Goal

Persist typed index-only records for unsupported and inaccessible source files so classification and diagnostics survive restart and later format-policy changes can promote files through normal reconciliation.

Closes OPT-1262.

## Scope and non-goals

- Add typed unsupported-audio, unsupported-non-audio, inaccessible, and practically-unsupported classifications with bounded diagnostics and format-policy versioning.
- Add a versioned `source_index_entries` schema, independent index revision, and read snapshot/list APIs.
- Reconcile index-only create/change/move/delete in full scans and targeted sync, while preserving uncertain subtrees and promoting newly supported paths without inheriting sample metadata.
- Retain user metadata but remove an inaccessible supported path from the live manifest/readiness set until recovery.
- Exclude Wavecrate database files, links/reparse targets, and AppleDouble sidecars, including when type/metadata probing fails.
- Do not add codecs, playback/editing behavior, or an `all files` UI.

## Definition of Done

- [x] Unsupported audio and non-audio persist as distinct index-only classifications across restart.
- [x] Inaccessible/unclassifiable observations persist typed diagnostics without paths outside the source root.
- [x] Supported manifest rows remain the only entries eligible for sample metadata and readiness work.
- [x] Full and targeted create/change/move/delete reconciliation and format-policy promotion have regression coverage.
- [x] Existing source databases migrate without changing manifest revision or user metadata, with rollback/failure coverage.
- [x] Public read APIs expose typed index-only snapshots and path-scoped entries.

## Validation

- `cargo test -p wavecrate-library` — pass (266 unit tests plus process-boundary readiness test)
- `cargo test -p wavecrate-scan --lib` — pass (144 tests)
- `bash scripts/ci.sh smoke` — pass
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass
- `bash scripts/ci.sh agent` — repository baseline blocker: the pinned, unchanged Radiant test `gpu_signal_shader_keeps_waveform_bands_visually_distinct` expects a shader literal absent from the pinned shader. The remaining broad root library suite also has existing parallel/global-state failures; the deferred native-open failure was reproduced unchanged at `main` (`4421be0eb`) in a clean detached worktree.

## Known limitations

- The future `all files`/diagnostics UI remains out of scope.
- The current format policy defines the practically-unsupported state but has no active WAV practical limit to assign it during traversal.

User approval is required before merge.