### PR TITLE
fix(scan): make targeted subtree SQL path-component exact

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use super::schema;
-use super::util::{map_sql_error, normalize_relative_path, parse_relative_path_from_db};
+use super::util::{
+    EXACT_SUBTREE_PATH_PREDICATE, exact_subtree_path_bounds, map_sql_error,
+    normalize_relative_path, parse_relative_path_from_db,
+};
 use super::{
     META_SOURCE_INDEX_REVISION, SourceDatabase, SourceDbError, SourceIndexClassification,
     SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceWriteBatch,
@@ -62,15 +65,17 @@ impl SourceDatabase {
             return Ok(Vec::new());
         }
         let normalized = normalize_relative_path(relative_path)?;
-        let prefix = format!("{}/%", escape_like_pattern(&normalized));
+        let (lower_bound, upper_bound) = exact_subtree_path_bounds(&normalized);
         collect_entries(
             &self.connection,
-            "SELECT path, classification, file_size, modified_ns, file_identity,
+            &format!(
+                "SELECT path, classification, file_size, modified_ns, file_identity,
                     diagnostic, format_policy_version
              FROM source_index_entries
-             WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'
-             ORDER BY path ASC",
-            params![normalized, prefix],
+             WHERE {EXACT_SUBTREE_PATH_PREDICATE}
+             ORDER BY path ASC"
+            ),
+            params![normalized, lower_bound, upper_bound],
         )
     }
 }
@@ -238,13 +243,6 @@ fn saturating_i64(value: u64) -> i64 {
     value.min(i64::MAX as u64) as i64
 }
 
-fn escape_like_pattern(value: &str) -> String {
-    value
-        .replace('!', "!!")
-        .replace('%', "!%")
-        .replace('_', "!_")
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -354,16 +352,21 @@ mod tests {
         let directory = tempfile::tempdir().expect("source root");
         let database =
             SourceDatabase::open_for_source_write(directory.path()).expect("source database");
-        let entries =
-            ["literal%/inside.txt", "literalx/outside.txt"].map(|path| SourceIndexEntry {
-                relative_path: PathBuf::from(path),
-                classification: SourceIndexClassification::UnsupportedNonAudio,
-                file_size: Some(5),
-                modified_ns: Some(10),
-                file_identity: None,
-                diagnostic: None,
-                format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
-            });
+        let entries = [
+            "literal%_!/inside.txt",
+            "literal%_!/nested/deep.txt",
+            "literalx_Yx!/outside.txt",
+            "Literal%_!/case-distinct.txt",
+        ]
+        .map(|path| SourceIndexEntry {
+            relative_path: PathBuf::from(path),
+            classification: SourceIndexClassification::UnsupportedNonAudio,
+            file_size: Some(5),
+            modified_ns: Some(10),
+            file_identity: None,
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        });
         let mut batch = database.write_batch().expect("index batch");
         for entry in &entries {
             batch
@@ -374,9 +377,9 @@ mod tests {
 
         assert_eq!(
             database
-                .list_source_index_entries_under_path(Path::new("literal%"))
+                .list_source_index_entries_under_path(Path::new("literal%_!"))
                 .expect("read literal subtree"),
-            vec![entries[0].clone()]
+            vec![entries[0].clone(), entries[1].clone()]
         );
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use rusqlite::{OptionalExtension, Params};
 
-use super::super::super::util::map_sql_error;
+use super::super::super::util::{
+    EXACT_SUBTREE_PATH_PREDICATE, exact_subtree_path_bounds, map_sql_error,
+};
 use super::super::super::{Rating, SourceDatabase, SourceDbError, SourceManifestEntry, WavEntry};
 use super::super::decode::{
     decode_path_row, decode_wav_entry_row, wav_file_has_column, wav_file_select_columns,
@@ -182,20 +184,20 @@ impl SourceDatabase {
         path: &std::path::Path,
     ) -> Result<Vec<WavEntry>, SourceDbError> {
         let path_str = super::super::super::normalize_relative_path(path)?;
-        let prefix = format!("{path_str}/%");
+        let (lower_bound, upper_bound) = exact_subtree_path_bounds(&path_str);
         let filter = wav_file_supported_audio_filter(self)?;
         let columns = wav_file_select_columns(self)?;
         let sql = format!(
             "SELECT {columns}
              FROM wav_files
              WHERE {filter}
-               AND (path = ?1 OR path LIKE ?2)
+               AND {EXACT_SUBTREE_PATH_PREDICATE}
              ORDER BY path ASC"
         );
         collect_wav_entries(
             self,
             &sql,
-            rusqlite::params![path_str, prefix],
+            rusqlite::params![path_str, lower_bound, upper_bound],
             "Skipping wav row with invalid relative path during prefix lookup",
         )
     }

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -5,6 +5,8 @@ use tempfile::tempdir;
 
 use super::super::{DB_FILE_NAME, Rating, SampleCollection, SampleSoundType, SourceDatabase};
 
+use super::super::util::{EXACT_SUBTREE_PATH_PREDICATE, exact_subtree_path_bounds};
+
 #[test]
 fn browser_metadata_snapshot_reads_multi_collection_rows_coherently() {
     let dir = tempdir().unwrap();
@@ -346,6 +348,55 @@ fn legacy_read_only_collection_query_falls_back_to_wav_files_column() {
     assert_eq!(
         db.collection_for_path(Path::new("one.wav")).unwrap(),
         Some(expected)
+    );
+}
+
+#[test]
+fn subtree_file_reads_use_an_exact_binary_path_range() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    for path in [
+        "drum_kits%_!/inside.wav",
+        "drum_kits%_!/nested/deep.wav",
+        "drum_kitsX_YX!/outside.wav",
+        "Drum_kits%_!/case-distinct.wav",
+    ] {
+        db.upsert_file(Path::new(path), 10, 5).unwrap();
+    }
+
+    let paths = db
+        .list_files_under_path(Path::new("drum_kits%_!"))
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.relative_path)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        paths,
+        vec![
+            PathBuf::from("drum_kits%_!/inside.wav"),
+            PathBuf::from("drum_kits%_!/nested/deep.wav"),
+        ]
+    );
+
+    let (lower_bound, upper_bound) = exact_subtree_path_bounds("drum_kits%_!");
+    let explain_sql = format!(
+        "EXPLAIN QUERY PLAN SELECT path FROM wav_files WHERE {EXACT_SUBTREE_PATH_PREDICATE}"
+    );
+    let mut statement = db.connection.prepare(&explain_sql).unwrap();
+    let details = statement
+        .query_map(
+            rusqlite::params!["drum_kits%_!", lower_bound, upper_bound],
+            |row| row.get::<_, String>(3),
+        )
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("path>? AND path<?")),
+        "expected the exact subtree predicate to use the path index, got {details:?}"
     );
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -2,6 +2,21 @@ use std::path::{Component, Path, PathBuf};
 
 use super::SourceDbError;
 
+/// Exact subtree predicate for normalized, persisted source-relative paths.
+///
+/// The slash in the lower bound is immediately followed by `0` in the upper
+/// bound. SQLite's default BINARY collation therefore keeps every descendant
+/// of `path/` in the half-open range while excluding sibling names such as
+/// `path-other`. The equality arm includes a file or directory row targeted
+/// directly. This avoids LIKE's wildcard and ASCII case-folding semantics and
+/// remains compatible with the path primary-key indexes.
+pub(super) const EXACT_SUBTREE_PATH_PREDICATE: &str =
+    "(path = ?1 COLLATE BINARY OR (path >= ?2 COLLATE BINARY AND path < ?3 COLLATE BINARY))";
+
+pub(super) fn exact_subtree_path_bounds(path: &str) -> (String, String) {
+    (format!("{path}/"), format!("{path}0"))
+}
+
 /// Translate rusqlite errors into friendlier SourceDbError variants.
 pub(super) fn map_sql_error(err: rusqlite::Error) -> SourceDbError {
     match err {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/targeted_sync.rs
@@ -25,6 +25,31 @@ fn targeted_sync_updates_only_requested_file() {
     assert!(stats.committed_delta.revision > 0);
 }
 
+#[test]
+fn targeted_sync_does_not_reconcile_wildcard_sibling_subtrees() {
+    let dir = tempdir().unwrap();
+    let target = dir.path().join("drum_kits%_!");
+    let sibling = dir.path().join("drumXkitsX_Y!");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(target.join("removed.wav"), b"removed").unwrap();
+    std::fs::write(sibling.join("unrelated.wav"), b"unrelated").unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+    std::fs::remove_file(target.join("removed.wav")).unwrap();
+
+    sync_paths(&db, &[PathBuf::from("drum_kits%_!")]).unwrap();
+
+    let rows = db.list_files().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].relative_path,
+        Path::new("drumXkitsX_Y!/unrelated.wav")
+    );
+    assert!(!rows[0].missing);
+}
+
 #[cfg(unix)]
 #[test]
 fn targeted_sync_rejects_a_root_swap_before_commit() {


### PR DESCRIPTION
## Goal

Implement Linear issue OPT-1280 so targeted source refreshes select only the requested persisted source-relative subtree.

## Scope and non-goals

- Centralize one exact binary path-range predicate for wav-file and index-only subtree reads.
- Preserve direct-target equality, path-component boundaries, literal wildcard characters, case distinctions, and existing path indexes.
- Add database planner and targeted-sync regressions.
- No schema migration, audio-filter change, path-schema redesign, or targeted-manifest performance work.

## Definition of Done

- Percent, underscore, and exclamation-mark path components are treated literally.
- Case-distinct and similarly named sibling directories are not crossed.
- Wav and index-only subtree reads use the same predicate contract.
- Query-plan evidence confirms path-index use.
- Targeted reconciliation does not select or mutate unrelated rows.

## Validation

- cargo test -p wavecrate-library --all-targets --no-fail-fast — 270 passed.
- cargo test -p wavecrate-scan --all-targets --no-fail-fast — 178 passed.
- cargo fmt --all -- --check — passed.
- git diff --check — passed.
- bash scripts/ci.sh agent — Wavecrate checks passed; the gate then failed in the unrelated vendored Radiant test gui_runtime::native_vello::generic_runtime::tests::gpu_surface_runtime::signal_summary::gpu_signal_shader_keeps_waveform_bands_visually_distinct at vendor/radiant/src/gui_runtime/native_vello/generic_runtime/tests/gpu_surface_runtime/signal_summary.rs:69.

## Known limitations

The agent gate remains blocked by the pre-existing vendored Radiant shader-color assertion; no vendor changes are included.

User approval is required before merge.