### PR TITLE
Guard watcher barriers on manifest coverage

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/mod.rs
@@ -13,11 +13,12 @@ mod scan_writer;
 
 pub use scan::{
     ChangedSample, CommittedScanBatch, CommittedSourceDelta, ContentAuditActivity,
-    ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind, ManifestIdentityDelta,
-    MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats, SourceTreeDiagnostic,
-    SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source, audit_source_and_record,
-    audit_source_and_record_with_budget_and_progress,
+    ContentAuditBudget, ContentAuditStorage, DirectoryRepeatKind, ManifestAuditOutcome,
+    ManifestIdentityDelta, MovedManifestIdentity, RenamedSample, ScanError, ScanMode, ScanStats,
+    SourceTreeDiagnostic, SourceTreeFile, SourceTreeSnapshot, UpdatedSample, audit_source,
+    audit_source_and_record, audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
+    audit_source_and_record_with_budget_and_progress_and_writer_outcome,
     audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
     complete_deferred_rename_candidates_with_cancel,

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/mod.rs
@@ -7,9 +7,10 @@ pub use super::scan_hash::{ContentAuditActivity, ContentAuditBudget, ContentAudi
 pub(crate) use context::ScanContext;
 pub use errors::ScanError;
 pub use runner::{
-    ScanMode, audit_source, audit_source_and_record,
+    ManifestAuditOutcome, ScanMode, audit_source, audit_source_and_record,
     audit_source_and_record_with_budget_and_progress,
     audit_source_and_record_with_budget_and_progress_and_writer,
+    audit_source_and_record_with_budget_and_progress_and_writer_outcome,
     audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
     complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
     complete_deferred_rename_candidates_with_cancel,
@@ -20,7 +21,9 @@ pub use runner::{
 };
 #[cfg(test)]
 pub(crate) use runner::{
-    audit_source_and_record_with_post_scan_hook, audit_source_and_record_with_pre_record_hook,
+    audit_source_and_record_with_post_scan_hook,
+    audit_source_and_record_with_post_scan_hook_outcome,
+    audit_source_and_record_with_pre_record_hook,
 };
 pub(crate) use runner::{finish_scan_result, reconcile_scan_renames};
 pub use stats::{

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -355,9 +355,12 @@ fn audit_source_and_record_after_scan_outcome(
             tracing::warn!(
                 %error,
                 revision = stats.committed_delta.revision,
-                "Publishing committed manifest repair before retrying incomplete content audit"
+                "Retaining committed manifest repair before retrying failed content audit"
             );
-            content_incomplete = Some(error.to_string());
+            return Ok(ManifestAuditOutcome::Incomplete {
+                committed: stats,
+                error: error.to_string(),
+            });
         }
         Err(error) => return Err(error),
     }

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/runner.rs
@@ -182,7 +182,66 @@ pub fn audit_source_and_record_with_budget_and_progress_and_writer(
     on_progress: &mut impl FnMut(usize, &Path),
     writer: &impl ScanWriter,
 ) -> Result<ScanStats, ScanError> {
-    audit_source_and_record_after_scan(
+    match audit_source_and_record_after_scan_outcome(
+        db,
+        cancel,
+        budget,
+        completed_at,
+        Some(on_progress),
+        writer,
+        || {},
+        || {},
+    )? {
+        ManifestAuditOutcome::Complete {
+            stats,
+            content_incomplete,
+        } => match content_incomplete {
+            Some(error) => Err(ScanError::Incomplete {
+                committed: Box::new(stats),
+                error,
+            }),
+            None => Ok(stats),
+        },
+        ManifestAuditOutcome::Incomplete { committed, error } => Err(ScanError::Incomplete {
+            committed: Box::new(committed),
+            error,
+        }),
+    }
+}
+
+/// Outcome of a source manifest audit with bounded content verification.
+///
+/// Manifest traversal coverage is represented independently from resumable content
+/// verification. Callers that own watcher recovery barriers must advance them only for the
+/// `Complete` variant; a `Complete` outcome may still carry a content checkpoint pause.
+#[derive(Debug)]
+pub enum ManifestAuditOutcome {
+    /// The authoritative manifest traversal and reconciliation completed.
+    Complete {
+        /// Statistics and committed manifest delta from the audit.
+        stats: ScanStats,
+        /// Content verification stopped after a durable checkpoint, if applicable.
+        content_incomplete: Option<String>,
+    },
+    /// Manifest traversal or reconciliation was uncertain after a committed checkpoint.
+    Incomplete {
+        /// Statistics and committed partial manifest delta to publish before retrying.
+        committed: ScanStats,
+        /// Diagnostic describing why authoritative coverage remains incomplete.
+        error: String,
+    },
+}
+
+/// Reconcile and durably record a source audit while preserving manifest coverage ownership.
+pub fn audit_source_and_record_with_budget_and_progress_and_writer_outcome(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    budget: ContentAuditBudget,
+    completed_at: i64,
+    on_progress: &mut impl FnMut(usize, &Path),
+    writer: &impl ScanWriter,
+) -> Result<ManifestAuditOutcome, ScanError> {
+    audit_source_and_record_after_scan_outcome(
         db,
         cancel,
         budget,
@@ -204,10 +263,47 @@ fn audit_source_and_record_after_scan(
     before_record: impl FnOnce(),
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
+    match audit_source_and_record_after_scan_outcome(
+        db,
+        cancel,
+        budget,
+        completed_at,
+        on_progress,
+        writer,
+        before_record,
+        after_scan,
+    )? {
+        ManifestAuditOutcome::Complete {
+            stats,
+            content_incomplete,
+        } => match content_incomplete {
+            Some(error) => Err(ScanError::Incomplete {
+                committed: Box::new(stats),
+                error,
+            }),
+            None => Ok(stats),
+        },
+        ManifestAuditOutcome::Incomplete { committed, error } => Err(ScanError::Incomplete {
+            committed: Box::new(committed),
+            error,
+        }),
+    }
+}
+
+fn audit_source_and_record_after_scan_outcome(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    budget: ContentAuditBudget,
+    completed_at: i64,
+    on_progress: Option<&mut dyn FnMut(usize, &Path)>,
+    writer: &impl ScanWriter,
+    before_record: impl FnOnce(),
+    after_scan: impl FnOnce(),
+) -> Result<ManifestAuditOutcome, ScanError> {
     let root = ensure_root_dir(db)?;
     let source_root = SourceRootCapability::open(&root)?;
     source_root.ensure_current_generation()?;
-    let mut stats = scan_with_writer_using_root(
+    let mut stats = match scan_with_writer_using_root(
         db,
         &root,
         &source_root,
@@ -217,31 +313,60 @@ fn audit_source_and_record_after_scan(
         Some(completed_at),
         false,
         writer,
-    )?;
+    ) {
+        Ok(stats) => stats,
+        Err(ScanError::Incomplete { committed, error }) => {
+            return Ok(ManifestAuditOutcome::Incomplete {
+                committed: *committed,
+                error,
+            });
+        }
+        Err(error) => return Err(error),
+    };
     before_record();
     if let Err(error) =
         record_manifest_audit_completion(db, &mut stats, completed_at, writer, &source_root)
     {
         if stats.committed_delta.revision > 0 {
-            return Err(ScanError::Incomplete {
-                committed: Box::new(stats),
+            return Ok(ManifestAuditOutcome::Incomplete {
+                committed: stats,
                 error: error.to_string(),
             });
         }
         return Err(error);
     }
     after_scan();
-    let mut stats = merge_audit_verification(
-        &mut stats,
-        super::super::scan_hash::verify_content_batch_with_source_root(
-            db,
-            &source_root,
-            cancel,
-            budget,
-            completed_at,
-            writer,
-        ),
-    )?;
+    let verification = super::super::scan_hash::verify_content_batch_with_source_root(
+        db,
+        &source_root,
+        cancel,
+        budget,
+        completed_at,
+        writer,
+    );
+    let mut content_incomplete = None;
+    match verification {
+        Ok(verified) => stats.merge_deferred_hashes(verified),
+        Err(ScanError::Incomplete { committed, error }) => {
+            stats.merge_deferred_hashes(*committed);
+            content_incomplete = Some(error);
+        }
+        Err(error) if stats.committed_delta.revision > 0 => {
+            tracing::warn!(
+                %error,
+                revision = stats.committed_delta.revision,
+                "Publishing committed manifest repair before retrying incomplete content audit"
+            );
+            content_incomplete = Some(error.to_string());
+        }
+        Err(error) => return Err(error),
+    }
+    if content_incomplete.is_some() {
+        return Ok(ManifestAuditOutcome::Complete {
+            stats,
+            content_incomplete,
+        });
+    }
     finalize_pending_rename_completion(
         db,
         &mut stats,
@@ -249,7 +374,10 @@ fn audit_source_and_record_after_scan(
         writer,
         Some(&source_root),
     )?;
-    Ok(stats)
+    Ok(ManifestAuditOutcome::Complete {
+        stats,
+        content_incomplete,
+    })
 }
 
 fn record_manifest_audit_completion(
@@ -296,6 +424,26 @@ pub(crate) fn audit_source_and_record_with_post_scan_hook(
     after_scan: impl FnOnce(),
 ) -> Result<ScanStats, ScanError> {
     audit_source_and_record_after_scan(
+        db,
+        cancel,
+        ContentAuditBudget::entry_limited(max_hashes),
+        completed_at,
+        None,
+        &UncoordinatedScanWriter,
+        || {},
+        after_scan,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn audit_source_and_record_with_post_scan_hook_outcome(
+    db: &SourceDatabase,
+    cancel: Option<&AtomicBool>,
+    max_hashes: usize,
+    completed_at: i64,
+    after_scan: impl FnOnce(),
+) -> Result<ManifestAuditOutcome, ScanError> {
+    audit_source_and_record_after_scan_outcome(
         db,
         cancel,
         ContentAuditBudget::entry_limited(max_hashes),

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sample_sources::scanner::UncoordinatedScanWriter;
 use crate::sample_sources::scanner::scan_fs::{
     force_directory_entry_failure, force_directory_read_failure, force_file_type_failure,
 };
@@ -979,6 +980,41 @@ fn manifest_audit_keeps_an_unreadable_subtree_due_for_retry() {
 }
 
 #[test]
+fn typed_manifest_audit_outcome_retains_coverage_barrier_for_unreadable_traversal() {
+    let dir = tempdir().unwrap();
+    let protected = dir.path().join("protected");
+    std::fs::create_dir(&protected).unwrap();
+    std::fs::write(protected.join("kick.wav"), b"kick").unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    scan_once(&db).unwrap();
+
+    std::fs::remove_file(protected.join("kick.wav")).unwrap();
+    let failure = force_directory_read_failure(&protected);
+    let outcome = audit_source_and_record_with_budget_and_progress_and_writer_outcome(
+        &db,
+        None,
+        ContentAuditBudget::entry_limited(8),
+        1_234,
+        &mut |_, _| {},
+        &UncoordinatedScanWriter,
+    )
+    .unwrap();
+    drop(failure);
+
+    let ManifestAuditOutcome::Incomplete { committed, error } = outcome else {
+        panic!("uncertain traversal must retain the manifest coverage barrier");
+    };
+    assert!(error.contains("retry required"));
+    assert!(committed.committed_delta.deleted.is_empty());
+    assert!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .is_none(),
+        "incomplete traversal must not publish authoritative audit completion"
+    );
+}
+
+#[test]
 fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled() {
     let dir = tempdir().unwrap();
     let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
@@ -1019,6 +1055,36 @@ fn manifest_audit_publishes_scan_repair_when_content_verification_is_cancelled()
             .authoritative_generation,
         generation_before,
         "failed audit verification must not authorize retention pruning"
+    );
+}
+
+#[test]
+fn typed_manifest_audit_outcome_keeps_coverage_complete_when_content_pauses() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    std::fs::write(dir.path().join("missed.wav"), b"missed watcher event").unwrap();
+    let cancel = std::sync::atomic::AtomicBool::new(false);
+
+    let outcome =
+        audit_source_and_record_with_post_scan_hook_outcome(&db, Some(&cancel), 8, 1_234, || {
+            cancel.store(true, std::sync::atomic::Ordering::Release)
+        })
+        .unwrap();
+
+    let ManifestAuditOutcome::Complete {
+        stats,
+        content_incomplete,
+    } = outcome
+    else {
+        panic!("content verification pause must not downgrade manifest coverage");
+    };
+    assert_eq!(content_incomplete.as_deref(), Some("Scan canceled"));
+    assert_eq!(stats.committed_delta.created.len(), 1);
+    assert_eq!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .as_deref(),
+        Some("1234")
     );
 }
 

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/basics.rs
@@ -1089,6 +1089,39 @@ fn typed_manifest_audit_outcome_keeps_coverage_complete_when_content_pauses() {
 }
 
 #[test]
+fn typed_manifest_audit_outcome_retains_barrier_for_noncheckpoint_verification_error() {
+    let dir = tempdir().unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    std::fs::write(dir.path().join("missed.wav"), b"missed watcher event").unwrap();
+    let displaced_parent = tempdir().unwrap();
+    let displaced = displaced_parent.path().join("displaced-root");
+    let source_root = dir.path().to_path_buf();
+
+    let outcome = audit_source_and_record_with_post_scan_hook_outcome(&db, None, 8, 1_234, || {
+        std::fs::rename(&source_root, &displaced).unwrap();
+        std::fs::create_dir(&source_root).unwrap();
+    })
+    .unwrap();
+
+    std::fs::remove_dir(&source_root).unwrap();
+    std::fs::rename(&displaced, &source_root).unwrap();
+
+    let ManifestAuditOutcome::Incomplete { committed, error } = outcome else {
+        panic!("non-checkpoint verification errors must retain the recovery barrier");
+    };
+    assert!(error.contains("generation changed"));
+    assert_eq!(committed.committed_delta.created.len(), 1);
+    assert!(committed.content_audit.is_none());
+    assert_eq!(
+        db.get_metadata(crate::sample_sources::db::META_LAST_MANIFEST_AUDIT_AT)
+            .unwrap()
+            .as_deref(),
+        Some("1234"),
+        "manifest repair may be durable, but the caller must retry the failed verification"
+    );
+}
+
+#[test]
 fn manifest_audit_publishes_unchanged_committed_revision_when_verification_is_cancelled() {
     let dir = tempdir().unwrap();
     std::fs::write(dir.path().join("known.wav"), b"known").unwrap();

--- a/docs/TARGET.md
+++ b/docs/TARGET.md
@@ -413,6 +413,12 @@ Manifest audits, indexed hashing, similarity finalization, and retirement keep t
 existing serial compatibility paths until each can preserve its current atomic contract
 across the same typed phase boundary.
 
+Watcher recovery barriers advance only after an authoritative manifest traversal and
+reconciliation completes. A cancelled, stale, or unreadable traversal retains the prior
+barrier even when it publishes a committed partial delta for retry. A traversal that does
+complete may separately pause bounded content verification at its durable checkpoint without
+withholding the manifest-coverage completion.
+
 Source retirement keeps the audio folder, authoritative source database, source manifest, reusable analysis/similarity artifacts, and safe content-addressed analysis caches. It releases source-owned in-memory playback/preview/browser state and asynchronously removes readiness-managed jobs and unshared managed cache payloads. The source descriptor registry retains role, metadata-storage policy, and primary-import settings so protected/AppData sources rehydrate safely; corrupt present descriptor values fail closed. Cleanup is idempotent, retryable after unavailable/read-only storage, recovered from retained inactive descriptors at startup, and bounded so removal never waits for database maintenance or cache garbage collection.
 
 For every current eligible file, the readiness stages are:

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -33,7 +33,7 @@ use wavecrate::sample_sources::{
     },
     scanner::{
         CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget, ContentAuditStorage,
-        ScanError, audit_source_and_record_with_budget_and_progress_and_writer,
+        ManifestAuditOutcome, audit_source_and_record_with_budget_and_progress_and_writer_outcome,
         complete_pending_deep_hash_for_path, sync_paths_with_progress,
     },
 };

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -5,10 +5,11 @@ use super::{
 };
 use super::{
     AtomicBool, ContentAuditActivity, ContentAuditBudget, ContentAuditStorage, DatabaseWriterGate,
-    Duration, ExecutionOutcome, Instant, Ordering, RuntimeCandidate, RuntimeTask, ScanError,
-    SourceDatabase, SourceProcessingActivity, SourceProcessingEvent, SourceProcessingLifecycle,
-    SourceProcessingProgressEvent, audit_source_and_record_with_budget_and_progress_and_writer,
-    execute_readiness_target, manifest_audit_source_row_active, now_epoch_seconds,
+    Duration, ExecutionOutcome, Instant, ManifestAuditOutcome, Ordering, RuntimeCandidate,
+    RuntimeTask, SourceDatabase, SourceProcessingActivity, SourceProcessingEvent,
+    SourceProcessingLifecycle, SourceProcessingProgressEvent,
+    audit_source_and_record_with_budget_and_progress_and_writer_outcome, execute_readiness_target,
+    manifest_audit_source_row_active, now_epoch_seconds,
 };
 
 pub(super) fn execute_candidate(
@@ -80,8 +81,8 @@ pub(super) fn execute_candidate(
                 ));
                 last_progress_publish_at = Some(Instant::now());
             };
-            let (outcome, content_incomplete_error) =
-                match audit_source_and_record_with_budget_and_progress_and_writer(
+            let (outcome, manifest_complete, content_incomplete_error) =
+                match audit_source_and_record_with_budget_and_progress_and_writer_outcome(
                     &database,
                     Some(cancel),
                     content_budget,
@@ -89,8 +90,13 @@ pub(super) fn execute_candidate(
                     &mut publish_progress,
                     database_writer,
                 ) {
-                    Ok(outcome) => (outcome, None),
-                    Err(ScanError::Incomplete { committed, error }) => (*committed, Some(error)),
+                    Ok(ManifestAuditOutcome::Complete {
+                        stats,
+                        content_incomplete,
+                    }) => (stats, true, content_incomplete),
+                    Ok(ManifestAuditOutcome::Incomplete { committed, error }) => {
+                        (committed, false, Some(error))
+                    }
                     Err(error) => {
                         publish_event(SourceProcessingEvent::ManifestAuditFinished {
                             lifecycle: SourceProcessingLifecycle::new(
@@ -164,19 +170,20 @@ pub(super) fn execute_candidate(
                     candidate.source.id.as_str(),
                     lifecycle_generation,
                 ),
-                complete: true,
+                complete: manifest_complete,
             });
             if let Some(error) = content_incomplete_error {
                 tracing::warn!(
                     target: "wavecrate::source_processing",
                     source_id = candidate.source.id.as_str(),
                     error,
-                    "Manifest audit completed; content verification paused at its durable checkpoint"
+                    manifest_complete,
+                    "Manifest audit did not complete all work"
                 );
             }
             Ok(manifest_audit_execution_outcome(
                 foreground_refresh_owns_reconciliation,
-                false,
+                !manifest_complete,
                 cancel.load(Ordering::Acquire),
             ))
         }

--- a/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
@@ -470,6 +470,10 @@ fn delivered_manifest_handoff_survives_post_commit_cancellation() {
         manifest_audit_execution_outcome(false, false, true),
         ExecutionOutcome::Cancelled
     );
+    assert_eq!(
+        manifest_audit_execution_outcome(false, true, false),
+        ExecutionOutcome::Failed
+    );
 }
 
 #[test]

--- a/src/sample_sources/mod.rs
+++ b/src/sample_sources/mod.rs
@@ -22,10 +22,11 @@ pub mod scan_state {
 pub mod scanner {
     pub use wavecrate_scan::sample_sources::scanner::{
         ChangedSample, CommittedSourceDelta, ContentAuditActivity, ContentAuditBudget,
-        ContentAuditStorage, ManifestIdentityDelta, MovedManifestIdentity, RenamedSample,
-        ScanError, ScanMode, ScanStats, UpdatedSample, audit_source, audit_source_and_record,
-        audit_source_and_record_with_budget_and_progress,
+        ContentAuditStorage, ManifestAuditOutcome, ManifestIdentityDelta, MovedManifestIdentity,
+        RenamedSample, ScanError, ScanMode, ScanStats, UpdatedSample, audit_source,
+        audit_source_and_record, audit_source_and_record_with_budget_and_progress,
         audit_source_and_record_with_budget_and_progress_and_writer,
+        audit_source_and_record_with_budget_and_progress_and_writer_outcome,
         audit_source_and_record_with_progress, audit_source_with_budget, complete_deferred_hashes,
         complete_deferred_hashes_with_cancel, complete_deferred_rename_candidates,
         complete_deferred_rename_candidates_with_cancel, complete_pending_deep_hash_for_path,


### PR DESCRIPTION
## Goal
Ensure source watcher recovery barriers advance only after authoritative manifest traversal and reconciliation, while preserving resumable content-verification checkpoints as a distinct outcome.

## Scope and non-goals
- Add a typed manifest-audit outcome at the scanner/supervisor boundary.
- Publish `complete: false` for incomplete, cancelled, stale, or unreadable manifest traversal.
- Keep `complete: true` when manifest coverage succeeds but bounded content verification pauses at its durable checkpoint.
- Add deterministic scanner and supervisor regression coverage and document the contract.
- Non-goals: atomic external-delta handoff, safety-probe redesign, typed progress units, or unrelated watcher changes.

## Definition of Done
- Manifest traversal uncertainty cannot advance the watcher recovery barrier.
- Content-verification checkpoint pauses remain resumable without downgrading manifest coverage.
- Focused tests and formatting pass.
- Existing unrelated `vendor/radiant` gitlink work remains untouched.

## Validation
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo check -p wavecrate-scan -p wavecrate` — passed
- `cargo test -p wavecrate-scan typed_manifest_audit_outcome -- --nocapture` — 2 passed
- `cargo test -p wavecrate periodic_manifest_audit_wakes_browser_projection_after_committed_repair -- --nocapture` — passed
- `cargo test -p wavecrate delivered_manifest_handoff_survives_post_commit_cancellation -- --nocapture` — passed

## Limitations
Full workspace CI was not run; the focused scanner and supervisor lanes cover the changed behavior.

User approval is required before merge.
