### PR TITLE
Fix Windows clipboard owner and initialization cleanup

### DIFF
--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1503,6 +1503,11 @@ Wavecrate should support clipboard-based audio handoff.
 
 When the user selects one or more supported sample files in the sample browser and presses copy, Wavecrate should place those files on the system clipboard in a format that DAWs and Explorer can consume as ordinary audio files.
 
+On Windows, the compatibility clipboard writer must open the clipboard with the
+current Wavecrate UI thread's active window as a non-null owner. It must close
+the clipboard on every post-open failure, including an `EmptyClipboard` failure,
+before returning the error.
+
 Playback-only unsupported audio files should not be eligible for Wavecrate's DAW/external audio handoff workflows, even when the original file path could technically be copied or dragged. Wavecrate cannot guarantee DAW compatibility for unsupported formats, so clipboard and drag/drop audio handoff should stay limited to supported sample formats. Users may still reveal, rename, move, copy, or remove the unsupported file through filesystem-management actions where those actions are available.
 
 Wavecrate should distinguish between path-copy commands and file-copy commands. "Copy Path" is a context-menu utility that copies one absolute path as text. It must not place the file itself on the clipboard. Copying the actual file is a separate file handoff action, such as the normal copy command on selected browser files.

--- a/src/external_clipboard/windows/handle.rs
+++ b/src/external_clipboard/windows/handle.rs
@@ -1,41 +1,113 @@
-use windows::Win32::Foundation::{GlobalFree, HGLOBAL};
+use windows::Win32::Foundation::{GlobalFree, HGLOBAL, HWND};
 use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, OpenClipboard};
 use windows::Win32::System::Memory::{
     GMEM_MOVEABLE, GMEM_ZEROINIT, GlobalAlloc, GlobalLock, GlobalUnlock,
 };
 
-pub(super) struct ClipboardWriter;
+pub(super) struct ClipboardWriter {
+    _clipboard: ClipboardOpenGuard,
+}
 
 impl ClipboardWriter {
     pub(super) fn new() -> Result<Self, String> {
-        unsafe { OpenClipboard(None) }.map_err(|err| format!("OpenClipboard failed: {err}"))?;
-        unsafe { EmptyClipboard() }.map_err(|err| format!("EmptyClipboard failed: {err}"))?;
-        Ok(Self)
+        let owner = active_window_owner()?;
+        Self::new_with_owner(owner)
+    }
+
+    fn new_with_owner(owner: HWND) -> Result<Self, String> {
+        unsafe { OpenClipboard(Some(owner)) }
+            .map_err(|err| format!("OpenClipboard failed: {err}"))?;
+        Self::after_opened(close_clipboard, || {
+            unsafe { EmptyClipboard() }.map_err(|err| err.to_string())
+        })
+    }
+
+    fn after_opened<E>(close: fn(), empty: E) -> Result<Self, String>
+    where
+        E: FnOnce() -> Result<(), String>,
+    {
+        let writer = Self {
+            _clipboard: ClipboardOpenGuard { close },
+        };
+        empty().map_err(|err| format!("EmptyClipboard failed: {err}"))?;
+        Ok(writer)
+    }
+
+    #[cfg(test)]
+    fn test_after_opened<E>(close: fn(), empty: E) -> Result<Self, String>
+    where
+        E: FnOnce() -> Result<(), String>,
+    {
+        Self::after_opened(close, empty)
     }
 }
 
-impl Drop for ClipboardWriter {
+fn active_window_owner() -> Result<HWND, String> {
+    let owner = unsafe { windows::Win32::UI::WindowsAndMessaging::GetActiveWindow() };
+    if owner.0.is_null() {
+        Err("GetActiveWindow returned no clipboard owner".to_string())
+    } else {
+        Ok(owner)
+    }
+}
+
+fn close_clipboard() {
+    unsafe {
+        let _ = CloseClipboard();
+    }
+}
+
+struct ClipboardOpenGuard {
+    close: fn(),
+}
+
+impl Drop for ClipboardOpenGuard {
     fn drop(&mut self) {
-        unsafe {
-            let _ = CloseClipboard();
-        }
+        (self.close)();
     }
 }
 
-pub(super) struct ClipboardReader;
+pub(super) struct ClipboardReader {
+    _clipboard: ClipboardOpenGuard,
+}
 
 impl ClipboardReader {
     pub(super) fn new() -> Result<Self, String> {
         unsafe { OpenClipboard(None) }.map_err(|err| format!("OpenClipboard failed: {err}"))?;
-        Ok(Self)
+        Ok(Self {
+            _clipboard: ClipboardOpenGuard {
+                close: close_clipboard,
+            },
+        })
     }
 }
 
-impl Drop for ClipboardReader {
-    fn drop(&mut self) {
-        unsafe {
-            let _ = CloseClipboard();
-        }
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::ClipboardWriter;
+
+    static CLOSE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn record_close() {
+        CLOSE_CALLS.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn writer_closes_exactly_once_after_empty_failure_or_normal_drop() {
+        CLOSE_CALLS.store(0, Ordering::SeqCst);
+        let empty_failure = ClipboardWriter::test_after_opened(record_close, || {
+            Err("injected EmptyClipboard failure".to_string())
+        });
+        assert!(empty_failure.is_err());
+        assert_eq!(CLOSE_CALLS.load(Ordering::SeqCst), 1);
+
+        CLOSE_CALLS.store(0, Ordering::SeqCst);
+        let writer = ClipboardWriter::test_after_opened(record_close, || Ok(()))
+            .expect("injected clipboard setup should succeed");
+        drop(writer);
+        assert_eq!(CLOSE_CALLS.load(Ordering::SeqCst), 1);
     }
 }
 


### PR DESCRIPTION
Fixes OPT-1265.

## Goal

Make the compatibility Windows clipboard writer use a valid non-null owner and release the clipboard lock on every post-open failure.

## Scope

- Resolve the current UI-thread active window as the clipboard owner and pass it to `OpenClipboard`.
- Construct the clipboard close guard immediately after a successful open, before `EmptyClipboard`.
- Preserve existing `HGLOBAL` transfer and cleanup behavior.
- Add injected lifetime tests for initialization failure and normal post-initialization drop.
- Document the Windows clipboard ownership and cleanup contract.

## Non-goals

- No changes to Radiant's native clipboard service.
- No drag/drop redesign.
- No retry loops or Linux clipboard work.

## Definition of Done

- Windows clipboard writes never call `OpenClipboard(None)` and reject a missing active owner.
- `CloseClipboard` runs exactly once after every successful open, including `EmptyClipboard` failure.
- Existing file and text payload paths retain their ownership semantics.

## Validation

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo check --lib` — passed on macOS.
- `cargo test -p wavecrate external_clipboard` — passed (3 tests on macOS; Windows-only guard tests are cfg-gated).
- `cargo test -p wavecrate --lib` — 3974 passed, 55 unrelated existing failures, 27 ignored.
- `cargo check --lib --target x86_64-pc-windows-msvc` — blocked by the host's missing MSVC/Windows C toolchain headers in `ring` and SQLite, before Wavecrate diagnostics.

## Known limitations

Windows Explorer/Notepad smoke testing requires a Windows host and was not available in this environment.

User approval is required before merge.