### PR TITLE
Repin Radiant for composed transient overlays

### DIFF
--- a/src/native_app/tests/toolbar_playback/frame_overlay.rs
+++ b/src/native_app/tests/toolbar_playback/frame_overlay.rs
@@ -1096,9 +1096,12 @@ fn manifest_maintenance_does_not_paint_source_row_pulse_overlay() {
 }
 
 #[test]
-fn scene_installs_playback_cursor_transient_overlay() {
+fn scene_composes_playback_cursor_with_waveform_overflow_fade() {
     let mut state = gui_state_for_span_tests();
+    state.waveform.current.set_play_selection_range(0.2, 0.8);
+    state.waveform.current.zoom_to_play_selection();
     state.waveform.current.start_playback(0.25);
+    state.ui.chrome.overflow_fades.arm();
     let theme = radiant::theme::ThemeTokens::default();
     let bridge = radiant::app(state)
         .view(crate::native_app::test_support::state::view)
@@ -1107,9 +1110,32 @@ fn scene_installs_playback_cursor_transient_overlay() {
     let mut runtime = SurfaceRuntime::new(bridge, Vector2::new(900.0, 620.0));
     apply_strict_update_diagnostics(&mut runtime);
     let frame = runtime.frame(&theme);
-    let mut primitives = Vec::new();
 
     assert!(runtime.has_transient_overlay_host());
+    let is_live_playback_cursor_fill = |fill: &radiant::runtime::PaintFillRect| {
+        is_playback_cursor_fill(fill) && fill.color.a == u8::MAX
+    };
+    assert!(
+        !frame
+            .paint_plan
+            .fill_rects_for_widget(crate::native_app::test_support::waveform::WAVEFORM_WIDGET_ID)
+            .any(is_live_playback_cursor_fill),
+        "the cached waveform base must not contain the live playback cursor"
+    );
+
+    let before_overlay = runtime.refresh_counters();
+    let activity = runtime.host_animation_activity();
+    assert!(
+        activity.needs_animation(),
+        "playback and waveform overflow fade should keep the host overlay active"
+    );
+    assert_eq!(
+        runtime.refresh_counters(),
+        before_overlay,
+        "polling transient overlay activity must not refresh the cached base"
+    );
+
+    let mut primitives = Vec::new();
     runtime.host_paint_transient_overlay(
         TransientOverlayContext::new(
             &frame.paint_plan,
@@ -1123,8 +1149,39 @@ fn scene_installs_playback_cursor_transient_overlay() {
         primitives
             .iter()
             .filter_map(|primitive| primitive.fill_rect())
-            .any(is_playback_cursor_fill),
-        "root scene should install the paint-only playback cursor overlay"
+            .any(is_live_playback_cursor_fill),
+        "root scene should paint the live playback cursor over the cached waveform base"
+    );
+
+    primitives.clear();
+    runtime.host_paint_transient_overlay(
+        TransientOverlayContext::new(
+            &frame.paint_plan,
+            Vector2::new(900.0, 620.0),
+            Duration::from_millis(130),
+        ),
+        &mut primitives,
+    );
+
+    assert!(
+        primitives
+            .iter()
+            .filter_map(|primitive| primitive.fill_rect())
+            .any(is_live_playback_cursor_fill),
+        "advancing root overlay should keep painting the live playback cursor"
+    );
+    assert!(
+        primitives.iter().any(|primitive| matches!(
+            primitive,
+            PaintPrimitive::FillPath(fill)
+                if matches!(fill.brush, radiant::runtime::PaintBrush::LinearGradient(_))
+        )),
+        "advancing root overlay should paint the active waveform overflow gradient"
+    );
+    assert_eq!(
+        runtime.refresh_counters(),
+        before_overlay,
+        "polling and painting transient overlays must reuse the cached base without refreshes"
     );
 }
 


### PR DESCRIPTION
## Goal

Adopt merged Radiant PR #1438 in Wavecrate so the retained host path composes normal waveform playback with an active waveform overflow fade.

## Scope

- Repin `vendor/radiant` from `c83987441d55ccd897562b84cfcb62fd7637d43e` to `7dadebb87216e68bc61f0f91a29c6b1ec3a5a469`.
- Extend the real Wavecrate root-scene retained-runtime regression to verify:
  - the cached waveform base has no live playback cursor;
  - host transient-overlay activity is active during playback plus overflow fade;
  - the host overlay paints both the live accent cursor and overflow-gradient fade;
  - activity polling and overlay painting reuse the cached base without refresh/scene rebuild.
- No Radiant source changes are included.

## Non-goals

- No Wavecrate-local overlay merger or production overlay composition changes.
- No playback/audio behavior, fade geometry, cadence policy, or overlay declaration-order changes.
- No unrelated cleanup, release publication, or merge.

## Definition of Done

- Parent gitlink is exactly `7dadebb87216e68bc61f0f91a29c6b1ec3a5a469`.
- The regression uses the real root Scene and `host_paint_transient_overlay` entrypoint and fails against the old singular-overlay host.
- Cached-base reuse and no refresh/scene rebuild are asserted.
- Focused validation and a signed release app build are complete.
- This PR remains open and unmerged until explicit user approval.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused regression: `scene_composes_playback_cursor_with_waveform_overflow_fade` (`1 passed`)
- Release build: `bash scripts/build.sh --release`
- Old-pin comparison: the new regression fails at `c8398744` and passes at `7dadebb`.

Baseline/known failures recorded precisely:

- Full `frame_overlay` module at the new pin: `48 passed, 2 failed`; unchanged `paused_source_cache_progress_does_not_force_playback_surface_frames` and `playback_cursor_paints_as_transient_overlay`. Both also fail at the old Radiant pin.
- `window_chrome::app_bridge`: `4 passed, 2 failed`; unchanged native-file-drop tests `app_bridge_scene_routes_native_file_drop_to_waveform_view` and `app_bridge_scene_routes_targetless_native_file_drop_to_single_waveform_target` observe `None` instead of `Some("kick.wav")`.
- `bash scripts/agent.sh request`: baseline native-app-boundary guardrail reports existing imports in `src/native_app/audio/playback/progress/waveform_publish.rs`, `src/native_app/waveform/edit_fade_paint.rs`, `src/native_app/waveform/playmark_label.rs`, `src/native_app/waveform/selection_paint.rs`, and `src/native_app/waveform/widget.rs`; none are changed here.
- `bash scripts/ci.sh agent`: dependency/app compilation and guardrails pass, then the exact Radiant pin's existing `gpu_signal_shader_keeps_waveform_bands_visually_distinct` lane reports `1699 passed, 1 failed` on the shader color-string assertion; no Wavecrate production source is changed.

## Known limitations

No live DAW/audible or interactive UI smoke was performed in this task. The branch-specific macOS app bundle was built and signed successfully at `target/app-bundles/opt1301/Wavecrate OPT-1301.app`.

User approval is required before merge.