### PR TITLE
Defer browser refreshes during playmark drags

### DIFF
--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -291,10 +291,11 @@ fn empty_starmap_items() -> Arc<[StarmapItem]> {
 
 fn waveform_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bool {
     state.waveform.current.active_drag_kind().is_some()
-        && !state
+        && (!state
             .library
             .folder_browser
             .visible_sample_window_needs_content_refresh()
+            || state.library.folder_browser.scan_content_refresh_pending())
 }
 
 fn starmap_audition_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bool {
@@ -316,7 +317,11 @@ mod tests {
     use crate::native_app::test_support::state::{NativeAppStateFixture, WaveformInteraction};
     use crate::native_app::waveform::WaveformSelectionKind;
     use crate::native_app::{
-        app::SampleBrowserDisplayMode, sample_library::folder_browser::FolderBrowserState,
+        app::SampleBrowserDisplayMode,
+        sample_library::folder_browser::{
+            FolderBrowserState,
+            scan::{FolderScanDiscoveryBatch, FolderScanLifecycle, scan_source_with_progress},
+        },
     };
     use radiant::{
         gui::types::Point,
@@ -390,6 +395,248 @@ mod tests {
             "extracted row should be visible before the active playmark drag ends"
         );
         assert!(waveform_drag_defers_sample_browser_preparation(&state));
+    }
+
+    #[test]
+    fn active_waveform_drag_defers_scan_dirty_refresh_until_release() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let original = source.join("original.wav");
+        fs::write(&original, [0_u8; 8]).expect("write original");
+        let sample_source = wavecrate::sample_sources::SampleSource::new(source.clone());
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_sample_sources_deferred(&[
+                sample_source,
+            ]))
+            .with_synthetic_waveform()
+            .build();
+        prepare_sample_browser_view(&mut state);
+
+        let request = state
+            .library
+            .begin_selected_source_scan(17)
+            .expect("source scan request");
+        state.library.start_folder_scan(&request);
+        assert!(state.library.folder_scan_active());
+
+        let mut discoveries = Vec::new();
+        let _result =
+            scan_source_with_progress(request.clone(), |_| {}, |event| discoveries.push(event));
+        assert!(
+            !discoveries.is_empty(),
+            "scan should discover the source file"
+        );
+        for (sequence, chunk) in discoveries.chunks(64).enumerate() {
+            assert!(
+                state
+                    .library
+                    .apply_folder_scan_discovery_batch(FolderScanDiscoveryBatch {
+                        task_id: request.task_id,
+                        source_id: request.source_id.clone(),
+                        committed_revision: chunk[0].committed_revision,
+                        lifecycle_generation: None,
+                        sequence: sequence as u64,
+                        events: chunk.to_vec(),
+                    })
+            );
+        }
+        assert!(state.library.folder_browser.scan_content_refresh_pending());
+        assert!(
+            state
+                .library
+                .finish_folder_scan_terminal(
+                    request.task_id,
+                    &request.source_id,
+                    None,
+                    FolderScanLifecycle::Complete,
+                )
+                .is_some()
+        );
+        assert!(!state.library.folder_scan_active());
+
+        state.waveform.current.set_play_selection_range(0.2, 0.4);
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+        assert!(
+            state
+                .library
+                .folder_browser
+                .visible_sample_window_needs_content_refresh()
+        );
+        assert!(waveform_drag_defers_sample_browser_preparation(&state));
+
+        prepare_sample_browser_view(&mut state);
+        assert!(
+            state
+                .library
+                .folder_browser
+                .visible_sample_window_needs_content_refresh()
+        );
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::FinishSelection {
+                visible_ratio: 0.45,
+            });
+        assert!(!waveform_drag_defers_sample_browser_preparation(&state));
+        prepare_sample_browser_view(&mut state);
+        let projection = SampleBrowserViewProjection::from_prepared_app_state(&state);
+
+        assert!(
+            !state
+                .library
+                .folder_browser
+                .visible_sample_window_needs_content_refresh()
+        );
+        assert!(
+            projection
+                .visible_samples
+                .rows
+                .iter()
+                .any(|row| row.file.id == original.to_string_lossy().as_ref()),
+            "the scan-discovered row should become visible after the drag ends"
+        );
+    }
+
+    #[test]
+    fn active_waveform_drag_allows_foreground_file_refresh_while_scan_active() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let original = source.join("original.wav");
+        let extracted = source.join("original_extraction.wav");
+        fs::write(&original, [0_u8; 8]).expect("write original");
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_root(source.clone()))
+            .with_synthetic_waveform()
+            .build();
+        prepare_sample_browser_view(&mut state);
+
+        let request = state
+            .library
+            .begin_selected_source_scan(19)
+            .expect("source scan request");
+        state.library.start_folder_scan(&request);
+        state.waveform.current.set_play_selection_range(0.2, 0.4);
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+        fs::write(&extracted, [1_u8; 8]).expect("write extraction");
+        assert!(state.library.folder_browser.refresh_file_path(&extracted));
+        assert!(!state.library.folder_browser.scan_content_refresh_pending());
+        assert!(!waveform_drag_defers_sample_browser_preparation(&state));
+
+        prepare_sample_browser_view(&mut state);
+        let projection = SampleBrowserViewProjection::from_prepared_app_state(&state);
+        assert!(
+            projection
+                .visible_samples
+                .rows
+                .iter()
+                .any(|row| row.file.id == extracted.to_string_lossy().as_ref()),
+            "foreground extraction should be visible during the active drag"
+        );
+    }
+
+    #[test]
+    fn active_waveform_drag_preserves_scan_deferral_after_foreground_refresh() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let original = source.join("original.wav");
+        let scan_file = source.join("scan_discovered.wav");
+        let extracted = source.join("aaa_extraction.wav");
+        fs::write(&original, [0_u8; 8]).expect("write original");
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_root(source.clone()))
+            .with_synthetic_waveform()
+            .build();
+        prepare_sample_browser_view(&mut state);
+
+        let request = state
+            .library
+            .begin_selected_source_scan(23)
+            .expect("source scan request");
+        state.library.start_folder_scan(&request);
+        fs::write(&scan_file, [2_u8; 8]).expect("write scan file");
+        let scan_result = scan_source_with_progress(request, |_| {}, |_| {});
+        assert!(
+            state
+                .library
+                .folder_browser
+                .apply_scan_finished(scan_result)
+        );
+        assert!(
+            state
+                .library
+                .folder_browser
+                .selected_source_audio_files()
+                .iter()
+                .any(|file| file.id == scan_file.to_string_lossy().as_ref())
+        );
+        assert!(state.library.folder_browser.scan_content_refresh_pending());
+
+        state.waveform.current.set_play_selection_range(0.2, 0.4);
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+        fs::write(&extracted, [1_u8; 8]).expect("write extraction");
+        assert!(state.library.folder_browser.refresh_file_path(&extracted));
+        assert!(state.library.folder_browser.scan_content_refresh_pending());
+        assert!(waveform_drag_defers_sample_browser_preparation(&state));
+
+        prepare_sample_browser_view(&mut state);
+        assert!(
+            state
+                .library
+                .folder_browser
+                .visible_sample_window_needs_content_refresh()
+        );
+        let during_drag = SampleBrowserViewProjection::from_prepared_app_state(&state);
+        assert!(
+            during_drag
+                .visible_samples
+                .rows
+                .iter()
+                .any(|row| row.file.id == extracted.to_string_lossy().as_ref())
+        );
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::FinishSelection {
+                visible_ratio: 0.45,
+            });
+        prepare_sample_browser_view(&mut state);
+        assert!(
+            !state
+                .library
+                .folder_browser
+                .visible_sample_window_needs_content_refresh()
+        );
+        let released = SampleBrowserViewProjection::from_prepared_app_state(&state);
+        assert!(
+            released
+                .visible_samples
+                .rows
+                .iter()
+                .any(|row| row.file.id == scan_file.to_string_lossy().as_ref())
+        );
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
+++ b/src/native_app/sample_library/folder_browser/filesystem_refresh.rs
@@ -36,19 +36,35 @@ impl FolderBrowserState {
         let refreshes_selected_file =
             self.selection.selected_file_id() == Some(refreshed_file_id.as_str());
         let parent_id = path_id(parent);
-        let source = &mut self.source.sources[source_index];
-        let Some(root_folder) = &mut source.root_folder else {
-            return false;
+        let selected_source = self.source.selected_source.clone();
+        let source_root = self.source.sources[source_index].root.clone();
+        let source_database_root = self.source.sources[source_index].database_root.clone();
+        let selected_tree_active = selected_source == self.source.sources[source_index].id
+            && self.tree.folders.first().is_some();
+        let root_folder = if selected_tree_active {
+            self.tree
+                .folders
+                .first_mut()
+                .expect("checked selected tree")
+        } else {
+            let source = &mut self.source.sources[source_index];
+            let Some(root_folder) = &mut source.root_folder else {
+                return false;
+            };
+            root_folder
         };
-        let source_database_root = source.database_root.clone();
         let Some(parent_folder) = root_folder.find_mut(&parent_id) else {
             return false;
         };
         upsert_file(
             &mut parent_folder.files,
-            file_entry_for_source_path(&path.to_path_buf(), &source.root, &source_database_root),
+            file_entry_for_source_path(&path.to_path_buf(), &source_root, &source_database_root),
         );
-        self.tree.folders = vec![root_folder.clone()];
+        if selected_tree_active {
+            self.source.sources[source_index].root_folder = self.tree.folders.first().cloned();
+        } else {
+            self.tree.folders = vec![root_folder.clone()];
+        }
         if refreshes_selected_file {
             self.request_selected_file_view_refollow_after_content_change();
         }

--- a/src/native_app/sample_library/folder_browser/sample_queries.rs
+++ b/src/native_app/sample_library/folder_browser/sample_queries.rs
@@ -189,6 +189,9 @@ impl FolderBrowserState {
         let curation_now = curation::now_epoch_seconds();
         let mut files = self.scoped_audio_files_for_listing();
         files.retain(|file| {
+            if self.scan_file_deferred(&file.id) {
+                return false;
+            }
             if reveal_id == Some(file.id.as_str()) {
                 return true;
             }

--- a/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
+++ b/src/native_app/sample_library/folder_browser/source_management/scan_lifecycle.rs
@@ -87,6 +87,7 @@ impl FolderBrowserState {
                 self.retain_tree_state_after_selected_source_refresh();
             }
             self.bump_file_content_revision();
+            self.mark_scan_content_refresh_pending();
             self.refresh_missing_collection_state();
         }
         true
@@ -378,6 +379,7 @@ impl FolderBrowserState {
         if !result.source_root_available {
             self.source.sources[source_index].mark_missing();
             self.refresh_selected_source_from_cache_or_placeholder(source_index);
+            self.mark_scan_content_refresh_pending();
             return true;
         }
         self.source.sources[source_index].mark_available();
@@ -400,10 +402,12 @@ impl FolderBrowserState {
                 self.select_loaded_source(source_id, result.folder);
                 self.refresh_missing_collection_state();
             }
+            self.mark_scan_content_refresh_pending();
         } else {
             self.source.sources[source_index].root_folder = Some(result.folder);
             self.source.sources[source_index].parked_tree_loaded = true;
             self.bump_file_content_revision();
+            self.mark_scan_content_refresh_pending();
             self.refresh_missing_collection_state();
         }
         true
@@ -470,6 +474,7 @@ impl FolderBrowserState {
         }
         self.retain_tree_state_after_selected_source_refresh();
         self.bump_file_content_revision();
+        self.mark_scan_content_refresh_pending();
         self.refresh_missing_collection_state();
         true
     }
@@ -536,6 +541,7 @@ impl FolderBrowserState {
             }
             if changed {
                 self.bump_file_content_revision();
+                self.mark_scan_content_refresh_pending();
             }
             return changed;
         }
@@ -550,6 +556,7 @@ impl FolderBrowserState {
         if changed && self.source.selected_source == batch.source_id {
             self.tree.folders = vec![root_folder.clone()];
             self.bump_file_content_revision();
+            self.mark_scan_content_refresh_pending();
         }
         changed
     }
@@ -620,6 +627,7 @@ impl FolderBrowserState {
         self.retain_tree_state_after_selected_source_refresh();
         self.reset_tree_view();
         self.bump_file_content_revision();
+        self.mark_scan_content_refresh_pending();
         self.refresh_missing_collection_state();
     }
 

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -25,6 +25,9 @@ pub(in crate::native_app) struct FolderBrowserState {
     pub(super) collection_panel: CollectionPanelState,
     pub(super) panel_layout: BrowserPanelLayoutState,
     pub(super) sample_list: SampleListState,
+    scan_content_refresh_revision: Option<u64>,
+    prepared_audio_file_ids: HashSet<String>,
+    deferred_scan_file_ids: HashSet<String>,
     /// Most recent keyboard or pointer focus activity. Pointer focus records
     /// its exact folder target when selection state alone is ambiguous.
     keyboard_focus_shown_at: Option<Instant>,
@@ -96,6 +99,9 @@ impl FolderBrowserState {
             collection_panel: CollectionPanelState::new(),
             panel_layout: BrowserPanelLayoutState::new(),
             sample_list: SampleListState::new(),
+            scan_content_refresh_revision: None,
+            prepared_audio_file_ids: HashSet::new(),
+            deferred_scan_file_ids: HashSet::new(),
             keyboard_focus_shown_at: None,
             keyboard_focus_hold: Duration::ZERO,
             keyboard_focus_alpha: 0,
@@ -127,6 +133,9 @@ impl FolderBrowserState {
             collection_panel: CollectionPanelState::new(),
             panel_layout: BrowserPanelLayoutState::new(),
             sample_list: SampleListState::new(),
+            scan_content_refresh_revision: None,
+            prepared_audio_file_ids: HashSet::new(),
+            deferred_scan_file_ids: HashSet::new(),
             keyboard_focus_shown_at: None,
             keyboard_focus_hold: Duration::ZERO,
             keyboard_focus_alpha: 0,
@@ -540,7 +549,45 @@ impl FolderBrowserState {
     }
 
     pub(super) fn bump_file_content_revision(&mut self) {
+        let preserve_scan_refresh = self.scan_content_refresh_revision
+            == Some(self.sample_list.content_revision)
+            && self.visible_sample_window_needs_content_refresh();
         self.sample_list.bump_content_revision();
+        self.scan_content_refresh_revision =
+            preserve_scan_refresh.then_some(self.sample_list.content_revision);
+    }
+
+    pub(super) fn mark_scan_content_refresh_pending(&mut self) {
+        self.scan_content_refresh_revision = Some(self.sample_list.content_revision);
+        let prepared_audio_file_ids = self.prepared_audio_file_ids.clone();
+        self.deferred_scan_file_ids = self
+            .selected_source_audio_files()
+            .into_iter()
+            .map(|file| file.id.clone())
+            .filter(|file_id| !prepared_audio_file_ids.contains(file_id))
+            .collect();
+    }
+
+    pub(super) fn clear_scan_content_refresh_pending(&mut self) {
+        self.scan_content_refresh_revision = None;
+        self.deferred_scan_file_ids.clear();
+    }
+
+    pub(super) fn remember_prepared_audio_file_ids(&mut self) {
+        self.prepared_audio_file_ids = self
+            .selected_source_audio_files()
+            .into_iter()
+            .map(|file| file.id.clone())
+            .collect();
+    }
+
+    pub(super) fn scan_file_deferred(&self, file_id: &str) -> bool {
+        self.deferred_scan_file_ids.contains(file_id)
+    }
+
+    pub(in crate::native_app) fn scan_content_refresh_pending(&self) -> bool {
+        self.scan_content_refresh_revision == Some(self.sample_list.content_revision)
+            && self.visible_sample_window_needs_content_refresh()
     }
 
     pub(in crate::native_app) fn visible_sample_window_needs_content_refresh(&self) -> bool {

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -659,6 +659,7 @@ impl FolderBrowserState {
         &mut self,
         policy: VisibleSampleWindowPolicy<'_>,
     ) -> ui::VirtualListWindow {
+        self.clear_scan_content_refresh_pending();
         let window = self.follow_selected_file_view_matching_tags(
             policy.viewport_rows,
             policy.overscan_rows,
@@ -666,6 +667,7 @@ impl FolderBrowserState {
             policy.tags_by_file,
         );
         self.sample_list.prepared_content_revision = self.sample_list.content_revision;
+        self.remember_prepared_audio_file_ids();
         window
     }
 


### PR DESCRIPTION
## Goal
Prevent playmark-drag stalls while a source folder scan updates browser contents.

## Scope
Defer scan-driven browser projection refreshes during an active waveform drag, then apply the latest refresh when the drag ends. Preserve immediate foreground file refreshes during a drag.

## Non-goals
No changes to scanning, source processing, extraction behavior, or waveform audio behavior.

## Definition of Done
- Scan-backed dirty browser refreshes do not rebuild during an active playmark drag.
- The latest browser projection refreshes after release.
- Direct foreground file refreshes remain visible during a drag.

## Validation
- `cargo test -p wavecrate active_waveform_drag_defers_scan_dirty_refresh_until_release` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.

## Known limitations
None.

User approval authorizes merge.