### PR TITLE
Fix capability-scoped scanner hash reads (OPT-1261)

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -1,5 +1,6 @@
 mod manifest;
 mod scan;
+mod scan_capability;
 mod scan_db_sync;
 mod scan_diff;
 mod scan_diff_phase;

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -7,6 +7,8 @@ use wavecrate_library::sample_sources::SourceManifestEntry;
 
 use super::{ScanError, ScanMode, ScanStats};
 
+const MANIFEST_AUDIT_CHECKPOINT_SIZE: usize = 64;
+
 pub(crate) struct ScanContext {
     pub(crate) existing: HashMap<PathBuf, WavEntry>,
     pub(crate) stats: ScanStats,
@@ -196,11 +198,10 @@ impl ScanContext {
 
     pub(in crate::sample_sources::scanner) fn record_manifest_audit_paths(
         &mut self,
-        db: &SourceDatabase,
         paths: impl IntoIterator<Item = PathBuf>,
-    ) -> Result<(), ScanError> {
+    ) {
         let Some(audit) = self.manifest_audit.as_mut() else {
-            return Ok(());
+            return;
         };
         for path in paths {
             if audit.previously_checked.insert(path.clone()) {
@@ -208,11 +209,33 @@ impl ScanContext {
                 self.stats.total_files = self.stats.total_files.saturating_add(1);
             }
         }
-        if audit.pending.len() >= 64 {
-            db.checkpoint_manifest_audit_paths(&audit.pending)?;
-            audit.pending.clear();
-        }
-        Ok(())
+    }
+
+    pub(in crate::sample_sources::scanner) fn manifest_audit_checkpoint_due(&self) -> bool {
+        self.manifest_audit
+            .as_ref()
+            .is_some_and(|audit| audit.pending.len() >= MANIFEST_AUDIT_CHECKPOINT_SIZE)
+    }
+
+    pub(in crate::sample_sources::scanner) fn discard_manifest_audit_paths(
+        &mut self,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) {
+        let Some(audit) = self.manifest_audit.as_mut() else {
+            return;
+        };
+        let paths = paths.into_iter().collect::<HashSet<_>>();
+        let mut discarded = 0_usize;
+        audit.pending.retain(|path| {
+            if paths.contains(path) {
+                audit.previously_checked.remove(path);
+                discarded += 1;
+                false
+            } else {
+                true
+            }
+        });
+        self.stats.total_files = self.stats.total_files.saturating_sub(discarded);
     }
 
     pub(in crate::sample_sources::scanner) fn flush_manifest_audit_checkpoint(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
@@ -1,0 +1,262 @@
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
+use cap_std::fs::{Dir, OpenOptions};
+
+use super::scan::ScanError;
+
+/// A source-root directory capability used for no-follow content access.
+pub(super) struct SourceRootCapability {
+    root: PathBuf,
+    dir: Dir,
+}
+
+/// The current relationship between a manifest path and a retained file descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SourcePathBinding {
+    Matches,
+    Retire,
+    Changed,
+}
+
+impl SourceRootCapability {
+    pub(super) fn open(root: &Path) -> Result<Self, ScanError> {
+        let dir =
+            Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
+                path: root.to_path_buf(),
+                source,
+            })?;
+        Ok(Self {
+            root: root.to_path_buf(),
+            dir,
+        })
+    }
+
+    /// Open a regular file beneath the source root without following any path component.
+    ///
+    /// `None` means the path disappeared, became a link/reparse point, or no longer names a
+    /// regular file. Other failures remain uncertain and are returned to the caller.
+    pub(super) fn open_regular_file(
+        &self,
+        relative_path: &Path,
+    ) -> Result<Option<fs::File>, ScanError> {
+        let Some((parent, name)) = self.open_parent(relative_path)? else {
+            return Ok(None);
+        };
+        let current = match open_file_nofollow(&parent, &name) {
+            Ok(file) => file,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                if parent
+                    .symlink_metadata(&name)
+                    .is_ok_and(|metadata| metadata.is_symlink())
+                {
+                    return Ok(None);
+                }
+                return Err(ScanError::Io {
+                    path: self.root.join(relative_path),
+                    source,
+                });
+            }
+        };
+        let metadata = current.metadata().map_err(|source| ScanError::Io {
+            path: self.root.join(relative_path),
+            source,
+        })?;
+        if metadata.is_file() {
+            Ok(Some(current))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Reopen a manifest path without following links and compare it with a retained descriptor.
+    pub(super) fn path_binding(
+        &self,
+        relative_path: &Path,
+        expected: &fs::File,
+    ) -> Result<SourcePathBinding, ScanError> {
+        let current = match self.open_regular_file(relative_path) {
+            Ok(Some(current)) => current,
+            Ok(None) => return Ok(SourcePathBinding::Retire),
+            Err(ScanError::Io { .. }) => return Ok(SourcePathBinding::Changed),
+            Err(error) => return Err(error),
+        };
+        let matches = same_open_file(expected, &current).map_err(|source| ScanError::Io {
+            path: self.root.join(relative_path),
+            source,
+        })?;
+        Ok(if matches {
+            SourcePathBinding::Matches
+        } else {
+            SourcePathBinding::Changed
+        })
+    }
+
+    /// Report whether the final entry still exists without resolving links or replaced ancestors.
+    pub(super) fn entry_exists_nofollow(&self, relative_path: &Path) -> Result<bool, ScanError> {
+        let Some((parent, name)) = self.open_parent(relative_path)? else {
+            return Ok(false);
+        };
+        match parent.symlink_metadata(&name) {
+            Ok(_) => Ok(true),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(ScanError::Io {
+                path: self.root.join(relative_path),
+                source,
+            }),
+        }
+    }
+
+    fn open_parent(&self, relative_path: &Path) -> Result<Option<(Dir, PathBuf)>, ScanError> {
+        let Some(name) = relative_path.file_name() else {
+            return Ok(None);
+        };
+        let mut dir = self.dir.try_clone().map_err(|source| ScanError::Io {
+            path: self.root.clone(),
+            source,
+        })?;
+        let mut traversed = PathBuf::new();
+        for component in relative_path
+            .parent()
+            .into_iter()
+            .flat_map(Path::components)
+        {
+            let part = match component {
+                Component::Normal(part) => part,
+                Component::CurDir => continue,
+                _ => return Err(ScanError::InvalidRoot(self.root.join(relative_path))),
+            };
+            traversed.push(part);
+            dir = match dir.open_dir_nofollow(part) {
+                Ok(dir) => dir,
+                Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(source) => {
+                    if dir
+                        .symlink_metadata(part)
+                        .is_ok_and(|metadata| metadata.is_symlink())
+                    {
+                        return Ok(None);
+                    }
+                    return Err(ScanError::Io {
+                        path: self.root.join(&traversed),
+                        source,
+                    });
+                }
+            };
+        }
+        Ok(Some((dir, PathBuf::from(name))))
+    }
+}
+
+fn open_file_nofollow(parent: &Dir, name: &Path) -> std::io::Result<fs::File> {
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    parent.open_with(name, &options).map(|file| file.into_std())
+}
+
+#[cfg(unix)]
+fn same_open_file(left: &fs::File, right: &fs::File) -> std::io::Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let left = left.metadata()?;
+    let right = right.metadata()?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
+}
+
+#[cfg(windows)]
+fn same_open_file(left: &fs::File, right: &fs::File) -> std::io::Result<bool> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
+    };
+
+    let information = |file: &fs::File| {
+        let mut information = BY_HANDLE_FILE_INFORMATION::default();
+        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
+            .map_err(std::io::Error::other)?;
+        Ok::<_, std::io::Error>((
+            information.dwVolumeSerialNumber,
+            information.nFileIndexHigh,
+            information.nFileIndexLow,
+        ))
+    };
+    Ok(information(left)? == information(right)?)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_open_file(_left: &fs::File, _right: &fs::File) -> std::io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn nofollow_open_rejects_file_and_ancestor_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let source = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("outside.wav"), b"outside").unwrap();
+        symlink(
+            outside.path().join("outside.wav"),
+            source.path().join("linked.wav"),
+        )
+        .unwrap();
+        symlink(outside.path(), source.path().join("linked-dir")).unwrap();
+        let capability = SourceRootCapability::open(source.path()).unwrap();
+
+        assert!(
+            capability
+                .open_regular_file(Path::new("linked.wav"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            capability
+                .open_regular_file(Path::new("linked-dir/outside.wav"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn nofollow_open_rejects_windows_file_and_directory_links_when_supported() {
+        use std::os::windows::fs::{symlink_dir, symlink_file};
+
+        let source = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("outside.wav"), b"outside").unwrap();
+        if symlink_file(
+            outside.path().join("outside.wav"),
+            source.path().join("linked.wav"),
+        )
+        .is_err()
+            || symlink_dir(outside.path(), source.path().join("linked-dir")).is_err()
+        {
+            return;
+        }
+        let capability = SourceRootCapability::open(source.path()).unwrap();
+
+        assert!(
+            capability
+                .open_regular_file(Path::new("linked.wav"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            capability
+                .open_regular_file(Path::new("linked-dir/outside.wav"))
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
@@ -235,28 +235,33 @@ mod tests {
         let source = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         fs::write(outside.path().join("outside.wav"), b"outside").unwrap();
-        if symlink_file(
+        let file_link_supported = symlink_file(
             outside.path().join("outside.wav"),
             source.path().join("linked.wav"),
         )
-        .is_err()
-            || symlink_dir(outside.path(), source.path().join("linked-dir")).is_err()
-        {
+        .is_ok();
+        let directory_link_supported =
+            symlink_dir(outside.path(), source.path().join("linked-dir")).is_ok();
+        if !file_link_supported && !directory_link_supported {
             return;
         }
         let capability = SourceRootCapability::open(source.path()).unwrap();
 
-        assert!(
-            capability
-                .open_regular_file(Path::new("linked.wav"))
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            capability
-                .open_regular_file(Path::new("linked-dir/outside.wav"))
-                .unwrap()
-                .is_none()
-        );
+        if file_link_supported {
+            assert!(
+                capability
+                    .open_regular_file(Path::new("linked.wav"))
+                    .unwrap()
+                    .is_none()
+            );
+        }
+        if directory_link_supported {
+            assert!(
+                capability
+                    .open_regular_file(Path::new("linked-dir/outside.wav"))
+                    .unwrap()
+                    .is_none()
+            );
+        }
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -17,11 +17,9 @@ pub(super) struct PreparedFile {
     pub(super) requires_apply: bool,
     pub(super) identity_replaced: bool,
     pub(super) content_hash: Option<String>,
-    /// A targeted-sync descriptor opened through the source-root capability.
-    /// It is consumed during preparation so hashing cannot re-resolve a path
-    /// that was replaced by a link after classification.
-    pub(super) targeted_file: Option<std::fs::File>,
-    pub(super) targeted_handle_verified: bool,
+    /// A descriptor opened through the source-root capability and retained through apply.
+    pub(super) source_file: Option<std::fs::File>,
+    pub(super) source_handle_verified: bool,
 }
 
 pub(super) fn apply_diff(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -1,8 +1,14 @@
-use super::scan::{ScanContext, ScanError, ScanMode};
+#[cfg(test)]
+use super::scan::ScanError;
+use super::scan::{ScanContext, ScanMode};
 use super::scan_diff::{PreparedFile, should_compute_full_hash};
-use super::scan_fs::{FileFacts, read_facts};
+use super::scan_fs::FileFacts;
+#[cfg(test)]
+use super::scan_fs::read_facts;
+#[cfg(test)]
 use std::path::Path;
 
+#[cfg(test)]
 pub(super) fn prepare_diff(
     root: &Path,
     path: &Path,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff_phase.rs
@@ -54,7 +54,7 @@ pub(super) fn prepare_diff_from_facts(facts: FileFacts, context: &ScanContext) -
         requires_apply,
         identity_replaced,
         content_hash: None,
-        targeted_file: None,
-        targeted_handle_verified: false,
+        source_file: None,
+        source_handle_verified: false,
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -477,15 +477,10 @@ pub(super) fn read_facts_from_open_file(
         relative,
         size: meta.len(),
         modified_ns,
-        // On Windows these helpers reopen the supplied path to query handle
-        // metadata. A targeted path may have changed after its no-follow open,
-        // so keep the capability guarantee by omitting the optional markers.
-        // The targeted mode already hashes existing rows and records the
-        // descriptor-derived size and modification time.
         file_identity: {
             #[cfg(windows)]
             {
-                None
+                stable_filesystem_identity_from_open_file(file)
             }
             #[cfg(not(windows))]
             {
@@ -495,7 +490,7 @@ pub(super) fn read_facts_from_open_file(
         change_marker: {
             #[cfg(windows)]
             {
-                None
+                filesystem_change_marker_from_open_file(file)
             }
             #[cfg(not(windows))]
             {
@@ -503,6 +498,47 @@ pub(super) fn read_facts_from_open_file(
             }
         },
     })
+}
+
+#[cfg(windows)]
+fn stable_filesystem_identity_from_open_file(file: &fs::File) -> Option<String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }.ok()?;
+    let file_index =
+        (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
+    let creation_time = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
+        | u64::from(information.ftCreationTime.dwLowDateTime);
+    Some(format!(
+        "windows:{}:{}:{}",
+        information.dwVolumeSerialNumber, file_index, creation_time
+    ))
+}
+
+#[cfg(windows)]
+fn filesystem_change_marker_from_open_file(file: &fs::File) -> Option<String> {
+    use std::os::windows::io::AsRawHandle;
+    use windows::Win32::{
+        Foundation::HANDLE,
+        Storage::FileSystem::{FILE_BASIC_INFO, FileBasicInfo, GetFileInformationByHandleEx},
+    };
+
+    let mut information = FILE_BASIC_INFO::default();
+    unsafe {
+        GetFileInformationByHandleEx(
+            HANDLE(file.as_raw_handle()),
+            FileBasicInfo,
+            (&mut information as *mut FILE_BASIC_INFO).cast(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    }
+    .ok()?;
+    (information.ChangeTime != 0).then(|| format!("windows:{}", information.ChangeTime))
 }
 
 pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
@@ -519,18 +555,6 @@ fn source_entry_file_type(file_type: &fs::FileType) -> SourceEntryFileType {
         file_type.is_file(),
         file_type.is_symlink(),
     )
-}
-
-/// Hash the entire file contents for change detection, honoring cancellation when requested.
-pub(super) fn compute_content_hash(
-    path: &Path,
-    cancel: Option<&AtomicBool>,
-) -> Result<String, ScanError> {
-    let mut file = fs::File::open(path).map_err(|source| ScanError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    compute_content_hash_with_reader(path, &mut file, cancel)
 }
 
 pub(super) fn compute_content_hash_with_reader(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -415,6 +415,7 @@ fn display_relative(root: &Path, path: &Path) -> String {
         .to_string()
 }
 
+#[cfg(test)]
 pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanError> {
     let relative = strip_relative(root, path)?;
     #[cfg(test)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -8,19 +9,33 @@ use crate::sample_sources::db::{
     ContentAuditForwardCandidate, ContentAuditRetryCandidate, ContentAuditSkipReason,
     PendingRenameEntry, SourceWriteBatch, WavEntry,
 };
-use wavecrate_library::sample_sources::{SourceEntryFileType, classify_source_entry};
+use wavecrate_library::sample_sources::SourceManifestEntry;
 
 use super::scan::{ChangedSample, RenamedSample, ScanError, ScanStats, UpdatedSample};
-use super::scan_fs::{compute_content_hash, ensure_root_dir, read_facts};
+use super::scan_capability::{SourcePathBinding, SourceRootCapability};
+#[cfg(test)]
+use super::scan_fs::read_facts;
+use super::scan_fs::{
+    FileFacts, compute_content_hash_with_reader, ensure_root_dir, read_facts_from_open_file,
+};
 use super::scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct HashBackfill {
     relative_path: PathBuf,
     file_size: u64,
     modified_ns: i64,
     content_hash: String,
     file_identity: Option<String>,
+    file: std::fs::File,
+}
+
+#[derive(Debug)]
+struct VerifiedContentAudit {
+    previous: SourceManifestEntry,
+    facts: FileFacts,
+    content_hash: String,
+    file: std::fs::File,
 }
 
 const CONTENT_AUDIT_RETRY_SECONDS: i64 = 15 * 60;
@@ -269,6 +284,7 @@ fn verify_content_batch_with_hooks(
     let planning_started = Instant::now();
     let manifest_revision = db.get_revision()?;
     let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
     let checkpoint = {
         let _writer = writer.lock(ScanWritePhase::Manifest);
         db.begin_or_resume_content_audit(now, manifest_revision)?
@@ -361,23 +377,42 @@ fn verify_content_batch_with_hooks(
             retry_next = true;
         }
         let absolute = root.join(&entry.relative_path);
-        if !is_supported_regular_audio_file(&absolute) {
-            let reason = if absolute.exists() {
-                ContentAuditSkipReason::Unsupported
-            } else {
-                ContentAuditSkipReason::Unavailable
-            };
-            skipped.push((entry.clone(), reason, 0));
-            continue;
-        }
-        let before_hash = match read_facts(&root, &absolute) {
+        let mut file = match source_root.open_regular_file(&entry.relative_path) {
+            Ok(Some(file)) => file,
+            Ok(None) => {
+                let reason = if source_root
+                    .entry_exists_nofollow(&entry.relative_path)
+                    .unwrap_or(false)
+                {
+                    ContentAuditSkipReason::Unsupported
+                } else {
+                    ContentAuditSkipReason::Unavailable
+                };
+                skipped.push((entry.clone(), reason, 0));
+                continue;
+            }
+            Err(_) => {
+                skipped.push((entry.clone(), ContentAuditSkipReason::Unavailable, 0));
+                continue;
+            }
+        };
+        let before_hash = match read_facts_from_open_file(&root, &absolute, &file) {
             Ok(facts) => facts,
             Err(_) => {
                 skipped.push((entry.clone(), ContentAuditSkipReason::Unavailable, 0));
                 continue;
             }
         };
-        let content_hash = match compute_content_hash(&absolute, cancel) {
+        if let Err(source) = file.seek(SeekFrom::Start(0)) {
+            skipped.push((entry.clone(), ContentAuditSkipReason::HashFailed, 0));
+            tracing::warn!(
+                path = %absolute.display(),
+                error = %source,
+                "Source content audit could not rewind its retained descriptor"
+            );
+            continue;
+        }
+        let content_hash = match compute_content_hash_with_reader(&absolute, &mut file, cancel) {
             Ok(hash) => hash,
             Err(ScanError::Canceled) => break,
             Err(_) => {
@@ -392,7 +427,7 @@ fn verify_content_batch_with_hooks(
         };
         post_hash(&absolute);
         attempted_bytes = attempted_bytes.saturating_add(before_hash.size);
-        let after_hash = match read_facts(&root, &absolute) {
+        let after_hash = match read_facts_from_open_file(&root, &absolute, &file) {
             Ok(facts) => facts,
             Err(_) => {
                 skipped.push((
@@ -411,7 +446,12 @@ fn verify_content_batch_with_hooks(
             ));
             continue;
         }
-        verified.push((entry.clone(), after_hash, content_hash));
+        verified.push(VerifiedContentAudit {
+            previous: entry.clone(),
+            facts: after_hash,
+            content_hash,
+            file,
+        });
         stats.hashes_computed += 1;
     }
     let cancelled = cancel_requested(cancel);
@@ -425,19 +465,30 @@ fn verify_content_batch_with_hooks(
             });
         }
         let mut committed_verified = Vec::with_capacity(verified.len());
-        for (previous, facts, content_hash) in verified {
-            match read_facts(&root, &root.join(&previous.relative_path)) {
-                Ok(committed_facts) if facts.same_content_snapshot(&committed_facts) => {
-                    committed_verified.push((previous, facts, content_hash));
+        for verified in verified {
+            let absolute = root.join(&verified.previous.relative_path);
+            let descriptor_still_current =
+                read_facts_from_open_file(&root, &absolute, &verified.file)
+                    .is_ok_and(|current| verified.facts.same_content_snapshot(&current));
+            let binding =
+                source_root.path_binding(&verified.previous.relative_path, &verified.file);
+            match (descriptor_still_current, binding) {
+                (true, Ok(SourcePathBinding::Matches)) => committed_verified.push(verified),
+                (_, Ok(SourcePathBinding::Retire)) | (_, Err(_)) => {
+                    skipped.push((verified.previous, ContentAuditSkipReason::Unavailable, 0))
                 }
-                Ok(_) => skipped.push((previous, ContentAuditSkipReason::ChangedDuringHash, 0)),
-                Err(_) => {
-                    skipped.push((previous, ContentAuditSkipReason::Unavailable, 0));
-                }
+                _ => skipped.push((
+                    verified.previous,
+                    ContentAuditSkipReason::ChangedDuringHash,
+                    0,
+                )),
             }
         }
         let mut changed_before = Vec::new();
-        for (previous, facts, content_hash) in &committed_verified {
+        for verified in &committed_verified {
+            let previous = &verified.previous;
+            let facts = &verified.facts;
+            let content_hash = &verified.content_hash;
             batch.record_content_audit_verified(
                 &previous.relative_path,
                 checkpoint.rotation_id,
@@ -550,21 +601,6 @@ fn verify_content_batch_with_hooks(
     }
 }
 
-fn is_supported_regular_audio_file(path: &std::path::Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
-        let file_type = metadata.file_type();
-        classify_source_entry(
-            path,
-            SourceEntryFileType::from_no_followed_type(
-                file_type.is_dir(),
-                file_type.is_file(),
-                file_type.is_symlink(),
-            ),
-        )
-        .has_supported_audio()
-    })
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum DeferredHashScope {
     AllUnhashed,
@@ -621,6 +657,7 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         return Err(ScanError::Canceled);
     }
     let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
     let rename_candidates = rename_candidates.clone();
     if rename_candidates.is_empty() {
         return Ok(Vec::new());
@@ -631,7 +668,10 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
         .list_files()?
         .into_iter()
         .filter(|entry| {
-            !entry.missing && is_supported_regular_audio_file(&root.join(&entry.relative_path))
+            !entry.missing
+                && source_root
+                    .open_regular_file(&entry.relative_path)
+                    .is_ok_and(|file| file.is_some())
         })
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect::<HashMap<_, _>>();
@@ -688,6 +728,7 @@ fn deep_hash_scan_with_post_hash_hook(
 ) -> Result<ScanStats, ScanError> {
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
     let entries = if let Some(exact_path) = exact_path {
@@ -702,11 +743,9 @@ fn deep_hash_scan_with_post_hash_hook(
         .map(|entry| (entry.relative_path.clone(), entry))
         .collect();
     let has_unhashed_files = scope == DeferredHashScope::AllUnhashed
-        && entries_by_path.values().any(|entry| {
-            !entry.missing
-                && entry.content_hash.is_none()
-                && root.join(&entry.relative_path).is_file()
-        });
+        && entries_by_path
+            .values()
+            .any(|entry| !entry.missing && entry.content_hash.is_none());
     if !has_unhashed_files && rename_candidates.is_empty() {
         let mut stats = ScanStats::default();
         let committed_snapshot = db.manifest_snapshot_with_revision()?;
@@ -751,13 +790,18 @@ fn deep_hash_scan_with_post_hash_hook(
             continue;
         }
         let absolute = root.join(&entry.relative_path);
-        if !is_supported_regular_audio_file(&absolute) {
+        let Some(mut file) = source_root.open_regular_file(&entry.relative_path)? else {
             continue;
-        }
-        let facts = read_facts(&root, &absolute)?;
-        let hash = compute_content_hash(&absolute, cancel)?;
+        };
+        let facts = read_facts_from_open_file(&root, &absolute, &file)?;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|source| ScanError::Io {
+                path: absolute.clone(),
+                source,
+            })?;
+        let hash = compute_content_hash_with_reader(&absolute, &mut file, cancel)?;
         post_hash(&absolute);
-        let after_hash = read_facts(&root, &absolute)?;
+        let after_hash = read_facts_from_open_file(&root, &absolute, &file)?;
         if !facts.same_content_snapshot(&after_hash) {
             continue;
         }
@@ -767,10 +811,8 @@ fn deep_hash_scan_with_post_hash_hook(
             modified_ns: after_hash.modified_ns,
             content_hash: hash.clone(),
             file_identity: after_hash.file_identity,
+            file,
         });
-        entry.file_size = after_hash.size;
-        entry.modified_ns = after_hash.modified_ns;
-        entry.content_hash = Some(hash.clone());
         if was_unhashed {
             stats.hashes_computed += 1;
         }
@@ -793,7 +835,22 @@ fn deep_hash_scan_with_post_hash_hook(
             actual: db.get_revision()?,
         });
     }
-    for backfill in &hash_backfills {
+    for backfill in hash_backfills {
+        let absolute = root.join(&backfill.relative_path);
+        let descriptor_still_current = read_facts_from_open_file(&root, &absolute, &backfill.file)
+            .is_ok_and(|facts| {
+                facts.size == backfill.file_size
+                    && facts.modified_ns == backfill.modified_ns
+                    && facts.file_identity == backfill.file_identity
+            });
+        if !descriptor_still_current
+            || !matches!(
+                source_root.path_binding(&backfill.relative_path, &backfill.file),
+                Ok(SourcePathBinding::Matches)
+            )
+        {
+            continue;
+        }
         batch.upsert_file_with_hash(
             &backfill.relative_path,
             backfill.file_size,
@@ -801,6 +858,11 @@ fn deep_hash_scan_with_post_hash_hook(
             &backfill.content_hash,
         )?;
         batch.set_file_identity(&backfill.relative_path, backfill.file_identity.as_deref())?;
+        if let Some(entry) = entries_by_path.get_mut(&backfill.relative_path) {
+            entry.file_size = backfill.file_size;
+            entry.modified_ns = backfill.modified_ns;
+            entry.content_hash = Some(backfill.content_hash.clone());
+        }
         if let Some(identity) = backfill.file_identity.as_ref() {
             candidate_identities.insert(backfill.relative_path.clone(), identity.clone());
         }
@@ -1388,6 +1450,48 @@ mod tests {
         assert_eq!(state[Path::new("sample-00000.wav")].attempts, 2);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn content_audit_does_not_publish_an_outside_link_target() {
+        use std::os::unix::fs::symlink;
+
+        let (directory, database) = content_fixture(1, 32);
+        let relative = Path::new("sample-00000.wav");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+
+        let stats = verify_content_batch_with_post_hash_hook(
+            &database,
+            None,
+            ContentAuditBudget::entry_limited(1),
+            100,
+            &UncoordinatedScanWriter,
+            |path| {
+                std::fs::remove_file(path).expect("remove source file");
+                symlink(&outside_file, path).expect("replace source with outside link");
+            },
+        )
+        .expect("defer replaced audit entry");
+
+        assert_eq!(
+            stats
+                .content_audit
+                .expect("content audit report")
+                .verified_entries,
+            0
+        );
+        assert!(
+            database
+                .entry_for_path(relative)
+                .expect("read source row")
+                .expect("source row")
+                .content_hash
+                .is_none()
+        );
+        drop(directory);
+    }
+
     #[test]
     fn due_retry_cannot_consume_the_only_forward_progress_slot() {
         let (directory, database) = content_fixture(2, 32);
@@ -1696,6 +1800,45 @@ mod tests {
                 .content_hash
                 .is_none(),
             "an unstable read must remain pending for a later hash pass"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_exact_hash_does_not_publish_an_outside_link_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("temp source");
+        let relative = Path::new("pending.wav");
+        let absolute = dir.path().join(relative);
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&absolute, b"inside").expect("write source file");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(relative, 6, 1).expect("insert pending row");
+
+        deep_hash_scan_with_post_hash_hook(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(relative),
+            &UncoordinatedScanWriter,
+            |path| {
+                std::fs::remove_file(path).expect("remove source file");
+                symlink(&outside_file, path).expect("replace source with outside link");
+            },
+        )
+        .expect("defer replaced exact hash");
+
+        assert!(
+            db.entry_for_path(relative)
+                .expect("read pending row")
+                .expect("pending row")
+                .content_hash
+                .is_none()
         );
     }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -23,6 +23,7 @@ use super::scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};
 #[derive(Debug)]
 struct HashBackfill {
     relative_path: PathBuf,
+    facts: FileFacts,
     file_size: u64,
     modified_ns: i64,
     content_hash: String,
@@ -267,9 +268,16 @@ fn verify_content_batch_with_post_hash_hook(
     mut post_hash: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
     let started = Instant::now();
-    verify_content_batch_with_hooks(db, cancel, budget, now, writer, &mut post_hash, &mut || {
-        started.elapsed()
-    })
+    verify_content_batch_with_hooks(
+        db,
+        cancel,
+        budget,
+        now,
+        writer,
+        &mut post_hash,
+        &mut |_| {},
+        &mut || started.elapsed(),
+    )
 }
 
 fn verify_content_batch_with_hooks(
@@ -279,6 +287,7 @@ fn verify_content_batch_with_hooks(
     now: i64,
     writer: &impl ScanWriter,
     post_hash: &mut impl FnMut(&std::path::Path),
+    precommit: &mut impl FnMut(&std::path::Path),
     elapsed: &mut impl FnMut() -> Duration,
 ) -> Result<ScanStats, ScanError> {
     let planning_started = Instant::now();
@@ -458,6 +467,7 @@ fn verify_content_batch_with_hooks(
     if !verified.is_empty() || !skipped.is_empty() || cursor_only_progress {
         let _writer = writer.lock(ScanWritePhase::DeferredHash);
         let mut batch = db.write_batch()?;
+        let stats_before_staging = stats.clone();
         if !batch.matches_revision(manifest_revision)? {
             return Err(ScanError::StaleRevision {
                 expected: manifest_revision,
@@ -557,6 +567,33 @@ fn verify_content_batch_with_hooks(
             attempted_bytes,
             now,
         )?;
+        for verified in &committed_verified {
+            precommit(&verified.previous.relative_path);
+        }
+        let final_bindings_match = committed_verified.iter().all(|verified| {
+            let absolute = root.join(&verified.previous.relative_path);
+            let descriptor_matches = read_facts_from_open_file(&root, &absolute, &verified.file)
+                .is_ok_and(|current| verified.facts.same_content_snapshot(&current));
+            descriptor_matches
+                && matches!(
+                    source_root.path_binding(&verified.previous.relative_path, &verified.file),
+                    Ok(SourcePathBinding::Matches)
+                )
+        });
+        if !final_bindings_match {
+            drop(batch);
+            stats = stats_before_staging;
+            stats.committed_delta.revision = db.get_revision()?;
+            stats.content_audit = Some(db.content_audit_report(now)?);
+            return if cancelled {
+                Err(ScanError::Incomplete {
+                    committed: Box::new(stats),
+                    error: ScanError::Canceled.to_string(),
+                })
+            } else {
+                Ok(stats)
+            };
+        }
         let (revision, changes) = batch.commit_with_bounded_manifest_changes(manifest_revision)?;
         let changed_after = changes
             .into_iter()
@@ -724,7 +761,32 @@ fn deep_hash_scan_with_post_hash_hook(
     max_hashes: Option<usize>,
     exact_path: Option<&std::path::Path>,
     writer: &impl ScanWriter,
+    post_hash: impl FnMut(&std::path::Path),
+) -> Result<ScanStats, ScanError> {
+    deep_hash_scan_with_hooks(
+        db,
+        cancel,
+        rename_candidates,
+        scope,
+        max_hashes,
+        exact_path,
+        writer,
+        post_hash,
+        |_| {},
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn deep_hash_scan_with_hooks(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
+    max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
+    writer: &impl ScanWriter,
     mut post_hash: impl FnMut(&std::path::Path),
+    mut precommit: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
@@ -807,6 +869,7 @@ fn deep_hash_scan_with_post_hash_hook(
         }
         hash_backfills.push(HashBackfill {
             relative_path: entry.relative_path.clone(),
+            facts: after_hash.clone(),
             file_size: after_hash.size,
             modified_ns: after_hash.modified_ns,
             content_hash: hash.clone(),
@@ -829,20 +892,18 @@ fn deep_hash_scan_with_post_hash_hook(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    let stats_before_staging = stats.clone();
     if !batch.matches_revision(manifest_revision)? {
         return Err(ScanError::StaleRevision {
             expected: manifest_revision,
             actual: db.get_revision()?,
         });
     }
+    let mut accepted_backfills = Vec::with_capacity(hash_backfills.len());
     for backfill in hash_backfills {
         let absolute = root.join(&backfill.relative_path);
         let descriptor_still_current = read_facts_from_open_file(&root, &absolute, &backfill.file)
-            .is_ok_and(|facts| {
-                facts.size == backfill.file_size
-                    && facts.modified_ns == backfill.modified_ns
-                    && facts.file_identity == backfill.file_identity
-            });
+            .is_ok_and(|facts| backfill.facts.same_content_snapshot(&facts));
         if !descriptor_still_current
             || !matches!(
                 source_root.path_binding(&backfill.relative_path, &backfill.file),
@@ -866,6 +927,7 @@ fn deep_hash_scan_with_post_hash_hook(
         if let Some(identity) = backfill.file_identity.as_ref() {
             candidate_identities.insert(backfill.relative_path.clone(), identity.clone());
         }
+        accepted_backfills.push(backfill);
     }
     let (renamed_samples, _) = reconcile_indexed_rename_candidates(
         &mut batch,
@@ -879,6 +941,26 @@ fn deep_hash_scan_with_post_hash_hook(
 
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
+    }
+    for backfill in &accepted_backfills {
+        precommit(&backfill.relative_path);
+    }
+    let final_bindings_match = accepted_backfills.iter().all(|backfill| {
+        let absolute = root.join(&backfill.relative_path);
+        let descriptor_matches = read_facts_from_open_file(&root, &absolute, &backfill.file)
+            .is_ok_and(|facts| backfill.facts.same_content_snapshot(&facts));
+        descriptor_matches
+            && matches!(
+                source_root.path_binding(&backfill.relative_path, &backfill.file),
+                Ok(SourcePathBinding::Matches)
+            )
+    });
+    if !final_bindings_match {
+        drop(batch);
+        stats = stats_before_staging;
+        stats.committed_delta.revision = db.get_revision()?;
+        stats.pending_rename_diagnostics = Some(db.pending_rename_diagnostics()?);
+        return Ok(stats);
     }
     let committed_snapshot = batch.commit_with_manifest_snapshot()?;
     super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
@@ -1344,6 +1426,7 @@ mod tests {
             100,
             &UncoordinatedScanWriter,
             &mut post_hash,
+            &mut |_| {},
             &mut observe_elapsed,
         )
         .expect("time-bounded slice");
@@ -1490,6 +1573,50 @@ mod tests {
                 .is_none()
         );
         drop(directory);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn content_audit_does_not_publish_a_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let (directory, database) = content_fixture(1, 32);
+        let relative = Path::new("sample-00000.wav");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+
+        let stats = verify_content_batch_with_hooks(
+            &database,
+            None,
+            ContentAuditBudget::entry_limited(1),
+            100,
+            &UncoordinatedScanWriter,
+            &mut |_| {},
+            &mut |path| {
+                let absolute = directory.path().join(path);
+                std::fs::remove_file(&absolute).expect("remove source file");
+                symlink(&outside_file, absolute).expect("replace source with outside link");
+            },
+            &mut || Duration::ZERO,
+        )
+        .expect("defer late replacement");
+
+        assert_eq!(
+            stats
+                .content_audit
+                .expect("content audit report")
+                .verified_entries,
+            0
+        );
+        assert!(
+            database
+                .entry_for_path(relative)
+                .expect("read source row")
+                .expect("source row")
+                .content_hash
+                .is_none()
+        );
     }
 
     #[test]
@@ -1832,6 +1959,47 @@ mod tests {
             },
         )
         .expect("defer replaced exact hash");
+
+        assert!(
+            db.entry_for_path(relative)
+                .expect("read pending row")
+                .expect("pending row")
+                .content_hash
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_exact_hash_does_not_publish_a_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("temp source");
+        let relative = Path::new("pending.wav");
+        let absolute = dir.path().join(relative);
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&absolute, b"inside").expect("write source file");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+        let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
+        db.upsert_file(relative, 6, 1).expect("insert pending row");
+
+        deep_hash_scan_with_hooks(
+            &db,
+            None,
+            &HashSet::new(),
+            DeferredHashScope::AllUnhashed,
+            Some(1),
+            Some(relative),
+            &UncoordinatedScanWriter,
+            |_| {},
+            |path| {
+                let absolute = dir.path().join(path);
+                std::fs::remove_file(&absolute).expect("remove source file");
+                symlink(&outside_file, absolute).expect("replace source with outside link");
+            },
+        )
+        .expect("defer late replacement");
 
         assert!(
             db.entry_for_path(relative)

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -32,6 +32,13 @@ struct HashBackfill {
 }
 
 #[derive(Debug)]
+struct RetainedRenameCandidate {
+    relative_path: PathBuf,
+    facts: FileFacts,
+    file: std::fs::File,
+}
+
+#[derive(Debug)]
 struct VerifiedContentAudit {
     previous: SourceManifestEntry,
     facts: FileFacts,
@@ -690,6 +697,16 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<Vec<RenamedSample>, ScanError> {
+    reconcile_hashed_rename_candidates_with_hook(db, rename_candidates, cancel, writer, |_| {})
+}
+
+fn reconcile_hashed_rename_candidates_with_hook(
+    db: &SourceDatabase,
+    rename_candidates: &HashSet<PathBuf>,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+    mut precommit: impl FnMut(&std::path::Path),
+) -> Result<Vec<RenamedSample>, ScanError> {
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
@@ -701,27 +718,49 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
     }
 
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
-    let entries_by_path = db
-        .list_files()?
+    let persisted_identities = manifest_before
         .into_iter()
-        .filter(|entry| {
-            !entry.missing
-                && source_root
-                    .open_regular_file(&entry.relative_path)
-                    .is_ok_and(|file| file.is_some())
-        })
-        .map(|entry| (entry.relative_path.clone(), entry))
-        .collect::<HashMap<_, _>>();
-    if !db.has_pending_renames()? {
-        return Ok(Vec::new());
-    }
-    let candidate_identities = manifest_before
-        .into_iter()
-        .filter(|entry| rename_candidates.contains(&entry.relative_path))
         .filter_map(|entry| {
             entry
                 .file_identity
                 .map(|identity| (entry.relative_path, identity))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut entries_by_path = HashMap::new();
+    let mut retained = Vec::new();
+    for entry in db.list_files()? {
+        if entry.missing || !rename_candidates.contains(&entry.relative_path) {
+            continue;
+        }
+        let Some(file) = source_root.open_regular_file(&entry.relative_path)? else {
+            continue;
+        };
+        let absolute = root.join(&entry.relative_path);
+        let facts = read_facts_from_open_file(&root, &absolute, &file)?;
+        if entry.file_size != facts.size
+            || entry.modified_ns != facts.modified_ns
+            || persisted_identities.get(&entry.relative_path) != facts.file_identity.as_ref()
+        {
+            continue;
+        }
+        entries_by_path.insert(entry.relative_path.clone(), entry);
+        retained.push(RetainedRenameCandidate {
+            relative_path: facts.relative.clone(),
+            facts,
+            file,
+        });
+    }
+    if !db.has_pending_renames()? {
+        return Ok(Vec::new());
+    }
+    let candidate_identities = retained
+        .iter()
+        .filter_map(|candidate| {
+            candidate
+                .facts
+                .file_identity
+                .clone()
+                .map(|identity| (candidate.relative_path.clone(), identity))
         })
         .collect::<HashMap<_, _>>();
 
@@ -748,6 +787,23 @@ pub(super) fn reconcile_hashed_rename_candidates_with_writer(
     )?;
     if renamed_samples.is_empty() && retained_candidates == 0 {
         return Ok(renamed_samples);
+    }
+    for candidate in &retained {
+        precommit(&candidate.relative_path);
+    }
+    let final_bindings_match = retained.iter().all(|candidate| {
+        let absolute = root.join(&candidate.relative_path);
+        let descriptor_matches = read_facts_from_open_file(&root, &absolute, &candidate.file)
+            .is_ok_and(|facts| candidate.facts.same_content_snapshot(&facts));
+        descriptor_matches
+            && matches!(
+                source_root.path_binding(&candidate.relative_path, &candidate.file),
+                Ok(SourcePathBinding::Matches)
+            )
+    });
+    if !final_bindings_match {
+        drop(batch);
+        return Ok(Vec::new());
     }
     batch.commit()?;
     Ok(renamed_samples)
@@ -929,12 +985,17 @@ fn deep_hash_scan_with_hooks(
         }
         accepted_backfills.push(backfill);
     }
+    let admitted_rename_candidates = accepted_backfills
+        .iter()
+        .filter(|backfill| rename_candidates.contains(&backfill.relative_path))
+        .map(|backfill| backfill.relative_path.clone())
+        .collect::<HashSet<_>>();
     let (renamed_samples, _) = reconcile_indexed_rename_candidates(
         &mut batch,
         &root,
         &entries_by_path,
         &candidate_identities,
-        &rename_candidates,
+        &admitted_rename_candidates,
     )?;
     stats.renames_reconciled = renamed_samples.len();
     stats.renamed_samples = renamed_samples;
@@ -1126,6 +1187,93 @@ mod tests {
     struct InterleavedManifestWriter {
         root: PathBuf,
         committed: AtomicBool,
+    }
+
+    struct HashedRenameFixture {
+        _directory: tempfile::TempDir,
+        database: SourceDatabase,
+        old_relative: PathBuf,
+        new_relative: PathBuf,
+    }
+
+    fn hashed_rename_fixture(new_relative: &Path) -> HashedRenameFixture {
+        let directory = tempfile::tempdir().expect("temp source");
+        let old_relative = PathBuf::from("old.wav");
+        let old_absolute = directory.path().join(&old_relative);
+        let new_relative = new_relative.to_path_buf();
+        let new_absolute = directory.path().join(&new_relative);
+        if let Some(parent) = new_absolute.parent() {
+            std::fs::create_dir_all(parent).expect("create destination parent");
+        }
+        std::fs::write(&old_absolute, [5_u8; 32]).expect("write original wav");
+        let facts = read_facts(directory.path(), &old_absolute).expect("read original facts");
+        let database = SourceDatabase::open_for_source_write(directory.path()).expect("source db");
+        let mut batch = database.write_batch().expect("seed source batch");
+        batch
+            .upsert_file_with_hash(&old_relative, facts.size, facts.modified_ns, "shared-hash")
+            .expect("insert original row");
+        batch
+            .set_file_identity(&old_relative, facts.file_identity.as_deref())
+            .expect("store original identity");
+        batch
+            .set_tag(
+                &old_relative,
+                wavecrate_library::sample_sources::Rating::KEEP_1,
+            )
+            .expect("curate original row");
+        batch.commit().expect("commit original row");
+
+        let original = database
+            .entry_for_path(&old_relative)
+            .expect("read original row")
+            .expect("original row");
+        let mut batch = database.write_batch().expect("stage rename batch");
+        batch
+            .stage_pending_rename(&original)
+            .expect("stage pending rename");
+        batch
+            .remove_file(&old_relative)
+            .expect("remove original row");
+        batch.commit().expect("commit pending rename");
+        std::fs::rename(&old_absolute, &new_absolute).expect("rename wav");
+
+        let mut batch = database.write_batch().expect("seed destination batch");
+        batch
+            .upsert_file_with_hash(&new_relative, facts.size, facts.modified_ns, "shared-hash")
+            .expect("insert destination row");
+        batch
+            .set_file_identity(&new_relative, facts.file_identity.as_deref())
+            .expect("store destination identity");
+        batch.commit().expect("commit destination row");
+
+        HashedRenameFixture {
+            _directory: directory,
+            database,
+            old_relative,
+            new_relative,
+        }
+    }
+
+    fn assert_hashed_rename_remains_pending(fixture: &HashedRenameFixture) {
+        assert!(
+            fixture
+                .database
+                .list_pending_renames()
+                .expect("read pending renames")
+                .iter()
+                .any(|entry| entry.relative_path == fixture.old_relative),
+            "rejected reconciliation must preserve pending rename state"
+        );
+        assert_eq!(
+            fixture
+                .database
+                .entry_for_path(&fixture.new_relative)
+                .expect("read destination row")
+                .expect("destination row")
+                .tag,
+            wavecrate_library::sample_sources::Rating::NEUTRAL,
+            "rejected reconciliation must not transfer source metadata"
+        );
     }
 
     impl Drop for ObservedWriterGuard {
@@ -2010,6 +2158,149 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn deferred_rename_excludes_an_outside_link_before_admission() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = hashed_rename_fixture(Path::new("new.wav"));
+        let destination = fixture._directory.path().join(&fixture.new_relative);
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+        std::fs::remove_file(&destination).expect("remove destination");
+        symlink(&outside_file, &destination).expect("replace destination with outside link");
+
+        let stats = deep_hash_scan(
+            &fixture.database,
+            None,
+            &HashSet::from([fixture.new_relative.clone()]),
+            DeferredHashScope::RenameCandidates,
+            None,
+            Some(&fixture.new_relative),
+        )
+        .expect("defer linked rename candidate");
+
+        assert_eq!(stats.renames_reconciled, 0);
+        assert_hashed_rename_remains_pending(&fixture);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_rename_rejects_a_final_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = hashed_rename_fixture(Path::new("new.wav"));
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+
+        let stats = deep_hash_scan_with_hooks(
+            &fixture.database,
+            None,
+            &HashSet::from([fixture.new_relative.clone()]),
+            DeferredHashScope::RenameCandidates,
+            None,
+            Some(&fixture.new_relative),
+            &UncoordinatedScanWriter,
+            |_| {},
+            |path| {
+                let destination = fixture._directory.path().join(path);
+                std::fs::remove_file(&destination).expect("remove destination");
+                symlink(&outside_file, destination).expect("replace destination with outside link");
+            },
+        )
+        .expect("reject late linked rename candidate");
+
+        assert_eq!(stats.renames_reconciled, 0);
+        assert_hashed_rename_remains_pending(&fixture);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deferred_rename_rejects_a_link_ancestor_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = hashed_rename_fixture(Path::new("nested/new.wav"));
+        let outside = tempfile::tempdir().expect("outside directory");
+        std::fs::write(outside.path().join("new.wav"), b"outside").expect("write outside file");
+
+        let stats = deep_hash_scan_with_hooks(
+            &fixture.database,
+            None,
+            &HashSet::from([fixture.new_relative.clone()]),
+            DeferredHashScope::RenameCandidates,
+            None,
+            Some(&fixture.new_relative),
+            &UncoordinatedScanWriter,
+            |_| {},
+            |_| {
+                let nested = fixture._directory.path().join("nested");
+                std::fs::rename(&nested, fixture._directory.path().join("moved"))
+                    .expect("move destination ancestor");
+                symlink(outside.path(), nested).expect("replace ancestor with outside link");
+            },
+        )
+        .expect("reject late linked rename ancestor");
+
+        assert_eq!(stats.renames_reconciled, 0);
+        assert_hashed_rename_remains_pending(&fixture);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fast_hashed_rename_rejects_a_final_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = hashed_rename_fixture(Path::new("new.wav"));
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+
+        let reconciled = reconcile_hashed_rename_candidates_with_hook(
+            &fixture.database,
+            &HashSet::from([fixture.new_relative.clone()]),
+            None,
+            &UncoordinatedScanWriter,
+            |path| {
+                let destination = fixture._directory.path().join(path);
+                std::fs::remove_file(&destination).expect("remove destination");
+                symlink(&outside_file, destination).expect("replace destination with outside link");
+            },
+        )
+        .expect("reject late linked fast candidate");
+
+        assert!(reconciled.is_empty());
+        assert_hashed_rename_remains_pending(&fixture);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fast_hashed_rename_rejects_a_link_ancestor_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = hashed_rename_fixture(Path::new("nested/new.wav"));
+        let outside = tempfile::tempdir().expect("outside directory");
+        std::fs::write(outside.path().join("new.wav"), b"outside").expect("write outside file");
+
+        let reconciled = reconcile_hashed_rename_candidates_with_hook(
+            &fixture.database,
+            &HashSet::from([fixture.new_relative.clone()]),
+            None,
+            &UncoordinatedScanWriter,
+            |_| {
+                let nested = fixture._directory.path().join("nested");
+                std::fs::rename(&nested, fixture._directory.path().join("moved"))
+                    .expect("move destination ancestor");
+                symlink(outside.path(), nested).expect("replace ancestor with outside link");
+            },
+        )
+        .expect("reject late linked fast ancestor");
+
+        assert!(reconciled.is_empty());
+        assert_hashed_rename_remains_pending(&fixture);
+    }
+
     #[test]
     fn hashed_rename_reconciliation_rejects_a_stale_manifest_revision() {
         let dir = tempfile::tempdir().expect("temp source");
@@ -2018,11 +2309,20 @@ mod tests {
         let old_absolute = dir.path().join(old_relative);
         let new_absolute = dir.path().join(new_relative);
         std::fs::write(&old_absolute, [5_u8; 32]).expect("write original wav");
+        let original_facts = read_facts(dir.path(), &old_absolute).expect("read original facts");
         let db = SourceDatabase::open_for_source_write(dir.path()).expect("source db");
         let mut batch = db.write_batch().expect("seed source batch");
         batch
-            .upsert_file_with_hash(old_relative, 32, 1, "shared-hash")
+            .upsert_file_with_hash(
+                old_relative,
+                original_facts.size,
+                original_facts.modified_ns,
+                "shared-hash",
+            )
             .expect("insert original row");
+        batch
+            .set_file_identity(old_relative, original_facts.file_identity.as_deref())
+            .expect("store original identity");
         batch
             .set_tag(
                 old_relative,
@@ -2046,8 +2346,16 @@ mod tests {
         std::fs::rename(&old_absolute, &new_absolute).expect("rename wav");
         let mut batch = db.write_batch().expect("seed destination batch");
         batch
-            .upsert_file_with_hash(new_relative, 32, 1, "shared-hash")
+            .upsert_file_with_hash(
+                new_relative,
+                original_facts.size,
+                original_facts.modified_ns,
+                "shared-hash",
+            )
             .expect("insert destination row");
+        batch
+            .set_file_identity(new_relative, original_facts.file_identity.as_deref())
+            .expect("store destination identity");
         batch.commit().expect("commit destination row");
 
         let writer = InterleavedManifestWriter {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -85,8 +85,8 @@ pub fn sync_paths_with_progress_and_writer(
             }
             let absolute = root.join(&targeted_file.relative);
             let mut prepared_file = prepare_diff_from_facts(targeted_file.facts, &context);
-            prepared_file.targeted_file = Some(targeted_file.file);
-            prepared_file.targeted_handle_verified = true;
+            prepared_file.source_file = Some(targeted_file.file);
+            prepared_file.source_handle_verified = true;
             prepared.push(prepared_file);
             context.stats.total_files += 1;
             on_progress(context.stats.total_files, &absolute);

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -36,6 +36,7 @@ pub(super) fn walk_phase(
     // resumes from the durable partial index without presenting it as a complete generation.
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
+    let mut pending_noops = Vec::with_capacity(APPLY_BATCH_SIZE);
     let source_root = SourceRootCapability::open(root)?;
     let source_tree_snapshot =
         visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
@@ -93,8 +94,21 @@ pub(super) fn walk_phase(
                 prepared = refreshed;
             }
             if !prepared.requires_apply {
-                skip_noop(context, &prepared);
-                context.record_manifest_audit_paths(db, [relative_path])?;
+                if context.resumable_manifest_audit_active() {
+                    context.record_manifest_audit_paths([relative_path]);
+                    pending_noops.push(prepared);
+                    if context.manifest_audit_checkpoint_due() {
+                        flush_manifest_audit_checkpoint_with_noops(
+                            db,
+                            root,
+                            &source_root,
+                            context,
+                            &mut pending_noops,
+                        )?;
+                    }
+                } else {
+                    skip_noop(context, &prepared);
+                }
                 publish_manifest_audit_progress(context, root, path, on_progress);
                 return Ok(());
             }
@@ -107,7 +121,16 @@ pub(super) fn walk_phase(
                     committed.set(true);
                 }
                 let last_path = outcome.audited_paths.last().cloned();
-                context.record_manifest_audit_paths(db, outcome.audited_paths)?;
+                context.record_manifest_audit_paths(outcome.audited_paths);
+                if context.manifest_audit_checkpoint_due() {
+                    flush_manifest_audit_checkpoint_with_noops(
+                        db,
+                        root,
+                        &source_root,
+                        context,
+                        &mut pending_noops,
+                    )?;
+                }
                 if let Some(last_path) = last_path {
                     publish_manifest_audit_progress(
                         context,
@@ -125,12 +148,18 @@ pub(super) fn walk_phase(
             committed.set(true);
         }
         let last_path = outcome.audited_paths.last().cloned();
-        context.record_manifest_audit_paths(db, outcome.audited_paths)?;
+        context.record_manifest_audit_paths(outcome.audited_paths);
         if let Some(last_path) = last_path {
             publish_manifest_audit_progress(context, root, &root.join(last_path), on_progress);
         }
     }
-    context.flush_manifest_audit_checkpoint(db)?;
+    flush_manifest_audit_checkpoint_with_noops(
+        db,
+        root,
+        &source_root,
+        context,
+        &mut pending_noops,
+    )?;
     context.mark_uncertain_prefixes(source_tree_snapshot.uncertain_prefixes.clone());
     context.observe_index_entries(source_tree_snapshot.index_entries.clone());
     context.stats.source_tree_snapshot =
@@ -148,6 +177,68 @@ fn finalize_source_tree_snapshot(
         ));
     }
     source_tree_snapshot
+}
+
+fn flush_manifest_audit_checkpoint_with_noops(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    context: &mut ScanContext,
+    pending_noops: &mut Vec<PreparedFile>,
+) -> Result<(), ScanError> {
+    flush_manifest_audit_checkpoint_with_noops_hook(
+        db,
+        root,
+        source_root,
+        context,
+        pending_noops,
+        |_| {},
+    )
+}
+
+fn flush_manifest_audit_checkpoint_with_noops_hook(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    context: &mut ScanContext,
+    pending_noops: &mut Vec<PreparedFile>,
+    mut precheckpoint: impl FnMut(&Path),
+) -> Result<(), ScanError> {
+    for prepared in pending_noops.iter() {
+        precheckpoint(&prepared.facts.relative);
+    }
+    let retained = std::mem::take(pending_noops);
+    let mut valid = Vec::with_capacity(retained.len());
+    let mut invalid_paths = Vec::new();
+    for prepared in retained {
+        let relative_path = prepared.facts.relative.clone();
+        let Some(file) = prepared.source_file.as_ref() else {
+            context.existing.remove(&relative_path);
+            invalid_paths.push(relative_path);
+            context.mark_source_tree_incomplete();
+            continue;
+        };
+        let absolute = root.join(&relative_path);
+        let descriptor_matches = read_facts_from_open_file(root, &absolute, file)
+            .is_ok_and(|facts| prepared_still_current(&prepared, &facts));
+        let binding = source_root
+            .path_binding(&relative_path, file)
+            .unwrap_or(SourcePathBinding::Changed);
+        if descriptor_matches && binding == SourcePathBinding::Matches {
+            skip_noop(context, &prepared);
+            valid.push(prepared);
+            continue;
+        }
+        if binding != SourcePathBinding::Retire {
+            context.existing.remove(&relative_path);
+        }
+        invalid_paths.push(relative_path);
+        context.mark_source_tree_incomplete();
+    }
+    context.discard_manifest_audit_paths(invalid_paths);
+    context.flush_manifest_audit_checkpoint(db)?;
+    drop(valid);
+    Ok(())
 }
 
 fn publish_manifest_audit_progress(
@@ -686,8 +777,9 @@ fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
 mod tests {
     use super::{
         PrepareForApply, SourceRootCapability, apply_batch, apply_batch_with_precommit_hook,
-        finalize_source_tree_snapshot, prepare_diff_from_capability, prepare_for_apply,
-        prepare_for_apply_with_post_hash_hook, refresh_noop_preparation_or_skip,
+        finalize_source_tree_snapshot, flush_manifest_audit_checkpoint_with_noops_hook,
+        prepare_diff_from_capability, prepare_for_apply, prepare_for_apply_with_post_hash_hook,
+        refresh_noop_preparation_or_skip,
     };
     use crate::sample_sources::SourceDatabase;
     use crate::sample_sources::scanner::scan::{ScanContext, ScanMode, scan_once};
@@ -808,6 +900,128 @@ mod tests {
         assert!(refreshed.is_none());
         assert!(context.source_tree_incomplete());
         assert!(context.existing.contains_key(relative));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn manifest_audit_noop_rejects_a_final_link_before_checkpoint() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let relative = Path::new("one.wav");
+        let source = dir.path().join(relative);
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        let entry = db.entry_for_path(relative).unwrap().unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::from([(relative.to_path_buf(), entry)]),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        context.resume_manifest_audit(&db, 100).unwrap();
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let prepared = prepare_diff_from_capability(&source_root, dir.path(), relative, &context)
+            .unwrap()
+            .unwrap();
+        let prepared = refresh_noop_preparation_or_skip(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            prepared,
+            false,
+        )
+        .unwrap()
+        .unwrap();
+        context.record_manifest_audit_paths([relative.to_path_buf()]);
+        let mut pending_noops = vec![prepared];
+
+        flush_manifest_audit_checkpoint_with_noops_hook(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            &mut pending_noops,
+            |_| {
+                std::fs::remove_file(&source).unwrap();
+                symlink(&outside_file, &source).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !db.begin_or_resume_manifest_audit(101)
+                .unwrap()
+                .contains(&relative.to_path_buf())
+        );
+        assert!(context.existing.contains_key(relative));
+        assert!(context.source_tree_incomplete());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn manifest_audit_noop_rejects_a_link_ancestor_before_checkpoint() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        let relative = Path::new("nested/one.wav");
+        std::fs::write(nested.join("one.wav"), b"inside").unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("one.wav"), b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        let entry = db.entry_for_path(relative).unwrap().unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::from([(relative.to_path_buf(), entry)]),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        context.resume_manifest_audit(&db, 100).unwrap();
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let prepared = prepare_diff_from_capability(&source_root, dir.path(), relative, &context)
+            .unwrap()
+            .unwrap();
+        let prepared = refresh_noop_preparation_or_skip(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            prepared,
+            false,
+        )
+        .unwrap()
+        .unwrap();
+        context.record_manifest_audit_paths([relative.to_path_buf()]);
+        let mut pending_noops = vec![prepared];
+
+        flush_manifest_audit_checkpoint_with_noops_hook(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            &mut pending_noops,
+            |_| {
+                std::fs::rename(&nested, dir.path().join("moved")).unwrap();
+                symlink(outside.path(), &nested).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !db.begin_or_resume_manifest_audit(101)
+                .unwrap()
+                .contains(&relative.to_path_buf())
+        );
+        assert!(context.existing.contains_key(relative));
+        assert!(context.source_tree_incomplete());
     }
 
     #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -305,17 +305,46 @@ fn refresh_noop_preparation(
     let relative_path = prepared.facts.relative.clone();
     let current = db.entry_for_path(&relative_path)?;
     let snapshot = context.existing.get(&relative_path);
-    if current
-        .as_ref()
-        .zip(snapshot)
-        .is_some_and(|(entry, snapshot)| {
-            !entry.missing
-                && entry.file_size == prepared.facts.size
-                && entry.modified_ns == prepared.facts.modified_ns
-                && entry.content_hash == snapshot.content_hash
-        })
-    {
-        return Ok(Some(prepared));
+    let database_snapshot_matches =
+        current
+            .as_ref()
+            .zip(snapshot)
+            .is_some_and(|(entry, snapshot)| {
+                !entry.missing
+                    && entry.file_size == prepared.facts.size
+                    && entry.modified_ns == prepared.facts.modified_ns
+                    && entry.content_hash == snapshot.content_hash
+            });
+    if database_snapshot_matches {
+        let mut prepared = prepared;
+        let file = match prepared.source_file.take() {
+            Some(file) => file,
+            None => {
+                let Some(file) = source_root.open_regular_file(&relative_path)? else {
+                    return Ok(None);
+                };
+                file
+            }
+        };
+        let absolute = root.join(&relative_path);
+        let descriptor_matches = read_facts_from_open_file(root, &absolute, &file)
+            .is_ok_and(|facts| prepared_still_current(&prepared, &facts));
+        match source_root
+            .path_binding(&relative_path, &file)
+            .unwrap_or(SourcePathBinding::Changed)
+        {
+            SourcePathBinding::Matches if descriptor_matches => {
+                prepared.source_file = Some(file);
+                prepared.source_handle_verified = true;
+                return Ok(Some(prepared));
+            }
+            // Leave the prior row eligible for missing reconciliation.
+            SourcePathBinding::Retire => return Ok(None),
+            SourcePathBinding::Matches | SourcePathBinding::Changed => {
+                context.existing.remove(&relative_path);
+                return Ok(None);
+            }
+        }
     }
     match current {
         Some(entry) => {
@@ -734,6 +763,51 @@ mod tests {
         assert!(context.source_tree_incomplete());
         let snapshot = finalize_source_tree_snapshot(&context, Default::default());
         assert!(!snapshot.is_complete());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_scan_noop_does_not_audit_a_late_outside_link_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let relative = Path::new("one.wav");
+        let source = dir.path().join(relative);
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        scan_once(&db).unwrap();
+        let entry = db.entry_for_path(relative).unwrap().unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::from([(relative.to_path_buf(), entry)]),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let prepared = prepare_diff_from_capability(&source_root, dir.path(), relative, &context)
+            .unwrap()
+            .unwrap();
+        assert!(!prepared.requires_apply);
+
+        std::fs::remove_file(&source).unwrap();
+        symlink(&outside_file, &source).unwrap();
+
+        let refreshed = refresh_noop_preparation_or_skip(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            prepared,
+            false,
+        )
+        .unwrap();
+
+        assert!(refreshed.is_none());
+        assert!(context.source_tree_incomplete());
+        assert!(context.existing.contains_key(relative));
     }
 
     #[test]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -3,22 +3,20 @@
 use std::{
     cell::Cell,
     io::{Seek, SeekFrom},
-    path::{Component, Path, PathBuf},
+    path::Path,
     sync::atomic::{AtomicBool, Ordering},
 };
-
-use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
-use cap_std::fs::{Dir, OpenOptions};
 
 use crate::sample_sources::SourceDatabase;
 use wavecrate_library::sample_sources::SourceIndexDiagnostic;
 
 use super::scan::{ScanContext, ScanError};
+use super::scan_capability::{SourcePathBinding, SourceRootCapability};
 use super::scan_diff::{PreparedFile, apply_diff};
 use super::scan_diff_phase::prepare_diff;
 use super::scan_fs::{
-    compute_content_hash, compute_content_hash_with_reader, is_supported_scannable_audio_file,
-    read_facts, read_facts_from_open_file, visit_dir_with_cancel_check,
+    compute_content_hash_with_reader, is_supported_scannable_audio_file, read_facts_from_open_file,
+    visit_dir_with_cancel_check,
 };
 use super::scan_index::inaccessible_index_entry;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
@@ -272,10 +270,19 @@ fn apply_batch(
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
 ) -> Result<ApplyBatchOutcome, ScanError> {
+    let source_root = SourceRootCapability::open(root)?;
     let mut ready = Vec::with_capacity(prepared.len());
+    let mut post_hash = |_: &Path| {};
     for file in prepared {
         let relative_path = file.facts.relative.clone();
-        let outcome = match prepare_for_apply(db, root, cancel, file) {
+        let outcome = match prepare_for_apply_with_capability(
+            db,
+            root,
+            &source_root,
+            cancel,
+            file,
+            &mut post_hash,
+        ) {
             Ok(outcome) => outcome,
             Err(ScanError::Canceled) => return Err(ScanError::Canceled),
             Err(error) if tolerate_file_errors => {
@@ -314,31 +321,27 @@ fn apply_batch(
     let mut audited_paths = Vec::with_capacity(ready.len());
     for file in ready {
         let relative_path = file.facts.relative.clone();
-        if file.targeted_handle_verified {
-            let file_handle = file
-                .targeted_file
-                .as_ref()
-                .expect("verified targeted files retain their descriptor through apply");
-            match targeted_path_binding(root, &relative_path, file_handle)? {
-                TargetedPathBinding::Matches => {}
-                // A link or absence is a definite deletion: leave its old row
-                // in `existing` for the missing phase to retire.
-                TargetedPathBinding::Retire => continue,
-                TargetedPathBinding::Changed => {
-                    context.mark_source_tree_incomplete();
-                    context.existing.remove(&relative_path);
-                    continue;
-                }
-            }
-        } else {
-            let absolute = root.join(&relative_path);
-            match read_facts(root, &absolute) {
-                Ok(current) if prepared_still_current(&file, &current) => {}
-                _ => {
-                    context.mark_source_tree_incomplete();
-                    skip_changed_or_unavailable(context, root, &relative_path);
-                    continue;
-                }
+        let file_handle = file
+            .source_file
+            .as_ref()
+            .expect("prepared source files retain their descriptor through apply");
+        let absolute = root.join(&relative_path);
+        let descriptor_still_current = read_facts_from_open_file(root, &absolute, file_handle)
+            .is_ok_and(|current| prepared_still_current(&file, &current));
+        if !descriptor_still_current {
+            context.mark_source_tree_incomplete();
+            context.existing.remove(&relative_path);
+            continue;
+        }
+        match source_root.path_binding(&relative_path, file_handle)? {
+            SourcePathBinding::Matches => {}
+            // A link or absence is a definite deletion: leave its old row in
+            // `existing` for the missing phase to retire.
+            SourcePathBinding::Retire => continue,
+            SourcePathBinding::Changed => {
+                context.mark_source_tree_incomplete();
+                context.existing.remove(&relative_path);
+                continue;
             }
         }
         apply_diff(db, &mut batch, file, context)?;
@@ -372,6 +375,7 @@ enum PrepareForApply {
     Skip,
 }
 
+#[cfg(test)]
 fn prepare_for_apply(
     db: &SourceDatabase,
     root: &Path,
@@ -381,81 +385,49 @@ fn prepare_for_apply(
     prepare_for_apply_with_post_hash_hook(db, root, cancel, prepared, |_| {})
 }
 
+#[cfg(test)]
 fn prepare_for_apply_with_post_hash_hook(
     db: &SourceDatabase,
     root: &Path,
     cancel: Option<&AtomicBool>,
-    mut prepared: PreparedFile,
+    prepared: PreparedFile,
     mut post_hash: impl FnMut(&Path),
 ) -> Result<PrepareForApply, ScanError> {
-    if prepared.targeted_handle_verified {
-        return prepare_targeted_for_apply(db, root, cancel, prepared, &mut post_hash);
-    }
-    let absolute = root.join(&prepared.facts.relative);
-    if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
-        return Ok(PrepareForApply::Gone);
-    }
-    let Ok(before_hash) = read_facts(root, &absolute) else {
-        return Ok(if absolute.exists() {
-            PrepareForApply::Skip
-        } else {
-            PrepareForApply::Gone
-        });
-    };
-    if !facts_match(&prepared, &before_hash) {
-        return Ok(PrepareForApply::Skip);
-    }
-    let current_needs_hash = db
-        .entry_for_path(&prepared.facts.relative)?
-        .is_none_or(|entry| {
-            entry.file_size != prepared.facts.size
-                || entry.modified_ns != prepared.facts.modified_ns
-                || entry.content_hash.is_none()
-        });
-    if prepared.hash_required && (prepared.needs_hash || current_needs_hash) {
-        prepared.facts = before_hash;
-        prepared.content_hash = Some(compute_content_hash(&absolute, cancel)?);
-        post_hash(&absolute);
-        let Ok(after_hash) = read_facts(root, &absolute) else {
-            return Ok(if absolute.exists() {
-                PrepareForApply::Skip
-            } else {
-                PrepareForApply::Gone
-            });
-        };
-        if !is_supported_scannable_audio_file(root, &prepared.facts.relative) {
-            return Ok(PrepareForApply::Gone);
-        }
-        if !prepared.facts.same_content_snapshot(&after_hash) {
-            return Ok(PrepareForApply::Skip);
-        }
-    }
-    Ok(PrepareForApply::Ready(prepared))
+    let source_root = SourceRootCapability::open(root)?;
+    prepare_for_apply_with_capability(db, root, &source_root, cancel, prepared, &mut post_hash)
 }
 
-fn prepare_targeted_for_apply(
+fn prepare_for_apply_with_capability(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     cancel: Option<&AtomicBool>,
     mut prepared: PreparedFile,
     post_hash: &mut impl FnMut(&Path),
 ) -> Result<PrepareForApply, ScanError> {
     let absolute = root.join(&prepared.facts.relative);
+    if !prepared.source_handle_verified {
+        let Some(file) = source_root.open_regular_file(&prepared.facts.relative)? else {
+            return Ok(PrepareForApply::Gone);
+        };
+        prepared.source_file = Some(file);
+        prepared.source_handle_verified = true;
+    }
     let before_hash = read_facts_from_open_file(
         root,
         &absolute,
         prepared
-            .targeted_file
+            .source_file
             .as_ref()
-            .expect("verified targeted files retain their open descriptor until preparation"),
+            .expect("verified source files retain their open descriptor until preparation"),
     )?;
     if !facts_match(&prepared, &before_hash) {
         return Ok(PrepareForApply::Skip);
     }
     let file = prepared
-        .targeted_file
+        .source_file
         .as_mut()
-        .expect("verified targeted files retain their open descriptor until preparation");
+        .expect("verified source files retain their open descriptor until preparation");
     let current_needs_hash = db
         .entry_for_path(&prepared.facts.relative)?
         .is_none_or(|entry| {
@@ -477,143 +449,10 @@ fn prepare_targeted_for_apply(
             return Ok(PrepareForApply::Skip);
         }
         prepared.facts = after_hash;
+    } else {
+        prepared.facts = before_hash;
     }
     Ok(PrepareForApply::Ready(prepared))
-}
-
-/// Confirm that the path used as the manifest key is still bound to the same
-/// no-follow file descriptor that targeted discovery classified and hashed.
-enum TargetedPathBinding {
-    Matches,
-    Retire,
-    Changed,
-}
-
-fn targeted_path_binding(
-    root: &Path,
-    relative_path: &Path,
-    expected: &std::fs::File,
-) -> Result<TargetedPathBinding, ScanError> {
-    let source_root =
-        Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
-    let Some((parent, name)) = open_target_parent_nofollow(&source_root, root, relative_path)?
-    else {
-        return Ok(TargetedPathBinding::Retire);
-    };
-    let mut options = OpenOptions::new();
-    options.read(true).follow(FollowSymlinks::No);
-    let current = match parent.open_with(&name, &options) {
-        Ok(file) => file.into_std(),
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(TargetedPathBinding::Retire);
-        }
-        Err(source) => {
-            if parent
-                .symlink_metadata(&name)
-                .is_ok_and(|metadata| metadata.is_symlink())
-            {
-                return Ok(TargetedPathBinding::Retire);
-            }
-            tracing::warn!(
-                path = %root.join(relative_path).display(),
-                error = %source,
-                "Skipping targeted sync path that no longer opens without following links"
-            );
-            return Ok(TargetedPathBinding::Changed);
-        }
-    };
-    if !current.metadata().is_ok_and(|metadata| metadata.is_file()) {
-        return Ok(TargetedPathBinding::Retire);
-    }
-    let matches = same_open_file(expected, &current).map_err(|source| ScanError::Io {
-        path: root.join(relative_path),
-        source,
-    })?;
-    Ok(if matches {
-        TargetedPathBinding::Matches
-    } else {
-        TargetedPathBinding::Changed
-    })
-}
-
-fn open_target_parent_nofollow(
-    source_root: &Dir,
-    root: &Path,
-    relative_path: &Path,
-) -> Result<Option<(Dir, PathBuf)>, ScanError> {
-    let Some(name) = relative_path.file_name() else {
-        return Ok(None);
-    };
-    let mut dir = source_root.try_clone().map_err(|source| ScanError::Io {
-        path: root.to_path_buf(),
-        source,
-    })?;
-    let mut traversed = PathBuf::new();
-    for component in relative_path
-        .parent()
-        .into_iter()
-        .flat_map(Path::components)
-    {
-        let Component::Normal(part) = component else {
-            continue;
-        };
-        traversed.push(part);
-        dir = match dir.open_dir_nofollow(part) {
-            Ok(dir) => dir,
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(source) => {
-                if dir
-                    .symlink_metadata(part)
-                    .is_ok_and(|metadata| metadata.is_symlink())
-                {
-                    return Ok(None);
-                }
-                return Err(ScanError::Io {
-                    path: root.join(&traversed),
-                    source,
-                });
-            }
-        };
-    }
-    Ok(Some((dir, PathBuf::from(name))))
-}
-
-#[cfg(unix)]
-fn same_open_file(left: &std::fs::File, right: &std::fs::File) -> std::io::Result<bool> {
-    use std::os::unix::fs::MetadataExt;
-
-    let left = left.metadata()?;
-    let right = right.metadata()?;
-    Ok(left.dev() == right.dev() && left.ino() == right.ino())
-}
-
-#[cfg(windows)]
-fn same_open_file(left: &std::fs::File, right: &std::fs::File) -> std::io::Result<bool> {
-    use std::os::windows::io::AsRawHandle;
-    use windows::Win32::{
-        Foundation::HANDLE,
-        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
-    };
-
-    let information = |file: &std::fs::File| {
-        let mut information = BY_HANDLE_FILE_INFORMATION::default();
-        unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }
-            .map_err(std::io::Error::other)?;
-        Ok::<_, std::io::Error>((
-            information.dwVolumeSerialNumber,
-            information.nFileIndexHigh,
-            information.nFileIndexLow,
-        ))
-    };
-    Ok(information(left)? == information(right)?)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn same_open_file(_left: &std::fs::File, _right: &std::fs::File) -> std::io::Result<bool> {
-    Ok(false)
 }
 
 fn facts_match(prepared: &PreparedFile, current: &super::scan_fs::FileFacts) -> bool {
@@ -662,8 +501,8 @@ mod tests {
             requires_apply: true,
             identity_replaced: false,
             content_hash: None,
-            targeted_file: None,
-            targeted_handle_verified: false,
+            source_file: None,
+            source_handle_verified: false,
         };
 
         assert!(prepared.requires_apply);
@@ -754,8 +593,8 @@ mod tests {
             requires_apply: true,
             identity_replaced: false,
             content_hash: None,
-            targeted_file: None,
-            targeted_handle_verified: false,
+            source_file: None,
+            source_handle_verified: false,
         };
 
         let outcome =
@@ -764,6 +603,67 @@ mod tests {
             })
             .unwrap();
 
+        assert!(matches!(outcome, PrepareForApply::Skip));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_scan_hash_open_rejects_an_outside_link_replacement_after_classification() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("one.wav");
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let prepared = prepare_diff(dir.path(), &source, &context).unwrap();
+
+        std::fs::remove_file(&source).unwrap();
+        symlink(&outside_file, &source).unwrap();
+
+        assert!(matches!(
+            prepare_for_apply(&db, dir.path(), None, prepared).unwrap(),
+            PrepareForApply::Gone
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_scan_hash_rejects_an_outside_link_replacement_during_hashing() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("one.wav");
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let prepared = PreparedFile {
+            facts: read_facts(dir.path(), &source).unwrap(),
+            hash_required: true,
+            needs_hash: true,
+            requires_apply: true,
+            identity_replaced: false,
+            content_hash: None,
+            source_file: None,
+            source_handle_verified: false,
+        };
+
+        let outcome =
+            prepare_for_apply_with_post_hash_hook(&db, dir.path(), None, prepared, |path| {
+                std::fs::remove_file(path).unwrap();
+                symlink(&outside_file, path).unwrap();
+            })
+            .unwrap();
         assert!(matches!(outcome, PrepareForApply::Skip));
     }
 
@@ -784,8 +684,11 @@ mod tests {
         symlink(&outside_file, &source).unwrap();
 
         assert!(matches!(
-            super::targeted_path_binding(dir.path(), Path::new("one.wav"), &expected).unwrap(),
-            super::TargetedPathBinding::Retire
+            super::SourceRootCapability::open(dir.path())
+                .unwrap()
+                .path_binding(Path::new("one.wav"), &expected)
+                .unwrap(),
+            super::SourcePathBinding::Retire
         ));
     }
 
@@ -807,9 +710,11 @@ mod tests {
         symlink(outside.path(), &nested).unwrap();
 
         assert!(matches!(
-            super::targeted_path_binding(dir.path(), Path::new("nested/one.wav"), &expected,)
+            super::SourceRootCapability::open(dir.path())
+                .unwrap()
+                .path_binding(Path::new("nested/one.wav"), &expected)
                 .unwrap(),
-            super::TargetedPathBinding::Retire
+            super::SourcePathBinding::Retire
         ));
     }
 
@@ -842,8 +747,8 @@ mod tests {
             requires_apply: true,
             identity_replaced: false,
             content_hash: None,
-            targeted_file: Some(file),
-            targeted_handle_verified: true,
+            source_file: Some(file),
+            source_handle_verified: true,
         };
 
         std::fs::remove_file(&source).unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -13,7 +13,7 @@ use wavecrate_library::sample_sources::SourceIndexDiagnostic;
 use super::scan::{ScanContext, ScanError};
 use super::scan_capability::{SourcePathBinding, SourceRootCapability};
 use super::scan_diff::{PreparedFile, apply_diff};
-use super::scan_diff_phase::prepare_diff;
+use super::scan_diff_phase::prepare_diff_from_facts;
 use super::scan_fs::{
     compute_content_hash_with_reader, is_supported_scannable_audio_file, read_facts_from_open_file,
     visit_dir_with_cancel_check,
@@ -36,6 +36,7 @@ pub(super) fn walk_phase(
     // resumes from the durable partial index without presenting it as a complete generation.
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
+    let source_root = SourceRootCapability::open(root)?;
     let source_tree_snapshot =
         visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
             if cancel_requested(cancel) {
@@ -48,25 +49,29 @@ pub(super) fn walk_phase(
             if context.skip_previously_audited_path(&relative_path) {
                 return Ok(());
             }
-            let mut prepared = match prepare_diff(root, path, context) {
-                Ok(prepared) => prepared,
-                Err(error) => {
-                    context.mark_source_tree_incomplete();
-                    context.existing.remove(&relative_path);
-                    context.mark_uncertain_prefixes([relative_path.clone()]);
-                    context.observe_index_entries([inaccessible_index_entry(
-                        relative_path,
-                        SourceIndexDiagnostic::MetadataUnavailable,
-                    )]);
-                    tracing::warn!(
-                        path = %path.display(),
-                        error = %error,
-                        committed = committed.get(),
-                        "Persisting an inaccessible supported file for retry"
-                    );
-                    return Ok(());
-                }
-            };
+            let mut prepared =
+                match prepare_diff_from_capability(&source_root, root, &relative_path, context) {
+                    Ok(Some(prepared)) => prepared,
+                    Ok(None) => {
+                        record_unavailable_preparation(
+                            context,
+                            relative_path,
+                            path,
+                            committed.get(),
+                        );
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        record_inaccessible_preparation(
+                            context,
+                            relative_path,
+                            path,
+                            committed.get(),
+                            &error,
+                        );
+                        return Ok(());
+                    }
+                };
             if !context.resumable_manifest_audit_active() {
                 context.stats.total_files += 1;
                 if let Some(on_progress) = on_progress.as_mut() {
@@ -74,8 +79,14 @@ pub(super) fn walk_phase(
                 }
             }
             if !prepared.requires_apply {
-                let Some(refreshed) =
-                    refresh_noop_preparation_or_skip(db, root, context, prepared, committed.get())?
+                let Some(refreshed) = refresh_noop_preparation_or_skip(
+                    db,
+                    root,
+                    &source_root,
+                    context,
+                    prepared,
+                    committed.get(),
+                )?
                 else {
                     return Ok(());
                 };
@@ -153,6 +164,61 @@ fn publish_manifest_audit_progress(
     }
 }
 
+fn prepare_diff_from_capability(
+    source_root: &SourceRootCapability,
+    root: &Path,
+    relative_path: &Path,
+    context: &ScanContext,
+) -> Result<Option<PreparedFile>, ScanError> {
+    let Some(file) = source_root.open_regular_file(relative_path)? else {
+        return Ok(None);
+    };
+    let absolute = root.join(relative_path);
+    let facts = read_facts_from_open_file(root, &absolute, &file)?;
+    let mut prepared = prepare_diff_from_facts(facts, context);
+    prepared.source_file = Some(file);
+    prepared.source_handle_verified = true;
+    Ok(Some(prepared))
+}
+
+fn record_unavailable_preparation(
+    context: &mut ScanContext,
+    relative_path: std::path::PathBuf,
+    path: &Path,
+    committed: bool,
+) {
+    context.mark_source_tree_incomplete();
+    context.existing.remove(&relative_path);
+    context.mark_uncertain_prefixes([relative_path]);
+    tracing::warn!(
+        path = %path.display(),
+        committed,
+        "Persisting a source file that no longer opens without following links for retry"
+    );
+}
+
+fn record_inaccessible_preparation(
+    context: &mut ScanContext,
+    relative_path: std::path::PathBuf,
+    path: &Path,
+    committed: bool,
+    error: &ScanError,
+) {
+    context.mark_source_tree_incomplete();
+    context.existing.remove(&relative_path);
+    context.mark_uncertain_prefixes([relative_path.clone()]);
+    context.observe_index_entries([inaccessible_index_entry(
+        relative_path,
+        SourceIndexDiagnostic::MetadataUnavailable,
+    )]);
+    tracing::warn!(
+        path = %path.display(),
+        %error,
+        committed,
+        "Persisting an inaccessible supported file for retry"
+    );
+}
+
 pub(super) fn apply_prepared_chunk(
     db: &SourceDatabase,
     root: &Path,
@@ -162,11 +228,18 @@ pub(super) fn apply_prepared_chunk(
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
 ) -> Result<bool, ScanError> {
+    let source_root = SourceRootCapability::open(root)?;
     let mut pending = Vec::with_capacity(prepared.len());
     for mut file in prepared {
         if !file.requires_apply {
-            let Some(refreshed) =
-                refresh_noop_preparation_or_skip(db, root, context, file, tolerate_file_errors)?
+            let Some(refreshed) = refresh_noop_preparation_or_skip(
+                db,
+                root,
+                &source_root,
+                context,
+                file,
+                tolerate_file_errors,
+            )?
             else {
                 continue;
             };
@@ -196,13 +269,18 @@ pub(super) fn apply_prepared_chunk(
 fn refresh_noop_preparation_or_skip(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     context: &mut ScanContext,
     prepared: PreparedFile,
     tolerate_file_errors: bool,
 ) -> Result<Option<PreparedFile>, ScanError> {
     let relative_path = prepared.facts.relative.clone();
-    match refresh_noop_preparation(db, root, context, prepared) {
-        Ok(prepared) => Ok(Some(prepared)),
+    match refresh_noop_preparation(db, root, source_root, context, prepared) {
+        Ok(Some(prepared)) => Ok(Some(prepared)),
+        Ok(None) => {
+            context.mark_source_tree_incomplete();
+            Ok(None)
+        }
         Err(error) if tolerate_file_errors => {
             context.mark_source_tree_incomplete();
             skip_changed_or_unavailable(context, root, &relative_path);
@@ -220,9 +298,10 @@ fn refresh_noop_preparation_or_skip(
 fn refresh_noop_preparation(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     context: &mut ScanContext,
     prepared: PreparedFile,
-) -> Result<PreparedFile, ScanError> {
+) -> Result<Option<PreparedFile>, ScanError> {
     let relative_path = prepared.facts.relative.clone();
     let current = db.entry_for_path(&relative_path)?;
     let snapshot = context.existing.get(&relative_path);
@@ -236,7 +315,7 @@ fn refresh_noop_preparation(
                 && entry.content_hash == snapshot.content_hash
         })
     {
-        return Ok(prepared);
+        return Ok(Some(prepared));
     }
     match current {
         Some(entry) => {
@@ -246,7 +325,7 @@ fn refresh_noop_preparation(
             context.existing.remove(&relative_path);
         }
     }
-    prepare_diff(root, &root.join(relative_path), context)
+    prepare_diff_from_capability(source_root, root, &relative_path, context)
 }
 
 pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {
@@ -269,6 +348,29 @@ fn apply_batch(
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
+) -> Result<ApplyBatchOutcome, ScanError> {
+    apply_batch_with_precommit_hook(
+        db,
+        root,
+        cancel,
+        context,
+        prepared,
+        tolerate_file_errors,
+        writer,
+        |_| {},
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_batch_with_precommit_hook(
+    db: &SourceDatabase,
+    root: &Path,
+    cancel: Option<&AtomicBool>,
+    context: &mut ScanContext,
+    prepared: Vec<PreparedFile>,
+    tolerate_file_errors: bool,
+    writer: &impl ScanWriter,
+    mut precommit: impl FnMut(&Path),
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let source_root = SourceRootCapability::open(root)?;
     let mut ready = Vec::with_capacity(prepared.len());
@@ -317,9 +419,12 @@ fn apply_batch(
         return Err(ScanError::Canceled);
     }
     let mut batch = db.write_batch()?;
+    let stats_before_staging = context.stats.clone();
+    let generation_before_staging = context.rename_candidate_generation;
     context.ensure_rename_candidate_generation(&mut batch)?;
     let mut audited_paths = Vec::with_capacity(ready.len());
-    for file in ready {
+    let mut retained = Vec::with_capacity(ready.len());
+    for mut file in ready {
         let relative_path = file.facts.relative.clone();
         let file_handle = file
             .source_file
@@ -333,7 +438,10 @@ fn apply_batch(
             context.existing.remove(&relative_path);
             continue;
         }
-        match source_root.path_binding(&relative_path, file_handle)? {
+        match source_root
+            .path_binding(&relative_path, file_handle)
+            .unwrap_or(SourcePathBinding::Changed)
+        {
             SourcePathBinding::Matches => {}
             // A link or absence is a definite deletion: leave its old row in
             // `existing` for the missing phase to retire.
@@ -344,17 +452,91 @@ fn apply_batch(
                 continue;
             }
         }
+        let retained_file = file
+            .source_file
+            .take()
+            .expect("validated source files retain their descriptor until commit");
+        let retained_facts = file.facts.clone();
+        let content_was_hashed = file.content_hash.is_some();
+        let existing_before = context.existing.get(&relative_path).cloned();
         apply_diff(db, &mut batch, file, context)?;
-        audited_paths.push(relative_path);
+        audited_paths.push(relative_path.clone());
+        retained.push(RetainedPublication {
+            relative_path,
+            facts: retained_facts,
+            content_was_hashed,
+            file: retained_file,
+            existing_before,
+        });
     }
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
+    }
+    for publication in &retained {
+        precommit(&publication.relative_path);
+    }
+    let final_bindings = retained
+        .iter()
+        .map(|publication| {
+            let absolute = root.join(&publication.relative_path);
+            let descriptor_matches = read_facts_from_open_file(root, &absolute, &publication.file)
+                .is_ok_and(|facts| {
+                    if publication.content_was_hashed {
+                        publication.facts.same_content_snapshot(&facts)
+                    } else {
+                        publication.facts.same_file_facts(&facts)
+                    }
+                });
+            let binding = source_root
+                .path_binding(&publication.relative_path, &publication.file)
+                .unwrap_or(SourcePathBinding::Changed);
+            (
+                publication.relative_path.clone(),
+                descriptor_matches,
+                binding,
+            )
+        })
+        .collect::<Vec<_>>();
+    if final_bindings
+        .iter()
+        .any(|(_, descriptor_matches, binding)| {
+            !descriptor_matches || *binding != SourcePathBinding::Matches
+        })
+    {
+        drop(batch);
+        context.stats = stats_before_staging;
+        context.rename_candidate_generation = generation_before_staging;
+        for publication in &retained {
+            if let Some(existing) = publication.existing_before.clone() {
+                context
+                    .existing
+                    .insert(publication.relative_path.clone(), existing);
+            } else {
+                context.existing.remove(&publication.relative_path);
+            }
+        }
+        for (relative_path, _descriptor_matches, binding) in final_bindings {
+            if binding == SourcePathBinding::Retire {
+                continue;
+            }
+            context.existing.remove(&relative_path);
+        }
+        context.mark_source_tree_incomplete();
+        return Ok(ApplyBatchOutcome::default());
     }
     context.commit_batch(batch)?;
     Ok(ApplyBatchOutcome {
         committed: true,
         audited_paths,
     })
+}
+
+struct RetainedPublication {
+    relative_path: std::path::PathBuf,
+    facts: super::scan_fs::FileFacts,
+    content_was_hashed: bool,
+    file: std::fs::File,
+    existing_before: Option<crate::sample_sources::WavEntry>,
 }
 
 #[derive(Default)]
@@ -474,7 +656,8 @@ fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        PrepareForApply, apply_batch, finalize_source_tree_snapshot, prepare_for_apply,
+        PrepareForApply, SourceRootCapability, apply_batch, apply_batch_with_precommit_hook,
+        finalize_source_tree_snapshot, prepare_diff_from_capability, prepare_for_apply,
         prepare_for_apply_with_post_hash_hook, refresh_noop_preparation_or_skip,
     };
     use crate::sample_sources::SourceDatabase;
@@ -536,9 +719,16 @@ mod tests {
         batch.remove_file(Path::new("one.wav")).unwrap();
         batch.commit().unwrap();
 
-        let refreshed =
-            refresh_noop_preparation_or_skip(&db, dir.path(), &mut context, prepared, true)
-                .unwrap();
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let refreshed = refresh_noop_preparation_or_skip(
+            &db,
+            dir.path(),
+            &source_root,
+            &mut context,
+            prepared,
+            true,
+        )
+        .unwrap();
 
         assert!(refreshed.is_none());
         assert!(context.source_tree_incomplete());
@@ -637,6 +827,71 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn full_scan_fact_collection_rejects_an_outside_link_replacement() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("one.wav");
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+
+        std::fs::remove_file(&source).unwrap();
+        symlink(&outside_file, &source).unwrap();
+
+        assert!(
+            prepare_diff_from_capability(&source_root, dir.path(), Path::new("one.wav"), &context,)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_scan_fact_collection_rejects_an_outside_link_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        let moved = dir.path().join("moved");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("one.wav"), b"inside").unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::write(outside.path().join("one.wav"), b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+
+        std::fs::rename(&nested, &moved).unwrap();
+        symlink(outside.path(), &nested).unwrap();
+
+        assert!(!matches!(
+            prepare_diff_from_capability(
+                &source_root,
+                dir.path(),
+                Path::new("nested/one.wav"),
+                &context,
+            ),
+            Ok(Some(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn full_scan_hash_rejects_an_outside_link_replacement_during_hashing() {
         use std::os::unix::fs::symlink;
 
@@ -665,6 +920,93 @@ mod tests {
             })
             .unwrap();
         assert!(matches!(outcome, PrepareForApply::Skip));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_scan_does_not_publish_an_outside_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let relative = Path::new("one.wav");
+        let source = dir.path().join(relative);
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let prepared = prepare_diff_from_capability(&source_root, dir.path(), relative, &context)
+            .unwrap()
+            .unwrap();
+
+        let outcome = apply_batch_with_precommit_hook(
+            &db,
+            dir.path(),
+            None,
+            &mut context,
+            vec![prepared],
+            false,
+            &super::super::scan_writer::UncoordinatedScanWriter,
+            |path| {
+                let absolute = dir.path().join(path);
+                std::fs::remove_file(&absolute).unwrap();
+                symlink(&outside_file, absolute).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(!outcome.committed);
+        assert!(context.source_tree_incomplete());
+        assert!(db.entry_for_path(relative).unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn targeted_sync_does_not_publish_an_outside_link_replacement_before_commit() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let relative = Path::new("one.wav");
+        let source = dir.path().join(relative);
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.wav");
+        std::fs::write(&source, b"inside").unwrap();
+        std::fs::write(&outside_file, b"outside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let prepared = prepare_diff(dir.path(), &source, &context).unwrap();
+
+        let outcome = apply_batch_with_precommit_hook(
+            &db,
+            dir.path(),
+            None,
+            &mut context,
+            vec![prepared],
+            false,
+            &super::super::scan_writer::UncoordinatedScanWriter,
+            |path| {
+                let absolute = dir.path().join(path);
+                std::fs::remove_file(&absolute).unwrap();
+                symlink(&outside_file, absolute).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(!outcome.committed);
+        assert!(context.source_tree_incomplete());
+        assert!(db.entry_for_path(relative).unwrap().is_none());
     }
 
     #[cfg(unix)]

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1305,6 +1305,8 @@ Relinking should validate the chosen folder, reopen or reconcile the source data
 
 Scanning should be recursive by default. Wavecrate should skip hidden or system folders only when configured to do so, and it should avoid traversing dangerous or redundant filesystem structures such as cycles, inaccessible junctions, or repeated symlink targets. The authoritative scanner and native browser projection must classify source entries without following links: directory and file symlinks, junctions, and equivalent reparse-point links stay outside both the manifest and browser tree. Entry-type inspection failures should be logged and skipped without making the source unavailable or exposing paths beyond its configured root.
 
+Every scanner content-hash path, including full scans, periodic content audits, deferred hashing, exact-path hashing, and targeted watcher reconciliation, must open through a source-root capability without following the final component or any ancestor. Filesystem facts, content reads, and post-read revalidation must use the retained descriptor for one object, and the manifest path must still bind to that object immediately before publication. A path that disappears, becomes linked, or is replaced remains retired or retryable without reading the replacement target, and content reads must remain outside source-database writer ownership.
+
 The final scanner should not silently impose arbitrary product limits on folder depth, number of child folders, or number of files per source. Any defensive scan limit used to protect responsiveness should be explicit, configurable where practical, logged, and visible as a partial-scan warning with a clear rescan or settings path.
 
 The scanner should classify discovered files as:


### PR DESCRIPTION
## Goal

Close OPT-1261 by keeping every scanner content-hash read capability-scoped and bound to one no-follow filesystem object from open through publication.

## Scope and non-goals

- Add a shared source-root capability that rejects linked/reparse final components and replaced ancestors.
- Route full-scan, content-audit, deferred, exact-path, and targeted hash preparation through retained descriptors.
- Derive facts and hashes from the descriptor, then revalidate both descriptor state and manifest-path binding immediately before database publication.
- Keep cancellation and content reads outside source-database writer ownership.
- Add Unix race regressions plus Windows link/reparse coverage where link creation is supported.
- Update the durable scanner contract in `docs/TARGET.md`.
- Do not add symlink traversal or redesign watcher debounce, source-root replacement, or database path protection.

## Definition of Done

- [x] Scanner hash inputs cannot follow final-component or ancestor link replacements outside the configured source.
- [x] Classification, facts, hashing, and revalidation refer to the retained descriptor.
- [x] Missing, linked, mutated, or replaced bindings retire or remain retryable instead of publishing replacement content.
- [x] Full scan, audit, deferred/exact hash, and targeted sync share the invariant.
- [x] Regression coverage exercises classification-to-open, during-hash, and pre-publication replacement boundaries.

## Validation

- PASS: `cargo check -p wavecrate-scan --all-targets`
- PASS: `cargo test -p wavecrate-scan --lib` (163 passed)
- PASS: `bash scripts/ci.sh smoke`
- PARTIAL: `bash scripts/ci.sh agent` passed branch policy, smoke compilation, non-blocking architecture, and readiness boundary checks, then failed in the unrelated Radiant library assertion `gpu_signal_shader_keeps_waveform_bands_visually_distinct`. The pre-existing dirty `vendor/radiant` submodule was not included in this PR.
- NOT RUN: manual macOS churn smoke; the deterministic scanner regressions exercise file and ancestor replacement.
- NOT COMPLETED: Windows cross-target check on macOS because the host lacks `ml64.exe` and Windows C headers; Windows-specific no-follow/handle code is platform-gated.

## Known limitations

None in the implementation. Validation environment limitations are listed above.

User approval is required before merge.