### PR TITLE
OPT-1264 Relaunch after committed updater cleanup warnings

### DIFF
--- a/apps/updater-helper/src/main.rs
+++ b/apps/updater-helper/src/main.rs
@@ -27,6 +27,9 @@ fn try_main() -> Result<(), String> {
 
 fn run_headless(args: UpdaterRunArgs) -> Result<(), String> {
     let plan = run_headless_with(args, apply_update)?;
+    for warning in cleanup_warning_messages(&plan) {
+        eprintln!("{warning}");
+    }
     eprintln!(
         "Updated {} from {} into {}",
         APP_NAME,
@@ -34,6 +37,24 @@ fn run_headless(args: UpdaterRunArgs) -> Result<(), String> {
         plan.install_dir.display()
     );
     Ok(())
+}
+
+fn cleanup_warning_messages(plan: &ApplyPlan) -> Vec<String> {
+    let committed_cleanup = plan.post_commit_cleanup_failures.iter().map(|failure| {
+        format!(
+            "Warning: update committed but cleanup left {}: {}",
+            failure.path.display(),
+            failure.error
+        )
+    });
+    let stale_cleanup = plan.stale_removal_failures.iter().map(|failure| {
+        format!(
+            "Warning: failed to remove stale path {}: {}",
+            failure.path.display(),
+            failure.error
+        )
+    });
+    committed_cleanup.chain(stale_cleanup).collect()
 }
 
 fn run_headless_with(

--- a/apps/updater-helper/src/main.rs
+++ b/apps/updater-helper/src/main.rs
@@ -6,8 +6,8 @@
 use std::path::PathBuf;
 
 use wavecrate::updater::{
-    APP_NAME, ApplyPlan, REPO_SLUG, RuntimeIdentity, UpdateChannel, UpdateError, UpdaterRunArgs,
-    apply_update, supported_release_target_for_platform_arch,
+    APP_NAME, ApplyPlan, REPO_SLUG, RuntimeIdentity, UpdateChannel, UpdateError, UpdateProgress,
+    UpdaterRunArgs, apply_update_with_progress, supported_release_target_for_platform_arch,
 };
 
 #[cfg(test)]
@@ -26,10 +26,11 @@ fn try_main() -> Result<(), String> {
 }
 
 fn run_headless(args: UpdaterRunArgs) -> Result<(), String> {
-    let plan = run_headless_with(args, apply_update)?;
-    for warning in cleanup_warning_messages(&plan) {
-        eprintln!("{warning}");
-    }
+    let plan = run_headless_with(
+        args,
+        |args, progress| apply_update_with_progress(args, progress),
+        |warning| eprintln!("{warning}"),
+    )?;
     eprintln!(
         "Updated {} from {} into {}",
         APP_NAME,
@@ -39,29 +40,17 @@ fn run_headless(args: UpdaterRunArgs) -> Result<(), String> {
     Ok(())
 }
 
-fn cleanup_warning_messages(plan: &ApplyPlan) -> Vec<String> {
-    let committed_cleanup = plan.post_commit_cleanup_failures.iter().map(|failure| {
-        format!(
-            "Warning: update committed but cleanup left {}: {}",
-            failure.path.display(),
-            failure.error
-        )
-    });
-    let stale_cleanup = plan.stale_removal_failures.iter().map(|failure| {
-        format!(
-            "Warning: failed to remove stale path {}: {}",
-            failure.path.display(),
-            failure.error
-        )
-    });
-    committed_cleanup.chain(stale_cleanup).collect()
-}
-
 fn run_headless_with(
     args: UpdaterRunArgs,
-    apply: impl FnOnce(UpdaterRunArgs) -> Result<ApplyPlan, UpdateError>,
+    apply: impl FnOnce(UpdaterRunArgs, &mut dyn FnMut(UpdateProgress)) -> Result<ApplyPlan, UpdateError>,
+    mut warning: impl FnMut(String),
 ) -> Result<ApplyPlan, String> {
-    apply(args).map_err(|err| err.to_string())
+    let mut progress = |progress: UpdateProgress| {
+        if progress.message.starts_with("Warning:") {
+            warning(progress.message);
+        }
+    };
+    apply(args, &mut progress).map_err(|err| err.to_string())
 }
 
 fn parse_args(args: Vec<String>) -> Result<(UpdaterRunArgs, bool), String> {

--- a/apps/updater-helper/src/tests.rs
+++ b/apps/updater-helper/src/tests.rs
@@ -158,6 +158,7 @@ fn run_headless_with_passes_args_through_to_apply() {
             relaunch: true,
             copied_files: Vec::new(),
             replaced_dirs: Vec::new(),
+            post_commit_cleanup_failures: Vec::new(),
             stale_removal_failures: Vec::new(),
         })
     })
@@ -177,6 +178,30 @@ fn run_headless_with_passes_args_through_to_apply() {
     assert_eq!(received.requested_tag, args.requested_tag);
     assert_eq!(plan.release_tag, "v1.2.3");
     assert_eq!(plan.install_dir, sample_install_dir());
+}
+
+#[test]
+fn cleanup_warning_messages_include_committed_remnant_path_and_error() {
+    let remnant = sample_install_dir().join("wavecrate.exe.old");
+    let plan = ApplyPlan {
+        release_tag: "v1.2.3".to_string(),
+        install_dir: sample_install_dir(),
+        relaunch: true,
+        copied_files: Vec::new(),
+        replaced_dirs: Vec::new(),
+        post_commit_cleanup_failures: vec![wavecrate::updater::PostCommitCleanupFailure {
+            path: remnant.clone(),
+            error: "file is locked".to_string(),
+        }],
+        stale_removal_failures: Vec::new(),
+    };
+
+    let messages = cleanup_warning_messages(&plan);
+
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].contains(&remnant.display().to_string()));
+    assert!(messages[0].contains("file is locked"));
+    assert!(messages[0].contains("update committed"));
 }
 
 #[test]

--- a/apps/updater-helper/src/tests.rs
+++ b/apps/updater-helper/src/tests.rs
@@ -150,18 +150,22 @@ fn parse_args_rejects_unknown_argument_with_help_text() {
 fn run_headless_with_passes_args_through_to_apply() {
     let args = sample_args();
     let captured = RefCell::new(None);
-    let plan = run_headless_with(args.clone(), |received| {
-        captured.replace(Some(received));
-        Ok(ApplyPlan {
-            release_tag: "v1.2.3".to_string(),
-            install_dir: sample_install_dir(),
-            relaunch: true,
-            copied_files: Vec::new(),
-            replaced_dirs: Vec::new(),
-            post_commit_cleanup_failures: Vec::new(),
-            stale_removal_failures: Vec::new(),
-        })
-    })
+    let plan = run_headless_with(
+        args.clone(),
+        |received, _progress| {
+            captured.replace(Some(received));
+            Ok(ApplyPlan {
+                release_tag: "v1.2.3".to_string(),
+                install_dir: sample_install_dir(),
+                relaunch: true,
+                copied_files: Vec::new(),
+                replaced_dirs: Vec::new(),
+                post_commit_cleanup_failures: Vec::new(),
+                stale_removal_failures: Vec::new(),
+            })
+        },
+        |_| {},
+    )
     .expect("headless run");
 
     let received = captured
@@ -181,34 +185,35 @@ fn run_headless_with_passes_args_through_to_apply() {
 }
 
 #[test]
-fn cleanup_warning_messages_include_committed_remnant_path_and_error() {
+fn run_headless_with_forwards_cleanup_warning_before_apply_error() {
     let remnant = sample_install_dir().join("wavecrate.exe.old");
-    let plan = ApplyPlan {
-        release_tag: "v1.2.3".to_string(),
-        install_dir: sample_install_dir(),
-        relaunch: true,
-        copied_files: Vec::new(),
-        replaced_dirs: Vec::new(),
-        post_commit_cleanup_failures: vec![wavecrate::updater::PostCommitCleanupFailure {
-            path: remnant.clone(),
-            error: "file is locked".to_string(),
-        }],
-        stale_removal_failures: Vec::new(),
-    };
+    let expected_warning = format!(
+        "Warning: update committed but cleanup left {}: file is locked",
+        remnant.display()
+    );
+    let mut warnings = Vec::new();
 
-    let messages = cleanup_warning_messages(&plan);
+    let err = run_headless_with(
+        sample_args(),
+        |_, progress| {
+            progress(UpdateProgress::new(expected_warning.clone()));
+            Err(UpdateError::Invalid("relaunch blocked".to_string()))
+        },
+        |warning| warnings.push(warning),
+    )
+    .expect_err("relaunch failure must remain fatal");
 
-    assert_eq!(messages.len(), 1);
-    assert!(messages[0].contains(&remnant.display().to_string()));
-    assert!(messages[0].contains("file is locked"));
-    assert!(messages[0].contains("update committed"));
+    assert!(err.contains("relaunch blocked"));
+    assert_eq!(warnings, vec![expected_warning]);
 }
 
 #[test]
 fn run_headless_with_returns_apply_errors_as_strings() {
-    let err = run_headless_with(sample_args(), |_| {
-        Err(UpdateError::Invalid("test failure".to_string()))
-    })
+    let err = run_headless_with(
+        sample_args(),
+        |_, _progress| Err(UpdateError::Invalid("test failure".to_string())),
+        |_| {},
+    )
     .unwrap_err();
 
     assert_eq!(err, "Invalid update: test failure");

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -2804,6 +2804,17 @@ Updater behavior is intentionally conservative:
 * Windows release installs are manual by design
 * development-only overrides belong behind explicit env vars
 * updater failures should preserve the installed app rather than forcing risky writes
+* a staged update is not committed until every destination swap succeeds; failures
+  before that boundary must roll back and remain fatal
+* once every swap succeeds, failure to remove disposable `.old` or `.new` siblings is
+  a warning-bearing committed outcome and must not prevent the relaunch attempt
+* post-commit cleanup diagnostics retain each affected path and error, while a later
+  cleanup attempt may act only on `.old` or `.new` siblings reconstructed from
+  manifest destinations under a newly validated install root
+* transaction-remnant cleanup removes symlinks rather than following them, and the
+  next update run retries safe remnant cleanup before staging the same destination
+* relaunch failure remains independent and fatal even when the committed update also
+  carries cleanup warnings
 
 See `docs/TROUBLESHOOTING.md` and `docs/ENV_VARS.md` for diagnostics and overrides.
 

--- a/src/updater/apply.rs
+++ b/src/updater/apply.rs
@@ -240,12 +240,13 @@ fn finish_applied_update(
             ),
         );
     }
-    if !applied.stale_removal_failures.is_empty() {
+    for failure in &applied.stale_removal_failures {
         report(
             progress,
             format!(
-                "Warning: failed to remove {} stale paths",
-                applied.stale_removal_failures.len()
+                "Warning: failed to remove stale path {}: {}",
+                failure.path.display(),
+                failure.error
             ),
         );
     }

--- a/src/updater/apply.rs
+++ b/src/updater/apply.rs
@@ -12,9 +12,9 @@ use std::{
 use serde::Deserialize;
 
 use super::{
-    UpdateChannel, UpdateError, UpdateProgress, UpdaterRunArgs, ValidatedInstallRoot, archive,
-    expected_checksums_name, expected_checksums_signature_name, expected_zip_asset_name, fs_ops,
-    github,
+    PostCommitCleanupFailure, UpdateChannel, UpdateError, UpdateProgress, UpdaterRunArgs,
+    ValidatedInstallRoot, archive, expected_checksums_name, expected_checksums_signature_name,
+    expected_zip_asset_name, fs_ops, github,
 };
 
 mod archive_root;
@@ -101,6 +101,8 @@ pub struct ApplyPlan {
     pub copied_files: Vec<String>,
     /// Directories replaced during the update.
     pub replaced_dirs: Vec<String>,
+    /// Disposable `.old` or `.new` paths that remained after the update committed.
+    pub post_commit_cleanup_failures: Vec<PostCommitCleanupFailure>,
     /// Stale paths that could not be removed after applying the update.
     pub stale_removal_failures: Vec<StaleRemovalFailure>,
 }
@@ -114,9 +116,16 @@ pub struct StaleRemovalFailure {
     pub error: String,
 }
 
-/// Return type for `apply_files_and_dirs` to keep the tuple shape explicit.
-type ApplyFilesPlanResult =
-    Result<(Vec<String>, Vec<String>, Vec<StaleRemovalFailure>), UpdateError>;
+#[derive(Debug)]
+struct AppliedFilesPlan {
+    copied_files: Vec<String>,
+    replaced_dirs: Vec<String>,
+    post_commit_cleanup_failures: Vec<PostCommitCleanupFailure>,
+    stale_removal_failures: Vec<StaleRemovalFailure>,
+}
+
+/// Return type for `apply_files_and_dirs`.
+type ApplyFilesPlanResult = Result<AppliedFilesPlan, UpdateError>;
 
 /// Apply the selected update payload into the installation directory.
 /// Returns an [`ApplyPlan`] describing copied files, replaced directories, and stale
@@ -202,33 +211,61 @@ where
     }
 
     report(&mut progress, "Applying update transaction...");
-    let (copied_files, replaced_dirs, stale_removal_failures) =
-        apply_files_and_dirs(&args.install_dir, &root_dir, &manifest)?;
-    if !stale_removal_failures.is_empty() {
+    let applied = apply_files_and_dirs(&args.install_dir, &root_dir, &manifest)?;
+    finish_applied_update(
+        &args,
+        release.tag_name,
+        &manifest,
+        applied,
+        &mut progress,
+        relaunch_app,
+    )
+}
+
+fn finish_applied_update(
+    args: &UpdaterRunArgs,
+    release_tag: String,
+    manifest: &UpdateManifest,
+    applied: AppliedFilesPlan,
+    progress: &mut impl FnMut(UpdateProgress),
+    relaunch: impl FnOnce(&Path, &str, &UpdateManifest) -> Result<(), UpdateError>,
+) -> Result<ApplyPlan, UpdateError> {
+    for failure in &applied.post_commit_cleanup_failures {
         report(
-            &mut progress,
+            progress,
+            format!(
+                "Warning: update committed but cleanup left {}: {}",
+                failure.path.display(),
+                failure.error
+            ),
+        );
+    }
+    if !applied.stale_removal_failures.is_empty() {
+        report(
+            progress,
             format!(
                 "Warning: failed to remove {} stale paths",
-                stale_removal_failures.len()
+                applied.stale_removal_failures.len()
             ),
         );
     }
 
     if args.relaunch {
-        report(&mut progress, "Relaunching app...");
-        if let Err(err) = relaunch_app(&args.install_dir, &args.identity.app, &manifest) {
-            report(&mut progress, format!("Relaunch failed: {err}"));
+        report(progress, "Relaunching app...");
+        if let Err(err) = relaunch(&args.install_dir, &args.identity.app, manifest) {
+            report(progress, format!("Relaunch failed: {err}"));
             return Err(err);
         }
     }
 
     Ok(ApplyPlan {
-        release_tag: release.tag_name,
-        install_dir: args.install_dir,
+        release_tag,
+        install_dir: args.install_dir.clone(),
         relaunch: args.relaunch,
-        copied_files,
-        replaced_dirs,
-        stale_removal_failures,
+        copied_files: applied.copied_files,
+        replaced_dirs: applied.replaced_dirs,
+        post_commit_cleanup_failures: applied.post_commit_cleanup_failures,
+        stale_removal_failures: applied.stale_removal_failures,
     })
 }
 
@@ -240,6 +277,19 @@ fn apply_files_and_dirs(
     install_dir: &Path,
     root_dir: &Path,
     manifest: &UpdateManifest,
+) -> ApplyFilesPlanResult {
+    apply_files_and_dirs_with_commit(install_dir, root_dir, manifest, |transaction| {
+        transaction.commit()
+    })
+}
+
+fn apply_files_and_dirs_with_commit(
+    install_dir: &Path,
+    root_dir: &Path,
+    manifest: &UpdateManifest,
+    commit: impl FnOnce(
+        fs_ops::UpdateTransaction,
+    ) -> Result<fs_ops::TransactionCommitOutcome, UpdateError>,
 ) -> ApplyFilesPlanResult {
     let install_root = ValidatedInstallRoot::new(install_dir)?;
     let installed_manifest = load_installed_manifest(install_root.path())?;
@@ -265,11 +315,19 @@ fn apply_files_and_dirs(
         replaced_dirs.push("resources".to_string());
     }
 
-    transaction.commit()?;
+    let post_commit_cleanup_failures = match commit(transaction)? {
+        fs_ops::TransactionCommitOutcome::Committed => Vec::new(),
+        fs_ops::TransactionCommitOutcome::CommittedWithCleanupFailures(failures) => failures,
+    };
 
     let stale_removal_failures = remove_stale_paths(&stale_files, &install_root)?;
 
-    Ok((copied, replaced_dirs, stale_removal_failures))
+    Ok(AppliedFilesPlan {
+        copied_files: copied,
+        replaced_dirs,
+        post_commit_cleanup_failures,
+        stale_removal_failures,
+    })
 }
 
 fn channel_label(channel: UpdateChannel) -> &'static str {

--- a/src/updater/apply/tests.rs
+++ b/src/updater/apply/tests.rs
@@ -1,8 +1,8 @@
 use super::super::RuntimeIdentity;
 use super::*;
-use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::{cell::Cell, fs};
 use tempfile::tempdir;
 
 const MACOS_TARGET: &str = "x86_64-apple-darwin";
@@ -91,6 +91,68 @@ fn apply_files_and_dirs_keeps_running_executable_on_stage_failure() {
     assert_eq!(fs::read_to_string(&running_dest).unwrap(), "old-binary");
     assert!(!install_dir.join(format!("{running_name}.old")).exists());
     assert!(!install_dir.join(format!("{running_name}.new")).exists());
+}
+
+#[test]
+fn committed_cleanup_failure_warns_and_still_attempts_relaunch() {
+    let tmp = tempdir().unwrap();
+    let install_dir = tmp.path().join("install");
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&install_dir).unwrap();
+    fs::create_dir_all(&root_dir).unwrap();
+
+    let executable = install_dir.join("wavecrate");
+    let old_path = install_dir.canonicalize().unwrap().join("wavecrate.old");
+    fs::write(&executable, "old-binary").unwrap();
+    fs::write(root_dir.join("wavecrate"), "new-binary").unwrap();
+    let manifest = UpdateManifest {
+        app: "wavecrate".to_string(),
+        channel: "stable".to_string(),
+        target: MACOS_TARGET.to_string(),
+        platform: MACOS_PLATFORM.to_string(),
+        arch: X86_64_ARCH.to_string(),
+        files: vec!["wavecrate".to_string()],
+    };
+    let args = UpdaterRunArgs {
+        repo: "owner/repo".to_string(),
+        identity: identity(UpdateChannel::Stable),
+        install_dir: install_dir.clone(),
+        relaunch: true,
+        requested_tag: Some("v1.2.3".to_string()),
+    };
+    let cleanup_path = old_path.clone();
+    let applied =
+        apply_files_and_dirs_with_commit(&install_dir, &root_dir, &manifest, |transaction| {
+            transaction.commit_with_cleanup_failure(cleanup_path)
+        })
+        .expect("post-commit cleanup failure must remain non-fatal");
+    let relaunch_attempted = Cell::new(false);
+    let mut messages = Vec::new();
+
+    let plan = finish_applied_update(
+        &args,
+        "v1.2.3".to_string(),
+        &manifest,
+        applied,
+        &mut |progress| messages.push(progress.message),
+        |received_install_dir, app, _manifest| {
+            relaunch_attempted.set(true);
+            assert_eq!(received_install_dir, install_dir);
+            assert_eq!(app, "wavecrate");
+            assert_eq!(fs::read_to_string(&executable).unwrap(), "new-binary");
+            Ok(())
+        },
+    )
+    .expect("committed update should return a warning-bearing plan");
+
+    assert!(relaunch_attempted.get());
+    assert_eq!(plan.post_commit_cleanup_failures.len(), 1);
+    assert_eq!(plan.post_commit_cleanup_failures[0].path, old_path);
+    assert!(messages.iter().any(|message| {
+        message.contains("Warning: update committed but cleanup left")
+            && message.contains("wavecrate.old")
+    }));
+    assert!(old_path.exists());
 }
 
 #[test]
@@ -238,8 +300,8 @@ fn apply_files_and_dirs_reports_stale_removal_failures() {
     fs::write(root_dir.join("update-manifest.json"), "new-manifest").unwrap();
     fs::write(root_dir.join("current.txt"), "new-current").unwrap();
 
-    let (_copied, _replaced, failures) =
-        apply_files_and_dirs(&install_dir, &root_dir, &next_manifest).unwrap();
+    let applied = apply_files_and_dirs(&install_dir, &root_dir, &next_manifest).unwrap();
+    let failures = applied.stale_removal_failures;
 
     if stale_file.exists() {
         let expected_stale_file = stale_file.canonicalize().unwrap_or(stale_file.clone());

--- a/src/updater/apply/tests.rs
+++ b/src/updater/apply/tests.rs
@@ -156,6 +156,58 @@ fn committed_cleanup_failure_warns_and_still_attempts_relaunch() {
 }
 
 #[test]
+fn committed_cleanup_warning_is_reported_before_fatal_relaunch_failure() {
+    let tmp = tempdir().unwrap();
+    let install_dir = tmp.path().join("install");
+    fs::create_dir_all(&install_dir).unwrap();
+    let remnant = install_dir.join("wavecrate.old");
+    let args = UpdaterRunArgs {
+        repo: "owner/repo".to_string(),
+        identity: identity(UpdateChannel::Stable),
+        install_dir,
+        relaunch: true,
+        requested_tag: Some("v1.2.3".to_string()),
+    };
+    let applied = AppliedFilesPlan {
+        copied_files: vec!["wavecrate".to_string()],
+        replaced_dirs: Vec::new(),
+        post_commit_cleanup_failures: vec![PostCommitCleanupFailure {
+            path: remnant.clone(),
+            error: "file is locked".to_string(),
+        }],
+        stale_removal_failures: Vec::new(),
+    };
+    let mut messages = Vec::new();
+
+    let err = finish_applied_update(
+        &args,
+        "v1.2.3".to_string(),
+        &manifest("stable"),
+        applied,
+        &mut |progress| messages.push(progress.message),
+        |_install_dir, _app, _manifest| Err(UpdateError::Invalid("relaunch blocked".to_string())),
+    )
+    .expect_err("relaunch failure must remain fatal");
+
+    let expected_warning = format!(
+        "Warning: update committed but cleanup left {}: file is locked",
+        remnant.display()
+    );
+    assert!(err.to_string().contains("relaunch blocked"));
+    assert_eq!(messages.first(), Some(&expected_warning));
+    assert!(
+        messages
+            .iter()
+            .any(|message| message == "Relaunching app...")
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("Relaunch failed"))
+    );
+}
+
+#[test]
 fn apply_files_and_dirs_removes_stale_files_from_prior_manifest() {
     let tmp = tempdir().unwrap();
     let install_dir = tmp.path().join("install");

--- a/src/updater/fs_ops.rs
+++ b/src/updater/fs_ops.rs
@@ -30,6 +30,24 @@ enum StagedKind {
     Dir,
 }
 
+/// A disposable transaction path that remained after the update was committed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostCommitCleanupFailure {
+    /// Validated path to the `.old` or `.new` remnant.
+    pub path: PathBuf,
+    /// Human-readable cleanup error.
+    pub error: String,
+}
+
+/// Outcome of committing every staged update entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum TransactionCommitOutcome {
+    /// Every entry was committed and all transaction remnants were removed.
+    Committed,
+    /// Every entry was committed, but disposable transaction remnants remain.
+    CommittedWithCleanupFailures(Vec<PostCommitCleanupFailure>),
+}
+
 #[derive(Debug, Clone)]
 struct StagedEntry {
     dest: PathBuf,
@@ -73,28 +91,38 @@ impl UpdateTransaction {
     }
 
     /// Commit all staged updates, rolling back if any swap fails.
-    pub(super) fn commit(mut self) -> Result<(), UpdateError> {
+    pub(super) fn commit(self) -> Result<TransactionCommitOutcome, UpdateError> {
+        self.commit_with_cleanup(remove_path_if_exists)
+    }
+
+    fn commit_with_cleanup(
+        mut self,
+        mut cleanup: impl FnMut(&Path, StagedKind) -> Result<(), UpdateError>,
+    ) -> Result<TransactionCommitOutcome, UpdateError> {
         if let Err(err) = self.commit_staged() {
             let rollback_result = self.rollback_committed();
-            let cleanup_result = self.cleanup_staged();
+            let cleanup_failures = self.cleanup_staged_with(&mut cleanup);
             if let Err(rollback_err) = rollback_result {
                 return Err(UpdateError::Invalid(format!(
                     "Update transaction failed: {err}; rollback failed: {rollback_err}"
                 )));
             }
-            if let Err(cleanup_err) = cleanup_result {
+            if !cleanup_failures.is_empty() {
                 return Err(UpdateError::Invalid(format!(
-                    "Update transaction failed: {err}; cleanup failed: {cleanup_err}"
+                    "Update transaction failed: {err}; cleanup failed: {}",
+                    format_cleanup_failures(&cleanup_failures)
                 )));
             }
             return Err(err);
         }
-        if let Err(err) = self.cleanup_staged() {
-            return Err(UpdateError::Invalid(format!(
-                "Update applied but cleanup failed: {err}"
-            )));
+        let cleanup_failures = self.cleanup_staged_with(&mut cleanup);
+        if cleanup_failures.is_empty() {
+            Ok(TransactionCommitOutcome::Committed)
+        } else {
+            Ok(TransactionCommitOutcome::CommittedWithCleanupFailures(
+                cleanup_failures,
+            ))
         }
-        Ok(())
     }
 
     fn stage_entry(&mut self, src: &Path, dest: &str, kind: StagedKind) -> Result<(), UpdateError> {
@@ -108,10 +136,11 @@ impl UpdateTransaction {
                 Ok(())
             }
             Err(err) => {
-                let cleanup_result = self.cleanup_staged();
-                if let Err(cleanup_err) = cleanup_result {
+                let cleanup_failures = self.cleanup_staged();
+                if !cleanup_failures.is_empty() {
                     return Err(UpdateError::Invalid(format!(
-                        "Failed to stage update: {err}; cleanup failed: {cleanup_err}"
+                        "Failed to stage update: {err}; cleanup failed: {}",
+                        format_cleanup_failures(&cleanup_failures)
                     )));
                 }
                 Err(err)
@@ -134,11 +163,32 @@ impl UpdateTransaction {
         Ok(())
     }
 
-    fn cleanup_staged(&self) -> Result<(), UpdateError> {
+    fn cleanup_staged(&self) -> Vec<PostCommitCleanupFailure> {
+        self.cleanup_staged_with(&mut remove_path_if_exists)
+    }
+
+    fn cleanup_staged_with(
+        &self,
+        cleanup: &mut impl FnMut(&Path, StagedKind) -> Result<(), UpdateError>,
+    ) -> Vec<PostCommitCleanupFailure> {
+        let mut failures = Vec::new();
         for entry in &self.staged {
-            cleanup_entry(entry)?;
+            cleanup_entry_with(entry, cleanup, &mut failures);
         }
-        Ok(())
+        failures
+    }
+
+    #[cfg(test)]
+    pub(super) fn commit_with_cleanup_failure(
+        self,
+        fail_path: PathBuf,
+    ) -> Result<TransactionCommitOutcome, UpdateError> {
+        self.commit_with_cleanup(|path, kind| {
+            if path == fail_path {
+                return Err(std::io::Error::other("injected cleanup failure").into());
+            }
+            remove_path_if_exists(path, kind)
+        })
     }
 }
 
@@ -185,14 +235,29 @@ fn rollback_entry(entry: &CommittedEntry) -> Result<(), UpdateError> {
     Ok(())
 }
 
-fn cleanup_entry(entry: &StagedEntry) -> Result<(), UpdateError> {
-    remove_path_if_exists(&entry.new_path, entry.kind)?;
-    remove_path_if_exists(&entry.old_path, entry.kind)?;
-    Ok(())
+fn cleanup_entry_with(
+    entry: &StagedEntry,
+    cleanup: &mut impl FnMut(&Path, StagedKind) -> Result<(), UpdateError>,
+    failures: &mut Vec<PostCommitCleanupFailure>,
+) {
+    for path in [&entry.new_path, &entry.old_path] {
+        if let Err(err) = cleanup(path, entry.kind) {
+            failures.push(PostCommitCleanupFailure {
+                path: path.clone(),
+                error: err.to_string(),
+            });
+        }
+    }
 }
 
 fn remove_path_if_exists(path: &Path, kind: StagedKind) -> Result<(), UpdateError> {
-    if !path.exists() {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(path)?;
         return Ok(());
     }
     match kind {
@@ -204,6 +269,14 @@ fn remove_path_if_exists(path: &Path, kind: StagedKind) -> Result<(), UpdateErro
         }
     }
     Ok(())
+}
+
+fn format_cleanup_failures(failures: &[PostCommitCleanupFailure]) -> String {
+    failures
+        .iter()
+        .map(|failure| format!("{} ({})", failure.path.display(), failure.error))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
@@ -280,6 +353,83 @@ mod tests {
         assert!(!file_a.with_file_name("a.txt.old").exists());
         assert!(!file_b.with_file_name("b.txt.new").exists());
         assert!(!file_b.with_file_name("b.txt.old").exists());
+    }
+
+    #[test]
+    fn update_transaction_reports_cleanup_failure_after_committing_new_file() {
+        let tmp = tempdir().unwrap();
+        let install_dir = tmp.path().join("install");
+        let src_dir = tmp.path().join("src");
+        fs::create_dir_all(&install_dir).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let dest = install_dir.join("wavecrate");
+        fs::write(&dest, "old-binary").unwrap();
+        fs::write(src_dir.join("wavecrate"), "new-binary").unwrap();
+
+        let install_root = ValidatedInstallRoot::new(&install_dir).unwrap();
+        let mut tx = UpdateTransaction::new(install_root);
+        tx.stage_file(&src_dir.join("wavecrate"), "wavecrate")
+            .unwrap();
+        let old_path = install_dir.canonicalize().unwrap().join("wavecrate.old");
+
+        let outcome = tx
+            .commit_with_cleanup_failure(old_path.clone())
+            .expect("committed update must not become fatal");
+
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "new-binary");
+        assert_eq!(
+            outcome,
+            TransactionCommitOutcome::CommittedWithCleanupFailures(vec![
+                PostCommitCleanupFailure {
+                    path: old_path.clone(),
+                    error: "I/O error: injected cleanup failure".to_string(),
+                }
+            ])
+        );
+        assert!(old_path.exists());
+    }
+
+    #[test]
+    fn update_transaction_removes_prior_remnants_before_restaging() {
+        let tmp = tempdir().unwrap();
+        let install_dir = tmp.path().join("install");
+        let src_dir = tmp.path().join("src");
+        fs::create_dir_all(&install_dir).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let dest = install_dir.join("wavecrate");
+        let old_path = dest.with_file_name("wavecrate.old");
+        let new_path = dest.with_file_name("wavecrate.new");
+        fs::write(&dest, "current-binary").unwrap();
+        fs::write(&old_path, "prior-backup").unwrap();
+        fs::write(&new_path, "prior-staging").unwrap();
+        fs::write(src_dir.join("wavecrate"), "next-binary").unwrap();
+
+        let install_root = ValidatedInstallRoot::new(&install_dir).unwrap();
+        let mut tx = UpdateTransaction::new(install_root);
+        tx.stage_file(&src_dir.join("wavecrate"), "wavecrate")
+            .expect("validated prior remnants should be retryable");
+
+        assert!(!old_path.exists());
+        assert_eq!(fs::read_to_string(new_path).unwrap(), "next-binary");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remnant_cleanup_removes_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside.txt");
+        let remnant = tmp.path().join("wavecrate.old");
+        fs::write(&outside, "keep").unwrap();
+        symlink(&outside, &remnant).unwrap();
+
+        remove_path_if_exists(&remnant, StagedKind::File).unwrap();
+
+        assert!(!remnant.exists());
+        assert_eq!(fs::read_to_string(outside).unwrap(), "keep");
     }
 
     #[test]

--- a/src/updater/fs_ops.rs
+++ b/src/updater/fs_ops.rs
@@ -257,8 +257,7 @@ fn remove_path_if_exists(path: &Path, kind: StagedKind) -> Result<(), UpdateErro
         Err(err) => return Err(err.into()),
     };
     if metadata.file_type().is_symlink() {
-        fs::remove_file(path)?;
-        return Ok(());
+        return remove_symlink(path, &metadata.file_type());
     }
     match kind {
         StagedKind::File => {
@@ -267,6 +266,29 @@ fn remove_path_if_exists(path: &Path, kind: StagedKind) -> Result<(), UpdateErro
         StagedKind::Dir => {
             fs::remove_dir_all(path)?;
         }
+    }
+    Ok(())
+}
+
+fn remove_symlink(path: &Path, file_type: &fs::FileType) -> Result<(), UpdateError> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileTypeExt;
+
+        return remove_symlink_path(path, file_type.is_symlink_dir());
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = file_type;
+        remove_symlink_path(path, false)
+    }
+}
+
+fn remove_symlink_path(path: &Path, directory_link: bool) -> Result<(), UpdateError> {
+    if directory_link {
+        fs::remove_dir(path)?;
+    } else {
+        fs::remove_file(path)?;
     }
     Ok(())
 }
@@ -430,6 +452,38 @@ mod tests {
 
         assert!(!remnant.exists());
         assert_eq!(fs::read_to_string(outside).unwrap(), "keep");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remnant_cleanup_removes_directory_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        let remnant = tmp.path().join("resources.old");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("keep.txt"), "keep").unwrap();
+        symlink(&outside, &remnant).unwrap();
+
+        remove_path_if_exists(&remnant, StagedKind::Dir).unwrap();
+
+        assert!(!remnant.exists());
+        assert_eq!(
+            fs::read_to_string(outside.join("keep.txt")).unwrap(),
+            "keep"
+        );
+    }
+
+    #[test]
+    fn directory_link_cleanup_uses_directory_unlink_operation() {
+        let tmp = tempdir().unwrap();
+        let remnant = tmp.path().join("resources.old");
+        fs::create_dir(&remnant).unwrap();
+
+        remove_symlink_path(&remnant, true).unwrap();
+
+        assert!(!remnant.exists());
     }
 
     #[test]

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -24,6 +24,7 @@ pub(super) use path_guard::ValidatedInstallRoot;
 
 pub use apply::{ApplyPlan, StaleRemovalFailure, UpdateManifest};
 pub use check::{UpdateCheckOutcome, UpdateCheckRequest};
+pub use fs_ops::PostCommitCleanupFailure;
 pub use github::ReleaseSummary;
 pub use public_catalog::{
     PUBLIC_RELEASE_CATALOG_URL, PUBLIC_RELEASE_PAGE_URL, PublicReleaseCheckRequest,


### PR DESCRIPTION
## Goal

Ensure a successfully committed Wavecrate update still attempts relaunch when disposable `.old`/`.new` cleanup fails, while preserving fatal rollback semantics before commit.

Linear: [OPT-1264](https://linear.app/boostnlvp/issue/OPT-1264/wavecrate-updater-relaunch-after-a-committed-update-when-backup)

## Scope and non-goals

- Return a typed transaction outcome that distinguishes a clean commit from a committed update with cleanup failures.
- Carry affected remnant paths and errors through `ApplyPlan`, progress warnings, and updater-helper diagnostics.
- Continue relaunch after post-commit cleanup warnings; keep relaunch failures independently fatal.
- Retry safe `.old`/`.new` cleanup before staging the same validated destination on a later update run.
- Remove remnant symlinks without following them and document the validated-root retry contract.
- Keep pre-commit swap failures, rollback failures, archive/release selection, and stable-release policy unchanged.

## Definition of Done

- [x] Post-commit cleanup failure returns a warning-bearing committed outcome instead of a fatal apply error.
- [x] The newly installed files remain active and relaunch is attempted.
- [x] Helper diagnostics include each affected cleanup path and error, including when relaunch then fails.
- [x] Pre-commit failures still roll back and remain fatal.
- [x] Safe next-run remnant cleanup and symlink behavior have deterministic coverage.
- [x] Existing updater path-guard and rollback coverage remains green.

## Validation

Passed:

- `cargo test -p wavecrate updater::fs_ops --lib` — 7 passed
- `cargo test -p wavecrate updater::apply --lib` — 14 passed
- `cargo test -p wavecrate updater` — 71 passed
- `cargo test -p wavecrate-updater-helper` — 11 passed
- `cargo fmt --all`
- `git diff --check`
- `bash scripts/ci.sh agent` passed branch policy, smoke compilation, non-blocking architecture, and readiness boundary checks before reaching the unrelated Radiant baseline failure described below.

## Known limitations

- The full agent gate stops in the pinned Radiant library suite after 1,686 passing tests because `gpu_signal_shader_keeps_waveform_bands_visually_distinct` fails against the current baseline shader; OPT-1264 does not modify Radiant.
- Request preflight also reports five pre-existing native-app palette boundary violations outside updater scope.
- Focused clippy is blocked by pre-existing warnings in `wavecrate-library` and Radiant.
- A Windows cross-check was attempted but this macOS host lacks the MSVC C sysroot/headers required by `ring` and bundled SQLite. The live Windows locked-backup-path exercise remains outstanding.
- The user's untracked `vendor/radiant/docs/DESIGN_DIRECTION.md` is preserved and excluded from this PR.

User approval is required before merge.