### PR TITLE
Defer background browser refresh during interaction

### DIFF
--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -295,7 +295,20 @@ fn waveform_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bo
             .library
             .folder_browser
             .visible_sample_window_needs_content_refresh()
-            || state.library.folder_browser.scan_content_refresh_pending())
+            || state.library.folder_browser.scan_content_refresh_pending()
+            || state
+                .library
+                .folder_browser
+                .background_content_refresh_pending())
+}
+
+fn browser_drag_defers_background_refresh(state: &NativeAppState) -> bool {
+    state
+        .library
+        .folder_browser
+        .background_content_refresh_pending()
+        && (state.library.folder_browser.drag_active()
+            || state.library.folder_browser.source_reorder_drag_active())
 }
 
 fn starmap_audition_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bool {
@@ -309,6 +322,7 @@ fn starmap_audition_drag_defers_sample_browser_preparation(state: &NativeAppStat
 fn live_drag_defers_sample_browser_preparation(state: &NativeAppState) -> bool {
     waveform_drag_defers_sample_browser_preparation(state)
         || starmap_audition_drag_defers_sample_browser_preparation(state)
+        || browser_drag_defers_background_refresh(state)
 }
 
 #[cfg(test)]
@@ -395,6 +409,79 @@ mod tests {
             "extracted row should be visible before the active playmark drag ends"
         );
         assert!(waveform_drag_defers_sample_browser_preparation(&state));
+    }
+
+    #[test]
+    fn active_waveform_drag_defers_readiness_score_refresh_until_release() {
+        let root = tempfile::tempdir().expect("source root");
+        let source = root.path().join("source");
+        fs::create_dir_all(&source).expect("create source folder");
+        let original = source.join("original.wav");
+        fs::write(&original, [0_u8; 8]).expect("write original");
+        let mut state = NativeAppStateFixture::default()
+            .with_folder_browser(FolderBrowserState::from_root(source.clone()))
+            .with_synthetic_waveform()
+            .build();
+        prepare_sample_browser_view(&mut state);
+
+        state
+            .library
+            .folder_browser
+            .toggle_similarity_anchor(original.to_string_lossy().into_owned());
+        prepare_sample_browser_view(&mut state);
+        state.waveform.current.set_play_selection_range(0.2, 0.4);
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::BeginSelectionMove {
+                kind: WaveformSelectionKind::Play,
+                visible_ratio: 0.25,
+            });
+
+        state
+            .library
+            .folder_browser
+            .set_similarity_scores_for_tests(
+                original.to_string_lossy().into_owned(),
+                [(original.to_string_lossy().into_owned(), 1.0)]
+                    .into_iter()
+                    .collect(),
+            );
+        assert!(
+            state
+                .library
+                .folder_browser
+                .background_content_refresh_pending()
+        );
+        assert!(waveform_drag_defers_sample_browser_preparation(&state));
+        prepare_sample_browser_view(&mut state);
+        assert!(
+            state
+                .library
+                .folder_browser
+                .background_content_refresh_pending(),
+            "readiness refresh must remain deferred during the active Playmark drag"
+        );
+
+        state
+            .waveform
+            .current
+            .apply_interaction(WaveformInteraction::FinishSelection {
+                visible_ratio: 0.45,
+            });
+        prepare_sample_browser_view(&mut state);
+        assert!(
+            !state
+                .library
+                .folder_browser
+                .background_content_refresh_pending()
+        );
+        let selection = state
+            .waveform
+            .current
+            .play_selection()
+            .expect("Playmark selection survives deferred refresh");
+        assert!(selection.end() > selection.start());
     }
 
     #[test]

--- a/src/native_app/app_chrome/view_models/sample_browser.rs
+++ b/src/native_app/app_chrome/view_models/sample_browser.rs
@@ -481,7 +481,8 @@ mod tests {
             .current
             .play_selection()
             .expect("Playmark selection survives deferred refresh");
-        assert!(selection.end() > selection.start());
+        assert!((selection.start() - 0.4).abs() < 0.001);
+        assert!((selection.end() - 0.6).abs() < 0.001);
     }
 
     #[test]

--- a/src/native_app/sample_library/folder_browser/state.rs
+++ b/src/native_app/sample_library/folder_browser/state.rs
@@ -26,6 +26,7 @@ pub(in crate::native_app) struct FolderBrowserState {
     pub(super) panel_layout: BrowserPanelLayoutState,
     pub(super) sample_list: SampleListState,
     scan_content_refresh_revision: Option<u64>,
+    background_content_refresh_revision: Option<u64>,
     prepared_audio_file_ids: HashSet<String>,
     deferred_scan_file_ids: HashSet<String>,
     /// Most recent keyboard or pointer focus activity. Pointer focus records
@@ -100,6 +101,7 @@ impl FolderBrowserState {
             panel_layout: BrowserPanelLayoutState::new(),
             sample_list: SampleListState::new(),
             scan_content_refresh_revision: None,
+            background_content_refresh_revision: None,
             prepared_audio_file_ids: HashSet::new(),
             deferred_scan_file_ids: HashSet::new(),
             keyboard_focus_shown_at: None,
@@ -134,6 +136,7 @@ impl FolderBrowserState {
             panel_layout: BrowserPanelLayoutState::new(),
             sample_list: SampleListState::new(),
             scan_content_refresh_revision: None,
+            background_content_refresh_revision: None,
             prepared_audio_file_ids: HashSet::new(),
             deferred_scan_file_ids: HashSet::new(),
             keyboard_focus_shown_at: None,
@@ -378,6 +381,7 @@ impl FolderBrowserState {
             aspect_scores_by_file,
         ));
         self.bump_file_content_revision();
+        self.mark_background_content_refresh_pending();
     }
 
     #[cfg(test)]
@@ -552,9 +556,14 @@ impl FolderBrowserState {
         let preserve_scan_refresh = self.scan_content_refresh_revision
             == Some(self.sample_list.content_revision)
             && self.visible_sample_window_needs_content_refresh();
+        let preserve_background_refresh = self.background_content_refresh_revision
+            == Some(self.sample_list.content_revision)
+            && self.visible_sample_window_needs_content_refresh();
         self.sample_list.bump_content_revision();
         self.scan_content_refresh_revision =
             preserve_scan_refresh.then_some(self.sample_list.content_revision);
+        self.background_content_refresh_revision =
+            preserve_background_refresh.then_some(self.sample_list.content_revision);
     }
 
     pub(super) fn mark_scan_content_refresh_pending(&mut self) {
@@ -573,6 +582,14 @@ impl FolderBrowserState {
         self.deferred_scan_file_ids.clear();
     }
 
+    pub(super) fn mark_background_content_refresh_pending(&mut self) {
+        self.background_content_refresh_revision = Some(self.sample_list.content_revision);
+    }
+
+    pub(super) fn clear_background_content_refresh_pending(&mut self) {
+        self.background_content_refresh_revision = None;
+    }
+
     pub(super) fn remember_prepared_audio_file_ids(&mut self) {
         self.prepared_audio_file_ids = self
             .selected_source_audio_files()
@@ -587,6 +604,11 @@ impl FolderBrowserState {
 
     pub(in crate::native_app) fn scan_content_refresh_pending(&self) -> bool {
         self.scan_content_refresh_revision == Some(self.sample_list.content_revision)
+            && self.visible_sample_window_needs_content_refresh()
+    }
+
+    pub(in crate::native_app) fn background_content_refresh_pending(&self) -> bool {
+        self.background_content_refresh_revision == Some(self.sample_list.content_revision)
             && self.visible_sample_window_needs_content_refresh()
     }
 

--- a/src/native_app/sample_library/folder_browser/visible_samples.rs
+++ b/src/native_app/sample_library/folder_browser/visible_samples.rs
@@ -660,6 +660,7 @@ impl FolderBrowserState {
         policy: VisibleSampleWindowPolicy<'_>,
     ) -> ui::VirtualListWindow {
         self.clear_scan_content_refresh_pending();
+        self.clear_background_content_refresh_pending();
         let window = self.follow_selected_file_view_matching_tags(
             policy.viewport_rows,
             policy.overscan_rows,


### PR DESCRIPTION
## Goal
Prevent similarity/readiness background refresh from interrupting an active Playmark or browser drag.

## Scope
- Mark similarity-score publication as a background content refresh.
- Defer browser preparation while an active interaction is in progress.
- Add Playmark regression coverage.

## Non-goals
- Does not fix or redefine the recurring one-target readiness safety-sweep defect.
- Does not alter scanner, supervisor, persistence, watcher, or lifecycle behavior.

## Definition of Done
- A readiness score refresh arriving during an active Playmark drag is applied after release.
- The Playmark range commits to the release coordinate.
- Existing drag-deferral behavior remains covered.

## Validation
- `cargo check -p wavecrate`
- `cargo fmt --all -- --check`
- `cargo test -p wavecrate active_waveform_drag_ --lib -- --nocapture`
- `git diff --check`

## Known limitations
The repeated one-target readiness recurrence remains outside this patch and requires separate deterministic evidence.

User approval is required before merge.