### PR TITLE
fix(starmap): refresh worker anchors on activity edges

### DIFF
--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -88,6 +88,7 @@ impl NativeAppState {
                 if !source_is_current {
                     return;
                 }
+                let worker_progress_visible_before = self.worker_progress_indicator_visible();
                 if !progress.active {
                     self.background.source_processing_progress = None;
                     self.ui.chrome.job_details_open = false;
@@ -95,7 +96,11 @@ impl NativeAppState {
                     self.background.source_processing_progress = Some(progress);
                 }
                 context.repaint(if self.starmap_retained_scene_active() {
-                    ui::RepaintScope::PaintOnly
+                    if worker_progress_visible_before != self.worker_progress_indicator_visible() {
+                        ui::RepaintScope::Surface
+                    } else {
+                        ui::RepaintScope::PaintOnly
+                    }
                 } else {
                     ui::RepaintScope::Projection
                 });

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -179,7 +179,7 @@ fn source_processing_progress_refreshes_the_retained_details_projection() {
 }
 
 #[test]
-fn source_processing_progress_does_not_reproject_during_starmap_audition() {
+fn source_processing_progress_repaints_retained_worker_anchor_on_visibility_edges() {
     let mut state = NativeAppStateFixture::default().build();
     let source_id = state
         .library
@@ -217,8 +217,48 @@ fn source_processing_progress_does_not_reproject_during_starmap_audition() {
 
     assert_eq!(
         context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::Surface),
+        "starting the aggregate worker during audition must install its retained anchor"
+    );
+
+    let mut tick_context = ui::UiUpdateContext::default();
+    state.handle_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: source_id.clone(),
+            lifecycle_generation: 0,
+            active: true,
+            source_row_active: true,
+            completed: 5,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from("hat.wav"),
+        }),
+        &mut tick_context,
+    );
+    assert_eq!(
+        tick_context.into_command().repaint_scope(),
         Some(ui::RepaintScope::PaintOnly),
-        "background progress must not rebuild the starmap scene during audition"
+        "steady aggregate worker ticks must remain paint-only during audition"
+    );
+
+    let mut finish_context = ui::UiUpdateContext::default();
+    state.handle_message(
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: source_id.clone(),
+            lifecycle_generation: 0,
+            active: false,
+            source_row_active: false,
+            completed: 10,
+            total: 10,
+            stage: String::from("Building similarity layout"),
+            detail: String::from("Finalizing source"),
+        }),
+        &mut finish_context,
+    );
+    assert_eq!(
+        finish_context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::Surface),
+        "finishing the last aggregate worker must remove its retained anchor"
     );
 
     state.ui.chrome.starmap_audition_drag = None;
@@ -248,8 +288,8 @@ fn source_processing_progress_does_not_reproject_during_starmap_audition() {
     );
     assert_eq!(
         active_session_context.into_command().repaint_scope(),
-        Some(ui::RepaintScope::PaintOnly),
-        "the retained scene must cover an audible starmap release session"
+        Some(ui::RepaintScope::Surface),
+        "a worker starting during an audible starmap release must install its global anchor"
     );
 
     state.audio.clear_sample_playback_session();
@@ -271,6 +311,70 @@ fn source_processing_progress_does_not_reproject_during_starmap_audition() {
         settled_context.into_command().repaint_scope(),
         Some(ui::RepaintScope::Projection),
         "normal progress projection must resume when the starmap session ends"
+    );
+}
+
+#[test]
+fn source_processing_progress_keeps_retained_repaint_paint_only_when_another_worker_is_visible() {
+    let mut state = NativeAppStateFixture::default().build();
+    let source_id = state
+        .library
+        .folder_browser
+        .defer_add_source_path(
+            std::path::PathBuf::from("/tmp/starmap-progress-shared-worker-source"),
+            false,
+        )
+        .expect("source registered");
+    state
+        .background
+        .source_lifecycle_generations
+        .insert(source_id.clone(), 0);
+    state.background.normalization_progress = Some(
+        crate::native_app::test_support::state::NormalizationProgress {
+            task_id: 1,
+            label: String::from("another worker"),
+            completed: 1,
+            total: 2,
+            work_completed: 1,
+            work_total: 2,
+            queued: 0,
+            detail: String::from("normalizing"),
+        },
+    );
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+
+    let progress = |active, completed, detail| {
+        GuiMessage::SourceProcessingProgress(crate::native_app::app::SourceProcessingProgress {
+            source_id: source_id.clone(),
+            lifecycle_generation: 0,
+            active,
+            source_row_active: active,
+            completed,
+            total: 10,
+            stage: String::from("Preparing similarity"),
+            detail: String::from(detail),
+        })
+    };
+
+    let mut start_context = ui::UiUpdateContext::default();
+    state.handle_message(progress(true, 1, "start.wav"), &mut start_context);
+    assert_eq!(
+        start_context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::PaintOnly),
+        "a source worker starting behind another aggregate worker must stay paint-only"
+    );
+
+    let mut finish_context = ui::UiUpdateContext::default();
+    state.handle_message(progress(false, 10, "finish.wav"), &mut finish_context);
+    assert_eq!(
+        finish_context.into_command().repaint_scope(),
+        Some(ui::RepaintScope::PaintOnly),
+        "a source worker finishing behind another aggregate worker must stay paint-only"
     );
 }
 

--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -683,6 +683,203 @@ fn scene_source_processing_frame_uses_paint_only_repaint_scope() {
 }
 
 #[test]
+fn retained_starmap_worker_plan_tracks_source_rail_and_global_anchor_visibility() {
+    let (mut state, _source_root, _selected_file) =
+        native_app_state_with_temp_sample("retained-worker-anchors.wav");
+    state.ui.chrome.sample_browser_display = crate::native_app::app::SampleBrowserDisplayMode::Map;
+    crate::native_app::test_support::sample_browser::complete_starmap_layout_for_selected_source(
+        &mut state,
+    );
+    crate::native_app::test_support::sample_browser::prepare_sample_browser_view(&mut state);
+    let source_id = state
+        .library
+        .folder_browser
+        .selected_source_id()
+        .to_string();
+    state.waveform.cache.active_folder_warm_folder_id = None;
+    state.waveform.cache.active_folder_warm_total = 0;
+    assert!(
+        !state.worker_progress_indicator_visible(),
+        "fixture must start without another aggregate worker"
+    );
+    state
+        .background
+        .source_lifecycle_generations
+        .insert(source_id.clone(), 0);
+    state.ui.chrome.starmap_audition_drag =
+        Some(crate::native_app::app::StarmapAuditionDragState {
+            last_hit_file_id: Some(String::from("/samples/kick.wav")),
+            last_position: radiant::gui::types::Point::new(50.0, 50.0),
+            modifiers: radiant::widgets::PointerModifiers::default(),
+        });
+    let theme = radiant::theme::ThemeTokens::default();
+    let mut runtime = native_runtime_for_tests(state, Vector2::new(900.0, 620.0));
+    let row_widget_id =
+        crate::native_app::app_chrome::library_browser::library_sidebar::source_row_widget_id(
+            &source_id,
+        );
+    let idle_frame = runtime.frame(&theme);
+    assert!(
+        idle_frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::SAMPLE_BROWSER_MAP_ID])
+            .is_some(),
+        "retained Starmap must have a real idle map plan before checking worker anchors"
+    );
+    assert!(
+        idle_frame
+            .paint_plan
+            .first_widget_rect_by_priority([row_widget_id])
+            .is_some(),
+        "the source row must be present before checking its processing rail"
+    );
+    assert!(
+        idle_frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::WORKER_PROGRESS_ROOT_ID,])
+            .is_none(),
+        "an idle retained Starmap must not install the global progress anchor"
+    );
+
+    let start_command = runtime.dispatch_message(
+        crate::native_app::test_support::state::GuiMessage::SourceProcessingProgress(
+            crate::native_app::test_support::state::SourceProcessingProgress {
+                source_id: source_id.clone(),
+                lifecycle_generation: 0,
+                active: true,
+                source_row_active: true,
+                completed: 3,
+                total: 10,
+                stage: String::from("Analyzing audio"),
+                detail: String::from("retained-worker-anchors.wav"),
+            },
+        ),
+    );
+    assert_eq!(
+        start_command.surface_refresh_scope,
+        Some(RepaintScope::Surface),
+        "starting the first retained worker must refresh the global anchor topology"
+    );
+
+    let active_frame = runtime.frame(&theme);
+    assert!(
+        active_frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::WORKER_PROGRESS_ROOT_ID,])
+            .is_some(),
+        "an active source worker must install the global progress anchor"
+    );
+
+    let mut active_primitives = Vec::new();
+    runtime
+        .bridge_mut()
+        .state_mut()
+        .paint_source_processing_source_pulse(
+            TransientOverlayContext::new(
+                &active_frame.paint_plan,
+                Vector2::new(900.0, 620.0),
+                Duration::ZERO,
+            ),
+            &mut active_primitives,
+        );
+    assert!(
+        !active_primitives.is_empty(),
+        "an active source worker must paint its retained source rail"
+    );
+
+    let tick_command = runtime.dispatch_message(
+        crate::native_app::test_support::state::GuiMessage::SourceProcessingProgress(
+            crate::native_app::test_support::state::SourceProcessingProgress {
+                source_id: source_id.clone(),
+                lifecycle_generation: 0,
+                active: true,
+                source_row_active: true,
+                completed: 4,
+                total: 10,
+                stage: String::from("Analyzing audio"),
+                detail: String::from("retained-worker-anchors-tick.wav"),
+            },
+        ),
+    );
+    assert!(
+        tick_command.paint_only_requested,
+        "steady retained worker ticks must request paint-only repaint"
+    );
+    assert_eq!(
+        tick_command.surface_refresh_scope, None,
+        "steady retained worker ticks must reuse the retained plan"
+    );
+    let tick_frame = runtime.frame(&theme);
+    assert!(
+        tick_frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::WORKER_PROGRESS_ROOT_ID,])
+            .is_some(),
+        "a paint-only worker tick must retain the global progress anchor"
+    );
+    let mut tick_primitives = Vec::new();
+    runtime
+        .bridge_mut()
+        .state_mut()
+        .paint_source_processing_source_pulse(
+            TransientOverlayContext::new(
+                &tick_frame.paint_plan,
+                Vector2::new(900.0, 620.0),
+                Duration::from_millis(100),
+            ),
+            &mut tick_primitives,
+        );
+    assert!(
+        !tick_primitives.is_empty(),
+        "a paint-only worker tick must retain the source processing rail"
+    );
+
+    let finish_command = runtime.dispatch_message(
+        crate::native_app::test_support::state::GuiMessage::SourceProcessingProgress(
+            crate::native_app::test_support::state::SourceProcessingProgress {
+                source_id: source_id.clone(),
+                lifecycle_generation: 0,
+                active: false,
+                source_row_active: false,
+                completed: 10,
+                total: 10,
+                stage: String::from("Finished"),
+                detail: String::from("retained-worker-anchors.wav"),
+            },
+        ),
+    );
+    assert_eq!(
+        finish_command.surface_refresh_scope,
+        Some(RepaintScope::Surface),
+        "finishing the last retained worker must invalidate its global anchor"
+    );
+    let finished_frame = runtime.frame(&theme);
+    assert!(
+        finished_frame
+            .paint_plan
+            .first_widget_rect_by_priority([crate::native_app::ui::ids::WORKER_PROGRESS_ROOT_ID,])
+            .is_none(),
+        "finishing the last worker must remove the global progress anchor"
+    );
+    let mut finished_primitives = Vec::new();
+    runtime
+        .bridge_mut()
+        .state_mut()
+        .paint_source_processing_source_pulse(
+            TransientOverlayContext::new(
+                &finished_frame.paint_plan,
+                Vector2::new(900.0, 620.0),
+                Duration::ZERO,
+            ),
+            &mut finished_primitives,
+        );
+    assert!(
+        finished_primitives.is_empty(),
+        "finishing the source worker must remove its retained source rail"
+    );
+}
+
+#[test]
 fn worker_progress_indicator_pulses_in_transient_overlay_without_input() {
     let mut state = gui_state_for_span_tests();
     state.background.source_processing_progress = Some(


### PR DESCRIPTION
## Goal

Keep retained-Starmap source-processing feedback structurally consistent: when source processing is the first or last aggregate worker, the source-row rail and global worker dot must appear or disappear together.

## Scope

- Compare aggregate worker-indicator visibility before and after an accepted source-processing progress update.
- Request `Surface` only for aggregate inactive-to-active and active-to-inactive edges.
- Keep retained-Starmap active progress ticks paint-only.
- Keep source start/finish paint-only when another worker already owns the global anchor.
- Preserve non-retained projection refresh, lifecycle rejection, and aggregate-worker priority.
- Add dispatch-policy and retained-plan/runtime regressions.

## Non-goals

- No scanner supervisor, scheduler, database, filesystem, watcher, health-state, or publication changes.
- No worker-dot redesign or Starmap audition refactor.
- No Radiant submodule change.
- No monolithic UI/scanner state machine.

## Definition of Done

- [x] First source worker installs the retained global worker anchor immediately.
- [x] Source-row rail and global worker dot agree while processing is active.
- [x] Steady active ticks reuse the retained plan with paint-only repaint.
- [x] Last source worker removes the global anchor and rail on completion.
- [x] Another active worker prevents unnecessary structural refreshes.
- [x] Stale lifecycle and removed-source messages remain rejected.
- [x] Fresh isolated macOS runtime shows no stuck processing state after completion or source remove/re-add.

## Validation

- `cargo test -p wavecrate source_processing_progress -- --test-threads=1` — 4 passed.
- `cargo test -p wavecrate retained_starmap_worker_plan_tracks_source_rail_and_global_anchor_visibility -- --test-threads=1` — 1 passed.
- `cargo test -p wavecrate toolbar_playback::frame_overlay -- --test-threads=1` — 48 passed; two unrelated baseline failures remain: `paused_source_cache_progress_does_not_force_playback_surface_frames` and `playback_cursor_paints_as_transient_overlay`.
- `cargo fmt --all` — passed.
- `git diff --check` — passed.
- `bash scripts/build.sh --release` — passed at exact head `6f5a8dc35`; produced the branch-specific macOS app bundle.
- Native `small-multi-source` sandbox smoke at `6f5a8dc35`:
  - retained Starmap processing showed the source rail and global worker dot together;
  - completion removed the dot with no stuck processing state;
  - a closed-app scripted same-size mutation was discovered on relaunch, with committed source metadata matching the mutated file timestamp;
  - source remove/re-add through the macOS picker returned without stale worker state.

## Known limitations

- `bash scripts/agent.sh request` is blocked on canonical base `d61948332` by five pre-existing native-app boundary violations importing `app_chrome::palette` from playback/waveform modules; this PR does not touch those files.
- The sandbox relaunch emitted an unrelated persisted metadata-tag warning for a missing fixture WAL path; it did not affect the target source-processing behavior.

User approval is required before merge.