### PR TITLE
fix(scan): bind traversal to one source-root generation

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/errors.rs
@@ -26,6 +26,12 @@ pub enum ScanError {
         /// Current manifest revision observed before commit.
         actual: u64,
     },
+    /// The configured source path no longer names the retained root directory.
+    #[error("Source root generation changed while scanning: {root}")]
+    StaleRootGeneration {
+        /// Configured source root whose identity changed or became unavailable.
+        root: PathBuf,
+    },
     /// The hidden-directory policy changed while the scan was in progress.
     #[error("Source traversal policy changed while the scan was in progress")]
     TraversalPolicyChanged,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -6,8 +6,6 @@ mod stats;
 pub use super::scan_hash::{ContentAuditActivity, ContentAuditBudget, ContentAuditStorage};
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
-#[cfg(test)]
-pub(crate) use runner::audit_source_and_record_with_post_scan_hook;
 pub use runner::{
     ScanMode, audit_source, audit_source_and_record,
     audit_source_and_record_with_budget_and_progress,
@@ -18,6 +16,10 @@ pub use runner::{
     complete_deferred_rename_candidates_with_cancel_and_writer,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
     scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
+};
+#[cfg(test)]
+pub(crate) use runner::{
+    audit_source_and_record_with_post_scan_hook, audit_source_and_record_with_pre_record_hook,
 };
 pub(crate) use runner::{finish_scan_result, reconcile_scan_renames};
 pub use stats::{

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -8,6 +8,7 @@ use std::thread;
 use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::SourceManifestEntry;
 
+use super::super::scan_capability::SourceRootCapability;
 use super::super::scan_db_sync::db_sync_phase;
 use super::super::scan_fs::ensure_root_dir;
 use super::super::scan_hash::ContentAuditBudget;
@@ -56,7 +57,13 @@ pub fn audit_source(
             now_epoch_seconds(),
         ),
     )?;
-    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, &UncoordinatedScanWriter)?;
+    finalize_pending_rename_completion(
+        db,
+        &mut stats,
+        ScanMode::Quick,
+        &UncoordinatedScanWriter,
+        None,
+    )?;
     Ok(stats)
 }
 
@@ -71,7 +78,13 @@ pub fn audit_source_with_budget(
         &mut stats,
         super::super::scan_hash::verify_content_batch(db, cancel, budget, now_epoch_seconds()),
     )?;
-    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, &UncoordinatedScanWriter)?;
+    finalize_pending_rename_completion(
+        db,
+        &mut stats,
+        ScanMode::Quick,
+        &UncoordinatedScanWriter,
+        None,
+    )?;
     Ok(stats)
 }
 
@@ -172,7 +185,7 @@ fn audit_source_and_record_after_scan(
             writer,
         ),
     )?;
-    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, writer)?;
+    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, writer, None)?;
     Ok(stats)
 }
 
@@ -318,6 +331,8 @@ fn scan_with_writer(
     let (manifest_revision, manifest_before) =
         super::super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
     let traversal_policy = db.source_traversal_policy()?;
     let mut context = ScanContext::new(db, mode, manifest_revision, manifest_before.clone())?;
     context.set_traversal_policy(traversal_policy);
@@ -333,16 +348,18 @@ fn scan_with_writer(
     let result = walk_phase(
         db,
         &root,
+        &source_root,
         traversal_policy,
         cancel,
         &mut on_progress,
         &mut context,
         writer,
     )
-    .and_then(|()| db_sync_phase(db, &mut context, cancel, writer))
+    .and_then(|()| db_sync_phase(db, &source_root, &mut context, cancel, writer))
     .and_then(|committed_snapshot| {
         reconcile_scan_renames(
             db,
+            &source_root,
             &mut context,
             &manifest_before,
             committed_snapshot,
@@ -352,7 +369,13 @@ fn scan_with_writer(
     })
     .and_then(|committed_snapshot| {
         if finalize_pending_renames && !context.has_uncertain_prefixes() {
-            finalize_pending_rename_completion(db, &mut context.stats, mode, writer)?;
+            finalize_pending_rename_completion(
+                db,
+                &mut context.stats,
+                mode,
+                writer,
+                Some(&source_root),
+            )?;
         }
         Ok(committed_snapshot)
     });
@@ -361,12 +384,14 @@ fn scan_with_writer(
 
 pub(crate) fn reconcile_scan_renames(
     db: &SourceDatabase,
+    source_root: &SourceRootCapability,
     context: &mut ScanContext,
     manifest_before: &[SourceManifestEntry],
     committed_snapshot: (u64, Vec<SourceManifestEntry>),
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+    source_root.ensure_current_generation()?;
     // A partial traversal cannot safely consume pending rename state: a
     // retained source beneath an uncertain prefix may otherwise be claimed as
     // a move by an observed destination elsewhere. This also keeps hard
@@ -415,6 +440,7 @@ pub(crate) fn reconcile_scan_renames(
             writer,
         )?
     };
+    source_root.ensure_current_generation()?;
     if renamed.is_empty() && context.mode != ScanMode::Hard {
         return Ok(committed_snapshot);
     }
@@ -452,8 +478,12 @@ fn finalize_pending_rename_completion(
     stats: &mut ScanStats,
     mode: ScanMode,
     writer: &impl ScanWriter,
+    source_root: Option<&SourceRootCapability>,
 ) -> Result<(), ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
+    if let Some(source_root) = source_root {
+        source_root.ensure_current_generation()?;
+    }
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
     let mut batch = db.write_batch()?;
     if mode == ScanMode::Hard {
@@ -462,6 +492,9 @@ fn finalize_pending_rename_completion(
     let report = batch.complete_pending_rename_authoritative_scan(mode == ScanMode::Hard)?;
     if mode == ScanMode::Hard && report.diagnostics.candidate_count == 0 {
         batch.clear_unretained_pending_rename_destinations()?;
+    }
+    if let Some(source_root) = source_root {
+        source_root.ensure_current_generation()?;
     }
     batch.commit_auxiliary_state()?;
     stats.pending_renames_pruned = stats

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -9,7 +9,7 @@ use crate::sample_sources::SourceDatabase;
 use crate::sample_sources::db::SourceManifestEntry;
 
 use super::super::scan_capability::SourceRootCapability;
-use super::super::scan_db_sync::db_sync_phase;
+use super::super::scan_db_sync::{complete_scan_generation, db_sync_phase};
 use super::super::scan_fs::ensure_root_dir;
 use super::super::scan_hash::ContentAuditBudget;
 use super::super::scan_walk::walk_phase;
@@ -378,7 +378,8 @@ fn scan_with_writer(
             )?;
         }
         Ok(committed_snapshot)
-    });
+    })
+    .and_then(|_| complete_scan_generation(db, &source_root, &mut context, cancel, writer));
     finish_scan_result(manifest_before, context, result)
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -47,14 +47,29 @@ pub fn audit_source(
     cancel: Option<&AtomicBool>,
     max_hashes: usize,
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None, None, false)?;
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    let mut stats = scan_with_writer_using_root(
+        db,
+        &root,
+        &source_root,
+        ScanMode::Quick,
+        cancel,
+        None,
+        None,
+        false,
+        &UncoordinatedScanWriter,
+    )?;
     let mut stats = merge_audit_verification(
         &mut stats,
-        super::super::scan_hash::verify_content_batch(
+        super::super::scan_hash::verify_content_batch_with_source_root(
             db,
+            &source_root,
             cancel,
             ContentAuditBudget::entry_limited(max_hashes),
             now_epoch_seconds(),
+            &UncoordinatedScanWriter,
         ),
     )?;
     finalize_pending_rename_completion(
@@ -62,7 +77,7 @@ pub fn audit_source(
         &mut stats,
         ScanMode::Quick,
         &UncoordinatedScanWriter,
-        None,
+        Some(&source_root),
     )?;
     Ok(stats)
 }
@@ -73,17 +88,37 @@ pub fn audit_source_with_budget(
     cancel: Option<&AtomicBool>,
     budget: ContentAuditBudget,
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan(db, ScanMode::Quick, cancel, None, None, false)?;
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    let mut stats = scan_with_writer_using_root(
+        db,
+        &root,
+        &source_root,
+        ScanMode::Quick,
+        cancel,
+        None,
+        None,
+        false,
+        &UncoordinatedScanWriter,
+    )?;
     let mut stats = merge_audit_verification(
         &mut stats,
-        super::super::scan_hash::verify_content_batch(db, cancel, budget, now_epoch_seconds()),
+        super::super::scan_hash::verify_content_batch_with_source_root(
+            db,
+            &source_root,
+            cancel,
+            budget,
+            now_epoch_seconds(),
+            &UncoordinatedScanWriter,
+        ),
     )?;
     finalize_pending_rename_completion(
         db,
         &mut stats,
         ScanMode::Quick,
         &UncoordinatedScanWriter,
-        None,
+        Some(&source_root),
     )?;
     Ok(stats)
 }
@@ -164,8 +199,13 @@ fn audit_source_and_record_after_scan(
     writer: &impl ScanWriter,
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
-    let mut stats = scan_with_writer(
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    let mut stats = scan_with_writer_using_root(
         db,
+        &root,
+        &source_root,
         ScanMode::Quick,
         cancel,
         on_progress,
@@ -173,19 +213,26 @@ fn audit_source_and_record_after_scan(
         false,
         writer,
     )?;
-    record_manifest_audit_completion(db, &mut stats, completed_at, writer)?;
+    record_manifest_audit_completion(db, &mut stats, completed_at, writer, &source_root)?;
     after_scan();
     let mut stats = merge_audit_verification(
         &mut stats,
-        super::super::scan_hash::verify_content_batch_with_writer(
+        super::super::scan_hash::verify_content_batch_with_source_root(
             db,
+            &source_root,
             cancel,
             budget,
             completed_at,
             writer,
         ),
     )?;
-    finalize_pending_rename_completion(db, &mut stats, ScanMode::Quick, writer, None)?;
+    finalize_pending_rename_completion(
+        db,
+        &mut stats,
+        ScanMode::Quick,
+        writer,
+        Some(&source_root),
+    )?;
     Ok(stats)
 }
 
@@ -194,7 +241,9 @@ fn record_manifest_audit_completion(
     stats: &mut ScanStats,
     completed_at: i64,
     writer: &impl ScanWriter,
+    source_root: &SourceRootCapability,
 ) -> Result<(), ScanError> {
+    source_root.ensure_current_generation()?;
     let before = stats.manifest_before.clone();
     let _writer = writer.lock(super::super::scan_writer::ScanWritePhase::Manifest);
     let mut batch = db.write_batch()?;
@@ -216,6 +265,7 @@ fn record_manifest_audit_completion(
         }
     }
     batch.complete_manifest_audit(completed_at)?;
+    source_root.ensure_current_generation()?;
     let committed = batch.commit_with_manifest_snapshot()?;
     super::super::manifest::publish_committed_delta(stats, before, committed);
     Ok(())
@@ -322,6 +372,33 @@ fn scan_with_writer(
     db: &SourceDatabase,
     mode: ScanMode,
     cancel: Option<&AtomicBool>,
+    on_progress: Option<&mut dyn FnMut(usize, &Path)>,
+    manifest_audit_started_at: Option<i64>,
+    finalize_pending_renames: bool,
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    scan_with_writer_using_root(
+        db,
+        &root,
+        &source_root,
+        mode,
+        cancel,
+        on_progress,
+        manifest_audit_started_at,
+        finalize_pending_renames,
+        writer,
+    )
+}
+
+fn scan_with_writer_using_root(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    mode: ScanMode,
+    cancel: Option<&AtomicBool>,
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     manifest_audit_started_at: Option<i64>,
     finalize_pending_renames: bool,
@@ -330,8 +407,6 @@ fn scan_with_writer(
     debug_assert_ne!(mode, ScanMode::Targeted);
     let (manifest_revision, manifest_before) =
         super::super::manifest::capture_manifest_with_revision(db)?;
-    let root = ensure_root_dir(db)?;
-    let source_root = SourceRootCapability::open(&root)?;
     source_root.ensure_current_generation()?;
     let traversal_policy = db.source_traversal_policy()?;
     let mut context = ScanContext::new(db, mode, manifest_revision, manifest_before.clone())?;
@@ -342,24 +417,24 @@ fn scan_with_writer(
             && checked > 0
             && let Some(on_progress) = on_progress.as_mut()
         {
-            on_progress(checked, &root);
+            on_progress(checked, root);
         }
     }
     let result = walk_phase(
         db,
-        &root,
-        &source_root,
+        root,
+        source_root,
         traversal_policy,
         cancel,
         &mut on_progress,
         &mut context,
         writer,
     )
-    .and_then(|()| db_sync_phase(db, &source_root, &mut context, cancel, writer))
+    .and_then(|()| db_sync_phase(db, source_root, &mut context, cancel, writer))
     .and_then(|committed_snapshot| {
         reconcile_scan_renames(
             db,
-            &source_root,
+            source_root,
             &mut context,
             &manifest_before,
             committed_snapshot,
@@ -374,7 +449,7 @@ fn scan_with_writer(
                 &mut context.stats,
                 mode,
                 writer,
-                Some(&source_root),
+                Some(source_root),
             )?;
         }
         Ok(committed_snapshot)
@@ -423,8 +498,9 @@ pub(crate) fn reconcile_scan_renames(
         .pending_renames_considered
         .saturating_add(candidates.len());
     let renamed = if carried_candidates_need_revalidation {
-        super::super::scan_hash::deep_hash_scan_with_writer(
+        super::super::scan_hash::deep_hash_scan_with_source_root_and_writer(
             db,
+            source_root,
             cancel,
             &candidates,
             super::super::scan_hash::DeferredHashScope::RenameCandidates,
@@ -434,8 +510,9 @@ pub(crate) fn reconcile_scan_renames(
         )?
         .renamed_samples
     } else {
-        super::super::scan_hash::reconcile_hashed_rename_candidates_with_writer(
+        super::super::scan_hash::reconcile_hashed_rename_candidates_with_source_root_and_writer(
             db,
+            source_root,
             &candidates,
             cancel,
             writer,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -149,6 +149,7 @@ pub fn audit_source_and_record_with_progress(
         Some(on_progress),
         &UncoordinatedScanWriter,
         || {},
+        || {},
     )
 }
 
@@ -187,6 +188,7 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
         Some(on_progress),
         writer,
         || {},
+        || {},
     )
 }
 
@@ -197,6 +199,7 @@ fn audit_source_and_record_after_scan(
     completed_at: i64,
     on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     writer: &impl ScanWriter,
+    before_record: impl FnOnce(),
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
     let root = ensure_root_dir(db)?;
@@ -213,7 +216,18 @@ fn audit_source_and_record_after_scan(
         false,
         writer,
     )?;
-    record_manifest_audit_completion(db, &mut stats, completed_at, writer, &source_root)?;
+    before_record();
+    if let Err(error) =
+        record_manifest_audit_completion(db, &mut stats, completed_at, writer, &source_root)
+    {
+        if stats.committed_delta.revision > 0 {
+            return Err(ScanError::Incomplete {
+                committed: Box::new(stats),
+                error: error.to_string(),
+            });
+        }
+        return Err(error);
+    }
     after_scan();
     let mut stats = merge_audit_verification(
         &mut stats,
@@ -286,7 +300,28 @@ pub(crate) fn audit_source_and_record_with_post_scan_hook(
         completed_at,
         None,
         &UncoordinatedScanWriter,
+        || {},
         after_scan,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn audit_source_and_record_with_pre_record_hook(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+    before_record: impl FnOnce(),
+) -> Result<ScanStats, ScanError> {
+    audit_source_and_record_after_scan(
+        db,
+        cancel,
+        ContentAuditBudget::entry_limited(max_hashes),
+        completed_at,
+        None,
+        &UncoordinatedScanWriter,
+        before_record,
+        || {},
     )
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -1027,6 +1027,34 @@ fn manifest_audit_publishes_unchanged_committed_revision_when_verification_is_ca
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn manifest_audit_root_swap_after_scan_returns_committed_checkpoint() {
+    let parent = tempdir().unwrap();
+    let root = parent.path().join("source");
+    std::fs::create_dir(&root).unwrap();
+    std::fs::write(root.join("known.wav"), b"known").unwrap();
+    let db = SourceDatabase::open_for_scan(&root).unwrap();
+
+    let old_root = parent.path().join("old-source");
+    let result = audit_source_and_record_with_pre_record_hook(&db, None, 0, 1_234, || {
+        std::fs::rename(&root, &old_root).unwrap();
+        std::fs::create_dir(&root).unwrap();
+    });
+    let ScanError::Incomplete { committed, error } = result.unwrap_err() else {
+        panic!("stale audit completion must return the committed checkpoint");
+    };
+
+    assert!(error.contains("Source root generation changed"));
+    assert_eq!(committed.committed_delta.created.len(), 1);
+    assert!(db.entry_for_path(Path::new("known.wav")).unwrap().is_some());
+    assert!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .is_none()
+    );
+}
+
 #[test]
 fn skipped_existing_file_is_not_used_as_a_rename_source() {
     let dir = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/filesystem_edges.rs
@@ -33,6 +33,40 @@ fn scan_tolerates_vanishing_nested_directories() {
 }
 
 #[test]
+fn full_scan_rejects_a_root_swap_before_the_first_checkpoint() {
+    let parent = tempdir().unwrap();
+    let root = parent.path().join("source");
+    std::fs::create_dir(&root).unwrap();
+    for index in 0..64 {
+        std::fs::write(
+            root.join(format!("sample-{index}.wav")),
+            format!("old-{index}"),
+        )
+        .unwrap();
+    }
+    let db = SourceDatabase::open_for_scan(&root).unwrap();
+    let mut swapped = false;
+    let result = scan_with_progress(&db, ScanMode::Quick, None, &mut |count, _| {
+        if count == 64 && !swapped {
+            swapped = true;
+            let old_root = parent.path().join("old-source");
+            std::fs::rename(&root, &old_root).unwrap();
+            std::fs::create_dir(&root).unwrap();
+            for index in 0..64 {
+                std::fs::write(
+                    root.join(format!("sample-{index}.wav")),
+                    format!("new-{index}"),
+                )
+                .unwrap();
+            }
+        }
+    });
+
+    assert!(matches!(result, Err(ScanError::StaleRootGeneration { .. })));
+    assert!(db.list_files().unwrap().is_empty());
+}
+
+#[test]
 fn scan_skips_symlink_directories() {
     use std::os::unix::fs as unix_fs;
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -23,6 +23,36 @@ fn targeted_sync_updates_only_requested_file() {
     assert!(stats.committed_delta.revision > 0);
 }
 
+#[cfg(unix)]
+#[test]
+fn targeted_sync_rejects_a_root_swap_before_commit() {
+    let parent = tempdir().unwrap();
+    let root = parent.path().join("source");
+    std::fs::create_dir(&root).unwrap();
+    let path = root.join("one.wav");
+    std::fs::write(&path, b"old").unwrap();
+    let db = SourceDatabase::open_for_scan(&root).unwrap();
+    scan_once(&db).unwrap();
+    let before = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+
+    let mut swapped = false;
+    let result = sync_paths_with_progress(&db, &[PathBuf::from("one.wav")], None, &mut |_, _| {
+        if !swapped {
+            swapped = true;
+            let old_root = parent.path().join("old-source");
+            std::fs::rename(&root, &old_root).unwrap();
+            std::fs::create_dir(&root).unwrap();
+            std::fs::write(root.join("one.wav"), b"new").unwrap();
+        }
+    });
+
+    assert!(matches!(result, Err(ScanError::StaleRootGeneration { .. })));
+    let after = db.entry_for_path(Path::new("one.wav")).unwrap().unwrap();
+    assert_eq!(after.file_size, before.file_size);
+    assert_eq!(after.modified_ns, before.modified_ns);
+    assert_eq!(after.content_hash, before.content_hash);
+}
+
 #[test]
 fn targeted_sync_detects_same_size_edit_with_restored_mtime() {
     let dir = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
@@ -5,6 +5,7 @@ use std::{
 
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
 use cap_std::fs::{Dir, OpenOptions};
+use wavecrate_library::filesystem_identity::stable_filesystem_identity;
 
 use super::scan::ScanError;
 
@@ -12,6 +13,7 @@ use super::scan::ScanError;
 pub(super) struct SourceRootCapability {
     root: PathBuf,
     dir: Dir,
+    generation: String,
 }
 
 /// The current relationship between a manifest path and a retained file descriptor.
@@ -24,15 +26,58 @@ pub(super) enum SourcePathBinding {
 
 impl SourceRootCapability {
     pub(super) fn open(root: &Path) -> Result<Self, ScanError> {
+        let metadata = fs::symlink_metadata(root).map_err(|source| ScanError::Io {
+            path: root.to_path_buf(),
+            source,
+        })?;
+        if !metadata.file_type().is_dir() {
+            return Err(ScanError::InvalidRoot(root.to_path_buf()));
+        }
         let dir =
             Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
                 path: root.to_path_buf(),
                 source,
             })?;
+        let retained_metadata = dir
+            .try_clone()
+            .and_then(|dir| dir.into_std_file().metadata())
+            .map_err(|source| ScanError::Io {
+                path: root.to_path_buf(),
+                source,
+            })?;
+        let Some(generation) = stable_filesystem_identity(root, &retained_metadata) else {
+            return Err(ScanError::StaleRootGeneration {
+                root: root.to_path_buf(),
+            });
+        };
         Ok(Self {
             root: root.to_path_buf(),
             dir,
+            generation,
         })
+    }
+
+    pub(super) fn clone_root_dir(&self) -> Result<Dir, ScanError> {
+        self.dir.try_clone().map_err(|source| ScanError::Io {
+            path: self.root.clone(),
+            source,
+        })
+    }
+
+    /// Revalidate that the configured ambient path still names this retained root.
+    pub(super) fn ensure_current_generation(&self) -> Result<(), ScanError> {
+        let Ok(metadata) = fs::symlink_metadata(&self.root) else {
+            return Err(ScanError::StaleRootGeneration {
+                root: self.root.clone(),
+            });
+        };
+        let current = stable_filesystem_identity(&self.root, &metadata);
+        if current.as_deref() != Some(self.generation.as_str()) {
+            return Err(ScanError::StaleRootGeneration {
+                root: self.root.clone(),
+            });
+        }
+        Ok(())
     }
 
     /// Open a regular file beneath the source root without following any path component.

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_capability.rs
@@ -26,7 +26,7 @@ pub(super) enum SourcePathBinding {
 
 impl SourceRootCapability {
     pub(super) fn open(root: &Path) -> Result<Self, ScanError> {
-        let metadata = fs::symlink_metadata(root).map_err(|source| ScanError::Io {
+        let metadata = fs::metadata(root).map_err(|source| ScanError::Io {
             path: root.to_path_buf(),
             source,
         })?;
@@ -66,7 +66,7 @@ impl SourceRootCapability {
 
     /// Revalidate that the configured ambient path still names this retained root.
     pub(super) fn ensure_current_generation(&self) -> Result<(), ScanError> {
-        let Ok(metadata) = fs::symlink_metadata(&self.root) else {
+        let Ok(metadata) = fs::metadata(&self.root) else {
             return Err(ScanError::StaleRootGeneration {
                 root: self.root.clone(),
             });

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::scan::{ScanContext, ScanError};
 use super::scan_capability::SourceRootCapability;
@@ -68,15 +67,28 @@ pub(super) fn db_sync_phase(
     if context.has_uncertain_prefixes() {
         return Ok(context.latest_committed_snapshot());
     }
+    Ok(context.latest_committed_snapshot())
+}
+
+pub(super) fn complete_scan_generation(
+    db: &SourceDatabase,
+    source_root: &SourceRootCapability,
+    context: &mut ScanContext,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+) -> Result<(u64, Vec<SourceManifestEntry>), ScanError> {
+    if context.has_uncertain_prefixes() {
+        return Ok(context.latest_committed_snapshot());
+    }
+    source_root.ensure_current_generation()?;
     let _writer = writer.lock(ScanWritePhase::Manifest);
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    source_root.ensure_current_generation()?;
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
         .to_string();
@@ -84,8 +96,8 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    let revision = context.commit_batch(batch)?;
-    Ok(context.committed_snapshot(revision))
+    source_root.ensure_current_generation()?;
+    Ok(batch.commit_with_manifest_snapshot()?)
 }
 
 fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_db_sync.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::scan::{ScanContext, ScanError};
+use super::scan_capability::SourceRootCapability;
 use super::scan_diff::mark_missing;
 use super::scan_index::reconcile_index_entries;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
@@ -13,6 +14,7 @@ const MISSING_BATCH_SIZE: usize = 64;
 
 pub(super) fn db_sync_phase(
     db: &SourceDatabase,
+    source_root: &SourceRootCapability,
     context: &mut ScanContext,
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
@@ -49,13 +51,16 @@ pub(super) fn db_sync_phase(
         if cancel_requested(cancel) {
             return Err(ScanError::Canceled);
         }
+        source_root.ensure_current_generation()?;
         context.commit_batch(batch)?;
     }
 
-    reconcile_index_entries(db, context, writer)?;
+    source_root.ensure_current_generation()?;
+    reconcile_index_entries(db, source_root, context, writer)?;
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
+    source_root.ensure_current_generation()?;
     // An unreadable subtree is not a completed source scan. Keep its prior
     // manifest rows and completion metadata intact so the existing retry/audit
     // owner will revisit it instead of treating the partial traversal as
@@ -67,6 +72,7 @@ pub(super) fn db_sync_phase(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
+    source_root.ensure_current_generation()?;
     let mut batch = db.write_batch()?;
     context.ensure_rename_candidate_generation(&mut batch)?;
     let timestamp = SystemTime::now()

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -294,7 +294,6 @@ pub(super) fn visit_dir_with_cancel_check(
                     snapshot.directories.push(relative.clone());
                     match dir.open_dir_nofollow(Path::new(&name)) {
                         Ok(child) => stack.push((child, relative)),
-                        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
                         Err(source) => {
                             warn!(
                                 path = %path.display(),

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -9,6 +9,8 @@ use std::{
 #[cfg(test)]
 use std::{cell::RefCell, collections::BTreeSet};
 
+use cap_fs_ext::{DirExt, OpenOptionsFollowExt};
+use cap_std::fs::{Dir, OpenOptions};
 use tracing::warn;
 use wavecrate_library::filesystem_identity::{
     filesystem_change_marker, stable_filesystem_identity,
@@ -23,6 +25,7 @@ use crate::sample_sources::SourceDatabase;
 
 use super::scan::ScanError;
 use super::scan::{SourceTreeFile, SourceTreeSnapshot};
+use super::scan_capability::SourceRootCapability;
 use super::scan_index::{inaccessible_index_entry, index_entry_from_file_facts};
 
 const MAX_LAYOUT_DIAGNOSTICS: usize = 16;
@@ -193,6 +196,7 @@ pub(super) fn ensure_root_dir(db: &SourceDatabase) -> Result<PathBuf, ScanError>
 }
 
 pub(super) fn visit_dir_with_cancel_check(
+    source_root: &SourceRootCapability,
     root: &Path,
     policy: SourceTraversalPolicy,
     should_cancel: &mut impl FnMut() -> bool,
@@ -202,39 +206,43 @@ pub(super) fn visit_dir_with_cancel_check(
         directories: vec![PathBuf::new()],
         ..SourceTreeSnapshot::default()
     };
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
+    let mut stack = vec![(source_root.clone_root_dir()?, PathBuf::new())];
+    while let Some((dir, relative_dir)) = stack.pop() {
         if should_cancel() {
             return Err(ScanError::Canceled);
         }
-        let entries = match read_dir(&dir) {
+        let absolute_dir = root.join(&relative_dir);
+        let entries = match read_dir(&dir, &absolute_dir) {
             Ok(entries) => entries,
-            Err(source) if dir != root => {
+            Err(source) if !relative_dir.as_os_str().is_empty() => {
                 warn!(
-                    dir = %dir.display(),
+                    dir = %absolute_dir.display(),
                     error = %source,
                     "Failed to read directory during scan"
                 );
                 record_layout_diagnostic(
                     &mut snapshot,
-                    format!("read directory {}: {source}", display_relative(root, &dir)),
+                    format!(
+                        "read directory {}: {source}",
+                        display_relative(root, &absolute_dir)
+                    ),
                 );
-                record_uncertain_prefix(&mut snapshot, root, &dir);
+                record_uncertain_prefix(&mut snapshot, root, &absolute_dir);
                 continue;
             }
             Err(source) => {
                 return Err(ScanError::Io {
-                    path: dir.clone(),
+                    path: absolute_dir,
                     source,
                 });
             }
         };
         for entry_result in entries {
-            let entry = match read_dir_entry(entry_result, &dir) {
+            let entry = match read_dir_entry(entry_result, &absolute_dir) {
                 Ok(entry) => entry,
                 Err(err) => {
                     warn!(
-                        dir = %dir.display(),
+                        dir = %absolute_dir.display(),
                         error = %err,
                         "Failed to read directory entry during scan"
                     );
@@ -242,19 +250,17 @@ pub(super) fn visit_dir_with_cancel_check(
                         &mut snapshot,
                         format!(
                             "read directory entry {}: {err}",
-                            display_relative(root, &dir)
+                            display_relative(root, &absolute_dir)
                         ),
                     );
-                    record_uncertain_prefix(&mut snapshot, root, &dir);
+                    record_uncertain_prefix(&mut snapshot, root, &absolute_dir);
                     continue;
                 }
             };
 
-            let path = entry.path();
-            let relative = path
-                .strip_prefix(root)
-                .map(Path::to_path_buf)
-                .map_err(|_| ScanError::InvalidRoot(path.clone()))?;
+            let name = entry.file_name();
+            let relative = relative_dir.join(&name);
+            let path = root.join(&relative);
             let file_type = match read_file_type(&entry, &path) {
                 Ok(file_type) => file_type,
                 Err(err) => {
@@ -281,12 +287,35 @@ pub(super) fn visit_dir_with_cancel_check(
             };
             match classify_source_entry_with_policy(
                 &relative,
-                source_entry_file_type(&file_type),
+                cap_source_entry_file_type(&file_type),
                 policy,
             ) {
                 SourceEntryClassification::Directory { .. } => {
-                    snapshot.directories.push(relative);
-                    stack.push(path);
+                    snapshot.directories.push(relative.clone());
+                    match dir.open_dir_nofollow(Path::new(&name)) {
+                        Ok(child) => stack.push((child, relative)),
+                        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(source) => {
+                            warn!(
+                                path = %path.display(),
+                                error = %source,
+                                "Failed to open directory during scan"
+                            );
+                            record_layout_diagnostic(
+                                &mut snapshot,
+                                format!(
+                                    "open directory {}: {source}",
+                                    display_relative(root, &path)
+                                ),
+                            );
+                            if !dir
+                                .symlink_metadata(Path::new(&name))
+                                .is_ok_and(|metadata| metadata.is_symlink())
+                            {
+                                record_uncertain_prefix(&mut snapshot, root, &path);
+                            }
+                        }
+                    }
                 }
                 classification @ SourceEntryClassification::File { .. } => {
                     if classification.indexes_audio() {
@@ -294,7 +323,13 @@ pub(super) fn visit_dir_with_cancel_check(
                     } else if let Some(file_classification) = classification.file_classification()
                         && file_classification != SourceFileClassification::SupportedAudio
                     {
-                        match source_index_entry(root, &path, file_classification) {
+                        match source_index_entry(
+                            &dir,
+                            Path::new(&name),
+                            root,
+                            &relative,
+                            file_classification,
+                        ) {
                             Ok(index_entry) => {
                                 if let Some(file_size) = index_entry.file_size {
                                     snapshot.other_files.push(SourceTreeFile {
@@ -337,15 +372,20 @@ pub(super) fn visit_dir_with_cancel_check(
 }
 
 fn source_index_entry(
+    parent: &Dir,
+    name: &Path,
     root: &Path,
-    path: &Path,
+    relative_path: &Path,
     classification: SourceFileClassification,
 ) -> Result<SourceIndexEntry, std::io::Error> {
+    let path = root.join(relative_path);
     #[cfg(test)]
-    if let Some(error) = forced_file_metadata_error(path) {
+    if let Some(error) = forced_file_metadata_error(&path) {
         return Err(error);
     }
-    let metadata = fs::symlink_metadata(path)?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(cap_fs_ext::FollowSymlinks::No);
+    let metadata = parent.open_with(name, &options)?.into_std().metadata()?;
     if !metadata.file_type().is_file() {
         return Err(std::io::Error::other(
             "entry changed type during metadata inspection",
@@ -357,16 +397,12 @@ fn source_index_entry(
         .unwrap_or_default()
         .as_nanos()
         .min(i64::MAX as u128) as i64;
-    let relative_path = path
-        .strip_prefix(root)
-        .map(Path::to_path_buf)
-        .map_err(|_| std::io::Error::other("entry is outside the source root"))?;
     index_entry_from_file_facts(
-        relative_path,
+        relative_path.to_path_buf(),
         classification,
         metadata.len(),
         modified_ns,
-        stable_filesystem_identity(path, &metadata),
+        stable_filesystem_identity(&path, &metadata),
     )
     .ok_or_else(|| std::io::Error::other("supported audio is not an index-only entry"))
 }
@@ -381,15 +417,20 @@ fn record_uncertain_prefix(snapshot: &mut SourceTreeSnapshot, root: &Path, path:
     }
 }
 
-fn read_dir(path: &Path) -> Result<fs::ReadDir, std::io::Error> {
+fn read_dir(dir: &Dir, path: &Path) -> Result<cap_std::fs::ReadDir, std::io::Error> {
     #[cfg(test)]
     if let Some(error) = forced_directory_read_error(path) {
         return Err(error);
     }
-    fs::read_dir(path)
+    #[cfg(not(test))]
+    let _ = path;
+    dir.entries()
 }
 
-fn read_file_type(entry: &fs::DirEntry, _path: &Path) -> Result<fs::FileType, std::io::Error> {
+fn read_file_type(
+    entry: &cap_std::fs::DirEntry,
+    _path: &Path,
+) -> Result<cap_std::fs::FileType, std::io::Error> {
     #[cfg(test)]
     if let Some(error) = forced_file_type_error(_path) {
         return Err(error);
@@ -398,9 +439,9 @@ fn read_file_type(entry: &fs::DirEntry, _path: &Path) -> Result<fs::FileType, st
 }
 
 fn read_dir_entry(
-    entry: Result<fs::DirEntry, std::io::Error>,
+    entry: Result<cap_std::fs::DirEntry, std::io::Error>,
     _directory: &Path,
-) -> Result<fs::DirEntry, std::io::Error> {
+) -> Result<cap_std::fs::DirEntry, std::io::Error> {
     #[cfg(test)]
     if let Some(error) = forced_directory_entry_error(_directory) {
         return Err(error);
@@ -562,6 +603,14 @@ pub(super) fn is_supported_scannable_audio_file(
 }
 
 fn source_entry_file_type(file_type: &fs::FileType) -> SourceEntryFileType {
+    SourceEntryFileType::from_no_followed_type(
+        file_type.is_dir(),
+        file_type.is_file(),
+        file_type.is_symlink(),
+    )
+}
+
+fn cap_source_entry_file_type(file_type: &cap_std::fs::FileType) -> SourceEntryFileType {
     SourceEntryFileType::from_no_followed_type(
         file_type.is_dir(),
         file_type.is_file(),

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -247,6 +247,7 @@ fn cancel_requested(cancel: Option<&AtomicBool>) -> bool {
     cancel.is_some_and(|cancel| cancel.load(Ordering::Relaxed))
 }
 
+#[cfg(test)]
 pub(super) fn verify_content_batch(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
@@ -256,6 +257,7 @@ pub(super) fn verify_content_batch(
     verify_content_batch_with_writer(db, cancel, budget, now, &UncoordinatedScanWriter)
 }
 
+#[cfg(test)]
 pub(super) fn verify_content_batch_with_writer(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
@@ -266,6 +268,31 @@ pub(super) fn verify_content_batch_with_writer(
     verify_content_batch_with_post_hash_hook(db, cancel, budget, now, writer, |_| {})
 }
 
+pub(super) fn verify_content_batch_with_source_root(
+    db: &SourceDatabase,
+    source_root: &SourceRootCapability,
+    cancel: Option<&AtomicBool>,
+    budget: ContentAuditBudget,
+    now: i64,
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    let root = db.root().to_path_buf();
+    let started = Instant::now();
+    verify_content_batch_with_source_root_hooks(
+        db,
+        &root,
+        source_root,
+        cancel,
+        budget,
+        now,
+        writer,
+        &mut |_| {},
+        &mut |_| {},
+        &mut || started.elapsed(),
+    )
+}
+
+#[cfg(test)]
 fn verify_content_batch_with_post_hash_hook(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
@@ -287,6 +314,7 @@ fn verify_content_batch_with_post_hash_hook(
     )
 }
 
+#[cfg(test)]
 fn verify_content_batch_with_hooks(
     db: &SourceDatabase,
     cancel: Option<&AtomicBool>,
@@ -297,10 +325,38 @@ fn verify_content_batch_with_hooks(
     precommit: &mut impl FnMut(&std::path::Path),
     elapsed: &mut impl FnMut() -> Duration,
 ) -> Result<ScanStats, ScanError> {
-    let planning_started = Instant::now();
-    let manifest_revision = db.get_revision()?;
     let root = ensure_root_dir(db)?;
     let source_root = SourceRootCapability::open(&root)?;
+    verify_content_batch_with_source_root_hooks(
+        db,
+        &root,
+        &source_root,
+        cancel,
+        budget,
+        now,
+        writer,
+        post_hash,
+        precommit,
+        elapsed,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_content_batch_with_source_root_hooks(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    cancel: Option<&AtomicBool>,
+    budget: ContentAuditBudget,
+    now: i64,
+    writer: &impl ScanWriter,
+    post_hash: &mut impl FnMut(&std::path::Path),
+    precommit: &mut impl FnMut(&std::path::Path),
+    elapsed: &mut impl FnMut() -> Duration,
+) -> Result<ScanStats, ScanError> {
+    let planning_started = Instant::now();
+    let manifest_revision = db.get_revision()?;
+    source_root.ensure_current_generation()?;
     let checkpoint = {
         let _writer = writer.lock(ScanWritePhase::Manifest);
         db.begin_or_resume_content_audit(now, manifest_revision)?
@@ -472,6 +528,7 @@ fn verify_content_batch_with_hooks(
     }
     let cancelled = cancel_requested(cancel);
     if !verified.is_empty() || !skipped.is_empty() || cursor_only_progress {
+        source_root.ensure_current_generation()?;
         let _writer = writer.lock(ScanWritePhase::DeferredHash);
         let mut batch = db.write_batch()?;
         let stats_before_staging = stats.clone();
@@ -601,6 +658,7 @@ fn verify_content_batch_with_hooks(
                 Ok(stats)
             };
         }
+        source_root.ensure_current_generation()?;
         let result = batch.commit_with_bounded_manifest_changes(manifest_revision)?;
         let changed_after = result
             .touched_path_changes
@@ -621,6 +679,7 @@ fn verify_content_batch_with_hooks(
         db.content_audit_report(now)?
     };
     if report.remaining_entries == 0 && report.total_entries > 0 {
+        source_root.ensure_current_generation()?;
         let _writer = writer.lock(ScanWritePhase::Manifest);
         let mut batch = db.write_batch()?;
         if !batch.matches_revision(stats.committed_delta.revision)? {
@@ -694,17 +753,97 @@ pub(super) fn deep_hash_scan_with_writer(
     )
 }
 
+pub(super) fn deep_hash_scan_with_source_root_and_writer(
+    db: &SourceDatabase,
+    source_root: &SourceRootCapability,
+    cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
+    max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    let root = db.root().to_path_buf();
+    source_root.ensure_current_generation()?;
+    deep_hash_scan_with_root_hooks(
+        db,
+        &root,
+        source_root,
+        cancel,
+        rename_candidates,
+        scope,
+        max_hashes,
+        exact_path,
+        writer,
+        |_| {},
+        |_| {},
+    )
+}
+
+#[cfg(test)]
 pub(super) fn reconcile_hashed_rename_candidates_with_writer(
     db: &SourceDatabase,
     rename_candidates: &HashSet<PathBuf>,
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
 ) -> Result<Vec<RenamedSample>, ScanError> {
-    reconcile_hashed_rename_candidates_with_hook(db, rename_candidates, cancel, writer, |_| {})
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    reconcile_hashed_rename_candidates_with_source_root_and_hook(
+        db,
+        &root,
+        &source_root,
+        rename_candidates,
+        cancel,
+        writer,
+        |_| {},
+    )
 }
 
+pub(super) fn reconcile_hashed_rename_candidates_with_source_root_and_writer(
+    db: &SourceDatabase,
+    source_root: &SourceRootCapability,
+    rename_candidates: &HashSet<PathBuf>,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+) -> Result<Vec<RenamedSample>, ScanError> {
+    let root = db.root().to_path_buf();
+    reconcile_hashed_rename_candidates_with_source_root_and_hook(
+        db,
+        &root,
+        source_root,
+        rename_candidates,
+        cancel,
+        writer,
+        |_| {},
+    )
+}
+
+#[cfg(test)]
 fn reconcile_hashed_rename_candidates_with_hook(
     db: &SourceDatabase,
+    rename_candidates: &HashSet<PathBuf>,
+    cancel: Option<&AtomicBool>,
+    writer: &impl ScanWriter,
+    precommit: impl FnMut(&std::path::Path),
+) -> Result<Vec<RenamedSample>, ScanError> {
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    reconcile_hashed_rename_candidates_with_source_root_and_hook(
+        db,
+        &root,
+        &source_root,
+        rename_candidates,
+        cancel,
+        writer,
+        precommit,
+    )
+}
+
+fn reconcile_hashed_rename_candidates_with_source_root_and_hook(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
     rename_candidates: &HashSet<PathBuf>,
     cancel: Option<&AtomicBool>,
     writer: &impl ScanWriter,
@@ -713,8 +852,7 @@ fn reconcile_hashed_rename_candidates_with_hook(
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
     }
-    let root = ensure_root_dir(db)?;
-    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
     let rename_candidates = rename_candidates.clone();
     if rename_candidates.is_empty() {
         return Ok(Vec::new());
@@ -808,6 +946,7 @@ fn reconcile_hashed_rename_candidates_with_hook(
         drop(batch);
         return Ok(Vec::new());
     }
+    source_root.ensure_current_generation()?;
     batch.commit()?;
     Ok(renamed_samples)
 }
@@ -822,8 +961,12 @@ fn deep_hash_scan_with_post_hash_hook(
     writer: &impl ScanWriter,
     post_hash: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
-    deep_hash_scan_with_hooks(
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    deep_hash_scan_with_root_hooks(
         db,
+        &root,
+        &source_root,
         cancel,
         rename_candidates,
         scope,
@@ -836,8 +979,10 @@ fn deep_hash_scan_with_post_hash_hook(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn deep_hash_scan_with_hooks(
+fn deep_hash_scan_with_root_hooks(
     db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
     cancel: Option<&AtomicBool>,
     rename_candidates: &HashSet<PathBuf>,
     scope: DeferredHashScope,
@@ -847,9 +992,8 @@ fn deep_hash_scan_with_hooks(
     mut post_hash: impl FnMut(&std::path::Path),
     mut precommit: impl FnMut(&std::path::Path),
 ) -> Result<ScanStats, ScanError> {
+    source_root.ensure_current_generation()?;
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
-    let root = ensure_root_dir(db)?;
-    let source_root = SourceRootCapability::open(&root)?;
     let mut rename_candidates = rename_candidates.clone();
     rename_candidates.extend(db.list_pending_rename_destinations()?);
     let entries = if let Some(exact_path) = exact_path {
@@ -914,7 +1058,7 @@ fn deep_hash_scan_with_hooks(
         let Some(mut file) = source_root.open_regular_file(&entry.relative_path)? else {
             continue;
         };
-        let facts = read_facts_from_open_file(&root, &absolute, &file)?;
+        let facts = read_facts_from_open_file(root, &absolute, &file)?;
         file.seek(SeekFrom::Start(0))
             .map_err(|source| ScanError::Io {
                 path: absolute.clone(),
@@ -922,7 +1066,7 @@ fn deep_hash_scan_with_hooks(
             })?;
         let hash = compute_content_hash_with_reader(&absolute, &mut file, cancel)?;
         post_hash(&absolute);
-        let after_hash = read_facts_from_open_file(&root, &absolute, &file)?;
+        let after_hash = read_facts_from_open_file(root, &absolute, &file)?;
         if !facts.same_content_snapshot(&after_hash) {
             continue;
         }
@@ -946,6 +1090,7 @@ fn deep_hash_scan_with_hooks(
         return Err(ScanError::Canceled);
     }
 
+    source_root.ensure_current_generation()?;
     let _writer = writer.lock(ScanWritePhase::DeferredHash);
     if cancel_requested(cancel) {
         return Err(ScanError::Canceled);
@@ -961,7 +1106,7 @@ fn deep_hash_scan_with_hooks(
     let mut accepted_backfills = Vec::with_capacity(hash_backfills.len());
     for backfill in hash_backfills {
         let absolute = root.join(&backfill.relative_path);
-        let descriptor_still_current = read_facts_from_open_file(&root, &absolute, &backfill.file)
+        let descriptor_still_current = read_facts_from_open_file(root, &absolute, &backfill.file)
             .is_ok_and(|facts| backfill.facts.same_content_snapshot(&facts));
         if !descriptor_still_current
             || !matches!(
@@ -995,7 +1140,7 @@ fn deep_hash_scan_with_hooks(
         .collect::<HashSet<_>>();
     let (renamed_samples, _) = reconcile_indexed_rename_candidates(
         &mut batch,
-        &root,
+        root,
         &entries_by_path,
         &candidate_identities,
         &admitted_rename_candidates,
@@ -1011,7 +1156,7 @@ fn deep_hash_scan_with_hooks(
     }
     let final_bindings_match = accepted_backfills.iter().all(|backfill| {
         let absolute = root.join(&backfill.relative_path);
-        let descriptor_matches = read_facts_from_open_file(&root, &absolute, &backfill.file)
+        let descriptor_matches = read_facts_from_open_file(root, &absolute, &backfill.file)
             .is_ok_and(|facts| backfill.facts.same_content_snapshot(&facts));
         descriptor_matches
             && matches!(
@@ -1021,15 +1166,46 @@ fn deep_hash_scan_with_hooks(
     });
     if !final_bindings_match {
         drop(batch);
-        stats = stats_before_staging;
+        let mut stats = stats_before_staging;
         stats.committed_delta.revision = db.get_revision()?;
         stats.pending_rename_diagnostics = Some(db.pending_rename_diagnostics()?);
         return Ok(stats);
     }
+    source_root.ensure_current_generation()?;
     let committed_snapshot = batch.commit_with_manifest_snapshot()?;
     super::manifest::publish_committed_delta(&mut stats, manifest_before, committed_snapshot);
     stats.pending_rename_diagnostics = Some(db.pending_rename_diagnostics()?);
     Ok(stats)
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn deep_hash_scan_with_hooks(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    rename_candidates: &HashSet<PathBuf>,
+    scope: DeferredHashScope,
+    max_hashes: Option<usize>,
+    exact_path: Option<&std::path::Path>,
+    writer: &impl ScanWriter,
+    post_hash: impl FnMut(&std::path::Path),
+    precommit: impl FnMut(&std::path::Path),
+) -> Result<ScanStats, ScanError> {
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    deep_hash_scan_with_root_hooks(
+        db,
+        &root,
+        &source_root,
+        cancel,
+        rename_candidates,
+        scope,
+        max_hashes,
+        exact_path,
+        writer,
+        post_hash,
+        precommit,
+    )
 }
 
 fn reconcile_indexed_rename_candidates(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
@@ -8,6 +8,7 @@ use wavecrate_library::sample_sources::{
 use crate::sample_sources::SourceDatabase;
 
 use super::scan::{ScanContext, ScanError};
+use super::scan_capability::SourceRootCapability;
 use super::scan_writer::{ScanWritePhase, ScanWriter};
 
 pub(super) fn index_entry_from_file_facts(
@@ -58,6 +59,7 @@ pub(super) fn inaccessible_index_entry(
 
 pub(super) fn reconcile_index_entries(
     database: &SourceDatabase,
+    source_root: &SourceRootCapability,
     context: &mut ScanContext,
     writer: &impl ScanWriter,
 ) -> Result<(), ScanError> {
@@ -95,6 +97,7 @@ pub(super) fn reconcile_index_entries(
     if removals.is_empty() && upserts.is_empty() && unavailable_manifest_paths.is_empty() {
         return Ok(());
     }
+    source_root.ensure_current_generation()?;
     let _writer = writer.lock(ScanWritePhase::Manifest);
     let mut batch = database.write_batch()?;
     for path in &unavailable_manifest_paths {
@@ -107,9 +110,11 @@ pub(super) fn reconcile_index_entries(
     for entry in upserts {
         batch.upsert_source_index_entry(&entry)?;
     }
+    source_root.ensure_current_generation()?;
     if unavailable_manifest_paths.is_empty() {
         batch.commit_auxiliary_state()?;
     } else {
+        source_root.ensure_current_generation()?;
         context.commit_batch(batch)?;
     }
     Ok(())

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -18,7 +18,7 @@ use crate::sample_sources::{SourceDatabase, WavEntry};
 use super::{
     scan::{ScanContext, ScanError, ScanMode, ScanStats},
     scan_capability::SourceRootCapability,
-    scan_db_sync::db_sync_phase,
+    scan_db_sync::{complete_scan_generation, db_sync_phase},
     scan_diff_phase::prepare_diff_from_facts,
     scan_fs::ensure_root_dir,
     scan_index::{inaccessible_index_entry, index_entry_from_file_facts},
@@ -132,7 +132,8 @@ pub fn sync_paths_with_progress_and_writer(
             committed_snapshot,
             cancel,
             writer,
-        )
+        )?;
+        complete_scan_generation(db, &source_root, &mut context, cancel, writer)
     })();
     super::scan::finish_scan_result(manifest_before, context, result)
 }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -5,7 +5,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt, ambient_authority};
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::fs::{Dir, OpenOptions};
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
@@ -17,6 +17,7 @@ use crate::sample_sources::{SourceDatabase, WavEntry};
 
 use super::{
     scan::{ScanContext, ScanError, ScanMode, ScanStats},
+    scan_capability::SourceRootCapability,
     scan_db_sync::db_sync_phase,
     scan_diff_phase::prepare_diff_from_facts,
     scan_fs::ensure_root_dir,
@@ -56,8 +57,10 @@ pub fn sync_paths_with_progress_and_writer(
 ) -> Result<ScanStats, ScanError> {
     let (manifest_revision, manifest_before) = super::manifest::capture_manifest_with_revision(db)?;
     let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
     let policy = db.source_traversal_policy()?;
-    let targets = collect_targets(db, &root, paths, cancel, policy)?;
+    let targets = collect_targets(db, &root, &source_root, paths, cancel, policy)?;
     let TargetedScanTargets {
         current_files,
         existing,
@@ -99,6 +102,7 @@ pub fn sync_paths_with_progress_and_writer(
                 committed |= apply_prepared_chunk(
                     db,
                     &root,
+                    &source_root,
                     cancel,
                     &mut context,
                     chunk,
@@ -108,12 +112,21 @@ pub fn sync_paths_with_progress_and_writer(
             }
         }
         if !prepared.is_empty() {
-            let _ =
-                apply_prepared_chunk(db, &root, cancel, &mut context, prepared, committed, writer)?;
+            let _ = apply_prepared_chunk(
+                db,
+                &root,
+                &source_root,
+                cancel,
+                &mut context,
+                prepared,
+                committed,
+                writer,
+            )?;
         }
-        let committed_snapshot = db_sync_phase(db, &mut context, cancel, writer)?;
+        let committed_snapshot = db_sync_phase(db, &source_root, &mut context, cancel, writer)?;
         super::scan::reconcile_scan_renames(
             db,
+            &source_root,
             &mut context,
             &manifest_before,
             committed_snapshot,
@@ -141,15 +154,12 @@ struct TargetedFile {
 fn collect_targets(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     paths: &[PathBuf],
     cancel: Option<&AtomicBool>,
     policy: SourceTraversalPolicy,
 ) -> Result<TargetedScanTargets, ScanError> {
-    let source_root =
-        Dir::open_ambient_dir(root, ambient_authority()).map_err(|source| ScanError::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
+    let source_root_dir = source_root.clone_root_dir()?;
     let mut current_files = BTreeMap::new();
     let mut existing = HashMap::new();
     let mut current_index_entries = BTreeMap::new();
@@ -164,7 +174,7 @@ fn collect_targets(
         collect_existing_rows(db, &relative_path, &mut existing)?;
         collect_existing_index_entries(db, &relative_path, &mut existing_index_entries)?;
         collect_current_files(
-            &source_root,
+            &source_root_dir,
             root,
             &relative_path,
             cancel,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -26,6 +26,7 @@ const APPLY_BATCH_SIZE: usize = 64;
 pub(super) fn walk_phase(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     policy: SourceTraversalPolicy,
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
@@ -38,8 +39,8 @@ pub(super) fn walk_phase(
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
     let mut pending_noops = Vec::with_capacity(APPLY_BATCH_SIZE);
-    let source_root = SourceRootCapability::open(root)?;
     let source_tree_snapshot = visit_dir_with_cancel_check(
+        source_root,
         root,
         policy,
         &mut || cancel_requested(cancel),
@@ -116,8 +117,16 @@ pub(super) fn walk_phase(
             pending.push(prepared);
             if pending.len() == APPLY_BATCH_SIZE {
                 let files = std::mem::replace(&mut pending, Vec::with_capacity(APPLY_BATCH_SIZE));
-                let outcome =
-                    apply_batch(db, root, cancel, context, files, committed.get(), writer)?;
+                let outcome = apply_batch_with_source_root(
+                    db,
+                    root,
+                    source_root,
+                    cancel,
+                    context,
+                    files,
+                    committed.get(),
+                    writer,
+                )?;
                 if outcome.committed {
                     committed.set(true);
                 }
@@ -145,7 +154,16 @@ pub(super) fn walk_phase(
         },
     )?;
     if !pending.is_empty() {
-        let outcome = apply_batch(db, root, cancel, context, pending, committed.get(), writer)?;
+        let outcome = apply_batch_with_source_root(
+            db,
+            root,
+            source_root,
+            cancel,
+            context,
+            pending,
+            committed.get(),
+            writer,
+        )?;
         if outcome.committed {
             committed.set(true);
         }
@@ -241,6 +259,7 @@ fn flush_manifest_audit_checkpoint_with_noops_hook(
         context.mark_source_tree_incomplete();
     }
     context.discard_manifest_audit_paths(invalid_paths);
+    source_root.ensure_current_generation()?;
     context.flush_manifest_audit_checkpoint(db)?;
     drop(valid);
     Ok(())
@@ -318,13 +337,13 @@ fn record_inaccessible_preparation(
 pub(super) fn apply_prepared_chunk(
     db: &SourceDatabase,
     root: &Path,
+    source_root: &SourceRootCapability,
     cancel: Option<&AtomicBool>,
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
 ) -> Result<bool, ScanError> {
-    let source_root = SourceRootCapability::open(root)?;
     let mut pending = Vec::with_capacity(prepared.len());
     for mut file in prepared {
         if !file.requires_apply {
@@ -350,9 +369,10 @@ pub(super) fn apply_prepared_chunk(
     if pending.is_empty() {
         return Ok(false);
     }
-    apply_batch(
+    apply_batch_with_source_root(
         db,
         root,
+        source_root,
         cancel,
         context,
         pending,
@@ -465,6 +485,7 @@ pub(super) fn skip_noop(context: &mut ScanContext, prepared: &PreparedFile) {
     let _ = context.existing.remove(&prepared.facts.relative);
 }
 
+#[cfg(test)]
 fn apply_batch(
     db: &SourceDatabase,
     root: &Path,
@@ -474,9 +495,33 @@ fn apply_batch(
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
 ) -> Result<ApplyBatchOutcome, ScanError> {
-    apply_batch_with_precommit_hook(
+    let source_root = SourceRootCapability::open(root)?;
+    apply_batch_with_source_root(
         db,
         root,
+        &source_root,
+        cancel,
+        context,
+        prepared,
+        tolerate_file_errors,
+        writer,
+    )
+}
+
+fn apply_batch_with_source_root(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    cancel: Option<&AtomicBool>,
+    context: &mut ScanContext,
+    prepared: Vec<PreparedFile>,
+    tolerate_file_errors: bool,
+    writer: &impl ScanWriter,
+) -> Result<ApplyBatchOutcome, ScanError> {
+    apply_batch_with_source_root_and_precommit_hook(
+        db,
+        root,
+        source_root,
         cancel,
         context,
         prepared,
@@ -487,6 +532,7 @@ fn apply_batch(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 fn apply_batch_with_precommit_hook(
     db: &SourceDatabase,
     root: &Path,
@@ -495,9 +541,34 @@ fn apply_batch_with_precommit_hook(
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
-    mut precommit: impl FnMut(&Path),
+    precommit: impl FnMut(&Path),
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let source_root = SourceRootCapability::open(root)?;
+    apply_batch_with_source_root_and_precommit_hook(
+        db,
+        root,
+        &source_root,
+        cancel,
+        context,
+        prepared,
+        tolerate_file_errors,
+        writer,
+        precommit,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_batch_with_source_root_and_precommit_hook(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    cancel: Option<&AtomicBool>,
+    context: &mut ScanContext,
+    prepared: Vec<PreparedFile>,
+    tolerate_file_errors: bool,
+    writer: &impl ScanWriter,
+    mut precommit: impl FnMut(&Path),
+) -> Result<ApplyBatchOutcome, ScanError> {
     let mut ready = Vec::with_capacity(prepared.len());
     let mut post_hash = |_: &Path| {};
     for file in prepared {
@@ -649,6 +720,7 @@ fn apply_batch_with_precommit_hook(
         context.mark_source_tree_incomplete();
         return Ok(ApplyBatchOutcome::default());
     }
+    source_root.ensure_current_generation()?;
     context.commit_batch(batch)?;
     Ok(ApplyBatchOutcome {
         committed: true,

--- a/src/native_app/source_processing/worker.rs
+++ b/src/native_app/source_processing/worker.rs
@@ -244,6 +244,13 @@ impl From<wavecrate_scan::ScanError> for SourceProcessingFailure {
                     "Source changed while completing deferred deep hash (expected revision {expected}, found {actual})"
                 ),
             ),
+            wavecrate_scan::ScanError::StaleRootGeneration { root } => {
+                Self::retryable_with_source_error(
+                    SourceProcessingFailureCode::ScannerIncomplete,
+                    "Source root changed while scanning",
+                    root.display().to_string(),
+                )
+            }
             wavecrate_scan::ScanError::TraversalPolicyChanged => Self::retryable(
                 SourceProcessingFailureCode::ScannerStaleRevision,
                 "Source traversal policy changed while scanning",


### PR DESCRIPTION
## Goal

Implement OPT-1278 so full and targeted scans bind traversal, file preparation, content reads, and publication fences to one retained source-root generation.

## Scope and non-goals

- Full traversal now enumerates through the retained no-follow source-root capability.
- Targeted traversal and apply batches reuse the same retained capability instead of reopening the ambient root.
- Full-scan rename reconciliation and bounded audit hashing also reuse that capability.
- Root identity is revalidated before batch checkpoints, index reconciliation, completion metadata, and pending-rename completion.
- Root replacement returns typed `StaleRootGeneration`, or existing retryable `Incomplete` semantics after a committed checkpoint.
- Added deterministic full-scan, targeted-scan, and post-checkpoint audit root-swap regressions.
- No symlink-following changes, watcher/source UX redesign, or browser-cache authority changes.

## Definition of Done

Traversal, reads, and completion must not publish facts from one root generation under another; root swaps before traversal, during traversal, and before commit must schedule normal retry/recovery while ordinary cancellation, progress, no-follow, and partial-enumeration behavior remains intact.

## Validation

- `cargo test -p wavecrate-scan --all-targets` — 171 passed.
- `cargo check -p wavecrate --tests --bins` — passed.
- `git diff --check` — passed.
- `bash scripts/ci.sh agent` — reached the full Wavecrate checks, then failed on one unrelated existing Radiant vendor test: `gpu_signal_shader_keeps_waveform_bands_visually_distinct` expects a shader color literal absent from the current vendor tree.

## Known limitations

The complete agent gate remains blocked by the unrelated Radiant vendor test above; no vendor files were changed.

User approval is required before merge.