### PR TITLE
fix(watcher): cfg-gate macOS journal recovery

### DIFF
--- a/src/native_app/sample_library/source_watcher/handle.rs
+++ b/src/native_app/sample_library/source_watcher/handle.rs
@@ -889,6 +889,7 @@ fn publish_closed_app_journal_recovery(
         .zip(journal::recover_sources(sources, native_watcher))
     {
         match recovery {
+            #[cfg(target_os = "macos")]
             JournalRecovery::Changes { paths, event_id } if paths.is_empty() => {
                 journal::advance_after_reconciliation(sources, source.id.as_str(), event_id);
                 tracing::debug!(
@@ -896,6 +897,7 @@ fn publish_closed_app_journal_recovery(
                     "Durable source watcher journal found no closed-application changes"
                 );
             }
+            #[cfg(target_os = "macos")]
             JournalRecovery::Changes { paths, event_id } => {
                 tracing::info!(
                     source_id = source.id.as_str(),

--- a/src/native_app/sample_library/source_watcher/journal.rs
+++ b/src/native_app/sample_library/source_watcher/journal.rs
@@ -6,8 +6,10 @@
 //! filesystem identity, or any FSEvents history-loss flag fails closed to the existing bounded
 //! manifest audit.
 
+#[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "macos")]
 use notify::EventKind;
 use serde::{Deserialize, Serialize};
 use wavecrate::sample_sources::{SampleSource, db::SourceDatabase};
@@ -27,8 +29,14 @@ pub(super) struct AuditBarrier(SourceWatcherCheckpoint);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum JournalRecovery {
-    Changes { paths: Vec<PathBuf>, event_id: u64 },
-    FullAudit { reason: &'static str },
+    #[cfg(target_os = "macos")]
+    Changes {
+        paths: Vec<PathBuf>,
+        event_id: u64,
+    },
+    FullAudit {
+        reason: &'static str,
+    },
 }
 
 /// Recover the changes made while the process was not observing a source root.


### PR DESCRIPTION
## Goal
Fix the Linux GitHub Actions `#![deny(warnings)]` failure after the durable source-watcher journal change by keeping macOS-only journal data and consumers platform-owned.

## Scope and non-goals
- Gate macOS-only `Path`, `PathBuf`, and `notify::EventKind` imports.
- Gate `JournalRecovery::Changes` and both matching consumer arms on macOS.
- Preserve macOS replay/history-loss/barrier/checkpoint/root-identity behavior and the non-macOS bounded `FullAudit` fallback.
- No lint suppression, FSEvents redesign, persistence/schema/audit cadence/lifecycle/UI changes.

## Definition of Done
- Linux wavecrate library/test targets compile under `warnings = "deny"`.
- No warning suppression or dummy construction.
- macOS replay behavior remains unchanged; non-macOS retains `FullAudit` fallback.
- Diff is limited to the two source-watcher files.

## Validation
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo test -p wavecrate --lib source_watcher --no-default-features --no-run` — passed.
- `cargo test --workspace --locked --exclude radiant --no-run` — passed.
- `bash scripts/internal/release/run_release_validation.sh` — passed (release contract 31/31, workflow helpers 23/23, scanner 193/193).
- `cargo test -p wavecrate --lib source_watcher --no-default-features` — build passed; 42 passed, 4 failed due local watcher-readiness timeouts in existing integration tests (`source watcher did not become ready` at `handle.rs:357`).

## Known limitations
- macOS-specific compilation/replay tests were not run on this Linux host.
- The four local watcher-readiness timeout failures remain environmental and are unrelated to this two-file cfg-only diff.

User approval is required before merge.