### PR TITLE
Retain accepted readiness revisions across delta fallback

### DIFF
--- a/src/native_app/app/message.rs
+++ b/src/native_app/app/message.rs
@@ -105,6 +105,7 @@ pub(in crate::native_app) enum GuiMessage {
         source_id: String,
         lifecycle_generation: u64,
         committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta,
+        complete: bool,
     },
     SourceManifestAuditFinished {
         source_id: String,

--- a/src/native_app/app/source_processing_events.rs
+++ b/src/native_app/app/source_processing_events.rs
@@ -47,10 +47,12 @@ fn map_event(event: SourceProcessingEvent) -> GuiMessage {
         SourceProcessingEvent::ManifestAuditCommitted {
             lifecycle,
             committed_delta,
+            complete,
         } => GuiMessage::SourceManifestAuditCommitted {
             source_id: lifecycle.source_id,
             lifecycle_generation: lifecycle.generation,
             committed_delta,
+            complete,
         },
         SourceProcessingEvent::ManifestAuditFinished {
             lifecycle,
@@ -407,6 +409,7 @@ mod tests {
                 lifecycle: SourceProcessingLifecycle::new("source", 23),
                 committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta::default(
                 ),
+                complete: true,
             })
         );
 

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -307,6 +307,7 @@ impl FileMutationChange {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(in crate::native_app) struct CommittedFileMutation {
     pub(in crate::native_app) source_id: String,
+    pub(in crate::native_app) lifecycle_generation: u64,
     pub(in crate::native_app) operation_id: u64,
     pub(in crate::native_app) operation: FileMutationOperation,
     pub(in crate::native_app) committed_source_revision: u64,
@@ -387,7 +388,14 @@ impl NativeAppState {
             })
             .collect::<Vec<_>>();
         let sources = self.library.folder_browser.configured_sample_sources();
-        let requests = build_source_requests(operation_id, operation, changes, &sources);
+        let mut requests = build_source_requests(operation_id, operation, changes, &sources);
+        let lifecycle_generations = self.background.source_processing.lifecycle_generations();
+        for request in &mut requests {
+            request.lifecycle_generation = lifecycle_generations
+                .get(request.source.id.as_str())
+                .copied()
+                .unwrap_or_default();
+        }
         if requests.is_empty() {
             let mut failures = failures;
             if had_changes {
@@ -550,6 +558,7 @@ impl NativeAppState {
             );
             self.background.source_processing.request_source_delta(
                 &event.source_id,
+                event.lifecycle_generation,
                 &event.committed_delta,
                 "committed_file_mutation_delta",
             );

--- a/src/native_app/sample_library/committed_file_mutations/mod.rs
+++ b/src/native_app/sample_library/committed_file_mutations/mod.rs
@@ -505,6 +505,21 @@ impl NativeAppState {
         };
 
         for event in committed {
+            let current_lifecycle_generation = self
+                .background
+                .source_lifecycle_generations
+                .get(&event.source_id)
+                .copied();
+            if current_lifecycle_generation != Some(event.lifecycle_generation) {
+                tracing::debug!(
+                    source_id = %event.source_id,
+                    operation_id = event.operation_id,
+                    event_lifecycle_generation = event.lifecycle_generation,
+                    current_lifecycle_generation = ?current_lifecycle_generation,
+                    "Ignoring committed file-mutation completion from a stale source lifecycle"
+                );
+                continue;
+            }
             let last_commit = self
                 .transactions
                 .latest_committed_mutation

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -1,4 +1,9 @@
-use std::{fs, path::Path, sync::atomic::AtomicBool};
+use std::{
+    fs,
+    path::Path,
+    sync::{atomic::AtomicBool, mpsc},
+    time::Duration,
+};
 
 use wavecrate::sample_sources::scanner::ManifestIdentityDelta;
 use wavecrate::sample_sources::{SampleSource, SourceDatabase, SourceId, scanner};
@@ -11,6 +16,7 @@ use super::worker::{
     reconcile_file_mutation_requests_with_database_roots, reconcile_source_mutation,
 };
 use super::*;
+use crate::native_app::sample_library::source_watcher::GuiSourceWatcherHandle;
 
 fn request(
     root: &Path,
@@ -329,6 +335,176 @@ fn failed_reconciliation_does_not_apply_browser_projection() {
     assert_eq!(
         state.library.folder_browser.selected_file_id(),
         Some(selected.to_string_lossy().as_ref())
+    );
+}
+
+#[test]
+fn stale_lifecycle_completion_has_no_committed_mutation_side_effects() {
+    let root = tempfile::tempdir().expect("source root");
+    let path = root.path().join("stale.wav");
+    fs::write(&path, b"committed").expect("create source file");
+    let source =
+        SampleSource::new_with_id(SourceId::from_string("source-a"), root.path().to_path_buf());
+    let mut state = crate::native_app::test_support::state::NativeAppStateFixture::default()
+        .with_folder_browser(
+            crate::native_app::test_support::state::FolderBrowserState::from_sample_sources(&[
+                source.clone(),
+            ]),
+        )
+        .build();
+    state
+        .library
+        .folder_browser
+        .select_file("before.wav".to_string());
+
+    let (message_tx, message_rx) = mpsc::channel();
+    let watcher = GuiSourceWatcherHandle::spawn(vec![source.clone()], message_tx);
+    watcher.wait_until_ready_for_tests();
+    while message_rx.try_recv().is_ok() {}
+    state.library.source_watcher = Some(watcher);
+
+    state
+        .background
+        .source_processing
+        .replace_sources(vec![source.clone()])
+        .expect("configure source lifecycle");
+    state.background.source_lifecycle_generations =
+        state.background.source_processing.lifecycle_generations();
+    let stale_lifecycle_generation = state.background.source_lifecycle_generations["source-a"];
+
+    let replacement = source.clone().protected();
+    state
+        .background
+        .source_processing
+        .replace_sources(vec![replacement])
+        .expect("replace source lifecycle");
+    state.background.source_lifecycle_generations =
+        state.background.source_processing.lifecycle_generations();
+    assert_ne!(
+        state.background.source_lifecycle_generations["source-a"],
+        stale_lifecycle_generation
+    );
+    state
+        .background
+        .source_processing
+        .set_selected_source(Some("unrelated-source"));
+
+    let projected_path = root.path().join("stale-projection.wav");
+    let mut changes = vec![
+        FileMutationChange::content_changed(path.clone()).with_projection(
+            FileMutationProjection::SelectAndFollow {
+                path: projected_path,
+            },
+        ),
+    ];
+    capture_expected_filesystem_state(&mut changes);
+    let watcher_echoes = watcher_echoes_for_changes(root.path(), &changes);
+    let event = CommittedFileMutation {
+        source_id: String::from("source-a"),
+        lifecycle_generation: stale_lifecycle_generation,
+        operation_id: 91,
+        operation: FileMutationOperation::Edit,
+        committed_source_revision: 7,
+        changes,
+        invalidated_stages: BTreeSet::from([ReadinessStage::AnalysisFeatures]),
+        committed_delta: CommittedSourceDelta {
+            revision: 7,
+            changed: vec![ManifestIdentityDelta {
+                identity: String::from("stale-identity"),
+                relative_path: PathBuf::from("stale.wav"),
+                content_generation: String::from("stale-generation"),
+                source_metadata_changed: false,
+            }],
+            ..CommittedSourceDelta::default()
+        },
+        affected_relative_paths: vec![PathBuf::from("stale.wav")],
+        watcher_echoes,
+    };
+    let selected_before = state
+        .library
+        .folder_browser
+        .selected_file_id()
+        .map(str::to_owned);
+    let status_before = state.ui.status.sample.clone();
+    let metadata_pending_before = state
+        .metadata
+        .persisted_tag_sources_pending
+        .contains("source-a");
+    let indicator_active_before = state.waveform.cache.indicator_refresh_task.active();
+    let selected_source_priority_before = state
+        .background
+        .source_processing
+        .selected_source_priority_for_tests();
+
+    state.finish_committed_file_mutation(
+        FileMutationOutcome::Committed(vec![event]),
+        &mut radiant::prelude::UiUpdateContext::default(),
+    );
+
+    assert_eq!(
+        state.transactions.latest_committed_mutation.get("source-a"),
+        None,
+        "stale completion must not advance the mutation ledger"
+    );
+    assert_eq!(
+        state.library.folder_browser.selected_file_id(),
+        selected_before.as_deref(),
+        "stale completion must not apply browser projection"
+    );
+    assert_eq!(
+        state
+            .background
+            .source_processing
+            .pending_source_delta_contains_identity_for_tests("source-a", "stale-identity"),
+        false,
+        "stale completion must not publish a readiness delta"
+    );
+    assert_eq!(
+        state
+            .metadata
+            .persisted_tag_sources_pending
+            .contains("source-a"),
+        metadata_pending_before,
+        "stale completion must not schedule source metadata preparation"
+    );
+    assert_eq!(
+        state.waveform.cache.indicator_refresh_task.active(),
+        indicator_active_before,
+        "stale completion must not schedule waveform source preparation"
+    );
+    assert_eq!(
+        state
+            .background
+            .source_processing
+            .selected_source_priority_for_tests(),
+        selected_source_priority_before,
+        "stale completion must not promote source preparation priority"
+    );
+    assert_eq!(state.ui.status.sample, status_before);
+
+    state
+        .library
+        .source_watcher
+        .as_ref()
+        .expect("source watcher")
+        .inject_paths_for_tests(vec![path]);
+    let mut reported_watcher_change = false;
+    for _ in 0..20 {
+        match message_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(GuiMessage::SourceFilesystemChanged {
+                source_id, paths, ..
+            }) if source_id == "source-a" && paths.contains(&PathBuf::from("stale.wav")) => {
+                reported_watcher_change = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    assert!(
+        reported_watcher_change,
+        "stale completion must not install watcher suppression"
     );
 }
 

--- a/src/native_app/sample_library/committed_file_mutations/tests.rs
+++ b/src/native_app/sample_library/committed_file_mutations/tests.rs
@@ -20,6 +20,7 @@ fn request(
     capture_expected_filesystem_state(&mut changes);
     SourceMutationRequest {
         source: SampleSource::new_with_id(SourceId::from_string("source-a"), root.to_path_buf()),
+        lifecycle_generation: 0,
         operation_id: 42,
         operation,
         affected_relative_paths: changes

--- a/src/native_app/sample_library/committed_file_mutations/worker.rs
+++ b/src/native_app/sample_library/committed_file_mutations/worker.rs
@@ -17,6 +17,7 @@ use crate::native_app::sample_library::folder_scan_actions::sync_source_database
 #[derive(Clone, Debug)]
 pub(super) struct SourceMutationRequest {
     pub(super) source: SampleSource,
+    pub(super) lifecycle_generation: u64,
     pub(super) operation_id: u64,
     pub(super) operation: FileMutationOperation,
     pub(super) changes: Vec<FileMutationChange>,
@@ -28,6 +29,7 @@ impl PartialEq for SourceMutationRequest {
     fn eq(&self, other: &Self) -> bool {
         self.source.id == other.source.id
             && self.source.root == other.source.root
+            && self.lifecycle_generation == other.lifecycle_generation
             && self.source.is_protected() == other.source.is_protected()
             && self.source.is_primary() == other.source.is_primary()
             && self.source.primary_import_path() == other.source.primary_import_path()
@@ -132,6 +134,7 @@ pub(super) fn build_source_requests(
                     .entry(source_id.clone())
                     .or_insert_with(|| SourceMutationRequest {
                         source: source.clone(),
+                        lifecycle_generation: 0,
                         operation_id,
                         operation,
                         changes: Vec::new(),
@@ -304,6 +307,7 @@ pub(super) fn reconcile_source_mutation(
 
     Ok(CommittedFileMutation {
         source_id: request.source.id.as_str().to_string(),
+        lifecycle_generation: request.lifecycle_generation,
         operation_id: request.operation_id,
         operation: request.operation,
         committed_source_revision,

--- a/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_scan_actions/filesystem_refresh.rs
@@ -168,6 +168,7 @@ impl NativeAppState {
                 if !result.cancelled && incomplete_error.is_none() {
                     self.background.source_processing.request_source_delta(
                         &source_id,
+                        result.lifecycle_generation,
                         &delta,
                         "filesystem_sync_committed_delta",
                     );
@@ -245,6 +246,7 @@ impl NativeAppState {
         source_id: String,
         lifecycle_generation: u64,
         committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta,
+        complete: bool,
         context: &mut ui::UiUpdateContext<GuiMessage>,
     ) {
         if self.background.source_lifecycle_generations.get(&source_id)
@@ -254,8 +256,18 @@ impl NativeAppState {
         {
             return;
         }
+        if !complete {
+            self.background
+                .source_processing
+                .wake_source_for_full_reconciliation(
+                    &source_id,
+                    "manifest_audit_incomplete_after_commit",
+                );
+            return;
+        }
         self.background.source_processing.request_source_delta(
             &source_id,
+            lifecycle_generation,
             &committed_delta,
             "manifest_audit_committed_delta",
         );

--- a/src/native_app/sample_library/folder_scan_actions/worker.rs
+++ b/src/native_app/sample_library/folder_scan_actions/worker.rs
@@ -380,6 +380,13 @@ impl NativeAppState {
                 committed_delta,
                 source_root_available,
             } => {
+                let Some(lifecycle_generation) = lifecycle_generation else {
+                    tracing::debug!(
+                        source_id,
+                        "Discarding folder scan completion without a captured source lifecycle"
+                    );
+                    return;
+                };
                 if let Some(progress) = applying_progress {
                     self.library
                         .resume_folder_scan_progress_after_projection(progress);
@@ -388,7 +395,7 @@ impl NativeAppState {
                     task_id,
                     source_id: source_id.clone(),
                     label: label.clone(),
-                    lifecycle_generation,
+                    lifecycle_generation: Some(lifecycle_generation),
                     source_root_available,
                     source_db_error: source_db_error.clone(),
                     metadata_hydration_error: metadata_hydration_error.clone(),
@@ -406,6 +413,7 @@ impl NativeAppState {
                     AppliedFolderScan {
                         source_id,
                         label,
+                        lifecycle_generation,
                         file_count,
                         folder_count,
                         source_db_error,
@@ -645,6 +653,7 @@ impl NativeAppState {
             if let Some(committed_delta) = scan.committed_delta.as_ref() {
                 self.background.source_processing.request_source_delta(
                     &scan.source_id,
+                    scan.lifecycle_generation,
                     committed_delta,
                     "foreground_scan_committed_delta",
                 );
@@ -779,6 +788,7 @@ mod lifecycle_tests {
 struct AppliedFolderScan {
     source_id: String,
     label: String,
+    lifecycle_generation: u64,
     file_count: usize,
     folder_count: usize,
     source_db_error: Option<String>,

--- a/src/native_app/shell/message_dispatch/browser.rs
+++ b/src/native_app/shell/message_dispatch/browser.rs
@@ -164,11 +164,13 @@ impl NativeAppState {
                 source_id,
                 lifecycle_generation,
                 committed_delta,
+                complete,
             } => {
                 self.finish_source_manifest_audit(
                     source_id,
                     lifecycle_generation,
                     committed_delta,
+                    complete,
                     context,
                 );
             }

--- a/src/native_app/shell/message_dispatch/tests.rs
+++ b/src/native_app/shell/message_dispatch/tests.rs
@@ -548,6 +548,7 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
                 }],
                 ..Default::default()
             },
+            complete: true,
         },
         &mut context,
     );
@@ -555,6 +556,71 @@ fn source_completions_from_previous_readded_epoch_are_ignored() {
         !current_cancel.load(Ordering::Acquire),
         "an old completion must not cancel the re-added source generation"
     );
+    drop(current_permit);
+}
+
+#[test]
+fn incomplete_current_manifest_audit_delivery_requests_full_reconciliation() {
+    let directory = tempfile::tempdir().expect("completion source");
+    let mut state = NativeAppStateFixture::default().build();
+    let source_id = state
+        .library
+        .folder_browser
+        .defer_add_source_path(directory.path().to_path_buf(), false)
+        .expect("source registered");
+    state.sync_source_watcher();
+    let lifecycle_generation = state.background.source_lifecycle_generations[&source_id];
+    let current_permit = state
+        .background
+        .source_processing
+        .budget_handle()
+        .acquire_scan(&source_id)
+        .expect("current source scan permit");
+    let current_cancel = current_permit.cancel_token();
+    let identity = String::from("incomplete-file");
+    let mut context = ui::UiUpdateContext::default();
+
+    state.apply_message(
+        GuiMessage::SourceManifestAuditCommitted {
+            source_id: source_id.clone(),
+            lifecycle_generation,
+            committed_delta: wavecrate::sample_sources::scanner::CommittedSourceDelta {
+                revision: 3,
+                changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+                    identity: identity.clone(),
+                    relative_path: std::path::PathBuf::from("incomplete.wav"),
+                    content_generation: String::from("incomplete-generation"),
+                    source_metadata_changed: true,
+                }],
+                ..Default::default()
+            },
+            complete: false,
+        },
+        &mut context,
+    );
+
+    assert!(current_cancel.load(Ordering::Acquire));
+    assert!(
+        state
+            .background
+            .source_processing
+            .source_dirty_for_tests(&source_id)
+    );
+    assert!(
+        !state
+            .background
+            .source_processing
+            .pending_source_delta_contains_identity_for_tests(&source_id, &identity)
+    );
+    assert_eq!(
+        state
+            .background
+            .source_processing
+            .accepted_manifest_revision_for_tests(&source_id),
+        None,
+        "an incomplete audit delivery must not create an accepted revision fence"
+    );
+
     drop(current_permit);
 }
 

--- a/src/native_app/source_processing/events.rs
+++ b/src/native_app/source_processing/events.rs
@@ -103,6 +103,7 @@ pub(in crate::native_app) enum SourceProcessingEvent {
     ManifestAuditCommitted {
         lifecycle: SourceProcessingLifecycle,
         committed_delta: CommittedSourceDelta,
+        complete: bool,
     },
     ManifestAuditFinished {
         lifecycle: SourceProcessingLifecycle,

--- a/src/native_app/source_processing/supervisor/admission.rs
+++ b/src/native_app/source_processing/supervisor/admission.rs
@@ -1,7 +1,7 @@
 use super::{
     Arc, AtomicBool, CommittedSourceDelta, DatabaseWriterGate, ExternalScanAdmission,
     ExternalScanRegistration, Ordering, PathBuf, ProcessingLane, SampleSource, Shared,
-    resolve_registered_source_for_scan_locked,
+    SourceDeltaQueueResult, resolve_registered_source_for_scan_locked,
 };
 
 /// The typed handoff an external scan must make before releasing its source-processing budget.
@@ -280,10 +280,14 @@ impl SourceProcessingBudgetPermit {
         if current {
             match handoff {
                 ExternalScanHandoff::CommittedDelta(delta) if !delta.is_empty() => {
-                    if !control.queue_source_delta(
-                        &source_id,
-                        &delta,
-                        "external_scan_committed_delta",
+                    if matches!(
+                        control.queue_source_delta(
+                            &source_id,
+                            self.lifecycle_generation,
+                            &delta,
+                            "external_scan_committed_delta",
+                        ),
+                        SourceDeltaQueueResult::Rejected
                     ) {
                         control.pending_readiness_deltas.remove(&source_id);
                         control.cancel_source_work(&source_id);

--- a/src/native_app/source_processing/supervisor/commands.rs
+++ b/src/native_app/source_processing/supervisor/commands.rs
@@ -1,6 +1,7 @@
 use super::{
     Arc, BTreeMap, CommittedSourceDelta, ControlState, MAX_VISIBLE_PRIORITY_PATHS, SampleSource,
-    SourceProcessingBudgetHandle, SourceProcessingSupervisor, register_source_for_scan_locked,
+    SourceDeltaQueueResult, SourceProcessingBudgetHandle, SourceProcessingSupervisor,
+    register_source_for_scan_locked,
 };
 
 /// Lifecycle hints that may require source-audit admission, but are not proof that a complete
@@ -175,6 +176,7 @@ impl SourceProcessingSupervisor {
     pub(in crate::native_app) fn request_source_delta(
         &self,
         source_id: &str,
+        lifecycle_generation: u64,
         delta: &CommittedSourceDelta,
         reason: &'static str,
     ) {
@@ -182,7 +184,10 @@ impl SourceProcessingSupervisor {
             return;
         }
         let mut control = self.shared.control();
-        if !queue_source_delta(&mut control, source_id, delta, reason) {
+        if !matches!(
+            queue_source_delta(&mut control, source_id, lifecycle_generation, delta, reason),
+            SourceDeltaQueueResult::Queued | SourceDeltaQueueResult::Fallback
+        ) {
             return;
         }
         drop(control);
@@ -200,6 +205,23 @@ impl SourceProcessingSupervisor {
             .pending_readiness_deltas
             .get(source_id)
             .is_some_and(|delta| delta.scope_ids.contains(identity))
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn source_dirty_for_tests(&self, source_id: &str) -> bool {
+        self.shared.control().dirty_sources.contains(source_id)
+    }
+
+    #[cfg(test)]
+    pub(in crate::native_app) fn accepted_manifest_revision_for_tests(
+        &self,
+        source_id: &str,
+    ) -> Option<u64> {
+        self.shared
+            .control()
+            .accepted_manifest_revisions
+            .get(source_id)
+            .map(|fence| fence.revision)
     }
 
     /// Requeue exact current feature, embedding, and similarity targets after
@@ -342,8 +364,9 @@ impl SourceProcessingSupervisor {
 pub(super) fn queue_source_delta(
     control: &mut ControlState,
     source_id: &str,
+    lifecycle_generation: u64,
     delta: &CommittedSourceDelta,
     reason: &'static str,
-) -> bool {
-    control.queue_source_delta(source_id, delta, reason)
+) -> SourceDeltaQueueResult {
+    control.queue_source_delta(source_id, lifecycle_generation, delta, reason)
 }

--- a/src/native_app/source_processing/supervisor/control.rs
+++ b/src/native_app/source_processing/supervisor/control.rs
@@ -1,7 +1,7 @@
 use super::{
-    Arc, AtomicBool, BTreeMap, BTreeSet, CommittedSourceDelta, Ordering, PendingReadinessDelta,
-    PendingReadinessDeltaMerge, PendingSourceRetirement, PriorityContext, SampleSource,
-    source_storage_identity_matches,
+    AcceptedManifestRevision, Arc, AtomicBool, BTreeMap, BTreeSet, CommittedSourceDelta, Ordering,
+    PendingReadinessDelta, PendingReadinessDeltaMerge, PendingSourceRetirement, PriorityContext,
+    SampleSource, source_storage_identity_matches,
 };
 
 pub(super) struct ControlState {
@@ -17,6 +17,7 @@ pub(super) struct ControlState {
     pub(super) lifecycle_audits_deferred_until_watcher_ready: bool,
     pub(super) deferred_lifecycle_audit_sources: BTreeSet<String>,
     pub(super) pending_readiness_deltas: BTreeMap<String, PendingReadinessDelta>,
+    pub(super) accepted_manifest_revisions: BTreeMap<String, AcceptedManifestRevision>,
     pub(super) awaiting_foreground_refresh_sources: BTreeSet<String>,
     pub(super) force_manifest_audit_sources: BTreeSet<String>,
     pub(super) force_reanalysis_sources: BTreeSet<String>,
@@ -73,15 +74,64 @@ impl ControlState {
     pub(super) fn queue_source_delta(
         &mut self,
         source_id: &str,
+        lifecycle_generation: u64,
         delta: &CommittedSourceDelta,
         reason: &'static str,
-    ) -> bool {
+    ) -> SourceDeltaQueueResult {
         #[cfg(test)]
         if std::mem::take(&mut self.reject_next_delta_delivery) {
-            return false;
+            return SourceDeltaQueueResult::Rejected;
         }
-        if !self.source_is_active(source_id) {
-            return false;
+        if !self.source_is_active(source_id)
+            || self.source_lifecycle_generations.get(source_id) != Some(&lifecycle_generation)
+        {
+            return SourceDeltaQueueResult::Rejected;
+        }
+        if let Some(fence) = self.accepted_manifest_revisions.get(source_id)
+            && fence.lifecycle_generation == lifecycle_generation
+            && (delta.revision <= fence.revision
+                || fence
+                    .recovery_floor
+                    .is_some_and(|floor| delta.revision <= floor))
+        {
+            return SourceDeltaQueueResult::Ignored;
+        }
+        if self
+            .accepted_manifest_revisions
+            .get(source_id)
+            .is_some_and(|fence| {
+                fence.lifecycle_generation == lifecycle_generation
+                    && fence.recovery_floor.is_none()
+                    && delta.revision > fence.revision.saturating_add(1)
+            })
+        {
+            self.pending_readiness_deltas.remove(source_id);
+            let fence = self
+                .accepted_manifest_revisions
+                .get_mut(source_id)
+                .expect("accepted revision was present");
+            fence.recovery_floor = Some(delta.revision);
+            self.cancel_source_work(source_id);
+            self.mark_source_dirty(source_id, "source_delta_revision_gap");
+            return SourceDeltaQueueResult::Fallback;
+        }
+        if self
+            .accepted_manifest_revisions
+            .get(source_id)
+            .is_some_and(|fence| {
+                fence.lifecycle_generation == lifecycle_generation && fence.recovery_floor.is_some()
+            })
+        {
+            self.pending_readiness_deltas.remove(source_id);
+            let fence = self
+                .accepted_manifest_revisions
+                .get_mut(source_id)
+                .expect("recovery floor was present");
+            fence.recovery_floor =
+                Some(fence.recovery_floor.unwrap_or_default().max(delta.revision));
+            self.cancel_source_work(source_id);
+            self.mark_source_dirty(source_id, "source_delta_recovery_pending");
+            return SourceDeltaQueueResult::Fallback;
         }
         let merge = self
             .pending_readiness_deltas
@@ -91,14 +141,54 @@ impl ControlState {
         if merge == PendingReadinessDeltaMerge::RevisionGap {
             self.pending_readiness_deltas.remove(source_id);
             self.cancel_source_work(source_id);
+            let fence = self
+                .accepted_manifest_revisions
+                .entry(source_id.to_string())
+                .or_insert(AcceptedManifestRevision {
+                    lifecycle_generation,
+                    ..AcceptedManifestRevision::default()
+                });
+            fence.lifecycle_generation = lifecycle_generation;
+            fence.recovery_floor =
+                Some(fence.recovery_floor.unwrap_or_default().max(delta.revision));
             self.mark_source_dirty(source_id, "source_delta_revision_gap");
-            return false;
+            return SourceDeltaQueueResult::Fallback;
         }
         if merge == PendingReadinessDeltaMerge::Stale {
-            return true;
+            return SourceDeltaQueueResult::Ignored;
         }
         self.mark_source_dirty(source_id, reason);
-        true
+        SourceDeltaQueueResult::Queued
+    }
+
+    pub(super) fn accept_reconciled_manifest_revision(
+        &mut self,
+        source_id: &str,
+        lifecycle_generation: u64,
+        revision: u64,
+    ) {
+        if !self.source_is_active(source_id)
+            || self.source_lifecycle_generations.get(source_id) != Some(&lifecycle_generation)
+        {
+            return;
+        }
+        let fence = self
+            .accepted_manifest_revisions
+            .entry(source_id.to_string())
+            .or_insert(AcceptedManifestRevision {
+                lifecycle_generation,
+                ..AcceptedManifestRevision::default()
+            });
+        if fence.lifecycle_generation != lifecycle_generation {
+            *fence = AcceptedManifestRevision {
+                lifecycle_generation,
+                revision,
+                recovery_floor: None,
+            };
+            return;
+        }
+        fence.revision = fence.revision.max(revision);
+        fence.recovery_floor = fence.recovery_floor.filter(|floor| *floor > fence.revision);
     }
 
     pub(super) fn mark_all_sources_dirty(&mut self, reason: &'static str) {
@@ -149,4 +239,12 @@ impl ControlState {
             })
             .collect();
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SourceDeltaQueueResult {
+    Queued,
+    Ignored,
+    Fallback,
+    Rejected,
 }

--- a/src/native_app/source_processing/supervisor/discovery.rs
+++ b/src/native_app/source_processing/supervisor/discovery.rs
@@ -99,6 +99,18 @@ pub(super) fn discover_candidates(
                     telemetry.delta_reconciliations =
                         telemetry.delta_reconciliations.saturating_add(1);
                 }
+                let pending_revision = pending_readiness_deltas
+                    .get(source.id.as_str())
+                    .and_then(|pending| pending.latest_manifest_revision);
+                let mut control = shared.control();
+                if let Some(revision) = manifest_revision_to_accept(&stats, pending_revision) {
+                    control.accept_reconciled_manifest_revision(
+                        source.id.as_str(),
+                        in_flight_work.lifecycle_generation,
+                        revision,
+                    );
+                }
+                drop(control);
                 candidates.append(&mut source_candidates);
                 if !stats.cheap_noop_sweep {
                     source_stats.insert(source.id.as_str().to_string(), stats);
@@ -185,6 +197,17 @@ pub(super) fn discover_candidates(
         consumed_readiness_deltas,
         progress_published,
     )
+}
+
+pub(super) fn manifest_revision_to_accept(
+    stats: &SourceDiscoveryStats,
+    pending_revision: Option<u64>,
+) -> Option<u64> {
+    if stats.delta_reconciled {
+        pending_revision
+    } else {
+        stats.reconciled_manifest_revision
+    }
 }
 
 #[cfg(test)]

--- a/src/native_app/source_processing/supervisor/discovery_reconcile.rs
+++ b/src/native_app/source_processing/supervisor/discovery_reconcile.rs
@@ -571,6 +571,21 @@ pub(super) fn discover_source_candidates_with_connection_and_progress(
     if cancelled(cancel) {
         Ok(Cancellable::Cancelled)
     } else {
+        if readiness_source_exists {
+            stats.reconciled_manifest_revision = Some(
+                connection
+                    .query_row(
+                        "SELECT COALESCE(
+                            (SELECT CAST(value AS INTEGER) FROM metadata WHERE key = ?1),
+                            0
+                         )",
+                        [META_WAV_PATHS_REVISION],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|error| error.to_string())?
+                    .max(0) as u64,
+            );
+        }
         Ok(Cancellable::Completed((candidates, stats, health)))
     }
 }

--- a/src/native_app/source_processing/supervisor/execution.rs
+++ b/src/native_app/source_processing/supervisor/execution.rs
@@ -162,6 +162,7 @@ pub(super) fn execute_candidate(
                     lifecycle_generation,
                 ),
                 committed_delta: outcome.committed_delta,
+                complete: manifest_complete,
             });
             let foreground_refresh_owns_reconciliation =
                 browser_refresh_required && audit_published;

--- a/src/native_app/source_processing/supervisor/lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/lifecycle.rs
@@ -126,7 +126,7 @@ impl SourceProcessingSupervisor {
         }
         control.sources = sources;
         control.source_work_cancels = source_work_cancels;
-        control.source_lifecycle_generations = source_lifecycle_generations;
+        control.source_lifecycle_generations = source_lifecycle_generations.clone();
         control.quarantined_sources.clear();
         let retained_source_ids = control.sources.keys().cloned().collect::<BTreeSet<_>>();
         control
@@ -153,6 +153,14 @@ impl SourceProcessingSupervisor {
         control.pending_readiness_deltas.retain(|source_id, _| {
             retained_source_ids.contains(source_id) && !changed_source_ids.contains(source_id)
         });
+        control
+            .accepted_manifest_revisions
+            .retain(|source_id, fence| {
+                retained_source_ids.contains(source_id)
+                    && !changed_source_ids.contains(source_id)
+                    && source_lifecycle_generations.get(source_id)
+                        == Some(&fence.lifecycle_generation)
+            });
         control
             .awaiting_foreground_refresh_sources
             .retain(|source_id| {

--- a/src/native_app/source_processing/supervisor/model.rs
+++ b/src/native_app/source_processing/supervisor/model.rs
@@ -20,6 +20,13 @@ pub(super) struct PendingReadinessDelta {
     pub(super) state_machine_inputs: BTreeSet<(u64, &'static str)>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct AcceptedManifestRevision {
+    pub(super) lifecycle_generation: u64,
+    pub(super) revision: u64,
+    pub(super) recovery_floor: Option<u64>,
+}
+
 impl PendingReadinessDelta {
     pub(super) fn merge(
         &mut self,
@@ -110,6 +117,7 @@ pub(super) struct SourceDiscoveryStats {
     pub(super) progress_total: usize,
     pub(super) cheap_noop_sweep: bool,
     pub(super) delta_reconciled: bool,
+    pub(super) reconciled_manifest_revision: Option<u64>,
 }
 
 pub(super) enum Cancellable<T> {

--- a/src/native_app/source_processing/supervisor/state.rs
+++ b/src/native_app/source_processing/supervisor/state.rs
@@ -147,6 +147,7 @@ impl Shared {
                 lifecycle_audits_deferred_until_watcher_ready,
                 deferred_lifecycle_audit_sources: BTreeSet::new(),
                 pending_readiness_deltas: BTreeMap::new(),
+                accepted_manifest_revisions: BTreeMap::new(),
                 awaiting_foreground_refresh_sources: BTreeSet::new(),
                 force_manifest_audit_sources: BTreeSet::new(),
                 force_reanalysis_sources: BTreeSet::new(),

--- a/src/native_app/source_processing/supervisor/state_machine_observation.rs
+++ b/src/native_app/source_processing/supervisor/state_machine_observation.rs
@@ -1,5 +1,5 @@
 use super::commands::queue_source_delta;
-use super::{BTreeSet, CommittedSourceDelta, SourceProcessingSupervisor};
+use super::{BTreeSet, CommittedSourceDelta, SourceDeltaQueueResult, SourceProcessingSupervisor};
 
 pub(super) struct StateMachineQueueObservation {
     pub(super) lifecycle_generation: u64,
@@ -31,9 +31,16 @@ impl SourceProcessingSupervisor {
             .get(source_id)
             .map(|pending| pending.scope_ids.clone())
             .unwrap_or_default();
+        let lifecycle_generation = control
+            .source_lifecycle_generations
+            .get(source_id)
+            .copied()?;
         let delivery_rejected = if reject_delivery_once {
             control.reject_next_delta_delivery = true;
-            !queue_source_delta(&mut control, source_id, delta, reason)
+            matches!(
+                queue_source_delta(&mut control, source_id, lifecycle_generation, delta, reason,),
+                SourceDeltaQueueResult::Rejected
+            )
         } else {
             false
         };
@@ -43,12 +50,8 @@ impl SourceProcessingSupervisor {
             .map(|pending| pending.scope_ids.clone())
             .unwrap_or_default();
         for _ in 0..repetitions {
-            queue_source_delta(&mut control, source_id, delta, reason);
+            queue_source_delta(&mut control, source_id, lifecycle_generation, delta, reason);
         }
-        let lifecycle_generation = control
-            .source_lifecycle_generations
-            .get(source_id)
-            .copied()?;
         let pending = control.pending_readiness_deltas.get(source_id)?;
         let observation = StateMachineQueueObservation {
             lifecycle_generation,

--- a/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/admission_lifecycle.rs
@@ -12,6 +12,7 @@ fn bounded_manifest_delta_preserves_unaffected_in_flight_generation() {
     };
     supervisor.request_source_delta(
         source.id.as_str(),
+        supervisor.lifecycle_generations()[source.id.as_str()],
         &CommittedSourceDelta {
             revision: 1,
             changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
@@ -84,8 +85,7 @@ fn unchanged_foreground_scan_release_does_not_request_generic_discovery() {
             .remove(source.id.as_str());
     }
 
-    supervisor
-        .finish_foreground_source_refresh(source.id.as_str(), "unchanged_foreground_scan");
+    supervisor.finish_foreground_source_refresh(source.id.as_str(), "unchanged_foreground_scan");
 
     let control = supervisor.shared.control();
     assert!(
@@ -211,6 +211,7 @@ fn targeted_scan_handoff_is_registered_before_delayed_gui_delivery() {
     // The delayed GUI completion may coalesce the same revision without widening the target set.
     supervisor.request_source_delta(
         source.id.as_str(),
+        supervisor.lifecycle_generations()[source.id.as_str()],
         &delta,
         "delayed_targeted_gui_completion",
     );
@@ -250,9 +251,11 @@ fn foreground_scan_handoff_uses_full_fallback_before_capacity_release() {
 
     let control = supervisor.shared.control();
     assert!(control.dirty_sources.contains(source.id.as_str()));
-    assert!(!control
-        .pending_readiness_deltas
-        .contains_key(source.id.as_str()));
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
     drop(control);
     assert_eq!(supervisor.shutdown()["joined"], true);
 }
@@ -319,7 +322,12 @@ fn coalesced_scan_delta_revision_gap_promotes_to_full_reconciliation() {
         }],
         ..CommittedSourceDelta::default()
     };
-    supervisor.request_source_delta(source.id.as_str(), &first, "first_scan_delta");
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        supervisor.lifecycle_generations()[source.id.as_str()],
+        &first,
+        "first_scan_delta",
+    );
     let gap = CommittedSourceDelta {
         revision: 9,
         changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
@@ -330,12 +338,19 @@ fn coalesced_scan_delta_revision_gap_promotes_to_full_reconciliation() {
         }],
         ..CommittedSourceDelta::default()
     };
-    supervisor.request_source_delta(source.id.as_str(), &gap, "gap_scan_delta");
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        supervisor.lifecycle_generations()[source.id.as_str()],
+        &gap,
+        "gap_scan_delta",
+    );
 
     let control = supervisor.shared.control();
-    assert!(!control
-        .pending_readiness_deltas
-        .contains_key(source.id.as_str()));
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
     assert!(control.dirty_sources.contains(source.id.as_str()));
     drop(control);
     assert_eq!(supervisor.shutdown()["joined"], true);
@@ -612,7 +627,11 @@ fn watcher_ready_probe_coalesces_after_an_older_probe_was_captured() {
             control.safety_probe_sources.contains(source.id.as_str()),
             "the watcher-ready probe must survive an older captured lifecycle probe"
         );
-        assert!(!control.force_manifest_audit_sources.contains(source.id.as_str()));
+        assert!(
+            !control
+                .force_manifest_audit_sources
+                .contains(source.id.as_str())
+        );
         control.dirty_sources.remove(source.id.as_str());
         control.safety_probe_sources.remove(source.id.as_str());
     }
@@ -644,9 +663,17 @@ fn watcher_history_gap_forces_only_the_affected_source_audit() {
     supervisor.request_source_manifest_audit(first.id.as_str(), "watcher_history_gap");
 
     let control = supervisor.shared.control();
-    assert!(control.force_manifest_audit_sources.contains(first.id.as_str()));
+    assert!(
+        control
+            .force_manifest_audit_sources
+            .contains(first.id.as_str())
+    );
     assert!(control.dirty_sources.contains(first.id.as_str()));
-    assert!(!control.force_manifest_audit_sources.contains(second.id.as_str()));
+    assert!(
+        !control
+            .force_manifest_audit_sources
+            .contains(second.id.as_str())
+    );
     assert!(!control.dirty_sources.contains(second.id.as_str()));
     drop(control);
     assert_eq!(supervisor.shutdown()["joined"], true);
@@ -685,6 +712,287 @@ fn external_admission_rejects_generation_captured_before_descriptor_replacement(
             .lifecycle_generation(old_source.id.as_str())
             .expect("replacement generation"),
         old_generation
+    );
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+fn readiness_delta(revision: u64, identity: &str) -> CommittedSourceDelta {
+    CommittedSourceDelta {
+        revision,
+        changed: vec![wavecrate::sample_sources::scanner::ManifestIdentityDelta {
+            identity: identity.to_string(),
+            relative_path: PathBuf::from(format!("{identity}.wav")),
+            content_generation: format!("generation-{revision}"),
+            source_metadata_changed: false,
+        }],
+        ..CommittedSourceDelta::default()
+    }
+}
+
+#[test]
+fn full_reconciliation_accepts_durable_revision_when_delta_was_not_applied() {
+    let full_reconciliation = SourceDiscoveryStats {
+        delta_reconciled: false,
+        reconciled_manifest_revision: Some(7),
+        ..SourceDiscoveryStats::default()
+    };
+    assert_eq!(
+        manifest_revision_to_accept(&full_reconciliation, Some(5)),
+        Some(7),
+        "a complete full reconciliation must fence through its durable revision"
+    );
+
+    let delta_reconciliation = SourceDiscoveryStats {
+        delta_reconciled: true,
+        reconciled_manifest_revision: Some(7),
+        ..SourceDiscoveryStats::default()
+    };
+    assert_eq!(
+        manifest_revision_to_accept(&delta_reconciliation, Some(5)),
+        Some(5),
+        "an applied bounded delta retains its accepted delta revision"
+    );
+}
+
+#[test]
+fn accepted_manifest_revision_survives_delta_consumption_without_rescheduling() {
+    let (_directory, source) = unhashed_source("accepted-revision-consumption");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let lifecycle_generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    let delta = readiness_delta(4, "consumed");
+    {
+        let mut control = supervisor.shared.control();
+        assert_eq!(
+            control.queue_source_delta(
+                source.id.as_str(),
+                lifecycle_generation,
+                &delta,
+                "test_consumption",
+            ),
+            SourceDeltaQueueResult::Queued
+        );
+        control.accept_reconciled_manifest_revision(
+            source.id.as_str(),
+            lifecycle_generation,
+            delta.revision,
+        );
+        control.pending_readiness_deltas.remove(source.id.as_str());
+        control.dirty_sources.clear();
+        let wake_generation = control.wake_generation;
+        drop(control);
+        supervisor.request_source_delta(
+            source.id.as_str(),
+            lifecycle_generation,
+            &delta,
+            "delayed_consumption_completion",
+        );
+        let control = supervisor.shared.control();
+        assert_eq!(
+            control.accepted_manifest_revisions[source.id.as_str()].revision,
+            delta.revision
+        );
+        assert!(!control.dirty_sources.contains(source.id.as_str()));
+        assert!(
+            !control
+                .pending_readiness_deltas
+                .contains_key(source.id.as_str())
+        );
+        assert_eq!(control.wake_generation, wake_generation);
+    }
+    let next = readiness_delta(5, "newly-accepted");
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        lifecycle_generation,
+        &next,
+        "new_accepted_revision",
+    );
+    {
+        let mut control = supervisor.shared.control();
+        assert!(
+            control
+                .pending_readiness_deltas
+                .contains_key(source.id.as_str())
+        );
+        control.accept_reconciled_manifest_revision(
+            source.id.as_str(),
+            lifecycle_generation,
+            next.revision,
+        );
+        assert_eq!(
+            control.accepted_manifest_revisions[source.id.as_str()].revision,
+            next.revision
+        );
+    }
+    let gap = readiness_delta(7, "post_consumption_gap");
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        lifecycle_generation,
+        &gap,
+        "post_consumption_gap",
+    );
+    let control = supervisor.shared.control();
+    assert!(
+        !control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    assert_eq!(
+        control.accepted_manifest_revisions[source.id.as_str()].recovery_floor,
+        Some(gap.revision)
+    );
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn gap_fallback_fences_delayed_revisions_until_recovery_is_reconciled() {
+    let (_directory, source) = unhashed_source("accepted-revision-gap");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let lifecycle_generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    let first = readiness_delta(7, "first-gap");
+    let gap = readiness_delta(9, "gap");
+    {
+        let mut control = supervisor.shared.control();
+        assert_eq!(
+            control.queue_source_delta(
+                source.id.as_str(),
+                lifecycle_generation,
+                &first,
+                "test_gap_first",
+            ),
+            SourceDeltaQueueResult::Queued
+        );
+        assert_eq!(
+            control.queue_source_delta(
+                source.id.as_str(),
+                lifecycle_generation,
+                &gap,
+                "test_gap_fallback",
+            ),
+            SourceDeltaQueueResult::Fallback
+        );
+        control.dirty_sources.clear();
+    }
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        lifecycle_generation,
+        &first,
+        "delayed_gap_first",
+    );
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        lifecycle_generation,
+        &gap,
+        "delayed_gap_completion",
+    );
+    {
+        let control = supervisor.shared.control();
+        let fence = &control.accepted_manifest_revisions[source.id.as_str()];
+        assert_eq!(
+            fence.revision, 0,
+            "recovery has not been durably reconciled"
+        );
+        assert_eq!(fence.recovery_floor, Some(gap.revision));
+        assert!(!control.dirty_sources.contains(source.id.as_str()));
+        assert!(
+            !control
+                .pending_readiness_deltas
+                .contains_key(source.id.as_str())
+        );
+    }
+    {
+        let mut control = supervisor.shared.control();
+        control.accept_reconciled_manifest_revision(
+            source.id.as_str(),
+            lifecycle_generation,
+            gap.revision,
+        );
+        assert_eq!(
+            control.accepted_manifest_revisions[source.id.as_str()].revision,
+            gap.revision
+        );
+        assert_eq!(
+            control.accepted_manifest_revisions[source.id.as_str()].recovery_floor,
+            None
+        );
+    }
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn cancelled_reconciliation_does_not_advance_accepted_manifest_revision() {
+    let (_directory, source) = unhashed_source("accepted-revision-cancelled");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let lifecycle_generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    let delta = readiness_delta(5, "cancelled");
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        lifecycle_generation,
+        &delta,
+        "cancelled_delta",
+    );
+    let mut control = supervisor.shared.control();
+    control.cancel_source_work(source.id.as_str());
+    assert!(
+        !control
+            .accepted_manifest_revisions
+            .contains_key(source.id.as_str())
+    );
+    assert!(
+        control
+            .pending_readiness_deltas
+            .contains_key(source.id.as_str())
+    );
+    drop(control);
+    assert_eq!(supervisor.shutdown()["joined"], true);
+}
+
+#[test]
+fn lifecycle_replacement_resets_manifest_revision_fence() {
+    let (_directory, source) = unhashed_source("accepted-revision-lifecycle");
+    let mut supervisor = SourceProcessingSupervisor::dormant();
+    supervisor
+        .replace_sources(vec![source.clone()])
+        .expect("configure source");
+    let old_generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    {
+        let mut control = supervisor.shared.control();
+        control.accept_reconciled_manifest_revision(source.id.as_str(), old_generation, 12);
+    }
+    let replacement_directory = tempfile::tempdir().expect("replacement source root");
+    let replacement = SampleSource::new_with_id(
+        source.id.clone(),
+        replacement_directory.path().to_path_buf(),
+    );
+    supervisor
+        .replace_sources(vec![replacement])
+        .expect("replace source lifecycle");
+    let new_generation = supervisor.lifecycle_generations()[source.id.as_str()];
+    assert_ne!(new_generation, old_generation);
+    let control = supervisor.shared.control();
+    assert!(
+        !control
+            .accepted_manifest_revisions
+            .contains_key(source.id.as_str())
+    );
+    drop(control);
+    supervisor.request_source_delta(
+        source.id.as_str(),
+        old_generation,
+        &readiness_delta(12, "old-lifecycle"),
+        "delayed_old_lifecycle",
+    );
+    assert!(
+        !supervisor
+            .pending_source_delta_contains_identity_for_tests(source.id.as_str(), "old-lifecycle",)
     );
     assert_eq!(supervisor.shutdown()["joined"], true);
 }

--- a/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
+++ b/src/native_app/source_processing/supervisor/tests/progress_lifecycle.rs
@@ -428,6 +428,7 @@ fn periodic_manifest_audit_wakes_browser_projection_after_committed_repair() {
             SourceProcessingEvent::ManifestAuditCommitted {
                 lifecycle,
                 committed_delta,
+                ..
             } => Some((lifecycle, committed_delta)),
             _ => None,
         })
@@ -502,6 +503,7 @@ fn manifest_projection_handoff_defers_discovery_until_external_scan_releases() {
         if let SourceProcessingEvent::ManifestAuditCommitted {
             lifecycle,
             committed_delta,
+            ..
         } = event
             && lifecycle.source_id == source.id.as_str()
             && !committed_delta.created.is_empty()

--- a/src/test_support/source_processing_liveness/scenarios.rs
+++ b/src/test_support/source_processing_liveness/scenarios.rs
@@ -611,6 +611,7 @@ fn profile_revision_gated_readiness_sweeps_10k() {
     let completions_before = supervisor.shared.telemetry().completed;
     supervisor.request_source_delta(
         source.id.as_str(),
+        supervisor.lifecycle_generations()[source.id.as_str()],
         &CommittedSourceDelta {
             revision: 1,
             changed: vec![ManifestIdentityDelta {


### PR DESCRIPTION
## Goal

Retain accepted source-readiness manifest revisions across pending-delta consumption and full-reconciliation fallback so delayed GUI delivery cannot recreate stale bounded readiness work.

## Scope and non-goals

This change adds a lifecycle-generation-fenced accepted-revision watermark separate from pending deltas, keeps it after consumption and gap fallback, ignores revisions at or below the watermark without scheduling effects, and carries the lifecycle generation through delayed GUI and worker delivery paths. The watermark advances only after complete durable reconciliation; incomplete audits retain existing cancellation and recovery semantics.

Non-goals: redesigning audit admission, readiness classification, progress presentation, or the full reconciliation algorithm.

## Definition of Done

- Stale readiness revisions cannot recreate bounded processing after normal consumption, gap fallback, cancellation, or delayed GUI delivery.
- A newer accepted revision schedules exactly once.
- Lifecycle replacement resets the watermark and fences predecessor work, including delayed committed-mutation completions before GUI/watcher/prep effects.
- Incomplete reconciliation does not advance recovery barriers, cursors, or the accepted revision.
- Deterministic regressions cover normal consumption, gap fallback, delayed delivery, cancellation, lifecycle replacement, newer revisions, incomplete reconciliation, and stale committed-mutation completion.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo check -p wavecrate --lib` — passed.
- `cargo test -p wavecrate --lib source_processing::supervisor --no-fail-fast` — passed (120 passed, 7 ignored).
- `cargo test -p wavecrate --lib native_app::shell::message_dispatch::tests --no-fail-fast` — passed (16 tests).
- `cargo test -p wavecrate --lib native_app::sample_library::committed_file_mutations::tests --no-fail-fast` — passed (16 tests).
- `git diff --check` — passed.
- `bash scripts/ci.sh agent` — Wavecrate checks and architecture guardrails passed; the gate is blocked by an unrelated existing `vendor/radiant` failure in `gpu_signal_shader_keeps_waveform_bands_visually_distinct` (expected shader color literal).

## Review follow-up

An independent Terra/high review identified a stale committed-file-mutation GUI completion path. The fix was added in commit `92b6a17b5`, with a deterministic replacement-before-delivery regression, and the focused validation above was rerun.

## Known limitations

The full agent gate remains red on the pre-existing Radiant shader-color assertion above; no Radiant files are changed by this PR.

## Merge

This PR is ready for review. User approval is required before merge; do not merge without explicit approval.