### PR TITLE
OPT-1260: Add parallel test-isolation stress lane

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -30,6 +30,37 @@ Use the lightest lane that still gives trustworthy coverage for the change.
    - macOS/Linux/WSL:
      `bash scripts/ci.sh local`
 
+### Opt-in parallel-isolation stress lane
+
+Use the normal `agent` lane for routine compile and broad library validation.
+Use the parallel-isolation stress lane after changing test runtime guards,
+process environment/current-directory handling, mutable global test controls,
+worker cleanup, or when investigating a failure that disappears on retry:
+
+- Windows PowerShell:
+  `powershell -ExecutionPolicy Bypass -File scripts/ci.ps1 isolation-stress -Iterations 5 -TestThreads 8`
+- macOS/Linux/WSL:
+  `bash scripts/ci.sh isolation-stress --iterations 5 --test-threads 8`
+
+This lane is deliberately not part of `scripts/ci.* agent`. It compiles the
+Wavecrate library harness once, proves that deliberately injected
+process-state and mutable-global-control leaks are detected, and then starts a
+fresh test-binary process for every bounded iteration. Each process uses the
+requested explicit libtest parallelism and a 15-minute default timeout. The
+lane stops at the first unexpected failure instead of retrying until green.
+
+Every process writes one compact JSONL record containing the test binary,
+iteration, parallelism, status, test name, failure class, and disposition. The
+metadata record separately identifies known quarantined coverage and its
+exclusion reason. Reports default to a timestamped file under
+`target/test-isolation-stress/`; pass `--output` on Bash or `-Output` on
+PowerShell to select a stable artifact path.
+
+Focused runner coverage, including report parsing, fresh-process invocation,
+timeouts, exit behavior, and injected-leak classification, is available with:
+
+`python3 -m unittest scripts/internal/ci/test_parallel_isolation_stress.py`
+
 ## Agent preflight and Git hooks
 
 `scripts/agent.sh preflight` / `scripts/agent.sh request` and their PowerShell

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,9 +13,10 @@ dispatcher maps. These are the public entrypoints people should run directly:
   repo-root `.\run.ps1` delegates these public run commands to `scripts/run.ps1`.
 - `doctor.{sh,ps1}`: diagnose environment issues.
 - `agent.{sh,ps1}`: agent request, preflight, checks, and hook install helpers.
-- `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`).
-  `local` is the broad local validation lane; perf and GUI checks use their own
-  entrypoints.
+- `ci.{sh,ps1}`: validation lanes (`smoke`, `agent`, `quick`, `local`) plus the
+  opt-in `isolation-stress` lane. `local` is the broad local validation lane;
+  `isolation-stress` repeats the library harness in fresh parallel processes
+  with JSONL evidence. Perf and GUI checks use their own entrypoints.
 - `check.{sh,ps1}`: focused guardrails and report helpers.
 - `run.{sh,ps1}`: sandbox, cleanup, log, and bug-bundle helpers.
 - `perf.{sh,ps1}`: performance guard commands. `scripts/perf.* guard` is the

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -21,12 +21,13 @@ $psExe = (Get-Process -Id $PID).Path
 $commands = @{
   "smoke" = "devcheck.ps1"
   "agent" = "ci_agent.ps1"
+  "isolation-stress" = "ci_isolation_stress.ps1"
   "quick" = "ci_quick.ps1"
   "local" = "ci_local.ps1"
 }
 
 if ([string]::IsNullOrWhiteSpace($Command)) {
-  Write-Host "Usage: scripts/ci.ps1 <smoke|agent|quick|local> [args...]"
+  Write-Host "Usage: scripts/ci.ps1 <smoke|agent|quick|local|isolation-stress> [args...]"
   exit 0
 }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/ci.sh <smoke|agent|quick|local> [args...]
+Usage: scripts/ci.sh <smoke|agent|quick|local|isolation-stress> [args...]
 EOF
 }
 
@@ -23,6 +23,7 @@ case "$command" in
   agent) script="$script_dir/ci_agent.sh" ;;
   quick) script="$script_dir/ci_quick.sh" ;;
   local) script="$script_dir/ci_local.sh" ;;
+  isolation-stress) script="$script_dir/ci_isolation_stress.sh" ;;
   -h|--help)
     usage
     exit 0

--- a/scripts/command-inventory.json
+++ b/scripts/command-inventory.json
@@ -37,12 +37,12 @@
     },
     {
       "path": "scripts/ci.ps1",
-      "role": "Validation lanes: smoke, agent, quick, and local.",
+      "role": "Validation lanes: smoke, agent, quick, local, and opt-in parallel test-isolation stress.",
       "windows_supported": true
     },
     {
       "path": "scripts/ci.sh",
-      "role": "Validation lanes: smoke, agent, quick, and local.",
+      "role": "Validation lanes: smoke, agent, quick, local, and opt-in parallel test-isolation stress.",
       "windows_supported": false
     },
     {
@@ -307,6 +307,10 @@
         {
           "name": "agent",
           "target": "ci_agent.ps1"
+        },
+        {
+          "name": "isolation-stress",
+          "target": "ci_isolation_stress.ps1"
         },
         {
           "name": "local",

--- a/scripts/internal/check/check_script_guardrails.sh
+++ b/scripts/internal/check/check_script_guardrails.sh
@@ -556,6 +556,13 @@ run_expect_exit_code \
   --help
 
 run_expect_exit_code \
+  "ci isolation-stress --help" \
+  0 \
+  "$ROOT_DIR" \
+  scripts/ci.sh isolation-stress \
+  --help
+
+run_expect_exit_code \
   "ci_quick --help" \
   0 \
   "$ROOT_DIR" \
@@ -589,6 +596,15 @@ run_cleanup_audit_fixture
 run_docs_index_fixture
 run_taste_invariants_fixture
 run_nextest_quick_profile_fixture
+
+run_expect_exit_code \
+  "parallel isolation runner unit tests" \
+  0 \
+  "$ROOT_DIR" \
+  python3 \
+  -m \
+  unittest \
+  scripts/internal/ci/test_parallel_isolation_stress.py
 
 run_expect_exit_code \
   "validation watchdog fixtures" \

--- a/scripts/internal/ci/ci_isolation_stress.ps1
+++ b/scripts/internal/ci/ci_isolation_stress.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+Runs the opt-in parallel test-isolation stress lane.
+
+.DESCRIPTION
+Builds the Wavecrate library test harness once, verifies injected process-state
+and mutable-global-control leak sentinels, then runs bounded repetitions in
+fresh explicitly parallel test processes. Results are emitted as JSONL.
+#>
+
+param(
+  [ValidateRange(1, 100)]
+  [int]$Iterations = 5,
+  [ValidateRange(2, 256)]
+  [int]$TestThreads = [Math]::Min(8, [Math]::Max(2, [Environment]::ProcessorCount)),
+  [ValidateRange(1, 3600)]
+  [int]$TimeoutSeconds = 900,
+  [string]$Output = "",
+  [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+
+if ($Help) {
+  Write-Host "Usage: scripts/ci.ps1 isolation-stress [-Iterations N] [-TestThreads N] [-TimeoutSeconds N] [-Output PATH]"
+  Write-Host ""
+  Write-Host "Runs bounded fresh-process repetitions of the Wavecrate library suite."
+  Write-Host "The lane verifies injected leak sentinels and emits one JSONL record per process."
+  exit 0
+}
+
+$python = $null
+$pythonPrefix = @()
+foreach ($candidate in @("python3", "py", "python")) {
+  $resolved = Get-Command $candidate -ErrorAction SilentlyContinue
+  if ($null -ne $resolved) {
+    $python = $resolved.Path
+    if ($candidate -eq "py") {
+      $pythonPrefix = @("-3")
+    }
+    break
+  }
+}
+if ($null -eq $python) {
+  throw "[parallel_isolation] Python 3 was not found."
+}
+
+$arguments = @(
+  (Join-Path $PSScriptRoot "parallel_isolation_stress.py"),
+  "--iterations",
+  $Iterations.ToString(),
+  "--test-threads",
+  $TestThreads.ToString(),
+  "--timeout-seconds",
+  $TimeoutSeconds.ToString()
+)
+if (-not [string]::IsNullOrWhiteSpace($Output)) {
+  $arguments += @("--output", $Output)
+}
+
+Push-Location $rootDir
+try {
+  & $python @pythonPrefix @arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "[parallel_isolation] Lane failed with exit code $LASTEXITCODE."
+  }
+} finally {
+  Pop-Location
+}

--- a/scripts/internal/ci/ci_isolation_stress.sh
+++ b/scripts/internal/ci/ci_isolation_stress.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Repeat the Wavecrate library harness in fresh explicitly parallel processes.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+# shellcheck source=scripts/internal/use_cargo_cache.sh
+source "$ROOT_DIR/scripts/internal/use_cargo_cache.sh"
+wavecrate_enable_cargo_cache
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci.sh isolation-stress [options]
+
+Options:
+  --iterations N       Fresh test processes to run (default: 5).
+  --test-threads N     Parallel libtest threads per process (default: 2-8 by CPU).
+  --timeout-seconds N  Per-process timeout (default: 900).
+  --output PATH        JSONL report path (default: timestamped target artifact).
+  -h, --help           Show this help.
+
+This opt-in lane verifies its injected leak sentinels, then runs the Wavecrate
+library suite repeatedly. It stops at the first unexpected failure and never
+retries a failing iteration until green.
+USAGE
+}
+
+for argument in "$@"; do
+  case "$argument" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+exec python3 "$ROOT_DIR/scripts/internal/ci/parallel_isolation_stress.py" "$@"

--- a/scripts/internal/ci/parallel_isolation_stress.py
+++ b/scripts/internal/ci/parallel_isolation_stress.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Run the Wavecrate library test harness repeatedly in fresh parallel processes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TextIO
+
+
+SCHEMA_VERSION = 1
+PROCESS_LEAK_ENV = "WAVECRATE_ISOLATION_INJECT_PROCESS_LEAK"
+GLOBAL_HOOK_LEAK_ENV = "WAVECRATE_ISOLATION_INJECT_GLOBAL_HOOK_LEAK"
+INJECTION_ENV_VARS = (PROCESS_LEAK_ENV, GLOBAL_HOOK_LEAK_ENV)
+PROCESS_SENTINEL = (
+    "test_isolation_sentinels::"
+    "parallel_isolation_sentinel_process_state_guard_under_contention"
+)
+GLOBAL_HOOK_SENTINEL = (
+    "app::controller::library::source_write_priority::tests::"
+    "parallel_isolation_sentinel_scoped_global_control_lifecycle_under_contention"
+)
+QUARANTINED_TESTS = (
+    {
+        "test_name": "prepare_auto_rename_requests_logs_looped_provenance",
+        "disposition": "known_quarantine",
+        "reason": "excluded from the agent-safe and isolation-stress library lanes",
+    },
+    {
+        "test_name": "rating_previous_random_history_entry_restores_waveform_for_replacement",
+        "disposition": "known_quarantine",
+        "reason": "excluded from the agent-safe and isolation-stress library lanes",
+    },
+)
+FAILURE_MARKERS = {
+    "WAVECRATE_ISOLATION:process_state_contamination": "process_state_contamination",
+    "WAVECRATE_ISOLATION:mutable_global_control_leak": "mutable_global_control_leak",
+    "WAVECRATE_ISOLATION:leaked_worker": "leaked_worker",
+}
+FAILED_TEST_RE = re.compile(r"^test (?P<name>.+) \.\.\. FAILED(?: .*)?$")
+FAILURE_SECTION_RE = re.compile(
+    r"^---- (?P<name>[^\r\n]+) stdout ----\r?\n"
+    r"(?P<body>.*?)(?=^---- [^\r\n]+ stdout ----\r?\n|^failures:\r?\n|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class Failure:
+    """One classified test-harness failure."""
+
+    test_name: str | None
+    failure_class: str
+    disposition: str
+    evidence: str
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    """Result of one fresh test-binary process."""
+
+    status: str
+    exit_code: int | None
+    duration_ms: int
+    failures: list[Failure]
+    output: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--iterations",
+        type=lambda value: bounded_int(value, minimum=1, maximum=100),
+        default=5,
+        help="Fresh library-test processes to run, 1-100 (default: 5).",
+    )
+    parser.add_argument(
+        "--test-threads",
+        type=lambda value: bounded_int(value, minimum=2, maximum=256),
+        default=min(8, max(2, os.cpu_count() or 2)),
+        help="Explicit libtest parallelism, 2-256, for every stress iteration.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=lambda value: bounded_int(value, minimum=1, maximum=3600),
+        default=900,
+        help="Per-process timeout, 1-3600 seconds (default: 900).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="JSONL report path. Defaults to a timestamped target/test-isolation-stress file.",
+    )
+    parser.add_argument(
+        "--test-binary",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args()
+
+
+def bounded_int(value: str, *, minimum: int, maximum: int) -> int:
+    parsed = int(value)
+    if not minimum <= parsed <= maximum:
+        raise argparse.ArgumentTypeError(f"must be between {minimum} and {maximum}")
+    return parsed
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit("parallel-isolation stress must run inside the Wavecrate repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def default_report_path(root: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return root / "target" / "test-isolation-stress" / f"{stamp}-{os.getpid()}.jsonl"
+
+
+def discover_test_binary(root: Path) -> Path:
+    command = [
+        "cargo",
+        "test",
+        "-p",
+        "wavecrate",
+        "--lib",
+        "--no-run",
+        "--message-format=json",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=clean_environment(),
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(f"failed to compile the Wavecrate library test harness ({result.returncode})")
+
+    executables: list[Path] = []
+    for line in result.stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        target = message.get("target", {})
+        executable = message.get("executable")
+        if (
+            message.get("reason") == "compiler-artifact"
+            and message.get("profile", {}).get("test") is True
+            and target.get("name") == "wavecrate"
+            and "lib" in target.get("kind", [])
+            and executable
+        ):
+            executables.append(Path(executable).resolve())
+
+    if len(executables) != 1:
+        raise SystemExit(
+            "expected exactly one Wavecrate library test executable, "
+            f"found {len(executables)}"
+        )
+    return executables[0]
+
+
+def clean_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = os.environ.copy()
+    for key in INJECTION_ENV_VARS:
+        environment.pop(key, None)
+    environment["CARGO_TERM_COLOR"] = "never"
+    environment["NO_COLOR"] = "1"
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def extract_failures(output: str, exit_code: int | None) -> list[Failure]:
+    sections = {
+        match.group("name"): match.group("body")
+        for match in FAILURE_SECTION_RE.finditer(output)
+    }
+    names: list[str] = []
+    for line in output.splitlines():
+        match = FAILED_TEST_RE.match(line)
+        if match and match.group("name") not in names:
+            names.append(match.group("name"))
+
+    failures = [
+        Failure(
+            test_name=name,
+            failure_class=classify_failure(sections.get(name, output)),
+            disposition="unexpected",
+            evidence=failure_evidence(sections.get(name, output)),
+        )
+        for name in names
+    ]
+    if not failures and exit_code not in (0, None):
+        failures.append(
+            Failure(
+                test_name=None,
+                failure_class="test_binary_failure",
+                disposition="unexpected",
+                evidence=failure_evidence(output),
+            )
+        )
+    return failures
+
+
+def classify_failure(output: str) -> str:
+    for marker, failure_class in FAILURE_MARKERS.items():
+        if marker in output:
+            return failure_class
+    return "test_failure"
+
+
+def failure_evidence(output: str) -> str:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    evidence = next(
+        (line for line in lines if "WAVECRATE_ISOLATION:" in line),
+        None,
+    )
+    if evidence is None:
+        evidence = next(
+            (
+                line
+                for line in lines
+                if "panicked at" in line or line.startswith("error:")
+            ),
+            None,
+        )
+    if evidence is None:
+        evidence = next(
+            (line.strip() for line in output.splitlines() if line.strip()),
+            "test binary exited without diagnostic output",
+        )
+    return evidence[:500]
+
+
+def terminate_process_tree(process: subprocess.Popen[str]) -> None:
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def process_group_has_survivors(process_group: int) -> bool:
+    if os.name == "nt":
+        return False
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def run_fresh_process(
+    command: list[str],
+    *,
+    root: Path,
+    timeout_seconds: float,
+    environment: dict[str, str],
+) -> ProcessResult:
+    started = time.monotonic()
+    popen_kwargs: dict[str, object] = {}
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    process = subprocess.Popen(
+        command,
+        cwd=root,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        **popen_kwargs,
+    )
+    try:
+        output, _ = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as timeout:
+        terminate_process_tree(process)
+        remainder, _ = process.communicate()
+        output = (timeout.output or "") + (remainder or "")
+        duration_ms = round((time.monotonic() - started) * 1000)
+        return ProcessResult(
+            status="timeout",
+            exit_code=None,
+            duration_ms=duration_ms,
+            failures=[
+                Failure(
+                    test_name=None,
+                    failure_class="timeout",
+                    disposition="unexpected",
+                    evidence=f"test process exceeded {timeout_seconds:g} seconds",
+                )
+            ],
+            output=output,
+        )
+
+    duration_ms = round((time.monotonic() - started) * 1000)
+    failures = extract_failures(output, process.returncode)
+    if process_group_has_survivors(process.pid):
+        terminate_process_tree(process)
+        failures.append(
+            Failure(
+                test_name=None,
+                failure_class="leaked_worker",
+                disposition="unexpected",
+                evidence="test process exited while an owned worker process remained alive",
+            )
+        )
+        return ProcessResult(
+            status="leaked_worker",
+            exit_code=process.returncode,
+            duration_ms=duration_ms,
+            failures=failures,
+            output=output,
+        )
+    return ProcessResult(
+        status="passed" if process.returncode == 0 else "failed",
+        exit_code=process.returncode,
+        duration_ms=duration_ms,
+        failures=failures,
+        output=output,
+    )
+
+
+def stress_command(test_binary: Path, test_threads: int) -> list[str]:
+    command = [
+        str(test_binary),
+        f"--test-threads={test_threads}",
+    ]
+    for quarantine in QUARANTINED_TESTS:
+        command.extend(["--skip", quarantine["test_name"]])
+    return command
+
+
+def sentinel_command(test_binary: Path, test_name: str) -> list[str]:
+    return [
+        str(test_binary),
+        test_name,
+        "--exact",
+        "--test-threads=1",
+    ]
+
+
+def emit(report: TextIO, payload: dict[str, object]) -> None:
+    line = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    report.write(line + "\n")
+    report.flush()
+    print(line, flush=True)
+
+
+def result_payload(
+    *,
+    phase: str,
+    iteration: int,
+    iterations: int,
+    test_binary: Path,
+    test_threads: int,
+    result: ProcessResult,
+) -> dict[str, object]:
+    first_failure = result.failures[0] if result.failures else None
+    failure_class_counts = Counter(failure.failure_class for failure in result.failures)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "phase": phase,
+        "iteration": iteration,
+        "iterations": iterations,
+        "test_binary": str(test_binary),
+        "test_threads": test_threads,
+        "status": result.status,
+        "exit_code": result.exit_code,
+        "duration_ms": result.duration_ms,
+        "first_test_name": first_failure.test_name if first_failure else None,
+        "first_failure_class": first_failure.failure_class if first_failure else None,
+        "failure_class_counts": dict(sorted(failure_class_counts.items())),
+        "failures": [asdict(failure) for failure in result.failures],
+    }
+
+
+def verify_injected_sentinel(
+    *,
+    root: Path,
+    test_binary: Path,
+    test_name: str,
+    injection_env: str,
+    expected_class: str,
+    timeout_seconds: int,
+) -> ProcessResult:
+    result = run_fresh_process(
+        sentinel_command(test_binary, test_name),
+        root=root,
+        timeout_seconds=min(timeout_seconds, 60),
+        environment=clean_environment({injection_env: "1"}),
+    )
+    detected = (
+        result.status == "failed"
+        and any(
+            failure.test_name == test_name and failure.failure_class == expected_class
+            for failure in result.failures
+        )
+    )
+    if detected:
+        return ProcessResult(
+            status="expected_failure_detected",
+            exit_code=result.exit_code,
+            duration_ms=result.duration_ms,
+            failures=[
+                Failure(
+                    test_name=failure.test_name,
+                    failure_class=failure.failure_class,
+                    disposition="injected_sentinel",
+                    evidence=failure.evidence,
+                )
+                for failure in result.failures
+            ],
+            output=result.output,
+        )
+    return ProcessResult(
+        status="detector_verification_failed",
+        exit_code=result.exit_code,
+        duration_ms=result.duration_ms,
+        failures=result.failures,
+        output=result.output,
+    )
+
+
+def print_failure_output(result: ProcessResult) -> None:
+    if not result.output:
+        return
+    lines = result.output.splitlines()
+    sys.stderr.write("\n[first failing test process output]\n")
+    sys.stderr.write("\n".join(lines[-120:]) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    test_binary = args.test_binary.resolve() if args.test_binary else discover_test_binary(root)
+    report_path = (args.output or default_report_path(root)).resolve()
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with report_path.open("w", encoding="utf-8", newline="\n") as report:
+        emit(
+            report,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "phase": "metadata",
+                "test_binary": str(test_binary),
+                "iterations": args.iterations,
+                "test_threads": args.test_threads,
+                "timeout_seconds": args.timeout_seconds,
+                "quarantined_coverage": list(QUARANTINED_TESTS),
+            },
+        )
+
+        sentinel_specs = (
+            (
+                PROCESS_SENTINEL,
+                PROCESS_LEAK_ENV,
+                "process_state_contamination",
+            ),
+            (
+                GLOBAL_HOOK_SENTINEL,
+                GLOBAL_HOOK_LEAK_ENV,
+                "mutable_global_control_leak",
+            ),
+        )
+        for index, (test_name, injection_env, expected_class) in enumerate(
+            sentinel_specs, start=1
+        ):
+            result = verify_injected_sentinel(
+                root=root,
+                test_binary=test_binary,
+                test_name=test_name,
+                injection_env=injection_env,
+                expected_class=expected_class,
+                timeout_seconds=args.timeout_seconds,
+            )
+            emit(
+                report,
+                result_payload(
+                    phase="detector_verification",
+                    iteration=index,
+                    iterations=len(sentinel_specs),
+                    test_binary=test_binary,
+                    test_threads=1,
+                    result=result,
+                ),
+            )
+            if result.status != "expected_failure_detected":
+                print_failure_output(result)
+                print(f"[parallel_isolation] report={report_path}", file=sys.stderr)
+                return 1
+
+        for iteration in range(1, args.iterations + 1):
+            result = run_fresh_process(
+                stress_command(test_binary, args.test_threads),
+                root=root,
+                timeout_seconds=args.timeout_seconds,
+                environment=clean_environment(),
+            )
+            emit(
+                report,
+                result_payload(
+                    phase="stress",
+                    iteration=iteration,
+                    iterations=args.iterations,
+                    test_binary=test_binary,
+                    test_threads=args.test_threads,
+                    result=result,
+                ),
+            )
+            if result.status != "passed":
+                print_failure_output(result)
+                print(f"[parallel_isolation] report={report_path}", file=sys.stderr)
+                return 1
+
+        emit(
+            report,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "phase": "summary",
+                "status": "passed",
+                "completed_iterations": args.iterations,
+                "test_binary": str(test_binary),
+                "report": str(report_path),
+            },
+        )
+
+    print(f"[parallel_isolation] report={report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/internal/ci/parallel_isolation_stress.py
+++ b/scripts/internal/ci/parallel_isolation_stress.py
@@ -17,6 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
+from parallel_isolation_windows_job import (
+    WindowsJob,
+    bootstrap_command,
+    run_bootstrap,
+)
 
 SCHEMA_VERSION = 1
 PROCESS_LEAK_ENV = "WAVECRATE_ISOLATION_INJECT_PROCESS_LEAK"
@@ -254,31 +259,7 @@ def failure_evidence(output: str) -> str:
     return evidence[:500]
 
 
-def terminate_process_tree(process: subprocess.Popen[str]) -> None:
-    if os.name == "nt":
-        subprocess.run(
-            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        return
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        return
-    try:
-        process.wait(timeout=1)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-
-
 def process_group_has_survivors(process_group: int) -> bool:
-    if os.name == "nt":
-        return False
     try:
         os.killpg(process_group, 0)
     except ProcessLookupError:
@@ -286,6 +267,43 @@ def process_group_has_survivors(process_group: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def terminate_posix_process_group(process: subprocess.Popen[str]) -> None:
+    process_group = process.pid
+    if not process_group_has_survivors(process_group):
+        return
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 1
+    while process_group_has_survivors(process_group) and time.monotonic() < deadline:
+        process.poll()
+        time.sleep(0.02)
+    if process_group_has_survivors(process_group):
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except (PermissionError, ProcessLookupError):
+            if process.poll() is None:
+                process.kill()
+
+
+def collect_terminated_output(
+    process: subprocess.Popen[str], previous_output: str | None
+) -> str:
+    try:
+        output, _ = process.communicate(timeout=2)
+        return output or previous_output or ""
+    except subprocess.TimeoutExpired as timeout:
+        process.kill()
+        try:
+            output, _ = process.communicate(timeout=1)
+            return output or timeout.output or previous_output or ""
+        except subprocess.TimeoutExpired as final_timeout:
+            if process.stdout is not None:
+                process.stdout.close()
+            return final_timeout.output or timeout.output or previous_output or ""
 
 
 def run_fresh_process(
@@ -297,8 +315,11 @@ def run_fresh_process(
 ) -> ProcessResult:
     started = time.monotonic()
     popen_kwargs: dict[str, object] = {}
+    owned_job: WindowsJob | None = None
     if os.name == "nt":
+        command = bootstrap_command(command, Path(__file__).resolve())
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        popen_kwargs["stdin"] = subprocess.PIPE
     else:
         popen_kwargs["start_new_session"] = True
 
@@ -311,13 +332,42 @@ def run_fresh_process(
         text=True,
         **popen_kwargs,
     )
+    if os.name == "nt":
+        try:
+            owned_job = WindowsJob(process)
+        except OSError as error:
+            process.kill()
+            output = collect_terminated_output(process, None)
+            return ProcessResult(
+                status="ownership_error",
+                exit_code=process.returncode,
+                duration_ms=round((time.monotonic() - started) * 1000),
+                failures=[
+                    Failure(
+                        test_name=None,
+                        failure_class="worker_ownership_error",
+                        disposition="unexpected",
+                        evidence=f"could not create an owned Windows process tree: {error}",
+                    )
+                ],
+                output=output,
+            )
+        assert process.stdin is not None
+        process.stdin.write("1")
+        process.stdin.close()
+        process.stdin = None
+
     try:
         output, _ = process.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired as timeout:
-        terminate_process_tree(process)
-        remainder, _ = process.communicate()
-        output = (timeout.output or "") + (remainder or "")
+        if owned_job is not None:
+            owned_job.terminate()
+        else:
+            terminate_posix_process_group(process)
+        output = collect_terminated_output(process, timeout.output)
         duration_ms = round((time.monotonic() - started) * 1000)
+        if owned_job is not None:
+            owned_job.close()
         return ProcessResult(
             status="timeout",
             exit_code=None,
@@ -335,8 +385,17 @@ def run_fresh_process(
 
     duration_ms = round((time.monotonic() - started) * 1000)
     failures = extract_failures(output, process.returncode)
-    if process_group_has_survivors(process.pid):
-        terminate_process_tree(process)
+    leaked_worker = (
+        owned_job.active_processes() > 0
+        if owned_job is not None
+        else process_group_has_survivors(process.pid)
+    )
+    if leaked_worker:
+        if owned_job is not None:
+            owned_job.terminate()
+            owned_job.close()
+        else:
+            terminate_posix_process_group(process)
         failures.append(
             Failure(
                 test_name=None,
@@ -352,6 +411,8 @@ def run_fresh_process(
             failures=failures,
             output=output,
         )
+    if owned_job is not None:
+        owned_job.close()
     return ProcessResult(
         status="passed" if process.returncode == 0 else "failed",
         exit_code=process.returncode,
@@ -412,6 +473,33 @@ def result_payload(
         "first_failure_class": first_failure.failure_class if first_failure else None,
         "failure_class_counts": dict(sorted(failure_class_counts.items())),
         "failures": [asdict(failure) for failure in result.failures],
+    }
+
+
+def summary_payload(
+    *,
+    status: str,
+    completed_iterations: int,
+    test_binary: Path,
+    report_path: Path,
+    result: ProcessResult | None,
+) -> dict[str, object]:
+    failures = result.failures if result else []
+    first_failure = failures[0] if failures else None
+    failure_class_counts = Counter(failure.failure_class for failure in failures)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "phase": "summary",
+        "status": status,
+        "completed_iterations": completed_iterations,
+        "test_binary": str(test_binary),
+        "report": str(report_path),
+        "exit_code": result.exit_code if result else 0,
+        "first_test_name": first_failure.test_name if first_failure else None,
+        "first_failure_class": first_failure.failure_class if first_failure else None,
+        "failure_class_counts": dict(sorted(failure_class_counts.items())),
+        "failures": [asdict(failure) for failure in failures],
+        "quarantined_coverage": list(QUARANTINED_TESTS),
     }
 
 
@@ -526,6 +614,16 @@ def main() -> int:
                 ),
             )
             if result.status != "expected_failure_detected":
+                emit(
+                    report,
+                    summary_payload(
+                        status="failed",
+                        completed_iterations=0,
+                        test_binary=test_binary,
+                        report_path=report_path,
+                        result=result,
+                    ),
+                )
                 print_failure_output(result)
                 print(f"[parallel_isolation] report={report_path}", file=sys.stderr)
                 return 1
@@ -549,20 +647,29 @@ def main() -> int:
                 ),
             )
             if result.status != "passed":
+                emit(
+                    report,
+                    summary_payload(
+                        status="failed",
+                        completed_iterations=iteration,
+                        test_binary=test_binary,
+                        report_path=report_path,
+                        result=result,
+                    ),
+                )
                 print_failure_output(result)
                 print(f"[parallel_isolation] report={report_path}", file=sys.stderr)
                 return 1
 
         emit(
             report,
-            {
-                "schema_version": SCHEMA_VERSION,
-                "phase": "summary",
-                "status": "passed",
-                "completed_iterations": args.iterations,
-                "test_binary": str(test_binary),
-                "report": str(report_path),
-            },
+            summary_payload(
+                status="passed",
+                completed_iterations=args.iterations,
+                test_binary=test_binary,
+                report_path=report_path,
+                result=None,
+            ),
         )
 
     print(f"[parallel_isolation] report={report_path}")
@@ -570,4 +677,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--windows-job-bootstrap":
+        raise SystemExit(run_bootstrap(sys.argv[2]))
     raise SystemExit(main())

--- a/scripts/internal/ci/parallel_isolation_windows_job.py
+++ b/scripts/internal/ci/parallel_isolation_windows_job.py
@@ -1,0 +1,108 @@
+"""Windows Job Object ownership for the parallel-isolation runner."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+class WindowsJob:
+    """Own a Windows process tree through a Job Object."""
+
+    class BasicAccountingInformation(ctypes.Structure):
+        _fields_ = [
+            ("total_user_time", ctypes.c_longlong),
+            ("total_kernel_time", ctypes.c_longlong),
+            ("this_period_total_user_time", ctypes.c_longlong),
+            ("this_period_total_kernel_time", ctypes.c_longlong),
+            ("total_page_fault_count", ctypes.c_uint32),
+            ("total_processes", ctypes.c_uint32),
+            ("active_processes", ctypes.c_uint32),
+            ("total_terminated_processes", ctypes.c_uint32),
+        ]
+
+    def __init__(self, process: subprocess.Popen[str]) -> None:
+        if os.name != "nt":
+            raise RuntimeError("Windows Job Objects are only available on Windows")
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self.kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
+        self.kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+        self.kernel32.AssignProcessToJobObject.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+        ]
+        self.kernel32.AssignProcessToJobObject.restype = ctypes.c_int
+        self.kernel32.QueryInformationJobObject.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_uint32),
+        ]
+        self.kernel32.QueryInformationJobObject.restype = ctypes.c_int
+        self.kernel32.TerminateJobObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+        self.kernel32.TerminateJobObject.restype = ctypes.c_int
+        self.kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+        self.kernel32.CloseHandle.restype = ctypes.c_int
+        self.handle = self.kernel32.CreateJobObjectW(None, None)
+        if not self.handle:
+            raise ctypes.WinError(ctypes.get_last_error())
+        process_handle = int(getattr(process, "_handle"))
+        if not self.kernel32.AssignProcessToJobObject(self.handle, process_handle):
+            error = ctypes.WinError(ctypes.get_last_error())
+            self.close()
+            raise error
+
+    def active_processes(self) -> int:
+        """Return the number of live processes still owned by the job."""
+        information = self.BasicAccountingInformation()
+        returned_length = ctypes.c_uint32()
+        succeeded = self.kernel32.QueryInformationJobObject(
+            self.handle,
+            1,
+            ctypes.byref(information),
+            ctypes.sizeof(information),
+            ctypes.byref(returned_length),
+        )
+        if not succeeded:
+            raise ctypes.WinError(ctypes.get_last_error())
+        return int(information.active_processes)
+
+    def terminate(self) -> None:
+        """Terminate every process still owned by the job."""
+        if self.handle and not self.kernel32.TerminateJobObject(self.handle, 1):
+            error_code = ctypes.get_last_error()
+            if error_code:
+                raise ctypes.WinError(error_code)
+
+    def close(self) -> None:
+        """Release the Job Object handle."""
+        if self.handle:
+            self.kernel32.CloseHandle(self.handle)
+            self.handle = None
+
+
+def bootstrap_command(command: list[str], runner_path: Path) -> list[str]:
+    """Build a child command that waits until its Job Object is attached."""
+    return [
+        sys.executable,
+        str(runner_path),
+        "--windows-job-bootstrap",
+        json.dumps(command),
+    ]
+
+
+def run_bootstrap(command_json: str) -> int:
+    """Wait for ownership handoff, then run the actual test command inside the job."""
+    if os.name != "nt":
+        return 125
+    if sys.stdin.read(1) != "1":
+        return 125
+    command = json.loads(command_json)
+    if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+        return 125
+    return subprocess.run(command, check=False).returncode

--- a/scripts/internal/ci/test_parallel_isolation_stress.py
+++ b/scripts/internal/ci/test_parallel_isolation_stress.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 
 MODULE_PATH = Path(__file__).with_name("parallel_isolation_stress.py")
+sys.path.insert(0, str(MODULE_PATH.parent))
 SPEC = importlib.util.spec_from_file_location("parallel_isolation_stress", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 stress = importlib.util.module_from_spec(SPEC)
@@ -191,31 +192,93 @@ class ParallelIsolationStressTests(unittest.TestCase):
             encoded = json.dumps(payload)
             self.assertEqual(json.loads(encoded)["failures"][0]["test_name"], None)
 
-    @unittest.skipIf(os.name == "nt", "POSIX process groups own worker leak detection")
     def test_successful_parent_with_leaked_worker_is_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result = self.run_leaked_worker_fixture(Path(temporary))
+
+            self.assertEqual(result.status, "leaked_worker")
+            self.assertEqual(result.failures[-1].failure_class, "leaked_worker")
+
+    @unittest.skipUnless(os.name == "nt", "Windows Job Object coverage")
+    def test_windows_job_object_owns_leaked_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result = self.run_leaked_worker_fixture(Path(temporary))
+
+            self.assertEqual(result.status, "leaked_worker")
+
+    @unittest.skipUnless(os.name != "nt", "POSIX process-group coverage")
+    def test_timeout_kills_child_that_ignores_sigterm_and_holds_output(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             fixture = self.write_fixture(
                 root,
                 """
-                import subprocess, sys
-                subprocess.Popen(
-                    [sys.executable, "-c", "import time; time.sleep(60)"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-                print("test fixture::leaks_worker ... ok")
+                import subprocess, sys, time
+                subprocess.Popen([
+                    sys.executable,
+                    "-c",
+                    "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)",
+                ])
+                time.sleep(60)
                 """,
             )
+            started = stress.time.monotonic()
             result = stress.run_fresh_process(
                 [sys.executable, str(fixture)],
                 root=root,
-                timeout_seconds=5,
+                timeout_seconds=0.05,
                 environment=stress.clean_environment(),
             )
 
-            self.assertEqual(result.status, "leaked_worker")
-            self.assertEqual(result.failures[-1].failure_class, "leaked_worker")
+            self.assertEqual(result.status, "timeout")
+            self.assertLess(stress.time.monotonic() - started, 4)
+
+    def test_failed_summary_retains_complete_failure_inventory(self) -> None:
+        result = stress.ProcessResult(
+            status="failed",
+            exit_code=101,
+            duration_ms=10,
+            failures=[
+                stress.Failure("fixture::first", "test_failure", "unexpected", "first"),
+                stress.Failure("fixture::second", "leaked_worker", "unexpected", "second"),
+            ],
+            output="",
+        )
+        payload = stress.summary_payload(
+            status="failed",
+            completed_iterations=1,
+            test_binary=Path("fixture"),
+            report_path=Path("report.jsonl"),
+            result=result,
+        )
+
+        self.assertEqual(payload["phase"], "summary")
+        self.assertEqual(payload["first_test_name"], "fixture::first")
+        self.assertEqual(payload["failure_class_counts"], {"leaked_worker": 1, "test_failure": 1})
+        self.assertEqual(len(payload["failures"]), 2)
+        self.assertEqual(
+            payload["quarantined_coverage"][0]["disposition"], "known_quarantine"
+        )
+
+    def run_leaked_worker_fixture(self, root: Path) -> stress.ProcessResult:
+        fixture = self.write_fixture(
+            root,
+            """
+            import subprocess, sys
+            subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            print("test fixture::leaks_worker ... ok")
+            """,
+        )
+        return stress.run_fresh_process(
+            [sys.executable, str(fixture)],
+            root=root,
+            timeout_seconds=5,
+            environment=stress.clean_environment(),
+        )
 
     @staticmethod
     def write_fixture(root: Path, body: str) -> Path:

--- a/scripts/internal/ci/test_parallel_isolation_stress.py
+++ b/scripts/internal/ci/test_parallel_isolation_stress.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Focused tests for the parallel-isolation stress runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("parallel_isolation_stress.py")
+SPEC = importlib.util.spec_from_file_location("parallel_isolation_stress", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+stress = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = stress
+SPEC.loader.exec_module(stress)
+
+
+class ParallelIsolationStressTests(unittest.TestCase):
+    def test_failure_parser_preserves_test_identity_and_failure_family(self) -> None:
+        output = textwrap.dedent(
+            """
+            running 1 test
+            test test_isolation_sentinels::sentinel ... FAILED
+
+            failures:
+
+            ---- test_isolation_sentinels::sentinel stdout ----
+            thread 'test_isolation_sentinels::sentinel' panicked at src/lib.rs:1:1:
+            WAVECRATE_ISOLATION:process_state_contamination env,cwd
+
+            failures:
+                test_isolation_sentinels::sentinel
+            """
+        ).strip()
+
+        failures = stress.extract_failures(output, 101)
+
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(
+            failures[0].test_name, "test_isolation_sentinels::sentinel"
+        )
+        self.assertEqual(
+            failures[0].failure_class, "process_state_contamination"
+        )
+        self.assertIn("WAVECRATE_ISOLATION:", failures[0].evidence)
+
+    def test_failure_parser_associates_each_test_with_its_own_evidence(self) -> None:
+        output = textwrap.dedent(
+            """
+            test fixture::first ... FAILED
+            test fixture::second ... FAILED
+
+            failures:
+
+            ---- fixture::first stdout ----
+            thread 'fixture::first' panicked at first.rs:1: first evidence
+
+            ---- fixture::second stdout ----
+            thread 'fixture::second' panicked at second.rs:2: second evidence
+
+            failures:
+                fixture::first
+                fixture::second
+            """
+        ).strip()
+
+        failures = stress.extract_failures(output, 101)
+
+        self.assertEqual(len(failures), 2)
+        self.assertIn("first.rs", failures[0].evidence)
+        self.assertIn("second.rs", failures[1].evidence)
+
+    def test_each_iteration_starts_a_new_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pid_log = root / "pids.jsonl"
+            fixture = self.write_fixture(
+                root,
+                """
+                import json, os, pathlib
+                log = pathlib.Path(os.environ["PID_LOG"])
+                with log.open("a", encoding="utf-8") as output:
+                    output.write(json.dumps({"pid": os.getpid()}) + "\\n")
+                print("test fixture::passes ... ok")
+                """,
+            )
+            command = [sys.executable, str(fixture)]
+            environment = stress.clean_environment({"PID_LOG": str(pid_log)})
+
+            first = stress.run_fresh_process(
+                command, root=root, timeout_seconds=5, environment=environment
+            )
+            second = stress.run_fresh_process(
+                command, root=root, timeout_seconds=5, environment=environment
+            )
+
+            self.assertEqual(first.status, "passed")
+            self.assertEqual(second.status, "passed")
+            pids = [
+                json.loads(line)["pid"]
+                for line in pid_log.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(pids), 2)
+            self.assertNotEqual(pids[0], pids[1])
+
+    def test_injected_process_and_global_hook_leaks_are_classified(self) -> None:
+        cases = (
+            (
+                stress.PROCESS_LEAK_ENV,
+                stress.PROCESS_SENTINEL,
+                "process_state_contamination",
+            ),
+            (
+                stress.GLOBAL_HOOK_LEAK_ENV,
+                stress.GLOBAL_HOOK_SENTINEL,
+                "mutable_global_control_leak",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.write_fixture(
+                root,
+                """
+                import os, sys
+                process_env = "WAVECRATE_ISOLATION_INJECT_PROCESS_LEAK"
+                global_env = "WAVECRATE_ISOLATION_INJECT_GLOBAL_HOOK_LEAK"
+                if process_env in os.environ:
+                    name = (
+                        "test_isolation_sentinels::"
+                        "parallel_isolation_sentinel_process_state_guard_under_contention"
+                    )
+                    marker = "WAVECRATE_ISOLATION:process_state_contamination"
+                elif global_env in os.environ:
+                    name = (
+                        "app::controller::library::source_write_priority::tests::"
+                        "parallel_isolation_sentinel_scoped_global_control_lifecycle_under_contention"
+                    )
+                    marker = "WAVECRATE_ISOLATION:mutable_global_control_leak"
+                else:
+                    raise SystemExit(2)
+                print(f"test {name} ... FAILED")
+                print(f"\\n---- {name} stdout ----")
+                print(f"thread '{name}' panicked at fixture:1: {marker}")
+                raise SystemExit(101)
+                """,
+            )
+
+            for injection_env, test_name, expected_class in cases:
+                with self.subTest(expected_class=expected_class):
+                    result = stress.run_fresh_process(
+                        [sys.executable, str(fixture)],
+                        root=root,
+                        timeout_seconds=5,
+                        environment=stress.clean_environment({injection_env: "1"}),
+                    )
+                    detected = any(
+                        failure.test_name == test_name
+                        and failure.failure_class == expected_class
+                        for failure in result.failures
+                    )
+                    self.assertEqual(result.status, "failed")
+                    self.assertTrue(detected)
+
+    def test_timeout_is_blocking_and_machine_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.write_fixture(root, "import time; time.sleep(2)")
+            result = stress.run_fresh_process(
+                [sys.executable, str(fixture)],
+                root=root,
+                timeout_seconds=0.05,
+                environment=stress.clean_environment(),
+            )
+
+            self.assertEqual(result.status, "timeout")
+            self.assertEqual(result.failures[0].failure_class, "timeout")
+            payload = stress.result_payload(
+                phase="stress",
+                iteration=1,
+                iterations=1,
+                test_binary=fixture,
+                test_threads=4,
+                result=result,
+            )
+            encoded = json.dumps(payload)
+            self.assertEqual(json.loads(encoded)["failures"][0]["test_name"], None)
+
+    @unittest.skipIf(os.name == "nt", "POSIX process groups own worker leak detection")
+    def test_successful_parent_with_leaked_worker_is_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture = self.write_fixture(
+                root,
+                """
+                import subprocess, sys
+                subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(60)"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                print("test fixture::leaks_worker ... ok")
+                """,
+            )
+            result = stress.run_fresh_process(
+                [sys.executable, str(fixture)],
+                root=root,
+                timeout_seconds=5,
+                environment=stress.clean_environment(),
+            )
+
+            self.assertEqual(result.status, "leaked_worker")
+            self.assertEqual(result.failures[-1].failure_class, "leaked_worker")
+
+    @staticmethod
+    def write_fixture(root: Path, body: str) -> Path:
+        fixture = root / "fixture.py"
+        fixture.write_text(textwrap.dedent(body), encoding="utf-8")
+        if os.name != "nt":
+            fixture.chmod(0o755)
+        return fixture
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/internal/data/validation_contract.json
+++ b/scripts/internal/data/validation_contract.json
@@ -14,6 +14,7 @@
       "scripts/internal/agent/run_agent_preflight.ps1",
       "scripts/internal/ci/devcheck.ps1",
       "scripts/internal/ci/ci_agent.ps1",
+      "scripts/internal/ci/ci_isolation_stress.ps1",
       "scripts/internal/ci/ci_quick.ps1",
       "scripts/internal/ci/ci_local.ps1",
       "scripts/internal/perf/run_perf_guard.ps1",
@@ -38,6 +39,7 @@
       "scripts/internal/validation/use_validation_target.sh",
       "scripts/internal/validation/test_validation_watchdog.sh",
       "scripts/ci.sh",
+      "scripts/internal/ci/ci_isolation_stress.sh",
       "scripts/internal/agent/install_agent_preflight_hooks.sh",
       "scripts/internal/check/check_file_size_budget.sh",
       "scripts/internal/check/check_docs_index.sh",
@@ -148,6 +150,16 @@
         "label": "Bash ci agent preserves legacy controller integration coverage",
         "path": "scripts/internal/ci/ci_agent.sh",
         "fragment": "--test controller_browser_integration --features legacy-controller"
+      },
+      {
+        "label": "PowerShell isolation stress lane uses the shared runner",
+        "path": "scripts/internal/ci/ci_isolation_stress.ps1",
+        "fragment": "parallel_isolation_stress.py"
+      },
+      {
+        "label": "Bash isolation stress lane uses the shared runner",
+        "path": "scripts/internal/ci/ci_isolation_stress.sh",
+        "fragment": "parallel_isolation_stress.py"
       },
       {
         "label": "PowerShell quick CI validates its package filter against discovered binaries",

--- a/src/app/controller/library/source_write_priority.rs
+++ b/src/app/controller/library/source_write_priority.rs
@@ -311,8 +311,17 @@ mod tests {
     }
 
     #[test]
-    fn same_source_test_scopes_are_exclusive() {
+    fn parallel_isolation_sentinel_scoped_global_control_lifecycle_under_contention() {
         let source_id = SourceId::from_string("same-source-scope-ownership");
+        if std::env::var_os("WAVECRATE_ISOLATION_INJECT_GLOBAL_HOOK_LEAK").is_some() {
+            let leaked = FileOpWritePriorityGuard::new(&source_id);
+            std::mem::forget(leaked);
+            assert!(
+                !file_op_write_priority_active(&source_id),
+                "WAVECRATE_ISOLATION:mutable_global_control_leak file-op priority guard leaked"
+            );
+        }
+
         let first_scope = FileOpWritePriorityGuard::new(&source_id);
         let worker_source_id = source_id.clone();
         let (started_tx, started_rx) = mpsc::channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub mod release_metadata;
 pub mod sample_sources;
 /// Selection math utilities.
 pub mod selection;
+#[cfg(test)]
+mod test_isolation_sentinels;
 /// Shared display formatting used across Wavecrate UI runtimes.
 mod ui_formatting;
 /// Optional SQLite extension loader.

--- a/src/test_isolation_sentinels.rs
+++ b/src/test_isolation_sentinels.rs
@@ -1,0 +1,102 @@
+use std::{
+    ffi::OsString,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Duration,
+};
+
+use tempfile::tempdir;
+use wavecrate_library::test_runtime::TestRuntimeGuard;
+
+const SENTINEL_ENV: &str = "WAVECRATE_PARALLEL_ISOLATION_SENTINEL";
+const INJECT_PROCESS_LEAK_ENV: &str = "WAVECRATE_ISOLATION_INJECT_PROCESS_LEAK";
+
+#[test]
+fn parallel_isolation_sentinel_process_state_guard_under_contention() {
+    if std::env::var_os(INJECT_PROCESS_LEAK_ENV).is_some() {
+        inject_process_state_leak();
+    }
+
+    let original_dir = std::env::current_dir().expect("read original working directory");
+    let owner_dir = tempdir().expect("create owner working directory");
+    let contender_dir = tempdir().expect("create contender working directory");
+    let mut owner = TestRuntimeGuard::acquire();
+    owner.remove_var(SENTINEL_ENV);
+    owner.set_var(SENTINEL_ENV, "owner");
+    owner
+        .set_current_dir(owner_dir.path())
+        .expect("enter owner working directory");
+
+    let attempting = Arc::new(AtomicBool::new(false));
+    let contender_attempting = Arc::clone(&attempting);
+    let contender_path = contender_dir.path().to_path_buf();
+    let expected_dir = original_dir.clone();
+    let (acquired_tx, acquired_rx) = mpsc::channel();
+    let contender = thread::spawn(move || {
+        contender_attempting.store(true, Ordering::Release);
+        let mut scope = TestRuntimeGuard::acquire();
+        assert_eq!(
+            std::env::var_os(SENTINEL_ENV),
+            None,
+            "owner environment mutation must be restored before handoff"
+        );
+        assert_eq!(
+            std::env::current_dir().expect("read restored working directory"),
+            expected_dir,
+            "owner working-directory mutation must be restored before handoff"
+        );
+        scope.set_var(SENTINEL_ENV, "contender");
+        scope
+            .set_current_dir(&contender_path)
+            .expect("enter contender working directory");
+        acquired_tx.send(()).expect("report contender acquisition");
+    });
+
+    while !attempting.load(Ordering::Acquire) {
+        thread::yield_now();
+    }
+    assert!(
+        acquired_rx.recv_timeout(Duration::from_millis(25)).is_err(),
+        "contender acquired shared process state before owner cleanup"
+    );
+    drop(owner);
+    acquired_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("contender acquired shared process state after cleanup");
+    contender.join().expect("join process-state contender");
+
+    let _verification_scope = TestRuntimeGuard::acquire();
+    assert_eq!(std::env::var_os(SENTINEL_ENV), None);
+    assert_eq!(
+        std::env::current_dir().expect("read final working directory"),
+        original_dir
+    );
+}
+
+fn inject_process_state_leak() -> ! {
+    let leaked_dir = tempdir()
+        .expect("create injected leaked working directory")
+        .keep();
+    let mut leaked = TestRuntimeGuard::acquire();
+    leaked.set_var(SENTINEL_ENV, "leaked");
+    leaked
+        .set_current_dir(&leaked_dir)
+        .expect("enter injected leaked working directory");
+    std::mem::forget(leaked);
+
+    let leaked_environment = std::env::var_os(SENTINEL_ENV) == Some(OsString::from("leaked"));
+    let leaked_directory = std::env::current_dir()
+        .expect("read injected working directory")
+        .canonicalize()
+        .expect("canonicalize injected working directory")
+        == leaked_dir
+            .canonicalize()
+            .expect("canonicalize leaked working directory");
+    panic!(
+        "WAVECRATE_ISOLATION:process_state_contamination environment_leaked={leaked_environment} current_directory_leaked={leaked_directory}"
+    );
+}


### PR DESCRIPTION
## Goal

Add a repeatable opt-in CI lane that proves the Wavecrate library harness runs in fresh, explicitly parallel processes and produces durable failure evidence for shared-state flakes.

## Scope and non-goals

- Add `scripts/ci.* isolation-stress` with bounded repetitions, explicit parallelism, and per-process timeouts.
- Compile once, launch a fresh test-binary process per iteration, and stop at the first unexpected failure without retrying until green.
- Emit JSONL metadata, detector-verification, iteration, and summary records with the test binary, first test identity, failure class counts, full failure inventory, and known-quarantine disposition.
- Verify deliberately injected environment/current-directory and mutable-global-control leaks in isolated sentinel processes.
- Detect timeouts and leaked owned worker processes on POSIX process groups and Windows Job Objects, and keep the normal `agent` lane unchanged.
- Do not fix or mask the shared-state failures owned by OPT-1258/OPT-1259 or newly exposed by this lane.

## Definition of Done

- [x] Documented Bash and PowerShell commands run a bounded, explicitly parallel, fresh-process lane.
- [x] Every launched process emits a machine-readable JSONL record and preserves the first failure identity.
- [x] Injected process-state and mutable-global-control leaks are detected before stress iterations start.
- [x] Runner tests cover parsing, fresh-process invocation, timeout exit behavior, leak classification, failed summaries, and leaked workers.
- [x] Normal agent-lane intent and command remain unchanged.
- [ ] Repeated full parallel library runs pass: current `main` still reproduces 49 unexpected shared-state-sensitive failures, which the new lane reports and blocks.

## Validation

Passed:

- `python3 -m unittest -v scripts/internal/ci/test_parallel_isolation_stress.py` — 9 tests: 8 passed on macOS and the Windows Job Object runtime test was skipped off-platform.
- `cargo test -p wavecrate --lib parallel_isolation_sentinel -- --test-threads=4` — 2 passed.
- `bash scripts/check.sh script-guardrails`.
- `bash scripts/check.sh docs-index`.
- `cargo fmt --all -- --check`.
- `git diff --check`.
- Python syntax checks for the runner, Windows Job Object helper, and runner tests; JSON syntax checks for the updated inventories.
- POSIX timeout regression fixture proved a child that ignores `SIGTERM` and holds the output pipe is killed within the bounded cleanup window.
- Failed stress runs now emit a terminal JSONL summary with completed iterations, first failure, failure-family counts, full inventory, known quarantine coverage, and report path.

Expected blocking evidence:

- `bash scripts/ci.sh isolation-stress --iterations 1 --test-threads 4 --timeout-seconds 900 --output target/test-isolation-stress/opt-1260-fix-validation.jsonl` — both injected detector checks passed; the stress iteration failed with 49 unexpected tests and emitted the complete failed summary. First failure: `native_app::app_chrome::library_browser::library_sidebar::folder_tree::status::tests::selected_folder_status_paints_missing_source_as_warning`.
- A direct Cargo comparison with the same filters and parallelism reproduced the same 49 failures, confirming the runner did not create the failure family.
- `bash scripts/ci.sh agent` progressed through smoke and architecture checks, then failed in the pinned Radiant suite at `gpu_signal_shader_keeps_waveform_bands_visually_distinct`; this is outside the Wavecrate diff.
- `bash scripts/check.sh file-size-budget` could not run because the existing helper reads an empty Bash array under `set -u` at line 219.

## Known limitations

- The newly durable gate exposes that the current head still does not satisfy the issue's repeated-green requirement; the failures are intentionally not quarantined or retried away.
- PowerShell syntax and dispatcher contracts were checked, and Windows process ownership has a Windows-only Job Object regression test, but the lane was not executed on a Windows host in this change.

User approval is required before merge.
