### PR TITLE
fix(scan): publish manifest-audit progress after durable checkpoint

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/context.rs
@@ -277,6 +277,12 @@ impl ScanContext {
             .is_some_and(|audit| audit.pending.len() >= MANIFEST_AUDIT_CHECKPOINT_SIZE)
     }
 
+    pub(in crate::sample_sources::scanner) fn manifest_audit_checkpoint_pending(&self) -> bool {
+        self.manifest_audit
+            .as_ref()
+            .is_some_and(|audit| !audit.pending.is_empty() || !audit.revalidated_pending.is_empty())
+    }
+
     pub(in crate::sample_sources::scanner) fn discard_manifest_audit_paths(
         &mut self,
         paths: impl IntoIterator<Item = PathBuf>,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -681,6 +681,35 @@ fn interrupted_manifest_audit_resumes_checked_paths_and_finishes_deletion_reconc
 }
 
 #[test]
+fn manifest_audit_progress_is_published_after_durable_checkpoint() {
+    let dir = tempdir().unwrap();
+    let relative = Path::new("missed.wav");
+    std::fs::write(dir.path().join(relative), b"missed watcher file").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    let mut progress = Vec::new();
+
+    audit_source_and_record_with_progress(&db, None, 0, 100, &mut |checked, path| {
+        let (checkpointed_paths, persisted_checked) = db
+            .begin_or_resume_manifest_audit_batch(101, usize::MAX)
+            .expect("read the checkpoint while publishing progress");
+        progress.push((
+            checked,
+            persisted_checked,
+            path.to_path_buf(),
+            checkpointed_paths,
+        ));
+    })
+    .expect("manifest audit should complete");
+
+    assert_eq!(progress.len(), 1);
+    let (checked, persisted_checked, path, checkpointed_paths) = &progress[0];
+    assert_eq!(*checked, 1);
+    assert_eq!(*persisted_checked, 1);
+    assert_eq!(path, relative);
+    assert_eq!(checkpointed_paths, &vec![relative.to_path_buf()]);
+}
+
+#[test]
 fn interrupted_manifest_audit_revalidates_a_checkpointed_file() {
     use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_walk.rs
@@ -40,6 +40,7 @@ pub(super) fn walk_phase(
     let committed = Cell::new(false);
     let mut pending = Vec::with_capacity(APPLY_BATCH_SIZE);
     let mut pending_noops = Vec::with_capacity(APPLY_BATCH_SIZE);
+    let mut last_manifest_audit_path = None::<std::path::PathBuf>;
     let source_tree_snapshot = visit_dir_with_cancel_check(
         source_root,
         root,
@@ -98,22 +99,27 @@ pub(super) fn walk_phase(
             }
             if !prepared.requires_apply {
                 if context.resumable_manifest_audit_active() {
+                    last_manifest_audit_path = Some(path.to_path_buf());
                     context.record_manifest_audit_paths([relative_path]);
                     pending_noops.push(prepared);
                     if context.manifest_audit_checkpoint_due() {
-                        flush_manifest_audit_checkpoint_with_noops(
+                        checkpoint_manifest_audit_with_progress(
                             db,
                             root,
                             &source_root,
                             context,
                             &mut pending_noops,
+                            Some(path),
+                            on_progress,
                         )?;
                     }
                 } else {
                     skip_noop(context, &prepared);
                 }
-                publish_manifest_audit_progress(context, root, path, on_progress);
                 return Ok(());
+            }
+            if context.resumable_manifest_audit_active() {
+                last_manifest_audit_path = Some(path.to_path_buf());
             }
             pending.push(prepared);
             if pending.len() == APPLY_BATCH_SIZE {
@@ -135,21 +141,16 @@ pub(super) fn walk_phase(
                 let last_path = outcome.audited_paths.last().cloned();
                 context.record_manifest_audit_paths(outcome.audited_paths);
                 if context.manifest_audit_checkpoint_due() {
-                    flush_manifest_audit_checkpoint_with_noops(
+                    let progress_path = last_path.map(|path| root.join(path));
+                    checkpoint_manifest_audit_with_progress(
                         db,
                         root,
                         &source_root,
                         context,
                         &mut pending_noops,
-                    )?;
-                }
-                if let Some(last_path) = last_path {
-                    publish_manifest_audit_progress(
-                        context,
-                        root,
-                        &root.join(last_path),
+                        progress_path.as_deref(),
                         on_progress,
-                    );
+                    )?;
                 }
             }
             Ok(())
@@ -172,20 +173,29 @@ pub(super) fn walk_phase(
         }
         let last_path = outcome.audited_paths.last().cloned();
         context.record_manifest_audit_paths(outcome.audited_paths);
-        if let Some(last_path) = last_path {
-            publish_manifest_audit_progress(context, root, &root.join(last_path), on_progress);
-        }
+        let progress_path = last_path.map(|path| root.join(path));
+        checkpoint_manifest_audit_with_progress(
+            db,
+            root,
+            &source_root,
+            context,
+            &mut pending_noops,
+            progress_path.as_deref(),
+            on_progress,
+        )?;
     }
     context.mark_uncertain_prefixes(source_tree_snapshot.uncertain_prefixes.clone());
     if !context.has_uncertain_prefixes() {
         context.complete_missing_manifest_audit_paths();
     }
-    flush_manifest_audit_checkpoint_with_noops(
+    checkpoint_manifest_audit_with_progress(
         db,
         root,
         &source_root,
         context,
         &mut pending_noops,
+        last_manifest_audit_path.as_deref(),
+        on_progress,
     )?;
     context.observe_index_entries(source_tree_snapshot.index_entries.clone());
     context.stats.source_tree_snapshot =
@@ -220,6 +230,25 @@ fn flush_manifest_audit_checkpoint_with_noops(
         pending_noops,
         |_| {},
     )
+}
+
+fn checkpoint_manifest_audit_with_progress(
+    db: &SourceDatabase,
+    root: &Path,
+    source_root: &SourceRootCapability,
+    context: &mut ScanContext,
+    pending_noops: &mut Vec<PreparedFile>,
+    progress_path: Option<&Path>,
+    on_progress: &mut Option<&mut dyn FnMut(usize, &Path)>,
+) -> Result<(), ScanError> {
+    let checkpoint_pending = context.manifest_audit_checkpoint_pending();
+    flush_manifest_audit_checkpoint_with_noops(db, root, source_root, context, pending_noops)?;
+    if checkpoint_pending {
+        if let Some(progress_path) = progress_path {
+            publish_manifest_audit_progress(context, root, progress_path, on_progress);
+        }
+    }
+    Ok(())
 }
 
 fn flush_manifest_audit_checkpoint_with_noops_hook(


### PR DESCRIPTION
## Goal
Ensure manifest-audit progress describes only durably checkpointed, resumable audit state. A one-file missed-watcher repair reports 1/1 instead of 0/0.

## Scope and non-goals
- Route periodic and final manifest-audit checkpoints through one checkpoint-then-progress path.
- Keep ordinary scan progress, audit cadence, watcher/FSEvents behavior, schema, containment, cancellation, incomplete-audit handling, and browser policy unchanged.

## Definition of Done
- Newly repaired and revalidated audit work publishes progress only after its durable checkpoint.
- Counts remain monotonic and do not lead persisted checkpoint state.
- Existing periodic browser-projection lifecycle coverage passes unchanged.

## Validation
- `cargo test -p wavecrate-scan` — 194 passed, 0 failed.
- `cargo test -p wavecrate-scan manifest_audit` — 11 passed, 0 failed.
- `cargo test -p wavecrate manifest_audit` — 7 passed, 0 failed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Known limitations
None.

User approval is required before merge.