### PR TITLE
fix(source-processing): atomically hand off external scan commits

### DIFF
--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -13,7 +13,9 @@ use crate::native_app::sample_library::source_prep::{
     CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
     SourcePrepIntents, SourcePriorityIntent,
 };
-use crate::native_app::source_processing::manifest_delta_requires_browser_refresh;
+use crate::native_app::source_processing::{
+    ExternalScanHandoff, manifest_delta_requires_browser_refresh,
+};
 
 pub(in crate::native_app) const FILESYSTEM_SYNC_PREP_INTENTS: SourcePrepIntents =
     SourcePrepIntents {
@@ -163,12 +165,14 @@ impl NativeAppState {
                     renames_reconciled,
                     "Committed filesystem source delta"
                 );
-                self.background.source_processing.request_source_delta(
-                    &source_id,
-                    &delta,
-                    "filesystem_sync_committed_delta",
-                );
-                if !delta.is_empty() && incomplete_error.is_none() {
+                if !result.cancelled && incomplete_error.is_none() {
+                    self.background.source_processing.request_source_delta(
+                        &source_id,
+                        &delta,
+                        "filesystem_sync_committed_delta",
+                    );
+                }
+                if !result.cancelled && !delta.is_empty() && incomplete_error.is_none() {
                     self.ui.status.sample = format!("Synced {changed_count} filesystem change(s)");
                     self.queue_source_prep(
                         source_id.clone(),
@@ -541,7 +545,15 @@ impl NativeAppState {
                     },
                 );
                 result.journal_checkpoint_event_id = journal_checkpoint_event_id;
-                drop(permit);
+                let handoff = match &result.result {
+                    Ok(success) if !result.cancelled && success.incomplete_error.is_none() => {
+                        ExternalScanHandoff::CommittedDelta(success.committed_delta.clone())
+                    }
+                    _ => ExternalScanHandoff::FullReconciliation {
+                        reason: "targeted_source_sync_incomplete",
+                    },
+                };
+                permit.release_after_handoff(handoff);
                 result
             },
             GuiMessage::SourceFilesystemSyncFinished,

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -15,7 +15,7 @@ use crate::native_app::{
         CacheWarmIntent, MetadataRefreshIntent, ReadinessIntent, SourceFeedbackIntent,
         SourcePrepIntents, SourcePriorityIntent,
     },
-    source_processing::SourceScanAdmissionState,
+    source_processing::{ExternalScanHandoff, SourceScanAdmissionState},
 };
 use wavecrate::sample_sources::config::{AppConfig, reserve_save_revision};
 use wavecrate_scan::sample_sources::scanner::UncoordinatedScanWriter;
@@ -245,7 +245,8 @@ impl NativeAppState {
                             Some(generation),
                         );
                     }
-                    drop(permit);
+                    let handoff = foreground_scan_handoff(&result.scan);
+                    permit.release_after_handoff(handoff);
                     result
                 }));
                 match outcome {
@@ -687,6 +688,26 @@ impl NativeAppState {
         self.sync_source_watcher();
         self.open_ready_audio_documents(context, started_at);
     }
+}
+
+fn foreground_scan_handoff(
+    scan: &crate::native_app::sample_library::folder_browser::scan::FolderScanResult,
+) -> ExternalScanHandoff {
+    if scan.cancelled
+        || !scan.source_root_available
+        || scan.source_db_error.is_some()
+        || scan.metadata_hydration.error().is_some()
+    {
+        return ExternalScanHandoff::FullReconciliation {
+            reason: "foreground_source_scan_incomplete",
+        };
+    }
+    scan.committed_delta.as_ref().map_or(
+        ExternalScanHandoff::FullReconciliation {
+            reason: "foreground_source_scan_missing_delta",
+        },
+        |delta| ExternalScanHandoff::CommittedDelta(delta.clone()),
+    )
 }
 
 fn classify_terminal_outcome(

--- a/src/native_app/source_processing/mod.rs
+++ b/src/native_app/source_processing/mod.rs
@@ -11,7 +11,8 @@ pub(in crate::native_app) use events::{
     SourceProcessingLifecycle, SourceProcessingProgressEvent,
 };
 pub(in crate::native_app) use supervisor::{
-    SourceAuditLifecycleCause, SourceProcessingSupervisor, SourceScanAdmissionState,
+    ExternalScanHandoff, SourceAuditLifecycleCause, SourceProcessingSupervisor,
+    SourceScanAdmissionState,
 };
 pub(in crate::native_app) use worker::run_internal_source_analysis_from_args;
 #[cfg(not(test))]

--- a/src/native_app/source_processing/supervisor.rs
+++ b/src/native_app/source_processing/supervisor.rs
@@ -90,7 +90,7 @@ mod state;
 mod state_machine_observation;
 mod telemetry;
 
-pub(in crate::native_app) use admission::SourceScanAdmissionState;
+pub(in crate::native_app) use admission::{ExternalScanHandoff, SourceScanAdmissionState};
 use admission::{SourceProcessingBudgetHandle, install_worker_app_root};
 use cache_ownership::*;
 pub(in crate::native_app) use commands::SourceAuditLifecycleCause;

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -1,7 +1,19 @@
 use super::{
-    Arc, AtomicBool, DatabaseWriterGate, ExternalScanAdmission, ExternalScanRegistration, Ordering,
-    PathBuf, ProcessingLane, SampleSource, Shared, resolve_registered_source_for_scan_locked,
+    Arc, AtomicBool, CommittedSourceDelta, DatabaseWriterGate, ExternalScanAdmission,
+    ExternalScanRegistration, Ordering, PathBuf, ProcessingLane, SampleSource, Shared,
+    resolve_registered_source_for_scan_locked,
 };
+
+/// The typed handoff an external scan must make before releasing its source-processing budget.
+///
+/// A committed manifest mutation is visible to the supervisor either as its exact revision-aware
+/// delta or as an explicit full-reconciliation fallback. Keeping this ownership on the permit
+/// makes releasing capacity and publishing the mutation one ordered operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::native_app) enum ExternalScanHandoff {
+    CommittedDelta(CommittedSourceDelta),
+    FullReconciliation { reason: &'static str },
+}
 
 #[derive(Clone)]
 pub(in crate::native_app) struct SourceProcessingBudgetHandle {
@@ -14,6 +26,7 @@ pub(in crate::native_app) struct SourceProcessingBudgetPermit {
     registration_id: u64,
     pub(super) lifecycle_generation: u64,
     pub(super) cancel: Arc<AtomicBool>,
+    handoff_registered: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -155,6 +168,7 @@ impl SourceProcessingBudgetHandle {
                     registration_id: admission_id,
                     lifecycle_generation,
                     cancel,
+                    handoff_registered: false,
                 };
                 if permit.should_cancel_now() {
                     permit.cancel.store(true, Ordering::Release);
@@ -233,6 +247,63 @@ impl SourceProcessingBudgetPermit {
         self.shared.database_writer.clone()
     }
 
+    /// Register the committed scan result before releasing the source-processing budget.
+    ///
+    /// This consumes the permit so callers cannot accidentally release capacity first and rely
+    /// on delayed GUI delivery to tell the supervisor what changed. If the exact delta cannot be
+    /// admitted for the current lifecycle, the handoff is conservatively promoted to a full
+    /// reconciliation while the permit is still owned.
+    pub(in crate::native_app) fn release_after_handoff(mut self, handoff: ExternalScanHandoff) {
+        self.register_handoff(handoff);
+        drop(self);
+    }
+
+    fn register_handoff(&mut self, handoff: ExternalScanHandoff) {
+        if self.handoff_registered {
+            return;
+        }
+        let source_id = self
+            .permit
+            .as_ref()
+            .map(|permit| permit.source_id().to_string());
+        let Some(source_id) = source_id else {
+            self.handoff_registered = true;
+            return;
+        };
+        let mut control = self.shared.control();
+        let current_generation = control
+            .source_lifecycle_generations
+            .get(&source_id)
+            .copied();
+        let current = control.source_is_active(&source_id)
+            && current_generation == Some(self.lifecycle_generation);
+        if current {
+            match handoff {
+                ExternalScanHandoff::CommittedDelta(delta) if !delta.is_empty() => {
+                    if !control.queue_source_delta(
+                        &source_id,
+                        &delta,
+                        "external_scan_committed_delta",
+                    ) {
+                        control.pending_readiness_deltas.remove(&source_id);
+                        control.cancel_source_work(&source_id);
+                        control
+                            .mark_source_dirty(&source_id, "external_scan_delta_handoff_fallback");
+                    }
+                }
+                ExternalScanHandoff::CommittedDelta(_) => {}
+                ExternalScanHandoff::FullReconciliation { reason } => {
+                    control.pending_readiness_deltas.remove(&source_id);
+                    control.cancel_source_work(&source_id);
+                    control.mark_source_dirty(&source_id, reason);
+                }
+            }
+        }
+        drop(control);
+        self.handoff_registered = true;
+        self.shared.wake.notify_one();
+    }
+
     fn should_cancel_now(&self) -> bool {
         if self.shared.cancel.load(Ordering::Acquire) {
             return true;
@@ -252,6 +323,13 @@ impl SourceProcessingBudgetPermit {
 
 impl Drop for SourceProcessingBudgetPermit {
     fn drop(&mut self) {
+        // A panic, cancellation, or early-return path that skipped the explicit handoff must still
+        // publish a conservative full reconciliation before capacity becomes available again.
+        if !self.handoff_registered {
+            self.register_handoff(ExternalScanHandoff::FullReconciliation {
+                reason: "external_scan_dropped_without_handoff",
+            });
+        }
         let registration = self
             .shared
             .external_scans()
@@ -274,20 +352,8 @@ impl Drop for SourceProcessingBudgetPermit {
             self.shared.wake.notify_one();
         }
         if let Some(permit) = self.permit.take() {
-            let source_id = permit.source_id().to_string();
             self.shared.budgets().release(permit);
             self.shared.budget_wake.notify_all();
-            let mut control = self.shared.control();
-            if control.source_is_active(&source_id)
-                && control.source_lifecycle_generations.get(&source_id)
-                    == Some(&self.lifecycle_generation)
-            {
-                control.cancel_source_work(&source_id);
-                control.mark_source_dirty(&source_id, "external_source_work_committed");
-            } else {
-                control.notify("external_budget_released");
-            }
-            drop(control);
             self.shared.wake.notify_one();
         }
     }

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -345,18 +345,5 @@ pub(super) fn queue_source_delta(
     delta: &CommittedSourceDelta,
     reason: &'static str,
 ) -> bool {
-    #[cfg(test)]
-    if std::mem::take(&mut control.reject_next_delta_delivery) {
-        return false;
-    }
-    if !control.source_is_active(source_id) {
-        return false;
-    }
-    control
-        .pending_readiness_deltas
-        .entry(source_id.to_string())
-        .or_default()
-        .merge(delta, reason);
-    control.mark_source_dirty(source_id, reason);
-    true
+    control.queue_source_delta(source_id, delta, reason)
 }

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -1,6 +1,7 @@
 use super::{
-    Arc, AtomicBool, BTreeMap, BTreeSet, Ordering, PendingReadinessDelta, PendingSourceRetirement,
-    PriorityContext, SampleSource, source_storage_identity_matches,
+    Arc, AtomicBool, BTreeMap, BTreeSet, CommittedSourceDelta, Ordering, PendingReadinessDelta,
+    PendingReadinessDeltaMerge, PendingSourceRetirement, PriorityContext, SampleSource,
+    source_storage_identity_matches,
 };
 
 pub(super) struct ControlState {
@@ -67,6 +68,37 @@ impl ControlState {
             self.dirty_sources.insert(source_id.to_string());
             self.notify(reason);
         }
+    }
+
+    pub(super) fn queue_source_delta(
+        &mut self,
+        source_id: &str,
+        delta: &CommittedSourceDelta,
+        reason: &'static str,
+    ) -> bool {
+        #[cfg(test)]
+        if std::mem::take(&mut self.reject_next_delta_delivery) {
+            return false;
+        }
+        if !self.source_is_active(source_id) {
+            return false;
+        }
+        let merge = self
+            .pending_readiness_deltas
+            .entry(source_id.to_string())
+            .or_default()
+            .merge(delta, reason);
+        if merge == PendingReadinessDeltaMerge::RevisionGap {
+            self.pending_readiness_deltas.remove(source_id);
+            self.cancel_source_work(source_id);
+            self.mark_source_dirty(source_id, "source_delta_revision_gap");
+            return false;
+        }
+        if merge == PendingReadinessDeltaMerge::Stale {
+            return true;
+        }
+        self.mark_source_dirty(source_id, reason);
+        true
     }
 
     pub(super) fn mark_all_sources_dirty(&mut self, reason: &'static str) {

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -15,12 +15,29 @@ pub(super) struct PendingSourceRetirement {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct PendingReadinessDelta {
     pub(super) scope_ids: BTreeSet<String>,
+    pub(super) latest_manifest_revision: Option<u64>,
     #[cfg(test)]
     pub(super) state_machine_inputs: BTreeSet<(u64, &'static str)>,
 }
 
 impl PendingReadinessDelta {
-    pub(super) fn merge(&mut self, delta: &CommittedSourceDelta, reason: &'static str) {
+    pub(super) fn merge(
+        &mut self,
+        delta: &CommittedSourceDelta,
+        reason: &'static str,
+    ) -> PendingReadinessDeltaMerge {
+        if let Some(previous) = self.latest_manifest_revision {
+            if delta.revision < previous {
+                return PendingReadinessDeltaMerge::Stale;
+            }
+            if delta.revision > previous.saturating_add(1) {
+                return PendingReadinessDeltaMerge::RevisionGap;
+            }
+        }
+        self.latest_manifest_revision = Some(
+            self.latest_manifest_revision
+                .map_or(delta.revision, |previous| previous.max(delta.revision)),
+        );
         self.scope_ids.extend(
             delta
                 .created
@@ -35,11 +52,19 @@ impl PendingReadinessDelta {
         self.state_machine_inputs.insert((delta.revision, reason));
         #[cfg(not(test))]
         let _ = reason;
+        PendingReadinessDeltaMerge::Merged
     }
 
     pub(super) fn is_empty(&self) -> bool {
         self.scope_ids.is_empty()
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PendingReadinessDeltaMerge {
+    Merged,
+    Stale,
+    RevisionGap,
 }
 
 #[cfg(test)]

--- a/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
@@ -172,6 +172,176 @@ fn external_scan_release_invalidates_retained_source_generation() {
 }
 
 #[test]
+fn targeted_scan_handoff_is_registered_before_delayed_gui_delivery() {
+    let (_directory, source) = unhashed_source("targeted-scan-handoff");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan(source.id.as_str())
+        .expect("admit targeted sync");
+    let delta = CommittedSourceDelta {
+        revision: 11,
+        changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: String::from("targeted.wav"),
+            relative_path: PathBuf::from("targeted.wav"),
+            content_generation: String::from("generation-11"),
+            source_metadata_changed: false,
+        }],
+        ..CommittedSourceDelta::default()
+    };
+
+    permit.release_after_handoff(ExternalScanHandoff::CommittedDelta(delta.clone()));
+
+    let control = supervisor.shared.control();
+    let pending = control
+        .pending_readiness_deltas
+        .get(source.id.as_str())
+        .expect("targeted commit is owned before GUI delivery");
+    assert!(pending.scope_ids.contains("targeted.wav"));
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    drop(control);
+
+    // The delayed GUI completion may coalesce the same revision without widening the target set.
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        &delta,
+        "delayed_targeted_gui_completion",
+    );
+    let control = supervisor.shared.control();
+    assert_eq!(
+        control
+            .pending_readiness_deltas
+            .get(source.id.as_str())
+            .expect("coalesced delta remains pending")
+            .scope_ids
+            .len(),
+        1
+    );
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn foreground_scan_handoff_uses_full_fallback_before_capacity_release() {
+    let (_directory, source) = unhashed_source("foreground-scan-fallback");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan(source.id.as_str())
+        .expect("admit foreground scan");
+
+    permit.release_after_handoff(ExternalScanHandoff::FullReconciliation {
+        reason: "foreground_scan_test_fallback",
+    });
+
+    let control = supervisor.shared.control();
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    assert!(!control
+        .pending_readiness_deltas
+        .contains_key(source.id.as_str()));
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn foreground_scan_handoff_keeps_one_file_delta_bounded_before_gui_delivery() {
+    let (_directory, source) = unhashed_source("foreground-scan-delta");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let permit = supervisor
+        .budget_handle()
+        .acquire_scan(source.id.as_str())
+        .expect("admit foreground scan");
+    let delta = CommittedSourceDelta {
+        revision: 3,
+        created: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: String::from("foreground.wav"),
+            relative_path: PathBuf::from("foreground.wav"),
+            content_generation: String::from("generation-3"),
+            source_metadata_changed: false,
+        }],
+        ..CommittedSourceDelta::default()
+    };
+
+    permit.release_after_handoff(ExternalScanHandoff::CommittedDelta(delta));
+
+    let control = supervisor.shared.control();
+    assert_eq!(
+        control
+            .pending_readiness_deltas
+            .get(source.id.as_str())
+            .expect("foreground commit is owned before GUI delivery")
+            .scope_ids,
+        [String::from("foreground.wav")].into_iter().collect()
+    );
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn coalesced_scan_delta_revision_gap_promotes_to_full_reconciliation() {
+    let (_directory, source) = unhashed_source("scan-revision-gap");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    {
+        let mut control = supervisor.shared.control();
+        control.dirty_sources.clear();
+    }
+    let first = CommittedSourceDelta {
+        revision: 7,
+        changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: String::from("first"),
+            relative_path: PathBuf::from("first.wav"),
+            content_generation: String::from("generation-7"),
+            source_metadata_changed: false,
+        }],
+        ..CommittedSourceDelta::default()
+    };
+    supervisor.request_source_delta(source.id.as_str(), &first, "first_scan_delta");
+    let gap = CommittedSourceDelta {
+        revision: 9,
+        changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: String::from("gap"),
+            relative_path: PathBuf::from("gap.wav"),
+            content_generation: String::from("generation-9"),
+            source_metadata_changed: false,
+        }],
+        ..CommittedSourceDelta::default()
+    };
+    supervisor.request_source_delta(source.id.as_str(), &gap, "gap_scan_delta");
+
+    let control = supervisor.shared.control();
+    assert!(!control
+        .pending_readiness_deltas
+        .contains_key(source.id.as_str()));
+    assert!(control.dirty_sources.contains(source.id.as_str()));
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
 fn scan_registration_only_adds_absent_matching_sources() {
     let (_directory, source) = unhashed_source("scan-registration");
     let mut supervisor = SourceProcessingSupervisor::dormant();

--- a/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
+++ b/src/native_app/source_processing/supervisor/tests/retirement_recovery.rs
@@ -558,6 +558,7 @@ fn discovery_progress_committed_delta_uses_changed_target_counts() {
         .expect("advance manifest generation");
     let delta = PendingReadinessDelta {
         scope_ids: [identity.clone()].into_iter().collect(),
+        latest_manifest_revision: None,
         state_machine_inputs: Default::default(),
     };
 


### PR DESCRIPTION
## Goal

Ensure targeted sync and foreground source scans publish their authoritative committed manifest outcome to the source-processing supervisor before releasing SourceProcessingBudgetPermit capacity. Delayed GUI completion remains a browser/projection handoff, never the first owner of readiness work.

## Scope and non-goals

- Add a typed permit-owned handoff: exact committed delta or explicit full-reconciliation fallback.
- Make panic/early-drop paths conservatively hand off full reconciliation before capacity release.
- Retain lifecycle generation fencing and GUI projection behavior.
- Track pending manifest revision continuity: contiguous deltas coalesce, stale deliveries are ignored, and revision gaps promote to full reconciliation.
- Non-goal: no GUI redesign, scanner traversal-policy changes, or changes to PR #946.

## Definition of Done

- Once an external scan commit is visible, the supervisor owns an exact revision-aware delta or explicit full-reconciliation fallback before admission capacity is released/woken.
- Targeted sync and foreground scan paths use the typed ownership boundary.
- Delayed GUI delivery cannot widen a one-file commit into unscoped source-wide target publication.
- Lifecycle cancellation and stale-generation behavior remain fenced.
- Deterministic regression coverage covers targeted handoff, foreground exact/fallback handoff, delayed GUI coalescing, and revision gaps.

## Validation

- cargo fmt --all -- --check — passed.
- git diff --check — passed.
- cargo check -p wavecrate --tests — passed.
- Focused lib tests for targeted handoff, foreground exact/fallback handoff, and revision-gap promotion — passed.
- Broader cargo test -p wavecrate --lib handoff -- --test-threads=1: 33 passed, 1 unrelated existing waveform clipboard test failed at src/native_app/tests/waveform_playback.rs:2281.

## Limitations

- The shared checkout retains the pre-existing dirty vendor/radiant gitlink and it is intentionally not included in this PR.
- User approval is required before merge.