### PR TITLE
test: repair OPT-1206 converged readiness profile fixture

### DIFF
--- a/src/test_support/source_processing_liveness/artifacts.rs
+++ b/src/test_support/source_processing_liveness/artifacts.rs
@@ -1,5 +1,27 @@
 use super::*;
 
+#[cfg(target_os = "macos")]
+pub(super) fn seed_durable_watcher_checkpoint(connection: &mut Connection, source: &SampleSource) {
+    let metadata = fs::metadata(&source.root).expect("read source root metadata");
+    let root_identity =
+        wavecrate_library::filesystem_identity::stable_filesystem_identity(&source.root, &metadata)
+            .expect("temporary source root should expose stable identity");
+    connection
+        .execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![
+                wavecrate_library::sample_sources::db::META_SOURCE_WATCHER_CHECKPOINT,
+                serde_json::json!({
+                    "root_identity": root_identity,
+                    "event_id": 1_u64,
+                })
+                .to_string(),
+            ],
+        )
+        .expect("persist durable watcher checkpoint");
+}
+
 pub(super) fn assert_exact_artifact_coverage(source: &SampleSource, snapshot: &ReadinessSnapshot) {
     let connection = open_connection(source).expect("open exact coverage database");
     let eligible_count = connection

--- a/src/test_support/source_processing_liveness/scenarios.rs
+++ b/src/test_support/source_processing_liveness/scenarios.rs
@@ -499,6 +499,18 @@ fn profile_revision_gated_readiness_sweeps_10k() {
             .expect("reconcile seeded profile")
             .is_fully_ready()
     );
+    #[cfg(target_os = "macos")]
+    seed_durable_watcher_checkpoint(&mut connection, &source);
+    let probe = readiness_safety_probe(&mut connection, &source, now_epoch_seconds(), false)
+        .expect("probe seeded revision-gated readiness");
+    assert!(
+        probe.current,
+        "seeded readiness safety probe must be current"
+    );
+    assert!(
+        probe.earliest_deadline.is_none(),
+        "seeded readiness safety probe must have no deadline"
+    );
     drop(connection);
 
     let mut supervisor =


### PR DESCRIPTION
## Goal
Repair the OPT-1206 ignored 10k readiness profile so its synthetic source models fully converged durable macOS watcher coverage and can take the revision-gated cheap-probe path.

## Scope and non-goals
- Add a test-only macOS helper that derives the temporary source root stable filesystem identity and persists `META_SOURCE_WATCHER_CHECKPOINT` with deterministic nonzero `event_id: 1`.
- Invoke it only from `profile_revision_gated_readiness_sweeps_10k`.
- Assert the seeded safety probe is current with no pending deadline before starting the synthetic supervisor.
- No production supervisor, watcher, readiness, scanner, or persistence changes. No timeout, telemetry, or synthetic executor-persistence changes.

## Definition of Done
- The profile reports 30,001 initial targets.
- Ten safety probes perform zero target writes and zero full audits with zero contention.
- A one-file revision produces exactly four target updates, including source-scoped similarity, while preserving unaffected work.
- The profile reaches full convergence and emits elapsed/CPU/heap/disk-I/O measurements.
- Missing/malformed/mismatched watcher coverage remains audit-eligible.

## Validation
- `cargo fmt --all -- --check` — pass.
- `git diff --check` — pass.
- `cargo test -p wavecrate --lib discovery_progress_converged_safety_probe_is_a_silent_noop` — pass.
- `cargo test -p wavecrate --lib macos_safety_probe_requires_durable_watcher_coverage` — pass.
- `cargo test -p wavecrate --lib native_app::source_processing::supervisor::tests` — 108 passed, 1 ignored.
- `cargo test -p wavecrate-library --lib readiness` — 50 passed.
- `cargo test -p wavecrate --lib profile_revision_gated_readiness_sweeps_10k -- --ignored --nocapture` — pass: 30,001 targets; 10 sweeps; 0 steady target writes; 0 full audits; 0 contention; exact 4-target delta; full convergence; metrics emitted.
- `bash scripts/ci.sh agent` — Wavecrate guardrails and readiness boundary passed; the gate stopped on an unrelated pinned Radiant test failure (`gpu_signal_shader_keeps_waveform_bands_visually_distinct`) in `vendor/radiant`.

## Known limitations
The full agent gate remains red only because the pinned `vendor/radiant` submodule test expects a shader color absent from commit `c8398744`; this PR does not modify that dependency or its tests.

User approval is required before merge.
