### PR TITLE
fix(scan): honor configurable hidden-folder policy

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -7,6 +7,8 @@ use std::{
 use rusqlite::{Connection, Transaction};
 use std::fmt;
 
+use super::source_entry::SourceTraversalPolicy;
+
 mod content_audit;
 mod error;
 /// Persistent file operation journal for crash recovery.
@@ -89,6 +91,8 @@ pub const META_WAV_IDENTITIES_REVISION: &str = "wav_identities_revision_v1";
 pub const META_READINESS_DUPLICATE_IDENTITY: &str = "readiness_duplicate_identity_v1";
 /// Metadata key storing the revision of the index-only unsupported file set.
 pub const META_SOURCE_INDEX_REVISION: &str = "source_index_revision_v1";
+/// Metadata key for the persisted source traversal/visibility policy.
+pub const META_SOURCE_TRAVERSAL_POLICY: &str = "source_traversal_policy_v1";
 /// Env var that enables read-only source DB opening by default.
 pub const SOURCE_DB_READ_ONLY_ENV: &str = "WAVECRATE_SOURCE_DB_READ_ONLY";
 
@@ -137,6 +141,23 @@ impl SourceDatabase {
         self.connection
             .busy_timeout(timeout)
             .map_err(SourceDbError::from)
+    }
+
+    /// Read the source traversal policy, defaulting to recursive inclusion for legacy sources.
+    pub fn source_traversal_policy(&self) -> Result<SourceTraversalPolicy, SourceDbError> {
+        Ok(self
+            .get_metadata(META_SOURCE_TRAVERSAL_POLICY)?
+            .as_deref()
+            .map(SourceTraversalPolicy::from_stored)
+            .unwrap_or_default())
+    }
+
+    /// Persist the source traversal policy used by full scans, audits, and targeted sync.
+    pub fn set_source_traversal_policy(
+        &self,
+        policy: SourceTraversalPolicy,
+    ) -> Result<(), SourceDbError> {
+        self.set_metadata(META_SOURCE_TRAVERSAL_POLICY, policy.as_str())
     }
 
     /// Open a writable source database for general source-owned mutations.

--- a/crates/wavecrate-library/src/sample_sources/db/write/tests/upsert.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/tests/upsert.rs
@@ -4,6 +4,7 @@ use tempfile::tempdir;
 
 use super::super::super::{Rating, SampleCollection, SourceDatabase};
 use super::helpers::revision_value;
+use crate::sample_sources::SourceTraversalPolicy;
 
 #[test]
 fn upsert_wrapper_matches_batch_insert_contract() {
@@ -32,6 +33,23 @@ fn upsert_wrapper_matches_batch_insert_contract() {
     assert_eq!(single_rows[0].last_played_at, batch_rows[0].last_played_at);
     assert_eq!(revision_value(&single), 1);
     assert_eq!(revision_value(&batch_db), 1);
+}
+
+#[test]
+fn source_traversal_policy_defaults_to_include_and_persists() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+
+    assert_eq!(
+        db.source_traversal_policy().unwrap(),
+        SourceTraversalPolicy::default()
+    );
+    db.set_source_traversal_policy(SourceTraversalPolicy::exclude_hidden_directories())
+        .unwrap();
+    assert_eq!(
+        db.source_traversal_policy().unwrap(),
+        SourceTraversalPolicy::exclude_hidden_directories()
+    );
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/write/transaction.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use rusqlite::OptionalExtension;
 
 use super::super::util::{map_sql_error, normalize_relative_path};
-use super::super::{SourceDatabase, SourceDbError, SourceManifestEntry, SourceWriteBatch};
+use super::super::{
+    META_SOURCE_TRAVERSAL_POLICY, SourceDatabase, SourceDbError, SourceManifestEntry,
+    SourceTraversalPolicy, SourceWriteBatch,
+};
 
 /// Manifest state published by a committed source-database write batch.
 pub struct ManifestCommitResult {
@@ -16,6 +19,27 @@ pub struct ManifestCommitResult {
 }
 
 impl SourceWriteBatch<'_> {
+    /// Return whether the source traversal policy still matches the scan snapshot.
+    pub fn matches_source_traversal_policy(
+        &self,
+        expected: SourceTraversalPolicy,
+    ) -> Result<bool, SourceDbError> {
+        let value = self
+            .tx
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                [META_SOURCE_TRAVERSAL_POLICY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?;
+        let actual = value
+            .as_deref()
+            .map(SourceTraversalPolicy::from_stored)
+            .unwrap_or_default();
+        Ok(actual == expected)
+    }
+
     /// Return whether this write transaction began at `expected_revision`.
     ///
     /// The batch owns SQLite's immediate writer reservation, so a successful match remains valid

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -29,9 +29,11 @@ pub use library::{
     LIBRARY_DB_FILE_NAME, LibraryError, LibraryState, NewHarvestDerivation,
 };
 pub use source_entry::{
-    SOURCE_FORMAT_POLICY_VERSION, SourceEntryClassification, SourceEntryFileType, SourceEntryKind,
-    SourceEntryProbeError, SourceEntryRejection, SourceFileClassification,
-    classify_path_without_following, classify_source_entry, is_rejected_source_file_path,
+    HiddenDirectoryPolicy, SOURCE_FORMAT_POLICY_VERSION, SourceEntryClassification,
+    SourceEntryFileType, SourceEntryKind, SourceEntryProbeError, SourceEntryRejection,
+    SourceFileClassification, SourceTraversalPolicy, classify_path_without_following,
+    classify_path_without_following_with_policy, classify_source_entry,
+    classify_source_entry_with_policy, is_rejected_source_file_path,
 };
 
 /// Identifier for a configured sample source.

--- a/crates/wavecrate-library/src/sample_sources/source_entry.rs
+++ b/crates/wavecrate-library/src/sample_sources/source_entry.rs
@@ -5,10 +5,79 @@ use std::{
     path::{Component, Path},
 };
 
+use serde::{Deserialize, Serialize};
+
 use super::{is_apple_double_sidecar, is_recognized_audio, is_supported_audio};
 
 /// Version of the source format-classification policy persisted with index-only rows.
 pub const SOURCE_FORMAT_POLICY_VERSION: u32 = 1;
+
+/// Whether hidden directories participate in source traversal.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HiddenDirectoryPolicy {
+    /// Recursively include hidden directories (the default for existing sources).
+    #[default]
+    Include,
+    /// Exclude hidden directories and everything below them.
+    Exclude,
+}
+
+impl HiddenDirectoryPolicy {
+    /// Stable source-database representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Include => "include",
+            Self::Exclude => "exclude",
+        }
+    }
+
+    /// Parse a stored policy, defaulting missing or unknown values to inclusion.
+    pub fn from_stored(value: &str) -> Self {
+        match value {
+            "exclude" => Self::Exclude,
+            _ => Self::Include,
+        }
+    }
+}
+
+/// Shared source traversal policy consumed by all source-entry classifiers.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceTraversalPolicy {
+    /// Policy for dot-prefixed (and equivalent configured hidden) directories.
+    pub hidden_directories: HiddenDirectoryPolicy,
+}
+
+impl SourceTraversalPolicy {
+    /// Policy that recursively includes hidden directories.
+    pub const fn include_hidden_directories() -> Self {
+        Self {
+            hidden_directories: HiddenDirectoryPolicy::Include,
+        }
+    }
+
+    /// Policy that excludes hidden directories.
+    pub const fn exclude_hidden_directories() -> Self {
+        Self {
+            hidden_directories: HiddenDirectoryPolicy::Exclude,
+        }
+    }
+
+    /// Stable source-database representation.
+    pub fn as_str(self) -> &'static str {
+        self.hidden_directories.as_str()
+    }
+
+    /// Parse a stored policy, defaulting missing or unknown values to inclusion.
+    pub fn from_stored(value: &str) -> Self {
+        Self {
+            hidden_directories: HiddenDirectoryPolicy::from_stored(value),
+        }
+    }
+
+    fn includes_hidden_directories(self) -> bool {
+        self.hidden_directories == HiddenDirectoryPolicy::Include
+    }
+}
 
 /// A filesystem entry type observed without following links or reparse points.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -72,6 +141,8 @@ pub enum SourceEntryRejection {
     AppleDouble,
     /// Wavecrate's embedded source database and SQLite sidecars are implementation metadata.
     SourceDatabase,
+    /// A hidden directory excluded by the configured traversal policy.
+    HiddenDirectory,
     /// The entry is neither a regular file nor a directory.
     UnsupportedType,
 }
@@ -90,6 +161,8 @@ pub enum SourceEntryClassification {
         classification: SourceFileClassification,
         /// Whether the file is below a hidden directory.
         below_hidden_directory: bool,
+        /// Whether the file is eligible for indexing under the active policy.
+        indexes_audio: bool,
     },
     /// An entry excluded by the shared source boundary policy.
     Rejected(SourceEntryRejection),
@@ -110,8 +183,8 @@ impl SourceEntryClassification {
         matches!(
             self,
             Self::File {
-                classification: SourceFileClassification::SupportedAudio,
-                below_hidden_directory: false,
+                indexes_audio: true,
+                ..
             }
         )
     }
@@ -138,12 +211,19 @@ impl SourceEntryClassification {
 
 /// Classify a path relative to a sample-source root from no-follow type facts.
 ///
-/// This policy deliberately preserves the browser's visibility of unsupported
-/// files and hidden directories while preventing audio indexing below hidden
-/// directories. Callers retain their own traversal mechanics and diagnostics.
+/// This default policy preserves recursive scanning for existing sources.
 pub fn classify_source_entry(
     relative_path: &Path,
     file_type: SourceEntryFileType,
+) -> SourceEntryClassification {
+    classify_source_entry_with_policy(relative_path, file_type, SourceTraversalPolicy::default())
+}
+
+/// Classify a path using an explicit source traversal policy.
+pub fn classify_source_entry_with_policy(
+    relative_path: &Path,
+    file_type: SourceEntryFileType,
+    policy: SourceTraversalPolicy,
 ) -> SourceEntryClassification {
     match file_type {
         SourceEntryFileType::Link => {
@@ -152,25 +232,36 @@ pub fn classify_source_entry(
         SourceEntryFileType::Other => {
             SourceEntryClassification::Rejected(SourceEntryRejection::UnsupportedType)
         }
-        SourceEntryFileType::Directory => SourceEntryClassification::Directory {
-            hidden: path_name_is_hidden(relative_path),
-        },
+        SourceEntryFileType::Directory => {
+            let hidden = path_name_is_hidden(relative_path);
+            if hidden && !policy.includes_hidden_directories() {
+                SourceEntryClassification::Rejected(SourceEntryRejection::HiddenDirectory)
+            } else {
+                SourceEntryClassification::Directory { hidden }
+            }
+        }
         SourceEntryFileType::File if is_apple_double_sidecar(relative_path) => {
             SourceEntryClassification::Rejected(SourceEntryRejection::AppleDouble)
         }
         SourceEntryFileType::File if is_source_database_artifact(relative_path) => {
             SourceEntryClassification::Rejected(SourceEntryRejection::SourceDatabase)
         }
-        SourceEntryFileType::File => SourceEntryClassification::File {
-            classification: if is_supported_audio(relative_path) {
-                SourceFileClassification::SupportedAudio
-            } else if is_recognized_audio(relative_path) {
-                SourceFileClassification::UnsupportedAudio
-            } else {
-                SourceFileClassification::UnsupportedNonAudio
-            },
-            below_hidden_directory: has_hidden_ancestor(relative_path),
-        },
+        SourceEntryFileType::File => {
+            let supported_audio = is_supported_audio(relative_path);
+            let below_hidden_directory = has_hidden_ancestor(relative_path);
+            SourceEntryClassification::File {
+                classification: if supported_audio {
+                    SourceFileClassification::SupportedAudio
+                } else if is_recognized_audio(relative_path) {
+                    SourceFileClassification::UnsupportedAudio
+                } else {
+                    SourceFileClassification::UnsupportedNonAudio
+                },
+                below_hidden_directory,
+                indexes_audio: supported_audio
+                    && (policy.includes_hidden_directories() || !below_hidden_directory),
+            }
+        }
     }
 }
 
@@ -200,15 +291,24 @@ fn is_source_database_artifact(relative_path: &Path) -> bool {
 pub fn classify_path_without_following(
     path: &Path,
 ) -> Result<SourceEntryClassification, SourceEntryProbeError> {
+    classify_path_without_following_with_policy(path, SourceTraversalPolicy::default())
+}
+
+/// Inspect and classify one path without following links using an explicit policy.
+pub fn classify_path_without_following_with_policy(
+    path: &Path,
+    policy: SourceTraversalPolicy,
+) -> Result<SourceEntryClassification, SourceEntryProbeError> {
     let metadata = fs::symlink_metadata(path).map_err(SourceEntryProbeError::from)?;
     let file_type = metadata.file_type();
-    Ok(classify_source_entry(
+    Ok(classify_source_entry_with_policy(
         path,
         SourceEntryFileType::from_no_followed_type(
             file_type.is_dir(),
             file_type.is_file(),
             file_type.is_symlink(),
         ),
+        policy,
     ))
 }
 
@@ -277,8 +377,12 @@ mod tests {
             classify_source_entry(Path::new("kick.wav"), SourceEntryFileType::File).indexes_audio()
         );
         assert!(
-            !classify_source_entry(Path::new(".cache/kick.wav"), SourceEntryFileType::File)
-                .indexes_audio()
+            !classify_source_entry_with_policy(
+                Path::new(".cache/kick.wav"),
+                SourceEntryFileType::File,
+                SourceTraversalPolicy::exclude_hidden_directories(),
+            )
+            .indexes_audio()
         );
         assert_eq!(
             classify_source_entry(Path::new("linked.wav"), SourceEntryFileType::Link),
@@ -291,6 +395,44 @@ mod tests {
         assert_eq!(
             classify_source_entry(Path::new(".wavecrate.db-wal"), SourceEntryFileType::File),
             SourceEntryClassification::Rejected(SourceEntryRejection::SourceDatabase)
+        );
+    }
+
+    #[test]
+    fn default_includes_nested_hidden_audio_but_exclusion_does_not() {
+        let path = Path::new(".hidden/kick.wav");
+        assert!(classify_source_entry(path, SourceEntryFileType::File).indexes_audio());
+        assert!(
+            classify_source_entry_with_policy(
+                path,
+                SourceEntryFileType::File,
+                SourceTraversalPolicy::include_hidden_directories(),
+            )
+            .indexes_audio()
+        );
+        assert!(
+            !classify_source_entry_with_policy(
+                path,
+                SourceEntryFileType::File,
+                SourceTraversalPolicy::exclude_hidden_directories(),
+            )
+            .indexes_audio()
+        );
+        assert_eq!(
+            classify_source_entry_with_policy(
+                Path::new(".hidden"),
+                SourceEntryFileType::Directory,
+                SourceTraversalPolicy::exclude_hidden_directories(),
+            ),
+            SourceEntryClassification::Rejected(SourceEntryRejection::HiddenDirectory)
+        );
+        assert!(
+            classify_source_entry_with_policy(
+                Path::new(".kick.wav"),
+                SourceEntryFileType::File,
+                SourceTraversalPolicy::exclude_hidden_directories(),
+            )
+            .indexes_audio()
         );
     }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{SourceIndexEntry, SourceWriteBatch, WavEntry};
-use wavecrate_library::sample_sources::SourceManifestEntry;
+use wavecrate_library::sample_sources::{SourceManifestEntry, SourceTraversalPolicy};
 
 use super::{ScanError, ScanMode, ScanStats};
 
@@ -22,6 +22,7 @@ pub(crate) struct ScanContext {
     manifest_audit: Option<ManifestAuditCheckpoint>,
     source_tree_incomplete: bool,
     uncertain_prefixes: BTreeSet<PathBuf>,
+    traversal_policy: SourceTraversalPolicy,
 }
 
 struct ManifestAuditCheckpoint {
@@ -71,7 +72,19 @@ impl ScanContext {
             manifest_audit: None,
             source_tree_incomplete: false,
             uncertain_prefixes: BTreeSet::new(),
+            traversal_policy: SourceTraversalPolicy::default(),
         }
+    }
+
+    pub(in crate::sample_sources::scanner) fn set_traversal_policy(
+        &mut self,
+        policy: SourceTraversalPolicy,
+    ) {
+        self.traversal_policy = policy;
+    }
+
+    pub(in crate::sample_sources::scanner) fn traversal_policy(&self) -> SourceTraversalPolicy {
+        self.traversal_policy
     }
 
     pub(in crate::sample_sources::scanner) fn set_targeted_index_entries(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -336,6 +336,9 @@ impl ScanContext {
         batch: SourceWriteBatch<'_>,
         post_commit_hook: impl FnOnce(),
     ) -> Result<u64, ScanError> {
+        if !batch.matches_source_traversal_policy(self.traversal_policy)? {
+            return Err(ScanError::TraversalPolicyChanged);
+        }
         let result = batch.commit_with_manifest_changes(self.committed_manifest_revision)?;
         post_commit_hook();
         if let Some(snapshot) = result.authoritative_snapshot {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
@@ -26,6 +26,9 @@ pub enum ScanError {
         /// Current manifest revision observed before commit.
         actual: u64,
     },
+    /// The hidden-directory policy changed while the scan was in progress.
+    #[error("Source traversal policy changed while the scan was in progress")]
+    TraversalPolicyChanged,
     /// A source revision committed before later work stopped.
     #[error("Scan incomplete after committed checkpoint: {error}")]
     Incomplete {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -318,7 +318,9 @@ fn scan_with_writer(
     let (manifest_revision, manifest_before) =
         super::super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
+    let traversal_policy = db.source_traversal_policy()?;
     let mut context = ScanContext::new(db, mode, manifest_revision, manifest_before.clone())?;
+    context.set_traversal_policy(traversal_policy);
     if let Some(started_at) = manifest_audit_started_at {
         context.resume_manifest_audit(db, started_at)?;
         if let Some((checked, _expected)) = context.manifest_audit_progress()
@@ -328,24 +330,32 @@ fn scan_with_writer(
             on_progress(checked, &root);
         }
     }
-    let result = walk_phase(db, &root, cancel, &mut on_progress, &mut context, writer)
-        .and_then(|()| db_sync_phase(db, &mut context, cancel, writer))
-        .and_then(|committed_snapshot| {
-            reconcile_scan_renames(
-                db,
-                &mut context,
-                &manifest_before,
-                committed_snapshot,
-                cancel,
-                writer,
-            )
-        })
-        .and_then(|committed_snapshot| {
-            if finalize_pending_renames && !context.has_uncertain_prefixes() {
-                finalize_pending_rename_completion(db, &mut context.stats, mode, writer)?;
-            }
-            Ok(committed_snapshot)
-        });
+    let result = walk_phase(
+        db,
+        &root,
+        traversal_policy,
+        cancel,
+        &mut on_progress,
+        &mut context,
+        writer,
+    )
+    .and_then(|()| db_sync_phase(db, &mut context, cancel, writer))
+    .and_then(|committed_snapshot| {
+        reconcile_scan_renames(
+            db,
+            &mut context,
+            &manifest_before,
+            committed_snapshot,
+            cancel,
+            writer,
+        )
+    })
+    .and_then(|committed_snapshot| {
+        if finalize_pending_renames && !context.has_uncertain_prefixes() {
+            finalize_pending_rename_completion(db, &mut context.stats, mode, writer)?;
+        }
+        Ok(committed_snapshot)
+    });
     finish_scan_result(manifest_before, context, result)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -235,7 +235,7 @@ fn scan_ignores_non_wav_and_counts_nested() {
 }
 
 #[test]
-fn scan_tracks_dot_prefixed_wav_files_but_not_files_below_hidden_directories() {
+fn scan_includes_dot_prefixed_files_and_nested_hidden_audio_by_default() {
     let dir = tempdir().unwrap();
     let hidden = dir.path().join(".hidden");
     std::fs::create_dir(&hidden).unwrap();
@@ -245,12 +245,12 @@ fn scan_tracks_dot_prefixed_wav_files_but_not_files_below_hidden_directories() {
     let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
     let stats = scan_once(&db).unwrap();
 
-    assert_eq!(stats.added, 1);
+    assert_eq!(stats.added, 2);
     assert!(db.entry_for_path(Path::new(".kick.wav")).unwrap().is_some());
     assert!(
         db.entry_for_path(Path::new(".hidden/ignored.wav"))
             .unwrap()
-            .is_none()
+            .is_some()
     );
 }
 
@@ -414,7 +414,14 @@ fn missing_stage_keeps_concurrently_restored_live_row() {
     let mut stats = ScanStats::default();
     let mut batch = db.write_batch().unwrap();
 
-    super::super::super::scan_diff::mark_missing(&db, &mut batch, [stale], &mut stats).unwrap();
+    super::super::super::scan_diff::mark_missing(
+        &db,
+        db.source_traversal_policy().unwrap(),
+        &mut batch,
+        [stale],
+        &mut stats,
+    )
+    .unwrap();
     batch.commit().unwrap();
 
     assert_eq!(stats.missing, 0);
@@ -447,13 +454,17 @@ fn missing_stage_prunes_path_replaced_by_directory() {
 }
 
 #[test]
-fn full_scan_prunes_tracked_files_below_hidden_directories() {
+fn configured_hidden_directory_exclusion_prunes_tracked_files() {
     let dir = tempdir().unwrap();
     let hidden = dir.path().join(".hidden");
     std::fs::create_dir(&hidden).unwrap();
     std::fs::write(hidden.join("one.wav"), b"hidden").unwrap();
     let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
     db.upsert_file(Path::new(".hidden/one.wav"), 6, 1).unwrap();
+    db.set_source_traversal_policy(
+        wavecrate_library::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+    )
+    .unwrap();
 
     let stats = scan_once(&db).unwrap();
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -123,7 +123,7 @@ fn full_scan_captures_browser_layout_in_the_authoritative_traversal() {
 }
 
 #[test]
-fn browser_layout_keeps_hidden_non_audio_entries_but_excludes_hidden_audio() {
+fn browser_layout_includes_hidden_entries_by_default() {
     let dir = tempdir().unwrap();
     let hidden = dir.path().join(".hidden");
     std::fs::create_dir_all(&hidden).unwrap();
@@ -139,17 +139,36 @@ fn browser_layout_keeps_hidden_non_audio_entries_but_excludes_hidden_audio() {
         file.relative_path == Path::new(".hidden/notes.txt") && file.file_size == 5
     }));
     assert!(
+        db.entry_for_path(Path::new(".hidden/kick.wav"))
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn configured_hidden_directory_exclusion_removes_hidden_browser_entries() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::write(hidden.join("kick.wav"), b"kick").unwrap();
+    std::fs::write(hidden.join("notes.txt"), b"notes").unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    db.set_source_traversal_policy(
+        wavecrate_library::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+    )
+    .unwrap();
+    let stats = scan_once(&db).unwrap();
+    let snapshot = stats.source_tree_snapshot.expect("source tree snapshot");
+
+    assert!(!snapshot.directories.contains(&PathBuf::from(".hidden")));
+    assert!(
         snapshot
             .other_files
             .iter()
-            .all(|file| file.relative_path != Path::new(".hidden/kick.wav"))
+            .all(|file| !file.relative_path.starts_with(".hidden"))
     );
-    assert!(
-        db.list_files()
-            .unwrap()
-            .iter()
-            .all(|file| file.relative_path != Path::new(".hidden/kick.wav"))
-    );
+    assert!(db.list_files().unwrap().is_empty());
 }
 
 #[cfg(unix)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -131,6 +131,50 @@ fn targeted_sync_prunes_removed_folder_prefix() {
 }
 
 #[test]
+fn targeted_sync_reconciles_hidden_directory_policy_changes() {
+    let dir = tempdir().unwrap();
+    let hidden = dir.path().join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::write(hidden.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+
+    assert_eq!(scan_once(&db).unwrap().added, 1);
+    db.set_source_traversal_policy(
+        wavecrate_library::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+    )
+    .unwrap();
+    assert_eq!(
+        sync_paths(&db, &[PathBuf::from(".hidden")])
+            .unwrap()
+            .missing,
+        1
+    );
+    assert!(db.list_files().unwrap().is_empty());
+
+    db.set_source_traversal_policy(
+        wavecrate_library::sample_sources::SourceTraversalPolicy::include_hidden_directories(),
+    )
+    .unwrap();
+    assert_eq!(
+        sync_paths(&db, &[PathBuf::from(".hidden")]).unwrap().added,
+        1
+    );
+    assert_eq!(db.list_files().unwrap().len(), 1);
+
+    db.set_source_traversal_policy(
+        wavecrate_library::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+    )
+    .unwrap();
+    assert_eq!(
+        sync_paths(&db, &[PathBuf::from(".hidden")])
+            .unwrap()
+            .missing,
+        1
+    );
+    assert!(db.list_files().unwrap().is_empty());
+}
+
+#[test]
 fn targeted_sync_preserves_an_unreadable_directory_until_recovery() {
     let dir = tempdir().unwrap();
     let protected = dir.path().join("protected");

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -39,7 +39,13 @@ pub(super) fn db_sync_phase(
         }
         let mut batch = db.write_batch()?;
         context.ensure_rename_candidate_generation(&mut batch)?;
-        mark_missing(db, &mut batch, chunk, &mut context.stats)?;
+        mark_missing(
+            db,
+            context.traversal_policy(),
+            &mut batch,
+            chunk,
+            &mut context.stats,
+        )?;
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_diff.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::{RenameMetadataSnapshot, SourceWriteBatch, WavEntry};
+use wavecrate_library::sample_sources::SourceTraversalPolicy;
 
 use super::scan::{
     ChangedSample, RenamedSample, ScanContext, ScanError, ScanMode, ScanStats, UpdatedSample,
@@ -188,12 +189,13 @@ fn required_prepared_hash(content_hash: Option<String>) -> String {
 
 pub(super) fn mark_missing(
     db: &SourceDatabase,
+    policy: SourceTraversalPolicy,
     batch: &mut SourceWriteBatch<'_>,
     existing: impl IntoIterator<Item = WavEntry>,
     stats: &mut ScanStats,
 ) -> Result<(), ScanError> {
     for stale in existing {
-        if is_supported_scannable_audio_file(db.root(), &stale.relative_path) {
+        if is_supported_scannable_audio_file(db.root(), &stale.relative_path, policy) {
             continue;
         }
         let Some(leftover) = db.entry_for_path(&stale.relative_path)? else {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -15,7 +15,8 @@ use wavecrate_library::filesystem_identity::{
 };
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
-    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry, is_rejected_source_file_path,
+    SourceIndexDiagnostic, SourceIndexEntry, SourceTraversalPolicy,
+    classify_source_entry_with_policy, is_rejected_source_file_path,
 };
 
 use crate::sample_sources::SourceDatabase;
@@ -193,6 +194,7 @@ pub(super) fn ensure_root_dir(db: &SourceDatabase) -> Result<PathBuf, ScanError>
 
 pub(super) fn visit_dir_with_cancel_check(
     root: &Path,
+    policy: SourceTraversalPolicy,
     should_cancel: &mut impl FnMut() -> bool,
     visitor: &mut impl FnMut(&Path) -> Result<(), ScanError>,
 ) -> Result<SourceTreeSnapshot, ScanError> {
@@ -277,7 +279,11 @@ pub(super) fn visit_dir_with_cancel_check(
                     continue;
                 }
             };
-            match classify_source_entry(&relative, source_entry_file_type(&file_type)) {
+            match classify_source_entry_with_policy(
+                &relative,
+                source_entry_file_type(&file_type),
+                policy,
+            ) {
                 SourceEntryClassification::Directory { .. } => {
                     snapshot.directories.push(relative);
                     stack.push(path);
@@ -542,11 +548,16 @@ fn filesystem_change_marker_from_open_file(file: &fs::File) -> Option<String> {
     (information.ChangeTime != 0).then(|| format!("windows:{}", information.ChangeTime))
 }
 
-pub(super) fn is_supported_scannable_audio_file(root: &Path, relative_path: &Path) -> bool {
+pub(super) fn is_supported_scannable_audio_file(
+    root: &Path,
+    relative_path: &Path,
+    policy: SourceTraversalPolicy,
+) -> bool {
     let absolute_path = root.join(relative_path);
     fs::symlink_metadata(&absolute_path).is_ok_and(|metadata| {
         let file_type = metadata.file_type();
-        classify_source_entry(relative_path, source_entry_file_type(&file_type)).indexes_audio()
+        classify_source_entry_with_policy(relative_path, source_entry_file_type(&file_type), policy)
+            .indexes_audio()
     })
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -9,7 +9,8 @@ use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority
 use cap_std::fs::{Dir, OpenOptions};
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
-    SourceIndexDiagnostic, SourceIndexEntry, classify_source_entry, is_rejected_source_file_path,
+    SourceIndexDiagnostic, SourceIndexEntry, SourceTraversalPolicy,
+    classify_source_entry_with_policy, is_rejected_source_file_path,
 };
 
 use crate::sample_sources::{SourceDatabase, WavEntry};
@@ -55,7 +56,8 @@ pub fn sync_paths_with_progress_and_writer(
 ) -> Result<ScanStats, ScanError> {
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
-    let targets = collect_targets(db, &root, paths, cancel)?;
+    let policy = db.source_traversal_policy()?;
+    let targets = collect_targets(db, &root, paths, cancel, policy)?;
     let TargetedScanTargets {
         current_files,
         existing,
@@ -69,6 +71,7 @@ pub fn sync_paths_with_progress_and_writer(
         manifest_revision,
         manifest_before.clone(),
     );
+    context.set_traversal_policy(policy);
     context.set_targeted_index_entries(
         existing_index_entries.into_values(),
         current_index_entries.into_values(),
@@ -140,6 +143,7 @@ fn collect_targets(
     root: &Path,
     paths: &[PathBuf],
     cancel: Option<&AtomicBool>,
+    policy: SourceTraversalPolicy,
 ) -> Result<TargetedScanTargets, ScanError> {
     let source_root =
         Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
@@ -164,6 +168,7 @@ fn collect_targets(
             root,
             &relative_path,
             cancel,
+            policy,
             &mut current_files,
             &mut current_index_entries,
             &mut uncertain_prefixes,
@@ -227,6 +232,7 @@ fn collect_current_files(
     root: &Path,
     relative_path: &Path,
     cancel: Option<&AtomicBool>,
+    policy: SourceTraversalPolicy,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
     current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
@@ -263,7 +269,11 @@ fn collect_current_files(
         }
     };
     let file_type = metadata.file_type();
-    match classify_source_entry(relative_path, targeted_source_entry_file_type(&file_type)) {
+    match classify_source_entry_with_policy(
+        relative_path,
+        targeted_source_entry_file_type(&file_type),
+        policy,
+    ) {
         SourceEntryClassification::Directory { .. } => {
             let dir = match parent.open_dir_nofollow(name_path) {
                 Ok(dir) => dir,
@@ -283,6 +293,7 @@ fn collect_current_files(
                 root,
                 relative_path,
                 cancel,
+                policy,
                 current_files,
                 current_index_entries,
                 uncertain_prefixes,
@@ -296,6 +307,7 @@ fn collect_current_files(
                 Path::new(&name),
                 root,
                 relative_path,
+                policy,
                 current_files,
                 current_index_entries,
                 uncertain_prefixes,
@@ -369,6 +381,7 @@ fn collect_current_files_in_dir(
     root: &Path,
     start_relative: &Path,
     cancel: Option<&AtomicBool>,
+    policy: SourceTraversalPolicy,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
     current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
@@ -433,8 +446,11 @@ fn collect_current_files_in_dir(
                 }
             };
             let relative_path = relative_dir.join(name_path);
-            match classify_source_entry(&relative_path, targeted_source_entry_file_type(&file_type))
-            {
+            match classify_source_entry_with_policy(
+                &relative_path,
+                targeted_source_entry_file_type(&file_type),
+                policy,
+            ) {
                 SourceEntryClassification::Directory { .. } => {
                     let child_dir = match dir.open_dir_nofollow(name_path) {
                         Ok(child_dir) => child_dir,
@@ -464,6 +480,7 @@ fn collect_current_files_in_dir(
                         name_path,
                         root,
                         &relative_path,
+                        policy,
                         current_files,
                         current_index_entries,
                         uncertain_prefixes,
@@ -492,12 +509,15 @@ fn collect_current_file(
     name: &Path,
     root: &Path,
     relative_path: &Path,
+    policy: SourceTraversalPolicy,
     current_files: &mut BTreeMap<PathBuf, TargetedFile>,
     current_index_entries: &mut BTreeMap<PathBuf, SourceIndexEntry>,
     uncertain_prefixes: &mut BTreeSet<PathBuf>,
 ) -> Result<(), ScanError> {
     let absolute_path = root.join(relative_path);
-    if !classify_source_entry(relative_path, SourceEntryFileType::File).indexes_audio() {
+    if !classify_source_entry_with_policy(relative_path, SourceEntryFileType::File, policy)
+        .indexes_audio()
+    {
         return Ok(());
     }
     let mut options = OpenOptions::new();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::sample_sources::SourceDatabase;
-use wavecrate_library::sample_sources::SourceIndexDiagnostic;
+use wavecrate_library::sample_sources::{SourceIndexDiagnostic, SourceTraversalPolicy};
 
 use super::scan::{ScanContext, ScanError};
 use super::scan_capability::{SourcePathBinding, SourceRootCapability};
@@ -26,6 +26,7 @@ const APPLY_BATCH_SIZE: usize = 64;
 pub(super) fn walk_phase(
     db: &SourceDatabase,
     root: &Path,
+    policy: SourceTraversalPolicy,
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
@@ -38,8 +39,11 @@ pub(super) fn walk_phase(
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
     let mut pending_noops = Vec::with_capacity(APPLY_BATCH_SIZE);
     let source_root = SourceRootCapability::open(root)?;
-    let source_tree_snapshot =
-        visit_dir_with_cancel_check(root, &mut || cancel_requested(cancel), &mut |path| {
+    let source_tree_snapshot = visit_dir_with_cancel_check(
+        root,
+        policy,
+        &mut || cancel_requested(cancel),
+        &mut |path| {
             if cancel_requested(cancel) {
                 return Err(ScanError::Canceled);
             }
@@ -138,7 +142,8 @@ pub(super) fn walk_phase(
                 }
             }
             Ok(())
-        })?;
+        },
+    )?;
     if !pending.is_empty() {
         let outcome = apply_batch(db, root, cancel, context, pending, committed.get(), writer)?;
         if outcome.committed {
@@ -666,7 +671,7 @@ struct ApplyBatchOutcome {
 }
 
 fn skip_changed_or_unavailable(context: &mut ScanContext, root: &Path, relative_path: &Path) {
-    if is_supported_scannable_audio_file(root, relative_path) {
+    if is_supported_scannable_audio_file(root, relative_path, context.traversal_policy()) {
         context.existing.remove(relative_path);
     }
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -787,7 +787,7 @@ mod tests {
         refresh_noop_preparation_or_skip,
     };
     use crate::sample_sources::SourceDatabase;
-    use crate::sample_sources::scanner::scan::{ScanContext, ScanMode, scan_once};
+    use crate::sample_sources::scanner::scan::{ScanContext, ScanError, ScanMode, scan_once};
     use crate::sample_sources::scanner::scan_diff::PreparedFile;
     use crate::sample_sources::scanner::scan_diff_phase::prepare_diff;
     use crate::sample_sources::scanner::scan_fs::read_facts;
@@ -1260,6 +1260,42 @@ mod tests {
 
         assert!(!outcome.committed);
         assert!(context.source_tree_incomplete());
+        assert!(db.entry_for_path(relative).unwrap().is_none());
+    }
+
+    #[test]
+    fn scan_batch_rejects_a_changed_traversal_policy_before_commit() {
+        let dir = tempdir().unwrap();
+        let relative = Path::new("one.wav");
+        let source = dir.path().join(relative);
+        std::fs::write(&source, b"inside").unwrap();
+        let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+        let mut context = ScanContext::from_existing(
+            HashMap::new(),
+            ScanMode::Quick,
+            db.get_revision().unwrap(),
+            db.list_manifest_entries().unwrap(),
+        );
+        let source_root = SourceRootCapability::open(dir.path()).unwrap();
+        let prepared = prepare_diff_from_capability(&source_root, dir.path(), relative, &context)
+            .unwrap()
+            .unwrap();
+        db.set_source_traversal_policy(
+            wavecrate_library::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+        )
+        .unwrap();
+
+        let result = apply_batch(
+            &db,
+            dir.path(),
+            None,
+            &mut context,
+            vec![prepared],
+            false,
+            &super::super::scan_writer::UncoordinatedScanWriter,
+        );
+
+        assert!(matches!(result, Err(ScanError::TraversalPolicyChanged)));
         assert!(db.entry_for_path(relative).unwrap().is_none());
     }
 

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -287,6 +287,8 @@ pub(in crate::native_app) struct FolderTreeRefreshResult {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct FolderVerifyRequest {
     pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) source_root: PathBuf,
+    pub(in crate::native_app) database_root: PathBuf,
     pub(in crate::native_app) folder_path: PathBuf,
     pub(in crate::native_app) cached_child_ids: Vec<String>,
     pub(in crate::native_app) cached_file_signatures: Vec<(String, u64)>,

--- a/src/native_app/sample_library/folder_browser/scanning/entry.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/entry.rs
@@ -3,8 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 use wavecrate_library::sample_sources::{
-    SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
-    classify_path_without_following as classify_source_entry_path, classify_source_entry,
+    SourceDatabase, SourceEntryFileType, SourceEntryKind, SourceEntryProbeError,
+    SourceTraversalPolicy, classify_source_entry_with_policy,
 };
 
 use super::super::path_helpers::file_label;
@@ -20,7 +20,16 @@ pub(super) struct BrowserEntry {
 pub(in crate::native_app::sample_library::folder_browser) fn classify_path_without_following(
     path: &Path,
 ) -> Option<BrowserEntryKind> {
-    match classify_source_entry_path(path) {
+    classify_path_without_following_with_policy(path, SourceTraversalPolicy::default())
+}
+
+pub(in crate::native_app::sample_library::folder_browser) fn classify_path_without_following_with_policy(
+    path: &Path,
+    policy: SourceTraversalPolicy,
+) -> Option<BrowserEntryKind> {
+    match wavecrate_library::sample_sources::classify_path_without_following_with_policy(
+        path, policy,
+    ) {
         Ok(classification) => classification.visible_kind(),
         Err(SourceEntryProbeError::Missing) => None,
         Err(error) => {
@@ -34,8 +43,16 @@ pub(in crate::native_app::sample_library::folder_browser) fn classify_path_witho
     }
 }
 
-pub(super) fn read_sorted_entries(path: &Path) -> Option<Vec<BrowserEntry>> {
-    if classify_path_without_following(path) != Some(BrowserEntryKind::Directory) {
+pub(super) fn read_sorted_entries(
+    path: &Path,
+    source_root: &Path,
+    policy: SourceTraversalPolicy,
+) -> Option<Vec<BrowserEntry>> {
+    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    if classify_source_entry_with_policy(relative_path, SourceEntryFileType::Directory, policy)
+        .visible_kind()
+        != Some(BrowserEntryKind::Directory)
+    {
         return None;
     }
     let read_dir = match fs::read_dir(path) {
@@ -65,12 +82,17 @@ pub(super) fn read_sorted_entries(path: &Path) -> Option<Vec<BrowserEntry>> {
             let entry_path = entry.path();
             match entry.file_type() {
                 Ok(file_type) => {
-                    classify_source_entry(&entry_path, source_entry_file_type(&file_type))
-                        .visible_kind()
-                        .map(|kind| BrowserEntry {
-                            path: entry_path,
-                            kind,
-                        })
+                    let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+                    classify_source_entry_with_policy(
+                        relative_path,
+                        source_entry_file_type(&file_type),
+                        policy,
+                    )
+                    .visible_kind()
+                    .map(|kind| BrowserEntry {
+                        path: entry_path,
+                        kind,
+                    })
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -89,6 +111,12 @@ pub(super) fn read_sorted_entries(path: &Path) -> Option<Vec<BrowserEntry>> {
             .cmp(&file_label(&b.path).to_ascii_lowercase())
     });
     Some(entries)
+}
+
+pub(super) fn source_traversal_policy(root: &Path, database_root: &Path) -> SourceTraversalPolicy {
+    SourceDatabase::open_for_ui_read_with_database_root(root, database_root)
+        .and_then(|db| db.source_traversal_policy())
+        .unwrap_or_default()
 }
 
 fn source_entry_file_type(file_type: &FileType) -> SourceEntryFileType {

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -6,7 +6,9 @@ use std::{
 
 use super::super::FileEntry;
 use super::{
-    entry::{BrowserEntryKind, classify_path_without_following},
+    entry::{
+        BrowserEntryKind, classify_path_without_following_with_policy, source_traversal_policy,
+    },
     file_entry_metadata::file_entry_with_metadata,
 };
 use wavecrate::sample_sources::{
@@ -104,9 +106,13 @@ pub(in crate::native_app::sample_library::folder_browser) fn refreshed_file_entr
             tracing::warn!(source = %source_root.display(), "{error}");
             SourceMetadataMap::new()
         });
+    let policy = source_traversal_policy(source_root, source_database_root);
     paths
         .iter()
-        .filter(|path| classify_path_without_following(path) == Some(BrowserEntryKind::File))
+        .filter(|path| {
+            classify_path_without_following_with_policy(path, policy)
+                == Some(BrowserEntryKind::File)
+        })
         .map(|path| rated_file_entry(path, source_root, &ratings))
         .collect()
 }

--- a/src/native_app/sample_library/folder_browser/scanning/traversal.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/traversal.rs
@@ -7,7 +7,10 @@ use super::{
         path_helpers::{folder_label, path_id},
         scan_types::{FolderTreeRefreshRequest, FolderTreeRefreshResult},
     },
-    entry::{BrowserEntryKind, classify_path_without_following, read_sorted_entries},
+    entry::{
+        BrowserEntryKind, classify_path_without_following, read_sorted_entries,
+        source_traversal_policy,
+    },
     metadata::{SourceMetadataMap, rated_file_entry, source_rating_map},
 };
 
@@ -27,7 +30,9 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_source_snapsho
             tracing::warn!(source = %root.display(), "{error}");
             SourceMetadataMap::new()
         });
-    let folder = load_folder(&root, &root, &ratings).unwrap_or_else(|| placeholder_folder(&root));
+    let policy = source_traversal_policy(&root, &database_root);
+    let folder =
+        load_folder(&root, &root, &ratings, policy).unwrap_or_else(|| placeholder_folder(&root));
     let missing_collection_snapshot =
         MissingCollectionSnapshot::from_source_metadata(&root, &folder, &ratings);
     LoadedSourceSnapshot {
@@ -50,8 +55,9 @@ pub(in crate::native_app::sample_library::folder_browser) fn placeholder_folder(
 pub(in crate::native_app) fn refresh_folder_tree_only(
     request: FolderTreeRefreshRequest,
 ) -> FolderTreeRefreshResult {
+    let policy = source_traversal_policy(&request.root, &request.database_root);
     let mut folder_count = 0;
-    let folder = load_folder_tree_only(&request.root, &mut folder_count)
+    let folder = load_folder_tree_only(&request.root, &request.root, policy, &mut folder_count)
         .unwrap_or_else(|| placeholder_folder(&request.root));
     FolderTreeRefreshResult {
         source_id: request.source_id,
@@ -74,19 +80,21 @@ pub(in crate::native_app::sample_library::folder_browser) fn load_folder_at_path
             tracing::warn!(source = %source_root.display(), "{error}");
             SourceMetadataMap::new()
         });
-    load_folder(path, source_root, &ratings)
+    let policy = source_traversal_policy(source_root, source_database_root);
+    load_folder(path, source_root, &ratings, policy)
 }
 
 pub(super) fn load_folder(
     path: &Path,
     source_root: &Path,
     ratings: &SourceMetadataMap,
+    policy: wavecrate_library::sample_sources::SourceTraversalPolicy,
 ) -> Option<FolderEntry> {
-    let entries = read_sorted_entries(path)?;
+    let entries = read_sorted_entries(path, source_root, policy)?;
     let children = entries
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::Directory)
-        .filter_map(|entry| load_folder(&entry.path, source_root, ratings))
+        .filter_map(|entry| load_folder(&entry.path, source_root, ratings, policy))
         .collect::<Vec<_>>();
     let files = entries
         .iter()
@@ -101,13 +109,18 @@ pub(super) fn load_folder(
     })
 }
 
-fn load_folder_tree_only(path: &Path, folder_count: &mut usize) -> Option<FolderEntry> {
-    let entries = read_sorted_entries(path)?;
+fn load_folder_tree_only(
+    path: &Path,
+    source_root: &Path,
+    policy: wavecrate_library::sample_sources::SourceTraversalPolicy,
+    folder_count: &mut usize,
+) -> Option<FolderEntry> {
+    let entries = read_sorted_entries(path, source_root, policy)?;
     *folder_count += 1;
     let children = entries
         .iter()
         .filter(|entry| entry.kind == BrowserEntryKind::Directory)
-        .filter_map(|entry| load_folder_tree_only(&entry.path, folder_count))
+        .filter_map(|entry| load_folder_tree_only(&entry.path, source_root, policy, folder_count))
         .collect::<Vec<_>>();
     Some(FolderEntry {
         id: path_id(path),

--- a/src/native_app/sample_library/folder_browser/scanning/verification.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/verification.rs
@@ -7,24 +7,29 @@ use super::{
             FolderVerifyOutcome, FolderVerifyRequest, FolderVerifyResult, FolderVerifySnapshot,
         },
     },
-    entry::{BrowserEntryKind, classify_path_without_following, read_sorted_entries},
+    entry::{
+        BrowserEntryKind, classify_path_without_following, read_sorted_entries,
+        source_traversal_policy,
+    },
     file_entry_metadata::file_entry,
 };
 
 pub(in crate::native_app) fn verify_direct_folder(
     request: FolderVerifyRequest,
 ) -> FolderVerifyResult {
-    let outcome = match read_direct_folder_snapshot(&request.folder_path) {
-        DirectFolderSnapshot::Missing => FolderVerifyOutcome::Missing,
-        DirectFolderSnapshot::Unavailable => FolderVerifyOutcome::Unchanged,
-        DirectFolderSnapshot::Available(snapshot) => {
-            if direct_folder_changed(&request, &snapshot) {
-                FolderVerifyOutcome::Changed(snapshot)
-            } else {
-                FolderVerifyOutcome::Unchanged
+    let policy = source_traversal_policy(&request.source_root, &request.database_root);
+    let outcome =
+        match read_direct_folder_snapshot(&request.folder_path, &request.source_root, policy) {
+            DirectFolderSnapshot::Missing => FolderVerifyOutcome::Missing,
+            DirectFolderSnapshot::Unavailable => FolderVerifyOutcome::Unchanged,
+            DirectFolderSnapshot::Available(snapshot) => {
+                if direct_folder_changed(&request, &snapshot) {
+                    FolderVerifyOutcome::Changed(snapshot)
+                } else {
+                    FolderVerifyOutcome::Unchanged
+                }
             }
-        }
-    };
+        };
     FolderVerifyResult {
         source_id: request.source_id,
         folder_path: request.folder_path,
@@ -38,11 +43,24 @@ enum DirectFolderSnapshot {
     Unavailable,
 }
 
-fn read_direct_folder_snapshot(path: &Path) -> DirectFolderSnapshot {
-    if classify_path_without_following(path) != Some(BrowserEntryKind::Directory) {
+fn read_direct_folder_snapshot(
+    path: &Path,
+    source_root: &Path,
+    policy: wavecrate_library::sample_sources::SourceTraversalPolicy,
+) -> DirectFolderSnapshot {
+    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    if wavecrate_library::sample_sources::classify_source_entry_with_policy(
+        relative_path,
+        wavecrate_library::sample_sources::SourceEntryFileType::Directory,
+        policy,
+    )
+    .visible_kind()
+        != Some(BrowserEntryKind::Directory)
+        || classify_path_without_following(path) != Some(BrowserEntryKind::Directory)
+    {
         return DirectFolderSnapshot::Missing;
     }
-    let Some(entries) = read_sorted_entries(path) else {
+    let Some(entries) = read_sorted_entries(path, source_root, policy) else {
         return DirectFolderSnapshot::Unavailable;
     };
     let child_paths = entries

--- a/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
@@ -389,6 +389,30 @@ fn folder_tree_refresh_adds_new_empty_folder() {
 }
 
 #[test]
+fn folder_tree_refresh_honors_excluded_hidden_directory_policy() {
+    let root = temp_source_root("wavecrate-gui-folder-tree-refresh-hidden-policy");
+    let hidden = root.join(".hidden");
+    fs::create_dir_all(&hidden).expect("create hidden folder");
+    fs::write(hidden.join("kick.wav"), [0_u8; 8]).expect("write hidden sample");
+    SourceDatabase::open_for_source_write(&root)
+        .expect("open source db")
+        .set_source_traversal_policy(
+            wavecrate::sample_sources::SourceTraversalPolicy::exclude_hidden_directories(),
+        )
+        .expect("set hidden directory policy");
+
+    let result = refresh_folder_tree_only(FolderTreeRefreshRequest {
+        source_id: String::from("source"),
+        label: String::from("Assets"),
+        root: root.clone(),
+        database_root: root.clone(),
+    });
+
+    assert!(result.folder.find(&path_id(&hidden)).is_none());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn folder_tree_refresh_reconciles_deleted_selected_folder() {
     let root = temp_source_root("wavecrate-gui-folder-tree-refresh-selected");
     let stale = root.join("stale");

--- a/src/native_app/sample_library/folder_browser/tree_state.rs
+++ b/src/native_app/sample_library/folder_browser/tree_state.rs
@@ -57,8 +57,15 @@ impl FolderBrowserState {
         &self,
     ) -> Option<FolderVerifyRequest> {
         let folder = self.selected_folder()?;
+        let source = self
+            .source
+            .sources
+            .iter()
+            .find(|source| source.id == self.source.selected_source)?;
         Some(FolderVerifyRequest {
             source_id: self.source.selected_source.clone(),
+            source_root: source.root.clone(),
+            database_root: source.database_root.clone(),
             folder_path: std::path::PathBuf::from(&folder.id),
             cached_child_ids: folder
                 .children

--- a/src/native_app/source_processing/worker.rs
+++ b/src/native_app/source_processing/worker.rs
@@ -244,6 +244,10 @@ impl From<wavecrate_scan::ScanError> for SourceProcessingFailure {
                     "Source changed while completing deferred deep hash (expected revision {expected}, found {actual})"
                 ),
             ),
+            wavecrate_scan::ScanError::TraversalPolicyChanged => Self::retryable(
+                SourceProcessingFailureCode::ScannerStaleRevision,
+                "Source traversal policy changed while scanning",
+            ),
             wavecrate_scan::ScanError::Incomplete { error, .. } => {
                 Self::retryable_with_source_error(
                     SourceProcessingFailureCode::ScannerIncomplete,

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -45,12 +45,13 @@ pub mod db {
         ContentAuditReport, ContentAuditSkipReason, DB_FILE_NAME, LEGACY_DB_FILE_NAME,
         META_DEFERRED_MAINTENANCE_REVISION, META_DEFERRED_MAINTENANCE_SCHEMA,
         META_LAST_MANIFEST_AUDIT_AT, META_LAST_SCAN_COMPLETED_AT,
-        META_READINESS_DUPLICATE_IDENTITY, META_WAV_IDENTITIES_REVISION, META_WAV_PATHS_REVISION,
-        PendingRenameEntry, Rating, SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType,
-        SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
-        SourceDatabaseConnectionRole, SourceDatabaseWriteFence, SourceDbError, SourceFileWrite,
-        SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry,
-        file_ops_journal, normalize_relative_path, read, schema, tags, util, write,
+        META_READINESS_DUPLICATE_IDENTITY, META_SOURCE_TRAVERSAL_POLICY,
+        META_WAV_IDENTITIES_REVISION, META_WAV_PATHS_REVISION, PendingRenameEntry, Rating,
+        SOURCE_DB_READ_ONLY_ENV, SampleCollection, SampleSoundType, SourceCollectionWrite,
+        SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole,
+        SourceDatabaseWriteFence, SourceDbError, SourceFileWrite, SourceTag, SourceTagUsage,
+        SourceTagWrite, SourceWriteBatch, SourceWriteCommand, WavEntry, file_ops_journal,
+        normalize_relative_path, read, schema, tags, util, write,
     };
 }
 
@@ -99,6 +100,7 @@ pub use wavecrate_library::sample_sources::{
     SourceMetadataStorage, SourceRole, SourceTagWrite, SourceWriteCommand, WavEntry,
     database_path_for, default_primary_import_folder, normalize_path,
 };
+pub use wavecrate_library::sample_sources::{HiddenDirectoryPolicy, SourceTraversalPolicy};
 pub use wavecrate_scan::sample_sources::ScanTracker;
 pub use wavecrate_scan::sample_sources::{
     ChangedSample, CommittedSourceDelta, ManifestIdentityDelta, MovedManifestIdentity,


### PR DESCRIPTION
## Goal

Implement OPT-1277 so Wavecrate scanning is recursive by default and honors an explicit per-source hidden-directory policy.

## Scope

- Add a shared source-entry traversal policy with default inclusion and explicit hidden-directory exclusion.
- Persist the policy in each source database, with legacy databases defaulting to inclusion.
- Apply the policy consistently to full scans, manifest-audit reconciliation, targeted watcher sync, authoritative browser projection, legacy folder-browser startup/refresh/verification, and explicit refresh.
- Fence scan batches when the traversal policy changes during an in-flight scan so stale visibility results are retried.
- Preserve dot-prefixed audio-file handling, no-follow link/source-database/AppleDouble exclusions, and source-root containment.
- Add regression coverage for default inclusion, configured pruning, browser projection, persistence, targeted policy changes, folder refresh, and stale-policy fencing.

### Non-goals

- No new audio formats, symlink behavior changes, UI redesign, or unrelated cleanup.
- The policy consumes the existing shared entry facts; it does not add a new OS-specific hidden-attribute acquisition layer.

## Definition of Done

- Supported audio under nested dot-prefixed directories is indexed by default and appears in committed browser/readiness projections.
- Configured hidden-directory exclusion prevents traversal and prunes previously indexed hidden descendants from manifest/readiness state.
- Dot-prefixed audio files remain distinct from hidden directories.
- Full, audit, targeted, browser, and explicit-refresh synchronization produce consistent results.
- Policy changes cannot let an in-flight scan publish a stale visibility set.
- Existing link, AppleDouble, source database, and source containment protections remain intact.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo check -p wavecrate-library -p wavecrate-scan` — passed.
- `cargo check -p wavecrate` — passed.
- `cargo test -p wavecrate-library source_entry --lib` — 5 passed.
- `cargo test -p wavecrate-library source_traversal_policy --lib` — 1 passed.
- `cargo test -p wavecrate-scan --lib` — 167 passed.
- `cargo test -p wavecrate-scan --lib scan_batch_rejects_a_changed_traversal_policy_before_commit` — passed.
- `cargo test -p wavecrate --lib folder_tree_refresh_honors_excluded_hidden_directory_policy` — passed.
- `cargo check -p wavecrate` — passed after the follow-up.
- `bash scripts/ci.sh agent` — reached the vendor architecture/readiness checks, then stopped on an unrelated pre-existing Radiant shader assertion in `vendor/radiant/src/gui_runtime/native_vello/generic_runtime/tests/gpu_surface_runtime/signal_summary.rs`.
- `cargo test -p wavecrate --lib` — 3,975 passed, 58 unrelated existing controller/watcher/GUI-automation/waveform-playback failures, 27 ignored.

## Known limitations

The full application test suite and agent gate remain affected by unrelated baseline failures described above. The changed library, scanner, native browser refresh, and policy-fence tests pass.

User approval is required before merge.