### PR TITLE
OPT-1281: isolate non-Unicode source paths during scan

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -5,7 +5,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use super::schema;
 use super::util::{
     EXACT_SUBTREE_PATH_PREDICATE, exact_subtree_path_bounds, map_sql_error,
-    normalize_relative_path, parse_relative_path_from_db,
+    normalize_source_index_path, parse_source_index_path_from_db,
 };
 use super::{
     META_SOURCE_INDEX_REVISION, SourceDatabase, SourceDbError, SourceIndexClassification,
@@ -39,12 +39,10 @@ impl SourceDatabase {
             .unchecked_transaction()
             .map_err(map_sql_error)?;
         let revision = read_index_revision(&transaction)?;
+        let path_encoding = source_index_path_encoding_available(&transaction)?;
         let entries = collect_entries(
             &transaction,
-            "SELECT path, classification, file_size, modified_ns, file_identity,
-                    diagnostic, format_policy_version
-             FROM source_index_entries
-             ORDER BY path ASC",
+            &source_index_select_sql(path_encoding, false),
             [],
         )?;
         transaction.rollback().map_err(map_sql_error)?;
@@ -64,17 +62,12 @@ impl SourceDatabase {
         if !source_index_schema_available(&self.connection)? {
             return Ok(Vec::new());
         }
-        let normalized = normalize_relative_path(relative_path)?;
+        let (normalized, _path_encoding) = normalize_source_index_path(relative_path)?;
         let (lower_bound, upper_bound) = exact_subtree_path_bounds(&normalized);
+        let path_encoding = source_index_path_encoding_available(&self.connection)?;
         collect_entries(
             &self.connection,
-            &format!(
-                "SELECT path, classification, file_size, modified_ns, file_identity,
-                    diagnostic, format_policy_version
-             FROM source_index_entries
-             WHERE {EXACT_SUBTREE_PATH_PREDICATE}
-             ORDER BY path ASC"
-            ),
+            &source_index_select_sql(path_encoding, true),
             params![normalized, lower_bound, upper_bound],
         )
     }
@@ -87,7 +80,7 @@ impl SourceWriteBatch<'_> {
         entry: &SourceIndexEntry,
     ) -> Result<(), SourceDbError> {
         validate_entry(entry)?;
-        let path = normalize_relative_path(&entry.relative_path)?;
+        let (path, path_encoding) = normalize_source_index_path(&entry.relative_path)?;
         let live_manifest_row = self
             .tx
             .query_row(
@@ -105,10 +98,11 @@ impl SourceWriteBatch<'_> {
             .tx
             .execute(
                 "INSERT INTO source_index_entries (
-                    path, classification, file_size, modified_ns, file_identity,
+                    path, path_encoding, classification, file_size, modified_ns, file_identity,
                     diagnostic, format_policy_version
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                  ON CONFLICT(path) DO UPDATE SET
+                    path_encoding = excluded.path_encoding,
                     classification = excluded.classification,
                     file_size = excluded.file_size,
                     modified_ns = excluded.modified_ns,
@@ -123,6 +117,7 @@ impl SourceWriteBatch<'_> {
                     OR format_policy_version IS NOT excluded.format_policy_version",
                 params![
                     path,
+                    path_encoding,
                     entry.classification.token(),
                     entry.file_size.map(saturating_i64),
                     entry.modified_ns,
@@ -138,7 +133,7 @@ impl SourceWriteBatch<'_> {
 
     /// Remove one index-only row, including during promotion to the supported manifest.
     pub fn remove_source_index_entry(&mut self, relative_path: &Path) -> Result<(), SourceDbError> {
-        let path = normalize_relative_path(relative_path)?;
+        let (path, _path_encoding) = normalize_source_index_path(relative_path)?;
         let changed = self
             .tx
             .execute("DELETE FROM source_index_entries WHERE path = ?1", [path])
@@ -153,6 +148,30 @@ fn source_index_schema_available(connection: &Connection) -> Result<bool, Source
     Ok(REQUIRED_COLUMNS
         .iter()
         .all(|column| columns.contains(*column)))
+}
+
+fn source_index_path_encoding_available(connection: &Connection) -> Result<bool, SourceDbError> {
+    Ok(schema::table_columns(connection, "source_index_entries")?.contains("path_encoding"))
+}
+
+fn source_index_select_sql(path_encoding: bool, under_path: bool) -> String {
+    let encoding = if path_encoding {
+        "path_encoding"
+    } else {
+        "0 AS path_encoding"
+    };
+    let predicate = if under_path {
+        format!("WHERE {EXACT_SUBTREE_PATH_PREDICATE}")
+    } else {
+        String::new()
+    };
+    format!(
+        "SELECT path, {encoding}, classification, file_size, modified_ns, file_identity,
+                diagnostic, format_policy_version
+         FROM source_index_entries
+         {predicate}
+         ORDER BY path ASC"
+    )
 }
 
 fn read_index_revision(connection: &Connection) -> Result<u64, SourceDbError> {
@@ -178,7 +197,8 @@ fn collect_entries(
     let rows = statement
         .query_map(query_params, |row| {
             let raw_path: String = row.get(0)?;
-            let relative_path = match parse_relative_path_from_db(&raw_path) {
+            let path_encoding: i64 = row.get(1)?;
+            let relative_path = match parse_source_index_path_from_db(&raw_path, path_encoding) {
                 Ok(path) => path,
                 Err(error) => {
                     tracing::warn!(
@@ -189,7 +209,7 @@ fn collect_entries(
                     return Ok(None);
                 }
             };
-            let raw_classification: String = row.get(1)?;
+            let raw_classification: String = row.get(2)?;
             let Some(classification) = SourceIndexClassification::from_token(&raw_classification)
             else {
                 tracing::warn!(
@@ -199,19 +219,19 @@ fn collect_entries(
                 return Ok(None);
             };
             let diagnostic = row
-                .get::<_, Option<String>>(5)?
+                .get::<_, Option<String>>(6)?
                 .as_deref()
                 .and_then(SourceIndexDiagnostic::from_token);
             Ok(Some(SourceIndexEntry {
                 relative_path,
                 classification,
                 file_size: row
-                    .get::<_, Option<i64>>(2)?
+                    .get::<_, Option<i64>>(3)?
                     .map(|value| value.max(0) as u64),
-                modified_ns: row.get(3)?,
-                file_identity: row.get(4)?,
+                modified_ns: row.get(4)?,
+                file_identity: row.get(5)?,
                 diagnostic,
-                format_policy_version: row.get::<_, i64>(6)?.clamp(0, i64::from(u32::MAX)) as u32,
+                format_policy_version: row.get::<_, i64>(7)?.clamp(0, i64::from(u32::MAX)) as u32,
             }))
         })
         .map_err(map_sql_error)?
@@ -380,6 +400,46 @@ mod tests {
                 .list_source_index_entries_under_path(Path::new("literal%_!"))
                 .expect("read literal subtree"),
             vec![entries[0].clone(), entries[1].clone()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_unicode_index_paths_and_diagnostics_round_trip_without_aliasing() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let path = PathBuf::from_iter([
+            OsString::from("folder"),
+            OsString::from_vec(b"raw-\xFF.wav".to_vec()),
+        ]);
+        let entry = SourceIndexEntry {
+            relative_path: path.clone(),
+            classification: SourceIndexClassification::Inaccessible,
+            file_size: Some(3),
+            modified_ns: Some(10),
+            file_identity: Some(String::from("file-raw")),
+            diagnostic: Some(SourceIndexDiagnostic::NonUnicodePath),
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&entry)
+            .expect("upsert raw index entry");
+        batch.commit_auxiliary_state().expect("commit index row");
+
+        assert_eq!(
+            database.list_source_index_entries().unwrap(),
+            vec![entry.clone()]
+        );
+        assert_eq!(
+            database
+                .list_source_index_entries_under_path(Path::new("folder"))
+                .unwrap(),
+            vec![entry]
         );
     }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -4,8 +4,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 
 use super::schema;
 use super::util::{
-    EXACT_SUBTREE_PATH_PREDICATE, exact_subtree_path_bounds, map_sql_error,
-    normalize_source_index_path, parse_source_index_path_from_db,
+    EXACT_SUBTREE_PATH_PREDICATE, INDEX_PATH_ENCODING_PLAIN, exact_subtree_path_bounds,
+    map_sql_error, normalize_source_index_path, parse_source_index_path_from_db,
 };
 use super::{
     META_SOURCE_INDEX_REVISION, SourceDatabase, SourceDbError, SourceIndexClassification,
@@ -81,16 +81,19 @@ impl SourceWriteBatch<'_> {
     ) -> Result<(), SourceDbError> {
         validate_entry(entry)?;
         let (path, path_encoding) = normalize_source_index_path(&entry.relative_path)?;
-        let live_manifest_row = self
-            .tx
-            .query_row(
-                "SELECT 1 FROM wav_files WHERE path = ?1 AND missing = 0",
-                [&path],
-                |_| Ok(()),
-            )
-            .optional()
-            .map_err(map_sql_error)?
-            .is_some();
+        let live_manifest_row = if path_encoding == INDEX_PATH_ENCODING_PLAIN {
+            self.tx
+                .query_row(
+                    "SELECT 1 FROM wav_files WHERE path = ?1 AND missing = 0",
+                    [&path],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(map_sql_error)?
+                .is_some()
+        } else {
+            false
+        };
         if live_manifest_row {
             return Err(SourceDbError::Unexpected);
         }
@@ -324,6 +327,49 @@ mod tests {
             batch.upsert_source_index_entry(&entry),
             Err(SourceDbError::Unexpected)
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lossless_index_key_can_coexist_with_an_equal_manifest_storage_key() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().expect("source root");
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+        let raw_path = PathBuf::from_iter([
+            OsString::from_vec(b"raw-\xFF".to_vec()),
+            OsString::from("sample.wav"),
+        ]);
+        let (encoded_path, path_encoding) = normalize_source_index_path(&raw_path).unwrap();
+        assert_ne!(path_encoding, INDEX_PATH_ENCODING_PLAIN);
+        database
+            .upsert_file(Path::new(&encoded_path), 5, 10)
+            .expect("supported Unicode row with colliding storage key");
+
+        let entry = SourceIndexEntry {
+            relative_path: raw_path,
+            classification: SourceIndexClassification::Inaccessible,
+            file_size: Some(3),
+            modified_ns: Some(20),
+            file_identity: None,
+            diagnostic: Some(SourceIndexDiagnostic::NonUnicodePath),
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&entry)
+            .expect("lossless key must not alias a plain manifest path");
+        batch.commit_auxiliary_state().expect("commit index row");
+
+        assert_eq!(database.list_source_index_entries().unwrap(), vec![entry]);
+        assert!(
+            database
+                .entry_for_path(Path::new(&encoded_path))
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/index_entries.rs
@@ -442,4 +442,70 @@ mod tests {
             vec![entry]
         );
     }
+
+    #[test]
+    fn legacy_reserved_prefix_rows_rekey_before_update_and_delete() {
+        let directory = tempfile::tempdir().expect("source root");
+        let relative_path = PathBuf::from("~wavecrate-nu~ff.wav");
+        {
+            let database =
+                SourceDatabase::open_for_source_write(directory.path()).expect("source database");
+            database
+                .connection
+                .execute(
+                    "INSERT INTO source_index_entries (
+                        path, path_encoding, classification, file_size, modified_ns,
+                        diagnostic, format_policy_version
+                     ) VALUES (?1, 0, 'unsupported_non_audio', 5, 10, NULL, ?2)",
+                    params![
+                        relative_path.to_string_lossy(),
+                        i64::from(SOURCE_FORMAT_POLICY_VERSION)
+                    ],
+                )
+                .expect("legacy index row");
+        }
+
+        let database =
+            SourceDatabase::open_for_source_write(directory.path()).expect("reopened database");
+        let updated = SourceIndexEntry {
+            relative_path: relative_path.clone(),
+            classification: SourceIndexClassification::UnsupportedNonAudio,
+            file_size: Some(8),
+            modified_ns: Some(20),
+            file_identity: None,
+            diagnostic: None,
+            format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+        };
+        assert_eq!(
+            database.list_source_index_entries().unwrap(),
+            vec![SourceIndexEntry {
+                file_size: Some(5),
+                modified_ns: Some(10),
+                ..updated.clone()
+            }]
+        );
+
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .upsert_source_index_entry(&updated)
+            .expect("update rekeyed row");
+        batch.commit_auxiliary_state().expect("commit update");
+        assert_eq!(database.list_source_index_entries().unwrap(), vec![updated]);
+        assert_eq!(
+            database
+                .connection
+                .query_row("SELECT COUNT(*) FROM source_index_entries", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            1
+        );
+
+        let mut batch = database.write_batch().expect("index batch");
+        batch
+            .remove_source_index_entry(&relative_path)
+            .expect("remove rekeyed row");
+        batch.commit_auxiliary_state().expect("commit removal");
+        assert!(database.list_source_index_entries().unwrap().is_empty());
+    }
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/ddl.rs
@@ -66,6 +66,7 @@ const BASE_SCHEMA_SQL: &str = "CREATE TABLE IF NOT EXISTS metadata (
     );
     CREATE TABLE IF NOT EXISTS source_index_entries (
         path TEXT PRIMARY KEY,
+        path_encoding INTEGER NOT NULL DEFAULT 0,
         classification TEXT NOT NULL CHECK(classification IN (
             'unsupported_audio',
             'unsupported_non_audio',

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -1,11 +1,14 @@
 //! Incremental schema migrations for older source database files.
 
 use std::collections::HashSet;
+use std::path::Path;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension, params};
 
 use super::super::SourceDbError;
-use super::super::util::map_sql_error;
+use super::super::util::{
+    map_sql_error, normalize_source_index_path, source_index_plain_path_needs_rekey,
+};
 
 mod analysis_jobs;
 mod aspect_descriptors;
@@ -58,9 +61,9 @@ fn apply_structural_migrations(connection: &Connection) -> Result<(), SourceDbEr
 }
 
 fn ensure_source_index_schema(connection: &Connection) -> Result<(), SourceDbError> {
-    connection
-        .execute_batch(
-            "CREATE TABLE IF NOT EXISTS source_index_entries (
+    let tx = connection.unchecked_transaction().map_err(map_sql_error)?;
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS source_index_entries (
                 path TEXT PRIMARY KEY,
                 path_encoding INTEGER NOT NULL DEFAULT 0,
                 classification TEXT NOT NULL CHECK(classification IN (
@@ -77,16 +80,83 @@ fn ensure_source_index_schema(connection: &Connection) -> Result<(), SourceDbErr
             ) WITHOUT ROWID;
             CREATE INDEX IF NOT EXISTS idx_source_index_entries_classification_path
                 ON source_index_entries(classification, path);",
+    )
+    .map_err(map_sql_error)?;
+    if !table_columns(&tx, "source_index_entries")?.contains("path_encoding") {
+        tx.execute(
+            "ALTER TABLE source_index_entries
+                 ADD COLUMN path_encoding INTEGER NOT NULL DEFAULT 0",
+            [],
         )
         .map_err(map_sql_error)?;
-    if !table_columns(connection, "source_index_entries")?.contains("path_encoding") {
-        connection
-            .execute(
-                "ALTER TABLE source_index_entries
-                 ADD COLUMN path_encoding INTEGER NOT NULL DEFAULT 0",
-                [],
+    }
+    migrate_legacy_source_index_paths(&tx)?;
+    tx.commit().map_err(map_sql_error)?;
+    Ok(())
+}
+
+fn migrate_legacy_source_index_paths(connection: &Connection) -> Result<(), SourceDbError> {
+    let legacy_paths = {
+        let mut statement = connection
+            .prepare(
+                "SELECT path
+                 FROM source_index_entries
+                 WHERE path_encoding = 0
+                 ORDER BY path",
             )
             .map_err(map_sql_error)?;
+        statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(map_sql_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(map_sql_error)?
+    };
+
+    for legacy_path in legacy_paths {
+        if !source_index_plain_path_needs_rekey(&legacy_path) {
+            continue;
+        }
+        let (canonical_path, path_encoding) =
+            match normalize_source_index_path(Path::new(&legacy_path)) {
+                Ok(normalized) => normalized,
+                Err(error) => {
+                    tracing::warn!(
+                        path = legacy_path,
+                        %error,
+                        "Skipping invalid legacy source index path during reserved-prefix migration"
+                    );
+                    continue;
+                }
+            };
+        if path_encoding == 0 || canonical_path == legacy_path {
+            continue;
+        }
+        let canonical_exists = connection
+            .query_row(
+                "SELECT 1 FROM source_index_entries WHERE path = ?1",
+                [&canonical_path],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .is_some();
+        if canonical_exists {
+            connection
+                .execute(
+                    "DELETE FROM source_index_entries WHERE path = ?1",
+                    [&legacy_path],
+                )
+                .map_err(map_sql_error)?;
+        } else {
+            connection
+                .execute(
+                    "UPDATE source_index_entries
+                     SET path = ?1, path_encoding = ?2
+                     WHERE path = ?3",
+                    params![canonical_path, path_encoding, legacy_path],
+                )
+                .map_err(map_sql_error)?;
+        }
     }
     Ok(())
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations.rs
@@ -62,6 +62,7 @@ fn ensure_source_index_schema(connection: &Connection) -> Result<(), SourceDbErr
         .execute_batch(
             "CREATE TABLE IF NOT EXISTS source_index_entries (
                 path TEXT PRIMARY KEY,
+                path_encoding INTEGER NOT NULL DEFAULT 0,
                 classification TEXT NOT NULL CHECK(classification IN (
                     'unsupported_audio',
                     'unsupported_non_audio',
@@ -78,6 +79,15 @@ fn ensure_source_index_schema(connection: &Connection) -> Result<(), SourceDbErr
                 ON source_index_entries(classification, path);",
         )
         .map_err(map_sql_error)?;
+    if !table_columns(connection, "source_index_entries")?.contains("path_encoding") {
+        connection
+            .execute(
+                "ALTER TABLE source_index_entries
+                 ADD COLUMN path_encoding INTEGER NOT NULL DEFAULT 0",
+                [],
+            )
+            .map_err(map_sql_error)?;
+    }
     Ok(())
 }
 

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -532,7 +532,10 @@ fn source_index_migration_adds_lossless_path_encoding_to_legacy_tables() {
         ) WITHOUT ROWID;
         INSERT INTO source_index_entries (
             path, classification, file_size, modified_ns, format_policy_version
-        ) VALUES ('notes.txt', 'unsupported_non_audio', 5, 10, 1);",
+        ) VALUES
+            ('notes.txt', 'unsupported_non_audio', 5, 10, 1),
+            ('~wavecrate-nu~ff.wav', 'unsupported_non_audio', 6, 11, 1),
+            ('folder/~wavecrate-escaped~name.txt', 'unsupported_non_audio', 7, 12, 1);",
     )
     .unwrap();
 
@@ -551,5 +554,63 @@ fn source_index_migration_adds_lossless_path_encoding_to_legacy_tables() {
         )
         .unwrap(),
         0
+    );
+    for (legacy_path, file_size) in [
+        ("~wavecrate-nu~ff.wav", 6_i64),
+        ("folder/~wavecrate-escaped~name.txt", 7_i64),
+    ] {
+        let (canonical_path, path_encoding) =
+            normalize_source_index_path(Path::new(legacy_path)).unwrap();
+        assert_ne!(canonical_path, legacy_path);
+        assert_eq!(path_encoding, 1);
+        assert_eq!(
+            conn.query_row(
+                "SELECT path_encoding, file_size
+                 FROM source_index_entries
+                 WHERE path = ?1",
+                [&canonical_path],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .unwrap(),
+            (1, file_size)
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM source_index_entries WHERE path = ?1",
+                [legacy_path],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+    }
+
+    conn.execute(
+        "INSERT INTO source_index_entries (
+            path, path_encoding, classification, file_size, modified_ns, format_policy_version
+         ) VALUES (?1, 0, 'unsupported_non_audio', 99, 99, 1)",
+        ["~wavecrate-nu~ff.wav"],
+    )
+    .unwrap();
+    ensure_source_index_schema(&conn).unwrap();
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM source_index_entries", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .unwrap(),
+        3,
+        "a legacy/canonical collision must converge to one canonical row"
+    );
+    let (canonical_path, _) =
+        normalize_source_index_path(Path::new("~wavecrate-nu~ff.wav")).unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT file_size FROM source_index_entries WHERE path = ?1",
+            [&canonical_path],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        6,
+        "the already-canonical row must win a mixed-state collision"
     );
 }

--- a/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/schema/migrations/tests.rs
@@ -516,3 +516,40 @@ fn readiness_schema_repairs_current_stamped_analysis_storage() {
         assert!(exists, "missing readiness table {table}");
     }
 }
+
+#[test]
+fn source_index_migration_adds_lossless_path_encoding_to_legacy_tables() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE source_index_entries (
+            path TEXT PRIMARY KEY,
+            classification TEXT NOT NULL,
+            file_size INTEGER,
+            modified_ns INTEGER,
+            file_identity TEXT,
+            diagnostic TEXT,
+            format_policy_version INTEGER NOT NULL
+        ) WITHOUT ROWID;
+        INSERT INTO source_index_entries (
+            path, classification, file_size, modified_ns, format_policy_version
+        ) VALUES ('notes.txt', 'unsupported_non_audio', 5, 10, 1);",
+    )
+    .unwrap();
+
+    ensure_source_index_schema(&conn).unwrap();
+
+    assert!(
+        table_columns(&conn, "source_index_entries")
+            .unwrap()
+            .contains("path_encoding")
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT path_encoding FROM source_index_entries WHERE path = 'notes.txt'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0
+    );
+}

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -357,6 +357,8 @@ pub enum SourceIndexDiagnostic {
     OpenUnavailable,
     /// An explicit practical audio constraint rejected the file.
     PracticalSupportLimit,
+    /// The file name is not Unicode and cannot become a normal sample row.
+    NonUnicodePath,
 }
 
 impl SourceIndexDiagnostic {
@@ -366,6 +368,7 @@ impl SourceIndexDiagnostic {
             Self::MetadataUnavailable => "metadata_unavailable",
             Self::OpenUnavailable => "open_unavailable",
             Self::PracticalSupportLimit => "practical_support_limit",
+            Self::NonUnicodePath => "non_unicode_path",
         }
     }
 
@@ -375,6 +378,7 @@ impl SourceIndexDiagnostic {
             "metadata_unavailable" => Some(Self::MetadataUnavailable),
             "open_unavailable" => Some(Self::OpenUnavailable),
             "practical_support_limit" => Some(Self::PracticalSupportLimit),
+            "non_unicode_path" => Some(Self::NonUnicodePath),
             _ => None,
         }
     }

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -1,4 +1,8 @@
+use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
 use super::SourceDbError;
 
@@ -16,6 +20,11 @@ pub(super) const EXACT_SUBTREE_PATH_PREDICATE: &str =
 pub(super) fn exact_subtree_path_bounds(path: &str) -> (String, String) {
     (format!("{path}/"), format!("{path}0"))
 }
+
+const INDEX_PATH_ENCODING_PLAIN: i64 = 0;
+const INDEX_PATH_ENCODING_LOSSLESS: i64 = 1;
+const INDEX_NON_UNICODE_COMPONENT_PREFIX: &str = "~wavecrate-nu~";
+const INDEX_ESCAPED_COMPONENT_PREFIX: &str = "~wavecrate-escaped~";
 
 /// Translate rusqlite errors into friendlier SourceDbError variants.
 pub(super) fn map_sql_error(err: rusqlite::Error) -> SourceDbError {
@@ -43,11 +52,138 @@ pub fn normalize_relative_path(path: &Path) -> Result<String, SourceDbError> {
     Ok(value.replace('\\', "/"))
 }
 
+/// Normalize an index-only path while preserving non-Unicode components.
+///
+/// Supported sample rows intentionally continue to use `normalize_relative_path`:
+/// they require a normal UTF-8 database key. Index-only rows have a separate
+/// encoding bit so their SQLite key can retain the exact raw bytes without
+/// changing the representation of existing Unicode paths. Plain components
+/// stay readable and therefore retain exact-subtree prefix ordering.
+pub(super) fn normalize_source_index_path(path: &Path) -> Result<(String, i64), SourceDbError> {
+    let cleaned = sanitize_relative_path(path)?;
+    let has_reserved_component = cleaned.components().any(|component| {
+        let Component::Normal(part) = component else {
+            return false;
+        };
+        part.to_str().is_some_and(|value| {
+            value.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
+                || value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX)
+        })
+    });
+    if cleaned.to_str().is_some() && !has_reserved_component {
+        return normalize_relative_path(&cleaned).map(|value| (value, INDEX_PATH_ENCODING_PLAIN));
+    }
+
+    #[cfg(unix)]
+    {
+        let mut components = Vec::new();
+        for component in cleaned.components() {
+            let Component::Normal(part) = component else {
+                return Err(SourceDbError::InvalidRelativePath(cleaned));
+            };
+            let bytes = part.as_bytes();
+            let encoded = match part.to_str() {
+                Some(value)
+                    if !value.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
+                        && !value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX) =>
+                {
+                    value.to_owned()
+                }
+                Some(_) => format!("{INDEX_ESCAPED_COMPONENT_PREFIX}{}", encode_hex(bytes)),
+                None => format!("{INDEX_NON_UNICODE_COMPONENT_PREFIX}{}", encode_hex(bytes)),
+            };
+            components.push(encoded);
+        }
+        Ok((components.join("/"), INDEX_PATH_ENCODING_LOSSLESS))
+    }
+
+    #[cfg(not(unix))]
+    {
+        Err(SourceDbError::NonUnicodeRelativePath(cleaned))
+    }
+}
+
 /// Parse and validate a stored relative path from the database.
 ///
 /// Returns a normalized `PathBuf` without `.` components.
 pub(super) fn parse_relative_path_from_db(path: &str) -> Result<PathBuf, SourceDbError> {
     sanitize_relative_path(Path::new(path))
+}
+
+pub(super) fn parse_source_index_path_from_db(
+    path: &str,
+    encoding: i64,
+) -> Result<PathBuf, SourceDbError> {
+    match encoding {
+        INDEX_PATH_ENCODING_PLAIN => parse_relative_path_from_db(path),
+        INDEX_PATH_ENCODING_LOSSLESS => parse_lossless_index_path(path),
+        _ => Err(SourceDbError::Unexpected),
+    }
+}
+
+#[cfg(unix)]
+fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
+    if path.is_empty() {
+        return Err(SourceDbError::InvalidRelativePath(PathBuf::from(path)));
+    }
+    let mut decoded = PathBuf::new();
+    for component in path.split('/') {
+        if component.is_empty() {
+            return Err(SourceDbError::InvalidRelativePath(PathBuf::from(path)));
+        }
+        let value = if let Some(hex) = component.strip_prefix(INDEX_NON_UNICODE_COMPONENT_PREFIX) {
+            OsString::from_vec(
+                decode_hex(hex)
+                    .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?,
+            )
+        } else if let Some(hex) = component.strip_prefix(INDEX_ESCAPED_COMPONENT_PREFIX) {
+            let bytes = decode_hex(hex)
+                .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
+            OsString::from_vec(bytes)
+        } else {
+            OsString::from(component)
+        };
+        decoded.push(value);
+    }
+    Ok(decoded)
+}
+
+#[cfg(not(unix))]
+fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
+    // A non-Unicode source key can only be authored on Unix. Keep a readable
+    // encoded projection if such a database is opened on another platform;
+    // that platform cannot reconstruct the original raw name.
+    Ok(PathBuf::from(path))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[usize::from(byte >> 4)] as char);
+        encoded.push(HEX[usize::from(byte & 0x0f)] as char);
+    }
+    encoded
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    if value.is_empty() || !value.len().is_multiple_of(2) {
+        return None;
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| Some((hex_digit(pair[0])? << 4) | hex_digit(pair[1])?))
+        .collect()
+}
+
+fn hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// Validate a relative path and normalize away `.` components.
@@ -154,6 +290,62 @@ mod tests {
         let path = PathBuf::from(std::ffi::OsString::from_vec(b"kick-\xFF.wav".to_vec()));
         let err = normalize_relative_path(&path).unwrap_err();
         assert!(matches!(err, SourceDbError::NonUnicodeRelativePath(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_index_path_encoding_round_trips_raw_components_and_subtree_prefixes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from_iter([
+            std::ffi::OsString::from("folder"),
+            std::ffi::OsString::from_vec(b"kick-\xFF.wav".to_vec()),
+        ]);
+        let (encoded, encoding) = normalize_source_index_path(&path).unwrap();
+        assert_eq!(encoding, INDEX_PATH_ENCODING_LOSSLESS);
+        assert_eq!(
+            parse_source_index_path_from_db(&encoded, encoding).unwrap(),
+            path
+        );
+        let (lower, upper) = exact_subtree_path_bounds(&encoded);
+        assert!(lower.starts_with("folder/"));
+        assert!(upper.starts_with("folder/"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_index_path_encoding_escapes_reserved_unicode_components() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let path = PathBuf::from_iter([
+            std::ffi::OsString::from_vec(b"raw-\xFF".to_vec()),
+            std::ffi::OsString::from("~wavecrate-nu~ff.wav"),
+        ]);
+        let (encoded, encoding) = normalize_source_index_path(&path).unwrap();
+        assert_eq!(encoding, INDEX_PATH_ENCODING_LOSSLESS);
+        assert_eq!(
+            parse_source_index_path_from_db(&encoded, encoding).unwrap(),
+            path
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_index_path_encoding_does_not_alias_reserved_unicode_names() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let raw = PathBuf::from(OsString::from_vec(b"~wavecrate-nu~ff".to_vec()));
+        let invalid = PathBuf::from(OsString::from_vec(b"~wavecrate-nu~\xFF".to_vec()));
+        let (raw_key, raw_encoding) = normalize_source_index_path(&raw).unwrap();
+        let (invalid_key, invalid_encoding) = normalize_source_index_path(&invalid).unwrap();
+        assert_ne!(
+            (raw_key.clone(), raw_encoding),
+            (invalid_key, invalid_encoding)
+        );
+        assert_eq!(
+            parse_source_index_path_from_db(&raw_key, raw_encoding).unwrap(),
+            raw
+        );
     }
 
     #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -26,6 +26,13 @@ const INDEX_PATH_ENCODING_LOSSLESS: i64 = 1;
 const INDEX_NON_UNICODE_COMPONENT_PREFIX: &str = "~wavecrate-nu~";
 const INDEX_ESCAPED_COMPONENT_PREFIX: &str = "~wavecrate-escaped~";
 
+pub(super) fn source_index_plain_path_needs_rekey(path: &str) -> bool {
+    path.split('/').any(|component| {
+        component.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
+            || component.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX)
+    })
+}
+
 /// Translate rusqlite errors into friendlier SourceDbError variants.
 pub(super) fn map_sql_error(err: rusqlite::Error) -> SourceDbError {
     match err {
@@ -74,33 +81,33 @@ pub(super) fn normalize_source_index_path(path: &Path) -> Result<(String, i64), 
         return normalize_relative_path(&cleaned).map(|value| (value, INDEX_PATH_ENCODING_PLAIN));
     }
 
-    #[cfg(unix)]
-    {
-        let mut components = Vec::new();
-        for component in cleaned.components() {
-            let Component::Normal(part) = component else {
-                return Err(SourceDbError::InvalidRelativePath(cleaned));
-            };
-            let bytes = part.as_bytes();
-            let encoded = match part.to_str() {
-                Some(value)
-                    if !value.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
-                        && !value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX) =>
-                {
-                    value.to_owned()
-                }
-                Some(_) => format!("{INDEX_ESCAPED_COMPONENT_PREFIX}{}", encode_hex(bytes)),
-                None => format!("{INDEX_NON_UNICODE_COMPONENT_PREFIX}{}", encode_hex(bytes)),
-            };
-            components.push(encoded);
-        }
-        Ok((components.join("/"), INDEX_PATH_ENCODING_LOSSLESS))
+    let mut components = Vec::new();
+    for component in cleaned.components() {
+        let Component::Normal(part) = component else {
+            return Err(SourceDbError::InvalidRelativePath(cleaned));
+        };
+        let encoded = match part.to_str() {
+            Some(value)
+                if !value.starts_with(INDEX_NON_UNICODE_COMPONENT_PREFIX)
+                    && !value.starts_with(INDEX_ESCAPED_COMPONENT_PREFIX) =>
+            {
+                value.to_owned()
+            }
+            Some(value) => format!(
+                "{INDEX_ESCAPED_COMPONENT_PREFIX}{}",
+                encode_hex(value.as_bytes())
+            ),
+            #[cfg(unix)]
+            None => format!(
+                "{INDEX_NON_UNICODE_COMPONENT_PREFIX}{}",
+                encode_hex(part.as_bytes())
+            ),
+            #[cfg(not(unix))]
+            None => return Err(SourceDbError::NonUnicodeRelativePath(cleaned)),
+        };
+        components.push(encoded);
     }
-
-    #[cfg(not(unix))]
-    {
-        Err(SourceDbError::NonUnicodeRelativePath(cleaned))
-    }
+    Ok((components.join("/"), INDEX_PATH_ENCODING_LOSSLESS))
 }
 
 /// Parse and validate a stored relative path from the database.
@@ -150,10 +157,25 @@ fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
 
 #[cfg(not(unix))]
 fn parse_lossless_index_path(path: &str) -> Result<PathBuf, SourceDbError> {
-    // A non-Unicode source key can only be authored on Unix. Keep a readable
-    // encoded projection if such a database is opened on another platform;
-    // that platform cannot reconstruct the original raw name.
-    Ok(PathBuf::from(path))
+    let mut decoded = PathBuf::new();
+    for component in path.split('/') {
+        if component.is_empty() {
+            return Err(SourceDbError::InvalidRelativePath(PathBuf::from(path)));
+        }
+        if let Some(hex) = component.strip_prefix(INDEX_ESCAPED_COMPONENT_PREFIX) {
+            let bytes = decode_hex(hex)
+                .ok_or_else(|| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
+            let value = String::from_utf8(bytes)
+                .map_err(|_| SourceDbError::InvalidRelativePath(PathBuf::from(path)))?;
+            decoded.push(value);
+        } else {
+            // A non-Unicode source key can only be authored on Unix. Preserve
+            // that component's encoded projection on platforms that cannot
+            // reconstruct the original raw name.
+            decoded.push(component);
+        }
+    }
+    Ok(decoded)
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
@@ -312,13 +334,10 @@ mod tests {
         assert!(upper.starts_with("folder/"));
     }
 
-    #[cfg(unix)]
     #[test]
     fn source_index_path_encoding_escapes_reserved_unicode_components() {
-        use std::os::unix::ffi::OsStringExt;
-
         let path = PathBuf::from_iter([
-            std::ffi::OsString::from_vec(b"raw-\xFF".to_vec()),
+            std::ffi::OsString::from("folder"),
             std::ffi::OsString::from("~wavecrate-nu~ff.wav"),
         ]);
         let (encoded, encoding) = normalize_source_index_path(&path).unwrap();

--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -21,7 +21,7 @@ pub(super) fn exact_subtree_path_bounds(path: &str) -> (String, String) {
     (format!("{path}/"), format!("{path}0"))
 }
 
-const INDEX_PATH_ENCODING_PLAIN: i64 = 0;
+pub(super) const INDEX_PATH_ENCODING_PLAIN: i64 = 0;
 const INDEX_PATH_ENCODING_LOSSLESS: i64 = 1;
 const INDEX_NON_UNICODE_COMPONENT_PREFIX: &str = "~wavecrate-nu~";
 const INDEX_ESCAPED_COMPONENT_PREFIX: &str = "~wavecrate-escaped~";

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -70,11 +70,14 @@ fn non_unicode_supported_paths_are_isolated_and_converge_in_full_and_targeted_sc
     let raw_path = PathBuf::from(&raw_name);
     let renamed_path = PathBuf::from(&renamed_name);
     std::fs::write(directory.path().join("ordinary.wav"), b"ordinary").unwrap();
-    std::fs::write(directory.path().join(&raw_name), b"raw").unwrap();
 
     let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
     scan_once(&database).unwrap();
     assert_eq!(database.list_files().unwrap().len(), 1);
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+
+    std::fs::write(directory.path().join(&raw_name), b"raw").unwrap();
+    sync_paths(&database, std::slice::from_ref(&raw_path)).unwrap();
     let entry = database.list_source_index_entries().unwrap().remove(0);
     assert_eq!(entry.relative_path, raw_path);
     assert_eq!(

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -166,6 +166,38 @@ fn targeted_sync_preserves_non_unicode_unsupported_classifications() {
     assert_eq!(database.list_files().unwrap().len(), 1);
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn lossless_raw_path_key_does_not_alias_a_unicode_sample_path() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let directory = tempdir().unwrap();
+    let raw_path = PathBuf::from_iter([
+        OsString::from_vec(b"raw-\xFF".to_vec()),
+        OsString::from("sample.wav"),
+    ]);
+    let unicode_path = PathBuf::from("~wavecrate-nu~7261772dff/sample.wav");
+    std::fs::create_dir_all(directory.path().join(&raw_path).parent().unwrap()).unwrap();
+    std::fs::create_dir_all(directory.path().join(&unicode_path).parent().unwrap()).unwrap();
+    std::fs::write(directory.path().join(&raw_path), b"raw").unwrap();
+    std::fs::write(directory.path().join(&unicode_path), b"unicode").unwrap();
+
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+
+    let manifest = database.list_manifest_entries().unwrap();
+    assert_eq!(manifest.len(), 1);
+    assert_eq!(manifest[0].relative_path, unicode_path);
+    let index_entries = database.list_source_index_entries().unwrap();
+    assert_eq!(index_entries.len(), 1);
+    assert_eq!(index_entries[0].relative_path, raw_path);
+    assert_eq!(
+        index_entries[0].diagnostic,
+        Some(SourceIndexDiagnostic::NonUnicodePath)
+    );
+}
+
 #[test]
 fn full_scan_reconciles_index_only_change_move_and_delete() {
     let directory = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -123,6 +123,49 @@ fn non_unicode_supported_paths_are_isolated_and_converge_in_full_and_targeted_sc
     );
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn targeted_sync_preserves_non_unicode_unsupported_classifications() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let directory = tempdir().unwrap();
+    let unsupported_audio = PathBuf::from(OsString::from_vec(b"raw-\xFF.flac".to_vec()));
+    let unsupported_non_audio = PathBuf::from(OsString::from_vec(b"notes-\xFE.txt".to_vec()));
+    std::fs::write(directory.path().join("ordinary.wav"), b"ordinary").unwrap();
+
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    std::fs::write(directory.path().join(&unsupported_audio), b"audio").unwrap();
+    std::fs::write(directory.path().join(&unsupported_non_audio), b"notes").unwrap();
+    sync_paths(
+        &database,
+        &[unsupported_audio.clone(), unsupported_non_audio.clone()],
+    )
+    .unwrap();
+
+    let entries = database.list_source_index_entries().unwrap();
+    assert_eq!(entries.len(), 2);
+    for (path, expected_classification) in [
+        (
+            unsupported_audio,
+            SourceIndexClassification::UnsupportedAudio,
+        ),
+        (
+            unsupported_non_audio,
+            SourceIndexClassification::UnsupportedNonAudio,
+        ),
+    ] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.relative_path == path)
+            .expect("targeted non-Unicode index entry");
+        assert_eq!(entry.classification, expected_classification);
+        assert_eq!(entry.diagnostic, None);
+    }
+    assert_eq!(database.list_files().unwrap().len(), 1);
+}
+
 #[test]
 fn full_scan_reconciles_index_only_change_move_and_delete() {
     let directory = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/index_entries.rs
@@ -58,6 +58,68 @@ fn full_scan_persists_typed_index_only_entries_across_restart() {
     );
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn non_unicode_supported_paths_are_isolated_and_converge_in_full_and_targeted_scans() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let directory = tempdir().unwrap();
+    let raw_name = OsString::from_vec(b"raw-\xFF.wav".to_vec());
+    let renamed_name = OsString::from_vec(b"renamed-\xFE.wav".to_vec());
+    let raw_path = PathBuf::from(&raw_name);
+    let renamed_path = PathBuf::from(&renamed_name);
+    std::fs::write(directory.path().join("ordinary.wav"), b"ordinary").unwrap();
+    std::fs::write(directory.path().join(&raw_name), b"raw").unwrap();
+
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    assert_eq!(database.list_files().unwrap().len(), 1);
+    let entry = database.list_source_index_entries().unwrap().remove(0);
+    assert_eq!(entry.relative_path, raw_path);
+    assert_eq!(
+        entry.classification,
+        SourceIndexClassification::Inaccessible
+    );
+    assert_eq!(
+        entry.diagnostic,
+        Some(SourceIndexDiagnostic::NonUnicodePath)
+    );
+    assert_eq!(entry.file_size, Some(3));
+
+    std::fs::write(directory.path().join(&raw_name), b"raw-modified").unwrap();
+    sync_paths(&database, std::slice::from_ref(&raw_path)).unwrap();
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].file_size,
+        Some(12)
+    );
+    assert_eq!(database.list_files().unwrap().len(), 1);
+
+    std::fs::rename(
+        directory.path().join(&raw_name),
+        directory.path().join(&renamed_name),
+    )
+    .unwrap();
+    sync_paths(&database, &[raw_path.clone(), renamed_path.clone()]).unwrap();
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].relative_path,
+        renamed_path
+    );
+
+    std::fs::remove_file(directory.path().join(&renamed_name)).unwrap();
+    sync_paths(&database, std::slice::from_ref(&renamed_path)).unwrap();
+    assert!(database.list_source_index_entries().unwrap().is_empty());
+    assert_eq!(database.list_files().unwrap().len(), 1);
+
+    std::fs::write(directory.path().join(&raw_name), b"raw-again").unwrap();
+    scan_once(&database).unwrap();
+    assert_eq!(database.list_files().unwrap().len(), 1);
+    assert_eq!(
+        database.list_source_index_entries().unwrap()[0].relative_path,
+        raw_path
+    );
+}
+
 #[test]
 fn full_scan_reconciles_index_only_change_move_and_delete() {
     let directory = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -27,7 +27,9 @@ use crate::sample_sources::SourceDatabase;
 use super::scan::ScanError;
 use super::scan::{DirectoryRepeatKind, SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot};
 use super::scan_capability::SourceRootCapability;
-use super::scan_index::{inaccessible_index_entry, index_entry_from_file_facts};
+use super::scan_index::{
+    inaccessible_index_entry, index_entry_from_file_facts, non_unicode_index_entry,
+};
 
 const MAX_LAYOUT_DIAGNOSTICS: usize = 16;
 
@@ -444,10 +446,11 @@ pub(super) fn visit_dir_with_cancel_check(
                     }
                 }
                 classification @ SourceEntryClassification::File { .. } => {
-                    if classification.indexes_audio() {
+                    if classification.indexes_audio() && relative.to_str().is_some() {
                         visitor(&path)?;
                     } else if let Some(file_classification) = classification.file_classification()
-                        && file_classification != SourceFileClassification::SupportedAudio
+                        && (file_classification != SourceFileClassification::SupportedAudio
+                            || relative.to_str().is_none())
                     {
                         match source_index_entry(
                             &dir,
@@ -527,14 +530,28 @@ fn source_index_entry(
         .unwrap_or_default()
         .as_nanos()
         .min(i64::MAX as u128) as i64;
-    index_entry_from_file_facts(
+    if let Some(entry) = index_entry_from_file_facts(
         relative_path.to_path_buf(),
         classification,
         metadata.len(),
         modified_ns,
         stable_filesystem_identity(&path, &metadata),
-    )
-    .ok_or_else(|| std::io::Error::other("supported audio is not an index-only entry"))
+    ) {
+        return Ok(entry);
+    }
+    if classification == SourceFileClassification::SupportedAudio
+        && relative_path.to_str().is_none()
+    {
+        return Ok(non_unicode_index_entry(
+            relative_path.to_path_buf(),
+            Some(metadata.len()),
+            Some(modified_ns),
+            stable_filesystem_identity(&path, &metadata),
+        ));
+    }
+    Err(std::io::Error::other(
+        "supported audio is not an index-only entry",
+    ))
 }
 
 fn record_uncertain_prefix(snapshot: &mut SourceTreeSnapshot, root: &Path, path: &Path) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_index.rs
@@ -57,6 +57,23 @@ pub(super) fn inaccessible_index_entry(
     }
 }
 
+pub(super) fn non_unicode_index_entry(
+    relative_path: PathBuf,
+    file_size: Option<u64>,
+    modified_ns: Option<i64>,
+    file_identity: Option<String>,
+) -> SourceIndexEntry {
+    SourceIndexEntry {
+        relative_path,
+        classification: SourceIndexClassification::Inaccessible,
+        file_size,
+        modified_ns,
+        file_identity,
+        diagnostic: Some(SourceIndexDiagnostic::NonUnicodePath),
+        format_policy_version: SOURCE_FORMAT_POLICY_VERSION,
+    }
+}
+
 pub(super) fn reconcile_index_entries(
     database: &SourceDatabase,
     source_root: &SourceRootCapability,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -21,7 +21,7 @@ use super::{
     scan_db_sync::{complete_scan_generation, db_sync_phase},
     scan_diff_phase::prepare_diff_from_facts,
     scan_fs::{DirectoryVisit, VisitedDirectories, ensure_root_dir},
-    scan_index::{inaccessible_index_entry, index_entry_from_file_facts},
+    scan_index::{inaccessible_index_entry, index_entry_from_file_facts, non_unicode_index_entry},
     scan_walk::apply_prepared_chunk,
     scan_writer::{ScanWriter, UncoordinatedScanWriter},
 };
@@ -190,7 +190,12 @@ fn collect_targets(
         {
             return Err(ScanError::Canceled);
         }
-        collect_existing_rows(db, &relative_path, &mut existing)?;
+        // A non-Unicode target cannot have a supported manifest row: normal
+        // sample paths remain deliberately UTF-8-only. Its prior state, if
+        // any, is carried by the lossless index-only lookup below.
+        if relative_path.to_str().is_some() {
+            collect_existing_rows(db, &relative_path, &mut existing)?;
+        }
         collect_existing_index_entries(db, &relative_path, &mut existing_index_entries)?;
         collect_current_files(
             &source_root_dir,
@@ -626,6 +631,18 @@ fn collect_current_file(
             return Ok(());
         }
     };
+    if relative_path.to_str().is_none() {
+        current_index_entries.insert(
+            relative_path.to_path_buf(),
+            non_unicode_index_entry(
+                relative_path.to_path_buf(),
+                Some(facts.size),
+                Some(facts.modified_ns),
+                facts.file_identity,
+            ),
+        );
+        return Ok(());
+    }
     current_files
         .entry(relative_path.to_path_buf())
         .or_insert(TargetedFile {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_paths.rs
@@ -632,6 +632,9 @@ fn collect_current_file(
         }
     };
     if relative_path.to_str().is_none() {
+        // This helper is reached only for entries whose policy classification
+        // indexes audio, which implies supported audio. Unsupported entries
+        // retain their classification through collect_current_index_file.
         current_index_entries.insert(
             relative_path.to_path_buf(),
             non_unicode_index_entry(

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1329,6 +1329,8 @@ Scanning should be recursive by default. Wavecrate should skip hidden or system 
 
 Every scanner content-hash path, including full scans, periodic content audits, deferred hashing, exact-path hashing, and targeted watcher reconciliation, must open through a source-root capability without following the final component or any ancestor. Filesystem facts, content reads, and post-read revalidation must use the retained descriptor for one object, and the manifest path must still bind to that object immediately before publication. A path that disappears, becomes linked, or is replaced remains retired or retryable without reading the replacement target, and content reads must remain outside source-database writer ownership.
 
+On platforms that expose raw non-Unicode filenames, scanner classification must not let one such entry abort publication for the surrounding source. Supported audio with a non-Unicode relative path remains outside the normal sample manifest and is retained as a typed, lossless index-only diagnostic; other index-only classifications use the same lossless path identity. The encoding must preserve distinct raw names, round-trip across restart, and remain consistent for full scans, targeted sync, deletion, rename, and browser/index projections. Existing Unicode source paths retain their current readable database representation.
+
 The final scanner should not silently impose arbitrary product limits on folder depth, number of child folders, or number of files per source. Any defensive scan limit used to protect responsiveness should be explicit, configurable where practical, logged, and visible as a partial-scan warning with a clear rescan or settings path.
 
 The scanner should classify discovered files as:

--- a/tests/unit/source_db_migration_tests/index_entries.rs
+++ b/tests/unit/source_db_migration_tests/index_entries.rs
@@ -34,6 +34,7 @@ fn v10_migration_adds_index_only_schema_without_changing_sample_metadata() {
         column_names(&db.connection, "source_index_entries"),
         vec![
             "path",
+            "path_encoding",
             "classification",
             "file_size",
             "modified_ns",


### PR DESCRIPTION
## Goal

Prevent a single Unix filesystem entry with a non-UTF-8 path component from aborting Wavecrate source scan publication.

## Scope

- Persist non-Unicode source paths losslessly in the source index with an explicit path-encoding marker.
- Preserve a typed NonUnicodePath diagnostic for supported audio entries while allowing sibling entries to publish.
- Apply equivalent behavior to full scans and targeted add, modify, rename, and delete synchronization.
- Add schema migration compatibility and Unix regression coverage.

## Non-goals

- Changing ordinary UTF-8 path normalization or sample database path semantics.
- Converting arbitrary non-Unicode filesystem names into displayable Unicode.
- Broad scanner or schema cleanup unrelated to this failure mode.

## Definition of Done

- Supported and unsupported non-Unicode entries remain represented in the source index without normalization failure.
- Supported non-Unicode entries receive a typed diagnostic and do not become readable samples.
- Sibling entries continue to scan and publish.
- Targeted synchronization handles add, modify, rename, and removal of non-Unicode entries.
- Existing databases migrate and remain readable.

## Validation

- cargo test -p wavecrate-library --all-targets --no-fail-fast: 277 passed.
- cargo test -p wavecrate-scan --all-targets --no-fail-fast: 178 passed.
- Focused migration, reserved-prefix lifecycle, and manifest/index key-collision regressions: passed.
- Focused index-entry regression: 10 passed on macOS; raw-byte filesystem cases are platform-gated because Darwin rejects such filenames.
- cargo fmt --all -- --check: passed.
- git diff --check: passed.

## Known limitations

- bash scripts/ci.sh agent reaches the unrelated Radiant assertion gpu_signal_shader_keeps_waveform_bands_visually_distinct. Tracked in OPT-1288.
- Package-wide Clippy reports pre-existing warnings in untouched files; changed code and focused tests pass.

Fixes OPT-1281.

User approval is required before merge. Approval received on 2026-07-24.