### PR TITLE
fix(browser): stream generation-fenced scan discoveries

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -55,9 +55,9 @@ pub use open_profiles::SourceDatabaseConnectionRole;
 pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingRenamePruneReport};
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
-    BrowserFileMetadata, BrowserMetadataSnapshot, Rating, SampleCollection, SampleSoundType,
-    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
-    SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
+    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, Rating, SampleCollection,
+    SampleSoundType, SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry,
+    SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
 };
 pub use util::normalize_relative_path;
 pub use write::{

--- a/crates/wavecrate-library/src/sample_sources/db/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/mod.rs
@@ -55,9 +55,10 @@ pub use open_profiles::SourceDatabaseConnectionRole;
 pub use pending_renames::{PendingRenameDiagnostics, PendingRenameEntry, PendingRenamePruneReport};
 pub use rename_metadata::RenameMetadataSnapshot;
 pub use types::{
-    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, Rating, SampleCollection,
-    SampleSoundType, SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry,
-    SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage, WavEntry,
+    BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
+    Rating, SampleCollection, SampleSoundType, SourceIndexClassification, SourceIndexDiagnostic,
+    SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage,
+    WavEntry,
 };
 pub use util::normalize_relative_path;
 pub use write::{

--- a/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/file_queries/entries.rs
@@ -141,34 +141,36 @@ impl SourceDatabase {
             .collect::<Result<Vec<_>, _>>()?;
         normalized_paths.sort();
         normalized_paths.dedup();
-        let mut parameters = Vec::with_capacity(normalized_paths.len() * 3);
-        let predicates = normalized_paths
-            .iter()
-            .enumerate()
-            .map(|(index, path)| {
-                let first = index * 3 + 1;
-                let lower = format!("{path}/");
-                let upper = format!("{path}0");
-                parameters.push(path.clone());
-                parameters.push(lower);
-                parameters.push(upper);
-                format!(
-                    "(path = ?{first} COLLATE BINARY OR \
-                     (path >= ?{} COLLATE BINARY AND path < ?{} COLLATE BINARY))",
-                    first + 1,
-                    first + 2
-                )
-            })
-            .collect::<Vec<_>>();
         let filter = wav_file_supported_audio_filter(self)?;
-        let sql = format!(
-            "SELECT path, file_identity, content_hash, file_size, modified_ns
-             FROM wav_files
-             WHERE {filter} AND missing = 0 AND ({})
-             ORDER BY path ASC",
-            predicates.join(" OR ")
-        );
-        let entries = {
+        const PATHS_PER_QUERY: usize = 128;
+        let mut entries = Vec::new();
+        for chunk in normalized_paths.chunks(PATHS_PER_QUERY) {
+            let mut parameters = Vec::with_capacity(chunk.len() * 3);
+            let predicates = chunk
+                .iter()
+                .enumerate()
+                .map(|(index, path)| {
+                    let first = index * 3 + 1;
+                    let lower = format!("{path}/");
+                    let upper = format!("{path}0");
+                    parameters.push(path.clone());
+                    parameters.push(lower);
+                    parameters.push(upper);
+                    format!(
+                        "(path = ?{first} COLLATE BINARY OR \
+                         (path >= ?{} COLLATE BINARY AND path < ?{} COLLATE BINARY))",
+                        first + 1,
+                        first + 2
+                    )
+                })
+                .collect::<Vec<_>>();
+            let sql = format!(
+                "SELECT path, file_identity, content_hash, file_size, modified_ns
+                 FROM wav_files
+                 WHERE {filter} AND missing = 0 AND ({})
+                 ORDER BY path ASC",
+                predicates.join(" OR ")
+            );
             let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
             let rows = statement
                 .query_map(params_from_iter(parameters.iter()), |row| {
@@ -190,8 +192,10 @@ impl SourceDatabase {
                 .map_err(map_sql_error)?
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(map_sql_error)?;
-            rows.into_iter().flatten().collect()
-        };
+            entries.extend(rows.into_iter().flatten());
+        }
+        entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        entries.dedup_by(|left, right| left.relative_path == right.relative_path);
         transaction.rollback().map_err(map_sql_error)?;
         Ok((revision, entries))
     }

--- a/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
@@ -4,8 +4,9 @@ use rusqlite::OptionalExtension;
 
 use super::super::util::map_sql_error;
 use super::super::{
-    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, META_WAV_PATHS_REVISION,
-    Rating, SampleCollection, SampleSoundType, SourceDatabase, SourceDbError,
+    BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
+    META_WAV_PATHS_REVISION, Rating, SampleCollection, SampleSoundType, SourceDatabase,
+    SourceDbError,
 };
 use super::decode::{
     decode_path_row, decode_relative_path, table_has_columns, wav_file_has_column,
@@ -228,12 +229,12 @@ impl SourceDatabase {
 
     /// Fetch one bounded browser metadata page at an exact source revision.
     ///
-    /// `after_path` is an exclusive keyset cursor. A revision mismatch fails closed so pages
+    /// `after_cursor` is an exclusive raw-SQL keyset cursor. A revision mismatch fails closed so pages
     /// cannot be combined across committed source states.
     pub fn browser_metadata_page(
         &self,
         expected_revision: u64,
-        after_path: Option<&Path>,
+        after_cursor: Option<&BrowserMetadataCursor>,
         requested_limit: usize,
     ) -> Result<BrowserMetadataPage, SourceDbError> {
         const MAX_PAGE_SIZE: usize = 64;
@@ -270,9 +271,6 @@ impl SourceDatabase {
         };
         let legacy_collection =
             optional_browser_column(&wav_columns, "collection", "NULL AS collection");
-        let cursor = after_path
-            .map(super::super::normalize_relative_path)
-            .transpose()?;
         let sql = format!(
             "SELECT path, {}, {}, {}, {}, {legacy_collection}, {}, {}, {}
              FROM wav_files
@@ -286,44 +284,62 @@ impl SourceDatabase {
             optional_browser_column(&wav_columns, "modified_ns", "0 AS modified_ns"),
             optional_browser_column(&wav_columns, "missing", "0 AS missing"),
         );
-        let mut files = {
+        let raw_rows = {
             let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
             statement
-                .query_map(rusqlite::params![cursor, limit as i64], |row| {
-                    let Some(relative_path) = decode_path_row(
-                        row,
-                        "Skipping browser metadata row with invalid relative path",
-                    )?
-                    else {
-                        return Ok(None);
-                    };
-                    let legacy_collection = if memberships_available {
-                        Vec::new()
-                    } else {
-                        row.get::<_, Option<i64>>(5)?
-                            .and_then(SampleCollection::from_i64)
-                            .into_iter()
-                            .collect()
-                    };
-                    Ok(Some(BrowserFileMetadata {
-                        relative_path,
-                        file_size: u64::try_from(row.get::<_, i64>(6)?).unwrap_or_default(),
-                        modified_ns: row.get(7)?,
-                        missing: row.get::<_, i64>(8)? != 0,
-                        rating: Rating::from_i64(row.get(1)?),
-                        locked: row.get::<_, i64>(2)? != 0,
-                        collections: legacy_collection,
-                        last_played_at: row.get(3)?,
-                        last_curated_at: row.get(4)?,
-                    }))
-                })
+                .query_map(
+                    rusqlite::params![
+                        after_cursor.map(BrowserMetadataCursor::as_str),
+                        limit as i64
+                    ],
+                    |row| {
+                        let raw_path: String = row.get(0)?;
+                        let Some(relative_path) = decode_relative_path(
+                            raw_path.clone(),
+                            "Skipping browser metadata row with invalid relative path",
+                        )?
+                        else {
+                            return Ok((raw_path, None));
+                        };
+                        let legacy_collection = if memberships_available {
+                            Vec::new()
+                        } else {
+                            row.get::<_, Option<i64>>(5)?
+                                .and_then(SampleCollection::from_i64)
+                                .into_iter()
+                                .collect()
+                        };
+                        Ok((
+                            raw_path,
+                            Some(BrowserFileMetadata {
+                                relative_path,
+                                file_size: u64::try_from(row.get::<_, i64>(6)?).unwrap_or_default(),
+                                modified_ns: row.get(7)?,
+                                missing: row.get::<_, i64>(8)? != 0,
+                                rating: Rating::from_i64(row.get(1)?),
+                                locked: row.get::<_, i64>(2)? != 0,
+                                collections: legacy_collection,
+                                last_played_at: row.get(3)?,
+                                last_curated_at: row.get(4)?,
+                            }),
+                        ))
+                    },
+                )
                 .map_err(map_sql_error)?
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(map_sql_error)?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
         };
+        let next_cursor = (raw_rows.len() == limit)
+            .then(|| {
+                raw_rows
+                    .last()
+                    .map(|(raw_path, _)| BrowserMetadataCursor::from_raw(raw_path.clone()))
+            })
+            .flatten();
+        let mut files = raw_rows
+            .into_iter()
+            .filter_map(|(_, file)| file)
+            .collect::<Vec<_>>();
         if memberships_available && !files.is_empty() {
             let first = super::super::normalize_relative_path(&files[0].relative_path)?;
             let last = super::super::normalize_relative_path(
@@ -354,14 +370,11 @@ impl SourceDatabase {
                 }
             }
         }
-        let next_path = (files.len() == limit)
-            .then(|| files.last().map(|file| file.relative_path.clone()))
-            .flatten();
         transaction.rollback().map_err(map_sql_error)?;
         Ok(BrowserMetadataPage {
             revision,
             files,
-            next_path,
+            next_cursor,
         })
     }
     /// Return the numeric metadata value for `key` (0 if missing).

--- a/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/metadata_queries.rs
@@ -4,8 +4,8 @@ use rusqlite::OptionalExtension;
 
 use super::super::util::map_sql_error;
 use super::super::{
-    BrowserFileMetadata, BrowserMetadataSnapshot, META_WAV_PATHS_REVISION, Rating,
-    SampleCollection, SampleSoundType, SourceDatabase, SourceDbError,
+    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, META_WAV_PATHS_REVISION,
+    Rating, SampleCollection, SampleSoundType, SourceDatabase, SourceDbError,
 };
 use super::decode::{
     decode_path_row, decode_relative_path, table_has_columns, wav_file_has_column,
@@ -224,6 +224,145 @@ impl SourceDatabase {
     /// of the number of tracked files.
     pub fn browser_metadata_snapshot(&self) -> Result<BrowserMetadataSnapshot, SourceDbError> {
         browser_metadata_snapshot_with_observer(self, || {})
+    }
+
+    /// Fetch one bounded browser metadata page at an exact source revision.
+    ///
+    /// `after_path` is an exclusive keyset cursor. A revision mismatch fails closed so pages
+    /// cannot be combined across committed source states.
+    pub fn browser_metadata_page(
+        &self,
+        expected_revision: u64,
+        after_path: Option<&Path>,
+        requested_limit: usize,
+    ) -> Result<BrowserMetadataPage, SourceDbError> {
+        const MAX_PAGE_SIZE: usize = 64;
+        let limit = requested_limit.clamp(1, MAX_PAGE_SIZE);
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .map_err(map_sql_error)?;
+        let revision = transaction
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'revision'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_sql_error)?
+            .map(|raw| raw.parse::<u64>().map_err(|_| SourceDbError::Unexpected))
+            .transpose()?
+            .unwrap_or_default();
+        if revision != expected_revision {
+            return Err(SourceDbError::Unexpected);
+        }
+        let wav_columns = super::super::schema::table_columns(&transaction, "wav_files")?;
+        let collection_columns =
+            super::super::schema::table_columns(&transaction, "wav_file_collections")?;
+        let memberships_available =
+            collection_columns.contains("path") && collection_columns.contains("collection");
+        let supported_filter = if wav_columns.contains("extension") {
+            crate::sample_sources::supported_audio_where_clause()
+        } else {
+            String::from(
+                "lower(path) GLOB '*.wav' AND path NOT GLOB '._*' AND path NOT GLOB '*/._*'",
+            )
+        };
+        let legacy_collection =
+            optional_browser_column(&wav_columns, "collection", "NULL AS collection");
+        let cursor = after_path
+            .map(super::super::normalize_relative_path)
+            .transpose()?;
+        let sql = format!(
+            "SELECT path, {}, {}, {}, {}, {legacy_collection}, {}, {}, {}
+             FROM wav_files
+             WHERE {supported_filter} AND (?1 IS NULL OR path > ?1)
+             ORDER BY path ASC LIMIT ?2",
+            optional_browser_column(&wav_columns, "tag", "0 AS tag"),
+            optional_browser_column(&wav_columns, "locked", "0 AS locked"),
+            optional_browser_column(&wav_columns, "last_played_at", "NULL AS last_played_at"),
+            optional_browser_column(&wav_columns, "last_curated_at", "NULL AS last_curated_at"),
+            optional_browser_column(&wav_columns, "file_size", "0 AS file_size"),
+            optional_browser_column(&wav_columns, "modified_ns", "0 AS modified_ns"),
+            optional_browser_column(&wav_columns, "missing", "0 AS missing"),
+        );
+        let mut files = {
+            let mut statement = transaction.prepare(&sql).map_err(map_sql_error)?;
+            statement
+                .query_map(rusqlite::params![cursor, limit as i64], |row| {
+                    let Some(relative_path) = decode_path_row(
+                        row,
+                        "Skipping browser metadata row with invalid relative path",
+                    )?
+                    else {
+                        return Ok(None);
+                    };
+                    let legacy_collection = if memberships_available {
+                        Vec::new()
+                    } else {
+                        row.get::<_, Option<i64>>(5)?
+                            .and_then(SampleCollection::from_i64)
+                            .into_iter()
+                            .collect()
+                    };
+                    Ok(Some(BrowserFileMetadata {
+                        relative_path,
+                        file_size: u64::try_from(row.get::<_, i64>(6)?).unwrap_or_default(),
+                        modified_ns: row.get(7)?,
+                        missing: row.get::<_, i64>(8)? != 0,
+                        rating: Rating::from_i64(row.get(1)?),
+                        locked: row.get::<_, i64>(2)? != 0,
+                        collections: legacy_collection,
+                        last_played_at: row.get(3)?,
+                        last_curated_at: row.get(4)?,
+                    }))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+        };
+        if memberships_available && !files.is_empty() {
+            let first = super::super::normalize_relative_path(&files[0].relative_path)?;
+            let last = super::super::normalize_relative_path(
+                &files[files.len().saturating_sub(1)].relative_path,
+            )?;
+            let mut statement = transaction
+                .prepare(
+                    "SELECT path, collection FROM wav_file_collections
+                     WHERE path >= ?1 AND path <= ?2 ORDER BY path ASC, collection ASC",
+                )
+                .map_err(map_sql_error)?;
+            let memberships = statement
+                .query_map(rusqlite::params![first, last], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .map_err(map_sql_error)?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(map_sql_error)?;
+            for (path, collection) in memberships {
+                if let (Some(file), Some(collection)) = (
+                    files.iter_mut().find(|file| {
+                        super::super::normalize_relative_path(&file.relative_path)
+                            .is_ok_and(|candidate| candidate == path)
+                    }),
+                    SampleCollection::from_i64(collection),
+                ) {
+                    file.collections.push(collection);
+                }
+            }
+        }
+        let next_path = (files.len() == limit)
+            .then(|| files.last().map(|file| file.relative_path.clone()))
+            .flatten();
+        transaction.rollback().map_err(map_sql_error)?;
+        Ok(BrowserMetadataPage {
+            revision,
+            files,
+            next_path,
+        })
     }
     /// Return the numeric metadata value for `key` (0 if missing).
     fn get_numeric_metadata(&self, key: &str) -> Result<u64, SourceDbError> {

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -62,15 +62,53 @@ fn browser_metadata_page_is_keyset_paged_and_revision_fenced() {
     );
     assert_eq!(first.files.len(), 2);
     let second = db
-        .browser_metadata_page(revision, first.next_path.as_deref(), 2)
+        .browser_metadata_page(revision, first.next_cursor.as_ref(), 2)
         .unwrap();
     assert_eq!(second.files.len(), 1);
 
     db.set_tag(Path::new("a.wav"), Rating::KEEP_1).unwrap();
     assert!(
-        db.browser_metadata_page(revision, second.next_path.as_deref(), 2)
+        db.browser_metadata_page(revision, second.next_cursor.as_ref(), 2)
             .is_err()
     );
+}
+
+#[test]
+fn browser_metadata_page_advances_past_invalid_raw_path_rows() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    for name in ["a.wav", "zz.wav"] {
+        db.upsert_file(Path::new(name), 10, 5).unwrap();
+    }
+    db.connection
+        .execute(
+            "INSERT INTO wav_files (path, file_size, modified_ns, extension)
+             VALUES (?1, 10, 5, 'wav')",
+            ["z/../broken.wav"],
+        )
+        .unwrap();
+    let revision = db.get_revision().unwrap();
+
+    let first = db.browser_metadata_page(revision, None, 2).unwrap();
+    assert_eq!(first.files.len(), 1);
+    assert_eq!(first.files[0].relative_path, Path::new("a.wav"));
+    assert_eq!(
+        first.next_cursor.as_ref().map(|cursor| cursor.as_str()),
+        Some("z/../broken.wav")
+    );
+
+    let second = db
+        .browser_metadata_page(revision, first.next_cursor.as_ref(), 2)
+        .unwrap();
+    assert_eq!(
+        second
+            .files
+            .iter()
+            .map(|file| file.relative_path.clone())
+            .collect::<Vec<_>>(),
+        vec![PathBuf::from("zz.wav")]
+    );
+    assert!(second.next_cursor.is_none());
 }
 
 #[test]

--- a/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/read/tests.rs
@@ -44,6 +44,36 @@ fn browser_metadata_snapshot_reads_multi_collection_rows_coherently() {
 }
 
 #[test]
+fn browser_metadata_page_is_keyset_paged_and_revision_fenced() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_source_write(dir.path()).unwrap();
+    for name in ["c.wav", "a.wav", "b.wav"] {
+        db.upsert_file(Path::new(name), 10, 5).unwrap();
+    }
+    let revision = db.get_revision().unwrap();
+    let first = db.browser_metadata_page(revision, None, 2).unwrap();
+    assert_eq!(
+        first
+            .files
+            .iter()
+            .map(|file| file.relative_path.clone())
+            .collect::<Vec<_>>(),
+        vec![PathBuf::from("a.wav"), PathBuf::from("b.wav")]
+    );
+    assert_eq!(first.files.len(), 2);
+    let second = db
+        .browser_metadata_page(revision, first.next_path.as_deref(), 2)
+        .unwrap();
+    assert_eq!(second.files.len(), 1);
+
+    db.set_tag(Path::new("a.wav"), Rating::KEEP_1).unwrap();
+    assert!(
+        db.browser_metadata_page(revision, second.next_path.as_deref(), 2)
+            .is_err()
+    );
+}
+
+#[test]
 fn browser_metadata_snapshot_has_constant_statement_count_for_large_sources() {
     let dir = tempdir().unwrap();
     let mut db = SourceDatabase::open_for_source_write(dir.path()).unwrap();

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -297,6 +297,21 @@ pub struct BrowserMetadataSnapshot {
     pub files: Vec<BrowserFileMetadata>,
 }
 
+/// Opaque keyset cursor retaining the exact raw SQLite path key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMetadataCursor(String);
+
+impl BrowserMetadataCursor {
+    pub(crate) fn from_raw(raw: String) -> Self {
+        Self(raw)
+    }
+
+    /// Borrow the raw SQLite path key for the next page query.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// One bounded, keyset-paged browser metadata result at an exact source revision.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserMetadataPage {
@@ -304,8 +319,8 @@ pub struct BrowserMetadataPage {
     pub revision: u64,
     /// Metadata rows in deterministic path order, including collection memberships.
     pub files: Vec<BrowserFileMetadata>,
-    /// Cursor to pass to the next page, or `None` when this is the final page.
-    pub next_path: Option<PathBuf>,
+    /// Opaque cursor to pass to the next page, or `None` when this is the final page.
+    pub next_cursor: Option<BrowserMetadataCursor>,
 }
 
 /// Authoritative identity facts for one live source-manifest row.

--- a/crates/wavecrate-library/src/sample_sources/db/types.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/types.rs
@@ -297,6 +297,17 @@ pub struct BrowserMetadataSnapshot {
     pub files: Vec<BrowserFileMetadata>,
 }
 
+/// One bounded, keyset-paged browser metadata result at an exact source revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMetadataPage {
+    /// Source metadata revision observed by the page.
+    pub revision: u64,
+    /// Metadata rows in deterministic path order, including collection memberships.
+    pub files: Vec<BrowserFileMetadata>,
+    /// Cursor to pass to the next page, or `None` when this is the final page.
+    pub next_path: Option<PathBuf>,
+}
+
 /// Authoritative identity facts for one live source-manifest row.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceManifestEntry {

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -17,11 +17,11 @@ pub use audio_support::{
 };
 pub use db::normalize_relative_path;
 pub use db::{
-    BrowserFileMetadata, BrowserMetadataSnapshot, DB_FILE_NAME, ManifestCommitResult, Rating,
-    SampleCollection, SourceCollectionWrite, SourceContentHashWrite, SourceDatabase,
-    SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite, SourceIndexClassification,
-    SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot, SourceManifestEntry, SourceTag,
-    SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
+    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, DB_FILE_NAME,
+    ManifestCommitResult, Rating, SampleCollection, SourceCollectionWrite, SourceContentHashWrite,
+    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite,
+    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
+    SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-library/src/sample_sources/mod.rs
+++ b/crates/wavecrate-library/src/sample_sources/mod.rs
@@ -17,11 +17,12 @@ pub use audio_support::{
 };
 pub use db::normalize_relative_path;
 pub use db::{
-    BrowserFileMetadata, BrowserMetadataPage, BrowserMetadataSnapshot, DB_FILE_NAME,
-    ManifestCommitResult, Rating, SampleCollection, SourceCollectionWrite, SourceContentHashWrite,
-    SourceDatabase, SourceDatabaseConnectionRole, SourceDbError, SourceFileWrite,
-    SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry, SourceIndexSnapshot,
-    SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite, SourceWriteCommand, WavEntry,
+    BrowserFileMetadata, BrowserMetadataCursor, BrowserMetadataPage, BrowserMetadataSnapshot,
+    DB_FILE_NAME, ManifestCommitResult, Rating, SampleCollection, SourceCollectionWrite,
+    SourceContentHashWrite, SourceDatabase, SourceDatabaseConnectionRole, SourceDbError,
+    SourceFileWrite, SourceIndexClassification, SourceIndexDiagnostic, SourceIndexEntry,
+    SourceIndexSnapshot, SourceManifestEntry, SourceTag, SourceTagUsage, SourceTagWrite,
+    SourceWriteCommand, WavEntry,
 };
 pub use library::{
     HarvestDerivationOperation, HarvestDerivationRecord, HarvestFileIdentity, HarvestFileKey,

--- a/crates/wavecrate-scan/src/lib.rs
+++ b/crates/wavecrate-scan/src/lib.rs
@@ -8,11 +8,12 @@ pub mod sample_sources;
 
 pub use sample_sources::ScanTracker;
 pub use sample_sources::scanner::{
-    ChangedSample, CommittedSourceDelta, DirectoryRepeatKind, ManifestIdentityDelta,
-    MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic,
-    SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source, audit_source_and_record,
-    audit_source_and_record_with_progress, complete_deferred_hashes,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, DirectoryRepeatKind,
+    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats,
+    SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source,
+    audit_source_and_record, audit_source_and_record_with_progress, complete_deferred_hashes,
     complete_deferred_rename_candidates, complete_deferred_rename_candidates_with_cancel,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
-    scan_in_background, scan_once, scan_with_progress, sync_paths, sync_paths_with_progress,
+    scan_in_background, scan_once, scan_with_progress,
+    scan_with_progress_and_writer_and_committed_batch, sync_paths, sync_paths_with_progress,
 };

--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -12,10 +12,10 @@ mod scan_walk;
 mod scan_writer;
 
 pub use scan::{
-    ChangedSample, CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget,
-    ContentAuditStorage, DirectoryRepeatKind, ManifestIdentityDelta, MovedManifestIdentity,
-    RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic, SourceTreeFile,
-    SourceTreeSnapshot, UpdatedSample, audit_source, audit_source_and_record,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, ContentAuditActivity,
+    ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind, ManifestIdentityDelta,
+    MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic,
+    SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source, audit_source_and_record,
     audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
     audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
@@ -24,6 +24,7 @@ pub use scan::{
     complete_deferred_rename_candidates_with_cancel_and_writer,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
     scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
+    scan_with_progress_and_writer_and_committed_batch,
 };
 pub use scan_paths::{sync_paths, sync_paths_with_progress, sync_paths_with_progress_and_writer};
 pub use scan_writer::{ScanWritePhase, ScanWriter, UncoordinatedScanWriter};

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -16,6 +16,7 @@ pub use runner::{
     complete_deferred_rename_candidates_with_cancel_and_writer,
     complete_pending_deep_hash_for_path, complete_pending_deep_hashes, hard_rescan,
     scan_in_background, scan_once, scan_with_progress, scan_with_progress_and_writer,
+    scan_with_progress_and_writer_and_committed_batch,
 };
 #[cfg(test)]
 pub(crate) use runner::{
@@ -23,9 +24,9 @@ pub(crate) use runner::{
 };
 pub(crate) use runner::{finish_scan_result, reconcile_scan_renames};
 pub use stats::{
-    ChangedSample, CommittedSourceDelta, DirectoryRepeatKind, ManifestIdentityDelta,
-    MovedManifestIdentity, RenamedSample, ScanStats, SourceTreeDiagnostic, SourceTreeFile,
-    SourceTreeSnapshot, UpdatedSample,
+    ChangedSample, CommittedScanBatch, CommittedSourceDelta, DirectoryRepeatKind,
+    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanStats, SourceTreeDiagnostic,
+    SourceTreeFile, SourceTreeSnapshot, UpdatedSample,
 };
 
 #[cfg(test)]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -14,7 +14,7 @@ use super::super::scan_fs::ensure_root_dir;
 use super::super::scan_hash::ContentAuditBudget;
 use super::super::scan_walk::walk_phase;
 use super::super::scan_writer::{ScanWriter, UncoordinatedScanWriter};
-use super::{ScanContext, ScanError, ScanStats};
+use super::{CommittedScanBatch, ScanContext, ScanError, ScanStats};
 
 const TARGETED_RENAME_CANDIDATE_LIMIT: usize = 256;
 
@@ -405,6 +405,35 @@ fn scan(
     )
 }
 
+/// Scan with progress and invoke a callback after every bounded manifest transaction commits.
+///
+/// The callback receives only paths from the committed transaction and its exact committed
+/// revision. It runs on the scanning worker, before the scan continues to the next batch.
+pub fn scan_with_progress_and_writer_and_committed_batch(
+    db: &SourceDatabase,
+    mode: ScanMode,
+    cancel: Option<&AtomicBool>,
+    on_progress: &mut impl FnMut(usize, &Path),
+    on_committed_batch: &mut impl FnMut(CommittedScanBatch),
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    let root = ensure_root_dir(db)?;
+    let source_root = SourceRootCapability::open(&root)?;
+    source_root.ensure_current_generation()?;
+    scan_with_writer_using_root_and_committed_batch(
+        db,
+        &root,
+        &source_root,
+        mode,
+        cancel,
+        Some(on_progress),
+        None,
+        true,
+        on_committed_batch,
+        writer,
+    )
+}
+
 fn scan_with_writer(
     db: &SourceDatabase,
     mode: ScanMode,
@@ -436,9 +465,35 @@ fn scan_with_writer_using_root(
     source_root: &SourceRootCapability,
     mode: ScanMode,
     cancel: Option<&AtomicBool>,
+    on_progress: Option<&mut dyn FnMut(usize, &Path)>,
+    manifest_audit_started_at: Option<i64>,
+    finalize_pending_renames: bool,
+    writer: &impl ScanWriter,
+) -> Result<ScanStats, ScanError> {
+    scan_with_writer_using_root_and_committed_batch(
+        db,
+        root,
+        source_root,
+        mode,
+        cancel,
+        on_progress,
+        manifest_audit_started_at,
+        finalize_pending_renames,
+        &mut |_| {},
+        writer,
+    )
+}
+
+fn scan_with_writer_using_root_and_committed_batch(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    mode: ScanMode,
+    cancel: Option<&AtomicBool>,
     mut on_progress: Option<&mut dyn FnMut(usize, &Path)>,
     manifest_audit_started_at: Option<i64>,
     finalize_pending_renames: bool,
+    on_committed_batch: &mut dyn FnMut(CommittedScanBatch),
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
     debug_assert_ne!(mode, ScanMode::Targeted);
@@ -465,6 +520,7 @@ fn scan_with_writer_using_root(
         cancel,
         &mut on_progress,
         &mut context,
+        on_committed_batch,
         writer,
     )
     .and_then(|()| db_sync_phase(db, source_root, &mut context, cancel, writer))

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/stats.rs
@@ -3,6 +3,15 @@ use std::{fmt, path::PathBuf};
 use wavecrate_library::sample_sources::db::{ContentAuditReport, PendingRenameDiagnostics};
 use wavecrate_library::sample_sources::{SourceIndexEntry, SourceManifestEntry};
 
+/// One bounded group of source-manifest rows after its database transaction commits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommittedScanBatch {
+    /// Monotonic source-manifest revision assigned by the committed transaction.
+    pub revision: u64,
+    /// Source-relative paths changed by this transaction, in scan order.
+    pub paths: Vec<PathBuf>,
+}
+
 /// Why a directory was not fully represented by a source traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceTreeDiagnostic {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::sample_sources::SourceDatabase;
 use wavecrate_library::sample_sources::{SourceIndexDiagnostic, SourceTraversalPolicy};
 
-use super::scan::{ScanContext, ScanError};
+use super::scan::{CommittedScanBatch, ScanContext, ScanError};
 use super::scan_capability::{SourcePathBinding, SourceRootCapability};
 use super::scan_diff::{PreparedFile, apply_diff};
 use super::scan_diff_phase::prepare_diff_from_facts;
@@ -31,6 +31,7 @@ pub(super) fn walk_phase(
     cancel: Option<&AtomicBool>,
     on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
     context: &mut ScanContext,
+    on_committed_batch: &mut dyn FnMut(CommittedScanBatch),
     writer: &impl ScanWriter,
 ) -> Result<(), ScanError> {
     // Each committed batch is a valid checkpoint. Cancellation may stop the scan between batches;
@@ -125,6 +126,7 @@ pub(super) fn walk_phase(
                     context,
                     files,
                     committed.get(),
+                    on_committed_batch,
                     writer,
                 )?;
                 if outcome.committed {
@@ -162,6 +164,7 @@ pub(super) fn walk_phase(
             context,
             pending,
             committed.get(),
+            on_committed_batch,
             writer,
         )?;
         if outcome.committed {
@@ -369,6 +372,7 @@ pub(super) fn apply_prepared_chunk(
     if pending.is_empty() {
         return Ok(false);
     }
+    let mut on_committed_batch = |_| {};
     apply_batch_with_source_root(
         db,
         root,
@@ -377,6 +381,7 @@ pub(super) fn apply_prepared_chunk(
         context,
         pending,
         tolerate_file_errors,
+        &mut on_committed_batch,
         writer,
     )
     .map(|outcome| outcome.committed)
@@ -496,6 +501,7 @@ fn apply_batch(
     writer: &impl ScanWriter,
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let source_root = SourceRootCapability::open(root)?;
+    let mut on_committed_batch = |_| {};
     apply_batch_with_source_root(
         db,
         root,
@@ -504,6 +510,7 @@ fn apply_batch(
         context,
         prepared,
         tolerate_file_errors,
+        &mut on_committed_batch,
         writer,
     )
 }
@@ -516,6 +523,7 @@ fn apply_batch_with_source_root(
     context: &mut ScanContext,
     prepared: Vec<PreparedFile>,
     tolerate_file_errors: bool,
+    on_committed_batch: &mut dyn FnMut(CommittedScanBatch),
     writer: &impl ScanWriter,
 ) -> Result<ApplyBatchOutcome, ScanError> {
     apply_batch_with_source_root_and_precommit_hook(
@@ -528,6 +536,7 @@ fn apply_batch_with_source_root(
         tolerate_file_errors,
         writer,
         |_| {},
+        on_committed_batch,
     )
 }
 
@@ -544,6 +553,7 @@ fn apply_batch_with_precommit_hook(
     precommit: impl FnMut(&Path),
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let source_root = SourceRootCapability::open(root)?;
+    let mut on_committed_batch = |_| {};
     apply_batch_with_source_root_and_precommit_hook(
         db,
         root,
@@ -554,6 +564,7 @@ fn apply_batch_with_precommit_hook(
         tolerate_file_errors,
         writer,
         precommit,
+        &mut on_committed_batch,
     )
 }
 
@@ -568,6 +579,7 @@ fn apply_batch_with_source_root_and_precommit_hook(
     tolerate_file_errors: bool,
     writer: &impl ScanWriter,
     mut precommit: impl FnMut(&Path),
+    on_committed_batch: &mut dyn FnMut(CommittedScanBatch),
 ) -> Result<ApplyBatchOutcome, ScanError> {
     let mut ready = Vec::with_capacity(prepared.len());
     let mut post_hash = |_: &Path| {};
@@ -721,7 +733,11 @@ fn apply_batch_with_source_root_and_precommit_hook(
         return Ok(ApplyBatchOutcome::default());
     }
     source_root.ensure_current_generation()?;
-    context.commit_batch(db, batch)?;
+    let revision = context.commit_batch(db, batch)?;
+    on_committed_batch(CommittedScanBatch {
+        revision,
+        paths: audited_paths.clone(),
+    });
     Ok(ApplyBatchOutcome {
         committed: true,
         audited_paths,

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -69,11 +69,14 @@ fn run_folder_scan_worker_with_emit_and_cancel(
         request.task_id,
         request.source_id.clone(),
         lifecycle_generation,
+        cancel,
     );
     let scan = scan::scan_source_with_progress_cancellable(
         request,
         |progress| {
-            let _ = emit(FolderScanWorkerEvent::Progress(progress));
+            if !cancel.load(Ordering::Acquire) {
+                let _ = emit(FolderScanWorkerEvent::Progress(progress));
+            }
         },
         |event| {
             discovery_transport.push(event);
@@ -96,7 +99,7 @@ fn run_folder_scan_worker_with_emit_and_cancel(
     }
 }
 
-struct FolderScanDiscoveryTransport<Emit> {
+struct FolderScanDiscoveryTransport<'cancel, Emit> {
     emit: Emit,
     task_id: u64,
     source_id: String,
@@ -104,13 +107,20 @@ struct FolderScanDiscoveryTransport<Emit> {
     pending: Vec<FolderScanDiscovery>,
     pending_revision: Option<u64>,
     next_sequence: u64,
+    cancel: &'cancel AtomicBool,
 }
 
-impl<Emit> FolderScanDiscoveryTransport<Emit>
+impl<'cancel, Emit> FolderScanDiscoveryTransport<'cancel, Emit>
 where
     Emit: Fn(FolderScanWorkerEvent) -> bool,
 {
-    fn new(emit: Emit, task_id: u64, source_id: String, lifecycle_generation: Option<u64>) -> Self {
+    fn new(
+        emit: Emit,
+        task_id: u64,
+        source_id: String,
+        lifecycle_generation: Option<u64>,
+        cancel: &'cancel AtomicBool,
+    ) -> Self {
         Self {
             emit,
             task_id,
@@ -119,12 +129,19 @@ where
             pending: Vec::with_capacity(DISCOVERY_BATCH_SIZE),
             pending_revision: None,
             next_sequence: 0,
+            cancel,
         }
     }
 
     fn push(&mut self, discovery: FolderScanDiscovery) {
+        if self.cancel.load(Ordering::Acquire) {
+            return;
+        }
         if !self.pending.is_empty() && self.pending_revision != discovery.committed_revision {
             self.flush();
+        }
+        if self.cancel.load(Ordering::Acquire) {
+            return;
         }
         self.pending_revision = discovery.committed_revision;
         self.pending.push(discovery);
@@ -134,7 +151,7 @@ where
     }
 
     fn flush(&mut self) {
-        if self.pending.is_empty() {
+        if self.pending.is_empty() || self.cancel.load(Ordering::Acquire) {
             return;
         }
         let _ = (self.emit)(FolderScanWorkerEvent::DiscoveryBatch(
@@ -164,7 +181,7 @@ mod tests {
     };
 
     use crate::native_app::sample_library::folder_browser::scan::{
-        FolderScanItem, FolderScanRequest, INDEX_PROGRESS_REPORT_INTERVAL,
+        FolderScanDiscovery, FolderScanItem, FolderScanRequest, INDEX_PROGRESS_REPORT_INTERVAL,
     };
     use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
 
@@ -312,5 +329,47 @@ mod tests {
 
         assert!(result.scan.cancelled);
         assert!(result.scan.file_count < file_count);
+    }
+
+    #[test]
+    fn buffered_discovery_transport_drops_events_after_cancellation() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let callback_cancel = Arc::clone(&cancel);
+        let (sender, receiver) = mpsc::channel();
+        let mut transport = super::FolderScanDiscoveryTransport::new(
+            move |event| {
+                if matches!(&event, FolderScanWorkerEvent::DiscoveryBatch(_)) {
+                    callback_cancel.store(true, Ordering::Release);
+                }
+                sender.send(event).is_ok()
+            },
+            42,
+            String::from("source"),
+            Some(7),
+            cancel.as_ref(),
+        );
+
+        for _ in 0..=DISCOVERY_BATCH_SIZE {
+            transport.push(FolderScanDiscovery {
+                task_id: 42,
+                source_id: String::from("source"),
+                committed_revision: Some(9),
+                parent_id: String::from("root"),
+                item: FolderScanItem::ResetFolder,
+            });
+        }
+        transport.flush();
+
+        let batches = receiver
+            .try_iter()
+            .filter_map(|event| match event {
+                FolderScanWorkerEvent::DiscoveryBatch(batch) => Some(batch),
+                FolderScanWorkerEvent::Progress(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].events.len(), DISCOVERY_BATCH_SIZE);
+        assert_eq!(batches[0].sequence, 0);
+        assert!(cancel.load(Ordering::Acquire));
     }
 }

--- a/src/native_app/app/state/source_scan_worker.rs
+++ b/src/native_app/app/state/source_scan_worker.rs
@@ -24,12 +24,14 @@ pub(in crate::native_app) fn run_folder_scan_worker(
     request: FolderScanRequest,
     events: ui::BusinessEventSink<FolderScanWorkerEvent>,
     cancel: Arc<AtomicBool>,
+    lifecycle_generation: Option<u64>,
     writer: &impl ScanWriter,
 ) -> PreparedFolderScanResult {
     run_folder_scan_worker_with_emit_and_cancel(
         request,
         move |event| events.emit(event),
         cancel.as_ref(),
+        lifecycle_generation,
         writer,
     )
 }
@@ -43,6 +45,7 @@ fn run_folder_scan_worker_with_emit(
         request,
         emit,
         &AtomicBool::new(false),
+        None,
         &UncoordinatedScanWriter,
     )
 }
@@ -51,6 +54,7 @@ fn run_folder_scan_worker_with_emit_and_cancel(
     request: FolderScanRequest,
     emit: impl Fn(FolderScanWorkerEvent) -> bool + Clone,
     cancel: &AtomicBool,
+    lifecycle_generation: Option<u64>,
     writer: &impl ScanWriter,
 ) -> PreparedFolderScanResult {
     let rating_decay_maintenance =
@@ -60,8 +64,12 @@ fn run_folder_scan_worker_with_emit_and_cancel(
             database_root: request.database_root.clone(),
             rating_decay_weeks: request.rating_decay_weeks,
         };
-    let mut discovery_transport =
-        FolderScanDiscoveryTransport::new(emit.clone(), request.task_id, request.source_id.clone());
+    let mut discovery_transport = FolderScanDiscoveryTransport::new(
+        emit.clone(),
+        request.task_id,
+        request.source_id.clone(),
+        lifecycle_generation,
+    );
     let scan = scan::scan_source_with_progress_cancellable(
         request,
         |progress| {
@@ -92,23 +100,33 @@ struct FolderScanDiscoveryTransport<Emit> {
     emit: Emit,
     task_id: u64,
     source_id: String,
+    lifecycle_generation: Option<u64>,
     pending: Vec<FolderScanDiscovery>,
+    pending_revision: Option<u64>,
+    next_sequence: u64,
 }
 
 impl<Emit> FolderScanDiscoveryTransport<Emit>
 where
     Emit: Fn(FolderScanWorkerEvent) -> bool,
 {
-    fn new(emit: Emit, task_id: u64, source_id: String) -> Self {
+    fn new(emit: Emit, task_id: u64, source_id: String, lifecycle_generation: Option<u64>) -> Self {
         Self {
             emit,
             task_id,
             source_id,
+            lifecycle_generation,
             pending: Vec::with_capacity(DISCOVERY_BATCH_SIZE),
+            pending_revision: None,
+            next_sequence: 0,
         }
     }
 
     fn push(&mut self, discovery: FolderScanDiscovery) {
+        if !self.pending.is_empty() && self.pending_revision != discovery.committed_revision {
+            self.flush();
+        }
+        self.pending_revision = discovery.committed_revision;
         self.pending.push(discovery);
         if self.pending.len() >= DISCOVERY_BATCH_SIZE {
             self.flush();
@@ -123,9 +141,14 @@ where
             FolderScanDiscoveryBatch {
                 task_id: self.task_id,
                 source_id: self.source_id.clone(),
+                committed_revision: self.pending_revision,
+                lifecycle_generation: self.lifecycle_generation,
+                sequence: self.next_sequence,
                 events: std::mem::take(&mut self.pending),
             },
         ));
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.pending_revision = None;
     }
 }
 
@@ -231,6 +254,21 @@ mod tests {
                 )
             })
             .count();
+        let first_discovery = events
+            .iter()
+            .position(|message| matches!(message, FolderScanWorkerEvent::DiscoveryBatch(_)))
+            .expect("large scan should publish a committed discovery batch");
+        assert!(
+            events
+                .iter()
+                .skip(first_discovery + 1)
+                .any(|message| matches!(
+                    message,
+                    FolderScanWorkerEvent::Progress(progress)
+                        if progress.detail.starts_with("Indexing | ")
+                )),
+            "committed discoveries must arrive before indexing completes"
+        );
         let batch_lengths = batches.iter().map(|batch| batch.len()).collect::<Vec<_>>();
         let published_file_count = batches
             .iter()
@@ -268,6 +306,7 @@ mod tests {
                 true
             },
             cancel.as_ref(),
+            None,
             &UncoordinatedScanWriter,
         );
 

--- a/src/native_app/app/state/source_scan_workflow.rs
+++ b/src/native_app/app/state/source_scan_workflow.rs
@@ -29,6 +29,7 @@ pub(in crate::native_app) struct SourceScanWorkflow {
     pending_targeted_syncs: BTreeMap<String, QueuedTargetedSourceSync>,
     active_targeted_syncs: BTreeMap<String, u64>,
     retry_counts: BTreeMap<String, u32>,
+    last_discovery_sequences: BTreeMap<String, (u64, u64)>,
 }
 
 pub(in crate::native_app) enum SourceFilesystemChangePlan {
@@ -95,6 +96,7 @@ impl SourceScanWorkflow {
             pending_targeted_syncs: BTreeMap::new(),
             active_targeted_syncs: BTreeMap::new(),
             retry_counts: BTreeMap::new(),
+            last_discovery_sequences: BTreeMap::new(),
         }
     }
 
@@ -245,6 +247,7 @@ impl SourceScanWorkflow {
 
     pub(in crate::native_app) fn start_scan(&mut self, request: &FolderScanRequest) {
         self.remove_pending_targeted_sync(&request.source_id);
+        self.last_discovery_sequences.remove(&request.source_id);
         let mut progress = FolderScanProgress::transition(
             request.task_id,
             request.source_id.clone(),
@@ -331,7 +334,40 @@ impl SourceScanWorkflow {
         browser: &mut FolderBrowserState,
         batch: FolderScanDiscoveryBatch,
     ) -> bool {
-        browser.apply_scan_discovered_batch(batch)
+        if batch.events.is_empty() || batch.events.len() > 64 {
+            return false;
+        }
+        let Some(progress) = self.progress.as_ref() else {
+            return false;
+        };
+        if progress.task_id != batch.task_id || progress.source_id != batch.source_id {
+            return false;
+        }
+        if progress.lifecycle_generation != batch.lifecycle_generation {
+            return false;
+        }
+        if batch.events.iter().any(|event| {
+            event.task_id != batch.task_id
+                || event.source_id != batch.source_id
+                || event.committed_revision != batch.committed_revision
+        }) {
+            return false;
+        }
+        match self.last_discovery_sequences.get(&batch.source_id) {
+            Some((task_id, sequence))
+                if *task_id != batch.task_id || batch.sequence != sequence.saturating_add(1) =>
+            {
+                return false;
+            }
+            None if batch.sequence != 0 => return false,
+            _ => {}
+        }
+        if !browser.apply_scan_discovered_batch(batch.clone()) {
+            return false;
+        }
+        self.last_discovery_sequences
+            .insert(batch.source_id, (batch.task_id, batch.sequence));
+        true
     }
 
     pub(in crate::native_app) fn plan_filesystem_change_for_generation(

--- a/src/native_app/app/state/source_scan_workflow/tests.rs
+++ b/src/native_app/app/state/source_scan_workflow/tests.rs
@@ -1294,6 +1294,9 @@ fn switching_away_parks_live_discoveries_from_an_active_scan() {
             FolderScanDiscoveryBatch {
                 task_id: event.task_id,
                 source_id: event.source_id.clone(),
+                committed_revision: event.committed_revision,
+                lifecycle_generation: None,
+                sequence: 0,
                 events: vec![event],
             },
         );

--- a/src/native_app/sample_library/folder_browser/scan_types.rs
+++ b/src/native_app/sample_library/folder_browser/scan_types.rs
@@ -171,6 +171,7 @@ pub(in crate::native_app) enum FolderScanItem {
 pub(in crate::native_app) struct FolderScanDiscovery {
     pub(in crate::native_app) task_id: u64,
     pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) committed_revision: Option<u64>,
     pub(in crate::native_app) parent_id: String,
     pub(in crate::native_app) item: FolderScanItem,
 }
@@ -179,6 +180,9 @@ pub(in crate::native_app) struct FolderScanDiscovery {
 pub(in crate::native_app) struct FolderScanDiscoveryBatch {
     pub(in crate::native_app) task_id: u64,
     pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) committed_revision: Option<u64>,
+    pub(in crate::native_app) lifecycle_generation: Option<u64>,
+    pub(in crate::native_app) sequence: u64,
     pub(in crate::native_app) events: Vec<FolderScanDiscovery>,
 }
 

--- a/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/discovery_merge.rs
@@ -112,6 +112,7 @@ mod tests {
         let event = FolderScanDiscovery {
             task_id: 1,
             source_id: String::from("source"),
+            committed_revision: None,
             parent_id: String::from("root"),
             item: FolderScanItem::ResetFolder,
         };

--- a/src/native_app/sample_library/folder_browser/scanning/metadata.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/metadata.rs
@@ -68,16 +68,6 @@ pub(super) fn source_rating_map(
     Ok((metadata, revision))
 }
 
-pub(super) fn source_browser_snapshot(
-    root: &Path,
-    database_root: &Path,
-) -> Result<BrowserMetadataSnapshot, SourceMetadataHydrationError> {
-    let db = SourceDatabase::open_for_ui_read_with_database_root(root, database_root)
-        .map_err(|error| SourceMetadataHydrationError::Open(error.to_string()))?;
-    db.browser_metadata_snapshot()
-        .map_err(|error| SourceMetadataHydrationError::Snapshot(error.to_string()))
-}
-
 pub(in crate::native_app::sample_library::folder_browser) fn file_entry_for_source_path(
     path: &PathBuf,
     source_root: &Path,

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     time::Instant,
@@ -16,21 +16,35 @@ use super::{
         },
     },
     entry::{BrowserEntryKind, classify_path_without_following},
-    file_entry_metadata::file_entry_with_snapshot_metadata,
-    metadata::{SourceMetadataMap, source_browser_snapshot},
+    file_entry_metadata::{file_entry_with_metadata, file_entry_with_snapshot_metadata},
+    metadata::SourceMetadataMap,
     traversal::placeholder_folder,
 };
-use wavecrate::sample_sources::{BrowserMetadataSnapshot, Rating, SourceDatabase};
+use wavecrate::sample_sources::{Rating, SourceDatabase};
+use wavecrate_library::sample_sources::BrowserFileMetadata;
 #[cfg(test)]
 use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
 use wavecrate_scan::{
     ScanStats, SourceTreeSnapshot,
-    sample_sources::scanner::{self, CommittedSourceDelta, ScanWritePhase, ScanWriter},
+    sample_sources::scanner::{
+        self, CommittedScanBatch, CommittedSourceDelta, ScanWritePhase, ScanWriter,
+    },
 };
 
 struct CommittedSourceTreeSnapshot {
     delta: CommittedSourceDelta,
     layout: SourceTreeSnapshot,
+}
+
+#[derive(Default)]
+struct ProvisionalDiscoveryState {
+    emitted_root: bool,
+}
+
+impl ProvisionalDiscoveryState {
+    fn clear(&mut self) {
+        self.emitted_root = false;
+    }
 }
 
 /// Publish at most one source-index progress update per bounded file batch.
@@ -60,13 +74,27 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
 ) -> FolderScanResult {
     let source_root_available =
         classify_path_without_following(&request.root) == Some(BrowserEntryKind::Directory);
+    let mut provisional = ProvisionalDiscoveryState::default();
     let (source_db_error, source_tree_snapshot) = if source_root_available {
-        sync_source_database(&request, &mut progress, cancel, writer)
+        sync_source_database(
+            &request,
+            &mut progress,
+            &mut discovered,
+            &mut provisional,
+            cancel,
+            writer,
+        )
     } else {
         (None, None)
     };
     let projection = if source_root_available && !cancel.load(Ordering::Acquire) {
-        build_committed_projection(&request, source_tree_snapshot)
+        build_committed_projection(
+            &request,
+            source_tree_snapshot,
+            &mut discovered,
+            &mut provisional,
+            cancel,
+        )
     } else {
         Err(String::from("source projection was not attempted"))
     };
@@ -79,12 +107,18 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
             },
             Some(committed_delta),
         ),
-        Err(error) if source_root_available && !cancel.load(Ordering::Acquire) => (
-            placeholder_folder(&request.root),
-            SourceMetadataMap::new(),
-            MetadataHydrationStatus::Failed { error },
-            None,
-        ),
+        Err(error) if source_root_available && !cancel.load(Ordering::Acquire) => {
+            if provisional.emitted_root {
+                discovered(reset_discovery(&request, None));
+                provisional.clear();
+            }
+            (
+                placeholder_folder(&request.root),
+                SourceMetadataMap::new(),
+                MetadataHydrationStatus::Failed { error },
+                None,
+            )
+        }
         Err(_) => (
             placeholder_folder(&request.root),
             SourceMetadataMap::new(),
@@ -92,7 +126,7 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
             None,
         ),
     };
-    let publish_discoveries = metadata_hydration.error().is_none();
+    let publish_discoveries = false;
     let mut scan = ScanProgressContext {
         request: &request,
         ratings,
@@ -105,6 +139,7 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
         discovered: &mut discovered,
         cancel,
         publish_discoveries,
+        committed_revision: committed_delta.as_ref().map(|delta| delta.revision),
     };
     scan.report_initial();
     publish_projection(&folder, &mut scan);
@@ -132,6 +167,8 @@ pub(in crate::native_app) fn scan_source_with_progress_cancellable(
 fn sync_source_database(
     request: &FolderScanRequest,
     progress: &mut impl FnMut(FolderScanProgress),
+    discovered: &mut impl FnMut(FolderScanDiscovery),
+    provisional: &mut ProvisionalDiscoveryState,
     cancel: &AtomicBool,
     writer: &impl ScanWriter,
 ) -> (Option<String>, Option<CommittedSourceTreeSnapshot>) {
@@ -150,6 +187,58 @@ fn sync_source_database(
         Err(err) => return (Some(format!("open source index: {err}")), None),
     };
     drop(_writer);
+    let mut publish_committed_batch = |batch: CommittedScanBatch| {
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
+        if !provisional.emitted_root {
+            discovered(reset_discovery(request, Some(batch.revision)));
+            provisional.emitted_root = true;
+        }
+        let mut folders = BTreeSet::new();
+        for path in &batch.paths {
+            let mut parent = path.parent().map(Path::to_path_buf);
+            while let Some(folder) = parent.filter(|path| !path.as_os_str().is_empty()) {
+                let next_parent = folder.parent().map(Path::to_path_buf);
+                folders.insert(folder);
+                parent = next_parent;
+            }
+        }
+        for folder in folders {
+            let absolute = request.root.join(&folder);
+            let parent = folder.parent().unwrap_or_else(|| Path::new(""));
+            let parent_absolute = if parent.as_os_str().is_empty() {
+                request.root.clone()
+            } else {
+                request.root.join(parent)
+            };
+            discovered(FolderScanDiscovery {
+                task_id: request.task_id,
+                source_id: request.source_id.clone(),
+                committed_revision: Some(batch.revision),
+                parent_id: path_id(&parent_absolute),
+                item: FolderScanItem::Folder(placeholder_folder(&absolute)),
+            });
+        }
+        for path in batch.paths {
+            let absolute = request.root.join(&path);
+            let parent = absolute.parent().unwrap_or(&request.root);
+            discovered(FolderScanDiscovery {
+                task_id: request.task_id,
+                source_id: request.source_id.clone(),
+                committed_revision: Some(batch.revision),
+                parent_id: path_id(parent),
+                item: FolderScanItem::File(file_entry_with_metadata(
+                    &absolute,
+                    Rating::NEUTRAL,
+                    false,
+                    Vec::new(),
+                    None,
+                    None,
+                )),
+            });
+        }
+    };
     let mut sync_progress = |completed: usize, path: &Path| {
         if completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL) {
             return;
@@ -164,15 +253,22 @@ fn sync_source_database(
             format!("Indexing | {}", path.display()),
         ));
     };
-    let stats = match scanner::scan_with_progress_and_writer(
+    let stats = match scanner::scan_with_progress_and_writer_and_committed_batch(
         &db,
         scanner::ScanMode::Quick,
         Some(cancel),
         &mut sync_progress,
+        &mut publish_committed_batch,
         writer,
     ) {
         Ok(stats) => stats,
-        Err(err) => return (Some(format!("sync source index: {err}")), None),
+        Err(err) => {
+            if !cancel.load(Ordering::Acquire) && provisional.emitted_root {
+                discovered(reset_discovery(request, None));
+                provisional.clear();
+            }
+            return (Some(format!("sync source index: {err}")), None);
+        }
     };
     let fallback_snapshot =
         stats
@@ -206,6 +302,16 @@ fn sync_source_database(
     }
 }
 
+fn reset_discovery(request: &FolderScanRequest, revision: Option<u64>) -> FolderScanDiscovery {
+    FolderScanDiscovery {
+        task_id: request.task_id,
+        source_id: request.source_id.clone(),
+        committed_revision: revision,
+        parent_id: path_id(&request.root),
+        item: FolderScanItem::ResetFolder,
+    }
+}
+
 #[derive(Default)]
 struct ProjectionFolder {
     children: Vec<PathBuf>,
@@ -215,6 +321,9 @@ struct ProjectionFolder {
 fn build_committed_projection(
     request: &FolderScanRequest,
     source_tree_snapshot: Option<CommittedSourceTreeSnapshot>,
+    discovered: &mut impl FnMut(FolderScanDiscovery),
+    provisional: &mut ProvisionalDiscoveryState,
+    cancel: &AtomicBool,
 ) -> Result<(FolderEntry, SourceMetadataMap, CommittedSourceDelta), String> {
     let started_at = Instant::now();
     let committed = source_tree_snapshot
@@ -231,15 +340,26 @@ fn build_committed_projection(
                 .join("; ")
         ));
     }
-    let BrowserMetadataSnapshot { revision, files } =
-        source_browser_snapshot(&request.root, &request.database_root)
+    let db =
+        SourceDatabase::open_for_ui_read_with_database_root(&request.root, &request.database_root)
             .map_err(|error| error.to_string())?;
-    if revision != committed.delta.revision {
-        return Err(format!(
-            "browser snapshot revision {revision} did not match authoritative traversal revision {}",
-            committed.delta.revision
-        ));
+    let revision = committed.delta.revision;
+    let mut files = Vec::new();
+    let mut cursor = None;
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            return Err(String::from("source projection canceled"));
+        }
+        let page = db
+            .browser_metadata_page(revision, cursor.as_deref(), 64)
+            .map_err(|error| error.to_string())?;
+        files.extend(page.files);
+        cursor = page.next_path;
+        if cursor.is_none() {
+            break;
+        }
     }
+    emit_authoritative_discoveries(request, &layout, &files, revision, discovered, provisional);
     let ratings = files
         .iter()
         .map(|entry| {
@@ -339,13 +459,109 @@ fn build_committed_projection(
         source_id = request.source_id,
         revision,
         filesystem_traversals = 1,
-        sqlite_snapshots = 1,
+        metadata_pages = (files.len().saturating_add(63)) / 64,
         folder_count,
         file_count,
         elapsed_ms = started_at.elapsed().as_millis(),
         "Built browser projection from committed source snapshot"
     );
     Ok((folder, ratings, committed.delta))
+}
+
+fn emit_authoritative_discoveries(
+    request: &FolderScanRequest,
+    layout: &SourceTreeSnapshot,
+    files: &[BrowserFileMetadata],
+    revision: u64,
+    discovered: &mut impl FnMut(FolderScanDiscovery),
+    provisional: &mut ProvisionalDiscoveryState,
+) {
+    if provisional.emitted_root {
+        return;
+    }
+    discovered(reset_discovery(request, Some(revision)));
+    provisional.emitted_root = true;
+    for folder in layout
+        .directories
+        .iter()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        let absolute = request.root.join(folder);
+        let parent = folder.parent().unwrap_or_else(|| Path::new(""));
+        let parent_absolute = if parent.as_os_str().is_empty() {
+            request.root.clone()
+        } else {
+            request.root.join(parent)
+        };
+        discovered(FolderScanDiscovery {
+            task_id: request.task_id,
+            source_id: request.source_id.clone(),
+            committed_revision: Some(revision),
+            parent_id: path_id(&parent_absolute),
+            item: FolderScanItem::Folder(placeholder_folder(&absolute)),
+        });
+        discovered(FolderScanDiscovery {
+            task_id: request.task_id,
+            source_id: request.source_id.clone(),
+            committed_revision: Some(revision),
+            parent_id: path_id(&absolute),
+            item: FolderScanItem::ResetFolder,
+        });
+    }
+    for entry in files.iter().filter(|entry| !entry.missing) {
+        let absolute = request.root.join(&entry.relative_path);
+        let parent = entry
+            .relative_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""));
+        let parent_absolute = if parent.as_os_str().is_empty() {
+            request.root.clone()
+        } else {
+            request.root.join(parent)
+        };
+        discovered(FolderScanDiscovery {
+            task_id: request.task_id,
+            source_id: request.source_id.clone(),
+            committed_revision: Some(revision),
+            parent_id: path_id(&parent_absolute),
+            item: FolderScanItem::File(file_entry_with_snapshot_metadata(
+                &absolute,
+                entry.file_size,
+                entry.rating,
+                entry.locked,
+                entry.collections.clone(),
+                entry.last_played_at,
+                entry.last_curated_at,
+            )),
+        });
+    }
+    for entry in &layout.other_files {
+        let absolute = request.root.join(&entry.relative_path);
+        let parent = entry
+            .relative_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""));
+        let parent_absolute = if parent.as_os_str().is_empty() {
+            request.root.clone()
+        } else {
+            request.root.join(parent)
+        };
+        discovered(FolderScanDiscovery {
+            task_id: request.task_id,
+            source_id: request.source_id.clone(),
+            committed_revision: Some(revision),
+            parent_id: path_id(&parent_absolute),
+            item: FolderScanItem::File(file_entry_with_snapshot_metadata(
+                &absolute,
+                entry.file_size,
+                Rating::NEUTRAL,
+                false,
+                Vec::new(),
+                None,
+                None,
+            )),
+        });
+    }
 }
 
 fn materialize_projection_folder(
@@ -395,6 +611,7 @@ where
     discovered: &'a mut D,
     cancel: &'a AtomicBool,
     publish_discoveries: bool,
+    committed_revision: Option<u64>,
 }
 
 impl<P, D> ScanProgressContext<'_, P, D>
@@ -422,6 +639,7 @@ where
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
+                committed_revision: self.committed_revision,
                 parent_id: parent_id.to_string(),
                 item: FolderScanItem::Folder(placeholder_folder(path)),
             });
@@ -433,6 +651,7 @@ where
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
+                committed_revision: self.committed_revision,
                 parent_id: folder_id.to_string(),
                 item: FolderScanItem::ResetFolder,
             });
@@ -447,6 +666,7 @@ where
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
+                committed_revision: self.committed_revision,
                 parent_id: parent_id.to_string(),
                 item: FolderScanItem::File(file),
             });

--- a/src/native_app/sample_library/folder_browser/scanning/progress.rs
+++ b/src/native_app/sample_library/folder_browser/scanning/progress.rs
@@ -195,6 +195,9 @@ fn sync_source_database(
             discovered(reset_discovery(request, Some(batch.revision)));
             provisional.emitted_root = true;
         }
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
         let mut folders = BTreeSet::new();
         for path in &batch.paths {
             let mut parent = path.parent().map(Path::to_path_buf);
@@ -205,6 +208,9 @@ fn sync_source_database(
             }
         }
         for folder in folders {
+            if cancel.load(Ordering::Acquire) {
+                return;
+            }
             let absolute = request.root.join(&folder);
             let parent = folder.parent().unwrap_or_else(|| Path::new(""));
             let parent_absolute = if parent.as_os_str().is_empty() {
@@ -221,6 +227,9 @@ fn sync_source_database(
             });
         }
         for path in batch.paths {
+            if cancel.load(Ordering::Acquire) {
+                return;
+            }
             let absolute = request.root.join(&path);
             let parent = absolute.parent().unwrap_or(&request.root);
             discovered(FolderScanDiscovery {
@@ -240,7 +249,9 @@ fn sync_source_database(
         }
     };
     let mut sync_progress = |completed: usize, path: &Path| {
-        if completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL) {
+        if cancel.load(Ordering::Acquire)
+            || (completed != 1 && !completed.is_multiple_of(INDEX_PROGRESS_REPORT_INTERVAL))
+        {
             return;
         }
         progress(FolderScanProgress::new(
@@ -351,15 +362,23 @@ fn build_committed_projection(
             return Err(String::from("source projection canceled"));
         }
         let page = db
-            .browser_metadata_page(revision, cursor.as_deref(), 64)
+            .browser_metadata_page(revision, cursor.as_ref(), 64)
             .map_err(|error| error.to_string())?;
         files.extend(page.files);
-        cursor = page.next_path;
+        cursor = page.next_cursor;
         if cursor.is_none() {
             break;
         }
     }
-    emit_authoritative_discoveries(request, &layout, &files, revision, discovered, provisional);
+    emit_authoritative_discoveries(
+        request,
+        &layout,
+        &files,
+        revision,
+        discovered,
+        provisional,
+        cancel,
+    );
     let ratings = files
         .iter()
         .map(|entry| {
@@ -475,8 +494,9 @@ fn emit_authoritative_discoveries(
     revision: u64,
     discovered: &mut impl FnMut(FolderScanDiscovery),
     provisional: &mut ProvisionalDiscoveryState,
+    cancel: &AtomicBool,
 ) {
-    if provisional.emitted_root {
+    if provisional.emitted_root || cancel.load(Ordering::Acquire) {
         return;
     }
     discovered(reset_discovery(request, Some(revision)));
@@ -486,6 +506,9 @@ fn emit_authoritative_discoveries(
         .iter()
         .filter(|path| !path.as_os_str().is_empty())
     {
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
         let absolute = request.root.join(folder);
         let parent = folder.parent().unwrap_or_else(|| Path::new(""));
         let parent_absolute = if parent.as_os_str().is_empty() {
@@ -500,6 +523,9 @@ fn emit_authoritative_discoveries(
             parent_id: path_id(&parent_absolute),
             item: FolderScanItem::Folder(placeholder_folder(&absolute)),
         });
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
         discovered(FolderScanDiscovery {
             task_id: request.task_id,
             source_id: request.source_id.clone(),
@@ -509,6 +535,9 @@ fn emit_authoritative_discoveries(
         });
     }
     for entry in files.iter().filter(|entry| !entry.missing) {
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
         let absolute = request.root.join(&entry.relative_path);
         let parent = entry
             .relative_path
@@ -536,6 +565,9 @@ fn emit_authoritative_discoveries(
         });
     }
     for entry in &layout.other_files {
+        if cancel.load(Ordering::Acquire) {
+            return;
+        }
         let absolute = request.root.join(&entry.relative_path);
         let parent = entry
             .relative_path
@@ -620,6 +652,9 @@ where
     D: FnMut(FolderScanDiscovery),
 {
     fn report_initial(&mut self) {
+        if self.cancel.load(Ordering::Acquire) {
+            return;
+        }
         (self.progress)(FolderScanProgress::new(
             self.request.task_id,
             self.request.source_id.clone(),
@@ -632,10 +667,13 @@ where
     }
 
     fn record_folder(&mut self, path: &Path, parent_id: &str) {
+        if self.cancel.load(Ordering::Acquire) {
+            return;
+        }
         self.counter.completed += 1;
         self.counter.folders += 1;
         self.maybe_report_progress(path);
-        if self.publish_discoveries {
+        if self.publish_discoveries && !self.cancel.load(Ordering::Acquire) {
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
@@ -647,7 +685,7 @@ where
     }
 
     fn record_folder_snapshot_start(&mut self, folder_id: &str) {
-        if self.publish_discoveries {
+        if self.publish_discoveries && !self.cancel.load(Ordering::Acquire) {
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
@@ -659,10 +697,13 @@ where
     }
 
     fn record_file(&mut self, path: &Path, parent_id: &str, file: FileEntry) {
+        if self.cancel.load(Ordering::Acquire) {
+            return;
+        }
         self.counter.completed += 1;
         self.counter.files += 1;
         self.maybe_report_progress(path);
-        if self.publish_discoveries {
+        if self.publish_discoveries && !self.cancel.load(Ordering::Acquire) {
             (self.discovered)(FolderScanDiscovery {
                 task_id: self.request.task_id,
                 source_id: self.request.source_id.clone(),
@@ -674,7 +715,9 @@ where
     }
 
     fn maybe_report_progress(&mut self, path: &Path) {
-        if self.counter.completed == 1 || self.counter.completed.is_multiple_of(64) {
+        if !self.cancel.load(Ordering::Acquire)
+            && (self.counter.completed == 1 || self.counter.completed.is_multiple_of(64))
+        {
             (self.progress)(FolderScanProgress::new(
                 self.request.task_id,
                 self.request.source_id.clone(),

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -410,18 +410,29 @@ impl FolderBrowserState {
     }
 
     pub(in crate::native_app) fn cancel_scan(&mut self, source_id: &str, task_id: u64) -> bool {
-        let Some(source) = self
+        let Some(source_index) = self
             .source
             .sources
-            .iter_mut()
-            .find(|source| source.id == source_id)
+            .iter()
+            .position(|source| source.id == source_id)
         else {
             return false;
         };
-        if source.loading_task != Some(task_id) {
+        if self.source.sources[source_index].loading_task != Some(task_id) {
             return false;
         }
-        source.loading_task = None;
+        let preserve_loaded_tree = self.source.selected_tree_loaded
+            && self.source.selected_source == source_id
+            || self.source.sources[source_index].parked_tree_loaded;
+        self.source.sources[source_index].loading_task = None;
+        if !preserve_loaded_tree {
+            self.source.sources[source_index].root_folder = None;
+            self.source.sources[source_index].parked_tree_loaded = false;
+            if self.source.selected_source == source_id {
+                let root = self.source.sources[source_index].root.clone();
+                self.tree.folders = vec![placeholder_folder(&root)];
+            }
+        }
         true
     }
 
@@ -471,6 +482,9 @@ impl FolderBrowserState {
         self.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
             task_id: event.task_id,
             source_id: event.source_id.clone(),
+            committed_revision: event.committed_revision,
+            lifecycle_generation: None,
+            sequence: 0,
             events: vec![event],
         })
     }
@@ -479,6 +493,9 @@ impl FolderBrowserState {
         &mut self,
         batch: FolderScanDiscoveryBatch,
     ) -> bool {
+        if batch.events.is_empty() || batch.events.len() > 64 {
+            return false;
+        }
         let selected_source = self.source.selected_source == batch.source_id;
         let preserve_selected_tree = selected_source && self.source.selected_tree_loaded;
         let Some(source) = self
@@ -490,6 +507,19 @@ impl FolderBrowserState {
             return false;
         };
         if source.loading_task != Some(batch.task_id) {
+            return false;
+        }
+        if batch.events.iter().any(|event| {
+            event.task_id != batch.task_id
+                || event.source_id != batch.source_id
+                || event.committed_revision != batch.committed_revision
+        }) {
+            return false;
+        }
+        if let (Some(current), Some(incoming)) =
+            (source.projection_revision, batch.committed_revision)
+            && incoming < current
+        {
             return false;
         }
         if preserve_selected_tree || (!selected_source && source.root_folder.is_some()) {

--- a/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/tests/filesystem_refresh.rs
@@ -552,6 +552,11 @@ fn reselecting_loaded_source_reconciles_disk_without_clearing_cached_tree() {
         !browser.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
             task_id: 95,
             source_id: source_id.clone(),
+            committed_revision: discoveries
+                .first()
+                .and_then(|event| event.committed_revision),
+            lifecycle_generation: None,
+            sequence: 0,
             events: discoveries,
         }),
         "background discoveries must not mutate a fully loaded selected tree"

--- a/src/native_app/sample_library/folder_browser/tests/mod.rs
+++ b/src/native_app/sample_library/folder_browser/tests/mod.rs
@@ -7,7 +7,7 @@ use crate::native_app::sample_library::folder_browser::commands::{
 };
 use crate::native_app::sample_library::folder_browser::scan::{
     FolderScanDiscoveryBatch, FolderTreeRefreshRequest, refresh_folder_tree_only,
-    scan_source_with_progress,
+    scan_source_with_progress, scan_source_with_progress_cancellable,
 };
 use crate::native_app::sample_library::folder_browser::test_support::{
     FolderDragPreview, MIN_FILE_COLUMN_WIDTH,

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::native_app::app::BrowserProjectionDelta;
 use crate::native_app::sample_library::folder_browser::model::file_entry_with_snapshot_metadata;
 use crate::native_app::sample_library::folder_browser::scan_types::{
-    FolderScanItem, MetadataHydrationStatus,
+    FolderScanDiscovery, FolderScanItem, MetadataHydrationStatus,
 };
 
 #[test]
@@ -507,13 +507,32 @@ fn batched_scan_discoveries_clone_selected_tree_once_per_batch() {
         discovery_events.first().map(|event| &event.item),
         Some(FolderScanItem::ResetFolder)
     ));
-    assert!(
-        browser.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
-            task_id: 88,
-            source_id: path_id(&root),
-            events: discovery_events,
-        })
-    );
+    let mut batches = Vec::<Vec<FolderScanDiscovery>>::new();
+    for event in discovery_events {
+        if batches
+            .last()
+            .and_then(|batch| batch.first())
+            .is_some_and(|first| first.committed_revision != event.committed_revision)
+        {
+            batches.push(Vec::new());
+        }
+        if batches.is_empty() {
+            batches.push(Vec::new());
+        }
+        batches.last_mut().expect("batch").push(event);
+    }
+    for (sequence, events) in batches.into_iter().enumerate() {
+        assert!(
+            browser.apply_scan_discovered_batch(FolderScanDiscoveryBatch {
+                task_id: 88,
+                source_id: path_id(&root),
+                committed_revision: events.first().and_then(|event| event.committed_revision),
+                lifecycle_generation: None,
+                sequence: sequence as u64,
+                events,
+            })
+        );
+    }
     browser.activate_folder(path_id(&drums));
     assert_eq!(browser.selected_audio_files().len(), 2);
 

--- a/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
+++ b/src/native_app/sample_library/folder_browser/tests/source_scanning.rs
@@ -4,6 +4,40 @@ use crate::native_app::sample_library::folder_browser::model::file_entry_with_sn
 use crate::native_app::sample_library::folder_browser::scan_types::{
     FolderScanDiscovery, FolderScanItem, MetadataHydrationStatus,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[test]
+fn committed_discovery_emission_stops_at_the_cancellation_boundary() {
+    let root = temp_source_root("wavecrate-gui-source-cancelled-discovery");
+    for index in 0..96 {
+        fs::write(root.join(format!("sample-{index:03}.wav")), [0_u8; 8]).expect("write sample");
+    }
+    let mut browser = FolderBrowserState::load_default();
+    let request = browser
+        .begin_add_source_path(root.clone(), 89)
+        .expect("new source should request scan");
+    let cancel = AtomicBool::new(false);
+    let mut discovery_events = Vec::new();
+
+    let result = scan_source_with_progress_cancellable(
+        request,
+        |_| {},
+        |event| {
+            discovery_events.push(event);
+            cancel.store(true, Ordering::Release);
+        },
+        &cancel,
+        &wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter,
+    );
+
+    assert!(result.cancelled);
+    assert_eq!(
+        discovery_events.len(),
+        1,
+        "a cancellation raised by the first committed discovery must fence every later event"
+    );
+    let _ = fs::remove_dir_all(root);
+}
 
 #[test]
 fn switching_away_from_pending_source_does_not_cache_its_placeholder() {

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -149,6 +149,7 @@ impl NativeAppState {
                             request,
                             events,
                             cancel,
+                            None,
                             &UncoordinatedScanWriter,
                         );
                     };
@@ -184,6 +185,7 @@ impl NativeAppState {
                                 request,
                                 events,
                                 cancel,
+                                None,
                                 &UncoordinatedScanWriter,
                             );
                         }
@@ -220,13 +222,20 @@ impl NativeAppState {
                             request,
                             events,
                             cancel,
+                            Some(generation),
                             &UncoordinatedScanWriter,
                         );
                     };
                     let cancel = permit.cancel_token();
                     let scan_writer = permit.scan_writer();
                     let completion_events = events.clone();
-                    let mut result = run_folder_scan_worker(request, events, cancel, &scan_writer);
+                    let mut result = run_folder_scan_worker(
+                        request,
+                        events,
+                        cancel,
+                        Some(generation),
+                        &scan_writer,
+                    );
                     result.lifecycle_generation = Some(generation);
                     if result.scan.cancelled {
                         emit_lifecycle(
@@ -266,6 +275,7 @@ impl NativeAppState {
                             recovery_request,
                             recovery_events,
                             cancel,
+                            recovery_generation.get(),
                             &UncoordinatedScanWriter,
                         );
                         recovery.lifecycle_generation = recovery_generation.get();


### PR DESCRIPTION
## Goal
Stream generation-fenced browser discoveries from native source scans before authoritative projection materialization.

## Scope and non-goals
- Add exact-revision, raw-cursor-paged browser metadata reads.
- Publish committed scan batches with task/source/revision/lifecycle/sequence fences.
- Apply bounded discovery batches incrementally while preserving the last loaded tree during refresh.
- Keep final authoritative projection and deterministic ordering.
- Bound large-path deferred-rename manifest queries.
- No uncommitted facts become authoritative; no UI-thread filesystem or SQLite work; no redesign of scan ordering.

## Definition of Done
- New scans show bounded discovery batches before terminal indexing work completes.
- Cancellation, source switching/replacement, stale lifecycle generations, and revision mismatches cannot mutate the active projection.
- Final projection remains authoritative and converges to the same contents/order.
- Large source transport and manifest work remain bounded.

## Validation
- cargo test -p wavecrate-library browser_metadata -- --nocapture — 5 passed.
- cargo test -p wavecrate-scan --all-targets — 188 passed.
- cargo test -p wavecrate --lib source_scan_ -- --nocapture — 59 passed.
- cargo test -p wavecrate --lib filesystem_refresh -- --nocapture — 28 passed.
- CARGO_INCREMENTAL=0 cargo check -p wavecrate --bin wavecrate — passed.
- cargo fmt --all -- --check — passed.
- git diff --check — passed.
- bash scripts/ci.sh agent reached the repository-wide Radiant suite but stopped on the pre-existing Radiant shader assertion gpu_signal_shader_keeps_waveform_bands_visually_distinct.
- Broader native-library baseline: 454/456; unrelated existing failures remain in the starmap preview candidate and root facade stability tests.

## Known limitations
Runtime RSS/frame responsiveness profiling is not included in this change; focused transport bounds, cancellation, and ordering tests are included.

User approval is required before merge.