### PR TITLE
fix(source-processing): park duplicate hard-link readiness identities

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -83,6 +83,8 @@ pub const META_DEFERRED_MAINTENANCE_REVISION: &str = "deferred_maintenance_revis
 pub const META_DEFERRED_MAINTENANCE_SCHEMA: &str = "deferred_maintenance_schema_v1";
 /// Metadata key storing the last revision that changed the ordered wav path set.
 pub const META_WAV_PATHS_REVISION: &str = "wav_paths_revision_v1";
+/// Metadata key storing a revision-fenced readiness diagnostic for duplicate file identities.
+pub const META_READINESS_DUPLICATE_IDENTITY: &str = "readiness_duplicate_identity_v1";
 /// Metadata key storing the revision of the index-only unsupported file set.
 pub const META_SOURCE_INDEX_REVISION: &str = "source_index_revision_v1";
 /// Env var that enables read-only source DB opening by default.

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -83,6 +83,8 @@ pub const META_DEFERRED_MAINTENANCE_REVISION: &str = "deferred_maintenance_revis
 pub const META_DEFERRED_MAINTENANCE_SCHEMA: &str = "deferred_maintenance_schema_v1";
 /// Metadata key storing the last revision that changed the ordered wav path set.
 pub const META_WAV_PATHS_REVISION: &str = "wav_paths_revision_v1";
+/// Metadata key storing the last revision that changed live wav filesystem identities.
+pub const META_WAV_IDENTITIES_REVISION: &str = "wav_identities_revision_v1";
 /// Metadata key storing a revision-fenced readiness diagnostic for duplicate file identities.
 pub const META_READINESS_DUPLICATE_IDENTITY: &str = "readiness_duplicate_identity_v1";
 /// Metadata key storing the revision of the index-only unsupported file set.
@@ -122,6 +124,7 @@ pub struct SourceWriteBatch<'conn> {
     tx: Transaction<'conn>,
     db_path: PathBuf,
     paths_revision_dirty: bool,
+    identities_revision_dirty: bool,
     index_revision_dirty: bool,
     manifest_touched_paths: BTreeSet<PathBuf>,
     telemetry_label: &'static str,

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -204,6 +204,7 @@ impl<'conn> SourceWriteBatch<'conn> {
         missing: bool,
     ) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.identities_revision_dirty = true;
         self.manifest_touched_paths
             .insert(relative_path.to_path_buf());
         self.clear_pending_rename_for_live_path(relative_path)?;
@@ -287,6 +288,7 @@ impl<'conn> SourceWriteBatch<'conn> {
         relative_path: &Path,
         missing: bool,
     ) -> Result<(), SourceDbError> {
+        self.identities_revision_dirty = true;
         self.manifest_touched_paths
             .insert(relative_path.to_path_buf());
         update_flag_statement(&self.tx, UPDATE_MISSING_SQL, relative_path, missing)

--- a/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/batch.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 
 use super::super::util::map_sql_error;
 use super::super::{Rating, SampleSoundType, SourceDbError, SourceWriteBatch};
@@ -164,6 +164,19 @@ impl<'conn> SourceWriteBatch<'conn> {
         relative_path: &Path,
         file_identity: Option<&str>,
     ) -> Result<(), SourceDbError> {
+        let previous_identity = self
+            .tx
+            .query_row(
+                "SELECT file_identity FROM wav_files WHERE path = ?1",
+                [relative_path.to_string_lossy().as_ref()],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .flatten();
+        if previous_identity.as_deref() != file_identity {
+            self.identities_revision_dirty = true;
+        }
         self.manifest_touched_paths
             .insert(relative_path.to_path_buf());
         match file_identity {

--- a/crates/wavecrate-library/src/sample_sources/db/write/database.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/database.rs
@@ -175,6 +175,7 @@ impl SourceDatabase {
             tx,
             db_path: self.db_path.clone(),
             paths_revision_dirty: false,
+            identities_revision_dirty: false,
             index_revision_dirty: false,
             manifest_touched_paths: std::collections::BTreeSet::new(),
             telemetry_label: self.telemetry_label,
@@ -194,6 +195,12 @@ impl SourceDatabase {
         conn: &rusqlite::Connection,
     ) -> Result<(), SourceDbError> {
         Self::bump_metadata_counter(conn, META_WAV_PATHS_REVISION)
+    }
+
+    pub(super) fn bump_wav_identities_revision(
+        conn: &rusqlite::Connection,
+    ) -> Result<(), SourceDbError> {
+        Self::bump_metadata_counter(conn, super::super::META_WAV_IDENTITIES_REVISION)
     }
 
     pub(super) fn bump_source_index_revision(

--- a/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/paths.rs
@@ -9,6 +9,7 @@ impl SourceWriteBatch<'_> {
     /// Remove a wav row within the batch.
     pub fn remove_file(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.identities_revision_dirty = true;
         self.manifest_touched_paths
             .insert(relative_path.to_path_buf());
         delete_path_statement(&self.tx, relative_path)
@@ -21,6 +22,7 @@ impl SourceWriteBatch<'_> {
         new_relative_path: &Path,
     ) -> Result<(), SourceDbError> {
         self.paths_revision_dirty = true;
+        self.identities_revision_dirty = true;
         self.manifest_touched_paths
             .insert(old_relative_path.to_path_buf());
         self.manifest_touched_paths

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -43,7 +43,10 @@ impl SourceWriteBatch<'_> {
     /// Callers use it for transactionally coherent auxiliary lifecycle state whose publication
     /// must not impersonate a new source-manifest generation.
     pub fn commit_auxiliary_state(self) -> Result<(), SourceDbError> {
-        if self.paths_revision_dirty || !self.manifest_touched_paths.is_empty() {
+        if self.paths_revision_dirty
+            || self.identities_revision_dirty
+            || !self.manifest_touched_paths.is_empty()
+        {
             return Err(SourceDbError::Unexpected);
         }
         if self.index_revision_dirty {
@@ -158,6 +161,9 @@ impl SourceWriteBatch<'_> {
         SourceDatabase::bump_revision(&self.tx)?;
         if self.paths_revision_dirty {
             SourceDatabase::bump_wav_paths_revision(&self.tx)?;
+        }
+        if self.identities_revision_dirty {
+            SourceDatabase::bump_wav_identities_revision(&self.tx)?;
         }
         if self.index_revision_dirty {
             SourceDatabase::bump_source_index_revision(&self.tx)?;

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -424,6 +424,16 @@ For every current eligible file, the readiness stages are:
 
 This is exactly three file-scoped targets per current eligible file plus one source-scoped similarity target. Playback-cache residency is not a fifth readiness stage.
 
+Stable filesystem identity is an ownership key, not a uniqueness assertion over visible manifest
+paths. If two supported live paths are hard links to the same filesystem object, the current
+readiness executor must not collapse one path into a silently incomplete browser record. Until
+path-alias-aware analysis and browser projections are implemented, discovery records a bounded,
+actionable `duplicate_manifest_identity` terminal diagnostic containing the affected relative
+paths, parks that unchanged manifest revision without a five-second retry, and rechecks only after
+the manifest revision changes or an explicit manifest repair is requested. It remains parked if
+the duplicate condition persists. Distinct identities are never merged based on size, timestamps,
+or content hash.
+
 Each target and completion must carry the committed source generation, a non-empty file content generation or source-membership generation, and the stage's artifact-contract version. Desired-state publications also carry a per-source monotonic readiness revision; a writer whose revision is not newer than the persisted revision is stale even when its source generation is equal, so delayed lifecycle writers cannot reactivate an offline or disabled source. The source generation is a publication and diagnostic fence, not a blanket invalidation token for file-scoped artifacts: an unchanged stable file identity remains current across unrelated manifest changes when its stage version and stage-relevant content/path generation still match. Source-scoped similarity work must additionally match the current source generation and membership generation. A late completion may publish only when the values relevant to its scope still match the current desired target. Timestamps, total row counts, source-prep markers, or the existence of some artifacts are diagnostic inputs only; they must never make a source look ready when a current eligible identity lacks an exact artifact or when stale/deleted identities are still the only covered rows.
 
 The readiness classifier must distinguish current, pending, running with a lease, retryable failure with a retry deadline, permanent failure, unsupported terminal state, offline, disabled, deleted, and stale-by-generation. Unsupported, deleted, and permanent-failure targets remain observable but do not spin. Offline and disabled sources retain desired state without being scheduled until they become active and available. Expired leases and due retryable failures become actionable deficits after restart or worker interruption.

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -429,10 +429,10 @@ paths. If two supported live paths are hard links to the same filesystem object,
 readiness executor must not collapse one path into a silently incomplete browser record. Until
 path-alias-aware analysis and browser projections are implemented, discovery records a bounded,
 actionable `duplicate_manifest_identity` terminal diagnostic containing the affected relative
-paths, parks that unchanged manifest revision without a five-second retry, and rechecks only after
-the manifest revision changes or an explicit manifest repair is requested. It remains parked if
-the duplicate condition persists. Distinct identities are never merged based on size, timestamps,
-or content hash.
+paths, parks that unchanged identity-membership revision without a five-second retry, and rechecks
+only after a supported live identity changes or an explicit manifest repair is requested. It remains
+parked if the duplicate condition persists. Distinct identities are never merged based on size,
+timestamps, or content hash.
 
 Each target and completion must carry the committed source generation, a non-empty file content generation or source-membership generation, and the stage's artifact-contract version. Desired-state publications also carry a per-source monotonic readiness revision; a writer whose revision is not newer than the persisted revision is stale even when its source generation is equal, so delayed lifecycle writers cannot reactivate an offline or disabled source. The source generation is a publication and diagnostic fence, not a blanket invalidation token for file-scoped artifacts: an unchanged stable file identity remains current across unrelated manifest changes when its stage version and stage-relevant content/path generation still match. Source-scoped similarity work must additionally match the current source generation and membership generation. A late completion may publish only when the values relevant to its scope still match the current desired target. Timestamps, total row counts, source-prep markers, or the existence of some artifacts are diagnostic inputs only; they must never make a source look ready when a current eligible identity lacks an exact artifact or when stale/deleted identities are still the only covered rows.
 

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -18,7 +18,7 @@ use rusqlite::params;
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole, SourceMetadataStorage,
-    db::{META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION},
+    db::{META_LAST_MANIFEST_AUDIT_AT, META_READINESS_DUPLICATE_IDENTITY, META_WAV_PATHS_REVISION},
     readiness::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessActivity, ReadinessClassification,
         ReadinessDeltaPublicationOutcome, ReadinessEligibility, ReadinessFailureClassification,

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -18,7 +18,10 @@ use rusqlite::params;
 use serde_json::Value;
 use wavecrate::sample_sources::{
     SampleSource, SourceDatabase, SourceDatabaseConnectionRole, SourceMetadataStorage,
-    db::{META_LAST_MANIFEST_AUDIT_AT, META_READINESS_DUPLICATE_IDENTITY, META_WAV_PATHS_REVISION},
+    db::{
+        META_LAST_MANIFEST_AUDIT_AT, META_READINESS_DUPLICATE_IDENTITY,
+        META_WAV_IDENTITIES_REVISION, META_WAV_PATHS_REVISION,
+    },
     readiness::{
         ArtifactPublishOutcome, ClaimedReadinessWork, ReadinessActivity, ReadinessClassification,
         ReadinessDeltaPublicationOutcome, ReadinessEligibility, ReadinessFailureClassification,

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -1,11 +1,12 @@
 use super::{
     AtomicBool, Cancellable, DiscoveryProgressUpdate, MANIFEST_AUDIT_INTERVAL_SECONDS,
-    META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION, PendingReadinessDelta, ProcessingLane,
-    ReadinessClassification, ReadinessProgress, ReadinessStore, ReadinessView, RuntimeCandidate,
-    RuntimeTask, SampleSource, SourceAvailability, SourceDiscoveryPhase, SourceDiscoveryStats,
-    SourceHealthSummary, WorkCandidate, active_recording_deferrals, cancelled,
-    clear_duplicate_identity_diagnostic, duplicate_identity_diagnostic_for_revision,
-    earliest_deadline, find_duplicate_identity_diagnostics, legacy_unsupported_decode_failure_text,
+    META_LAST_MANIFEST_AUDIT_AT, META_WAV_IDENTITIES_REVISION, META_WAV_PATHS_REVISION,
+    PendingReadinessDelta, ProcessingLane, ReadinessClassification, ReadinessProgress,
+    ReadinessStore, ReadinessView, RuntimeCandidate, RuntimeTask, SampleSource, SourceAvailability,
+    SourceDiscoveryPhase, SourceDiscoveryStats, SourceHealthSummary, WorkCandidate,
+    active_recording_deferrals, cancelled, clear_duplicate_identity_diagnostic,
+    duplicate_identity_diagnostic_for_revision, earliest_deadline,
+    find_duplicate_identity_diagnostics, legacy_unsupported_decode_failure_text,
     persist_duplicate_identity_diagnostic, publish_current_readiness_delta_with_cancel,
     publish_current_readiness_targets_with_cancel_and_checkpoint, readiness_contract_version,
     retire_legacy_playback_readiness, similarity_prerequisite_blocker_stats,
@@ -206,24 +207,24 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
             )),
         )));
     }
-    let manifest_revision = connection
+    let identity_revision = connection
         .query_row(
             "SELECT COALESCE(
                 (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1),
                 0
              )",
-            [META_WAV_PATHS_REVISION],
+            [META_WAV_IDENTITIES_REVISION],
             |row| row.get::<_, i64>(0),
         )
         .map_err(|error| error.to_string())?;
     if !force_manifest_audit
-        && duplicate_identity_diagnostic_for_revision(connection, manifest_revision)?.is_some()
+        && duplicate_identity_diagnostic_for_revision(connection, identity_revision)?.is_some()
     {
         tracing::warn!(
             target: "wavecrate::source_processing",
             event = "source_processing.duplicate_identity_terminal",
             source_id,
-            manifest_revision,
+            identity_revision,
             "Skipped unchanged readiness reconciliation after a durable duplicate-identity diagnosis"
         );
         return Ok(Cancellable::Completed((
@@ -239,7 +240,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
     if !duplicate_identities.is_empty() {
         persist_duplicate_identity_diagnostic(
             connection,
-            manifest_revision,
+            identity_revision,
             &duplicate_identities,
         )?;
         for diagnostic in &duplicate_identities {
@@ -247,7 +248,7 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
                 target: "wavecrate::source_processing",
                 event = "source_processing.duplicate_identity_terminal",
                 source_id,
-                manifest_revision,
+                identity_revision,
                 identity = diagnostic.identity.as_str(),
                 alias_count = diagnostic.paths.len(),
                 paths = ?diagnostic.paths,

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -3,8 +3,10 @@ use super::{
     META_LAST_MANIFEST_AUDIT_AT, META_WAV_PATHS_REVISION, PendingReadinessDelta, ProcessingLane,
     ReadinessClassification, ReadinessProgress, ReadinessStore, ReadinessView, RuntimeCandidate,
     RuntimeTask, SampleSource, SourceAvailability, SourceDiscoveryPhase, SourceDiscoveryStats,
-    SourceHealthSummary, WorkCandidate, active_recording_deferrals, cancelled, earliest_deadline,
-    legacy_unsupported_decode_failure_text, publish_current_readiness_delta_with_cancel,
+    SourceHealthSummary, WorkCandidate, active_recording_deferrals, cancelled,
+    clear_duplicate_identity_diagnostic, duplicate_identity_diagnostic_for_revision,
+    earliest_deadline, find_duplicate_identity_diagnostics, legacy_unsupported_decode_failure_text,
+    persist_duplicate_identity_diagnostic, publish_current_readiness_delta_with_cancel,
     publish_current_readiness_targets_with_cancel_and_checkpoint, readiness_contract_version,
     retire_legacy_playback_readiness, similarity_prerequisite_blocker_stats,
     source_processing_schema_available,
@@ -201,6 +203,62 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
             stats,
             Some(SourceHealthSummary::reconciliation_failed(
                 "readiness_schema_unavailable",
+            )),
+        )));
+    }
+    let manifest_revision = connection
+        .query_row(
+            "SELECT COALESCE(
+                (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1),
+                0
+             )",
+            [META_WAV_PATHS_REVISION],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if !force_manifest_audit
+        && duplicate_identity_diagnostic_for_revision(connection, manifest_revision)?.is_some()
+    {
+        tracing::warn!(
+            target: "wavecrate::source_processing",
+            event = "source_processing.duplicate_identity_terminal",
+            source_id,
+            manifest_revision,
+            "Skipped unchanged readiness reconciliation after a durable duplicate-identity diagnosis"
+        );
+        return Ok(Cancellable::Completed((
+            candidates,
+            stats,
+            Some(SourceHealthSummary::reconciliation_failed(
+                "duplicate_manifest_identity",
+            )),
+        )));
+    }
+    clear_duplicate_identity_diagnostic(connection)?;
+    let duplicate_identities = find_duplicate_identity_diagnostics(connection)?;
+    if !duplicate_identities.is_empty() {
+        persist_duplicate_identity_diagnostic(
+            connection,
+            manifest_revision,
+            &duplicate_identities,
+        )?;
+        for diagnostic in &duplicate_identities {
+            tracing::warn!(
+                target: "wavecrate::source_processing",
+                event = "source_processing.duplicate_identity_terminal",
+                source_id,
+                manifest_revision,
+                identity = diagnostic.identity.as_str(),
+                alias_count = diagnostic.paths.len(),
+                paths = ?diagnostic.paths,
+                "Readiness reconciliation is parked because multiple manifest paths share one stable filesystem identity"
+            );
+        }
+        return Ok(Cancellable::Completed((
+            candidates,
+            stats,
+            Some(SourceHealthSummary::reconciliation_failed(
+                "duplicate_manifest_identity",
             )),
         )));
     }

--- a/src/native_app/source_processing/supervisor/discovery_schema.rs
+++ b/src/native_app/source_processing/supervisor/discovery_schema.rs
@@ -1,4 +1,150 @@
-use super::{ACTIVE_RECORDING_QUIET_SECONDS, BTreeSet, ReadinessStore, earliest_deadline, params};
+use super::{
+    ACTIVE_RECORDING_QUIET_SECONDS, BTreeSet, META_READINESS_DUPLICATE_IDENTITY, ReadinessStore,
+    earliest_deadline, params,
+};
+use rusqlite::OptionalExtension;
+
+const MAX_DUPLICATE_IDENTITY_GROUPS: usize = 8;
+const MAX_DUPLICATE_IDENTITY_PATHS: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DuplicateIdentityDiagnostic {
+    pub(super) identity: String,
+    pub(super) paths: Vec<String>,
+}
+
+/// Return the durable duplicate-identity diagnostic only while it belongs to this manifest
+/// revision. A changed revision invalidates the old terminal diagnosis automatically.
+pub(super) fn duplicate_identity_diagnostic_for_revision(
+    connection: &rusqlite::Connection,
+    revision: i64,
+) -> Result<Option<Vec<DuplicateIdentityDiagnostic>>, String> {
+    let Some(raw) = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [META_READINESS_DUPLICATE_IDENTITY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(None);
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Ok(None);
+    };
+    if value.get("revision").and_then(serde_json::Value::as_i64) != Some(revision) {
+        return Ok(None);
+    }
+    let Some(identities) = value
+        .get("identities")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return Ok(None);
+    };
+    let diagnostics = identities
+        .iter()
+        .filter_map(|identity| {
+            Some(DuplicateIdentityDiagnostic {
+                identity: identity.get("identity")?.as_str()?.to_string(),
+                paths: identity
+                    .get("paths")?
+                    .as_array()?
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .take(MAX_DUPLICATE_IDENTITY_PATHS)
+                    .collect(),
+            })
+        })
+        .filter(|diagnostic| !diagnostic.identity.is_empty() && diagnostic.paths.len() > 1)
+        .take(MAX_DUPLICATE_IDENTITY_GROUPS)
+        .collect::<Vec<_>>();
+    Ok((!diagnostics.is_empty()).then_some(diagnostics))
+}
+
+/// Find supported live manifest rows that share one stable filesystem identity.
+pub(super) fn find_duplicate_identity_diagnostics(
+    connection: &rusqlite::Connection,
+) -> Result<Vec<DuplicateIdentityDiagnostic>, String> {
+    let filter = wavecrate_library::sample_sources::supported_audio_where_clause();
+    let mut groups = connection
+        .prepare(&format!(
+            "SELECT file_identity
+             FROM wav_files
+             WHERE missing = 0
+               AND file_identity IS NOT NULL
+               AND TRIM(file_identity) != ''
+               AND {filter}
+             GROUP BY file_identity
+             HAVING COUNT(*) > 1
+             ORDER BY file_identity
+             LIMIT {MAX_DUPLICATE_IDENTITY_GROUPS}"
+        ))
+        .map_err(|error| error.to_string())?;
+    let identities = groups
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|error| error.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    drop(groups);
+
+    identities
+        .into_iter()
+        .map(|identity| {
+            let mut paths = connection
+                .prepare(&format!(
+                    "SELECT path FROM wav_files
+                     WHERE missing = 0 AND file_identity = ?1 AND {filter}
+                     ORDER BY path
+                     LIMIT ?2"
+                ))
+                .map_err(|error| error.to_string())?;
+            let paths = paths
+                .query_map(params![identity, MAX_DUPLICATE_IDENTITY_PATHS], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| error.to_string())?;
+            Ok(DuplicateIdentityDiagnostic { identity, paths })
+        })
+        .collect()
+}
+
+pub(super) fn persist_duplicate_identity_diagnostic(
+    connection: &rusqlite::Connection,
+    revision: i64,
+    diagnostics: &[DuplicateIdentityDiagnostic],
+) -> Result<(), String> {
+    let value = serde_json::json!({
+        "revision": revision,
+        "identities": diagnostics.iter().map(|diagnostic| serde_json::json!({
+            "identity": diagnostic.identity,
+            "paths": diagnostic.paths,
+        })).collect::<Vec<_>>(),
+    });
+    connection
+        .execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![META_READINESS_DUPLICATE_IDENTITY, value.to_string()],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+pub(super) fn clear_duplicate_identity_diagnostic(
+    connection: &rusqlite::Connection,
+) -> Result<(), String> {
+    connection
+        .execute(
+            "DELETE FROM metadata WHERE key = ?1",
+            [META_READINESS_DUPLICATE_IDENTITY],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
 
 #[derive(Debug, Default)]
 pub(super) struct ActiveRecordingDeferrals {

--- a/src/native_app/source_processing/supervisor/discovery_schema.rs
+++ b/src/native_app/source_processing/supervisor/discovery_schema.rs
@@ -13,11 +13,11 @@ pub(super) struct DuplicateIdentityDiagnostic {
     pub(super) paths: Vec<String>,
 }
 
-/// Return the durable duplicate-identity diagnostic only while it belongs to this manifest
-/// revision. A changed revision invalidates the old terminal diagnosis automatically.
+/// Return the durable duplicate-identity diagnostic only while it belongs to this identity
+/// revision. A changed identity revision invalidates the old terminal diagnosis automatically.
 pub(super) fn duplicate_identity_diagnostic_for_revision(
     connection: &rusqlite::Connection,
-    revision: i64,
+    identity_revision: i64,
 ) -> Result<Option<Vec<DuplicateIdentityDiagnostic>>, String> {
     let Some(raw) = connection
         .query_row(
@@ -33,7 +33,11 @@ pub(super) fn duplicate_identity_diagnostic_for_revision(
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
         return Ok(None);
     };
-    if value.get("revision").and_then(serde_json::Value::as_i64) != Some(revision) {
+    if value
+        .get("identity_revision")
+        .and_then(serde_json::Value::as_i64)
+        != Some(identity_revision)
+    {
         return Ok(None);
     }
     let Some(identities) = value
@@ -114,11 +118,11 @@ pub(super) fn find_duplicate_identity_diagnostics(
 
 pub(super) fn persist_duplicate_identity_diagnostic(
     connection: &rusqlite::Connection,
-    revision: i64,
+    identity_revision: i64,
     diagnostics: &[DuplicateIdentityDiagnostic],
 ) -> Result<(), String> {
     let value = serde_json::json!({
-        "revision": revision,
+        "identity_revision": identity_revision,
         "identities": diagnostics.iter().map(|diagnostic| serde_json::json!({
             "identity": diagnostic.identity,
             "paths": diagnostic.paths,

--- a/src/native_app/source_processing/supervisor/health.rs
+++ b/src/native_app/source_processing/supervisor/health.rs
@@ -57,6 +57,16 @@ impl SourceHealthSummary {
             failure_codes: self.failure_codes,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn retry_at_for_test(&self) -> Option<i64> {
+        self.retry_at
+    }
+
+    #[cfg(test)]
+    pub(crate) fn failure_codes_for_test(&self) -> &[String] {
+        &self.failure_codes
+    }
 }
 
 pub(super) fn source_health_summary(

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -74,7 +74,7 @@ pub(super) struct RuntimeCandidate {
     pub(super) task: RuntimeTask,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(super) struct SourceDiscoveryStats {
     pub(super) readiness_queue_depth: usize,
     pub(super) prerequisites_blocked: usize,

--- a/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
+++ b/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
@@ -87,6 +87,16 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
     let db = source.open_db().expect("open hard-link source");
     db.upsert_file(Path::new("alias.wav"), 64, 1)
         .expect("insert hard-link alias manifest row");
+    let mut identity_batch = db.write_batch().expect("open hard-link identity batch");
+    identity_batch
+        .set_file_identity(Path::new("pending.wav"), Some("hard-link-identity"))
+        .expect("assign canonical hard-link identity");
+    identity_batch
+        .set_file_identity(Path::new("alias.wav"), Some("hard-link-identity"))
+        .expect("assign alias hard-link identity");
+    identity_batch
+        .commit()
+        .expect("commit shared hard-link identity");
     drop(db);
 
     let database_root = source.database_root().expect("database root");
@@ -96,14 +106,6 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
         SourceDatabaseConnectionRole::JobWorker,
     )
     .expect("open readiness database");
-    connection
-        .execute(
-            "UPDATE wav_files SET file_identity = 'hard-link-identity'
-             WHERE path IN ('pending.wav', 'alias.wav')",
-            [],
-        )
-        .expect("assign shared hard-link identity");
-
     let Cancellable::Completed((candidates, stats, health)) =
         discover_source_candidates_with_connection_and_progress(
             &source,
@@ -134,7 +136,7 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
         )
         .expect("read duplicate identity marker");
     let marker: serde_json::Value = serde_json::from_str(&marker).expect("decode marker");
-    assert_eq!(marker["revision"].as_i64(), Some(2));
+    assert_eq!(marker["identity_revision"].as_i64(), Some(2));
     assert_eq!(
         marker["identities"][0]["paths"],
         serde_json::json!(["alias.wav", "pending.wav"])
@@ -167,9 +169,15 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
 
     drop(connection);
     std::fs::remove_file(&alias_path).expect("remove hard-link alias");
+    std::fs::write(&alias_path, [2_u8; 64]).expect("replace hard-link alias contents");
     let db = source.open_db().expect("reopen hard-link source");
-    db.remove_file(Path::new("alias.wav"))
-        .expect("remove hard-link alias from manifest");
+    let mut identity_batch = db.write_batch().expect("open repaired identity batch");
+    identity_batch
+        .set_file_identity(Path::new("alias.wav"), Some("repaired-identity"))
+        .expect("assign repaired alias identity");
+    identity_batch
+        .commit()
+        .expect("commit repaired alias identity");
     drop(db);
     let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
         &source.root,

--- a/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
+++ b/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
@@ -79,6 +79,138 @@ fn zero_byte_audio_is_terminally_non_analyzable_and_never_enters_the_work_queue(
 }
 
 #[test]
+fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() {
+    let (_directory, source) = unhashed_source("hard-link-identity-terminal");
+    let canonical_path = source.root.join("pending.wav");
+    let alias_path = source.root.join("alias.wav");
+    std::fs::hard_link(&canonical_path, &alias_path).expect("create hard-link alias");
+    let db = source.open_db().expect("open hard-link source");
+    db.upsert_file(Path::new("alias.wav"), 64, 1)
+        .expect("insert hard-link alias manifest row");
+    drop(db);
+
+    let database_root = source.database_root().expect("database root");
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("open readiness database");
+    connection
+        .execute(
+            "UPDATE wav_files SET file_identity = 'hard-link-identity'
+             WHERE path IN ('pending.wav', 'alias.wav')",
+            [],
+        )
+        .expect("assign shared hard-link identity");
+
+    let Cancellable::Completed((candidates, stats, health)) =
+        discover_source_candidates_with_connection_and_progress(
+            &source,
+            &mut connection,
+            100,
+            false,
+            false,
+            None,
+            false,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("classify hard-link identity")
+    else {
+        panic!("hard-link discovery unexpectedly cancelled");
+    };
+    assert!(candidates.is_empty());
+    assert_eq!(stats.earliest_retry_at, None);
+    let health = health.expect("hard-link terminal health");
+    assert_eq!(health.retry_at_for_test(), None);
+    assert_eq!(health.failure_codes_for_test(), ["duplicate_manifest_identity"]);
+
+    let marker: String = connection
+        .query_row(
+            "SELECT value FROM metadata WHERE key = ?1",
+            [wavecrate_library::sample_sources::db::META_READINESS_DUPLICATE_IDENTITY],
+            |row| row.get(0),
+        )
+        .expect("read duplicate identity marker");
+    let marker: serde_json::Value = serde_json::from_str(&marker).expect("decode marker");
+    assert_eq!(marker["revision"].as_i64(), Some(2));
+    assert_eq!(
+        marker["identities"][0]["paths"],
+        serde_json::json!(["alias.wav", "pending.wav"])
+    );
+
+    let Cancellable::Completed((candidates, stats, health)) =
+        discover_source_candidates_with_connection_and_progress(
+            &source,
+            &mut connection,
+            101,
+            false,
+            false,
+            None,
+            true,
+            &AtomicBool::new(false),
+            &mut |_| panic!("unchanged duplicate identity must not run a safety probe"),
+        )
+        .expect("park unchanged hard-link identity")
+    else {
+        panic!("hard-link rediscovery unexpectedly cancelled");
+    };
+    assert!(candidates.is_empty());
+    assert_eq!(stats, SourceDiscoveryStats::default());
+    assert_eq!(
+        health
+            .expect("parked terminal health")
+            .retry_at_for_test(),
+        None
+    );
+
+    drop(connection);
+    std::fs::remove_file(&alias_path).expect("remove hard-link alias");
+    let db = source.open_db().expect("reopen hard-link source");
+    db.remove_file(Path::new("alias.wav"))
+        .expect("remove hard-link alias from manifest");
+    drop(db);
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen repaired readiness database");
+    let Cancellable::Completed((candidates, _stats, health)) =
+        discover_source_candidates_with_connection_and_progress(
+            &source,
+            &mut connection,
+            102,
+            false,
+            false,
+            None,
+            false,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("resume after hard-link repair")
+    else {
+        panic!("repaired discovery unexpectedly cancelled");
+    };
+    assert!(candidates.iter().any(|candidate| {
+        matches!(&candidate.task, RuntimeTask::Readiness(_))
+    }));
+    assert!(health
+        .expect("repaired source health")
+        .failure_codes_for_test()
+        .is_empty());
+    let marker_exists: bool = connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM metadata WHERE key = ?1)",
+            [wavecrate_library::sample_sources::db::META_READINESS_DUPLICATE_IDENTITY],
+            |row| row.get(0),
+        )
+        .expect("check cleared duplicate identity marker");
+    assert!(!marker_exists);
+}
+
+#[test]
 fn deferred_full_hash_blocks_all_content_derived_targets_until_identity_is_exact() {
     let (_directory, source) = unhashed_source("deferred-full-hash");
     let database_root = source.database_root().expect("database root");

--- a/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
+++ b/src/native_app/source_processing/supervisor/tests/terminal_inputs.rs
@@ -136,7 +136,7 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
         )
         .expect("read duplicate identity marker");
     let marker: serde_json::Value = serde_json::from_str(&marker).expect("decode marker");
-    assert_eq!(marker["identity_revision"].as_i64(), Some(2));
+    assert_eq!(marker["identity_revision"].as_i64(), Some(4));
     assert_eq!(
         marker["identities"][0]["paths"],
         serde_json::json!(["alias.wav", "pending.wav"])
@@ -168,10 +168,48 @@ fn hard_link_identity_is_parked_without_retry_until_manifest_revision_changes() 
     );
 
     drop(connection);
+    let db = source.open_db().expect("open missing-row repair source");
+    db.set_missing(Path::new("alias.wav"), true)
+        .expect("mark duplicate alias missing");
+    drop(db);
+    let mut connection = SourceDatabase::open_connection_with_role_and_database_root(
+        &source.root,
+        &database_root,
+        SourceDatabaseConnectionRole::JobWorker,
+    )
+    .expect("reopen missing-row repair database");
+    let Cancellable::Completed((candidates, _stats, health)) =
+        discover_source_candidates_with_connection_and_progress(
+            &source,
+            &mut connection,
+            102,
+            false,
+            false,
+            None,
+            false,
+            &AtomicBool::new(false),
+            &mut |_| {},
+        )
+        .expect("resume after missing-row repair")
+    else {
+        panic!("missing-row repair discovery unexpectedly cancelled");
+    };
+    assert!(candidates.iter().any(|candidate| {
+        matches!(&candidate.task, RuntimeTask::Readiness(_))
+    }));
+    assert!(health
+        .expect("missing-row repaired source health")
+        .failure_codes_for_test()
+        .is_empty());
+
+    drop(connection);
     std::fs::remove_file(&alias_path).expect("remove hard-link alias");
     std::fs::write(&alias_path, [2_u8; 64]).expect("replace hard-link alias contents");
     let db = source.open_db().expect("reopen hard-link source");
     let mut identity_batch = db.write_batch().expect("open repaired identity batch");
+    identity_batch
+        .set_missing(Path::new("alias.wav"), false)
+        .expect("restore repaired alias row");
     identity_batch
         .set_file_identity(Path::new("alias.wav"), Some("repaired-identity"))
         .expect("assign repaired alias identity");

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -44,12 +44,13 @@ pub mod db {
         BrowserMetadataSnapshot, ContentAuditCheckpoint, ContentAuditEntryState,
         ContentAuditReport, ContentAuditSkipReason, DB_FILE_NAME, LEGACY_DB_FILE_NAME,
         META_DEFERRED_MAINTENANCE_REVISION, META_DEFERRED_MAINTENANCE_SCHEMA,
-        META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT, META_WAV_PATHS_REVISION,
-        PendingRenameEntry, Rating, SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType,
-        SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
-        SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError, SourceFileWrite,
-        SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry,
-        file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
+        META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT,
+        META_READINESS_DUPLICATE_IDENTITY, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
+        SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceCollectionWrite,
+        SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
+        SourceDatabaseWriteFence, SourceDbError, SourceFileWrite, SourceTag, SourceTagUsage,
+        SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry, file_ops_journal,
+        normalize_relative_path, read, schema, tags, util, write,
     };
 }
 

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -45,12 +45,12 @@ pub mod db {
         ContentAuditReport, ContentAuditSkipReason, DB_FILE_NAME, LEGACY_DB_FILE_NAME,
         META_DEFERRED_MAINTENANCE_REVISION, META_DEFERRED_MAINTENANCE_SCHEMA,
         META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT,
-        META_READINESS_DUPLICATE_IDENTITY, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
-        SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceCollectionWrite,
-        SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
-        SourceDatabaseWriteFence, SourceDbError, SourceFileWrite, SourceTag, SourceTagUsage,
-        SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry, file_ops_journal,
-        normalize_relative_path, read, schema, tags, util, write,
+        META_READINESS_DUPLICATE_IDENTITY, META_WAV_IDENTITIES_REVISION, META_WAV_PATHS_REVISION,
+        PendingRenameEntry, Rating, SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType,
+        SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
+        SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError, SourceFileWrite,
+        SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry,
+        file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
     };
 }
 


### PR DESCRIPTION
## Goal

Stop unchanged hard-linked manifest identities from entering the five-second full-discovery retry loop.

## Scope

- Detect duplicate stable filesystem identities among supported live manifest rows before readiness publication.
- Persist a bounded, identity-membership-revision-keyed terminal diagnostic with affected relative paths.
- Advance that revision for identity, live-row, missing-state, and supported-eligibility mutations.
- Publish actionable terminal source health with no retry deadline and skip unchanged safety reconciliation.
- Recheck after a supported identity membership change or explicit manifest audit.
- Preserve the existing retry behavior for transient discovery/database failures.
- Document the readiness identity policy and add a hard-link regression test covering diagnosis, retry suppression, missing-state repair, same-path identity repair, and recovery.

## Non-goals

- No symlink following.
- No content/size/mtime-based identity collapsing.
- No redesign of per-path analysis/browser projections.
- No change to transient readiness retry policy.

## Definition of Done

- Unchanged duplicate identities do not hot-loop full reconciliation.
- The diagnostic is bounded and contains affected relative paths.
- Live-state or identity changes clear the diagnosis and resume readiness discovery.
- Ordinary transient discovery failures remain scheduled for retry.
- Other sources can continue through the coordinator without a duplicate-identity source retaining work ownership.

## Validation

- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests::hard_link_identity_is_parked_without_retry_until_manifest_revision_changes -- --exact --nocapture` — passed, including missing-state repair and same-path alias replacement.
- `cargo test -p wavecrate-library --lib sample_sources::db::write::tests::revision -- --nocapture` — 5 passed.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests -- --skip periodic_manifest_audit_wakes_browser_projection_after_committed_repair` — 97 passed, 1 ignored.
- `cargo test -p wavecrate-scan --all-targets` — 165 passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `bash scripts/ci.sh agent` — repository guardrails and readiness boundary passed; reached vendor/Radiant tests and failed on the pre-existing shader assertion `gpu_signal_shader_keeps_waveform_bands_visually_distinct` (1690 passed, 1 failed).
- The full supervisor filter also reproduces the pre-existing `periodic_manifest_audit_wakes_browser_projection_after_committed_repair` failure at `progress_lifecycle.rs:371`; it is unchanged by this PR.

## Known limitations

Per-path alias-aware readiness execution and browser projection remain a follow-up. Until that model exists, duplicate stable identities are surfaced as an actionable terminal source state rather than silently collapsing one visible path.

User approval is required before merge.