### PR TITLE
fix(library): cfg-gate Unix source index import

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/util.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/util.rs
@@ -1,3 +1,4 @@
+#[cfg(unix)]
 use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
 


### PR DESCRIPTION
## Goal
Fix the Windows `wavecrate-library` warnings-denied build by scoping the Unix-only `OsString` import to Unix targets.

## Scope and non-goals
- Scope: add `#[cfg(unix)]` to `std::ffi::OsString` in `sample_sources/db/util.rs`.
- Non-goals: no source-index encoding/decoding changes, persistence changes, scanner architecture changes, or vendor updates.

## Definition of done
- Unix-only `OsString` import is absent from Windows builds, with no lint suppression.
- Existing Unix lossless source-index path coverage remains green.
- The diff is limited to the configuration-scoped import fix.

## Validation
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `RUSTFLAGS='-D warnings' cargo test -p wavecrate-library sample_sources::db::util::tests -- --nocapture` — passed (11 tests).
- `RUSTFLAGS='-D warnings' cargo check -p wavecrate-library` — passed.
- Windows target check attempted with `RUSTFLAGS='-D warnings' cargo check -p wavecrate-library --target x86_64-pc-windows-msvc`; local macOS environment lacks the MSVC toolchain/headers (`ml64.exe`, Windows CRT), so GitHub Windows checks are the authoritative cross-target evidence.

## Limitations
Local Windows cross-compilation is unavailable on this macOS host; no behavior or persistence changes are introduced.

User approval is required before merge.
