### PR TITLE
fix(scan): persist signed pre-epoch filesystem timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6261,6 +6261,7 @@ dependencies = [
  "blake3",
  "cap-fs-ext",
  "cap-std",
+ "filetime",
  "libc",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/wavecrate-scan/Cargo.toml
+++ b/crates/wavecrate-scan/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "2.0.17"
 tracing = "0.1.41"
 
 [dev-dependencies]
+filetime = "0.2.26"
 tempfile = "3.23.0"
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests.rs
@@ -12,6 +12,7 @@ mod index_entries;
 mod rename_reconciliation;
 mod rename_retention;
 mod targeted_sync;
+mod timestamps;
 
 #[cfg(unix)]
 fn set_file_times(path: &Path, seconds: i64, nanos: i64) {

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/timestamps.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/timestamps.rs
@@ -1,0 +1,70 @@
+use super::*;
+use crate::sample_sources::scanner::sync_paths;
+use std::path::Path;
+
+#[cfg(any(unix, windows))]
+#[test]
+fn pre_epoch_timestamps_persist_for_full_rescan_and_targeted_sync() {
+    let directory = tempdir().unwrap();
+    let supported = Path::new("supported.wav");
+    let index_only = Path::new("notes.txt");
+    let supported_path = directory.path().join(supported);
+    let index_only_path = directory.path().join(index_only);
+    std::fs::write(&supported_path, b"wav").unwrap();
+    std::fs::write(&index_only_path, b"notes").unwrap();
+
+    let initial_mtime = filetime::FileTime::from_unix_time(-1, 0);
+    filetime::set_file_mtime(&supported_path, initial_mtime).unwrap();
+    filetime::set_file_mtime(&index_only_path, initial_mtime).unwrap();
+
+    let database = SourceDatabase::open_for_scan(directory.path()).unwrap();
+    scan_once(&database).unwrap();
+    assert_persisted_timestamp(&database, supported, index_only, -1_000_000_000);
+
+    let no_change = scan_once(&database).unwrap();
+    assert_eq!(no_change.content_changed, 0);
+    assert_persisted_timestamp(&database, supported, index_only, -1_000_000_000);
+
+    let targeted_mtime = filetime::FileTime::from_unix_time(-2, 0);
+    filetime::set_file_mtime(&supported_path, targeted_mtime).unwrap();
+    filetime::set_file_mtime(&index_only_path, targeted_mtime).unwrap();
+    sync_paths(
+        &database,
+        &[supported.to_path_buf(), index_only.to_path_buf()],
+    )
+    .unwrap();
+    assert_persisted_timestamp(&database, supported, index_only, -2_000_000_000);
+}
+
+#[cfg(any(unix, windows))]
+fn assert_persisted_timestamp(
+    database: &SourceDatabase,
+    supported: &Path,
+    index_only: &Path,
+    expected_modified_ns: i64,
+) {
+    assert_eq!(
+        database
+            .entry_for_path(supported)
+            .unwrap()
+            .expect("supported file manifest entry")
+            .modified_ns,
+        expected_modified_ns
+    );
+    assert_eq!(
+        database
+            .list_source_index_entries()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.relative_path == index_only)
+            .expect("index-only file entry")
+            .modified_ns,
+        Some(expected_modified_ns)
+    );
+}
+
+#[cfg(not(any(unix, windows)))]
+#[test]
+fn pre_epoch_filetime_integration_is_explicitly_unsupported() {
+    assert!(!cfg!(unix));
+}

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -525,11 +525,7 @@ fn source_index_entry(
         ));
     }
     let modified = metadata.modified()?;
-    let modified_ns = modified
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos()
-        .min(i64::MAX as u128) as i64;
+    let modified_ns = system_time_to_unix_nanos(modified);
     if let Some(entry) = index_entry_from_file_facts(
         relative_path.to_path_buf(),
         classification,
@@ -627,13 +623,11 @@ pub(super) fn read_facts(root: &Path, path: &Path) -> Result<FileFacts, ScanErro
         path: path.to_path_buf(),
         source,
     })?;
-    let modified_ns = to_nanos(
-        &meta.modified().map_err(|source| ScanError::Io {
+    let modified_ns =
+        system_time_to_unix_nanos(meta.modified().map_err(|source| ScanError::Io {
             path: path.to_path_buf(),
             source,
-        })?,
-        path,
-    )?;
+        })?);
     Ok(FileFacts {
         relative,
         size: meta.len(),
@@ -665,13 +659,11 @@ pub(super) fn read_facts_from_open_file(
         path: path.to_path_buf(),
         source,
     })?;
-    let modified_ns = to_nanos(
-        &meta.modified().map_err(|source| ScanError::Io {
+    let modified_ns =
+        system_time_to_unix_nanos(meta.modified().map_err(|source| ScanError::Io {
             path: path.to_path_buf(),
             source,
-        })?,
-        path,
-    )?;
+        })?);
     Ok(FileFacts {
         relative,
         size: meta.len(),
@@ -806,13 +798,31 @@ fn strip_relative(root: &Path, path: &Path) -> Result<PathBuf, ScanError> {
     Err(ScanError::InvalidRoot(path.to_path_buf()))
 }
 
-fn to_nanos(time: &SystemTime, path: &Path) -> Result<i64, ScanError> {
-    let duration = time
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| ScanError::Time {
-            path: path.to_path_buf(),
-        })?;
-    Ok(duration.as_nanos().min(i64::MAX as u128) as i64)
+/// Convert a filesystem timestamp to the signed nanoseconds stored by the scanner.
+///
+/// The conversion preserves every representable nanosecond, including values before
+/// the Unix epoch, and clamps timestamps outside the signed `i64` range.
+fn system_time_to_unix_nanos(time: SystemTime) -> i64 {
+    const NANOS_PER_SECOND: u128 = 1_000_000_000;
+    const MIN_MAGNITUDE: u128 = i64::MAX as u128 + 1;
+
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => {
+            let nanos = u128::from(duration.as_secs()) * NANOS_PER_SECOND
+                + u128::from(duration.subsec_nanos());
+            nanos.min(i64::MAX as u128) as i64
+        }
+        Err(error) => {
+            let duration = error.duration();
+            let nanos = u128::from(duration.as_secs()) * NANOS_PER_SECOND
+                + u128::from(duration.subsec_nanos());
+            if nanos >= MIN_MAGNITUDE {
+                i64::MIN
+            } else {
+                -(nanos as i64)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -820,6 +830,49 @@ mod tests {
     use super::*;
     use std::io;
     use std::sync::atomic::AtomicBool;
+
+    #[test]
+    fn system_time_to_unix_nanos_preserves_epoch_and_negative_nanoseconds() {
+        assert_eq!(system_time_to_unix_nanos(UNIX_EPOCH), 0);
+        assert_eq!(
+            system_time_to_unix_nanos(UNIX_EPOCH - std::time::Duration::from_nanos(1)),
+            -1
+        );
+        assert_eq!(
+            system_time_to_unix_nanos(UNIX_EPOCH + std::time::Duration::from_nanos(1)),
+            1
+        );
+    }
+
+    #[test]
+    fn system_time_to_unix_nanos_preserves_exact_i64_bounds() {
+        let max = UNIX_EPOCH + std::time::Duration::from_nanos(i64::MAX as u64);
+        let min = UNIX_EPOCH - std::time::Duration::from_nanos(i64::MAX as u64 + 1);
+
+        assert_eq!(system_time_to_unix_nanos(min), i64::MIN);
+        assert_eq!(system_time_to_unix_nanos(max), i64::MAX);
+    }
+
+    #[test]
+    fn system_time_to_unix_nanos_saturates_both_overflow_directions() {
+        let above_max = UNIX_EPOCH + std::time::Duration::from_nanos(i64::MAX as u64 + 1);
+        let below_min = UNIX_EPOCH - std::time::Duration::from_nanos(i64::MAX as u64 + 2);
+
+        assert_eq!(system_time_to_unix_nanos(above_max), i64::MAX);
+        assert_eq!(system_time_to_unix_nanos(below_min), i64::MIN);
+    }
+
+    #[test]
+    fn system_time_to_unix_nanos_orders_timestamps_across_zero() {
+        let before = system_time_to_unix_nanos(UNIX_EPOCH - std::time::Duration::from_nanos(1));
+        let epoch = system_time_to_unix_nanos(UNIX_EPOCH);
+        let after = system_time_to_unix_nanos(UNIX_EPOCH + std::time::Duration::from_nanos(1));
+
+        assert!(before < epoch);
+        assert!(epoch < after);
+        assert_eq!(before + 1, epoch);
+        assert_eq!(epoch + 1, after);
+    }
 
     struct CancelingReader {
         remaining: usize,

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -1331,6 +1331,8 @@ Every scanner content-hash path, including full scans, periodic content audits, 
 
 On platforms that expose raw non-Unicode filenames, scanner classification must not let one such entry abort publication for the surrounding source. Supported audio with a non-Unicode relative path remains outside the normal sample manifest and is retained as a typed, lossless index-only diagnostic; other index-only classifications use the same lossless path identity. The encoding must preserve distinct raw names, round-trip across restart, and remain consistent for full scans, targeted sync, deletion, rename, and browser/index projections. Existing Unicode source paths retain their current readable database representation.
 
+Filesystem modification timestamps persisted by the scanner use signed Unix nanoseconds in the existing `i64` database units. Exact pre-epoch values, including nanoseconds immediately before the epoch, remain negative and preserve ordering across zero; timestamps outside the representable range saturate deterministically to `i64::MIN` or `i64::MAX`. Full scans, targeted scans, index-only entries, and descriptor revalidation share this conversion contract.
+
 The final scanner should not silently impose arbitrary product limits on folder depth, number of child folders, or number of files per source. Any defensive scan limit used to protect responsiveness should be explicit, configurable where practical, logged, and visible as a partial-scan warning with a clear rescan or settings path.
 
 The scanner should classify discovered files as:


### PR DESCRIPTION
## Goal

Fix scanner timestamp persistence so filesystem modification times before the Unix epoch are represented consistently as signed nanoseconds.

## Scope and non-goals

- Centralize scanner `SystemTime` conversion for manifest and source-index facts.
- Preserve exact in-range negative nanoseconds and saturate outside the `i64` range.
- Cover full scans, targeted scans, index-only entries, and descriptor revalidation through the shared facts path.
- Add boundary, ordering, and pre-epoch filetime regression coverage.
- Document the durable signed-nanosecond contract.
- No SQLite schema/unit changes, filesystem timestamp rewriting, timezone handling, or timestamp-only content identity changes.

## Definition of Done

- Epoch and pre-epoch timestamps persist as signed nanoseconds.
- Exact `i64` bounds and deterministic overflow saturation are covered.
- Full and targeted manifest/index paths converge without rejecting pre-epoch files.
- Existing ordinary timestamp and changed-file behavior remains green.

## Validation

- `cargo test -p wavecrate-scan --all-targets` — 193 passed.
- `cargo test -p wavecrate-library --all-targets` — 282 unit tests passed plus process-boundary coverage passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `bash scripts/ci.sh agent` — baseline failure in unrelated Radiant visual-shader test `gpu_signal_shader_keeps_waveform_bands_visually_distinct`; Wavecrate package tests passed.

## Known limitations

Windows execution was not available locally; the filetime integration test is gated for Unix and Windows, with a deterministic unit-test contract on other platforms.

User approval is required before merge.