### PR TITLE
OPT-1255 clear released Shift selection on navigation

### DIFF
--- a/src/native_app/sample_library/folder_browser/file_selection_model.rs
+++ b/src/native_app/sample_library/folder_browser/file_selection_model.rs
@@ -7,6 +7,7 @@ pub(super) struct FileSelectionModel {
     focused_id: Option<String>,
     selected_ids: HashSet<String>,
     explicit: bool,
+    keyboard_range: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -26,6 +27,7 @@ impl FileSelectionModel {
             focused_id,
             selected_ids,
             explicit,
+            keyboard_range: false,
         }
     }
 
@@ -39,6 +41,15 @@ impl FileSelectionModel {
 
     pub(super) fn explicit(&self) -> bool {
         self.explicit
+    }
+
+    pub(super) fn keyboard_range(&self) -> bool {
+        self.keyboard_range
+    }
+
+    pub(super) fn with_keyboard_range(mut self, keyboard_range: bool) -> Self {
+        self.keyboard_range = keyboard_range;
+        self
     }
 
     pub(super) fn active_ids(&self) -> HashSet<String> {
@@ -111,7 +122,8 @@ impl FileSelectionModel {
         extend: bool,
         visible_ids: &[String],
     ) -> Option<String> {
-        if self.explicit && !extend {
+        let marked_selection = self.explicit && !self.keyboard_range;
+        if marked_selection && !extend {
             return self.navigate_focus_preserving_selection(delta, visible_ids);
         }
 
@@ -123,6 +135,7 @@ impl FileSelectionModel {
         };
         self.apply_keyed_selection(selection);
         self.explicit = extend;
+        self.keyboard_range = extend && !marked_selection;
         Some(target)
     }
 
@@ -130,7 +143,7 @@ impl FileSelectionModel {
         if self.focused_id.as_deref() == Some(target.as_str()) {
             return None;
         }
-        if self.explicit {
+        if self.explicit && !self.keyboard_range {
             self.focused_id = Some(target.clone());
             return Some(target);
         }
@@ -139,6 +152,7 @@ impl FileSelectionModel {
         self.selected_ids.clear();
         self.selected_ids.insert(target.clone());
         self.explicit = false;
+        self.keyboard_range = false;
         Some(target)
     }
 
@@ -151,6 +165,7 @@ impl FileSelectionModel {
         self.selected_ids.clear();
         self.selected_ids.insert(target);
         self.explicit = false;
+        self.keyboard_range = false;
         changed
     }
 
@@ -254,6 +269,7 @@ impl FileSelectionModel {
         self.focused_id = selection.focused_key().cloned();
         self.selected_ids = selection.selected_keys().iter().cloned().collect();
         self.explicit = false;
+        self.keyboard_range = false;
     }
 }
 

--- a/src/native_app/sample_library/folder_browser/selection_state.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state.rs
@@ -16,6 +16,7 @@ pub(super) struct BrowserSelectionState {
     pub(super) selected_file: Option<String>,
     pub(super) selected_file_ids: HashSet<String>,
     pub(super) selected_file_ids_explicit: bool,
+    pub(super) selected_file_ids_keyboard_range: bool,
     pub(super) selected_collection: Option<SampleCollection>,
     pub(super) folder_before_collection: Option<String>,
 }
@@ -29,6 +30,7 @@ pub(super) struct BrowserSelectionSnapshot {
     pub(super) selected_file: Option<String>,
     pub(super) selected_file_ids: HashSet<String>,
     pub(super) selected_file_ids_explicit: bool,
+    pub(super) selected_file_ids_keyboard_range: bool,
     pub(super) selected_collection: Option<SampleCollection>,
     pub(super) folder_before_collection: Option<String>,
 }
@@ -43,6 +45,7 @@ impl BrowserSelectionState {
             selected_file: None,
             selected_file_ids: HashSet::new(),
             selected_file_ids_explicit: false,
+            selected_file_ids_keyboard_range: false,
             selected_collection: None,
             folder_before_collection: None,
         }

--- a/src/native_app/sample_library/folder_browser/selection_state/files.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state/files.rs
@@ -10,6 +10,7 @@ impl BrowserSelectionState {
         self.selected_file = None;
         self.selected_file_ids.clear();
         self.selected_file_ids_explicit = false;
+        self.selected_file_ids_keyboard_range = false;
     }
 
     pub(in crate::native_app::sample_library::folder_browser) fn active_file_ids(
@@ -66,6 +67,7 @@ impl BrowserSelectionState {
             selected_file: self.selected_file.clone(),
             selected_file_ids: self.selected_file_ids.clone(),
             selected_file_ids_explicit: self.selected_file_ids_explicit,
+            selected_file_ids_keyboard_range: self.selected_file_ids_keyboard_range,
             selected_collection: self.selected_collection,
             folder_before_collection: self.folder_before_collection.clone(),
         }
@@ -82,6 +84,7 @@ impl BrowserSelectionState {
         self.selected_file = snapshot.selected_file;
         self.selected_file_ids = snapshot.selected_file_ids;
         self.selected_file_ids_explicit = snapshot.selected_file_ids_explicit;
+        self.selected_file_ids_keyboard_range = snapshot.selected_file_ids_keyboard_range;
         self.selected_collection = snapshot.selected_collection;
         self.folder_before_collection = snapshot.folder_before_collection;
     }
@@ -222,6 +225,7 @@ impl BrowserSelectionState {
     ) {
         self.selected_file = Some(focused_id);
         self.selected_file_ids_explicit = selected_ids.len() > 1;
+        self.selected_file_ids_keyboard_range = false;
         self.selected_file_ids = selected_ids;
     }
 
@@ -231,11 +235,13 @@ impl BrowserSelectionState {
             self.selected_file_ids.clone(),
             self.selected_file_ids_explicit,
         )
+        .with_keyboard_range(self.selected_file_ids_keyboard_range)
     }
 
     fn apply_file_selection_model(&mut self, selection: FileSelectionModel) {
         self.selected_file = selection.focused_id().map(ToOwned::to_owned);
         self.selected_file_ids = selection.selected_ids().clone();
         self.selected_file_ids_explicit = selection.explicit();
+        self.selected_file_ids_keyboard_range = selection.keyboard_range();
     }
 }

--- a/src/native_app/sample_library/folder_browser/selection_state/reconciliation.rs
+++ b/src/native_app/sample_library/folder_browser/selection_state/reconciliation.rs
@@ -57,6 +57,8 @@ impl BrowserSelectionState {
             .collect();
         self.selected_file_ids_explicit =
             snapshot.selected_file_ids_explicit && self.selected_file_ids.len() > 1;
+        self.selected_file_ids_keyboard_range =
+            snapshot.selected_file_ids_keyboard_range && !self.selected_file_ids.is_empty();
         self.selected_file = snapshot
             .selected_file
             .and_then(|id| visible_moved_or_original_id(id, &moved_ids, &visible_id_set))
@@ -75,6 +77,7 @@ impl BrowserSelectionState {
             self.set_focus_file_set(first_visible);
         } else if self.selected_file.is_none() && self.selected_file_ids.is_empty() {
             self.selected_file_ids_explicit = false;
+            self.selected_file_ids_keyboard_range = false;
         } else if let Some(selected_file) = self.selected_file.clone()
             && self.selected_file_ids.is_empty()
         {
@@ -146,6 +149,7 @@ impl BrowserSelectionState {
         };
         self.selected_folder = target_folder_id;
         self.selected_file_ids_explicit = self.selected_file_ids.len() > 1;
+        self.selected_file_ids_keyboard_range = false;
     }
 
     pub(in crate::native_app::sample_library::folder_browser) fn discard_files(
@@ -163,6 +167,7 @@ impl BrowserSelectionState {
             .retain(|id| !removed_ids.contains(id));
         if self.selected_file.is_none() && self.selected_file_ids.is_empty() {
             self.selected_file_ids_explicit = false;
+            self.selected_file_ids_keyboard_range = false;
         }
     }
 }

--- a/src/native_app/sample_library/folder_browser/tests/file_keyboard_selection.rs
+++ b/src/native_app/sample_library/folder_browser/tests/file_keyboard_selection.rs
@@ -53,6 +53,42 @@ fn file_keyboard_navigation_can_extend_audio_selection() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn file_keyboard_navigation_clears_shift_range_after_shift_release() {
+    let root = temp_source_root("wavecrate-gui-file-keyboard-release-shift");
+    let drums = root.join("drums");
+    fs::create_dir_all(&drums).expect("create drums folder");
+    let hat = drums.join("hat.wav");
+    let kick = drums.join("kick.wav");
+    let snare = drums.join("snare.wav");
+    let tom = drums.join("tom.wav");
+    for file in [&hat, &kick, &snare, &tom] {
+        fs::write(file, [0_u8; 8]).expect("write wav");
+    }
+    let mut browser = FolderBrowserState::from_root(root.clone());
+    browser.activate_folder(path_id(&drums));
+    browser.select_file(path_id(&hat));
+
+    let tags_by_file = std::collections::HashMap::new();
+    assert_eq!(
+        browser.navigate_vertical_matching_tags(1, true, false, &tags_by_file),
+        Some(path_id(&kick))
+    );
+    assert_eq!(
+        browser.navigate_vertical_matching_tags(1, true, false, &tags_by_file),
+        Some(path_id(&snare))
+    );
+
+    assert_eq!(
+        browser.navigate_vertical_matching_tags(1, false, false, &tags_by_file),
+        Some(path_id(&tom))
+    );
+    assert_eq!(browser.selected_file_paths(), vec![tom.clone()]);
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn toggle_focused_sample_selection_marks_without_advancing() {
     let root = temp_source_root("wavecrate-gui-toggle-mark-stationary");
@@ -203,7 +239,11 @@ fn file_keyboard_navigation_preserves_toggle_marked_samples() {
         .expect("mark first sample");
     assert_eq!(browser.selected_file_id(), Some(path_id(&hat).as_str()));
 
-    assert_eq!(browser.navigate_vertical(1, false), Some(path_id(&kick)));
+    let tags_by_file = std::collections::HashMap::new();
+    assert_eq!(
+        browser.navigate_vertical_matching_tags(1, false, false, &tags_by_file),
+        Some(path_id(&kick))
+    );
     assert_eq!(browser.selected_file_paths(), vec![hat.clone()]);
 
     browser
@@ -216,7 +256,10 @@ fn file_keyboard_navigation_preserves_toggle_marked_samples() {
     );
     assert_eq!(browser.selected_file_id(), Some(path_id(&kick).as_str()));
 
-    assert_eq!(browser.navigate_vertical(1, false), Some(path_id(&snare)));
+    assert_eq!(
+        browser.navigate_vertical_matching_tags(1, false, false, &tags_by_file),
+        Some(path_id(&snare))
+    );
     assert_eq!(
         browser.selected_file_paths(),
         vec![hat.clone(), kick.clone()]


### PR DESCRIPTION
## Goal

Fix browser selection behavior after Shift+keyboard range selection.

## Scope

Track transient Shift-navigation ranges separately from persistent `x`/marked selections.

Non-goals: no changes to pointer selection behavior or unrelated audio/runtime work.

## Definition of Done

- Releasing Shift and navigating again collapses the transient range to the newly focused item.
- Items marked with `x` remain selected during plain keyboard navigation.
- Regression coverage exercises both behaviors through the optimized browser navigation path.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wavecrate --lib file_keyboard_navigation_` — 5 passed

Known limitations: None.

This PR is ready for review. User approval is required before merge.