### PR TITLE
Fix Windows nightly build and adopt Radiant widget semantics

### DIFF
--- a/src/external_clipboard/windows/handle.rs
+++ b/src/external_clipboard/windows/handle.rs
@@ -3,6 +3,7 @@ use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, OpenC
 use windows::Win32::System::Memory::{
     GMEM_MOVEABLE, GMEM_ZEROINIT, GlobalAlloc, GlobalLock, GlobalUnlock,
 };
+use windows::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
 
 pub(super) struct ClipboardWriter {
     _clipboard: ClipboardOpenGuard,
@@ -43,7 +44,7 @@ impl ClipboardWriter {
 }
 
 fn active_window_owner() -> Result<HWND, String> {
-    let owner = unsafe { windows::Win32::UI::WindowsAndMessaging::GetActiveWindow() };
+    let owner = unsafe { GetActiveWindow() };
     if owner.0.is_null() {
         Err("GetActiveWindow returned no clipboard owner".to_string())
     } else {

--- a/src/native_app/app_chrome/toolbar/beat_count_input.rs
+++ b/src/native_app/app_chrome/toolbar/beat_count_input.rs
@@ -2,8 +2,8 @@ use radiant::{
     gui::automation::AutomationRole,
     prelude as ui,
     widgets::{
-        TextEditCommand, TextInputMessage, TextInputWidget, Widget, WidgetCommon, WidgetInput,
-        WidgetKey, WidgetOutput, WidgetSizing,
+        TextEditCommand, TextInputMessage, TextInputWidget, Widget, WidgetCapabilities,
+        WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSemantics, WidgetSizing,
     },
 };
 
@@ -161,16 +161,8 @@ impl Widget for BeatGuideCountInputWidget {
         true
     }
 
-    fn automation_role(&self) -> AutomationRole {
-        self.input.automation_role()
-    }
-
-    fn automation_label(&self) -> Option<String> {
-        Some(String::from("Beat guide count"))
-    }
-
-    fn automation_value_text(&self) -> Option<String> {
-        self.input.automation_value_text()
+    fn capabilities(&self) -> WidgetCapabilities<'_> {
+        WidgetCapabilities::new().semantics(self)
     }
 
     fn selected_text_slice(&self) -> Option<&str> {
@@ -189,6 +181,20 @@ impl Widget for BeatGuideCountInputWidget {
         theme: &ui::ThemeTokens,
     ) {
         self.input.append_paint(primitives, bounds, layout, theme);
+    }
+}
+
+impl WidgetSemantics for BeatGuideCountInputWidget {
+    fn automation_role(&self) -> AutomationRole {
+        self.input.automation_role()
+    }
+
+    fn automation_label(&self) -> Option<String> {
+        Some(String::from("Beat guide count"))
+    }
+
+    fn automation_value_text(&self) -> Option<String> {
+        self.input.automation_value_text()
     }
 }
 

--- a/src/native_app/sample_library/exclusive_file_transfer.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer.rs
@@ -283,13 +283,23 @@ fn committed_file(path: &Path, owned_file: File) -> CommittedFile {
 }
 
 fn rename_requires_copy_fallback(error: &io::Error) -> bool {
-    error.kind() == ErrorKind::CrossesDevices
-        || error.kind() == ErrorKind::Unsupported
-        || cfg!(any(target_os = "linux", target_os = "android"))
-            && matches!(
-                error.raw_os_error(),
-                Some(libc::ENOSYS | libc::EINVAL | libc::EOPNOTSUPP)
-            )
+    matches!(
+        error.kind(),
+        ErrorKind::CrossesDevices | ErrorKind::Unsupported
+    ) || platform_rename_requires_copy_fallback(error)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn platform_rename_requires_copy_fallback(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::ENOSYS | libc::EINVAL | libc::EOPNOTSUPP)
+    )
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn platform_rename_requires_copy_fallback(_error: &io::Error) -> bool {
+    false
 }
 
 mod platform;

--- a/src/native_app/sample_library/exclusive_file_transfer/tests.rs
+++ b/src/native_app/sample_library/exclusive_file_transfer/tests.rs
@@ -223,3 +223,34 @@ fn cross_device_fallback_commits_before_removing_the_source() {
     assert!(!source.exists());
     assert_eq!(fs::read(destination).unwrap(), b"source");
 }
+
+#[test]
+fn rename_fallback_accepts_unconditional_error_kinds() {
+    assert!(rename_requires_copy_fallback(&io::Error::from(
+        ErrorKind::CrossesDevices,
+    )));
+    assert!(rename_requires_copy_fallback(&io::Error::from(
+        ErrorKind::Unsupported,
+    )));
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[test]
+fn rename_fallback_accepts_linux_raw_errnos() {
+    for errno in [libc::ENOSYS, libc::EINVAL, libc::EOPNOTSUPP] {
+        let error = io::Error::from_raw_os_error(errno);
+        assert!(rename_requires_copy_fallback(&error));
+    }
+}
+
+#[test]
+fn rename_fallback_rejects_unrelated_errors() {
+    assert!(!rename_requires_copy_fallback(&io::Error::from(
+        ErrorKind::AlreadyExists,
+    )));
+    assert!(!rename_requires_copy_fallback(&io::Error::from(
+        ErrorKind::PermissionDenied,
+    )));
+    let unrelated_raw_error = io::Error::from_raw_os_error(i32::MAX);
+    assert!(!rename_requires_copy_fallback(&unrelated_raw_error));
+}

--- a/src/native_app/waveform/playmark_beat_controls.rs
+++ b/src/native_app/waveform/playmark_beat_controls.rs
@@ -2,7 +2,8 @@ use radiant::{
     gui::automation::AutomationRole,
     prelude as ui,
     widgets::{
-        ButtonWidget, Widget, WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
+        ButtonWidget, Widget, WidgetCapabilities, WidgetCommon, WidgetInput, WidgetKey,
+        WidgetOutput, WidgetSemantics, WidgetSizing,
     },
 };
 use std::sync::{Arc, Mutex};
@@ -109,6 +110,25 @@ impl Widget for PlaymarkBeatToggleWidget {
         })
     }
 
+    fn capabilities(&self) -> WidgetCapabilities<'_> {
+        WidgetCapabilities::new().semantics(self)
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: ui::Rect,
+        layout: &ui::LayoutOutput,
+        theme: &ui::ThemeTokens,
+    ) {
+        remember_painted_bounds(&self.painted_bounds, bounds);
+        if let Some(rect) = self.control_rect(bounds) {
+            self.button.append_paint(primitives, rect, layout, theme);
+        }
+    }
+}
+
+impl WidgetSemantics for PlaymarkBeatToggleWidget {
     fn automation_role(&self) -> AutomationRole {
         AutomationRole::Toggle
     }
@@ -123,19 +143,6 @@ impl Widget for PlaymarkBeatToggleWidget {
 
     fn automation_checked(&self) -> Option<bool> {
         Some(self.checked)
-    }
-
-    fn append_paint(
-        &self,
-        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
-        bounds: ui::Rect,
-        layout: &ui::LayoutOutput,
-        theme: &ui::ThemeTokens,
-    ) {
-        remember_painted_bounds(&self.painted_bounds, bounds);
-        if let Some(rect) = self.control_rect(bounds) {
-            self.button.append_paint(primitives, rect, layout, theme);
-        }
     }
 }
 
@@ -229,16 +236,8 @@ impl Widget for PlaymarkBeatCountWidget {
             })
     }
 
-    fn automation_role(&self) -> AutomationRole {
-        self.input.automation_role()
-    }
-
-    fn automation_label(&self) -> Option<String> {
-        Some(String::from("Playmark beat count"))
-    }
-
-    fn automation_value_text(&self) -> Option<String> {
-        self.input.automation_value_text()
+    fn capabilities(&self) -> WidgetCapabilities<'_> {
+        WidgetCapabilities::new().semantics(self)
     }
 
     fn selected_text_slice(&self) -> Option<&str> {
@@ -260,6 +259,20 @@ impl Widget for PlaymarkBeatCountWidget {
         if let Some(rect) = self.control_rect(bounds) {
             self.input.append_paint(primitives, rect, layout, theme);
         }
+    }
+}
+
+impl WidgetSemantics for PlaymarkBeatCountWidget {
+    fn automation_role(&self) -> AutomationRole {
+        self.input.automation_role()
+    }
+
+    fn automation_label(&self) -> Option<String> {
+        Some(String::from("Playmark beat count"))
+    }
+
+    fn automation_value_text(&self) -> Option<String> {
+        self.input.automation_value_text()
     }
 }
 

--- a/src/native_app/waveform/playmark_label_editor.rs
+++ b/src/native_app/waveform/playmark_label_editor.rs
@@ -3,8 +3,9 @@ use radiant::{
     prelude as ui,
     runtime::WidgetPaint,
     widgets::{
-        FocusBehavior, PointerButton, TextInputMessage, TextInputWidget, Widget, WidgetCommon,
-        WidgetInput, WidgetKey, WidgetOutput, WidgetSizing,
+        FocusBehavior, PointerButton, TextInputMessage, TextInputWidget, Widget,
+        WidgetCapabilities, WidgetCommon, WidgetInput, WidgetKey, WidgetOutput, WidgetSemantics,
+        WidgetSizing,
     },
 };
 use std::sync::{Arc, Mutex};
@@ -220,6 +221,30 @@ impl Widget for PlaymarkLabelWidget {
             })
     }
 
+    fn capabilities(&self) -> WidgetCapabilities<'_> {
+        WidgetCapabilities::new().semantics(self)
+    }
+
+    fn selected_text_slice(&self) -> Option<&str> {
+        self.input.as_ref().and_then(Widget::selected_text_slice)
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        self.input.as_ref().and_then(Widget::selected_text)
+    }
+
+    fn append_paint(
+        &self,
+        primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
+        bounds: ui::Rect,
+        layout: &ui::LayoutOutput,
+        theme: &ui::ThemeTokens,
+    ) {
+        self.append_paint_impl(primitives, bounds, layout, theme);
+    }
+}
+
+impl WidgetSemantics for PlaymarkLabelWidget {
     fn automation_role(&self) -> AutomationRole {
         if self.editing() {
             AutomationRole::TextInput
@@ -244,16 +269,10 @@ impl Widget for PlaymarkLabelWidget {
             .map(|input| input.state.value.clone())
             .or_else(|| Some(self.label.clone()))
     }
+}
 
-    fn selected_text_slice(&self) -> Option<&str> {
-        self.input.as_ref().and_then(Widget::selected_text_slice)
-    }
-
-    fn selected_text(&self) -> Option<String> {
-        self.input.as_ref().and_then(Widget::selected_text)
-    }
-
-    fn append_paint(
+impl PlaymarkLabelWidget {
+    fn append_paint_impl(
         &self,
         primitives: &mut Vec<radiant::runtime::PaintPrimitive>,
         bounds: ui::Rect,


### PR DESCRIPTION
## Goal

Restore the Windows nightly artifact build and adopt the canonical Radiant widget-semantics API so Wavecrate builds against the merged Radiant main.

## Scope and non-goals

- Call `GetActiveWindow` from `Win32::UI::Input::KeyboardAndMouse`, as exported by `windows` 0.62.2.
- Compile raw `libc` rename-fallback errnos only on Linux and Android.
- Add focused fallback-classification regressions.
- Repin `vendor/radiant` to canonical Radiant main `e66b3a6b1d0a5870517e71d962c3abef90907c1d`.
- Migrate Wavecrate's four custom widgets from `Widget` automation methods to Radiant's `WidgetSemantics` capability descriptor without changing behavior.
- Preserve the existing active-window clipboard owner policy and exclusive transfer semantics.
- No broader Radiant changes, release-workflow changes, or behavioral refactor.

## Definition of Done

- Windows compilation no longer reports E0425 for `GetActiveWindow` or E0433 for `libc`.
- Cross-device and unsupported rename errors still select the copy fallback on every platform.
- Linux/Android continue to treat ENOSYS, EINVAL, and EOPNOTSUPP as unsupported no-replace rename behavior.
- Unrelated errors do not select the fallback.
- Wavecrate's library compiles against Radiant `e66b3a6b`.
- The Windows nightly artifact job can progress past Wavecrate compilation.

## Validation

- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo check -p wavecrate --lib --locked` — passed with Radiant `e66b3a6b`.
- `cargo test --locked -p wavecrate --lib native_app::sample_library::exclusive_file_transfer::tests -- --test-threads=1` — 12 passed, 0 failed (prior nightly-fix validation).
- A macOS-hosted `cargo check --locked -p wavecrate --lib --target x86_64-pc-windows-msvc` reached Windows-target dependencies, then stopped in `ring` because the host lacks MSVC/Windows SDK headers. The authoritative Windows artifact build remains the GitHub Windows runner after merge.
- The broad `cargo check --workspace --all-targets --locked` remains blocked by pre-existing Radiant-owned example/test failures at `e66b3a6b` (unused imports/variables and `DemoMessage::GpuInput`); Wavecrate's library target itself is green.

## Known limitations

- The Windows nightly workflow resolves `main`, so this branch cannot be exercised by dispatching it without merging.
- Full all-target workspace validation requires separate Radiant example/test cleanup outside this bounded Wavecrate adaptation.

User approval is required before merge.