### PR TITLE
OPT-1263 restore strict manifest commit Clippy lane

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/content_audit.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/content_audit.rs
@@ -295,8 +295,7 @@ impl SourceDatabase {
             return Ok(Vec::new());
         }
         let pool_limit = limit.saturating_mul(2);
-        let sql = format!(
-            "SELECT wav.path, wav.file_identity, wav.content_hash,
+        let sql = "SELECT wav.path, wav.file_identity, wav.content_hash,
                     wav.file_size, wav.modified_ns, wav.extension, wav.missing
              FROM source_content_audit_entries AS audit
                   INDEXED BY idx_source_content_audit_retry_due
@@ -305,7 +304,7 @@ impl SourceDatabase {
                AND COALESCE(audit.retry_at, 0) <= ?1
              ORDER BY COALESCE(audit.retry_at, 0) ASC, audit.path ASC
              LIMIT ?2"
-        );
+            .to_string();
         let mut statement = self.connection.prepare(&sql).map_err(map_sql_error)?;
         let rows = statement
             .query_map(

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -59,8 +59,8 @@ pub use types::{
 };
 pub use util::normalize_relative_path;
 pub use write::{
-    SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
-    SourceWriteCommand,
+    ManifestCommitResult, SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite,
+    SourceTagWrite, SourceWriteCommand,
 };
 
 /// Hidden filename used for per-source databases.

--- a/crates/wavecrate-library/src/sample_sources/db/write.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write.rs
@@ -14,6 +14,7 @@ pub use command::{
     SourceCollectionWrite, SourceContentHashWrite, SourceFileWrite, SourceTagWrite,
     SourceWriteCommand,
 };
+pub use transaction::ManifestCommitResult;
 
 #[cfg(test)]
 mod tests;

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -79,11 +79,11 @@ impl SourceWriteBatch<'_> {
 
     /// Commit the batch and return its exact revision plus manifest state owned by that revision.
     ///
-    /// When the caller's cached revision is current, the second tuple element contains only
-    /// touched paths and the optional full snapshot is `None`, keeping chunked scans linear. When
-    /// another writer has advanced the manifest, the touched-path list is empty and the optional
-    /// full snapshot is captured inside this committing transaction before the write lock is
-    /// released.
+    /// When the caller's cached revision is current, `touched_path_changes` contains only touched
+    /// paths and `authoritative_snapshot` is `None`, keeping chunked scans linear. When another
+    /// writer has advanced the manifest, `touched_path_changes` is empty and
+    /// `authoritative_snapshot` contains the full manifest captured inside this committing
+    /// transaction before the write lock is released.
     pub fn commit_with_manifest_changes(
         self,
         expected_previous_revision: u64,

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -5,6 +5,16 @@ use rusqlite::OptionalExtension;
 use super::super::util::{map_sql_error, normalize_relative_path};
 use super::super::{SourceDatabase, SourceDbError, SourceManifestEntry, SourceWriteBatch};
 
+/// Manifest state published by a committed source-database write batch.
+pub struct ManifestCommitResult {
+    /// Revision assigned to the committed manifest state.
+    pub revision: u64,
+    /// Manifest rows for paths touched by this batch when the cached revision was current.
+    pub touched_path_changes: Vec<(PathBuf, Option<SourceManifestEntry>)>,
+    /// Complete manifest captured in the committing transaction when the cached revision was stale.
+    pub authoritative_snapshot: Option<Vec<SourceManifestEntry>>,
+}
+
 impl SourceWriteBatch<'_> {
     /// Return whether this write transaction began at `expected_revision`.
     ///
@@ -77,14 +87,7 @@ impl SourceWriteBatch<'_> {
     pub fn commit_with_manifest_changes(
         self,
         expected_previous_revision: u64,
-    ) -> Result<
-        (
-            u64,
-            Vec<(PathBuf, Option<SourceManifestEntry>)>,
-            Option<Vec<SourceManifestEntry>>,
-        ),
-        SourceDbError,
-    > {
+    ) -> Result<ManifestCommitResult, SourceDbError> {
         self.prepare_commit()?;
         let revision = manifest_revision(&self.tx)?;
         let (changes, snapshot) = if revision == expected_previous_revision.saturating_add(1) {
@@ -108,7 +111,11 @@ impl SourceWriteBatch<'_> {
             "source_db",
             self.telemetry_label,
         );
-        Ok((revision, changes, snapshot))
+        Ok(ManifestCommitResult {
+            revision,
+            touched_path_changes: changes,
+            authoritative_snapshot: snapshot,
+        })
     }
 
     /// Commit a revision-fenced batch and return only the manifest rows touched by that batch.
@@ -119,7 +126,7 @@ impl SourceWriteBatch<'_> {
     pub fn commit_with_bounded_manifest_changes(
         self,
         expected_previous_revision: u64,
-    ) -> Result<(u64, Vec<(PathBuf, Option<SourceManifestEntry>)>), SourceDbError> {
+    ) -> Result<ManifestCommitResult, SourceDbError> {
         if manifest_revision(&self.tx)? != expected_previous_revision {
             return Err(SourceDbError::Unexpected);
         }
@@ -140,7 +147,11 @@ impl SourceWriteBatch<'_> {
             "source_db",
             self.telemetry_label,
         );
-        Ok((revision, changes))
+        Ok(ManifestCommitResult {
+            revision,
+            touched_path_changes: changes,
+            authoritative_snapshot: None,
+        })
     }
 
     fn prepare_commit(&self) -> Result<(), SourceDbError> {
@@ -332,15 +343,18 @@ mod tests {
         batch
             .upsert_file_with_hash(Path::new("created.wav"), 7, 30, "created-hash")
             .expect("insert created file");
-        let (revision, changes, snapshot) = batch
+        let result = batch
             .commit_with_manifest_changes(expected_previous_revision)
             .expect("commit manifest changes");
 
-        assert_eq!(revision, database.get_revision().expect("current revision"));
-        assert!(snapshot.is_none());
-        assert_eq!(changes.len(), 2);
         assert_eq!(
-            changes[0],
+            result.revision,
+            database.get_revision().expect("current revision")
+        );
+        assert!(result.authoritative_snapshot.is_none());
+        assert_eq!(result.touched_path_changes.len(), 2);
+        assert_eq!(
+            result.touched_path_changes[0],
             (
                 PathBuf::from("created.wav"),
                 Some(SourceManifestEntry {
@@ -352,7 +366,44 @@ mod tests {
                 })
             )
         );
-        assert_eq!(changes[1], (PathBuf::from("removed.wav"), None));
+        assert_eq!(
+            result.touched_path_changes[1],
+            (PathBuf::from("removed.wav"), None)
+        );
+    }
+
+    #[test]
+    fn commit_manifest_changes_returns_authoritative_snapshot_when_revision_advanced() {
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        database
+            .upsert_file(Path::new("existing.wav"), 5, 10)
+            .expect("insert existing file");
+
+        let mut batch = database.write_batch().expect("manifest batch");
+        batch
+            .upsert_file_with_hash(Path::new("created.wav"), 7, 30, "created-hash")
+            .expect("insert created file");
+        let result = batch
+            .commit_with_manifest_changes(0)
+            .expect("commit manifest changes");
+
+        assert_eq!(
+            result.revision,
+            database.get_revision().expect("current revision")
+        );
+        assert!(result.touched_path_changes.is_empty());
+        let snapshot = result
+            .authoritative_snapshot
+            .expect("authoritative manifest snapshot");
+        assert_eq!(
+            snapshot
+                .into_iter()
+                .map(|entry| entry.relative_path)
+                .collect::<Vec<_>>(),
+            vec![PathBuf::from("created.wav"), PathBuf::from("existing.wav")]
+        );
     }
 
     #[test]
@@ -366,15 +417,18 @@ mod tests {
             .upsert_file_with_hash(Path::new(r"nested\kick.wav"), 7, 30, "kick-hash")
             .expect("insert nested file");
 
-        let (_revision, changes, snapshot) = batch
+        let result = batch
             .commit_with_manifest_changes(expected_previous_revision)
             .expect("commit manifest changes");
 
-        assert!(snapshot.is_none());
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].0, Path::new("nested/kick.wav"));
+        assert!(result.authoritative_snapshot.is_none());
+        assert_eq!(result.touched_path_changes.len(), 1);
         assert_eq!(
-            changes[0]
+            result.touched_path_changes[0].0,
+            Path::new("nested/kick.wav")
+        );
+        assert_eq!(
+            result.touched_path_changes[0]
                 .1
                 .as_ref()
                 .map(|entry| entry.relative_path.as_path()),

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -17,11 +17,11 @@ pub use audio_support::{
 };
 pub use db::normalize_relative_path;
 pub use db::{
-    BrowserFileMetadata, BrowserMetadataSnapshot, DB_FILE_NAME, Rating, SampleCollection,
-    SourceCollectionWrite, SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
-    SourceDbError, SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic,
-    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
-    SourceTagWrite, SourceWriteCommand, WavEntry,
+    BrowserFileMetadata, BrowserMetadataSnapshot, DB_FILE_NAME, ManifestCommitResult, Rating,
+    SampleCollection, SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
+    SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceIndexClassification,
+    SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag,
+    SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -294,16 +294,15 @@ impl ScanContext {
         batch: SourceWriteBatch<'_>,
         post_commit_hook: impl FnOnce(),
     ) -> Result<u64, ScanError> {
-        let (revision, changes, snapshot) =
-            batch.commit_with_manifest_changes(self.committed_manifest_revision)?;
+        let result = batch.commit_with_manifest_changes(self.committed_manifest_revision)?;
         post_commit_hook();
-        if let Some(snapshot) = snapshot {
+        if let Some(snapshot) = result.authoritative_snapshot {
             self.committed_manifest = snapshot
                 .into_iter()
                 .map(|entry| (entry.relative_path.clone(), entry))
                 .collect();
         } else {
-            for (path, entry) in changes {
+            for (path, entry) in result.touched_path_changes {
                 if let Some(entry) = entry {
                     self.committed_manifest.insert(path, entry);
                 } else {
@@ -311,9 +310,9 @@ impl ScanContext {
                 }
             }
         }
-        self.committed_manifest_revision = revision;
-        self.last_committed_revision = Some(revision);
-        Ok(revision)
+        self.committed_manifest_revision = result.revision;
+        self.last_committed_revision = Some(result.revision);
+        Ok(result.revision)
     }
 
     pub(in crate::sample_sources::scanner) fn committed_snapshot(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -601,13 +601,17 @@ fn verify_content_batch_with_hooks(
                 Ok(stats)
             };
         }
-        let (revision, changes) = batch.commit_with_bounded_manifest_changes(manifest_revision)?;
-        let changed_after = changes
+        let result = batch.commit_with_bounded_manifest_changes(manifest_revision)?;
+        let changed_after = result
+            .touched_path_changes
             .into_iter()
             .filter_map(|(_, entry)| entry)
             .collect::<Vec<_>>();
-        stats.committed_delta =
-            super::manifest::build_committed_delta(&changed_before, &changed_after, revision);
+        stats.committed_delta = super::manifest::build_committed_delta(
+            &changed_before,
+            &changed_after,
+            result.revision,
+        );
         stats.manifest_updates = changed_after;
     } else {
         stats.committed_delta.revision = db.get_revision()?;
@@ -626,10 +630,9 @@ fn verify_content_batch_with_hooks(
             });
         }
         batch.complete_content_audit_rotation(now, stats.committed_delta.revision)?;
-        let (revision, changes) =
-            batch.commit_with_bounded_manifest_changes(stats.committed_delta.revision)?;
-        debug_assert!(changes.is_empty());
-        stats.committed_delta.revision = revision;
+        let result = batch.commit_with_bounded_manifest_changes(stats.committed_delta.revision)?;
+        debug_assert!(result.touched_path_changes.is_empty());
+        stats.committed_delta.revision = result.revision;
     }
     stats.content_audit = Some({
         let _writer = writer.lock(ScanWritePhase::Manifest);


### PR DESCRIPTION
## Goal

Restore the denied-warning Clippy lane for Wavecrate manifest commit results without changing transaction or revision semantics.

## Scope

- Replace the nested manifest commit result tuple with the documented `ManifestCommitResult` type.
- Use named fields for revision, touched-path changes, and the optional authoritative snapshot.
- Apply the same result type to the bounded manifest commit helper so the full library lane remains warning-free.
- Update scanner consumers and cover both incremental and authoritative-snapshot branches.
- Remove an existing `useless_format` warning in the affected Wavecrate library package.

## Non-goals

- No Clippy allowance or lint suppression.
- No source discovery, hashing, or manifest reconciliation redesign.
- No unrelated Radiant changes.

## Definition of Done

- Manifest commit results are named, documented, and consumed through named fields.
- Incremental and authoritative snapshot semantics remain unchanged and are covered by tests.
- The focused Wavecrate library Clippy lane passes with `-D warnings`.
- Existing Wavecrate source database and scan tests pass.

## Validation

- `cargo test -p wavecrate-library` — 267 passed.
- `cargo test -p wavecrate-scan` — 163 passed.
- `cargo clippy -p wavecrate-library --all-targets --all-features -- -D warnings` — passed.
- `bash scripts/ci.sh agent` — reached the unrelated Radiant test suite, where `gpu_signal_shader_keeps_waveform_bands_visually_distinct` failed on the existing expected shader color assertion; no vendor files were changed.

## Known limitations

The repository-wide agent gate remains blocked by the unrelated Radiant shader-color assertion described above.

User approval is required before merge.