### PR TITLE
fix(scan): reconcile source after similarity layout

### DIFF
--- a/src/native_app/source_processing/supervisor/coordinator_completion.rs
+++ b/src/native_app/source_processing/supervisor/coordinator_completion.rs
@@ -222,7 +222,8 @@ pub(super) fn handle_completion(
             RuntimeTask::Readiness(ReadinessTarget {
                 stage: ReadinessStage::IndexedIdentity
                     | ReadinessStage::AnalysisFeatures
-                    | ReadinessStage::EmbeddingAspects,
+                    | ReadinessStage::EmbeddingAspects
+                    | ReadinessStage::SimilarityLayout,
                 ..
             }),
             Some(ExecutionOutcome::Completed),

--- a/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
@@ -157,6 +157,74 @@ fn completion_from_removed_lifecycle_cannot_mutate_readded_source_state() {
 }
 
 #[test]
+fn final_similarity_layout_completion_wakes_durable_reconciliation() {
+    let directory = tempfile::tempdir().expect("temporary source");
+    let source = SampleSource::new_with_id(
+        SourceId::from_string("similarity-layout-refresh-source"),
+        directory.path().to_path_buf(),
+    );
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let shared = Arc::new(Shared::new(vec![source.clone()], Some(Arc::new(sender))));
+    let cancel = shared.control().source_work_cancels[source.id.as_str()].clone();
+    let in_flight = shared
+        .begin_in_flight_work(source.id.as_str(), &cancel)
+        .expect("begin similarity layout work");
+    let lifecycle_generation = in_flight.lifecycle_generation;
+    let target = ReadinessTarget::source(
+        source.id.as_str(),
+        ReadinessStage::SimilarityLayout,
+        "layout-v1",
+        1,
+        "layout-generation-1",
+    );
+    let candidate = RuntimeCandidate {
+        schedule: WorkCandidate::readiness(&target, 1),
+        source: source.clone(),
+        task: RuntimeTask::Readiness(target),
+    };
+    let permit = shared
+        .budgets()
+        .try_acquire(source.id.as_str(), ProcessingLane::Finalization)
+        .expect("reserve finalization budget");
+    let mut candidates = Vec::new();
+    let mut source_stats = BTreeMap::new();
+    let mut state = CoordinatorExecutionState {
+        next_retry_at: None,
+        pending_similarity_refresh_lifecycles: BTreeSet::new(),
+        last_similarity_refresh_publish_at: None,
+        active_progress_source: None,
+        last_progress_publish_at: None,
+        progress_visible: true,
+    };
+
+    handle_completion(
+        &shared,
+        &mut candidates,
+        &mut source_stats,
+        &mut state,
+        ExecutionResult {
+            candidate,
+            permit,
+            lifecycle_generation,
+            result: Ok(ExecutionOutcome::Completed),
+            elapsed_ms: 1.0,
+            in_flight,
+        },
+    );
+
+    let control = shared.control();
+    assert!(
+        control
+            .dirty_sources
+            .contains(source.id.as_str()),
+        "final similarity layout completion must request a fresh durable snapshot"
+    );
+    assert_eq!(control.wake_reason, "source_stage_progress");
+    drop(control);
+    assert!(receiver.try_recv().is_err());
+}
+
+#[test]
 fn lifecycle_fence_remains_held_until_event_delivery_finishes() {
     #[derive(Default)]
     struct BlockingSink {


### PR DESCRIPTION
## Goal
Ensure a source cannot retain sidebar `(processing)` after its final `SimilarityLayout` work succeeds and global activity becomes idle.

## Scope and non-goals
- Include successful `SimilarityLayout` completions in the existing lifecycle-fenced durable source reconciliation wake path.
- Preserve durable health publication, lifecycle identity, cancellation, source replacement fences, coalescing, retained-source behavior, and lock ordering.
- No new lifecycle state machine, schema migration, scheduler/lease redesign, similarity algorithm change, UI copy redesign, direct UI writes, or supervisor decomposition.

## Definition of Done
- Final `SimilarityLayout` completion marks the current source dirty so durable rediscovery can publish terminal health before `Completed` becomes observable.
- Stale lifecycle completions remain fenced from removed/re-added sources.
- Failure and deferred outcomes remain truthful and no rediscovery loop is introduced.
- Regression coverage protects the final-layout dirty wake and existing browser progress/health behavior.

## Validation
- `cargo fmt --all -- --check` — pass.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests::final_similarity_layout_completion_wakes_durable_reconciliation --no-default-features -- --exact` — pass.
- `cargo test -p wavecrate --lib native_app::shell::message_dispatch::tests::source_processing_progress_opens_the_shared_job_details_popover --no-default-features -- --exact` — pass (progress clears while terminal health remains).
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests --no-default-features` — 98 passed, 1 ignored, 1 unrelated timing failure; exact rerun of `readiness_lease_heartbeat_keeps_long_claim_current` passed.
- `bash scripts/ci.sh agent` — guardrails and Wavecrate checks passed; stopped at an unrelated pre-existing Radiant vendor failure in `gpu_signal_shader_keeps_waveform_bands_visually_distinct`.
- `git diff --check` — pass.

## Known limitations
- No fresh app-profile smoke was run; this is a backend supervisor lifecycle fix with focused native dispatch coverage.
- The broad agent lane remains blocked by the unrelated Radiant shader assertion noted above.

User approval is required before merge.
