### PR TITLE
Fix Windows scanner filesystem helper conflict

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_fs.rs
@@ -13,8 +13,10 @@ use std::{cell::RefCell, collections::BTreeSet};
 use cap_fs_ext::{DirExt, OpenOptionsFollowExt};
 use cap_std::fs::{Dir, OpenOptions};
 use tracing::warn;
+#[cfg(any(test, not(windows)))]
+use wavecrate_library::filesystem_identity::filesystem_change_marker;
 use wavecrate_library::filesystem_identity::{
-    filesystem_change_marker, stable_filesystem_identity, stable_filesystem_identity_from_open_file,
+    stable_filesystem_identity, stable_filesystem_identity_from_open_file,
 };
 use wavecrate_library::sample_sources::{
     SourceEntryClassification, SourceEntryFileType, SourceFileClassification,
@@ -689,26 +691,6 @@ pub(super) fn read_facts_from_open_file(
             }
         },
     })
-}
-
-#[cfg(windows)]
-fn stable_filesystem_identity_from_open_file(file: &fs::File) -> Option<String> {
-    use std::os::windows::io::AsRawHandle;
-    use windows::Win32::{
-        Foundation::HANDLE,
-        Storage::FileSystem::{BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle},
-    };
-
-    let mut information = BY_HANDLE_FILE_INFORMATION::default();
-    unsafe { GetFileInformationByHandle(HANDLE(file.as_raw_handle()), &mut information) }.ok()?;
-    let file_index =
-        (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
-    let creation_time = (u64::from(information.ftCreationTime.dwHighDateTime) << 32)
-        | u64::from(information.ftCreationTime.dwLowDateTime);
-    Some(format!(
-        "windows:{}:{}:{}",
-        information.dwVolumeSerialNumber, file_index, creation_time
-    ))
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Goal

Restore warning-clean Windows nightly compilation for `wavecrate-scan` by using the canonical library-owned open-file filesystem identity helper.

The Windows failure is recorded in [nightly run 30152629151](https://github.com/PORTALSURFER/wavecrate/actions/runs/30152629151), job `Build windows x86_64 nightly`.

## Scope and non-goals

- Remove the stale scanner-local Windows `stable_filesystem_identity_from_open_file` implementation.
- Continue using `wavecrate_library::filesystem_identity::stable_filesystem_identity_from_open_file`.
- Import the path-based `filesystem_change_marker` only for tests or non-Windows production builds, where it is used.
- Retain the scanner-local Windows open-file change-marker helper.
- Non-goals: filesystem identity behavior changes, change-marker ownership refactors, dependency updates, workflow changes, or broader scanner cleanup.

## Definition of Done

- The Windows non-test build has only one `stable_filesystem_identity_from_open_file` binding.
- `deny(warnings)` no longer rejects `filesystem_change_marker` as unused on Windows.
- Open-descriptor identity and change-marker behavior are unchanged.
- The scanner library tests and Wavecrate smoke lane pass.
- Only `scan_fs.rs` changes.

## Validation

Current head `8f276d09dddbeabd727d4402e3b3884400e411c5`:

- PASS: `cargo fmt --all -- --check`
- PASS: `git diff --check`
- PASS: `cargo test --locked -p wavecrate-scan --lib` (194 passed)
- PASS: `bash scripts/ci.sh smoke`
- NOT RUN: real Windows `cargo check --locked -p wavecrate-scan --lib --target x86_64-pc-windows-msvc`; the macOS host has the Rust target but lacks the MSVC assembler and Windows C headers required by transitive native dependencies.

## Known limitations

The failing Windows nightly job has not been re-run from this branch because the existing release workflow would publish artifacts on success. Exact Windows-runner confirmation remains pending after merge or an explicitly authorized release workflow dispatch.

User approval is required before merge.