### PR TITLE
OPT-1273 preserve retryable indexed scanner failures

### DIFF
--- a/src/native_app/source_processing/supervisor/execution_readiness.rs
+++ b/src/native_app/source_processing/supervisor/execution_readiness.rs
@@ -144,6 +144,15 @@ pub(super) fn execute_readiness_target(
                 .map_err(|error| error.to_string())?;
             Ok(execution_outcome_for_failure(outcome))
         }
+        Err(ref failure) if failure.is_cancelled() => {
+            cleanup_unpublished_readiness_output(&outcome);
+            cancel_claim(
+                &mut connection,
+                &claim,
+                &failure.context,
+                now_epoch_seconds(),
+            )
+        }
         Err(failure) => {
             let policy = ReadinessRetryPolicy::new(5, 5 * 60, READINESS_MAX_ATTEMPTS)
                 .expect("valid readiness retry policy");

--- a/src/native_app/source_processing/supervisor/execution_stages.rs
+++ b/src/native_app/source_processing/supervisor/execution_stages.rs
@@ -48,8 +48,9 @@ pub(super) fn run_readiness_stage(
                     )
                     .map_err(SourceProcessingFailure::from)?;
                 if !has_content_hash {
-                    let database_root =
-                        source.database_root().map_err(|error| error.to_string())?;
+                    let database_root = source
+                        .database_root()
+                        .map_err(SourceProcessingFailure::from)?;
                     let db = SourceDatabase::open_for_background_job_with_database_root(
                         &source.root,
                         database_root,
@@ -60,7 +61,7 @@ pub(super) fn run_readiness_stage(
                         std::path::Path::new(relative_path),
                         Some(cancel),
                     )
-                    .map_err(|error| error.to_string())?;
+                    .map_err(SourceProcessingFailure::from)?;
                 }
                 let committed_content_hash = connection
                     .query_row(

--- a/src/native_app/source_processing/supervisor/tests/execution_retries.rs
+++ b/src/native_app/source_processing/supervisor/tests/execution_retries.rs
@@ -1,7 +1,12 @@
+#[cfg(unix)]
 #[test]
 fn unavailable_hash_path_backs_off_without_starving_later_files() {
+    use std::os::unix::fs::PermissionsExt;
+
     let directory = tempfile::tempdir().expect("temporary hash source");
+    let unavailable_path = directory.path().join("a-unavailable.wav");
     let good_path = directory.path().join("z-good.wav");
+    std::fs::write(&unavailable_path, [3_u8; 64]).expect("write temporarily unavailable sample");
     std::fs::write(&good_path, [7_u8; 64]).expect("write hashable sample");
     let source = SampleSource::new_with_id(
         SourceId::from_string("hash-fairness"),
@@ -13,7 +18,7 @@ fn unavailable_hash_path_backs_off_without_starving_later_files() {
     db.upsert_file(Path::new("z-good.wav"), 64, 1)
         .expect("insert good hash row");
     let database_root = source.database_root().expect("database root");
-    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
         &database_root,
         SourceDatabaseConnectionRole::JobWorker,
@@ -27,69 +32,64 @@ fn unavailable_hash_path_backs_off_without_starving_later_files() {
                  WHERE path = 'z-good.wav';",
         )
         .expect("assign hash identities");
-    connection
-        .execute(
-            "INSERT INTO metadata (key, value) VALUES (?1, ?2)
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            params![META_LAST_MANIFEST_AUDIT_AT, now_epoch_seconds().to_string()],
-        )
-        .expect("mark the fixture manifest audit current");
+    let now = now_epoch_seconds();
+    assert!(publish_current_readiness_targets(&mut connection, source.id.as_str(), now)
+        .expect("publish readiness targets"));
+    let snapshot = reconcile_readiness(&connection, source.id.as_str(), now)
+        .expect("reconcile readiness targets");
+    persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+        .expect("persist readiness work");
+    let targets = snapshot
+        .entries
+        .iter()
+        .filter(|entry| entry.target.stage == ReadinessStage::IndexedIdentity)
+        .map(|entry| (entry.target.relative_path.clone(), entry.target.clone()))
+        .collect::<Vec<_>>();
+    let unavailable_target = targets
+        .iter()
+        .find(|(path, _)| path.as_deref() == Some("a-unavailable.wav"))
+        .expect("unavailable readiness target")
+        .1
+        .clone();
+    let good_target = targets
+        .iter()
+        .find(|(path, _)| path.as_deref() == Some("z-good.wav"))
+        .expect("healthy readiness target")
+        .1
+        .clone();
     drop(connection);
 
-    let mut supervisor =
-        SourceProcessingSupervisor::start_without_forced_manifest_audit(vec![source.clone()]);
-    let deadline = Instant::now() + Duration::from_secs(10);
-    loop {
-        let good_hashed = source
-            .open_db()
-            .expect("open hash source")
-            .entry_for_path(Path::new("z-good.wav"))
-            .expect("read good hash row")
-            .and_then(|entry| entry.content_hash)
-            .is_some();
-        let failure_recorded = SourceDatabase::open_connection_with_role_and_database_root(
-            &source.root,
-            &database_root,
-            SourceDatabaseConnectionRole::JobWorker,
-        )
-        .ok()
-        .and_then(|connection| {
-            connection
-                .query_row(
-                    "SELECT status
-                         FROM analysis_jobs
-                         WHERE readiness_managed = 1
-                           AND readiness_stage = 'indexed_identity'
-                           AND relative_path = 'a-unavailable.wav'",
-                    [],
-                    |row| row.get::<_, String>(0),
-                )
-                .optional()
-                .ok()
-                .flatten()
-        })
-        .as_deref()
-            == Some("failed");
-        if good_hashed && failure_recorded {
-            break;
-        }
-        if Instant::now() >= deadline {
-            let telemetry = supervisor.shared.telemetry();
-            panic!(
-                "hash fairness did not converge: good_hashed={good_hashed} \
-                     unavailable_status={failure_recorded} claimed={} completed={} failed={} \
-                     retried={} stale={} queue_depth={}",
-                telemetry.claimed,
-                telemetry.completed,
-                telemetry.failed,
-                telemetry.retried,
-                telemetry.stale,
-                telemetry.queue_depth,
-            );
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    assert_eq!(supervisor.shutdown()["joined"], true);
+    std::fs::set_permissions(&unavailable_path, std::fs::Permissions::from_mode(0o000))
+        .expect("make deferred hash path unavailable");
+
+    let writer = DatabaseWriterGate::default();
+    let unavailable_outcome = execute_readiness_target(
+        &source,
+        &unavailable_target,
+        &AtomicBool::new(false),
+        &writer,
+    )
+    .expect("execute unavailable readiness target");
+    assert!(matches!(
+        unavailable_outcome,
+        ExecutionOutcome::Retried { .. }
+    ));
+
+    let good_outcome = execute_readiness_target(
+        &source,
+        &good_target,
+        &AtomicBool::new(false),
+        &writer,
+    )
+    .expect("execute healthy readiness target");
+    assert!(!matches!(good_outcome, ExecutionOutcome::Failed));
+    assert!(source
+        .open_db()
+        .expect("reopen hash source")
+        .entry_for_path(Path::new("z-good.wav"))
+        .expect("read good hash row")
+        .and_then(|entry| entry.content_hash)
+        .is_some());
 
     let connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,
@@ -97,21 +97,105 @@ fn unavailable_hash_path_backs_off_without_starving_later_files() {
         SourceDatabaseConnectionRole::JobWorker,
     )
     .expect("reopen hash database");
-    let failure: (String, Option<String>, Option<i64>, i64) = connection
+    let failure: (String, Option<String>, Option<String>, Option<i64>, i64) = connection
         .query_row(
-            "SELECT status, failure_kind, retry_at, attempts
+            "SELECT status, failure_kind, failure_code, retry_at, attempts
                  FROM analysis_jobs
                  WHERE readiness_managed = 1
                    AND readiness_stage = 'indexed_identity'
                    AND relative_path = 'a-unavailable.wav'",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
         )
         .expect("read durable hash failure");
     assert_eq!(failure.0, "failed");
     assert_eq!(failure.1.as_deref(), Some("retryable"));
-    assert!(failure.2.is_some());
-    assert_eq!(failure.3, 1);
+    assert_eq!(failure.2.as_deref(), Some("scanner_io"));
+    assert!(failure.3.is_some());
+    assert_eq!(failure.4, 1);
+
+    std::fs::set_permissions(&unavailable_path, std::fs::Permissions::from_mode(0o644))
+        .expect("restore deferred hash path");
+    connection
+        .execute(
+            "UPDATE analysis_jobs SET retry_at = ?1
+             WHERE readiness_managed = 1
+               AND readiness_stage = 'indexed_identity'
+               AND relative_path = 'a-unavailable.wav'",
+            [now_epoch_seconds().saturating_sub(1)],
+        )
+        .expect("make retry due");
+    drop(connection);
+
+    let restored_outcome = execute_readiness_target(
+        &source,
+        &unavailable_target,
+        &AtomicBool::new(false),
+        &writer,
+    )
+    .expect("retry restored readiness target");
+    assert!(!matches!(restored_outcome, ExecutionOutcome::Failed));
+    assert!(source
+        .open_db()
+        .expect("reopen restored hash source")
+        .entry_for_path(Path::new("a-unavailable.wav"))
+        .expect("read restored hash row")
+        .and_then(|entry| entry.content_hash)
+        .is_some());
+}
+
+#[test]
+fn cancelled_readiness_claim_returns_without_blocking_publication() {
+    let (_directory, source) = unhashed_source("cancelled-readiness-claim");
+    let database_root = source.database_root().expect("database root");
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("open readiness database");
+    let now = now_epoch_seconds();
+    assert!(publish_current_readiness_targets(&mut connection, source.id.as_str(), now)
+        .expect("publish readiness targets"));
+    let snapshot = reconcile_readiness(&connection, source.id.as_str(), now)
+        .expect("reconcile readiness targets");
+    persist_readiness_deficits(&mut connection, &snapshot.deficits, now)
+        .expect("persist readiness work");
+    let target = snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.target.stage == ReadinessStage::IndexedIdentity)
+        .expect("indexed identity target")
+        .target
+        .clone();
+    drop(connection);
+
+    let outcome = execute_readiness_target(
+        &source,
+        &target,
+        &AtomicBool::new(true),
+        &DatabaseWriterGate::default(),
+    )
+    .expect("cancel readiness target");
+    assert_eq!(outcome, ExecutionOutcome::Cancelled);
+
+    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen readiness database");
+    let state: (String, Option<String>, Option<String>) = connection
+        .query_row(
+            "SELECT status, failure_kind, failure_code
+             FROM analysis_jobs
+             WHERE readiness_managed = 1
+               AND readiness_stage = 'indexed_identity'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read cancelled readiness work");
+    assert_eq!(state, ("pending".to_string(), Some("cancelled".to_string()), Some("cancelled".to_string())));
 }
 
 #[test]

--- a/src/native_app/source_processing/supervisor/tests/mod.rs
+++ b/src/native_app/source_processing/supervisor/tests/mod.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::{io, sync::Mutex};
 
-use rusqlite::OptionalExtension;
 use tracing_subscriber::fmt::MakeWriter;
 use wavecrate::sample_sources::{
     SourceId,

--- a/src/native_app/source_processing/worker.rs
+++ b/src/native_app/source_processing/worker.rs
@@ -59,6 +59,7 @@ pub(super) enum SourceProcessingFailureClass {
     Retryable,
     Permanent,
     Unsupported,
+    Cancelled,
 }
 
 /// Stable execution-failure code persisted independently from display text.
@@ -69,6 +70,13 @@ pub(super) enum SourceProcessingFailureCode {
     SqliteBusy,
     WorkerProcessFailed,
     WorkerProtocol,
+    ScannerIo,
+    ScannerStaleRevision,
+    ScannerIncomplete,
+    ScannerCancelled,
+    ScannerInvalidRoot,
+    ScannerTimeConversion,
+    SourceDatabaseRoot,
     ExecutionUnclassified,
 }
 
@@ -79,6 +87,13 @@ impl SourceProcessingFailureCode {
             Self::SqliteBusy => "sqlite_busy",
             Self::WorkerProcessFailed => "worker_process_failed",
             Self::WorkerProtocol => "worker_protocol",
+            Self::ScannerIo => "scanner_io",
+            Self::ScannerStaleRevision => "scanner_stale_revision",
+            Self::ScannerIncomplete => "scanner_incomplete",
+            Self::ScannerCancelled => "scanner_cancelled",
+            Self::ScannerInvalidRoot => "scanner_invalid_root",
+            Self::ScannerTimeConversion => "scanner_time_conversion",
+            Self::SourceDatabaseRoot => "source_database_root",
             Self::ExecutionUnclassified => "execution_unclassified",
         }
     }
@@ -96,7 +111,7 @@ pub(super) struct SourceProcessingFailure {
 }
 
 impl SourceProcessingFailure {
-    pub(super) const fn readiness_failure_classification(
+    pub(super) fn readiness_failure_classification(
         &self,
     ) -> wavecrate::sample_sources::readiness::ReadinessFailureClassification {
         match self.class {
@@ -108,6 +123,9 @@ impl SourceProcessingFailure {
             }
             SourceProcessingFailureClass::Unsupported => {
                 wavecrate::sample_sources::readiness::ReadinessFailureClassification::Unsupported
+            }
+            SourceProcessingFailureClass::Cancelled => {
+                unreachable!()
             }
         }
     }
@@ -132,6 +150,32 @@ impl SourceProcessingFailure {
             context: context.into(),
             source_error,
         }
+    }
+
+    fn retryable_with_source_error(
+        code: SourceProcessingFailureCode,
+        context: impl Into<String>,
+        source_error: impl Into<String>,
+    ) -> Self {
+        Self {
+            class: SourceProcessingFailureClass::Retryable,
+            code,
+            context: context.into(),
+            source_error: Some(source_error.into()),
+        }
+    }
+
+    fn cancelled() -> Self {
+        Self {
+            class: SourceProcessingFailureClass::Cancelled,
+            code: SourceProcessingFailureCode::ScannerCancelled,
+            context: "Source scanner cancelled".to_string(),
+            source_error: None,
+        }
+    }
+
+    pub(super) const fn is_cancelled(&self) -> bool {
+        matches!(self.class, SourceProcessingFailureClass::Cancelled)
     }
 }
 
@@ -168,6 +212,62 @@ impl From<rusqlite::Error> for SourceProcessingFailure {
             "Source database operation failed",
             Some(error.to_string()),
         )
+    }
+}
+
+impl From<wavecrate::app_dirs::AppDirError> for SourceProcessingFailure {
+    fn from(error: wavecrate::app_dirs::AppDirError) -> Self {
+        match error {
+            wavecrate::app_dirs::AppDirError::CreateDir { path, source } => {
+                Self::retryable_with_source_error(
+                    SourceProcessingFailureCode::SourceDatabaseRoot,
+                    "Source database root is temporarily unavailable",
+                    format!("{}: {source}", path.display()),
+                )
+            }
+            error => Self::permanent(
+                SourceProcessingFailureCode::SourceDatabaseRoot,
+                "Source database root could not be resolved",
+                Some(error.to_string()),
+            ),
+        }
+    }
+}
+
+impl From<wavecrate_scan::ScanError> for SourceProcessingFailure {
+    fn from(error: wavecrate_scan::ScanError) -> Self {
+        match error {
+            wavecrate_scan::ScanError::Canceled => Self::cancelled(),
+            wavecrate_scan::ScanError::StaleRevision { expected, actual } => Self::retryable(
+                SourceProcessingFailureCode::ScannerStaleRevision,
+                format!(
+                    "Source changed while completing deferred deep hash (expected revision {expected}, found {actual})"
+                ),
+            ),
+            wavecrate_scan::ScanError::Incomplete { error, .. } => {
+                Self::retryable_with_source_error(
+                    SourceProcessingFailureCode::ScannerIncomplete,
+                    "Deferred deep hash did not complete",
+                    error,
+                )
+            }
+            wavecrate_scan::ScanError::Io { path, source } => Self::retryable_with_source_error(
+                SourceProcessingFailureCode::ScannerIo,
+                "Source file was unavailable while completing deferred deep hash",
+                format!("{}: {source}", path.display()),
+            ),
+            wavecrate_scan::ScanError::Db(error) => source_database_failure(error),
+            wavecrate_scan::ScanError::InvalidRoot(path) => Self::permanent(
+                SourceProcessingFailureCode::ScannerInvalidRoot,
+                "Source root is not available for deferred deep hash",
+                Some(path.display().to_string()),
+            ),
+            wavecrate_scan::ScanError::Time { path } => Self::permanent(
+                SourceProcessingFailureCode::ScannerTimeConversion,
+                "Source file timestamp could not be converted",
+                Some(path.display().to_string()),
+            ),
+        }
     }
 }
 

--- a/src/native_app/source_processing/worker/tests.rs
+++ b/src/native_app/source_processing/worker/tests.rs
@@ -1,7 +1,48 @@
 use super::*;
+use std::path::PathBuf;
 use std::sync::{Arc, atomic::Ordering};
 use std::time::{Duration, Instant};
 use wavecrate::sample_sources::{SourceDatabase, SourceId};
+
+#[test]
+fn scanner_failures_preserve_retry_and_cancellation_policy() {
+    let unavailable = SourceProcessingFailure::from(wavecrate_scan::ScanError::Io {
+        path: PathBuf::from("unavailable.wav"),
+        source: std::io::Error::new(std::io::ErrorKind::NotFound, "temporarily unavailable"),
+    });
+    assert!(matches!(
+        unavailable.class,
+        SourceProcessingFailureClass::Retryable
+    ));
+    assert_eq!(unavailable.code.as_str(), "scanner_io");
+    assert_eq!(
+        unavailable.readiness_failure_classification(),
+        wavecrate::sample_sources::readiness::ReadinessFailureClassification::Retryable
+    );
+
+    let stale = SourceProcessingFailure::from(wavecrate_scan::ScanError::StaleRevision {
+        expected: 4,
+        actual: 5,
+    });
+    assert!(matches!(
+        stale.class,
+        SourceProcessingFailureClass::Retryable
+    ));
+    assert_eq!(stale.code.as_str(), "scanner_stale_revision");
+
+    let cancelled = SourceProcessingFailure::from(wavecrate_scan::ScanError::Canceled);
+    assert!(cancelled.is_cancelled());
+    assert_eq!(cancelled.code.as_str(), "scanner_cancelled");
+
+    let invalid_root = SourceProcessingFailure::from(wavecrate_scan::ScanError::InvalidRoot(
+        PathBuf::from("missing-source"),
+    ));
+    assert!(matches!(
+        invalid_root.class,
+        SourceProcessingFailureClass::Permanent
+    ));
+    assert_eq!(invalid_root.code.as_str(), "scanner_invalid_root");
+}
 
 #[test]
 fn cancelled_embedding_waiting_for_writer_does_not_publish() {


### PR DESCRIPTION
## Goal

Preserve typed scanner/deep-hash failures through indexed-identity readiness so transient filesystem failures enter bounded retry/backoff instead of the permanent `From<String>` fallback.

## Scope and non-goals

- Add an explicit `wavecrate_scan::ScanError` to source-processing failure conversion.
- Classify scanner I/O, stale revision, and incomplete work as retryable; preserve cancellation as a typed cancellation outcome; keep deterministic root/time failures permanent.
- Remove string-based classification from the indexed-identity readiness path.
- Strengthen the regression for retry code, attempt count, fairness, and restoration.
- No global retry/backoff redesign, unsupported-file retry broadening, lifecycle-fencing change, or merge is included.

## Definition of Done

- Temporarily unavailable deferred-hash paths persist as `retryable/scanner_io` with a retry deadline.
- Healthy later files hash in the same work lane.
- Restoring the path allows the deferred hash to run again.
- Cancellation, stale revision, retryable, permanent, and unsupported outcomes remain typed and distinguishable.
- Indexed-identity readiness no longer relies on `From<String>` for scanner classification.

## Validation

- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests -- --nocapture` — 96 passed, 1 ignored.
- `cargo test -p wavecrate-scan --all-targets` — 163 passed.
- Focused scanner-policy regression — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `bash scripts/ci.sh agent` — Wavecrate checks passed, but the unchanged vendored Radiant suite fails `gpu_signal_shader_keeps_waveform_bands_visually_distinct` on an existing shader-string assertion.

## Known limitations

The full agent gate remains blocked by the pre-existing vendored Radiant shader assertion; no vendor files are changed.

User approval is required before merge.