### PR TITLE
fix(file-ops): restore Windows journal recovery compilation

### DIFF
--- a/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
+++ b/crates/wavecrate-library/src/sample_sources/db/file_ops_journal/recovery_io.rs
@@ -451,14 +451,17 @@ impl RecoveryRoot {
             });
         }
 
-        let capability = self.capability.try_clone().map_err(|error| {
-            format!("failed to retain source-root capability for database recovery: {error}")
-        })?;
-        let path = database_root_alias(&capability, &self.path, &self.identity)?;
-        Ok(BoundDatabaseRoot {
-            path,
-            _capability: capability,
-        })
+        #[cfg(not(windows))]
+        {
+            let capability = self.capability.try_clone().map_err(|error| {
+                format!("failed to retain source-root capability for database recovery: {error}")
+            })?;
+            let path = database_root_alias(&capability, &self.path, &self.identity)?;
+            Ok(BoundDatabaseRoot {
+                path,
+                _capability: capability,
+            })
+        }
     }
 
     #[cfg(any(windows, test))]


### PR DESCRIPTION
## Goal

Restore the Windows nightly build after the merged OPT-1303 descriptor-bound journal recovery work began compiling the non-Windows database-root alias path on Windows.

## Scope and non-goals

This PR only cfg-gates the non-Windows database_root_alias branch in RecoveryRoot::bind_database_root. The existing Windows descriptor-bound handle, final-path identity validation, capability retention, and fail-closed behavior are unchanged.

Non-goals: no journal/reconciliation redesign, pathname fallback, lint weakening, Windows finalization changes, or unrelated cleanup.

## Definition of Done

- Windows compiles without the denied unreachable-code and missing-symbol errors.
- Windows and non-Windows compile exactly their intended database-root binding branch.
- Windows retains descriptor-bound identity validation and capability lifetime.
- Non-Windows alias and unsupported-platform fail-closed behavior are unchanged.
- Focused recovery tests and repository guardrails are run and recorded below.

## Validation

- cargo fmt --all -- --check — pass.
- git diff --check — pass.
- cargo test --locked -p wavecrate-library recovery_io::tests — pass (3 passed).
- cargo check --locked -p wavecrate-library --target x86_64-pc-windows-msvc — blocked on this macOS host by missing MSVC ml64.exe and Windows C headers in native dependencies; the installed target was selected and compilation reached those host-tool prerequisites.
- bash scripts/ci.sh agent — Wavecrate checks and non-blocking/readiness guardrails passed; the gate ended on one unrelated pre-existing Radiant fixture failure: gpu_signal_shader_keeps_waveform_bands_visually_distinct (1699 passed, 1 failed).

## Known limitations

Real Windows/MSVC compilation and Windows-only tests require a Windows runner with the MSVC toolchain. The full agent gate has the unrelated Radiant baseline failure noted above.

User approval is required before merge.