### PR TITLE
fix(scan): use no-follow liveness for rename recovery

### DIFF
--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan/tests/rename_reconciliation.rs
@@ -139,6 +139,110 @@ fn hard_rescan_preserves_genuine_rename_metadata_and_analysis_identity() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn hard_rescan_reconciles_identity_move_when_old_path_is_an_external_link() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let renamed = dir.path().join("renamed.wav");
+    let outside_file = outside.path().join("outside.wav");
+    let outside_payload = b"outside target must remain untouched";
+    std::fs::write(&old, b"same sample").unwrap();
+    std::fs::write(&outside_file, outside_payload).unwrap();
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("External-link move"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::rename(&old, &renamed).unwrap();
+    symlink(&outside_file, &old).unwrap();
+    let stats = hard_rescan(&db).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 1);
+    let entry = db
+        .entry_for_path(Path::new("renamed.wav"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.tag, Rating::KEEP_1);
+    assert_eq!(entry.user_tag.as_deref(), Some("External-link move"));
+    assert!(db.entry_for_path(Path::new("old.wav")).unwrap().is_none());
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::renamed.wav"),
+        1
+    );
+    assert_eq!(
+        analysis_job_relative_path(dir.path(), "source::renamed.wav"),
+        "renamed.wav"
+    );
+    assert_eq!(std::fs::read(&outside_file).unwrap(), outside_payload);
+    assert_eq!(std::fs::read_link(&old).unwrap(), outside_file);
+}
+
+#[cfg(unix)]
+#[test]
+fn deferred_hash_copy_delete_recovers_when_old_path_is_an_external_link() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    let old = dir.path().join("old.wav");
+    let copied = dir.path().join("copied.wav");
+    let outside_file = outside.path().join("outside.wav");
+    let outside_payload = b"outside hash target must remain untouched";
+    let payload = vec![7_u8; 9 * 1024 * 1024];
+    std::fs::write(&old, &payload).unwrap();
+    std::fs::write(&outside_file, outside_payload).unwrap();
+
+    let db = SourceDatabase::open_for_scan(dir.path()).unwrap();
+    hard_rescan(&db).unwrap();
+    db.set_tag(Path::new("old.wav"), Rating::KEEP_1).unwrap();
+    db.set_user_tag(Path::new("old.wav"), Some("External-link copy-delete"))
+        .unwrap();
+    insert_analysis_artifacts(dir.path(), "source::old.wav", "old.wav");
+
+    std::fs::copy(&old, &copied).unwrap();
+    std::fs::remove_file(&old).unwrap();
+    symlink(&outside_file, &old).unwrap();
+    let removed = sync_paths(
+        &db,
+        &[PathBuf::from("copied.wav"), PathBuf::from("old.wav")],
+    )
+    .unwrap();
+    let stats = complete_deferred_hashes(&db, removed).unwrap();
+
+    assert_eq!(stats.renames_reconciled, 1);
+    let entry = db.entry_for_path(Path::new("copied.wav")).unwrap().unwrap();
+    assert_eq!(entry.tag, Rating::KEEP_1);
+    assert_eq!(entry.user_tag.as_deref(), Some("External-link copy-delete"));
+    assert!(db.entry_for_path(Path::new("old.wav")).unwrap().is_none());
+    assert!(db.list_pending_renames().unwrap().is_empty());
+    assert!(db.list_pending_rename_destinations().unwrap().is_empty());
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::old.wav"),
+        0
+    );
+    assert_eq!(
+        sample_id_count(dir.path(), "features", "source::copied.wav"),
+        1
+    );
+    assert_eq!(
+        analysis_job_relative_path(dir.path(), "source::copied.wav"),
+        "copied.wav"
+    );
+    assert_eq!(std::fs::read(&outside_file).unwrap(), outside_payload);
+    assert_eq!(std::fs::read_link(&old).unwrap(), outside_file);
+}
+
 #[test]
 fn hard_rescan_retains_metadata_for_ambiguous_same_content_destinations() {
     let dir = tempdir().unwrap();

--- a/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
+++ b/crates/wavecrate-scan/src/sample_sources/scanner/scan_hash.rs
@@ -1068,7 +1068,7 @@ fn reconcile_hashed_rename_candidates_with_source_root_and_hook(
     }
     let (renamed_samples, retained_candidates) = reconcile_indexed_rename_candidates(
         &mut batch,
-        root,
+        source_root,
         &entries_by_path,
         &candidate_identities,
         &rename_candidates,
@@ -1476,7 +1476,7 @@ fn deep_hash_scan_window_with_root_hooks(
     }
     let (renamed_samples, _) = reconcile_indexed_rename_candidates(
         &mut batch,
-        root,
+        source_root,
         &entries_by_path,
         &candidate_identities,
         &admitted_rename_candidates,
@@ -1583,7 +1583,7 @@ fn deep_hash_scan_with_hooks(
 
 fn reconcile_indexed_rename_candidates(
     batch: &mut SourceWriteBatch<'_>,
-    root: &std::path::Path,
+    source_root: &SourceRootCapability,
     entries_by_path: &HashMap<PathBuf, WavEntry>,
     candidate_identities: &HashMap<PathBuf, String>,
     rename_candidates: &HashSet<PathBuf>,
@@ -1626,7 +1626,9 @@ fn reconcile_indexed_rename_candidates(
             continue;
         };
         if pending_entry.relative_path == *present_path
-            || root.join(&pending_entry.relative_path).exists()
+            || source_root
+                .open_regular_file(&pending_entry.relative_path)?
+                .is_some()
             || pending_entry.file_size != present_entry.file_size
             || pending_entry.modified_ns != present_entry.modified_ns
         {
@@ -1672,7 +1674,9 @@ fn reconcile_indexed_rename_candidates(
         };
         if pending_entry.relative_path == *present_path
             || reconciled_paths.contains(&pending_entry.relative_path)
-            || root.join(&pending_entry.relative_path).exists()
+            || source_root
+                .open_regular_file(&pending_entry.relative_path)?
+                .is_some()
         {
             continue;
         }


### PR DESCRIPTION
## Goal
Allow bounded rename reconciliation to recover metadata and analysis identity when a removed old path is replaced by an excluded symlink, without following that link outside the source root.

## Scope
- Pass the retained `SourceRootCapability` into indexed rename reconciliation.
- Replace both old-path `exists()` gates with capability-scoped, no-follow regular-file liveness.
- Add deterministic Unix regressions for identity moves and hash copy-delete recovery with an external-target symlink.

## Non-goals
- No broader symlink redesign.
- No schema, TOCTOU, or unrelated scanner behavior changes.

## Definition of Done
- A live regular old path blocks transfer.
- Missing, symlink, or non-regular old paths permit reconciliation.
- Capability I/O uncertainty remains conservative and returns an error.
- Metadata, analysis identity, pending-rename cleanup, and external-target safety are covered by regression tests.

## Validation
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo test -p wavecrate-scan --lib external_link -- --nocapture` — 2 passed
- `cargo test -p wavecrate-scan --lib rename_reconciliation` — 36 passed
- `cargo test -p wavecrate-scan --lib` — 195 passed
- `cargo check -p wavecrate-scan --all-targets` — passed

## Known limitations
None within the approved scope.

User approval is required before merge; this PR is ready for review and has not been merged.
