### PR TITLE
Recover readiness retries and expired leases after restart

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/readiness/model.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/model.rs
@@ -513,6 +513,23 @@ pub struct ReadinessWorkStats {
     pub completed: usize,
 }
 
+impl ReadinessWorkStats {
+    /// Whether durable readiness work can be claimed immediately.
+    pub fn has_actionable_work(&self) -> bool {
+        self.pending > 0 || self.expired_leases > 0 || self.retries_due > 0
+    }
+
+    /// Return the earliest future retry or lease deadline.
+    pub fn earliest_future_deadline(&self) -> Option<i64> {
+        match (self.earliest_retry_at, self.earliest_lease_expiry_at) {
+            (Some(retry_at), Some(lease_expires_at)) => Some(retry_at.min(lease_expires_at)),
+            (Some(retry_at), None) => Some(retry_at),
+            (None, Some(lease_expires_at)) => Some(lease_expires_at),
+            (None, None) => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct ReadinessKey {
     pub(crate) source_id: String,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store.rs
@@ -394,6 +394,15 @@ impl<'connection> ReadinessStore<'connection> {
         work::readiness_work_stats(self.connection, now)
     }
 
+    /// Load bounded queue and lease-recovery telemetry for one source.
+    pub fn source_work_stats(
+        &mut self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessWorkStats, ReadinessError> {
+        work::readiness_work_stats_for_source(self.connection, source_id, now)
+    }
+
     /// Publish an independently produced artifact if its target is still current.
     pub fn publish_artifact(
         &mut self,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/view.rs
@@ -49,6 +49,15 @@ impl<'connection> ReadinessView<'connection> {
         work::readiness_work_stats(self.connection, now)
     }
 
+    /// Read bounded queue and lease-recovery telemetry for one source.
+    pub fn source_work_stats(
+        &self,
+        source_id: &str,
+        now: i64,
+    ) -> Result<ReadinessWorkStats, ReadinessError> {
+        work::readiness_work_stats_for_source(self.connection, source_id, now)
+    }
+
     /// Check whether a prerequisite stage is terminally unsupported.
     pub fn stage_is_unsupported(
         &self,

--- a/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
+++ b/crates/wavecrate-library/src/sample_sources/readiness/store/work.rs
@@ -610,19 +610,44 @@ pub(crate) fn readiness_work_stats(
     connection: &Connection,
     now: i64,
 ) -> Result<ReadinessWorkStats, ReadinessError> {
+    readiness_work_stats_for_source_inner(connection, None, now)
+}
+
+/// Read readiness work stats for one source without loading its target set.
+pub(crate) fn readiness_work_stats_for_source(
+    connection: &Connection,
+    source_id: &str,
+    now: i64,
+) -> Result<ReadinessWorkStats, ReadinessError> {
+    readiness_work_stats_for_source_inner(connection, Some(source_id), now)
+}
+
+fn readiness_work_stats_for_source_inner(
+    connection: &Connection,
+    source_id: Option<&str>,
+    now: i64,
+) -> Result<ReadinessWorkStats, ReadinessError> {
+    let source_filter = source_id.map_or(String::new(), |_| {
+        String::from("\n           AND source.source_id = ?2")
+    });
+    let mut parameters = vec![rusqlite::types::Value::Integer(now)];
+    if let Some(source_id) = source_id {
+        parameters.push(rusqlite::types::Value::Text(source_id.to_string()));
+    }
     let values = connection.query_row(
-        "SELECT
+        &format!(
+            "SELECT
             COUNT(*),
             SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END),
             SUM(CASE WHEN status = 'running' AND lease_expires_at > ?1 THEN 1 ELSE 0 END),
             SUM(CASE WHEN status = 'running' AND (
                 lease_expires_at IS NULL OR lease_expires_at <= ?1
             ) THEN 1 ELSE 0 END),
-            SUM(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+            SUM(CASE WHEN status = 'failed' AND (failure_kind IS NULL OR failure_kind = 'retryable')
                 AND (retry_at IS NULL OR retry_at <= ?1) THEN 1 ELSE 0 END),
-            SUM(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+            SUM(CASE WHEN status = 'failed' AND (failure_kind IS NULL OR failure_kind = 'retryable')
                 AND retry_at > ?1 THEN 1 ELSE 0 END),
-            MIN(CASE WHEN status = 'failed' AND failure_kind = 'retryable'
+            MIN(CASE WHEN status = 'failed' AND (failure_kind IS NULL OR failure_kind = 'retryable')
                 AND retry_at > ?1 THEN retry_at ELSE NULL END),
             MIN(CASE WHEN status = 'running' AND lease_expires_at > ?1
                 THEN lease_expires_at ELSE NULL END),
@@ -660,8 +685,9 @@ pub(crate) fn readiness_work_stats(
            AND (
                target.scope_kind = 'file'
                OR job.source_generation = target.source_generation
-           )",
-        [now],
+           ){source_filter}",
+        ),
+        rusqlite::params_from_iter(parameters.iter()),
         |row| {
             Ok((
                 row.get::<_, i64>(0)?,

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -25,8 +25,8 @@ use wavecrate::sample_sources::{
         ReadinessFailureOutcome, ReadinessLeaseRenewalOutcome, ReadinessMembership,
         ReadinessProgress, ReadinessRetryPolicy, ReadinessScopeKind, ReadinessSnapshot,
         ReadinessStage, ReadinessStageCounts, ReadinessStore, ReadinessTarget,
-        ReadinessTargetDeltaPublication, ReadinessTargetPublication, ReadinessWorkMutationOutcome,
-        SourceAvailability,
+        ReadinessTargetDeltaPublication, ReadinessTargetPublication, ReadinessView,
+        ReadinessWorkMutationOutcome, SourceAvailability,
     },
     scanner::{
         CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget, ContentAuditStorage,

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -4,7 +4,7 @@ use super::{
     RuntimeCandidate, SOURCE_DISCOVERY_RETRY_SECONDS, SampleSource, Shared, SourceDatabase,
     SourceDatabaseConnectionRole, SourceDiscoveryStats, SourceHealthSummary, cancelled,
     discover_source_candidates_with_connection_and_progress, now_epoch_seconds,
-    readiness_safety_probe_is_current, source_health_summary, source_processing_schema_available,
+    readiness_safety_probe, source_health_summary, source_processing_schema_available,
 };
 
 pub(super) fn scheduler_candidate_indices(
@@ -270,12 +270,13 @@ pub(super) fn discover_source_candidates_with_progress(
             SourceDatabaseConnectionRole::BackgroundRead,
         ) {
             Ok(mut probe_connection) => {
-                if readiness_safety_probe_is_current(
+                let probe = readiness_safety_probe(
                     &mut probe_connection,
                     source,
                     now,
                     force_manifest_audit,
-                )? {
+                )?;
+                if probe.current && probe.earliest_deadline.is_none() {
                     tracing::debug!(
                         target: "wavecrate::source_processing",
                         event = "source_processing.safety_sweep_noop",
@@ -286,6 +287,15 @@ pub(super) fn discover_source_candidates_with_progress(
                         Vec::new(),
                         SourceDiscoveryStats {
                             cheap_noop_sweep: true,
+                            ..SourceDiscoveryStats::default()
+                        },
+                        None,
+                    )));
+                } else if probe.current {
+                    return Ok(Cancellable::Completed((
+                        Vec::new(),
+                        SourceDiscoveryStats {
+                            earliest_retry_at: probe.earliest_deadline,
                             ..SourceDiscoveryStats::default()
                         },
                         None,

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -1,8 +1,8 @@
 use super::{
     AtomicBool, Cancellable, DiscoveryProgressUpdate, MANIFEST_AUDIT_INTERVAL_SECONDS,
     META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION, PendingReadinessDelta, ProcessingLane,
-    ReadinessClassification, ReadinessProgress, ReadinessStore, RuntimeCandidate, RuntimeTask,
-    SampleSource, SourceAvailability, SourceDiscoveryPhase, SourceDiscoveryStats,
+    ReadinessClassification, ReadinessProgress, ReadinessStore, ReadinessView, RuntimeCandidate,
+    RuntimeTask, SampleSource, SourceAvailability, SourceDiscoveryPhase, SourceDiscoveryStats,
     SourceHealthSummary, WorkCandidate, active_recording_deferrals, cancelled, earliest_deadline,
     legacy_unsupported_decode_failure_text, publish_current_readiness_delta_with_cancel,
     publish_current_readiness_targets_with_cancel_and_checkpoint, readiness_contract_version,
@@ -16,14 +16,20 @@ use wavecrate_library::{
     sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
 };
 
-pub(super) fn readiness_safety_probe_is_current(
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct ReadinessSafetyProbe {
+    pub(super) current: bool,
+    pub(super) earliest_deadline: Option<i64>,
+}
+
+pub(super) fn readiness_safety_probe(
     connection: &mut rusqlite::Connection,
     source: &SampleSource,
     now: i64,
     force_manifest_audit: bool,
-) -> Result<bool, String> {
+) -> Result<ReadinessSafetyProbe, String> {
     if force_manifest_audit || !source_processing_schema_available(connection)? {
-        return Ok(false);
+        return Ok(ReadinessSafetyProbe::default());
     }
     let source_id = source.id.as_str();
     let last_manifest_audit_at = connection
@@ -37,7 +43,7 @@ pub(super) fn readiness_safety_probe_is_current(
         .and_then(|value| value.parse::<i64>().ok())
         .unwrap_or_default();
     if now.saturating_sub(last_manifest_audit_at) >= MANIFEST_AUDIT_INTERVAL_SECONDS {
-        return Ok(false);
+        return Ok(ReadinessSafetyProbe::default());
     }
     let source_generation = connection
         .query_row(
@@ -58,7 +64,16 @@ pub(super) fn readiness_safety_probe_is_current(
                 && state.availability == SourceAvailability::Active
                 && state.contract_version == contract_version
         });
-    Ok(readiness_is_current && durable_watcher_coverage_is_current(connection, source)?)
+    if !readiness_is_current || !durable_watcher_coverage_is_current(connection, source)? {
+        return Ok(ReadinessSafetyProbe::default());
+    }
+    let work = ReadinessView::new(connection)
+        .source_work_stats(source_id, now)
+        .map_err(|error| error.to_string())?;
+    Ok(ReadinessSafetyProbe {
+        current: !work.has_actionable_work(),
+        earliest_deadline: work.earliest_future_deadline(),
+    })
 }
 
 /// On macOS a current readiness revision is only safe to skip when its root still matches the
@@ -200,17 +215,29 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
         .map_err(|error| error.to_string())?
         .and_then(|value| value.parse::<i64>().ok())
         .unwrap_or_default();
-    if safety_probe_only
-        && readiness_safety_probe_is_current(connection, source, now, force_manifest_audit)?
-    {
-        stats.cheap_noop_sweep = true;
-        tracing::debug!(
-            target: "wavecrate::source_processing",
-            event = "source_processing.safety_sweep_noop",
-            source_id,
-            "Periodic readiness safety probe found no durable delta"
-        );
-        return Ok(Cancellable::Completed((candidates, stats, None)));
+    if safety_probe_only {
+        let probe = readiness_safety_probe(connection, source, now, force_manifest_audit)?;
+        if probe.current {
+            if probe.earliest_deadline.is_none() {
+                stats.cheap_noop_sweep = true;
+                tracing::debug!(
+                    target: "wavecrate::source_processing",
+                    event = "source_processing.safety_sweep_noop",
+                    source_id,
+                    "Periodic readiness safety probe found no durable delta"
+                );
+            } else {
+                stats.earliest_retry_at = probe.earliest_deadline;
+                tracing::debug!(
+                    target: "wavecrate::source_processing",
+                    event = "source_processing.safety_sweep_deadline",
+                    source_id,
+                    deadline = probe.earliest_deadline,
+                    "Readiness safety probe parked until durable work is actionable"
+                );
+            }
+            return Ok(Cancellable::Completed((candidates, stats, None)));
+        }
     }
     if force_reanalysis {
         let changed = ReadinessStore::new(connection)

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -179,6 +179,201 @@ fn discovery_progress_converged_safety_probe_is_a_silent_noop() {
 }
 
 #[test]
+fn safety_probe_recovers_durable_retry_and_lease_deadlines_after_restart() {
+    let (_directory, source) = unhashed_source("durable-readiness-deadlines");
+    let database_root = source.database_root().expect("database root");
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("open source database");
+    publish_current_readiness_targets(&mut connection, source.id.as_str(), 100)
+        .expect("publish readiness targets");
+    let snapshot = reconcile_readiness(&connection, source.id.as_str(), 100)
+        .expect("reconcile readiness targets");
+    let target = snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.target.stage == ReadinessStage::IndexedIdentity)
+        .expect("indexed identity target")
+        .target
+        .clone();
+    persist_readiness_deficits(&mut connection, &snapshot.deficits, 100)
+        .expect("persist readiness work");
+    connection
+        .execute(
+            "UPDATE analysis_jobs
+             SET status = 'done', running_at = NULL, retry_at = NULL,
+                 failure_kind = NULL, failure_code = NULL, lease_expires_at = NULL
+             WHERE readiness_managed = 1",
+            [],
+        )
+        .expect("settle unrelated readiness work");
+    connection
+        .execute(
+            "UPDATE analysis_jobs
+             SET status = 'pending'
+             WHERE readiness_managed = 1
+               AND readiness_scope_id = ?1
+               AND readiness_stage = 'indexed_identity'",
+            [target.scope_id.as_str()],
+        )
+        .expect("retain one readiness job");
+    connection
+        .execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, '100')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [META_LAST_MANIFEST_AUDIT_AT],
+        )
+        .expect("persist recent manifest audit");
+    #[cfg(target_os = "macos")]
+    {
+        let metadata = std::fs::metadata(&source.root).expect("source root metadata");
+        let root_identity =
+            wavecrate_library::filesystem_identity::stable_filesystem_identity(&source.root, &metadata)
+                .expect("stable source root identity");
+        connection
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                rusqlite::params![
+                    wavecrate_library::sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
+                    serde_json::json!({ "root_identity": root_identity, "event_id": 1_u64 })
+                        .to_string(),
+                ],
+            )
+            .expect("persist durable watcher coverage");
+    }
+
+    let claim = claim_readiness_target(&mut connection, &target, 100, 50)
+        .expect("claim readiness target")
+        .expect("target is claimable");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| panic!("future deadline probe must not materialize targets"),
+        )
+        .expect("probe future lease deadline")
+    else {
+        panic!("future deadline probe unexpectedly cancelled");
+    };
+    assert!(candidates.is_empty());
+    assert!(!stats.cheap_noop_sweep);
+    assert_eq!(stats.earliest_retry_at, Some(150));
+
+    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen source database");
+    let claim_generation_before = claim.claim_generation;
+    connection
+        .execute(
+            "UPDATE analysis_jobs SET lease_expires_at = 99
+             WHERE readiness_managed = 1 AND readiness_claim_generation = ?1",
+            [claim_generation_before],
+        )
+        .expect("expire readiness lease");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("probe expired lease")
+    else {
+        panic!("expired lease probe unexpectedly cancelled");
+    };
+    assert!(!stats.cheap_noop_sweep);
+    assert!(!candidates.is_empty(), "expired lease must become candidate work");
+
+    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen source database for retry");
+    connection
+        .execute(
+            "UPDATE analysis_jobs
+             SET status = 'failed', failure_kind = NULL, failure_code = 'test_retry',
+                 retry_at = 250, lease_expires_at = NULL
+             WHERE readiness_managed = 1",
+            [],
+        )
+        .expect("park retryable readiness work");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| panic!("future retry probe must not materialize targets"),
+        )
+        .expect("probe future retry deadline")
+    else {
+        panic!("future retry probe unexpectedly cancelled");
+    };
+    assert!(candidates.is_empty());
+    assert!(!stats.cheap_noop_sweep);
+    assert_eq!(stats.earliest_retry_at, Some(250));
+
+    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen source database for due retry");
+    connection
+        .execute(
+            "UPDATE analysis_jobs SET retry_at = NULL WHERE readiness_managed = 1",
+            [],
+        )
+        .expect("make retry compatibility-null and due");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("probe due retry deadline")
+    else {
+        panic!("due retry probe unexpectedly cancelled");
+    };
+    assert!(!stats.cheap_noop_sweep);
+    assert!(!candidates.is_empty(), "due retry must become candidate work");
+}
+
+#[test]
 fn macos_safety_probe_requires_durable_watcher_coverage() {
     let (_directory, source) = unhashed_source(&format!(
         "missing-watcher-coverage-{}",

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -309,6 +309,43 @@ fn safety_probe_recovers_durable_retry_and_lease_deadlines_after_restart() {
         &database_root,
         SourceDatabaseConnectionRole::JobWorker,
     )
+    .expect("reopen source database for null lease");
+    connection
+        .execute(
+            "UPDATE analysis_jobs
+             SET status = 'running', lease_expires_at = NULL
+             WHERE readiness_managed = 1",
+            [],
+        )
+        .expect("simulate compatibility-null running lease");
+    drop(connection);
+
+    let Cancellable::Completed((candidates, stats, _health)) =
+        discover_source_candidates_with_progress(
+            &source,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("probe compatibility-null lease")
+    else {
+        panic!("compatibility-null lease probe unexpectedly cancelled");
+    };
+    assert!(!stats.cheap_noop_sweep);
+    assert!(
+        !candidates.is_empty(),
+        "compatibility-null lease must become candidate work"
+    );
+
+    let connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
     .expect("reopen source database for retry");
     connection
         .execute(


### PR DESCRIPTION
## Goal

Recover durable readiness retries and expired leases immediately after a Wavecrate restart.

## Scope

- Add a bounded, source-indexed readiness work aggregate for pending, due/future retries, and running lease deadlines.
- Make startup and periodic safety probes consult durable work before taking the cheap no-op path.
- Schedule the earliest future retry or lease deadline without materializing file targets.
- Preserve claim-generation and unexpired-lease ownership semantics, including compatibility-null leases and legacy retry classifications.

Non-goals: no manifest traversal for deadline discovery, retry-policy redesign, startup reset of running jobs, high-frequency polling of unavailable sources, or changes to generation/claim fencing.

## Definition of Done

- Due retryable work and expired or compatibility-reclaimable leases become actionable after restart.
- Unexpired leases remain untouched and produce a wake at their persisted expiry.
- Future retry deadlines produce a coordinator wake no later than the deadline.
- Fully converged sources retain the bounded cheap no-op path.
- Regression coverage exercises future/due retries, future/expired/null leases, and restart probe behavior.

## Validation

- `cargo test -p wavecrate-library --lib sample_sources::readiness::tests::` — 47 passed.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests::` — 97 passed, 1 ignored.
- `cargo test -p wavecrate --lib safety_probe_recovers_durable_retry_and_lease_deadlines_after_restart` — passed.
- `bash scripts/ci.sh agent` — stopped at an unrelated pre-existing vendor/radiant shader assertion: `gpu_signal_shader_keeps_waveform_bands_visually_distinct`; all changed files are outside `vendor/`.

## Known limitations

The full agent gate remains blocked by the unrelated existing vendor shader test failure. No task-local test failure was observed.

Related issue: OPT-1274

User approval is required before merge.